### PR TITLE
fix(inbox): notify + cockpit aggregator use workspace-root DB (#271)

### DIFF
--- a/src/pollypm/cockpit.py
+++ b/src/pollypm/cockpit.py
@@ -83,30 +83,66 @@ def _render_work_service_issues(project: object) -> str:
     return "\n".join(lines)
 
 
+def _inbox_db_sources(config) -> list[tuple[str | None, Path, Path]]:
+    """Return ``(project_key, db_path, project_path)`` for every inbox source.
+
+    Includes the per-project ``.pollypm/state.db`` for every registered
+    project **and** the workspace-root ``<workspace_root>/.pollypm/state.db``
+    — the latter is where ``pm notify`` (with defaults) lands items that
+    don't belong to any one project (#271). Duplicates are dropped so a
+    project whose path happens to equal the workspace root is scanned once.
+
+    ``project_key`` is ``None`` for the workspace-root source; callers that
+    need a project filter treat ``None`` as "no filter".
+    """
+    sources: list[tuple[str | None, Path, Path]] = []
+    seen: set[Path] = set()
+    for project_key, project in getattr(config, "projects", {}).items():
+        project_path = Path(project.path)
+        db_path = project_path / ".pollypm" / "state.db"
+        resolved = db_path.resolve() if db_path.exists() else db_path
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        sources.append((project_key, db_path, project_path))
+
+    workspace_root = getattr(getattr(config, "project", None), "workspace_root", None)
+    if workspace_root is not None:
+        ws_path = Path(workspace_root)
+        ws_db = ws_path / ".pollypm" / "state.db"
+        resolved = ws_db.resolve() if ws_db.exists() else ws_db
+        if resolved not in seen:
+            seen.add(resolved)
+            sources.append((None, ws_db, ws_path))
+    return sources
+
+
 def _count_inbox_tasks_for_label(config) -> int:
-    """Sum of inbox tasks across all tracked projects.
+    """Sum of inbox tasks across all tracked projects + workspace-root.
 
     Used by the cockpit rail label and the dashboard summary line; the
     aggregate must match what :func:`_render_inbox_panel` would render.
+    Dedupes tasks by ``task_id`` so a task that somehow appears in more
+    than one DB counts exactly once.
     """
     try:
         from pollypm.work.inbox_view import inbox_tasks
         from pollypm.work.sqlite_service import SQLiteWorkService
     except Exception:  # noqa: BLE001
         return 0
-    total = 0
-    for project_key, project in getattr(config, "projects", {}).items():
-        db_path = project.path / ".pollypm" / "state.db"
+    seen_task_ids: set[str] = set()
+    for project_key, db_path, project_path in _inbox_db_sources(config):
         if not db_path.exists():
             continue
         try:
             with SQLiteWorkService(
-                db_path=db_path, project_path=project.path,
+                db_path=db_path, project_path=project_path,
             ) as svc:
-                total += len(inbox_tasks(svc, project=project_key))
+                for task in inbox_tasks(svc, project=project_key):
+                    seen_task_ids.add(task.task_id)
         except Exception:  # noqa: BLE001
             continue
-    return total
+    return len(seen_task_ids)
 
 
 def render_inbox_panel(service, projects: list[object] | None = None) -> str:
@@ -233,21 +269,25 @@ def _render_inbox_panel(config) -> str:
 
     agg = _AggregateService()
     opened: list[SQLiteWorkService] = []
+    seen_task_ids: set[str] = set()
     try:
-        for project_key, project in getattr(config, "projects", {}).items():
-            db_path = project.path / ".pollypm" / "state.db"
+        for project_key, db_path, project_path in _inbox_db_sources(config):
             if not db_path.exists():
                 continue
             try:
                 svc = SQLiteWorkService(
-                    db_path=db_path, project_path=project.path,
+                    db_path=db_path, project_path=project_path,
                 )
             except Exception:  # noqa: BLE001
                 continue
             opened.append(svc)
             agg._flows_by_svc.append(svc)
             try:
-                agg._tasks.extend(svc.list_tasks(project=project_key))
+                for task in svc.list_tasks(project=project_key):
+                    if task.task_id in seen_task_ids:
+                        continue
+                    seen_task_ids.add(task.task_id)
+                    agg._tasks.append(task)
             except Exception:  # noqa: BLE001
                 pass
 

--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -81,17 +81,25 @@ def _run(fn, *args, **kwargs):
 def _resolve_db_path(db: str, project: str | None = None) -> Path:
     """Resolve the database path, trying the pollypm config for project root.
 
-    When *project* is given and the default ``--db`` wasn't overridden,
-    resolve to that project's ``.pollypm/state.db``.
+    When *project* is given and resolves to a registered project (and the
+    default ``--db`` wasn't overridden), resolve to that project's
+    ``.pollypm/state.db``.
 
-    When the default relative ``--db .pollypm/state.db`` doesn't exist in the
-    cwd, fall back to the pollypm config's known project paths so that agents
-    running in workspace-root (e.g. the operator in ``/Users/sam/dev``) find
-    the project-level database.
+    When the default ``--db .pollypm/state.db`` is used with no (or an
+    unregistered) project, prefer the canonical workspace-root DB at
+    ``<workspace_root>/.pollypm/state.db`` so ``pm notify`` and ``pm inbox``
+    land in the same place regardless of cwd (#271). The cockpit inbox
+    aggregator also scans workspace-root alongside per-project DBs, so
+    notifications stay visible.
+
+    A caller that explicitly passes ``--db`` always wins; that escape hatch
+    keeps tests and CI paths that stage their own DB working unchanged.
     """
     is_default = db == ".pollypm/state.db"
 
-    # If a specific project is requested, always use that project's db
+    # If a specific, registered project is requested, always use that
+    # project's db. Unknown project names (e.g. the sentinel "inbox" used
+    # by `pm notify`) fall through to the workspace-root default below.
     if project and is_default:
         try:
             from pollypm.config import load_config
@@ -109,21 +117,24 @@ def _resolve_db_path(db: str, project: str | None = None) -> Path:
         except Exception:
             pass
 
-    db_path = Path(db)
-    if db_path.exists():
-        return db_path
-
-    # Fall back to any project with an existing db
+    # Default resolution: workspace-root DB. Every `pm notify`/`pm inbox`
+    # call without an explicit --db lands here, so items are always visible
+    # regardless of which worktree or directory the caller invoked from.
     if is_default:
         try:
             from pollypm.config import load_config
             config = load_config()
-            for proj in config.projects.values():
-                candidate = proj.path / ".pollypm" / "state.db"
-                if candidate.exists():
-                    return candidate
+            workspace_root = getattr(config.project, "workspace_root", None)
+            if workspace_root is not None:
+                candidate = Path(workspace_root) / ".pollypm" / "state.db"
+                candidate.parent.mkdir(parents=True, exist_ok=True)
+                return candidate
         except Exception:
             pass
+
+    db_path = Path(db)
+    if db_path.exists():
+        return db_path
 
     db_path.parent.mkdir(parents=True, exist_ok=True)
     return db_path

--- a/tests/test_inbox_aggregator_workspace_root.py
+++ b/tests/test_inbox_aggregator_workspace_root.py
@@ -1,0 +1,150 @@
+"""Cockpit inbox aggregator + CLI default DB — workspace-root resolution (#271).
+
+``pm notify`` (with defaults) writes to ``<workspace_root>/.pollypm/state.db``.
+The cockpit's inbox count scans per-project DBs *and* the workspace-root DB
+so notifications are never invisible.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm.cli import app as root_app
+from pollypm.cockpit import _count_inbox_tasks_for_label
+from pollypm.work.inbox_cli import inbox_app
+from pollypm.work.sqlite_service import SQLiteWorkService
+
+
+runner = CliRunner()
+
+
+def _write_config(
+    workspace_root: Path, project_path: Path, config_path: Path,
+) -> None:
+    config_path.write_text(
+        "[project]\n"
+        'tmux_session = "pollypm-test"\n'
+        f'workspace_root = "{workspace_root}"\n'
+        "\n"
+        "[projects.demo]\n"
+        'key = "demo"\n'
+        'name = "Demo"\n'
+        f'path = "{project_path}"\n'
+    )
+
+
+def _seed(db_path: Path, project_path: Path, *, project: str, title: str) -> str:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+    try:
+        task = svc.create(
+            title=title, description=f"body for {title}", type="task",
+            project=project, flow_template="chat",
+            roles={"requester": "user", "operator": "polly"},
+            priority="normal", created_by="polly",
+        )
+        return task.task_id
+    finally:
+        svc.close()
+
+
+@pytest.fixture
+def env(tmp_path: Path):
+    workspace_root = tmp_path / "dev"
+    workspace_root.mkdir()
+    project_path = workspace_root / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(workspace_root, project_path, config_path)
+    return {
+        "workspace_root": workspace_root,
+        "project_path": project_path,
+        "config_path": config_path,
+        "project_db": project_path / ".pollypm" / "state.db",
+        "workspace_db": workspace_root / ".pollypm" / "state.db",
+    }
+
+
+def _pin_load_config(monkeypatch, config_path: Path) -> None:
+    """Redirect no-arg ``load_config()`` to the test workspace config."""
+    from pollypm import config as config_module
+    real_load = config_module.load_config
+    monkeypatch.setattr(
+        config_module, "load_config",
+        lambda path=None: real_load(config_path if path is None else path),
+    )
+
+
+def _load_cfg(config_path: Path):
+    from pollypm.config import load_config
+    return load_config(config_path)
+
+
+def test_notify_default_db_writes_to_workspace_root(
+    env, tmp_path: Path, monkeypatch,
+) -> None:
+    """``pm notify`` without ``--db`` lands in ``<workspace_root>/.pollypm/state.db``."""
+    _pin_load_config(monkeypatch, env["config_path"])
+    cwd = tmp_path / "somewhere_else"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    result = runner.invoke(
+        root_app, ["notify", "Deploy blocked", "Needs verification"],
+    )
+    assert result.exit_code == 0, result.output
+
+    assert env["workspace_db"].exists()
+    # The cwd-relative DB must NOT have been created.
+    assert not (cwd / ".pollypm" / "state.db").exists()
+
+
+def test_inbox_default_db_reads_from_workspace_root(
+    env, tmp_path: Path, monkeypatch,
+) -> None:
+    """``pm inbox`` without ``--db`` reads from the workspace-root DB."""
+    task_id = _seed(
+        env["workspace_db"], env["workspace_root"],
+        project="inbox", title="only workspace item",
+    )
+    _pin_load_config(monkeypatch, env["config_path"])
+    cwd = tmp_path / "somewhere_else"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    result = runner.invoke(inbox_app, ["--json"])
+    assert result.exit_code == 0, result.output
+    returned = [t["task_id"] for t in json.loads(result.output)["tasks"]]
+    assert task_id in returned
+
+
+def test_aggregator_counts_both_project_and_workspace_root(env) -> None:
+    """Cockpit aggregator sums per-project + workspace-root inbox items."""
+    _seed(env["project_db"], env["project_path"],
+          project="demo", title="project-local item")
+    _seed(env["workspace_db"], env["workspace_root"],
+          project="inbox", title="workspace-root item")
+    assert _count_inbox_tasks_for_label(_load_cfg(env["config_path"])) == 2
+
+
+def test_aggregator_dedupes_same_task_id_across_sources(env) -> None:
+    """If the same task_id appears in two DBs, it's counted once."""
+    _seed(env["project_db"], env["project_path"],
+          project="demo", title="first copy")
+    _seed(env["workspace_db"], env["workspace_root"],
+          project="demo", title="second copy")
+    # Both DBs numbered their tasks ``demo/1`` — dedupe on task_id.
+    assert _count_inbox_tasks_for_label(_load_cfg(env["config_path"])) == 1
+
+
+def test_aggregator_skips_missing_workspace_root_db(env) -> None:
+    """Aggregator must not raise when the workspace-root DB is absent."""
+    _seed(env["project_db"], env["project_path"],
+          project="demo", title="only project")
+    assert not env["workspace_db"].exists()
+    assert _count_inbox_tasks_for_label(_load_cfg(env["config_path"])) == 1


### PR DESCRIPTION
Closes the earlier 'inbox shows empty' symptom.

## Changes (3 files)
- `work/cli.py` `_resolve_db_path`: default prefers `<workspace_root>/.pollypm/state.db`. Explicit `--db` still wins. Fixes both `pm notify` writes and `pm inbox` reads.
- `cockpit.py`: new `_inbox_db_sources(config)` yields per-project + workspace-root DB tuples with dedup. `_count_inbox_tasks_for_label` and `_render_inbox_panel` use it and dedupe by task_id.
- Tests: `tests/test_inbox_aggregator_workspace_root.py` (5 tests, 150 lines).

## Targeted test run
26 passed (5 new + 5 existing notify + 16 existing cockpit UI).

Closes #271