### PR TITLE
feat(cockpit-palette): recent command history in empty-query state

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import gc
 import resource
+from collections import deque
 from pathlib import Path
 import subprocess
 
@@ -17,7 +18,7 @@ from rich.text import Text
 from textual import events, on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.containers import Container, Horizontal, Vertical, VerticalScroll
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Button, DataTable, Input, ListItem, ListView, Static
 
@@ -215,6 +216,23 @@ class _PaletteListItem(ListItem):
         return f"{title}\n  {line2}"
 
 
+class _PaletteSectionHeader(ListItem):
+    """Non-selectable header row that labels a group in the palette.
+
+    Used to separate the "Recent" group from the full "All commands"
+    list on empty-query open. Marked ``disabled`` so Textual skips it
+    during arrow-key navigation and so Enter cannot fire on it.
+    """
+
+    def __init__(self, label: str) -> None:
+        body = Static(
+            f"[#6b7a88]\u2500\u2500 {label} \u2500\u2500[/#6b7a88]",
+            markup=True,
+        )
+        super().__init__(body, classes="palette-section-header")
+        self.disabled = True
+
+
 class CommandPaletteModal(ModalScreen[str | None]):
     """Global ``:`` command palette — fuzzy-searchable command list.
 
@@ -274,6 +292,12 @@ class CommandPaletteModal(ModalScreen[str | None]):
         background: #253140;
         color: #f2f6f8;
     }
+    #palette-list > .palette-section-header {
+        height: 1;
+        padding: 0 1;
+        color: #6b7a88;
+        background: transparent;
+    }
     #palette-empty {
         height: 3;
         padding: 1;
@@ -293,10 +317,33 @@ class CommandPaletteModal(ModalScreen[str | None]):
         Binding("enter", "run_selected", "Run", show=False),
     ]
 
-    def __init__(self, commands: list[PaletteCommand]) -> None:
+    def __init__(
+        self,
+        commands: list[PaletteCommand],
+        *,
+        recent_tags: list[str] | None = None,
+    ) -> None:
         super().__init__()
         self._all_commands: list[PaletteCommand] = list(commands)
+        # Most-recent-first list of recently-run PaletteCommands, deduped
+        # and capped to 5 entries for empty-query rendering. Each tag is
+        # resolved back to its PaletteCommand so the row renders with
+        # the same title/subtitle/category as the main list. Tags that
+        # no longer exist in ``commands`` are dropped silently.
+        self._recent_commands: list[PaletteCommand] = _resolve_recent_commands(
+            commands, recent_tags or [], limit=5,
+        )
+        # ``_visible`` is the flat list of *selectable* PaletteCommands
+        # currently on screen (recent + all when empty query; filtered
+        # only otherwise). It mirrors the ListView index 1:1 after
+        # accounting for header rows, so ``action_run_selected`` can map
+        # the cursor row back to a tag.
         self._visible: list[PaletteCommand] = list(commands)
+        # ``_row_kinds`` mirrors ListView children 1:1 with "header" or
+        # "item" so keyboard navigation (``action_run_selected``) can
+        # resolve a ListView index to the right ``_visible`` slot without
+        # assuming header positions.
+        self._row_kinds: list[str] = []
         self.input = Input(placeholder="Type a command\u2026", id="palette-input")
         self.list_view = ListView(id="palette-list")
         self.empty = Static(
@@ -321,29 +368,71 @@ class CommandPaletteModal(ModalScreen[str | None]):
             yield self.hint
 
     def on_mount(self) -> None:
-        self._populate(self._all_commands)
+        # Empty query on open → render the Recent section (if any) above
+        # the full command list. ``_filter("")`` routes through the
+        # shared rendering path so repeat-opens land on the same layout.
+        self._filter("")
         self.input.focus()
 
     # ------------------------------------------------------------------
     # Population / filtering
     # ------------------------------------------------------------------
 
-    def _populate(self, commands: list[PaletteCommand]) -> None:
-        self._visible = list(commands)
+    def _populate(
+        self,
+        commands: list[PaletteCommand],
+        *,
+        recent: list[PaletteCommand] | None = None,
+    ) -> None:
+        """Render the palette list.
+
+        When ``recent`` is non-empty we prepend a ``-- Recent --`` header
+        and the recent rows, then a ``-- All commands --`` header and
+        the full ``commands`` list. When ``recent`` is empty/None we fall
+        back to the original single-section layout — callers get the
+        existing behaviour for free.
+        """
+        recent = recent or []
+        self._visible = list(recent) + list(commands)
+        self._row_kinds = []
         self.list_view.clear()
-        if not commands:
+        if not self._visible:
             self.empty.display = True
             self.list_view.display = False
             return
         self.empty.display = False
         self.list_view.display = True
-        items = [_PaletteListItem(cmd) for cmd in commands]
-        self.list_view.extend(items)
-        # Always cursor the top match so Enter runs the most relevant
-        # command without needing to arrow.
-        self.list_view.index = 0
+
+        first_item_index: int | None = None
+        if recent:
+            self.list_view.append(_PaletteSectionHeader("Recent"))
+            self._row_kinds.append("header")
+            for cmd in recent:
+                if first_item_index is None:
+                    first_item_index = len(self._row_kinds)
+                self.list_view.append(_PaletteListItem(cmd))
+                self._row_kinds.append("item")
+            self.list_view.append(_PaletteSectionHeader("All commands"))
+            self._row_kinds.append("header")
+        for cmd in commands:
+            if first_item_index is None:
+                first_item_index = len(self._row_kinds)
+            self.list_view.append(_PaletteListItem(cmd))
+            self._row_kinds.append("item")
+
+        # Cursor the first selectable row — Enter should re-run the
+        # most recent command when Recent is present, else the top of
+        # the full list.
+        self.list_view.index = first_item_index if first_item_index is not None else 0
 
     def _filter(self, query: str) -> None:
+        # Empty query reveals the Recent section above the full list;
+        # any non-empty query suppresses Recent so search results aren't
+        # polluted by history.
+        stripped = (query or "").strip()
+        if not stripped:
+            self._populate(self._all_commands, recent=self._recent_commands)
+            return
         matches = filter_palette_commands(self._all_commands, query)
         self._populate(matches)
 
@@ -362,6 +451,8 @@ class CommandPaletteModal(ModalScreen[str | None]):
     @on(ListView.Selected, "#palette-list")
     def _on_row_selected(self, event: ListView.Selected) -> None:
         row = event.item
+        # Section headers are ``ListItem``s but not ``_PaletteListItem``;
+        # ignore clicks on them so Enter-on-header doesn't dispatch.
         if isinstance(row, _PaletteListItem):
             self.dismiss(row.command.tag)
 
@@ -379,12 +470,40 @@ class CommandPaletteModal(ModalScreen[str | None]):
         self.list_view.action_cursor_up()
 
     def action_run_selected(self) -> None:
-        idx = self.list_view.index or 0
         if not self._visible:
             return
-        if idx < 0 or idx >= len(self._visible):
-            idx = 0
-        self.dismiss(self._visible[idx].tag)
+        # ListView index addresses every row including headers; translate
+        # it to a ``_visible`` slot by counting non-header rows up to the
+        # cursor. Falling through a header (shouldn't normally happen
+        # since headers are disabled) lands on the next selectable row.
+        raw_idx = self.list_view.index or 0
+        item_idx = self._resolve_item_index(raw_idx)
+        if item_idx is None:
+            return
+        self.dismiss(self._visible[item_idx].tag)
+
+    def _resolve_item_index(self, list_view_index: int) -> int | None:
+        """Map a ListView row index to the matching ``_visible`` slot.
+
+        Returns ``None`` if ``list_view_index`` points past the end, is
+        negative, or lands on a header with no selectable row after it.
+        If the cursor is on a header we walk forward to the next item so
+        Enter always dispatches something reasonable.
+        """
+        if not self._row_kinds:
+            return 0 if self._visible else None
+        if list_view_index < 0:
+            list_view_index = 0
+        # Count item rows strictly before the cursor — that's the
+        # _visible index of the next item we encounter at or after the
+        # cursor, since headers don't consume a _visible slot.
+        items_before = sum(
+            1 for kind in self._row_kinds[:list_view_index] if kind == "item"
+        )
+        for kind in self._row_kinds[list_view_index:]:
+            if kind == "item":
+                return items_before
+        return None
 
 
 def _current_project_for_palette(app: App) -> str | None:
@@ -579,17 +698,90 @@ def _palette_show_shortcuts(app: App) -> None:
     _palette_notify(app, body)
 
 
+# Session-scoped history cap — 10 entries total (we display the last 5 on
+# empty query, the extra headroom lets short-lived repeats bubble back up
+# without evicting older distinct commands prematurely). Bump cautiously;
+# a deeper history is cheap but clutters the "Recent" section when the
+# user only wants the last few.
+_PALETTE_HISTORY_MAX = 10
+_PALETTE_RECENT_DISPLAY = 5
+
+
+def _palette_history(app: App) -> deque[str]:
+    """Return the per-App command history deque, initialising lazily.
+
+    Session-scoped: nothing persists across cockpit restarts (by design —
+    see the TODO below for the follow-up plan). The deque is ordered
+    oldest-first; callers reverse it when rendering "Recent". We dedup
+    before pushing so a repeat-run moves the tag to the most-recent slot
+    without inflating the list.
+
+    TODO(v1.1): persist to ``~/.pollypm/.palette_history.json`` (last 20)
+    so opening a fresh cockpit keeps the last session's "Recent" row.
+    """
+    history = getattr(app, "_palette_recent_history", None)
+    if not isinstance(history, deque):
+        history = deque(maxlen=_PALETTE_HISTORY_MAX)
+        setattr(app, "_palette_recent_history", history)
+    return history
+
+
+def _record_palette_command(app: App, tag: str) -> None:
+    """Record a dispatched command tag on the host App's history.
+
+    Deduplicates by tag (repeat runs move the tag to the most-recent end
+    rather than pushing a new entry) and caps via the deque ``maxlen``.
+    """
+    if not tag:
+        return
+    history = _palette_history(app)
+    try:
+        history.remove(tag)
+    except ValueError:
+        pass
+    history.append(tag)
+
+
+def _resolve_recent_commands(
+    all_commands: list[PaletteCommand],
+    recent_tags: list[str],
+    *,
+    limit: int,
+) -> list[PaletteCommand]:
+    """Resolve a most-recent-first list of tags back to ``PaletteCommand``s.
+
+    Tags that aren't in ``all_commands`` are dropped silently — this can
+    happen if the config changes between cockpit runs (project removed,
+    etc.) or, more commonly, because the command doesn't live in the
+    current palette scope. Result length is capped at ``limit``.
+    """
+    by_tag = {cmd.tag: cmd for cmd in all_commands}
+    resolved: list[PaletteCommand] = []
+    for tag in recent_tags:
+        cmd = by_tag.get(tag)
+        if cmd is None:
+            continue
+        resolved.append(cmd)
+        if len(resolved) >= limit:
+            break
+    return resolved
+
+
 def _open_command_palette(app: App) -> None:
     """Push :class:`CommandPaletteModal` onto ``app`` with the full command set.
 
     Builds the command registry from the App's config + current-project
     hint, then dispatches the selected tag once the modal dismisses.
