### PR TITLE
fix(workservice): set busy_timeout=30000 so inbox UI doesn't error on brief locks

### DIFF
--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -108,10 +108,14 @@ class SQLiteWorkService:
         self._project_path = project_path
         self._sync = sync_manager
         self._session_mgr = session_manager
-        self._conn = sqlite3.connect(str(db_path))
+        self._conn = sqlite3.connect(str(db_path), timeout=30.0)
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA foreign_keys=ON")
+        # Wait up to 30s for busy locks before raising — prevents the
+        # Textual inbox UI from erroring when the heartbeat or other
+        # writers hold the DB briefly.
+        self._conn.execute("PRAGMA busy_timeout=30000")
         create_work_tables(self._conn)
         self._gate_registry = GateRegistry(project_path=project_path)
         # Last-provision-error breadcrumb — set by ``claim()`` when


### PR DESCRIPTION
Sam reported DB locking errors in the Textual inbox UI during reply/archive.

`SQLiteWorkService` opened connections with default `timeout=0` — any concurrent writer (heartbeat sweep, worker commit, event record) caused immediate `database is locked` errors. Matches the StateStore's 30s busy_timeout (already set at storage/state.py:501). WAL mode was already enabled so readers never block; this fixes writer-writer contention.

4-line change. Full inbox test suite (22 tests) still passing.