### PR TITLE
test: fix 3 known-flaky tests (persona-swap guard fixtures + /tmp symlink)

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,7 +48,10 @@ def test_discover_config_path_returns_global_default(monkeypatch, tmp_path: Path
 
     resolved = cli._discover_config_path(DEFAULT_CONFIG_PATH)
 
-    assert resolved == DEFAULT_CONFIG_PATH
+    # Compare via .resolve() to handle macOS /tmp -> /private/tmp symlink
+    # when HOME is under /tmp (agent-run isolated HOME); _discover_config_path
+    # resolves symlinks whereas DEFAULT_CONFIG_PATH is built from the raw HOME.
+    assert resolved.resolve() == DEFAULT_CONFIG_PATH.resolve()
 
 
 def test_discover_config_path_returns_global_config(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1160,7 +1160,14 @@ def test_build_review_nudge_evicts_dropped_projects(monkeypatch, tmp_path: Path)
 def _make_launch_for_role(
     config: PollyPMConfig, tmp_path: Path, role: str, *, initial_input: str = "hello worker"
 ) -> SessionLaunchSpec:
-    """Build a SessionLaunchSpec with a real fresh-launch marker on disk."""
+    """Build a SessionLaunchSpec with a real fresh-launch marker on disk.
+
+    Also registers the session in ``config.sessions`` so the persona-swap
+    guard introduced in #266 (``_assert_session_launch_matches``) can
+    resolve a matching launch via ``launch_by_session``. Without this,
+    the guard raises ``persona_swap_detected: no launch for session_name=...``
+    before ``send_keys`` is ever reached.
+    """
     session = SessionConfig(
         name=f"{role}-session",
         role=role,
@@ -1170,6 +1177,9 @@ def _make_launch_for_role(
         project="pollypm",
         window_name=f"pm-{role}",
     )
+    # Register the session so the planner can resolve it and the
+    # persona-swap guard finds a matching launch (#266).
+    config.sessions[session.name] = session
     marker_dir = tmp_path / ".pollypm-state" / "fresh-markers"
     marker_dir.mkdir(parents=True, exist_ok=True)
     marker = marker_dir / f"{role}-session.marker"


### PR DESCRIPTION
From the test-suite triage: 2 persona-swap fixture drift + 1 macOS /tmp symlink artefact.

## Fixes (2 test files only, no src/ changes)
- `tests/test_supervisor.py`: `_make_launch_for_role` now registers the SessionConfig in config.sessions[session.name] so the #266 persona-swap guard can resolve it via launch_by_session.
- `tests/test_cli.py`: default-path assertion uses `.resolve()` on both sides so it tolerates macOS /tmp → /private/tmp under isolated HOME.

All 3 targeted tests pass. Full test_supervisor (43) + test_cli (11) green. Clears the known-flaky list.