### PR TITLE
feat(cockpit-inbox): filter + search for growing inboxes

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -3267,6 +3267,166 @@ def _task_is_rollup(task) -> bool:
     return "ready for review" in title and "updates" in title
 
 
+def _fuzzy_subseq_match(query: str, hay: str) -> bool:
+    """Subsequence fuzzy match: every char in ``query`` appears in ``hay`` in order.
+
+    ``"shp"`` matches ``"shipped"`` (s, h, p land in order). Substring
+    matches are a subset, so a plain ``"deploy"`` query against
+    ``"deploy blocked"`` still matches via the same algorithm.
+    Empty query matches everything; case is folded before compare so
+    the call site doesn't have to.
+    """
+    if not query:
+        return True
+    if not hay:
+        return False
+    qi = 0
+    q = query
+    for ch in hay:
+        if ch == q[qi]:
+            qi += 1
+            if qi == len(q):
+                return True
+    return False
+
+
+def _task_recent_timestamp(task) -> float | None:
+    """Return the most-recent updated/created stamp as a unix timestamp.
+
+    Prefers ``updated_at`` (newer thread activity wins), falls back to
+    ``created_at``. Returns ``None`` for unparseable values so the
+    "recent 24h" filter simply drops them rather than including weirdly
+    dated tasks by accident.
+    """
+    from datetime import datetime as _dt
+
+    for attr in ("updated_at", "created_at"):
+        value = getattr(task, attr, None)
+        if value is None:
+            continue
+        try:
+            if hasattr(value, "timestamp"):
+                return float(value.timestamp())
+            return _dt.fromisoformat(str(value)).timestamp()
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+class _InboxProjectPickerModal(ModalScreen[str | None]):
+    """Tiny modal listing project keys for the ``p`` filter chip.
+
+    Returns the selected key (string) or ``None`` when dismissed via
+    Esc. Selecting the currently-active project clears the chip.
+    """
+
+    CSS = """
+    _InboxProjectPickerModal {
+        align: center middle;
+        background: rgba(0, 0, 0, 0.45);
+    }
+    #ipp-dialog {
+        width: 48;
+        max-width: 90%;
+        height: auto;
+        max-height: 18;
+        padding: 1 1 0 1;
+        background: #141a20;
+        border: round #2a3340;
+    }
+    #ipp-title {
+        height: 1;
+        padding: 0 1;
+        color: #97a6b2;
+    }
+    #ipp-list {
+        height: auto;
+        max-height: 14;
+        background: #141a20;
+        border: none;
+        margin-top: 1;
+        padding: 0;
+    }
+    #ipp-list > .ipp-row {
+        height: 1;
+        padding: 0 1;
+        color: #d6dee5;
+        background: transparent;
+    }
+    #ipp-list > .ipp-row.-highlight {
+        background: #1e2730;
+    }
+    #ipp-hint {
+        height: 1;
+        padding: 0 1;
+        color: #3e4c5a;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Close"),
+        Binding("down,j", "cursor_down", "Down", show=False),
+        Binding("up,k", "cursor_up", "Up", show=False),
+        Binding("enter", "select", "Pick", show=False),
+    ]
+
+    def __init__(self, keys: list[str], current: str | None) -> None:
+        super().__init__()
+        self._keys = list(keys)
+        self._current = current
+        self.list_view = ListView(id="ipp-list")
+        self.title_bar = Static(
+            "[b]Filter by project[/b]", id="ipp-title", markup=True,
+        )
+        self.hint = Static(
+            "[dim]\u21b5 select  \u00b7  esc cancel  \u00b7  pick the active "
+            "project to clear[/dim]",
+            id="ipp-hint", markup=True,
+        )
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="ipp-dialog"):
+            yield self.title_bar
+            yield self.list_view
+            yield self.hint
+
+    def on_mount(self) -> None:
+        for key in self._keys:
+            label = key
+            if key == self._current:
+                label = f"\u25cf {key}"
+            self.list_view.append(
+                ListItem(Static(label, markup=False), classes="ipp-row")
+            )
+        self.list_view.index = 0
+        self.list_view.focus()
+
+    def action_cursor_down(self) -> None:
+        self.list_view.action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        self.list_view.action_cursor_up()
+
+    def action_select(self) -> None:
+        idx = self.list_view.index or 0
+        if 0 <= idx < len(self._keys):
+            picked = self._keys[idx]
+            # Picking the current chip again is a "clear" gesture.
+            if picked == self._current:
+                self.dismiss("")
+            else:
+                self.dismiss(picked)
+        else:
+            self.dismiss(None)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    @on(ListView.Selected, "#ipp-list")
+    def _on_row_selected(self, _event: ListView.Selected) -> None:
+        self.action_select()
+
+
 def _resolve_pm_target(config_path: Path, project_key: str | None) -> tuple[str, str]:
     """Resolve the cockpit-router key + display name for a project's PM.
 
