### PR TITLE
refactor(accounts): Phase A — substrate package + ProviderAdapter Protocol + entry-point registry (#397)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,14 @@ pollypm = "pollypm.cli:app"
 [project.entry-points."pollypm.store_backend"]
 sqlite = "pollypm.store.sqlalchemy_store:SQLAlchemyStore"
 
+# Phase A of #397 — provider substrate. The Phase A adapters delegate
+# to the existing pollypm.accounts / pollypm.onboarding functions so
+# the registry has something to resolve while Phases B/C extract the
+# real provider packages.
+[project.entry-points."pollypm.provider"]
+claude = "pollypm.acct._legacy_adapters:LegacyClaudeAdapter"
+codex = "pollypm.acct._legacy_adapters:LegacyCodexAdapter"
+
 [build-system]
 requires = ["setuptools>=80", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/src/pollypm/acct/__init__.py
+++ b/src/pollypm/acct/__init__.py
@@ -1,0 +1,44 @@
+"""``pollypm.acct`` — provider substrate for the account-management refactor.
+
+Phase A of #397 ships this package as a new namespace that sits
+alongside the existing ``pollypm.accounts`` module. The substrate
+contains:
+
+* :mod:`pollypm.acct.model` — data shapes (``AccountConfig``,
+  ``AccountStatus``, ``RuntimeStatus``).
+* :mod:`pollypm.acct.protocol` — the ``ProviderAdapter`` Protocol every
+  provider package implements.
+* :mod:`pollypm.acct.registry` — ``get_provider()`` / ``list_providers()``
+  backed by the ``pollypm.provider`` entry-point group.
+* :mod:`pollypm.acct.errors` — ``ProviderNotFound`` / ``AccountNotFound``
+  with three-question-rule messages.
+
+Phase B (#397) moves the Claude implementation into a dedicated package
+under this namespace; Phase C does the same for Codex; Phase D
+introduces the higher-level manager and migrates callers away from
+``pollypm.accounts``.
+
+During Phase A this ``__init__`` re-exports the **stable** public
+surface only. The ``_legacy_adapters`` module is intentionally private
+— it exists solely to give the entry-point registry something to
+resolve during Phase A and will be deleted once Phases B/C land.
+"""
+
+from __future__ import annotations
+
+from .errors import AccountNotFound, AcctError, ProviderNotFound
+from .model import AccountConfig, AccountStatus, RuntimeStatus
+from .protocol import ProviderAdapter
+from .registry import get_provider, list_providers
+
+__all__ = [
+    "AccountConfig",
+    "AccountNotFound",
+    "AccountStatus",
+    "AcctError",
+    "ProviderAdapter",
+    "ProviderNotFound",
+    "RuntimeStatus",
+    "get_provider",
+    "list_providers",
+]

--- a/src/pollypm/acct/_legacy_adapters.py
+++ b/src/pollypm/acct/_legacy_adapters.py
@@ -1,0 +1,151 @@
+"""Phase A placeholder adapters that delegate to the existing modules.
+
+These classes exist so the ``pollypm.acct`` registry has something to
+resolve from day one. They are wired via
+``[project.entry-points."pollypm.provider"]`` in ``pyproject.toml`` and
+will be **replaced wholesale** in Phase B (Claude) and Phase C (Codex)
+by real provider packages.
+
+Each method delegates to the current implementation in
+``pollypm.accounts`` / ``pollypm.onboarding`` / ``pollypm.providers.*``.
+No behavior change: every call path ends in the same function the code
+base has always used.
+
+The adapters are deliberately thin — see the docstring on each method
+for the exact delegation target. Anything that cannot be answered from
+``AccountConfig`` alone (e.g. ``probe_usage`` needs a config_path to
+locate the state DB) raises ``NotImplementedError`` with a message that
+points at the higher-level API that already handles it. Phase D
+introduces the manager class that ties them together; Phase A does not
+need that surface yet.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pollypm.models import AccountConfig as _ModelAccountConfig
+from pollypm.models import ProviderKind
+
+from .model import AccountConfig, AccountStatus
+
+
+class _LegacyAdapterBase:
+    """Shared scaffolding for the two Phase A legacy adapters.
+
+    Subclasses set ``name`` + ``_provider_kind`` and override the two
+    env helpers. Everything else is generic enough to share.
+    """
+
+    name: str = ""
+    _provider_kind: ProviderKind
+
+    def detect_logged_in(self, account: AccountConfig) -> bool:
+        """Delegate to ``pollypm.accounts._account_logged_in``.
+
+        The legacy helper already honours the ``home is None`` guard
+        and returns False in that case, so we forward verbatim.
+        """
+        from pollypm.accounts import _account_logged_in
+
+        return _account_logged_in(account)
+
+    def detect_email(self, account: AccountConfig) -> str | None:
+        """Delegate to ``pollypm.onboarding._detect_account_email``."""
+        from pollypm.onboarding import _detect_account_email
+
+        if account.home is None:
+            return None
+        return _detect_account_email(account.provider, account.home)
+
+    def run_login_flow(self, account: AccountConfig) -> None:
+        """Not wired in Phase A — use the existing ``pm accounts`` CLI.
+
+        The login flow threads a ``TmuxClient`` and a window label that
+        the substrate does not yet model. Phase B/C move the flow into
+        the provider packages; until then, callers must keep using
+        ``pollypm.accounts.add_account_via_login`` and
+        ``pollypm.accounts.relogin_account``, which is what every CLI
+        path already does.
+        """
+        raise NotImplementedError(
+            f"Phase A of #397 does not wire the login flow through the "
+            f"provider substrate.\n\n"
+            f"Why: login requires a TmuxClient and window label that the "
+            f"substrate does not yet model; those arguments will be added "
+            f"in Phase B ({self._provider_kind.value}).\n\n"
+            f"Fix: use `pollypm.accounts.add_account_via_login` or "
+            f"`pollypm.accounts.relogin_account` for now."
+        )
+
+    def probe_usage(self, account: AccountConfig) -> AccountStatus:
+        """Not wired in Phase A — use ``pollypm.accounts.probe_account_usage``.
+
+        The legacy probe reads the config path to locate the state DB
+        and pass isolation context. Phase A's Protocol intentionally
+        takes only an ``AccountConfig``; Phase B/C will add the context
+        object the real implementation needs.
+        """
+        raise NotImplementedError(
+            f"Phase A of #397 does not wire probe_usage through the "
+            f"provider substrate.\n\n"
+            f"Why: the legacy probe needs the project config path to "
+            f"locate the state DB, which the Phase A Protocol does not "
+            f"yet carry.\n\n"
+            f"Fix: call `pollypm.accounts.probe_account_usage(config_path, "
+            f"account_name)` for now; Phase B/C will route this through "
+            f"the substrate."
+        )
+
+    def worker_launch_cmd(
+        self,
+        account: AccountConfig,
+        args: list[str],
+    ) -> list[str]:
+        """Return ``[binary, *args]`` — the same shape the adapters use.
+
+        Delegates binary resolution to the existing
+        ``pollypm.providers`` adapters so the two surfaces stay in
+        sync. Phase B/C replace this with a proper argv builder that
+        knows about resume markers, fresh-launch markers, etc.
+        """
+        from pollypm.providers import get_provider as _legacy_get_provider
+
+        provider = _legacy_get_provider(self._provider_kind)
+        return [provider.binary, *args]
+
+    def isolated_env(self, home: Path) -> dict[str, str]:
+        """Delegate to ``pollypm.runtime_env.provider_profile_env_for_provider``."""
+        from pollypm.runtime_env import provider_profile_env_for_provider
+
+        # ``base_env={}`` so callers see only the additive contribution
+        # of the provider — matches the Protocol's contract.
+        return provider_profile_env_for_provider(
+            self._provider_kind,
+            home,
+            base_env={},
+        )
+
+
+class LegacyClaudeAdapter(_LegacyAdapterBase):
+    """Phase A placeholder for the Claude provider."""
+
+    name = "claude"
+    _provider_kind = ProviderKind.CLAUDE
+
+
+class LegacyCodexAdapter(_LegacyAdapterBase):
+    """Phase A placeholder for the Codex provider."""
+
+    name = "codex"
+    _provider_kind = ProviderKind.CODEX
+
+
+# Re-export the legacy AccountConfig under the private type alias so
+# static checkers can confirm the Protocol methods accept the same
+# dataclass the rest of the codebase uses. The two symbols resolve to
+# the same class — this is just a reminder for code-search.
+_LegacyAccountConfig = _ModelAccountConfig
+
+
+__all__ = ["LegacyClaudeAdapter", "LegacyCodexAdapter"]

--- a/src/pollypm/acct/errors.py
+++ b/src/pollypm/acct/errors.py
@@ -1,0 +1,73 @@
+"""Error types for the ``pollypm.acct`` provider substrate.
+
+Every message follows PollyPM's three-question rule (#240):
+
+    * **what happened** — the trigger (e.g. "provider 'foo' is not
+      registered").
+    * **why it matters** — the consequence (e.g. "the account cannot be
+      launched because no adapter knows how to drive it").
+    * **how to fix it** — a concrete next step the user can take.
+"""
+
+from __future__ import annotations
+
+
+class AcctError(Exception):
+    """Base class for ``pollypm.acct`` errors.
+
+    Provider substrate code raises subclasses so callers can catch the
+    whole family with one ``except`` clause without pulling in unrelated
+    ``Exception`` subclasses.
+    """
+
+
+class ProviderNotFound(AcctError):
+    """Raised when ``get_provider(name)`` cannot resolve a provider.
+
+    The message names the requested provider, explains why the call
+    failed, and lists the providers that *are* registered so the user
+    can pick one or fix the typo.
+    """
+
+    def __init__(self, name: str, *, available: list[str] | None = None) -> None:
+        self.name = name
+        self.available = list(available or [])
+        available_str = ", ".join(self.available) if self.available else "(none registered)"
+        super().__init__(
+            f"No PollyPM provider is registered under the name {name!r}.\n\n"
+            f"Why: provider adapters are loaded from the "
+            f"`pollypm.provider` entry-point group; a missing name "
+            f"means the plugin that ships this provider is not "
+            f"installed or did not register itself.\n\n"
+            f"Fix: install the plugin that ships the {name!r} provider, "
+            f"or pick one of the providers that is already registered: "
+            f"{available_str}."
+        )
+
+
+class AccountNotFound(AcctError):
+    """Raised when an account name cannot be resolved in the config.
+
+    Phase A does not yet use this — it is provided up front so Phases
+    B-D can migrate call sites that currently raise
+    ``typer.BadParameter`` with ad-hoc phrasing. Keeping the exception
+    in the public surface lets callers write ``except AccountNotFound``
+    instead of string-matching on the legacy phrasing.
+    """
+
+    def __init__(self, identifier: str, *, available: list[str] | None = None) -> None:
+        self.identifier = identifier
+        self.available = list(available or [])
+        available_str = ", ".join(self.available) if self.available else "(none configured)"
+        super().__init__(
+            f"No account matches the identifier {identifier!r}.\n\n"
+            f"Why: account operations look up accounts by their config "
+            f"name or email address; the identifier did not match any "
+            f"of the configured accounts.\n\n"
+            f"Fix: run `pm accounts list` to see configured accounts, "
+            f"or add the missing one with `pm accounts add`. Configured "
+            f"accounts: {available_str}."
+        )
+
+
+__all__ = ["AcctError", "AccountNotFound", "ProviderNotFound"]

--- a/src/pollypm/acct/model.py
+++ b/src/pollypm/acct/model.py
@@ -1,0 +1,49 @@
+"""Data models for the ``pollypm.acct`` provider substrate.
+
+This module is part of Phase A of the account-management refactor
+(#397). It re-exports the existing ``AccountConfig`` and
+``AccountStatus`` shapes under the new ``pollypm.acct`` namespace so
+subsequent phases can migrate callers without a flag-day rename.
+
+``RuntimeStatus`` is a lightweight read-only view of the runtime health
+data that ``pollypm.storage.state.StateStore`` records for each account.
+The dataclass lives here (rather than being re-exported) because the
+legacy code path reads the fields directly off the ``StateStore`` row
+dataclass — the shape is defined here as the public contract the
+provider substrate exposes, independent of storage schema drift.
+
+No behavior change: ``AccountConfig`` and ``AccountStatus`` are imported
+from their current homes. Phase D of #397 will physically move the
+definitions into this module and drop the re-exports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Re-export the existing shapes. Callers that want the provider
+# substrate's public surface can now write::
+#
+#     from pollypm.acct.model import AccountConfig, AccountStatus
+#
+# while the legacy modules keep working unchanged.
+from pollypm.accounts import AccountStatus  # noqa: F401 — public re-export
+from pollypm.models import AccountConfig  # noqa: F401 — public re-export
+
+
+@dataclass(slots=True, frozen=True)
+class RuntimeStatus:
+    """Read-only snapshot of an account's runtime-health record.
+
+    Mirrors the subset of ``StateStore.get_account_runtime()`` columns
+    the provider substrate cares about. Kept separate from the storage
+    dataclass so provider adapters don't depend on the state-db schema.
+    """
+
+    status: str = "unknown"
+    reason: str = ""
+    available_at: str | None = None
+    access_expires_at: str | None = None
+
+
+__all__ = ["AccountConfig", "AccountStatus", "RuntimeStatus"]

--- a/src/pollypm/acct/protocol.py
+++ b/src/pollypm/acct/protocol.py
@@ -1,0 +1,98 @@
+"""The ``ProviderAdapter`` Protocol — Phase A of #397.
+
+Every provider package (``pollypm.acct.claude``, ``pollypm.acct.codex``,
+and any third-party plugins) implements this contract. Phase A ships
+the Protocol plus two legacy adapters (see ``_legacy_adapters``) that
+delegate to the existing ``pollypm.accounts`` + ``pollypm.onboarding``
+functions so no caller has to move yet.
+
+The Protocol is intentionally narrow: six methods that cover the four
+life-cycle events (detect, login, probe, launch) plus the env shim that
+makes isolated-home execution possible. Anything broader lives in the
+higher-level manager that Phase D will introduce.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from .model import AccountConfig, AccountStatus
+
+
+@runtime_checkable
+class ProviderAdapter(Protocol):
+    """Contract every provider package implements.
+
+    Attributes:
+        name: Stable identifier used by the entry-point registry
+            (``"claude"``, ``"codex"``, …). Must match the entry-point
+            name so ``get_provider(adapter.name)`` round-trips.
+
+    The six methods below mirror the four life-cycle events a provider
+    participates in — detect, login, probe, launch — plus the env shim
+    that makes isolated-home execution possible.
+    """
+
+    name: str
+
+    def detect_logged_in(self, account: AccountConfig) -> bool:
+        """Return True iff the account currently holds valid credentials.
+
+        Implementations must be side-effect-free: no network calls that
+        mutate server state, no writes to ``account.home``.
+        """
+        ...
+
+    def detect_email(self, account: AccountConfig) -> str | None:
+        """Return the authenticated email address, or None if unknown.
+
+        The return value is used as a presence check, not an identity
+        source. For providers whose auth API does not expose the email
+        (Claude Max 2.x), a stable non-None sentinel is acceptable.
+        """
+        ...
+
+    def run_login_flow(self, account: AccountConfig) -> None:
+        """Drive the interactive login for the account.
+
+        Blocks until the user completes login or aborts. Implementations
+        should be idempotent: running login twice on an already-logged-in
+        account must not corrupt the existing credentials.
+        """
+        ...
+
+    def probe_usage(self, account: AccountConfig) -> AccountStatus:
+        """Return a fresh ``AccountStatus`` snapshot for the account.
+
+        This is the "pull me the latest" entry point; callers that want
+        cached data should read from the state store directly.
+        """
+        ...
+
+    def worker_launch_cmd(
+        self,
+        account: AccountConfig,
+        args: list[str],
+    ) -> list[str]:
+        """Return the argv to launch a worker session for this account.
+
+        The returned list is the command the runtime wrapper (local or
+        Docker) will execute. It does **not** include env — env is
+        delivered separately via ``isolated_env()`` so the runtime
+        layer can merge it with its own env contributions.
+        """
+        ...
+
+    def isolated_env(self, home: Path) -> dict[str, str]:
+        """Return env vars that pin the provider binary to ``home``.
+
+        For Claude this is ``CLAUDE_CONFIG_DIR``; for Codex it is
+        ``CODEX_HOME``. The returned dict is layered onto whatever env
+        the runtime provides — callers should treat it as purely
+        additive.
+        """
+        ...
+
+
+__all__ = ["ProviderAdapter"]

--- a/src/pollypm/acct/registry.py
+++ b/src/pollypm/acct/registry.py
@@ -1,0 +1,65 @@
+"""Entry-point-backed registry for provider adapters.
+
+Phase A ships two adapters — ``claude`` and ``codex`` — registered via
+``pyproject.toml``'s ``[project.entry-points."pollypm.provider"]``
+section. Third-party plugins can register additional providers the same
+way; ``get_provider()`` does not distinguish built-in from third-party.
+
+The registry is cached with ``functools.lru_cache`` so repeated
+``get_provider()`` calls in the same process return the same adapter
+instance. That matters for adapters that hold lazy state (a subprocess
+pool, a cached login timestamp). The cache is keyed by the provider
+name only — clearing it is normally unnecessary, but tests that mutate
+the entry-point table can call ``get_provider.cache_clear()``.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from functools import lru_cache
+
+from .errors import ProviderNotFound
+from .protocol import ProviderAdapter
+
+_ENTRY_POINT_GROUP = "pollypm.provider"
+
+
+def _entry_points() -> list[importlib.metadata.EntryPoint]:
+    """Return all registered ``pollypm.provider`` entry points.
+
+    Wrapped in a helper so ``get_provider`` and ``list_providers`` share
+    one implementation and tests only need to monkeypatch one function.
+    """
+    eps = importlib.metadata.entry_points(group=_ENTRY_POINT_GROUP)
+    # ``entry_points()`` returns an ``EntryPoints`` selectable view on
+    # 3.10+ but iterating it yields ``EntryPoint``s — normalize to a
+    # list so callers can cheaply len()/sort() the result.
+    return list(eps)
+
+
+@lru_cache(maxsize=None)
+def get_provider(name: str) -> ProviderAdapter:
+    """Resolve a provider adapter by name.
+
+    Loads the class registered under the ``pollypm.provider``
+    entry-point group, instantiates it, and returns the instance. The
+    result is cached — see the module docstring.
+
+    Raises:
+        ProviderNotFound: no adapter is registered under ``name``.
+    """
+    available: list[str] = []
+    for ep in _entry_points():
+        available.append(ep.name)
+        if ep.name == name:
+            cls = ep.load()
+            return cls()
+    raise ProviderNotFound(name, available=sorted(available))
+
+
+def list_providers() -> list[str]:
+    """Return the sorted names of every registered provider."""
+    return sorted(ep.name for ep in _entry_points())
+
+
+__all__ = ["get_provider", "list_providers"]

--- a/tests/test_acct_substrate.py
+++ b/tests/test_acct_substrate.py
@@ -1,0 +1,152 @@
+"""Phase A substrate tests for ``pollypm.acct`` (#397).
+
+Run with::
+
+    HOME=/tmp/pytest-acct-substrate uv run --with pytest \\
+        pytest tests/test_acct_substrate.py -x
+
+These tests cover the Phase A deliverables only — Protocol shape,
+entry-point registry, and the two placeholder adapters. Real provider
+behavior is exercised by the existing ``test_accounts.py`` /
+``test_onboarding.py`` suites, which must still pass unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pollypm.acct import (
+    AccountConfig,
+    AccountStatus,
+    ProviderAdapter,
+    ProviderNotFound,
+    RuntimeStatus,
+    get_provider,
+    list_providers,
+)
+from pollypm.acct._legacy_adapters import LegacyClaudeAdapter, LegacyCodexAdapter
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_cache():
+    """Clear the ``lru_cache`` so tests that monkeypatch see a clean slate."""
+    get_provider.cache_clear()
+    yield
+    get_provider.cache_clear()
+
+
+def test_get_provider_claude_returns_protocol_conforming_instance():
+    """``get_provider("claude")`` returns a ``ProviderAdapter``."""
+    provider = get_provider("claude")
+    assert isinstance(provider, ProviderAdapter)
+    assert provider.name == "claude"
+
+
+def test_get_provider_codex_returns_protocol_conforming_instance():
+    """``get_provider("codex")`` returns a ``ProviderAdapter``."""
+    provider = get_provider("codex")
+    assert isinstance(provider, ProviderAdapter)
+    assert provider.name == "codex"
+
+
+def test_get_provider_unknown_raises_provider_not_found():
+    """Missing providers raise ``ProviderNotFound`` with a 3-question message."""
+    with pytest.raises(ProviderNotFound) as exc_info:
+        get_provider("nonexistent-provider-xyz")
+
+    message = str(exc_info.value)
+    # What happened
+    assert "'nonexistent-provider-xyz'" in message
+    # Why it matters
+    assert "entry-point" in message.lower() or "registered" in message.lower()
+    # Fix
+    assert "Fix:" in message
+    # Lists available providers so the user can pick one
+    assert "claude" in message
+    assert "codex" in message
+    # The exception carries the structured data for programmatic callers
+    assert exc_info.value.name == "nonexistent-provider-xyz"
+    assert "claude" in exc_info.value.available
+    assert "codex" in exc_info.value.available
+
+
+def test_provider_not_found_reports_empty_registry_explicitly():
+    """When no providers are registered, the message says so plainly."""
+    err = ProviderNotFound("anything", available=[])
+    assert "(none registered)" in str(err)
+
+
+def test_list_providers_returns_sorted_names():
+    """``list_providers()`` returns the sorted built-in providers."""
+    providers = list_providers()
+    assert providers == sorted(providers)
+    assert "claude" in providers
+    assert "codex" in providers
+    # The two Phase A adapters are the only built-ins.
+    assert set(providers) >= {"claude", "codex"}
+
+
+def test_get_provider_caches_instances():
+    """Repeated ``get_provider()`` calls return the same instance."""
+    first = get_provider("claude")
+    second = get_provider("claude")
+    assert first is second
+
+
+def test_legacy_claude_adapter_satisfies_protocol():
+    """The Phase A Claude adapter runtime-checks as ``ProviderAdapter``."""
+    adapter = LegacyClaudeAdapter()
+    assert isinstance(adapter, ProviderAdapter)
+    assert adapter.name == "claude"
+
+
+def test_legacy_codex_adapter_satisfies_protocol():
+    """The Phase A Codex adapter runtime-checks as ``ProviderAdapter``."""
+    adapter = LegacyCodexAdapter()
+    assert isinstance(adapter, ProviderAdapter)
+    assert adapter.name == "codex"
+
+
+def test_legacy_adapters_have_required_method_names():
+    """All six Protocol methods are defined on the legacy adapters."""
+    for adapter_cls in (LegacyClaudeAdapter, LegacyCodexAdapter):
+        adapter = adapter_cls()
+        for method in (
+            "detect_logged_in",
+            "detect_email",
+            "run_login_flow",
+            "probe_usage",
+            "worker_launch_cmd",
+            "isolated_env",
+        ):
+            assert hasattr(adapter, method), f"{adapter_cls.__name__} missing {method}"
+            assert callable(getattr(adapter, method))
+
+
+def test_model_reexports_are_the_canonical_types():
+    """``acct.model`` re-exports the same ``AccountConfig`` the rest of the codebase uses."""
+    from pollypm.accounts import AccountStatus as _LegacyStatus
+    from pollypm.models import AccountConfig as _LegacyConfig
+
+    # Object identity — these must be re-exports, not copies, so
+    # callers can pass either name interchangeably during the
+    # migration window.
+    assert AccountConfig is _LegacyConfig
+    assert AccountStatus is _LegacyStatus
+
+
+def test_runtime_status_defaults_are_safe():
+    """``RuntimeStatus`` default values represent "no data yet"."""
+    status = RuntimeStatus()
+    assert status.status == "unknown"
+    assert status.reason == ""
+    assert status.available_at is None
+    assert status.access_expires_at is None
+
+
+def test_unknown_provider_message_includes_fix_line():
+    """Three-question rule: the error message ends with a ``Fix:`` line."""
+    with pytest.raises(ProviderNotFound) as exc_info:
+        get_provider("no-such-thing")
+    lines = str(exc_info.value).splitlines()
+    assert any(line.startswith("Fix:") for line in lines)


### PR DESCRIPTION
Phase A of #397. Substrate only — no caller migrates, no behavior change.

- `src/pollypm/acct/` (new package, deliberately named `acct` to avoid collision with existing `accounts.py`)
- `ProviderAdapter` runtime-checkable Protocol with 6 methods
- `get_provider(name)` registry reading `[project.entry-points.\"pollypm.provider\"]`
- LegacyClaudeAdapter + LegacyCodexAdapter thin delegates to current `accounts.py`/`onboarding.py` functions
- Three-question-rule errors

Next phases: B (Claude extract → `providers/claude/`), C (Codex extract → `providers/codex/`), D (manager), E (cleanup).

## Test plan
- 12/12 new acct substrate tests green
- Full unit regression 2823/2823 green