### PR TITLE
fix(task-assignment): dedupe key includes execution version so reject-bounce unlocks retry ping (#279)

### DIFF
--- a/src/pollypm/plugins_builtin/task_assignment_notify/handlers/notify.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/handlers/notify.py
@@ -53,6 +53,7 @@ def _event_from_payload(payload: dict[str, Any]) -> TaskAssignmentEvent:
         transitioned_at=transitioned_at,
         transitioned_by=str(payload.get("transitioned_by", "system")),
         commit_ref=payload.get("commit_ref"),
+        execution_version=int(payload.get("execution_version", 0) or 0),
     )
 
 
@@ -72,6 +73,9 @@ def event_to_payload(event: TaskAssignmentEvent) -> dict[str, Any]:
         "transitioned_at": event.transitioned_at.isoformat(),
         "transitioned_by": event.transitioned_by,
         "commit_ref": event.commit_ref,
+        # #279: carry the node's execution visit so the dedupe key on
+        # the receiving side treats a reject-bounce as a fresh ping.
+        "execution_version": int(event.execution_version or 0),
     }
 
 

--- a/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
@@ -117,6 +117,21 @@ def _build_event_for_task(work_service: Any, task: Any) -> TaskAssignmentEvent |
     if not actor_name:
         return None
     priority = getattr(task.priority, "value", str(task.priority))
+    # #279: look up the current execution's visit number so the dedupe
+    # key includes ``(session, task, execution_version)``. A rejection
+    # that bounces the task back to an earlier node opens a fresh visit,
+    # which correctly lets the retry ping through even inside the 30-min
+    # window. Best-effort — missing helper / errors fall back to 0,
+    # matching the pre-migration default for existing dedupe rows.
+    execution_version = 0
+    visit_fn = getattr(work_service, "current_node_visit", None)
+    if callable(visit_fn):
+        try:
+            execution_version = int(
+                visit_fn(task.project, task.task_number, node_id) or 0
+            )
+        except Exception:  # noqa: BLE001
+            execution_version = 0
     return TaskAssignmentEvent(
         task_id=task.task_id,
         project=task.project,
@@ -131,6 +146,7 @@ def _build_event_for_task(work_service: Any, task: Any) -> TaskAssignmentEvent |
         transitioned_at=datetime.now(timezone.utc),
         transitioned_by="sweeper",
         commit_ref=None,
+        execution_version=execution_version,
     )
 
 

