### PR TITLE
fix(packaging): include plugin profiles/*.md + flows/*.yaml in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ where = ["src"]
 [tool.setuptools.package-data]
 pollypm = [
   "plugins_builtin/*/pollypm-plugin.toml",
+  "plugins_builtin/*/profiles/*.md",
+  "plugins_builtin/*/flows/*.yaml",
+  "plugins_builtin/*/skills/*.md",
   "defaults/rules/*.md",
   "defaults/magic/*.md",
   "defaults/magic/*/*.md",


### PR DESCRIPTION
Fixes `pm doctor`'s `architect-profile: architect profile missing` failure on fresh install. The `plugins_builtin/*/profiles/*.md` and `plugins_builtin/*/flows/*.yaml` globs were missing from package-data.