### PR TITLE
fix(notify): bug/gap/finding/regression keywords land at immediate priority

### DIFF
--- a/src/pollypm/notification_staging.py
+++ b/src/pollypm/notification_staging.py
@@ -59,6 +59,21 @@ _IMMEDIATE_KEYWORDS: tuple[str, ...] = (
     "stuck",
     "failed",
     "persona swap",
+    # Bug-report shape — operator (Polly) flagged that "dogfood
+    # finding" / "Archie skips per-stage pm task done" / "Gap A
+    # fallback doesn't fire" notifications were silently classified as
+    # digest because they happened to contain a completion keyword
+    # ("done"). Bug reports must surface immediately so the user can
+    # triage before a milestone flush. Single-word tokens are matched
+    # on word boundary so "bug" doesn't hit "debug" / "bugged" and
+    # "gap" doesn't hit "stopgap".
+    "bug",
+    "gap",
+    "finding",
+    "regression",
+    "broken",
+    "misclassification",
+    "skips",
 )
 
 _DIGEST_KEYWORDS: tuple[str, ...] = (

--- a/tests/test_notification_tiering.py
+++ b/tests/test_notification_tiering.py
@@ -183,6 +183,74 @@ class TestClassifyPriority:
         # — the existing audit-trail behaviour must not regress.
         assert ns.classify_priority("Test pass", "") == "silent"
 
+    # ---- Bug-report shape upgrades (operator-surfaced regression:
+    # dogfood findings #3 and #4 were auto-classified as digest because
+    # the literal "done" keyword in "Archie skips per-stage pm task
+    # done" hit ``_DIGEST_KEYWORDS``. Bug-report-shape keywords must
+    # take precedence so findings reach the inbox immediately rather
+    # than waiting for the next milestone flush.
+    def test_bug_finding_classifies_immediate(self):
+        # Polly's literal repro string — co-occurring "done" must NOT
+        # downgrade this to digest because "skips" flags a bug shape.
+        assert (
+            ns.classify_priority(
+                "#4: Archie skips per-stage pm task done", "",
+            )
+            == "immediate"
+        )
+
+    def test_gap_finding_classifies_immediate(self):
+        assert (
+            ns.classify_priority(
+                "Gap A fallback doesn't fire from cron pm heartbeat", "",
+            )
+            == "immediate"
+        )
+
+    def test_dogfood_finding_classifies_immediate(self):
+        assert (
+            ns.classify_priority(
+                "dogfood finding: replan misclassification", "",
+            )
+            == "immediate"
+        )
+
+    def test_regression_classifies_immediate(self):
+        assert ns.classify_priority("regression in foo bar", "") == "immediate"
+
+    def test_bug_keyword_classifies_immediate(self):
+        # Even when paired with a digest keyword, "bug" wins.
+        assert (
+            ns.classify_priority("Bug: deploy completed but page 500s", "")
+            == "immediate"
+        )
+
+    def test_broken_keyword_classifies_immediate(self):
+        assert (
+            ns.classify_priority("Broken: heartbeat skipped a tick", "")
+            == "immediate"
+        )
+
+    def test_misclassification_keyword_classifies_immediate(self):
+        assert (
+            ns.classify_priority("replan misclassification shipped", "")
+            == "immediate"
+        )
+
+    def test_non_bug_done_remains_digest(self):
+        # The new bug-shape keywords must NOT swallow routine
+        # completions. "Build done." has no bug keyword and should
+        # still classify as digest so milestone rollups keep working.
+        assert ns.classify_priority("Build done.", "") == "digest"
+
+    def test_debug_does_not_trigger_bug(self):
+        # Word-boundary safety: "debug" / "bugfix" must not match the
+        # bare "bug" token (otherwise routine "debug logs shipped"
+        # status updates would over-notify).
+        assert (
+            ns.classify_priority("debug logs shipped", "") == "digest"
+        )
+
 
 # ---------------------------------------------------------------------------
 # pm notify CLI — tier routing


### PR DESCRIPTION
## Summary
- Polly (operator) flagged a real false-positive in her overnight dogfood recap: `classify_priority("#4: Archie skips per-stage pm task done", ...)` was returning `"digest"` because of the literal "done" — but the message is a BUG REPORT about Archie skipping a step, not a completion. Findings would have buried in milestone rollup.
- Added 7 keywords to `_IMMEDIATE_KEYWORDS` (which take precedence over digest in `classify_priority`): `bug`, `gap`, `finding`, `regression`, `broken`, `misclassification`, `skips`. All single-word, matched on word-boundary.
- Skipped multi-word phrases (`doesn't fire` / `stays draft`) per the "be conservative" guidance.

Note on `skips`: arguable but needed for Polly's exact repro string. If you'd rather drop it, swap the test subject to one matching a stricter keyword. Reversible.

## Test plan
- [x] `HOME=/tmp/pytest-agent-notify-classifier uv run pytest tests/test_notification_tiering.py -x` → 49 passed
- [x] 8 new tests cover Polly's literal repro + gap/finding/regression/broken/misclassification variants + two guards (`Build done.` still digest, `debug logs shipped` not falsely tripping `bug` via word-boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)