--- a/src/pollypm/plugins_builtin/task_assignment_notify/resolver.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/resolver.py
@@ -163,15 +163,31 @@ def notify(
 
     target_name = getattr(handle, "name", "")
 
+    # #279: key the dedupe on ``(session, task, execution_version)``.
+    # A rejection that bounces the task back to an earlier node opens a
+    # fresh ``work_node_executions.visit`` — that shows up here as a new
+    # ``execution_version`` and correctly lets the retry ping through
+    # even inside the 30-minute window that originally throttled the
+    # first ping at ``visit=1``. Events with no version (``0``) still
+    # dedupe against pre-migration rows (column DEFAULT 0), preserving
+    # the original throttle semantics across the upgrade.
+    execution_version = int(getattr(event, "execution_version", 0) or 0)
+
     # Dedupe: don't re-ping the same session about the same task within
-    # the throttle window.
+    # the throttle window at the same execution_version.
     if store is not None and throttle_seconds > 0:
         try:
-            if store.was_notified_within(target_name, event.task_id, throttle_seconds):
+            if store.was_notified_within(
+                target_name,
+                event.task_id,
+                throttle_seconds,
+                execution_version,
+            ):
                 return {
                     "outcome": "deduped",
                     "task_id": event.task_id,
                     "session": target_name,
+                    "execution_version": execution_version,
                 }
         except Exception:  # noqa: BLE001
             logger.debug(
@@ -203,6 +219,7 @@ def notify(
                     project=event.project,
                     message=message,
                     delivery_status=f"failed: {exc}"[:200],
+                    execution_version=execution_version,
                 )
             except Exception:  # noqa: BLE001
                 pass
@@ -211,6 +228,7 @@ def notify(
             "task_id": event.task_id,
             "session": target_name,
             "error": str(exc),
+            "execution_version": execution_version,
         }
 
     if store is not None:
@@ -221,6 +239,7 @@ def notify(
                 project=event.project,
                 message=message,
                 delivery_status="sent",
+                execution_version=execution_version,
             )
         except Exception:  # noqa: BLE001
             logger.debug(
@@ -232,6 +251,7 @@ def notify(
         "outcome": "sent",
         "task_id": event.task_id,
         "session": target_name,
+        "execution_version": execution_version,
     }
 
 

--- a/src/pollypm/storage/state.py
+++ b/src/pollypm/storage/state.py
@@ -771,6 +771,27 @@ class StateStore:
             """CREATE INDEX IF NOT EXISTS idx_task_notifications_session_task
                ON task_notifications(session_name, task_id, notified_at DESC)""",
         ]),
+        # --- Migration 12 ----------------------------------------------
+        # Reject-bounce retry fix (#279). The dedupe for task-assignment
+        # pings was keyed on ``(session_name, task_id)`` only, which
+        # meant a rejected worker couldn't be re-pinged when the task
+        # bounced back to ``implement`` — the 30-minute dedupe window
+        # kept the retry ping suppressed. We add an ``execution_version``
+        # column (the ``work_node_executions.visit`` counter for the
+        # task's current node at ping time) so the dedupe key becomes
+        # ``(session_name, task_id, execution_version)``. A reject that
+        # opens a fresh ``(node, visit=N+1)`` execution counts as a new
+        # ping opportunity; identical-state pings within the window are
+        # still suppressed. Existing rows default to ``0`` (column
+        # DEFAULT) — the same default a freshly-built event carries when
+        # the work service can't compute a visit — so pre-migration
+        # dedupe semantics survive the upgrade.
+        (12, "Dedupe includes execution_version (#279)", [
+            # Column addition + index creation handled via the dispatch
+            # block below (_safe_add_column + explicit CREATE INDEX) so
+            # the column is guaranteed to exist before the index touches
+            # it, and a fresh DB re-running the migration is idempotent.
+        ]),
     ]
 
     def _migrate(self) -> None:
