### PR TITLE
feat(db): incremental auto-vacuum + TTL sweeper for memory_entries

### DIFF
--- a/src/pollypm/plugins_builtin/core_recurring/plugin.py
+++ b/src/pollypm/plugins_builtin/core_recurring/plugin.py
@@ -313,6 +313,44 @@ def alerts_gc_handler(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def db_vacuum_handler(payload: dict[str, Any]) -> dict[str, Any]:
+    """Run an incremental vacuum against StateStore to reclaim freelist pages.
+
+    Incremental vacuum is a low-cost operation that only touches pages on
+    the SQLite freelist — it does not rewrite the whole database the way
+    a full ``VACUUM`` would. Safe to call daily. The shared StateStore
+    connection coordinates with concurrent writers via busy_timeout, so
+    no external lock is needed beyond what StateStore already holds.
+    """
+    _config, store = _load_config_and_store(payload)
+    bytes_reclaimed = store.incremental_vacuum()
+    mb_reclaimed = bytes_reclaimed / (1024 * 1024)
+    store.record_event(
+        session_name="system",
+        event_type="db.vacuum",
+        message=f"reclaimed {mb_reclaimed:.1f}MB",
+    )
+    return {"bytes_reclaimed": bytes_reclaimed, "mb_reclaimed": mb_reclaimed}
+
+
+def memory_ttl_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
+    """Drop expired memory_entries (TTL in the past).
+
+    Only affects rows with ``ttl_at IS NOT NULL``. Rows without an
+    explicit TTL are left alone — retention policy for those is a
+    separate decision, this handler just enforces what's already on
+    the row.
+    """
+    _config, store = _load_config_and_store(payload)
+    deleted = store.sweep_expired_memory_entries()
+    store.record_event(
+        session_name="system",
+        event_type="memory.ttl_sweep",
+        message=f"dropped {deleted} expired entries",
+    )
+    return {"deleted": deleted}
+
+
 # ---------------------------------------------------------------------------
 # Plugin registration
 # ---------------------------------------------------------------------------
@@ -339,6 +377,16 @@ def _register_handlers(api: JobHandlerAPI) -> None:
         "work.progress_sweep", work_progress_sweep_handler,
         max_attempts=1, timeout_seconds=60.0,
     )
+    # DB hygiene — incremental vacuum + memory TTL sweep. Both are cheap
+    # daily sweeps that coordinate with the shared StateStore connection.
+    api.register_handler(
+        "db.vacuum", db_vacuum_handler,
+        max_attempts=1, timeout_seconds=120.0,
+    )
+    api.register_handler(
+        "memory.ttl_sweep", memory_ttl_sweep_handler,
+        max_attempts=1, timeout_seconds=60.0,
+    )
 
 
 def _register_roster(api: RosterAPI) -> None:
@@ -350,6 +398,14 @@ def _register_roster(api: RosterAPI) -> None:
     api.register_recurring("@every 5m", "alerts.gc", {})
     # #249 — work-service-aware stuck-task sweeper.
     api.register_recurring("@every 5m", "work.progress_sweep", {})
