### PR TITLE
feat(scheduler): hourly agent-worktree prune handler

### DIFF
--- a/src/pollypm/plugins_builtin/core_recurring/plugin.py
+++ b/src/pollypm/plugins_builtin/core_recurring/plugin.py
@@ -438,6 +438,130 @@ def memory_ttl_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
     return {"deleted": deleted}
 
 
+def agent_worktree_prune_handler(payload: dict[str, Any]) -> dict[str, Any]:
+    """Prune stale Claude Code harness agent worktrees under ``.claude/worktrees/``.
+
+    These are NOT PollyPM task worktrees (those live under ``<project>/.pollypm/
+    worktrees/...`` and are owned by ``teardown_worker``). They are harness
+    worktrees spawned by background ``Agent()`` calls with
+    ``isolation: "worktree"``. The harness doesn't always clean up after
+    itself — on Sam's machine the directory bloated to 6.6 GB across 59
+    worktrees. This handler performs conservative cleanup:
+
+    * Merged-to-main branches: prune via ``git worktree remove --force`` and
+      drop the local branch.
+    * Unmerged + mtime > 7 days: log a warning but do not delete (may be
+      in-progress uncommitted work).
+    * mtime < 1 hour: skip (still actively in use).
+
+    Only directories matching ``<repo_root>/.claude/worktrees/agent-*`` are
+    considered. The repo root is taken from ``payload['project_root']`` if
+    provided, otherwise from config's ``project.root_dir``.
+    """
+    import subprocess
+    import time
+
+    hint = payload.get("project_root") if isinstance(payload, dict) else None
+    if hint:
+        repo_root = Path(hint)
+    else:
+        config, _store = _load_config_and_store(payload)
+        repo_root = config.project.root_dir
+
+    worktrees_dir = repo_root / ".claude" / "worktrees"
+    if not worktrees_dir.is_dir():
+        return {"pruned": 0, "skipped_active": 0, "warned_stale": 0, "errors": 0}
+
+    now = time.time()
+    one_hour = 3600.0
+    seven_days = 7 * 86400.0
+
+    def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", "-C", str(cwd), *args],
+            capture_output=True, text=True, check=False,
+        )
+
+    # Pre-compute the merged-branch set once via two cheap calls — cheaper
+    # than spawning two git processes per worktree.
+    merged_local = _git(repo_root, "branch", "--merged", "main")
+    merged_remote = _git(repo_root, "branch", "-r", "--merged", "origin/main")
+    merged_names: set[str] = set()
+    for proc in (merged_local, merged_remote):
+        if proc.returncode != 0:
+            continue
+        for raw in proc.stdout.splitlines():
+            # ``git branch`` prefixes lines with ``* `` (current),
+            # ``+ `` (checked out in another worktree), or spaces.
+            name = raw.strip().lstrip("*+").strip()
+            if not name or name.startswith("("):
+                continue
+            # Normalize ``origin/foo`` → ``foo`` so local+remote merge into
+            # one name set.
+            if name.startswith("origin/"):
+                name = name[len("origin/"):]
+            merged_names.add(name)
+
+    pruned = 0
+    skipped_active = 0
+    warned_stale = 0
+    errors = 0
+
+    for wt in sorted(worktrees_dir.glob("agent-*")):
+        if not wt.is_dir():
+            continue
+        try:
+            mtime = wt.stat().st_mtime
+            age = now - mtime
+            if age < one_hour:
+                skipped_active += 1
+                continue
+
+            branch_proc = _git(wt, "branch", "--show-current")
+            if branch_proc.returncode != 0:
+                errors += 1
+                continue
+            branch = branch_proc.stdout.strip()
+            if not branch:
+                errors += 1
+                continue
+
+            if branch in merged_names:
+                remove_proc = _git(
+                    repo_root, "worktree", "remove", "--force", str(wt),
+                )
+                if remove_proc.returncode != 0:
+                    errors += 1
+                    continue
+                # Best-effort local branch delete — don't fail the prune
+                # if the branch was already gone.
+                _git(repo_root, "branch", "-D", branch)
+                pruned += 1
+            elif age > seven_days:
+                logger.warning(
+                    "agent_worktree.prune: stale unmerged worktree %s "
+                    "(branch=%s, age_days=%.1f) — leaving in place",
+                    wt, branch, age / 86400.0,
+                )
+                warned_stale += 1
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "agent_worktree.prune: error processing %s", wt, exc_info=True,
+            )
+            errors += 1
+
+    # Clean up any dangling worktree admin entries (e.g. directories that
+    # were removed on disk but still registered in ``.git/worktrees``).
+    _git(repo_root, "worktree", "prune")
+
+    return {
+        "pruned": pruned,
+        "skipped_active": skipped_active,
+        "warned_stale": warned_stale,
+        "errors": errors,
+    }
+
+
 def notification_staging_prune_handler(payload: dict[str, Any]) -> dict[str, Any]:
     """Drop flushed + silent notification_staging rows older than 30d.
 
@@ -520,6 +644,12 @@ def _register_handlers(api: JobHandlerAPI) -> None:
         "notification_staging.prune", notification_staging_prune_handler,
         max_attempts=1, timeout_seconds=60.0,
     )
+    # Harness agent-worktree hygiene — hourly prune of merged/stale
+    # worktrees under ``<repo_root>/.claude/worktrees/agent-*``.
+    api.register_handler(
+        "agent_worktree.prune", agent_worktree_prune_handler,
+        max_attempts=1, timeout_seconds=120.0,
+    )
 
 
 def _register_roster(api: RosterAPI) -> None:
@@ -546,6 +676,13 @@ def _register_roster(api: RosterAPI) -> None:
         "19 4 * * *", "notification_staging.prune", {},
         dedupe_key="notification_staging.prune",
     )
+    # Harness agent-worktree hygiene — every hour at minute 23, off-pattern
+    # from the 4am DB hygiene window. Only prunes merged branches; stale
+    # unmerged trees are logged but left intact.
+    api.register_recurring(
+        "23 * * * *", "agent_worktree.prune", {},
+        dedupe_key="agent_worktree.prune",
+    )
 
 
 plugin = PollyPMPlugin(
@@ -567,6 +704,7 @@ plugin = PollyPMPlugin(
         Capability(kind="job_handler", name="db.vacuum"),
         Capability(kind="job_handler", name="memory.ttl_sweep"),
         Capability(kind="job_handler", name="notification_staging.prune"),
+        Capability(kind="job_handler", name="agent_worktree.prune"),
         Capability(kind="roster_entry", name="core_recurring"),
     ),
     register_handlers=_register_handlers,

--- a/src/pollypm/plugins_builtin/core_recurring/pollypm-plugin.toml
+++ b/src/pollypm/plugins_builtin/core_recurring/pollypm-plugin.toml
@@ -46,6 +46,11 @@ name = "notification_staging.prune"
 requires_api = ">=1,<2"
 
 [[capabilities]]
+kind = "job_handler"
+name = "agent_worktree.prune"
+requires_api = ">=1,<2"
+
+[[capabilities]]
 kind = "roster_entry"
 name = "core_recurring"
 requires_api = ">=1,<2"

--- a/tests/test_agent_worktree_prune.py
+++ b/tests/test_agent_worktree_prune.py
@@ -1,0 +1,200 @@
+"""Tests for the hourly ``agent_worktree.prune`` recurring handler.
+
+The handler targets Claude Code harness worktrees under
+``<repo_root>/.claude/worktrees/agent-*`` — the ones that accumulate from
+background ``Agent()`` calls with ``isolation: "worktree"`` and are NOT
+the PollyPM task worktrees under ``<project>/.pollypm/worktrees/...``.
+
+Behaviour under test:
+
+* A merged agent worktree is removed from disk, its local branch is
+  deleted, and the ``pruned`` counter reflects the action.
+* A worktree whose mtime is under 1 hour old is left alone ("still in
+  use"), counted as ``skipped_active``.
+* An unmerged worktree older than 7 days is warned about but NOT deleted
+  — the branch may hold uncommitted in-progress work.
+* An unmerged worktree ≤ 7 days old is left in place with no warning.
+* The result dict always includes the four counters.
+* Running the handler twice on a clean tree is a no-op the second pass.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+from pollypm.plugins_builtin.core_recurring.plugin import (
+    agent_worktree_prune_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    """Run a git/shell command with captured output + check=True."""
+    return subprocess.run(
+        list(args),
+        cwd=str(cwd) if cwd else None,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _make_repo(root: Path) -> Path:
+    """Initialize a real git repo with one commit on ``main``."""
+    root.mkdir(parents=True, exist_ok=True)
+    _run("git", "init", "-b", "main", str(root))
+    _run("git", "-C", str(root), "config", "user.email", "prune@test")
+    _run("git", "-C", str(root), "config", "user.name", "Prune Test")
+    (root / "README.md").write_text("seed\n")
+    _run("git", "-C", str(root), "add", "README.md")
+    _run("git", "-C", str(root), "commit", "-m", "init")
+    return root
+
+
+def _make_agent_worktree(
+    repo: Path, slug: str, *, merge_to_main: bool, age_seconds: float | None = None,
+) -> Path:
+    """Add a worktree under ``<repo>/.claude/worktrees/agent-<slug>``.
+
+    If ``merge_to_main`` is True, the worktree's branch is merged into
+    main before returning (leaves the worktree + its branch behind so the
+    prune handler sees a merged state).
+
+    If ``age_seconds`` is provided, the worktree directory's mtime is
+    back-dated that many seconds so the handler's age checks fire.
+    """
+    worktrees_dir = repo / ".claude" / "worktrees"
+    worktrees_dir.mkdir(parents=True, exist_ok=True)
+    wt_path = worktrees_dir / f"agent-{slug}"
+    branch = f"worktree-agent-{slug}"
+
+    _run("git", "-C", str(repo), "worktree", "add", "-b", branch, str(wt_path))
+    # Add a commit on the worktree's branch so there's something to merge.
+    (wt_path / "work.txt").write_text(f"{slug} work\n")
+    _run("git", "-C", str(wt_path), "add", "work.txt")
+    _run("git", "-C", str(wt_path), "commit", "-m", f"{slug} commit")
+
+    if merge_to_main:
+        _run("git", "-C", str(repo), "merge", "--no-ff", "-m", f"merge {slug}", branch)
+
+    if age_seconds is not None:
+        target = time.time() - age_seconds
+        os.utime(wt_path, (target, target))
+
+    return wt_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_pruning_merged_worktree_removes_dir_and_branch(tmp_path: Path) -> None:
+    """A merged worktree is removed from disk and its local branch is gone."""
+    repo = _make_repo(tmp_path / "repo")
+    wt = _make_agent_worktree(
+        repo, "merged-one", merge_to_main=True, age_seconds=2 * 3600,
+    )
+    assert wt.exists()
+
+    result = agent_worktree_prune_handler({"project_root": str(repo)})
+
+    assert result["pruned"] == 1
+    assert result["skipped_active"] == 0
+    assert result["warned_stale"] == 0
+    assert result["errors"] == 0
+    assert not wt.exists(), "merged worktree directory should be gone"
+
+    # Local branch should be deleted.
+    branches = _run("git", "-C", str(repo), "branch").stdout
+    assert "worktree-agent-merged-one" not in branches
+
+
+def test_pruning_skips_active_worktree_under_one_hour(tmp_path: Path) -> None:
+    """A worktree with mtime < 1h is left alone, counted as active."""
+    repo = _make_repo(tmp_path / "repo")
+    # Freshly created — mtime is "now", well under an hour — and merged,
+    # so the only reason to skip is the age guard.
+    wt = _make_agent_worktree(repo, "fresh", merge_to_main=True)
+    assert wt.exists()
+
+    result = agent_worktree_prune_handler({"project_root": str(repo)})
+
+    assert result["pruned"] == 0
+    assert result["skipped_active"] == 1
+    assert result["warned_stale"] == 0
+    assert result["errors"] == 0
+    assert wt.exists(), "fresh worktree must be preserved"
+
+
+def test_pruning_warns_on_stale_unmerged_worktree(tmp_path: Path) -> None:
+    """Unmerged + >7d old → warn counter increments; worktree survives."""
+    repo = _make_repo(tmp_path / "repo")
+    wt = _make_agent_worktree(
+        repo, "stale-unmerged", merge_to_main=False, age_seconds=10 * 86400,
+    )
+    assert wt.exists()
+
+    result = agent_worktree_prune_handler({"project_root": str(repo)})
+
+    assert result["pruned"] == 0
+    assert result["warned_stale"] == 1
+    assert result["errors"] == 0
+    assert wt.exists(), "unmerged worktree must not be deleted"
+    branches = _run("git", "-C", str(repo), "branch").stdout
+    assert "worktree-agent-stale-unmerged" in branches
+
+
+def test_pruning_skips_unmerged_recent_worktree_silently(tmp_path: Path) -> None:
+    """Unmerged + ≤7d old → no warn, no prune, silent skip."""
+    repo = _make_repo(tmp_path / "repo")
+    # 3 days old: over the 1-hour "active" bar, well under the 7-day "stale"
+    # bar. Handler should not touch it and should not warn either.
+    wt = _make_agent_worktree(
+        repo, "recent-unmerged", merge_to_main=False, age_seconds=3 * 86400,
+    )
+
+    result = agent_worktree_prune_handler({"project_root": str(repo)})
+
+    assert result["pruned"] == 0
+    assert result["warned_stale"] == 0
+    assert result["skipped_active"] == 0
+    assert result["errors"] == 0
+    assert wt.exists()
+
+
+def test_result_dict_has_all_counters_when_no_worktrees_dir(tmp_path: Path) -> None:
+    """Missing ``.claude/worktrees`` → zeros for every counter."""
+    repo = _make_repo(tmp_path / "repo")
+    result = agent_worktree_prune_handler({"project_root": str(repo)})
+    assert result == {
+        "pruned": 0,
+        "skipped_active": 0,
+        "warned_stale": 0,
+        "errors": 0,
+    }
+
+
+def test_idempotent_on_clean_tree(tmp_path: Path) -> None:
+    """Second pass after a full prune is a no-op."""
+    repo = _make_repo(tmp_path / "repo")
+    _make_agent_worktree(
+        repo, "clean-me", merge_to_main=True, age_seconds=2 * 3600,
+    )
+    first = agent_worktree_prune_handler({"project_root": str(repo)})
+    assert first["pruned"] == 1
+
+    second = agent_worktree_prune_handler({"project_root": str(repo)})
+    assert second == {
+        "pruned": 0,
+        "skipped_active": 0,
+        "warned_stale": 0,
+        "errors": 0,
+    }

--- a/tests/test_core_recurring_migration.py
+++ b/tests/test_core_recurring_migration.py
@@ -74,6 +74,8 @@ class TestCoreRecurringPlugin:
             # Notification-staging 30-day prune — lands next to the
             # other daily cron entries around 4am.
             "notification_staging.prune",
+            # Harness agent-worktree hygiene — hourly at minute :23.
+            "agent_worktree.prune",
         }
 
         # Cadences per issue #164 / #249.
@@ -96,6 +98,9 @@ class TestCoreRecurringPlugin:
         ns_prune = entries["notification_staging.prune"].schedule
         assert isinstance(ns_prune, CronSchedule)
         assert ns_prune.expression() == "19 4 * * *"
+        agent_prune = entries["agent_worktree.prune"].schedule
+        assert isinstance(agent_prune, CronSchedule)
+        assert agent_prune.expression() == "23 * * * *"
 
     def test_plugin_declares_expected_capabilities(self) -> None:
         kinds = {cap.kind for cap in core_plugin.capabilities}


### PR DESCRIPTION
Prunes `.claude/worktrees/agent-*` whose branches are merged to main. Currently 59 worktrees / 6.6 GB of residue from completed agent runs.

## Safety guarantees
- Only touches `.claude/worktrees/agent-*` (NEVER `.pollypm/worktrees/...` which belongs to teardown_worker).
- Skips worktrees < 1h old (potentially in active use).
- Only prunes if branch is merged to main (local or origin).
- Warns-only for unmerged worktrees > 7d old (preserves potential in-progress work).
- Uses `git worktree remove --force` + local `branch -D`. Origin untouched.
- Final `git worktree prune` cleans dangling pointers.

## Cron
`23 * * * *` — every hour at minute :23. Off-pattern from the 4am DB hygiene window.

## Tests (+6, 0 regressions)
17 passed (6 new + 11 updated test_core_recurring_migration).