+    Also passes the session-scoped command history so empty-query opens
+    render a "Recent" section above the full list.
     """
     config_path = getattr(app, "config_path", None)
     if config_path is None:
         return
 
     def _on_dismiss(tag: str | None) -> None:
+        if tag:
+            _record_palette_command(app, tag)
         _dispatch_palette_tag(app, tag)
 
     try:
@@ -598,7 +790,11 @@ def _open_command_palette(app: App) -> None:
         )
     except Exception:  # noqa: BLE001
         commands = []
-    app.push_screen(CommandPaletteModal(commands), _on_dismiss)
+    # Most-recent-first snapshot — the modal dedupes + caps internally.
+    recent_tags = list(reversed(_palette_history(app)))
+    app.push_screen(
+        CommandPaletteModal(commands, recent_tags=recent_tags), _on_dismiss,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_palette_recent_history.py
+++ b/tests/test_palette_recent_history.py
@@ -1,0 +1,379 @@
+"""Targeted tests for the command-palette recent-history UX.
+
+The rest of the palette surface lives in
+``tests/test_command_palette.py`` — this file sticks to the empty-query
+"Recent" section and its supporting history plumbing so each case stays
+fast and isolated.
+
+Run targeted (not the whole suite)::
+
+    HOME=/tmp/pytest-agent-palhistory uv run pytest \\
+        tests/test_palette_recent_history.py \\
+        tests/test_command_palette.py -q
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from pollypm.cockpit import PaletteCommand
+from pollypm.cockpit_ui import (
+    _PaletteListItem,
+    _PaletteSectionHeader,
+    _palette_history,
+    _record_palette_command,
+    _resolve_recent_commands,
+)
+from pollypm.work.sqlite_service import SQLiteWorkService
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — mirror the lightweight single-project setup used by the
+# existing command-palette tests so the two files share a mental model.
+# ---------------------------------------------------------------------------
+
+
+def _write_single_project_config(project_path: Path, config_path: Path) -> None:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "[project]\n"
+        'tmux_session = "pollypm-test"\n'
+        f'workspace_root = "{project_path.parent}"\n'
+        "\n"
+        "[projects.demo]\n"
+        'key = "demo"\n'
+        'name = "Demo"\n'
+        f'path = "{project_path}"\n'
+    )
+
+
+def _seed_project_db(project_path: Path) -> None:
+    db_path = project_path / ".pollypm" / "state.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with SQLiteWorkService(db_path=db_path, project_path=project_path) as svc:
+        svc.create(
+            title="Palette history smoke",
+            description="body",
+            type="task",
+            project="demo",
+            flow_template="chat",
+            roles={"requester": "user", "operator": "polly"},
+            priority="normal",
+            created_by="polly",
+        )
+
+
+@pytest.fixture
+def single_project_config(tmp_path: Path) -> Path:
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    config_path = tmp_path / "pollypm.toml"
+    _write_single_project_config(project_path, config_path)
+    _seed_project_db(project_path)
+    return config_path
+
+
+def _load_config_compatible(config_path: Path) -> bool:
+    try:
+        from pollypm.config import load_config
+        cfg = load_config(config_path)
+        return len(getattr(cfg, "projects", {})) > 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _run(coro) -> None:
+    asyncio.run(coro)
+
+
+def _palette_cmd(tag: str, title: str = "") -> PaletteCommand:
+    """Construct a throwaway PaletteCommand for the unit-level tests."""
+    return PaletteCommand(
+        title=title or tag,
+        subtitle="",
+        category="Navigation",
+        keybind=None,
+        tag=tag,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper-layer tests — no Textual, run in microseconds.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_recent_commands_drops_unknown_tags() -> None:
+    """Tags that aren't in the current palette scope are silently dropped."""
+    commands = [_palette_cmd("nav.inbox"), _palette_cmd("nav.workers")]
+    resolved = _resolve_recent_commands(
+        commands, ["nav.inbox", "nav.missing", "nav.workers"], limit=5,
+    )
+    assert [c.tag for c in resolved] == ["nav.inbox", "nav.workers"]
+
+
+def test_resolve_recent_commands_respects_limit() -> None:
+    """Limit caps the resolved list before the full history is walked."""
+    commands = [_palette_cmd(f"nav.{i}") for i in range(10)]
+    recent_tags = [f"nav.{i}" for i in range(10)]
+    resolved = _resolve_recent_commands(commands, recent_tags, limit=3)
+    assert [c.tag for c in resolved] == ["nav.0", "nav.1", "nav.2"]
+
+
+def test_record_palette_command_dedupes_preserving_most_recent() -> None:
+    """Running the same tag twice keeps it once, at the most-recent slot."""
+    class _Stub:
+        pass
+    app = _Stub()
+    _record_palette_command(app, "nav.inbox")
+    _record_palette_command(app, "nav.workers")
+    _record_palette_command(app, "nav.inbox")  # re-run
+    history = _palette_history(app)
+    assert list(history) == ["nav.workers", "nav.inbox"]
+
+
+def test_record_palette_command_caps_history_at_ten() -> None:
+    """More than 10 distinct runs drops the oldest (deque maxlen)."""
+    class _Stub:
+        pass
+    app = _Stub()
+    for i in range(15):
+        _record_palette_command(app, f"nav.cmd-{i}")
+    history = _palette_history(app)
+    assert len(history) == 10
+    # Oldest five were evicted; the 10 most-recent remain in order.
+    assert list(history) == [f"nav.cmd-{i}" for i in range(5, 15)]
+
+
+def test_record_palette_command_ignores_empty_tag() -> None:
+    """None/empty dispatches must not inflate the history."""
+    class _Stub:
+        pass
+    app = _Stub()
+    _record_palette_command(app, "")
+    assert not _palette_history(app)
+
+
+# ---------------------------------------------------------------------------
+# Modal-layer tests — drive the modal directly so we don't need the full
+# cockpit rail. These bypass ``run_test`` since we only need the pure
+# rendering contract (``_visible`` / ``_row_kinds``); the UI plumbing is
+# already covered by ``tests/test_command_palette.py``.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_history_empty_query_shows_only_full_list(
+    single_project_config: Path,
+) -> None:
+    """No Recent section renders when the history is empty."""
+    if not _load_config_compatible(single_project_config):
+        pytest.skip("config fixture not supported by loader")
+    from pollypm.cockpit_ui import PollyInboxApp
+    app = PollyInboxApp(single_project_config)
+
+    async def body() -> None:
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            await pilot.press("colon")
+            await pilot.pause()
+            modal = None
+            from pollypm.cockpit_ui import CommandPaletteModal as _M
+            for screen in app.screen_stack:
+                if isinstance(screen, _M):
+                    modal = screen
+                    break
+            assert modal is not None
+            # Recent resolved list is empty → no header rows rendered.
+            assert modal._recent_commands == []
+            assert all(kind == "item" for kind in modal._row_kinds)
+            # _visible exactly matches the full command set (no
+            # duplicated Recent entries).
+            assert len(modal._visible) == len(modal._all_commands)
+    _run(body())
+
+
+def test_three_distinct_commands_reopen_shows_recent_section(
+    single_project_config: Path,
+) -> None:
+    """Running 3 distinct commands then reopening renders them in reverse order."""
+    if not _load_config_compatible(single_project_config):
+        pytest.skip("config fixture not supported by loader")
+    from pollypm.cockpit_ui import PollyInboxApp
+    app = PollyInboxApp(single_project_config)
+
+    async def body() -> None:
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            # Seed the App's history in the same order the user would:
+            # inbox → workers → activity. Most-recent-first is
+            # activity, workers, inbox.
+            _record_palette_command(app, "nav.inbox")
+            _record_palette_command(app, "nav.workers")
+            _record_palette_command(app, "nav.activity")
+
+            await pilot.press("colon")
+            await pilot.pause()
+            from pollypm.cockpit_ui import CommandPaletteModal as _M
+            modal = next(
+                (s for s in app.screen_stack if isinstance(s, _M)), None,
+            )
+            assert modal is not None
+            # Recent section rendered, in reverse-chronological order.
+            tags = [c.tag for c in modal._recent_commands]
+            assert tags == ["nav.activity", "nav.workers", "nav.inbox"]
+            # Two headers rendered (Recent + All commands).
+            assert modal._row_kinds.count("header") == 2
+            # First rendered item is the most recent command — Enter
+            # would re-run it.
+            first_item_idx = modal._row_kinds.index("item")
+            assert modal.list_view.index == first_item_idx
+            assert modal._visible[0].tag == "nav.activity"
+    _run(body())
+
+
+def test_running_same_command_twice_dedupes_in_recent(
+    single_project_config: Path,
+) -> None:
+    """Recent shows a repeated command once, not twice."""
+    if not _load_config_compatible(single_project_config):
+        pytest.skip("config fixture not supported by loader")
+    from pollypm.cockpit_ui import PollyInboxApp
+    app = PollyInboxApp(single_project_config)
+
+    async def body() -> None:
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            _record_palette_command(app, "nav.inbox")
+            _record_palette_command(app, "nav.workers")
+            _record_palette_command(app, "nav.inbox")  # repeat
+
+            await pilot.press("colon")
+            await pilot.pause()
+            from pollypm.cockpit_ui import CommandPaletteModal as _M
+            modal = next(
+                (s for s in app.screen_stack if isinstance(s, _M)), None,
+            )
+            assert modal is not None
+            tags = [c.tag for c in modal._recent_commands]
+            assert tags == ["nav.inbox", "nav.workers"], (
+                f"expected dedup with inbox moved to most-recent; got {tags}"
+            )
+    _run(body())
+
+
+def test_recent_section_caps_at_five_even_when_history_is_ten(
+    single_project_config: Path,
+) -> None:
+    """History stores up to 10, but the Recent section only renders 5."""
+    if not _load_config_compatible(single_project_config):
+        pytest.skip("config fixture not supported by loader")
+    from pollypm.cockpit_ui import PollyInboxApp
+    app = PollyInboxApp(single_project_config)
+
+    async def body() -> None:
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            # 12 distinct commands → history keeps the last 10; Recent
+            # still only surfaces 5 in the modal.
+            tags = [
+                "nav.inbox", "nav.workers", "nav.activity", "nav.metrics",
+                "nav.settings", "nav.dashboard", "session.refresh",
+                "session.restart", "session.shortcuts", "system.doctor",
+                "system.edit_config", "inbox.notify",
+            ]
+            for tag in tags:
+                _record_palette_command(app, tag)
+            assert len(_palette_history(app)) == 10
+
+            await pilot.press("colon")
+            await pilot.pause()
+            from pollypm.cockpit_ui import CommandPaletteModal as _M
+            modal = next(
+                (s for s in app.screen_stack if isinstance(s, _M)), None,
+            )
+            assert modal is not None
+            assert len(modal._recent_commands) == 5
+            # Most-recent-first — the last tag pushed is the first row.
+            assert modal._recent_commands[0].tag == "inbox.notify"
+    _run(body())
+
+
+def test_non_empty_query_hides_recent_section(
+    single_project_config: Path,
+) -> None:
+    """Typing any query collapses the palette back to a single section."""
+    if not _load_config_compatible(single_project_config):
+        pytest.skip("config fixture not supported by loader")
+    from pollypm.cockpit_ui import PollyInboxApp
+    app = PollyInboxApp(single_project_config)
+
+    async def body() -> None:
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            _record_palette_command(app, "nav.inbox")
+            _record_palette_command(app, "nav.workers")
+
+            await pilot.press("colon")
+            await pilot.pause()
+            from pollypm.cockpit_ui import CommandPaletteModal as _M
+            modal = next(
+                (s for s in app.screen_stack if isinstance(s, _M)), None,
+            )
+            assert modal is not None
+            # Sanity: empty-query open rendered Recent.
+            assert modal._row_kinds.count("header") == 2
+            # Now type — recent section must disappear.
+            modal._filter("inbox")
+            await pilot.pause()
+            assert modal._row_kinds.count("header") == 0, (
+                f"expected no headers while filtering; "
+                f"kinds={modal._row_kinds}"
+            )
+            # Every _visible entry is a fresh filter match against the
+            # full list — not pulled from Recent.
+            for cmd in modal._visible:
+                assert "inbox" in cmd.haystack()
+            # Clearing the query brings Recent back.
+            modal._filter("")
+            await pilot.pause()
+            assert modal._row_kinds.count("header") == 2
+    _run(body())
+
+
+def test_history_is_session_scoped_new_app_starts_empty(
+    single_project_config: Path,
+) -> None:
+    """A fresh PollyCockpitApp has no recent history (no persistence)."""
+    if not _load_config_compatible(single_project_config):
+        pytest.skip("config fixture not supported by loader")
+    from pollypm.cockpit_ui import PollyCockpitApp, PollyInboxApp
+
+    # First App instance: record something.
+    first = PollyInboxApp(single_project_config)
+    _record_palette_command(first, "nav.inbox")
+    _record_palette_command(first, "nav.workers")
+    assert len(_palette_history(first)) == 2
+
+    # Second instance: history starts empty because it's stored on the
+    # instance, not persisted. Covers the session-scoping promise in the
+    # brief.
+    second = PollyInboxApp(single_project_config)
+    assert len(_palette_history(second)) == 0
+
+    # Extra coverage: the cockpit rail App shares the same plumbing.
+    rail = PollyCockpitApp(single_project_config)
+    assert len(_palette_history(rail)) == 0
+
+
+def test_section_header_is_disabled_listitem() -> None:
+    """Header rows are marked disabled so arrow keys skip them."""
+    header = _PaletteSectionHeader("Recent")
+    assert header.disabled is True
+    # It's a ListItem but NOT a _PaletteListItem — this is how the
+    # click-dispatch handler ignores it.
+    from textual.widgets import ListItem
+    assert isinstance(header, ListItem)
+    assert not isinstance(header, _PaletteListItem)


### PR DESCRIPTION
Empty-query state of the `:` palette now shows recent commands. Fast re-run via Enter.

## Behavior
- Empty query opens with `-- Recent --` header + last 5 distinct commands (most-recent first), then `-- All commands --` with full list
- Cursor starts on first Recent row
- Enter re-runs the most recent command
- Non-empty query hides Recent section (existing behavior preserved)
- Running the same command twice moves it to most-recent slot (dedup)

## Storage
- Session-scoped: `deque[str]` with maxlen=10
- Stored lazily as `_palette_recent_history` on host App
- TODO for v1.1: persist to `~/.pollypm/.palette_history.json`

## Files (2)
- cockpit_ui.py — _PaletteSectionHeader (disabled ListItem), _resolve_recent_commands, _record_palette_command
- tests/test_palette_recent_history.py (new) — 12 tests

## Tests (+12, 0 regressions)
27 pass (12 new + 15 existing palette). 16 inbox tests still green.