### PR TITLE
feat(planner): route pm project new on existing projects through replan (#274)

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -16,12 +16,18 @@ Subcommands:
 Implementation detail: the ``pm project new`` flow delegates to the
 same ``_plan_project_task`` helper that the ``plan`` subcommand uses,
 so both exercises the same code path end-to-end.
+
+Issue #274: ``pm project new`` auto-classifies the target directory as
+``greenfield`` or ``existing`` and routes to the drift-aware replan
+flow in the ``existing`` case so cold-start decompositions don't fight
+against prior code. Use ``--force-cold-start`` to override.
 """
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 import typer
 
@@ -108,6 +114,134 @@ def _resolve_project_key(
         err=True,
     )
     raise typer.Exit(code=1)
+
+
+# ---------------------------------------------------------------------------
+# Project-state classification (issue #274)
+# ---------------------------------------------------------------------------
+
+
+# Source-file suffixes we treat as "this directory already has code".
+# Conservative but covers the major languages users currently run
+# PollyPM against. A ``README`` alone is not enough — docs without code
+# or history usually land in the greenfield bucket.
+_SOURCE_SUFFIXES: frozenset[str] = frozenset(
+    {".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rs", ".java", ".rb"}
+)
+
+
+def _git_commit_count(project_path: Path) -> int:
+    """Return the number of commits reachable from HEAD, or 0 on error.
+
+    Returns 0 for a non-git directory, a freshly-``git init``-ed
+    directory with no commits, or any other error (network, permissions,
+    git binary missing). Deliberately conservative — a read failure must
+    never force the existing-project branch on an actually-fresh dir.
+    """
+    if not (project_path / ".git").exists():
+        return 0
+    try:
+        result = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD"],
+            cwd=str(project_path),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return 0
+    if result.returncode != 0:
+        return 0
+    try:
+        return int(result.stdout.strip() or "0")
+    except ValueError:
+        return 0
+
+
+def _has_source_files(project_path: Path, *, max_scan: int = 2000) -> bool:
+    """Return True iff ``project_path`` contains at least one source file.
+
+    Walks the tree (skipping ``.git``, ``.pollypm``, and common venv /
+    node_modules dirs) and bails on the first match. Capped at
+    ``max_scan`` entries to keep the classifier fast on giant repos —
+    the ``rglob`` itself is cheap, but an uncooperative filesystem can
+    still stall us.
+    """
+    skip_dirs = {".git", ".pollypm", ".pollypm-state", "node_modules",
+                 "__pycache__", ".venv", "venv", "dist", "build", ".tox"}
+    count = 0
+    try:
+        for entry in project_path.rglob("*"):
+            # Cheap prune: any parent hit on the skip list → move on.
+            if any(part in skip_dirs for part in entry.parts):
+                continue
+            if not entry.is_file():
+                continue
+            if entry.suffix in _SOURCE_SUFFIXES:
+                return True
+            count += 1
+            if count >= max_scan:
+                break
+    except OSError:
+        return False
+    return False
+
+
+def _has_work_tasks(project_path: Path) -> bool:
+    """Return True iff the project's work-service DB has ≥1 work_tasks row.
+
+    Reads the sqlite table directly — ``SQLiteWorkService`` is a heavier
+    entrypoint and this path runs on the happy path for every
+    ``pm project new`` invocation, so we keep it lean. Fails closed:
+    any DB / IO error returns False so we don't accidentally flag a
+    greenfield project as existing on a transient error.
+    """
+    db_path = project_path / ".pollypm" / "state.db"
+    if not db_path.exists():
+        return False
+    try:
+        import sqlite3
+
+        with sqlite3.connect(str(db_path)) as conn:
+            cur = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' "
+                "AND name='work_tasks' LIMIT 1"
+            )
+            if cur.fetchone() is None:
+                return False
+            cur = conn.execute("SELECT 1 FROM work_tasks LIMIT 1")
+            return cur.fetchone() is not None
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _classify_project_state(
+    project_path: Path,
+) -> Literal["greenfield", "existing"]:
+    """Classify a project directory for the ``pm project new`` routing.
+
+    Returns ``"existing"`` if ANY of the following hold:
+
+    * ``git rev-list --count HEAD`` > 1 (i.e. more than just an initial
+      "init" commit).
+    * ``<path>/docs/plan/plan.md`` exists.
+    * Any source file (``.py``/``.ts``/``.js``/``.go``/``.rs``/
+      ``.java``/``.rb``/``.tsx``/``.jsx``) exists at any depth.
+    * The work-service DB already has ≥ 1 row in ``work_tasks``.
+
+    Otherwise ``"greenfield"``. The heuristic is intentionally loose —
+    the user can still override with ``--force-cold-start`` when the
+    auto-classification guesses wrong.
+    """
+    if _git_commit_count(project_path) > 1:
+        return "existing"
+    if (project_path / "docs" / "plan" / "plan.md").exists():
+        return "existing"
+    if _has_source_files(project_path):
+        return "existing"
+    if _has_work_tasks(project_path):
+        return "existing"
+    return "greenfield"
 
 
 def _plan_project_task(
@@ -287,6 +421,15 @@ def new_cmd(
             "`--skip-planner` prompt toggle."
         ),
     ),
+    force_cold_start: bool = typer.Option(
+        False, "--force-cold-start",
+        help=(
+            "Override the existing-project auto-detection (issue #274) "
+            "and run the cold-start planner even when the target "
+            "directory already has commits, a prior plan, source files, "
+            "or work-service rows."
+        ),
+    ),
     yes: bool = typer.Option(
         False, "--yes", "-y",
         help="Non-interactive: auto-accept the planner prompt.",
@@ -302,6 +445,12 @@ def new_cmd(
     ``--yes`` accepts the prompt non-interactively. ``--skip-plan``
     suppresses the project_planning plugin's auto-fire on the emitted
     ``project.created`` event (#255).
+
+    Issue #274: when the target directory already looks like an
+    existing project (commits, ``docs/plan/plan.md``, source files, or
+    prior work_tasks rows) the auto-fired planner task uses the
+    drift-aware replan description instead of cold-start decomposition.
+    Pass ``--force-cold-start`` to override.
     """
     from pollypm.projects import register_project, normalize_project_path
 
@@ -329,6 +478,25 @@ def new_cmd(
         f"Registered project {project.name or project.key} at {project.path}"
     )
 
+    # Issue #274: classify the project directory so we can choose
+    # between cold-start and drift-aware replan. Only meaningful when a
+    # planner task is actually going to fire — suppress the classifier
+    # echo when the user explicitly opted out.
+    suppress_all_planning = bool(skip_plan or skip_planner)
+    if suppress_all_planning:
+        mode: Literal["greenfield", "existing"] = "greenfield"
+    elif force_cold_start:
+        mode = "greenfield"
+        typer.echo("Fresh project — running cold-start planner.")
+    else:
+        mode = _classify_project_state(project.path)
+        if mode == "existing":
+            typer.echo(
+                "Detected existing project — running drift-aware replan."
+            )
+        else:
+            typer.echo("Fresh project — running cold-start planner.")
+
     # Fire the ``project.created`` observer chain so plugins (including
     # project_planning itself) can react. Best-effort — never block the
     # CLI on observer failures. Only fire on genuinely-new registrations
@@ -351,7 +519,14 @@ def new_cmd(
                     # interactive prompt + the explicit ``_plan_project_task``
                     # call below) also suppresses auto-fire so the combined
                     # UX stays "no planner task".
-                    "skip_plan": bool(skip_plan or skip_planner),
+                    "skip_plan": suppress_all_planning,
+                    # Issue #274: mode hint lets the observer pick
+                    # cold-start vs. drift-aware replan phrasing when
+                    # auto-firing the plan task. Defaults to
+                    # ``greenfield`` so observers from other plugins
+                    # that don't know about this payload key behave
+                    # identically to the pre-#274 world.
+                    "mode": mode,
                 },
                 metadata={
                     "source": "pm project new",
@@ -370,8 +545,9 @@ def new_cmd(
             pass
 
     if auto_fired:
+        mode_label = "replan" if mode == "existing" else "plan_project"
         typer.echo(
-            f"Auto-created plan_project task for '{project.key}' via "
+            f"Auto-created {mode_label} task for '{project.key}' via "
             "project.created hook (see `[planner] auto_on_project_created`)."
         )
         _auto_spawn_architect(path, project.key)
@@ -380,7 +556,7 @@ def new_cmd(
     # ``--skip-plan`` or ``--skip-planner`` both short-circuit the prompt +
     # legacy task-creation path. This keeps the CLI idempotent with the
     # event payload we sent to observers above.
-    if skip_plan or skip_planner:
+    if suppress_all_planning:
         typer.echo(
             "Skipped planner. Run `pm project plan "
             + project.key + "` later to start planning."
@@ -399,9 +575,22 @@ def new_cmd(
         )
         return
 
-    task = _plan_project_task(
-        project.key, project.path, title_prefix="Plan project",
-    )
+    # Issue #274: even on the legacy (auto-fire-disabled) path, route
+    # to the replan description when the directory looks existing.
+    if mode == "existing":
+        task = _plan_project_task(
+            project.key, project.path,
+            title_prefix="Replan project",
+            description=(
+                f"Re-run the architecture planner on {project.key}. Stage-0 "
+                "research should read the existing plan and produce a "
+                "drift analysis before proposing changes."
+            ),
+        )
+    else:
+        task = _plan_project_task(
+            project.key, project.path, title_prefix="Plan project",
+        )
     typer.echo(
         f"Created planning task {task.task_id} on project "
         f"'{project.key}' (flow={task.flow_template_id})."

--- a/src/pollypm/plugins_builtin/project_planning/plugin.py
+++ b/src/pollypm/plugins_builtin/project_planning/plugin.py
@@ -105,6 +105,15 @@ def _on_project_created(context) -> None:
             )
             return
         skip_plan_flag = bool(payload.get("skip_plan", False))
+        # Issue #274: cold-start vs. drift-aware replan.  ``mode`` is
+        # an opt-in payload field set by ``pm project new`` after
+        # classifying the project directory.  Any value other than
+        # the literal "existing" falls back to cold-start behaviour
+        # so callers from before #274 (or other plugins that raise
+        # ``project.created`` without this field) keep the same task
+        # wording.
+        mode_raw = payload.get("mode", "greenfield")
+        is_replan = mode_raw == "existing"
 
         # Config lookup: the observer doesn't get a PluginAPI, so we
         # re-read the global config here. Callers may pass an explicit
@@ -161,15 +170,26 @@ def _on_project_created(context) -> None:
         project_path = _Path(project_path_raw)
         db_path = project_path / ".pollypm" / "state.db"
         db_path.parent.mkdir(parents=True, exist_ok=True)
+        if is_replan:
+            title = f"Replan project {project_key}"
+            description = (
+                f"Auto-created on project.created for an existing project "
+                f"(#274). Re-run the architecture planner on {project_key}. "
+                "Stage-0 research should read the existing plan and produce "
+                "a drift analysis before proposing changes."
+            )
+        else:
+            title = f"Plan project {project_key}"
+            description = (
+                f"Auto-created on project.created. Run the architect "
+                f"+ 5-critic planning pipeline on {project_key}."
+            )
         with SQLiteWorkService(
             db_path=db_path, project_path=project_path,
         ) as svc:
             task = svc.create(
-                title=f"Plan project {project_key}",
-                description=(
-                    f"Auto-created on project.created. Run the architect "
-                    f"+ 5-critic planning pipeline on {project_key}."
-                ),
+                title=title,
+                description=description,
                 type="task",
                 project=project_key,
                 flow_template="plan_project",
@@ -177,8 +197,10 @@ def _on_project_created(context) -> None:
                 priority="high",
             )
         log.info(
-            "project_planning: auto-fired plan_project task %s for '%s'.",
+            "project_planning: auto-fired %s task %s for '%s' (mode=%s).",
+            "replan" if is_replan else "plan_project",
             task.task_id, project_key,
+            "existing" if is_replan else "greenfield",
         )
     except Exception as exc:  # noqa: BLE001
         # Observers are best-effort.

--- a/tests/test_project_new_replan_routing.py
+++ b/tests/test_project_new_replan_routing.py
@@ -1,0 +1,306 @@
+"""Tests for ``pm project new`` drift-aware routing (issue #274).
+
+Covers ``_classify_project_state`` + the routing in ``new_cmd``. A
+fresh directory should land on the cold-start planner task; a
+directory with commits, a prior ``docs/plan/plan.md``, pre-existing
+source files, or prior work_tasks rows should land on the replan
+task instead. ``--skip-planner`` still suppresses both paths, and
+``--force-cold-start`` overrides classification.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from pollypm.config import write_config
+from pollypm.models import (
+    KnownProject,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectKind,
+    ProjectSettings,
+)
+from pollypm.plugins_builtin.project_planning.cli import project as project_cli
+from pollypm.plugins_builtin.project_planning.cli.project import project_app
+
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _git_init(path: Path, *, commits: int = 0) -> None:
+    """Initialise a real git repo at ``path`` with ``commits`` commits."""
+    subprocess.run(["git", "init", "-q"], cwd=str(path), check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "t@t.test"], cwd=str(path), check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "t"], cwd=str(path), check=True,
+    )
+    subprocess.run(
+        ["git", "config", "commit.gpgsign", "false"],
+        cwd=str(path), check=True,
+    )
+    for i in range(commits):
+        marker = path / f"c{i}.txt"
+        marker.write_text(f"commit {i}\n")
+        subprocess.run(
+            ["git", "add", marker.name], cwd=str(path), check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-q", "-m", f"c{i}"],
+            cwd=str(path), check=True,
+        )
+
+
+def _make_project_repo(tmp_path: Path, name: str = "demo") -> Path:
+    path = tmp_path / name
+    path.mkdir()
+    (path / ".git").mkdir()
+    return path
+
+
+def _write_minimal_config(
+    tmp_path: Path, *, projects: dict[str, Path] | None = None,
+) -> Path:
+    projects = projects or {}
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            base_dir=tmp_path / ".pollypm-state",
+            logs_dir=tmp_path / ".pollypm-state/logs",
+            snapshots_dir=tmp_path / ".pollypm-state/snapshots",
+            state_db=tmp_path / ".pollypm-state/state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account=""),
+        accounts={},
+        sessions={},
+        projects={
+            key: KnownProject(
+                key=key,
+                path=path,
+                name=key,
+                persona_name="",
+                kind=ProjectKind.FOLDER,
+            )
+            for key, path in projects.items()
+        },
+    )
+    config_path = tmp_path / "pollypm.toml"
+    write_config(config, config_path, force=True)
+    return config_path
+
+
+def _only_plan_task(repo: Path, project_key: str):
+    """Return the single plan_project task on ``repo``, failing clearly."""
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    db_path = repo / ".pollypm" / "state.db"
+    assert db_path.exists(), "auto-fire should have opened the work DB"
+    with SQLiteWorkService(db_path=db_path, project_path=repo) as svc:
+        tasks = [
+            t for t in svc.list_tasks(project=project_key)
+            if t.flow_template_id == "plan_project"
+        ]
+    assert len(tasks) == 1, f"expected exactly 1 plan_project task, got {tasks}"
+    return tasks[0]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestProjectNewReplanRouting:
+    def test_fresh_dir_classifies_greenfield_cold_start(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """Fresh git init, no commits → greenfield → cold-start task."""
+        repo = tmp_path / "fresh"
+        repo.mkdir()
+        _git_init(repo, commits=0)
+        config_path = _write_minimal_config(tmp_path)
+
+        # Sanity-check the classifier directly.
+        assert project_cli._classify_project_state(repo) == "greenfield"
+
+        monkeypatch.setattr(
+            project_cli, "_prompt_run_planner",
+            lambda default_yes=True: (_ for _ in ()).throw(
+                AssertionError("prompt should not fire"),
+            ),
+        )
+
+        result = runner.invoke(
+            project_app,
+            ["new", str(repo), "--config", str(config_path)],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert "Fresh project" in result.stdout
+        assert "cold-start planner" in result.stdout
+        # Auto-fired task is a plan (not replan).
+        assert "Auto-created plan_project task" in result.stdout
+        task = _only_plan_task(repo, "fresh")
+        assert task.title.startswith("Plan project")
+        assert "Re-run" not in (task.description or "")
+
+    def test_existing_commits_classifies_existing_replan(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """> 1 git commit → existing → drift-aware replan task."""
+        repo = tmp_path / "existing"
+        repo.mkdir()
+        _git_init(repo, commits=3)
+        config_path = _write_minimal_config(tmp_path)
+
+        assert project_cli._classify_project_state(repo) == "existing"
+
+        monkeypatch.setattr(
+            project_cli, "_prompt_run_planner",
+            lambda default_yes=True: (_ for _ in ()).throw(
+                AssertionError("prompt should not fire"),
+            ),
+        )
+
+        result = runner.invoke(
+            project_app,
+            ["new", str(repo), "--config", str(config_path)],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert "Detected existing project" in result.stdout
+        assert "drift-aware replan" in result.stdout
+        assert "Auto-created replan task" in result.stdout
+        task = _only_plan_task(repo, "existing")
+        assert task.title.startswith("Replan project")
+        assert "drift" in (task.description or "").lower()
+
+    def test_existing_plan_md_classifies_existing_replan(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """``docs/plan/plan.md`` present → existing → replan task."""
+        repo = tmp_path / "planned"
+        repo.mkdir()
+        (repo / ".git").mkdir()  # no commits, but plan.md triggers existing.
+        (repo / "docs" / "plan").mkdir(parents=True)
+        (repo / "docs" / "plan" / "plan.md").write_text(
+            "# Old plan\n\nSome prior decisions.\n",
+        )
+        config_path = _write_minimal_config(tmp_path)
+
+        assert project_cli._classify_project_state(repo) == "existing"
+
+        monkeypatch.setattr(
+            project_cli, "_prompt_run_planner",
+            lambda default_yes=True: (_ for _ in ()).throw(
+                AssertionError("prompt should not fire"),
+            ),
+        )
+
+        result = runner.invoke(
+            project_app,
+            ["new", str(repo), "--config", str(config_path)],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert "Detected existing project" in result.stdout
+        task = _only_plan_task(repo, "planned")
+        assert task.title.startswith("Replan project")
+
+    def test_existing_py_files_classifies_existing_replan(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """Any ``*.py`` file in the tree → existing → replan."""
+        repo = tmp_path / "pycode"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        (repo / "main.py").write_text("print('hi')\n")
+        config_path = _write_minimal_config(tmp_path)
+
+        assert project_cli._classify_project_state(repo) == "existing"
+
+        monkeypatch.setattr(
+            project_cli, "_prompt_run_planner",
+            lambda default_yes=True: (_ for _ in ()).throw(
+                AssertionError("prompt should not fire"),
+            ),
+        )
+
+        result = runner.invoke(
+            project_app,
+            ["new", str(repo), "--config", str(config_path)],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert "Detected existing project" in result.stdout
+        task = _only_plan_task(repo, "pycode")
+        assert task.title.startswith("Replan project")
+
+    def test_skip_planner_suppresses_both_paths(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """``--skip-planner`` on an existing project still skips everything."""
+        repo = tmp_path / "skipme"
+        repo.mkdir()
+        _git_init(repo, commits=3)
+        (repo / "main.py").write_text("x = 1\n")
+        config_path = _write_minimal_config(tmp_path)
+
+        monkeypatch.setattr(
+            project_cli, "_prompt_run_planner",
+            lambda default_yes=True: (_ for _ in ()).throw(
+                AssertionError("prompt should not fire with --skip-planner"),
+            ),
+        )
+
+        result = runner.invoke(
+            project_app,
+            [
+                "new", str(repo), "--skip-planner",
+                "--config", str(config_path),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert "Skipped planner" in result.stdout
+        assert "Auto-created" not in result.stdout
+        assert "Detected existing project" not in result.stdout
+        assert "Fresh project" not in result.stdout
+        # No plan task (no DB at all).
+        assert not (repo / ".pollypm" / "state.db").exists()
+
+    def test_force_cold_start_overrides_existing_classification(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """``--force-cold-start`` on an existing project forces cold-start."""
+        repo = tmp_path / "override"
+        repo.mkdir()
+        _git_init(repo, commits=3)
+        (repo / "main.py").write_text("x = 1\n")
+        config_path = _write_minimal_config(tmp_path)
+
+        assert project_cli._classify_project_state(repo) == "existing"
+
+        monkeypatch.setattr(
+            project_cli, "_prompt_run_planner",
+            lambda default_yes=True: (_ for _ in ()).throw(
+                AssertionError("prompt should not fire"),
+            ),
+        )
+
+        result = runner.invoke(
+            project_app,
+            [
+                "new", str(repo), "--force-cold-start",
+                "--config", str(config_path),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert "Fresh project" in result.stdout
+        assert "Detected existing project" not in result.stdout
+        assert "Auto-created plan_project task" in result.stdout
+        task = _only_plan_task(repo, "override")
+        assert task.title.startswith("Plan project")
+        assert "drift" not in (task.description or "").lower()


### PR DESCRIPTION
`pm project new` on an existing project (has commits, docs/plan/plan.md, source files, or prior work_tasks) now auto-selects drift-aware replan instead of cold-start decomposition. Greenfield still uses cold-start.

## Changes (3 files)
- `project_planning/cli/project.py` — `_classify_project_state` + helpers, `--force-cold-start` flag, mode echo.
- `project_planning/plugin.py` — observer honours `mode` payload; auto-fired task uses replan wording when existing.
- `tests/test_project_new_replan_routing.py` — 6 tests.

## Constraints honored
- Replan flow itself untouched.
- No schema changes.
- Architect bootstrap (#257) auto-spawn unchanged.
- Integrates via existing `project.created` observer.

## Tests
6 new + 25 pre-existing CLI tests + 105 adjacent + 9 architect-bootstrap all pass.

Closes #274