### PR TITLE
feat(cli): pm backup + pm restore with safety snapshot and retention

### DIFF
--- a/src/pollypm/backup.py
+++ b/src/pollypm/backup.py
@@ -1,0 +1,490 @@
+"""Backup + restore of the PollyPM state database.
+
+This module is the implementation behind ``pm backup`` / ``pm restore``. The
+CLI layer in :mod:`pollypm.cli` is kept thin — all of the IO, sanity
+checks, and retention logic live here so they are testable without going
+through Typer.
+
+Design notes:
+
+* The DB snapshot uses SQLite's online backup API (``sqlite3.Connection.backup``),
+  NOT ``shutil.copy``. That is the only safe way to copy a live WAL-mode
+  database while the heartbeat / cockpit may be writing to it.
+* Snapshots are gzipped on disk. The backup API needs a plain sqlite
+  file to write into, so we back up to a temporary uncompressed file
+  first and then gzip it.
+* ``--full`` tar.gz archives include the snapshot DB plus config /
+  logs / snapshots / agent homes. They are not touched by retention —
+  operators use them for point-in-time rescue, not routine cleanup.
+* Restores always write a ``.before-restore`` sibling copy of the live
+  DB before replacing it. This is the safety net; it's non-negotiable
+  and the CLI layer cannot skip it.
+"""
+
+from __future__ import annotations
+
+import gzip
+import shutil
+import sqlite3
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Retention only applies to plain DB snapshots (``state-db-*.db.gz``).
+# ``--full`` tar.gz archives are left alone because they are larger and
+# more precious — an operator who ran ``pm backup --full`` almost
+# always did so intentionally before a risky change.
+_DB_SNAPSHOT_PREFIX = "state-db-"
+_DB_SNAPSHOT_SUFFIX = ".db.gz"
+_FULL_SNAPSHOT_PREFIX = "full-"
+_FULL_SNAPSHOT_SUFFIX = ".tar.gz"
+
+# Default retention for plain DB snapshots; keep the last N.
+DEFAULT_KEEP = 7
+
+
+# --------------------------------------------------------------------- #
+# Result dataclasses
+# --------------------------------------------------------------------- #
+
+
+@dataclass(slots=True)
+class BackupResult:
+    path: Path
+    db_size_before: int
+    archive_size: int
+    pruned: list[Path]
+    full: bool
+
+
+@dataclass(slots=True)
+class RestorePlan:
+    snapshot_path: Path
+    live_db_path: Path
+    safety_path: Path
+    is_tar: bool
+
+
+@dataclass(slots=True)
+class RestoreResult:
+    snapshot_path: Path
+    live_db_path: Path
+    safety_path: Path
+    is_tar: bool
+
+
+# --------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------- #
+
+
+def _timestamp() -> str:
+    """Return a filename-safe local timestamp."""
+    return datetime.now(timezone.utc).astimezone().strftime("%Y%m%d-%H%M%S")
+
+
+def _default_backup_dir(base_dir: Path) -> Path:
+    """Return ``~/.pollypm/backups`` (or the configured ``base_dir``)."""
+    return base_dir / "backups"
+
+
+def _size_or_zero(path: Path) -> int:
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
+
+
+def _is_valid_sqlite_file(path: Path) -> bool:
+    """Return True if ``path`` looks like a readable SQLite DB.
+
+    We do a cheap header check (``SQLite format 3\\0``) plus a
+    ``PRAGMA schema_version`` query. We don't validate the schema —
+    the caller may be restoring from a snapshot that predates a
+    migration, and the cockpit will handle that on next startup.
+    """
+    try:
+        with path.open("rb") as fh:
+            header = fh.read(16)
+    except OSError:
+        return False
+    if not header.startswith(b"SQLite format 3\x00"):
+        return False
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        try:
+            conn.execute("PRAGMA schema_version").fetchone()
+        finally:
+            conn.close()
+    except sqlite3.DatabaseError:
+        return False
+    return True
+
+
+def _is_valid_tar_gz(path: Path) -> bool:
+    try:
+        with tarfile.open(path, mode="r:gz") as _:
+            return True
+    except (tarfile.TarError, OSError):
+        return False
+
+
+def _classify_snapshot(path: Path) -> str:
+    """Return ``"db"``, ``"tar"``, or raise ``ValueError``."""
+    name = path.name
+    if name.endswith(_DB_SNAPSHOT_SUFFIX) or name.endswith(".db") or name.endswith(".sqlite"):
+        # Allow both the canonical gzipped form and raw .db files
+        # (handy for quick dev snapshots and for verifying a file
+        # that was decompressed manually).
+        return "db"
+    if name.endswith(_FULL_SNAPSHOT_SUFFIX) or name.endswith(".tar.gz") or name.endswith(".tgz"):
+        return "tar"
+    # Fall back to magic-byte sniffing so operators can rename files.
+    try:
+        with path.open("rb") as fh:
+            magic = fh.read(4)
+    except OSError as exc:
+        raise ValueError(f"cannot read snapshot at {path}: {exc}") from exc
+    if magic.startswith(b"SQLite"):
+        return "db"
+    if magic[:2] == b"\x1f\x8b":
+        # Could be a raw gzipped DB or a tar.gz. Peek inside.
+        try:
+            with tarfile.open(path, mode="r:gz"):
+                return "tar"
+        except tarfile.TarError:
+            return "db"
+    raise ValueError(f"unrecognized snapshot format: {path}")
+
+
+def _online_backup_to_plain_file(source_db: Path, dest: Path) -> None:
+    """Use SQLite's online backup API to copy ``source_db`` -> ``dest``."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    src = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+    try:
+        dst = sqlite3.connect(dest)
+        try:
+            src.backup(dst)
+        finally:
+            dst.close()
+    finally:
+        src.close()
+
+
+def _gzip_file(src: Path, dest_gz: Path) -> None:
+    dest_gz.parent.mkdir(parents=True, exist_ok=True)
+    with src.open("rb") as fin, gzip.open(dest_gz, "wb") as fout:
+        shutil.copyfileobj(fin, fout)
+
+
+def _gunzip_file(src_gz: Path, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(src_gz, "rb") as fin, dest.open("wb") as fout:
+        shutil.copyfileobj(fin, fout)
+
+
+# --------------------------------------------------------------------- #
+# Retention
+# --------------------------------------------------------------------- #
+
+
+def _list_db_snapshots(backup_dir: Path) -> list[Path]:
+    if not backup_dir.exists():
+        return []
+    out: list[Path] = []
+    for child in backup_dir.iterdir():
+        if not child.is_file():
+            continue
+        if child.name.startswith(_DB_SNAPSHOT_PREFIX) and child.name.endswith(_DB_SNAPSHOT_SUFFIX):
+            out.append(child)
+    # Oldest first so retention pruning is a simple slice.
+    out.sort(key=lambda p: p.stat().st_mtime)
+    return out
+
+
+def _prune_db_snapshots(backup_dir: Path, keep: int) -> list[Path]:
+    """Delete db snapshots past ``keep``. Returns the deleted paths."""
+    if keep < 0:
+        raise ValueError("keep must be >= 0")
+    snapshots = _list_db_snapshots(backup_dir)
+    if len(snapshots) <= keep:
+        return []
+    to_delete = snapshots[: len(snapshots) - keep]
+    deleted: list[Path] = []
+    for path in to_delete:
+        try:
+            path.unlink()
+            deleted.append(path)
+        except OSError:
+            # Best-effort — leave stragglers in place rather than
+            # failing the whole backup.
+            continue
+    return deleted
+
+
+# --------------------------------------------------------------------- #
+# Public API — backup
+# --------------------------------------------------------------------- #
+
+
+def backup_state_db(
+    state_db: Path,
+    *,
+    base_dir: Path,
+    output: Path | None = None,
+    full: bool = False,
+    keep: int = DEFAULT_KEEP,
+    extra_roots: list[Path] | None = None,
+) -> BackupResult:
+    """Snapshot ``state_db`` to the backup directory (or ``output``).
+
+    Parameters
+    ----------
+    state_db:
+        Path to the live SQLite DB (typically ``~/.pollypm/state.db``).
+    base_dir:
+        The ``config.project.base_dir`` — used to locate the default
+        backup directory and, for ``--full``, to pick up logs /
+        snapshots / agent homes that live under it.
+    output:
+        Optional custom destination path. Directories are created.
+        When ``full`` is True the output is interpreted as a
+        ``.tar.gz`` path; otherwise as a ``.db.gz`` path.
+    full:
+        If True, create a tar.gz that bundles the DB snapshot plus the
+        contents of ``base_dir`` and any ``extra_roots``.
+    keep:
+        Retention count for plain DB snapshots. Ignored when ``full``.
+    extra_roots:
+        Additional paths to include in a ``--full`` archive. Missing
+        paths are silently skipped.
+    """
+    if not state_db.exists():
+        raise FileNotFoundError(f"state.db not found at {state_db}")
+
+    db_size_before = _size_or_zero(state_db)
+    backup_dir = _default_backup_dir(base_dir)
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = _timestamp()
+
+    if full:
+        # Stage the DB snapshot into a temp file, then pack everything
+        # into a tar.gz. We keep the DB inside the archive under a
+        # stable path (``state.db``) so ``pm restore`` can find it
+        # without knowing the original hostname / timestamp.
+        if output is not None:
+            archive_path = output
+        else:
+            archive_path = backup_dir / f"{_FULL_SNAPSHOT_PREFIX}{timestamp}{_FULL_SNAPSHOT_SUFFIX}"
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with tempfile.TemporaryDirectory() as staging:
+            staging_db = Path(staging) / "state.db"
+            _online_backup_to_plain_file(state_db, staging_db)
+
+            with tarfile.open(archive_path, mode="w:gz") as tar:
+                tar.add(staging_db, arcname="state.db")
+                # Bundle the base_dir tree — but skip the ``backups/``
+                # subdir so archives don't grow recursively each run.
+                if base_dir.exists():
+                    for child in sorted(base_dir.iterdir()):
+                        if child.resolve() == backup_dir.resolve():
+                            continue
+                        if child.resolve() == state_db.resolve():
+                            # Already captured as the online backup
+                            continue
+                        tar.add(child, arcname=f"base/{child.name}")
+                for extra in extra_roots or []:
+                    if not extra.exists():
+                        continue
+                    tar.add(extra, arcname=f"extra/{extra.name}")
+
+        return BackupResult(
+            path=archive_path,
+            db_size_before=db_size_before,
+            archive_size=_size_or_zero(archive_path),
+            pruned=[],
+            full=True,
+        )
+
+    # Plain DB snapshot path.
+    if output is not None:
+        snapshot_path = output
+    else:
+        snapshot_path = backup_dir / f"{_DB_SNAPSHOT_PREFIX}{timestamp}{_DB_SNAPSHOT_SUFFIX}"
+    snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as staging:
+        staging_db = Path(staging) / "state.db"
+        _online_backup_to_plain_file(state_db, staging_db)
+        _gzip_file(staging_db, snapshot_path)
+
+    pruned: list[Path] = []
+    # Only prune the default backup dir. If the user wrote a snapshot
+    # to a custom ``--output`` we leave their file layout alone.
+    if output is None:
+        pruned = _prune_db_snapshots(backup_dir, keep)
+
+    return BackupResult(
+        path=snapshot_path,
+        db_size_before=db_size_before,
+        archive_size=_size_or_zero(snapshot_path),
+        pruned=pruned,
+        full=False,
+    )
+
+
+# --------------------------------------------------------------------- #
+# Public API — restore
+# --------------------------------------------------------------------- #
+
+
+def plan_restore(snapshot_path: Path, live_db: Path) -> RestorePlan:
+    """Validate the snapshot and describe what would happen.
+
+    Raises ``FileNotFoundError`` / ``ValueError`` on invalid input.
+    Does NOT touch the filesystem.
+    """
+    if not snapshot_path.exists():
+        raise FileNotFoundError(f"snapshot not found: {snapshot_path}")
+
+    kind = _classify_snapshot(snapshot_path)
+
+    # Verify the snapshot is actually well-formed. For gzipped DBs we
+    # have to decompress into a temp file to run the sqlite header +
+    # schema_version probe.
+    if kind == "db":
+        if snapshot_path.suffix == ".gz":
+            with tempfile.TemporaryDirectory() as staging:
+                decompressed = Path(staging) / "probe.db"
+                try:
+                    _gunzip_file(snapshot_path, decompressed)
+                except OSError as exc:
+                    raise ValueError(f"failed to decompress snapshot: {exc}") from exc
+                if not _is_valid_sqlite_file(decompressed):
+                    raise ValueError(
+                        f"snapshot is not a valid SQLite database: {snapshot_path}"
+                    )
+        else:
+            if not _is_valid_sqlite_file(snapshot_path):
+                raise ValueError(
+                    f"snapshot is not a valid SQLite database: {snapshot_path}"
+                )
+    else:  # tar
+        if not _is_valid_tar_gz(snapshot_path):
+            raise ValueError(f"snapshot is not a valid tar.gz: {snapshot_path}")
+        # Ensure it contains a state.db member.
+        with tarfile.open(snapshot_path, mode="r:gz") as tar:
+            names = tar.getnames()
+        if "state.db" not in names:
+            raise ValueError(
+                f"full backup is missing state.db at the archive root: {snapshot_path}"
+            )
+
+    safety_path = live_db.with_name(f"{live_db.name}.before-restore-{_timestamp()}")
+    return RestorePlan(
+        snapshot_path=snapshot_path,
+        live_db_path=live_db,
+        safety_path=safety_path,
+        is_tar=(kind == "tar"),
+    )
+
+
+def execute_restore(plan: RestorePlan) -> RestoreResult:
+    """Apply ``plan``: safety-snapshot the live DB, then replace it.
+
+    Caller is responsible for having stopped the cockpit first. This
+    function does NOT attempt to stop anything.
+    """
+    live_db = plan.live_db_path
+    snapshot = plan.snapshot_path
+    safety = plan.safety_path
+
+    # 1. Safety snapshot of the live DB (if present). This runs BEFORE
+    #    we touch anything, so an operator who aborts mid-restore
+    #    still has the pre-restore state.
+    if live_db.exists():
+        safety.parent.mkdir(parents=True, exist_ok=True)
+        # Use the online backup API when possible so we don't race
+        # with any lingering writers. Fall back to copy2 if it isn't
+        # a valid SQLite DB anymore (e.g. it's already truncated).
+        try:
+            _online_backup_to_plain_file(live_db, safety)
+        except sqlite3.DatabaseError:
+            shutil.copy2(live_db, safety)
+
+    # 2. Materialize the snapshot into a plain file we can move into
+    #    place.
+    live_db.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as staging:
+        staged_db = Path(staging) / "restored.db"
+
+        if plan.is_tar:
+            with tarfile.open(snapshot, mode="r:gz") as tar:
+                member = tar.getmember("state.db")
+                extracted = tar.extractfile(member)
+                if extracted is None:
+                    raise RuntimeError("tarfile could not open state.db entry")
+                with staged_db.open("wb") as fout:
+                    shutil.copyfileobj(extracted, fout)
+        elif snapshot.suffix == ".gz":
+            _gunzip_file(snapshot, staged_db)
+        else:
+            shutil.copy2(snapshot, staged_db)
+
+        # 3. Atomic-ish replace. On POSIX ``os.replace`` is atomic on
+        #    the same filesystem; the tempdir is in /tmp which may
+        #    differ, so we copy into place instead.
+        shutil.copy2(staged_db, live_db)
+
+    # 4. Clean up WAL / SHM sidecars from the old DB — they belong to
+    #    the previous transaction log and would confuse SQLite after
+    #    we've swapped in a cold snapshot. Best-effort.
+    for sidecar in (
+        live_db.with_name(live_db.name + "-wal"),
+        live_db.with_name(live_db.name + "-shm"),
+    ):
+        try:
+            if sidecar.exists():
+                sidecar.unlink()
+        except OSError:
+            pass
+
+    return RestoreResult(
+        snapshot_path=snapshot,
+        live_db_path=live_db,
+        safety_path=safety,
+        is_tar=plan.is_tar,
+    )
+
+
+# --------------------------------------------------------------------- #
+# Utility used by ``pm backup`` summary text
+# --------------------------------------------------------------------- #
+
+
+def humanize_bytes(n: int) -> str:
+    """Return a compact human-readable size for CLI output."""
+    if n < 1024:
+        return f"{n} B"
+    size = float(n)
+    for unit in ("KB", "MB", "GB", "TB"):
+        size /= 1024.0
+        if size < 1024.0 or unit == "TB":
+            return f"{size:.2f} {unit}"
+    return f"{n} B"
+
+
+__all__ = [
+    "BackupResult",
+    "RestorePlan",
+    "RestoreResult",
+    "DEFAULT_KEEP",
+    "backup_state_db",
+    "plan_restore",
+    "execute_restore",
+    "humanize_bytes",
+]

--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -2255,3 +2255,164 @@ def upgrade(
             if actions:
                 typer.echo(f"  [{key}] {len(actions)} doc(s) updated")
     typer.echo(f"Upgrade to {latest} complete. Running sessions are unaffected — restart with `pm reset && pm up` when ready.")
+
+
+# --------------------------------------------------------------------- #
+# pm backup / pm restore — disaster-recovery helpers.
+#
+# The CLI layer stays thin: it resolves paths from config, formats
+# output, and handles Typer exits. All IO + safety logic lives in
+# :mod:`pollypm.backup`.
+# --------------------------------------------------------------------- #
+
+
+@app.command("backup")
+def backup_cmd(
+    output: Path | None = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Custom destination path for the snapshot. Default: ~/.pollypm/backups/state-db-<ts>.db.gz",
+    ),
+    full: bool = typer.Option(
+        False,
+        "--full",
+        help="Bundle state.db + ~/.pollypm/ tree into a single .tar.gz. Not subject to retention.",
+    ),
+    keep: int = typer.Option(
+        None,
+        "--keep",
+        help="Keep N most recent DB snapshots; prune the rest. Ignored with --full.",
+    ),
+    config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
+) -> None:
+    """Snapshot ~/.pollypm/state.db using SQLite's online backup API.
+
+    Safe to run while the cockpit + heartbeat are live. Default output
+    is a gzipped DB snapshot; pass ``--full`` to also bundle config /
+    logs / agent homes.
+    """
+    from pollypm import backup as backup_mod
+
+    try:
+        config = load_config(config_path)
+    except FileNotFoundError:
+        typer.echo(f"Config not found at {config_path}. Run `pm` to onboard first.", err=True)
+        raise typer.Exit(code=1)
+
+    state_db = config.project.state_db
+    base_dir = config.project.base_dir
+    keep_value = backup_mod.DEFAULT_KEEP if keep is None else keep
+
+    try:
+        result = backup_mod.backup_state_db(
+            state_db,
+            base_dir=base_dir,
+            output=output,
+            full=full,
+            keep=keep_value,
+        )
+    except FileNotFoundError as exc:
+        typer.echo(f"Backup failed: {exc}", err=True)
+        raise typer.Exit(code=1)
+    except Exception as exc:
+        typer.echo(f"Backup failed: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    before = backup_mod.humanize_bytes(result.db_size_before)
+    after = backup_mod.humanize_bytes(result.archive_size)
+    typer.echo(f"Backed up to {result.path}. DB size before: {before}. Archive size: {after}.")
+    if result.pruned:
+        typer.echo(f"Pruned {len(result.pruned)} older snapshot(s) (keep={keep_value}).")
+
+
+@app.command("restore")
+def restore_cmd(
+    snapshot_path: Path = typer.Argument(..., help="Path to a .db.gz DB snapshot or --full .tar.gz archive."),
+    confirm: bool = typer.Option(
+        False,
+        "--confirm",
+        help="Required to actually replace the live DB. Without this flag, restore refuses.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Describe what would happen without touching any files.",
+    ),
+    config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
+) -> None:
+    """Restore state.db from a snapshot produced by ``pm backup``.
+
+    Creates a ``.before-restore-<ts>`` sibling copy of the live DB
+    before replacing it — even with ``--confirm``. You must stop the
+    cockpit first (``pm reset`` / detach the tmux session); this
+    command will not do it for you.
+    """
+    from pollypm import backup as backup_mod
+
+    try:
+        config = load_config(config_path)
+    except FileNotFoundError:
+        typer.echo(f"Config not found at {config_path}. Run `pm` to onboard first.", err=True)
+        raise typer.Exit(code=1)
+
+    live_db = config.project.state_db
+
+    try:
+        plan = backup_mod.plan_restore(snapshot_path, live_db)
+    except FileNotFoundError as exc:
+        typer.echo(f"Restore failed: {exc}", err=True)
+        raise typer.Exit(code=1)
+    except ValueError as exc:
+        typer.echo(f"Restore failed: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    if dry_run:
+        typer.echo("Dry run — no files will be touched.")
+        typer.echo(f"  snapshot:      {plan.snapshot_path}")
+        typer.echo(f"  live DB:       {plan.live_db_path}")
+        typer.echo(f"  safety copy:   {plan.safety_path}")
+        typer.echo(f"  snapshot kind: {'full tar.gz' if plan.is_tar else 'db snapshot'}")
+        return
+
+    if not confirm:
+        session_name = config.project.tmux_session
+        typer.echo("Restore refused — this replaces the live state.db.")
+        typer.echo("")
+        typer.echo("Before you proceed:")
+        typer.echo(f"  1. Stop the cockpit: `tmux kill-session -t {session_name}` (or `pm reset`).")
+        typer.echo(f"  2. Re-run with `--confirm`:")
+        typer.echo(f"       pm restore {snapshot_path} --confirm")
+        typer.echo("")
+        typer.echo(
+            "A safety copy of the live DB will be written to "
+            f"{plan.safety_path} before anything is replaced."
+        )
+        raise typer.Exit(code=1)
+
+    # Soft warning if the cockpit session is visibly running. We don't
+    # refuse — operators sometimes want to stomp in a recovery
+    # scenario — but we do surface the state so it's an informed
+    # choice.
+    try:
+        if probe_session(config.project.tmux_session):
+            typer.echo(
+                f"WARNING: tmux session '{config.project.tmux_session}' appears to still be running. "
+                "Stop it first or the restored DB may be overwritten by the live cockpit."
+            )
+    except Exception:
+        # probe_session failures are non-fatal for the restore itself.
+        pass
+
+    try:
+        result = backup_mod.execute_restore(plan)
+    except Exception as exc:
+        typer.echo(f"Restore failed mid-flight: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    typer.echo(f"Restored {result.live_db_path} from {result.snapshot_path}.")
+    typer.echo(f"Safety copy of the previous live DB: {result.safety_path}")
+    typer.echo("")
+    typer.echo("Next steps:")
+    typer.echo("  pm up                  # relaunch the cockpit")
+    typer.echo("  pm doctor              # verify the restored state")

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -1,0 +1,419 @@
+"""Tests for ``pm backup`` + ``pm restore`` and the underlying
+:mod:`pollypm.backup` module.
+
+Coverage target (from the issue spec):
+
+1. ``pm backup`` creates a gzipped snapshot at the expected path.
+2. Backup is a valid SQLite DB (can open + query).
+3. Retention prunes older backups past ``--keep N``.
+4. ``--full`` creates a tar.gz with the expected contents.
+5. ``pm restore <path>`` without ``--confirm`` refuses + prints guidance.
+6. ``pm restore <path> --confirm`` writes a .before-restore sibling
+   and replaces live DB.
+7. ``pm restore --dry-run`` prints what would happen without touching
+   files.
+8. Invalid snapshot path → error + exit 1.
+9. Corrupt snapshot (not a valid SQLite) → error + exit 1.
+"""
+
+from __future__ import annotations
+
+import gzip
+import sqlite3
+import tarfile
+import time
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm import backup as backup_mod
+from pollypm.cli import app as root_app
+
+
+runner = CliRunner()
+
+
+# --------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------- #
+
+
+def _seed_state_db(path: Path) -> None:
+    """Create a tiny SQLite DB with one row so snapshots have content."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("CREATE TABLE IF NOT EXISTS probe (k TEXT PRIMARY KEY, v TEXT)")
+        conn.execute("INSERT OR REPLACE INTO probe(k, v) VALUES (?, ?)", ("hello", "world"))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path) -> Path:
+    """A ``base_dir`` root that mimics ``~/.pollypm/``."""
+    base = tmp_path / ".pollypm"
+    base.mkdir()
+    return base
+
+
+@pytest.fixture
+def state_db(fake_home: Path) -> Path:
+    db = fake_home / "state.db"
+    _seed_state_db(db)
+    return db
+
+
+@pytest.fixture
+def pollypm_config(tmp_path: Path, fake_home: Path, state_db: Path) -> Path:
+    """Minimal pollypm.toml that points at ``fake_home`` / ``state_db``.
+
+    We keep ``tmux_session`` set to something invented so the soft
+    probe in ``pm restore`` can't accidentally match a real session
+    on the developer machine.
+    """
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "PollyPM-Test"',
+                'tmux_session = "pollypm-backup-test-session-does-not-exist"',
+                f'workspace_root = "{tmp_path}"',
+                f'base_dir = "{fake_home}"',
+                f'logs_dir = "{fake_home}/logs"',
+                f'snapshots_dir = "{fake_home}/snapshots"',
+                f'state_db = "{state_db}"',
+                "",
+                "[pollypm]",
+                'controller_account = "claude_test"',
+                "",
+                "[accounts.claude_test]",
+                'provider = "claude"',
+                'email = "test@example.com"',
+                "",
+            ]
+        )
+    )
+    return config_path
+
+
+def _invoke(*args: str) -> "CliRunner.invoke":  # type: ignore[name-defined]
+    return runner.invoke(root_app, list(args))
+
+
+def _backup(config_path: Path, *extra: str):
+    return _invoke("backup", "--config", str(config_path), *extra)
+
+
+def _restore(config_path: Path, snapshot: Path, *extra: str):
+    return _invoke("restore", str(snapshot), "--config", str(config_path), *extra)
+
+
+# --------------------------------------------------------------------- #
+# 1 + 2. pm backup creates a gzipped snapshot; it's a valid SQLite DB.
+# --------------------------------------------------------------------- #
+
+
+def test_pm_backup_creates_gzipped_snapshot_at_expected_path(
+    pollypm_config: Path, fake_home: Path
+) -> None:
+    result = _backup(pollypm_config)
+    assert result.exit_code == 0, result.output
+    backups_dir = fake_home / "backups"
+    assert backups_dir.exists(), f"expected backup dir at {backups_dir}"
+    snapshots = sorted(backups_dir.glob("state-db-*.db.gz"))
+    assert len(snapshots) == 1, f"expected 1 snapshot, found {snapshots}"
+
+    # Path name must be in the CLI summary.
+    assert str(snapshots[0]) in result.output
+    assert "DB size before:" in result.output
+    assert "Archive size:" in result.output
+
+
+def test_backup_is_a_valid_sqlite_db_after_decompression(
+    pollypm_config: Path, fake_home: Path, tmp_path: Path
+) -> None:
+    result = _backup(pollypm_config)
+    assert result.exit_code == 0, result.output
+
+    snapshot = next((fake_home / "backups").glob("state-db-*.db.gz"))
+    decompressed = tmp_path / "probe.db"
+    with gzip.open(snapshot, "rb") as fin, decompressed.open("wb") as fout:
+        fout.write(fin.read())
+
+    conn = sqlite3.connect(decompressed)
+    try:
+        # Our seed row from the fixture must round-trip.
+        row = conn.execute("SELECT v FROM probe WHERE k = ?", ("hello",)).fetchone()
+        assert row == ("world",)
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------- #
+# 3. Retention prunes older backups past --keep N.
+# --------------------------------------------------------------------- #
+
+
+def test_retention_prunes_older_backups_past_keep(
+    pollypm_config: Path, fake_home: Path
+) -> None:
+    backups_dir = fake_home / "backups"
+    backups_dir.mkdir(parents=True, exist_ok=True)
+
+    # Seed 4 fake "old" snapshots with staggered mtimes so we can
+    # reason about which ones survive. The newest `backup` run will
+    # produce a 5th file, and with --keep 2 we expect only the 2
+    # newest to remain.
+    now = time.time()
+    old_files: list[Path] = []
+    for i in range(4):
+        p = backups_dir / f"state-db-2020010{i}-010203.db.gz"
+        p.write_bytes(b"not-a-real-backup")
+        import os
+
+        os.utime(p, (now - (100 - i), now - (100 - i)))
+        old_files.append(p)
+
+    result = _backup(pollypm_config, "--keep", "2")
+    assert result.exit_code == 0, result.output
+
+    remaining = sorted((fake_home / "backups").glob("state-db-*.db.gz"))
+    assert len(remaining) == 2, f"expected 2 snapshots post-prune, got {remaining}"
+
+    # The brand-new snapshot (mtime ~= now) is always among the
+    # survivors. The second survivor is the youngest of the seeded
+    # pre-existing files.
+    assert old_files[3] in remaining or any(
+        r.stat().st_mtime >= old_files[3].stat().st_mtime for r in remaining
+    )
+    # The two oldest seeded files must be gone.
+    assert not old_files[0].exists()
+    assert not old_files[1].exists()
+
+
+# --------------------------------------------------------------------- #
+# 4. --full creates a tar.gz with the expected contents.
+# --------------------------------------------------------------------- #
+
+
+def test_full_backup_creates_tar_gz_with_expected_contents(
+    pollypm_config: Path, fake_home: Path
+) -> None:
+    # Drop a couple of files into the base_dir so we can assert they
+    # come along for the ride.
+    (fake_home / "logs").mkdir(exist_ok=True)
+    (fake_home / "logs" / "heartbeat.log").write_text("tick\n")
+    (fake_home / "snapshots").mkdir(exist_ok=True)
+    (fake_home / "snapshots" / "snap.txt").write_text("frozen\n")
+
+    result = _backup(pollypm_config, "--full")
+    assert result.exit_code == 0, result.output
+
+    archives = list((fake_home / "backups").glob("full-*.tar.gz"))
+    assert len(archives) == 1, f"expected 1 full archive, got {archives}"
+
+    with tarfile.open(archives[0], mode="r:gz") as tar:
+        names = set(tar.getnames())
+
+    # state.db is always at the archive root (restore looks for it there).
+    assert "state.db" in names
+    # Other base_dir contents are preserved under base/.
+    assert any(n.startswith("base/logs") for n in names), names
+    assert any(n.startswith("base/snapshots") for n in names), names
+    # The backups/ subdir itself must NOT be inside the archive
+    # (otherwise each run would grow quadratically).
+    assert not any(n.startswith("base/backups") for n in names), names
+
+
+# --------------------------------------------------------------------- #
+# 5. pm restore without --confirm refuses.
+# --------------------------------------------------------------------- #
+
+
+def test_restore_without_confirm_refuses_and_prints_guidance(
+    pollypm_config: Path, fake_home: Path
+) -> None:
+    backup_result = _backup(pollypm_config)
+    assert backup_result.exit_code == 0, backup_result.output
+    snapshot = next((fake_home / "backups").glob("state-db-*.db.gz"))
+
+    result = _restore(pollypm_config, snapshot)
+    assert result.exit_code == 1, result.output
+    assert "refused" in result.output.lower() or "confirm" in result.output.lower()
+    # Guidance must reference the --confirm flag and tmux kill-session.
+    assert "--confirm" in result.output
+    assert "tmux" in result.output or "pm reset" in result.output
+
+    # No safety copy should have been written yet — we refused.
+    assert not list(fake_home.glob("state.db.before-restore-*"))
+
+
+# --------------------------------------------------------------------- #
+# 6. pm restore --confirm writes a .before-restore sibling and replaces DB.
+# --------------------------------------------------------------------- #
+
+
+def test_restore_with_confirm_saves_safety_copy_and_replaces_db(
+    pollypm_config: Path, fake_home: Path, state_db: Path
+) -> None:
+    # Take a clean baseline snapshot.
+    backup_result = _backup(pollypm_config)
+    assert backup_result.exit_code == 0, backup_result.output
+    snapshot = next((fake_home / "backups").glob("state-db-*.db.gz"))
+
+    # Mutate the live DB so we can tell the restore actually reverted it.
+    conn = sqlite3.connect(state_db)
+    try:
+        conn.execute("UPDATE probe SET v = ? WHERE k = ?", ("mutated", "hello"))
+        conn.commit()
+    finally:
+        conn.close()
+
+    result = _restore(pollypm_config, snapshot, "--confirm")
+    assert result.exit_code == 0, result.output
+
+    # Safety sibling must exist and contain the MUTATED value (it is
+    # a snapshot of the live DB *before* we restored).
+    safeties = list(fake_home.glob("state.db.before-restore-*"))
+    assert len(safeties) == 1, safeties
+    safety_conn = sqlite3.connect(safeties[0])
+    try:
+        row = safety_conn.execute(
+            "SELECT v FROM probe WHERE k = ?", ("hello",)
+        ).fetchone()
+        assert row == ("mutated",), "safety copy should hold pre-restore state"
+    finally:
+        safety_conn.close()
+
+    # Live DB must now reflect the snapshot — back to "world".
+    live_conn = sqlite3.connect(state_db)
+    try:
+        row = live_conn.execute(
+            "SELECT v FROM probe WHERE k = ?", ("hello",)
+        ).fetchone()
+        assert row == ("world",), "live DB should have been rolled back"
+    finally:
+        live_conn.close()
+
+    assert "Restored" in result.output
+    assert str(safeties[0]) in result.output
+
+
+# --------------------------------------------------------------------- #
+# 7. pm restore --dry-run prints plan without touching files.
+# --------------------------------------------------------------------- #
+
+
+def test_restore_dry_run_does_not_touch_files(
+    pollypm_config: Path, fake_home: Path, state_db: Path
+) -> None:
+    backup_result = _backup(pollypm_config)
+    assert backup_result.exit_code == 0, backup_result.output
+    snapshot = next((fake_home / "backups").glob("state-db-*.db.gz"))
+
+    live_mtime_before = state_db.stat().st_mtime
+    live_size_before = state_db.stat().st_size
+
+    result = _restore(pollypm_config, snapshot, "--dry-run")
+    assert result.exit_code == 0, result.output
+    assert "Dry run" in result.output
+    assert str(snapshot) in result.output
+    assert str(state_db) in result.output
+
+    # No .before-restore safety copy should have been written.
+    assert not list(fake_home.glob("state.db.before-restore-*"))
+    # Live DB must be untouched.
+    assert state_db.stat().st_mtime == live_mtime_before
+    assert state_db.stat().st_size == live_size_before
+
+
+# --------------------------------------------------------------------- #
+# 8. Invalid snapshot path → error + exit 1.
+# --------------------------------------------------------------------- #
+
+
+def test_restore_nonexistent_snapshot_errors_and_exits_one(
+    pollypm_config: Path, tmp_path: Path
+) -> None:
+    bogus = tmp_path / "does-not-exist.db.gz"
+    result = _restore(pollypm_config, bogus, "--confirm")
+    assert result.exit_code == 1, result.output
+    assert "not found" in result.output.lower() or "failed" in result.output.lower()
+
+
+# --------------------------------------------------------------------- #
+# 9. Corrupt snapshot (not a valid SQLite) → error + exit 1.
+# --------------------------------------------------------------------- #
+
+
+def test_restore_corrupt_snapshot_errors_and_exits_one(
+    pollypm_config: Path, tmp_path: Path
+) -> None:
+    # A .db.gz whose decompressed contents aren't SQLite at all.
+    corrupt = tmp_path / "state-db-00000000-000000.db.gz"
+    with gzip.open(corrupt, "wb") as fout:
+        fout.write(b"this is not a sqlite database")
+
+    result = _restore(pollypm_config, corrupt, "--confirm")
+    assert result.exit_code == 1, result.output
+    assert "valid" in result.output.lower() or "failed" in result.output.lower()
+
+
+# --------------------------------------------------------------------- #
+# Library-level checks that don't go through the CLI — these catch
+# regressions in backup.py directly.
+# --------------------------------------------------------------------- #
+
+
+def test_backup_module_output_flag_writes_to_custom_path(
+    fake_home: Path, state_db: Path, tmp_path: Path
+) -> None:
+    custom = tmp_path / "custom" / "mine.db.gz"
+    result = backup_mod.backup_state_db(
+        state_db,
+        base_dir=fake_home,
+        output=custom,
+        full=False,
+        keep=7,
+    )
+    assert result.path == custom
+    assert custom.exists()
+
+
+def test_backup_module_retention_prunes_only_default_dir(
+    fake_home: Path, state_db: Path, tmp_path: Path
+) -> None:
+    # Seed many "old" snapshots in the default backup dir.
+    backups_dir = fake_home / "backups"
+    backups_dir.mkdir(parents=True, exist_ok=True)
+    import os
+
+    now = time.time()
+    for i in range(10):
+        p = backups_dir / f"state-db-2020010{i}-010203.db.gz"
+        p.write_bytes(b"x")
+        os.utime(p, (now - (1000 - i), now - (1000 - i)))
+
+    result = backup_mod.backup_state_db(
+        state_db, base_dir=fake_home, full=False, keep=3
+    )
+    assert len(result.pruned) >= 8  # 11 total pre-prune, minus 3 survivors
+    remaining = list(backups_dir.glob("state-db-*.db.gz"))
+    assert len(remaining) == 3
+
+
+def test_plan_restore_rejects_full_archive_missing_state_db(
+    fake_home: Path, tmp_path: Path
+) -> None:
+    broken = tmp_path / "busted.tar.gz"
+    with tarfile.open(broken, mode="w:gz") as tar:
+        junk = tmp_path / "junk.txt"
+        junk.write_text("hi")
+        tar.add(junk, arcname="junk.txt")
+
+    with pytest.raises(ValueError):
+        backup_mod.plan_restore(broken, fake_home / "state.db")


