### PR TITLE
feat(cli): implement pm notify via work-service inbox (#258)

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -1331,6 +1331,99 @@ def send(
     typer.echo(f"Sent input to {session_name}")
 
 
+@app.command()
+def notify(
+    subject: str = typer.Argument(..., help="Short title for the inbox item."),
+    body: str = typer.Argument(..., help="Message body. Pass '-' to read from stdin."),
+    actor: str = typer.Option("polly", "--actor", help="Who is posting the notification."),
+    project: str = typer.Option(
+        "inbox", "--project", "-p",
+        help="Project namespace for the notification task (default: 'inbox').",
+    ),
+    db: str = typer.Option(
+        ".pollypm/state.db", "--db",
+        help="Path to SQLite database (default: same resolution as `pm inbox`).",
+    ),
+) -> None:
+    """Create a work-service inbox item for the human user.
+
+    This is the canonical escalation channel referenced by the operator
+    runbook and control prompts. Polly (or any agent) uses ``pm notify``
+    to reach the user when something needs attention — a blocker, a
+    completed deliverable, a status update.
+
+    The notification is stored as a work-service task on the ``chat``
+    flow with ``roles.requester=user``, so it appears in ``pm inbox``
+    immediately.
+
+    Examples:
+
+    • pm notify "Deploy blocked" "Needs verification email click."
+    • pm notify "Done: homepage rewrite" "Review at https://…"
+    • echo "long body" | pm notify "Subject" -
+    """
+    if not subject.strip():
+        typer.echo("Error: subject must not be empty.", err=True)
+        raise typer.Exit(code=1)
+
+    if body == "-":
+        body = sys.stdin.read()
+    if not body.strip():
+        typer.echo(
+            "Error: body must not be empty (pass '-' to read from stdin).",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    # Use the same work-service entry point pm inbox reads through, so
+    # the notification lands in the identical DB and surfaces immediately.
+    from pollypm.plugins_builtin.activity_feed.summaries import activity_summary
+    from pollypm.storage.state import StateStore
+    from pollypm.work.cli import _resolve_db_path, _svc
+
+    svc = _svc(db, project=project)
+    try:
+        task = svc.create(
+            title=subject,
+            description=body,
+            type="task",
+            project=project,
+            flow_template="chat",
+            # requester=user makes _roles_match_user() trip in the
+            # inbox_view filter — the canonical mark for "user must
+            # look at this".
+            roles={"requester": "user", "operator": actor},
+            priority="normal",
+            created_by=actor,
+        )
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(f"Failed to create inbox task: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    # Audit event — mirrors the legacy inbox_message_created shape so the
+    # activity feed projector/consumers see the notification.
+    db_path = _resolve_db_path(db, project=project)
+    store = StateStore(db_path)
+    try:
+        store.record_event(
+            actor,
+            "inbox.message.created",
+            activity_summary(
+                summary=f"{actor} -> user: {subject}",
+                severity="recommendation",
+                verb="notified",
+                subject=subject,
+                project=project,
+                task_id=task.task_id,
+                body=body,
+            ),
+        )
+    finally:
+        store.close()
+
+    typer.echo(task.task_id)
+
+
 @alert_app.command("raise")
 def alert_raise(
     alert_type: str = typer.Argument(..., help="Alert type."),

--- a/tests/test_cli_notify.py
+++ b/tests/test_cli_notify.py
@@ -1,0 +1,134 @@
+"""Tests for ``pm notify`` — routes writes into the work-service inbox.
+
+The notification must land as a task that :mod:`pollypm.work.inbox_view`
+considers an inbox member, so ``pm inbox`` surfaces it through the same
+read path operators use.
+
+Tests cover:
+  * create creates a work-service task (not a legacy ``inbox_messages`` row)
+  * created task appears in ``pm inbox list`` via the canonical read path
+  * ``--actor`` is recorded on the task
+  * ``-`` body reads from stdin
+  * empty subject yields non-zero exit
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm.cli import app as root_app
+from pollypm.storage.state import StateStore
+from pollypm.work.cli import task_app
+from pollypm.work.inbox_cli import inbox_app
+
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> str:
+    return str(tmp_path / "state.db")
+
+
+def _invoke_notify(db_path: str, *args: str, input_text: str | None = None):
+    return runner.invoke(
+        root_app,
+        ["notify", *args, "--db", db_path],
+        input=input_text,
+    )
+
+
+class TestNotifyCreatesWorkServiceTask:
+    def test_notify_creates_task_visible_to_pm_inbox(self, db_path):
+        result = _invoke_notify(
+            db_path,
+            "Deploy blocked",
+            "Needs verification email click.",
+        )
+        assert result.exit_code == 0, result.output
+        task_id = result.output.strip().splitlines()[-1]
+        assert "/" in task_id, f"expected project/number task_id, got {task_id!r}"
+
+        # The task must show up via the same read path pm inbox uses.
+        inbox_result = runner.invoke(
+            inbox_app, ["--db", db_path, "--json"]
+        )
+        assert inbox_result.exit_code == 0, inbox_result.output
+        payload = json.loads(inbox_result.output)
+        assert payload["assigned_count"] == 1
+        assert payload["tasks"][0]["task_id"] == task_id
+        assert payload["tasks"][0]["title"] == "Deploy blocked"
+        assert payload["tasks"][0]["description"] == (
+            "Needs verification email click."
+        )
+
+    def test_notify_writes_to_work_tasks_not_legacy_inbox_messages(
+        self, db_path,
+    ):
+        """Regression: the previous attempt at #258 wrote to the legacy
+        ``inbox_messages`` table, which ``pm inbox`` does not read from.
+        Ensure we wrote to ``work_tasks`` and *not* to ``inbox_messages``.
+        """
+        result = _invoke_notify(db_path, "Subject", "Body")
+        assert result.exit_code == 0, result.output
+
+        # inbox_messages table is part of the legacy schema and gets
+        # created whenever StateStore opens the db — we must not have
+        # inserted a row there.
+        store = StateStore(Path(db_path))
+        try:
+            rows = store.list_inbox_messages()
+            assert rows == [], (
+                "pm notify must not write to the deprecated inbox_messages "
+                "table — route through work-service instead; got: " + str(rows)
+            )
+        finally:
+            store.close()
+
+    def test_actor_flag_is_recorded_on_task(self, db_path):
+        result = _invoke_notify(
+            db_path,
+            "Heads up",
+            "Something happened.",
+            "--actor", "morning-briefing",
+        )
+        assert result.exit_code == 0, result.output
+        task_id = result.output.strip().splitlines()[-1]
+
+        # created_by + roles.operator both carry the actor.
+        get_result = runner.invoke(
+            task_app,
+            ["get", task_id, "--db", db_path, "--json"],
+        )
+        assert get_result.exit_code == 0, get_result.output
+        task = json.loads(get_result.output)
+        assert task["roles"].get("operator") == "morning-briefing"
+        # Canonical user-mark — this is what makes it an inbox item.
+        assert task["roles"].get("requester") == "user"
+
+    def test_body_from_stdin_via_dash(self, db_path):
+        result = _invoke_notify(
+            db_path,
+            "Long body",
+            "-",
+            input_text="line 1\nline 2\nline 3\n",
+        )
+        assert result.exit_code == 0, result.output
+        task_id = result.output.strip().splitlines()[-1]
+
+        get_result = runner.invoke(
+            task_app,
+            ["get", task_id, "--db", db_path, "--json"],
+        )
+        assert get_result.exit_code == 0, get_result.output
+        task = json.loads(get_result.output)
+        assert "line 1" in task["description"]
+        assert "line 3" in task["description"]
+
+    def test_empty_subject_exits_nonzero(self, db_path):
+        result = _invoke_notify(db_path, "", "non-empty body")
+        assert result.exit_code != 0, result.output


### PR DESCRIPTION
Supersedes the earlier half-fix (branch worktree-agent-a440d857) which wrote to the deprecated `inbox_messages` table invisible to `pm inbox`. This rewrite routes through the canonical work-service inbox so notifications appear in `pm inbox` immediately.

## Design
- Uses `SQLiteWorkService.create()` with `flow_template="chat"`, `roles={"requester": "user", "operator": actor}`, `title=subject`, `description=body`
- `roles.requester=user` trips `inbox_view._roles_match_user()` — task appears in `pm inbox` at draft status instantly
- Emits `inbox.message.created` audit event
- Body `-` reads stdin; empty subject/body exits 1
- **Does NOT touch deprecated `inbox_messages` table**

## Tests (+5, 0 regressions)
- pm notify creates a task visible in pm inbox --json
- regression guard: zero writes to deprecated table
- --actor flows into roles.operator
- stdin body reading
- empty subject → nonzero exit

Closes #258