### PR TITLE
feat(recovery): state-drift detection — heartbeat catches agent-ended-turn-without-advance (#296)

### DIFF
--- a/src/pollypm/plugins_builtin/core_recurring/plugin.py
+++ b/src/pollypm/plugins_builtin/core_recurring/plugin.py
@@ -133,6 +133,9 @@ def work_progress_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
     from pollypm.plugins_builtin.task_assignment_notify.resolver import (
         notify as _notify,
     )
+    from pollypm.recovery.state_reconciliation import (
+        reconcile_expected_advance,
+    )
     from pollypm.work.models import ActorType
     from pollypm.work.task_assignment import SessionRoleIndex
 
@@ -157,6 +160,13 @@ def work_progress_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
     skipped_recent_event = 0
     skipped_no_session = 0
     deduped = 0
+    # #296 — state-drift counters. ``drift_detected`` is the number of
+    # tasks whose observable deliverables outpace their flow node on
+    # this sweep; ``drift_alerted`` is the subset where we actually
+    # raised a fresh alert (the rest were deduped by upsert_alert's
+    # per-type uniqueness guard).
+    drift_detected = 0
+    drift_alerted = 0
 
     try:
         try:
@@ -212,6 +222,81 @@ def work_progress_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
                         if bool(checker(target_name)):
                             skipped_active_turn += 1
                             continue
+                    except Exception:  # noqa: BLE001
+                        pass
+
+            # #296 — observable flow-state drift. Check BEFORE the
+            # recent-event skip: a session that just fired a ``pm
+            # notify`` has a very fresh event on the ledger (the
+            # notify itself), which would otherwise suppress the
+            # stuck_on_task path AND mask the drift. Drift detection
+            # has its own dedupe via ``upsert_alert`` — the
+            # ``state_drift:<task_id>`` alert type is unique per task
+            # per open alert, so repeated sweeps don't spam.
+            try:
+                resolver = getattr(work, "_resolve_project_path", None)
+                project_path = None
+                if callable(resolver):
+                    try:
+                        project_path = resolver(task.project)
+                    except Exception:  # noqa: BLE001
+                        project_path = None
+                if project_path is None:
+                    project_path = services.project_root
+                drift = reconcile_expected_advance(
+                    task,
+                    Path(project_path),
+                    work,
+                    state_store=state_store,
+                    now=now,
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "work.progress_sweep: drift reconcile failed for %s",
+                    task.task_id, exc_info=True,
+                )
+                drift = None
+            if drift is not None:
+                drift_detected += 1
+                current_node = getattr(task, "current_node_id", "") or ""
+                message = (
+                    f"task {task.task_id}: observed "
+                    f"{drift.advance_to_node} deliverables, advancing "
+                    f"from {current_node} to {drift.advance_to_node} — "
+                    f"{drift.reason}"
+                )
+                if state_store is not None:
+                    # Event — permanent record of the drift detection.
+                    # Keyed to the session so operators can scope.
+                    try:
+                        state_store.record_event(
+                            target_name, "state_drift", message,
+                        )
+                    except Exception:  # noqa: BLE001
+                        pass
+                    # Alert — visible warning for Polly / the cockpit.
+                    # Alert type carries the task id so drift on two
+                    # different tasks surfaces as two distinct alerts.
+                    alert_type = f"state_drift:{task.task_id}"
+                    try:
+                        # Detect whether the alert is new so our counter
+                        # reflects real user-visible notifications.
+                        existing = state_store.execute(
+                            "SELECT id FROM alerts WHERE session_name = ? "
+                            "AND alert_type = ? AND status = 'open'",
+                            (target_name, alert_type),
+                        ).fetchone()
+                        state_store.upsert_alert(
+                            target_name,
+                            alert_type,
+                            "warn",
+                            (
+                                f"{target_name} drift on {task.task_id}: "
+                                f"{drift.reason}"
+                            ),
+                        )
+                        if existing is None:
+                            drift_alerted += 1
                     except Exception:  # noqa: BLE001
                         pass
 
@@ -286,6 +371,8 @@ def work_progress_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
         "skipped_active_turn": skipped_active_turn,
         "skipped_recent_event": skipped_recent_event,
         "skipped_no_session": skipped_no_session,
+        "drift_detected": drift_detected,
+        "drift_alerted": drift_alerted,
     }
 
 

--- a/src/pollypm/recovery/base.py
+++ b/src/pollypm/recovery/base.py
@@ -42,6 +42,10 @@ class SessionHealth(StrEnum):
     # #249 — work-service-aware classifications
     STUCK_ON_TASK = "stuck_on_task"
     SILENT_WORKER = "silent_worker"
+    # #296 — observable-deliverables drift: the agent ended its turn
+    # with plan/artefacts already on disk but the task's flow node
+    # didn't advance. Alert + event only; no auto-advance in v1.
+    STATE_DRIFT = "state_drift"
 
 
 # Intervention escalation ladder
