### PR TITLE
feat(cockpit-inbox): list shows project · age on 2 lines, reply box always visible

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -1888,35 +1888,44 @@ def _format_sender(task) -> str:
     return "polly"
 
 
-def _format_inbox_row(task, *, is_unread: bool) -> Text:
-    """Render one inbox-list row as Rich text.
+def _format_inbox_row(task, *, is_unread: bool, width: int = 38) -> Text:
+    """Render one inbox-list row as two lines of Rich text.
 
     Matches the cockpit aesthetic from RailItem: yellow diamond for
-    unread, dim open circle for read. Subject truncates at ~38 chars so
-    age + indicator stay visible on a 60-col list pane.
+    unread, dim open circle for read.
+
+    Line 1 is the bold message title (truncated with an ellipsis if it
+    won't fit ``width`` chars after the unread-marker glyph — no wrap).
+    Line 2 is dim ``project · age`` metadata indented under the title.
     """
     from pollypm.tz import format_relative
 
-    text = Text()
+    text = Text(no_wrap=True, overflow="ellipsis")
     if is_unread:
         text.append("\u25c6 ", style="#f0c45a")  # yellow diamond
     else:
         text.append("\u25cb ", style="#4a5568")  # dim circle
-    sender = _format_sender(task)
-    text.append(f"{sender:<7}", style="#97a6b2")
-    text.append("  ")
     subject = task.title or "(no subject)"
-    max_subject = 38
+    # Account for the 2-char marker glyph prefix so the total row still
+    # fits the target list-pane width without wrapping.
+    max_subject = max(8, width - 2)
     if len(subject) > max_subject:
         subject = subject[: max_subject - 1] + "\u2026"
-    subject_style = "bold #eef2f4" if is_unread else "#b8c4cf"
+    subject_style = "bold #eef2f4" if is_unread else "bold #b8c4cf"
     text.append(subject, style=subject_style)
+
+    # Line 2: project · age, dim. Indent by 2 so it lines up under the
+    # subject text (past the marker glyph).
     updated = task.updated_at
     iso = updated.isoformat() if hasattr(updated, "isoformat") else str(updated or "")
     age = format_relative(iso) if iso else ""
+    project = (task.project or "").strip() or "\u2014"
+    meta_bits = [project]
     if age:
-        # Right-align age as a separate dim run so the subject can flex.
-        text.append(f"  · {age}", style="#4a5568")
+        meta_bits.append(age)
+    meta_line = "  " + "  \u00b7  ".join(meta_bits)
+    text.append("\n")
+    text.append(meta_line, style="#6b7a88")
     return text
 
 
@@ -1973,7 +1982,7 @@ class PollyInboxApp(App[None]):
         scrollbar-color: #2a3340;
     }
     #inbox-list > .inbox-row {
-        height: 2;
+        height: 3;
         padding: 0 1;
         color: #d6dee5;
         background: transparent;
@@ -2010,10 +2019,10 @@ class PollyInboxApp(App[None]):
         padding: 0 1;
         background: #111820;
         border: round #2a3340;
-        display: none;
+        color: #d6dee5;
     }
-    #inbox-reply.visible {
-        display: block;
+    #inbox-reply:focus {
+        border: round #5b8aff;
     }
     #inbox-status {
         height: 1;
@@ -2062,7 +2071,7 @@ class PollyInboxApp(App[None]):
         self.list_view = ListView(id="inbox-list")
         self.detail = Static("", id="inbox-detail", markup=True)
         self.reply_input = Input(
-            placeholder="Reply … (Enter to send, Esc to cancel)",
+            placeholder="Reply \u2026 (Enter to send, Esc back to list)",
             id="inbox-reply",
         )
         self.status = Static("", id="inbox-status")
@@ -2072,7 +2081,6 @@ class PollyInboxApp(App[None]):
         )
         self._tasks: list = []
         self._selected_task_id: str | None = None
-        self._reply_target_id: str | None = None
         self._unread_ids: set[str] = set()
 
     def compose(self) -> ComposeResult:
@@ -2304,6 +2312,10 @@ class PollyInboxApp(App[None]):
         if task.task_id == self._selected_task_id:
             return
         self._selected_task_id = task.task_id
+        # Clear any in-progress reply draft when the selection changes so
+        # a half-typed message doesn't get posted to a different task.
+        if self.reply_input.value:
+            self.reply_input.value = ""
         self._render_detail(task.task_id)
         self._mark_open_read(task.task_id, idx)
 
@@ -2336,9 +2348,11 @@ class PollyInboxApp(App[None]):
         self._refresh_list(select_first=False)
 
     def action_back_or_cancel(self) -> None:
-        """Esc/q cancels an open reply; otherwise returns to cockpit nav."""
-        if self.reply_input.has_class("visible"):
-            self._cancel_reply()
+        """Esc/q returns focus to the list from the reply box, else exits."""
+        if self.reply_input.has_focus:
+            # Return focus to the list so j/k works again. Don't exit the
+            # app — the reply input is always present on the detail pane.
+            self.list_view.focus()
             return
         self.exit()
 
@@ -2362,6 +2376,8 @@ class PollyInboxApp(App[None]):
         if self._selected_task_id == row.task_id:
             return
         self._selected_task_id = row.task_id
+        if self.reply_input.value:
+            self.reply_input.value = ""
         self._render_detail(row.task_id)
 
     # ------------------------------------------------------------------
@@ -2431,37 +2447,33 @@ class PollyInboxApp(App[None]):
         self._render_list(select_first=bool(self._tasks))
 
     def action_start_reply(self) -> None:
+        """Keyboard shortcut: focus the always-visible reply input."""
         task_id = self._selected_task_id
         if task_id is None:
             return
-        self._reply_target_id = task_id
-        self.reply_input.value = ""
-        self.reply_input.add_class("visible")
         self.reply_input.focus()
-
-    def _cancel_reply(self) -> None:
-        self._reply_target_id = None
-        self.reply_input.value = ""
-        self.reply_input.remove_class("visible")
-        self.list_view.focus()
 
     @on(Input.Submitted, "#inbox-reply")
     def _on_reply_submitted(self, event: Input.Submitted) -> None:
         body = (event.value or "").strip()
-        task_id = self._reply_target_id
+        task_id = self._selected_task_id
         if not body or not task_id:
-            self._cancel_reply()
+            # Empty submit — just hand focus back to the list.
+            self.reply_input.value = ""
+            self.list_view.focus()
             return
         svc = self._svc_for_task(task_id)
         if svc is None:
             self.notify("Could not open project database.", severity="error")
-            self._cancel_reply()
+            self.reply_input.value = ""
+            self.list_view.focus()
             return
         try:
             svc.add_reply(task_id, body, actor="user")
         except Exception as exc:  # noqa: BLE001
             self.notify(f"Reply failed: {exc}", severity="error")
-            self._cancel_reply()
+            self.reply_input.value = ""
+            self.list_view.focus()
             return
         finally:
             try:
@@ -2471,8 +2483,10 @@ class PollyInboxApp(App[None]):
         self._emit_event(
             task_id, "inbox.reply_received", f"user replied to {task_id}: {body[:60]}",
         )
-        self._cancel_reply()
-        # Re-render the detail pane so the new reply appears in-thread.
+        # Clear the input and re-render so the new reply appears in-thread.
+        # Keep focus on the list so j/k works without further keystrokes.
+        self.reply_input.value = ""
+        self.list_view.focus()
         self._render_detail(task_id)
 
     # ------------------------------------------------------------------

--- a/tests/test_cockpit_inbox_ui.py
+++ b/tests/test_cockpit_inbox_ui.py
@@ -126,6 +126,43 @@ def test_inbox_lists_seeded_messages(inbox_env, inbox_app) -> None:
     _run(body())
 
 
+def test_list_row_renders_title_on_line1_and_project_age_on_line2(
+    inbox_env, inbox_app,
+) -> None:
+    """Each row is two lines: bold title, then dim ``project · age``.
+
+    The sender (always "polly") must NOT appear in the row; project key
+    is more useful across a multi-project workspace.
+    """
+    async def body() -> None:
+        async with inbox_app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            from pollypm.cockpit_ui import _InboxListItem, _format_inbox_row
+            rows = [
+                child for child in inbox_app.list_view.children
+                if isinstance(child, _InboxListItem)
+            ]
+            assert rows, "expected at least one inbox row"
+            first = rows[0]
+            # Re-derive the Rich Text from the public helper so we're not
+            # probing Textual's private Static internals.
+            rendered = _format_inbox_row(first.task_ref, is_unread=first.is_unread)
+            plain = rendered.plain
+            # Two lines — title then metadata.
+            lines = plain.split("\n")
+            assert len(lines) == 2, f"expected 2 lines, got: {lines!r}"
+            # Line 1 holds the subject (one of the seeded titles).
+            assert any(
+                s in lines[0] for s in ("Smoke", "Deploy", "Homepage")
+            ), f"expected a seeded title on line 1, got: {lines[0]!r}"
+            # Line 2 has the project key; never the sender "polly".
+            assert "demo" in lines[1]
+            assert "polly" not in lines[1].lower()
+            # Age is relative — "just now" is fine for a freshly-seeded row.
+            assert "\u00b7" in lines[1] or "ago" in lines[1] or "now" in lines[1]
+    _run(body())
+
+
 def test_selecting_a_row_renders_detail_and_clears_unread(inbox_env, inbox_app) -> None:
     """Keyboard navigation opens the message and records a read marker."""
     async def body() -> None:
@@ -152,8 +189,63 @@ def test_selecting_a_row_renders_detail_and_clears_unread(inbox_env, inbox_app) 
     _run(body())
 
 
+def test_reply_input_is_always_present_on_detail_open(inbox_env, inbox_app) -> None:
+    """Reply Input is visible from mount — not gated by pressing ``r``.
+
+    The list keeps focus on mount so j/k still works; the user must
+    explicitly press ``r`` (or Tab/click) to land in the reply box.
+    """
+    async def body() -> None:
+        async with inbox_app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            # Reply Input exists in the widget tree from first paint.
+            assert inbox_app.reply_input.is_mounted
+            # It is visually shown (always-visible design — no toggle class).
+            assert inbox_app.reply_input.display is not False
+            # The list, not the reply box, has focus on mount.
+            assert inbox_app.list_view.has_focus
+            assert not inbox_app.reply_input.has_focus
+    _run(body())
+
+
+def test_r_shortcut_focuses_reply_without_toggling_visibility(
+    inbox_env, inbox_app,
+) -> None:
+    """Pressing ``r`` focuses the already-visible reply box."""
+    async def body() -> None:
+        async with inbox_app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            inbox_app.list_view.index = 0
+            await pilot.press("enter")
+            await pilot.pause()
+            assert not inbox_app.reply_input.has_focus
+            await pilot.press("r")
+            await pilot.pause()
+            assert inbox_app.reply_input.has_focus
+    _run(body())
+
+
+def test_esc_from_reply_returns_focus_to_list(inbox_env, inbox_app) -> None:
+    """Esc inside the reply box hands focus back to the list (no exit)."""
+    async def body() -> None:
+        async with inbox_app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            inbox_app.list_view.index = 0
+            await pilot.press("enter")
+            await pilot.pause()
+            await pilot.press("r")
+            await pilot.pause()
+            assert inbox_app.reply_input.has_focus
+            await pilot.press("escape")
+            await pilot.pause()
+            # Focus is back on the list and the app is still running.
+            assert inbox_app.list_view.has_focus
+            assert not inbox_app.reply_input.has_focus
+    _run(body())
+
+
 def test_reply_flow_persists_and_appears_in_thread(inbox_env, inbox_app) -> None:
-    """r opens the reply input; Enter posts; detail pane re-renders the thread."""
+    """Typing in the always-visible reply + Enter posts and clears the input."""
     async def body() -> None:
         async with inbox_app.run_test(size=(140, 40)) as pilot:
             await pilot.pause()
@@ -163,10 +255,9 @@ def test_reply_flow_persists_and_appears_in_thread(inbox_env, inbox_app) -> None
             task_id = inbox_app._selected_task_id
             assert task_id is not None
 
-            # Pressing r reveals the reply input.
+            # Focus the reply box via the keyboard shortcut.
             await pilot.press("r")
             await pilot.pause()
-            assert inbox_app.reply_input.has_class("visible")
             assert inbox_app.reply_input.has_focus
 
             # Type a reply and submit.
@@ -174,8 +265,9 @@ def test_reply_flow_persists_and_appears_in_thread(inbox_env, inbox_app) -> None
             await pilot.press("enter")
             await pilot.pause()
 
-            # Input closes, focus returns to the list.
-            assert not inbox_app.reply_input.has_class("visible")
+            # Input is cleared and focus returns to the list.
+            assert inbox_app.reply_input.value == ""
+            assert inbox_app.list_view.has_focus
 
             # The reply is persisted as a reply context row.
             svc = inbox_app._svc_for_task(task_id)


### PR DESCRIPTION
Sam's first-pass UX refinements to the Textual inbox:

## List items (was: sender · subject · age)
Two-line rows:
- Line 1: bold title (truncated with ellipsis)
- Line 2: dim project · age

Yellow-diamond unread marker still leftmost. 3-row CSS height gives breathing room.

## Reply box
Always visible at bottom of detail pane — no need to press 'r' to reveal it. 'r' now just focuses the existing input. Esc from input returns focus to list. List nav keys don't steal focus from input.

## Design choices
- Selection-change clears partial reply draft (prevents accidentally replying to wrong task)
- Empty state still mounts the input (no-op on Enter; no crash)
- Detail header still shows sender (not specified to remove)

## Tests (+4, 0 regressions)
26 passed (was 22) in tests/test_cockpit_inbox_ui.py + tests/test_inbox_actions.py. Full cockpit/inbox suite green.