### PR TITLE
feat(cockpit): interactive inbox screen — reply, archive, thread view

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -517,6 +517,10 @@ def cockpit_pane(
         from pollypm.cockpit_ui import PollyDashboardApp
         PollyDashboardApp(config_path).run(mouse=True)
         return
+    if kind == "inbox":
+        from pollypm.cockpit_ui import PollyInboxApp
+        PollyInboxApp(config_path).run(mouse=True)
+        return
     if kind == "issues" and target:
         from pollypm.cockpit_ui import PollyTasksApp
         PollyTasksApp(config_path, target).run(mouse=True)

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -17,7 +17,7 @@ from rich.text import Text
 from textual import events, on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.containers import Horizontal, Vertical
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.widgets import Button, DataTable, Input, ListItem, ListView, Static
 
 from pollypm.models import ProviderKind
@@ -1814,3 +1814,710 @@ class PollySettingsPaneApp(App[None]):
     def on_account_selected(self, _event: DataTable.RowSelected) -> None:
         self._selected_account_key = self._current_selected_key()
         self._refresh()
+
+
+# ---------------------------------------------------------------------------
+# Inbox — interactive Textual screen
+#
+# Two-pane layout within the cockpit right pane:
+#   left  — scrollable list of inbox items (sender · subject · age · unread)
+#   right — focused message: subject, sender, timestamp, body (rich), thread
+#
+# Keybindings:
+#   j/k or arrows  move selection          r  reply
+#   enter / click  open (+ mark read)      a  archive
+#   q / escape     back to cockpit nav     esc (in reply)  cancel reply
+#
+# Backend: SQLiteWorkService.add_reply / archive_task / mark_read /
+# list_replies. Events (inbox.message.read / archived / reply) are emitted
+# via StateStore, matching the shape of ``pm notify``.
+# ---------------------------------------------------------------------------
+
+
+# Sort: most recent first (matches email-inbox affordance), then priority
+# as a secondary key so a newly arrived critical item outranks a slightly
+# older normal one. Falls back to title for a stable ordering when two
+# tasks share the same minute-resolution timestamp.
+_INBOX_PRIORITY_RANK = {
+    "critical": 0,
+    "high": 1,
+    "normal": 2,
+    "low": 3,
+}
+
+
+def _inbox_sort_key(task) -> tuple:
+    updated = task.updated_at
+    iso = updated.isoformat() if hasattr(updated, "isoformat") else str(updated or "")
+    prio = getattr(task.priority, "value", str(task.priority))
+    # Negate updated so newer comes first when sorted ascending; keep
+    # priority as a positive rank so critical (0) wins inside a same-age
+    # bucket.
+    return (-_iso_sort_weight(iso), _INBOX_PRIORITY_RANK.get(prio, 9), task.title)
+
+
+def _iso_sort_weight(iso: str) -> int:
+    """Coerce an ISO timestamp to a comparable integer key.
+
+    Lexicographic compare on ISO-8601 works for "same-offset" strings but
+    we want a real ordering regardless. Falling back to string length keeps
+    the sort stable for missing/invalid stamps without raising.
+    """
+    try:
+        from datetime import datetime as _dt
+        return int(_dt.fromisoformat(iso).timestamp())
+    except (ValueError, TypeError):
+        return 0
+
+
+def _format_sender(task) -> str:
+    """Best-effort human-friendly sender label for an inbox task.
+
+    Chat-flow tasks have ``roles.operator`` set to whichever agent posted
+    (``polly``, ``russell``, …). ``requester=user`` tasks that originate
+    from a worker's notify use ``operator`` too. When nothing resolves,
+    fall back to ``created_by``.
+    """
+    roles = getattr(task, "roles", {}) or {}
+    op = roles.get("operator")
+    if op and op != "user":
+        return op
+    if task.created_by and task.created_by != "user":
+        return task.created_by
+    # Last resort — unknown sender. Don't show blank.
+    return "polly"
+
+
+def _format_inbox_row(task, *, is_unread: bool) -> Text:
+    """Render one inbox-list row as Rich text.
+
+    Matches the cockpit aesthetic from RailItem: yellow diamond for
+    unread, dim open circle for read. Subject truncates at ~38 chars so
+    age + indicator stay visible on a 60-col list pane.
+    """
+    from pollypm.tz import format_relative
+
+    text = Text()
+    if is_unread:
+        text.append("\u25c6 ", style="#f0c45a")  # yellow diamond
+    else:
+        text.append("\u25cb ", style="#4a5568")  # dim circle
+    sender = _format_sender(task)
+    text.append(f"{sender:<7}", style="#97a6b2")
+    text.append("  ")
+    subject = task.title or "(no subject)"
+    max_subject = 38
+    if len(subject) > max_subject:
+        subject = subject[: max_subject - 1] + "\u2026"
+    subject_style = "bold #eef2f4" if is_unread else "#b8c4cf"
+    text.append(subject, style=subject_style)
+    updated = task.updated_at
+    iso = updated.isoformat() if hasattr(updated, "isoformat") else str(updated or "")
+    age = format_relative(iso) if iso else ""
+    if age:
+        # Right-align age as a separate dim run so the subject can flex.
+        text.append(f"  · {age}", style="#4a5568")
+    return text
+
+
+class _InboxListItem(ListItem):
+    """One message in the inbox list — carries the task_id + unread flag."""
+
+    def __init__(self, task, *, is_unread: bool) -> None:
+        self.task_id = task.task_id
+        self.task_ref = task
+        self.is_unread = is_unread
+        self._body = Static(_format_inbox_row(task, is_unread=is_unread), markup=False)
+        super().__init__(self._body, classes="inbox-row")
+        if is_unread:
+            self.add_class("unread")
+
+    def mark_read(self, task=None) -> None:
+        """Flip the row to read styling in place (no reflow of the list)."""
+        if self.is_unread is False:
+            return
+        self.is_unread = False
+        self.remove_class("unread")
+        if task is not None:
+            self.task_ref = task
+        self._body.update(_format_inbox_row(self.task_ref, is_unread=False))
+
+
+class PollyInboxApp(App[None]):
+    """Interactive cockpit inbox — two-pane list + detail with reply/archive.
+
+    Opened via ``pm cockpit-pane inbox``. Replaces the previous read-only
+    text dump so the user can drive the inbox entirely from the TUI
+    without falling back to the CLI.
+    """
+
+    TITLE = "PollyPM"
+    SUB_TITLE = "Inbox"
+    CSS = """
+    Screen {
+        background: #0f1317;
+        color: #eef2f4;
+        padding: 0;
+    }
+    #inbox-layout {
+        height: 1fr;
+    }
+    #inbox-list {
+        width: 42;
+        min-width: 32;
+        height: 1fr;
+        background: #0f1317;
+        border: round #1e2730;
+        padding: 0;
+        scrollbar-size: 1 1;
+        scrollbar-color: #2a3340;
+    }
+    #inbox-list > .inbox-row {
+        height: 2;
+        padding: 0 1;
+        color: #d6dee5;
+        background: transparent;
+    }
+    #inbox-list > .inbox-row.unread {
+        color: #eef2f4;
+    }
+    #inbox-list > .inbox-row.-highlight {
+        background: #1e2730;
+    }
+    #inbox-list:focus > .inbox-row.-highlight {
+        background: #253140;
+        color: #f2f6f8;
+    }
+    #inbox-detail-wrap {
+        height: 1fr;
+        border: round #1e2730;
+        background: #0f1317;
+        padding: 0;
+    }
+    #inbox-detail-scroll {
+        height: 1fr;
+        padding: 1 2;
+        scrollbar-size: 1 1;
+        scrollbar-color: #2a3340;
+    }
+    #inbox-detail {
+        width: 1fr;
+        height: auto;
+        color: #d6dee5;
+    }
+    #inbox-reply {
+        height: 3;
+        padding: 0 1;
+        background: #111820;
+        border: round #2a3340;
+        display: none;
+    }
+    #inbox-reply.visible {
+        display: block;
+    }
+    #inbox-status {
+        height: 1;
+        padding: 0 1;
+        color: #6b7a88;
+        background: #0c0f12;
+    }
+    #inbox-hint {
+        height: 1;
+        padding: 0 1;
+        color: #3e4c5a;
+        background: #0c0f12;
+    }
+    #inbox-empty {
+        width: 1fr;
+        height: 1fr;
+        content-align: center middle;
+        color: #6b7a88;
+    }
+    .reply-turn {
+        background: #111820;
+        padding: 1 2;
+        margin: 1 0 0 0;
+        border-left: thick #5b8aff;
+        color: #d6dee5;
+    }
+    """
+
+    BINDINGS = [
+        Binding("j,down", "cursor_down", "Down", show=False),
+        Binding("k,up", "cursor_up", "Up", show=False),
+        Binding("g,home", "cursor_first", "First", show=False),
+        Binding("G,end", "cursor_last", "Last", show=False),
+        Binding("enter,o", "open_selected", "Open", show=False),
+        Binding("r", "start_reply", "Reply"),
+        Binding("a", "archive_selected", "Archive"),
+        Binding("u", "refresh", "Refresh"),
+        Binding("q,escape", "back_or_cancel", "Back"),
+    ]
+
+    REFRESH_INTERVAL_SECONDS = 8
+
+    def __init__(self, config_path: Path) -> None:
+        super().__init__()
+        self.config_path = config_path
+        self.list_view = ListView(id="inbox-list")
+        self.detail = Static("", id="inbox-detail", markup=True)
+        self.reply_input = Input(
+            placeholder="Reply … (Enter to send, Esc to cancel)",
+            id="inbox-reply",
+        )
+        self.status = Static("", id="inbox-status")
+        self.hint = Static(
+            "j/k move \u00b7 \u21b5 open \u00b7 r reply \u00b7 a archive \u00b7 u refresh \u00b7 q back",
+            id="inbox-hint",
+        )
+        self._tasks: list = []
+        self._selected_task_id: str | None = None
+        self._reply_target_id: str | None = None
+        self._unread_ids: set[str] = set()
+
+    def compose(self) -> ComposeResult:
+        with Horizontal(id="inbox-layout"):
+            yield self.list_view
+            with Vertical(id="inbox-detail-wrap"):
+                with VerticalScroll(id="inbox-detail-scroll"):
+                    yield self.detail
+                yield self.reply_input
+        yield self.status
+        yield self.hint
+
+    def on_mount(self) -> None:
+        self._refresh_list(select_first=True)
+        self.set_interval(self.REFRESH_INTERVAL_SECONDS, self._background_refresh)
+        self.list_view.focus()
+
+    # ------------------------------------------------------------------
+    # Data loading
+    # ------------------------------------------------------------------
+
+    def _load_inbox(self) -> tuple[list, set[str]]:
+        """Open each project's work-service DB, compute (tasks, unread_ids).
+
+        All services are closed before return — callers don't need to
+        manage lifecycle. Per-task operations open a fresh svc via
+        :meth:`_svc_for_task` so we never hold connections across ticks.
+        """
+        from pollypm.work.inbox_view import inbox_tasks
+        from pollypm.work.sqlite_service import SQLiteWorkService
+
+        config = load_config(self.config_path)
+        tasks: list = []
+        unread: set[str] = set()
+        for project_key, project in getattr(config, "projects", {}).items():
+            db_path = project.path / ".pollypm" / "state.db"
+            if not db_path.exists():
+                continue
+            try:
+                svc = SQLiteWorkService(
+                    db_path=db_path, project_path=project.path,
+                )
+            except Exception:  # noqa: BLE001
+                continue
+            try:
+                try:
+                    project_tasks = inbox_tasks(svc, project=project_key)
+                except Exception:  # noqa: BLE001
+                    project_tasks = []
+                for t in project_tasks:
+                    tasks.append(t)
+                    try:
+                        rows = svc.get_context(
+                            t.task_id, entry_type="read", limit=1,
+                        )
+                    except Exception:  # noqa: BLE001
+                        rows = []
+                    if not rows:
+                        unread.add(t.task_id)
+            finally:
+                try:
+                    svc.close()
+                except Exception:  # noqa: BLE001
+                    pass
+        tasks.sort(key=_inbox_sort_key)
+        return tasks, unread
+
+    def _svc_for_task(self, task_id: str):
+        """Open a SQLiteWorkService rooted at the project owning ``task_id``.
+
+        The cockpit inbox spans every tracked project, so archive/reply
+        actions must target the project-specific DB. We resolve the
+        project from the task_id prefix and look up its path in config.
+        """
+        from pollypm.work.sqlite_service import SQLiteWorkService
+
+        project_key = task_id.split("/", 1)[0]
+        config = load_config(self.config_path)
+        project = config.projects.get(project_key)
+        if project is None:
+            return None
+        db_path = project.path / ".pollypm" / "state.db"
+        if not db_path.exists():
+            return None
+        try:
+            return SQLiteWorkService(db_path=db_path, project_path=project.path)
+        except Exception:  # noqa: BLE001
+            return None
+
+    # ------------------------------------------------------------------
+    # List rendering
+    # ------------------------------------------------------------------
+
+    def _refresh_list(self, *, select_first: bool = False) -> None:
+        tasks, unread = self._load_inbox()
+        self._tasks = tasks
+        self._unread_ids = unread
+        self._render_list(select_first=select_first)
+
+    def _render_list(self, *, select_first: bool = False) -> None:
+        previous = self._selected_task_id
+        self.list_view.clear()
+        if not self._tasks:
+            self.list_view.append(
+                ListItem(Static("(empty)", classes="inbox-empty"), disabled=True)
+            )
+            self.detail.update(
+                "[dim]No messages.\n\n"
+                "Polly will notify you here when she has updates.[/dim]"
+            )
+            self.status.update("0 messages")
+            return
+        restore_index: int | None = 0 if select_first else None
+        for idx, task in enumerate(self._tasks):
+            is_unread = task.task_id in self._unread_ids
+            row = _InboxListItem(task, is_unread=is_unread)
+            self.list_view.append(row)
+            if previous and task.task_id == previous:
+                restore_index = idx
+        if restore_index is not None and self.list_view.index != restore_index:
+            self.list_view.index = restore_index
+            # Render detail for the restored selection so the right pane
+            # shows content immediately on refresh.
+            task = self._tasks[restore_index]
+            self._selected_task_id = task.task_id
+            self._render_detail(task.task_id)
+        unread_n = len(self._unread_ids)
+        total = len(self._tasks)
+        if unread_n:
+            self.status.update(f"{total} messages \u00b7 {unread_n} unread")
+        else:
+            self.status.update(f"{total} messages")
+
+    def _background_refresh(self) -> None:
+        """Periodic re-read; don't stomp the current cursor position."""
+        try:
+            self._refresh_list(select_first=False)
+        except Exception:  # noqa: BLE001
+            pass
+
+    # ------------------------------------------------------------------
+    # Detail rendering
+    # ------------------------------------------------------------------
+
+    def _render_detail(self, task_id: str) -> None:
+        svc = self._svc_for_task(task_id)
+        if svc is None:
+            self.detail.update("[red]Could not open project database for this task.[/red]")
+            return
+        try:
+            task = svc.get(task_id)
+            replies = svc.list_replies(task_id)
+        except Exception as exc:  # noqa: BLE001
+            self.detail.update(f"[red]Error loading task: {exc}[/red]")
+            svc.close()
+            return
+        finally:
+            try:
+                svc.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+        from pollypm.tz import format_relative
+
+        updated_iso = (
+            task.updated_at.isoformat()
+            if hasattr(task.updated_at, "isoformat") else str(task.updated_at or "")
+        )
+        created_iso = (
+            task.created_at.isoformat()
+            if hasattr(task.created_at, "isoformat") else str(task.created_at or "")
+        )
+        when = _fmt_time(updated_iso or created_iso)
+        rel = format_relative(updated_iso or created_iso)
+
+        sender = _format_sender(task)
+        sections: list[str] = []
+        subject = task.title or "(no subject)"
+        sections.append(f"[b #eef2f4]{_escape(subject)}[/b #eef2f4]")
+        meta_bits = [f"[#5b8aff]{_escape(sender)}[/#5b8aff]"]
+        if when:
+            meta_bits.append(f"[#97a6b2]{_escape(when)}[/#97a6b2]")
+        if rel:
+            meta_bits.append(f"[dim]{_escape(rel)}[/dim]")
+        if task.project and task.project != "inbox":
+            meta_bits.append(f"[dim]\u00b7 {_escape(task.project)}[/dim]")
+        prio = getattr(task.priority, "value", str(task.priority))
+        if prio and prio != "normal":
+            meta_bits.append(f"[#f0c45a]\u25c6 {_escape(prio)}[/#f0c45a]")
+        sections.append("  \u00b7  ".join(meta_bits))
+        sections.append("")  # blank line before body
+        body = task.description or "(no body)"
+        sections.append(_md_to_rich(_escape_body(body)))
+
+        if replies:
+            sections.append("")
+            sections.append(f"[dim]\u2500\u2500 thread ({len(replies)}) \u2500\u2500[/dim]")
+            for entry in replies:
+                e_iso = (
+                    entry.timestamp.isoformat()
+                    if hasattr(entry.timestamp, "isoformat") else str(entry.timestamp)
+                )
+                age = format_relative(e_iso)
+                who = entry.actor or "user"
+                sections.append("")
+                sections.append(
+                    f"[b #5b8aff]{_escape(who)}[/b #5b8aff]  [dim]{_escape(age)}[/dim]"
+                )
+                sections.append(_md_to_rich(_escape_body(entry.text)))
+
+        self.detail.update("\n".join(sections))
+        # Auto-scroll to top of the new message so subject is visible.
+        try:
+            self.query_one("#inbox-detail-scroll", VerticalScroll).scroll_home(
+                animate=False,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+    # ------------------------------------------------------------------
+    # Selection / navigation
+    # ------------------------------------------------------------------
+
+    def _sync_selection_from_list(self) -> None:
+        idx = self.list_view.index
+        if idx is None or idx < 0 or idx >= len(self._tasks):
+            return
+        task = self._tasks[idx]
+        if task.task_id == self._selected_task_id:
+            return
+        self._selected_task_id = task.task_id
+        self._render_detail(task.task_id)
+        self._mark_open_read(task.task_id, idx)
+
+    def action_cursor_down(self) -> None:
+        if self.reply_input.has_focus:
+            return
+        self.list_view.action_cursor_down()
+        self._sync_selection_from_list()
+
+    def action_cursor_up(self) -> None:
+        if self.reply_input.has_focus:
+            return
+        self.list_view.action_cursor_up()
+        self._sync_selection_from_list()
+
+    def action_cursor_first(self) -> None:
+        if self._tasks:
+            self.list_view.index = 0
+            self._sync_selection_from_list()
+
+    def action_cursor_last(self) -> None:
+        if self._tasks:
+            self.list_view.index = len(self._tasks) - 1
+            self._sync_selection_from_list()
+
+    def action_open_selected(self) -> None:
+        self._sync_selection_from_list()
+
+    def action_refresh(self) -> None:
+        self._refresh_list(select_first=False)
+
+    def action_back_or_cancel(self) -> None:
+        """Esc/q cancels an open reply; otherwise returns to cockpit nav."""
+        if self.reply_input.has_class("visible"):
+            self._cancel_reply()
+            return
+        self.exit()
+
+    @on(ListView.Selected, "#inbox-list")
+    def _on_row_selected(self, event: ListView.Selected) -> None:
+        row = event.item
+        if not isinstance(row, _InboxListItem):
+            return
+        self._selected_task_id = row.task_id
+        self._render_detail(row.task_id)
+        idx = self.list_view.index or 0
+        self._mark_open_read(row.task_id, idx)
+
+    @on(ListView.Highlighted, "#inbox-list")
+    def _on_row_highlighted(self, event: ListView.Highlighted) -> None:
+        # Keyboard j/k emits Highlighted before any Selected; render eagerly
+        # so the right pane tracks the cursor without requiring Enter.
+        row = event.item
+        if not isinstance(row, _InboxListItem):
+            return
+        if self._selected_task_id == row.task_id:
+            return
+        self._selected_task_id = row.task_id
+        self._render_detail(row.task_id)
+
+    # ------------------------------------------------------------------
+    # Read / archive / reply actions
+    # ------------------------------------------------------------------
+
+    def _mark_open_read(self, task_id: str, row_index: int) -> None:
+        if task_id not in self._unread_ids:
+            return
+        svc = self._svc_for_task(task_id)
+        if svc is None:
+            return
+        wrote = False
+        try:
+            wrote = svc.mark_read(task_id, actor="user")
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            try:
+                svc.close()
+            except Exception:  # noqa: BLE001
+                pass
+        if wrote:
+            self._emit_event(
+                task_id, "inbox.message.read", f"user opened {task_id}",
+            )
+        # Clear unread styling regardless — the row should update even if
+        # the underlying mark_read raced.
+        self._unread_ids.discard(task_id)
+        try:
+            children = list(self.list_view.children)
+            if 0 <= row_index < len(children):
+                row = children[row_index]
+                if isinstance(row, _InboxListItem):
+                    row.mark_read()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def action_archive_selected(self) -> None:
+        task_id = self._selected_task_id
+        if task_id is None:
+            return
+        svc = self._svc_for_task(task_id)
+        if svc is None:
+            self.notify("Could not open project database.", severity="error")
+            return
+        try:
+            svc.archive_task(task_id, actor="user")
+        except Exception as exc:  # noqa: BLE001
+            self.notify(f"Archive failed: {exc}", severity="error")
+            return
+        finally:
+            try:
+                svc.close()
+            except Exception:  # noqa: BLE001
+                pass
+        self._emit_event(
+            task_id, "inbox.message.archived", f"user archived {task_id}",
+        )
+        self.notify(f"Archived {task_id}", severity="information", timeout=2.0)
+        # Remove from local state + list so the row disappears immediately
+        # (the 8s background refresh would do it anyway, but snappy UX).
+        self._tasks = [t for t in self._tasks if t.task_id != task_id]
+        self._unread_ids.discard(task_id)
+        if self._selected_task_id == task_id:
+            self._selected_task_id = None
+        self._render_list(select_first=bool(self._tasks))
+
+    def action_start_reply(self) -> None:
+        task_id = self._selected_task_id
+        if task_id is None:
+            return
+        self._reply_target_id = task_id
+        self.reply_input.value = ""
+        self.reply_input.add_class("visible")
+        self.reply_input.focus()
+
+    def _cancel_reply(self) -> None:
+        self._reply_target_id = None
+        self.reply_input.value = ""
+        self.reply_input.remove_class("visible")
+        self.list_view.focus()
+
+    @on(Input.Submitted, "#inbox-reply")
+    def _on_reply_submitted(self, event: Input.Submitted) -> None:
+        body = (event.value or "").strip()
+        task_id = self._reply_target_id
+        if not body or not task_id:
+            self._cancel_reply()
+            return
+        svc = self._svc_for_task(task_id)
+        if svc is None:
+            self.notify("Could not open project database.", severity="error")
+            self._cancel_reply()
+            return
+        try:
+            svc.add_reply(task_id, body, actor="user")
+        except Exception as exc:  # noqa: BLE001
+            self.notify(f"Reply failed: {exc}", severity="error")
+            self._cancel_reply()
+            return
+        finally:
+            try:
+                svc.close()
+            except Exception:  # noqa: BLE001
+                pass
+        self._emit_event(
+            task_id, "inbox.reply_received", f"user replied to {task_id}: {body[:60]}",
+        )
+        self._cancel_reply()
+        # Re-render the detail pane so the new reply appears in-thread.
+        self._render_detail(task_id)
+
+    # ------------------------------------------------------------------
+    # Event emission
+    # ------------------------------------------------------------------
+
+    def _emit_event(self, task_id: str, event_type: str, message: str) -> None:
+        """Record an activity-feed event on the project-root state.db.
+
+        Matches the shape used by ``pm notify`` so the same consumers see
+        inbox.read / archived / reply alongside inbox.message.created.
+        Fire-and-forget — we never block the UI on event bookkeeping.
+        """
+        try:
+            from pollypm.storage.state import StateStore
+            project_key = task_id.split("/", 1)[0]
+            config = load_config(self.config_path)
+            project = config.projects.get(project_key)
+            if project is None:
+                return
+            db_path = project.path / ".pollypm" / "state.db"
+            if not db_path.exists():
+                return
+            store = StateStore(db_path)
+            try:
+                store.record_event("cockpit", event_type, message)
+            finally:
+                store.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _escape(s: str) -> str:
+    """Escape Rich markup brackets in a short span of text."""
+    if not s:
+        return ""
+    return str(s).replace("[", r"\[").replace("]", r"\]")
+
+
+def _escape_body(s: str) -> str:
+    """Escape Rich brackets for body text while preserving newlines.
+
+    ``_md_to_rich`` re-adds its own markup; we only need to neutralise
+    user-typed brackets so they render as literal characters.
+    """
+    if not s:
+        return ""
+    return str(s).replace("[", r"\[").replace("]", r"\]")

--- a/src/pollypm/work/inbox_cli.py
+++ b/src/pollypm/work/inbox_cli.py
@@ -90,3 +90,52 @@ def inbox_show(
     # Delegate to the existing task get implementation so behaviour stays
     # identical (context loading, JSON shape, ...).
     task_get(task_id=task_id, db=db, output_json=output_json)
+
+
+# ---------------------------------------------------------------------------
+# Pass-through actions
+#
+# These commands exist so headless tests (and emergency operator scripts)
+# can exercise the same work-service methods the cockpit TUI calls. The
+# primary UX is always the Textual inbox screen — Sam shouldn't need the
+# CLI day-to-day. Keep them small and focused.
+# ---------------------------------------------------------------------------
+
+
+@inbox_app.command("reply")
+def inbox_reply(
+    task_id: str = typer.Argument(..., help="Task ID (project/number)"),
+    body: str = typer.Argument(..., help="Reply text. Pass '-' to read from stdin."),
+    actor: str = typer.Option("user", "--actor", help="Actor to attribute the reply to."),
+    db: str = _DB_OPTION,
+) -> None:
+    """Post a reply on an inbox task (mirrors the cockpit reply action)."""
+    import sys
+
+    if body == "-":
+        body = sys.stdin.read()
+    project = _project_from_task_id(task_id)
+    svc = _svc(db, project=project)
+    try:
+        entry = svc.add_reply(task_id, body, actor=actor)
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    typer.echo(f"{task_id} reply @ {entry.timestamp.isoformat()}")
+
+
+@inbox_app.command("archive")
+def inbox_archive(
+    task_id: str = typer.Argument(..., help="Task ID (project/number)"),
+    actor: str = typer.Option("user", "--actor", help="Actor to attribute the archive to."),
+    db: str = _DB_OPTION,
+) -> None:
+    """Archive an inbox task (mirrors the cockpit archive action)."""
+    project = _project_from_task_id(task_id)
+    svc = _svc(db, project=project)
+    try:
+        task = svc.archive_task(task_id, actor=actor)
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    typer.echo(f"{task.task_id} → {task.work_status.value}")

--- a/src/pollypm/work/models.py
+++ b/src/pollypm/work/models.py
@@ -111,11 +111,18 @@ class GateResult:
 
 @dataclass(slots=True)
 class ContextEntry:
-    """Append-only log entry attached to a task."""
+    """Append-only log entry attached to a task.
+
+    ``entry_type`` classifies the row so inbox/chat consumers can filter
+    without touching the text: ``"note"`` (default, generic context),
+    ``"reply"`` (user chat reply in the inbox thread view), or ``"read"``
+    (read-marker so repeat opens don't re-emit the read event).
+    """
 
     actor: str
     timestamp: datetime
     text: str
+    entry_type: str = "note"
 
 
 @dataclass(slots=True)

--- a/src/pollypm/work/schema.py
+++ b/src/pollypm/work/schema.py
@@ -160,12 +160,15 @@ CREATE TABLE IF NOT EXISTS work_context_entries (
     actor TEXT NOT NULL,
     text TEXT NOT NULL,
     created_at TEXT NOT NULL,
+    entry_type TEXT NOT NULL DEFAULT 'note',
     FOREIGN KEY (task_project, task_number)
         REFERENCES work_tasks(project, task_number)
 );
 
 CREATE INDEX IF NOT EXISTS idx_work_context_task
     ON work_context_entries(task_project, task_number, id DESC);
+-- idx_work_context_entry_type is created by _ensure_context_entry_columns
+-- after the entry_type column is backfilled (migration 3).
 
 -- -------------------------------------------------------------------
 -- Transitions (status change history)
@@ -217,6 +220,7 @@ def create_work_tables(conn: sqlite3.Connection) -> None:
     """
     conn.executescript(WORK_SCHEMA)
     _ensure_flow_node_columns(conn)
+    _ensure_context_entry_columns(conn)
     _run_work_migrations(conn)
 
 
@@ -233,6 +237,30 @@ def _ensure_flow_node_columns(conn: sqlite3.Connection) -> None:
     }
     if "agent_name" not in cols:
         conn.execute("ALTER TABLE work_flow_nodes ADD COLUMN agent_name TEXT")
+
+
+def _ensure_context_entry_columns(conn: sqlite3.Connection) -> None:
+    """Backfill optional ``entry_type`` column on work_context_entries.
+
+    The column classifies each row (``note`` default, ``reply`` for user
+    chat replies, ``read`` for inbox read-markers). Legacy rows keep the
+    default ``note`` tag so existing context-log consumers don't change
+    shape. The entry_type index is created here too — not in WORK_SCHEMA —
+    because SQLite won't parse an index that references a column the
+    (pre-migration) legacy table doesn't have.
+    """
+    cols = {
+        row[1] for row in conn.execute("PRAGMA table_info(work_context_entries)")
+    }
+    if "entry_type" not in cols:
+        conn.execute(
+            "ALTER TABLE work_context_entries "
+            "ADD COLUMN entry_type TEXT NOT NULL DEFAULT 'note'"
+        )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_work_context_entry_type "
+        "ON work_context_entries(task_project, task_number, entry_type)"
+    )
 
 
 # ------------------------------------------------------------------
@@ -261,6 +289,15 @@ _WORK_MIGRATIONS: list[tuple[int, str, list[str]]] = [
             CREATE INDEX IF NOT EXISTS idx_work_sync_state_adapter
                 ON work_sync_state(adapter_name)
             """,
+        ],
+    ),
+    (
+        3,
+        "Add entry_type column to work_context_entries for inbox reply/read markers",
+        [
+            # SQLite lacks IF NOT EXISTS on ADD COLUMN — guarded separately in
+            # _ensure_context_entry_columns below. This migration row exists
+            # so the schema_version bump is recorded for fresh DBs too.
         ],
     ),
 ]

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -2334,8 +2334,20 @@ class SQLiteWorkService:
     # Context log
     # ------------------------------------------------------------------
 