@@ -57,8 +61,9 @@ INTERVENTION_LADDER = (
 # not part of the sequential ladder above; they're action kinds emitted
 # by the work-aware classifications and handled by the apply side.
 EXTENDED_INTERVENTIONS = (
-    "resume_ping",          # Re-emit a task_assignment notify event
-    "prompt_pm_task_next",  # Send `pm task next` to the session
+    "resume_ping",            # Re-emit a task_assignment notify event
+    "prompt_pm_task_next",    # Send `pm task next` to the session
+    "reconcile_flow_state",   # Log + alert observable flow drift (#296)
 )
 
 
@@ -96,6 +101,13 @@ class SessionSignals:
     # the session is currently processing — we should NOT classify as
     # stuck even if other timers have rolled over.
     turn_active: bool = False
+    # #296 — precomputed drift-reconciliation action. When populated, the
+    # classifier promotes the session to ``STATE_DRIFT`` instead of the
+    # generic ``IDLE`` ladder. Carries the inferred target node + reason
+    # so the intervention layer can log + alert without re-running the
+    # heuristics. Type is ``ReconciliationAction | None`` — typed as
+    # ``Any`` here to avoid a cycle with ``state_reconciliation``.
+    drift_action: Any | None = None
 
 
 @dataclass(slots=True)

--- a/src/pollypm/recovery/default.py
+++ b/src/pollypm/recovery/default.py
@@ -73,6 +73,19 @@ class DefaultRecoveryPolicy(RecoveryPolicy):
         ):
             return SessionHealth.STUCK_ON_TASK
 
+        # #296 — flow-state drift. Agent ended its turn, holds an active
+        # claim, and the precomputed reconciliation action says the task
+        # has observable deliverables past its current flow node. Evaluate
+        # AFTER turn_active (a live turn shouldn't be flagged) and BEFORE
+        # the generic IDLE classification so the drift alert takes
+        # priority over routine-idle nudges.
+        if (
+            not signals.turn_active
+            and signals.active_claim_task_id
+            and signals.drift_action is not None
+        ):
+            return SessionHealth.STATE_DRIFT
+
         # Worker session is up but has no active claim and hasn't done
         # anything for 30min — it likely missed a queue event. Only
         # applies to "worker" role to avoid flagging operator/reviewer
@@ -237,6 +250,28 @@ class DefaultRecoveryPolicy(RecoveryPolicy):
                 ),
                 details={
                     "last_event_seconds_ago": signals.last_event_seconds_ago,
+                },
+            )
+
+        # #296 — observable flow-state drift. V1 policy: log + alert only.
+        # We deliberately do NOT auto-advance the task node in v1; better
+        # to flag than silently mutate state. The apply side owns the
+        # event + alert writes (see ``work.progress_sweep``).
+        if health == SessionHealth.STATE_DRIFT:
+            action = signals.drift_action
+            target = getattr(action, "advance_to_node", "") if action else ""
+            reason = getattr(action, "reason", "") if action else ""
+            return InterventionAction(
+                session_name=signals.session_name,
+                action="reconcile_flow_state",
+                reason=(
+                    f"Observable drift on task {signals.active_claim_task_id}: "
+                    f"{reason}"
+                ),
+                details={
+                    "task_id": signals.active_claim_task_id,
+                    "advance_to_node": target,
+                    "drift_reason": reason,
                 },
             )
 

