### PR TITLE
feat(supervisor): detect and recover from persona swaps on session kickoff

### DIFF
--- a/src/pollypm/session_services/tmux.py
+++ b/src/pollypm/session_services/tmux.py
@@ -193,7 +193,12 @@ class TmuxSessionService:
                     task_description=task_description,
                     user_id=user_id,
                 )
-                kickoff = self._prepare_initial_input(name, injected_input)
+                kickoff = self._prepare_initial_input(
+                    name,
+                    injected_input,
+                    expected_window=wname,
+                    session_role=session_role,
+                )
                 time.sleep(0.5)
                 self.tmux.send_keys(target, kickoff)
                 self._verify_input_submitted(target, kickoff, provider)
@@ -857,7 +862,71 @@ class TmuxSessionService:
     # Internal: initial input preparation
     # ------------------------------------------------------------------
 
-    def _prepare_initial_input(self, session_name: str, initial_input: str) -> str:
+    def _assert_session_launch_matches(
+        self,
+        session_name: str,
+        *,
+        expected_window: str | None,
+        session_role: str | None,
+    ) -> None:
+        """Fail loud when a (session_name, target-window) tuple is crossed.
+
+        Mirrors :meth:`pollypm.supervisor.Supervisor._assert_session_launch_matches`
+        but operates on :class:`pollypm.config.PollyPMConfig.sessions` — the
+        session service layer doesn't have a launch planner handle.
+
+        Worker sessions are transient (per-task window names under a
+        dynamic tmux session), so they are never registered in the
+        static ``sessions`` config. Skip the check for those; the
+        supervisor-layer assertion covers the static control roles.
+        """
+        if session_role == "worker":
+            return
+        sessions = getattr(self._config, "sessions", None) or {}
+        cfg = sessions.get(session_name) if isinstance(sessions, dict) else None
+        if cfg is None:
+            # Session not in static config — likely an ad-hoc / worker
+            # session. Nothing to cross-check against.
+            return
+        configured_window = cfg.window_name or cfg.name
+        mismatch_window = (
+            expected_window is not None and configured_window != expected_window
+        )
+        if mismatch_window:
+            details = (
+                f"session_name={session_name!r} "
+                f"expected_window={expected_window!r} "
+                f"configured_window={configured_window!r} "
+                f"role={session_role!r}"
+            )
+            logger.error("persona_swap_detected (session_service): %s", details)
+            try:
+                self._store.record_event(
+                    session_name, "persona_swap_detected", details,
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            raise RuntimeError(f"persona_swap_detected: {details}")
+
+    def _prepare_initial_input(
+        self,
+        session_name: str,
+        initial_input: str,
+        *,
+        expected_window: str | None = None,
+        session_role: str | None = None,
+    ) -> str:
+        # Fail-loud persona-swap guard. The parallel path in
+        # ``pollypm.supervisor.Supervisor._prepare_initial_input`` has
+        # the same check against ``launch_by_session``; here we use the
+        # config-level session map because the session service layer
+        # has no launch planner handle. See 2026-04-16 commit that
+        # added this check for the overnight-E2E context.
+        self._assert_session_launch_matches(
+            session_name,
+            expected_window=expected_window,
+            session_role=session_role,
+        )
         if len(initial_input) <= 280:
             return initial_input
         prompts_dir = self._config.project.base_dir / "control-prompts"

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -31,18 +31,22 @@ Supervisor-direct imports are confined to the allow-list.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import shlex
 import shutil
 import subprocess
 import sys
+import threading
 import time
 from collections.abc import Callable
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from uuid import uuid4
+
+logger = logging.getLogger(__name__)
 
 from pollypm.agent_profiles import get_agent_profile
 from pollypm.agent_profiles.base import AgentProfileContext
@@ -72,6 +76,20 @@ _OWNER_PREFIXES = {
     "polly": "P:",
     "pollypm": "[PollyPM]",
     "operator": "P:",
+}
+
+
+# Map a session role to a persona marker that should appear in the
+# pane after a successful kickoff. Used by the verify-after-kickoff
+# backstop (see ``Supervisor._schedule_persona_verify``) to catch
+# (launch, target) tuple crosses where one role's control prompt
+# lands in a different role's window. ``worker`` has no stable
+# persona and ``triage`` does not currently brand itself, so both
+# are intentionally omitted.
+_ROLE_PERSONA_MARKER: dict[str, str] = {
+    "operator-pm": "Polly",
+    "reviewer": "Russell",
+    "heartbeat-supervisor": "Heartbeat",
 }
 
 
@@ -548,8 +566,6 @@ class Supervisor:
         launches: list[SessionLaunchSpec],
         on_status: Callable[[str], None] | None = None,
     ) -> None:
