### PR TITLE
feat(planner): improvement proposals via inbox — accept/reject (#275)

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -2026,6 +2026,55 @@ def _build_pm_context_line(
     return f're: inbox/{task_id} "{title}"'
 
 
+def _extract_proposal_spec(task, *, labels: list[str] | None = None) -> dict:
+    """Recover a proposal's ``proposed_task_spec`` from an inbox row.
+
+    The body was rendered at emit time by ``render_proposal_body`` which
+    intersperses the rationale with a ``## Proposed task`` markdown
+    block. Rather than parse that back, we fall back to title +
+    description: the accepted follow-on task uses the proposal title
+    and rationale as its description. Tests that care about the exact
+    spec shape can stub :meth:`PollyInboxApp._proposal_specs` directly.
+    """
+    spec: dict[str, object] = {}
+    subject = (getattr(task, "title", "") or "").strip()
+    if subject:
+        spec["title"] = subject
+    body = (getattr(task, "description", "") or "").strip()
+    # Split at the preview marker so the accepted follow-on task only
+    # carries the rationale, not the spec scaffold.
+    marker = "## Proposed task"
+    if marker in body:
+        rationale, _, tail = body.partition(marker)
+        spec["description"] = rationale.strip()
+        # Recover acceptance criteria from the preview, when present.
+        for line in tail.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("- **acceptance criteria**"):
+                # Subsequent indented lines form the AC block.
+                continue
+        # Heuristic AC extractor: grab the block after ``acceptance criteria:``.
+        ac_lines: list[str] = []
+        capturing = False
+        for line in tail.splitlines():
+            low = line.lstrip().lower()
+            if low.startswith("- **acceptance criteria**"):
+                capturing = True
+                continue
+            if capturing:
+                if line.startswith("- **") and not line.lstrip().startswith(
+                    "- **acceptance"
+                ):
+                    break
+                if line.strip():
+                    ac_lines.append(line.strip())
+        if ac_lines:
+            spec["acceptance_criteria"] = "\n".join(ac_lines)
+    else:
+        spec["description"] = body
+    return spec
+
+
 class _RollupItem(ListItem):
     """One sub-item in a rollup's expanded thread.
 
@@ -2246,6 +2295,11 @@ class PollyInboxApp(App[None]):
         Binding("r", "start_reply", "Reply"),
         Binding("a", "archive_selected", "Archive"),
         Binding("d", "jump_to_pm", "Discuss"),
+        # Improvement proposals (#275): capital A/X so plain lowercase
+        # ``a`` (archive) stays distinct. Accepting / rejecting IS
+        # archiving, but with a decision trail.
+        Binding("A", "accept_proposal", "Accept", show=False),
+        Binding("X", "reject_proposal", "Reject", show=False),
         Binding("e", "expand_all_rollup", "Expand all", show=False),
         Binding("u", "refresh", "Refresh"),
         Binding("q,escape", "back_or_cancel", "Back"),
@@ -2273,8 +2327,7 @@ class PollyInboxApp(App[None]):
         )
         self.status = Static("", id="inbox-status")
         self.hint = Static(
-            "j/k move \u00b7 \u21b5 open \u00b7 r reply \u00b7 a archive "
-            "\u00b7 d discuss \u00b7 u refresh \u00b7 q back",
+            PollyInboxApp._DEFAULT_HINT,
             id="inbox-hint",
         )
         self._tasks: list = []
@@ -2288,6 +2341,15 @@ class PollyInboxApp(App[None]):
         # Focused rollup sub-item for ``d`` dispatch. None when the whole
         # rollup is the jump target (or on a non-rollup task).
         self._rollup_focused_index: int | None = None
+        # Improvement-proposal state (#275). When the user presses ``X``
+        # on a proposal item, the shared reply_input becomes a rationale
+        # prompt. We flag it here so the Input.Submitted handler routes
+        # to record_proposal_rejection instead of add_reply.
+        self._awaiting_rejection_task_id: str | None = None
+        # Cache of parsed proposal_task_spec per inbox task_id, populated
+        # on _render_detail. Accept uses it to seed the follow-on task
+        # without re-reading the DB.
+        self._proposal_specs: dict[str, dict] = {}
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="inbox-layout"):
@@ -2508,6 +2570,22 @@ class PollyInboxApp(App[None]):
                     f"[b #5b8aff]{_escape(who)}[/b #5b8aff]  [dim]{_escape(age)}[/dim]"
                 )
                 sections.append(_md_to_rich(_escape_body(entry.text)))
+
+        # Improvement-proposal detection (#275). Proposal items carry a
+        # ``proposal`` label; when present, swap the hint bar for the
+        # accept/reject keybindings. The body itself already embeds the
+        # proposed-task-spec preview (written at emit time via
+        # ``render_proposal_body``), so we don't double-render it here.
+        _labels = list(getattr(task, "labels", []) or [])
+        _is_proposal = "proposal" in _labels
+        if _is_proposal:
+            self._proposal_specs[task_id] = _extract_proposal_spec(
+                task, labels=_labels,
+            )
+            self._update_hint_for_proposal()
+        else:
+            self._proposal_specs.pop(task_id, None)
+            self._restore_default_hint()
 
         self.detail.update("\n".join(sections))
         # Rebuild the rollup item list (empty for non-rollups).
@@ -2752,6 +2830,17 @@ class PollyInboxApp(App[None]):
         task_id = self._selected_task_id
         if task_id is None:
             return
+        # Improvement proposals force an explicit Accept (A) or Reject
+        # (X). Plain ``a`` must not silently archive them — the user
+        # gets a visible warning instead so they don't accidentally
+        # drop a suggestion without recording the decision.
+        task, _labels = self._selected_proposal_task()
+        if task is not None:
+            self.notify(
+                "This is an improvement proposal \u2014 press A to accept or X to reject.",
+                severity="warning", timeout=3.0,
+            )
+            return
         svc = self._svc_for_task(task_id)
         if svc is None:
             self.notify("Could not open project database.", severity="error")
@@ -2908,6 +2997,24 @@ class PollyInboxApp(App[None]):
     def _on_reply_submitted(self, event: Input.Submitted) -> None:
         body = (event.value or "").strip()
         task_id = self._selected_task_id
+        # Rejection path: when the user pressed ``X`` on a proposal, the
+        # shared reply input was repurposed to collect a rationale. Route
+        # submission through the rejection flow instead of add_reply so
+        # the bytes land in planner memory + the task archives with the
+        # ``proposal_rejected`` entry_type.
+        if self._awaiting_rejection_task_id is not None:
+            pending = self._awaiting_rejection_task_id
+            self._awaiting_rejection_task_id = None
+            self.reply_input.placeholder = (
+                "Reply \u2026 (Enter to send, Esc back to list)"
+            )
+            if not task_id or task_id != pending:
+                # Selection moved while typing — abandon the rejection.
+                self.reply_input.value = ""
+                self.list_view.focus()
+                return
+            self._finish_reject_proposal(task_id, body)
+            return
         if not body or not task_id:
             # Empty submit — just hand focus back to the list.
             self.reply_input.value = ""
@@ -2939,6 +3046,206 @@ class PollyInboxApp(App[None]):
         self.reply_input.value = ""
         self.list_view.focus()
         self._render_detail(task_id)
+
+    # ------------------------------------------------------------------
+    # Improvement proposals (#275) — Accept / Reject
+    # ------------------------------------------------------------------
+
+    _DEFAULT_HINT = (
+        "j/k move \u00b7 \u21b5 open \u00b7 r reply \u00b7 a archive "
+        "\u00b7 d discuss \u00b7 u refresh \u00b7 q back"
+    )
+    _PROPOSAL_HINT = (
+        "A accept \u00b7 X reject \u00b7 r reply \u00b7 q back"
+    )
+
+    def _update_hint_for_proposal(self) -> None:
+        try:
+            self.hint.update(self._PROPOSAL_HINT)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _restore_default_hint(self) -> None:
+        try:
+            self.hint.update(self._DEFAULT_HINT)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _selected_proposal_task(self):
+        """Return (task, labels) for the current selection if it's a proposal."""
+        task_id = self._selected_task_id
+        if task_id is None:
+            return None, []
+        svc = self._svc_for_task(task_id)
+        if svc is None:
+            return None, []
+        try:
+            task = svc.get(task_id)
+        except Exception:  # noqa: BLE001
+            return None, []
+        finally:
+            try:
+                svc.close()
+            except Exception:  # noqa: BLE001
+                pass
+        labels = list(getattr(task, "labels", []) or [])
+        if "proposal" not in labels:
+            return None, labels
+        return task, labels
+
+    def action_accept_proposal(self) -> None:
+        """Accept the selected proposal — create a follow-on task + archive."""
+        if self.reply_input.has_focus:
+            return
+        task_id = self._selected_task_id
+        if task_id is None:
+            return
+        task, labels = self._selected_proposal_task()
+        if task is None:
+            self.notify(
+                "Accept/Reject only applies to proposal items.",
+                severity="warning", timeout=2.0,
+            )
+            return
+        spec = self._proposal_specs.get(task_id) or _extract_proposal_spec(
+            task, labels=labels,
+        )
+        project_key = task.project
+        from pollypm.plugins_builtin.project_planning.proposals import (
+            accept_proposal as _accept_helper,
+        )
+        svc = self._svc_for_task(task_id)
+        if svc is None:
+            self.notify("Could not open project database.", severity="error")
+            return
+        try:
+            new_task = _accept_helper(
+                svc,
+                task_id=task_id,
+                proposal_spec=spec,
+                project_key=project_key,
+                actor="user",
+            )
+            svc.add_context(
+                task_id,
+                actor="user",
+                text=f"Proposal accepted \u2192 {new_task.task_id}",
+                entry_type="proposal_accepted",
+            )
+            svc.archive_task(task_id, actor="user")
+        except Exception as exc:  # noqa: BLE001
+            self.notify(f"Accept failed: {exc}", severity="error")
+            return
+        finally:
+            try:
+                svc.close()
+            except Exception:  # noqa: BLE001
+                pass
+        self._emit_event(
+            task_id, "inbox.proposal.accepted",
+            f"user accepted proposal {task_id} \u2192 {new_task.task_id}",
+        )
+        self.notify(
+            f"Accepted \u2014 created {new_task.task_id}",
+            severity="information", timeout=3.0,
+        )
+        # Drop the archived row locally so it disappears without waiting
+        # for the next background refresh.
+        self._tasks = [t for t in self._tasks if t.task_id != task_id]
+        self._unread_ids.discard(task_id)
+        self._proposal_specs.pop(task_id, None)
+        if self._selected_task_id == task_id:
+            self._selected_task_id = None
+        self._render_list(select_first=bool(self._tasks))
+        self._restore_default_hint()
+
+    def action_reject_proposal(self) -> None:
+        """Reject the selected proposal — prompt for a rationale first."""
+        if self.reply_input.has_focus:
+            return
+        task_id = self._selected_task_id
+        if task_id is None:
+            return
+        task, _labels = self._selected_proposal_task()
+        if task is None:
+            self.notify(
+                "Accept/Reject only applies to proposal items.",
+                severity="warning", timeout=2.0,
+            )
+            return
+        self._awaiting_rejection_task_id = task_id
+        self.reply_input.value = ""
+        self.reply_input.placeholder = (
+            "Why reject? (Enter to confirm, Esc to cancel)"
+        )
+        self.reply_input.focus()
+
+    def _finish_reject_proposal(self, task_id: str, rationale: str) -> None:
+        """Persist rejection in planner memory + archive the inbox row."""
+        task, labels = self._selected_proposal_task()
+        if task is None:
+            # Selection moved to a non-proposal item mid-typing.
+            self.reply_input.value = ""
+            self.list_view.focus()
+            return
+        from pollypm.plugins_builtin.project_planning.memory import (
+            record_proposal_rejection,
+        )
+        from pollypm.plugins_builtin.project_planning.proposals import (
+            memkey_from_labels,
+        )
+        memkey = memkey_from_labels(labels) or ""
+        project_key = task.project
+        try:
+            record_proposal_rejection(
+                project_key=project_key,
+                planner_memory_key=memkey,
+                rationale=rationale,
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.notify(f"Reject memory failed: {exc}", severity="error")
+            # Still try to archive so the user isn't stuck looking at
+            # the rejected proposal.
+        svc = self._svc_for_task(task_id)
+        if svc is None:
+            self.notify("Could not open project database.", severity="error")
+            self.reply_input.value = ""
+            self.list_view.focus()
+            return
+        try:
+            svc.add_context(
+                task_id,
+                actor="user",
+                text=f"Proposal rejected: {rationale[:200]}" if rationale else
+                     "Proposal rejected (no rationale given).",
+                entry_type="proposal_rejected",
+            )
+            svc.archive_task(task_id, actor="user")
+        except Exception as exc:  # noqa: BLE001
+            self.notify(f"Archive after reject failed: {exc}", severity="error")
+            self.reply_input.value = ""
+            self.list_view.focus()
+            return
+        finally:
+            try:
+                svc.close()
+            except Exception:  # noqa: BLE001
+                pass
+        self._emit_event(
+            task_id, "inbox.proposal.rejected",
+            f"user rejected proposal {task_id}",
+        )
+        self.notify("Rejected \u2014 planner will skip this next time.",
+                    severity="information", timeout=3.0)
+        self._tasks = [t for t in self._tasks if t.task_id != task_id]
+        self._unread_ids.discard(task_id)
+        self._proposal_specs.pop(task_id, None)
+        if self._selected_task_id == task_id:
+            self._selected_task_id = None
+        self.reply_input.value = ""
+        self.list_view.focus()
+        self._render_list(select_first=bool(self._tasks))
+        self._restore_default_hint()
 
     # ------------------------------------------------------------------
     # Event emission

--- a/src/pollypm/plugins_builtin/project_planning/memory.py
+++ b/src/pollypm/plugins_builtin/project_planning/memory.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 MEMORY_DIR = Path.home() / ".pollypm" / "memory"
 MEMORY_FILE = MEMORY_DIR / "planner.jsonl"
+REJECTIONS_FILE = MEMORY_DIR / "planner_rejections.jsonl"
 
 
 @dataclass(slots=True)
@@ -183,3 +184,85 @@ def summarise_for_prompt(entries: list[PlannerMemoryEntry]) -> str:
     )
     lines.append("</planner-memory>")
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Improvement-proposal rejection memory (issue #275)
+#
+# A separate JSONL so it doesn't collide with ``PlannerMemoryEntry`` reads
+# in :func:`read_entries`. One line per rejection, append-only. We never
+# need to enumerate rejections, only predicate-check them, so this file is
+# kept dead simple.
+# ---------------------------------------------------------------------------
+
+
+def _rejections_path(override: Path | None = None) -> Path:
+    """Return the active rejections file path (defaults to REJECTIONS_FILE)."""
+    return override if override is not None else REJECTIONS_FILE
+
+
+def record_proposal_rejection(
+    *,
+    project_key: str,
+    planner_memory_key: str,
+    rationale: str = "",
+    path: Path | None = None,
+) -> Path:
+    """Append a rejection record. Idempotent — duplicate rejections are a no-op.
+
+    The file layout is append-only JSONL; each line carries the project
+    key, the memkey, the optional free-form rationale, and a timestamp
+    for future analytics. The predicate :func:`is_proposal_rejected`
+    matches on (project_key, planner_memory_key) only, so re-adding the
+    same pair is harmless but wastes a byte or two.
+    """
+    target = _rejections_path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "project": project_key,
+        "planner_memory_key": planner_memory_key,
+        "rationale": (rationale or "").strip(),
+        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "entry_type": "proposal_rejected",
+    }
+    with target.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload, ensure_ascii=False))
+        fh.write("\n")
+    return target
+
+
+def is_proposal_rejected(
+    *,
+    project_key: str,
+    planner_memory_key: str,
+    path: Path | None = None,
+) -> bool:
+    """Predicate: has this (project, memkey) pair been rejected before?
+
+    Returns False when the rejections file doesn't exist yet (fresh
+    install). Malformed lines are skipped — the predicate degrades to
+    "no rejection found" rather than crashing the planner.
+    """
+    target = _rejections_path(path)
+    if not target.is_file():
+        return False
+    try:
+        content = target.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        if (
+            obj.get("project") == project_key
+            and obj.get("planner_memory_key") == planner_memory_key
+        ):
+            return True
+    return False

