### PR TITLE
feat(recovery): worker turn-end auto-reprompt (#302)

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -2060,6 +2060,37 @@ def _extract_plan_review_meta(labels: list[str] | None) -> dict:
     return meta
 
 
+def _extract_blocking_question_meta(labels: list[str] | None) -> dict:
+    """Parse ``blocking_question`` sidecar labels into a structured dict.
+
+    The drift sweep emits a blocking_question item with labels that
+    encode the blocked task id, the worker session doing the asking,
+    and the project key:
+
+        blocking_question
+        project:<key>
+        task:<project/number>
+        blocking_worker:<session_name>
+
+    Returns ``{task_id, blocking_worker, project}``; keys are
+    present only when the corresponding label was present.
+    """
+    meta: dict[str, object] = {}
+    for raw in labels or []:
+        if not isinstance(raw, str):
+            continue
+        label = raw.strip()
+        if label.startswith("task:"):
+            meta["task_id"] = label[len("task:"):].strip()
+        elif label.startswith("blocking_worker:"):
+            meta["blocking_worker"] = label[
+                len("blocking_worker:"):
+            ].strip()
+        elif label.startswith("project:"):
+            meta["project"] = label[len("project:"):].strip()
+    return meta
+
+
 def _plan_review_has_round_trip(
     replies, *, requester: str = "user",
 ) -> bool:
@@ -2474,6 +2505,11 @@ class PollyInboxApp(App[None]):
         #   user-plus-PM exchange that unlocks Accept (gating rule).
         self._plan_review_meta: dict[str, dict] = {}
         self._plan_review_round_trip: dict[str, bool] = {}
+        # Blocking-question state (#302). Worker drift → inbox handoff.
+        # Parsed sidecar labels (``task:<id>``, ``blocking_worker:<name>``,
+        # ``project:<key>``) land here so reply / jump paths don't have
+        # to re-parse on each keystroke.
+        self._blocking_question_meta: dict[str, dict] = {}
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="inbox-layout"):
@@ -2724,12 +2760,27 @@ class PollyInboxApp(App[None]):
         else:
             self._plan_review_meta.pop(task_id, None)
             self._plan_review_round_trip.pop(task_id, None)
+        # Blocking-question detection (#302). Worker sessions that end
+        # their turn without a state flip and show blocker language
+        # bubble up as a ``blocking_question`` item; the PM's inbox
+        # gets its own hint bar so Sam / the persona knows ``r`` sends
+        # a reply back to the worker via ``pm send --force`` and ``d``
+        # jumps straight into the worker's pane.
+        _is_blocking_question = "blocking_question" in _labels
+        if _is_blocking_question:
+            meta = _extract_blocking_question_meta(_labels)
+            self._blocking_question_meta[task_id] = meta
+            self._update_hint_for_blocking_question()
+        else:
+            self._blocking_question_meta.pop(task_id, None)
         if _is_proposal:
             self._proposal_specs[task_id] = _extract_proposal_spec(
                 task, labels=_labels,
             )
             self._update_hint_for_proposal()
         elif _is_plan_review:
+            self._proposal_specs.pop(task_id, None)
+        elif _is_blocking_question:
             self._proposal_specs.pop(task_id, None)
         else:
             self._proposal_specs.pop(task_id, None)
@@ -3072,13 +3123,35 @@ class PollyInboxApp(App[None]):
                 if sub_project:
                     project_for_pm = sub_project
 
+        # Blocking-question items (#302): ``d`` jumps to the worker
+        # session so the PM can talk to the blocked worker directly,
+        # not the PM persona. We short-circuit before the PM resolution
+        # below so the cockpit route lands in the worker window.
+        task_labels = list(getattr(task, "labels", []) or [])
+        if (
+            "blocking_question" in task_labels
+            and focus_item is None
+        ):
+            bq_meta = _extract_blocking_question_meta(task_labels)
+            worker_name = str(bq_meta.get("blocking_worker") or "")
+            if worker_name:
+                context_line = _build_pm_context_line(task, item=focus_item)
+                self.run_worker(
+                    lambda: self._dispatch_to_worker_sync(
+                        worker_name, context_line,
+                    ),
+                    thread=True,
+                    exclusive=True,
+                    group="jump_to_pm",
+                )
+                return
+
         cockpit_key, pm_label = _resolve_pm_target(
             self.config_path, project_for_pm,
         )
         # Plan-review items (#297) inject a richer primer instead of the
         # generic ``re: inbox/N ...`` line so the PM lands in the
         # conversation with the co-refinement brief already framed.
-        task_labels = list(getattr(task, "labels", []) or [])
         if "plan_review" in task_labels and focus_item is None:
             meta = _extract_plan_review_meta(task_labels)
             explainer_path = str(meta.get("explainer_path") or "")
@@ -3142,6 +3215,80 @@ class PollyInboxApp(App[None]):
             f"Jumped to {pm_label} \u2014 finish your message and hit Enter.",
             severity="information",
             timeout=3.0,