+    # DB hygiene — daily around 4am local. Off-minute (``7``) avoids
+    # fleet-wide sync if many cockpits run on the same host. Memory TTL
+    # sweep runs a few minutes later so its writes don't collide with
+    # the vacuum's page-reclaim pass.
+    api.register_recurring("7 4 * * *", "db.vacuum", {}, dedupe_key="db.vacuum")
+    api.register_recurring(
+        "13 4 * * *", "memory.ttl_sweep", {}, dedupe_key="memory.ttl_sweep",
+    )
 
 
 plugin = PollyPMPlugin(
@@ -368,6 +424,8 @@ plugin = PollyPMPlugin(
         Capability(kind="job_handler", name="transcript.ingest"),
         Capability(kind="job_handler", name="alerts.gc"),
         Capability(kind="job_handler", name="work.progress_sweep"),
+        Capability(kind="job_handler", name="db.vacuum"),
+        Capability(kind="job_handler", name="memory.ttl_sweep"),
         Capability(kind="roster_entry", name="core_recurring"),
     ),
     register_handlers=_register_handlers,

--- a/src/pollypm/plugins_builtin/core_recurring/pollypm-plugin.toml
+++ b/src/pollypm/plugins_builtin/core_recurring/pollypm-plugin.toml
@@ -31,6 +31,16 @@ name = "alerts.gc"
 requires_api = ">=1,<2"
 
 [[capabilities]]
+kind = "job_handler"
+name = "db.vacuum"
+requires_api = ">=1,<2"
+
+[[capabilities]]
+kind = "job_handler"
+name = "memory.ttl_sweep"
+requires_api = ">=1,<2"
+
+[[capabilities]]
 kind = "roster_entry"
 name = "core_recurring"
 requires_api = ">=1,<2"

--- a/src/pollypm/storage/state.py
+++ b/src/pollypm/storage/state.py
@@ -504,6 +504,13 @@ class StateStore:
                 # "readonly" mode we may have just created an empty DB
                 # (when the file didn't exist before connect).
                 self.execute("PRAGMA journal_mode=WAL")
+                # auto_vacuum=INCREMENTAL lets us reclaim freelist space on
+                # demand via ``PRAGMA incremental_vacuum``. This pragma must
+                # run BEFORE any tables are created to take effect on a
+                # fresh DB — on existing DBs it's a no-op and the one-shot
+                # VACUUM below (gated on the current mode) actually flips
+                # the page format.
+                self.execute("PRAGMA auto_vacuum=INCREMENTAL")
                 try:
                     self._conn.executescript(SCHEMA)
                 except sqlite3.IntegrityError:
@@ -517,6 +524,112 @@ class StateStore:
                     self._conn.rollback()
                     raise
                 self.commit()
+                # One-shot migration to flip existing NONE-mode DBs into
+                # INCREMENTAL mode. Must run OUTSIDE any transaction —
+                # VACUUM cannot run mid-tx, so we gate it behind a pragma
+                # read and skip if already in the right mode. New DBs hit
+                # this path with auto_vacuum already set, so the VACUUM is
+                # skipped for them (the initial pragma above sufficed).
+                self._ensure_incremental_auto_vacuum()
+
+    def _ensure_incremental_auto_vacuum(self) -> None:
+        """Flip pre-existing DBs into ``auto_vacuum=INCREMENTAL`` mode.
+
+        SQLite's ``auto_vacuum`` mode is baked into the page format, so the
+        only way to change it on an existing DB is to set the pragma and
+        then run a full ``VACUUM``. New DBs already pick up the setting
+        from the pragma issued before schema creation, so the VACUUM below
+        is skipped for them.
+
+        Must run outside any open transaction — callers are responsible
+        for committing first. ``PRAGMA auto_vacuum`` returns:
+            0 = NONE, 1 = FULL, 2 = INCREMENTAL.
+        """
+        try:
+            row = self._conn.execute("PRAGMA auto_vacuum").fetchone()
+        except sqlite3.DatabaseError:
+            return
+        mode = int(row[0]) if row else 0
+        if mode == 2:
+            return
+        # Fall back to a one-shot VACUUM to rewrite the page format. Use
+        # the raw connection so we bypass Python's implicit-tx layer; the
+        # connect path uses the default isolation_level ("") which
+        # auto-begins transactions on DML. For VACUUM we temporarily flip
+        # isolation_level to None so SQLite accepts the statement, then
+        # restore the original so downstream DML keeps its tx semantics.
+        previous = self._conn.isolation_level
+        try:
+            self._conn.isolation_level = None
+            self._conn.execute("PRAGMA auto_vacuum=INCREMENTAL")
+            self._conn.execute("VACUUM")
+        except sqlite3.DatabaseError:
+            # VACUUM can fail if another connection holds the DB — that's
+            # OK, we'll retry on the next StateStore open. Better to log
+            # and keep going than to block the cockpit boot on DB hygiene.
+            import logging
+            logging.getLogger(__name__).warning(
+                "StateStore: auto_vacuum=INCREMENTAL migration failed; will retry on next open",
+                exc_info=True,
+            )
+        finally:
+            self._conn.isolation_level = previous
+
+    def incremental_vacuum(self) -> int:
+        """Reclaim freelist pages via ``PRAGMA incremental_vacuum``.
+
+        Returns the number of bytes reclaimed (0 if no-op). Must run on
+        the shared connection so it coordinates with the existing write
+        lock — concurrent writers will block on the busy_timeout and pick
+        up once the vacuum is done. Safe to call any time after the
+        INCREMENTAL mode migration has run.
+        """
+        with self._lock:
+            try:
+                page_size_row = self._conn.execute("PRAGMA page_size").fetchone()
+                freelist_before_row = self._conn.execute("PRAGMA freelist_count").fetchone()
+            except sqlite3.DatabaseError:
+                return 0
+            page_size = int(page_size_row[0]) if page_size_row else 0
+            freelist_before = int(freelist_before_row[0]) if freelist_before_row else 0
+            if freelist_before == 0 or page_size == 0:
+                return 0
+            previous = self._conn.isolation_level
+            try:
+                # incremental_vacuum cannot run inside a transaction — use
+                # the same isolation_level=None trick as the one-shot
+                # migration above.
+                self._conn.isolation_level = None
+                self._conn.execute("PRAGMA incremental_vacuum")
+            finally:
+                self._conn.isolation_level = previous
+            freelist_after_row = self._conn.execute("PRAGMA freelist_count").fetchone()
+            freelist_after = int(freelist_after_row[0]) if freelist_after_row else 0
+            reclaimed_pages = max(freelist_before - freelist_after, 0)
+            return reclaimed_pages * page_size
+
+    def sweep_expired_memory_entries(self) -> int:
+        """Drop memory_entries whose ``ttl_at`` has elapsed.
+
+        Only touches entries that EXPLICITLY set a TTL — ``ttl_at IS NULL``
+        rows are left alone. Returns the number of rows deleted. Uses
+        ``datetime('now')`` so comparisons happen in SQL space against the
+        ISO-8601 strings already stored on the table.
+        """
+        with self._lock:
+            cursor = self._conn.execute(
+                "DELETE FROM memory_entries "
+                "WHERE ttl_at IS NOT NULL AND ttl_at < datetime('now')"
+            )
+            deleted = int(cursor.rowcount or 0)
+            self._conn.commit()
+        # Bump epoch outside the lock — matches commit()'s contract.
+        try:
+            from pollypm.state_epoch import bump
+            bump()
+        except Exception:  # noqa: BLE001
+            pass
+        return deleted
 
     def _deduplicate_alerts(self) -> None:
         """Remove duplicate alerts, keeping the most recently updated row."""

--- a/tests/test_core_recurring_migration.py
+++ b/tests/test_core_recurring_migration.py
@@ -46,6 +46,9 @@ class TestCoreRecurringPlugin:
             "alerts.gc",
             # #249 — work-service-aware progress sweeper.
             "work.progress_sweep",
+            # DB hygiene — incremental vacuum + TTL sweep for memory_entries.
+            "db.vacuum",
+            "memory.ttl_sweep",
         }
         assert expected.issubset(set(registry.names()))
         # inbox.sweep was retired with the legacy inbox subsystem (iv04).
