### PR TITLE
feat(store): entry-point backend registry + Postgres stub (#343)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dev = [
 pm = "pollypm.cli:app"
 pollypm = "pollypm.cli:app"
 
+[project.entry-points."pollypm.store_backend"]
+sqlite = "pollypm.store.sqlalchemy_store:SQLAlchemyStore"
+
 [build-system]
 requires = ["setuptools>=80", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -19,6 +19,7 @@ from pollypm.models import (
     ProviderKind,
     RuntimeKind,
     SessionConfig,
+    StorageSettings,
 )
 
 
@@ -374,6 +375,46 @@ def _parse_events_retention_settings(
     )
 
 
+def _parse_storage_settings(
+    raw: dict[str, object],
+    *,
+    project: ProjectSettings,
+) -> StorageSettings:
+    """Parse the ``[storage]`` TOML section (issue #343).
+
+    Recognised keys:
+
+    * ``backend`` — entry-point name under ``pollypm.store_backend``.
+      Defaults to ``"sqlite"`` (registered by this package).
+    * ``url`` — SQLAlchemy URL. When empty/missing, the resolver derives
+      ``sqlite:///<project.state_db>`` so first-run users don't have to
+      think about connection strings.
+
+    Missing section yields defaults. Fat-fingered value types (non-str)
+    silently fall back to defaults — a broken ``[storage]`` block must
+    never brick the CLI on a config the user can fix with ``pm repair``.
+    """
+    storage_raw = raw.get("storage", {})
+    if not isinstance(storage_raw, dict):
+        storage_raw = {}
+    backend_raw = storage_raw.get("backend", "sqlite")
+    if not isinstance(backend_raw, str) or not backend_raw.strip():
+        backend_raw = "sqlite"
+    url_raw = storage_raw.get("url", "")
+    if not isinstance(url_raw, str):
+        url_raw = ""
+    url_stripped = url_raw.strip()
+    if not url_stripped:
+        # Default-derive from the already-resolved state_db path. The
+        # resolver downstream uses this URL verbatim, so emit an absolute
+        # path that survives chdir.
+        url_stripped = f"sqlite:///{project.state_db.resolve()}"
+    return StorageSettings(
+        backend=backend_raw.strip(),
+        url=url_stripped,
+    )
+
+
 def _parse_plugin_settings(raw: dict[str, object]) -> PluginSettings:
     """Parse the ``[plugins]`` TOML section.
 
@@ -500,6 +541,7 @@ def load_config(path: Path = DEFAULT_CONFIG_PATH) -> PollyPMConfig:
     planner = _parse_planner_settings(raw)
     logging_settings = _parse_logging_settings(raw)
     events = _parse_events_retention_settings(raw)
+    storage = _parse_storage_settings(raw, project=project)
     projects = _parse_known_projects(raw, base=base)
     _merge_project_local_config(sessions, projects, plugins)
     _validate_cross_references(accounts=accounts, sessions=sessions, pollypm=pollypm)
@@ -516,6 +558,7 @@ def load_config(path: Path = DEFAULT_CONFIG_PATH) -> PollyPMConfig:
         planner=planner,
         logging=logging_settings,
         events=events,
+        storage=storage,
     )
     try:
         _config_cache[config_path] = (config_path.stat().st_mtime, config)

--- a/src/pollypm/doctor.py
+++ b/src/pollypm/doctor.py
@@ -624,6 +624,89 @@ def check_provider_account_configured() -> CheckResult:
     )
 
 
+def check_storage_backend() -> CheckResult:
+    """Resolve the configured storage backend via entry points (issue #343).
+
+    Calls :func:`pollypm.store.registry.get_store` and reports which
+    backend is active plus its URL. A missing config skips. A
+    :class:`~pollypm.errors.StoreBackendNotFound` surfaces the
+    three-question-rule message verbatim so the user sees what, why,
+    and how to fix.
+    """
+    from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+    from pollypm.errors import StoreBackendNotFound
+    from pollypm.store.registry import get_store
+
+    if not DEFAULT_CONFIG_PATH.exists():
+        return _skip("storage backend check skipped (no config)")
+    try:
+        config = load_config(DEFAULT_CONFIG_PATH)
+    except Exception as exc:  # noqa: BLE001
+        return _fail(
+            f"config failed to parse ({exc})",
+            why=(
+                "Doctor cannot resolve the storage backend without a "
+                "parseable ~/.pollypm/pollypm.toml."
+            ),
+            fix=(
+                "Inspect and fix the config —\n"
+                "  pm example-config   # reference template\n"
+                "  edit ~/.pollypm/pollypm.toml\n"
+                "Recheck: pm doctor"
+            ),
+            data={"error": str(exc)},
+        )
+    backend_name = config.storage.backend
+    try:
+        store = get_store(config)
+    except StoreBackendNotFound as exc:
+        return _fail(
+            f"storage backend '{backend_name}' not installed",
+            why=(
+                "PollyPM resolves its persistent-state backend via the "
+                "'pollypm.store_backend' entry-point group; no installed "
+                "package registered that name. Every subsystem that writes "
+                "state will fail until this is fixed."
+            ),
+            fix=(
+                "Set [storage].backend in ~/.pollypm/pollypm.toml to an "
+                "installed backend, or install the package that ships the "
+                f"'{backend_name}' backend.\n"
+                f"Available: {', '.join(exc.available) or 'none'}\n"
+                "Recheck: pm doctor"
+            ),
+            data={"backend": backend_name, "available": exc.available},
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _fail(
+            f"storage backend '{backend_name}' failed to initialise ({exc})",
+            why=(
+                "The entry point loaded but construction raised — the "
+                "backend is registered but not usable in this environment."
+            ),
+            fix=(
+                "Inspect the error above, check [storage].url in "
+                "~/.pollypm/pollypm.toml, and verify the backend package's "
+                "own dependencies.\n"
+                "Recheck: pm doctor"
+            ),
+            data={"backend": backend_name, "error": str(exc)},
+        )
+    # Grab the URL for reporting, then release the resources the store
+    # just opened. Doctor must not leave connection pools dangling.
+    url = getattr(store, "url", "<unknown>")
+    try:
+        dispose = getattr(store, "dispose", None)
+        if callable(dispose):
+            dispose()
+    except Exception:  # noqa: BLE001
+        pass
+    return _ok(
+        f"storage backend '{backend_name}' active at {url}",
+        data={"backend": backend_name, "url": url},
+    )
+
+
 # --------------------------------------------------------------------- #
 # Plugin health
 # --------------------------------------------------------------------- #
@@ -2394,6 +2477,7 @@ def _registered_checks() -> list[Check]:
         Check("pollypm-version-matches", check_installed_version_matches_pyproject, "install", severity="warning"),
         Check("config-file", check_config_file, "install"),
         Check("provider-account", check_provider_account_configured, "install"),
+        Check("storage-backend", check_storage_backend, "install"),
         # Plugins
         Check("builtin-plugin-manifests", check_builtin_plugin_manifests, "plugins"),
         Check("critical-plugins-enabled", check_no_critical_plugin_disabled, "plugins"),

--- a/src/pollypm/errors.py
+++ b/src/pollypm/errors.py
@@ -87,6 +87,36 @@ def format_probe_failure(
     return "\n".join(parts)
 
 
+class StoreBackendNotFound(LookupError):
+    """No ``pollypm.store_backend`` entry point matches the configured name.
+
+    Raised by :func:`pollypm.store.registry.get_store` when
+    ``config.storage.backend`` names a backend that is not currently
+    installed. The message follows the three-question rule (#240): what
+    happened, why it matters, how to fix it — including the list of
+    backends that *are* available so the user can eyeball a typo.
+    """
+
+    def __init__(self, backend: str, *, available: list[str]) -> None:
+        self.backend = backend
+        self.available = list(available)
+        available_list = ", ".join(available) if available else "none"
+        message = (
+            f"Storage backend '{backend}' is not installed.\n\n"
+            f"PollyPM loads its persistent-state backend via the "
+            f"'pollypm.store_backend' entry-point group, and no installed "
+            f"package registered a backend with that name — so the CLI "
+            f"cannot open the state DB and every subsystem that persists "
+            f"state will fail.\n\n"
+            f"Available backends: {available_list}.\n\n"
+            f"Fix: set ``[storage] backend`` in ~/.pollypm/pollypm.toml to "
+            f"one of the available names, or install the package that "
+            f"ships '{backend}' (e.g. `uv tool install "
+            f"pollypm-store-postgres` for the Postgres backend)."
+        )
+        super().__init__(message)
+
+
 def _last_lines(text: str, n: int = 5) -> str:
     """Return the last ``n`` non-empty lines of ``text``.
 

--- a/src/pollypm/models.py
+++ b/src/pollypm/models.py
@@ -193,6 +193,27 @@ class EventsRetentionSettings:
 
 
 @dataclass(slots=True)
+class StorageSettings:
+    """Storage-backend selection from the ``[storage]`` TOML section.
+
+    PollyPM loads its persistent-state backend via the
+    ``pollypm.store_backend`` entry-point group (issue #343). This
+    dataclass holds the config values the resolver feeds into
+    :func:`pollypm.store.registry.get_store`.
+
+    ``backend`` — entry-point name. ``"sqlite"`` is the built-in default
+    registered by this package; third-party packages (e.g. the future
+    ``pollypm-store-postgres``) can register additional names.
+    ``url`` — SQLAlchemy URL passed to the backend constructor. Empty
+    string means "derive from ``config.project.state_db``" —
+    ``sqlite:///<resolved-state-db-path>``.
+    """
+
+    backend: str = "sqlite"
+    url: str = ""
+
+
+@dataclass(slots=True)
 class PollyPMConfig:
     project: ProjectSettings
     pollypm: PollyPMSettings
@@ -207,6 +228,7 @@ class PollyPMConfig:
     events: EventsRetentionSettings = field(
         default_factory=EventsRetentionSettings,
     )
+    storage: StorageSettings = field(default_factory=StorageSettings)
 
 
 @dataclass(slots=True)

--- a/src/pollypm/store/backends/__init__.py
+++ b/src/pollypm/store/backends/__init__.py
@@ -1,0 +1,17 @@
+"""Non-default store backends (issue #343).
+
+This subpackage collects storage backends that don't ship as the
+PollyPM default — they exist so the ``Store`` protocol can be proven
+dialect-agnostic before a real implementation lands. The built-in
+SQLite/SQLAlchemy backend lives one directory up in
+:mod:`pollypm.store.sqlalchemy_store`; it's registered by the
+``pollypm.store_backend`` entry-point group in the project's
+``pyproject.toml`` and is what :func:`pollypm.store.registry.get_store`
+returns by default.
+
+Third-party backends — e.g. the future ``pollypm-store-postgres``
+package — register themselves under the same entry-point group and get
+picked up automatically by the registry. Nothing under
+:mod:`pollypm.store.backends` is registered in PollyPM's own
+``pyproject.toml``; these are **reference stubs only**.
+"""

--- a/src/pollypm/store/backends/postgres_stub.py
+++ b/src/pollypm/store/backends/postgres_stub.py
@@ -1,0 +1,99 @@
+"""Postgres backend stub — proves the :class:`Store` protocol is dialect-agnostic.
+
+Issue #343 lands this file as a **reference stub only**. It is
+intentionally *not* registered in PollyPM's ``pyproject.toml``
+entry-point group: the real Postgres backend will ship as a separate
+installable package (``pollypm-store-postgres``) that registers its own
+``pollypm.store_backend`` entry point at install time.
+
+The value of keeping this class in-tree is structural: every method on
+the :class:`pollypm.store.Store` protocol has a stub here, which forces
+the protocol to stay dialect-neutral. If a future change introduces a
+SQLite-only assumption into :class:`~pollypm.store.protocol.Store`, the
+stub will stop being trivially implementable and reviewers will catch
+the leak before it bakes in.
+
+Every method raises :class:`NotImplementedError` with a three-question
+message (what / why / fix — see issue #240).
+"""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from typing import Any
+
+
+_NOT_YET_IMPLEMENTED = (
+    "Postgres backend is v1.1; install pollypm-store-postgres. "
+    "The in-tree stub exists to prove the Store protocol stays "
+    "dialect-agnostic — it deliberately does not connect to a "
+    "database. Fix: `uv tool install pollypm-store-postgres` (once the "
+    "package is published), then set ``[storage] backend = 'postgres'`` "
+    "in ~/.pollypm/pollypm.toml."
+)
+
+
+class PostgresStore:
+    """Structural stub — every method raises :class:`NotImplementedError`.
+
+    Accepts ``url=`` so the resolver's construction contract
+    (``cls(url=...)``) is identical to the SQLite backend. The URL is
+    stored verbatim for debugging (e.g. ``pm doctor`` might print it)
+    but never opened.
+    """
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+
+    @property
+    def url(self) -> str:
+        """The URL the stub was constructed with. Never used to connect."""
+        return self._url
+
+    def dispose(self) -> None:
+        """No-op — the stub holds no resources."""
+        return None
+
+    # ------------------------------------------------------------------
+    # Store protocol — every method raises NotImplementedError.
+    # ------------------------------------------------------------------
+
+    def append_event(self, *, kind: str, payload: dict[str, Any]) -> None:
+        raise NotImplementedError(_NOT_YET_IMPLEMENTED)
+
+    def record_event(
+        self, session_name: str, event_type: str, message: str
+    ) -> None:
+        raise NotImplementedError(_NOT_YET_IMPLEMENTED)
+
+    def enqueue_message(self, message: dict[str, Any]) -> int:
+        raise NotImplementedError(_NOT_YET_IMPLEMENTED)
+
+    def update_message(self, message_id: int, **fields: Any) -> None:
+        raise NotImplementedError(_NOT_YET_IMPLEMENTED)
+
+    def close_message(
+        self, message_id: int, *, reason: str | None = None
+    ) -> None:
+        raise NotImplementedError(_NOT_YET_IMPLEMENTED)
+
+    def query_messages(self, **filters: Any) -> list[dict[str, Any]]:
+        raise NotImplementedError(_NOT_YET_IMPLEMENTED)
+
+    def upsert_alert(
+        self,
+        session_name: str,
+        alert_type: str,
+        severity: str,
+        message: str,
+    ) -> None:
+        raise NotImplementedError(_NOT_YET_IMPLEMENTED)
+
+    def clear_alert(self, session_name: str, alert_type: str) -> None:
+        raise NotImplementedError(_NOT_YET_IMPLEMENTED)
+
+    def transaction(self) -> AbstractContextManager[Any]:
+        raise NotImplementedError(_NOT_YET_IMPLEMENTED)
+
+
+__all__ = ["PostgresStore"]

--- a/src/pollypm/store/registry.py
+++ b/src/pollypm/store/registry.py
@@ -1,0 +1,102 @@
+"""Entry-point-driven storage backend registry (issue #343).
+
+PollyPM's persistent state backend is selected at runtime via the
+``pollypm.store_backend`` entry-point group. This module is the single
+public entry point for resolving a backend from a loaded
+:class:`~pollypm.models.PollyPMConfig`.
+
+Design
+------
+
+* **Entry points — not a hard-coded switch.** Built-in SQLite is
+  registered by PollyPM itself in ``pyproject.toml``. Third-party
+  packages (e.g. the future ``pollypm-store-postgres`` shipped via
+  :mod:`pollypm.store.backends.postgres_stub`) register their own
+  entry points under the same group and become selectable without any
+  code change in this repo.
+* **URL resolution lives in one place.** If ``config.storage.url`` is
+  empty, we derive ``sqlite:///<project.state_db>`` so a first-run user
+  who never touched ``[storage]`` still gets a working DB at the path
+  the rest of PollyPM already uses.
+* **Unknown backend fails loud.** :class:`StoreBackendNotFound` lists
+  the backends that *are* installed so a typo is immediately visible
+  (three-question rule — issue #240).
+
+The registry returns a :class:`pollypm.store.Store`-satisfying object.
+The entry-point target must be a callable taking a ``url=`` keyword —
+both :class:`SQLAlchemyStore` and the Postgres stub honour that shape.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from typing import TYPE_CHECKING
+
+from pollypm.errors import StoreBackendNotFound
+
+if TYPE_CHECKING:
+    from pollypm.models import PollyPMConfig
+    from pollypm.store.protocol import Store
+
+
+ENTRY_POINT_GROUP = "pollypm.store_backend"
+
+
+def _resolve_url(config: "PollyPMConfig") -> str:
+    """Return the SQLAlchemy URL for ``config``.
+
+    Honours ``config.storage.url`` verbatim when set. Otherwise derives
+    ``sqlite:///<project.state_db>`` so the resolver always produces a
+    concrete URL — backends never have to re-implement the fallback.
+    The config parser already applies the same default, but we re-check
+    here so test doubles and hand-built configs still work.
+    """
+    url = (config.storage.url or "").strip()
+    if url:
+        return url
+    return f"sqlite:///{config.project.state_db.resolve()}"
+
+
+def _available_backends() -> list[str]:
+    """Return sorted entry-point names registered under our group."""
+    return sorted(
+        ep.name
+        for ep in importlib.metadata.entry_points(group=ENTRY_POINT_GROUP)
+    )
+
+
+def get_store(config: "PollyPMConfig") -> "Store":
+    """Load the configured storage backend via entry points.
+
+    Parameters
+    ----------
+    config
+        The loaded :class:`~pollypm.models.PollyPMConfig`. Only
+        ``config.storage`` and ``config.project.state_db`` are read.
+
+    Returns
+    -------
+    Store
+        An instantiated backend satisfying the
+        :class:`pollypm.store.Store` protocol. The caller owns its
+        lifecycle — call ``store.dispose()`` when finished.
+
+    Raises
+    ------
+    StoreBackendNotFound
+        When ``config.storage.backend`` does not match any installed
+        entry point in the ``pollypm.store_backend`` group. The error
+        message lists every backend that *is* registered.
+    """
+    backend = config.storage.backend
+    for ep in importlib.metadata.entry_points(group=ENTRY_POINT_GROUP):
+        if ep.name == backend:
+            cls = ep.load()
+            return cls(url=_resolve_url(config))
+    raise StoreBackendNotFound(
+        backend,
+        available=_available_backends(),
+    )
+
+
+__all__ = ["ENTRY_POINT_GROUP", "get_store"]

--- a/tests/test_store_registry.py
+++ b/tests/test_store_registry.py
@@ -1,0 +1,373 @@
+"""Tests for :mod:`pollypm.store.registry` — entry-point backend resolver.
+
+Run with an isolated HOME so the suite never leaks into ``~/.pollypm/``:
+
+    HOME=/tmp/pytest-store-registry uv run pytest tests/test_store_registry.py -x
+
+Coverage (per issue #343 acceptance):
+
+1. :func:`get_store` returns a real :class:`SQLAlchemyStore` for the
+   default ``backend='sqlite'`` + derived URL.
+2. A test-only entry point (injected via monkeypatch) loads and gets
+   passed the resolved URL.
+3. An unknown backend raises :class:`StoreBackendNotFound` whose
+   message includes the requested name and the available backends.
+4. Config round-trip: missing ``[storage]`` applies defaults, a present
+   block parses ``backend`` / ``url``, and an empty URL auto-derives
+   ``sqlite:///<state_db>``.
+5. The ``pollypm.store_backend`` entry-point group is actually
+   populated by PollyPM's own ``pyproject.toml`` — sanity check that
+   the install registered the default.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pollypm.config import _parse_storage_settings, load_config
+from pollypm.errors import StoreBackendNotFound
+from pollypm.models import (
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectSettings,
+    StorageSettings,
+)
+from pollypm.store import SQLAlchemyStore
+from pollypm.store.registry import (
+    ENTRY_POINT_GROUP,
+    _resolve_url,
+    get_store,
+)
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _make_config(
+    tmp_path: Path,
+    *,
+    backend: str = "sqlite",
+    url: str = "",
+) -> PollyPMConfig:
+    state_db = tmp_path / "state.db"
+    project = ProjectSettings(
+        name="Test",
+        root_dir=tmp_path,
+        state_db=state_db,
+        base_dir=tmp_path,
+        logs_dir=tmp_path / "logs",
+        snapshots_dir=tmp_path / "snapshots",
+    )
+    return PollyPMConfig(
+        project=project,
+        pollypm=PollyPMSettings(controller_account=""),
+        accounts={},
+        sessions={},
+        storage=StorageSettings(backend=backend, url=url),
+    )
+
+
+@dataclass
+class _FakeEntryPoint:
+    """Minimal duck-type stand-in for :class:`importlib.metadata.EntryPoint`.
+
+    The real ``EntryPoint`` can't be constructed freely in all Python
+    versions; the registry only touches ``.name`` and ``.load()`` so
+    this is sufficient for the monkeypatch.
+    """
+
+    name: str
+    target: Any
+
+    def load(self) -> Any:
+        return self.target
+
+
+# --------------------------------------------------------------------------
+# 1. Default backend round-trip.
+# --------------------------------------------------------------------------
+
+
+def test_get_store_returns_sqlalchemy_store_by_default(tmp_path: Path) -> None:
+    config = _make_config(tmp_path)
+    store = get_store(config)
+    try:
+        assert isinstance(store, SQLAlchemyStore)
+        # URL auto-derives when config.storage.url is empty.
+        assert store.url == f"sqlite:///{(tmp_path / 'state.db').resolve()}"
+    finally:
+        store.dispose()
+
+
+def test_get_store_honours_explicit_url(tmp_path: Path) -> None:
+    explicit = f"sqlite:///{tmp_path / 'custom.db'}"
+    config = _make_config(tmp_path, url=explicit)
+    store = get_store(config)
+    try:
+        assert store.url == explicit
+    finally:
+        store.dispose()
+
+
+# --------------------------------------------------------------------------
+# 2. Fake entry-point injection.
+# --------------------------------------------------------------------------
+
+
+class _FakeBackend:
+    """Non-functional backend used to prove the registry loads arbitrary EPs."""
+
+    constructed_with: list[str] = []
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+        _FakeBackend.constructed_with.append(url)
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+    def dispose(self) -> None:
+        return None
+
+
+def _patch_entry_points(
+    monkeypatch: pytest.MonkeyPatch,
+    entries: list[_FakeEntryPoint],
+) -> None:
+    """Force :mod:`importlib.metadata` to return ``entries`` for our group."""
+    real = importlib.metadata.entry_points
+
+    def _fake(*args: Any, **kwargs: Any) -> Any:
+        group = kwargs.get("group")
+        if group == ENTRY_POINT_GROUP:
+            return entries
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", _fake)
+
+
+def test_get_store_loads_registered_fake_backend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _FakeBackend.constructed_with = []
+    fake_ep = _FakeEntryPoint(name="fake", target=_FakeBackend)
+    _patch_entry_points(monkeypatch, [fake_ep])
+
+    config = _make_config(tmp_path, backend="fake", url="postgresql://x/y")
+    store = get_store(config)
+    assert isinstance(store, _FakeBackend)
+    # URL must be passed through to the backend constructor.
+    assert _FakeBackend.constructed_with == ["postgresql://x/y"]
+    assert store.url == "postgresql://x/y"
+
+
+def test_get_store_passes_derived_url_to_backend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Empty URL → resolver derives, backend receives the derivation."""
+    _FakeBackend.constructed_with = []
+    _patch_entry_points(
+        monkeypatch,
+        [_FakeEntryPoint(name="fake", target=_FakeBackend)],
+    )
+    config = _make_config(tmp_path, backend="fake", url="")
+    store = get_store(config)
+    expected = f"sqlite:///{(tmp_path / 'state.db').resolve()}"
+    assert store.url == expected
+    assert _FakeBackend.constructed_with == [expected]
+
+
+# --------------------------------------------------------------------------
+# 3. Unknown backend error.
+# --------------------------------------------------------------------------
+
+
+def test_get_store_raises_when_backend_unknown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Install two fake backends so the "available" list is non-trivial.
+    _patch_entry_points(
+        monkeypatch,
+        [
+            _FakeEntryPoint(name="alpha", target=_FakeBackend),
+            _FakeEntryPoint(name="beta", target=_FakeBackend),
+        ],
+    )
+    config = _make_config(tmp_path, backend="gamma")
+    with pytest.raises(StoreBackendNotFound) as excinfo:
+        get_store(config)
+    err = excinfo.value
+    assert err.backend == "gamma"
+    # _available_backends sorts its output; validate membership rather
+    # than exact equality so future entry points added by tests don't
+    # break this assertion.
+    assert "alpha" in err.available
+    assert "beta" in err.available
+    msg = str(err)
+    # Three-question rule: the message names what, why, and how to fix.
+    assert "gamma" in msg
+    assert "alpha" in msg and "beta" in msg
+    assert "Fix:" in msg
+
+
+def test_store_backend_not_found_handles_empty_available() -> None:
+    """Message stays readable when no backends are installed at all."""
+    err = StoreBackendNotFound("nothing", available=[])
+    msg = str(err)
+    assert "nothing" in msg
+    assert "Available backends: none" in msg
+    assert "Fix:" in msg
+
+
+# --------------------------------------------------------------------------
+# 4. Config round-trip for [storage].
+# --------------------------------------------------------------------------
+
+
+def test_storage_settings_defaults_when_section_missing(tmp_path: Path) -> None:
+    project = ProjectSettings(
+        name="Test",
+        root_dir=tmp_path,
+        state_db=tmp_path / "state.db",
+        base_dir=tmp_path,
+        logs_dir=tmp_path / "logs",
+        snapshots_dir=tmp_path / "snapshots",
+    )
+    storage = _parse_storage_settings({}, project=project)
+    assert storage.backend == "sqlite"
+    # Default-derive from the resolved state_db path.
+    assert storage.url == f"sqlite:///{(tmp_path / 'state.db').resolve()}"
+
+
+def test_storage_settings_parses_backend_and_url(tmp_path: Path) -> None:
+    project = ProjectSettings(
+        name="Test",
+        root_dir=tmp_path,
+        state_db=tmp_path / "state.db",
+        base_dir=tmp_path,
+        logs_dir=tmp_path / "logs",
+        snapshots_dir=tmp_path / "snapshots",
+    )
+    storage = _parse_storage_settings(
+        {"storage": {"backend": "postgres", "url": "postgresql://u@h/db"}},
+        project=project,
+    )
+    assert storage.backend == "postgres"
+    assert storage.url == "postgresql://u@h/db"
+
+
+def test_storage_settings_empty_url_derives_from_state_db(tmp_path: Path) -> None:
+    project = ProjectSettings(
+        name="Test",
+        root_dir=tmp_path,
+        state_db=tmp_path / "custom.db",
+        base_dir=tmp_path,
+        logs_dir=tmp_path / "logs",
+        snapshots_dir=tmp_path / "snapshots",
+    )
+    storage = _parse_storage_settings(
+        {"storage": {"backend": "sqlite", "url": ""}},
+        project=project,
+    )
+    assert storage.url == f"sqlite:///{(tmp_path / 'custom.db').resolve()}"
+
+
+def test_storage_settings_bogus_types_fall_back_to_defaults(tmp_path: Path) -> None:
+    project = ProjectSettings(
+        name="Test",
+        root_dir=tmp_path,
+        state_db=tmp_path / "state.db",
+        base_dir=tmp_path,
+        logs_dir=tmp_path / "logs",
+        snapshots_dir=tmp_path / "snapshots",
+    )
+    # A non-dict [storage] section → defaults.
+    assert _parse_storage_settings({"storage": "nope"}, project=project).backend == "sqlite"
+    # Non-string backend → falls back.
+    storage = _parse_storage_settings(
+        {"storage": {"backend": 42, "url": None}},
+        project=project,
+    )
+    assert storage.backend == "sqlite"
+    assert storage.url.startswith("sqlite:///")
+
+
+def test_load_config_populates_storage_from_toml(tmp_path: Path) -> None:
+    """Full config round-trip: TOML → load_config → config.storage."""
+    config_dir = tmp_path / "home"
+    config_dir.mkdir()
+    config_path = config_dir / "pollypm.toml"
+    state_db = config_dir / ".pollypm-state" / "state.db"
+    config_path.write_text(
+        "[project]\n"
+        'name = "Test"\n'
+        f'base_dir = "{config_dir}"\n'
+        f'logs_dir = "{config_dir}/logs"\n'
+        f'snapshots_dir = "{config_dir}/snapshots"\n'
+        f'state_db = "{state_db}"\n'
+        "\n"
+        "[storage]\n"
+        'backend = "sqlite"\n'
+        'url = "sqlite:///tmp/override.db"\n'
+    )
+    config = load_config(config_path)
+    assert config.storage.backend == "sqlite"
+    assert config.storage.url == "sqlite:///tmp/override.db"
+
+
+def test_load_config_applies_storage_defaults_when_section_missing(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / "home"
+    config_dir.mkdir()
+    config_path = config_dir / "pollypm.toml"
+    state_db = config_dir / ".pollypm-state" / "state.db"
+    config_path.write_text(
+        "[project]\n"
+        'name = "Test"\n'
+        f'base_dir = "{config_dir}"\n'
+        f'logs_dir = "{config_dir}/logs"\n'
+        f'snapshots_dir = "{config_dir}/snapshots"\n'
+        f'state_db = "{state_db}"\n'
+    )
+    config = load_config(config_path)
+    assert config.storage.backend == "sqlite"
+    # Resolver derives from state_db.
+    assert config.storage.url == f"sqlite:///{state_db.resolve()}"
+
+
+# --------------------------------------------------------------------------
+# 5. Installed entry-point sanity.
+# --------------------------------------------------------------------------
+
+
+def test_sqlite_backend_registered_in_installed_entry_points() -> None:
+    """PollyPM's own pyproject.toml must register the sqlite default."""
+    names = {ep.name for ep in importlib.metadata.entry_points(group=ENTRY_POINT_GROUP)}
+    assert "sqlite" in names, (
+        f"expected 'sqlite' in entry-point group {ENTRY_POINT_GROUP}; "
+        f"found: {sorted(names)}"
+    )
+
+
+# --------------------------------------------------------------------------
+# 6. URL resolver fallback coverage (no entry point invoked).
+# --------------------------------------------------------------------------
+
+
+def test_resolve_url_prefers_explicit(tmp_path: Path) -> None:
+    config = _make_config(tmp_path, url="postgresql://x/y")
+    assert _resolve_url(config) == "postgresql://x/y"
+
+
+def test_resolve_url_derives_when_empty(tmp_path: Path) -> None:
+    config = _make_config(tmp_path, url="   ")  # whitespace only
+    assert _resolve_url(config) == f"sqlite:///{(tmp_path / 'state.db').resolve()}"


### PR DESCRIPTION
## Summary

Closes #343. Makes storage backend swappable via Python entry points so future Postgres+pgvector is a pip install + config change.

- `pyproject.toml` — registers `sqlite = pollypm.store.sqlalchemy_store:SQLAlchemyStore` under `[project.entry-points."pollypm.store_backend"]`
- `StorageSettings` dataclass + `PollyPMConfig.storage` field; config parser derives `sqlite:///<state_db>` when URL omitted
- `src/pollypm/store/registry.py` — `get_store(config)` resolves entry point, constructs with resolved URL
- `StoreBackendNotFound` error with three-question-rule message listing available backends
- `PostgresStore` stub (not registered — ships via separate `pollypm-store-postgres` package)
- `pm doctor` reports active backend + URL

## Test plan
- [x] `HOME=/tmp/pytest-store-registry uv run pytest tests/test_store_registry.py -x` → **15 passed**
- [x] Regression: `test_store_engine.py` (14) + `test_config.py` (7) + `test_doctor.py` (61) all green
- [x] `uv run python -c "from pollypm.store.registry import get_store"` succeeds
- [x] `entry_points(group="pollypm.store_backend")` returns `[('sqlite', ...)]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)