### PR TITLE
feat(heartbeat): worktree state audit handler (#251)

### DIFF
--- a/src/pollypm/plugins_builtin/core_recurring/plugin.py
+++ b/src/pollypm/plugins_builtin/core_recurring/plugin.py
@@ -701,6 +701,365 @@ def agent_worktree_prune_handler(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def worktree_state_audit_handler(payload: dict[str, Any]) -> dict[str, Any]:
+    """Classify every active worker-session worktree + surface blockers (#251).
+
+    Complements the hourly ``agent_worktree.prune`` handler (which GCs
+    orphans) with a 10-minute *state* sweep over the
+    ``work_sessions`` rows the session-manager owns. For each row with
+    a ``worktree_path`` we classify the worktree via
+    ``pollypm.worktree_audit.classify_worktree_state`` and act:
+
+    * ``merge_conflict`` → open ``worktree_state:<task>:merge_conflict``
+      alert (severity ``error``) AND, if the task is claimed, emit a
+      blocking inbox task via the same work-service path ``pm notify``
+      uses so the user sees it immediately.
+    * ``lock_file`` → alert ``worktree_state:<task>:lock_file``. Age
+      <5min → ``warn``; ≥5min → ``error`` (escalated).
+    * ``detached_head`` → alert ``worktree_state:<task>:detached_head``
+      (``warn``). No inbox — the heartbeat reprompt path handles
+      recovery.
+    * ``dirty_expected`` → tracked but silent *unless* the worktree's
+      mtime is >60 min old, in which case a low-severity
+      ``worktree_state:<task>:dirty_stale`` alert fires. The
+      staleness test uses the directory mtime because git operations
+      bump it — we stay silent while the worker is still typing.
+    * ``orphan_branch`` → inbox nudge (``routine`` priority) once per
+      task per sweep-dedup window. Alert also raised for cockpit
+      visibility.
+    * ``clean`` → any open ``worktree_state:<task>:*`` alerts are
+      cleared.
+
+    All alerts are keyed by ``(session_name, worktree_state:<task>:<st>)``
+    so the ``upsert_alert`` uniqueness guard auto-dedupes repeat
+    observations and ``clear_alert`` can resolve them when the state
+    flips back to ``clean``.
+
+    Returns a summary of counts for the job-result ledger — no per-
+    worktree detail to keep the event row small.
+    """
+    import time as _time
+
+    from pollypm.worktree_audit import (
+        WorktreeState,
+        classify_worktree_state,
+    )
+
+    config, store = _load_config_and_store(payload)
+
+    # Work service — required to list active work_sessions. Open via
+    # the same path ``work.progress_sweep`` uses so we honour the
+    # workspace-root DB convention.
+    try:
+        from pollypm.work.sqlite_service import SQLiteWorkService
+
+        project_root = config.project.root_dir
+        db_path = project_root / ".pollypm" / "state.db"
+        work = SQLiteWorkService(db_path=db_path, project_path=project_root)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "worktree.state_audit: work service unavailable", exc_info=True,
+        )
+        return {"outcome": "skipped", "reason": "no_work_service"}
+
+    # All alert types this handler owns — used to clear stale alerts
+    # when we transition into ``CLEAN``. Keep in sync with the
+    # branches below.
+    STATE_ALERT_TYPES: tuple[str, ...] = (
+        "merge_conflict", "lock_file", "detached_head",
+        "dirty_stale", "orphan_branch",
+    )
+
+    considered = 0
+    classified: dict[str, int] = {}
+    alerts_raised = 0
+    alerts_cleared = 0
+    inbox_emitted = 0
+
+    # Thresholds — kept local (no config knob yet) so they're explicit
+    # in the handler body for reviewers.
+    LOCK_ESCALATE_SECONDS = 5 * 60       # lock >5min → severity error
+    DIRTY_STALE_SECONDS = 60 * 60        # dirty + mtime > 60min → alert
+
+    now_epoch = _time.time()
+
+    try:
+        try:
+            sessions = work.list_worker_sessions(active_only=True)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "worktree.state_audit: list_worker_sessions failed",
+                exc_info=True,
+            )
+            return {"outcome": "failed", "reason": "list_sessions_error"}
+
+        for sess in sessions:
+            wt_path_raw = getattr(sess, "worktree_path", None)
+            if not wt_path_raw:
+                continue
+            considered += 1
+            wt_path = Path(wt_path_raw)
+            task_id = f"{sess.task_project}/{sess.task_number}"
+            agent = sess.agent_name or "worker"
+            # The alert namespace is the agent session name so the
+            # cockpit's per-session view shows the blocker alongside
+            # other heartbeat-raised alerts.
+            session_key = agent
+
+            try:
+                classification = classify_worktree_state(wt_path)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "worktree.state_audit: classify failed for %s",
+                    wt_path, exc_info=True,
+                )
+                continue
+            state = classification.state
+            classified[state.value] = classified.get(state.value, 0) + 1
+
+            # Resolve the all-clear path for CLEAN / MISSING so any
+            # prior alerts auto-close.
+            if state in (WorktreeState.CLEAN, WorktreeState.MISSING):
+                for kind in STATE_ALERT_TYPES:
+                    alert_type = f"worktree_state:{task_id}:{kind}"
+                    try:
+                        existing = store.execute(
+                            "SELECT id FROM alerts WHERE session_name = ? "
+                            "AND alert_type = ? AND status = 'open'",
+                            (session_key, alert_type),
+                        ).fetchone()
+                    except Exception:  # noqa: BLE001
+                        existing = None
+                    if existing is None:
+                        continue
+                    try:
+                        store.clear_alert(session_key, alert_type)
+                        alerts_cleared += 1
+                    except Exception:  # noqa: BLE001
+                        pass
+                continue
+
+            # --- non-clean branches ---
+            if state is WorktreeState.MERGE_CONFLICT:
+                alert_type = f"worktree_state:{task_id}:merge_conflict"
+                files = classification.metadata.get("conflict_files", [])
+                file_blurb = (
+                    f" ({len(files)} file{'s' if len(files) != 1 else ''})"
+                    if files else ""
+                )
+                message = (
+                    f"{agent}: merge conflict in {wt_path}{file_blurb} on task "
+                    f"{task_id}. Worker is blocked until the conflict resolves."
+                )
+                _raise_alert(store, session_key, alert_type, "error", message)
+                alerts_raised += 1
+                # Inbox — the user needs to either resolve or reassign.
+                fix_hint = (
+                    f"Run `git -C {wt_path} status` to inspect the conflict, "
+                    f"then resolve and `git commit` or reassign the task."
+                )
+                body = (
+                    f"Worker {agent} hit a merge conflict in {wt_path} while "
+                    f"working on task {task_id}.\n\n"
+                    f"{len(files)} conflicted file(s) detected.\n\n"
+                    f"Fix: {fix_hint}"
+                )
+                if _emit_inbox_task(
+                    work,
+                    subject=f"Merge conflict: {task_id}",
+                    body=body,
+                    actor=agent,
+                    dedupe_label=f"worktree_audit:{task_id}:merge_conflict",
+                    project=sess.task_project,
+                ):
+                    inbox_emitted += 1
+
+            elif state is WorktreeState.LOCK_FILE:
+                lock_age = float(
+                    classification.metadata.get("lock_age_seconds", 0.0),
+                )
+                severity = "error" if lock_age >= LOCK_ESCALATE_SECONDS else "warn"
+                minutes = max(1, int(lock_age // 60))
+                alert_type = f"worktree_state:{task_id}:lock_file"
+                lock_path = classification.metadata.get("lock_path", "")
+                message = (
+                    f"{agent}: git lock held on {wt_path} for ~{minutes}min "
+                    f"(task {task_id}). If no git process is running, remove "
+                    f"{lock_path or '<gitdir>/index.lock'}."
+                )
+                _raise_alert(store, session_key, alert_type, severity, message)
+                alerts_raised += 1
+
+            elif state is WorktreeState.DETACHED_HEAD:
+                alert_type = f"worktree_state:{task_id}:detached_head"
+                sha = classification.metadata.get("head_sha", "")
+                message = (
+                    f"{agent}: worktree {wt_path} on detached HEAD "
+                    f"{sha or '(unknown)'} (task {task_id}). "
+                    f"Fix: checkout the task branch before the worker "
+                    f"can push."
+                )
+                _raise_alert(store, session_key, alert_type, "warn", message)
+                alerts_raised += 1
+
+            elif state is WorktreeState.DIRTY_EXPECTED:
+                try:
+                    mtime = wt_path.stat().st_mtime
+                except OSError:
+                    mtime = now_epoch
+                age_s = now_epoch - mtime
+                alert_type = f"worktree_state:{task_id}:dirty_stale"
+                if age_s >= DIRTY_STALE_SECONDS:
+                    message = (
+                        f"{agent}: {wt_path} has uncommitted changes and "
+                        f"hasn't been touched in ~{int(age_s // 60)}min "
+                        f"(task {task_id}). Fix: check in on the worker — "
+                        f"likely stuck or idle."
+                    )
+                    _raise_alert(store, session_key, alert_type, "warn", message)
+                    alerts_raised += 1
+                else:
+                    # Fresh dirt — clear any prior stale alert.
+                    try:
+                        existing = store.execute(
+                            "SELECT id FROM alerts WHERE session_name = ? "
+                            "AND alert_type = ? AND status = 'open'",
+                            (session_key, alert_type),
+                        ).fetchone()
+                    except Exception:  # noqa: BLE001
+                        existing = None
+                    if existing is not None:
+                        try:
+                            store.clear_alert(session_key, alert_type)
+                            alerts_cleared += 1
+                        except Exception:  # noqa: BLE001
+                            pass
+
+            elif state is WorktreeState.ORPHAN_BRANCH:
+                age_days = float(classification.metadata.get("age_days", 0.0))
+                alert_type = f"worktree_state:{task_id}:orphan_branch"
+                message = (
+                    f"{agent}: {wt_path} on local-only branch "
+                    f"{classification.branch or '(unknown)'} with no upstream "
+                    f"and no commit in ~{age_days:.1f}d (task {task_id}). "
+                    f"Fix: push or archive the branch before the prune "
+                    f"handler GCs it."
+                )
+                _raise_alert(store, session_key, alert_type, "info", message)
+                alerts_raised += 1
+                # Low-severity inbox nudge.
+                body = (
+                    f"Worker {agent}'s worktree for task {task_id} is on a "
+                    f"local-only branch with no upstream and ~{age_days:.1f} "
+                    f"days of inactivity.\n\n"
+                    f"Path: {wt_path}\n\n"
+                    f"Fix: push the branch, merge/abandon the task, or let "
+                    f"the hourly `agent_worktree.prune` handler decide."
+                )
+                if _emit_inbox_task(
+                    work,
+                    subject=f"Orphan worktree branch: {task_id}",
+                    body=body,
+                    actor=agent,
+                    dedupe_label=f"worktree_audit:{task_id}:orphan_branch",
+                    project=sess.task_project,
+                ):
+                    inbox_emitted += 1
+    finally:
+        closer = getattr(work, "close", None)
+        if callable(closer):
+            try:
+                closer()
+            except Exception:  # noqa: BLE001
+                pass
+
+    return {
+        "outcome": "swept",
+        "considered": considered,
+        "classified": classified,
+        "alerts_raised": alerts_raised,
+        "alerts_cleared": alerts_cleared,
+        "inbox_emitted": inbox_emitted,
+    }
+
+
+def _raise_alert(
+    store: Any, session_name: str, alert_type: str, severity: str, message: str,
+) -> None:
+    """Thin wrapper that swallows a failing alert write.
+
+    Matches the ``try/except Exception`` pattern used by ``work.
+    progress_sweep`` — a single alert failure must not abort the rest
+    of the sweep.
+    """
+    try:
+        store.upsert_alert(session_name, alert_type, severity, message)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "worktree.state_audit: upsert_alert failed for %s/%s",
+            session_name, alert_type, exc_info=True,
+        )
+
+
+def _emit_inbox_task(
+    work: Any,
+    *,
+    subject: str,
+    body: str,
+    actor: str,
+    dedupe_label: str,
+    project: str,
+) -> bool:
+    """Create a user-routed inbox task on the chat flow.
+
+    Mirrors the ``pm notify`` immediate-tier path in ``cli.py`` — a
+    work-service task on the ``chat`` flow with ``roles.requester=user``
+    is what the inbox_view filter picks up. We attach
+    ``audit:worktree_state`` + the dedupe label so repeated sweeps of
+    the same blocker don't mint duplicate inbox items (the label-based
+    dedupe is done by the list-tasks query below).
+
+    Returns True when a fresh task was created, False on skip (dedup
+    or failure).
+    """
+    try:
+        # Dedupe: if any task on this project already carries our
+        # ``audit:<label>`` label and is still open, skip. The label
+        # namespace is distinct enough that a second ``startswith``
+        # scan stays cheap.
+        existing = work.list_tasks(project=project, work_status="queued")
+        existing += work.list_tasks(project=project, work_status="in_progress")
+        for task in existing:
+            labels = getattr(task, "labels", None) or ()
+            if dedupe_label in labels:
+                return False
+    except Exception:  # noqa: BLE001
+        # Listing failed — proceed to create. A duplicate is better
+        # than a missing blocker notification.
+        pass
+
+    try:
+        work.create(
+            title=subject,
+            description=body,
+            type="task",
+            project=project,
+            flow_template="chat",
+            labels=[
+                "audit:worktree_state",
+                dedupe_label,
+            ],
+            roles={"requester": "user", "actor": actor},
+        )
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "worktree.state_audit: create inbox task failed for %s",
+            dedupe_label, exc_info=True,
+        )
+        return False
+
+
 def log_rotate_handler(payload: dict[str, Any]) -> dict[str, Any]:
     """Rotate + prune oversized log files under ``config.project.logs_dir``.
 
@@ -950,6 +1309,13 @@ def _register_handlers(api: JobHandlerAPI) -> None:
         "log.rotate", log_rotate_handler,
         max_attempts=1, timeout_seconds=120.0,
     )
+    # Worker-worktree state audit — 10-minute classification of live
+    # work_sessions worktrees (merge conflicts, lock files, orphans).
+    # Issue #251.
+    api.register_handler(
+        "worktree.state_audit", worktree_state_audit_handler,
+        max_attempts=1, timeout_seconds=120.0,
+    )
 
 
 def _register_roster(api: RosterAPI) -> None:
@@ -999,6 +1365,12 @@ def _register_roster(api: RosterAPI) -> None:
         "31 * * * *", "log.rotate", {},
         dedupe_key="log.rotate",
     )
+    # Worker-worktree *state* audit — every 10 minutes. Complements the
+    # hourly ``agent_worktree.prune`` (which GCs orphan worktrees) by
+    # classifying live ``work_sessions`` worktrees into
+    # clean/dirty/conflict/lock/detached/orphan and surfacing blockers
+    # as alerts + inbox items. Issue #251.
+    api.register_recurring("@every 10m", "worktree.state_audit", {})
 
 
 plugin = PollyPMPlugin(
@@ -1023,6 +1395,7 @@ plugin = PollyPMPlugin(
         Capability(kind="job_handler", name="notification_staging.prune"),
         Capability(kind="job_handler", name="agent_worktree.prune"),
         Capability(kind="job_handler", name="log.rotate"),
+        Capability(kind="job_handler", name="worktree.state_audit"),
         Capability(kind="roster_entry", name="core_recurring"),
     ),
     register_handlers=_register_handlers,

--- a/src/pollypm/worktree_audit.py
+++ b/src/pollypm/worktree_audit.py
@@ -1,0 +1,263 @@
+"""Worktree state classification for the heartbeat audit handler (#251).
+
+This module houses the pure, subprocess-only classifier used by the
+``worktree.state_audit`` recurring handler. It deliberately does NOT
+touch SQLite, config, or the plugin host — the handler in
+``plugins_builtin/core_recurring/plugin.py`` is the only caller and
+owns the side-effect story (alerts / inbox / state store writes).
+
+States surfaced:
+
+* ``clean`` — no uncommitted changes, HEAD on a named branch, no lock
+  file. The expected steady-state for an in-progress worker.
+* ``dirty_expected`` — uncommitted working-tree changes. Fine during
+  active development; the handler separately checks the worktree's
+  mtime-derived staleness and raises a low-severity alert if the
+  directory hasn't been touched in >60 min.
+* ``merge_conflict`` — ``git status --porcelain`` reports one of the
+  unmerged-path codes (``UU``, ``AA``, ``DD``, ``AU``, ``UA``, ``UD``,
+  ``DU``). Blocks progress — worker can't commit.
+* ``detached_head`` — HEAD is not on a branch (e.g. after a
+  ``git checkout <sha>``). A worker session on detached HEAD cannot
+  push its work.
+* ``orphan_branch`` — HEAD is on a local branch but that branch has no
+  upstream AND no commits in the last 7 days. Indicates an abandoned
+  worktree whose work is at risk of being GC'd by the prune handler.
+* ``lock_file`` — ``.git/index.lock`` exists. We surface this so a
+  stuck git process (or a crashed one that left a lock behind) is
+  visible at the 10-minute cadence. Lock-file age is returned in
+  metadata so the handler can escalate severity at >5min.
+
+The classifier returns an enum + metadata dict. The metadata carries
+whatever downstream alerting needs (lock age, stale days, conflict
+file list) so the handler doesn't re-run git.
+"""
+
+from __future__ import annotations
+
+import enum
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+class WorktreeState(str, enum.Enum):
+    """Classification output for a single worktree."""
+
+    CLEAN = "clean"
+    DIRTY_EXPECTED = "dirty_expected"
+    MERGE_CONFLICT = "merge_conflict"
+    DETACHED_HEAD = "detached_head"
+    ORPHAN_BRANCH = "orphan_branch"
+    LOCK_FILE = "lock_file"
+    # Surfaces when the path doesn't exist or isn't a git directory.
+    # Treated as non-actionable by the handler — the prune pass owns
+    # those cases.
+    MISSING = "missing"
+
+
+# Unmerged-path prefixes per ``git status --porcelain`` section "Porcelain
+# Format". We treat any presence as a merge conflict signal.
+_CONFLICT_CODES: frozenset[str] = frozenset({
+    "UU", "AA", "DD", "AU", "UA", "UD", "DU",
+})
+
+
+@dataclass(slots=True)
+class WorktreeClassification:
+    """Classifier output — enum + metadata the handler consumes.
+
+    ``metadata`` intentionally stays a plain dict (not a typed
+    sub-record) so the handler can stash whatever context it found
+    without this module growing a state-specific schema per case.
+    """
+
+    state: WorktreeState
+    branch: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def _git(cwd: Path, *args: str, timeout: float = 15.0) -> subprocess.CompletedProcess[str]:
+    """Run ``git -C <cwd> <args>`` with captured output and ``check=False``.
+
+    Mirrors ``plugins_builtin/core_recurring/plugin.py::_git`` used by
+    the prune handler so behaviour (timeouts, text-mode, non-raising)
+    is consistent across the two worktree handlers. We keep our own
+    copy so this module stays import-independent.
+    """
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def classify_worktree_state(path: Path) -> WorktreeClassification:
+    """Classify ``path`` into one of the ``WorktreeState`` values.
+
+    The classifier is intentionally best-effort: each sub-check is
+    wrapped so a single failing git call (e.g. a corrupt worktree)
+    falls through to ``MISSING`` rather than crashing the whole sweep.
+
+    Order of checks matters:
+
+    1. Path existence + ``.git`` presence → ``MISSING`` when absent.
+    2. ``.git/index.lock`` → ``LOCK_FILE`` (win-LOSES against everything
+       else because a held lock means subsequent git calls will stall
+       or fail).
+    3. ``git symbolic-ref HEAD`` → ``DETACHED_HEAD`` on failure.
+    4. ``git status --porcelain`` → unmerged codes → ``MERGE_CONFLICT``.
+    5. Any dirty lines → ``DIRTY_EXPECTED`` (after the staleness check
+       the handler does on its side).
+    6. No upstream + last commit >7d → ``ORPHAN_BRANCH``.
+    7. Otherwise → ``CLEAN``.
+    """
+    if not path.exists() or not path.is_dir():
+        return WorktreeClassification(
+            state=WorktreeState.MISSING,
+            metadata={"reason": "path_missing"},
+        )
+
+    git_dir = path / ".git"
+    # ``.git`` may be a file (worktree checkout) or a directory (main
+    # clone). Either is acceptable — we only need the lock-file probe
+    # to resolve the actual gitdir.
+    if not git_dir.exists():
+        return WorktreeClassification(
+            state=WorktreeState.MISSING,
+            metadata={"reason": "not_a_git_worktree"},
+        )
+
+    # Resolve the real gitdir so ``index.lock`` is found on worktrees
+    # where ``.git`` is a gitlink file (``gitdir: ...``).
+    resolved_gitdir = _resolve_gitdir(git_dir)
+    lock_path = resolved_gitdir / "index.lock" if resolved_gitdir else git_dir / "index.lock"
+    if lock_path.exists():
+        try:
+            lock_age_s = time.time() - lock_path.stat().st_mtime
+        except OSError:
+            lock_age_s = 0.0
+        return WorktreeClassification(
+            state=WorktreeState.LOCK_FILE,
+            metadata={
+                "lock_path": str(lock_path),
+                "lock_age_seconds": float(lock_age_s),
+            },
+        )
+
+    # HEAD status — detached heads can't push, so flag them early.
+    head_proc = _git(path, "symbolic-ref", "--quiet", "HEAD")
+    if head_proc.returncode != 0:
+        # symbolic-ref returns non-zero on detached HEAD.
+        rev = _git(path, "rev-parse", "--short", "HEAD")
+        sha = rev.stdout.strip() if rev.returncode == 0 else ""
+        return WorktreeClassification(
+            state=WorktreeState.DETACHED_HEAD,
+            branch=None,
+            metadata={"head_sha": sha},
+        )
+    ref = head_proc.stdout.strip()
+    # ``refs/heads/foo`` → ``foo``.
+    branch = ref[len("refs/heads/"):] if ref.startswith("refs/heads/") else ref
+
+    # Porcelain status gives us both conflict codes and dirty indicator
+    # in a single call.
+    status_proc = _git(path, "status", "--porcelain")
+    if status_proc.returncode != 0:
+        # Degrade gracefully — if status fails we can't classify further.
+        return WorktreeClassification(
+            state=WorktreeState.MISSING,
+            branch=branch,
+            metadata={
+                "reason": "status_failed",
+                "stderr": status_proc.stderr.strip(),
+            },
+        )
+
+    dirty_lines = [
+        line for line in status_proc.stdout.splitlines() if line.strip()
+    ]
+    conflict_files: list[str] = []
+    for line in dirty_lines:
+        # Porcelain v1 format: first 2 chars = XY code, then space, then path.
+        if len(line) < 3:
+            continue
+        code = line[:2]
+        if code in _CONFLICT_CODES:
+            conflict_files.append(line[3:].strip())
+
+    if conflict_files:
+        return WorktreeClassification(
+            state=WorktreeState.MERGE_CONFLICT,
+            branch=branch,
+            metadata={"conflict_files": conflict_files},
+        )
+
+    if dirty_lines:
+        return WorktreeClassification(
+            state=WorktreeState.DIRTY_EXPECTED,
+            branch=branch,
+            metadata={"dirty_line_count": len(dirty_lines)},
+        )
+
+    # Orphan branch — local branch, no upstream, no commit in last 7d.
+    upstream_proc = _git(
+        path, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}",
+    )
+    has_upstream = upstream_proc.returncode == 0 and bool(upstream_proc.stdout.strip())
+    if not has_upstream:
+        # Get the commit epoch of HEAD.
+        commit_proc = _git(path, "log", "-1", "--format=%ct", "HEAD")
+        if commit_proc.returncode == 0 and commit_proc.stdout.strip():
+            try:
+                commit_ts = int(commit_proc.stdout.strip())
+            except ValueError:
+                commit_ts = int(time.time())
+            age_days = (time.time() - commit_ts) / 86400.0
+            if age_days > 7.0:
+                return WorktreeClassification(
+                    state=WorktreeState.ORPHAN_BRANCH,
+                    branch=branch,
+                    metadata={
+                        "age_days": float(age_days),
+                        "has_upstream": False,
+                    },
+                )
+
+    return WorktreeClassification(
+        state=WorktreeState.CLEAN,
+        branch=branch,
+        metadata={},
+    )
+
+
+def _resolve_gitdir(git_entry: Path) -> Path | None:
+    """Return the real gitdir for a worktree.
+
+    For a worktree checkout, ``.git`` is a file whose contents look
+    like ``gitdir: /abs/path/to/.git/worktrees/<name>``. Resolving the
+    real gitdir lets us check ``index.lock`` on worktrees, not just on
+    the main clone.
+    """
+    if git_entry.is_dir():
+        return git_entry
+    try:
+        text = git_entry.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return None
+    prefix = "gitdir:"
+    if not text.startswith(prefix):
+        return None
+    raw = text[len(prefix):].strip()
+    if not raw:
+        return None
+    candidate = Path(raw)
+    if not candidate.is_absolute():
+        candidate = (git_entry.parent / candidate).resolve()
+    if candidate.exists():
+        return candidate
+    return None

--- a/tests/test_core_recurring_migration.py
+++ b/tests/test_core_recurring_migration.py
@@ -49,6 +49,8 @@ class TestCoreRecurringPlugin:
             # DB hygiene — incremental vacuum + TTL sweep for memory_entries.
             "db.vacuum",
             "memory.ttl_sweep",
+            # #251 — worker-worktree state audit.
+            "worktree.state_audit",
         }
         assert expected.issubset(set(registry.names()))
         # inbox.sweep was retired with the legacy inbox subsystem (iv04).
@@ -80,6 +82,8 @@ class TestCoreRecurringPlugin:
             "log.rotate",
             # Events-table tiered retention — hourly at minute :37.
             "events.retention_sweep",
+            # #251 — worker-worktree state audit, @every 10m.
+            "worktree.state_audit",
         }
 
         # Cadences per issue #164 / #249.
@@ -111,6 +115,8 @@ class TestCoreRecurringPlugin:
         events_retention = entries["events.retention_sweep"].schedule
         assert isinstance(events_retention, CronSchedule)
         assert events_retention.expression() == "37 * * * *"
+        # #251 — worktree state audit uses EverySchedule(10m).
+        assert _interval_seconds(entries["worktree.state_audit"]) == 600
 
     def test_plugin_declares_expected_capabilities(self) -> None:
         kinds = {cap.kind for cap in core_plugin.capabilities}

--- a/tests/test_worktree_state_audit.py
+++ b/tests/test_worktree_state_audit.py
@@ -1,0 +1,465 @@
+"""Tests for the 10-minute ``worktree.state_audit`` recurring handler (#251).
+
+Run with:
+
+    HOME=/tmp/pytest-agent-worktree-audit \
+        uv run pytest tests/test_worktree_state_audit.py -x
+
+Two test surfaces:
+
+1. ``classify_worktree_state(path)`` — pure, subprocess-only classifier.
+   Seed real tmp git repos in each state, assert the enum + metadata.
+2. ``worktree_state_audit_handler(payload)`` — handler path. Uses a
+   fake work-service + in-memory state store to verify alerts fire on
+   bad states, inbox tasks are created for merge conflicts, and
+   open alerts auto-clear when the state returns to ``clean``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pollypm.worktree_audit import (
+    WorktreeState,
+    classify_worktree_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(*args: str, cwd: Path | None = None, check: bool = True):
+    return subprocess.run(
+        list(args),
+        cwd=str(cwd) if cwd else None,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _make_repo(root: Path) -> Path:
+    """Initialize a real git repo with one commit on ``main``."""
+    root.mkdir(parents=True, exist_ok=True)
+    _run("git", "init", "-b", "main", str(root))
+    _run("git", "-C", str(root), "config", "user.email", "audit@test")
+    _run("git", "-C", str(root), "config", "user.name", "Audit Test")
+    (root / "README.md").write_text("seed\n")
+    _run("git", "-C", str(root), "add", "README.md")
+    _run("git", "-C", str(root), "commit", "-m", "init")
+    return root
+
+
+def _add_worktree(repo: Path, slug: str) -> Path:
+    """Add a git worktree under ``<repo>/.claude/worktrees/agent-<slug>``."""
+    worktrees_dir = repo / ".claude" / "worktrees"
+    worktrees_dir.mkdir(parents=True, exist_ok=True)
+    wt_path = worktrees_dir / f"agent-{slug}"
+    branch = f"audit-{slug}"
+    _run("git", "-C", str(repo), "worktree", "add", "-b", branch, str(wt_path))
+    return wt_path
+
+
+# ---------------------------------------------------------------------------
+# Classifier tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassifier:
+    def test_clean_worktree(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        wt = _add_worktree(repo, "clean")
+        # Make sure the branch has an upstream to avoid orphan classification.
+        # We fake one with a bare "remote" clone.
+        remote = tmp_path / "remote.git"
+        _run("git", "init", "--bare", "-b", "main", str(remote))
+        _run("git", "-C", str(wt), "remote", "add", "origin", str(remote))
+        _run("git", "-C", str(wt), "push", "-u", "origin", "audit-clean")
+
+        result = classify_worktree_state(wt)
+        assert result.state is WorktreeState.CLEAN
+        assert result.branch == "audit-clean"
+
+    def test_dirty_expected(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        wt = _add_worktree(repo, "dirty")
+        (wt / "scratch.txt").write_text("in progress\n")
+
+        result = classify_worktree_state(wt)
+        assert result.state is WorktreeState.DIRTY_EXPECTED
+        assert result.metadata["dirty_line_count"] >= 1
+
+    def test_merge_conflict(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        # Create two branches that edit the same line, then try to merge.
+        wt = _add_worktree(repo, "conflict")
+        (wt / "file.txt").write_text("left\n")
+        _run("git", "-C", str(wt), "add", "file.txt")
+        _run("git", "-C", str(wt), "commit", "-m", "left side")
+        # Meanwhile on main:
+        (repo / "file.txt").write_text("right\n")
+        _run("git", "-C", str(repo), "add", "file.txt")
+        _run("git", "-C", str(repo), "commit", "-m", "right side")
+        # Merge main into the worktree branch — expect conflict.
+        merge = _run(
+            "git", "-C", str(wt), "merge", "main", check=False,
+        )
+        assert merge.returncode != 0, "merge should have conflicted"
+
+        result = classify_worktree_state(wt)
+        assert result.state is WorktreeState.MERGE_CONFLICT
+        assert "file.txt" in result.metadata.get("conflict_files", [])
+
+    def test_detached_head(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        wt = _add_worktree(repo, "detached")
+        # Add a second commit so we have a sha to detach to.
+        (wt / "f.txt").write_text("x\n")
+        _run("git", "-C", str(wt), "add", "f.txt")
+        _run("git", "-C", str(wt), "commit", "-m", "c2")
+        sha = _run("git", "-C", str(wt), "rev-parse", "HEAD").stdout.strip()
+        _run("git", "-C", str(wt), "checkout", "--detach", sha)
+
+        result = classify_worktree_state(wt)
+        assert result.state is WorktreeState.DETACHED_HEAD
+        assert result.branch is None
+        assert result.metadata.get("head_sha")
+
+    def test_lock_file(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        wt = _add_worktree(repo, "locked")
+        # Resolve the real gitdir for the worktree (``.git`` is a file).
+        git_entry = wt / ".git"
+        gitdir_text = git_entry.read_text().strip()
+        assert gitdir_text.startswith("gitdir:")
+        raw = gitdir_text.split(":", 1)[1].strip()
+        gitdir = Path(raw)
+        if not gitdir.is_absolute():
+            gitdir = (git_entry.parent / gitdir).resolve()
+        lock = gitdir / "index.lock"
+        lock.write_text("")
+        # Back-date the lock so we can assert a non-zero age.
+        target = time.time() - 120
+        os.utime(lock, (target, target))
+
+        result = classify_worktree_state(wt)
+        assert result.state is WorktreeState.LOCK_FILE
+        assert result.metadata.get("lock_age_seconds", 0) >= 60
+
+    def test_orphan_branch(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        wt = _add_worktree(repo, "orphan")
+        # No upstream, no remote. We need a commit older than 7 days —
+        # use ``commit --date`` + ``GIT_COMMITTER_DATE`` to back-date.
+        (wt / "old.txt").write_text("old\n")
+        _run("git", "-C", str(wt), "add", "old.txt")
+        env = os.environ.copy()
+        old_date = "2020-01-01T00:00:00"
+        env["GIT_AUTHOR_DATE"] = old_date
+        env["GIT_COMMITTER_DATE"] = old_date
+        subprocess.run(
+            ["git", "-C", str(wt), "commit", "-m", "old", "--date", old_date],
+            check=True, env=env, capture_output=True, text=True,
+        )
+
+        result = classify_worktree_state(wt)
+        assert result.state is WorktreeState.ORPHAN_BRANCH
+        assert result.metadata.get("age_days", 0) > 7
+        assert result.metadata.get("has_upstream") is False
+
+    def test_missing_path(self, tmp_path: Path) -> None:
+        result = classify_worktree_state(tmp_path / "does-not-exist")
+        assert result.state is WorktreeState.MISSING
+
+    def test_not_a_git_worktree(self, tmp_path: Path) -> None:
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        (plain / "a.txt").write_text("hi")
+        result = classify_worktree_state(plain)
+        assert result.state is WorktreeState.MISSING
+
+
+# ---------------------------------------------------------------------------
+# Handler tests — use a fake work-service + in-memory state store so we
+# can assert alert / inbox side effects without standing up the full rail.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeSession:
+    task_project: str
+    task_number: int
+    agent_name: str
+    worktree_path: str | None
+    pane_id: str | None = None
+    branch_name: str | None = None
+    started_at: str = "2026-01-01T00:00:00Z"
+
+
+class _FakeStore:
+    """In-memory stand-in for ``StateStore`` — captures alert calls."""
+
+    def __init__(self) -> None:
+        # dict keyed by (session_name, alert_type) → (severity, message, status)
+        self.alerts: dict[tuple[str, str], dict[str, Any]] = {}
+
+    # StateStore API surface the handler touches
+    def upsert_alert(
+        self, session_name: str, alert_type: str, severity: str, message: str,
+    ) -> None:
+        self.alerts[(session_name, alert_type)] = {
+            "severity": severity,
+            "message": message,
+            "status": "open",
+        }
+
+    def clear_alert(self, session_name: str, alert_type: str) -> None:
+        key = (session_name, alert_type)
+        if key in self.alerts:
+            self.alerts[key]["status"] = "cleared"
+
+    def execute(self, query: str, params: tuple = ()):  # noqa: ARG002
+        """Minimal SELECT-open-alert emulation used by the handler's
+        clear/stale-probe branches. Returns a cursor-like whose
+        fetchone() yields (id,) iff we have an open alert for the
+        queried session_name/alert_type.
+        """
+        session_name, alert_type = params
+        entry = self.alerts.get((session_name, alert_type))
+        is_open = bool(entry and entry.get("status") == "open")
+
+        class _Cur:
+            def fetchone(self_inner):
+                return (1,) if is_open else None
+
+        return _Cur()
+
+
+class _FakeWork:
+    """Minimal SQLiteWorkService stand-in — only the two methods the
+    handler uses (``list_worker_sessions`` + ``create`` + ``list_tasks``)."""
+
+    def __init__(self, sessions: list[_FakeSession]) -> None:
+        self._sessions = list(sessions)
+        self.created: list[dict[str, Any]] = []
+
+    def list_worker_sessions(self, *, active_only: bool = True):  # noqa: ARG002
+        return list(self._sessions)
+
+    def list_tasks(self, **_kwargs: Any):
+        return []
+
+    def create(self, **kwargs: Any):
+        self.created.append(kwargs)
+        # Mimic Task just enough — the handler doesn't read the result.
+        return object()
+
+    def close(self) -> None:
+        pass
+
+
+def _invoke_handler_with_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    sessions: list[_FakeSession],
+    project_root: Path,
+) -> tuple[dict[str, Any], _FakeStore, _FakeWork]:
+    """Run the handler with the SQLiteWorkService + _load_config_and_store
+    swapped for fakes. Returns (result, store, work) so assertions can
+    inspect side effects."""
+    from pollypm.plugins_builtin.core_recurring import plugin as plugin_module
+
+    fake_store = _FakeStore()
+    fake_work = _FakeWork(sessions)
+
+    @dataclass
+    class _FakeProject:
+        root_dir: Path
+
+    @dataclass
+    class _FakeConfig:
+        project: _FakeProject
+
+    cfg = _FakeConfig(project=_FakeProject(root_dir=project_root))
+
+    monkeypatch.setattr(
+        plugin_module, "_load_config_and_store",
+        lambda payload: (cfg, fake_store),
+    )
+    # Patch SQLiteWorkService to return our fake regardless of args.
+    import pollypm.work.sqlite_service as sqlite_service_mod
+
+    monkeypatch.setattr(
+        sqlite_service_mod, "SQLiteWorkService",
+        lambda *a, **kw: fake_work,
+    )
+
+    result = plugin_module.worktree_state_audit_handler({})
+    return result, fake_store, fake_work
+
+
+class TestHandler:
+    def test_clean_worktree_raises_no_alerts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        wt = _add_worktree(repo, "clean")
+        remote = tmp_path / "remote.git"
+        _run("git", "init", "--bare", "-b", "main", str(remote))
+        _run("git", "-C", str(wt), "remote", "add", "origin", str(remote))
+        _run("git", "-C", str(wt), "push", "-u", "origin", "audit-clean")
+
+        sessions = [
+            _FakeSession(
+                task_project="demo", task_number=1,
+                agent_name="worker-demo-1", worktree_path=str(wt),
+            ),
+        ]
+        result, store, work = _invoke_handler_with_fakes(
+            monkeypatch, sessions=sessions, project_root=repo,
+        )
+        assert result["outcome"] == "swept"
+        assert result["considered"] == 1
+        assert result["classified"].get("clean") == 1
+        # No alerts raised; no inbox.
+        assert result["alerts_raised"] == 0
+        assert work.created == []
+        # Store has no open alerts.
+        assert all(
+            entry["status"] != "open" for entry in store.alerts.values()
+        )
+
+    def test_merge_conflict_raises_alert_and_inbox(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        wt = _add_worktree(repo, "conflict")
+        (wt / "file.txt").write_text("left\n")
+        _run("git", "-C", str(wt), "add", "file.txt")
+        _run("git", "-C", str(wt), "commit", "-m", "L")
+        (repo / "file.txt").write_text("right\n")
+        _run("git", "-C", str(repo), "add", "file.txt")
+        _run("git", "-C", str(repo), "commit", "-m", "R")
+        merge = _run("git", "-C", str(wt), "merge", "main", check=False)
+        assert merge.returncode != 0
+
+        sessions = [
+            _FakeSession(
+                task_project="demo", task_number=7,
+                agent_name="worker-demo-7", worktree_path=str(wt),
+            ),
+        ]
+        result, store, work = _invoke_handler_with_fakes(
+            monkeypatch, sessions=sessions, project_root=repo,
+        )
+        assert result["classified"].get("merge_conflict") == 1
+        assert result["alerts_raised"] >= 1
+        assert result["inbox_emitted"] == 1
+        # Alert keyed by (agent, worktree_state:demo/7:merge_conflict).
+        key = ("worker-demo-7", "worktree_state:demo/7:merge_conflict")
+        assert key in store.alerts
+        assert store.alerts[key]["severity"] == "error"
+        # Inbox task created with the audit label.
+        assert len(work.created) == 1
+        created = work.created[0]
+        assert created["project"] == "demo"
+        assert "audit:worktree_state" in created["labels"]
+        assert any(
+            lbl.startswith("worktree_audit:demo/7:merge_conflict")
+            for lbl in created["labels"]
+        )
+
+    def test_lock_file_escalates_after_5min(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        repo = _make_repo(tmp_path / "repo")
+        wt = _add_worktree(repo, "locked")
+        git_entry = wt / ".git"
+        raw = git_entry.read_text().strip().split(":", 1)[1].strip()
+        gitdir = Path(raw)
+        if not gitdir.is_absolute():
+            gitdir = (git_entry.parent / gitdir).resolve()
+        lock = gitdir / "index.lock"
+        lock.write_text("")
+        # 10min old — should escalate to error.
+        target = time.time() - 10 * 60
+        os.utime(lock, (target, target))
+
+        sessions = [
+            _FakeSession(
+                task_project="demo", task_number=3,
+                agent_name="worker-demo-3", worktree_path=str(wt),
+            ),
+        ]
+        result, store, _work = _invoke_handler_with_fakes(
+            monkeypatch, sessions=sessions, project_root=repo,
+        )
+        assert result["classified"].get("lock_file") == 1
+        key = ("worker-demo-3", "worktree_state:demo/3:lock_file")
+        assert store.alerts[key]["severity"] == "error"
+
+    def test_clean_after_dirty_clears_existing_alert(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Alert raised on a prior dirty_stale sweep auto-clears when
+        the worktree returns to clean."""
+        repo = _make_repo(tmp_path / "repo")
+        wt = _add_worktree(repo, "recover")
+        remote = tmp_path / "remote.git"
+        _run("git", "init", "--bare", "-b", "main", str(remote))
+        _run("git", "-C", str(wt), "remote", "add", "origin", str(remote))
+        _run("git", "-C", str(wt), "push", "-u", "origin", "audit-recover")
+
+        sessions = [
+            _FakeSession(
+                task_project="demo", task_number=9,
+                agent_name="worker-demo-9", worktree_path=str(wt),
+            ),
+        ]
+        # Prime the store with a stale open alert simulating a prior sweep.
+        from pollypm.plugins_builtin.core_recurring import plugin as plugin_module
+
+        fake_store = _FakeStore()
+        fake_work = _FakeWork(sessions)
+        fake_store.upsert_alert(
+            "worker-demo-9",
+            "worktree_state:demo/9:dirty_stale",
+            "warn",
+            "legacy alert",
+        )
+
+        @dataclass
+        class _FakeProject:
+            root_dir: Path
+
+        @dataclass
+        class _FakeConfig:
+            project: _FakeProject
+
+        cfg = _FakeConfig(project=_FakeProject(root_dir=repo))
+        monkeypatch.setattr(
+            plugin_module, "_load_config_and_store",
+            lambda payload: (cfg, fake_store),
+        )
+        import pollypm.work.sqlite_service as sqlite_service_mod
+
+        monkeypatch.setattr(
+            sqlite_service_mod, "SQLiteWorkService",
+            lambda *a, **kw: fake_work,
+        )
+
+        result = plugin_module.worktree_state_audit_handler({})
+        assert result["classified"].get("clean") == 1
+        # Prior alert cleared.
+        key = ("worker-demo-9", "worktree_state:demo/9:dirty_stale")
+        assert fake_store.alerts[key]["status"] == "cleared"
+        assert result["alerts_cleared"] >= 1


### PR DESCRIPTION
## Summary
- New `worktree.state_audit` roster handler `@every 10m` classifies live worker worktrees: clean / dirty_expected / merge_conflict / detached_head / orphan_branch / lock_file / missing
- `merge_conflict` + `orphan_branch` emit user-routed inbox tasks (chat flow) with per-(task,state) dedupe; lock-file alerts escalate warn→error at 5min; dirty_expected only alerts when worktree mtime >60min old
- Alerts keyed `worktree_state:<task>:<state>` so `upsert_alert` dedupes and `clear_alert` resolves on return-to-clean
- New module `src/pollypm/worktree_audit.py` exposes pure `classify_worktree_state(path) -> WorktreeClassification` (handles git-worktree gitlinks correctly when probing `.git/index.lock`)

Closes #251.

## Test plan
- [x] `HOME=/tmp/pytest-agent-worktree-audit uv run pytest tests/test_worktree_state_audit.py tests/test_core_recurring_migration.py tests/test_agent_worktree_prune.py tests/test_worktrees.py -q` → 30 passed
- [x] 12 new tests cover each classifier branch with real seeded git repos (bare remote for clean, `--commit-date` back-dating for orphan, real merge conflict, simulated `index.lock`)
- [x] Roster registration test updated in `test_core_recurring_migration.py` (expected handler set + 600s cadence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)