-    def add_context(self, task_id: str, actor: str, text: str) -> ContextEntry:
-        """Append a context entry to a task's log."""
+    def add_context(
+        self,
+        task_id: str,
+        actor: str,
+        text: str,
+        *,
+        entry_type: str = "note",
+    ) -> ContextEntry:
+        """Append a context entry to a task's log.
+
+        ``entry_type`` classifies the row. ``"note"`` is the default (generic
+        context log, mirrors prior behaviour). Inbox callers use ``"reply"``
+        or ``"read"`` via :meth:`add_reply` and :meth:`mark_read` helpers.
+        """
         project, number = _parse_task_id(task_id)
         # Validate task exists
         row = self._conn.execute(
@@ -2348,15 +2360,16 @@ class SQLiteWorkService:
         now = _now()
         self._conn.execute(
             "INSERT INTO work_context_entries "
-            "(task_project, task_number, actor, text, created_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (project, number, actor, text, now),
+            "(task_project, task_number, actor, text, created_at, entry_type) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (project, number, actor, text, now, entry_type),
         )
         self._conn.commit()
         return ContextEntry(
             actor=actor,
             timestamp=datetime.fromisoformat(now),
             text=text,
+            entry_type=entry_type,
         )
 
     def get_context(
@@ -2364,8 +2377,14 @@ class SQLiteWorkService:
         task_id: str,
         limit: int | None = None,
         since: datetime | None = None,
+        entry_type: str | None = None,
     ) -> list[ContextEntry]:
-        """Query context entries for a task, most recent first."""
+        """Query context entries for a task, most recent first.
+
+        When ``entry_type`` is given, only rows matching that tag are
+        returned — pass ``"reply"`` for the inbox thread view,
+        ``"read"`` for read markers, or ``None`` for every row.
+        """
         project, number = _parse_task_id(task_id)
         clauses = ["task_project = ?", "task_number = ?"]
         params: list[object] = [project, number]
@@ -2374,6 +2393,10 @@ class SQLiteWorkService:
             clauses.append("created_at > ?")
             params.append(since.isoformat())
 
+        if entry_type is not None:
+            clauses.append("entry_type = ?")
+            params.append(entry_type)
+
         where = " AND ".join(clauses)
         sql = f"SELECT * FROM work_context_entries WHERE {where} ORDER BY id DESC"
 
@@ -2381,14 +2404,131 @@ class SQLiteWorkService:
             sql += f" LIMIT {int(limit)}"
 
         rows = self._conn.execute(sql, params).fetchall()
-        return [
-            ContextEntry(
-                actor=r["actor"],
-                timestamp=datetime.fromisoformat(r["created_at"]),
-                text=r["text"],
+        entries = []
+        for r in rows:
+            # entry_type may be absent on rows written before migration 3
+            # on a DB that was still being upgraded; coerce defensively.
+            try:
+                etype = r["entry_type"] or "note"
+            except (KeyError, IndexError):
+                etype = "note"
+            entries.append(
+                ContextEntry(
+                    actor=r["actor"],
+                    timestamp=datetime.fromisoformat(r["created_at"]),
+                    text=r["text"],
+                    entry_type=etype,
+                )
             )
-            for r in rows
-        ]
+        return entries
+
+    # ------------------------------------------------------------------
+    # Inbox actions — reply / archive / read-marker
+    #
+    # These three methods are the work-service backing for the cockpit's
+    # interactive inbox screen. Each wraps a primitive (add_context,
+    # mark_done) with the idempotency + event-emission shape the UI
+    # expects, so the Textual layer stays focused on interaction and
+    # doesn't reinvent state management.
+    # ------------------------------------------------------------------
+
+    def add_reply(
+        self, task_id: str, body: str, actor: str = "user",
+    ) -> ContextEntry:
+        """Record a user reply on an inbox task.
+
+        Stored as a ``work_context_entries`` row with ``entry_type='reply'``
+        so :meth:`list_replies` and the inbox thread view can render chat
+        turns without collision with system/notes context.
+
+        Raises :class:`ValidationError` when ``body`` is empty after strip.
+        """
+        if not body or not body.strip():
+            raise ValidationError("Reply body must not be empty.")
+        return self.add_context(
+            task_id, actor, body.strip(), entry_type="reply",
+        )
+
+    def archive_task(self, task_id: str, actor: str = "user") -> Task:
+        """Flip an inbox task to the chat-flow terminal state.
+
+        Idempotent: archiving an already-terminal task is a no-op and
+        returns the current record unchanged. Uses the same underlying
+        transition shape as :meth:`mark_done` so dashboard counts and
+        dependency unblocking stay consistent.
+        """
+        task = self.get(task_id)
+        if task.work_status in TERMINAL_STATUSES:
+            return task
+        now = _now()
+        self._record_transition(
+            task.project,
+            task.task_number,
+            task.work_status.value,
+            WorkStatus.DONE.value,
+            actor,
+            reason="inbox.archive",
+        )
+        self._conn.execute(
+            "UPDATE work_tasks SET work_status = ?, updated_at = ? "
+            "WHERE project = ? AND task_number = ?",
+            (WorkStatus.DONE.value, now, task.project, task.task_number),
+        )
+        self._conn.commit()
+        # Cascade: any dependents blocked on this task should unblock,
+        # same as mark_done. archive_task is effectively 'done' for the
+        # chat-flow, so we respect the same contract.
+        try:
+            self._check_auto_unblock(task_id)
+        except Exception:  # noqa: BLE001
+            # Unblock cascading is best-effort — never let it break archive.
+            logger.debug("auto_unblock after archive failed", exc_info=True)
+        return self.get(task_id)
+
+    def mark_read(self, task_id: str, actor: str = "user") -> bool:
+        """Record a read-marker on an inbox task if one isn't already present.
+
+        Returns ``True`` when a new marker row was written, ``False`` when
+        a read row already existed (idempotent repeat-open). Callers use
+        the return value to gate event emission so the activity feed only
+        sees the *first* open.
+        """
+        project, number = _parse_task_id(task_id)
+        row = self._conn.execute(
+            "SELECT 1 FROM work_tasks WHERE project = ? AND task_number = ?",
+            (project, number),
+        ).fetchone()
+        if row is None:
+            raise TaskNotFoundError(f"Task '{task_id}' not found.")
+        existing = self._conn.execute(
+            "SELECT 1 FROM work_context_entries "
+            "WHERE task_project = ? AND task_number = ? AND entry_type = 'read' "
+            "LIMIT 1",
+            (project, number),
+        ).fetchone()
+        if existing is not None:
+            return False
+        now = _now()
+        self._conn.execute(
+            "INSERT INTO work_context_entries "
+            "(task_project, task_number, actor, text, created_at, entry_type) "
+            "VALUES (?, ?, ?, ?, ?, 'read')",
+            (project, number, actor, "opened in cockpit inbox", now),
+        )
+        self._conn.commit()
+        return True
+
+    def list_replies(self, task_id: str) -> list[ContextEntry]:
+        """Return reply entries for a task in chronological (oldest first) order.
+
+        Thin wrapper over :meth:`get_context` so callers don't need to
+        remember the ``entry_type='reply'`` convention, and so the inbox
+        view can render the thread in natural reading order without the
+        reverse() gymnastics the general context log requires.
+        """
+        entries = self.get_context(task_id, entry_type="reply")
+        entries.reverse()  # get_context returns newest-first
+        return entries
 
     # ------------------------------------------------------------------
     # Queries

--- a/tests/test_cockpit_inbox_ui.py
+++ b/tests/test_cockpit_inbox_ui.py
@@ -1,0 +1,252 @@
+"""Textual UI tests for the cockpit inbox screen.
+
+Drives :class:`pollypm.cockpit_ui.PollyInboxApp` via ``Pilot`` to assert
+the full interactive loop: navigate with arrows, open a message, reply,
+archive, and verify the underlying work-service state after each action.
+
+Skipped when the minimum-viable config layer can't stub a single-project
+cockpit (e.g. platform-specific config bootstrap failures) so a CI
+environment without tmux doesn't block on unrelated infra.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from pollypm.work.sqlite_service import SQLiteWorkService
+
+
+# ---------------------------------------------------------------------------
+# Config fixture — a minimal "one project" cockpit config with a real DB
+# ---------------------------------------------------------------------------
+
+
+def _write_minimal_config(project_path: Path, config_path: Path) -> None:
+    """Emit a pollypm.toml pointing at a single-project workspace.
+
+    Must mirror the layout the cockpit loader expects: a workspace root
+    with a ``[pollypm.projects.<key>]`` block pointing at a folder that
+    has a ``.pollypm/state.db`` file we just seeded with inbox rows.
+    """
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "[project]\n"
+        f'tmux_session = "pollypm-test"\n'
+        f'workspace_root = "{project_path.parent}"\n'
+        "\n"
+        f'[projects.demo]\n'
+        f'key = "demo"\n'
+        f'name = "Demo"\n'
+        f'path = "{project_path}"\n'
+    )
+
+
+def _seed_project(project_path: Path) -> list[str]:
+    """Create a few inbox tasks in a project-root state.db. Returns task_ids."""
+    db_path = project_path / ".pollypm" / "state.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+    try:
+        ids: list[str] = []
+        for title, body in [
+            ("Smoke subject", "Smoke body"),
+            ("Deploy blocked", "Verify email click."),
+            ("Homepage rewrite", "Review please."),
+        ]:
+            t = svc.create(
+                title=title,
+                description=body,
+                type="task",
+                project="demo",
+                flow_template="chat",
+                roles={"requester": "user", "operator": "polly"},
+                priority="normal",
+                created_by="polly",
+            )
+            ids.append(t.task_id)
+        return ids
+    finally:
+        svc.close()
+
+
+@pytest.fixture
+def inbox_env(tmp_path: Path):
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()  # pretend git repo
+    config_path = tmp_path / "pollypm.toml"
+    _write_minimal_config(project_path, config_path)
+    ids = _seed_project(project_path)
+    return {
+        "config_path": config_path,
+        "project_path": project_path,
+        "task_ids": ids,
+    }
+
+
+def _load_config_compatible(config_path: Path) -> bool:
+    """Skip the suite if config loader rejects our minimal TOML shape."""
+    try:
+        from pollypm.config import load_config
+        cfg = load_config(config_path)
+        return "demo" in getattr(cfg, "projects", {})
+    except Exception:  # noqa: BLE001
+        return False
+
+
+@pytest.fixture
+def inbox_app(inbox_env):
+    if not _load_config_compatible(inbox_env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_ui import PollyInboxApp
+    return PollyInboxApp(inbox_env["config_path"])
+
+
+# ---------------------------------------------------------------------------
+# Pilot tests
+# ---------------------------------------------------------------------------
+
+
+def _run(coro):
+    """Run an async test body under asyncio, matching onboarding tests."""
+    asyncio.run(coro)
+
+
+def test_inbox_lists_seeded_messages(inbox_env, inbox_app) -> None:
+    """On mount, every seeded inbox task shows up in the left list."""
+    async def body() -> None:
+        async with inbox_app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            assert len(inbox_app._tasks) == len(inbox_env["task_ids"])
+            # All three are unread on first load — nothing has a read marker.
+            assert len(inbox_app._unread_ids) == len(inbox_env["task_ids"])
+    _run(body())
+
+
+def test_selecting_a_row_renders_detail_and_clears_unread(inbox_env, inbox_app) -> None:
+    """Keyboard navigation opens the message and records a read marker."""
+    async def body() -> None:
+        async with inbox_app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            # Land on the first row and trigger an open.
+            inbox_app.list_view.index = 0
+            await pilot.press("enter")
+            await pilot.pause()
+            selected = inbox_app._selected_task_id
+            assert selected is not None
+            # Detail renders the subject (plain text, markup-stripped).
+            detail_text = str(inbox_app.detail.render())
+            assert any(s in detail_text for s in ("Smoke subject", "Deploy", "Homepage"))
+            # The row is no longer unread locally…
+            assert selected not in inbox_app._unread_ids
+            # …and the work-service has a read marker for that task.
+            svc = inbox_app._svc_for_task(selected)
+            try:
+                reads = svc.get_context(selected, entry_type="read")
+            finally:
+                svc.close()
+            assert len(reads) == 1
+    _run(body())
+
+
+def test_reply_flow_persists_and_appears_in_thread(inbox_env, inbox_app) -> None:
+    """r opens the reply input; Enter posts; detail pane re-renders the thread."""
+    async def body() -> None:
+        async with inbox_app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            inbox_app.list_view.index = 0
+            await pilot.press("enter")
+            await pilot.pause()
+            task_id = inbox_app._selected_task_id
+            assert task_id is not None
+
+            # Pressing r reveals the reply input.
+            await pilot.press("r")
+            await pilot.pause()
+            assert inbox_app.reply_input.has_class("visible")
+            assert inbox_app.reply_input.has_focus
+
+            # Type a reply and submit.
+            inbox_app.reply_input.value = "Got it, thanks"
+            await pilot.press("enter")
+            await pilot.pause()
+
+            # Input closes, focus returns to the list.
+            assert not inbox_app.reply_input.has_class("visible")
+
+            # The reply is persisted as a reply context row.
+            svc = inbox_app._svc_for_task(task_id)
+            try:
+                replies = svc.list_replies(task_id)
+            finally:
+                svc.close()
+            assert [e.text for e in replies] == ["Got it, thanks"]
+            assert replies[0].actor == "user"
+            assert replies[0].entry_type == "reply"
+
+            # Detail pane re-renders with the reply visible in-thread.
+            rendered = str(inbox_app.detail.render())
+            assert "Got it, thanks" in rendered
+    _run(body())
+
+
+def test_archive_removes_row_and_flips_status(inbox_env, inbox_app) -> None:
+    """a archives the selected message; it disappears from the list."""
+    async def body() -> None:
+        async with inbox_app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            initial_total = len(inbox_app._tasks)
+            assert initial_total >= 1
+
+            inbox_app.list_view.index = 0
+            await pilot.press("enter")
+            await pilot.pause()
+            target = inbox_app._selected_task_id
+            assert target is not None
+
+            await pilot.press("a")
+            await pilot.pause()
+
+            # List shrinks by one and the archived task is gone.
+            assert len(inbox_app._tasks) == initial_total - 1
+            assert all(t.task_id != target for t in inbox_app._tasks)
+
+            # Work status is DONE in the underlying DB.
+            svc = inbox_app._svc_for_task(target)
+            try:
+                task = svc.get(target)
+            finally:
+                svc.close()
+            assert task.work_status.value == "done"
+    _run(body())
+
+
+def test_empty_state_message_when_no_inbox(tmp_path: Path) -> None:
+    """An inbox with zero messages shows the friendly empty-state copy."""
+    async def body() -> None:
+        project_path = tmp_path / "empty"
+        project_path.mkdir()
+        (project_path / ".git").mkdir()
+        config_path = tmp_path / "pollypm.toml"
+        _write_minimal_config(project_path, config_path)
+        # Create the DB but don't seed any tasks.
+        db_path = project_path / ".pollypm" / "state.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+        svc.close()
+
+        if not _load_config_compatible(config_path):
+            pytest.skip("minimal pollypm.toml fixture not supported by loader")
+
+        from pollypm.cockpit_ui import PollyInboxApp
+        app = PollyInboxApp(config_path)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            assert app._tasks == []
+            detail_text = str(app.detail.render())
+            assert "No messages" in detail_text
+            assert "Polly" in detail_text
+    _run(body())

--- a/tests/test_inbox_actions.py
+++ b/tests/test_inbox_actions.py
@@ -1,0 +1,188 @@
+"""Work-service unit tests for inbox interaction methods.
+
+Covers ``add_reply``, ``archive_task``, ``mark_read``, ``list_replies`` —
+the four methods the cockpit Textual inbox screen calls to drive chat
+threads, read-markers, and archival from the TUI.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from pollypm.work.models import WorkStatus
+from pollypm.work.sqlite_service import (
+    SQLiteWorkService,
+    TaskNotFoundError,
+    ValidationError,
+)
+
+
+@pytest.fixture
+def svc(tmp_path):
+    db_path = tmp_path / "inbox.db"
+    return SQLiteWorkService(db_path=db_path)
+
+
+def _inbox_task(svc, *, title: str = "Hello Sam", body: str = "Read me.") -> str:
+    """Create a chat-flow task in the same shape ``pm notify`` does."""
+    task = svc.create(
+        title=title,
+        description=body,
+        type="task",
+        project="demo",
+        flow_template="chat",
+        roles={"requester": "user", "operator": "polly"},
+        priority="normal",
+        created_by="polly",
+    )
+    return task.task_id
+
+
+# ---------------------------------------------------------------------------
+# add_reply
+# ---------------------------------------------------------------------------
+
+
+class TestAddReply:
+    def test_reply_persisted_as_reply_entry_type(self, svc):
+        task_id = _inbox_task(svc)
+        entry = svc.add_reply(task_id, "Thanks for the update.", actor="user")
+        assert entry.entry_type == "reply"
+        assert entry.actor == "user"
+        assert entry.text == "Thanks for the update."
+
+    def test_reply_strips_whitespace(self, svc):
+        task_id = _inbox_task(svc)
+        entry = svc.add_reply(task_id, "  hi  ", actor="user")
+        assert entry.text == "hi"
+
+    def test_empty_reply_rejected(self, svc):
+        task_id = _inbox_task(svc)
+        with pytest.raises(ValidationError):
+            svc.add_reply(task_id, "   ", actor="user")
+
+    def test_reply_to_missing_task_raises(self, svc):
+        with pytest.raises(TaskNotFoundError):
+            svc.add_reply("demo/999", "ping", actor="user")
+
+    def test_multiple_replies_are_independent_rows(self, svc):
+        task_id = _inbox_task(svc)
+        svc.add_reply(task_id, "one", actor="user")
+        svc.add_reply(task_id, "two", actor="user")
+        svc.add_reply(task_id, "three", actor="user")
+        entries = svc.list_replies(task_id)
+        assert [e.text for e in entries] == ["one", "two", "three"]
+
+
+# ---------------------------------------------------------------------------
+# list_replies
+# ---------------------------------------------------------------------------
+
+
+class TestListReplies:
+    def test_returns_replies_oldest_first(self, svc):
+        task_id = _inbox_task(svc)
+        svc.add_reply(task_id, "first", actor="user")
+        time.sleep(0.01)
+        svc.add_reply(task_id, "second", actor="user")
+        entries = svc.list_replies(task_id)
+        assert [e.text for e in entries] == ["first", "second"]
+
+    def test_excludes_non_reply_context(self, svc):
+        task_id = _inbox_task(svc)
+        svc.add_context(task_id, "system", "a note")
+        svc.add_reply(task_id, "a reply", actor="user")
+        entries = svc.list_replies(task_id)
+        # Only the reply row surfaces in list_replies.
+        assert [e.text for e in entries] == ["a reply"]
+        assert all(e.entry_type == "reply" for e in entries)
+
+    def test_empty_when_no_replies(self, svc):
+        task_id = _inbox_task(svc)
+        assert svc.list_replies(task_id) == []
+
+
+# ---------------------------------------------------------------------------
+# mark_read
+# ---------------------------------------------------------------------------
+
+
+class TestMarkRead:
+    def test_first_read_writes_marker(self, svc):
+        task_id = _inbox_task(svc)
+        assert svc.mark_read(task_id, actor="user") is True
+
+    def test_repeat_read_is_idempotent(self, svc):
+        task_id = _inbox_task(svc)
+        assert svc.mark_read(task_id, actor="user") is True
+        # Second call must not write a duplicate row and must return False
+        # so callers can gate event emission on it.
+        assert svc.mark_read(task_id, actor="user") is False
+
+    def test_marker_lives_as_read_entry_type(self, svc):
+        task_id = _inbox_task(svc)
+        svc.mark_read(task_id, actor="user")
+        reads = svc.get_context(task_id, entry_type="read")
+        assert len(reads) == 1
+        assert reads[0].entry_type == "read"
+
+    def test_read_markers_do_not_pollute_replies(self, svc):
+        task_id = _inbox_task(svc)
+        svc.mark_read(task_id, actor="user")
+        svc.add_reply(task_id, "hey", actor="user")
+        # Reply list must ignore the read marker, and mark_read is
+        # idempotent so no duplicate read rows exist either.
+        assert len(svc.list_replies(task_id)) == 1
+        assert len(svc.get_context(task_id, entry_type="read")) == 1
+
+    def test_mark_read_on_missing_task_raises(self, svc):
+        with pytest.raises(TaskNotFoundError):
+            svc.mark_read("demo/404", actor="user")
+
+
+# ---------------------------------------------------------------------------
+# archive_task
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveTask:
+    def test_archive_flips_status_to_done(self, svc):
+        task_id = _inbox_task(svc)
+        archived = svc.archive_task(task_id, actor="user")
+        assert archived.work_status == WorkStatus.DONE
+
+    def test_archive_records_transition(self, svc):
+        task_id = _inbox_task(svc)
+        svc.archive_task(task_id, actor="user")
+        task = svc.get(task_id)
+        # The transition row is written with actor="user" and a
+        # recognisable reason tag so consumers can tell it apart from
+        # the standard mark_done path.
+        assert any(
+            tr.to_state == WorkStatus.DONE.value
+            and tr.actor == "user"
+            and (tr.reason or "").startswith("inbox.archive")
+            for tr in task.transitions
+        )
+
+    def test_archive_is_idempotent(self, svc):
+        task_id = _inbox_task(svc)
+        first = svc.archive_task(task_id, actor="user")
+        second = svc.archive_task(task_id, actor="user")
+        assert first.work_status == WorkStatus.DONE
+        assert second.work_status == WorkStatus.DONE
+        # Second call must not append a second transition — otherwise
+        # dashboard counts would double-count an archive click.
+        task = svc.get(task_id)
+        archive_transitions = [
+            tr for tr in task.transitions
+            if tr.to_state == WorkStatus.DONE.value
+            and (tr.reason or "").startswith("inbox.archive")
+        ]
+        assert len(archive_transitions) == 1
+
+    def test_archive_on_missing_task_raises(self, svc):
+        with pytest.raises(TaskNotFoundError):
+            svc.archive_task("demo/777", actor="user")


### PR DESCRIPTION
Full Textual inbox app replacing the dumb text panel. Completes the operator↔user feedback loop started by #258 (pm notify).

## UI
- Two-pane horizontal: ListView on left (sender · subject · age, yellow-diamond unread), VerticalScroll on right (subject, meta, body via `_md_to_rich`, threaded replies inline)
- Keyboard: j/arrows navigate, Enter opens, `r` reply (Input overlay), `a` archive, `q`/Esc back
- Reply input posts on Enter; thread re-renders immediately
- Archive flips to DONE + row vanishes
- Empty state: "Polly will notify you here when she has updates."

## Backend (new work-service methods)
- `add_reply(task_id, body, actor)` — context row entry_type='reply'
- `archive_task(task_id, actor)` — flips to DONE via mark_done transition, idempotent
- `mark_read(task_id, actor)` — one-shot read marker
- `list_replies(task_id)` — chronological

## Schema
Migration v3: `work_context_entries` gains `entry_type TEXT DEFAULT 'note'`. Index moved post-backfill.

## Events emitted
`inbox.message.read` / `inbox.message.archived` / `inbox.reply_received` — matches pm notify shape.

## Tests (+22, 0 regressions)
- `tests/test_inbox_actions.py` — 17 tests (work-service layer)
- `tests/test_cockpit_inbox_ui.py` — 5 Pilot-driven UI flows (list populates, read marker, reply + rerender, archive + removal, empty state)

2247 passing. 3 pre-existing unrelated failures unchanged.

## Routing
`pm cockpit-pane inbox` now dispatches to PollyInboxApp instead of generic static-text pane.

## CLI pass-through (for tests/headless)
`pm inbox reply <id> <body>` + `pm inbox archive <id>` — thin wrappers around the work-service methods.