@@ -3718,8 +3878,40 @@ class PollyInboxApp(App[None]):
         margin: 1 0 0 0;
         color: #6b7a88;
     }
+    #inbox-filter-bar {
+        height: auto;
+        padding: 0 1;
+        background: #0c0f12;
+    }
+    #inbox-filter-input {
+        height: 3;
+        padding: 0 1;
+        background: #111820;
+        border: round #2a3340;
+        color: #d6dee5;
+    }
+    #inbox-filter-input:focus {
+        border: round #5b8aff;
+    }
+    #inbox-filter-chips {
+        height: 1;
+        padding: 0 1;
+        color: #97a6b2;
+    }
+    #inbox-empty-state {
+        height: 1fr;
+        content-align: center middle;
+        color: #6b7a88;
+        background: #0f1317;
+    }
     """
 
+    # Filter keybindings (inbox-search #NEW): `/` opens a fuzzy text
+    # filter, chip-toggle keys flip AND-combined filter chips, ``c``
+    # clears all. Conflicts with existing bindings resolved as:
+    #   * ``r`` stays as reply → capital ``R`` opens recent-24h.
+    #   * ``u`` was refresh → promoted filter (unread-only); refresh
+    #     remains available via ``ctrl+r`` and the ``:`` palette.
     BINDINGS = [
         Binding("j,down", "cursor_down", "Down", show=False),
         Binding("k,up", "cursor_up", "Up", show=False),
@@ -3741,7 +3933,17 @@ class PollyInboxApp(App[None]):
         # so no separate keybinding is needed here for approve.
         Binding("v", "open_plan_explainer", "Explainer", show=False),
         Binding("e", "expand_all_rollup", "Expand all", show=False),
-        Binding("u", "refresh", "Refresh"),
+        # Filter / search bar (#NEW).
+        Binding("slash", "start_filter", "Filter", show=False),
+        Binding("u", "toggle_filter_unread", "Unread", show=False),
+        Binding("p", "pick_filter_project", "Project", show=False),
+        Binding("R", "toggle_filter_recent", "Recent", show=False),
+        Binding("l", "toggle_filter_plan_review", "Plan review", show=False),
+        Binding("b", "toggle_filter_blocking", "Blocking", show=False),
+        Binding("c", "clear_filters", "Clear filters", show=False),
+        # Refresh: ``u`` re-bound to filter, so refresh moves to ``ctrl+r``
+        # (palette 'session.refresh' still works from any screen).
+        Binding("ctrl+r", "refresh", "Refresh", show=False),
         Binding("colon", "open_command_palette", "Palette", priority=True),
         Binding("q,escape", "back_or_cancel", "Back"),
     ]
@@ -3769,6 +3971,18 @@ class PollyInboxApp(App[None]):
             placeholder="Reply \u2026 (Enter to send, Esc back to list)",
             id="inbox-reply",
         )
+        # Filter bar (#NEW). Hidden until `/` mounts the Input. The
+        # chips Static is always part of the tree so toggles can update
+        # it without an explicit mount; it renders an empty string when
+        # no filters are active.
+        self.filter_input = Input(
+            placeholder="filter \u2026  (Esc clears + closes)",
+            id="inbox-filter-input",
+        )
+        self.filter_chips = Static("", id="inbox-filter-chips", markup=True)
+        self.filter_bar = Vertical(
+            self.filter_input, self.filter_chips, id="inbox-filter-bar",
+        )
         self.status = Static("", id="inbox-status")
         self.hint = Static(
             PollyInboxApp._DEFAULT_HINT,
@@ -3777,6 +3991,15 @@ class PollyInboxApp(App[None]):
         self._tasks: list = []
         self._selected_task_id: str | None = None
         self._unread_ids: set[str] = set()
+        # Filter state (#NEW). Session-scoped — cleared on each mount
+        # via :meth:`on_mount`. All filters AND-combine.
+        self._filter_text: str = ""
+        self._filter_unread_only: bool = False
+        self._filter_project: str | None = None
+        self._filter_recent: bool = False
+        self._filter_plan_review: bool = False
+        self._filter_blocking: bool = False
+        self._filter_bar_visible: bool = False
         # Rollup state — populated on each rollup render. Index-keyed so
         # the click handler can look up which item was expanded.
         self._rollup_items: list[dict] = []
@@ -3809,6 +4032,7 @@ class PollyInboxApp(App[None]):
         self._blocking_question_meta: dict[str, dict] = {}
 
     def compose(self) -> ComposeResult:
+        yield self.filter_bar
         with Horizontal(id="inbox-layout"):
             yield self.list_view
             with Vertical(id="inbox-detail-wrap"):
@@ -3820,6 +4044,12 @@ class PollyInboxApp(App[None]):
         yield self.hint
 
     def on_mount(self) -> None:
+        # Session-scoped filters: clear on each mount so restarts of the
+        # cockpit land on a pristine full-list view.
+        self._reset_filter_state()
+        self.filter_input.display = False
+        self.filter_bar.display = False
+        self.filter_chips.display = False
         self._refresh_list(select_first=True)
         self.set_interval(self.REFRESH_INTERVAL_SECONDS, self._background_refresh)
         self.list_view.focus()
@@ -3909,6 +4139,9 @@ class PollyInboxApp(App[None]):
     def _render_list(self, *, select_first: bool = False) -> None:
         previous = self._selected_task_id
         self.list_view.clear()
+        # Refresh chip line on every render so toggles + project changes
+        # land in the UI even when the list itself didn't shrink.
+        self._update_filter_chips()
         if not self._tasks:
             self.list_view.append(
                 ListItem(Static("(empty)", classes="inbox-empty"), disabled=True)
@@ -3919,8 +4152,30 @@ class PollyInboxApp(App[None]):
             )
             self.status.update("0 messages")
             return
+        # Apply filter stack — fuzzy text + chip toggles AND-combine.
+        visible = self._filtered_tasks(self._tasks)
+        total = len(self._tasks)
+        if not visible:
+            # Friendly empty-match copy so a fully-filtered list isn't a
+            # blank pane. The list stays in the tree (one disabled row)
+            # so cursor focus has somewhere to land without crashing.
+            self.list_view.append(
+                ListItem(
+                    Static(
+                        "No matches. Press c to clear filters.",
+                        classes="inbox-empty",
+                    ),
+                    disabled=True,
+                )
+            )
+            self.detail.update(
+                "[dim]No matches for the current filter set.\n\n"
+                "Press [b]c[/b] to clear filters and see every message.[/dim]"
+            )
+            self._update_status(total=total, shown=0)
+            return
         restore_index: int | None = 0 if select_first else None
-        for idx, task in enumerate(self._tasks):
+        for idx, task in enumerate(visible):
             is_unread = task.task_id in self._unread_ids
             row = _InboxListItem(task, is_unread=is_unread)
             self.list_view.append(row)
@@ -3930,15 +4185,29 @@ class PollyInboxApp(App[None]):
             self.list_view.index = restore_index
             # Render detail for the restored selection so the right pane
             # shows content immediately on refresh.
-            task = self._tasks[restore_index]
+            task = visible[restore_index]
             self._selected_task_id = task.task_id
             self._render_detail(task.task_id)
+        self._update_status(total=total, shown=len(visible))
+
+    def _update_status(self, *, total: int, shown: int) -> None:
+        """Render the bottom counter strip — folds in active filters.
+
+        ``shown`` may equal ``total`` when no filter narrows the list;
+        in that case we omit the "N of M" framing for visual calm.
+        """
         unread_n = len(self._unread_ids)
-        total = len(self._tasks)
-        if unread_n:
-            self.status.update(f"{total} messages \u00b7 {unread_n} unread")
+        bits: list[str] = []
+        if self._has_active_filters() and shown != total:
+            bits.append(f"{shown} of {total} shown")
         else:
-            self.status.update(f"{total} messages")
+            bits.append(f"{total} messages")
+        if unread_n:
+            bits.append(f"{unread_n} unread")
+        desc = self._describe_filters()
+        if desc:
+            bits.append(f"filters: {desc}")
+        self.status.update(" \u00b7 ".join(bits))
 
     def _background_refresh(self) -> None:
         """Periodic re-read; don't stomp the current cursor position."""