+        )
+
+    def _dispatch_to_worker_sync(
+        self, worker_name: str, context_line: str,
+    ) -> None:
+        """Worker-thread body: route cockpit to the worker window.
+
+        Used by the ``blocking_question`` flow when the PM jumps
+        straight to the stuck worker (``d`` key). Mirrors
+        :meth:`_dispatch_to_pm_sync` but keys the route on the worker
+        session name rather than a PM persona.
+        """
+        try:
+            router = CockpitRouter(self.config_path)
+            router.route_selected(worker_name)
+            supervisor = router._load_supervisor()
+            window_target = (
+                f"{supervisor.config.project.tmux_session}:"
+                f"{router._COCKPIT_WINDOW}"
+            )
+            right_pane = router._right_pane_id(window_target)
+            if right_pane is None:
+                router.tmux.send_keys(
+                    window_target, context_line, press_enter=False,
+                )
+            else:
+                router.tmux.send_keys(
+                    right_pane, context_line, press_enter=False,
+                )
+        except Exception as exc:  # noqa: BLE001
+            self.call_from_thread(
+                self.notify,
+                f"Jump to worker failed: {exc}",
+                severity="error",
+            )
+            return
+        self.call_from_thread(
+            self.notify,
+            f"Jumped to worker {worker_name}.",
+            severity="information", timeout=3.0,
+        )
+
+    def _send_reply_to_worker(
+        self, task_id: str, worker_name: str, body: str,
+    ) -> None:
+        """Forward a blocking_question reply back to the worker pane.
+
+        Uses the supervisor's ``send_input`` with ``force=True`` to
+        bypass the worker-role gate (``pm send --force`` semantics from
+        #261). Best-effort: any failure surfaces as a TUI notification
+        but does not roll back the in-thread reply that already landed
+        in the inbox task.
+        """
+        try:
+            from pollypm.service_api.v1 import PollyPMService
+            supervisor = PollyPMService(self.config_path).load_supervisor()
+            supervisor.send_input(
+                worker_name, body,
+                owner="pollypm", force=True, press_enter=True,
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.notify(
+                f"Reply to worker {worker_name} failed: {exc}",
+                severity="warning", timeout=3.0,
+            )
+            return
+        self._emit_event(
+            task_id,
+            "inbox.blocking_question.reply_forwarded",
+            f"reply forwarded to {worker_name} for {task_id}",
+        )
+        self.notify(
+            f"Reply sent to worker {worker_name}.",
+            severity="information", timeout=2.0,
         )
 
     def _perform_pm_dispatch(self, cockpit_key: str, context_line: str) -> None:
@@ -3226,6 +3373,16 @@ class PollyInboxApp(App[None]):
         self._emit_event(
             task_id, "inbox.reply_received", f"user replied to {task_id}: {body[:60]}",
         )
+        # Blocking-question reply (#302): when the inbox item carries
+        # the ``blocking_question`` label, route the reply back to the
+        # worker via ``pm send --force`` so the worker unblocks and
+        # resumes. The in-thread ``add_reply`` above still happens so
+        # the conversation is preserved for audit.
+        meta = self._blocking_question_meta.get(task_id)
+        if meta is not None:
+            worker_name = str(meta.get("blocking_worker") or "")
+            if worker_name:
+                self._send_reply_to_worker(task_id, worker_name, body)
         # Clear the input and re-render so the new reply appears in-thread.
         # Keep focus on the list so j/k works without further keystrokes.
         self.reply_input.value = ""
@@ -3254,6 +3411,20 @@ class PollyInboxApp(App[None]):
     _PLAN_REVIEW_HINT_FAST_TRACK = (
         "v open explainer \u00b7 d discuss \u00b7 A approve \u00b7 q back"
     )
+    # Blocking-question hint (#302). ``r`` replies to the worker via
+    # ``pm send --force`` so the blocker clears without the PM needing
+    # to jump to the pane; ``d`` is the direct-conversation escape
+    # hatch; ``a`` archives once the blocker is resolved.
+    _BLOCKING_QUESTION_HINT = (
+        "r reply to worker \u00b7 d jump to worker \u00b7 "
+        "a archive \u00b7 q back"
+    )
+
+    def _update_hint_for_blocking_question(self) -> None:
+        try:
+            self.hint.update(self._BLOCKING_QUESTION_HINT)
+        except Exception:  # noqa: BLE001
+            pass
 
     def _update_hint_for_proposal(self) -> None:
         try:

--- a/src/pollypm/plugins_builtin/core_recurring/plugin.py
+++ b/src/pollypm/plugins_builtin/core_recurring/plugin.py
@@ -136,6 +136,10 @@ def work_progress_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
     from pollypm.recovery.state_reconciliation import (
         reconcile_expected_advance,
     )
+    from pollypm.recovery.worker_turn_end import (
+        handle_worker_turn_end,
+        is_worker_session_name,
+    )
     from pollypm.work.models import ActorType
     from pollypm.work.task_assignment import SessionRoleIndex
 
@@ -167,6 +171,27 @@ def work_progress_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
     # per-type uniqueness guard).
     drift_detected = 0
     drift_alerted = 0
+    # #302 — worker-turn-end auto-reprompt counters. When drift fires
+    # on a ``worker-*`` session we either create a blocking_question
+    # inbox item (if the transcript tail shows blocker language) or
+    # send the canonical reprompt via the session service.
+    worker_blocking_questions = 0
+    worker_reprompts = 0
+    # Config is looked up once per sweep for persona_name resolution
+    # on the blocking_question path. Tolerant of any failure — the
+    # helper falls back to "polly" without a config.
+    try:
+        from pollypm.config import (
+            DEFAULT_CONFIG_PATH, load_config, resolve_config_path,
+        )
+        _cfg_override = payload.get("config_path")
+        _cfg_path = (
+            Path(_cfg_override) if _cfg_override
+            else resolve_config_path(DEFAULT_CONFIG_PATH)
+        )
+        sweep_config = load_config(_cfg_path) if _cfg_path and _cfg_path.exists() else None
+    except Exception:  # noqa: BLE001
+        sweep_config = None
 
     try:
         try:
@@ -300,6 +325,34 @@ def work_progress_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
                     except Exception:  # noqa: BLE001
                         pass
 
+                # #302 — worker-specific auto-reprompt. For worker
+                # sessions (and only worker sessions) we extend the
+                # log+alert path with a concrete action: either
+                # escalate the block to the project PM via an inbox
+                # task or nudge the worker with the canonical reprompt.
+                # Non-worker sessions (architect / reviewer / operator)
+                # fall through unchanged — the alert is enough.
+                if is_worker_session_name(target_name):
+                    try:
+                        outcome = handle_worker_turn_end(
+                            task,
+                            target_name,
+                            work_service=work,
+                            session_service=session_svc,
+                            state_store=state_store,
+                            config=sweep_config,
+                        )
+                    except Exception:  # noqa: BLE001
+                        logger.debug(
+                            "work.progress_sweep: worker_turn_end "
+                            "failed for %s", task.task_id, exc_info=True,
+                        )
+                        outcome = "skipped"
+                    if outcome == "blocking_question":
+                        worker_blocking_questions += 1
+                    elif outcome == "reprompt":
+                        worker_reprompts += 1
+
             # Skip sessions that have recorded ANY event recently — the
             # session is clearly still doing something; a stale task
             # here is orthogonal to session liveness.
@@ -373,6 +426,8 @@ def work_progress_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
         "skipped_no_session": skipped_no_session,
         "drift_detected": drift_detected,
         "drift_alerted": drift_alerted,
+        "worker_blocking_questions": worker_blocking_questions,
+        "worker_reprompts": worker_reprompts,
     }
 
 

