### PR TITLE
feat(store): SQLAlchemy foundation — Store protocol + dual-pool engine (#337)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
   "pyyaml>=6.0",
+  "sqlalchemy>=2.0",
   "textual>=6.1.0",
   "typer>=0.16.0",
 ]

--- a/src/pollypm/store/__init__.py
+++ b/src/pollypm/store/__init__.py
@@ -1,0 +1,32 @@
+"""PollyPM storage foundation — ``Store`` protocol and SQLAlchemy backend.
+
+This package is the structural replacement for the ad-hoc ``sqlite3.connect``
+callers scattered across the codebase. Every subsystem that needs persistent
+state will eventually route through the :class:`Store` protocol defined here.
+
+Issue #337 lands the foundation only:
+
+* :class:`Store` — the structural :class:`typing.Protocol` every caller targets.
+* :func:`make_engines` — the dual-pool engine factory (writer pool_size=1 for
+  serialized writes, reader pool_size=5 for WAL-concurrent reads).
+* :class:`SQLAlchemyStore` — a skeleton backend. Only ``transaction()`` is
+  functional; all other methods raise :class:`NotImplementedError` and land in
+  later issues (#338 schema, #340 callers).
+
+Downstream issues populate method bodies, define the metadata, and migrate
+callers off ``StateStore`` / direct ``sqlite3`` usage. Nothing in this module
+should reach into ``~/.pollypm/`` or open a connection at import time.
+"""
+
+from __future__ import annotations
+
+from pollypm.store.engine import is_sqlite, make_engines
+from pollypm.store.protocol import Store
+from pollypm.store.sqlalchemy_store import SQLAlchemyStore
+
+__all__ = [
+    "SQLAlchemyStore",
+    "Store",
+    "is_sqlite",
+    "make_engines",
+]