@@ -840,6 +861,32 @@ class StateStore:
                 self.execute(
                     "CREATE INDEX IF NOT EXISTS idx_memory_entries_tier "
                     "ON memory_entries(scope_tier, scope, id DESC)"
+                )
+            elif version == 12:
+                # Reject-bounce retry fix (#279). The dedupe key now
+                # includes the current node's execution version (the
+                # ``work_node_executions.visit`` counter at ping time).
+                # Existing rows back-fill to ``0`` via the column
+                # DEFAULT, which matches the default version emitted by
+                # freshly-rebuilt events whose work service can't
+                # compute a visit — so pre-migration dedupe semantics
+                # survive the upgrade intact.
+                self._safe_add_column(
+                    "task_notifications",
+                    "execution_version",
+                    "INTEGER NOT NULL DEFAULT 0",
+                )
+                # Composite index supports the new dedupe query path —
+                # ``WHERE session = ? AND task = ? AND version = ? AND
+                # notified_at >= ?``. The original per-session-task
+                # index (migration 11) stays in place for pickup-log
+                # filters that don't care about version.
+                self.execute(
+                    "CREATE INDEX IF NOT EXISTS "
+                    "idx_task_notifications_session_task_version "
+                    "ON task_notifications("
+                    "session_name, task_id, execution_version, "
+                    "notified_at DESC)"
                 )
             self.execute(
                 "INSERT INTO schema_version (version, description, applied_at) VALUES (?, ?, ?)",
@@ -1214,19 +1261,36 @@ class StateStore:
         project: str = "",
         message: str = "",
         delivery_status: str = "sent",
+        execution_version: int = 0,
     ) -> None:
         """Record a task-assignment ping sent to ``session_name``.
 
         The caller looks up ``was_notified_within`` beforehand to enforce
         the 30-minute throttle; this method just appends a row.
+
+        ``execution_version`` (#279) captures the ``visit`` counter of
+        the task's current node execution at ping time. A rejection that
+        bounces the task back to an earlier node spawns a fresh
+        execution with a higher visit — which the dedupe query below
+        correctly treats as a new ping opportunity instead of a
+        duplicate within the 30-minute window.
         """
         self.execute(
             """
             INSERT INTO task_notifications
-                (session_name, task_id, project, notified_at, delivery_status, message)
-            VALUES (?, ?, ?, ?, ?, ?)
+                (session_name, task_id, project, notified_at,
+                 delivery_status, message, execution_version)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            (session_name, task_id, project, self._now(), delivery_status, message),
+            (
+                session_name,
+                task_id,
+                project,
+                self._now(),
+                delivery_status,
+                message,
+                int(execution_version),
+            ),
         )
         self.commit()
 
@@ -1235,22 +1299,35 @@ class StateStore:
         session_name: str,
         task_id: str,
         window_seconds: int,
+        execution_version: int = 0,
     ) -> bool:
-        """Return ``True`` if ``(session, task)`` was pinged inside the window.
+        """Return ``True`` if ``(session, task, version)`` was pinged inside the window.
 
         ``window_seconds`` is the dedupe horizon — 30 min (``1800``) for
         the primary throttle, 5 min (``300``) for the sweeper's
         re-enqueue-avoidance cursor.
+
+        ``execution_version`` (#279) is matched exactly. A reject-bounce
+        that advances the task's current node execution to a fresh
+        ``visit`` yields a different version, so the dedupe returns
+        ``False`` and the retry ping gets through. Pre-#279 notification
+        rows back-fill to ``0`` via the column DEFAULT; events built
+        when the work service can't compute a visit also emit ``0``, so
+        identical-state pings still dedupe correctly across the
+        migration boundary.
         """
         from datetime import timedelta
         cutoff = (datetime.now(UTC) - timedelta(seconds=window_seconds)).isoformat()
         row = self.execute(
             """
             SELECT 1 FROM task_notifications
-            WHERE session_name = ? AND task_id = ? AND notified_at >= ?
+            WHERE session_name = ?
+              AND task_id = ?
+              AND execution_version = ?
+              AND notified_at >= ?
             LIMIT 1
             """,
-            (session_name, task_id, cutoff),
+            (session_name, task_id, int(execution_version), cutoff),
         ).fetchone()
         return row is not None
 
@@ -1282,7 +1359,8 @@ class StateStore:
         where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
         sql = (
             "SELECT session_name, task_id, project, notified_at, "
-            "delivery_status, message FROM task_notifications"
+            "delivery_status, message, execution_version "
+            "FROM task_notifications"
             f"{where} ORDER BY notified_at DESC LIMIT ?"
         )
         params.append(int(limit))
@@ -1295,6 +1373,7 @@ class StateStore:
                 "notified_at": r[3],
                 "delivery_status": r[4],
                 "message": r[5],
+                "execution_version": r[6] if len(r) > 6 else 0,
             }
             for r in rows
         ]

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -183,10 +183,24 @@ class SQLiteWorkService:
                 # Shallow copy avoids mutating the caller's dataclass.
                 from dataclasses import replace
                 effective_task = replace(task, current_node_id=node_id)
+            # #279: carry the current node's visit counter so the
+            # notifier's dedupe treats a reject-bounce (which opens a
+            # fresh execution row at a higher visit) as a new ping
+            # opportunity instead of suppressing it inside the 30-min
+            # window keyed on (session, task).
+            try:
+                execution_version = self.current_node_visit(
+                    effective_task.project,
+                    effective_task.task_number,
+                    node_id,
+                )
+            except Exception:  # noqa: BLE001
+                execution_version = 0
             event = build_event_from_task(
                 effective_task,
                 node,
                 transitioned_by=task.assignee or "system",
+                execution_version=execution_version,
             )
             if event is not None:
                 _dispatch_task_assignment(event)
