### PR TITLE
feat(db): events table retention with tiered policy

### DIFF
--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from pollypm.plugins_builtin.core_agent_profiles.profiles import heartbeat_prompt, polly_prompt
 from pollypm.models import (
     AccountConfig,
+    EventsRetentionSettings,
     LoggingSettings,
     MemorySettings,
     KnownProject,
@@ -322,6 +323,57 @@ def _parse_logging_settings(raw: dict[str, object]) -> LoggingSettings:
     return LoggingSettings(rotate_size_mb=size_mb, rotate_keep=keep)
 
 
+def _parse_events_retention_settings(
+    raw: dict[str, object],
+) -> EventsRetentionSettings:
+    """Parse the ``[events]`` TOML section.
+
+    Recognised keys (all ints, measured in days):
+
+    * ``audit_retention_days`` — default 365.
+    * ``operational_retention_days`` — default 30.
+    * ``high_volume_retention_days`` — default 7.
+    * ``default_retention_days`` — default 30.
+
+    Non-positive values or non-int types are silently coerced to the
+    defaults — a fat-fingered config must never accidentally delete
+    everything. See ``pollypm.storage.events_retention`` for tier
+    membership and the ``events.retention_sweep`` handler for cadence.
+    """
+    events_raw = raw.get("events", {})
+    if not isinstance(events_raw, dict):
+        return EventsRetentionSettings()
+
+    defaults = EventsRetentionSettings()
+
+    def _as_positive_int(value: object, fallback: int) -> int:
+        if isinstance(value, bool):
+            # ``bool`` is a subclass of ``int`` — reject explicitly.
+            return fallback
+        if isinstance(value, int) and value > 0:
+            return value
+        return fallback
+
+    return EventsRetentionSettings(
+        audit_retention_days=_as_positive_int(
+            events_raw.get("audit_retention_days"),
+            defaults.audit_retention_days,
+        ),
+        operational_retention_days=_as_positive_int(
+            events_raw.get("operational_retention_days"),
+            defaults.operational_retention_days,
+        ),
+        high_volume_retention_days=_as_positive_int(
+            events_raw.get("high_volume_retention_days"),
+            defaults.high_volume_retention_days,
+        ),
+        default_retention_days=_as_positive_int(
+            events_raw.get("default_retention_days"),
+            defaults.default_retention_days,
+        ),
+    )
+
+
 def _parse_plugin_settings(raw: dict[str, object]) -> PluginSettings:
     """Parse the ``[plugins]`` TOML section.
 
@@ -447,6 +499,7 @@ def load_config(path: Path = DEFAULT_CONFIG_PATH) -> PollyPMConfig:
     rail = _parse_rail_settings(raw)
     planner = _parse_planner_settings(raw)
     logging_settings = _parse_logging_settings(raw)
+    events = _parse_events_retention_settings(raw)
     projects = _parse_known_projects(raw, base=base)
     _merge_project_local_config(sessions, projects, plugins)
     _validate_cross_references(accounts=accounts, sessions=sessions, pollypm=pollypm)
@@ -462,6 +515,7 @@ def load_config(path: Path = DEFAULT_CONFIG_PATH) -> PollyPMConfig:
         rail=rail,
         planner=planner,
         logging=logging_settings,
+        events=events,
     )
     try:
         _config_cache[config_path] = (config_path.stat().st_mtime, config)

--- a/src/pollypm/models.py
+++ b/src/pollypm/models.py
@@ -176,6 +176,23 @@ class PlannerSettings:
 
 
 @dataclass(slots=True)
+class EventsRetentionSettings:
+    """Tiered retention windows for the ``events`` table.
+
+    Each tier's retention window is measured in days. The actual
+    event_type → tier mapping lives in
+    ``pollypm.storage.events_retention`` and is authoritative — this
+    dataclass only tunes the windows. See issue context in
+    ``core_recurring/plugin.py::events_retention_sweep_handler``.
+    """
+
+    audit_retention_days: int = 365
+    operational_retention_days: int = 30
+    high_volume_retention_days: int = 7
+    default_retention_days: int = 30
+
+
+@dataclass(slots=True)
 class PollyPMConfig:
     project: ProjectSettings
     pollypm: PollyPMSettings
@@ -187,6 +204,9 @@ class PollyPMConfig:
     rail: RailSettings = field(default_factory=RailSettings)
     planner: PlannerSettings = field(default_factory=PlannerSettings)
     logging: LoggingSettings = field(default_factory=LoggingSettings)
+    events: EventsRetentionSettings = field(
+        default_factory=EventsRetentionSettings,
+    )
 
 
 @dataclass(slots=True)

--- a/src/pollypm/plugins_builtin/core_recurring/plugin.py
+++ b/src/pollypm/plugins_builtin/core_recurring/plugin.py
@@ -475,6 +475,79 @@ def db_vacuum_handler(payload: dict[str, Any]) -> dict[str, Any]:
     return {"bytes_reclaimed": bytes_reclaimed, "mb_reclaimed": mb_reclaimed}
 
 
+def events_retention_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
+    """Apply tiered retention to the ``events`` table (issue-tracked as #267 follow-up).
+
+    The events ledger is written to on every heartbeat, token-ledger
+    bump, and task transition — unbounded growth is the single biggest
+    contributor to ``state.db`` bloat on long-running installations.
+    This handler walks four tiers (``audit`` / ``operational`` /
+    ``high_volume`` / ``default``) and DELETEs rows older than each
+    tier's retention window. One parameterized DELETE per tier — no
+    row-by-row work.
+
+    Runs hourly (``37 * * * *`` — off-pattern from the 4am DB hygiene
+    window) so the freelist stays small; the daily ``db.vacuum``
+    ``PRAGMA incremental_vacuum`` then reclaims the pages. No explicit
+    code dependency between the two — purely a cadence contract.
+
+    Tier membership is data, defined in
+    ``pollypm.storage.events_retention``. Retention *windows* are
+    configurable via the ``[events]`` TOML section; the handler honours
+    whatever ``config.events`` resolves to.
+
+    Emits a single ``events.retention_sweep`` event only when rows were
+    deleted — a no-op sweep stays silent to avoid the handler logging
+    its own cadence and defeating the purpose.
+    """
+    from pollypm.storage.events_retention import (
+        RetentionPolicy,
+        sweep_events,
+    )
+
+    config, store = _load_config_and_store(payload)
+
+    settings = config.events
+    policy = RetentionPolicy(
+        audit_days=settings.audit_retention_days,
+        operational_days=settings.operational_retention_days,
+        high_volume_days=settings.high_volume_retention_days,
+        default_days=settings.default_retention_days,
+    )
+
+    # Serialize against the StateStore's own lock so we don't race with
+    # writers on the shared connection. ``sweep_events`` issues a
+    # commit, so the rowcounts are durable before we return.
+    with store._lock:  # noqa: SLF001 — StateStore exposes no public wrapper
+        result = sweep_events(store._conn, policy)  # noqa: SLF001
+
+    counts = {
+        "deleted_audit": result.deleted_audit,
+        "deleted_operational": result.deleted_operational,
+        "deleted_high_volume": result.deleted_high_volume,
+        "deleted_default": result.deleted_default,
+        "total": result.total,
+    }
+
+    # Only log when something actually happened — otherwise every hourly
+    # sweep would itself become a ``high_volume`` event and grow the
+    # table we're trying to shrink.
+    if result.total > 0:
+        store.record_event(
+            session_name="system",
+            event_type="events.retention_sweep",
+            message=(
+                f"deleted {result.total} events "
+                f"(audit={result.deleted_audit}, "
+                f"operational={result.deleted_operational}, "
+                f"high_volume={result.deleted_high_volume}, "
+                f"default={result.deleted_default})"
+            ),
+        )
+
+    return counts
+
+
 def memory_ttl_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
     """Drop expired memory_entries (TTL in the past).
 
@@ -848,6 +921,10 @@ def _register_handlers(api: JobHandlerAPI) -> None:
         max_attempts=1, timeout_seconds=60.0,
     )
     api.register_handler(
+        "events.retention_sweep", events_retention_sweep_handler,
+        max_attempts=1, timeout_seconds=60.0,
+    )
+    api.register_handler(
         "notification_staging.prune", notification_staging_prune_handler,
         max_attempts=1, timeout_seconds=60.0,
     )
@@ -880,6 +957,14 @@ def _register_roster(api: RosterAPI) -> None:
     api.register_recurring("7 4 * * *", "db.vacuum", {}, dedupe_key="db.vacuum")
     api.register_recurring(
         "13 4 * * *", "memory.ttl_sweep", {}, dedupe_key="memory.ttl_sweep",
+    )
+    # Events-table retention — hourly at :37, off-pattern from the 4am
+    # hygiene window and from the ``23``/``23 * * * *`` agent-worktree
+    # prune. Tiered policy (audit 365d / operational 30d / high_volume
+    # 7d / default 30d) lives in pollypm.storage.events_retention.
+    api.register_recurring(
+        "37 * * * *", "events.retention_sweep", {},
+        dedupe_key="events.retention_sweep",
     )
     # Notification staging hygiene — flushed rollup rows and silent audit
     # rows older than 30 days are dropped. Pending digest rows are left
@@ -923,6 +1008,7 @@ plugin = PollyPMPlugin(
         Capability(kind="job_handler", name="work.progress_sweep"),
         Capability(kind="job_handler", name="db.vacuum"),
         Capability(kind="job_handler", name="memory.ttl_sweep"),
+        Capability(kind="job_handler", name="events.retention_sweep"),
         Capability(kind="job_handler", name="notification_staging.prune"),
         Capability(kind="job_handler", name="agent_worktree.prune"),
         Capability(kind="job_handler", name="log.rotate"),

--- a/src/pollypm/plugins_builtin/core_recurring/pollypm-plugin.toml
+++ b/src/pollypm/plugins_builtin/core_recurring/pollypm-plugin.toml
@@ -42,6 +42,11 @@ requires_api = ">=1,<2"
 
 [[capabilities]]
 kind = "job_handler"
+name = "events.retention_sweep"
+requires_api = ">=1,<2"
+
+[[capabilities]]
+kind = "job_handler"
 name = "notification_staging.prune"
 requires_api = ">=1,<2"
 

--- a/src/pollypm/storage/events_retention.py
+++ b/src/pollypm/storage/events_retention.py
@@ -1,0 +1,247 @@
+"""Tiered retention policy for the ``events`` table.
+
+The ``events`` table is written to constantly — every heartbeat sweep, every
+token-ledger bump, every task transition, every inbox message. Left
+unbounded it becomes the single largest contributor to ``state.db`` bloat
+(45k rows and growing on Sam's live DB as of 2026-04-17). The blanket
+7-day prune in :func:`StateStore.prune_old_data` used to keep it honest, but
+that policy is both too aggressive (drops task approvals after a week —
+useful audit trail gone) AND too lax (lets heartbeat_error rows accumulate
+for a full week when 24h is plenty).
+
+This module defines a **tiered retention policy**. Each ``event_type`` is
+classified into one of four tiers, each with its own retention window:
+
+* ``audit`` — 365 days. Task transitions, approvals, rejections, launches,
+  recoveries, alerts. Anything that forms a long-term audit trail.
+* ``operational`` — 30 days. Lease churn, send_input, nudge, delivery —
+  useful for post-mortem on recent incidents but not worth keeping a year.
+* ``high_volume`` — 7 days. Heartbeats, token-ledger entries, scheduler
+  tick rows. Pure noise after a week.
+* ``default`` — 30 days. Any event_type not explicitly mapped falls
+  through to this tier so brand-new event_types don't accumulate
+  unbounded while someone figures out where they belong.
+
+The policy is **data** — tier membership lives in the constants below and
+can be tuned in one place. The sweep itself is a single parameterized
+``DELETE`` per tier using an ``IN (?, ?, ?...)`` clause so SQLite plans it
+as an index-friendly scan rather than row-by-row Python.
+
+See issue #267 context and the ``events.retention_sweep`` handler in
+``core_recurring/plugin.py`` for the cron wiring.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Iterable
+
+
+# ---------------------------------------------------------------------------
+# Tier membership
+# ---------------------------------------------------------------------------
+#
+# Maps are frozensets for cheap membership checks. Order between tiers is
+# ``audit > operational > high_volume`` — if a type ever appears in two
+# tiers (it shouldn't) the sweep uses whichever tier iterates first; we
+# defensively keep them disjoint.
+
+
+AUDIT_EVENT_TYPES: frozenset[str] = frozenset({
+    "task.approved",
+    "task.rejected",
+    "task.done",
+    "task.claimed",
+    "task.queued",
+    "plan.approved",
+    "inbox.message.created",
+    "launch",
+    "recovered",
+    "recovery_prompt",
+    "state_drift",
+    "persona_swap_detected",
+    "alert",
+    "escalated",
+})
+
+
+OPERATIONAL_EVENT_TYPES: frozenset[str] = frozenset({
+    "lease",
+    "stop",
+    "send_input",
+    "nudge",
+    "ran",
+    "processed",
+    "stabilize_failed",
+    "delivery",
+})
+
+
+HIGH_VOLUME_EVENT_TYPES: frozenset[str] = frozenset({
+    "heartbeat",
+    "heartbeat_error",
+    "token_ledger",
+    "scheduled",
+})
+
+
+# Sanity check at import time — if a type ever slips into two tiers we
+# want the ImportError up front, not a silent overlap that deletes rows
+# twice (or, worse, under the wrong window).
+_OVERLAP = (
+    (AUDIT_EVENT_TYPES & OPERATIONAL_EVENT_TYPES)
+    | (AUDIT_EVENT_TYPES & HIGH_VOLUME_EVENT_TYPES)
+    | (OPERATIONAL_EVENT_TYPES & HIGH_VOLUME_EVENT_TYPES)
+)
+if _OVERLAP:  # pragma: no cover — structural assertion
+    raise RuntimeError(
+        f"events_retention: event types classified into multiple tiers: {_OVERLAP!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Retention policy + sweep
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True, frozen=True)
+class RetentionPolicy:
+    """Retention windows in days for each tier.
+
+    Defaults mirror the ``EventsRetentionSettings`` dataclass on
+    ``PollyPMConfig`` so handlers that don't wire the config still get
+    sensible behaviour.
+    """
+
+    audit_days: int = 365
+    operational_days: int = 30
+    high_volume_days: int = 7
+    default_days: int = 30
+
+
+@dataclass(slots=True, frozen=True)
+class RetentionSweepResult:
+    """Counts returned by :func:`sweep_events`."""
+
+    deleted_audit: int = 0
+    deleted_operational: int = 0
+    deleted_high_volume: int = 0
+    deleted_default: int = 0
+
+    @property
+    def total(self) -> int:
+        return (
+            self.deleted_audit
+            + self.deleted_operational
+            + self.deleted_high_volume
+            + self.deleted_default
+        )
+
+
+def _delete_by_types(
+    conn: sqlite3.Connection,
+    event_types: Iterable[str],
+    cutoff_iso: str,
+) -> int:
+    """DELETE rows whose type is in ``event_types`` AND older than cutoff.
+
+    Uses a single parameterized IN clause rather than row-by-row deletes.
+    Returns the row count.
+    """
+    types = tuple(event_types)
+    if not types:
+        return 0
+    placeholders = ",".join("?" for _ in types)
+    sql = (
+        f"DELETE FROM events "
+        f"WHERE event_type IN ({placeholders}) AND created_at < ?"
+    )
+    cursor = conn.execute(sql, (*types, cutoff_iso))
+    return int(cursor.rowcount or 0)
+
+
+def _delete_default_tier(
+    conn: sqlite3.Connection,
+    known_types: Iterable[str],
+    cutoff_iso: str,
+) -> int:
+    """DELETE rows whose type is NOT in any known tier, older than cutoff.
+
+    The default tier is everything we didn't explicitly classify — we
+    express it via ``NOT IN (<known>)`` so new event_types land here by
+    accident rather than living forever.
+    """
+    types = tuple(known_types)
+    if not types:
+        # Degenerate: no classified types means everything falls to default.
+        cursor = conn.execute(
+            "DELETE FROM events WHERE created_at < ?", (cutoff_iso,),
+        )
+        return int(cursor.rowcount or 0)
+    placeholders = ",".join("?" for _ in types)
+    sql = (
+        f"DELETE FROM events "
+        f"WHERE event_type NOT IN ({placeholders}) AND created_at < ?"
+    )
+    cursor = conn.execute(sql, (*types, cutoff_iso))
+    return int(cursor.rowcount or 0)
+
+
+def sweep_events(
+    conn: sqlite3.Connection,
+    policy: RetentionPolicy | None = None,
+    *,
+    now: datetime | None = None,
+) -> RetentionSweepResult:
+    """Apply the tiered retention policy against the ``events`` table.
+
+    Runs four DELETEs, one per tier, committing once at the end. Safe
+    to call concurrently with readers — SQLite serialises writes on the
+    shared connection and the shared ``busy_timeout`` coordinates with
+    any other writers.
+
+    ``conn`` is the caller's SQLite connection (usually
+    ``StateStore._conn``). The caller owns the connection lifecycle and
+    any thread-lock it may have wrapped around it; this function just
+    issues the four DELETEs + a single commit.
+
+    Returns a :class:`RetentionSweepResult` — zero counts are fine.
+    """
+    if policy is None:
+        policy = RetentionPolicy()
+    if now is None:
+        now = datetime.now(UTC)
+
+    audit_cutoff = (now - timedelta(days=policy.audit_days)).isoformat()
+    operational_cutoff = (
+        now - timedelta(days=policy.operational_days)
+    ).isoformat()
+    high_volume_cutoff = (
+        now - timedelta(days=policy.high_volume_days)
+    ).isoformat()
+    default_cutoff = (now - timedelta(days=policy.default_days)).isoformat()
+
+    known_types: set[str] = set()
+    known_types.update(AUDIT_EVENT_TYPES)
+    known_types.update(OPERATIONAL_EVENT_TYPES)
+    known_types.update(HIGH_VOLUME_EVENT_TYPES)
+
+    deleted_audit = _delete_by_types(conn, AUDIT_EVENT_TYPES, audit_cutoff)
+    deleted_operational = _delete_by_types(
+        conn, OPERATIONAL_EVENT_TYPES, operational_cutoff,
+    )
+    deleted_high_volume = _delete_by_types(
+        conn, HIGH_VOLUME_EVENT_TYPES, high_volume_cutoff,
+    )
+    deleted_default = _delete_default_tier(conn, known_types, default_cutoff)
+
+    conn.commit()
+
+    return RetentionSweepResult(
+        deleted_audit=deleted_audit,
+        deleted_operational=deleted_operational,
+        deleted_high_volume=deleted_high_volume,
+        deleted_default=deleted_default,
+    )

--- a/tests/test_core_recurring_migration.py
+++ b/tests/test_core_recurring_migration.py
@@ -78,6 +78,8 @@ class TestCoreRecurringPlugin:
             "agent_worktree.prune",
             # Log-file hygiene — hourly at minute :31.
             "log.rotate",
+            # Events-table tiered retention — hourly at minute :37.
+            "events.retention_sweep",
         }
 
         # Cadences per issue #164 / #249.
@@ -106,6 +108,9 @@ class TestCoreRecurringPlugin:
         log_rotate = entries["log.rotate"].schedule
         assert isinstance(log_rotate, CronSchedule)
         assert log_rotate.expression() == "31 * * * *"
+        events_retention = entries["events.retention_sweep"].schedule
+        assert isinstance(events_retention, CronSchedule)
+        assert events_retention.expression() == "37 * * * *"
 
     def test_plugin_declares_expected_capabilities(self) -> None:
         kinds = {cap.kind for cap in core_plugin.capabilities}

--- a/tests/test_events_retention.py
+++ b/tests/test_events_retention.py
@@ -1,0 +1,451 @@
+"""Tests for the tiered events-retention policy + hourly sweep handler.
+
+Three layers covered:
+
+1. Tier classification — every event_type spec'd in the policy falls into
+   the right tier and the four tiers are disjoint.
+2. ``sweep_events`` core — respects each tier's retention window; unknown
+   types fall through to default; multi-tier batches return correct
+   counts; idempotent on a clean table.
+3. ``events_retention_sweep_handler`` plugin wiring — loads config,
+   drives the core function, and logs an audit event only when
+   deletions happened (no-op sweeps stay silent so the handler doesn't
+   grow the table it's trying to shrink).
+
+Runs cheap — each test spins up an in-memory-style SQLite file under
+``tmp_path``. No live ``state.db`` is touched. Targeted invocation:
+
+    HOME=/tmp/pytest-agent-events uv run pytest tests/test_events_retention.py -q
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from pollypm.plugins_builtin.core_recurring.plugin import (
+    events_retention_sweep_handler,
+)
+from pollypm.storage.events_retention import (
+    AUDIT_EVENT_TYPES,
+    HIGH_VOLUME_EVENT_TYPES,
+    OPERATIONAL_EVENT_TYPES,
+    RetentionPolicy,
+    RetentionSweepResult,
+    sweep_events,
+)
+from pollypm.storage.state import StateStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_event(
+    conn: sqlite3.Connection,
+    *,
+    session_name: str,
+    event_type: str,
+    message: str,
+    created_at: datetime,
+) -> int:
+    """Insert one row with an arbitrary ``created_at`` — returns row id."""
+    cursor = conn.execute(
+        "INSERT INTO events (session_name, event_type, message, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        (session_name, event_type, message, created_at.isoformat()),
+    )
+    conn.commit()
+    return int(cursor.lastrowid or 0)
+
+
+def _row_count(conn: sqlite3.Connection, event_type: str) -> int:
+    row = conn.execute(
+        "SELECT COUNT(*) FROM events WHERE event_type = ?", (event_type,),
+    ).fetchone()
+    return int(row[0]) if row else 0
+
+
+def _fresh_store(tmp_path: Path) -> StateStore:
+    """Build a fresh StateStore so the events table migration runs."""
+    return StateStore(tmp_path / "state.db")
+
+
+# ---------------------------------------------------------------------------
+# 1. Tier classification invariants
+# ---------------------------------------------------------------------------
+
+
+class TestTierClassification:
+    def test_audit_tier_covers_every_spec_type(self) -> None:
+        """Every audit event_type from the spec is classified as audit."""
+        expected = {
+            "task.approved",
+            "task.rejected",
+            "task.done",
+            "task.claimed",
+            "task.queued",
+            "plan.approved",
+            "inbox.message.created",
+            "launch",
+            "recovered",
+            "recovery_prompt",
+            "state_drift",
+            "persona_swap_detected",
+            "alert",
+            "escalated",
+        }
+        assert expected.issubset(AUDIT_EVENT_TYPES)
+
+    def test_operational_tier_covers_every_spec_type(self) -> None:
+        expected = {
+            "lease", "stop", "send_input", "nudge", "ran",
+            "processed", "stabilize_failed", "delivery",
+        }
+        assert expected.issubset(OPERATIONAL_EVENT_TYPES)
+
+    def test_high_volume_tier_covers_every_spec_type(self) -> None:
+        expected = {"heartbeat", "heartbeat_error", "token_ledger", "scheduled"}
+        assert expected.issubset(HIGH_VOLUME_EVENT_TYPES)
+
+    def test_tiers_are_disjoint(self) -> None:
+        """No event_type lives in two tiers — the sweep assumes this."""
+        assert not (AUDIT_EVENT_TYPES & OPERATIONAL_EVENT_TYPES)
+        assert not (AUDIT_EVENT_TYPES & HIGH_VOLUME_EVENT_TYPES)
+        assert not (OPERATIONAL_EVENT_TYPES & HIGH_VOLUME_EVENT_TYPES)
+
+
+# ---------------------------------------------------------------------------
+# 2. sweep_events core behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSweepEventsCore:
+    def test_audit_event_older_than_window_is_deleted(
+        self, tmp_path: Path,
+    ) -> None:
+        """An audit row past 365 days is swept."""
+        store = _fresh_store(tmp_path)
+        try:
+            now = datetime.now(UTC)
+            old_id = _insert_event(
+                store._conn,
+                session_name="pm",
+                event_type="task.approved",
+                message="old approval",
+                created_at=now - timedelta(days=366),
+            )
+            result = sweep_events(store._conn, now=now)
+            assert result.deleted_audit == 1
+            # Row must be gone.
+            row = store._conn.execute(
+                "SELECT id FROM events WHERE id = ?", (old_id,),
+            ).fetchone()
+            assert row is None
+        finally:
+            store.close()
+
+    def test_audit_event_within_window_is_kept(self, tmp_path: Path) -> None:
+        """An audit row within 365 days survives."""
+        store = _fresh_store(tmp_path)
+        try:
+            now = datetime.now(UTC)
+            keep_id = _insert_event(
+                store._conn,
+                session_name="pm",
+                event_type="task.approved",
+                message="recent approval",
+                created_at=now - timedelta(days=300),
+            )
+            result = sweep_events(store._conn, now=now)
+            assert result.deleted_audit == 0
+            row = store._conn.execute(
+                "SELECT id FROM events WHERE id = ?", (keep_id,),
+            ).fetchone()
+            assert row is not None
+        finally:
+            store.close()
+
+    def test_operational_window_respected(self, tmp_path: Path) -> None:
+        """Operational events deleted past 30d, kept within 30d."""
+        store = _fresh_store(tmp_path)
+        try:
+            now = datetime.now(UTC)
+            _insert_event(
+                store._conn, session_name="pm", event_type="lease",
+                message="old lease",
+                created_at=now - timedelta(days=45),
+            )
+            _insert_event(
+                store._conn, session_name="pm", event_type="lease",
+                message="fresh lease",
+                created_at=now - timedelta(days=10),
+            )
+            result = sweep_events(store._conn, now=now)
+            assert result.deleted_operational == 1
+            assert _row_count(store._conn, "lease") == 1
+        finally:
+            store.close()
+
+    def test_high_volume_window_respected(self, tmp_path: Path) -> None:
+        """High-volume events deleted past 7d, kept within 7d."""
+        store = _fresh_store(tmp_path)
+        try:
+            now = datetime.now(UTC)
+            _insert_event(
+                store._conn, session_name="pm", event_type="heartbeat",
+                message="stale hb",
+                created_at=now - timedelta(days=10),
+            )
+            _insert_event(
+                store._conn, session_name="pm", event_type="heartbeat",
+                message="fresh hb",
+                created_at=now - timedelta(days=2),
+            )
+            _insert_event(
+                store._conn, session_name="pm", event_type="token_ledger",
+                message="stale token",
+                created_at=now - timedelta(days=8),
+            )
+            result = sweep_events(store._conn, now=now)
+            assert result.deleted_high_volume == 2
+            assert _row_count(store._conn, "heartbeat") == 1
+            assert _row_count(store._conn, "token_ledger") == 0
+        finally:
+            store.close()
+
+    def test_unknown_event_type_falls_into_default(
+        self, tmp_path: Path,
+    ) -> None:
+        """An event_type not in any tier follows the default window (30d)."""
+        store = _fresh_store(tmp_path)
+        try:
+            now = datetime.now(UTC)
+            _insert_event(
+                store._conn,
+                session_name="pm",
+                event_type="some.brand.new.type",
+                message="old",
+                created_at=now - timedelta(days=45),
+            )
+            _insert_event(
+                store._conn,
+                session_name="pm",
+                event_type="some.brand.new.type",
+                message="fresh",
+                created_at=now - timedelta(days=10),
+            )
+            result = sweep_events(store._conn, now=now)
+            assert result.deleted_default == 1
+            assert result.deleted_audit == 0
+            assert result.deleted_operational == 0
+            assert result.deleted_high_volume == 0
+            assert _row_count(store._conn, "some.brand.new.type") == 1
+        finally:
+            store.close()
+
+    def test_multi_tier_single_pass_counts_each_tier(
+        self, tmp_path: Path,
+    ) -> None:
+        """Several tiers cleaned in one pass — each counter is correct."""
+        store = _fresh_store(tmp_path)
+        try:
+            now = datetime.now(UTC)
+            # 2 audit past 365d.
+            _insert_event(
+                store._conn, session_name="pm", event_type="task.done",
+                message="a1", created_at=now - timedelta(days=400),
+            )
+            _insert_event(
+                store._conn, session_name="pm", event_type="launch",
+                message="a2", created_at=now - timedelta(days=400),
+            )
+            # 1 operational past 30d.
+            _insert_event(
+                store._conn, session_name="pm", event_type="send_input",
+                message="o1", created_at=now - timedelta(days=60),
+            )
+            # 3 high_volume past 7d.
+            for i in range(3):
+                _insert_event(
+                    store._conn, session_name="pm",
+                    event_type="heartbeat_error",
+                    message=f"hv{i}",
+                    created_at=now - timedelta(days=8),
+                )
+            # 2 default past 30d.
+            for i in range(2):
+                _insert_event(
+                    store._conn, session_name="pm",
+                    event_type="weird.type",
+                    message=f"d{i}",
+                    created_at=now - timedelta(days=40),
+                )
+            # Fresh rows that must survive across all tiers.
+            _insert_event(
+                store._conn, session_name="pm", event_type="task.done",
+                message="keep", created_at=now - timedelta(days=1),
+            )
+
+            result = sweep_events(store._conn, now=now)
+            assert result.deleted_audit == 2
+            assert result.deleted_operational == 1
+            assert result.deleted_high_volume == 3
+            assert result.deleted_default == 2
+            assert result.total == 8
+
+            # Survivor remains.
+            keep_row = store._conn.execute(
+                "SELECT COUNT(*) FROM events WHERE message = 'keep'",
+            ).fetchone()
+            assert int(keep_row[0]) == 1
+        finally:
+            store.close()
+
+    def test_idempotent_on_clean_state(self, tmp_path: Path) -> None:
+        """Second sweep after a clean pass deletes nothing."""
+        store = _fresh_store(tmp_path)
+        try:
+            now = datetime.now(UTC)
+            _insert_event(
+                store._conn, session_name="pm", event_type="heartbeat",
+                message="old", created_at=now - timedelta(days=10),
+            )
+            first = sweep_events(store._conn, now=now)
+            assert first.total == 1
+            second = sweep_events(store._conn, now=now)
+            assert second.total == 0
+            assert second.deleted_audit == 0
+            assert second.deleted_operational == 0
+            assert second.deleted_high_volume == 0
+            assert second.deleted_default == 0
+        finally:
+            store.close()
+
+    def test_empty_events_table_returns_zero_counts(
+        self, tmp_path: Path,
+    ) -> None:
+        """Sweep on a freshly-migrated (empty) events table is a no-op."""
+        store = _fresh_store(tmp_path)
+        try:
+            result = sweep_events(store._conn)
+            assert isinstance(result, RetentionSweepResult)
+            assert result.total == 0
+        finally:
+            store.close()
+
+    def test_custom_policy_overrides_default_windows(
+        self, tmp_path: Path,
+    ) -> None:
+        """A caller-supplied RetentionPolicy is honoured."""
+        store = _fresh_store(tmp_path)
+        try:
+            now = datetime.now(UTC)
+            # With the default 365d audit window this row would survive;
+            # under a 10-day policy it must be deleted.
+            _insert_event(
+                store._conn, session_name="pm", event_type="task.approved",
+                message="recent-but-over-10d",
+                created_at=now - timedelta(days=30),
+            )
+            policy = RetentionPolicy(
+                audit_days=10, operational_days=10,
+                high_volume_days=10, default_days=10,
+            )
+            result = sweep_events(store._conn, policy, now=now)
+            assert result.deleted_audit == 1
+        finally:
+            store.close()
+
+
+# ---------------------------------------------------------------------------
+# 3. Plugin handler wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRetentionSweepHandler:
+    def _write_minimal_config(
+        self, tmp_path: Path, state_db: Path,
+    ) -> Path:
+        """Produce the smallest pollypm.toml the handler can load."""
+        cfg_path = tmp_path / "pollypm.toml"
+        cfg_path.write_text(
+            "[project]\n"
+            f'name = "test"\n'
+            f'root = "{tmp_path.as_posix()}"\n'
+            f'state_db = "{state_db.as_posix()}"\n'
+            f'tmux_session = "test"\n'
+            "[runtime]\n"
+            "[schedulers]\n"
+            "[defaults]\n"
+        )
+        return cfg_path
+
+    def test_handler_sweeps_and_records_audit_event(
+        self, tmp_path: Path,
+    ) -> None:
+        """Handler deletes expired rows and records a summary event."""
+        state_db = tmp_path / "state.db"
+        # Prime the schema via the StateStore so the handler's own
+        # _load_config_and_store path finds the events table.
+        prime = StateStore(state_db)
+        now = datetime.now(UTC)
+        _insert_event(
+            prime._conn, session_name="pm", event_type="heartbeat",
+            message="old", created_at=now - timedelta(days=10),
+        )
+        _insert_event(
+            prime._conn, session_name="pm", event_type="task.done",
+            message="old-audit", created_at=now - timedelta(days=400),
+        )
+        prime.close()
+
+        cfg_path = self._write_minimal_config(tmp_path, state_db)
+        out = events_retention_sweep_handler({"config_path": str(cfg_path)})
+
+        assert out["total"] == 2
+        assert out["deleted_high_volume"] == 1
+        assert out["deleted_audit"] == 1
+
+        # The handler must have recorded a single retention-sweep event.
+        verify = StateStore(state_db)
+        try:
+            row = verify._conn.execute(
+                "SELECT COUNT(*) FROM events "
+                "WHERE event_type = 'events.retention_sweep'",
+            ).fetchone()
+            assert int(row[0]) == 1
+        finally:
+            verify.close()
+
+    def test_handler_silent_on_no_op_sweep(self, tmp_path: Path) -> None:
+        """No deletions → no ``events.retention_sweep`` log row emitted."""
+        state_db = tmp_path / "state.db"
+        prime = StateStore(state_db)
+        # Only fresh rows — nothing to delete.
+        now = datetime.now(UTC)
+        _insert_event(
+            prime._conn, session_name="pm", event_type="heartbeat",
+            message="fresh", created_at=now - timedelta(days=1),
+        )
+        prime.close()
+
+        cfg_path = self._write_minimal_config(tmp_path, state_db)
+        out = events_retention_sweep_handler({"config_path": str(cfg_path)})
+        assert out["total"] == 0
+
+        verify = StateStore(state_db)
+        try:
+            row = verify._conn.execute(
+                "SELECT COUNT(*) FROM events "
+                "WHERE event_type = 'events.retention_sweep'",
+            ).fetchone()
+            # Critical: no self-logging when nothing happened — otherwise
+            # the handler would grow the table it's pruning.
+            assert int(row[0]) == 0
+        finally:
+            verify.close()


### PR DESCRIPTION
Tiered retention for the events table. Replaces blanket 7-day prune with type-aware floors.

## Tiers
- audit (365d): task transitions, approvals, plan events, alerts, escalations, persona_swap_detected
- operational (30d): lease, send_input, nudge, ran, processed, delivery
- high-volume (7d): heartbeat, token_ledger, scheduled
- default (30d): unmapped

## Cron
`37 * * * *` — hourly at :37, off-pattern.

## Files (7)
- New `storage/events_retention.py` (230 lines)
- core_recurring/plugin.py + manifest + cron
- models.py + config.py — `EventsRetentionSettings` + `[events]` TOML round-trip
- 15 new tests + roster migration test update

## Dry-run vs Sam's live DB
50,449 rows / 2.07 GB. Would delete 491 (high-volume only — most events recent because alerts.gc prunes blunt at 7d).

## ⚠️ KNOWN CAVEAT — follow-up needed
`alerts.gc_handler` (in core_recurring) still calls `prune_old_data(event_days=7)` every 5 min, which deletes ALL events > 7d regardless of type. **The new 365-day audit floor is effectively neutralized by alerts.gc.** Filing follow-up immediately to align alerts.gc with the new policy.

Closes part of the events-bloat concern.