--- a/src/pollypm/recovery/worker_turn_end.py
+++ b/src/pollypm/recovery/worker_turn_end.py
@@ -1,0 +1,482 @@
+"""Worker turn-end auto-reprompt — #302.
+
+Workers are never supposed to require a user touch: every turn must end
+with a task state flip (done / bounce / notify). When #296's drift
+detector catches a worker that ended its turn without advancing the
+task, this module decides what to do next:
+
+1. If the worker's recent transcript carries blocker/question language
+   ("unclear", "waiting for", "need decision", etc.) OR an unfulfilled
+   ``pm notify`` attempt, we treat the turn-end as an implicit
+   escalation and create a ``blocking_question`` inbox item targeted
+   at the project's PM. The worker stays parked — the PM is the one
+   who unblocks.
+
+2. Otherwise we assume the worker stalled without asking and send a
+   standard reprompt via ``pm send --force``, reminding it that turns
+   must always flip task state.
+
+One path or the other — never both. The decision is a simple keyword
+heuristic; an LLM assist is a v2 concern (Sam's call). Non-worker
+sessions (PM / architect / reviewer) skip this module entirely; they
+fall back to the existing log + alert behaviour from #296.
+
+Keep this module pure-ish: the ``determine_worker_response`` function
+is a pure classifier over a transcript string, and the two apply
+helpers accept already-resolved services (work_service,
+session_service, state_store) so tests can wire fakes without
+bootstrapping a real runtime.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# Tail size the heuristic scans for blocker language. ~2000 characters
+# gives us plenty of surface without pulling the whole transcript —
+# workers that stall with a question almost always put it near the end.
+_TRANSCRIPT_TAIL_CHARS = 2000
+
+# Maximum number of characters a blocking_question excerpt carries into
+# the inbox body. Long enough to preserve a full paragraph, short
+# enough that the PM can skim it without scroll fatigue.
+_EXCERPT_MAX_CHARS = 800
+
+# Subject truncation for the inbox task title — work_service titles are
+# free-form but a shorter header reads better in the inbox list.
+_TITLE_EXCERPT_CHARS = 80
+
+# Phrases that mark the worker as blocked or asking a question. Match
+# is case-insensitive substring; any single hit triggers the
+# blocking_question classification. Keep the list tight — broad
+# phrasing catches too much normal completion chatter.
+_BLOCKER_PHRASES: tuple[str, ...] = (
+    "can't proceed",
+    "cannot proceed",
+    "waiting for",
+    "unclear",
+    "blocking",
+    "question:",
+    "need clarification",
+    "need approval",
+    "need decision",
+    "not sure how",
+    "stuck on",
+)
+
+
+# Reprompt text sent to the worker when no blocker language is detected.
+# Sam dictated this copy verbatim; do not reflow without his sign-off.
+WORKER_REPROMPT_TEXT = (
+    "Your turn ended without transitioning the task. Workers must "
+    "always end with a state flip.\n"
+    "\n"
+    "If you have a blocking question that only the PM can answer, "
+    "ask them:\n"
+    "  pm notify --to pm '<task_id>: <your question here>' "
+    "--priority immediate\n"
+    "\n"
+    "If you can work this through to completion, do so:\n"
+    "  pm task done <task_id> --actor worker --output '<summary>'\n"
+    "\n"
+    "If you can't complete it but don't have a specific blocker "
+    "question, make your best attempt and proceed. We can iterate via "
+    "review."
+)
+
+
+@dataclass(slots=True, frozen=True)
+class WorkerResponse:
+    """Classification of a worker's turn-end.
+
+    ``kind`` — ``"blocking_question"`` when blocker language is
+    detected, ``"reprompt"`` otherwise.
+
+    ``question_excerpt`` — the sanitized tail of the transcript the
+    PM will see in the blocking_question inbox item. Empty for the
+    reprompt path.
+    """
+
+    kind: str
+    question_excerpt: str = ""
+
+
+def _normalize_transcript(transcript: str) -> str:
+    """Strip ANSI escape codes and control junk from a tmux capture.
+
+    The tail window already limits size; this pass only removes the
+    bytes that would make an excerpt unreadable in a web UI. Leaves
+    newlines and normal punctuation alone.
+    """
+    if not transcript:
+        return ""
+    # Drop ANSI CSI escapes (colors, cursor moves) — they're common in
+    # captured panes and make excerpts unreadable outside a terminal.
+    text = re.sub(r"\x1b\[[0-9;?]*[ -/]*[@-~]", "", transcript)
+    # Drop other C0 control bytes except tab + newline.
+    text = re.sub(r"[\x00-\x08\x0b-\x1f\x7f]", "", text)
+    return text
+
+
+def _transcript_tail(transcript: str) -> str:
+    """Return the last ``_TRANSCRIPT_TAIL_CHARS`` of the transcript."""
+    if not transcript:
+        return ""
+    if len(transcript) <= _TRANSCRIPT_TAIL_CHARS:
+        return transcript
+    return transcript[-_TRANSCRIPT_TAIL_CHARS:]
+
+
+def _unfulfilled_pm_notify(tail: str, work_service: Any) -> bool:
+    """True when the tail mentions ``pm notify`` / ``pm task block``
+    but there's no record the notify actually succeeded.
+
+    Best-effort: in v1 we simply check for the command-shaped text in
+    the tail. If we see the intent and no corresponding
+    ``task_notifications`` row landed, we treat the turn-end as an
+    escalation attempt that the agent gave up on mid-flight. ``work_service``
+    is unused in v1 but the parameter stays so a v2 stricter match can
+    correlate on subject/body without changing callers.
+    """
+    _ = work_service
+    lower = tail.lower()
+    if "pm notify" in lower or "pm task block" in lower:
+        return True
+    return False
+
+
+def determine_worker_response(
+    task: Any,
+    session: Any,
+    work_service: Any,
+    transcript: str | None,
+) -> WorkerResponse:
+    """Classify a worker's turn-end as blocking_question or reprompt.
+
+    Heuristic (v1):
+
+    * Scan the last 2000 chars of the transcript for any phrase in
+      ``_BLOCKER_PHRASES`` → blocking_question.
+    * Otherwise, if the tail shows a ``pm notify`` / ``pm task block``
+      intent that has no matching row in ``task_notifications`` →
+      blocking_question.
+    * Otherwise → reprompt.
+
+    The ``task`` and ``session`` arguments are here so a v2 can
+    refine the classification using task metadata (flow kind, node
+    position) or session signals (idle time). The v1 heuristic only
+    reads the transcript.
+    """
+    _ = task, session  # reserved for v2 signals
+    tail = _transcript_tail(_normalize_transcript(transcript or ""))
+    if not tail:
+        return WorkerResponse(kind="reprompt")
+
+    lower = tail.lower()
+    for phrase in _BLOCKER_PHRASES:
+        if phrase in lower:
+            return WorkerResponse(
+                kind="blocking_question",
+                question_excerpt=_extract_excerpt(tail, phrase),
+            )
+    if _unfulfilled_pm_notify(tail, work_service):
+        return WorkerResponse(
+            kind="blocking_question",
+            question_excerpt=_extract_excerpt(tail, "pm notify"),
+        )
+    return WorkerResponse(kind="reprompt")
+
+
+def _extract_excerpt(tail: str, anchor: str) -> str:
+    """Pull a human-readable excerpt around ``anchor`` out of ``tail``.
+
+    Finds the first occurrence (case-insensitive), walks back to the
+    previous paragraph break (or 300 chars), and returns up to
+    ``_EXCERPT_MAX_CHARS`` of context.
+    """
+    lower_anchor = anchor.lower()
+    lower_tail = tail.lower()
+    idx = lower_tail.find(lower_anchor)
+    if idx < 0:
+        # Anchor not found — return the final paragraph of the tail.
+        return tail.strip()[-_EXCERPT_MAX_CHARS:]
+    # Walk back to the nearest blank-line boundary, capped at 300 chars.
+    window_start = max(0, idx - 300)
+    segment = tail[window_start:]
+    # Prefer to start at the beginning of a paragraph for readability.
+    lines = segment.split("\n")
+    # Drop leading junk lines (prompts like "╭── 2m ──╮" etc.).
+    while lines and not lines[0].strip():
+        lines.pop(0)
+    excerpt = "\n".join(lines).strip()
+    if len(excerpt) > _EXCERPT_MAX_CHARS:
+        excerpt = excerpt[:_EXCERPT_MAX_CHARS].rstrip() + "\u2026"
+    return excerpt
+
+
+# ---------------------------------------------------------------------------
+# Apply helpers — side-effectful, but the services are injected so tests
+# can wire fakes without booting a real runtime.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_pm_actor(task: Any, config: Any) -> str:
+    """Return the persona name the blocking_question should be targeted at.
+
+    Looks up ``config.projects[<key>].persona_name`` first; falls back
+    to ``"polly"`` when nothing is configured. Case is preserved
+    because downstream session resolution is case-sensitive for some
+    session names.
+    """
+    project_key = getattr(task, "project", "") or ""
+    if not project_key or config is None:
+        return "polly"
+    try:
+        projects = getattr(config, "projects", {}) or {}
+        project = projects.get(project_key)
+    except Exception:  # noqa: BLE001
+        return "polly"
+    if project is None:
+        return "polly"
+    persona = getattr(project, "persona_name", None)
+    if isinstance(persona, str) and persona.strip():
+        return persona.strip()
+    return "polly"
+
+
+def create_blocking_question_inbox_item(
+    task: Any,
+    session_name: str,
+    question_excerpt: str,
+    work_service: Any,
+    *,
+    config: Any = None,
+    state_store: Any = None,
+) -> Any:
+    """Create a ``blocking_question`` inbox task addressed at the PM.
+
+    Returns the created :class:`Task` (or ``None`` on any failure —
+    this helper is best-effort so a flaky work-service never crashes
+    the sweep).
+
+    Mirrors the label shape from the plan_review flow (#297): a
+    canonical top-level label identifies the kind, sidecar labels
+    carry structured metadata so the inbox UI can branch without
+    parsing the body.
+    """
+    if work_service is None or task is None:
+        return None
+    task_id = getattr(task, "task_id", "") or ""
+    project_key = getattr(task, "project", "") or ""
+    pm_actor = _resolve_pm_actor(task, config)
+
+    title_excerpt = (question_excerpt or "").strip().replace("\n", " ")
+    if len(title_excerpt) > _TITLE_EXCERPT_CHARS:
+        title_excerpt = (
+            title_excerpt[: _TITLE_EXCERPT_CHARS - 1] + "\u2026"
+        )
+    title = f"Blocking question from worker ({task_id}): {title_excerpt}"
+
+    body_parts = [
+        f"Worker session **{session_name}** ended its turn without "
+        f"transitioning task **{task_id}** and appears to be blocked.",
+        "",
+        "## Excerpt from worker transcript",
+        "",
+        question_excerpt.strip() or "(no excerpt available)",
+        "",
+        "## How to resolve",
+        "",
+        "- Reply in the inbox (r) — your reply is sent to the worker "
+        "via `pm send --force` so the worker can resume.",
+        f"- Or jump to the worker directly (d) to converse in its "
+        f"session ({session_name}).",
+        "- Archive (a) once the blocker is resolved.",
+        "",
+        f"Worker task: `pm task get {task_id}`",
+    ]
+    body = "\n".join(body_parts)
+
+    labels = [
+        "blocking_question",
+        f"project:{project_key}" if project_key else "project:inbox",
+        f"task:{task_id}" if task_id else "",
+        f"blocking_worker:{session_name}",
+    ]
+    labels = [label for label in labels if label]
+
+    try:
+        inbox_task = work_service.create(
+            title=title,
+            description=body,
+            type="task",
+            project=project_key or "inbox",
+            flow_template="chat",
+            roles={"requester": session_name, "operator": pm_actor},
+            priority="normal",
+            created_by=session_name,
+            labels=labels,
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "worker_turn_end: failed to create blocking_question for %s",
+            task_id,
+        )
+        return None
+
+    # Emit a ledger event so the activity feed / audit trail sees the
+    # blocking_question creation even if the inbox UI doesn't render
+    # it right away.
+    if state_store is not None:
+        try:
+            state_store.record_event(
+                session_name,
+                "inbox.blocking_question.created",
+                (
+                    f"worker {session_name} blocked on {task_id} — "
+                    f"created inbox item {inbox_task.task_id} for {pm_actor}"
+                ),
+            )
+        except Exception:  # noqa: BLE001
+            pass
+    return inbox_task
+
+
+def send_standard_reprompt(
+    session_name: str,
+    task: Any,
+    session_service: Any,
+    *,
+    state_store: Any = None,
+) -> bool:
+    """Nudge the worker with the canonical turn-end reprompt.
+
+    Uses ``session_service.send(..., press_enter=True)`` directly —
+    the supervisor-level ``pm send --force`` semantics are emulated
+    here (no lease check, no owner prefix) because the drift sweep
+    already owns its side-effect window. Returns ``True`` on a
+    successful send; ``False`` on any failure (best-effort).
+    """
+    if session_service is None or not session_name:
+        return False
+    try:
+        session_service.send(session_name, WORKER_REPROMPT_TEXT)
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "worker_turn_end: reprompt send to %s failed", session_name,
+        )
+        return False
+    if state_store is not None:
+        task_id = getattr(task, "task_id", "") or ""
+        try:
+            state_store.record_event(
+                session_name,
+                "inbox.worker_reprompted",
+                (
+                    f"worker {session_name} reprompted on {task_id} "
+                    f"(turn ended without transition)"
+                ),
+            )
+        except Exception:  # noqa: BLE001
+            pass
+    return True
+
+
+def is_worker_session_name(session_name: str) -> bool:
+    """True when the session follows the ``worker-<project>`` or
+    ``worker_<project>`` convention.
+
+    This is how the sweep side (which lacks a SessionConfig lookup)
+    decides whether to run the worker-specific path. Matches
+    :func:`pollypm.work.task_assignment.role_candidate_names` where
+    the worker role expands to exactly these two prefixes.
+    """
+    if not session_name:
+        return False
+    return session_name.startswith("worker-") or session_name.startswith(
+        "worker_",
+    )
+
+
+def load_transcript_tail(
+    session_service: Any,
+    session_name: str,
+    *,
+    tail_chars: int = _TRANSCRIPT_TAIL_CHARS,
+) -> str:
+    """Best-effort pane-text capture used to feed the classifier.
+
+    Prefers ``session_service.capture(name, lines=...)`` (what tmux
+    exposes); falls back to reading the transcript log file on disk
+    when the service doesn't implement ``capture``. Any error yields
+    an empty string so the caller routes to the reprompt path.
+    """
+    if session_service is None or not session_name:
+        return ""
+    capture = getattr(session_service, "capture", None)
+    if callable(capture):
+        try:
+            text = capture(session_name, lines=200)
+            if isinstance(text, str):
+                return text[-tail_chars:]
+        except Exception:  # noqa: BLE001
+            pass
+    # Transcript-file fallback.
+    transcript_fn = getattr(session_service, "transcript", None)
+    if callable(transcript_fn):
+        try:
+            stream = transcript_fn(session_name)
+            path = getattr(stream, "path", None) if stream else None
+            if path is not None:
+                data = Path(path).read_text(
+                    encoding="utf-8", errors="replace",
+                )
+                return data[-tail_chars:]
+        except Exception:  # noqa: BLE001
+            return ""
+    return ""
+
+
+def handle_worker_turn_end(
+    task: Any,
+    session_name: str,
+    *,
+    work_service: Any,
+    session_service: Any,
+    state_store: Any,
+    config: Any = None,
+) -> str:
+    """Top-level entry point invoked from the drift sweep.
+
+    Decides between ``blocking_question`` and ``reprompt``, applies
+    the chosen action, and returns the action name (``"blocking_question"``
+    / ``"reprompt"`` / ``"skipped"``). Never raises — the sweep is a
+    best-effort loop.
+    """
+    if not is_worker_session_name(session_name):
+        return "skipped"
+    transcript = load_transcript_tail(session_service, session_name)
+    response = determine_worker_response(
+        task, session_name, work_service, transcript,
+    )
+    if response.kind == "blocking_question":
+        create_blocking_question_inbox_item(
+            task,
+            session_name,
+            response.question_excerpt,
+            work_service,
+            config=config,
+            state_store=state_store,
+        )
+        return "blocking_question"
+    send_standard_reprompt(
+        session_name, task, session_service, state_store=state_store,
+    )
+    return "reprompt"

--- a/tests/test_worker_turn_end_reprompt.py
+++ b/tests/test_worker_turn_end_reprompt.py
@@ -1,0 +1,749 @@
+"""Tests for #302 — worker turn-end auto-reprompt.
+
+Covers:
+
+* ``determine_worker_response`` — the pure heuristic classifying a
+  transcript tail as blocking_question vs reprompt.
+* ``create_blocking_question_inbox_item`` — label shape + role
+  targeting on the inbox task written to the work-service.
+* ``send_standard_reprompt`` — session_service.send is invoked with
+  the canonical reprompt copy.
+* ``handle_worker_turn_end`` — the dispatcher picks exactly one
+  action path, never both, for a worker session; non-worker sessions
+  short-circuit.
+* Sweep integration — drift on a worker session (simulated) runs the
+  worker-specific path; drift on a non-worker session skips it.
+* Inbox UI — ``blocking_question`` label is detected; the hint bar
+  renders PM-appropriate copy; reply routes via the supervisor's
+  ``send_input`` with ``force=True``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pollypm.recovery.worker_turn_end import (
+    WORKER_REPROMPT_TEXT,
+    WorkerResponse,
+    create_blocking_question_inbox_item,
+    determine_worker_response,
+    handle_worker_turn_end,
+    is_worker_session_name,
+    send_standard_reprompt,
+)
+from pollypm.storage.state import StateStore
+from pollypm.work import task_assignment as bus
+from pollypm.work.sqlite_service import SQLiteWorkService
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeHandle:
+    name: str
+
+
+@dataclass
+class FakeSessionService:
+    """Minimal session service exposing ``list`` / ``send`` / ``capture``.
+
+    ``capture_text`` is a single canned transcript string; ``sent``
+    captures every ``send`` call for assertions.
+    """
+
+    handles: list[FakeHandle]
+    capture_text: str = ""
+    sent: list[tuple[str, str]] = field(default_factory=list)
+    busy: set[str] = field(default_factory=set)
+
+    def list(self) -> list[FakeHandle]:
+        return list(self.handles)
+
+    def send(self, name: str, text: str, *, press_enter: bool = True) -> None:
+        self.sent.append((name, text))
+
+    def is_turn_active(self, name: str) -> bool:
+        return name in self.busy
+
+    def capture(self, name: str, lines: int = 200) -> str:
+        return self.capture_text
+
+
+@dataclass
+class FakeProject:
+    path: Path
+    persona_name: str | None = None
+
+
+@dataclass
+class FakeConfig:
+    projects: dict[str, FakeProject]
+
+
+@dataclass
+class FakeTask:
+    project: str
+    task_number: int
+    current_node_id: str = "do_work"
+    flow_template_id: str = "standard"
+    title: str = "Do the work"
+
+    @property
+    def task_id(self) -> str:
+        return f"{self.project}/{self.task_number}"
+
+
+# ---------------------------------------------------------------------------
+# determine_worker_response — pure heuristic
+# ---------------------------------------------------------------------------
+
+
+class TestDetermineWorkerResponse:
+    def test_unclear_language_routes_to_blocking_question(self) -> None:
+        transcript = (
+            "Tried running the tests but the spec is unclear about "
+            "whether the retry should be idempotent."
+        )
+        task = FakeTask(project="demo", task_number=1)
+        result = determine_worker_response(
+            task, "worker-demo", work_service=None, transcript=transcript,
+        )
+        assert result.kind == "blocking_question"
+        assert "unclear" in result.question_excerpt.lower()
+
+    def test_waiting_for_routes_to_blocking_question(self) -> None:
+        transcript = "I'm waiting for clarification from the PM on the shape."
+        task = FakeTask(project="demo", task_number=1)
+        result = determine_worker_response(
+            task, "worker-demo", work_service=None, transcript=transcript,
+        )
+        assert result.kind == "blocking_question"
+
+    def test_need_decision_routes_to_blocking_question(self) -> None:
+        transcript = "I need decision: should we use SQLite or Postgres?"
+        task = FakeTask(project="demo", task_number=1)
+        result = determine_worker_response(
+            task, "worker-demo", work_service=None, transcript=transcript,
+        )
+        assert result.kind == "blocking_question"
+
+    def test_pm_notify_attempt_routes_to_blocking_question(self) -> None:
+        transcript = (
+            "About to hand off.\n"
+            "pm notify 'demo/3: how should errors be surfaced?' "
+            "--priority immediate"
+        )
+        task = FakeTask(project="demo", task_number=3)
+        result = determine_worker_response(
+            task, "worker-demo", work_service=None, transcript=transcript,
+        )
+        assert result.kind == "blocking_question"
+
+    def test_clean_tail_routes_to_reprompt(self) -> None:
+        transcript = (
+            "Ran the tests and they pass. Committed as abc123. "
+            "Ready to proceed to the next step."
+        )
+        task = FakeTask(project="demo", task_number=1)
+        result = determine_worker_response(
+            task, "worker-demo", work_service=None, transcript=transcript,
+        )
+        assert result.kind == "reprompt"
+        assert result.question_excerpt == ""
+
+    def test_empty_transcript_routes_to_reprompt(self) -> None:
+        task = FakeTask(project="demo", task_number=1)
+        result = determine_worker_response(
+            task, "worker-demo", work_service=None, transcript="",
+        )
+        assert result.kind == "reprompt"
+
+    def test_long_transcript_only_tail_scanned(self) -> None:
+        """Only the last ~2000 chars are scanned so an old 'unclear'
+        mention far from the tail doesn't falsely trip the classifier.
+        """
+        head = "unclear unclear unclear\n" + ("noise line\n" * 300)
+        transcript = head + "All good, ready to move on."
+        task = FakeTask(project="demo", task_number=1)
+        result = determine_worker_response(
+            task, "worker-demo", work_service=None, transcript=transcript,
+        )
+        # Tail (~2k chars) still contains "unclear" only if the head is
+        # shorter than the tail window. Build a transcript where the
+        # head is definitively past the tail window.
+        head = "unclear " * 300  # ~2400 chars of "unclear"
+        filler = ("x" * 80 + "\n") * 30  # another ~2.5k chars
+        clean_tail = "Everything passes. Proceeding to next step."
+        transcript = head + filler + clean_tail
+        assert len(transcript) > 4000
+        result = determine_worker_response(
+            task, "worker-demo", work_service=None, transcript=transcript,
+        )
+        assert result.kind == "reprompt", (
+            "tail-only scan should have missed the 'unclear' head"
+        )
+
+
+# ---------------------------------------------------------------------------
+# is_worker_session_name
+# ---------------------------------------------------------------------------
+
+
+class TestIsWorkerSessionName:
+    def test_dash_form_detected(self) -> None:
+        assert is_worker_session_name("worker-demo")
+
+    def test_underscore_form_detected(self) -> None:
+        assert is_worker_session_name("worker_demo")
+
+    def test_architect_not_worker(self) -> None:
+        assert not is_worker_session_name("architect-demo")
+
+    def test_reviewer_not_worker(self) -> None:
+        assert not is_worker_session_name("reviewer")
+
+    def test_polly_not_worker(self) -> None:
+        assert not is_worker_session_name("polly")
+
+    def test_empty_not_worker(self) -> None:
+        assert not is_worker_session_name("")
+
+
+# ---------------------------------------------------------------------------
+# create_blocking_question_inbox_item — label + role shape
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBlockingQuestionInboxItem:
+    def test_creates_task_with_expected_labels_and_roles(
+        self, tmp_path: Path,
+    ) -> None:
+        work = SQLiteWorkService(
+            db_path=tmp_path / "work.db",
+            project_path=tmp_path,
+        )
+        task = FakeTask(project="demo", task_number=7)
+        store = StateStore(tmp_path / "state.db")
+        config = FakeConfig(projects={
+            "demo": FakeProject(path=tmp_path, persona_name="Archie"),
+        })
+
+        inbox_task = create_blocking_question_inbox_item(
+            task,
+            "worker-demo",
+            "unclear whether retries should be idempotent",
+            work,
+            config=config,
+            state_store=store,
+        )
+        assert inbox_task is not None
+        labels = list(inbox_task.labels or [])
+        assert "blocking_question" in labels
+        assert "project:demo" in labels
+        assert "task:demo/7" in labels
+        assert "blocking_worker:worker-demo" in labels
+
+        roles = inbox_task.roles or {}
+        assert roles.get("requester") == "worker-demo"
+        assert roles.get("operator") == "Archie"
+
+        # Title surfaces the truncated excerpt alongside the task id.
+        assert "demo/7" in inbox_task.title
+
+        # Event landed on the ledger.
+        events = [
+            e for e in store.recent_events(limit=10)
+            if e.event_type == "inbox.blocking_question.created"
+        ]
+        assert len(events) == 1
+        assert events[0].session_name == "worker-demo"
+        work.close()
+
+    def test_falls_back_to_polly_when_no_persona(
+        self, tmp_path: Path,
+    ) -> None:
+        work = SQLiteWorkService(
+            db_path=tmp_path / "work.db",
+            project_path=tmp_path,
+        )
+        task = FakeTask(project="demo", task_number=7)
+        config = FakeConfig(projects={
+            "demo": FakeProject(path=tmp_path, persona_name=None),
+        })
+        inbox_task = create_blocking_question_inbox_item(
+            task,
+            "worker-demo",
+            "stuck on the edge case",
+            work,
+            config=config,
+        )
+        assert inbox_task is not None
+        assert (inbox_task.roles or {}).get("operator") == "polly"
+        work.close()
+
+    def test_soft_fail_on_none_work_service(self) -> None:
+        task = FakeTask(project="demo", task_number=7)
+        result = create_blocking_question_inbox_item(
+            task, "worker-demo", "stuck", work_service=None,
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# send_standard_reprompt
+# ---------------------------------------------------------------------------
+
+
+class TestSendStandardReprompt:
+    def test_sends_canonical_reprompt(self) -> None:
+        svc = FakeSessionService(handles=[FakeHandle("worker-demo")])
+        task = FakeTask(project="demo", task_number=2)
+        result = send_standard_reprompt("worker-demo", task, svc)
+        assert result is True
+        assert len(svc.sent) == 1
+        name, text = svc.sent[0]
+        assert name == "worker-demo"
+        assert text == WORKER_REPROMPT_TEXT
+        assert "pm task done" in text
+        assert "pm notify" in text
+
+    def test_records_event_on_state_store(self, tmp_path: Path) -> None:
+        svc = FakeSessionService(handles=[FakeHandle("worker-demo")])
+        store = StateStore(tmp_path / "state.db")
+        task = FakeTask(project="demo", task_number=2)
+        assert send_standard_reprompt(
+            "worker-demo", task, svc, state_store=store,
+        ) is True
+        events = [
+            e for e in store.recent_events(limit=10)
+            if e.event_type == "inbox.worker_reprompted"
+        ]
+        assert len(events) == 1
+        assert "demo/2" in events[0].message
+
+    def test_soft_fail_on_none_session(self) -> None:
+        task = FakeTask(project="demo", task_number=2)
+        assert send_standard_reprompt("worker-demo", task, None) is False
+
+
+# ---------------------------------------------------------------------------
+# handle_worker_turn_end — dispatcher: exactly one path runs
+# ---------------------------------------------------------------------------
+
+
+class TestHandleWorkerTurnEnd:
+    def test_worker_with_blocker_creates_inbox_item_only(
+        self, tmp_path: Path,
+    ) -> None:
+        work = SQLiteWorkService(
+            db_path=tmp_path / "work.db",
+            project_path=tmp_path,
+        )
+        task = FakeTask(project="demo", task_number=5)
+        svc = FakeSessionService(
+            handles=[FakeHandle("worker-demo")],
+            capture_text=(
+                "Trying to implement the retry. The spec is unclear "
+                "about idempotency — need guidance."
+            ),
+        )
+        store = StateStore(tmp_path / "state.db")
+        config = FakeConfig(projects={
+            "demo": FakeProject(path=tmp_path, persona_name="Polly"),
+        })
+
+        outcome = handle_worker_turn_end(
+            task, "worker-demo",
+            work_service=work,
+            session_service=svc,
+            state_store=store,
+            config=config,
+        )
+        assert outcome == "blocking_question"
+        # No reprompt was sent — one path only.
+        assert svc.sent == []
+        # But an inbox task was created.
+        inbox_tasks = work.list_tasks(project="demo")
+        blocking = [
+            t for t in inbox_tasks
+            if "blocking_question" in (t.labels or [])
+        ]
+        assert len(blocking) == 1
+        work.close()
+
+    def test_worker_with_clean_tail_reprompts_only(
+        self, tmp_path: Path,
+    ) -> None:
+        work = SQLiteWorkService(
+            db_path=tmp_path / "work.db",
+            project_path=tmp_path,
+        )
+        task = FakeTask(project="demo", task_number=6)
+        svc = FakeSessionService(
+            handles=[FakeHandle("worker-demo")],
+            capture_text="Tests pass. Committed. Ready for the next step.",
+        )
+        store = StateStore(tmp_path / "state.db")
+        config = FakeConfig(projects={
+            "demo": FakeProject(path=tmp_path, persona_name="Polly"),
+        })
+
+        outcome = handle_worker_turn_end(
+            task, "worker-demo",
+            work_service=work,
+            session_service=svc,
+            state_store=store,
+            config=config,
+        )
+        assert outcome == "reprompt"
+        # A reprompt was sent to the worker.
+        assert len(svc.sent) == 1
+        assert svc.sent[0][0] == "worker-demo"
+        assert svc.sent[0][1] == WORKER_REPROMPT_TEXT
+        # No blocking_question inbox task was created.
+        inbox_tasks = work.list_tasks(project="demo")
+        blocking = [
+            t for t in inbox_tasks
+            if "blocking_question" in (t.labels or [])
+        ]
+        assert blocking == []
+        work.close()
+
+    def test_non_worker_session_skipped(self, tmp_path: Path) -> None:
+        work = SQLiteWorkService(
+            db_path=tmp_path / "work.db",
+            project_path=tmp_path,
+        )
+        task = FakeTask(project="demo", task_number=8)
+        svc = FakeSessionService(
+            handles=[FakeHandle("architect-demo")],
+            capture_text="Even with unclear language here.",
+        )
+        store = StateStore(tmp_path / "state.db")
+
+        outcome = handle_worker_turn_end(
+            task, "architect-demo",
+            work_service=work,
+            session_service=svc,
+            state_store=store,
+        )
+        assert outcome == "skipped"
+        assert svc.sent == []
+        inbox_tasks = work.list_tasks(project="demo")
+        assert [t for t in inbox_tasks if "blocking_question" in (
+            t.labels or []
+        )] == []
+        work.close()
+
+    def test_operator_session_skipped(self, tmp_path: Path) -> None:
+        work = SQLiteWorkService(
+            db_path=tmp_path / "work.db",
+            project_path=tmp_path,
+        )
+        task = FakeTask(project="demo", task_number=9)
+        svc = FakeSessionService(
+            handles=[FakeHandle("operator")],
+            capture_text="unclear",
+        )
+        outcome = handle_worker_turn_end(
+            task, "operator",
+            work_service=work,
+            session_service=svc,
+            state_store=None,
+        )
+        assert outcome == "skipped"
+        work.close()
+
+
+# ---------------------------------------------------------------------------
+# Sweep integration — drift on a worker session routes through the
+# worker-specific path. We simulate drift by monkey-patching
+# ``reconcile_expected_advance`` since the v1 heuristic only fires on
+# plan_project flows (targeting architect sessions).
+# ---------------------------------------------------------------------------
+
+
+class TestSweepRoutesWorkerDrift:
+    def _patch_resolver(self, monkeypatch, tmp_path, svc, store):
+        from pollypm.plugins_builtin.task_assignment_notify.resolver import (
+            _RuntimeServices,
+        )
+
+        def _fake_loader(*, config_path=None):
+            work = SQLiteWorkService(
+                db_path=tmp_path / "work.db",
+                project_path=tmp_path,
+            )
+            return _RuntimeServices(
+                session_service=svc,
+                state_store=store,
+                work_service=work,
+                project_root=tmp_path,
+            )
+
+        monkeypatch.setattr(
+            "pollypm.plugins_builtin.task_assignment_notify.resolver.load_runtime_services",
+            _fake_loader,
+        )
+
+    def _force_drift_everywhere(self, monkeypatch):
+        """Force ``reconcile_expected_advance`` to return a drift action
+        regardless of flow. Lets us exercise the worker branch without
+        depending on plan_project's heuristic narrowness.
+
+        Patches the canonical module the sweep handler imports from
+        (``pollypm.recovery.state_reconciliation``) rather than
+        re-binding the name inside the handler — the handler does a
+        local import each sweep, so the patch is picked up on the
+        next call.
+        """
+        from pollypm.recovery.state_reconciliation import (
+            ReconciliationAction,
+        )
+
+        def _always_drift(
+            task, project_path, work_service,
+            *, state_store=None, now=None,
+        ):
+            return ReconciliationAction(
+                advance_to_node="next",
+                reason="forced drift for test",
+            )
+
+        monkeypatch.setattr(
+            "pollypm.recovery.state_reconciliation."
+            "reconcile_expected_advance",
+            _always_drift,
+        )
+
+    def test_worker_drift_runs_worker_specific_path(
+        self, tmp_path, monkeypatch,
+    ):
+        from pollypm.plugins_builtin.core_recurring.plugin import (
+            work_progress_sweep_handler,
+        )
+
+        bus.clear_listeners()
+        seed = SQLiteWorkService(
+            db_path=tmp_path / "work.db",
+            project_path=tmp_path,
+        )
+        # Standard flow → worker actor → target resolves to "worker-demo".
+        task = seed.create(
+            title="Do the thing",
+            description="desc",
+            type="task",
+            project="demo",
+            flow_template="standard",
+            roles={"worker": "worker", "reviewer": "reviewer"},
+            priority="normal",
+        )
+        seed.queue(task.task_id, "pm")
+        seed.claim(task.task_id, "worker")
+        seed.close()
+
+        store = StateStore(tmp_path / "state.db")
+        # Fresh capture_text: clean → reprompt path.
+        svc = FakeSessionService(
+            handles=[FakeHandle("worker-demo")],
+            capture_text="All tests pass. Committed.",
+        )
+        self._patch_resolver(monkeypatch, tmp_path, svc, store)
+        self._force_drift_everywhere(monkeypatch)
+
+        result = work_progress_sweep_handler({})
+        assert result["outcome"] == "swept"
+        assert result["drift_detected"] >= 1
+        # The worker-specific path chose reprompt.
+        assert result["worker_reprompts"] == 1
+        assert result["worker_blocking_questions"] == 0
+        # And the reprompt actually landed on the session service.
+        assert any(
+            name == "worker-demo" and WORKER_REPROMPT_TEXT in text
+            for name, text in svc.sent
+        )
+
+    def test_worker_drift_with_blocker_creates_inbox_item(
+        self, tmp_path, monkeypatch,
+    ):
+        from pollypm.plugins_builtin.core_recurring.plugin import (
+            work_progress_sweep_handler,
+        )
+
+        bus.clear_listeners()
+        seed = SQLiteWorkService(
+            db_path=tmp_path / "work.db",
+            project_path=tmp_path,
+        )
+        task = seed.create(
+            title="Do the thing",
+            description="desc",
+            type="task",
+            project="demo",
+            flow_template="standard",
+            roles={"worker": "worker", "reviewer": "reviewer"},
+            priority="normal",
+        )
+        seed.queue(task.task_id, "pm")
+        seed.claim(task.task_id, "worker")
+        seed.close()
+
+        store = StateStore(tmp_path / "state.db")
+        svc = FakeSessionService(
+            handles=[FakeHandle("worker-demo")],
+            capture_text=(
+                "Hit a wall — unclear whether we should retry on 5xx "
+                "or surface the error."
+            ),
+        )
+        self._patch_resolver(monkeypatch, tmp_path, svc, store)
+        self._force_drift_everywhere(monkeypatch)
+
+        result = work_progress_sweep_handler({})
+        assert result["drift_detected"] >= 1
+        assert result["worker_blocking_questions"] == 1
+        assert result["worker_reprompts"] == 0
+        # No reprompt was sent — inbox item path is exclusive.
+        assert svc.sent == []
+
+    def test_non_worker_drift_skips_worker_path(
+        self, tmp_path, monkeypatch,
+    ):
+        """Architect / reviewer drift falls through to log+alert only —
+        no reprompt, no blocking_question item."""
+        from pollypm.plugins_builtin.core_recurring.plugin import (
+            work_progress_sweep_handler,
+        )
+
+        bus.clear_listeners()
+        seed = SQLiteWorkService(
+            db_path=tmp_path / "work.db",
+            project_path=tmp_path,
+        )
+        task = seed.create(
+            title="Plan it",
+            description="desc",
+            type="task",
+            project="demo",
+            flow_template="plan_project",
+            roles={"architect": "architect"},
+            priority="normal",
+        )
+        seed.queue(task.task_id, "pm")
+        seed.claim(task.task_id, "architect")
+        seed.close()
+
+        store = StateStore(tmp_path / "state.db")
+        svc = FakeSessionService(
+            handles=[FakeHandle("architect-demo")],
+            capture_text="unclear unclear unclear",
+        )
+        self._patch_resolver(monkeypatch, tmp_path, svc, store)
+        self._force_drift_everywhere(monkeypatch)
+
+        result = work_progress_sweep_handler({})
+        assert result["drift_detected"] >= 1
+        assert result["worker_blocking_questions"] == 0
+        assert result["worker_reprompts"] == 0
+        # Architect should not receive a reprompt — non-worker roles
+        # keep the v1 log+alert-only behaviour.
+        assert svc.sent == []
+
+
+# ---------------------------------------------------------------------------
+# Inbox UI — blocking_question label detection + hint bar
+# ---------------------------------------------------------------------------
+
+
+class TestInboxUIBlockingQuestion:
+    def test_extract_meta_parses_sidecar_labels(self) -> None:
+        from pollypm.cockpit_ui import _extract_blocking_question_meta
+
+        labels = [
+            "blocking_question",
+            "project:demo",
+            "task:demo/7",
+            "blocking_worker:worker-demo",
+        ]
+        meta = _extract_blocking_question_meta(labels)
+        assert meta.get("task_id") == "demo/7"
+        assert meta.get("blocking_worker") == "worker-demo"
+        assert meta.get("project") == "demo"
+
+    def test_extract_meta_ignores_unrelated_labels(self) -> None:
+        from pollypm.cockpit_ui import _extract_blocking_question_meta
+
+        meta = _extract_blocking_question_meta([
+            "blocking_question", "other", "proposal",
+        ])
+        assert "task_id" not in meta
+        assert "blocking_worker" not in meta
+
+    def test_hint_bar_copy_covers_pm_actions(self) -> None:
+        """The hint bar for a blocking_question item surfaces the three
+        actions the PM needs: reply to worker, jump to worker, archive.
+        """
+        from pollypm.cockpit_ui import PollyInboxApp
+
+        hint = PollyInboxApp._BLOCKING_QUESTION_HINT
+        assert "reply to worker" in hint
+        assert "jump to worker" in hint
+        assert "archive" in hint
+
+    def test_pm_reply_routes_via_supervisor_send_with_force(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """When the PM presses ``r`` and sends a reply on a
+        blocking_question item, the text is forwarded to the worker
+        session via ``supervisor.send_input`` with ``force=True`` —
+        the ``pm send --force`` semantics from #261.
+        """
+        from pollypm.cockpit_ui import PollyInboxApp
+
+        # Partially-constructed instance — we only exercise the method
+        # directly, so __init__ isn't needed.
+        app = PollyInboxApp.__new__(PollyInboxApp)
+        app.config_path = tmp_path / "config.toml"
+
+        calls: list[dict[str, Any]] = []
+
+        class _FakeSupervisor:
+            def send_input(
+                self, name: str, text: str, *, owner: str,
+                force: bool, press_enter: bool,
+            ) -> None:
+                calls.append({
+                    "name": name, "text": text, "owner": owner,
+                    "force": force, "press_enter": press_enter,
+                })
+
+        class _FakeService:
+            def __init__(self, _path): ...
+            def load_supervisor(self): return _FakeSupervisor()
+
+        monkeypatch.setattr(
+            "pollypm.service_api.v1.PollyPMService", _FakeService,
+        )
+
+        notifications: list[tuple[str, str]] = []
+        app.notify = lambda msg, **kw: notifications.append(  # type: ignore[assignment]
+            (msg, kw.get("severity", "info")),
+        )
+        app._emit_event = lambda *args, **kw: None  # type: ignore[assignment]
+
+        app._send_reply_to_worker(
+            "demo/42", "worker-demo", "retry on 5xx, surface on 4xx",
+        )
+        assert len(calls) == 1
+        call = calls[0]
+        assert call["name"] == "worker-demo"
+        assert call["force"] is True
+        assert call["press_enter"] is True
+        assert "retry on 5xx" in call["text"]


### PR DESCRIPTION
Workers never require user touch. When a worker ends its turn without transitioning its task, the sweep either auto-creates a blocking_question inbox item targeted at the project's PM (if blocker language detected), or sends the standard reprompt via pm send --force.

## Files (4)
- `recovery/worker_turn_end.py` (new) — pure classifier + side-effect helpers + dispatcher
- `core_recurring/plugin.py` — handler call inside existing drift block, gated on is_worker_session_name. New counters: worker_blocking_questions / worker_reprompts
- `cockpit_ui.py` — blocking_question label branch in PollyInboxApp. 'r' reply forwards to worker via supervisor.send_input(force=True). 'd' jumps to worker session (not PM).
- Tests: 30 new

## Design
- V1 heuristic-only. Haiku assist deferred to v2 per spec.
- Exactly-one-path enforced — blocking_question OR reprompt, never both.
- Reprompt copy verbatim from issue.
- Non-worker drift paths unchanged.

## Tests (+30, 0 regressions)
116 pass across worker_turn_end_reprompt + state_drift + work_progress_sweep + cockpit_inbox_ui + plan_review_flow + recovery_policy.

Closes #302