@@ -65,6 +68,9 @@ class TestCoreRecurringPlugin:
             "alerts.gc",
             # #249 — work-service-aware progress sweeper.
             "work.progress_sweep",
+            # DB hygiene — daily cron at ~4am local.
+            "db.vacuum",
+            "memory.ttl_sweep",
         }
 
         # Cadences per issue #164 / #249.
@@ -73,6 +79,17 @@ class TestCoreRecurringPlugin:
         assert _interval_seconds(entries["transcript.ingest"]) == 30
         assert _interval_seconds(entries["alerts.gc"]) == 300
         assert _interval_seconds(entries["work.progress_sweep"]) == 300
+        # DB hygiene entries are 5-field cron, not @every — just verify
+        # they parse into a CronSchedule with the expected expression so
+        # the fleet doesn't sync on the hour.
+        from pollypm.heartbeat.roster import CronSchedule
+
+        db_vacuum = entries["db.vacuum"].schedule
+        assert isinstance(db_vacuum, CronSchedule)
+        assert db_vacuum.expression() == "7 4 * * *"
+        mem_sweep = entries["memory.ttl_sweep"].schedule
+        assert isinstance(mem_sweep, CronSchedule)
+        assert mem_sweep.expression() == "13 4 * * *"
 
     def test_plugin_declares_expected_capabilities(self) -> None:
         kinds = {cap.kind for cap in core_plugin.capabilities}

