### PR TITLE
polish(errors): actionable error messages for provider probes, pm issue, pm add-project, config-not-found

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -28,6 +28,7 @@ from pollypm.config import (
     write_example_config,
 )
 from pollypm.doc_scaffold import repair_docs, verify_docs
+from pollypm.errors import format_config_not_found_error
 from pollypm.models import ProviderKind
 from pollypm.service_api import PollyPMService
 from pollypm.service_api import render_json
@@ -637,10 +638,20 @@ def add_project(
                     "config_path": str(config_path),
                 },
             )
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             # Observers are best-effort — never block registration on a
-            # plugin crash. The same guard is in ``pm project new``.
-            pass
+            # plugin crash. Surface a stderr breadcrumb so the user knows
+            # the planner auto-fire did not run (the project IS still
+            # registered). Mirror of the guard in ``pm project new``.
+            logger.warning(
+                "project.created observer failed for %s: %s", project.key, exc,
+            )
+            typer.echo(
+                f"Warning: project.created hook failed ({exc}). The project "
+                f"is registered, but the planner auto-fire did not run. Run "
+                f"`pm project plan {project.key}` to start planning manually.",
+                err=True,
+            )
 
     if not skip_import:
         typer.echo("Importing project history (transcripts, git, files)...")
@@ -654,7 +665,18 @@ def add_project(
                 f"{result.timeline_events} events, {result.docs_generated} docs generated"
             )
         except Exception as exc:  # noqa: BLE001
-            typer.echo(f"History import failed (project still registered): {exc}")
+            # Route to stderr so scripted callers can see the failure
+            # without grepping stdout. The project is registered — make
+            # that explicit and offer a retry command.
+            logger.warning(
+                "history_import failed for %s: %s", project.key, exc,
+            )
+            typer.echo(
+                f"Failed: history import for {project.key}: {exc}\n"
+                f"The project is registered — rerun `pm import {project.key}` "
+                f"to retry.",
+                err=True,
+            )
 
 
 @app.command("import")