-        import threading
-
         storage_session = self.storage_closet_session_name()
         (self.config.project.base_dir / "cockpit_state.json").unlink(missing_ok=True)
         self._bootstrap_clear_markers()
@@ -2429,8 +2445,89 @@ class Supervisor:
         self.session_service.tmux.send_keys(target, kickoff)
         self._verify_input_submitted(target, kickoff, launch)
         fresh_marker.unlink(missing_ok=True)
+        # Backup defense against (launch, target) crossed tuples: capture
+        # the pane a few seconds later and confirm the expected persona
+        # marker shows up. Non-blocking — fire-and-forget.
+        self._schedule_persona_verify(launch, target)
+
+    def _assert_session_launch_matches(
+        self, session_name: str, initial_input: str,
+    ) -> None:
+        """Fail loud if ``session_name`` doesn't resolve to a matching launch.
+
+        Two conditions are checked before we write a control-prompt file
+        or hand text to the pane:
+
+        1. ``launch.session.name == session_name`` — the planner returned
+           a launch for the name we were asked to prepare for.
+        2. ``launch.window_name`` matches the session's configured window
+           (``SessionConfig.window_name`` or, when unset, the session
+           name) — the (launch, target) tuple hasn't been crossed.
+
+        On mismatch we log loudly, record a ``persona_swap_detected``
+        event, and raise. A stuck pane is far easier to debug than a
+        reviewer masquerading as Polly, which is the failure mode we
+        observed overnight (2026-04-16: ``pm-operator`` window was
+        running Russell's prompt; root cause in the recovery/bootstrap
+        threading path is untraced).
+        """
+        try:
+            launch = self.launch_by_session(session_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "persona_swap_detected: no launch for session_name=%r: %s",
+                session_name, exc,
+            )
+            try:
+                self.store.record_event(
+                    session_name,
+                    "persona_swap_detected",
+                    f"no launch resolves for session_name={session_name!r}: {exc}",
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            raise RuntimeError(
+                f"persona_swap_detected: no launch for session_name={session_name!r}"
+            ) from exc
+
+        cfg = self.config.sessions.get(session_name)
+        expected_window = None
+        if cfg is not None:
+            expected_window = cfg.window_name or cfg.name
+
+        mismatch_name = launch.session.name != session_name
+        mismatch_window = (
+            expected_window is not None and launch.window_name != expected_window
+        )
+        if mismatch_name or mismatch_window:
+            logger.error(
+                "persona_swap_detected: session_name=%r launch.session.name=%r "
+                "launch.window_name=%r expected_window=%r role=%r",
+                session_name,
+                launch.session.name,
+                launch.window_name,
+                expected_window,
+                launch.session.role,
+            )
+            details = (
+                f"session_name={session_name!r} "
+                f"launch.session.name={launch.session.name!r} "
+                f"launch.window_name={launch.window_name!r} "
+                f"expected_window={expected_window!r} "
+                f"role={launch.session.role!r}"
+            )
+            try:
+                self.store.record_event(
+                    session_name, "persona_swap_detected", details,
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            raise RuntimeError(f"persona_swap_detected: {details}")
 
     def _prepare_initial_input(self, session_name: str, initial_input: str) -> str:
+        # Fail-loud persona-swap guard. Raises before we touch disk or
+        # the pane when the (launch, target) tuple looks wrong.
+        self._assert_session_launch_matches(session_name, initial_input)
         if len(initial_input) <= 280:
             return initial_input
         prompts_dir = self.config.project.base_dir / "control-prompts"
@@ -2455,6 +2552,93 @@ class Supervisor:
         return (
             f'Read {display_path}, adopt it as your operating instructions, reply only "ready", then wait.'
         )
+
+    def _schedule_persona_verify(self, launch: SessionLaunchSpec, target: str) -> None:
+        """Schedule a one-shot verify-after-kickoff on a background thread.
+
+        Backup defense against crossed ``(launch, target)`` tuples. The
+        strict assertion in :meth:`_prepare_initial_input` is the
+        primary line of defense; this runs 5 s after the kickoff send
+        and confirms the pane actually contains the expected persona
+        marker. If the pane instead shows a *different* persona, we
+        record ``persona_swap_verified`` and re-send the correct prompt
+        (which will itself fail-safe through the assertion if something
+        is still wrong).
+
+        Tolerant by design: one capture attempt, one retry send, then
+        log and give up. Never loops.
+        """
+        role = launch.session.role
+        expected = _ROLE_PERSONA_MARKER.get(role)
+        if expected is None:
+            # Worker / triage: no stable persona marker — nothing to verify.
+            return
+
+        def _run() -> None:
+            try:
+                time.sleep(5.0)
+                try:
+                    pane = self.session_service.tmux.capture_pane(target, lines=50)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        "persona verify: capture_pane failed for %s: %s",
+                        launch.session.name, exc,
+                    )
+                    return
+                unexpected = [
+                    marker for other_role, marker in _ROLE_PERSONA_MARKER.items()
+                    if other_role != role and marker in pane
+                ]
+                if expected in pane and not unexpected:
+                    return  # All good.
+                if expected not in pane and unexpected:
+                    details = (
+                        f"session_name={launch.session.name!r} "
+                        f"role={role!r} expected={expected!r} "
+                        f"found_markers={unexpected!r} target={target!r}"
+                    )
+                    logger.error("persona_swap_verified: %s", details)
+                    try:
+                        self.store.record_event(
+                            launch.session.name,
+                            "persona_swap_verified",
+                            details,
+                        )
+                    except Exception:  # noqa: BLE001
+                        pass
+                    # Attempt one recovery resend. _prepare_initial_input
+                    # will re-run the strict assertion and raise if the
+                    # (launch, target) tuple is still crossed, which is
+                    # the fail-safe we want.
+                    initial_input = launch.initial_input
+                    if not initial_input:
+                        return
+                    try:
+                        kickoff = self._prepare_initial_input(
+                            launch.session.name, initial_input,
+                        )
+                        self.session_service.tmux.send_keys(target, kickoff)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.error(
+                            "persona verify: resend failed for %s: %s",
+                            launch.session.name, exc,
+                        )
+                # Otherwise: marker not present yet (pane still
+                # rendering), or both expected and unexpected present
+                # (control prompt being read, mentions other persona).
+                # Don't overreact.
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "persona verify thread crashed for %s: %s",
+                    launch.session.name, exc,
+                )
+
+        t = threading.Thread(
+            target=_run,
+            name=f"persona-verify-{launch.session.name}",
+            daemon=True,
+        )
+        t.start()
 
     def _stabilize_claude_launch(
         self, target: str, on_status: Callable[[str], None] | None = None,

--- a/tests/test_persona_swap_detection.py
+++ b/tests/test_persona_swap_detection.py
@@ -1,0 +1,396 @@
+"""Tests for persona-swap detection added 2026-04-16.
+
+Context: during an overnight E2E test, the ``pm-operator`` tmux window
+was observed running Russell's (reviewer) control prompt. Root cause in
+the recovery/bootstrap threading path is untraced. These tests cover the
+two fail-loud defenses that were added in response:
+
+1. A strict assertion in ``_prepare_initial_input`` that refuses to
+   write or send a kickoff when the ``(launch, target)`` tuple looks
+   crossed (both the supervisor path and the session_services path).
+2. A verify-after-kickoff backstop that re-captures the pane and
+   re-sends the correct prompt when a wrong-persona marker is detected.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from pollypm.models import (
+    AccountConfig,
+    KnownProject,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectKind,
+    ProjectSettings,
+    ProviderKind,
+    SessionConfig,
+)
+from pollypm.supervisor import Supervisor, _ROLE_PERSONA_MARKER
+
+
+def _config(tmp_path: Path) -> PollyPMConfig:
+    return PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            base_dir=tmp_path / ".pollypm-state",
+            logs_dir=tmp_path / ".pollypm-state/logs",
+            snapshots_dir=tmp_path / ".pollypm-state/snapshots",
+            state_db=tmp_path / ".pollypm-state/state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account="claude_controller"),
+        accounts={
+            "claude_controller": AccountConfig(
+                name="claude_controller",
+                provider=ProviderKind.CLAUDE,
+                email="claude@example.com",
+                home=tmp_path / ".pollypm-state/homes/claude_controller",
+            ),
+        },
+        sessions={
+            "heartbeat": SessionConfig(
+                name="heartbeat",
+                role="heartbeat-supervisor",
+                provider=ProviderKind.CLAUDE,
+                account="claude_controller",
+                cwd=tmp_path,
+                project="pollypm",
+                window_name="pm-heartbeat",
+            ),
+            "operator": SessionConfig(
+                name="operator",
+                role="operator-pm",
+                provider=ProviderKind.CLAUDE,
+                account="claude_controller",
+                cwd=tmp_path,
+                project="pollypm",
+                window_name="pm-operator",
+            ),
+            "reviewer": SessionConfig(
+                name="reviewer",
+                role="reviewer",
+                provider=ProviderKind.CLAUDE,
+                account="claude_controller",
+                cwd=tmp_path,
+                project="pollypm",
+                window_name="pm-reviewer",
+            ),
+        },
+        projects={
+            "pollypm": KnownProject(
+                key="pollypm",
+                path=tmp_path,
+                name="PollyPM",
+                kind=ProjectKind.FOLDER,
+            )
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1 — Assertion inside _prepare_initial_input (supervisor path)
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_initial_input_raises_for_unknown_session(tmp_path: Path) -> None:
+    """If ``session_name`` doesn't resolve to any launch, raise loudly."""
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+
+    with pytest.raises(RuntimeError, match="persona_swap_detected"):
+        supervisor._prepare_initial_input("no-such-session", "some prompt text")
+
+
+def test_prepare_initial_input_raises_when_window_mismatches(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Crossed (launch, target) tuple: launch.window_name != expected window."""
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+
+    # Fake the launch planner to return a launch whose window_name is
+    # the *reviewer* window under the operator session name — that's
+    # exactly the kind of cross we're trying to catch.
+    real_launch = supervisor.launch_by_session("operator")
+    bad_launch = replace(real_launch, window_name="pm-reviewer")
+    monkeypatch.setattr(
+        supervisor, "launch_by_session", lambda name: bad_launch,
+    )
+
+    with pytest.raises(RuntimeError, match="persona_swap_detected"):
+        supervisor._prepare_initial_input("operator", "kickoff")
+
+
+def test_prepare_initial_input_raises_when_name_mismatches(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Planner returned a launch for a different session than requested."""
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+
+    reviewer_launch = supervisor.launch_by_session("reviewer")
+    monkeypatch.setattr(
+        supervisor, "launch_by_session", lambda name: reviewer_launch,
+    )
+
+    with pytest.raises(RuntimeError, match="persona_swap_detected"):
+        supervisor._prepare_initial_input("operator", "kickoff")
+
+
+def test_prepare_initial_input_records_event_on_mismatch(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """On detected swap, a ``persona_swap_detected`` event is recorded."""
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+
+    real_launch = supervisor.launch_by_session("operator")
+    bad_launch = replace(real_launch, window_name="pm-reviewer")
+    monkeypatch.setattr(
+        supervisor, "launch_by_session", lambda name: bad_launch,
+    )
+
+    with pytest.raises(RuntimeError):
+        supervisor._prepare_initial_input("operator", "kickoff")
+
+    rows = supervisor.store.execute(
+        "SELECT event_type, message FROM events "
+        "WHERE session_name = ? AND event_type = ?",
+        ("operator", "persona_swap_detected"),
+    ).fetchall()
+    assert len(rows) == 1
+    _event_type, message = rows[0]
+    assert "pm-operator" in message
+    assert "pm-reviewer" in message
+
+
+def test_prepare_initial_input_happy_path_returns_prompt(tmp_path: Path) -> None:
+    """When everything matches, _prepare_initial_input returns normally."""
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+
+    # Short prompt — returned verbatim.
+    result = supervisor._prepare_initial_input("operator", "short prompt")
+    assert result == "short prompt"
+
+    # Long prompt — written to disk, return a reference string.
+    long_prompt = "x" * 500
+    result = supervisor._prepare_initial_input("operator", long_prompt)
+    assert "operator.md" in result
+
+
+# ---------------------------------------------------------------------------
+# #1 — Assertion inside session_services _prepare_initial_input
+# ---------------------------------------------------------------------------
+
+
+def test_session_service_prepare_raises_on_window_mismatch(tmp_path: Path) -> None:
+    from pollypm.session_services.tmux import TmuxSessionService
+
+    config = _config(tmp_path)
+    # The supervisor constructor sets up the state DB directory — reuse
+    # it so we can create a session service directly.
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+
+    service = TmuxSessionService(config=config, store=supervisor.store)
+
+    with pytest.raises(RuntimeError, match="persona_swap_detected"):
+        service._prepare_initial_input(
+            "operator",
+            "kickoff",
+            expected_window="pm-reviewer",  # wrong window for operator
+            session_role="operator-pm",
+        )
+
+
+def test_session_service_prepare_happy_path(tmp_path: Path) -> None:
+    from pollypm.session_services.tmux import TmuxSessionService
+
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+
+    service = TmuxSessionService(config=config, store=supervisor.store)
+
+    result = service._prepare_initial_input(
+        "operator",
+        "short",
+        expected_window="pm-operator",
+        session_role="operator-pm",
+    )
+    assert result == "short"
+
+
+def test_session_service_prepare_skips_check_for_worker(tmp_path: Path) -> None:
+    """Worker sessions are transient and not in static config; the
+    session-service assertion must no-op for them."""
+    from pollypm.session_services.tmux import TmuxSessionService
+
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+
+    service = TmuxSessionService(config=config, store=supervisor.store)
+
+    # Worker session name that's NOT in the static config — should not raise.
+    result = service._prepare_initial_input(
+        "worker-task-42",
+        "short",
+        expected_window="worker-task-42",
+        session_role="worker",
+    )
+    assert result == "short"
+
+
+# ---------------------------------------------------------------------------
+# #2 — Verify-after-kickoff
+# ---------------------------------------------------------------------------
+
+
+def _patch_tmux(monkeypatch, supervisor: Supervisor, pane_text: str, sends: list):
+    """Install fake tmux capture/send on the supervisor's session_service."""
+    monkeypatch.setattr(
+        supervisor.session_service.tmux,
+        "capture_pane",
+        lambda target, lines=50: pane_text,
+    )
+    monkeypatch.setattr(
+        supervisor.session_service.tmux,
+        "send_keys",
+        lambda target, text, **kw: sends.append((target, text)),
+    )
+
+
+def test_verify_after_kickoff_noop_when_marker_matches(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Expected marker present, no unexpected markers — do nothing."""
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+
+    launch = supervisor.launch_by_session("operator")
+    assert launch.session.role == "operator-pm"
+
+    sends: list[tuple[str, str]] = []
+    _patch_tmux(
+        monkeypatch,
+        supervisor,
+        pane_text="I am Polly, ready.",
+        sends=sends,
+    )
+    # Skip the 5 s wait.
+    monkeypatch.setattr("pollypm.supervisor.time.sleep", lambda _s: None)
+
+    supervisor._schedule_persona_verify(launch, "pollypm-storage-closet:pm-operator")
+    # Thread is daemon — join briefly.
+    import threading
+    for t in threading.enumerate():
+        if t.name.startswith("persona-verify-"):
+            t.join(timeout=2)
+
+    # Happy path: no resend.
+    assert sends == []
+
+    events = supervisor.store.execute(
+        "SELECT event_type FROM events WHERE session_name = 'operator'",
+    ).fetchall()
+    assert not any(row[0] == "persona_swap_verified" for row in events)
+
+
+def test_verify_after_kickoff_resends_on_wrong_persona(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Pane shows Russell in the Polly window — record + resend."""
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+
+    launch = supervisor.launch_by_session("operator")
+    # Ensure our launch has a non-empty initial_input so the resend
+    # branch has something to work with.
+    launch_with_input = replace(launch, initial_input="polly kickoff text")
+    monkeypatch.setattr(
+        supervisor, "launch_by_session", lambda name: launch_with_input,
+    )
+
+    sends: list[tuple[str, str]] = []
+    _patch_tmux(
+        monkeypatch,
+        supervisor,
+        pane_text="I am Russell, ready for review.",
+        sends=sends,
+    )
+    monkeypatch.setattr("pollypm.supervisor.time.sleep", lambda _s: None)
+
+    supervisor._schedule_persona_verify(
+        launch_with_input, "pollypm-storage-closet:pm-operator",
+    )
+    import threading
+    for t in threading.enumerate():
+        if t.name.startswith("persona-verify-"):
+            t.join(timeout=2)
+
+    # We expect one recovery resend attempt.
+    assert len(sends) == 1
+    assert sends[0][0] == "pollypm-storage-closet:pm-operator"
+
+    # And a persona_swap_verified event recorded.
+    events = supervisor.store.execute(
+        "SELECT event_type, message FROM events "
+        "WHERE session_name = 'operator' AND event_type = 'persona_swap_verified'",
+    ).fetchall()
+    assert len(events) == 1
+    assert "Russell" in events[0][1]
+
+
+def test_verify_after_kickoff_skips_for_worker_role(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Worker role has no persona marker — verification must short-circuit."""
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+
+    launch = supervisor.launch_by_session("operator")
+    worker_launch = replace(
+        launch,
+        session=replace(launch.session, role="worker"),
+    )
+
+    captures: list[str] = []
+    monkeypatch.setattr(
+        supervisor.session_service.tmux,
+        "capture_pane",
+        lambda target, lines=50: captures.append(target) or "",
+    )
+
+    supervisor._schedule_persona_verify(worker_launch, "some:target")
+
+    # No thread was spawned — capture should never be called.
+    import threading
+    import time
+    time.sleep(0.05)
+    for t in threading.enumerate():
+        if t.name.startswith("persona-verify-"):
+            t.join(timeout=0.1)
+    assert captures == []
+
+
+def test_role_persona_marker_covers_expected_roles() -> None:
+    """Sanity: the role→marker map covers every control role with a persona."""
+    assert _ROLE_PERSONA_MARKER["operator-pm"] == "Polly"
+    assert _ROLE_PERSONA_MARKER["reviewer"] == "Russell"
+    assert _ROLE_PERSONA_MARKER["heartbeat-supervisor"] == "Heartbeat"
+    # Worker and triage intentionally absent — no stable persona.
+    assert "worker" not in _ROLE_PERSONA_MARKER
+    assert "triage" not in _ROLE_PERSONA_MARKER


### PR DESCRIPTION
Defense in depth against the persona-swap bug observed live (pm-operator was running Russell's prompt). Root cause untraced — this adds two layers of detection/recovery at known send paths.

## Layer 1: strict assertion in `_prepare_initial_input`
- Supervisor path: cross-checks `session_name` against `launch.session.name` AND `launch.window_name` via `_assert_session_launch_matches()`.
- Session-service path: cross-checks against `PollyPMConfig.sessions`.
- Mismatch → logger.error + record_event("persona_swap_detected") + raise. Loud failure beats silent swap.

## Layer 2: verify-after-kickoff
- Fire-and-forget thread, 5s after kickoff, captures pane, looks for expected role marker.
- `_ROLE_PERSONA_MARKER` maps roles → expected strings (operator-pm→Polly, reviewer→Russell, heartbeat-supervisor→Heartbeat).
- If expected missing AND unexpected present: record_event("persona_swap_verified") and resend correct kickoff via `_prepare_initial_input` (which Layer 1 now fail-safes).
- Worker role intentionally no-op (no persona).

## Tests (+12)
- Unknown session, name mismatch, window mismatch, event recording
- Session-service path mismatch/happy/worker short-circuit
- Verify: match, resend-on-wrong, worker no-op, marker map

2199 passing, 1 pre-existing unrelated failure.

Gotcha: the session-service layer has no launch-planner handle; its assertion uses `PollyPMConfig.sessions[name].window_name` as the source of truth. Worker sessions no-op there (supervisor-layer still covers control roles).