### PR TITLE
fix(planner): gate reads plan_approved_at timestamp instead of file mtime (#281)

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/plan_presence.py
+++ b/src/pollypm/plugins_builtin/project_planning/plan_presence.py
@@ -1,4 +1,4 @@
-"""Plan-presence gate — issue #273.
+"""Plan-presence gate — issues #273, #281.
 
 The sweeper refuses to delegate implementation tasks for a project
 until that project has a non-trivial, user-approved plan on disk.
@@ -30,10 +30,15 @@ A plan is "acceptable" iff ALL of the following hold:
 3. That done task's ``user_approval`` flow-node execution carries a
    ``decision='approved'`` — a ``rejected`` decision disqualifies the
    plan even if the file looks complete.
-4. ``plan.md``'s mtime is greater than or equal to the most recent
-   non-planning task's ``created_at`` timestamp in the project. Projects
-   with no non-planning tasks (fresh planner run, nothing emitted yet)
-   auto-pass this check.
+4. The plan's approval timestamp is greater than or equal to the most
+   recent non-planning task's ``created_at`` timestamp in the project.
+   Projects with no non-planning tasks auto-pass this staleness check.
+   (#281) The approval timestamp comes from a ``plan_approved`` context
+   entry written when the user approves the user_approval node. For
+   plans approved before this change shipped, the timestamp falls back
+   to the ``user_approval`` execution's ``completed_at``. File mtime
+   is **not** used — git operations, editor saves, and the planner's
+   own stage-8 emit all perturb it, making the gate unstable.
 
 A separate helper — ``task_bypasses_plan_gate`` — returns True when a
 task should skip the gate entirely. Two cases:
@@ -148,6 +153,57 @@ def _find_approved_plan_task(work_service: Any, project_key: str) -> Any | None:
     return None
 
 
+def _plan_approved_at(work_service: Any, plan_task: Any) -> float | None:
+    """Return the approval timestamp (epoch seconds) for ``plan_task``.
+
+    Preferred source: a ``work_context_entries`` row with
+    ``entry_type='plan_approved'`` — written inside the work-service
+    ``approve()`` call when a ``plan_project`` task's ``user_approval``
+    node is approved (issue #281).
+
+    Fallback for plans approved before #281 shipped: derive the
+    timestamp from the ``user_approval`` execution's ``completed_at``.
+    The fallback is critical — without it, every project that planned
+    pre-fix would be stuck behind the gate forever.
+
+    Returns None only when the plan is malformed (approved but no
+    completion timestamp anywhere) — which is vanishingly rare and
+    fails closed on the staleness check.
+    """
+    task_id = getattr(plan_task, "task_id", None)
+    if task_id:
+        try:
+            entries = work_service.get_context(
+                task_id, entry_type="plan_approved",
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "plan_presence: get_context failed for %s", task_id,
+                exc_info=True,
+            )
+            entries = []
+        if entries:
+            # get_context returns newest-first; take the most recent.
+            ts = entries[0].timestamp
+            if ts is not None:
+                return ts.timestamp()
+
+    # Fallback: the user_approval execution's completed_at. Walk
+    # backwards to find the latest APPROVED execution, matching the
+    # scan in _find_approved_plan_task.
+    for execution in reversed(getattr(plan_task, "executions", []) or []):
+        if execution.node_id != _APPROVAL_NODE:
+            continue
+        if execution.status is not ExecutionStatus.COMPLETED:
+            continue
+        if execution.decision is Decision.APPROVED:
+            completed = execution.completed_at
+            if completed is not None:
+                return completed.timestamp()
+            return None
+    return None
+
+
 def _latest_backlog_created_at(work_service: Any, project_key: str) -> float | None:
     """Return the most recent ``created_at`` timestamp across non-planning tasks.
 
@@ -189,9 +245,8 @@ def has_acceptable_plan(
     """Return True iff the project has a non-trivial, approved, fresh plan.
 
     See module docstring for the precise four-part contract. Fails
-    closed on any error — if we can't read the plan file, we can't
-    resolve the work service, or the plan mtime can't be stat'd, the
-    gate denies.
+    closed on any error — if we can't read the plan file, or we can't
+    derive the plan's approval timestamp, the gate denies.
 
     Callers should cache results per ``(project_key, sweep_tick)`` to
     avoid repeated disk reads across the many-queued-tasks case.
@@ -201,18 +256,23 @@ def has_acceptable_plan(
     plan_path = _resolve_plan_path(project_path, plan_dir)
     if not _plan_file_non_trivial(plan_path):
         return False
-    if _find_approved_plan_task(work_service, project_key) is None:
+    plan_task = _find_approved_plan_task(work_service, project_key)
+    if plan_task is None:
         return False
-    # Staleness check: plan.md must be at least as new as the newest
-    # non-planning task. If there's no backlog yet, nothing to be
-    # stale against.
+    # Staleness check (#281): the plan_approved timestamp must be at
+    # least as recent as the newest non-planning task. Timestamp comes
+    # from the ``plan_approved`` context entry written at approve()
+    # time; falls back to the user_approval execution's completed_at
+    # for plans approved pre-#281. If there's no backlog yet, nothing
+    # to be stale against. File mtime is intentionally NOT used —
+    # it's perturbed by git checkouts, editor saves, and the
+    # planner's own stage-8 emit.
     latest_backlog = _latest_backlog_created_at(work_service, project_key)
     if latest_backlog is not None:
-        try:
-            plan_mtime = plan_path.stat().st_mtime
-        except OSError:
+        plan_approved_ts = _plan_approved_at(work_service, plan_task)
+        if plan_approved_ts is None:
             return False
-        if plan_mtime < latest_backlog:
+        if plan_approved_ts < latest_backlog:
             return False
     return True
 

--- a/tests/test_plan_presence_gate.py
+++ b/tests/test_plan_presence_gate.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import os
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from pollypm.plugins_builtin.project_planning.plan_presence import (
@@ -130,7 +130,12 @@ def _create_queued_impl_task(
 
 
 def _create_done_approved_plan_task(
-    project_path: Path, *, project_key: str, decision: Decision = Decision.APPROVED,
+    project_path: Path,
+    *,
+    project_key: str,
+    decision: Decision = Decision.APPROVED,
+    approved_at: datetime | None = None,
+    write_plan_approved_entry: bool = True,
 ) -> None:
     """Stamp a plan_project task as done + approved via direct SQL.
 
@@ -141,6 +146,16 @@ def _create_done_approved_plan_task(
 
     ``decision`` lets the caller simulate a rejected outcome for the
     ``rejected`` test case.
+
+    ``approved_at`` overrides the timestamp stamped on both the
+    ``user_approval`` execution and the ``plan_approved`` context
+    entry. Pass a past ``datetime`` to simulate a stale approval.
+    Defaults to "now".
+
+    ``write_plan_approved_entry`` gates whether the explicit
+    ``plan_approved`` context entry is written. Pass ``False`` to
+    simulate a project that was approved *before* issue #281 shipped,
+    so the gate must fall back to the execution's ``completed_at``.
     """
     db_path = project_path / ".pollypm" / "state.db"
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -164,7 +179,8 @@ def _create_done_approved_plan_task(
             (WorkStatus.DONE.value, project_key, task.task_number),
         )
         # Insert a user_approval execution row carrying the decision.
-        now = datetime.now(timezone.utc).isoformat()
+        stamp = approved_at or datetime.now(timezone.utc)
+        stamp_iso = stamp.isoformat()
         work._conn.execute(
             "INSERT INTO work_node_executions "
             "(task_project, task_number, node_id, visit, status, "
@@ -177,10 +193,31 @@ def _create_done_approved_plan_task(
                 1,
                 ExecutionStatus.COMPLETED.value,
                 decision.value,
-                now,
-                now,
+                stamp_iso,
+                stamp_iso,
             ),
         )
+        # Mirror the work-service behaviour (#281): on approve(), a
+        # plan_approved context entry is written. Tests can opt out
+        # to simulate pre-fix projects.
+        if (
+            decision is Decision.APPROVED
+            and write_plan_approved_entry
+        ):
+            work._conn.execute(
+                "INSERT INTO work_context_entries "
+                "(task_project, task_number, actor, text, "
+                "created_at, entry_type) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    project_key,
+                    task.task_number,
+                    "user",
+                    "plan approved",
+                    stamp_iso,
+                    "plan_approved",
+                ),
+            )
         work._conn.commit()
     finally:
         work.close()
@@ -307,6 +344,168 @@ class TestPredicate:
 
 
 # ---------------------------------------------------------------------------
+# #281 — plan_approved_at timestamp gate
+# ---------------------------------------------------------------------------
+
+
+class TestPlanApprovedAtTimestamp:
+    """Unit tests for the #281 timestamp-based freshness check.
+
+    These pin the fix that replaces file mtime with a work-service
+    timestamp. Each test drives the predicate directly via
+    ``has_acceptable_plan``; the sweep-handler layer is covered by
+    ``TestSweepHandlerGateIntegration``.
+    """
+
+    def test_gate_accepts_when_plan_approved_at_is_recent(self, tmp_path):
+        """plan_approved entry written → gate accepts, even with old file mtime."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        plan_path = _write_plan(proj)
+        # Force plan.md mtime into the past. Under the old mtime-based
+        # gate this would block; under #281 it is irrelevant because
+        # the gate reads the context-entry timestamp.
+        old = time.time() - 3600
+        os.utime(plan_path, (old, old))
+        # Queue the impl task first, then approve the plan — so the
+        # approval timestamp is strictly ≥ the impl task's created_at.
+        _create_queued_impl_task(proj, project_key="proj")
+        approved_at = datetime.now(timezone.utc) + timedelta(seconds=1)
+        _create_done_approved_plan_task(
+            proj, project_key="proj", approved_at=approved_at,
+        )
+
+        db_path = proj / ".pollypm" / "state.db"
+        work = SQLiteWorkService(db_path=db_path, project_path=proj)
+        try:
+            assert has_acceptable_plan("proj", proj, work) is True
+        finally:
+            work.close()
+
+    def test_gate_rejects_when_plan_not_yet_approved(self, tmp_path):
+        """No approved plan_project task → gate rejects."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        _write_plan(proj)
+        # A draft plan task — never approved.
+        _create_draft_plan_task(proj, project_key="proj")
+        _create_queued_impl_task(proj, project_key="proj")
+
+        db_path = proj / ".pollypm" / "state.db"
+        work = SQLiteWorkService(db_path=db_path, project_path=proj)
+        try:
+            assert has_acceptable_plan("proj", proj, work) is False
+        finally:
+            work.close()
+
+    def test_gate_rejects_when_plan_approved_at_predates_backlog(self, tmp_path):
+        """plan_approved_at < latest backlog task created_at → stale → reject."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        _write_plan(proj)
+        # Approval stamped an hour ago; the impl task below is created
+        # "now" so the approval is stale against it.
+        stale = datetime.now(timezone.utc) - timedelta(hours=1)
+        _create_done_approved_plan_task(
+            proj, project_key="proj", approved_at=stale,
+        )
+        _create_queued_impl_task(proj, project_key="proj")
+
+        db_path = proj / ".pollypm" / "state.db"
+        work = SQLiteWorkService(db_path=db_path, project_path=proj)
+        try:
+            assert has_acceptable_plan("proj", proj, work) is False
+        finally:
+            work.close()
+
+    def test_gate_falls_back_to_execution_completed_at_for_prefix_projects(
+        self, tmp_path,
+    ):
+        """Pre-#281 project (no plan_approved entry) → fallback accepts.
+
+        A project approved before #281 shipped won't have a
+        ``plan_approved`` context entry. The gate falls back to the
+        ``user_approval`` execution's ``completed_at`` — otherwise every
+        pre-fix project would be stuck behind the gate forever.
+        """
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        _write_plan(proj)
+        # Queue the impl task first so the approval (stamped after)
+        # is strictly ≥ its created_at — the fallback path is what we
+        # want to exercise here.
+        _create_queued_impl_task(proj, project_key="proj")
+        # write_plan_approved_entry=False simulates a pre-#281 task:
+        # execution row exists with decision=APPROVED + completed_at,
+        # but no plan_approved context entry.
+        approved_at = datetime.now(timezone.utc) + timedelta(seconds=1)
+        _create_done_approved_plan_task(
+            proj,
+            project_key="proj",
+            approved_at=approved_at,
+            write_plan_approved_entry=False,
+        )
+
+        db_path = proj / ".pollypm" / "state.db"
+        work = SQLiteWorkService(db_path=db_path, project_path=proj)
+        try:
+            # Sanity: no plan_approved entry exists — we're really
+            # testing the fallback.
+            task_rows = work._conn.execute(
+                "SELECT task_number FROM work_tasks "
+                "WHERE project = ? AND flow_template_id = 'plan_project'",
+                ("proj",),
+            ).fetchall()
+            assert len(task_rows) == 1
+            number = task_rows[0]["task_number"]
+            pae = work._conn.execute(
+                "SELECT COUNT(*) AS c FROM work_context_entries "
+                "WHERE task_project = ? AND task_number = ? "
+                "AND entry_type = 'plan_approved'",
+                ("proj", number),
+            ).fetchone()
+            assert pae["c"] == 0
+            assert has_acceptable_plan("proj", proj, work) is True
+        finally:
+            work.close()
+
+    def test_gate_ignores_file_mtime(self, tmp_path):
+        """File mtime is NOT consulted — backdating or future-dating is a no-op.
+
+        Pins the #281 invariant: git operations, editor saves, and the
+        planner's own stage-8 emit all perturb mtime. The gate must
+        ignore it entirely.
+        """
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        plan_path = _write_plan(proj)
+        # Queue the impl task first so the plan's approval timestamp
+        # is strictly newer than the backlog's created_at.
+        _create_queued_impl_task(proj, project_key="proj")
+        approved_at = datetime.now(timezone.utc) + timedelta(seconds=1)
+        _create_done_approved_plan_task(
+            proj, project_key="proj", approved_at=approved_at,
+        )
+
+        db_path = proj / ".pollypm" / "state.db"
+        work = SQLiteWorkService(db_path=db_path, project_path=proj)
+        try:
+            # Baseline: default mtime, gate accepts.
+            assert has_acceptable_plan("proj", proj, work) is True
+            # Future-dated mtime: still accepts.
+            future = time.time() + 3600
+            os.utime(plan_path, (future, future))
+            assert has_acceptable_plan("proj", proj, work) is True
+            # Backdated mtime: still accepts (decision is driven by
+            # the plan_approved context entry, not the file).
+            old = time.time() - 7200
+            os.utime(plan_path, (old, old))
+            assert has_acceptable_plan("proj", proj, work) is True
+        finally:
+            work.close()
+
+
+# ---------------------------------------------------------------------------
 # Sweep-handler integration tests
 # ---------------------------------------------------------------------------
 
@@ -319,13 +518,14 @@ class TestSweepHandlerGateIntegration:
         proj = tmp_path / "proj"
         proj.mkdir()
         _write_plan(proj)
-        _create_done_approved_plan_task(proj, project_key="proj")
+        # Queue the impl task first; approval timestamp sits strictly
+        # after its created_at, so the #281 staleness check passes.
         _create_queued_impl_task(proj, project_key="proj")
-        # The real pipeline touches plan.md during stage 8 so its mtime
-        # sits ≥ the emitted backlog's created_at. Simulate that here.
-        plan_path = proj / "docs" / "plan" / "plan.md"
-        future = time.time() + 1
-        os.utime(plan_path, (future, future))
+        _create_done_approved_plan_task(
+            proj,
+            project_key="proj",
+            approved_at=datetime.now(timezone.utc) + timedelta(seconds=1),
+        )
 
         store = StateStore(tmp_path / "workspace_state.db")
         session_svc = FakeSessionService(handles=[FakeHandle("worker-proj")])
@@ -431,18 +631,20 @@ class TestSweepHandlerGateIntegration:
         store.close()
 
     def test_stale_plan_blocks_delegation(self, tmp_path, monkeypatch):
-        """plan.md mtime older than latest backlog task → blocks."""
+        """plan_approved_at older than latest backlog task → blocks.
+
+        (#281) Freshness is keyed off the approval timestamp, not the
+        plan.md mtime. Stamp an approval from an hour ago; the queued
+        impl task's ``created_at`` is "now", so the plan is stale.
+        """
         proj = tmp_path / "proj"
         proj.mkdir()
-        # 1. Write the plan first.
-        plan_path = _write_plan(proj)
-        # 2. Backdate the plan's mtime to well before the queued task.
-        old = time.time() - 3600
-        os.utime(plan_path, (old, old))
-        # 3. Create the approved plan task + queued impl task — the
-        #    queued task's created_at timestamp is ``now``, so the
-        #    plan is stale by ~1h.
-        _create_done_approved_plan_task(proj, project_key="proj")
+        _write_plan(proj)
+        # Approval timestamp well before any backlog task is created.
+        stale = datetime.now(timezone.utc) - timedelta(hours=1)
+        _create_done_approved_plan_task(
+            proj, project_key="proj", approved_at=stale,
+        )
         _create_queued_impl_task(proj, project_key="proj")
 
         store = StateStore(tmp_path / "workspace_state.db")
@@ -578,12 +780,14 @@ class TestSweepHandlerGateIntegration:
         proj_a = tmp_path / "proj_a"
         proj_a.mkdir()
         _write_plan(proj_a)
-        _create_done_approved_plan_task(proj_a, project_key="alpha")
+        # Queue impl task first so the approval timestamp is strictly
+        # newer than the backlog's created_at (#281 staleness check).
         _create_queued_impl_task(proj_a, project_key="alpha")
-        # Touch plan.md so its mtime ≥ the impl task (see staleness rule).
-        plan_a = proj_a / "docs" / "plan" / "plan.md"
-        future = time.time() + 1
-        os.utime(plan_a, (future, future))
+        _create_done_approved_plan_task(
+            proj_a,
+            project_key="alpha",
+            approved_at=datetime.now(timezone.utc) + timedelta(seconds=1),
+        )
 
         # Project B: no plan, has impl task → plan_missing
         proj_b = tmp_path / "proj_b"


### PR DESCRIPTION
Supersedes #286 (which conflicted — the write path already landed via #283). This is the gate-read side only.

Has_acceptable_plan now reads the plan_approved context entry (written at approval time) instead of plan.md mtime. Mtime rotted under git checkouts, editor saves, and stage-8 emit.

+5 tests, 0 regressions. Closes #281.