--- a/src/pollypm/recovery/state_reconciliation.py
+++ b/src/pollypm/recovery/state_reconciliation.py
@@ -1,0 +1,318 @@
+"""Flow-state reconciliation — detect observable drift between a task's
+current flow node and the deliverables sitting on disk / in the ledger.
+
+Dogfood surfaced a class of failure the heartbeat couldn't catch: an
+agent writes the plan artifacts, fires a ``pm notify``, ends its turn,
+but the work-service task node never advances. Everything looks done
+except the one row of state the rest of the system reads from.
+
+This module owns the ``reconcile_expected_advance`` helper — a pure
+function that inspects the task's flow, the project's working tree, and
+the state-store ledger for ``inbox.message.created`` events, and
+returns the node the task *should* be at (if drift is detected) or
+``None`` when nothing's amiss.
+
+V1 scope — **log + alert only**. The heartbeat sweep raises a
+``state_drift`` alert and records a ``state_drift`` event so the
+operator sees the divergence; it does **not** auto-advance the task.
+Auto-advance is explicitly a v2 concern (``[recovery].auto_reconcile``
+flag) so we don't silently mutate work_tasks in response to a heuristic.
+
+Heuristics (start narrow; this is the first pass):
+
+* For tasks on the ``plan_project`` flow:
+    - ``<project_path>/docs/plan/plan.md`` OR
+      ``<project_path>/docs/project-plan.md`` exists AND is > 500
+      bytes of non-whitespace content → observable deliverables say
+      the ``synthesize`` stage has finished.
+    - An ``inbox.message.created`` event exists in the last hour whose
+      message mentions the plan being ready ("plan ready",
+      "plan is ready", "plan ready for approval") → observable
+      signal that the agent already announced completion, so the
+      intended next stage is ``user_approval``.
+    - Both → reconciliation target is ``user_approval``.
+    - Plan file only, no notify → target is ``synthesize`` (the plan
+      exists but the announcement hasn't landed yet; the agent is
+      mid-synthesize and needs a nudge to close out the node).
+
+* For any task:
+    - If the task's current node carries an ``artifact_gate`` that
+      points to a file, and that file exists with non-trivial
+      content, the node is observably done. (Left as a hook — no
+      flow currently uses ``artifact_gate``; the function is ready
+      for when one does.)
+
+* **Never** auto-advance past a human-review node. When the target
+  node is ``user_approval`` (or any node with ``actor_type=human``
+  in v2), the helper still returns the action — but the sweep
+  handler raises an alert rather than mutating state.
+
+The function is pure: take ``(task, project_path, work_service,
+state_store=None)`` → return ``ReconciliationAction | None``. Easy to
+unit-test without live sessions or a running work-service.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+
+# Minimum non-whitespace byte count before a plan file counts as a
+# real plan. Mirrors ``plan_presence.MIN_PLAN_SIZE_BYTES`` so the two
+# gates stay consistent — if you bump one, bump the other.
+MIN_PLAN_SIZE_BYTES = 500
+
+# Candidate plan-file locations scanned in order. The first match wins.
+# Matches the observable reality from the dogfood run: architects have
+# historically written either path depending on which spec revision
+# they were following.
+_PLAN_FILE_CANDIDATES: tuple[str, ...] = (
+    "docs/plan/plan.md",
+    "docs/project-plan.md",
+)
+
+# Window for matching a "plan ready" notify against the current sweep.
+# 1h is generous — the architect's turn might have ended anywhere from
+# a minute to 30min before the next sweep tick — but tight enough that
+# a stale notify from last week doesn't cause a false positive.
+_NOTIFY_LOOKBACK_SECONDS = 3600
+
+# Keywords / phrases that mark an ``inbox.message.created`` event as
+# the architect announcing plan completion. Case-insensitive substring
+# match; any single hit promotes the classification to ``user_approval``.
+_PLAN_READY_PHRASES: tuple[str, ...] = (
+    "plan ready for approval",
+    "plan is ready",
+    "plan ready",
+    "ready for approval",
+)
+
+
+@dataclass(slots=True, frozen=True)
+class ReconciliationAction:
+    """Observable drift → the node the task should be on.
+
+    ``advance_to_node`` is the inferred current node based on
+    observable deliverables (files on disk, events in the ledger).
+    ``reason`` is human-readable — it shows up in the event message
+    and the alert body so Sam can decide case-by-case.
+    """
+
+    advance_to_node: str
+    reason: str
+
+
+def _plan_file_present(project_path: Path) -> tuple[Path | None, int]:
+    """Return the first plan file that exists with > 500 bytes, or ``(None, 0)``.
+
+    Fails closed on any IO error — we'd rather skip reconciliation than
+    raise a spurious drift alert because the filesystem was momentarily
+    unhappy.
+    """
+    for candidate in _PLAN_FILE_CANDIDATES:
+        path = project_path / candidate
+        try:
+            if not path.is_file():
+                continue
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        stripped = len(text.strip())
+        if stripped > MIN_PLAN_SIZE_BYTES:
+            return path, stripped
+    return None, 0
+
+
+def _plan_ready_notify_recent(
+    state_store: Any,
+    project_key: str,
+    *,
+    now: datetime | None = None,
+    lookback_seconds: int = _NOTIFY_LOOKBACK_SECONDS,
+) -> bool:
+    """True iff a recent ``inbox.message.created`` event names plan-ready.
+
+    Scans the ledger for events in the last ``lookback_seconds`` whose
+    message mentions the project **and** contains a plan-ready phrase.
+    Case-insensitive; any one phrase hit is enough. Returns False on
+    any error — no drift alert should trigger because we couldn't
+    read the ledger.
+    """
+    if state_store is None:
+        return False
+    cutoff_dt = (now or datetime.now(UTC)) - timedelta(seconds=lookback_seconds)
+    cutoff_iso = cutoff_dt.isoformat()
+    try:
+        rows = state_store.execute(
+            """
+            SELECT message FROM events
+            WHERE event_type = 'inbox.message.created'
+              AND created_at >= ?
+            ORDER BY id DESC
+            LIMIT 50
+            """,
+            (cutoff_iso,),
+        ).fetchall()
+    except Exception:  # noqa: BLE001
+        return False
+    if not rows:
+        return False
+    project_key_lc = (project_key or "").lower()
+    for row in rows:
+        message = (row[0] or "").lower()
+        if not any(phrase in message for phrase in _PLAN_READY_PHRASES):
+            continue
+        # Soft project match — the notify carries the project key in
+        # the activity_summary body. When the project key is empty
+        # (unusual) we accept any match; otherwise require the key
+        # appear in the message. This keeps a plan-ready notify on
+        # project A from triggering drift on project B.
+        if project_key_lc and project_key_lc not in message:
+            continue
+        return True
+    return False
+
+
+def _flow_template_for_task(task: Any, work_service: Any) -> Any | None:
+    """Resolve the flow template bound to ``task``.
+
+    Returns ``None`` on any failure — reconciliation then skips the
+    per-node artifact_gate heuristic and returns None for anything
+    that depends on node metadata. The plan_project heuristic does
+    not need the template (it hard-codes the node names).
+    """
+    flow_id = getattr(task, "flow_template_id", None)
+    if not flow_id or work_service is None:
+        return None
+    try:
+        return work_service.get_flow(
+            flow_id, project=getattr(task, "project", None),
+        )
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _artifact_gate_satisfied(
+    task: Any, project_path: Path, work_service: Any,
+) -> ReconciliationAction | None:
+    """Check the current node's artifact_gate (if any) against disk.
+
+    The ``artifact_gate`` concept is forward-looking — no flow uses it
+    in the first cut. The hook is here so when a flow adds one, the
+    reconciler will honour it without a code change elsewhere. Expected
+    shape on a ``FlowNode``:
+
+        gates: ["artifact_gate:docs/whatever.md"]
+
+    Where the ``:<path>`` suffix names a file relative to the project
+    root. Presence + non-trivial content → the current node is done
+    and the reconciler proposes advancing to ``next_node_id``.
+    """
+    template = _flow_template_for_task(task, work_service)
+    if template is None:
+        return None
+    current = getattr(task, "current_node_id", None)
+    if not current:
+        return None
+    node = template.nodes.get(current) if hasattr(template, "nodes") else None
+    if node is None:
+        return None
+    gates = getattr(node, "gates", None) or []
+    for gate in gates:
+        if not isinstance(gate, str) or not gate.startswith("artifact_gate:"):
+            continue
+        rel = gate.split(":", 1)[1].strip()
+        if not rel:
+            continue
+        target = project_path / rel
+        try:
+            if not target.is_file():
+                continue
+            text = target.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if len(text.strip()) <= MIN_PLAN_SIZE_BYTES:
+            continue
+        next_node = getattr(node, "next_node_id", None)
+        if not next_node:
+            return None
+        return ReconciliationAction(
+            advance_to_node=next_node,
+            reason=(
+                f"artifact_gate satisfied: {rel} has "
+                f"{len(text.strip())} bytes — node {current} observably done"
+            ),
+        )
+    return None
+
+
+def reconcile_expected_advance(
+    task: Any,
+    project_path: Path,
+    work_service: Any,
+    *,
+    state_store: Any = None,
+    now: datetime | None = None,
+) -> ReconciliationAction | None:
+    """Return a :class:`ReconciliationAction` when drift is detected, else None.
+
+    Pure function — takes a task, the project's filesystem root, a
+    handle to the work service (for flow-template lookup), and
+    optionally the state store (for event-ledger heuristics). All of
+    the disk / ledger reads are soft-fail: any exception yields
+    ``None`` rather than a false positive.
+
+    See module docstring for the heuristic catalogue. When multiple
+    heuristics match, the first one wins in the order documented
+    there — ``plan_project`` specialisation before the generic
+    ``artifact_gate`` check.
+    """
+    if task is None or project_path is None:
+        return None
+
+    flow_id = getattr(task, "flow_template_id", "") or ""
+    current_node = getattr(task, "current_node_id", "") or ""
+    project_key = getattr(task, "project", "") or ""
+
+    # Plan-project heuristic. Only meaningful when the task is actually
+    # on the plan_project flow and sitting upstream of user_approval.
+    if flow_id == "plan_project":
+        # Nodes upstream of user_approval where drift is plausible.
+        # Once the architect is at user_approval (or past it) the
+        # node IS where we'd reconcile to — nothing to do.
+        _UPSTREAM_NODES = {
+            "research", "discover", "decompose", "test_strategy",
+            "magic", "critic_panel", "synthesize",
+        }
+        if current_node in _UPSTREAM_NODES:
+            plan_file, size = _plan_file_present(project_path)
+            notify_fired = _plan_ready_notify_recent(
+                state_store, project_key, now=now,
+            )
+            if plan_file is not None and notify_fired:
+                return ReconciliationAction(
+                    advance_to_node="user_approval",
+                    reason=(
+                        f"plan file {plan_file.name} present ({size} bytes) "
+                        f"and plan-ready notify fired in the last hour — "
+                        f"node {current_node} observably past synthesize"
+                    ),
+                )
+            if plan_file is not None:
+                return ReconciliationAction(
+                    advance_to_node="synthesize",
+                    reason=(
+                        f"plan file {plan_file.name} present ({size} bytes) "
+                        f"— node {current_node} observably past earlier stages"
+                    ),
+                )
+
+    # Generic artifact_gate heuristic (flow-agnostic).
+    action = _artifact_gate_satisfied(task, project_path, work_service)
+    if action is not None:
+        return action
+
+    return None

--- a/tests/test_state_drift_reconciliation.py
+++ b/tests/test_state_drift_reconciliation.py
@@ -1,0 +1,545 @@
+"""Tests for #296 — observable flow-state drift detection.
+
+Three layers of coverage:
+
+* ``reconcile_expected_advance`` as a pure function (no work-service
+  required for the plan-heuristic path) — the core decision table.
+* ``DefaultRecoveryPolicy.classify`` — the ``state_drift`` signal
+  path in/out of the intervention ladder.
+* ``work_progress_sweep_handler`` integration — drift detection
+  alongside the existing ``stuck_on_task`` path, including event +
+  alert emission and dedupe across sweeps.
+
+The plan-project scenario is the real dogfood motivator: Archie wrote
+the plan and fired a ``pm notify`` but his task node stayed on
+``research``. State said one thing, deliverables said another.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pollypm.plugins_builtin.core_recurring.plugin import (
+    work_progress_sweep_handler,
+)
+from pollypm.plugins_builtin.task_assignment_notify.resolver import (
+    _RuntimeServices,
+)
+from pollypm.recovery.base import SessionHealth, SessionSignals
+from pollypm.recovery.default import DefaultRecoveryPolicy
+from pollypm.recovery.state_reconciliation import (
+    MIN_PLAN_SIZE_BYTES,
+    ReconciliationAction,
+    reconcile_expected_advance,
+)
+from pollypm.storage.state import StateStore
+from pollypm.work import task_assignment as bus
+from pollypm.work.sqlite_service import SQLiteWorkService
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeHandle:
+    name: str
+
+
+@dataclass
+class FakeSessionService:
+    handles: list[FakeHandle]
+    sent: list[tuple[str, str]] = field(default_factory=list)
+    busy: set[str] = field(default_factory=set)
+
+    def list(self) -> list[FakeHandle]:
+        return list(self.handles)
+
+    def send(self, name: str, text: str, *, press_enter: bool = True) -> None:
+        self.sent.append((name, text))
+
+    def is_turn_active(self, name: str) -> bool:
+        return name in self.busy
+
+
+# ---------------------------------------------------------------------------
+# Task doubles — the reconciliation helper only reads attributes.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeTask:
+    project: str
+    task_number: int
+    flow_template_id: str
+    current_node_id: str
+    title: str = "Plan the project"
+
+    @property
+    def task_id(self) -> str:
+        return f"{self.project}/{self.task_number}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_plan(path: Path, size_bytes: int = MIN_PLAN_SIZE_BYTES + 200) -> Path:
+    """Write a plan.md of the requested size at the given path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    filler = "The plan. " * ((size_bytes // 10) + 1)
+    path.write_text(filler, encoding="utf-8")
+    return path
+
+
+def _record_plan_ready_notify(
+    store: StateStore, project: str, actor: str = "architect",
+) -> None:
+    """Record a ``pm notify``-shaped event so the reconciler sees it."""
+    store.record_event(
+        actor,
+        "inbox.message.created",
+        (
+            f"{actor} -> user: Plan ready for approval on {project} — "
+            f"please review docs/plan/plan.md"
+        ),
+    )
+
+
+def _claim_plan_task(work: SQLiteWorkService, project: str) -> str:
+    """Create + queue + claim a plan_project task. Returns its id."""
+    task = work.create(
+        title="Plan the project",
+        description="Produce the project plan.",
+        type="task",
+        project=project,
+        flow_template="plan_project",
+        roles={"architect": "architect"},
+        priority="normal",
+    )
+    work.queue(task.task_id, "pm")
+    work.claim(task.task_id, "architect")
+    return task.task_id
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure reconciliation function
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileExpectedAdvance:
+    """Pure-function tests. No work-service required for plan_project
+    heuristics — they're short-circuited on the flow id."""
+
+    def test_no_deliverables_returns_none(self, tmp_path: Path) -> None:
+        task = FakeTask(
+            project="demo", task_number=1,
+            flow_template_id="plan_project",
+            current_node_id="research",
+        )
+        result = reconcile_expected_advance(
+            task, tmp_path, work_service=None, state_store=None,
+        )
+        assert result is None
+
+    def test_plan_and_notify_routes_to_user_approval(
+        self, tmp_path: Path,
+    ) -> None:
+        _write_plan(tmp_path / "docs" / "plan" / "plan.md")
+        store = StateStore(tmp_path / "state.db")
+        _record_plan_ready_notify(store, project="demo")
+
+        task = FakeTask(
+            project="demo", task_number=1,
+            flow_template_id="plan_project",
+            current_node_id="research",
+        )
+        result = reconcile_expected_advance(
+            task, tmp_path, work_service=None, state_store=store,
+        )
+        assert result is not None
+        assert result.advance_to_node == "user_approval"
+        assert "plan" in result.reason.lower()
+
+    def test_plan_file_only_routes_to_synthesize(
+        self, tmp_path: Path,
+    ) -> None:
+        _write_plan(tmp_path / "docs" / "plan" / "plan.md")
+        store = StateStore(tmp_path / "state.db")
+        # No notify fired.
+
+        task = FakeTask(
+            project="demo", task_number=1,
+            flow_template_id="plan_project",
+            current_node_id="research",
+        )
+        result = reconcile_expected_advance(
+            task, tmp_path, work_service=None, state_store=store,
+        )
+        assert result is not None
+        assert result.advance_to_node == "synthesize"
+
+    def test_legacy_project_plan_path_accepted(
+        self, tmp_path: Path,
+    ) -> None:
+        """Tasks that wrote to docs/project-plan.md (pre-spec-revision
+        architects) are honoured too."""
+        _write_plan(tmp_path / "docs" / "project-plan.md")
+        store = StateStore(tmp_path / "state.db")
+        _record_plan_ready_notify(store, project="demo")
+
+        task = FakeTask(
+            project="demo", task_number=1,
+            flow_template_id="plan_project",
+            current_node_id="research",
+        )
+        result = reconcile_expected_advance(
+            task, tmp_path, work_service=None, state_store=store,
+        )
+        assert result is not None
+        assert result.advance_to_node == "user_approval"
+
+    def test_small_plan_is_ignored(self, tmp_path: Path) -> None:
+        """A plan.md under the 500-byte threshold is scaffolding, not a plan."""
+        plan = tmp_path / "docs" / "plan" / "plan.md"
+        plan.parent.mkdir(parents=True, exist_ok=True)
+        plan.write_text("# Plan\nTODO", encoding="utf-8")
+        store = StateStore(tmp_path / "state.db")
+        _record_plan_ready_notify(store, project="demo")
+
+        task = FakeTask(
+            project="demo", task_number=1,
+            flow_template_id="plan_project",
+            current_node_id="research",
+        )
+        result = reconcile_expected_advance(
+            task, tmp_path, work_service=None, state_store=store,
+        )
+        assert result is None
+
+    def test_non_plan_flow_returns_none(self, tmp_path: Path) -> None:
+        """A standard worker-flow task with a stray plan.md on disk
+        should NOT be treated as drift — heuristic is flow-specific."""
+        _write_plan(tmp_path / "docs" / "plan" / "plan.md")
+        store = StateStore(tmp_path / "state.db")
+        _record_plan_ready_notify(store, project="demo")
+
+        task = FakeTask(
+            project="demo", task_number=1,
+            flow_template_id="standard",
+            current_node_id="do_work",
+        )
+        result = reconcile_expected_advance(
+            task, tmp_path, work_service=None, state_store=store,
+        )
+        assert result is None
+
+    def test_task_already_at_user_approval_returns_none(
+        self, tmp_path: Path,
+    ) -> None:
+        """When the task has already advanced past synthesize, drift
+        detection must not fire — we only reconcile upstream nodes."""
+        _write_plan(tmp_path / "docs" / "plan" / "plan.md")
+        store = StateStore(tmp_path / "state.db")
+        _record_plan_ready_notify(store, project="demo")
+
+        task = FakeTask(
+            project="demo", task_number=1,
+            flow_template_id="plan_project",
+            current_node_id="user_approval",
+        )
+        result = reconcile_expected_advance(
+            task, tmp_path, work_service=None, state_store=store,
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Classifier behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestClassifierStateDrift:
+    """``DefaultRecoveryPolicy.classify`` promotes sessions with a
+    precomputed ``drift_action`` to STATE_DRIFT — but only when the
+    session is not turning and holds an active claim."""
+
+    def test_drift_action_routes_to_state_drift(self) -> None:
+        policy = DefaultRecoveryPolicy()
+        action = ReconciliationAction(
+            advance_to_node="user_approval", reason="plan present",
+        )
+        signals = SessionSignals(
+            session_name="architect-demo",
+            active_claim_task_id="demo/1",
+            turn_active=False,
+            drift_action=action,
+        )
+        assert policy.classify(signals) == SessionHealth.STATE_DRIFT
+
+    def test_turn_active_suppresses_drift(self) -> None:
+        """A live turn must never be classified as drift — the agent
+        is still working, the synthesize → advance may yet happen."""
+        policy = DefaultRecoveryPolicy()
+        action = ReconciliationAction(
+            advance_to_node="user_approval", reason="plan present",
+        )
+        signals = SessionSignals(
+            session_name="architect-demo",
+            active_claim_task_id="demo/1",
+            turn_active=True,
+            has_transcript_delta=True,
+            drift_action=action,
+        )
+        # turn_active=True + transcript delta → ACTIVE, not STATE_DRIFT.
+        assert policy.classify(signals) != SessionHealth.STATE_DRIFT
+
+    def test_no_claim_suppresses_drift(self) -> None:
+        """A session with no active claim can't have drift — nothing
+        to reconcile from."""
+        policy = DefaultRecoveryPolicy()
+        action = ReconciliationAction(
+            advance_to_node="user_approval", reason="plan present",
+        )
+        signals = SessionSignals(
+            session_name="architect-demo",
+            active_claim_task_id=None,
+            turn_active=False,
+            drift_action=action,
+        )
+        assert policy.classify(signals) != SessionHealth.STATE_DRIFT
+
+    def test_select_intervention_logs_alert_only(self) -> None:
+        """V1 policy: the intervention action is ``reconcile_flow_state``
+        and carries the target node in details. No auto-advance."""
+        policy = DefaultRecoveryPolicy()
+        action = ReconciliationAction(
+            advance_to_node="user_approval", reason="plan observed",
+        )
+        signals = SessionSignals(
+            session_name="architect-demo",
+            active_claim_task_id="demo/1",
+            turn_active=False,
+            drift_action=action,
+        )
+        result = policy.select_intervention(
+            SessionHealth.STATE_DRIFT, signals, [],
+        )
+        assert result is not None
+        assert result.action == "reconcile_flow_state"
+        assert result.details["advance_to_node"] == "user_approval"
+        assert result.details["task_id"] == "demo/1"
+
+
+# ---------------------------------------------------------------------------
+# 3. Integration with ``work.progress_sweep``
+# ---------------------------------------------------------------------------
+
+
+class TestSweepDriftIntegration:
+    """The 5-min sweeper detects drift, records a state_drift event, and
+    raises a warn-level alert keyed to ``state_drift:<task_id>``.
+    Dedupe comes from ``upsert_alert``'s per-type uniqueness guard."""
+
+    def _patch_resolver_with_factory(
+        self, monkeypatch, tmp_path, svc, store,
+    ):
+        def _fake_loader(*, config_path=None):
+            work = SQLiteWorkService(
+                db_path=tmp_path / "work.db",
+                project_path=tmp_path,
+            )
+            return _RuntimeServices(
+                session_service=svc,
+                state_store=store,
+                work_service=work,
+                project_root=tmp_path,
+            )
+
+        monkeypatch.setattr(
+            "pollypm.plugins_builtin.task_assignment_notify.resolver.load_runtime_services",
+            _fake_loader,
+        )
+
+    def test_drift_detected_emits_event_and_alert(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        bus.clear_listeners()
+        # Seed a plan_project task claimed by architect-demo.
+        seed = SQLiteWorkService(
+            db_path=tmp_path / "work.db",
+            project_path=tmp_path,
+        )
+        task_id = _claim_plan_task(seed, "demo")
+        seed.close()
+
+        # Write the deliverables + fire the notify.
+        _write_plan(tmp_path / "docs" / "plan" / "plan.md")
+        store = StateStore(tmp_path / "state.db")
+        _record_plan_ready_notify(store, project="demo")
+
+        svc = FakeSessionService(handles=[FakeHandle("architect-demo")])
+        self._patch_resolver_with_factory(monkeypatch, tmp_path, svc, store)
+
+        result = work_progress_sweep_handler({})
+        assert result["outcome"] == "swept"
+        assert result["drift_detected"] >= 1, (
+            f"expected drift_detected>=1, got {result!r}"
+        )
+        assert result["drift_alerted"] == 1
+
+        # The state_drift event landed on the architect session.
+        events = [
+            e for e in store.recent_events(limit=50)
+            if e.event_type == "state_drift"
+        ]
+        assert len(events) == 1
+        assert events[0].session_name == "architect-demo"
+        # The event message narrates the node transition so an operator
+        # can see the drift without chasing the alert.
+        assert task_id in events[0].message
+        assert "research" in events[0].message
+        assert "user_approval" in events[0].message
+
+        # The alert is keyed to the task and is open.
+        with store._lock:  # noqa: SLF001
+            rows = store._conn.execute(  # noqa: SLF001
+                "SELECT alert_type, severity, status FROM alerts WHERE "
+                "session_name = ?", ("architect-demo",),
+            ).fetchall()
+        alert_types = [r[0] for r in rows]
+        assert f"state_drift:{task_id}" in alert_types
+        row = next(r for r in rows if r[0] == f"state_drift:{task_id}")
+        assert row[1] == "warn"
+        assert row[2] == "open"
+
+    def test_repeated_sweep_dedupes_alert(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        """Calling the sweep twice in a row must not raise a second
+        alert — ``upsert_alert`` owns the (session, alert_type) dedupe."""
+        bus.clear_listeners()
+        seed = SQLiteWorkService(
+            db_path=tmp_path / "work.db",
+            project_path=tmp_path,
+        )
+        _claim_plan_task(seed, "demo")
+        seed.close()
+
+        _write_plan(tmp_path / "docs" / "plan" / "plan.md")
+        store = StateStore(tmp_path / "state.db")
+        _record_plan_ready_notify(store, project="demo")
+
+        svc = FakeSessionService(handles=[FakeHandle("architect-demo")])
+        self._patch_resolver_with_factory(monkeypatch, tmp_path, svc, store)
+
+        result1 = work_progress_sweep_handler({})
+        assert result1["drift_alerted"] == 1
+        result2 = work_progress_sweep_handler({})
+        # drift_detected can increment every sweep (the condition still
+        # holds), but drift_alerted must stay at 0 on the second sweep
+        # because the alert row already exists.
+        assert result2["drift_alerted"] == 0
+
+        # Only one alert row for the task.
+        with store._lock:  # noqa: SLF001
+            rows = store._conn.execute(  # noqa: SLF001
+                "SELECT COUNT(*) FROM alerts WHERE session_name = ? AND "
+                "alert_type LIKE 'state_drift:%' AND status = 'open'",
+                ("architect-demo",),
+            ).fetchone()
+        assert rows[0] == 1
+
+    def test_no_drift_when_no_deliverables(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        """A plan_project task on research with nothing on disk must
+        not trigger drift — the task really is upstream."""
+        bus.clear_listeners()
+        seed = SQLiteWorkService(
+            db_path=tmp_path / "work.db",
+            project_path=tmp_path,
+        )
+        _claim_plan_task(seed, "demo")
+        seed.close()
+
+        # No plan file, no notify.
+        store = StateStore(tmp_path / "state.db")
+        svc = FakeSessionService(handles=[FakeHandle("architect-demo")])
+        self._patch_resolver_with_factory(monkeypatch, tmp_path, svc, store)
+
+        result = work_progress_sweep_handler({})
+        assert result["drift_detected"] == 0
+        assert result["drift_alerted"] == 0
+
+    def test_non_plan_flow_no_drift(self, tmp_path: Path, monkeypatch):
+        """A standard-flow task with a random plan.md in the tree must
+        not trigger drift — the heuristic scopes to plan_project."""
+        bus.clear_listeners()
+        seed = SQLiteWorkService(
+            db_path=tmp_path / "work.db",
+            project_path=tmp_path,
+        )
+        # Standard flow, not plan_project — test #6 in the spec.
+        task = seed.create(
+            title="Do the thing",
+            description="desc",
+            type="task",
+            project="demo",
+            flow_template="standard",
+            roles={"worker": "agent-1", "reviewer": "agent-2"},
+            priority="normal",
+        )
+        seed.queue(task.task_id, "pm")
+        seed.claim(task.task_id, "agent-1")
+        seed.close()
+
+        # Even with an incidental plan file + notify on disk, the
+        # standard flow shouldn't trigger drift.
+        _write_plan(tmp_path / "docs" / "plan" / "plan.md")
+        store = StateStore(tmp_path / "state.db")
+        _record_plan_ready_notify(store, project="demo")
+
+        svc = FakeSessionService(handles=[FakeHandle("worker-demo")])
+        self._patch_resolver_with_factory(monkeypatch, tmp_path, svc, store)
+
+        result = work_progress_sweep_handler({})
+        assert result["drift_detected"] == 0
+        assert result["drift_alerted"] == 0
+
+    def test_active_turn_still_runs_drift_but_sweep_skips_session(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        """When the target session is actively turning, the sweep
+        skips it entirely — no drift event fires for a live turn.
+        This mirrors the ``stuck_on_task`` behaviour: don't touch
+        sessions that are still working."""
+        bus.clear_listeners()
+        seed = SQLiteWorkService(
+            db_path=tmp_path / "work.db",
+            project_path=tmp_path,
+        )
+        _claim_plan_task(seed, "demo")
+        seed.close()
+
+        _write_plan(tmp_path / "docs" / "plan" / "plan.md")
+        store = StateStore(tmp_path / "state.db")
+        _record_plan_ready_notify(store, project="demo")
+
+        svc = FakeSessionService(
+            handles=[FakeHandle("architect-demo")],
+            busy={"architect-demo"},
+        )
+        self._patch_resolver_with_factory(monkeypatch, tmp_path, svc, store)
+
+        result = work_progress_sweep_handler({})
+        assert result["skipped_active_turn"] == 1
+        assert result["drift_detected"] == 0
+        assert result["drift_alerted"] == 0


### PR DESCRIPTION
Extends #249's work-service-aware sweep with a new classification. When an agent ends its turn but observable deliverables outpace the task's flow node, heartbeat logs + alerts Polly.

## V1 — log + alert only
No `work_tasks` mutation. Auto-advance deferred to v2 behind `[recovery].auto_reconcile`.

## Files (5)
- `recovery/state_reconciliation.py` (new): pure `reconcile_expected_advance` returns `ReconciliationAction | None`. Plan_project heuristic: plan.md > 500 bytes + plan-ready notify in last hour → target `user_approval`. Forward-looking `artifact_gate:<path>` hook.
- `recovery/base.py`: `SessionHealth.STATE_DRIFT`, `reconcile_flow_state` in `EXTENDED_INTERVENTIONS`, `drift_action` on `SessionSignals`.
- `recovery/default.py`: `STATE_DRIFT` classification (after `turn_active`, before `IDLE`) + intervention returns log+alert details.
- `core_recurring/plugin.py`: wired into `work_progress_sweep_handler`. Emits `state_drift` event + alert. Dedupe via existing pattern. New `drift_detected` + `drift_alerted` counters.
- Tests: 16 across pure function, classifier, sweep integration. All 6 spec scenarios.

## Design notes
- Drift check runs BEFORE recent-event skip — the plan-ready notify would otherwise mask its own drift.
- Heuristic accepts both `docs/plan/plan.md` and legacy `docs/project-plan.md`.
- Active-turn sessions skipped entirely. Never fires on a live turn.

Closes #296