--- a/src/pollypm/store/engine.py
+++ b/src/pollypm/store/engine.py
@@ -1,0 +1,141 @@
+"""SQLAlchemy engine factory — dual-pool writer/reader split for SQLite WAL.
+
+Why dual pools: SQLite in WAL mode allows many concurrent readers but
+serializes writers. Instead of fighting that with ``busy_timeout`` + retry
+loops sprinkled through call sites, we expose it in the connection topology:
+
+* **Writer engine** — ``QueuePool(pool_size=1, max_overflow=0)``. Every write
+  transaction blocks on the single connection, so application code never sees
+  "database is locked" under contention.
+* **Reader engine** — ``QueuePool(pool_size=5)``. Multiple threads can read
+  concurrently against the WAL snapshot without stepping on the writer.
+
+SQLite pragmas (WAL, busy_timeout, synchronous=NORMAL, foreign_keys=ON) are
+applied on every new connection via ``event.listens_for(engine, "connect")``.
+:func:`is_sqlite` gates the pragma hook so the same factory will work against
+a future Postgres URL without throwing "unknown pragma" errors on connect.
+
+Issue #337 — foundation only. No schema, no table creation, no callers.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from urllib.parse import urlparse
+
+from sqlalchemy import create_engine, event
+from sqlalchemy.engine import Engine
+from sqlalchemy.engine.url import make_url
+from sqlalchemy.pool import QueuePool
+
+
+# --------------------------------------------------------------------------
+# Public helpers
+# --------------------------------------------------------------------------
+
+
+def is_sqlite(url: str) -> bool:
+    """Return ``True`` if ``url`` is a SQLite SQLAlchemy URL.
+
+    Used to gate the SQLite-specific pragma hook so :func:`make_engines`
+    stays portable when PollyPM eventually grows a Postgres backend.
+
+    Examples
+    --------
+    >>> is_sqlite("sqlite:///foo.db")
+    True
+    >>> is_sqlite("sqlite+pysqlite:///foo.db")
+    True
+    >>> is_sqlite("postgresql+psycopg://host/db")
+    False
+    """
+    try:
+        parsed = make_url(url)
+    except Exception:
+        # Fall back to the raw scheme if SQLAlchemy can't parse the URL.
+        # We don't want a malformed URL here to explode — that's
+        # ``create_engine``'s job to report downstream.
+        scheme = urlparse(url).scheme.lower()
+        return scheme.startswith("sqlite")
+    return parsed.get_backend_name() == "sqlite"
+
+
+def make_engines(url: str) -> tuple[Engine, Engine]:
+    """Return ``(write_engine, read_engine)`` for ``url``.
+
+    The writer serializes all writes on a single pooled connection; the
+    reader pool allows up to 5 concurrent reads. For SQLite URLs, the
+    WAL / busy_timeout / synchronous / foreign_keys pragmas are applied
+    on every new connection.
+
+    Parameters
+    ----------
+    url:
+        SQLAlchemy URL. Typically ``sqlite:///<path>``; may also be
+        ``sqlite:///:memory:`` for throwaway tests (but note memory DBs
+        are per-connection, so the two engines will not share state).
+
+    Returns
+    -------
+    (write_engine, read_engine)
+        Two separate :class:`~sqlalchemy.engine.Engine` instances backed
+        by independent ``QueuePool`` instances.
+    """
+    write_engine = create_engine(
+        url,
+        poolclass=QueuePool,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=30,
+        future=True,
+    )
+    read_engine = create_engine(
+        url,
+        poolclass=QueuePool,
+        pool_size=5,
+        future=True,
+    )
+
+    if is_sqlite(url):
+        _install_sqlite_pragmas(write_engine)
+        _install_sqlite_pragmas(read_engine)
+
+    return write_engine, read_engine
+
+
+# --------------------------------------------------------------------------
+# SQLite pragma hook
+# --------------------------------------------------------------------------
+
+
+_SQLITE_PRAGMAS: tuple[tuple[str, str], ...] = (
+    ("journal_mode", "WAL"),
+    ("busy_timeout", "30000"),
+    ("synchronous", "NORMAL"),
+    ("foreign_keys", "ON"),
+)
+
+
+def _install_sqlite_pragmas(engine: Engine) -> None:
+    """Register a ``connect`` listener that applies PollyPM's SQLite pragmas.
+
+    Called once per engine at construction time. SQLAlchemy invokes the
+    listener on every new physical connection the pool opens, so reused
+    pooled connections keep the pragmas they were initialized with.
+    """
+
+    @event.listens_for(engine, "connect")
+    def _set_pragmas(dbapi_connection: object, _connection_record: object) -> None:
+        # Only apply pragmas when the underlying DB-API is SQLite. If a
+        # future Postgres dialect somehow reaches this hook (via a pool
+        # configured with an unexpected URL), silently skip rather than
+        # raising — the ``is_sqlite`` gate in :func:`make_engines` is the
+        # primary guard; this is defense in depth.
+        if not isinstance(dbapi_connection, sqlite3.Connection):
+            return
+        cursor = dbapi_connection.cursor()
+        try:
+            for name, value in _SQLITE_PRAGMAS:
+                cursor.execute(f"PRAGMA {name}={value}")
+        finally:
+            cursor.close()

--- a/src/pollypm/store/protocol.py
+++ b/src/pollypm/store/protocol.py
@@ -1,0 +1,100 @@
+"""Structural :class:`Store` protocol — the contract every backend implements.
+
+This is a deliberately narrow surface: only the methods current PollyPM
+callers actually use today. It is defined as a :class:`typing.Protocol`
+so existing duck-typed callers (and the ``MockWorkService``-style test
+doubles sprinkled around the repo) satisfy it without inheritance.
+
+Method bodies live in :mod:`pollypm.store.sqlalchemy_store` (skeleton in
+#337, real impls in #338 / #340). Signatures here are the minimal shapes
+needed for Issue A — individual follow-ups may widen them (e.g. adding
+``*, actor`` kwargs) without breaking the protocol check because
+``Protocol`` methods are matched structurally by name + basic shape.
+"""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Store(Protocol):
+    """Structural contract for PollyPM's persistent-state backend.
+
+    Implementations:
+
+    * :class:`pollypm.store.sqlalchemy_store.SQLAlchemyStore` — the real
+      backend (skeleton in #337, impls in #338 + #340).
+    * Test doubles in ``tests/`` — duck-typed, not inheritance-based.
+
+    The protocol is intentionally small. If a caller needs a method that
+    is not listed here, add it in the PR that introduces the caller, not
+    speculatively.
+    """
+
+    # ------------------------------------------------------------------
+    # Event log (append-only journal)
+    # ------------------------------------------------------------------
+
+    def append_event(self, *, kind: str, payload: dict[str, Any]) -> None:
+        """Append an event to the journal. Fire-and-forget; no return value."""
+        ...
+
+    def record_event(
+        self, session_name: str, event_type: str, message: str
+    ) -> None:
+        """Record a session-scoped event (heartbeat / supervisor audit trail)."""
+        ...
+
+    # ------------------------------------------------------------------
+    # Inbox messages
+    # ------------------------------------------------------------------
+
+    def enqueue_message(self, message: dict[str, Any]) -> int:
+        """Insert a new inbox message. Returns the assigned row id."""
+        ...
+
+    def update_message(self, message_id: int, **fields: Any) -> None:
+        """Patch fields on an existing inbox message."""
+        ...
+
+    def close_message(self, message_id: int, *, reason: str | None = None) -> None:
+        """Mark an inbox message as closed/resolved."""
+        ...
+
+    def query_messages(self, **filters: Any) -> list[dict[str, Any]]:
+        """Return inbox messages matching ``filters`` (ordered by recency)."""
+        ...
+
+    # ------------------------------------------------------------------
+    # Alerts
+    # ------------------------------------------------------------------
+
+    def upsert_alert(
+        self,
+        session_name: str,
+        alert_type: str,
+        severity: str,
+        message: str,
+    ) -> None:
+        """Create or refresh an alert for ``(session_name, alert_type)``."""
+        ...
+
+    def clear_alert(self, session_name: str, alert_type: str) -> None:
+        """Clear any alert matching ``(session_name, alert_type)``."""
+        ...
+
+    # ------------------------------------------------------------------
+    # Transaction scope
+    # ------------------------------------------------------------------
+
+    def transaction(self) -> AbstractContextManager[Any]:
+        """Context manager yielding a write-scoped connection.
+
+        Commits on clean exit, rolls back on exception. Implementations
+        return a SQLAlchemy :class:`~sqlalchemy.engine.Connection`; test
+        doubles may yield a lighter-weight handle as long as it supports
+        ``execute(...)``.
+        """
+        ...

--- a/src/pollypm/store/sqlalchemy_store.py
+++ b/src/pollypm/store/sqlalchemy_store.py
@@ -1,0 +1,159 @@
+"""Skeleton SQLAlchemy-backed :class:`Store` — real method bodies land later.
+
+Issue #337 installs this scaffolding so downstream issues can implement one
+method at a time without churning imports:
+
+* :class:`SQLAlchemyStore.__init__` builds the writer + reader engines via
+  :func:`pollypm.store.engine.make_engines` and holds a shared
+  :class:`sqlalchemy.MetaData` placeholder that #338 will populate with
+  table definitions.
+* :meth:`SQLAlchemyStore.transaction` is fully functional — it yields a
+  SQLAlchemy :class:`~sqlalchemy.engine.Connection` from the write engine,
+  commits on clean exit, and rolls back on exception. Callers can start
+  using it immediately for ad-hoc writes.
+* Every other method raises :class:`NotImplementedError` with a message
+  pointing to the issue that implements it (#338 for schema/events,
+  #340 for callers). Those messages follow the three-question rule:
+  *what happened* / *why it matters* / *how to fix it* (→ wait for / look
+  at the issue).
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+from sqlalchemy import MetaData
+from sqlalchemy.engine import Connection, Engine
+
+from pollypm.store.engine import make_engines
+
+
+_NOT_YET_IMPLEMENTED = (
+    "SQLAlchemyStore.{method}() is not implemented yet. "
+    "The storage rewrite lands in phases — method bodies arrive in issue-B "
+    "(#338, schema + event log) and issue-D (#340, caller migration). "
+    "Fix: wait for those issues to merge, or track progress in the #337 epic."
+)
+
+
+class SQLAlchemyStore:
+    """Skeleton implementation of the :class:`pollypm.store.Store` protocol.
+
+    Construction wires up the dual-pool engines so downstream PRs can test
+    against a live DB without re-plumbing the factory. The ``transaction()``
+    context manager is the only fully working method in this PR.
+    """
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+        self._write_engine, self._read_engine = make_engines(url)
+        # Placeholder — #338 populates this with the full schema. Callers
+        # in this PR should treat it as opaque.
+        self._metadata = MetaData()
+
+    # ------------------------------------------------------------------
+    # Accessors (useful for tests + future issues; not part of ``Store``).
+    # ------------------------------------------------------------------
+
+    @property
+    def url(self) -> str:
+        """Original SQLAlchemy URL passed to ``__init__``."""
+        return self._url
+
+    @property
+    def write_engine(self) -> Engine:
+        """Writer engine — single-connection pool, serialized writes."""
+        return self._write_engine
+
+    @property
+    def read_engine(self) -> Engine:
+        """Reader engine — 5-connection pool, WAL-concurrent reads."""
+        return self._read_engine
+
+    @property
+    def metadata(self) -> MetaData:
+        """Shared :class:`~sqlalchemy.MetaData` — populated by #338."""
+        return self._metadata
+
+    def dispose(self) -> None:
+        """Dispose both pooled engines. Safe to call multiple times."""
+        self._write_engine.dispose()
+        self._read_engine.dispose()
+
+    # ------------------------------------------------------------------
+    # Transaction scope — the only functional method in this PR.
+    # ------------------------------------------------------------------
+
+    @contextmanager
+    def transaction(self) -> Iterator[Connection]:
+        """Yield a write-scoped :class:`~sqlalchemy.engine.Connection`.
+
+        Commits on clean exit, rolls back on exception. Uses the writer
+        engine so all writes serialize through its single pooled
+        connection — no "database is locked" races.
+        """
+        conn = self._write_engine.connect()
+        try:
+            trans = conn.begin()
+            try:
+                yield conn
+            except BaseException:
+                trans.rollback()
+                raise
+            else:
+                trans.commit()
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Store protocol stubs — bodies land in #338 / #340.
+    # ------------------------------------------------------------------
+
+    def append_event(self, *, kind: str, payload: dict[str, Any]) -> None:
+        raise NotImplementedError(
+            _NOT_YET_IMPLEMENTED.format(method="append_event")
+        )
+
+    def record_event(
+        self, session_name: str, event_type: str, message: str
+    ) -> None:
+        raise NotImplementedError(
+            _NOT_YET_IMPLEMENTED.format(method="record_event")
+        )
+
+    def enqueue_message(self, message: dict[str, Any]) -> int:
+        raise NotImplementedError(
+            _NOT_YET_IMPLEMENTED.format(method="enqueue_message")
+        )
+
+    def update_message(self, message_id: int, **fields: Any) -> None:
+        raise NotImplementedError(
+            _NOT_YET_IMPLEMENTED.format(method="update_message")
+        )
+
+    def close_message(self, message_id: int, *, reason: str | None = None) -> None:
+        raise NotImplementedError(
+            _NOT_YET_IMPLEMENTED.format(method="close_message")
+        )
+
+    def query_messages(self, **filters: Any) -> list[dict[str, Any]]:
+        raise NotImplementedError(
+            _NOT_YET_IMPLEMENTED.format(method="query_messages")
+        )
+
+    def upsert_alert(
+        self,
+        session_name: str,
+        alert_type: str,
+        severity: str,
+        message: str,
+    ) -> None:
+        raise NotImplementedError(
+            _NOT_YET_IMPLEMENTED.format(method="upsert_alert")
+        )
+
+    def clear_alert(self, session_name: str, alert_type: str) -> None:
+        raise NotImplementedError(
+            _NOT_YET_IMPLEMENTED.format(method="clear_alert")
+        )

--- a/tests/test_store_engine.py
+++ b/tests/test_store_engine.py
@@ -1,0 +1,245 @@
+"""Tests for :mod:`pollypm.store.engine` — the dual-pool engine factory.
+
+Run with an isolated HOME so the suite never leaks into ``~/.pollypm/``:
+
+    HOME=/tmp/pytest-store-foundation uv run pytest tests/test_store_engine.py -x
+
+Coverage (per issue #337 acceptance):
+
+1. All four SQLite pragmas (``journal_mode=WAL``, ``busy_timeout=30000``,
+   ``synchronous=NORMAL``, ``foreign_keys=ON``) take effect on every
+   connection the pool hands out.
+2. Writer pool serializes under thread contention — 10 threads each
+   holding a write transaction for ~0.05s produce wall-clock ≥ 0.5s with
+   no ``database is locked`` errors.
+3. Reader pool allows concurrent reads — 5 threads each sleeping ~0.1s
+   inside a read complete in well under the serial baseline.
+4. :func:`is_sqlite` correctly classifies SQLite vs non-SQLite URLs.
+5. :class:`SQLAlchemyStore.transaction` commits on success + rolls back
+   on exception, using the writer engine.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+
+from pollypm.store import SQLAlchemyStore, Store, is_sqlite, make_engines
+
+
+# --------------------------------------------------------------------------
+# is_sqlite — pure URL classification
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("sqlite:///foo.db", True),
+        ("sqlite:///:memory:", True),
+        ("sqlite+pysqlite:///bar.db", True),
+        ("postgresql+psycopg://host/db", False),
+        ("postgresql://user:pw@host:5432/db", False),
+        ("mysql+pymysql://user@host/db", False),
+    ],
+)
+def test_is_sqlite_classification(url: str, expected: bool) -> None:
+    assert is_sqlite(url) is expected
+
+
+# --------------------------------------------------------------------------
+# Pragmas
+# --------------------------------------------------------------------------
+
+
+def _db_url(tmp_path: Path, name: str = "store.db") -> str:
+    return f"sqlite:///{tmp_path / name}"
+
+
+def test_sqlite_pragmas_applied_on_writer(tmp_path: Path) -> None:
+    write_engine, _ = make_engines(_db_url(tmp_path))
+    with write_engine.connect() as conn:
+        assert (
+            conn.exec_driver_sql("PRAGMA journal_mode").scalar().lower() == "wal"
+        )
+        assert conn.exec_driver_sql("PRAGMA busy_timeout").scalar() == 30000
+        # synchronous: NORMAL == 1
+        assert conn.exec_driver_sql("PRAGMA synchronous").scalar() == 1
+        # foreign_keys: ON == 1
+        assert conn.exec_driver_sql("PRAGMA foreign_keys").scalar() == 1
+
+
+def test_sqlite_pragmas_applied_on_reader(tmp_path: Path) -> None:
+    # Writer has to create the file + flip WAL first so the reader sees
+    # the same journal_mode on its fresh connection.
+    write_engine, read_engine = make_engines(_db_url(tmp_path))
+    with write_engine.connect() as conn:
+        conn.exec_driver_sql("CREATE TABLE IF NOT EXISTS t (id INTEGER)")
+        conn.commit()
+
+    with read_engine.connect() as conn:
+        assert (
+            conn.exec_driver_sql("PRAGMA journal_mode").scalar().lower() == "wal"
+        )
+        assert conn.exec_driver_sql("PRAGMA busy_timeout").scalar() == 30000
+        assert conn.exec_driver_sql("PRAGMA synchronous").scalar() == 1
+        assert conn.exec_driver_sql("PRAGMA foreign_keys").scalar() == 1
+
+
+# --------------------------------------------------------------------------
+# Writer pool serialization
+# --------------------------------------------------------------------------
+
+
+def test_writer_pool_serializes_writes(tmp_path: Path) -> None:
+    """10 threads, each holding a write txn for 0.05s, wall time ≥ 0.5s."""
+    write_engine, _ = make_engines(_db_url(tmp_path))
+    with write_engine.begin() as conn:
+        conn.exec_driver_sql(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY AUTOINCREMENT, worker INTEGER)"
+        )
+
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+    hold = 0.05
+    n_workers = 10
+
+    def worker(i: int) -> None:
+        try:
+            with write_engine.begin() as conn:
+                time.sleep(hold)
+                conn.execute(text("INSERT INTO t (worker) VALUES (:w)"), {"w": i})
+        except BaseException as exc:  # pragma: no cover - failure capture
+            with errors_lock:
+                errors.append(exc)
+
+    start = time.monotonic()
+    with ThreadPoolExecutor(max_workers=n_workers) as pool:
+        futures = [pool.submit(worker, i) for i in range(n_workers)]
+        for fut in futures:
+            fut.result()
+    elapsed = time.monotonic() - start
+
+    assert not errors, f"writer threads raised: {errors!r}"
+    # With pool_size=1, the 10 transactions must run back-to-back.
+    assert elapsed >= hold * n_workers, (
+        f"writer pool did not serialize: {elapsed:.3f}s < "
+        f"{hold * n_workers:.3f}s expected floor"
+    )
+
+    # Sanity: all 10 inserts landed.
+    with write_engine.connect() as conn:
+        count = conn.execute(text("SELECT COUNT(*) FROM t")).scalar()
+    assert count == n_workers
+
+
+# --------------------------------------------------------------------------
+# Reader pool concurrency
+# --------------------------------------------------------------------------
+
+
+def test_reader_pool_allows_concurrent_reads(tmp_path: Path) -> None:
+    """5 threads each sleep 0.1s inside a read; wall time < serial total."""
+    write_engine, read_engine = make_engines(_db_url(tmp_path))
+    with write_engine.begin() as conn:
+        conn.exec_driver_sql("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)")
+        conn.exec_driver_sql("INSERT INTO t (id, v) VALUES (1, 42)")
+
+    hold = 0.1
+    n_readers = 5
+    serial_total = hold * n_readers
+
+    def reader() -> int:
+        with read_engine.connect() as conn:
+            row = conn.execute(text("SELECT v FROM t WHERE id=1")).scalar()
+            time.sleep(hold)
+            return int(row)
+
+    start = time.monotonic()
+    with ThreadPoolExecutor(max_workers=n_readers) as pool:
+        results = [f.result() for f in [pool.submit(reader) for _ in range(n_readers)]]
+    elapsed = time.monotonic() - start
+
+    assert results == [42] * n_readers
+    # Concurrent reads should finish well below the serial baseline.
+    # Allow generous headroom (0.7 * serial) to stay stable on busy CI.
+    assert elapsed < serial_total * 0.7, (
+        f"reader pool did not parallelize: {elapsed:.3f}s >= "
+        f"{serial_total * 0.7:.3f}s (serial total {serial_total:.3f}s)"
+    )
+
+
+# --------------------------------------------------------------------------
+# SQLAlchemyStore skeleton
+# --------------------------------------------------------------------------
+
+
+def test_store_protocol_is_satisfied_by_sqlalchemy_store(tmp_path: Path) -> None:
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    # Runtime-checkable Protocol: the isinstance check must pass.
+    assert isinstance(store, Store)
+    store.dispose()
+
+
+def test_store_transaction_commits_on_success(tmp_path: Path) -> None:
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    try:
+        with store.transaction() as conn:
+            conn.exec_driver_sql("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)")
+            conn.execute(text("INSERT INTO t (id, v) VALUES (1, 7)"))
+
+        with store.read_engine.connect() as conn:
+            assert conn.execute(text("SELECT v FROM t WHERE id=1")).scalar() == 7
+    finally:
+        store.dispose()
+
+
+def test_store_transaction_rolls_back_on_exception(tmp_path: Path) -> None:
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    try:
+        with store.transaction() as conn:
+            conn.exec_driver_sql("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER)")
+
+        class Boom(RuntimeError):
+            pass
+
+        with pytest.raises(Boom):
+            with store.transaction() as conn:
+                conn.execute(text("INSERT INTO t (id, v) VALUES (1, 99)"))
+                raise Boom("forced rollback")
+
+        with store.read_engine.connect() as conn:
+            assert conn.execute(text("SELECT COUNT(*) FROM t")).scalar() == 0
+    finally:
+        store.dispose()
+
+
+def test_store_stub_methods_raise_with_guidance(tmp_path: Path) -> None:
+    """Every unimplemented method must honor the three-question rule."""
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    try:
+        stubs = [
+            lambda: store.append_event(kind="x", payload={}),
+            lambda: store.record_event("s", "e", "m"),
+            lambda: store.enqueue_message({}),
+            lambda: store.update_message(1),
+            lambda: store.close_message(1),
+            lambda: store.query_messages(),
+            lambda: store.upsert_alert("s", "a", "warn", "m"),
+            lambda: store.clear_alert("s", "a"),
+        ]
+        for call in stubs:
+            with pytest.raises(NotImplementedError) as excinfo:
+                call()
+            msg = str(excinfo.value)
+            # Three-question rule: what / why / fix.
+            assert "not implemented" in msg.lower()
+            assert "#338" in msg or "#340" in msg
+            assert "Fix:" in msg
+    finally:
+        store.dispose()

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,37 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
+    { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/96/795619651d39c7fbd809a522f881aa6f0ead504cc8201c3a5b789dfaef99/greenlet-3.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a", size = 235498, upload-time = "2026-04-08T17:05:00.584Z" },
+    { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
+    { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
+    { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c4/6f621023364d7e85a4769c014c8982f98053246d142420e0328980933ceb/greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802", size = 236932, upload-time = "2026-04-08T17:04:33.551Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
+    { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
+    { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -124,6 +155,7 @@ version = "1.0.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },
+    { name = "sqlalchemy" },
     { name = "textual" },
     { name = "typer" },
 ]
@@ -137,6 +169,7 @@ dev = [
 requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "textual", specifier = ">=6.1.0" },
     { name = "typer", specifier = ">=0.16.0" },
 ]
@@ -223,6 +256,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547, upload-time = "2026-04-03T16:53:08.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782, upload-time = "2026-04-03T17:07:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156, upload-time = "2026-04-03T17:12:27.697Z" },
+    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832, upload-time = "2026-04-03T17:07:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000, upload-time = "2026-04-03T17:12:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641, upload-time = "2026-04-03T17:05:43.989Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498, upload-time = "2026-04-03T17:05:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807, upload-time = "2026-04-03T16:58:31.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481, upload-time = "2026-04-03T17:06:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565, upload-time = "2026-04-03T16:58:33.414Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769, upload-time = "2026-04-03T17:06:02.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319, upload-time = "2026-04-03T17:02:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104, upload-time = "2026-04-03T17:02:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #337. Foundation for the storage rewrite — no callers migrate yet, just the substrate.

- Add `sqlalchemy>=2.0` runtime dependency
- `src/pollypm/store/protocol.py` — runtime-checkable `Store` Protocol covering every operation future callers will need
- `src/pollypm/store/engine.py` — `make_engines(url)` returns dual-pool engines: **writer `pool_size=1, max_overflow=0, pool_timeout=30`** (serializes writes in-process, kills `database is locked` under contention) + **reader `pool_size=5`** (concurrent WAL reads)
- SQLite pragmas (`journal_mode=WAL`, `busy_timeout=30000`, `synchronous=NORMAL`, `foreign_keys=ON`) applied via `event.listens_for(engine, "connect")`, gated by `is_sqlite(url)` so Postgres can plug in unchanged
- `SQLAlchemyStore` skeleton — `__init__` builds both engines + MetaData. `transaction()` context manager commits/rollbacks properly. All other methods raise `NotImplementedError` with three-question-rule pointers to #338 / #340

## Test plan
- [x] `HOME=/tmp/pytest-store-foundation uv run pytest tests/test_store_engine.py -x` → **14 passed** in 0.86s
- [x] Writer serialization verified: 10 threads × 0.05s sleep → wall ≥ 0.5s (proves pool_size=1)
- [x] Reader concurrency verified: 5 threads → wall < 0.7× serial
- [x] All four pragmas verified on both engines
- [x] Protocol isinstance check, transaction commit + rollback paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)