### PR TITLE
feat(store): unified messages schema + fire-and-forget event buffer (#338)

### DIFF
--- a/src/pollypm/store/event_buffer.py
+++ b/src/pollypm/store/event_buffer.py
@@ -1,0 +1,466 @@
+"""Fire-and-forget event buffer — bounded queue → batched ``messages`` inserts.
+
+Most PollyPM subsystems want to emit a firehose event without caring whether
+the DB is momentarily busy: the supervisor heartbeat, flow-engine transitions,
+pane-pattern matches, etc. Routing every single emit through a synchronous
+insert puts a serialized-writer stall on the hot path and can cascade into
+worker-session latency.
+
+This module solves that with a classic producer/consumer:
+
+* Callers invoke :meth:`EventBuffer.append` — a non-blocking enqueue onto a
+  bounded :class:`queue.Queue` (capacity 10k). Overflow drops the oldest
+  pending event with a log line (never the new one — the newest signal is
+  usually the most interesting).
+* A single background thread drains the queue, batching up to
+  ``batch_size`` rows per transaction or flushing every ``flush_interval``
+  seconds — whichever comes first.
+* Every batch commits in one short-lived writer transaction so the pool's
+  ``pool_size=1`` never wedges.
+
+Shutdown paths (``close()`` and the ``SIGTERM``/``SIGINT`` handlers) are
+idempotent and guarantee a final flush of anything already enqueued. The
+signal handler intentionally chains to any pre-existing handler so PollyPM
+doesn't eat Ctrl-C for the host process.
+
+Issue #338. The buffer currently only emits rows with ``type='event'``;
+future issues layering on notify/alert tiers will inject via their own
+:class:`SQLAlchemyStore` methods rather than this queue.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import signal
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import insert
+
+from pollypm.store.schema import messages
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard
+    from pollypm.store.sqlalchemy_store import SQLAlchemyStore
+
+
+logger = logging.getLogger(__name__)
+
+
+# Module-level guard so multiple ``EventBuffer`` instances in the same
+# process don't each clobber the other's signal handler. The first buffer
+# wins; later buffers chain through it via the process-wide handler stack.
+_SIGNAL_HANDLERS_LOCK = threading.Lock()
+_BUFFERS_FOR_SIGNAL: list["EventBuffer"] = []
+_PREVIOUS_SIGNAL_HANDLERS: dict[int, Any] = {}
+_SIGNAL_HANDLERS_INSTALLED = False
+
+
+@dataclass(frozen=True)
+class _PendingEvent:
+    """One row queued for the background drain.
+
+    Frozen so the drain thread can hand it to SQLAlchemy without worrying
+    that the producer thread will mutate the dict mid-insert.
+    """
+
+    scope: str
+    sender: str
+    subject: str
+    payload_json: str
+
+
+# Sentinel pushed onto the queue by ``close()`` to unblock a drainer that
+# is parked on a blocking ``queue.get``. It is NOT a real event — the
+# drain loop filters it out before flushing a batch.
+_SHUTDOWN_SENTINEL = _PendingEvent(
+    scope="__shutdown__",
+    sender="__shutdown__",
+    subject="__shutdown__",
+    payload_json="{}",
+)
+
+
+class EventBuffer:
+    """Background-thread drain of events into the unified ``messages`` table.
+
+    Parameters
+    ----------
+    store:
+        The :class:`SQLAlchemyStore` owning the writer engine. Held by
+        reference so the buffer always uses the store's current engine
+        (important if the store ever hot-swaps URLs during tests).
+    batch_size:
+        Soft upper bound on rows drained per transaction. Default 100;
+        tuned so a single ``executemany`` fits comfortably below SQLite's
+        implicit statement cache ceiling.
+    flush_interval:
+        Seconds to wait for a full batch before committing whatever is
+        pending. Default 0.1s — low enough that events are visible to
+        readers within a frame of the UI refresh rate.
+    capacity:
+        Maximum number of queued-but-undrained events. Default 10_000.
+        Full-capacity behavior drops the OLDEST pending event (not the
+        new one) with a warning log, so live signals never vanish.
+    install_signal_handlers:
+        If ``True`` (default), install process-wide ``SIGTERM``/``SIGINT``
+        handlers on the first buffer in the process. The handlers chain
+        to whatever handler was previously registered, so Ctrl-C still
+        bubbles up to pytest / the supervisor main loop.
+    """
+
+    def __init__(
+        self,
+        store: "SQLAlchemyStore",
+        *,
+        batch_size: int = 100,
+        flush_interval: float = 0.1,
+        capacity: int = 10_000,
+        install_signal_handlers: bool = True,
+    ) -> None:
+        if batch_size <= 0:
+            raise ValueError(
+                "EventBuffer batch_size must be positive. "
+                "A non-positive batch disables the drain and wedges emitters. "
+                "Fix: pass batch_size=100 (the default) or a smaller positive int."
+            )
+        if flush_interval <= 0:
+            raise ValueError(
+                "EventBuffer flush_interval must be positive. "
+                "A non-positive interval disables the wake-up timer and stalls flushes. "
+                "Fix: pass flush_interval=0.1 (default) or any positive float."
+            )
+        if capacity <= 0:
+            raise ValueError(
+                "EventBuffer capacity must be positive. "
+                "A non-positive capacity means producers block forever on a full queue. "
+                "Fix: pass capacity=10_000 (default) or any positive int."
+            )
+
+        self._store = store
+        self._batch_size = batch_size
+        self._flush_interval = flush_interval
+        self._capacity = capacity
+
+        # Bounded deque-backed queue. We drive overflow manually so we drop
+        # the OLDEST pending event (not the incoming one): see ``append``.
+        self._queue: queue.Queue[_PendingEvent] = queue.Queue(maxsize=capacity)
+        self._stop_event = threading.Event()
+        self._closed = False
+        self._close_lock = threading.Lock()
+
+        self._thread = threading.Thread(
+            target=self._drain_loop,
+            name="pollypm-event-buffer",
+            daemon=True,
+        )
+        self._thread.start()
+
+        if install_signal_handlers:
+            _register_buffer_for_signals(self)
+
+    # ------------------------------------------------------------------
+    # Producer API
+    # ------------------------------------------------------------------
+
+    def append(
+        self,
+        scope: str,
+        sender: str,
+        subject: str,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        """Enqueue an event for the background drain. Never blocks.
+
+        If the queue is at ``capacity``, the OLDEST pending event is
+        dropped (with a warning log) to make room. Dropping the newest
+        incoming event would mean losing live signal while preserving
+        stale ones; the opposite is what operators actually want.
+
+        Parameters
+        ----------
+        scope:
+            Routing scope ('root', 'workspace', or a project key).
+        sender:
+            Logical origin of the event — session name, subsystem tag,
+            etc. Free-form string.
+        subject:
+            Short human-readable title. Flows straight into the row's
+            ``subject`` column.
+        payload:
+            Optional structured blob. Serialized with ``json.dumps`` so
+            it stays queryable via JSON1 operators downstream.
+        """
+        if self._closed:
+            # Dropped-after-close is worth a debug but not a warning — it
+            # generally means a worker emitted during shutdown, which is
+            # expected. Supervisors wanting stricter semantics should
+            # call ``close()`` only after fully quiescing producers.
+            logger.debug(
+                "event-buffer: dropped append after close (subject=%r)", subject
+            )
+            return
+
+        event = _PendingEvent(
+            scope=scope,
+            sender=sender,
+            subject=subject,
+            payload_json=json.dumps(payload if payload is not None else {}),
+        )
+        try:
+            self._queue.put_nowait(event)
+        except queue.Full:
+            # Make room by discarding the oldest queued event, then retry.
+            # Window between get + put is fine — we're the only one
+            # shrinking the queue on overflow, and the drain thread only
+            # shrinks it via get() which is safe to race with.
+            try:
+                dropped = self._queue.get_nowait()
+                logger.warning(
+                    "event-buffer: capacity (%d) reached, dropped oldest event "
+                    "(scope=%r, sender=%r, subject=%r)",
+                    self._capacity,
+                    dropped.scope,
+                    dropped.sender,
+                    dropped.subject,
+                )
+            except queue.Empty:
+                # The drain thread raced us and emptied the queue; fall
+                # through to put_nowait which will now succeed.
+                pass
+            try:
+                self._queue.put_nowait(event)
+            except queue.Full:  # pragma: no cover - extremely tight race
+                logger.warning(
+                    "event-buffer: capacity (%d) still full after eviction, "
+                    "dropping incoming event (subject=%r)",
+                    self._capacity,
+                    subject,
+                )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self, *, timeout: float = 5.0) -> None:
+        """Stop the drain thread after flushing pending events.
+
+        Idempotent — repeated calls are no-ops. The graceful path bounds
+        itself to ``timeout`` seconds (default 5s) so a hanging writer
+        doesn't block process shutdown indefinitely. Any events still
+        queued when the thread fails to join are logged.
+        """
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+
+        self._stop_event.set()
+        # Wake the drainer if it's parked on a blocking ``queue.get``.
+        # The sentinel is filtered out in ``_flush_batch`` so it never
+        # reaches the DB.
+        try:
+            self._queue.put_nowait(_SHUTDOWN_SENTINEL)
+        except queue.Full:
+            # Buffer is full — the drainer will wake when it next
+            # consumes anyway. Not worth evicting a real event for a
+            # wake-up nudge.
+            pass
+        self._thread.join(timeout=timeout)
+        if self._thread.is_alive():
+            remaining = self._queue.qsize()
+            logger.warning(
+                "event-buffer: drain thread did not exit within %.1fs; "
+                "%d events may be unflushed",
+                timeout,
+                remaining,
+            )
+
+        _deregister_buffer_from_signals(self)
+
+    def is_closed(self) -> bool:
+        """Return ``True`` if :meth:`close` has been invoked."""
+        return self._closed
+
+    def pending_count(self) -> int:
+        """Return the current queue depth. Useful for tests."""
+        return self._queue.qsize()
+
+    # ------------------------------------------------------------------
+    # Drain thread
+    # ------------------------------------------------------------------
+
+    def _drain_loop(self) -> None:
+        """Main loop for the background drainer thread.
+
+        Uses a short ``Queue.get(timeout=flush_interval)`` call as the
+        wake-up timer so the thread spends most of its life parked in
+        the kernel's condvar queue rather than polling.
+        """
+        while not self._stop_event.is_set():
+            batch = self._collect_batch()
+            if batch:
+                self._flush_batch(batch)
+
+        # Shutdown: drain whatever is still queued so ``close()`` /
+        # ``SIGTERM`` honor the "flush pending before exit" contract.
+        final = self._drain_remaining()
+        if final:
+            self._flush_batch(final)
+
+    def _collect_batch(self) -> list[_PendingEvent]:
+        """Gather up to ``batch_size`` events.
+
+        Blocks on the first ``get`` for up to ``flush_interval`` so an
+        idle buffer costs no CPU. Once that first event arrives, any
+        further events already in the queue are drained non-blockingly
+        — waiting for a full batch would delay flushes when traffic is
+        bursty, and the whole point of ``flush_interval`` is to bound
+        the time an event sits unflushed.
+        """
+        batch: list[_PendingEvent] = []
+        try:
+            first = self._queue.get(timeout=self._flush_interval)
+        except queue.Empty:
+            return batch
+        batch.append(first)
+
+        while len(batch) < self._batch_size:
+            try:
+                batch.append(self._queue.get_nowait())
+            except queue.Empty:
+                break
+        return batch
+
+    def _drain_remaining(self) -> list[_PendingEvent]:
+        """Non-blocking drain of whatever is currently queued."""
+        remaining: list[_PendingEvent] = []
+        while True:
+            try:
+                remaining.append(self._queue.get_nowait())
+            except queue.Empty:
+                return remaining
+
+    def _flush_batch(self, batch: list[_PendingEvent]) -> None:
+        """Insert ``batch`` as ``messages`` rows in a single writer transaction.
+
+        Errors are logged and swallowed — the buffer's contract is
+        fire-and-forget; a transient DB hiccup must not poison the
+        drain thread. Production callers that need delivery guarantees
+        should use the synchronous ``SQLAlchemyStore.record_event``.
+
+        The shutdown sentinel (if present) is filtered out here so it
+        never reaches the DB.
+        """
+        if not batch:
+            return
+        rows = [
+            {
+                "scope": ev.scope,
+                "type": "event",
+                "tier": "immediate",
+                "recipient": "*",
+                "sender": ev.sender,
+                "state": "open",
+                "subject": ev.subject,
+                "body": "",
+                "payload_json": ev.payload_json,
+                "labels": "[]",
+            }
+            for ev in batch
+            if ev is not _SHUTDOWN_SENTINEL
+        ]
+        if not rows:
+            return
+        try:
+            with self._store.transaction() as conn:
+                conn.execute(insert(messages), rows)
+        except Exception:  # pragma: no cover - defensive logging only
+            logger.exception(
+                "event-buffer: flush failed (%d rows dropped)", len(rows)
+            )
+
+
+# --------------------------------------------------------------------------
+# Signal handler plumbing
+# --------------------------------------------------------------------------
+
+
+def _register_buffer_for_signals(buffer: EventBuffer) -> None:
+    """Attach ``buffer`` to the process-wide signal-shutdown list.
+
+    First buffer in the process installs SIGTERM + SIGINT handlers that
+    call :meth:`EventBuffer.close` on every registered buffer, then
+    re-raises / delegates to the previously installed handler so host
+    code keeps the behavior it expects.
+    """
+    global _SIGNAL_HANDLERS_INSTALLED
+
+    with _SIGNAL_HANDLERS_LOCK:
+        _BUFFERS_FOR_SIGNAL.append(buffer)
+        if _SIGNAL_HANDLERS_INSTALLED:
+            return
+
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            try:
+                _PREVIOUS_SIGNAL_HANDLERS[sig] = signal.getsignal(sig)
+                signal.signal(sig, _on_shutdown_signal)
+            except (ValueError, OSError):
+                # signal.signal only works from the main thread. Tests or
+                # embedded hosts may invoke the buffer from a worker
+                # thread, in which case we silently skip installation —
+                # the buffer still supports explicit ``close()``.
+                logger.debug(
+                    "event-buffer: could not install signal handler for %s "
+                    "(not main thread?) — falling back to explicit close()",
+                    sig,
+                )
+                continue
+        _SIGNAL_HANDLERS_INSTALLED = True
+
+
+def _deregister_buffer_from_signals(buffer: EventBuffer) -> None:
+    """Remove ``buffer`` from the shutdown list.
+
+    We intentionally do NOT restore the previous signal handler here —
+    other buffers in the same process may still be registered. On final
+    process exit the OS tears the handler down anyway.
+    """
+    with _SIGNAL_HANDLERS_LOCK:
+        try:
+            _BUFFERS_FOR_SIGNAL.remove(buffer)
+        except ValueError:
+            pass
+
+
+def _on_shutdown_signal(signum: int, frame: Any) -> None:
+    """SIGTERM / SIGINT handler: flush every registered buffer, then chain."""
+    with _SIGNAL_HANDLERS_LOCK:
+        buffers = list(_BUFFERS_FOR_SIGNAL)
+        previous = _PREVIOUS_SIGNAL_HANDLERS.get(signum)
+
+    for buf in buffers:
+        try:
+            buf.close()
+        except Exception:  # pragma: no cover - shutdown best-effort
+            logger.exception("event-buffer: close() failed during signal flush")
+
+    # Chain to whatever handler was in place before we installed ours.
+    # ``signal.default_int_handler`` for SIGINT raises KeyboardInterrupt
+    # which is what pytest / interactive shells expect.
+    if callable(previous) and previous not in (
+        signal.SIG_DFL,
+        signal.SIG_IGN,
+        _on_shutdown_signal,
+    ):
+        previous(signum, frame)
+    elif previous == signal.SIG_DFL:
+        # Restore default and re-raise so the OS semantics take over.
+        signal.signal(signum, signal.SIG_DFL)
+        signal.raise_signal(signum)
+
+
+__all__ = ["EventBuffer"]

--- a/src/pollypm/store/schema.py
+++ b/src/pollypm/store/schema.py
@@ -1,0 +1,173 @@
+"""Unified ``messages`` table — one surface for every "something happened" row.
+
+PollyPM used to spread this concept across five separate tables (``events``,
+``inbox_messages``, ``work_tasks-chat``, ``notifications_staged``, …), each
+with its own schema + writers + readers. Issue #338 collapses them into a
+single ``messages`` table with ``type`` / ``tier`` / ``recipient`` / ``state``
+as first-class filter columns.
+
+The module exports:
+
+* :data:`metadata` — the :class:`sqlalchemy.MetaData` that :meth:`SQLAlchemyStore.__init__`
+  hands to ``metadata.create_all`` to materialize the schema.
+* :data:`messages` — the :class:`sqlalchemy.Table` definition. Importable so
+  callers can build ``select(messages).where(...)`` expressions without
+  resurrecting raw-SQL string concatenation.
+* :data:`FTS_DDL_STATEMENTS` — the list of raw DDL strings that create the
+  FTS5 shadow table + its sync triggers. :class:`SQLAlchemyStore` executes
+  these after ``create_all`` because SQLAlchemy Core has no portable
+  representation for FTS5 virtual tables or SQLite triggers.
+
+Anything beyond the messages surface belongs in a sibling schema module —
+please don't bolt additional tables onto this one just because they fit.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    Text,
+    func,
+)
+
+
+# --------------------------------------------------------------------------
+# Core metadata + table
+# --------------------------------------------------------------------------
+
+metadata = MetaData()
+"""Shared :class:`~sqlalchemy.MetaData` for the store package.
+
+:class:`pollypm.store.sqlalchemy_store.SQLAlchemyStore` reuses this exact
+instance so ``metadata.create_all(engine)`` materializes the full schema
+in one pass. Additional tables (alerts, worktree state, …) should attach
+to this same metadata so the store bootstrap stays single-source.
+"""
+
+
+messages = Table(
+    "messages",
+    metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    # scope partitions rows by blast radius. 'root' is workspace-wide; a
+    # concrete project key scopes to that project's view.
+    Column("scope", String, nullable=False),
+    # type distinguishes firehose entries ('event') from human-visible
+    # rows ('notify' / 'alert' / 'inbox_task' / 'audit').
+    Column("type", String, nullable=False),
+    # tier drives "show immediately" vs "batch into digest" vs "log-only".
+    Column("tier", String, nullable=False, default="immediate"),
+    # recipient is who should see this: 'user' / 'polly' / session name / '*'.
+    Column("recipient", String, nullable=False),
+    Column("sender", String, nullable=False),
+    # state tracks the open/closed lifecycle. 'archived' is a terminal state
+    # callers can use to hide without deleting.
+    Column("state", String, nullable=False, default="open"),
+    # parent_id lets rollup rows reference their rollup children without a
+    # separate join table.
+    Column(
+        "parent_id",
+        Integer,
+        ForeignKey("messages.id", ondelete="SET NULL"),
+        nullable=True,
+    ),
+    Column("subject", String, nullable=False),
+    Column("body", Text, nullable=False, default=""),
+    # payload_json / labels are stored as TEXT-JSON for portability; callers
+    # decode via ``json.loads`` at the store boundary.
+    Column("payload_json", Text, nullable=False, default="{}"),
+    Column("labels", Text, nullable=False, default="[]"),
+    Column(
+        "created_at",
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    ),
+    Column(
+        "updated_at",
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    ),
+    Column("closed_at", DateTime(timezone=True), nullable=True),
+    # Hot-path indexes: inbox list (recipient+state), firehose filter
+    # (type+tier), and per-scope recency scans.
+    Index("idx_messages_recipient_state", "recipient", "state"),
+    Index("idx_messages_type_tier", "type", "tier"),
+    Index("idx_messages_scope_created", "scope", "created_at"),
+)
+
+
+# --------------------------------------------------------------------------
+# FTS5 shadow table + triggers
+# --------------------------------------------------------------------------
+#
+# SQLAlchemy Core can't express SQLite FTS5 virtual tables or triggers
+# portably, so we ship raw DDL. ``SQLAlchemyStore.__init__`` executes these
+# statements in a single transaction immediately after ``create_all`` so
+# the FTS shadow is always in sync with the main table.
+#
+# Shape:
+#   * ``messages_fts`` — FTS5 virtual table indexing (subject, body, labels)
+#     with content='messages' + content_rowid='id' so the virtual table is
+#     "contentless" and only stores the tokenized tail.
+#   * Three triggers (``_ai``, ``_ad``, ``_au``) keep the FTS shadow
+#     synchronized on every INSERT / DELETE / UPDATE to ``messages``.
+#
+# The ``IF NOT EXISTS`` guards make the bootstrap idempotent, which matters
+# because the store __init__ path runs on every process start.
+
+FTS_DDL_STATEMENTS: list[str] = [
+    # Virtual table — FTS5 indexes subject/body/labels, backed by the real
+    # ``messages`` table via content='messages' / content_rowid='id'.
+    """
+    CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+        subject,
+        body,
+        labels,
+        content='messages',
+        content_rowid='id'
+    )
+    """,
+    # After-insert: project new row into the FTS shadow.
+    """
+    CREATE TRIGGER IF NOT EXISTS messages_ai
+    AFTER INSERT ON messages
+    BEGIN
+        INSERT INTO messages_fts (rowid, subject, body, labels)
+        VALUES (new.id, new.subject, new.body, new.labels);
+    END
+    """,
+    # After-delete: tombstone the row from FTS. The 'delete' command with
+    # matching payload is the FTS5 external-content cleanup idiom.
+    """
+    CREATE TRIGGER IF NOT EXISTS messages_ad
+    AFTER DELETE ON messages
+    BEGIN
+        INSERT INTO messages_fts (messages_fts, rowid, subject, body, labels)
+        VALUES ('delete', old.id, old.subject, old.body, old.labels);
+    END
+    """,
+    # After-update: delete old then insert new so the FTS index stays in
+    # lockstep with edits to subject/body/labels.
+    """
+    CREATE TRIGGER IF NOT EXISTS messages_au
+    AFTER UPDATE ON messages
+    BEGIN
+        INSERT INTO messages_fts (messages_fts, rowid, subject, body, labels)
+        VALUES ('delete', old.id, old.subject, old.body, old.labels);
+        INSERT INTO messages_fts (rowid, subject, body, labels)
+        VALUES (new.id, new.subject, new.body, new.labels);
+    END
+    """,
+]
+
+
+__all__ = ["FTS_DDL_STATEMENTS", "messages", "metadata"]

