### PR TITLE
fix(cli): pm send --force bypasses the worker-role gate (#261)

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -1398,11 +1398,13 @@ def send(
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
     supervisor = _load_supervisor(config_path)
-    # Block pm send to workers at the CLI level. The operator must use inbox
-    # (pm notify --to) so tasks are tracked with audit trail and reply path.
-    # The delivery system bypasses this by calling supervisor.send_input() directly.
+    # Block pm send to workers at the CLI level UNLESS --force is set.
+    # The default nudges the operator to use the task system (audit trail
+    # + reply path). --force is the escape hatch for when the auto-pickup
+    # path is broken and a human operator needs to push a command through
+    # directly — e.g., nudging a stuck worker. #261.
     session_cfg = supervisor.config.sessions.get(session_name)
-    if session_cfg and session_cfg.role == "worker":
+    if session_cfg and session_cfg.role == "worker" and not force:
         project = session_cfg.project or session_name.replace("worker_", "", 1)
         typer.echo(
             f"Blocked: dispatch work through the task system.\n"
@@ -1410,7 +1412,9 @@ def send(
             f"-f standard -r worker=worker -r reviewer=polly\n"
             f"  pm task queue {project}/<number>\n"
             f"\n"
-            f"The worker picks up queued tasks automatically."
+            f"The worker picks up queued tasks automatically.\n"
+            f"If the auto-pickup path is broken and you need to nudge "
+            f"this worker directly, re-run with --force."
         )
         raise typer.Exit(code=1)
     try:

--- a/tests/test_cli_send_force.py
+++ b/tests/test_cli_send_force.py
@@ -1,0 +1,73 @@
+"""Tests for the ``pm send`` worker-gate behaviour (#261).
+
+The default blocks ``pm send`` to worker sessions, nudging the operator
+toward ``pm task create``. When the auto-pickup path is broken,
+``--force`` is the escape hatch that lets the operator nudge a worker
+directly. These tests pin that contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm.cli import app
+
+
+runner = CliRunner()
+
+
+class _FakeSessionCfg:
+    def __init__(self, role: str, project: str = "demo") -> None:
+        self.role = role
+        self.project = project
+
+
+def _make_supervisor(sessions: dict) -> MagicMock:
+    supervisor = MagicMock()
+    supervisor.config.sessions = sessions
+    supervisor.send_input = MagicMock()
+    return supervisor
+
+
+def test_send_to_worker_without_force_is_blocked(tmp_path: Path) -> None:
+    """Default path: sending to a worker session exits non-zero with guidance."""
+    supervisor = _make_supervisor({"worker_demo": _FakeSessionCfg("worker")})
+    with patch("pollypm.cli._load_supervisor", return_value=supervisor):
+        result = runner.invoke(app, ["send", "worker_demo", "hello"])
+    assert result.exit_code == 1
+    assert "Blocked: dispatch work through the task system" in result.stdout
+    assert "--force" in result.stdout
+    supervisor.send_input.assert_not_called()
+
+
+def test_send_to_worker_with_force_is_allowed(tmp_path: Path) -> None:
+    """Escape hatch: --force bypasses the worker-role gate."""
+    supervisor = _make_supervisor({"worker_demo": _FakeSessionCfg("worker")})
+    with patch("pollypm.cli._load_supervisor", return_value=supervisor):
+        result = runner.invoke(app, ["send", "worker_demo", "hello", "--force"])
+    assert result.exit_code == 0, result.stdout
+    supervisor.send_input.assert_called_once()
+    args, kwargs = supervisor.send_input.call_args
+    assert kwargs.get("force") is True
+
+
+def test_send_to_non_worker_is_not_gated() -> None:
+    """pm send to operator/reviewer/heartbeat is unchanged — gate only fires for workers."""
+    supervisor = _make_supervisor({"pm-operator": _FakeSessionCfg("operator-pm")})
+    with patch("pollypm.cli._load_supervisor", return_value=supervisor):
+        result = runner.invoke(app, ["send", "pm-operator", "hello"])
+    assert result.exit_code == 0, result.stdout
+    supervisor.send_input.assert_called_once()
+
+
+def test_send_to_unknown_session_is_not_gated() -> None:
+    """Unknown session names fall through; the downstream send_input call decides."""
+    supervisor = _make_supervisor({})
+    with patch("pollypm.cli._load_supervisor", return_value=supervisor):
+        result = runner.invoke(app, ["send", "ghost_session", "hello"])
+    assert result.exit_code == 0, result.stdout
+    supervisor.send_input.assert_called_once()


### PR DESCRIPTION
Worker-role block was consulted before --force, so operators had no escape hatch when auto-pickup broke. Default still nudges toward the task system; --force is now the escape hatch.

Also updated the blocked-message guidance to mention --force.

+4 tests (block on worker, allow with force, non-worker passthrough, unknown-session passthrough).

Closes #261