### PR TITLE
fix(rail): background ticker + pm-heartbeat fallback (#268 Gap A)

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import shutil
 import subprocess
@@ -8,6 +9,8 @@ import sys
 from pathlib import Path
 
 import typer
+
+logger = logging.getLogger(__name__)
 
 from pollypm.accounts import (
     add_account_via_login,
@@ -1226,12 +1229,44 @@ def heartbeat(
         return
     supervisor = _load_supervisor(config_path)
     alerts = supervisor.run_heartbeat(snapshot_lines=snapshot_lines)
+    # Fallback rail driver ("suspenders" to the cockpit ticker's "belt"):
+    # when no persistent host is running, the every-minute cron still
+    # advances recurring roster handlers (task_assignment.sweep,
+    # transcript.ingest, work.progress_sweep, etc.). If the cockpit is
+    # running, the CoreRail's HeartbeatRail is already booted and this
+    # is just one extra tick — no harm. See issue #268 Gap A.
+    _tick_core_rail_if_available(supervisor)
     if json_output:
         _emit_json({"alerts": alerts})
         return
     typer.echo(f"Heartbeat completed. Open alerts: {len(alerts)}")
     for alert in alerts:
         typer.echo(f"- {alert.severity} {alert.session_name}/{alert.alert_type}#{alert.alert_id}: {alert.message}")
+
+
+def _tick_core_rail_if_available(supervisor) -> None:
+    """Tick the process-wide HeartbeatRail if the supervisor exposes one.
+
+    No-ops silently when the rail isn't available (legacy supervisors,
+    mocked test harnesses, boot failures). Swallows tick exceptions so
+    a bad roster entry can't break the session-health heartbeat that
+    already ran above.
+    """
+    rail_getter = getattr(supervisor, "core_rail", None)
+    if rail_getter is None:
+        return
+    try:
+        # CoreRail.start() is idempotent and ensures the HeartbeatRail
+        # is booted. This is a transient driver — the worker pool drains
+        # anything we enqueue synchronously over the next few seconds.
+        rail_getter.start()
+        heartbeat_rail = rail_getter.get_heartbeat_rail()
+        if heartbeat_rail is None:
+            return
+        heartbeat_rail.tick()
+    except Exception:  # noqa: BLE001
+        # Non-fatal — session-health sweep already succeeded above.
+        logger.debug("pm heartbeat: core rail tick failed", exc_info=True)
 
 
 @app.command()

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -449,6 +449,29 @@ class PollyCockpitApp(App[None]):
         # waiting ~30s for the periodic check to fix it. See issue #102.
         self.set_timer(0.4, self._enforce_rail_width_once)
         self.set_timer(1.5, self._enforce_rail_width_once)
+        # Boot the HeartbeatRail so recurring roster handlers
+        # (task_assignment.sweep, transcript.ingest, work.progress_sweep,
+        # etc.) actually fire while the cockpit is open. The cockpit is
+        # the only long-lived Python process in production; short-lived
+        # CLIs like `pm up` exit before the rail can do useful work.
+        # Failures here are non-fatal — the TUI still works, just
+        # without autonomous sweeps. See issue #268 Gap A.
+        self._start_core_rail()
+
+    def _start_core_rail(self) -> None:
+        """Start the process-wide HeartbeatRail via the supervisor, best-effort."""
+        try:
+            supervisor = self.router._load_supervisor()
+        except Exception:  # noqa: BLE001
+            return
+        rail = getattr(supervisor, "core_rail", None)
+        if rail is None:
+            return
+        try:
+            rail.start()
+        except Exception:  # noqa: BLE001
+            # Already logged by CoreRail; swallow so the TUI still mounts.
+            pass
 
     def _enforce_rail_width_once(self) -> None:
         try:
@@ -773,6 +796,15 @@ class PollyCockpitApp(App[None]):
         try:
             sup = self.router._supervisor
             if sup is not None:
+                # Stop the CoreRail (and its HeartbeatRail ticker thread)
+                # before closing the store so the ticker isn't racing
+                # shutdown. CoreRail.stop() is idempotent.
+                rail = getattr(sup, "core_rail", None)
+                if rail is not None:
+                    try:
+                        rail.stop()
+                    except Exception:  # noqa: BLE001
+                        pass
                 # Release any cockpit-held leases
                 for lease in sup.store.list_leases():
                     if lease.owner == "cockpit":

--- a/src/pollypm/heartbeat/boot.py
+++ b/src/pollypm/heartbeat/boot.py
@@ -21,6 +21,7 @@ the knob in config avoids plumbing it through every construction call.
 from __future__ import annotations
 
 import logging
+import threading
 import tomllib
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -38,6 +39,10 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_WORKER_CONCURRENCY = 4
+
+# Default ticker cadence. 15s gives two ticks per 30s roster entry so
+# any ``@every 30s`` handler fires with at most 15s latency.
+DEFAULT_TICK_INTERVAL_SECONDS = 15.0
 
 
 @dataclass(slots=True)
@@ -102,9 +107,18 @@ class HeartbeatRail:
     The roster is built from the plugin host at construction. The handler
     registry is also resolved via the plugin host so newly-registered
     handlers fire on the next tick without a restart.
+
+    ``start()`` also spawns a daemon ticker thread that calls ``tick()``
+    on a fixed interval so any long-lived process that calls
+    ``rail.start()`` gets periodic ticks for free. The ticker exits when
+    ``stop()`` sets the stop event. For tests, use ``tick()`` directly —
+    the ticker is a deployment-time convenience, not a test dependency.
     """
 
-    __slots__ = ("queue", "pool", "heartbeat", "roster", "_concurrency")
+    __slots__ = (
+        "queue", "pool", "heartbeat", "roster", "_concurrency",
+        "_tick_interval", "_tick_thread", "_tick_stop",
+    )
 
     def __init__(
         self,
@@ -114,12 +128,20 @@ class HeartbeatRail:
         heartbeat: Heartbeat,
         roster: Roster,
         concurrency: int = DEFAULT_WORKER_CONCURRENCY,
+        tick_interval_seconds: float = DEFAULT_TICK_INTERVAL_SECONDS,
     ) -> None:
         self.queue = queue
         self.pool = pool
         self.heartbeat = heartbeat
         self.roster = roster
         self._concurrency = concurrency
+        self._tick_interval = (
+            float(tick_interval_seconds)
+            if tick_interval_seconds and tick_interval_seconds > 0
+            else DEFAULT_TICK_INTERVAL_SECONDS
+        )
+        self._tick_thread: threading.Thread | None = None
+        self._tick_stop = threading.Event()
 
     # ------------------------------------------------------------------
     # Construction
@@ -133,6 +155,7 @@ class HeartbeatRail:
         plugin_host: Any,
         config_path: Path | None = None,
         concurrency: int | None = None,
+        tick_interval_seconds: float = DEFAULT_TICK_INTERVAL_SECONDS,
     ) -> "HeartbeatRail":
         """Build a HeartbeatRail from an already-resolved plugin host + DB path.
 
@@ -172,6 +195,7 @@ class HeartbeatRail:
         return cls(
             queue=queue, pool=pool, heartbeat=heartbeat,
             roster=roster, concurrency=effective_concurrency,
+            tick_interval_seconds=tick_interval_seconds,
         )
 
     @classmethod
@@ -191,13 +215,57 @@ class HeartbeatRail:
     # ------------------------------------------------------------------
 
     def start(self) -> None:
-        """Start the worker pool. Idempotent — no-op if already started."""
+        """Start the worker pool and the background ticker. Idempotent.
+
+        Spawns a daemon thread that calls :meth:`tick` every
+        ``tick_interval_seconds`` seconds so recurring roster handlers
+        actually fire in long-lived processes (cockpit TUI, future
+        daemons) without requiring callers to wire their own clock.
+        Calling ``start()`` again while already running is a silent
+        no-op — a second ticker thread is never spawned.
+        """
         if self.pool.is_running:
             return
         self.pool.start(concurrency=self._concurrency)
+        # Reset the stop event in case ``stop()`` + ``start()`` is called
+        # on the same rail (the pool is re-startable).
+        self._tick_stop.clear()
+        thread = self._tick_thread
+        if thread is not None and thread.is_alive():
+            # Defensive: should be unreachable because pool.is_running
+            # gates entry, but belt-and-suspenders if a caller manually
+            # pokes the pool.
+            return
+        self._tick_thread = threading.Thread(
+            target=self._tick_loop,
+            daemon=True,
+            name="HeartbeatRail-ticker",
+        )
+        self._tick_thread.start()
+
+    def _tick_loop(self) -> None:
+        """Background loop: ``tick()`` every ``_tick_interval`` seconds.
+
+        Exits as soon as ``_tick_stop`` is set. Exceptions from ``tick``
+        are logged and swallowed so one bad tick can't kill the thread —
+        the next iteration will try again.
+        """
+        # ``Event.wait(timeout)`` returns True when the event is set,
+        # False when the timeout elapses. Looping "while not wait()"
+        # gives us a clean interval-plus-fast-shutdown pattern.
+        while not self._tick_stop.wait(self._tick_interval):
+            try:
+                self.tick()
+            except Exception:  # noqa: BLE001
+                logger.exception("HeartbeatRail tick failed; continuing")
 
     def stop(self, *, timeout: float = 10.0) -> None:
-        """Stop the worker pool and close the queue connection."""
+        """Stop the ticker, the worker pool, and close the queue."""
+        self._tick_stop.set()
+        thread = self._tick_thread
+        if thread is not None:
+            thread.join(timeout=timeout)
+            self._tick_thread = None
         try:
             self.pool.stop(timeout=timeout)
         finally:

--- a/tests/test_rail_ticker.py
+++ b/tests/test_rail_ticker.py
@@ -1,0 +1,230 @@
+"""Tests for the HeartbeatRail background ticker thread + heartbeat CLI fallback.
+
+Covers the fix for #268 Gap A — in production nothing was calling
+``rail.tick(now)`` on a schedule, so roster-registered recurring
+handlers (e.g. ``task_assignment.sweep``) never fired. Two
+complementary drivers now exist:
+
+  1. A daemon ticker thread inside ``HeartbeatRail.start()`` that calls
+     ``tick()`` on a fixed interval (default 15s). Any long-lived
+     process that boots the rail (cockpit TUI) gets periodic ticks for
+     free.
+  2. ``pm heartbeat`` as a cron-driven fallback. Even without a
+     persistent host, the every-minute cron ticks the rail so the
+     pipeline keeps advancing.
+
+The ticker is deployment-time behavior — tests call ``tick()``
+directly and only use the thread in lifecycle assertions (spawn,
+idempotent, stop). Scheduling correctness belongs to the
+heartbeat-tick tests, not here.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from pollypm.heartbeat import Roster
+from pollypm.heartbeat.boot import HeartbeatRail
+from pollypm.jobs import JobHandlerRegistry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeHost:
+    """Minimal plugin-host stand-in (mirrors test_core_recurring_migration)."""
+
+    def __init__(self, roster: Roster, registry: JobHandlerRegistry) -> None:
+        self._roster = roster
+        self._registry = registry
+
+    def build_roster(self) -> Roster:
+        return self._roster
+
+    def job_handler_registry(self) -> JobHandlerRegistry:
+        return self._registry
+
+
+def _build_rail(tmp_path: Path, *, tick_interval: float = 0.05) -> HeartbeatRail:
+    roster = Roster()
+    registry = JobHandlerRegistry()
+    host = _FakeHost(roster, registry)
+    return HeartbeatRail.from_plugin_host(
+        state_db=tmp_path / "state.db",
+        plugin_host=host,
+        concurrency=1,
+        tick_interval_seconds=tick_interval,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ticker thread lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestTickerThreadLifecycle:
+    def test_start_spawns_daemon_ticker_thread(self, tmp_path: Path) -> None:
+        rail = _build_rail(tmp_path)
+        try:
+            rail.start()
+            ticker = rail._tick_thread
+            assert ticker is not None
+            assert ticker.is_alive()
+            assert ticker.daemon is True  # must not block interpreter exit
+            assert ticker.name == "HeartbeatRail-ticker"
+        finally:
+            rail.stop(timeout=2)
+
+    def test_start_is_idempotent_no_double_spawn(self, tmp_path: Path) -> None:
+        rail = _build_rail(tmp_path)
+        try:
+            rail.start()
+            first_ticker = rail._tick_thread
+            assert first_ticker is not None
+
+            # Count global HeartbeatRail-ticker threads before second start.
+            names_before = [
+                t.name for t in threading.enumerate()
+                if t.name == "HeartbeatRail-ticker"
+            ]
+            rail.start()  # second call must be a no-op
+            names_after = [
+                t.name for t in threading.enumerate()
+                if t.name == "HeartbeatRail-ticker"
+            ]
+
+            assert rail._tick_thread is first_ticker
+            assert len(names_after) == len(names_before)
+        finally:
+            rail.stop(timeout=2)
+
+    def test_stop_sets_event_and_thread_exits(self, tmp_path: Path) -> None:
+        rail = _build_rail(tmp_path, tick_interval=0.05)
+        rail.start()
+        ticker = rail._tick_thread
+        assert ticker is not None and ticker.is_alive()
+
+        rail.stop(timeout=2)
+
+        assert rail._tick_stop.is_set()
+        assert not ticker.is_alive(), "ticker thread did not exit after stop()"
+        assert rail._tick_thread is None
+
+    def test_tick_exception_does_not_kill_thread(self, tmp_path: Path) -> None:
+        """One bad tick must not kill the ticker — next iteration keeps going."""
+        call_count = {"n": 0}
+
+        class _FlakyRail(HeartbeatRail):
+            """HeartbeatRail subclass whose first tick() raises."""
+
+            __slots__ = ()
+
+            def tick(self, now=None):  # type: ignore[override]
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    raise RuntimeError("boom")
+                return super().tick(now)
+
+        # Build a rail and wrap it in the flaky subclass by adopting its
+        # state. Easiest path: construct the underlying trio ourselves.
+        roster = Roster()
+        registry = JobHandlerRegistry()
+        host = _FakeHost(roster, registry)
+        base = HeartbeatRail.from_plugin_host(
+            state_db=tmp_path / "state.db",
+            plugin_host=host,
+            concurrency=1,
+            tick_interval_seconds=0.02,
+        )
+        rail = _FlakyRail(
+            queue=base.queue,
+            pool=base.pool,
+            heartbeat=base.heartbeat,
+            roster=base.roster,
+            concurrency=1,
+            tick_interval_seconds=0.02,
+        )
+
+        rail.start()
+        try:
+            # Wait until the ticker has called tick() at least twice.
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline and call_count["n"] < 2:
+                time.sleep(0.02)
+            assert call_count["n"] >= 2, (
+                f"ticker died after first exception (calls={call_count['n']})"
+            )
+            # And the thread must still be alive.
+            assert rail._tick_thread is not None
+            assert rail._tick_thread.is_alive()
+        finally:
+            rail.stop(timeout=2)
+
+
+# ---------------------------------------------------------------------------
+# `pm heartbeat` CLI fallback driver
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatCliFallbackTick:
+    def test_tick_called_when_rail_available(self) -> None:
+        """``_tick_core_rail_if_available`` drives the heartbeat rail once."""
+        from pollypm.cli import _tick_core_rail_if_available
+
+        heartbeat_rail = MagicMock()
+        core_rail = MagicMock()
+        core_rail.get_heartbeat_rail.return_value = heartbeat_rail
+
+        supervisor = MagicMock()
+        supervisor.core_rail = core_rail
+
+        _tick_core_rail_if_available(supervisor)
+
+        core_rail.start.assert_called_once()
+        heartbeat_rail.tick.assert_called_once()
+
+    def test_noop_when_supervisor_has_no_core_rail(self) -> None:
+        """Legacy / mocked supervisors without ``core_rail`` don't crash."""
+        from pollypm.cli import _tick_core_rail_if_available
+
+        # A supervisor without ``core_rail`` attribute at all.
+        class _Legacy:
+            pass
+
+        # Should simply return without raising.
+        _tick_core_rail_if_available(_Legacy())
+
+    def test_noop_when_heartbeat_rail_not_booted(self) -> None:
+        """If CoreRail.get_heartbeat_rail returns None, silently skip tick."""
+        from pollypm.cli import _tick_core_rail_if_available
+
+        core_rail = MagicMock()
+        core_rail.get_heartbeat_rail.return_value = None
+
+        supervisor = MagicMock()
+        supervisor.core_rail = core_rail
+
+        # Must not raise even though there's no heartbeat rail to tick.
+        _tick_core_rail_if_available(supervisor)
+        core_rail.start.assert_called_once()
+
+    def test_tick_exception_is_swallowed(self) -> None:
+        """A raising tick() must not propagate out of the CLI helper."""
+        from pollypm.cli import _tick_core_rail_if_available
+
+        heartbeat_rail = MagicMock()
+        heartbeat_rail.tick.side_effect = RuntimeError("boom")
+        core_rail = MagicMock()
+        core_rail.get_heartbeat_rail.return_value = heartbeat_rail
+
+        supervisor = MagicMock()
+        supervisor.core_rail = core_rail
+
+        # Must not raise — session-health sweep already succeeded upstream.
+        _tick_core_rail_if_available(supervisor)
+        heartbeat_rail.tick.assert_called_once()


### PR DESCRIPTION
Scheduler was wired but no one called rail.tick() in production. pm up was short-lived so even if a caller existed, the worker pool died with it. Belt-and-suspenders fix per Polly's investigation.

## Changes
1. HeartbeatRail.start() spawns daemon 'HeartbeatRail-ticker' thread — tick() every tick_interval_seconds (default 15s). Stop event + join on stop(). Idempotent. Bad-tick exceptions swallowed.
2. Cockpit TUI boots the rail in on_mount / stops in on_unmount — the long-lived host for the ticker.
3. pm heartbeat CLI now also ticks the rail as fallback — covers the CLI-only case.

## Tests (+8, 0 new regressions)
Ticker lifecycle (spawn, double-start idempotence, stop-and-join, exception resilience) + CLI fallback tick (rail available/not-present/returns-None/raises).

2232 passing. 4 failures — 3 pre-existing known unrelated; 1 artifact of isolated-HOME test setup that passes with real HOME (verified).

## Heads up
Agent hit 2GB state.db slowing test runs. Sam — run pm heartbeat's new vacuum handler (#267 daily @ 4:07 am) or manual VACUUM to get that back under control.

Closes #268 Gap A