### PR TITLE
fix(task-assignment): _ROLE_STATIC_NAMES includes session-config keys (#272)

### DIFF
--- a/src/pollypm/work/task_assignment.py
+++ b/src/pollypm/work/task_assignment.py
@@ -107,11 +107,13 @@ def format_ping_for_role(event: TaskAssignmentEvent) -> str:
 # (one worker session per project); the other roles are process-wide
 # singletons.
 _ROLE_STATIC_NAMES: dict[str, tuple[str, ...]] = {
-    "reviewer": ("pm-reviewer",),
-    "operator": ("pm-operator",),
-    "heartbeat-supervisor": ("pm-heartbeat",),
-    "heartbeat": ("pm-heartbeat",),  # common alias
-    "triage": ("pm-triage",),
+    # Each role lists both the session-config key (what ``sessions`` table
+    # stores as ``name``) and the window name (legacy convention). #272.
+    "reviewer": ("reviewer", "pm-reviewer"),
+    "operator": ("operator", "pm-operator"),
+    "heartbeat-supervisor": ("heartbeat", "pm-heartbeat"),
+    "heartbeat": ("heartbeat", "pm-heartbeat"),  # common alias
+    "triage": ("triage", "pm-triage"),
 }
 
 

--- a/tests/test_task_assignment_notify.py
+++ b/tests/test_task_assignment_notify.py
@@ -117,18 +117,19 @@ class TestRoleCandidates:
         ]
 
     def test_reviewer_pins_to_pm_reviewer(self):
-        assert role_candidate_names("reviewer", "ignored") == ["pm-reviewer"]
+        # Returns both session-config key and window name (#272).
+        assert role_candidate_names("reviewer", "ignored") == ["reviewer", "pm-reviewer"]
 
     def test_operator_pins_to_pm_operator(self):
-        assert role_candidate_names("operator", "x") == ["pm-operator"]
+        assert role_candidate_names("operator", "x") == ["operator", "pm-operator"]
 
     def test_heartbeat_supervisor_pins_to_pm_heartbeat(self):
-        assert role_candidate_names("heartbeat-supervisor", "x") == ["pm-heartbeat"]
+        assert role_candidate_names("heartbeat-supervisor", "x") == ["heartbeat", "pm-heartbeat"]
         # alias
-        assert role_candidate_names("heartbeat", "x") == ["pm-heartbeat"]
+        assert role_candidate_names("heartbeat", "x") == ["heartbeat", "pm-heartbeat"]
 
     def test_triage(self):
-        assert role_candidate_names("triage", "x") == ["pm-triage"]
+        assert role_candidate_names("triage", "x") == ["triage", "pm-triage"]
 
     def test_critic_passes_through(self):
         assert role_candidate_names("critic_simplicity", "x") == ["critic_simplicity"]


### PR DESCRIPTION
Polly surfaced this after running the full worker-path E2E: with #259/#269/#270 merged, workers claim and complete tasks autonomously — but code_review pings still fail because _ROLE_STATIC_NAMES listed only window names while the sessions table stores the session-config key.

Before:
```python
"reviewer": ("pm-reviewer",),
```

After:
```python
"reviewer": ("reviewer", "pm-reviewer"),
```

Same for operator/heartbeat/triage. Mirrors the worker-X/worker_X pattern already in place. Additive — doesn't remove candidates.

+4 tests updated, 46 passing in task_assignment tests. Closes #272.