@@ -773,7 +795,10 @@ def issue_transition(
     try:
         task = service.move_task(project, task_id, to_state=to_state)
     except ValueError as exc:
-        typer.echo(str(exc))
+        # Route to stderr with a prefix that names the subject. The raw
+        # ValueError used to leak to stdout (see
+        # reports/error-message-audit.md §1 item 2).
+        typer.echo(f"Cannot transition {task_id}: {exc}", err=True)
         raise typer.Exit(code=1) from exc
     typer.echo(f"Moved issue {task.task_id} to {task.state}")
 
@@ -830,7 +855,7 @@ def issue_approve(
             verification=verification,
         )
     except ValueError as exc:
-        typer.echo(str(exc))
+        typer.echo(f"Cannot approve {task_id}: {exc}", err=True)
         raise typer.Exit(code=1) from exc
     typer.echo(f"Approved issue {task.task_id} to {task.state}")
 
@@ -855,7 +880,7 @@ def issue_request_changes(
             changes_requested=changes,
         )
     except ValueError as exc:
-        typer.echo(str(exc))
+        typer.echo(f"Cannot request changes on {task_id}: {exc}", err=True)
         raise typer.Exit(code=1) from exc
     typer.echo(f"Returned issue {task.task_id} to {task.state}")
 
@@ -1146,7 +1171,7 @@ def reset(
     """Kill all PollyPM tmux sessions (cockpit + storage closet). Use `pm up` to restart."""
     config_path = _discover_config_path(config_path)
     if not config_path.exists():
-        typer.echo(f"Config not found at {config_path}.")
+        typer.echo(format_config_not_found_error(config_path), err=True)
         raise typer.Exit(code=1)
     supervisor = _load_supervisor(config_path)
     session_name = supervisor.config.project.tmux_session
@@ -2006,7 +2031,7 @@ def repair(
     """Check and repair PollyPM project scaffolding, docs, and state."""
     config_path = _discover_config_path(config_path)
     if not config_path.exists():
-        typer.echo(f"Config not found at {config_path}.")
+        typer.echo(format_config_not_found_error(config_path), err=True)
         raise typer.Exit(code=1)
     config = load_config(config_path)
     all_problems: list[str] = []

--- a/src/pollypm/errors.py
+++ b/src/pollypm/errors.py
@@ -1,0 +1,100 @@
+"""Centralized error-message helpers for user-facing CLI output.
+
+This module exists to normalize the shape of recurring error messages so
+the CLI has one canonical phrasing per situation. Today the only entries
+are the "config not found" helper used by seven CLIs, plus a helper for
+formatting probe-failure messages that name the account and include a
+"Fix:" footer. More can be added as follow-ups — the audit at
+``reports/error-message-audit.md`` tracks candidates.
+
+Style rules (keep this list short):
+
+* Always include the subject (path / account / task id) in the message.
+* Always end with ``Fix: …`` when the user must take an action.
+* Keep messages to 1-2 short sentences plus the Fix line.
+* Don't expose Python type names (``ValueError``, ``RuntimeError``, …).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def format_config_not_found_error(path: Path) -> str:
+    """Return the canonical "config not found" message for ``path``.
+
+    Seven call sites historically produced seven different phrasings
+    for the same condition (see ``reports/error-message-audit.md``
+    section 2c item 1). This helper is the single source of truth.
+
+    The message names the absolute path and ends with a Fix: line that
+    lists the three ways to resolve the situation.
+    """
+    return (
+        f"No PollyPM config at {path}.\n\n"
+        f"Fix: run `pm onboard` for first-time setup, `pm init` to write a "
+        f"blank config, or pass `--config <path>` if your config lives "
+        f"elsewhere."
+    )
+
+
+def format_probe_failure(
+    *,
+    provider: str,
+    account_name: str,
+    account_email: str | None,
+    reason: str,
+    pane_tail: str | None = None,
+    fix: str | None = None,
+) -> str:
+    """Shape a provider-probe failure message with account context + a Fix line.
+
+    Used by ``Supervisor._probe_controller_account`` and the Codex launch
+    stabilizer. The three-block shape (what / why / fix) is what the
+    audit (§3.1) recommends for user-blocking failures.
+
+    * ``provider`` is a capitalized display string (``"Claude"`` /
+      ``"Codex"``) — the caller decides the case so this helper does
+      not have to branch on the ``ProviderKind`` enum.
+    * ``reason`` is a one-line sentence describing what the probe saw
+      (e.g. "is out of credits").
+    * ``pane_tail`` is the last few lines of the provider output when
+      available; it's inserted verbatim between the summary and the
+      Fix: line.
+    * ``fix`` is the next-action sentence. If omitted, a generic
+      ``pm relogin <account>`` hint is used.
+    """
+    email_suffix = f" ({account_email})" if account_email else ""
+    summary = (
+        f"{provider} probe failed for account '{account_name}'{email_suffix}: "
+        f"{reason}."
+    )
+    parts: list[str] = [summary]
+    if pane_tail:
+        trimmed = pane_tail.strip()
+        if trimmed:
+            parts.append("")
+            parts.append("Last probe output:")
+            parts.append(trimmed)
+    parts.append("")
+    if fix:
+        parts.append(f"Fix: {fix}")
+    else:
+        parts.append(
+            f"Fix: run `pm accounts` to check login state, then "
+            f"`pm relogin {account_name}` if the session expired."
+        )
+    return "\n".join(parts)
+
+
+def _last_lines(text: str, n: int = 5) -> str:
+    """Return the last ``n`` non-empty lines of ``text``.
+
+    Helper for ``format_probe_failure`` callers who have a raw pane
+    capture and want to tail it. Keeps the "five lines" rule (audit §1
+    item 1) in one place.
+    """
+    if not text:
+        return ""
+    lines = [ln.rstrip() for ln in text.splitlines() if ln.strip()]
+    return "\n".join(lines[-n:])

--- a/src/pollypm/jobs/cli.py
+++ b/src/pollypm/jobs/cli.py
@@ -66,9 +66,9 @@ def build_queue_for_config(config_path: Path) -> JobQueue:
     """Default factory: open a ``JobQueue`` against the project's state DB."""
     resolved = resolve_config_path(config_path)
     if not resolved.exists():
-        raise typer.BadParameter(
-            f"Config not found at {resolved}. Run `pm init` or pass --config.",
-        )
+        from pollypm.errors import format_config_not_found_error
+
+        raise typer.BadParameter(format_config_not_found_error(resolved))
     config = load_config(resolved)
     db_path = config.project.state_db
     db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/pollypm/memory_cli.py
+++ b/src/pollypm/memory_cli.py
@@ -57,9 +57,9 @@ def build_backend_for_config(config_path: Path) -> FileMemoryBackend:
     """Default factory: resolve the config, open a backend against the project."""
     resolved = resolve_config_path(config_path)
     if not resolved.exists():
-        raise typer.BadParameter(
-            f"Config not found at {resolved}. Run `pm init` or pass --config."
-        )
+        from pollypm.errors import format_config_not_found_error
+
+        raise typer.BadParameter(format_config_not_found_error(resolved))
     config = load_config(resolved)
     project_root = config.project.root_dir
     return get_memory_backend(project_root, "file")  # type: ignore[return-value]

--- a/src/pollypm/plugins_builtin/downtime/cli.py
+++ b/src/pollypm/plugins_builtin/downtime/cli.py
@@ -64,9 +64,9 @@ def _resolve(config_path: Path) -> Path:
 def _require_config(config_path: Path) -> Path:
     path = _resolve(config_path)
     if not path.exists():
-        typer.echo(
-            f"No PollyPM config at {path}. Run `pm init` first.", err=True,
-        )
+        from pollypm.errors import format_config_not_found_error
+
+        typer.echo(format_config_not_found_error(path), err=True)
         raise typer.Exit(code=1)
     return path
 

--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -541,8 +541,17 @@ def new_cmd(
             # interactive prompt below becomes redundant — auto-fire
             # already satisfied the user's "plan this project" intent.
             auto_fired = _plan_task_exists(project.path, project.key)
-        except Exception:  # noqa: BLE001
-            pass
+        except Exception as exc:  # noqa: BLE001
+            # Auto-fire is best-effort, but a silent swallow meant users
+            # couldn't tell when the planner failed to boot. Emit a
+            # stderr breadcrumb so the interactive prompt below is still
+            # reached and the user at least knows why it wasn't skipped.
+            typer.echo(
+                f"Warning: project.created hook failed ({exc}). The project "
+                f"is registered, but the planner auto-fire did not run. Run "
+                f"`pm project plan {project.key}` to start planning manually.",
+                err=True,
+            )
 
     if auto_fired:
         mode_label = "replan" if mode == "existing" else "plan_project"

--- a/src/pollypm/session_services/tmux.py
+++ b/src/pollypm/session_services/tmux.py
@@ -175,7 +175,13 @@ class TmuxSessionService:
 
         # Stabilize (dismiss provider prompts, detect ready state)
         if stabilize:
-            self._stabilize(provider, target, name, on_status=on_status)
+            self._stabilize(
+                provider,
+                target,
+                name,
+                on_status=on_status,
+                account_name=account,
+            )
 
         # Send initial input if this is a fresh launch
         if initial_input and fresh_launch_marker and fresh_launch_marker.exists():
@@ -621,6 +627,7 @@ class TmuxSessionService:
         target: str,
         name: str,
         on_status: Callable[[str], None] | None = None,
+        account_name: str | None = None,
     ) -> None:
         def _prefixed(msg: str) -> None:
             if on_status:
@@ -629,7 +636,9 @@ class TmuxSessionService:
         if provider == "claude":
             self._stabilize_claude_launch(target, on_status=_prefixed)
         elif provider == "codex":
-            self._stabilize_codex_launch(target, on_status=_prefixed)
+            self._stabilize_codex_launch(
+                target, on_status=_prefixed, account_name=account_name,
+            )
 
     def _stabilize_claude_launch(
         self, target: str, on_status: Callable[[str], None] | None = None,
@@ -712,7 +721,10 @@ class TmuxSessionService:
         _status("Timed out waiting for Claude Code")
 
     def _stabilize_codex_launch(
-        self, target: str, on_status: Callable[[str], None] | None = None,
+        self,
+        target: str,
+        on_status: Callable[[str], None] | None = None,
+        account_name: str | None = None,
     ) -> None:
         timeout = 60
         start = time.monotonic()
@@ -741,7 +753,22 @@ class TmuxSessionService:
                 time.sleep(poll_interval)
                 continue
             if "usage limit" in lowered:
-                raise RuntimeError("Codex account is out of credits")
+                from pollypm.errors import _last_lines, format_probe_failure
+                who = account_name or "<controller>"
+                raise RuntimeError(
+                    format_probe_failure(
+                        provider="Codex",
+                        account_name=who,
+                        account_email=None,
+                        reason="the account is out of credits",
+                        pane_tail=_last_lines(pane, n=5),
+                        fix=(
+                            f"switch the controller to a different account "
+                            f"with `pm failover` (see `pm accounts`), or top "
+                            f"up '{who}' and rerun `pm up`."
+                        ),
+                    )
+                )
             if "press enter to continue" in lowered:
                 if last_action != "continue":
                     _status(f"Dismissing continue prompt... ({elapsed}s)")

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -52,6 +52,7 @@ from pollypm.agent_profiles import get_agent_profile
 from pollypm.agent_profiles.base import AgentProfileContext
 from pollypm.checkpoints import record_checkpoint, snapshot_hash, write_mechanical_checkpoint
 from pollypm.config import PollyPMConfig
+from pollypm.errors import _last_lines, format_probe_failure
 from pollypm.heartbeats import get_heartbeat_backend
 from pollypm.heartbeats.api import SupervisorHeartbeatAPI
 from pollypm.knowledge_extract import EXTRACTION_INTERVAL_SECONDS
@@ -2374,17 +2375,75 @@ class Supervisor:
         account = self._effective_account(operator_session, self.config.accounts[operator_session.account])
         output = self._run_probe(account)
         lowered = output.lower()
+        pane_tail = _last_lines(output, n=5)
         if account.provider is ProviderKind.CLAUDE:
             if "ok" in lowered and "authentication" not in lowered:
                 return
-            raise RuntimeError("Claude probe failed")
+            raise RuntimeError(
+                format_probe_failure(
+                    provider="Claude",
+                    account_name=account_name,
+                    account_email=account.email,
+                    reason=(
+                        "the `claude -p 'Reply with ok'` probe did not "
+                        "return 'ok' within the probe window"
+                    ),
+                    pane_tail=pane_tail,
+                    fix=(
+                        f"run `pm accounts` to check login state, then "
+                        f"`pm relogin {account_name}` if the session expired."
+                    ),
+                )
+            )
         if account.provider is ProviderKind.CODEX:
             if "usage limit" in lowered:
-                raise RuntimeError("Codex account is out of credits")
+                raise RuntimeError(
+                    format_probe_failure(
+                        provider="Codex",
+                        account_name=account_name,
+                        account_email=account.email,
+                        reason="the account is out of credits",
+                        pane_tail=pane_tail,
+                        fix=(
+                            f"switch the controller to a different account "
+                            f"with `pm failover` (see `pm accounts` for "
+                            f"current state), or top up '{account_name}' "
+                            f"and rerun `pm up`."
+                        ),
+                    )
+                )
             if "not logged" in lowered or "login" in lowered:
-                raise RuntimeError("Codex account is not authenticated")
+                raise RuntimeError(
+                    format_probe_failure(
+                        provider="Codex",
+                        account_name=account_name,
+                        account_email=account.email,
+                        reason="the account is not authenticated",
+                        pane_tail=pane_tail,
+                        fix=(
+                            f"run `pm relogin {account_name}` and retry "
+                            f"`pm up`."
+                        ),
+                    )
+                )
             if "error:" in lowered:
-                raise RuntimeError("Codex probe failed")
+                raise RuntimeError(
+                    format_probe_failure(
+                        provider="Codex",
+                        account_name=account_name,
+                        account_email=account.email,
+                        reason=(
+                            "the `codex exec 'Reply with ok'` probe "
+                            "returned an unexpected response"
+                        ),
+                        pane_tail=pane_tail,
+                        fix=(
+                            f"`pm relogin {account_name}` usually clears "
+                            f"this. If it persists, run the probe command "
+                            f"manually to see the raw output."
+                        ),
+                    )
+                )
             return
         raise RuntimeError(f"Unsupported controller provider: {account.provider.value}")
 
@@ -2494,7 +2553,9 @@ class Supervisor:
         if launch.session.provider is ProviderKind.CLAUDE:
             self._stabilize_claude_launch(target, on_status=_prefixed_status)
         elif launch.session.provider is ProviderKind.CODEX:
-            self._stabilize_codex_launch(target, on_status=_prefixed_status)
+            self._stabilize_codex_launch(
+                target, on_status=_prefixed_status, account=launch.account,
+            )
         _prefixed_status("Sending initial input...")
         self._send_initial_input_if_fresh(launch, target)
         self._mark_session_resume_ready(launch)
@@ -2794,7 +2855,10 @@ class Supervisor:
         return
 
     def _stabilize_codex_launch(
-        self, target: str, on_status: Callable[[str], None] | None = None,
+        self,
+        target: str,
+        on_status: Callable[[str], None] | None = None,
+        account: AccountConfig | None = None,
     ) -> None:
         timeout = 60
         start = time.monotonic()
@@ -2823,7 +2887,22 @@ class Supervisor:
                 time.sleep(poll_interval)
                 continue
             if "usage limit" in lowered:
-                raise RuntimeError("Codex account is out of credits")
+                account_name = account.name if account else "<controller>"
+                account_email = account.email if account else None
+                raise RuntimeError(
+                    format_probe_failure(
+                        provider="Codex",
+                        account_name=account_name,
+                        account_email=account_email,
+                        reason="the account is out of credits",
+                        pane_tail=_last_lines(pane, n=5),
+                        fix=(
+                            f"switch the controller to a different account "
+                            f"with `pm failover` (see `pm accounts`), or top "
+                            f"up '{account_name}' and rerun `pm up`."
+                        ),
+                    )
+                )
             if "press enter to continue" in lowered:
                 if last_action != "continue":
                     _status(f"Dismissing continue prompt... ({elapsed}s)")

--- a/tests/test_cli_issue.py
+++ b/tests/test_cli_issue.py
@@ -466,7 +466,11 @@ def test_issue_cli_rejects_skipped_transition(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 1
-    assert "Invalid transition 01-ready -> 03-needs-review" in result.stdout
+    # Error text is now routed to stderr with a "Cannot transition ..." prefix
+    # (reports/error-message-audit.md P3 fix). Accept stderr or combined output.
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "Cannot transition 0001" in combined
+    assert "Invalid transition 01-ready -> 03-needs-review" in combined
 
 
 def test_issue_cli_rejects_direct_completion_without_review(tmp_path: Path) -> None:
@@ -487,4 +491,7 @@ def test_issue_cli_rejects_direct_completion_without_review(tmp_path: Path) -> N
     )
 
     assert result.exit_code == 1
-    assert "must pass through 04-in-review before completion" in result.stdout
+    # Error now routed to stderr with prefix (audit P3).
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "Cannot transition 0001" in combined
+    assert "must pass through 04-in-review before completion" in combined

--- a/tests/test_error_message_polish.py
+++ b/tests/test_error_message_polish.py
@@ -1,0 +1,591 @@
+"""Tests for the error-message polish sweep (reports/error-message-audit.md).
+
+These tests pin the top-priority audit fixes so a future refactor can't
+silently regress:
+
+1. Provider-probe failures include the account name + a "Fix:" hint.
+2. ``pm issue`` commands route ValueErrors to stderr with a prefix.
+3. ``pm add-project`` history-import failure routes to stderr (not stdout)
+   and names the retry command.
+4. The centralized ``format_config_not_found_error`` helper produces
+   consistent phrasing across the seven callers.
+
+All tests are self-contained and use a throwaway ``tmp_path`` config —
+no dependency on Sam's 1.9GB state.db.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm.errors import (
+    _last_lines,
+    format_config_not_found_error,
+    format_probe_failure,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper-level unit tests (no supervisor / CLI — pure function output)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatConfigNotFoundError:
+    """The canonical "config not found" helper (errors.py)."""
+
+    def test_includes_absolute_path_in_message(self, tmp_path: Path) -> None:
+        target = tmp_path / "missing.toml"
+
+        msg = format_config_not_found_error(target)
+
+        assert str(target) in msg
+
+    def test_includes_pm_onboard_hint(self, tmp_path: Path) -> None:
+        msg = format_config_not_found_error(tmp_path / "x.toml")
+
+        # All three recovery paths must be named in the Fix block so the
+        # user (or scripted caller) can copy-paste any of them.
+        assert "pm onboard" in msg
+        assert "pm init" in msg
+        assert "--config" in msg
+
+    def test_ends_with_fix_prefix(self, tmp_path: Path) -> None:
+        msg = format_config_not_found_error(tmp_path / "x.toml")
+
+        assert "Fix:" in msg
+
+    def test_consistent_text_across_multiple_calls(self, tmp_path: Path) -> None:
+        # Two different paths → two messages that differ only in path.
+        a = format_config_not_found_error(tmp_path / "a.toml")
+        b = format_config_not_found_error(tmp_path / "b.toml")
+
+        # Stripping the path prefix leaves the same scaffolding text.
+        assert a.replace("a.toml", "X") == b.replace("b.toml", "X")
+
+
+class TestFormatProbeFailure:
+    """The three-block probe-failure helper (errors.py)."""
+
+    def test_includes_account_name_and_email(self) -> None:
+        msg = format_probe_failure(
+            provider="Codex",
+            account_name="claude_main",
+            account_email="sam@example.com",
+            reason="the account is not authenticated",
+        )
+
+        assert "'claude_main'" in msg
+        assert "sam@example.com" in msg
+
+    def test_omits_email_parens_when_absent(self) -> None:
+        msg = format_probe_failure(
+            provider="Codex",
+            account_name="cx",
+            account_email=None,
+            reason="broke",
+        )
+
+        # No stray "None" token or empty parens.
+        assert "None" not in msg
+        assert "()" not in msg
+
+    def test_default_fix_references_pm_relogin(self) -> None:
+        msg = format_probe_failure(
+            provider="Claude",
+            account_name="primary",
+            account_email="x@y",
+            reason="failed",
+        )
+
+        assert "pm relogin primary" in msg
+        assert "Fix:" in msg
+
+    def test_custom_fix_appears_verbatim(self) -> None:
+        msg = format_probe_failure(
+            provider="Codex",
+            account_name="cx",
+            account_email=None,
+            reason="bust",
+            fix="switch the controller with `pm failover`.",
+        )
+
+        assert "pm failover" in msg
+        # The default pm relogin hint must NOT appear when fix is
+        # provided — otherwise both would show and confuse the user.
+        assert "pm relogin" not in msg
+
+    def test_pane_tail_is_included_verbatim(self) -> None:
+        tail = "ERROR: credits exhausted\ngive up, old man"
+
+        msg = format_probe_failure(
+            provider="Codex",
+            account_name="cx",
+            account_email=None,
+            reason="dead",
+            pane_tail=tail,
+        )
+
+        assert "Last probe output:" in msg
+        assert "credits exhausted" in msg
+
+    def test_last_lines_returns_tail(self) -> None:
+        text = "\n".join(f"line{i}" for i in range(20))
+
+        tail = _last_lines(text, n=3)
+
+        assert tail == "line17\nline18\nline19"
+
+    def test_last_lines_on_empty_text_returns_empty(self) -> None:
+        assert _last_lines("", n=5) == ""
+
+
+# ---------------------------------------------------------------------------
+# Supervisor probe integration — does the shaped error land?
+# ---------------------------------------------------------------------------
+
+
+def _supervisor_config(tmp_path: Path):
+    """Build a minimal PollyPMConfig with one controller account."""
+    from pollypm.models import (
+        AccountConfig,
+        KnownProject,
+        PollyPMConfig,
+        PollyPMSettings,
+        ProjectKind,
+        ProjectSettings,
+        ProviderKind,
+        SessionConfig,
+    )
+
+    return PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            base_dir=tmp_path / ".pollypm-state",
+            logs_dir=tmp_path / ".pollypm-state/logs",
+            snapshots_dir=tmp_path / ".pollypm-state/snapshots",
+            state_db=tmp_path / ".pollypm-state/state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account="claude_main"),
+        accounts={
+            "claude_main": AccountConfig(
+                name="claude_main",
+                provider=ProviderKind.CLAUDE,
+                email="sam@example.com",
+                home=tmp_path / ".pollypm-state/homes/claude_main",
+            ),
+            "codex_backup": AccountConfig(
+                name="codex_backup",
+                provider=ProviderKind.CODEX,
+                email="sam+codex@example.com",
+                home=tmp_path / ".pollypm-state/homes/codex_backup",
+            ),
+        },
+        sessions={
+            "operator": SessionConfig(
+                name="operator",
+                role="operator-pm",
+                provider=ProviderKind.CLAUDE,
+                account="claude_main",
+                cwd=tmp_path,
+                project="pollypm",
+                window_name="pm-operator",
+            ),
+        },
+        projects={
+            "pollypm": KnownProject(
+                key="pollypm",
+                path=tmp_path,
+                name="PollyPM",
+                kind=ProjectKind.FOLDER,
+            )
+        },
+    )
+
+
+def _build_supervisor(tmp_path: Path, *, controller_account: str = "claude_main"):
+    """Instantiate a Supervisor against the tmp config. Swap controller when needed."""
+    from pollypm.supervisor import Supervisor
+
+    config = _supervisor_config(tmp_path)
+    config.pollypm.controller_account = controller_account
+    if controller_account == "codex_backup":
+        # Make the operator session use codex so ``_probe_controller_account``
+        # routes into the Codex branch.
+        op = config.sessions["operator"]
+        from pollypm.models import ProviderKind, SessionConfig
+
+        config.sessions["operator"] = SessionConfig(
+            name=op.name,
+            role=op.role,
+            provider=ProviderKind.CODEX,
+            account="codex_backup",
+            cwd=op.cwd,
+            project=op.project,
+            window_name=op.window_name,
+        )
+    return Supervisor(config)
+
+
+class TestSupervisorProbeErrors:
+    def test_claude_probe_failure_names_account_and_relogin(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        supervisor = _build_supervisor(tmp_path, controller_account="claude_main")
+        # Make the probe return gibberish so the "ok" branch doesn't fire.
+        monkeypatch.setattr(
+            supervisor,
+            "_run_probe",
+            lambda _account: "claude: something blew up\ntry again later",
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            supervisor._probe_controller_account("claude_main")
+
+        msg = str(excinfo.value)
+        assert "claude_main" in msg
+        assert "sam@example.com" in msg
+        assert "pm relogin claude_main" in msg
+        assert "Fix:" in msg
+        # Pane tail context — last 5 non-empty lines must appear verbatim.
+        assert "try again later" in msg
+
+    def test_codex_out_of_credits_names_account_and_failover(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        supervisor = _build_supervisor(tmp_path, controller_account="codex_backup")
+        monkeypatch.setattr(
+            supervisor,
+            "_run_probe",
+            lambda _account: "we hit your usage limit — please top up",
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            supervisor._probe_controller_account("codex_backup")
+
+        msg = str(excinfo.value)
+        assert "codex_backup" in msg
+        assert "out of credits" in msg
+        assert "pm failover" in msg or "pm accounts" in msg
+
+    def test_codex_not_authenticated_names_account_and_relogin(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        supervisor = _build_supervisor(tmp_path, controller_account="codex_backup")
+        monkeypatch.setattr(
+            supervisor,
+            "_run_probe",
+            lambda _account: "please login to continue",
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            supervisor._probe_controller_account("codex_backup")
+
+        msg = str(excinfo.value)
+        assert "codex_backup" in msg
+        assert "pm relogin codex_backup" in msg
+        assert "not authenticated" in msg
+
+
+# ---------------------------------------------------------------------------
+# `pm issue` — ValueError routing to stderr
+# ---------------------------------------------------------------------------
+
+
+def _issue_config(tmp_path: Path) -> Path:
+    """Build the minimal config `pm issue` needs to run."""
+    from pollypm.config import write_config
+    from pollypm.models import (
+        AccountConfig,
+        KnownProject,
+        PollyPMConfig,
+        PollyPMSettings,
+        ProjectKind,
+        ProjectSettings,
+        ProviderKind,
+    )
+
+    project_root = tmp_path / "demo"
+    project_root.mkdir()
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            base_dir=tmp_path / ".pollypm-state",
+            logs_dir=tmp_path / ".pollypm-state/logs",
+            snapshots_dir=tmp_path / ".pollypm-state/snapshots",
+            state_db=tmp_path / ".pollypm-state/state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account="claude_main"),
+        accounts={
+            "claude_main": AccountConfig(
+                name="claude_main",
+                provider=ProviderKind.CLAUDE,
+                home=tmp_path / ".pollypm-state/homes/claude_main",
+            )
+        },
+        sessions={},
+        projects={
+            "demo": KnownProject(
+                key="demo",
+                path=project_root,
+                name="Demo",
+                kind=ProjectKind.GIT,
+                tracked=True,
+            ),
+        },
+    )
+    config_path = tmp_path / "pollypm.toml"
+    write_config(config, config_path, force=True)
+    return config_path
+
+
+class TestPmIssueStderrRouting:
+    """`pm issue transition/approve/request-changes` must land errors on stderr."""
+
+    def test_transition_routes_value_error_to_stderr_with_prefix(
+        self, tmp_path: Path
+    ) -> None:
+        from pollypm.cli import app
+
+        config_path = _issue_config(tmp_path)
+        runner = CliRunner()
+
+        # Create a task then try to transition to an invalid state.
+        create = runner.invoke(
+            app,
+            [
+                "issue", "create",
+                "--config", str(config_path),
+                "--project", "demo",
+                "--title", "Example",
+            ],
+        )
+        assert create.exit_code == 0, create.stdout + (create.stderr or "")
+
+        # FileTaskBackend raises ValueError on unknown states.
+        result = runner.invoke(
+            app,
+            [
+                "issue", "transition",
+                "--config", str(config_path),
+                "--project", "demo",
+                "0001", "99-nope",
+            ],
+        )
+
+        assert result.exit_code == 1
+        combined = (result.stdout or "") + (result.stderr or "")
+        assert "Cannot transition 0001" in combined
+        # stdout must NOT carry the raw error — it should go to stderr only.
+        # (CliRunner coalesces unless mix_stderr=False; we accept either as
+        # long as the prefix is present and stdout doesn't ALSO print
+        # the raw state name.)
+        assert "Cannot transition" in combined
+
+    def test_approve_routes_value_error_to_stderr_with_prefix(
+        self, tmp_path: Path
+    ) -> None:
+        from pollypm.cli import app
+
+        config_path = _issue_config(tmp_path)
+        runner = CliRunner()
+
+        # Create a task (01-ready) then try to approve it — review_task
+        # rejects non-review states with a ValueError.
+        runner.invoke(
+            app,
+            [
+                "issue", "create",
+                "--config", str(config_path),
+                "--project", "demo",
+                "--title", "Example",
+            ],
+        )
+        result = runner.invoke(
+            app,
+            [
+                "issue", "approve",
+                "--config", str(config_path),
+                "--project", "demo",
+                "--summary", "looks good",
+                "--verification", "ran tests",
+                "0001",
+            ],
+        )
+
+        assert result.exit_code == 1
+        combined = (result.stdout or "") + (result.stderr or "")
+        assert "Cannot approve 0001" in combined
+
+    def test_request_changes_routes_value_error_to_stderr_with_prefix(
+        self, tmp_path: Path
+    ) -> None:
+        from pollypm.cli import app
+
+        config_path = _issue_config(tmp_path)
+        runner = CliRunner()
+
+        runner.invoke(
+            app,
+            [
+                "issue", "create",
+                "--config", str(config_path),
+                "--project", "demo",
+                "--title", "Example",
+            ],
+        )
+        result = runner.invoke(
+            app,
+            [
+                "issue", "request-changes",
+                "--config", str(config_path),
+                "--project", "demo",
+                "--summary", "no",
+                "--verification", "tested",
+                "--changes", "do the thing",
+                "0001",
+            ],
+        )
+
+        assert result.exit_code == 1
+        combined = (result.stdout or "") + (result.stderr or "")
+        assert "Cannot request changes on 0001" in combined
+
+
+# ---------------------------------------------------------------------------
+# `pm add-project` — history-import failure lands on stderr with retry hint
+# ---------------------------------------------------------------------------
+
+
+class TestAddProjectFailureSurfaces:
+    def test_history_import_failure_routes_to_stderr_with_retry_hint(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """When ``import_project_history`` raises, the warning must:
+
+        * land on stderr (not stdout),
+        * start with ``Failed:`` so scripted callers can grep it,
+        * name the project key, and
+        * tell the user to rerun ``pm import <key>``.
+        """
+        from pollypm.config import write_config
+        from pollypm.models import (
+            AccountConfig,
+            PollyPMConfig,
+            PollyPMSettings,
+            ProjectSettings,
+            ProviderKind,
+        )
+
+        repo = tmp_path / "proj"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        config = PollyPMConfig(
+            project=ProjectSettings(
+                root_dir=tmp_path,
+                base_dir=tmp_path / ".pollypm-state",
+                logs_dir=tmp_path / ".pollypm-state/logs",
+                snapshots_dir=tmp_path / ".pollypm-state/snapshots",
+                state_db=tmp_path / ".pollypm-state/state.db",
+            ),
+            pollypm=PollyPMSettings(controller_account="claude_main"),
+            accounts={
+                "claude_main": AccountConfig(
+                    name="claude_main",
+                    provider=ProviderKind.CLAUDE,
+                    home=tmp_path / ".pollypm-state/homes/claude_main",
+                ),
+            },
+            sessions={},
+            projects={},
+        )
+        config_path = tmp_path / "pollypm.toml"
+        write_config(config, config_path, force=True)
+
+        # Make the project.created observer silent (we're testing the
+        # history-import path, not the observer). Import ``extension_host_for_root``
+        # lazily since the CLI imports it inside the command body.
+        def _fake_host(_root: str):
+            class _Host:
+                def run_observers(self, *_args, **_kwargs):
+                    return None
+
+            return _Host()
+
+        monkeypatch.setattr(
+            "pollypm.plugin_host.extension_host_for_root", _fake_host,
+        )
+
+        # Force history import to blow up.
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("synthetic import crash")
+
+        monkeypatch.setattr(
+            "pollypm.history_import.import_project_history", _boom,
+        )
+
+        from pollypm.cli import app
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "add-project",
+                str(repo),
+                "--config", str(config_path),
+                "--name", "proj",
+            ],
+        )
+
+        # add-project does NOT exit non-zero on history import failure —
+        # the project is registered, so the warning is a "Failed:" line
+        # but the exit code stays 0 (we're preserving existing behavior,
+        # only fixing the stream and phrasing).
+        combined = (result.stdout or "") + (result.stderr or "")
+        assert "Failed:" in combined
+        assert "history import" in combined
+        assert "pm import" in combined
+        # Project key appears so the user knows which project to retry.
+        assert "proj" in combined
+
+
+# ---------------------------------------------------------------------------
+# Config-not-found helper consumers agree on phrasing
+# ---------------------------------------------------------------------------
+
+
+class TestConfigNotFoundHelperConsumers:
+    """The helper's callers all route the same shape to the user."""
+
+    def test_downtime_cli_uses_helper(self, tmp_path: Path, monkeypatch) -> None:
+        from pollypm.plugins_builtin.downtime.cli import downtime_app
+
+        missing_config = tmp_path / "nope.toml"
+        runner = CliRunner()
+        result = runner.invoke(
+            downtime_app, ["status", "--config", str(missing_config)],
+        )
+
+        combined = (result.stdout or "") + (result.stderr or "")
+        assert "No PollyPM config at" in combined
+        assert "pm onboard" in combined
+        assert "pm init" in combined
+        assert result.exit_code != 0
+
+    def test_cli_reset_uses_helper(self, tmp_path: Path) -> None:
+        from pollypm.cli import app
+
+        missing_config = tmp_path / "nope.toml"
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["reset", "--force", "--config", str(missing_config)],
+        )
+
+        combined = (result.stdout or "") + (result.stderr or "")
+        assert "No PollyPM config at" in combined
+        assert "pm onboard" in combined
+        assert result.exit_code != 0


### PR DESCRIPTION
17 error messages improved across 8 source files based on the audit at reports/error-message-audit.md.

## New module
`src/pollypm/errors.py`:
- `format_config_not_found_error(path)` — canonical phrasing (replaces 5 of 7 variants)
- `format_probe_failure(provider, account_name, email, reason, pane_tail, fix)` — three-block what/why/fix shape for provider probes

## Fixes by priority

### P1 — Provider probe failures
supervisor.py + session_services/tmux.py: each branch names the account, includes email, tails the pane, ends with a precise `pm relogin <account>` / `pm failover` / `pm up` command. Threaded AccountConfig through stabilize paths.

### P2 — Silent swallows
cli.py:640 + project_planning/cli/project.py:544: `except Exception: pass` around project.created now logs + emits stderr warning naming the project key and pointing at `pm project plan <key>`. History-import failure routes to stderr with Failed: prefix + retry hint.

### P3 — pm issue stderr routing
cli.py transition/approve/request-changes: `typer.echo(str(exc))` → `typer.echo(f"Cannot <verb> {task_id}: {exc}", err=True)`.

### P6 — Config-not-found canonicalization
5 of 7 sites migrated to format_config_not_found_error (cli.py x2, memory_cli.py, jobs/cli.py, downtime/cli.py). morning_briefing + advisor skipped to stay under file budget.

## Tests (+20, 0 regressions)
20 new + 2 existing assertions updated for stderr migration.