### PR TITLE
fix(auth): Claude auth detection treats loggedIn:true + email:null as logged-in

### DIFF
--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -542,6 +542,14 @@ def _detect_claude_email(home: Path) -> str | None:
             email = data.get("email")
             if isinstance(email, str) and email:
                 return email.lower()
+            # Claude CLI 2.x returns loggedIn:true with email:null for Max
+            # subscribers. Fall back to a stable non-None sentinel so
+            # _account_logged_in() correctly reads True. The real email is
+            # already pinned in AccountConfig at registration; this return
+            # value is used downstream only as a presence check.
+            method = data.get("authMethod") or "claude"
+            sub = data.get("subscriptionType") or "unknown"
+            return f"{method}:{sub}".lower()
         except Exception:  # noqa: BLE001
             pass
 


### PR DESCRIPTION
Claude CLI 2.x returns `loggedIn:true, email:null` for Max subscribers; PollyPM's `_detect_claude_email` required non-empty email and returned None, causing `pm worker-start` to refuse with 'No healthy logged-in account available' even when the user is authenticated.

Live repro: `HOME=<agent_home> claude auth status --json` returns the null-email shape; `pm accounts` reads `logged_in=no`.

Fix: fall back to `authMethod:subscriptionType` as a non-None presence sentinel. Downstream uses only a presence check; the real email is pinned in AccountConfig at registration.

Discovered overnight during E2E runs — see /tmp/pollypm-overnight-report.md.