--- a/src/pollypm/plugins_builtin/project_planning/proposals.py
+++ b/src/pollypm/plugins_builtin/project_planning/proposals.py
@@ -1,0 +1,273 @@
+"""Planner improvement proposals — issue #275.
+
+Alongside the primary plan, the architect (cold-start or replan) can
+emit a list of improvement proposals: optional, bite-sized suggestions
+the user chooses to accept or reject one at a time. Each proposal lands
+in the cockpit inbox as its own task so the user gets a single decision
+to make rather than a wall of text to triage.
+
+This module owns three concerns:
+
+1. The :class:`ImprovementProposal` dataclass — the shape the architect
+   (or a fixture in tests) hands to the emitter.
+2. :func:`emit_proposals` — persist each accepted proposal as an inbox
+   task via the work service, tagged with ``proposal`` labels the TUI
+   detects.
+3. :func:`filter_rejected` — drop proposals the user previously
+   rejected, so we don't re-notify them on every replan.
+
+The emitter is the "plumbing" piece referenced in issue #275: even while
+the architect LLM's improvements channel is still being wired, tests
+and ``pm project replan`` flows can invoke this function with a hand-
+built proposal list and see the inbox behaviour end-to-end.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+
+# Severity values accepted on a proposal. Kept deliberately short so the
+# label suffix stays readable in the inbox row.
+VALID_SEVERITIES: tuple[str, ...] = ("info", "advisory", "important")
+
+
+@dataclass(slots=True)
+class ImprovementProposal:
+    """One improvement suggestion the architect surfaces for user review.
+
+    Fields:
+
+    * ``title`` — short summary (becomes the inbox subject).
+    * ``rationale`` — the "why" paragraph.
+    * ``proposed_task_spec`` — dict that seeds a work_tasks row if the
+      user accepts. ``description`` and ``acceptance_criteria`` are the
+      primary fields; extra keys are preserved verbatim for future
+      growth.
+    * ``severity`` — one of :data:`VALID_SEVERITIES`.
+    * ``planner_memory_key`` — stable id used to remember rejections.
+      If omitted, :meth:`derive_memory_key` computes a hash from title
+      + project at emit time.
+    """
+
+    title: str
+    rationale: str
+    proposed_task_spec: dict = field(default_factory=dict)
+    severity: str = "advisory"
+    planner_memory_key: str = ""
+
+    def derive_memory_key(self, project_key: str) -> str:
+        """Return a stable per-(project, title) identifier for rejection memory."""
+        if self.planner_memory_key:
+            return self.planner_memory_key
+        raw = f"{project_key}\x00{self.title.strip().lower()}".encode("utf-8")
+        return hashlib.sha1(raw).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Markdown preview rendering
+# ---------------------------------------------------------------------------
+
+
+def render_proposal_body(proposal: ImprovementProposal) -> str:
+    """Build the inbox-task body for an improvement proposal.
+
+    The body starts with the rationale paragraph and is followed by a
+    compact markdown preview of ``proposed_task_spec`` so the user can
+    assess the shape of the task they'd be opting into.
+    """
+    sections: list[str] = []
+    rationale = (proposal.rationale or "").strip()
+    if rationale:
+        sections.append(rationale)
+
+    spec = proposal.proposed_task_spec or {}
+    if spec:
+        sections.append("")  # blank line
+        sections.append("## Proposed task")
+        title = (spec.get("title") or proposal.title or "").strip()
+        if title:
+            sections.append(f"- **title**: {title}")
+        description = (spec.get("description") or "").strip()
+        if description:
+            sections.append("- **description**:")
+            for line in description.splitlines():
+                sections.append(f"  {line}")
+        ac = (spec.get("acceptance_criteria") or "").strip()
+        if ac:
+            sections.append("- **acceptance criteria**:")
+            for line in ac.splitlines():
+                sections.append(f"  {line}")
+        # Passthrough extras so a richer architect spec doesn't silently
+        # get dropped from the preview.
+        extras = {
+            k: v for k, v in spec.items()
+            if k not in ("title", "description", "acceptance_criteria")
+        }
+        if extras:
+            sections.append("- **extra**:")
+            sections.append("  " + json.dumps(extras, sort_keys=True, default=str))
+    return "\n".join(sections).strip()
+
+
+# ---------------------------------------------------------------------------
+# Label conventions
+# ---------------------------------------------------------------------------
+
+
+PROPOSAL_LABEL = "proposal"
+
+
+def proposal_labels(
+    proposal: ImprovementProposal, project_key: str,
+) -> list[str]:
+    """Labels emitted on the inbox task for this proposal.
+
+    Order matters only for readability — the TUI looks up by membership
+    / prefix, not by index.
+    """
+    severity = proposal.severity if proposal.severity in VALID_SEVERITIES else "advisory"
+    memkey = proposal.derive_memory_key(project_key)
+    return [
+        PROPOSAL_LABEL,
+        f"project:{project_key}",
+        f"severity:{severity}",
+        f"memkey:{memkey}",
+    ]
+
+
+def is_proposal_task(task) -> bool:
+    """Return True when a work_tasks row was emitted as a proposal."""
+    try:
+        labels = list(task.labels or [])
+    except AttributeError:
+        return False
+    return PROPOSAL_LABEL in labels
+
+
+def memkey_from_labels(labels: Iterable[str]) -> str | None:
+    """Pull the ``memkey:<hash>`` label off a task, if present."""
+    for label in labels or []:
+        if isinstance(label, str) and label.startswith("memkey:"):
+            return label.split(":", 1)[1]
+    return None
+
+
+def severity_from_labels(labels: Iterable[str]) -> str | None:
+    for label in labels or []:
+        if isinstance(label, str) and label.startswith("severity:"):
+            return label.split(":", 1)[1]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Emission
+# ---------------------------------------------------------------------------
+
+
+def emit_proposals(
+    service,
+    *,
+    project_key: str,
+    proposals: list[ImprovementProposal],
+    memory_path: Path | None = None,
+) -> list[str]:
+    """Persist ``proposals`` as inbox tasks on ``service``.
+
+    * Previously-rejected memory keys are filtered before emission.
+    * Each surviving proposal becomes one ``chat`` task with
+      ``proposal`` labels; the TUI handles Accept/Reject from there.
+
+    Returns the list of task_ids created (may be shorter than
+    ``proposals`` when rejections were filtered out).
+    """
+    kept = filter_rejected(proposals, project_key=project_key, memory_path=memory_path)
+    created: list[str] = []
+    for proposal in kept:
+        body = render_proposal_body(proposal)
+        labels = proposal_labels(proposal, project_key)
+        task = service.create(
+            title=proposal.title,
+            description=body,
+            type="task",
+            project=project_key,
+            flow_template="chat",
+            roles={"requester": "user", "operator": "architect"},
+            priority="normal",
+            created_by="architect",
+            labels=labels,
+        )
+        created.append(task.task_id)
+    return created
+
+
+# ---------------------------------------------------------------------------
+# Rejection filter
+# ---------------------------------------------------------------------------
+
+
+def filter_rejected(
+    proposals: list[ImprovementProposal],
+    *,
+    project_key: str,
+    memory_path: Path | None = None,
+) -> list[ImprovementProposal]:
+    """Return only proposals the user has not previously rejected."""
+    from pollypm.plugins_builtin.project_planning.memory import is_proposal_rejected
+
+    kept: list[ImprovementProposal] = []
+    for proposal in proposals:
+        memkey = proposal.derive_memory_key(project_key)
+        if is_proposal_rejected(
+            project_key=project_key,
+            planner_memory_key=memkey,
+            path=memory_path,
+        ):
+            continue
+        kept.append(proposal)
+    return kept
+
+
+# ---------------------------------------------------------------------------
+# Accept helper — used by the cockpit UI
+# ---------------------------------------------------------------------------
+
+
+def accept_proposal(
+    service,
+    *,
+    task_id: str,
+    proposal_spec: dict[str, Any],
+    project_key: str,
+    actor: str = "user",
+):
+    """Create a follow-on work_tasks row for an accepted proposal.
+
+    Returns the newly-created :class:`Task`. The caller is expected to
+    archive the inbox row and record a ``proposal_accepted`` context
+    entry on it separately.
+    """
+    spec = proposal_spec or {}
+    title = (spec.get("title") or "").strip() or "Proposal follow-up"
+    description = (spec.get("description") or "").strip()
+    acceptance_criteria = spec.get("acceptance_criteria") or None
+    task = service.create(
+        title=title,
+        description=description,
+        type="task",
+        project=project_key,
+        flow_template="standard",
+        roles={"worker": "worker", "reviewer": "user", "requester": "user"},
+        priority="normal",
+        created_by=actor,
+        acceptance_criteria=acceptance_criteria,
+        labels=["from_proposal", f"project:{project_key}"],
+    )
+    # Context entry on the ORIGINATING inbox task is the caller's job
+    # (``task_id`` above) — that way they can use their own service
+    # handle and keep transaction boundaries obvious.
+    return task

--- a/tests/test_improvement_proposals.py
+++ b/tests/test_improvement_proposals.py
@@ -1,0 +1,448 @@
+"""Tests for planner improvement proposals (#275).
+
+Covers the full pipeline:
+
+1. ``emit_proposals`` writes an inbox task with ``proposal`` labels.
+2. Previously-rejected memkeys get filtered out on the next planner run.
+3. Inbox Accept creates a new ``work_tasks`` row from the spec and
+   archives the originating proposal with a context entry.
+4. Inbox Reject with a rationale stores the rejection in planner memory
+   and archives with the matching context entry.
+5. Plain ``a`` (archive) on a proposal warns — it does NOT silently
+   archive the item; the user must press A or X explicitly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from pollypm.work.sqlite_service import SQLiteWorkService
+from pollypm.plugins_builtin.project_planning import memory as planner_memory
+from pollypm.plugins_builtin.project_planning.proposals import (
+    ImprovementProposal,
+    emit_proposals,
+    filter_rejected,
+    is_proposal_task,
+    memkey_from_labels,
+    render_proposal_body,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures shared with the cockpit UI tests — a single-project workspace
+# seeded with a proposal inbox task.
+# ---------------------------------------------------------------------------
+
+
+def _write_minimal_config(project_path: Path, config_path: Path) -> None:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "[project]\n"
+        f'tmux_session = "pollypm-test"\n'
+        f'workspace_root = "{project_path.parent}"\n'
+        "\n"
+        f'[projects.demo]\n'
+        f'key = "demo"\n'
+        f'name = "Demo"\n'
+        f'path = "{project_path}"\n'
+    )
+
+
+def _load_config_compatible(config_path: Path) -> bool:
+    try:
+        from pollypm.config import load_config
+        cfg = load_config(config_path)
+        return "demo" in getattr(cfg, "projects", {})
+    except Exception:  # noqa: BLE001
+        return False
+
+
+@pytest.fixture
+def proposal_env(tmp_path: Path):
+    """Seed a project DB and emit one proposal via the public emitter."""
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    config_path = tmp_path / "pollypm.toml"
+    _write_minimal_config(project_path, config_path)
+    db_path = project_path / ".pollypm" / "state.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    rejections_path = tmp_path / "planner_rejections.jsonl"
+
+    proposal = ImprovementProposal(
+        title="Add coverage gate for flow_engine",
+        rationale="Coverage on the flow engine is below 70%; a gate stops drift.",
+        proposed_task_spec={
+            "title": "Add coverage gate for flow_engine",
+            "description": "Wire a coverage-ratchet check into CI.",
+            "acceptance_criteria": (
+                "CI fails when coverage for src/pollypm/work/flow_engine.py "
+                "drops below the last-recorded value."
+            ),
+        },
+        severity="advisory",
+    )
+
+    svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+    try:
+        task_ids = emit_proposals(
+            svc,
+            project_key="demo",
+            proposals=[proposal],
+            memory_path=rejections_path,
+        )
+    finally:
+        svc.close()
+    assert task_ids, "expected at least one proposal task emitted"
+
+    return {
+        "config_path": config_path,
+        "project_path": project_path,
+        "db_path": db_path,
+        "rejections_path": rejections_path,
+        "proposal": proposal,
+        "proposal_task_id": task_ids[0],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. emit_proposals writes a proposal inbox task with the expected labels
+# ---------------------------------------------------------------------------
+
+
+def test_emit_proposals_writes_inbox_task_with_proposal_labels(
+    proposal_env,
+) -> None:
+    svc = SQLiteWorkService(
+        db_path=proposal_env["db_path"],
+        project_path=proposal_env["project_path"],
+    )
+    try:
+        task = svc.get(proposal_env["proposal_task_id"])
+    finally:
+        svc.close()
+    assert is_proposal_task(task)
+    assert "proposal" in task.labels
+    assert "project:demo" in task.labels
+    # Severity label normalised to one of the three accepted values.
+    severity_labels = [l for l in task.labels if l.startswith("severity:")]
+    assert severity_labels == ["severity:advisory"]
+    # The memkey is a short hex digest — present + non-empty.
+    memkey = memkey_from_labels(task.labels)
+    assert memkey and len(memkey) >= 8
+    # Rationale + preview markdown both present in the body.
+    assert "Coverage on the flow engine" in task.description
+    assert "## Proposed task" in task.description
+    assert "acceptance criteria" in task.description
+
+
+# ---------------------------------------------------------------------------
+# 2. Previously-rejected memkey is filtered on the next planner run
+# ---------------------------------------------------------------------------
+
+
+def test_previously_rejected_proposals_are_filtered_on_next_run(
+    tmp_path: Path,
+) -> None:
+    rejections_path = tmp_path / "planner_rejections.jsonl"
+    proposal = ImprovementProposal(
+        title="Add latency SLO dashboard",
+        rationale="We have no visibility into p95 latency by flow.",
+        proposed_task_spec={
+            "title": "Latency SLO dashboard",
+            "description": "Expose p50/p95 per flow template in the cockpit.",
+        },
+    )
+    memkey = proposal.derive_memory_key("demo")
+
+    # Before any rejection — proposal survives filtering.
+    kept = filter_rejected(
+        [proposal], project_key="demo", memory_path=rejections_path,
+    )
+    assert len(kept) == 1
+
+    # Record the rejection.
+    planner_memory.record_proposal_rejection(
+        project_key="demo",
+        planner_memory_key=memkey,
+        rationale="Not now — we're focused on P1 blockers.",
+        path=rejections_path,
+    )
+
+    # After rejection — the proposal is filtered out.
+    kept_after = filter_rejected(
+        [proposal], project_key="demo", memory_path=rejections_path,
+    )
+    assert kept_after == []
+
+    # And emit_proposals honours the filter end-to-end: no task written.
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    db_path = project_path / ".pollypm" / "state.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+    try:
+        task_ids = emit_proposals(
+            svc,
+            project_key="demo",
+            proposals=[proposal],
+            memory_path=rejections_path,
+        )
+    finally:
+        svc.close()
+    assert task_ids == []
+
+
+def test_is_proposal_rejected_cross_project_does_not_leak(
+    tmp_path: Path,
+) -> None:
+    """Rejection for project 'alpha' must not filter a same-title proposal for 'beta'."""
+    rejections_path = tmp_path / "planner_rejections.jsonl"
+    proposal = ImprovementProposal(title="X", rationale="why")
+    memkey_alpha = proposal.derive_memory_key("alpha")
+    planner_memory.record_proposal_rejection(
+        project_key="alpha",
+        planner_memory_key=memkey_alpha,
+        rationale="nope",
+        path=rejections_path,
+    )
+    # Same logical title, different project — memkey differs, not rejected.
+    assert planner_memory.is_proposal_rejected(
+        project_key="alpha",
+        planner_memory_key=memkey_alpha,
+        path=rejections_path,
+    ) is True
+    memkey_beta = proposal.derive_memory_key("beta")
+    assert planner_memory.is_proposal_rejected(
+        project_key="beta",
+        planner_memory_key=memkey_beta,
+        path=rejections_path,
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# Body rendering sanity check (used by the Accept spec-recovery path)
+# ---------------------------------------------------------------------------
+
+
+def test_render_proposal_body_embeds_spec_preview() -> None:
+    body = render_proposal_body(ImprovementProposal(
+        title="T",
+        rationale="Because.",
+        proposed_task_spec={
+            "title": "T",
+            "description": "Do the thing.",
+            "acceptance_criteria": "It works.",
+        },
+    ))
+    assert "Because." in body
+    assert "## Proposed task" in body
+    assert "Do the thing." in body
+    assert "It works." in body
+
+
+# ---------------------------------------------------------------------------
+# 3, 4, 5 — Inbox UI behaviour. Mirrors the pattern in
+# tests/test_cockpit_inbox_ui.py: Pilot-driven Textual harness.
+# ---------------------------------------------------------------------------
+
+
+def _run(coro):
+    asyncio.run(coro)
+
+
+@pytest.fixture
+def inbox_app(proposal_env):
+    if not _load_config_compatible(proposal_env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_ui import PollyInboxApp
+    return PollyInboxApp(proposal_env["config_path"])
+
+
+def _select_proposal(app, proposal_env) -> None:
+    target = proposal_env["proposal_task_id"]
+    for idx, task in enumerate(app._tasks):
+        if task.task_id == target:
+            app.list_view.index = idx
+            return
+    raise AssertionError(f"proposal task {target} not visible in inbox list")
+
+
+def test_inbox_accept_creates_follow_on_task_and_archives(
+    proposal_env, inbox_app,
+) -> None:
+    async def body() -> None:
+        async with inbox_app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            _select_proposal(inbox_app, proposal_env)
+            await pilot.press("enter")
+            await pilot.pause()
+            proposal_id = proposal_env["proposal_task_id"]
+            assert inbox_app._selected_task_id == proposal_id
+
+            # Hint bar switched to the proposal keybindings.
+            hint_rendered = str(inbox_app.hint.render())
+            assert "A accept" in hint_rendered
+            assert "X reject" in hint_rendered
+
+            # Spec was cached for the Accept path.
+            spec = inbox_app._proposal_specs.get(proposal_id)
+            assert spec is not None
+            assert "title" in spec
+
+            # Capital A triggers Accept.
+            await pilot.press("A")
+            await pilot.pause()
+
+            # Inbox list shrank (the proposal row is archived).
+            assert all(t.task_id != proposal_id for t in inbox_app._tasks)
+
+            # Underlying DB state: original archived DONE, new task exists.
+            svc = SQLiteWorkService(
+                db_path=proposal_env["db_path"],
+                project_path=proposal_env["project_path"],
+            )
+            try:
+                original = svc.get(proposal_id)
+                assert original.work_status.value == "done"
+                # A proposal_accepted context entry was written.
+                accepted_ctx = svc.get_context(
+                    proposal_id, entry_type="proposal_accepted",
+                )
+                assert accepted_ctx, "expected proposal_accepted context row"
+
+                # Look up every task in the project and find the one
+                # labelled from_proposal — that's the follow-on.
+                all_tasks = svc.list_tasks(project="demo")
+                follow_ons = [
+                    t for t in all_tasks
+                    if "from_proposal" in (t.labels or [])
+                ]
+                assert len(follow_ons) == 1
+                follow_on = follow_ons[0]
+                assert follow_on.task_id != proposal_id
+                # Spec fields populated.
+                assert follow_on.title == "Add coverage gate for flow_engine"
+                ac = (follow_on.acceptance_criteria or "")
+                assert "coverage" in ac.lower()
+                assert "flow_engine" in ac
+            finally:
+                svc.close()
+
+            # Hint bar snaps back to the default.
+            hint_after = str(inbox_app.hint.render())
+            assert "A accept" not in hint_after
+    _run(body())
+
+
+def test_inbox_reject_persists_rationale_and_archives(
+    proposal_env, inbox_app,
+) -> None:
+    async def body() -> None:
+        async with inbox_app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            _select_proposal(inbox_app, proposal_env)
+            await pilot.press("enter")
+            await pilot.pause()
+            proposal_id = proposal_env["proposal_task_id"]
+
+            # Reject a rationale path may write to the REAL user home —
+            # redirect it to the per-test path the fixture seeded.
+            rejections_path = proposal_env["rejections_path"]
+            import pollypm.plugins_builtin.project_planning.memory as pm_mem
+            original = pm_mem.record_proposal_rejection
+            captured_paths: list[Path] = []
+
+            def _record_override(**kwargs):
+                kwargs.setdefault("path", rejections_path)
+                captured_paths.append(kwargs["path"])
+                return original(**kwargs)
+            pm_mem.record_proposal_rejection = _record_override  # type: ignore[assignment]
+
+            try:
+                await pilot.press("X")
+                await pilot.pause()
+                # Reject focuses the reply Input in "rationale" mode.
+                assert inbox_app._awaiting_rejection_task_id == proposal_id
+                assert inbox_app.reply_input.has_focus
+                assert "reject" in (inbox_app.reply_input.placeholder or "").lower()
+
+                inbox_app.reply_input.value = "Too speculative for this milestone."
+                await pilot.press("enter")
+                await pilot.pause()
+            finally:
+                pm_mem.record_proposal_rejection = original  # type: ignore[assignment]
+
+            # Inbox row archived; underlying task is DONE.
+            assert all(t.task_id != proposal_id for t in inbox_app._tasks)
+            svc = SQLiteWorkService(
+                db_path=proposal_env["db_path"],
+                project_path=proposal_env["project_path"],
+            )
+            try:
+                task = svc.get(proposal_id)
+                assert task.work_status.value == "done"
+                rejected_ctx = svc.get_context(
+                    proposal_id, entry_type="proposal_rejected",
+                )
+                assert rejected_ctx
+                assert "Too speculative" in rejected_ctx[0].text
+            finally:
+                svc.close()
+
+            # Planner memory got the rejection — the memkey is stored.
+            assert rejections_path.exists()
+            content = rejections_path.read_text()
+            assert "Too speculative" in content
+            assert '"project": "demo"' in content
+
+            # And the filter function now excludes the proposal.
+            from pollypm.plugins_builtin.project_planning.proposals import (
+                filter_rejected as _filter,
+            )
+            remaining = _filter(
+                [proposal_env["proposal"]],
+                project_key="demo",
+                memory_path=rejections_path,
+            )
+            assert remaining == []
+    _run(body())
+
+
+def test_plain_a_on_proposal_warns_and_does_not_archive(
+    proposal_env, inbox_app,
+) -> None:
+    async def body() -> None:
+        async with inbox_app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            _select_proposal(inbox_app, proposal_env)
+            await pilot.press("enter")
+            await pilot.pause()
+            proposal_id = proposal_env["proposal_task_id"]
+            initial_count = len(inbox_app._tasks)
+
+            # Lowercase ``a`` MUST NOT silently archive a proposal.
+            await pilot.press("a")
+            await pilot.pause()
+
+            # Row still present — nothing got dropped.
+            assert len(inbox_app._tasks) == initial_count
+            assert any(
+                t.task_id == proposal_id for t in inbox_app._tasks
+            )
+            svc = SQLiteWorkService(
+                db_path=proposal_env["db_path"],
+                project_path=proposal_env["project_path"],
+            )
+            try:
+                task = svc.get(proposal_id)
+                # Still live (not DONE).
+                assert task.work_status.value != "done"
+            finally:
+                svc.close()
+    _run(body())


### PR DESCRIPTION
Planner surfaces improvement suggestions as inbox items you can Accept (promotes to task) or Reject (stores rationale in planner memory so it doesn't re-propose).

## Files (4)
- `project_planning/memory.py` — `record_proposal_rejection`, `is_proposal_rejected` via planner_rejections.jsonl (sidesteps strict schema).
- `project_planning/proposals.py` (new) — `ImprovementProposal`, `emit_proposals` (filters rejected), `filter_rejected`, `accept_proposal`.
- `cockpit_ui.py` — proposal detection, `A`/`X` keybindings, action handlers, archive-warns-on-proposal guard, reply-input repurposed for rejection rationale.
- Tests: 7 new covering emitter labels, filter-on-replan, Accept→follow-on+archive, Reject→rationale+archive, plain `a` warns, cross-project isolation, preview rendering.

## Design notes
- Plumbing-first: emit_proposals is the stable entry point. Architect synthesize LLM not yet wired programmatically (it's a .md prompt file); tests exercise via direct-call fixture.
- Accepted proposals create `standard` flow tasks labelled `from_proposal` — actionable worker+reviewer work, not another chat row.

## Tests (+7)
23 total in targeted run (all pass). test_project_planning_plugin.py (93) still green.

Closes #275