--- a/src/pollypm/store/sqlalchemy_store.py
+++ b/src/pollypm/store/sqlalchemy_store.py
@@ -1,59 +1,83 @@
-"""Skeleton SQLAlchemy-backed :class:`Store` — real method bodies land later.
+"""SQLAlchemy-backed :class:`Store` — schema bootstrap + message/event methods.
 
-Issue #337 installs this scaffolding so downstream issues can implement one
-method at a time without churning imports:
+Issue #337 landed the skeleton (engine factory + ``transaction()``). Issue
+#338 fills in the surface that writes to the unified ``messages`` table:
 
-* :class:`SQLAlchemyStore.__init__` builds the writer + reader engines via
-  :func:`pollypm.store.engine.make_engines` and holds a shared
-  :class:`sqlalchemy.MetaData` placeholder that #338 will populate with
-  table definitions.
-* :meth:`SQLAlchemyStore.transaction` is fully functional — it yields a
-  SQLAlchemy :class:`~sqlalchemy.engine.Connection` from the write engine,
-  commits on clean exit, and rolls back on exception. Callers can start
-  using it immediately for ad-hoc writes.
-* Every other method raises :class:`NotImplementedError` with a message
-  pointing to the issue that implements it (#338 for schema/events,
-  #340 for callers). Those messages follow the three-question rule:
-  *what happened* / *why it matters* / *how to fix it* (→ wait for / look
-  at the issue).
+* Schema bootstrap in ``__init__`` — ``metadata.create_all(write_engine)``
+  plus the FTS5 shadow DDL, all inside a single writer transaction so a
+  partial failure rolls back cleanly.
+* :meth:`append_event` — fire-and-forget; lazily provisions the private
+  :class:`EventBuffer` on first call so test doubles that never emit
+  events don't spin up a drainer thread.
+* :meth:`record_event`, :meth:`enqueue_message`, :meth:`update_message`,
+  :meth:`close_message`, :meth:`query_messages` — synchronous inserts /
+  updates / reads against the ``messages`` table.
+* :meth:`close` — idempotent teardown that flushes the event buffer and
+  disposes both engine pools.
+
+Alerts (``upsert_alert`` / ``clear_alert``) stay stubbed until their own
+issue lands; the unified alerts table is still under design. All other
+``NotImplementedError`` paths from #337 are gone.
 """
 
 from __future__ import annotations
 
+import json
+import threading
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from typing import Any, Iterator
 
-from sqlalchemy import MetaData
+from sqlalchemy import MetaData, and_, delete, insert, select, text, update
 from sqlalchemy.engine import Connection, Engine
 
 from pollypm.store.engine import make_engines
+from pollypm.store.event_buffer import EventBuffer
+from pollypm.store.schema import FTS_DDL_STATEMENTS, messages, metadata
 
 
 _NOT_YET_IMPLEMENTED = (
     "SQLAlchemyStore.{method}() is not implemented yet. "
-    "The storage rewrite lands in phases — method bodies arrive in issue-B "
-    "(#338, schema + event log) and issue-D (#340, caller migration). "
-    "Fix: wait for those issues to merge, or track progress in the #337 epic."
+    "The storage rewrite lands in phases — alert methods arrive in a "
+    "follow-up issue to #338. "
+    "Fix: wait for the unified-alerts issue to merge, or track progress "
+    "in the #337 epic."
 )
 
 
 class SQLAlchemyStore:
-    """Skeleton implementation of the :class:`pollypm.store.Store` protocol.
+    """SQLAlchemy-backed implementation of :class:`pollypm.store.Store`.
 
-    Construction wires up the dual-pool engines so downstream PRs can test
-    against a live DB without re-plumbing the factory. The ``transaction()``
-    context manager is the only fully working method in this PR.
+    Construction wires up the dual-pool engines (writer ``pool_size=1``,
+    reader ``pool_size=5``), creates the unified ``messages`` schema if
+    it does not yet exist, installs the FTS5 shadow + triggers, and
+    leaves the event buffer uninitialized until first :meth:`append_event`.
+
+    Parameters
+    ----------
+    url:
+        SQLAlchemy URL. Typically ``sqlite:///<path>``. ``:memory:`` is
+        supported for tests, with the caveat that the reader engine will
+        not see writes from the writer engine (separate connections,
+        separate in-memory DBs) — use a file on tmp_path in tests that
+        need cross-engine visibility.
     """
 
     def __init__(self, url: str) -> None:
         self._url = url
         self._write_engine, self._read_engine = make_engines(url)
-        # Placeholder — #338 populates this with the full schema. Callers
-        # in this PR should treat it as opaque.
-        self._metadata = MetaData()
+        self._metadata: MetaData = metadata
+
+        self._event_buffer: EventBuffer | None = None
+        self._event_buffer_lock = threading.Lock()
+
+        self._closed = False
+        self._close_lock = threading.Lock()
+
+        self._bootstrap_schema()
 
     # ------------------------------------------------------------------
-    # Accessors (useful for tests + future issues; not part of ``Store``).
+    # Accessors (tests + future issues; not part of ``Store`` protocol).
     # ------------------------------------------------------------------
 
     @property
@@ -73,25 +97,45 @@ class SQLAlchemyStore:
 
     @property
     def metadata(self) -> MetaData:
-        """Shared :class:`~sqlalchemy.MetaData` — populated by #338."""
+        """Shared :class:`~sqlalchemy.MetaData` with the ``messages`` table."""
         return self._metadata
 
     def dispose(self) -> None:
-        """Dispose both pooled engines. Safe to call multiple times."""
+        """Dispose both pooled engines without stopping the event buffer.
+
+        Callers that want a full teardown (flush events, then dispose
+        pools) should use :meth:`close` instead. ``dispose`` exists as
+        a narrow escape hatch for tests that need to drop a pool but
+        keep running.
+        """
         self._write_engine.dispose()
         self._read_engine.dispose()
 
+    def close(self) -> None:
+        """Idempotent shutdown: flush events, dispose pools.
+
+        Safe to call multiple times. Safe to call even if the event
+        buffer was never provisioned.
+        """
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+
+        if self._event_buffer is not None:
+            self._event_buffer.close()
+        self.dispose()
+
     # ------------------------------------------------------------------
-    # Transaction scope — the only functional method in this PR.
+    # Transaction scope
     # ------------------------------------------------------------------
 
     @contextmanager
     def transaction(self) -> Iterator[Connection]:
         """Yield a write-scoped :class:`~sqlalchemy.engine.Connection`.
 
-        Commits on clean exit, rolls back on exception. Uses the writer
-        engine so all writes serialize through its single pooled
-        connection — no "database is locked" races.
+        Commits on clean exit, rolls back on exception. All writes share
+        the writer engine's single pooled connection.
         """
         conn = self._write_engine.connect()
         try:
@@ -107,40 +151,238 @@ class SQLAlchemyStore:
             conn.close()
 
     # ------------------------------------------------------------------
-    # Store protocol stubs — bodies land in #338 / #340.
+    # Schema bootstrap
     # ------------------------------------------------------------------
 
-    def append_event(self, *, kind: str, payload: dict[str, Any]) -> None:
-        raise NotImplementedError(
-            _NOT_YET_IMPLEMENTED.format(method="append_event")
-        )
+    def _bootstrap_schema(self) -> None:
+        """Create ``messages`` + FTS5 shadow + triggers in one transaction.
+
+        ``metadata.create_all`` is itself idempotent thanks to SQLAlchemy's
+        ``checkfirst=True`` default, and the FTS DDL uses ``IF NOT EXISTS``
+        guards, so re-running on an already-bootstrapped DB is a no-op.
+        """
+        metadata.create_all(self._write_engine)
+        with self.transaction() as conn:
+            for stmt in FTS_DDL_STATEMENTS:
+                conn.execute(text(stmt))
+
+    # ------------------------------------------------------------------
+    # Event log — firehose ('event' type) entries.
+    # ------------------------------------------------------------------
+
+    def _get_or_create_event_buffer(self) -> EventBuffer:
+        """Lazily construct the private :class:`EventBuffer`.
+
+        Constructed on first :meth:`append_event` so long-lived but
+        quiet stores (e.g. integration-test fixtures) don't spin up a
+        background thread they'll never use.
+        """
+        if self._event_buffer is not None:
+            return self._event_buffer
+        with self._event_buffer_lock:
+            if self._event_buffer is None:
+                self._event_buffer = EventBuffer(self)
+            return self._event_buffer
+
+    def append_event(
+        self,
+        scope: str,
+        sender: str,
+        subject: str,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        """Fire-and-forget: enqueue an event for the background drain.
+
+        Routes through the private :class:`EventBuffer`, so the call
+        returns immediately even when the writer pool is saturated. Use
+        :meth:`record_event` when the caller needs the row to be durable
+        by the time the call returns.
+        """
+        buffer = self._get_or_create_event_buffer()
+        buffer.append(scope=scope, sender=sender, subject=subject, payload=payload)
 
     def record_event(
-        self, session_name: str, event_type: str, message: str
-    ) -> None:
-        raise NotImplementedError(
-            _NOT_YET_IMPLEMENTED.format(method="record_event")
-        )
+        self,
+        scope: str,
+        sender: str,
+        subject: str,
+        payload: dict[str, Any] | None = None,
+    ) -> int:
+        """Synchronously insert an event row. Returns the new row id.
 
-    def enqueue_message(self, message: dict[str, Any]) -> int:
-        raise NotImplementedError(
-            _NOT_YET_IMPLEMENTED.format(method="enqueue_message")
-        )
+        Blocks on the writer pool until the insert commits. Reserve for
+        audit-trail writes that must be visible on the next read.
+        """
+        row = {
+            "scope": scope,
+            "type": "event",
+            "tier": "immediate",
+            "recipient": "*",
+            "sender": sender,
+            "state": "open",
+            "subject": subject,
+            "body": "",
+            "payload_json": json.dumps(payload if payload is not None else {}),
+            "labels": "[]",
+        }
+        with self.transaction() as conn:
+            result = conn.execute(insert(messages), row)
+            inserted = result.inserted_primary_key
+        return int(inserted[0]) if inserted else 0
 
-    def update_message(self, message_id: int, **fields: Any) -> None:
-        raise NotImplementedError(
-            _NOT_YET_IMPLEMENTED.format(method="update_message")
-        )
+    # ------------------------------------------------------------------
+    # Message surface — notify / alert / inbox_task / audit rows.
+    # ------------------------------------------------------------------
 
-    def close_message(self, message_id: int, *, reason: str | None = None) -> None:
-        raise NotImplementedError(
-            _NOT_YET_IMPLEMENTED.format(method="close_message")
-        )
+    def enqueue_message(
+        self,
+        type: str,
+        tier: str,
+        recipient: str,
+        sender: str,
+        subject: str,
+        body: str,
+        scope: str,
+        labels: list[str] | None = None,
+        parent_id: int | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> int:
+        """Insert a single message row. Returns the new row id.
+
+        Keyword arguments map directly onto columns; JSON fields
+        (``labels`` / ``payload``) are serialized here so callers pass
+        native Python values.
+        """
+        row = {
+            "scope": scope,
+            "type": type,
+            "tier": tier,
+            "recipient": recipient,
+            "sender": sender,
+            "state": "open",
+            "parent_id": parent_id,
+            "subject": subject,
+            "body": body,
+            "payload_json": json.dumps(payload if payload is not None else {}),
+            "labels": json.dumps(labels if labels is not None else []),
+        }
+        with self.transaction() as conn:
+            result = conn.execute(insert(messages), row)
+            inserted = result.inserted_primary_key
+        return int(inserted[0]) if inserted else 0
+
+    def update_message(self, id: int, **fields: Any) -> None:
+        """Patch ``fields`` onto the message with the given ``id``.
+
+        ``labels`` and ``payload`` are JSON-encoded if passed as native
+        Python values. Unknown columns raise a ``ValueError`` so typos
+        don't silently no-op.
+        """
+        if not fields:
+            return
+
+        allowed = {col.name for col in messages.columns}
+        translated: dict[str, Any] = {}
+        for key, value in fields.items():
+            column = key
+            translated_value = value
+            if key == "payload":
+                column = "payload_json"
+                translated_value = (
+                    json.dumps(value) if not isinstance(value, str) else value
+                )
+            elif key == "labels" and not isinstance(value, str):
+                translated_value = json.dumps(value)
+            if column not in allowed:
+                raise ValueError(
+                    f"update_message received unknown field {key!r}. "
+                    f"No column by that name exists on ``messages`` so the "
+                    f"update would be silently dropped. "
+                    f"Fix: pass one of {sorted(allowed)} or extend the "
+                    f"schema in pollypm/store/schema.py."
+                )
+            translated[column] = translated_value
+
+        translated["updated_at"] = datetime.now(timezone.utc)
+
+        with self.transaction() as conn:
+            conn.execute(
+                update(messages).where(messages.c.id == id).values(**translated)
+            )
+
+    def close_message(self, id: int) -> None:
+        """Mark a message as closed and stamp ``closed_at`` / ``updated_at``."""
+        now = datetime.now(timezone.utc)
+        with self.transaction() as conn:
+            conn.execute(
+                update(messages)
+                .where(messages.c.id == id)
+                .values(state="closed", closed_at=now, updated_at=now)
+            )
 
     def query_messages(self, **filters: Any) -> list[dict[str, Any]]:
-        raise NotImplementedError(
-            _NOT_YET_IMPLEMENTED.format(method="query_messages")
-        )
+        """Return rows matching ``filters``, newest first.
+
+        Supported filters: ``type``, ``tier``, ``recipient``, ``state``,
+        ``scope``, ``sender``, ``parent_id``, ``since`` (``datetime``),
+        ``limit`` (``int``). Unknown filter keys raise ``ValueError`` —
+        silent filter drops have burned us in the legacy inbox code.
+        """
+        limit = filters.pop("limit", None)
+        since = filters.pop("since", None)
+
+        supported = {
+            "type",
+            "tier",
+            "recipient",
+            "state",
+            "scope",
+            "sender",
+            "parent_id",
+        }
+        unknown = set(filters) - supported
+        if unknown:
+            raise ValueError(
+                f"query_messages received unsupported filter(s) {sorted(unknown)!r}. "
+                f"Silent filter drops mask bugs in the inbox aggregation path. "
+                f"Fix: remove the key, or widen the supported set in "
+                f"SQLAlchemyStore.query_messages."
+            )
+
+        conditions = [messages.c[key] == value for key, value in filters.items()]
+        if since is not None:
+            conditions.append(messages.c.created_at >= since)
+
+        stmt = select(messages)
+        if conditions:
+            stmt = stmt.where(and_(*conditions))
+        stmt = stmt.order_by(messages.c.created_at.desc(), messages.c.id.desc())
+        if limit is not None:
+            stmt = stmt.limit(int(limit))
+
+        with self._read_engine.connect() as conn:
+            result = conn.execute(stmt)
+            rows = [dict(row._mapping) for row in result]
+
+        # Decode JSON text columns for caller convenience.
+        for row in rows:
+            payload_json = row.get("payload_json")
+            if isinstance(payload_json, str):
+                try:
+                    row["payload"] = json.loads(payload_json)
+                except json.JSONDecodeError:
+                    row["payload"] = {}
+            labels_json = row.get("labels")
+            if isinstance(labels_json, str):
+                try:
+                    row["labels"] = json.loads(labels_json)
+                except json.JSONDecodeError:
+                    row["labels"] = []
+        return rows
+
+    # ------------------------------------------------------------------
+    # Alerts — still stubbed; follow-up issue to #338.
+    # ------------------------------------------------------------------
 
     def upsert_alert(
         self,
@@ -157,3 +399,12 @@ class SQLAlchemyStore:
         raise NotImplementedError(
             _NOT_YET_IMPLEMENTED.format(method="clear_alert")
         )
+
+    # ------------------------------------------------------------------
+    # Test-only conveniences — do NOT call from production code paths.
+    # ------------------------------------------------------------------
+
+    def _delete_all_messages_for_tests(self) -> None:
+        """Wipe the ``messages`` table. Tests only — prod callers must not use."""
+        with self.transaction() as conn:
+            conn.execute(delete(messages))

--- a/tests/test_event_buffer.py
+++ b/tests/test_event_buffer.py
@@ -1,0 +1,233 @@
+"""Tests for :mod:`pollypm.store.event_buffer`.
+
+Run with an isolated HOME so the background thread never touches
+``~/.pollypm/`` state:
+
+    HOME=/tmp/pytest-store-messages uv run pytest tests/test_event_buffer.py -x
+
+Coverage (per issue #338 acceptance):
+
+1. 10k ``append`` calls land as 10k ``messages`` rows in <2s wall time.
+2. Capacity overflow drops the OLDEST pending event (not the new one).
+3. ``close()`` is idempotent — repeated calls are no-ops.
+4. ``close()`` on a buffer with queued events flushes them before
+   returning — simulates SIGTERM during active drain by stalling the
+   writer, filling the queue, then closing.
+5. ``append`` after ``close()`` is silently dropped (debug log only),
+   never raises.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+
+from pollypm.store import SQLAlchemyStore
+from pollypm.store.event_buffer import EventBuffer
+
+
+def _db_url(tmp_path: Path, name: str = "store.db") -> str:
+    return f"sqlite:///{tmp_path / name}"
+
+
+def _row_count(store: SQLAlchemyStore) -> int:
+    with store.read_engine.connect() as conn:
+        return int(conn.execute(text("SELECT COUNT(*) FROM messages")).scalar())
+
+
+# --------------------------------------------------------------------------
+# Throughput
+# --------------------------------------------------------------------------
+
+
+def test_ten_thousand_appends_land_under_two_seconds(tmp_path: Path) -> None:
+    """10k appends + flush complete end-to-end in under 2 seconds.
+
+    The 2s budget covers producer enqueue wall time AND drain-to-DB. If
+    the buffer regresses into per-event transactions the test will fail
+    loudly because SQLite serialized-writer latency can't keep up.
+    """
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    buffer = EventBuffer(
+        store,
+        batch_size=500,
+        flush_interval=0.05,
+        install_signal_handlers=False,
+    )
+    try:
+        n = 10_000
+        start = time.monotonic()
+        for i in range(n):
+            buffer.append(
+                scope="root",
+                sender="load-test",
+                subject=f"evt-{i}",
+                payload={"i": i},
+            )
+        # Flush by closing — guarantees all pending rows drained.
+        buffer.close(timeout=2.0)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 2.0, (
+            f"event buffer took {elapsed:.3f}s to drain {n} events; "
+            f"batching regression?"
+        )
+        assert _row_count(store) == n
+    finally:
+        if not buffer.is_closed():
+            buffer.close()
+        store.close()
+
+
+# --------------------------------------------------------------------------
+# Overflow
+# --------------------------------------------------------------------------
+
+
+def test_capacity_overflow_drops_oldest(tmp_path: Path) -> None:
+    """At capacity, the oldest pending event is discarded for the newest.
+
+    Strategy: construct a buffer with a tiny capacity and a long
+    flush_interval. Immediately monkey-patch the drainer's flush method
+    to no-op so events pile up; then fire more than capacity and inspect
+    the survivors before close().
+    """
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    buffer = EventBuffer(
+        store,
+        batch_size=100,
+        flush_interval=5.0,  # long — drain thread won't naturally wake
+        capacity=5,
+        install_signal_handlers=False,
+    )
+    # Neutralize the drain so the queue truly acts as a bounded buffer.
+    # The drain thread is already parked in ``queue.get(timeout=5.0)``;
+    # patching the flush is defensive in case it does wake.
+    buffer._flush_batch = lambda batch: None  # type: ignore[assignment]
+
+    try:
+        # Append 10 events to a 5-slot queue. The first 5 should overflow
+        # and be evicted; the last 5 should survive in the queue.
+        for i in range(10):
+            buffer.append(
+                scope="root",
+                sender="overflow-test",
+                subject=f"evt-{i:02d}",
+            )
+
+        # Inspect the surviving events directly from the queue before we
+        # close (close would call the patched no-op flush anyway).
+        survivors: list[str] = []
+        while True:
+            try:
+                ev = buffer._queue.get_nowait()
+            except Exception:
+                break
+            survivors.append(ev.subject)
+
+        # Exactly capacity items survive.
+        assert len(survivors) == 5, f"expected 5 survivors, got {survivors!r}"
+        # The NEWEST events survived; the oldest (evt-00..evt-04) were
+        # evicted.
+        assert survivors == [f"evt-{i:02d}" for i in range(5, 10)]
+    finally:
+        buffer.close(timeout=1.0)
+        store.close()
+
+
+# --------------------------------------------------------------------------
+# Shutdown / idempotency
+# --------------------------------------------------------------------------
+
+
+def test_close_is_idempotent(tmp_path: Path) -> None:
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    buffer = EventBuffer(store, install_signal_handlers=False)
+    try:
+        buffer.append(scope="root", sender="s", subject="once")
+        buffer.close()
+        assert buffer.is_closed()
+        # Repeat calls must not raise.
+        buffer.close()
+        buffer.close(timeout=0.1)
+        assert buffer.is_closed()
+        assert _row_count(store) == 1
+    finally:
+        store.close()
+
+
+def test_close_flushes_pending_events(tmp_path: Path) -> None:
+    """``close()`` during active backlog persists everything queued.
+
+    This simulates the SIGTERM-during-drain contract: on shutdown, the
+    buffer must flush whatever is already enqueued before the thread
+    exits, even if the drain loop hadn't gotten to them yet.
+    """
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    # Large flush_interval so the drain thread is idle-blocking on
+    # Queue.get most of the time; appends will queue up until close()
+    # triggers the final drain.
+    buffer = EventBuffer(
+        store,
+        batch_size=50,
+        flush_interval=5.0,
+        install_signal_handlers=False,
+    )
+    try:
+        n = 40
+        for i in range(n):
+            buffer.append(scope="root", sender="shutdown", subject=f"q-{i}")
+        # The drain thread may have already picked up the first item and
+        # started a batch; ``close()`` must still flush the remainder.
+        buffer.close(timeout=3.0)
+
+        assert _row_count(store) == n
+    finally:
+        store.close()
+
+
+def test_append_after_close_is_silent(tmp_path: Path) -> None:
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    buffer = EventBuffer(store, install_signal_handlers=False)
+    buffer.close()
+    # Must not raise — drop silently.
+    buffer.append(scope="root", sender="x", subject="dropped")
+    store.close()
+
+
+def test_store_close_flushes_event_buffer(tmp_path: Path) -> None:
+    """``SQLAlchemyStore.close()`` must tear down the lazily-created buffer."""
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    # Use the store's lazy buffer.
+    store.append_event(scope="root", sender="store-close", subject="a")
+    store.append_event(scope="root", sender="store-close", subject="b")
+
+    store.close()
+    # Fresh store against the same DB to read — the writer pool on the
+    # closed store is disposed.
+    verify = SQLAlchemyStore(_db_url(tmp_path))
+    try:
+        assert _row_count(verify) == 2
+    finally:
+        verify.close()
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+
+
+def test_invalid_batch_size_raises(tmp_path: Path) -> None:
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    try:
+        with pytest.raises(ValueError, match="batch_size"):
+            EventBuffer(store, batch_size=0, install_signal_handlers=False)
+        with pytest.raises(ValueError, match="flush_interval"):
+            EventBuffer(store, flush_interval=0, install_signal_handlers=False)
+        with pytest.raises(ValueError, match="capacity"):
+            EventBuffer(store, capacity=0, install_signal_handlers=False)
+    finally:
+        store.close()

--- a/tests/test_messages_schema.py
+++ b/tests/test_messages_schema.py
@@ -1,0 +1,207 @@
+"""Tests for :mod:`pollypm.store.schema` — unified ``messages`` table + FTS5.
+
+Run under an isolated HOME so the suite never leaks into ``~/.pollypm/``:
+
+    HOME=/tmp/pytest-store-messages uv run pytest tests/test_messages_schema.py -x
+
+Coverage (per issue #338 acceptance):
+
+1. Schema creates cleanly on an empty SQLite DB — all columns + indexes
+   present after bootstrap.
+2. FTS5 shadow table is created alongside the main table.
+3. Insert into ``messages`` is mirrored into ``messages_fts`` so
+   ``MATCH`` queries return the expected rowid.
+4. Update to ``messages`` keeps ``messages_fts`` in sync — old term no
+   longer matches, new term does.
+5. Delete from ``messages`` removes the row from ``messages_fts``.
+6. Bootstrap is idempotent — a second ``SQLAlchemyStore`` on the same
+   DB path neither raises nor duplicates rows/indexes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import inspect, text
+
+from pollypm.store import SQLAlchemyStore
+from pollypm.store.schema import FTS_DDL_STATEMENTS, messages
+
+
+def _db_url(tmp_path: Path, name: str = "store.db") -> str:
+    return f"sqlite:///{tmp_path / name}"
+
+
+# --------------------------------------------------------------------------
+# Schema shape
+# --------------------------------------------------------------------------
+
+
+def test_messages_table_has_expected_columns(tmp_path: Path) -> None:
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    try:
+        inspector = inspect(store.write_engine)
+        cols = {c["name"] for c in inspector.get_columns("messages")}
+        # All columns from the #338 spec must land.
+        expected = {
+            "id",
+            "scope",
+            "type",
+            "tier",
+            "recipient",
+            "sender",
+            "state",
+            "parent_id",
+            "subject",
+            "body",
+            "payload_json",
+            "labels",
+            "created_at",
+            "updated_at",
+            "closed_at",
+        }
+        assert expected <= cols, f"missing columns: {expected - cols}"
+    finally:
+        store.close()
+
+
+def test_messages_indexes_exist(tmp_path: Path) -> None:
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    try:
+        inspector = inspect(store.write_engine)
+        index_names = {idx["name"] for idx in inspector.get_indexes("messages")}
+        assert "idx_messages_recipient_state" in index_names
+        assert "idx_messages_type_tier" in index_names
+        assert "idx_messages_scope_created" in index_names
+    finally:
+        store.close()
+
+
+def test_fts_virtual_table_exists(tmp_path: Path) -> None:
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    try:
+        with store.read_engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='table' AND name='messages_fts'"
+                )
+            ).scalar()
+        assert row == "messages_fts"
+    finally:
+        store.close()
+
+
+def test_fts_ddl_statements_are_populated() -> None:
+    # Guards against a regression where someone empties the list while
+    # refactoring. The schema bootstrap depends on this being non-empty.
+    assert len(FTS_DDL_STATEMENTS) >= 4
+
+
+# --------------------------------------------------------------------------
+# FTS sync triggers
+# --------------------------------------------------------------------------
+
+
+def _insert_row(
+    store: SQLAlchemyStore,
+    subject: str,
+    body: str = "",
+    labels: str = "[]",
+) -> int:
+    with store.transaction() as conn:
+        result = conn.execute(
+            messages.insert(),
+            {
+                "scope": "root",
+                "type": "event",
+                "tier": "immediate",
+                "recipient": "*",
+                "sender": "test",
+                "state": "open",
+                "subject": subject,
+                "body": body,
+                "payload_json": "{}",
+                "labels": labels,
+            },
+        )
+        return int(result.inserted_primary_key[0])
+
+
+def _fts_rowids(store: SQLAlchemyStore, match: str) -> list[int]:
+    with store.read_engine.connect() as conn:
+        return [
+            int(r[0])
+            for r in conn.execute(
+                text("SELECT rowid FROM messages_fts WHERE messages_fts MATCH :q"),
+                {"q": match},
+            ).all()
+        ]
+
+
+def test_insert_triggers_sync_into_fts(tmp_path: Path) -> None:
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    try:
+        row_id = _insert_row(store, subject="unique-marlin-kite")
+        hits = _fts_rowids(store, "marlin")
+        assert row_id in hits
+    finally:
+        store.close()
+
+
+def test_update_triggers_resync_fts(tmp_path: Path) -> None:
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    try:
+        row_id = _insert_row(store, subject="alpha-token", body="hello")
+        assert _fts_rowids(store, "alpha") == [row_id]
+
+        with store.transaction() as conn:
+            conn.execute(
+                messages.update()
+                .where(messages.c.id == row_id)
+                .values(subject="beta-token", body="world")
+            )
+
+        # Old term no longer matches, new term does.
+        assert _fts_rowids(store, "alpha") == []
+        assert row_id in _fts_rowids(store, "beta")
+    finally:
+        store.close()
+
+
+def test_delete_removes_row_from_fts(tmp_path: Path) -> None:
+    store = SQLAlchemyStore(_db_url(tmp_path))
+    try:
+        row_id = _insert_row(store, subject="gamma-sentinel")
+        assert row_id in _fts_rowids(store, "gamma")
+
+        with store.transaction() as conn:
+            conn.execute(messages.delete().where(messages.c.id == row_id))
+
+        assert _fts_rowids(store, "gamma") == []
+    finally:
+        store.close()
+
+
+# --------------------------------------------------------------------------
+# Idempotent bootstrap
+# --------------------------------------------------------------------------
+
+
+def test_bootstrap_is_idempotent(tmp_path: Path) -> None:
+    url = _db_url(tmp_path)
+    first = SQLAlchemyStore(url)
+    row_id = _insert_row(first, subject="persist-me")
+    first.close()
+
+    # Second construction against the same DB must not raise or lose data.
+    second = SQLAlchemyStore(url)
+    try:
+        with second.read_engine.connect() as conn:
+            count = conn.execute(text("SELECT COUNT(*) FROM messages")).scalar()
+        assert count == 1
+
+        hits = _fts_rowids(second, "persist")
+        assert row_id in hits
+    finally:
+        second.close()

--- a/tests/test_store_engine.py
+++ b/tests/test_store_engine.py
@@ -220,16 +220,16 @@ def test_store_transaction_rolls_back_on_exception(tmp_path: Path) -> None:
 
 
 def test_store_stub_methods_raise_with_guidance(tmp_path: Path) -> None:
-    """Every unimplemented method must honor the three-question rule."""
+    """Remaining unimplemented methods must honor the three-question rule.
+
+    #338 implemented the messages + event-log surface. The alert methods
+    are still awaiting their dedicated issue, and their
+    ``NotImplementedError`` messages must still follow the what/why/fix
+    shape so a caller who trips on them gets an actionable pointer.
+    """
     store = SQLAlchemyStore(_db_url(tmp_path))
     try:
         stubs = [
-            lambda: store.append_event(kind="x", payload={}),
-            lambda: store.record_event("s", "e", "m"),
-            lambda: store.enqueue_message({}),
-            lambda: store.update_message(1),
-            lambda: store.close_message(1),
-            lambda: store.query_messages(),
             lambda: store.upsert_alert("s", "a", "warn", "m"),
             lambda: store.clear_alert("s", "a"),
         ]
@@ -242,4 +242,4 @@ def test_store_stub_methods_raise_with_guidance(tmp_path: Path) -> None:
             assert "#338" in msg or "#340" in msg
             assert "Fix:" in msg
     finally:
-        store.dispose()
+        store.close()


### PR DESCRIPTION
## Summary

Closes #338. Builds on the SQLAlchemy foundation (#337) to land the unified `messages` schema and the fire-and-forget event buffer.

- `src/pollypm/store/schema.py` — `messages` table with columns matching the issue spec (scope, type, tier, recipient, sender, state, parent_id, subject, body, payload_json, labels, timestamps), 3 indexes, and FTS5 virtual table + INSERT/UPDATE/DELETE sync triggers. `metadata` + `FTS_DDL_STATEMENTS: list[str]` exported.
- `src/pollypm/store/event_buffer.py` — `EventBuffer(store, batch_size=100, flush_interval=0.1, capacity=10_000)`. Background drain thread, oldest-eviction on overflow, SIGTERM/SIGINT handler chains to prior handler, idempotent `close()` bounded at 5s, shutdown sentinel unblocks `queue.get`.
- `src/pollypm/store/sqlalchemy_store.py` — `_bootstrap_schema()` runs `metadata.create_all` + FTS DDL in one txn. Implements `append_event` (lazy EventBuffer), `record_event` (sync insert), `enqueue_message`, `update_message`, `close_message`, `query_messages` (whitelisted filters, JSON decoded). `close()` added (flushes buffer). Alert methods still raise NotImplementedError until #340.

## Test plan
- [x] `HOME=/tmp/pytest-store-messages uv run pytest tests/test_messages_schema.py tests/test_event_buffer.py -x` → **15 passed** in 0.41s
- [x] 10k `append_event` calls land in <2s (batch draining verified)
- [x] Overflow drops oldest, SIGTERM during drain persists pending, close() idempotent
- [x] FTS triggers verified: insert→search, update→old fails+new succeeds, delete→search fails
- [x] Regression: `tests/test_store_engine.py` still 14 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)