--- a/tests/test_db_vacuum.py
+++ b/tests/test_db_vacuum.py
@@ -1,0 +1,145 @@
+"""Tests for state.db hygiene: auto_vacuum mode + TTL sweep for memory_entries.
+
+These guard against the class of bugs that bloated Sam's live cockpit DB to
+1.9 GB (1.6 GB dead space). The three checks, mirroring the remediation:
+
+* A fresh StateStore must come up in ``auto_vacuum=INCREMENTAL`` mode so
+  every future delete immediately adds pages to the freelist — ready for
+  the daily ``PRAGMA incremental_vacuum``.
+* ``incremental_vacuum()`` must actually reclaim disk space after a bulk
+  insert+delete cycle. It's an easy regression to miss if someone adds a
+  transaction wrapper around the pragma (which SQLite silently rejects).
+* ``sweep_expired_memory_entries()`` must drop exactly the expired rows
+  and leave non-expired + NULL-TTL rows untouched. Retention policy in
+  the live cockpit is decided at write-time; this sweep only enforces
+  what's already on the row.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from pollypm.storage.state import StateStore
+
+
+def test_auto_vacuum_incremental_on_fresh_db(tmp_path: Path) -> None:
+    """Fresh DB must be created with auto_vacuum=INCREMENTAL (mode 2)."""
+    store = StateStore(tmp_path / "state.db")
+    try:
+        # PRAGMA auto_vacuum returns: 0=NONE, 1=FULL, 2=INCREMENTAL.
+        row = store.execute("PRAGMA auto_vacuum").fetchone()
+        assert row is not None
+        assert int(row[0]) == 2, f"expected INCREMENTAL (2), got {row[0]}"
+    finally:
+        store.close()
+
+
+def test_incremental_vacuum_reclaims_space_after_bulk_delete(tmp_path: Path) -> None:
+    """After bulk insert+delete, incremental_vacuum should free pages."""
+    store = StateStore(tmp_path / "state.db")
+    try:
+        # Insert enough dummy rows to guarantee multiple pages land on the
+        # freelist after delete. ``events`` is a cheap table for this —
+        # no foreign keys, no triggers, no FTS. 2000 rows with a 1 KB
+        # message is ~2 MB, plenty to exceed a single 4 KB page.
+        big_message = "x" * 1024
+        for i in range(2000):
+            store.record_event(
+                session_name=f"bulk-{i}",
+                event_type="bulk.test",
+                message=big_message,
+            )
+
+        # Checkpoint the WAL so pages land in the main DB file — without
+        # this, the "reclaimed" measurement is dominated by WAL mechanics
+        # rather than freelist behaviour.
+        store.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        store.execute("DELETE FROM events WHERE event_type = 'bulk.test'")
+        store.commit()
+        store.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+
+        # Freelist should now hold the freed pages — measurable before we
+        # call incremental_vacuum.
+        freelist_row = store.execute("PRAGMA freelist_count").fetchone()
+        assert freelist_row is not None
+        pages_before = int(freelist_row[0])
+        assert pages_before > 0, (
+            "bulk delete should leave pages on the freelist under "
+            "auto_vacuum=INCREMENTAL; found 0"
+        )
+
+        reclaimed = store.incremental_vacuum()
+        assert reclaimed > 0, "incremental_vacuum should reclaim non-zero bytes"
+
+        # Freelist should be drained (or nearly so — SQLite may keep a
+        # handful of pages for bookkeeping, but the bulk should be gone).
+        after_row = store.execute("PRAGMA freelist_count").fetchone()
+        pages_after = int(after_row[0]) if after_row else 0
+        assert pages_after < pages_before, (
+            f"freelist_count should drop after vacuum: before={pages_before} "
+            f"after={pages_after}"
+        )
+    finally:
+        store.close()
+
+
+def test_memory_ttl_sweep_drops_expired_only(tmp_path: Path) -> None:
+    """Sweep drops expired rows; leaves non-expired + NULL-ttl rows."""
+    store = StateStore(tmp_path / "state.db")
+    try:
+        now = datetime.now(UTC)
+        expired_iso = (now - timedelta(days=1)).isoformat()
+        future_iso = (now + timedelta(days=7)).isoformat()
+
+        expired = store.record_memory_entry(
+            scope="proj",
+            kind="note",
+            title="expired entry",
+            body="should be swept",
+            tags=["ttl"],
+            source="test",
+            file_path="/dev/null",
+            summary_path="/dev/null",
+            ttl_at=expired_iso,
+        )
+        future = store.record_memory_entry(
+            scope="proj",
+            kind="note",
+            title="future entry",
+            body="should survive",
+            tags=["ttl"],
+            source="test",
+            file_path="/dev/null",
+            summary_path="/dev/null",
+            ttl_at=future_iso,
+        )
+        null = store.record_memory_entry(
+            scope="proj",
+            kind="note",
+            title="no-ttl entry",
+            body="should survive (NULL ttl)",
+            tags=[],
+            source="test",
+            file_path="/dev/null",
+            summary_path="/dev/null",
+            ttl_at=None,
+        )
+
+        deleted = store.sweep_expired_memory_entries()
+        assert deleted == 1, f"expected 1 deletion, got {deleted}"
+
+        assert store.get_memory_entry(expired.entry_id) is None
+        # Non-expired + NULL TTL rows must survive untouched.
+        survivor_future = store.get_memory_entry(future.entry_id)
+        assert survivor_future is not None
+        assert survivor_future.title == "future entry"
+        survivor_null = store.get_memory_entry(null.entry_id)
+        assert survivor_null is not None
+        assert survivor_null.title == "no-ttl entry"
+        assert survivor_null.ttl_at is None
+
+        # Second sweep on a clean DB should be a no-op.
+        assert store.sweep_expired_memory_entries() == 0
+    finally:
+        store.close()


### PR DESCRIPTION
State.db bloat fix. Live DB was 1.9 GB with 1.6 GB unvacuumed freelist (memory_entries + checkpoints). Three additions:

## Changes
**`storage/state.py`:**
- `PRAGMA auto_vacuum=INCREMENTAL` on fresh DBs
- `_ensure_incremental_auto_vacuum()` one-shot migration for existing DBs (runs one VACUUM to flip mode)
- `incremental_vacuum()` on shared connection with isolation_level coordination
- `sweep_expired_memory_entries()` — enforces existing `ttl_at` column (doesn't add default TTLs)

**`core_recurring/plugin.py`:**
- `db_vacuum_handler` at `7 4 * * *`, logs MB reclaimed
- `memory_ttl_sweep_handler` at `13 4 * * *`, logs rows dropped
- Dedupe keys prevent job-queue pile-up

## Tests (+3, 0 regressions)
- auto_vacuum=2 on fresh DB
- incremental_vacuum reclaims space after bulk delete
- TTL sweep drops expired only (NULL ttl_at preserved)

## Gotcha
First cockpit restart after merge will run the one-shot VACUUM on Sam's live 1.9GB DB — may pause for a moment. Acceptable per design (Sam runs this as operational step).

2204 passing.