### PR TITLE
fix(task-assignment): sweep iterates per-project work-service DBs (#259)

### DIFF
--- a/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
@@ -14,6 +14,17 @@ The ``in_progress`` branch (#246) is gated on session idleness — a
 worker that's actively turning shouldn't be pinged mid-work. When the
 target session is busy (active turn indicator visible in the pane),
 we skip the ping and let the sweeper re-check on its next cadence.
+
+#259: the sweeper now fans out across per-project work-service DBs.
+``pm project new`` creates tasks in ``<project_path>/.pollypm/state.db``
+— those are invisible to a sweep that only reads the workspace-root
+DB, so pickup pings never fire for operator-created projects. We
+enumerate ``config.projects`` (exposed as ``services.known_projects``)
+and run the same sweep body against each per-project DB, opening and
+closing the connection per tick. When a project has queued tasks for
+a role that has no live session, we emit a single deduped
+``no_session`` alert per ``(project, role)`` — surfacing the blocked
+worker to the operator instead of silently dropping pings.
 """
 
 from __future__ import annotations
@@ -24,7 +35,11 @@ from pathlib import Path
 from typing import Any
 
 from pollypm.work.models import ActorType, WorkStatus
-from pollypm.work.task_assignment import SessionRoleIndex, TaskAssignmentEvent
+from pollypm.work.task_assignment import (
+    SessionRoleIndex,
+    TaskAssignmentEvent,
+    role_candidate_names,
+)
 
 from pollypm.plugins_builtin.task_assignment_notify.resolver import (
     DEDUPE_WINDOW_SECONDS,
@@ -153,15 +168,155 @@ def _target_session_is_idle(
         return True
 
 
+def _emit_no_session_alert(
+    services: Any,
+    *,
+    project: str,
+    role: str,
+    actor_type: ActorType,
+    example_task_id: str,
+) -> None:
+    """Raise (or refresh) a ``no_session`` alert for a ``(project, role)``.
+
+    Sweep-level alert — complements the per-task ``no_session_for_assignment:<id>``
+    alerts from ``_escalate_no_session`` with a single human-readable row
+    per blocked role. The underlying ``upsert_alert`` already dedupes on
+    ``(session_name, alert_type, status='open')`` so repeat emissions
+    within a sweep cycle (or across sweep cycles) just refresh the row.
+    """
+    store = services.state_store
+    if store is None:
+        return
+    # Candidate session name we would *expect* if the worker were running —
+    # keeps the alert's session_name column aligned with the missing
+    # session's identity, which is what the cockpit's "alerts for session X"
+    # queries filter on.
+    candidates = role_candidate_names(role, project) if actor_type is ActorType.ROLE else [role]
+    expected_name = candidates[0] if candidates else f"{role}-{project}"
+    message = (
+        f"Queued task {example_task_id} has no live session for "
+        f"{actor_type.value}:{role} in project '{project}'. "
+        f"Fix: pm worker-start {project}"
+    )
+    try:
+        store.upsert_alert(expected_name, "no_session", "warn", message)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "task_assignment sweep: upsert_alert(no_session) failed for %s",
+            expected_name, exc_info=True,
+        )
+
+
+def _sweep_work_service(
+    work: Any,
+    services: Any,
+    *,
+    throttle_override: int,
+    totals: dict[str, Any],
+    alerted_pairs: set[tuple[str, str]],
+) -> None:
+    """Run one sweep pass over a single work-service DB.
+
+    Mutates ``totals`` (``considered`` count + ``by_outcome`` tally) in
+    place so the caller can aggregate across per-project DBs. Tracks
+    already-alerted ``(project, role)`` pairs in ``alerted_pairs`` so
+    we emit at most one ``no_session`` alert per pair per sweep cycle.
+    """
+    by_outcome = totals["by_outcome"]
+    for status in _SWEEPABLE_STATUSES:
+        try:
+            tasks = work.list_tasks(work_status=status)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "task_assignment sweep: list_tasks failed for %s", status,
+                exc_info=True,
+            )
+            continue
+        for task in tasks:
+            event = _build_event_for_task(work, task)
+            if event is None:
+                continue
+            # #246: for in_progress tasks, only ping if the worker
+            # session is idle. An active turn means they're working;
+            # resume pings are for the restart / crash-recovery case.
+            if status in _IDLE_GATED_STATUSES:
+                if not _target_session_is_idle(event, services):
+                    by_outcome["skipped_active_turn"] = (
+                        by_outcome.get("skipped_active_turn", 0) + 1
+                    )
+                    continue
+            totals["considered"] += 1
+            result = notify(
+                event, services=services, throttle_seconds=throttle_override,
+            )
+            outcome = str(result.get("outcome", "unknown"))
+            by_outcome[outcome] = by_outcome.get(outcome, 0) + 1
+
+            # #259: when the task can't be routed, also raise a
+            # sweep-level ``no_session`` alert keyed by (project, role)
+            # so the operator sees one row per blocked role instead of
+            # N per-task alerts. Dedupe within a cycle via the visited
+            # set; upsert_alert dedupes across cycles.
+            if outcome == "no_session":
+                pair = (event.project, event.actor_name)
+                if pair not in alerted_pairs:
+                    alerted_pairs.add(pair)
+                    _emit_no_session_alert(
+                        services,
+                        project=event.project,
+                        role=event.actor_name,
+                        actor_type=event.actor_type,
+                        example_task_id=event.task_id,
+                    )
+
+
+def _open_project_work_service(project: Any) -> Any | None:
+    """Open a per-project ``SQLiteWorkService`` if its state.db exists.
+
+    Returns ``None`` when the project path has no state.db yet (fresh
+    registration, never-touched project) or when any open-time error
+    prevents connecting. Never raises — the sweeper skips silently and
+    moves on to the next project.
+    """
+    project_path = getattr(project, "path", None)
+    if project_path is None:
+        return None
+    db_path = Path(project_path) / ".pollypm" / "state.db"
+    if not db_path.exists():
+        return None
+    try:
+        from pollypm.work.sqlite_service import SQLiteWorkService
+
+        return SQLiteWorkService(db_path=db_path, project_path=Path(project_path))
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "task_assignment sweep: failed to open per-project DB at %s",
+            db_path, exc_info=True,
+        )
+        return None
+
+
+def _close_quietly(svc: Any) -> None:
+    closer = getattr(svc, "close", None)
+    if callable(closer):
+        try:
+            closer()
+        except Exception:  # noqa: BLE001
+            pass
+
+
 def task_assignment_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
-    """Re-notify machine-actor tasks in queued/review/in_progress states."""
+    """Re-notify machine-actor tasks in queued/review/in_progress states.
+
+    Fans out across the workspace-root DB *and* every registered
+    per-project DB (``config.projects``) so tasks created via
+    ``pm project new`` are picked up. Each per-project connection is
+    opened, read, and closed within the sweep tick — we don't hold
+    20+ connections open permanently.
+    """
     config_path_hint = payload.get("config_path")
     config_path = Path(config_path_hint) if config_path_hint else None
     services = load_runtime_services(config_path=config_path)
-
-    work = services.work_service
-    if work is None:
-        return {"outcome": "skipped", "reason": "no_work_service"}
 
     # The sweeper uses a shorter throttle so pre-existing queued tasks
     # get re-pinged every 5 min if they stay unclaimed — that's the
@@ -170,47 +325,55 @@ def task_assignment_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
     if throttle_override < 1:
         throttle_override = SWEEPER_COOLDOWN_SECONDS
 
-    total = 0
-    by_outcome: dict[str, int] = {}
-    try:
-        for status in _SWEEPABLE_STATUSES:
-            try:
-                tasks = work.list_tasks(work_status=status)
-            except Exception:  # noqa: BLE001
-                logger.debug(
-                    "task_assignment sweep: list_tasks failed for %s", status,
-                    exc_info=True,
-                )
-                continue
-            for task in tasks:
-                event = _build_event_for_task(work, task)
-                if event is None:
-                    continue
-                # #246: for in_progress tasks, only ping if the worker
-                # session is idle. An active turn means they're working;
-                # resume pings are for the restart / crash-recovery case.
-                if status in _IDLE_GATED_STATUSES:
-                    if not _target_session_is_idle(event, services):
-                        by_outcome["skipped_active_turn"] = (
-                            by_outcome.get("skipped_active_turn", 0) + 1
-                        )
-                        continue
-                total += 1
-                result = notify(
-                    event, services=services, throttle_seconds=throttle_override,
-                )
-                outcome = str(result.get("outcome", "unknown"))
-                by_outcome[outcome] = by_outcome.get(outcome, 0) + 1
-    finally:
-        closer = getattr(work, "close", None)
-        if callable(closer):
-            try:
-                closer()
-            except Exception:  # noqa: BLE001
-                pass
+    totals: dict[str, Any] = {"considered": 0, "by_outcome": {}}
+    alerted_pairs: set[tuple[str, str]] = set()
+    projects_scanned = 0
+    projects_skipped = 0
+
+    # Pass 1: workspace-root DB (workspace-level tasks the pollypm repo
+    # itself uses, or tests that point services.work_service at a
+    # tmpdir without registered projects).
+    workspace_work = services.work_service
+    if workspace_work is not None:
+        try:
+            _sweep_work_service(
+                workspace_work, services,
+                throttle_override=throttle_override,
+                totals=totals,
+                alerted_pairs=alerted_pairs,
+            )
+        finally:
+            _close_quietly(workspace_work)
+    elif not services.known_projects:
+        # No workspace work service AND no registered projects → nothing
+        # to sweep. Keep the legacy "no_work_service" outcome for
+        # observability / existing callers.
+        return {"outcome": "skipped", "reason": "no_work_service"}
+
+    # Pass 2: per-project DBs. Each gets its own connection, opened and
+    # closed within the sweep tick so we don't pile up file handles
+    # when many projects are registered.
+    for project in services.known_projects:
+        project_work = _open_project_work_service(project)
+        if project_work is None:
+            projects_skipped += 1
+            continue
+        try:
+            _sweep_work_service(
+                project_work, services,
+                throttle_override=throttle_override,
+                totals=totals,
+                alerted_pairs=alerted_pairs,
+            )
+            projects_scanned += 1
+        finally:
+            _close_quietly(project_work)
 
     return {
         "outcome": "swept",
-        "considered": total,
-        "by_outcome": by_outcome,
+        "considered": totals["considered"],
+        "by_outcome": totals["by_outcome"],
+        "projects_scanned": projects_scanned,
+        "projects_skipped": projects_skipped,
+        "no_session_alerts": len(alerted_pairs),
     }

--- a/src/pollypm/plugins_builtin/task_assignment_notify/resolver.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/resolver.py
@@ -10,7 +10,7 @@ service instantiation, dedupe / escalate decisions.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -33,12 +33,19 @@ SWEEPER_COOLDOWN_SECONDS = 5 * 60
 
 @dataclass(slots=True)
 class _RuntimeServices:
-    """Container for the services a notify/sweep invocation needs."""
+    """Container for the services a notify/sweep invocation needs.
+
+    ``known_projects`` — the registered ``[projects.*]`` map from
+    config, used by the sweeper to fan out across per-project work-
+    service DBs (#259). Empty tuple when no projects are registered or
+    config didn't load; the sweep then only scans the workspace-root DB.
+    """
 
     session_service: Any | None
     state_store: Any | None
     work_service: Any | None
     project_root: Path
+    known_projects: tuple[Any, ...] = field(default_factory=tuple)
 
 
 def load_runtime_services(
@@ -60,6 +67,7 @@ def load_runtime_services(
             state_store=None,
             work_service=None,
             project_root=Path.cwd(),
+            known_projects=(),
         )
     config = load_config(resolved_path)
 
@@ -92,11 +100,17 @@ def load_runtime_services(
         logger.debug("task_assignment_notify: work service unavailable", exc_info=True)
         work_service = None
 
+    # #259: snapshot registered projects so the sweeper can open each
+    # per-project DB on its own tick. We store the KnownProject objects
+    # directly — the sweeper just needs ``.key`` and ``.path``.
+    known_projects = tuple(config.projects.values())
+
     return _RuntimeServices(
         session_service=session_service,
         state_store=store,
         work_service=work_service,
         project_root=config.project.root_dir,
+        known_projects=known_projects,
     )
 
 

--- a/tests/test_task_assignment_fanout.py
+++ b/tests/test_task_assignment_fanout.py
@@ -1,0 +1,343 @@
+"""Tests for the per-project sweep fanout — #259.
+
+The ``task_assignment.sweep`` handler used to open only the workspace-
+root state DB. Projects registered via ``pm project new`` store their
+tasks in ``<project_path>/.pollypm/state.db``, so those tasks were
+invisible to the sweep — workers never got their pickup pings.
+
+These tests verify the fixed sweeper:
+
+* iterates every ``config.projects`` entry, opening each per-project DB
+  and sweeping tasks inside;
+* skips missing per-project state.db files without error;
+* emits a ``no_session`` alert for queued tasks whose role has no live
+  session, deduped per ``(project, role)`` per sweep cycle;
+* preserves the legacy workspace-root behavior (no regression);
+* dedupes alerts across repeated sweeps (``upsert_alert`` refresh, not
+  duplicate row).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pollypm.plugins_builtin.task_assignment_notify.handlers.sweep import (
+    task_assignment_sweep_handler,
+)
+from pollypm.plugins_builtin.task_assignment_notify.resolver import _RuntimeServices
+from pollypm.storage.state import StateStore
+from pollypm.work import task_assignment as bus
+from pollypm.work.sqlite_service import SQLiteWorkService
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeHandle:
+    name: str
+
+
+@dataclass
+class FakeSessionService:
+    handles: list[FakeHandle]
+    sent: list[tuple[str, str]] = field(default_factory=list)
+    busy: set[str] = field(default_factory=set)
+
+    def list(self) -> list[FakeHandle]:
+        return list(self.handles)
+
+    def send(self, name: str, text: str, *, press_enter: bool = True) -> None:
+        self.sent.append((name, text))
+
+    def is_turn_active(self, name: str) -> bool:
+        return name in self.busy
+
+
+@dataclass
+class FakeKnownProject:
+    """Stand-in for ``pollypm.models.KnownProject`` — the sweeper reads
+    only ``.key`` and ``.path`` so we don't need the full dataclass."""
+
+    key: str
+    path: Path
+
+
+def _make_project_db(project_path: Path, *, project_key: str) -> Path:
+    """Create ``<project_path>/.pollypm/state.db`` with a queued task.
+
+    Returns the resulting DB path. The task lives under ``project_key``
+    with a ``worker`` role so the sweep's resolver expects a live
+    ``worker-<project_key>`` session (or a ``no_session`` alert).
+    """
+    db_dir = project_path / ".pollypm"
+    db_dir.mkdir(parents=True, exist_ok=True)
+    db_path = db_dir / "state.db"
+    bus.clear_listeners()
+    work = SQLiteWorkService(db_path=db_path, project_path=project_path)
+    try:
+        task = work.create(
+            title=f"Do something in {project_key}",
+            description="Queued work for the per-project sweep",
+            type="task",
+            project=project_key,
+            flow_template="standard",
+            roles={"worker": "agent-1", "reviewer": "agent-2"},
+            priority="normal",
+        )
+        work.queue(task.task_id, "pm")
+    finally:
+        work.close()
+    return db_path
+
+
+def _install_fake_loader(monkeypatch, services_factory):
+    """Patch ``load_runtime_services`` used by the sweep handler."""
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.task_assignment_notify.handlers.sweep.load_runtime_services",
+        lambda *, config_path=None: services_factory(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core: sweeper iterates per-project DBs
+# ---------------------------------------------------------------------------
+
+
+class TestPerProjectFanout:
+    """#259: the sweep must open every registered per-project DB."""
+
+    def test_sweeper_opens_multiple_per_project_dbs(self, tmp_path, monkeypatch):
+        """Two projects, each with a queued task — both pickup pings fire."""
+        proj_a = tmp_path / "proj_a"
+        proj_b = tmp_path / "proj_b"
+        proj_a.mkdir()
+        proj_b.mkdir()
+        _make_project_db(proj_a, project_key="alpha")
+        _make_project_db(proj_b, project_key="beta")
+
+        store = StateStore(tmp_path / "workspace_state.db")
+        session_svc = FakeSessionService(handles=[
+            FakeHandle("worker-alpha"),
+            FakeHandle("worker-beta"),
+        ])
+
+        def _factory():
+            return _RuntimeServices(
+                session_service=session_svc,
+                state_store=store,
+                work_service=None,  # no workspace-level tasks
+                project_root=tmp_path,
+                known_projects=(
+                    FakeKnownProject(key="alpha", path=proj_a),
+                    FakeKnownProject(key="beta", path=proj_b),
+                ),
+            )
+
+        _install_fake_loader(monkeypatch, _factory)
+
+        result = task_assignment_sweep_handler({})
+
+        assert result["outcome"] == "swept"
+        assert result["projects_scanned"] == 2
+        assert result["projects_skipped"] == 0
+        assert result["by_outcome"].get("sent", 0) == 2
+
+        # Both workers got their pickup ping.
+        recipients = {name for name, _text in session_svc.sent}
+        assert recipients == {"worker-alpha", "worker-beta"}
+        assert all("New work" in text for _name, text in session_svc.sent)
+
+        store.close()
+
+    def test_sweeper_skips_missing_per_project_db(self, tmp_path, monkeypatch):
+        """A project registered but never touched (no state.db) is skipped
+        silently, and the sweep still processes the other projects."""
+        proj_real = tmp_path / "proj_real"
+        proj_missing = tmp_path / "proj_missing"
+        proj_real.mkdir()
+        proj_missing.mkdir()
+        # Only proj_real has a state.db — proj_missing has an empty dir
+        # with no ``.pollypm`` subfolder.
+        _make_project_db(proj_real, project_key="real")
+
+        store = StateStore(tmp_path / "workspace_state.db")
+        session_svc = FakeSessionService(handles=[FakeHandle("worker-real")])
+
+        def _factory():
+            return _RuntimeServices(
+                session_service=session_svc,
+                state_store=store,
+                work_service=None,
+                project_root=tmp_path,
+                known_projects=(
+                    FakeKnownProject(key="real", path=proj_real),
+                    FakeKnownProject(key="missing", path=proj_missing),
+                ),
+            )
+
+        _install_fake_loader(monkeypatch, _factory)
+
+        result = task_assignment_sweep_handler({})
+
+        # Sweep didn't error on the missing DB — it scanned one and
+        # skipped one.
+        assert result["outcome"] == "swept"
+        assert result["projects_scanned"] == 1
+        assert result["projects_skipped"] == 1
+        assert result["by_outcome"].get("sent", 0) == 1
+        assert session_svc.sent and session_svc.sent[0][0] == "worker-real"
+
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# no_session alert emission
+# ---------------------------------------------------------------------------
+
+
+class TestNoSessionAlerts:
+    """A queued task with no matching worker session must raise an
+    operator-visible alert — previously silent (#259)."""
+
+    def test_queued_task_without_worker_raises_no_session_alert(
+        self, tmp_path, monkeypatch,
+    ):
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        _make_project_db(proj, project_key="ghost")
+
+        store = StateStore(tmp_path / "workspace_state.db")
+        # No live sessions — the queued ghost/1 task has no worker.
+        session_svc = FakeSessionService(handles=[])
+
+        def _factory():
+            return _RuntimeServices(
+                session_service=session_svc,
+                state_store=store,
+                work_service=None,
+                project_root=tmp_path,
+                known_projects=(FakeKnownProject(key="ghost", path=proj),),
+            )
+
+        _install_fake_loader(monkeypatch, _factory)
+
+        result = task_assignment_sweep_handler({})
+
+        assert result["outcome"] == "swept"
+        # The sweep-level aggregate alert fired once for (ghost, worker).
+        assert result["no_session_alerts"] == 1
+        assert result["by_outcome"].get("no_session", 0) >= 1
+        # No pings were sent.
+        assert session_svc.sent == []
+
+        alerts = store.open_alerts()
+        # One sweep-level (project, role) alert keyed by alert_type="no_session".
+        sweep_alerts = [a for a in alerts if a.alert_type == "no_session"]
+        assert len(sweep_alerts) == 1
+        alert = sweep_alerts[0]
+        # Session name is the first role candidate — ``worker-ghost``.
+        assert alert.session_name == "worker-ghost"
+        assert alert.severity == "warn"
+        assert "ghost" in alert.message
+        assert "pm worker-start ghost" in alert.message
+
+        store.close()
+
+    def test_repeated_sweeps_do_not_duplicate_alerts(
+        self, tmp_path, monkeypatch,
+    ):
+        """``upsert_alert`` dedupes on ``(session_name, alert_type, open)`` —
+        running the sweep twice should leave exactly one open alert row."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        _make_project_db(proj, project_key="ghost")
+
+        store = StateStore(tmp_path / "workspace_state.db")
+        session_svc = FakeSessionService(handles=[])
+
+        def _factory():
+            return _RuntimeServices(
+                session_service=session_svc,
+                state_store=store,
+                work_service=None,
+                project_root=tmp_path,
+                known_projects=(FakeKnownProject(key="ghost", path=proj),),
+            )
+
+        _install_fake_loader(monkeypatch, _factory)
+
+        # First sweep → alert created.
+        task_assignment_sweep_handler({})
+        first = [a for a in store.open_alerts() if a.alert_type == "no_session"]
+        assert len(first) == 1
+
+        # Second sweep → alert refreshed, not duplicated.
+        task_assignment_sweep_handler({})
+        second = [a for a in store.open_alerts() if a.alert_type == "no_session"]
+        assert len(second) == 1
+        # Same row id as the first emission (upsert path, not INSERT).
+        assert first[0].alert_id == second[0].alert_id
+
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Regression: workspace-root DB behavior preserved
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceRootRegression:
+    """Pre-#259 behavior: the workspace-root DB still gets swept. With no
+    projects registered, the sweep must behave exactly as before."""
+
+    def test_workspace_root_sweep_still_works_with_no_projects(
+        self, tmp_path, monkeypatch,
+    ):
+        bus.clear_listeners()
+        # Workspace-root work service with a queued task.
+        workspace_db = tmp_path / "workspace_work.db"
+        workspace_work = SQLiteWorkService(db_path=workspace_db)
+        task = workspace_work.create(
+            title="Root-level task",
+            description="Lives in the workspace-root DB",
+            type="task",
+            project="root",
+            flow_template="standard",
+            roles={"worker": "agent-1", "reviewer": "agent-2"},
+            priority="normal",
+        )
+        workspace_work.queue(task.task_id, "pm")
+        # The sweep will re-open + close the connection it receives; we
+        # detach our reference so the handler's close() is the only one.
+        workspace_work.close()
+        workspace_work = SQLiteWorkService(db_path=workspace_db)
+
+        store = StateStore(tmp_path / "workspace_state.db")
+        session_svc = FakeSessionService(handles=[FakeHandle("worker-root")])
+
+        def _factory():
+            return _RuntimeServices(
+                session_service=session_svc,
+                state_store=store,
+                work_service=workspace_work,
+                project_root=tmp_path,
+                known_projects=(),  # no registered projects
+            )
+
+        _install_fake_loader(monkeypatch, _factory)
+
+        result = task_assignment_sweep_handler({})
+
+        assert result["outcome"] == "swept"
+        assert result["projects_scanned"] == 0
+        assert result["by_outcome"].get("sent", 0) == 1
+        assert session_svc.sent and session_svc.sent[0][0] == "worker-root"
+
+        store.close()


### PR DESCRIPTION
Core pickup-pipeline fix. `task_assignment.sweep` was blind to per-project DBs, so `pm project new` tasks never got pickup pings — workers sat idle forever.

## Changes
- `resolver.py`: `_RuntimeServices` now carries `known_projects`, populated from `config.projects`
- `handlers/sweep.py`: extracted `_sweep_work_service()`, added `_open_project_work_service()` (best-effort; missing state.db skipped silently), added `_emit_no_session_alert()` with dedupe
- Sweep now scans workspace-root DB **then** iterates all registered projects
- Queued tasks with no candidate worker now fire a `no_session` alert (was silent before)

## Tests (+5, 0 regressions)
- multiple per-project DBs scanned
- missing per-project DB skipped silently
- no-session alert fires + deduped
- workspace-root regression guard

2192 passing. One pre-existing unrelated failure.

Closes #259