### PR TITLE
feat(planner): architect session bootstrap — pm worker-start --role + auto-launch on project new (#257)

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -1626,6 +1626,24 @@ def heartbeat_record(
 def worker_start(
     project_key: str = typer.Argument(..., help="Tracked project key."),
     prompt: str | None = typer.Option(None, "--prompt", help="Optional initial worker prompt."),
+    role: str = typer.Option(
+        "worker",
+        "--role",
+        help=(
+            "Session role. Defaults to 'worker'. Pass e.g. '--role architect' "
+            "to spawn a non-worker project-scoped session that the task "
+            "sweeper can find via the role-candidate-names resolver."
+        ),
+    ),
+    agent_profile: str | None = typer.Option(
+        None,
+        "--profile",
+        help=(
+            "Agent profile to pin on the new session (e.g. 'architect'). "
+            "When omitted, the supervisor falls back to the role's default "
+            "profile if one exists."
+        ),
+    ),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
     supervisor = _load_supervisor(config_path)
@@ -1634,16 +1652,23 @@ def worker_start(
         (
             session
             for session in supervisor.config.sessions.values()
-            if session.role == "worker" and session.project == project_key and session.enabled
+            if session.role == role and session.project == project_key and session.enabled
         ),
         None,
     )
-    session = existing or create_worker_session(config_path, project_key=project_key, prompt=prompt)
+    session = existing or create_worker_session(
+        config_path,
+        project_key=project_key,
+        prompt=prompt,
+        role=role,
+        agent_profile=agent_profile,
+    )
     launch_worker_session(config_path, session.name)
     refreshed = _load_supervisor(config_path)
     launch = next(item for item in refreshed.plan_launches() if item.session.name == session.name)
+    label = "Managed worker" if role == "worker" else f"Managed {role}"
     typer.echo(
-        f"Managed worker {session.name} ready for project {project_key} "
+        f"{label} {session.name} ready for project {project_key} "
         f"in {refreshed.tmux_session_for_launch(launch)}:{launch.window_name}"
     )
 

--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -374,6 +374,7 @@ def new_cmd(
             f"Auto-created plan_project task for '{project.key}' via "
             "project.created hook (see `[planner] auto_on_project_created`)."
         )
+        _auto_spawn_architect(path, project.key)
         return
 
     # ``--skip-plan`` or ``--skip-planner`` both short-circuit the prompt +
@@ -409,6 +410,83 @@ def new_cmd(
         "Next: `pm task queue " + task.task_id + "` to hand it off to the "
         "architect worker."
     )
+    _auto_spawn_architect(path, project.key)
+
+
+def _auto_spawn_architect(config_path: Path, project_key: str) -> None:
+    """Best-effort: spawn a project-scoped architect session for ``project_key``.
+
+    The planner's ``plan_project`` flow parks every stage on
+    ``actor_role: architect``. Without a live session named
+    ``architect_<project>`` the task-assignment sweeper (see
+    ``pollypm.work.task_assignment``) cannot resolve a recipient and the
+    pipeline stalls silently at the ``research`` node.
+
+    Called from ``pm project new`` after a plan_project task has been
+    created (either via the ``project.created`` observer or the legacy
+    interactive prompt). Honours the ``--skip-planner`` / ``--skip-plan``
+    flags at the callsite — this helper assumes a planner task was
+    actually created and the user wants the flow to run.
+
+    Failures here are swallowed: the task is already parked in queued
+    state, the user can always spawn the architect manually with
+    ``pm worker-start --role architect --profile architect <project>``.
+    """
+    import logging
+
+    log = logging.getLogger(__name__)
+    try:
+        # Local import — keeps the planner CLI importable in environments
+        # that haven't wired the full session/supervisor stack (tests
+        # running against ``pm project new`` with a minimal config).
+        from pollypm.config import load_config
+        from pollypm.workers import create_worker_session, launch_worker_session
+
+        config = load_config(config_path)
+        # Don't double-spawn if the caller (or an earlier invocation)
+        # already registered an architect session for this project.
+        for existing in config.sessions.values():
+            if (
+                existing.role == "architect"
+                and existing.project == project_key
+                and existing.enabled
+            ):
+                log.info(
+                    "project_planning: architect session %s already "
+                    "registered for '%s' — skipping auto-spawn.",
+                    existing.name, project_key,
+                )
+                return
+
+        session = create_worker_session(
+            config_path,
+            project_key=project_key,
+            prompt=None,
+            role="architect",
+            agent_profile="architect",
+        )
+        typer.echo(
+            f"Spawned architect session {session.name} for "
+            f"project '{project_key}'."
+        )
+        try:
+            launch_worker_session(config_path, session.name)
+        except Exception as exc:  # noqa: BLE001
+            log.info(
+                "project_planning: architect session %s registered but "
+                "not launched (%s). Start it manually with "
+                "`pm worker-start --role architect --profile architect %s`.",
+                session.name, exc, project_key,
+            )
+    except Exception as exc:  # noqa: BLE001
+        # Most common failure is no accounts configured yet (fresh
+        # install running ``pm project new`` before ``pm onboard``).
+        log.info(
+            "project_planning: architect auto-spawn skipped (%s). "
+            "Start it manually with "
+            "`pm worker-start --role architect --profile architect %s`.",
+            exc, project_key,
+        )
 
 
 def _plan_task_exists(project_path: Path, project_key: str) -> bool:

--- a/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
@@ -35,3 +35,11 @@ Every module entry in the plan includes: name, purpose, user-level test descript
 
 Stage-0 (Research) additionally produces `docs/planning-context.md` via a ReAct loop (grep/read/list_files/web_search). Stage 1 (Discover) will not start until that artifact is non-empty. Stage-0 details (loop, budget, contract) are spelled out in the research-stage prompt block that the flow engine injects when you enter the research node.
 </output_contract>
+
+<kickoff>
+You are Archie, the architect. On session start:
+
+1. Claim your work: run `pm task next` to find the highest-priority queued `plan_project` task routed to you. If nothing is queued yet, wait for a ping from the task-assignment bus — the sweeper will re-notify every few minutes.
+2. Walk the `plan_project` flow stages in order: research → discover → decompose → test_strategy → magic → critic_panel → synthesize → user_approval → emit_backlog.
+3. Stop at stage 7 (user_approval) and notify the user. Emission + worker delegation happens only after the user approves the plan.
+</kickoff>

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -184,10 +184,10 @@ def _review_tasks_for_project(project_key: str, db_path: Path) -> list[str]:
 class Supervisor:
     _CONTROL_ROLES = {"heartbeat-supervisor", "operator-pm", "triage", "reviewer"}
     # Roles that should receive an initial-input prompt on fresh launch.
-    # Workers are NOT control-plane sessions (not in _CONTROL_ROLES), but
-    # they DO need their profile prompt delivered on launch — same as the
-    # reviewer / operator / heartbeat / triage sessions.
-    _INITIAL_INPUT_ROLES = _CONTROL_ROLES | {"worker"}
+    # Workers + architects are NOT control-plane sessions (not in
+    # _CONTROL_ROLES — they're project-scoped), but they DO need their
+    # profile prompt delivered on launch so the agent knows its persona.
+    _INITIAL_INPUT_ROLES = _CONTROL_ROLES | {"worker", "architect"}
     #: Name of the PollyPM console/cockpit window inside a tmux session.
     CONSOLE_WINDOW = "PollyPM"
     _CONSOLE_WINDOW = CONSOLE_WINDOW  # deprecated alias — use CONSOLE_WINDOW
@@ -421,6 +421,8 @@ class Supervisor:
             return "worker"
         if session.role == "reviewer":
             return "russell"
+        if session.role == "architect":
+            return "architect"
         return None
 
     def _resolve_profile_prompt(self, session: SessionConfig, account: AccountConfig) -> str | None:

--- a/src/pollypm/work/task_assignment.py
+++ b/src/pollypm/work/task_assignment.py
@@ -103,9 +103,9 @@ def format_ping_for_role(event: TaskAssignmentEvent) -> str:
 # ---------------------------------------------------------------------------
 
 
-# Role → session naming conventions. ``role:worker`` is project-scoped
-# (one worker session per project); the other roles are process-wide
-# singletons.
+# Role → session naming conventions. ``role:worker`` and
+# ``role:architect`` are project-scoped (one session per project); the
+# other roles listed here are process-wide singletons.
 _ROLE_STATIC_NAMES: dict[str, tuple[str, ...]] = {
     "reviewer": ("pm-reviewer",),
     "operator": ("pm-operator",),
@@ -115,17 +115,27 @@ _ROLE_STATIC_NAMES: dict[str, tuple[str, ...]] = {
 }
 
 
+# Project-scoped roles expand to both hyphen- and underscore-separated
+# session names (``<role>-<project>`` and ``<role>_<project>``). The
+# worker shipping convention is underscore (``workers.py``), but the
+# resolver is tolerant of either so naming drift between operators,
+# tests, and docs doesn't break lookup.
+_PROJECT_SCOPED_ROLES: frozenset[str] = frozenset({"worker", "architect"})
+
+
 def role_candidate_names(role: str, project: str) -> list[str]:
     """Return the ordered list of session names a role *could* map to.
 
     Callers match the first candidate that actually has a live session.
-    ``role:worker`` expands to ``worker-<project>`` and ``worker_<project>``
-    (we accept both conventions — ``workers.py`` ships underscore but
-    operators/tests and docs use both interchangeably).
+    Project-scoped roles (``worker``, ``architect``) expand to both
+    ``<role>-<project>`` and ``<role>_<project>`` — we accept either
+    convention so drift between docs and shipping code doesn't break
+    lookup. Process-wide singletons (reviewer / operator / heartbeat /
+    triage) map to their fixed session names via ``_ROLE_STATIC_NAMES``.
     """
     key = role.strip().lower()
-    if key == "worker":
-        return [f"worker-{project}", f"worker_{project}"]
+    if key in _PROJECT_SCOPED_ROLES:
+        return [f"{key}-{project}", f"{key}_{project}"]
     if key.startswith("critic_") or key.startswith("critic-"):
         # Planner-spawned per-task critic sessions carry the role name
         # verbatim. Pass through so exact-name lookup picks them up.

--- a/src/pollypm/workers.py
+++ b/src/pollypm/workers.py
@@ -86,6 +86,8 @@ def create_worker_session(
     account_name: str | None = None,
     provider: ProviderKind | None = None,
     session_name: str | None = None,
+    role: str = "worker",
+    agent_profile: str | None = None,
 ) -> SessionConfig:
     config = load_config(config_path)
     project = config.projects.get(project_key)
@@ -102,6 +104,8 @@ def create_worker_session(
             f"    pm add-project <path> --name {project_key}"
         )
 
+    role = (role or "worker").strip() or "worker"
+
     if account_name is None:
         account_name = auto_select_worker_account(config_path, provider=provider)
     if account_name not in config.accounts:
@@ -115,28 +119,35 @@ def create_worker_session(
         prompt = suggest_worker_prompt(config_path, project_key=project_key)
 
     for existing in config.sessions.values():
-        if existing.role == "worker" and existing.project == project_key and existing.enabled:
+        if existing.role == role and existing.project == project_key and existing.enabled:
             raise typer.BadParameter(
-                f"Project {project_key} already has worker session {existing.name}"
+                f"Project {project_key} already has {role} session {existing.name}"
             )
 
-    session_key = session_name or _make_worker_session_name(project_key, set(config.sessions))
+    session_key = session_name or _make_role_session_name(
+        role, project_key, set(config.sessions)
+    )
+    # Workers use a ``pa`` worktree lane; non-worker roles (e.g. architect)
+    # take a lane named after the role so they don't collide with workers.
+    lane_kind = "pa" if role == "worker" else role
     worktree = ensure_worktree(
         config_path,
         project_key=project_key,
-        lane_kind="pa",
+        lane_kind=lane_kind,
         lane_key=session_key,
         session_name=session_key,
     )
+    window_prefix = "worker" if role == "worker" else role
     worker = SessionConfig(
         name=session_key,
-        role="worker",
+        role=role,
         provider=account.provider,
         account=account_name,
         cwd=Path(worktree.path) if worktree is not None else project.path,
         project=project_key,
-        window_name=f"worker-{project_key}",
+        window_name=f"{window_prefix}-{project_key}",
         prompt=prompt,
+        agent_profile=agent_profile,
         args=default_session_args(account.provider, open_permissions=config.pollypm.open_permissions_by_default),
     )
     config.sessions[session_key] = worker
@@ -210,7 +221,19 @@ def remove_worker_session(config_path: Path, session_name: str) -> None:
 
 
 def _make_worker_session_name(project_key: str, existing: set[str]) -> str:
-    base = f"worker_{project_key}"
+    return _make_role_session_name("worker", project_key, existing)
+
+
+def _make_role_session_name(role: str, project_key: str, existing: set[str]) -> str:
+    """Return an unused ``<role>_<project>`` session name.
+
+    Workers retain the historical ``worker_<project>`` convention. Other
+    roles (e.g. ``architect``) follow the same ``<role>_<project>`` layout
+    so the :func:`role_candidate_names` resolver (which probes both
+    hyphen- and underscore-separated forms) can find them without
+    bespoke per-role naming logic.
+    """
+    base = f"{role}_{project_key}"
     candidate = base
     index = 2
     while candidate in existing:

--- a/tests/test_architect_bootstrap.py
+++ b/tests/test_architect_bootstrap.py
@@ -1,0 +1,407 @@
+"""Tests for the architect session bootstrap (issue #257).
+
+Covers the three surfaces the fix adds:
+
+1. ``pm worker-start --role architect --profile architect <project>``
+   spawns an ``architect_<project>`` session (CLI wiring).
+2. ``role_candidate_names("architect", "<project>")`` expands to the
+   architect session names so the task-assignment sweeper can resolve
+   the recipient (work-service role-resolver wiring).
+3. ``pm project new`` on a fresh repo auto-creates the plan_project
+   task AND auto-spawns an architect session. ``--skip-planner``
+   suppresses both.
+4. The architect session's initial input resolves to the architect's
+   control prompt (not the worker prompt), so the session starts as
+   Archie even though the role is project-scoped and therefore not in
+   ``_CONTROL_ROLES``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pollypm.cli as cli
+from typer.testing import CliRunner
+
+from pollypm.config import write_config
+from pollypm.models import (
+    AccountConfig,
+    KnownProject,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectKind,
+    ProjectSettings,
+    ProviderKind,
+    SessionConfig,
+)
+from pollypm.plugins_builtin.project_planning.cli import project as project_cli
+from pollypm.plugins_builtin.project_planning.cli.project import project_app
+from pollypm.work.task_assignment import role_candidate_names
+
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_project_repo(tmp_path: Path, name: str = "demo") -> Path:
+    """Create a minimal git-looking directory on disk."""
+    path = tmp_path / name
+    path.mkdir()
+    (path / ".git").mkdir()
+    return path
+
+
+def _write_minimal_config(
+    tmp_path: Path, *, projects: dict[str, Path] | None = None,
+) -> Path:
+    projects = projects or {}
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            base_dir=tmp_path / ".pollypm-state",
+            logs_dir=tmp_path / ".pollypm-state/logs",
+            snapshots_dir=tmp_path / ".pollypm-state/snapshots",
+            state_db=tmp_path / ".pollypm-state/state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account=""),
+        accounts={},
+        sessions={},
+        projects={
+            key: KnownProject(
+                key=key,
+                path=path,
+                name=key,
+                persona_name="",
+                kind=ProjectKind.FOLDER,
+            )
+            for key, path in projects.items()
+        },
+    )
+    config_path = tmp_path / "pollypm.toml"
+    write_config(config, config_path, force=True)
+    return config_path
+
+
+# ---------------------------------------------------------------------------
+# (1) pm worker-start --role architect
+# ---------------------------------------------------------------------------
+
+
+def test_worker_start_role_architect_spawns_architect_session(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Passing ``--role architect`` forwards the role + profile into
+    ``create_worker_session`` and produces an ``architect_<project>``
+    session name.
+    """
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text("[project]\nname = \"pollypm\"\n")
+    created: list[dict[str, object]] = []
+    launched: list[tuple[Path, str]] = []
+
+    class FakeSupervisor:
+        def __init__(self) -> None:
+            self.config = type(
+                "Config",
+                (),
+                {
+                    "sessions": {},
+                    "project": type("Project", (), {"tmux_session": "pollypm"})(),
+                },
+            )()
+
+        def tmux_session_for_launch(self, launch) -> str:
+            return "pollypm-storage-closet"
+
+        def plan_launches(self):
+            session = type("Session", (), {"name": "architect_foo"})()
+            return [
+                type(
+                    "Launch",
+                    (),
+                    {"session": session, "window_name": "architect-foo"},
+                )()
+            ]
+
+    def fake_create(
+        path, project_key, prompt=None, role="worker", agent_profile=None,
+    ):
+        created.append(
+            {
+                "path": path,
+                "project": project_key,
+                "prompt": prompt,
+                "role": role,
+                "agent_profile": agent_profile,
+            }
+        )
+        return type("Session", (), {"name": "architect_foo"})()
+
+    monkeypatch.setattr(cli, "_require_pollypm_session", lambda supervisor: None)
+    monkeypatch.setattr(cli, "_load_supervisor", lambda path: FakeSupervisor())
+    monkeypatch.setattr(cli, "create_worker_session", fake_create)
+    monkeypatch.setattr(
+        cli,
+        "launch_worker_session",
+        lambda path, session_name: launched.append((path, session_name)),
+    )
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "worker-start",
+            "foo",
+            "--role", "architect",
+            "--profile", "architect",
+            "--config", str(config_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(created) == 1
+    assert created[0]["project"] == "foo"
+    assert created[0]["role"] == "architect"
+    assert created[0]["agent_profile"] == "architect"
+    assert launched == [(config_path, "architect_foo")]
+    # Text banner reflects the non-worker label.
+    assert "Managed architect architect_foo ready for project foo" in result.output
+
+
+def test_worker_start_no_role_still_spawns_worker(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Backward compat: ``pm worker-start <project>`` without ``--role``
+    still produces a worker session (not an architect)."""
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text("[project]\nname = \"pollypm\"\n")
+    created: list[dict[str, object]] = []
+
+    class FakeSupervisor:
+        def __init__(self) -> None:
+            self.config = type(
+                "Config",
+                (),
+                {
+                    "sessions": {},
+                    "project": type("Project", (), {"tmux_session": "pollypm"})(),
+                },
+            )()
+
+        def tmux_session_for_launch(self, launch) -> str:
+            return "pollypm-storage-closet"
+
+        def plan_launches(self):
+            session = type("Session", (), {"name": "worker_bar"})()
+            return [
+                type(
+                    "Launch",
+                    (),
+                    {"session": session, "window_name": "worker-bar"},
+                )()
+            ]
+
+    def fake_create(
+        path, project_key, prompt=None, role="worker", agent_profile=None,
+    ):
+        created.append({"role": role, "agent_profile": agent_profile})
+        return type("Session", (), {"name": "worker_bar"})()
+
+    monkeypatch.setattr(cli, "_require_pollypm_session", lambda supervisor: None)
+    monkeypatch.setattr(cli, "_load_supervisor", lambda path: FakeSupervisor())
+    monkeypatch.setattr(cli, "create_worker_session", fake_create)
+    monkeypatch.setattr(cli, "launch_worker_session", lambda path, name: None)
+
+    result = runner.invoke(
+        cli.app, ["worker-start", "bar", "--config", str(config_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert created == [{"role": "worker", "agent_profile": None}]
+    assert "Managed worker worker_bar" in result.output
+
+
+# ---------------------------------------------------------------------------
+# (2) Role-candidate-names expansion
+# ---------------------------------------------------------------------------
+
+
+def test_role_candidate_names_expands_architect_to_project_scoped_session() -> None:
+    """``role:architect`` expands to both ``architect-<project>`` and
+    ``architect_<project>`` — matching the dual-convention worker path so
+    the sweeper finds a session regardless of naming drift."""
+    candidates = role_candidate_names("architect", "foo")
+    assert candidates == ["architect-foo", "architect_foo"]
+
+
+def test_role_candidate_names_still_expands_worker() -> None:
+    """Regression: worker still expands to the dual-convention pair so
+    existing task-assignment wiring continues to work."""
+    candidates = role_candidate_names("worker", "foo")
+    assert candidates == ["worker-foo", "worker_foo"]
+
+
+def test_role_candidate_names_handles_mixed_case_architect() -> None:
+    """Resolver is case-insensitive on the role key."""
+    assert role_candidate_names("Architect", "demo") == [
+        "architect-demo", "architect_demo",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# (3) pm project new auto-spawns an architect session
+# ---------------------------------------------------------------------------
+
+
+def test_project_new_auto_spawns_architect_session(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Fresh ``pm project new`` creates a plan_project task (existing
+    behaviour) AND auto-spawns an architect session via the new
+    ``_auto_spawn_architect`` helper."""
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    repo = _make_project_repo(tmp_path, name="fresh")
+    config_path = _write_minimal_config(tmp_path)
+
+    spawned: list[tuple[Path, str]] = []
+
+    def fake_spawn(cfg_path: Path, project_key: str) -> None:
+        spawned.append((cfg_path, project_key))
+
+    monkeypatch.setattr(project_cli, "_auto_spawn_architect", fake_spawn)
+
+    result = runner.invoke(
+        project_app, ["new", str(repo), "--config", str(config_path)],
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    # Plan task was auto-created (regression guard against #255 breakage).
+    with SQLiteWorkService(
+        db_path=repo / ".pollypm" / "state.db", project_path=repo,
+    ) as svc:
+        tasks = svc.list_tasks(project="fresh")
+    plan_tasks = [t for t in tasks if t.flow_template_id == "plan_project"]
+    assert len(plan_tasks) == 1
+    # ...and the architect auto-spawn helper was invoked exactly once.
+    assert spawned == [(config_path, "fresh")]
+
+
+def test_project_new_skip_planner_does_not_spawn_architect(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """``--skip-planner`` suppresses both the plan task and the
+    architect auto-spawn."""
+    repo = _make_project_repo(tmp_path, name="fresh")
+    config_path = _write_minimal_config(tmp_path)
+
+    spawned: list[tuple[Path, str]] = []
+
+    def fake_spawn(cfg_path: Path, project_key: str) -> None:
+        spawned.append((cfg_path, project_key))
+
+    monkeypatch.setattr(project_cli, "_auto_spawn_architect", fake_spawn)
+
+    result = runner.invoke(
+        project_app,
+        ["new", str(repo), "--skip-planner", "--config", str(config_path)],
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    # No plan DB created (no planner task).
+    assert not (repo / ".pollypm" / "state.db").exists()
+    # No architect spawn either — ``--skip-planner`` is a full suppressor.
+    assert spawned == []
+
+
+# ---------------------------------------------------------------------------
+# (4) Architect session's initial input resolves to architect's control prompt
+# ---------------------------------------------------------------------------
+
+
+def _supervisor_with_architect(tmp_path: Path):
+    """Return a Supervisor wired with a single architect session."""
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            base_dir=tmp_path / ".pollypm-state",
+            logs_dir=tmp_path / ".pollypm-state/logs",
+            snapshots_dir=tmp_path / ".pollypm-state/snapshots",
+            state_db=tmp_path / ".pollypm-state/state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account="claude_1"),
+        accounts={
+            "claude_1": AccountConfig(
+                name="claude_1",
+                provider=ProviderKind.CLAUDE,
+                email="c@example.com",
+                home=tmp_path / ".pollypm-state/homes/claude_1",
+            ),
+        },
+        sessions={
+            "architect_demo": SessionConfig(
+                name="architect_demo",
+                role="architect",
+                provider=ProviderKind.CLAUDE,
+                account="claude_1",
+                cwd=tmp_path,
+                project="demo",
+                window_name="architect-demo",
+                agent_profile="architect",
+            ),
+        },
+        projects={
+            "demo": KnownProject(
+                key="demo",
+                path=tmp_path,
+                name="demo",
+                kind=ProjectKind.FOLDER,
+            )
+        },
+    )
+    # Imported lazily so the tmux/session_services wiring doesn't break
+    # simpler tests that only touch CLI.
+    from pollypm.supervisor import Supervisor
+
+    return Supervisor(config)
+
+
+def test_architect_session_resolves_architect_control_prompt(
+    tmp_path: Path,
+) -> None:
+    """``effective_session`` on an ``architect`` role session pulls the
+    architect persona's markdown prompt, NOT the worker prompt.
+
+    This is the load-bearing check for issue #257: without this the
+    architect session would start with either no prompt or (worse) the
+    worker's persona, producing nonsense behaviour at research-stage
+    kickoff.
+    """
+    sup = _supervisor_with_architect(tmp_path)
+    sup.ensure_layout()
+
+    session = sup.config.sessions["architect_demo"]
+    effective = sup.effective_session(session)
+    prompt = effective.prompt or ""
+    assert prompt, "architect session should receive a non-empty prompt"
+    # The architect persona markdown is unmistakable: it opens with
+    # "You are the PollyPM Architect" inside the <identity> block, and
+    # mentions "critic panel" in the principles. Assert both markers to
+    # prove we're not accidentally getting the worker prompt.
+    assert "PollyPM Architect" in prompt
+    assert "critic panel" in prompt.lower()
+    # Worker prompt opens with a different persona; guard against a
+    # silent swap by asserting the worker-specific phrasing is absent.
+    assert "You are a PollyPM worker" not in prompt
+
+
+def test_architect_role_is_in_initial_input_roles(tmp_path: Path) -> None:
+    """``_INITIAL_INPUT_ROLES`` gates whether the Supervisor actually
+    sends the control prompt into the pane on fresh launch. ``architect``
+    must be in the set or the session starts blank.
+    """
+    from pollypm.supervisor import Supervisor
+
+    assert "architect" in Supervisor._INITIAL_INPUT_ROLES
+    # But architect is NOT a control-plane role (project-scoped, not
+    # control-plane). The task description pins this as a constraint.
+    assert "architect" not in Supervisor._CONTROL_ROLES

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -219,7 +219,7 @@ def test_worker_start_creates_and_launches_managed_worker(monkeypatch, tmp_path:
     monkeypatch.setattr(
         cli,
         "create_worker_session",
-        lambda path, project_key, prompt=None: (
+        lambda path, project_key, prompt=None, role="worker", agent_profile=None: (
             created.append((path, project_key, prompt))
             or type("Session", (), {"name": "worker_pollypm"})()
         ),


### PR DESCRIPTION
Unblocks the planner flow. `pm project new` now auto-decomposes and drives to user approval.

## Changes
- `pm worker-start --role <role> --profile <profile>` — spawn non-worker sessions (default still worker)
- `_ROLE_STATIC_NAMES` + `role_candidate_names` handle architect as project-scoped role (same pattern as worker)
- Architect added to `_INITIAL_INPUT_ROLES` (#260 compat)
- `pm project new` auto-spawns architect session when planner is enabled (`--skip-planner` suppresses both)
- Architect's control prompt (`profiles/architect.md`) tells Archie to run pm task next on start

## Tests (+9, 0 new regressions)
- Architect session naming + lookup
- pm project new with/without --skip-planner
- Architect control prompt resolution
- Worker-start backward compatible

2234 passing. 3 pre-existing unrelated failures unchanged.

## Gotchas (tracked as follow-ups, not blocking)
1. Architect gets its own worktree lane (consistent with workers). Can switch to main-checkout later.
2. `pm task next --role <role>` aspirational — current command has `--agent` only.
3. `pm add-project` doesn't auto-spawn (only `pm project new` does).
4. Architect persistence in global config not per-project local. Minor.

Closes #257