@@ -1404,6 +1418,31 @@ class SQLiteWorkService:
             (project, task_number, node_id),
         ).fetchone()
         return row["max_v"] + 1
+
+    def current_node_visit(
+        self, project: str, task_number: int, node_id: str
+    ) -> int:
+        """Return the visit number of the current execution at ``node_id``.
+
+        Used by the task-assignment notifier (#279) to key its dedupe on
+        ``(session, task, execution_version)`` so a reject-bounce back to
+        an earlier node unlocks the retry ping instead of being
+        suppressed by the 30-minute window that originally pinged the
+        worker at ``visit=1``.
+
+        Returns ``0`` when the task has no recorded execution for the
+        node yet — a queued task whose start node hasn't been entered
+        carries an implicit "zeroth visit", and downstream dedupe
+        treats that as one identity bucket (matching the pre-#279
+        column default).
+        """
+        row = self._conn.execute(
+            "SELECT COALESCE(MAX(visit), 0) AS max_v "
+            "FROM work_node_executions "
+            "WHERE task_project = ? AND task_number = ? AND node_id = ?",
+            (project, task_number, node_id),
+        ).fetchone()
+        return int(row["max_v"] or 0)
 
     def _advance_to_node(
         self,

--- a/src/pollypm/work/task_assignment.py
+++ b/src/pollypm/work/task_assignment.py
@@ -44,6 +44,15 @@ class TaskAssignmentEvent:
     * ``work_status`` — the task's current work status (``"queued"`` /
       ``"in_progress"`` / ``"review"`` / ...). The sweeper uses this to
       re-enqueue only tasks sitting in ``queued`` or ``review``.