### PR DESCRIPTION
Disaster recovery. Snapshot state.db online (safe while heartbeat runs). Restore with safety net.

## pm backup
- Default: gzipped snapshot at `~/.pollypm/backups/state-db-<ts>.db.gz` via SQLite online backup API
- `--full` — tar.gz of state.db + full `.pollypm/` tree (config / logs / agent homes). NOT subject to retention.
- `--output <path>` — custom destination
- `--keep N` — retention (default 7). Ignored with --full.

## pm restore <snapshot>
- Requires `--confirm` to actually replace (refuses without)
- ALWAYS writes `.before-restore-<ts>` sibling copy first — even with --confirm
- Unlinks WAL/SHM sidecars after restore (don't replay old transaction log)
- `--dry-run` describes without touching
- Validates snapshot as SQLite OR tar.gz magic-bytes
- Does NOT stop cockpit — user must do that first (safer)

## Files (3)
- src/pollypm/backup.py (new) — backup_state_db / plan_restore / execute_restore / retention pruning / SQLite + tar.gz validation
- src/pollypm/cli.py — thin typer commands mapping module exceptions to Exit(1)
- tests/test_backup_restore.py (new) — 12 tests, stdlib-only

## Tests (+12, 0 regressions)
All 12 targeted tests pass.

## Impl notes
- `sqlite3.Connection.backup()` into tmp → gzip. Concurrent-safe.
- Safety snapshot uses same online API; falls back to shutil.copy2 if live DB is corrupt.
- `--full` skips backups/ subdir to prevent quadratic archive growth.
- Stdlib only. No new deps.