@@ -3946,6 +4215,210 @@ class PollyInboxApp(App[None]):
             self._refresh_list(select_first=False)
         except Exception:  # noqa: BLE001
             pass
+
+    # ------------------------------------------------------------------
+    # Filter / search (#NEW)
+    # ------------------------------------------------------------------
+
+    def _reset_filter_state(self) -> None:
+        """Clear every filter back to the "show everything" baseline."""
+        self._filter_text = ""
+        self._filter_unread_only = False
+        self._filter_project = None
+        self._filter_recent = False
+        self._filter_plan_review = False
+        self._filter_blocking = False
+        self._filter_bar_visible = False
+
+    def _has_active_filters(self) -> bool:
+        return any(
+            (
+                self._filter_text,
+                self._filter_unread_only,
+                self._filter_project,
+                self._filter_recent,
+                self._filter_plan_review,
+                self._filter_blocking,
+            )
+        )
+
+    def _filtered_tasks(self, tasks: list) -> list:
+        """Apply the AND-combined filter stack to ``tasks``.
+
+        Cheap O(N * filters) — the inbox is at most a few hundred rows
+        and the chips short-circuit, so we don't need anything fancier.
+        """
+        if not self._has_active_filters():
+            return list(tasks)
+        text_q = self._filter_text.strip().lower()
+        proj = self._filter_project
+        out: list = []
+        recent_cutoff_ts = self._recent_cutoff_timestamp() if self._filter_recent else None
+        for t in tasks:
+            if self._filter_unread_only and t.task_id not in self._unread_ids:
+                continue
+            if proj and (t.project or "") != proj:
+                continue
+            labels = list(getattr(t, "labels", []) or [])
+            if self._filter_plan_review and "plan_review" not in labels:
+                continue
+            if self._filter_blocking and "blocking_question" not in labels:
+                continue
+            if recent_cutoff_ts is not None:
+                ts = _task_recent_timestamp(t)
+                if ts is None or ts < recent_cutoff_ts:
+                    continue
+            if text_q:
+                hay = self._task_haystack(t).lower()
+                if not _fuzzy_subseq_match(text_q, hay):
+                    continue
+            out.append(t)
+        return out
+
+    def _task_haystack(self, task) -> str:
+        """Concatenate searchable fields for fuzzy matching."""
+        return " ".join(
+            [
+                task.title or "",
+                task.project or "",
+                _format_sender(task),
+            ]
+        )
+
+    def _recent_cutoff_timestamp(self) -> float:
+        from datetime import datetime as _dt, timedelta as _td, timezone as _tz
+        return (_dt.now(_tz.utc) - _td(hours=24)).timestamp()
+
+    def _describe_filters(self) -> str:
+        bits: list[str] = []
+        if self._filter_unread_only:
+            bits.append("unread")
+        if self._filter_project:
+            bits.append(f"project:{self._filter_project}")
+        if self._filter_recent:
+            bits.append("recent")
+        if self._filter_plan_review:
+            bits.append("plan_review")
+        if self._filter_blocking:
+            bits.append("blocking_question")
+        if self._filter_text:
+            bits.append(f'"{self._filter_text}"')
+        return " \u00b7 ".join(bits)
+
+    def _update_filter_chips(self) -> None:
+        """Re-render the chip strip + drive bar visibility.
+
+        The filter bar (Input + chips) hides entirely when there are no
+        active filters AND the user hasn't pressed `/` to open the
+        Input. Otherwise it shows: the Input is gated by
+        ``_filter_bar_visible``, the chips render whenever any chip is
+        on (so toggling without `/` still surfaces feedback).
+        """
+        chip_bits: list[str] = []
+        if self._filter_unread_only:
+            chip_bits.append("[on #1e2730] unread [/on #1e2730]")
+        if self._filter_project:
+            chip_bits.append(
+                f"[on #1e2730] project:{_escape(self._filter_project)} [/on #1e2730]"
+            )
+        if self._filter_recent:
+            chip_bits.append("[on #1e2730] recent 24h [/on #1e2730]")
+        if self._filter_plan_review:
+            chip_bits.append("[on #1e2730] plan_review [/on #1e2730]")
+        if self._filter_blocking:
+            chip_bits.append("[on #1e2730] blocking_question [/on #1e2730]")
+        if self._filter_text:
+            chip_bits.append(
+                f'[on #1e2730] "{_escape(self._filter_text)}" [/on #1e2730]'
+            )
+        if chip_bits:
+            self.filter_chips.update("  ".join(chip_bits))
+            self.filter_chips.display = True
+        else:
+            self.filter_chips.update("")
+            self.filter_chips.display = False
+        # Bar visibility tracks either the explicit Input toggle OR any
+        # active chip (so the user sees the chip rendered without
+        # needing to keep `/` open).
+        self.filter_input.display = self._filter_bar_visible
+        self.filter_bar.display = self._filter_bar_visible or bool(chip_bits)
+
+    # --- filter actions ------------------------------------------------
+
+    def action_start_filter(self) -> None:
+        """`/` — mount + focus the fuzzy filter Input."""
+        self._filter_bar_visible = True
+        self.filter_input.value = self._filter_text
+        self._update_filter_chips()
+        self.filter_input.focus()
+
+    def action_toggle_filter_unread(self) -> None:
+        if self.reply_input.has_focus or self.filter_input.has_focus:
+            return
+        self._filter_unread_only = not self._filter_unread_only
+        self._render_list(select_first=True)
+
+    def action_toggle_filter_recent(self) -> None:
+        if self.reply_input.has_focus or self.filter_input.has_focus:
+            return
+        self._filter_recent = not self._filter_recent
+        self._render_list(select_first=True)
+
+    def action_toggle_filter_plan_review(self) -> None:
+        if self.reply_input.has_focus or self.filter_input.has_focus:
+            return
+        self._filter_plan_review = not self._filter_plan_review
+        self._render_list(select_first=True)
+
+    def action_toggle_filter_blocking(self) -> None:
+        if self.reply_input.has_focus or self.filter_input.has_focus:
+            return
+        self._filter_blocking = not self._filter_blocking
+        self._render_list(select_first=True)
+
+    def action_clear_filters(self) -> None:
+        if self.reply_input.has_focus or self.filter_input.has_focus:
+            return
+        self._reset_filter_state()
+        self.filter_input.value = ""
+        self._render_list(select_first=True)
+
+    def action_pick_filter_project(self) -> None:
+        """`p` — open a small modal listing project keys for selection."""
+        if self.reply_input.has_focus or self.filter_input.has_focus:
+            return
+        keys = sorted({(t.project or "").strip() for t in self._tasks if t.project})
+        if not keys:
+            self.notify("No projects in the current inbox.", severity="warning")
+            return
+        # If only one project is in scope, just toggle it instead of
+        # bothering the user with a modal.
+        if len(keys) == 1:
+            self._filter_project = (
+                None if self._filter_project == keys[0] else keys[0]
+            )
+            self._render_list(select_first=True)
+            return
+
+        def _on_pick(value: str | None) -> None:
+            if value is None:
+                return
+            self._filter_project = value or None
+            self._render_list(select_first=True)
+
+        self.push_screen(_InboxProjectPickerModal(keys, self._filter_project), _on_pick)
+
+    @on(Input.Changed, "#inbox-filter-input")
+    def _on_filter_changed(self, event: Input.Changed) -> None:
+        # Live-filter as the user types — cheap enough on inbox-sized data.
+        self._filter_text = event.value or ""
+        self._render_list(select_first=True)
+
+    @on(Input.Submitted, "#inbox-filter-input")
+    def _on_filter_submitted(self, _event: Input.Submitted) -> None:
+        # Enter inside the filter Input applies + returns focus to the
+        # list so j/k works without an extra Esc.
+        self.list_view.focus()
 
     # ------------------------------------------------------------------
     # Detail rendering