+    * ``execution_version`` — the ``work_node_executions.visit`` counter
+      for ``(task, current_node)`` at event-build time (#279). A
+      reject-bounce that reopens an earlier node bumps the visit, which
+      lets the notify dedupe treat the retry ping as a meaningfully-new
+      event rather than suppressing it inside the 30-min window.
+      Defaults to ``0`` for environments that can't compute a visit
+      (bare test doubles, pre-#279 rehydrated events) — pre-migration
+      dedupe semantics survive the default because existing
+      ``task_notifications`` rows back-fill to ``0`` as well.
     """
 
     task_id: str
@@ -59,6 +68,7 @@ class TaskAssignmentEvent:
     transitioned_at: datetime
     transitioned_by: str
     commit_ref: str | None = None
+    execution_version: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -352,12 +362,19 @@ def build_event_from_task(
     *,
     transitioned_by: str,
     commit_ref: str | None = None,
+    execution_version: int = 0,
 ) -> TaskAssignmentEvent | None:
     """Build a :class:`TaskAssignmentEvent` from a task + its current node.
 
     Returns ``None`` if the node has no machine-actor binding (i.e. the
     node is a human-review node, a terminal node, or lacks the
     ``actor_type`` attribute).
+
+    ``execution_version`` (#279) should be the ``visit`` counter on the
+    current node's active execution row. Pass ``0`` when the work
+    service can't resolve it — the dedupe still behaves correctly for
+    pre-migration rows, and the notify path will simply treat
+    ``visit=0`` as one identity bucket.
     """
     actor_type = getattr(node, "actor_type", None)
     if actor_type is None:
@@ -397,4 +414,5 @@ def build_event_from_task(
         transitioned_at=datetime.now(timezone.utc),
         transitioned_by=transitioned_by,
         commit_ref=commit_ref,
+        execution_version=int(execution_version or 0),
     )

--- a/tests/test_task_assignment_notify.py
+++ b/tests/test_task_assignment_notify.py
@@ -658,10 +658,14 @@ class TestSweeperInProgressBranch:
             tmp_path, [FakeHandle("worker-proj")], busy=(),
         )
         task = self._queue_and_claim(work)
-        # Pre-populate a recent ping so the cooldown is hot.
+        # Pre-populate a recent ping so the cooldown is hot. The claim
+        # above puts the task at ``implement`` with visit=1, so the
+        # dedupe row must carry ``execution_version=1`` to match the
+        # event the sweeper will build for this state (#279).
         store.record_notification(
             session_name="worker-proj", task_id=task.task_id,
             project="proj", message="previous ping", delivery_status="sent",
+            execution_version=1,
         )
 
         def _fake_loader(*, config_path=None):
@@ -769,9 +773,13 @@ class TestSessionCreatedListener:
         work.claim(task.task_id, "agent-1")
 
         # Pre-populate a notification that's inside the 30-min window.
+        # The claim puts the task at ``implement`` with visit=1, so the
+        # dedupe row must carry ``execution_version=1`` to match the
+        # replay event's identity (#279).
         store.record_notification(
             session_name="worker-proj", task_id=task.task_id,
             project="proj", message="original ping", delivery_status="sent",
+            execution_version=1,
         )
 
         services = _RuntimeServices(
@@ -1097,3 +1105,370 @@ class TestSessionCreatedBus:
         ))
         assert received == ["x"]
         clear_session_listeners()
+
+
+# ---------------------------------------------------------------------------
+# #279 — reject-bounce unlocks retry ping via execution_version
+# ---------------------------------------------------------------------------
+
+
+class TestRejectBounceDedupe:
+    """The 30-minute dedupe was originally keyed on ``(session, task)``
+    only — a rejection that bounced the task back to ``implement`` v2
+    never got its retry ping because the dedupe still saw the stale
+    ``visit=1`` row as "already pinged". #279 keys the dedupe on
+    ``(session, task, execution_version)`` so a fresh visit counts as a
+    new ping opportunity."""
+
+    def _make_services(self, tmp_path, session_handles, busy=()):
+        db = tmp_path / "work.db"
+        state_db = tmp_path / "state.db"
+        work = SQLiteWorkService(db_path=db)
+        store = StateStore(state_db)
+        svc = FakeSessionService(
+            handles=list(session_handles), busy=set(busy),
+        )
+        return work, store, svc
+
+    def test_reject_bounce_unlocks_retry_ping(self, tmp_path):
+        """Ping → reject → ping: the retry ping at visit=2 gets through
+        even inside the 30-min window that throttled the visit=1 ping.
+
+        This is the headline fix: the live scenario (russell/1 on
+        e2e_auto_1776439172) where a rejected worker sat for 30 min
+        waiting for the dedupe to expire."""
+        from pollypm.work.models import (
+            Artifact, ArtifactKind, OutputType, WorkOutput,
+        )
+
+        bus.clear_listeners()
+        work, store, svc = self._make_services(
+            tmp_path, [FakeHandle("worker-proj")],
+        )
+        services = _RuntimeServices(
+            session_service=svc, state_store=store,
+            work_service=work, project_root=tmp_path,
+        )
+
+        task = work.create(
+            title="Build the thing",
+            description="Implement feature X",
+            type="task",
+            project="proj",
+            flow_template="standard",
+            roles={"worker": "agent-1", "reviewer": "agent-2"},
+            priority="normal",
+        )
+        # Claim puts the task at implement/visit=1.
+        work.queue(task.task_id, "pm")
+        work.claim(task.task_id, "agent-1")
+
+        # First ping: lands.
+        first_event = TaskAssignmentEvent(
+            task_id=task.task_id, project="proj",
+            task_number=task.task_number, title=task.title,
+            current_node="implement", current_node_kind="work",
+            actor_type=ActorType.ROLE, actor_name="worker",
+            work_status="in_progress", priority="normal",
+            transitioned_at=datetime.now(timezone.utc),
+            transitioned_by="tester",
+            execution_version=work.current_node_visit(
+                "proj", task.task_number, "implement",
+            ),
+        )
+        assert first_event.execution_version == 1
+        first = notify(first_event, services=services)
+        assert first["outcome"] == "sent"
+        assert first["execution_version"] == 1
+        assert len(svc.sent) == 1
+
+        # Worker finishes -> review (visit=1 at code_review).
+        out = WorkOutput(
+            type=OutputType.CODE_CHANGE,
+            summary="First attempt",
+            artifacts=[Artifact(
+                kind=ArtifactKind.COMMIT, description="impl", ref="abc",
+            )],
+        )
+        work.node_done(task.task_id, "agent-1", work_output=out)
+        # Reviewer rejects -> bounce to implement/visit=2.
+        work.reject(task.task_id, "agent-2", "try again")
+
+        second_visit = work.current_node_visit(
+            "proj", task.task_number, "implement",
+        )
+        assert second_visit == 2
+
+        # Second ping carries the new execution_version — dedupe must
+        # NOT suppress it even though we're well inside the 30-min
+        # window that throttled the first ping.
+        second_event = TaskAssignmentEvent(
+            task_id=task.task_id, project="proj",
+            task_number=task.task_number, title=task.title,
+            current_node="implement", current_node_kind="work",
+            actor_type=ActorType.ROLE, actor_name="worker",
+            work_status="in_progress", priority="normal",
+            transitioned_at=datetime.now(timezone.utc),
+            transitioned_by="tester",
+            execution_version=second_visit,
+        )
+        second = notify(second_event, services=services)
+        assert second["outcome"] == "sent", (
+            f"reject-bounce retry ping was suppressed: {second!r}"
+        )
+        assert second["execution_version"] == 2
+        assert len(svc.sent) == 2
+
+    def test_same_state_within_window_still_dedupes(self, state_store):
+        """Ping at visit=N → ping again at visit=N within the window →
+        suppressed. The version-aware dedupe must still catch pure
+        duplicates — we didn't just remove the throttle, we refined its
+        key."""
+        svc = FakeSessionService(handles=[FakeHandle("worker-demo")])
+        services = _RuntimeServices(
+            session_service=svc, state_store=state_store,
+            work_service=None, project_root=Path("."),
+        )
+        event = _event()
+        # _event() defaults to execution_version=0, matching the
+        # pre-#279 dedupe semantics for the "no work service" harness.
+        first = notify(event, services=services)
+        assert first["outcome"] == "sent"
+        second = notify(event, services=services)
+        assert second["outcome"] == "deduped"
+        assert second["execution_version"] == 0
+        assert len(svc.sent) == 1
+
+    def test_past_throttle_same_state_resends(self, state_store):
+        """Time-based dedupe still works for unchanged state. A ping at
+        version=0 that expires the window must re-send — we must not
+        have accidentally replaced the time window with a per-version
+        "ping exactly once" behaviour."""
+        svc = FakeSessionService(handles=[FakeHandle("worker-demo")])
+        services = _RuntimeServices(
+            session_service=svc, state_store=state_store,
+            work_service=None, project_root=Path("."),
+        )
+        notify(_event(), services=services)
+        # throttle_seconds=0 models "we're past the 30-min window".
+        outcome = notify(_event(), services=services, throttle_seconds=0)
+        assert outcome["outcome"] == "sent"
+        assert len(svc.sent) == 2
+
+    def test_sweeper_rebuilds_events_with_current_visit(
+        self, tmp_path, monkeypatch,
+    ):
+        """The sweeper's synthetic event must carry the current visit so
+        its dedupe lines up with the live work service state. This is
+        the path that runs on the @every 30s cadence and has to catch
+        the reject-bounce case when the in-process listener missed the
+        transition."""
+        from pollypm.work.models import (
+            Artifact, ArtifactKind, OutputType, WorkOutput,
+        )
+        from pollypm.plugins_builtin.task_assignment_notify.handlers.sweep import (
+            _build_event_for_task,
+        )
+
+        bus.clear_listeners()
+        work, store, svc = self._make_services(
+            tmp_path, [FakeHandle("worker-proj")],
+        )
+
+        task = work.create(
+            title="Build the thing",
+            description="Implement feature X",
+            type="task",
+            project="proj",
+            flow_template="standard",
+            roles={"worker": "agent-1", "reviewer": "agent-2"},
+            priority="normal",
+        )
+        work.queue(task.task_id, "pm")
+        work.claim(task.task_id, "agent-1")
+
+        # Visit 1 at implement.
+        t1 = work.get(task.task_id)
+        ev1 = _build_event_for_task(work, t1)
+        assert ev1 is not None
+        assert ev1.execution_version == 1
+
+        # Advance to review, then bounce back.
+        out = WorkOutput(
+            type=OutputType.CODE_CHANGE,
+            summary="First attempt",
+            artifacts=[Artifact(
+                kind=ArtifactKind.COMMIT, description="impl", ref="abc",
+            )],
+        )
+        work.node_done(task.task_id, "agent-1", work_output=out)
+        work.reject(task.task_id, "agent-2", "try again")
+
+        t2 = work.get(task.task_id)
+        ev2 = _build_event_for_task(work, t2)
+        assert ev2 is not None
+        assert ev2.execution_version == 2, (
+            f"sweeper rebuild missed the visit bump: {ev2.execution_version}"
+        )
+
+    def test_pre_migration_row_dedupes_default_version_event(self, state_store):
+        """An event rebuilt via a work service that can't compute a
+        visit (bare test double, failure path) emits ``version=0``. A
+        notification row created before #279 (column DEFAULT 0) must
+        still dedupe that event. This is the backward-compat contract
+        the spec called out."""
+        svc = FakeSessionService(handles=[FakeHandle("worker-demo")])
+        services = _RuntimeServices(
+            session_service=svc, state_store=state_store,
+            work_service=None, project_root=Path("."),
+        )
+        # Pre-populate a "pre-migration" row (execution_version omitted,
+        # so it lands as the column DEFAULT 0).
+        state_store.record_notification(
+            session_name="worker-demo", task_id="demo/1",
+            project="demo", message="legacy ping", delivery_status="sent",
+            # execution_version not passed — default 0, matching a row
+            # back-filled by migration 12.
+        )
+        outcome = notify(_event(), services=services)
+        assert outcome["outcome"] == "deduped", (
+            f"pre-migration dedupe compat broken: {outcome!r}"
+        )
+        assert len(svc.sent) == 0
+
+    def test_migration_adds_execution_version_column(self, tmp_path):
+        """Migration 12 adds ``execution_version`` with DEFAULT 0 and
+        creates the version-aware composite index. Fresh DBs get the
+        column from the migration runner; pre-#279 DBs back-fill
+        existing rows to ``0`` via the column DEFAULT."""
+        store = StateStore(tmp_path / "state.db")
+        try:
+            cols = {
+                r[1] for r in store.execute(
+                    "PRAGMA table_info(task_notifications)"
+                ).fetchall()
+            }
+            assert "execution_version" in cols
+            indexes = [
+                r[0] for r in store.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index' "
+                    "AND tbl_name='task_notifications'"
+                ).fetchall()
+            ]
+            assert any("session_task_version" in i for i in indexes), (
+                f"version-aware dedupe index missing: {indexes!r}"
+            )
+            # Round-trip with + without the column: both forms work,
+            # and default rows dedupe at version=0.
+            store.record_notification(
+                session_name="worker-demo", task_id="demo/1",
+                project="demo", message="default", delivery_status="sent",
+            )
+            assert store.was_notified_within("worker-demo", "demo/1", 60)
+            # Explicit version round-trip.
+            store.record_notification(
+                session_name="worker-demo", task_id="demo/2",
+                project="demo", message="v3", delivery_status="sent",
+                execution_version=3,
+            )
+            assert store.was_notified_within(
+                "worker-demo", "demo/2", 60, execution_version=3,
+            )
+            # Different version is NOT matched by the dedupe query.
+            assert not store.was_notified_within(
+                "worker-demo", "demo/2", 60, execution_version=2,
+            )
+            # The recent_notifications readback surfaces the version so
+            # downstream tooling can display it.
+            rows = store.recent_notifications(task_id="demo/2")
+            assert rows and rows[0]["execution_version"] == 3
+        finally:
+            store.close()
+
+    def test_migration_upgrades_pre_existing_v11_database(self, tmp_path):
+        """A database that existed before #279 (schema v11) with
+        ``task_notifications`` rows must upgrade cleanly to v12 — the
+        new column appears, existing rows back-fill to 0, and the old
+        dedupe behaviour survives for any still-pending ping."""
+        import sqlite3
+        p = tmp_path / "legacy.db"
+        # Hand-build a v11-shaped DB (no execution_version column).
+        conn = sqlite3.connect(p)
+        conn.executescript(
+            """
+            CREATE TABLE schema_version (
+                version INTEGER NOT NULL,
+                description TEXT NOT NULL,
+                applied_at TEXT NOT NULL
+            );
+            CREATE TABLE task_notifications (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_name TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                project TEXT NOT NULL DEFAULT '',
+                notified_at TEXT NOT NULL,
+                delivery_status TEXT NOT NULL DEFAULT 'sent',
+                message TEXT NOT NULL DEFAULT ''
+            );
+            INSERT INTO schema_version VALUES
+                (11, 'v11 baseline', '2026-01-01T00:00:00+00:00');
+            INSERT INTO task_notifications
+                (session_name, task_id, project, notified_at,
+                 delivery_status, message)
+            VALUES
+                ('worker-legacy', 'legacy/1', 'legacy',
+                 '2026-04-17T00:00:00+00:00', 'sent', 'legacy ping');
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        # Open via StateStore — the migration runner must upgrade in
+        # place without losing data.
+        store = StateStore(p)
+        try:
+            cols = {
+                r[1] for r in store.execute(
+                    "PRAGMA table_info(task_notifications)"
+                ).fetchall()
+            }
+            assert "execution_version" in cols, (
+                f"migration 12 did not add column: {cols!r}"
+            )
+            rows = store.execute(
+                "SELECT session_name, task_id, execution_version "
+                "FROM task_notifications"
+            ).fetchall()
+            assert rows == [("worker-legacy", "legacy/1", 0)], (
+                f"legacy row did not back-fill to version=0: {rows!r}"
+            )
+            version = store.execute(
+                "SELECT MAX(version) FROM schema_version"
+            ).fetchone()[0]
+            assert version == 12
+        finally:
+            store.close()
+
+    def test_event_payload_round_trip_preserves_version(self):
+        """The notify job payload must round-trip the version so a
+        sweeper-enqueued job handed off to a worker runner dedupes on
+        the same key the in-process path uses."""
+        from pollypm.plugins_builtin.task_assignment_notify.handlers.notify import (
+            _event_from_payload, event_to_payload,
+        )
+        ev = TaskAssignmentEvent(
+            task_id="proj/5", project="proj", task_number=5,
+            title="x", current_node="implement", current_node_kind="work",
+            actor_type=ActorType.ROLE, actor_name="worker",
+            work_status="in_progress", priority="normal",
+            transitioned_at=datetime.now(timezone.utc),
+            transitioned_by="tester",
+            execution_version=4,
+        )
+        payload = event_to_payload(ev)
+        assert payload["execution_version"] == 4
+        # Serializer is JSON-compatible.
+        import json
+        round = json.loads(json.dumps(payload))
+        restored = _event_from_payload(round)
+        assert restored.execution_version == 4


### PR DESCRIPTION
Worker rejected at code_review → implement v2 → 30min stall. The dedupe key ignored state changes.

## Fix
Dedupe key widened from `(session_name, task_id)` to `(session_name, task_id, execution_version)` where execution_version is the visit counter from work_node_executions. A reject-bounce (implement visit=2) is a distinct key from the original (implement visit=1) ping.

## Schema migration 12
Added `execution_version INTEGER NOT NULL DEFAULT 0` + composite index. Pre-existing rows backfill to 0. v11→v12 migration tested.

## Tests (+8, 2 existing tests updated)
Headline reject-bounce unlock end-to-end, same-state within window still dedupes, past-throttle same-state resends, sweeper rebuilds w/ current visit, pre-migration backward-compat, migration creates column + index, v11→v12 upgrade clean, payload round-trip.

2279 passing. 3 pre-existing unrelated failures.

Closes #279