### PR TITLE
test: speed up test_pm_up_bootstraps_worker_from_project_local_config (90s → 0.36s)

### DIFF
--- a/tests/integration/test_config_split_integration.py
+++ b/tests/integration/test_config_split_integration.py
@@ -146,6 +146,30 @@ def test_pm_up_bootstraps_worker_from_project_local_config(monkeypatch, tmp_path
 
     monkeypatch.setattr("pollypm.session_services.tmux.TmuxClient", lambda: fake_tmux)
     monkeypatch.setattr("pollypm.supervisor.Supervisor._stabilize_launch", lambda self, launch, target, on_status=None: None)
+    # ``_bootstrap_launches`` calls ``_stabilize_claude_launch`` directly from
+    # worker threads (not through ``_stabilize_launch``). Without stubbing it
+    # the per-thread poll loop runs to its 90s deadline against FakeTmux
+    # (which has no ``capture_pane``), dominating the test wall time.
+    monkeypatch.setattr(
+        "pollypm.supervisor.Supervisor._stabilize_claude_launch",
+        lambda self, target, on_status=None: None,
+    )
+    monkeypatch.setattr(
+        "pollypm.supervisor.Supervisor._stabilize_codex_launch",
+        lambda self, target, on_status=None, account=None: None,
+    )
+    # ``_send_initial_input_if_fresh`` does a 0.5s sleep before send_keys;
+    # skip it — the test doesn't assert on initial input delivery.
+    monkeypatch.setattr(
+        "pollypm.supervisor.Supervisor._send_initial_input_if_fresh",
+        lambda self, launch, target: None,
+    )
+    # ``cli.up`` sleeps 0.3s after the cockpit layout split. That sleep
+    # lives in an inline ``import time`` so monkey-patching ``time.sleep``
+    # on the module object is the simplest way to reach it. Scope is
+    # auto-restored by ``monkeypatch`` at teardown.
+    import time as _time
+    monkeypatch.setattr(_time, "sleep", lambda _s: None)
     monkeypatch.setattr("pollypm.supervisor.Supervisor.focus_console", lambda self: None)
 
     runner = CliRunner()


### PR DESCRIPTION
Suite's #1 hot spot per the triage report — was 55% of total wall-clock. Now 252x faster.

## Root cause
`_bootstrap_launches` spawns worker threads that call `_stabilize_claude_launch` directly, not through the `_stabilize_launch` wrapper the test was patching. `_stabilize_claude_launch` polls `tmux.capture_pane` every 0.2–1s; `FakeTmux` didn't have that method so the loop swallowed the AttributeError and burned its full 90s deadline. Three parallel threads → 91s wall.

## Fix (test-only, no src/ changes)
4 monkeypatches:
- Supervisor._stabilize_claude_launch → no-op (the culprit)
- Supervisor._stabilize_codex_launch → no-op (defense-in-depth)
- Supervisor._send_initial_input_if_fresh → no-op
- time.sleep → no-op

## Before / after
- 90.93s → 0.36s (single test)
- 91.22s → 0.60s (full file)

All assertions preserved (exit_code, create tmux session message, worker window creation, project-local cwd).