@@ -4254,7 +4727,19 @@ class PollyInboxApp(App[None]):
         self._refresh_list(select_first=False)
 
     def action_back_or_cancel(self) -> None:
-        """Esc/q returns focus to the list from the reply box, else exits."""
+        """Esc/q returns focus to the list from inputs, else exits.
+
+        From the filter Input: clears the typed query + closes the bar
+        (per the brief — "Esc clears + closes"). Chip toggles aren't
+        cleared here; ``c`` is the explicit "wipe everything" key.
+        """
+        if self.filter_input.has_focus:
+            self._filter_text = ""
+            self.filter_input.value = ""
+            self._filter_bar_visible = False
+            self._render_list(select_first=False)
+            self.list_view.focus()
+            return
         if self.reply_input.has_focus:
             # Return focus to the list so j/k works again. Don't exit the
             # app — the reply input is always present on the detail pane.
@@ -4692,7 +5177,7 @@ class PollyInboxApp(App[None]):
 
     _DEFAULT_HINT = (
         "j/k move \u00b7 \u21b5 open \u00b7 r reply \u00b7 a archive "
-        "\u00b7 d discuss \u00b7 u refresh \u00b7 q back"
+        "\u00b7 d discuss \u00b7 / filter \u00b7 c clear \u00b7 q back"
     )
     _PROPOSAL_HINT = (
         "A accept \u00b7 X reject \u00b7 r reply \u00b7 q back"

--- a/tests/test_inbox_filter.py
+++ b/tests/test_inbox_filter.py
@@ -1,0 +1,430 @@
+"""Tests for the cockpit inbox filter + search bar (#NEW).
+
+Drives :class:`pollypm.cockpit_ui.PollyInboxApp` via ``Pilot`` and
+asserts the filter overlay's behaviour: `/` mounts a fuzzy text Input,
+chip-toggle keys narrow by unread / project / recent / type, multiple
+chips AND-combine, ``c`` clears everything, and the friendly
+empty-match copy renders when nothing survives. Filters are
+session-scoped — a remount returns to the full list.
+
+Mirrors ``tests/test_cockpit_inbox_ui.py`` for fixture shape so the two
+suites can share monkeypatches if needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from pollypm.work.sqlite_service import SQLiteWorkService
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — single-project minimal cockpit + a multi-project variant
+# ---------------------------------------------------------------------------
+
+
+def _write_minimal_config(project_path: Path, config_path: Path) -> None:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "[project]\n"
+        f'tmux_session = "pollypm-test"\n'
+        f'workspace_root = "{project_path.parent}"\n'
+        "\n"
+        f'[projects.demo]\n'
+        f'key = "demo"\n'
+        f'name = "Demo"\n'
+        f'path = "{project_path}"\n'
+    )
+
+
+def _write_multi_config(
+    project_paths: list[tuple[str, Path]], config_path: Path,
+) -> None:
+    """Emit a config with multiple `[projects.<key>]` blocks."""
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    workspace_root = project_paths[0][1].parent
+    lines = [
+        "[project]\n",
+        f'tmux_session = "pollypm-test"\n',
+        f'workspace_root = "{workspace_root}"\n',
+        "\n",
+    ]
+    for key, path in project_paths:
+        lines.append(f'[projects.{key}]\n')
+        lines.append(f'key = "{key}"\n')
+        lines.append(f'name = "{key.title()}"\n')
+        lines.append(f'path = "{path}"\n')
+        lines.append("\n")
+    config_path.write_text("".join(lines))
+
+
+def _seed_project(
+    project_path: Path,
+    *,
+    project_key: str = "demo",
+    items: list[tuple[str, str, list[str] | None]] | None = None,
+) -> list[str]:
+    """Seed a project's state.db with inbox tasks.
+
+    ``items`` is a list of ``(title, body, labels)``. When unset, three
+    plain tasks are seeded (matching the broader inbox suite).
+    """
+    if items is None:
+        items = [
+            ("Smoke subject", "Smoke body", None),
+            ("Deploy blocked", "Verify email click.", None),
+            ("Homepage rewrite", "Review please.", None),
+        ]
+    db_path = project_path / ".pollypm" / "state.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+    try:
+        ids: list[str] = []
+        for title, body, labels in items:
+            t = svc.create(
+                title=title,
+                description=body,
+                type="task",
+                project=project_key,
+                flow_template="chat",
+                roles={"requester": "user", "operator": "polly"},
+                priority="normal",
+                created_by="polly",
+                labels=labels,
+            )
+            ids.append(t.task_id)
+        return ids
+    finally:
+        svc.close()
+
+
+@pytest.fixture
+def filter_env(tmp_path: Path):
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    config_path = tmp_path / "pollypm.toml"
+    _write_minimal_config(project_path, config_path)
+    # Seed a richer mix so the filter tests have something to narrow.
+    ids = _seed_project(
+        project_path,
+        items=[
+            ("shipped: cookie banner", "shipped to prod", ["shipped"]),
+            ("shipped: rollup of merges", "merge digest", ["rollup"]),
+            ("Deploy blocked on staging", "blocked", None),
+            ("Plan review request", "review the plan", ["plan_review"]),
+            ("Worker stuck on auth", "blocking question", ["blocking_question"]),
+        ],
+    )
+    return {
+        "config_path": config_path,
+        "project_path": project_path,
+        "task_ids": ids,
+    }
+
+
+def _load_config_compatible(config_path: Path) -> bool:
+    try:
+        from pollypm.config import load_config
+        cfg = load_config(config_path)
+        return bool(getattr(cfg, "projects", {}))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+@pytest.fixture
+def filter_app(filter_env):
+    if not _load_config_compatible(filter_env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_ui import PollyInboxApp
+    return PollyInboxApp(filter_env["config_path"])
+
+
+def _run(coro) -> None:
+    asyncio.run(coro)
+
+
+def _visible_titles(app) -> list[str]:
+    """Return the titles currently rendered in the list view.
+
+    Walks the ``ListView`` children rather than ``app._tasks`` so we
+    assert what the user actually sees, not just the unfiltered backing
+    store.
+    """
+    from pollypm.cockpit_ui import _InboxListItem
+    return [
+        c.task_ref.title
+        for c in app.list_view.children
+        if isinstance(c, _InboxListItem)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. `/` mounts the filter Input and typing live-filters the list
+# ---------------------------------------------------------------------------
+
+
+def test_slash_opens_filter_input_and_typing_filters_list(
+    filter_env, filter_app,
+) -> None:
+    async def body() -> None:
+        async with filter_app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            initial = len(_visible_titles(filter_app))
+            assert initial == 5
+
+            await pilot.press("slash")
+            await pilot.pause()
+            # Filter Input is now shown + focused.
+            assert filter_app.filter_input.display is True
+            assert filter_app.filter_input.has_focus
+            assert filter_app._filter_bar_visible is True
+
+            # Type a query. Use the Changed event path so we don't
+            # depend on the textual key dispatcher routing each char.
+            filter_app.filter_input.value = "shipped"
+            await pilot.pause()
+
+            # Two seeded titles begin with "shipped".
+            visible = _visible_titles(filter_app)
+            assert len(visible) == 2
+            assert all("shipped" in t.lower() for t in visible)
+    _run(body())
+
+
+# ---------------------------------------------------------------------------
+# 2. Fuzzy match: 'shp' matches 'shipped' titles
+# ---------------------------------------------------------------------------
+
+
+def test_fuzzy_subsequence_match(filter_env, filter_app) -> None:
+    async def body() -> None:
+        async with filter_app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            await pilot.press("slash")
+            await pilot.pause()
+            filter_app.filter_input.value = "shp"
+            await pilot.pause()
+
+            # 'shp' is a subsequence of 'shipped' → both shipped titles
+            # must be in the visible set. Other rows may also match
+            # because the haystack folds in project + sender (e.g. a row
+            # whose body has s/h and the sender 'polly' supplies the p)
+            # — that's working-as-intended for fuzzy search; we just
+            # require the obvious hits to land.
+            visible = _visible_titles(filter_app)
+            assert visible, "fuzzy match should keep at least one row"
+            assert any("cookie banner" in t.lower() for t in visible)
+            assert any("rollup of merges" in t.lower() for t in visible)
+
+            # And a query that demands letters that don't appear in any
+            # row at all returns the empty list (sanity).
+            filter_app.filter_input.value = "xyz_no_such_seq"
+            await pilot.pause()
+            assert _visible_titles(filter_app) == []
+    _run(body())
+
+
+# ---------------------------------------------------------------------------
+# 3. Unread-only chip narrows the list
+# ---------------------------------------------------------------------------
+
+
+def test_unread_only_filter_chip(filter_env, filter_app) -> None:
+    async def body() -> None:
+        async with filter_app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            # Open the first row → marks it read so the unread-only chip
+            # actually narrows.
+            filter_app.list_view.index = 0
+            await pilot.press("enter")
+            await pilot.pause()
+            initial_unread = len(filter_app._unread_ids)
+            assert initial_unread == 4  # 5 seeded, one read
+
+            await pilot.press("u")
+            await pilot.pause()
+
+            assert filter_app._filter_unread_only is True
+            visible = _visible_titles(filter_app)
+            # Visible count == unread count.
+            assert len(visible) == initial_unread
+            # The chip strip shows 'unread'.
+            assert "unread" in str(filter_app.filter_chips.render()).lower()
+    _run(body())
+
+
+# ---------------------------------------------------------------------------
+# 4. Project picker filter narrows correctly (multi-project workspace)
+# ---------------------------------------------------------------------------
+
+
+def test_project_picker_filter_narrows_list(tmp_path: Path) -> None:
+    async def body() -> None:
+        demo = tmp_path / "demo"
+        demo.mkdir()
+        (demo / ".git").mkdir()
+        other = tmp_path / "other"
+        other.mkdir()
+        (other / ".git").mkdir()
+        config_path = tmp_path / "pollypm.toml"
+        _write_multi_config([("demo", demo), ("other", other)], config_path)
+        _seed_project(
+            demo, project_key="demo",
+            items=[("demo task A", "x", None), ("demo task B", "y", None)],
+        )
+        _seed_project(
+            other, project_key="other",
+            items=[("other task 1", "z", None)],
+        )
+        if not _load_config_compatible(config_path):
+            pytest.skip("minimal pollypm.toml fixture not supported by loader")
+
+        from pollypm.cockpit_ui import PollyInboxApp
+        app = PollyInboxApp(config_path)
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            assert len(_visible_titles(app)) == 3
+
+            # Set the project filter directly — the picker modal would
+            # do the same via dismiss, and we don't need to drive the
+            # modal UI to validate the narrowing logic.
+            app._filter_project = "demo"
+            app._render_list(select_first=True)
+            await pilot.pause()
+
+            visible = _visible_titles(app)
+            assert len(visible) == 2
+            assert all("demo task" in t for t in visible)
+
+            # Chip strip mentions the selected project.
+            assert "demo" in str(app.filter_chips.render()).lower()
+    _run(body())
+
+
+# ---------------------------------------------------------------------------
+# 5. Multiple chips AND-combine
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_chips_and_combine(filter_env, filter_app) -> None:
+    async def body() -> None:
+        async with filter_app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            # Toggle plan_review chip — only the plan_review row remains.
+            await pilot.press("l")
+            await pilot.pause()
+            visible = _visible_titles(filter_app)
+            assert visible == ["Plan review request"]
+
+            # Layer in unread-only — plan_review row is still unread, so
+            # the result is unchanged but both chips are active.
+            await pilot.press("u")
+            await pilot.pause()
+            assert filter_app._filter_plan_review is True
+            assert filter_app._filter_unread_only is True
+            visible = _visible_titles(filter_app)
+            assert visible == ["Plan review request"]
+
+            # Add the blocking_question chip — AND-combined with
+            # plan_review there are zero matching rows.
+            await pilot.press("b")
+            await pilot.pause()
+            assert filter_app._filter_blocking is True
+            assert _visible_titles(filter_app) == []
+    _run(body())
+
+
+# ---------------------------------------------------------------------------
+# 6. `c` clears every chip + the typed text
+# ---------------------------------------------------------------------------
+
+
+def test_c_clears_all_filters(filter_env, filter_app) -> None:
+    async def body() -> None:
+        async with filter_app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            await pilot.press("u")
+            await pilot.pause()
+            await pilot.press("l")
+            await pilot.pause()
+            await pilot.press("slash")
+            await pilot.pause()
+            filter_app.filter_input.value = "shipped"
+            await pilot.pause()
+            assert filter_app._has_active_filters() is True
+
+            # Esc the input first so `c` lands as an action (not a
+            # character into the Input).
+            await pilot.press("escape")
+            await pilot.pause()
+            await pilot.press("c")
+            await pilot.pause()
+
+            assert filter_app._has_active_filters() is False
+            assert filter_app._filter_unread_only is False
+            assert filter_app._filter_plan_review is False
+            assert filter_app._filter_text == ""
+            # Full list is visible again.
+            assert len(_visible_titles(filter_app)) == 5
+    _run(body())
+
+
+# ---------------------------------------------------------------------------
+# 7. Empty-match state renders the friendly hint
+# ---------------------------------------------------------------------------
+
+
+def test_empty_match_state_shows_friendly_message(
+    filter_env, filter_app,
+) -> None:
+    async def body() -> None:
+        async with filter_app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            await pilot.press("slash")
+            await pilot.pause()
+            filter_app.filter_input.value = "zzz_definitely_no_hit_zzz"
+            await pilot.pause()
+
+            assert _visible_titles(filter_app) == []
+            detail_text = str(filter_app.detail.render())
+            assert "No matches" in detail_text
+            # Hint mentions ``c`` so the user knows the way out.
+            assert "c" in detail_text
+    _run(body())
+
+
+# ---------------------------------------------------------------------------
+# 8. Filters do NOT persist across PollyInboxApp remounts (session-scoped)
+# ---------------------------------------------------------------------------
+
+
+def test_filters_session_scoped_across_remounts(filter_env) -> None:
+    async def body() -> None:
+        from pollypm.cockpit_ui import PollyInboxApp
+        # First mount — set a couple of filters.
+        app1 = PollyInboxApp(filter_env["config_path"])
+        async with app1.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            await pilot.press("u")
+            await pilot.pause()
+            await pilot.press("l")
+            await pilot.pause()
+            assert app1._filter_unread_only is True
+            assert app1._filter_plan_review is True
+
+        # Second mount — fresh instance must start with everything clear.
+        app2 = PollyInboxApp(filter_env["config_path"])
+        async with app2.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            assert app2._filter_unread_only is False
+            assert app2._filter_plan_review is False
+            assert app2._filter_text == ""
+            assert app2._filter_project is None
+            assert app2._has_active_filters() is False
+            # Full list is visible — nothing has been narrowed.
+            assert len(_visible_titles(app2)) == 5
+    _run(body())


### PR DESCRIPTION
Filter bar above the inbox list. `/` for fuzzy text, chip toggles for unread/project/recent/plan_review/blocking_question.

## Keybindings
- `/` — open fuzzy filter Input
- `u` — unread-only chip
- `p` — project picker (modal)
- `R` — recent 24h
- `l` — plan_review only
- `b` — blocking_question only
- `c` — clear all filters
- All existing keys preserved (r reply, a archive, A approve, X reject, v explainer, d discuss, e expand, q/Esc back, : palette)

## Conflict resolutions
- `u` was refresh → promoted to unread-only. Refresh moved to ctrl+r + still in `:` palette
- Background auto-refresh unchanged

## UI
- Counter strip live: '2 of 5 shown · 4 unread · filters: unread · plan_review'
- Empty match: 'No matches. Press c to clear filters.'
- Session-scoped persistence (clears on cockpit restart, persists across open/close within session)

## Files (2)
- cockpit_ui.py
- tests/test_inbox_filter.py (new)

## Tests (+8, 0 regressions)
24 pass (8 new + 16 existing inbox UI)