### PR TITLE
refactor(accounts): Phase C — extract Codex into self-contained providers/codex/ package (#397)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,13 @@ pollypm = "pollypm.cli:app"
 [project.entry-points."pollypm.store_backend"]
 sqlite = "pollypm.store.sqlalchemy_store:SQLAlchemyStore"
 
-# Phase A of #397 — provider substrate. The Phase A adapters delegate
-# to the existing pollypm.accounts / pollypm.onboarding functions so
-# the registry has something to resolve while Phases B/C extract the
-# real provider packages.
+# Provider substrate — Phase A of #397. Phase C replaced the Codex
+# legacy adapter with the real pollypm.providers.codex.CodexProvider
+# class; Claude still uses the Phase A legacy adapter until Phase B
+# extracts it.
 [project.entry-points."pollypm.provider"]
 claude = "pollypm.acct._legacy_adapters:LegacyClaudeAdapter"
-codex = "pollypm.acct._legacy_adapters:LegacyCodexAdapter"
+codex = "pollypm.providers.codex:CodexProvider"
 
 [build-system]
 requires = ["setuptools>=80", "wheel"]

--- a/src/pollypm/accounts.py
+++ b/src/pollypm/accounts.py
@@ -151,12 +151,17 @@ def _parse_claude_usage_text(text: str) -> tuple[str, str]:
 
 
 def _parse_codex_status_text(text: str) -> tuple[str, str]:
-    summary_match = re.search(r"(\d+)% left", text)
-    if summary_match:
-        return ("healthy", f"{summary_match.group(1)}% left")
-    if "usage limit" in text.lower():
-        return ("capacity-exhausted", "usage limit reached")
-    return ("unknown", "usage unavailable")
+    """Back-compat shim: Phase C of #397 moved this to the Codex package.
+
+    The real parser now lives at
+    :func:`pollypm.providers.codex.usage_parse.parse_codex_status_text`.
+    This shim preserves the legacy private import path so existing
+    tests (``tests/test_account_usage.py``) and the state-store writer
+    keep working; Phase D migrates callers and drops the shim.
+    """
+    from pollypm.providers.codex.usage_parse import parse_codex_status_text
+
+    return parse_codex_status_text(text)
 
 
 def _codex_credentials_store(home: Path) -> str:

--- a/src/pollypm/acct/_legacy_adapters.py
+++ b/src/pollypm/acct/_legacy_adapters.py
@@ -1,23 +1,21 @@
-"""Phase A placeholder adapters that delegate to the existing modules.
+"""Phase A placeholder adapter(s) that delegate to the existing modules.
 
 These classes exist so the ``pollypm.acct`` registry has something to
-resolve from day one. They are wired via
-``[project.entry-points."pollypm.provider"]`` in ``pyproject.toml`` and
-will be **replaced wholesale** in Phase B (Claude) and Phase C (Codex)
-by real provider packages.
+resolve while Phase B (Claude) extracts the real provider package. The
+Phase C (Codex) adapter has already been replaced by
+:class:`pollypm.providers.codex.CodexProvider`; once Phase B lands,
+this whole module can be deleted.
 
 Each method delegates to the current implementation in
 ``pollypm.accounts`` / ``pollypm.onboarding`` / ``pollypm.providers.*``.
 No behavior change: every call path ends in the same function the code
 base has always used.
 
-The adapters are deliberately thin — see the docstring on each method
+The adapter is deliberately thin — see the docstring on each method
 for the exact delegation target. Anything that cannot be answered from
 ``AccountConfig`` alone (e.g. ``probe_usage`` needs a config_path to
 locate the state DB) raises ``NotImplementedError`` with a message that
-points at the higher-level API that already handles it. Phase D
-introduces the manager class that ties them together; Phase A does not
-need that surface yet.
+points at the higher-level API that already handles it.
 """
 
 from __future__ import annotations
@@ -134,13 +132,6 @@ class LegacyClaudeAdapter(_LegacyAdapterBase):
     _provider_kind = ProviderKind.CLAUDE
 
 
-class LegacyCodexAdapter(_LegacyAdapterBase):
-    """Phase A placeholder for the Codex provider."""
-
-    name = "codex"
-    _provider_kind = ProviderKind.CODEX
-
-
 # Re-export the legacy AccountConfig under the private type alias so
 # static checkers can confirm the Protocol methods accept the same
 # dataclass the rest of the codebase uses. The two symbols resolve to
@@ -148,4 +139,4 @@ class LegacyCodexAdapter(_LegacyAdapterBase):
 _LegacyAccountConfig = _ModelAccountConfig
 
 
-__all__ = ["LegacyClaudeAdapter", "LegacyCodexAdapter"]
+__all__ = ["LegacyClaudeAdapter"]

--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -506,19 +506,16 @@ def _decode_jwt_payload(token: str) -> dict[str, object]:
 
 
 def _detect_codex_email(home: Path) -> str | None:
-    auth_path = home / ".codex" / "auth.json"
-    if not auth_path.exists():
-        return None
-    try:
-        data = json.loads(auth_path.read_text())
-        id_token = data.get("tokens", {}).get("id_token")
-        if not isinstance(id_token, str) or id_token.count(".") < 2:
-            return None
-        payload = _decode_jwt_payload(id_token)
-        email = payload.get("email")
-        return str(email).lower() if isinstance(email, str) and email else None
-    except Exception:  # noqa: BLE001
-        return None
+    """Back-compat shim: Phase C of #397 moved this to the Codex package.
+
+    The real implementation now lives at
+    :func:`pollypm.providers.codex.detect.detect_codex_email`. Existing
+    call sites inside this module (and tests) import the shim name
+    unchanged; once Phase D migrates callers, this shim can be deleted.
+    """
+    from pollypm.providers.codex.detect import detect_codex_email
+
+    return detect_codex_email(home)
 
 
 def _isolated_env(provider: ProviderKind, home: Path) -> dict[str, str]:
@@ -576,10 +573,19 @@ def _detect_account_email(provider: ProviderKind, home: Path) -> str | None:
 
 
 def _detect_email_from_pane(provider: ProviderKind, pane_text: str) -> str | None:
+    """Dispatch Codex pane-scraping to the Codex package (Phase C of #397).
+
+    The Codex branch lives at
+    :func:`pollypm.providers.codex.detect.detect_email_from_pane`; the
+    Claude branch stays here until Phase B extracts it. Returning None
+    for unrecognised providers preserves the pre-split behaviour.
+    """
     if provider is ProviderKind.CODEX:
-        match = re.search(r"Account:\s+([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})", pane_text)
-        if match:
-            return match.group(1).lower()
+        from pollypm.providers.codex.detect import (
+            detect_email_from_pane as _codex_detect_email_from_pane,
+        )
+
+        return _codex_detect_email_from_pane(pane_text)
     return None
 
 

--- a/src/pollypm/providers/codex/__init__.py
+++ b/src/pollypm/providers/codex/__init__.py
@@ -1,0 +1,46 @@
+"""``pollypm.providers.codex`` — Codex provider package (Phase C of #397).
+
+This package replaces the old ``providers/codex.py`` single-file module
+and the Phase A ``LegacyCodexAdapter`` placeholder. It holds:
+
+* :class:`CodexProvider` — satisfies the
+  :class:`pollypm.acct.protocol.ProviderAdapter` Protocol; registered
+  as the ``codex`` entry point in ``pyproject.toml``.
+* :class:`CodexAdapter` — the launch-command adapter consumed by the
+  tmux launch path and the ``core_codex`` built-in plugin. Previously
+  at ``pollypm.providers.codex.CodexAdapter`` (via the single-file
+  module) — the import path is preserved by re-exporting here.
+* Sub-modules :mod:`.detect`, :mod:`.login`, :mod:`.probe`,
+  :mod:`.env`, :mod:`.usage_parse` — the helpers :class:`CodexProvider`
+  delegates to. Back-compat shims in ``pollypm.onboarding`` and
+  ``pollypm.accounts`` forward to these symbols so existing call sites
+  keep working.
+
+The dual export (``CodexProvider`` *and* ``CodexAdapter``) is
+deliberate: the two classes implement different Protocols at different
+layers of the stack. Phase D will collapse them once the manager API
+can carry both surfaces.
+"""
+
+from __future__ import annotations
+
+from .adapter import CodexAdapter
+from .detect import detect_codex_email, detect_email_from_pane, detect_logged_in
+from .env import codex_profile_dir, isolated_env
+from .login import run_login_flow
+from .probe import probe_usage
+from .provider import CodexProvider
+from .usage_parse import parse_codex_status_text
+
+__all__ = [
+    "CodexAdapter",
+    "CodexProvider",
+    "codex_profile_dir",
+    "detect_codex_email",
+    "detect_email_from_pane",
+    "detect_logged_in",
+    "isolated_env",
+    "parse_codex_status_text",
+    "probe_usage",
+    "run_login_flow",
+]

--- a/src/pollypm/providers/codex/adapter.py
+++ b/src/pollypm/providers/codex/adapter.py
@@ -1,16 +1,36 @@
+"""The launch-command adapter for Codex (formerly ``providers/codex.py``).
+
+This module holds :class:`CodexAdapter`, which the tmux launch path and
+built-in plugin consume to build ``LaunchCommand`` objects for Codex
+sessions. It is distinct from :class:`pollypm.providers.codex.CodexProvider`
+(Phase C of #397): the ``CodexProvider`` satisfies the high-level
+``pollypm.acct.protocol.ProviderAdapter`` Protocol, while
+:class:`CodexAdapter` implements ``pollypm.provider_sdk.ProviderAdapterBase``
+for the lower-level launch/transcript/usage-snapshot surface.
+
+The class body is a verbatim move from the old
+``src/pollypm/providers/codex.py`` file; collapsing ``providers/codex.py``
+and the new ``providers/codex/`` package into a single package requires
+one of the two to change path, and the legacy adapter is the one
+touched by fewer imports outside this module.
+
+Imports of ``pollypm.providers.codex.CodexAdapter`` continue to work via
+the re-export in ``providers/codex/__init__.py``.
+"""
+
 from __future__ import annotations
 
 import re
 import shutil
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pollypm.models import AccountConfig, SessionConfig
 from pollypm.providers.base import LaunchCommand
 from pollypm.provider_sdk import ProviderAdapterBase, ProviderUsageSnapshot, TranscriptSource
 from pollypm.runtime_env import codex_home_dir
 
-from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pollypm.tmux.client import TmuxClient
 
@@ -109,3 +129,6 @@ class CodexAdapter(ProviderAdapterBase):
             summary=f"{left}% left",
             raw_text=text,
         )
+
+
+__all__ = ["CodexAdapter"]

--- a/src/pollypm/providers/codex/detect.py
+++ b/src/pollypm/providers/codex/detect.py
@@ -1,0 +1,96 @@
+"""Codex email / login detection — Phase C of #397.
+
+Codex stores its OAuth tokens in ``<CODEX_HOME>/auth.json``. The
+authenticated email is embedded in the ``id_token`` JWT, so detecting
+login-state and detecting the user's email are the same operation.
+
+Two public helpers:
+
+* :func:`detect_codex_email` — read ``auth.json`` and return the email
+  or ``None``.
+* :func:`detect_logged_in` — convenience wrapper that returns a bool.
+
+Also :func:`detect_email_from_pane` handles the onboarding case where
+the tmux pane shows ``Account: <email>`` after Codex finishes its login
+flow. Moved from ``onboarding._detect_email_from_pane`` (Codex branch
+only — Claude parts live in Phase B's package).
+
+Previously lived in ``pollypm.onboarding._detect_codex_email``. That
+symbol is re-exported from ``pollypm.onboarding`` as a back-compat shim.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from pathlib import Path
+
+
+def _decode_jwt_payload(token: str) -> dict[str, object]:
+    """Decode the middle segment of a JWT into a dict.
+
+    Copied from ``onboarding._decode_jwt_payload`` (which remains as the
+    canonical implementation for now). Duplicated here so the Codex
+    provider package does not need to reach back into onboarding for a
+    three-line helper.
+    """
+    payload = token.split(".")[1]
+    payload += "=" * (-len(payload) % 4)
+    return json.loads(base64.urlsafe_b64decode(payload))
+
+
+def detect_codex_email(home: Path) -> str | None:
+    """Return the authenticated Codex email, or ``None`` if unknown.
+
+    Reads ``<home>/.codex/auth.json`` and extracts the ``email`` claim
+    from the ``id_token`` JWT. Any parse failure, missing file, or
+    malformed token is silently swallowed (returns ``None``) — the
+    caller treats ``None`` as "not logged in" so we do not surface the
+    distinction.
+    """
+    auth_path = home / ".codex" / "auth.json"
+    if not auth_path.exists():
+        return None
+    try:
+        data = json.loads(auth_path.read_text())
+        id_token = data.get("tokens", {}).get("id_token")
+        if not isinstance(id_token, str) or id_token.count(".") < 2:
+            return None
+        payload = _decode_jwt_payload(id_token)
+        email = payload.get("email")
+        return str(email).lower() if isinstance(email, str) and email else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def detect_logged_in(home: Path | None) -> bool:
+    """Return True iff the Codex profile at ``home`` is authenticated.
+
+    Null-safe: ``home is None`` returns False so callers can pass the
+    ``AccountConfig.home`` field without a pre-check. Matches the
+    contract of ``pollypm.accounts._account_logged_in`` for Codex.
+    """
+    if home is None:
+        return False
+    return detect_codex_email(home) is not None
+
+
+def detect_email_from_pane(pane_text: str) -> str | None:
+    """Extract the authenticated email from a Codex login-window pane.
+
+    Codex prints ``Account: <email>`` once its OAuth callback resolves.
+    We pull it straight out of the scrollback so onboarding can advance
+    the moment login completes, without waiting for ``auth.json`` to
+    hit disk. Returns ``None`` when the marker is not present.
+    """
+    match = re.search(
+        r"Account:\s+([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,})",
+        pane_text,
+    )
+    if match:
+        return match.group(1).lower()
+    return None
+
+
+__all__ = ["detect_codex_email", "detect_email_from_pane", "detect_logged_in"]

--- a/src/pollypm/providers/codex/env.py
+++ b/src/pollypm/providers/codex/env.py
@@ -1,0 +1,52 @@
+"""Environment helpers for the Codex provider — Phase C of #397.
+
+The runtime pins ``codex`` to an isolated ``CODEX_HOME`` so parallel
+accounts on the same host don't share auth state. This module owns the
+two helpers that answer "where does Codex keep its profile?" and
+"what env does a subprocess need to see to find it?".
+
+Both helpers delegate to ``pollypm.runtime_env`` — the provider package
+owns the public API but does not re-implement the logic. Moving the
+string literal ``"CODEX_HOME"`` through a single module makes it easy
+to spot every call site if the variable name ever changes upstream.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+from pollypm.models import ProviderKind
+from pollypm.runtime_env import codex_home_dir, provider_profile_env_for_provider
+
+
+def isolated_env(
+    home: Path,
+    *,
+    base_env: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Return the env a Codex subprocess needs to use ``home`` as ``CODEX_HOME``.
+
+    Mirrors the semantics of ``onboarding._isolated_env`` for Codex: the
+    returned dict starts from ``base_env`` (default: ``os.environ``) and
+    layers ``CODEX_HOME=<home>/.codex`` on top. Callers that want only
+    the additive contribution (no ``os.environ`` leak) should pass
+    ``base_env={}``.
+    """
+    env = dict(base_env if base_env is not None else os.environ)
+    return provider_profile_env_for_provider(ProviderKind.CODEX, home, base_env=env)
+
+
+def codex_profile_dir(home: Path) -> Path:
+    """Return the ``.codex`` directory inside ``home``.
+
+    Thin wrapper over ``pollypm.runtime_env.codex_home_dir`` so the
+    Codex provider package has a public symbol for the auth-file
+    location. The returned path is *not* created on disk — callers that
+    need the directory to exist must ``mkdir`` it themselves.
+    """
+    return codex_home_dir(home)
+
+
+__all__ = ["codex_profile_dir", "isolated_env"]

--- a/src/pollypm/providers/codex/login.py
+++ b/src/pollypm/providers/codex/login.py
@@ -1,0 +1,47 @@
+"""Codex login flow — Phase C of #397.
+
+The interactive ``codex login`` flow is driven by
+``pollypm.onboarding._run_login_window``, which threads a ``TmuxClient``
+and a window label the Phase A Protocol does not yet model. Until the
+Protocol carries that context (Phase D introduces the manager that
+will), this module delegates to the existing onboarding helper.
+
+Keeping the delegation in one place means Phase D can rewrite the
+flow without a scavenger hunt: replace :func:`run_login_flow` here and
+every caller that already routes through the substrate picks up the
+new implementation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def run_login_flow(home: Path, *, window_label: str | None = None) -> str:
+    """Drive the interactive ``codex login`` flow for ``home``.
+
+    Delegates to ``pollypm.onboarding._run_login_window`` with
+    ``provider=ProviderKind.CODEX``. Returns the final pane-text capture
+    so callers can parse the detected email from the ``Account:`` line
+    without a second tmux round-trip.
+
+    Raises :class:`pollypm.onboarding.LoginCancelled` if the user
+    detaches from the login tmux session without completing auth.
+    """
+    # Imports are local so the module loads without pulling in tmux
+    # machinery on systems that don't need it (e.g. probe-only callers).
+    from pollypm.models import ProviderKind
+    from pollypm.onboarding import _run_login_window
+    from pollypm.session_services import create_tmux_client
+
+    tmux = create_tmux_client()
+    label = window_label or f"codex-login-{home.name}"
+    return _run_login_window(
+        tmux,
+        provider=ProviderKind.CODEX,
+        home=home,
+        window_label=label,
+    )
+
+
+__all__ = ["run_login_flow"]

--- a/src/pollypm/providers/codex/probe.py
+++ b/src/pollypm/providers/codex/probe.py
@@ -1,0 +1,43 @@
+"""Codex usage probe — Phase C of #397.
+
+The probe boots a Codex session in a throwaway tmux pane, waits for the
+``openai codex`` banner to render (Codex prints its quota summary on
+the first screen), and parses the ``<n>% left`` fragment out of the
+scrollback. This module owns the high-level entry point; the regex
+lives in :mod:`.usage_parse` and the tmux plumbing stays in
+``pollypm.accounts._run_usage_probe``.
+
+The Phase A Protocol's ``probe_usage(AccountConfig) -> AccountStatus``
+signature does not carry the ``config_path`` the legacy probe needs to
+locate the state DB. Phase D will thread that context through; until
+then :func:`probe_usage` raises ``NotImplementedError`` with a
+three-question-rule message that points callers at
+``pollypm.accounts.probe_account_usage``.
+"""
+
+from __future__ import annotations
+
+from pollypm.acct.model import AccountConfig, AccountStatus
+
+
+def probe_usage(account: AccountConfig) -> AccountStatus:
+    """Return a fresh ``AccountStatus`` snapshot for ``account``.
+
+    Not wired in Phase C — see module docstring for why. Callers get a
+    three-question-rule ``NotImplementedError`` instead of a silent no-op
+    so the failure surfaces at the call site, not three layers deeper.
+    """
+    raise NotImplementedError(
+        f"The Codex provider's probe_usage is not yet wired through the "
+        f"pollypm.acct substrate (account {account.name!r}).\n\n"
+        f"Why: the legacy probe reads the project config path to locate "
+        f"the state DB and capture isolation context, which the Phase A "
+        f"Protocol does not yet carry. Phase D introduces the manager "
+        f"that threads that context through.\n\n"
+        f"Fix: call `pollypm.accounts.probe_account_usage(config_path, "
+        f"account_name)` for now; it returns the same AccountStatus "
+        f"shape and handles the state-db write."
+    )
+
+
+__all__ = ["probe_usage"]

--- a/src/pollypm/providers/codex/provider.py
+++ b/src/pollypm/providers/codex/provider.py
@@ -1,0 +1,112 @@
+"""The :class:`CodexProvider` adapter — Phase C of #397.
+
+``CodexProvider`` implements the ``pollypm.acct.protocol.ProviderAdapter``
+Protocol by delegating to the helpers in the sibling modules
+(``detect``, ``login``, ``probe``, ``env``). Keeping the class body
+thin means each life-cycle event has an obvious entry point for
+Phase D when the probe/login signatures grow to include the manager
+context.
+
+This replaces ``LegacyCodexAdapter`` from
+``pollypm.acct._legacy_adapters``: the entry-point registration in
+``pyproject.toml`` now points here, and the legacy adapter has been
+removed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pollypm.acct.model import AccountConfig, AccountStatus
+
+from .detect import detect_codex_email, detect_logged_in
+from .env import isolated_env as _codex_isolated_env
+from .login import run_login_flow as _codex_run_login_flow
+from .probe import probe_usage as _codex_probe_usage
+
+
+class CodexProvider:
+    """Codex adapter that satisfies ``ProviderAdapter``.
+
+    All six Protocol methods delegate to the sibling helpers in this
+    package. The class body is deliberately thin — behavior lives in
+    the helpers so tests can exercise each surface in isolation without
+    constructing a full adapter.
+    """
+
+    name = "codex"
+
+    def detect_logged_in(self, account: AccountConfig) -> bool:
+        """Return True iff the account's ``.codex/auth.json`` is valid."""
+        return detect_logged_in(account.home)
+
+    def detect_email(self, account: AccountConfig) -> str | None:
+        """Return the authenticated email or ``None``.
+
+        Null-safe on ``account.home`` so callers don't need to guard it.
+        """
+        if account.home is None:
+            return None
+        return detect_codex_email(account.home)
+
+    def run_login_flow(self, account: AccountConfig) -> None:
+        """Drive ``codex login`` for ``account``.
+
+        Raises ``ValueError`` when the account has no isolated home —
+        Codex refuses to share credentials between accounts on the same
+        host, so the caller must configure a home before login.
+        """
+        if account.home is None:
+            raise ValueError(
+                f"Cannot run the Codex login flow for account "
+                f"{account.name!r} without an isolated home.\n\n"
+                f"Why: Codex stores OAuth tokens under CODEX_HOME; "
+                f"without a home the login would write into the "
+                f"user's ambient ~/.codex and clobber other accounts.\n\n"
+                f"Fix: set `home` on the AccountConfig (PollyPM's "
+                f"onboarding picks a default under the project base "
+                f"dir) before calling run_login_flow."
+            )
+        _codex_run_login_flow(account.home, window_label=f"login-{account.name}")
+
+    def probe_usage(self, account: AccountConfig) -> AccountStatus:
+        """Return a fresh ``AccountStatus`` for ``account``.
+
+        Currently delegates to :func:`pollypm.providers.codex.probe.probe_usage`,
+        which raises ``NotImplementedError`` until Phase D threads the
+        manager context through.
+        """
+        return _codex_probe_usage(account)
+
+    def worker_launch_cmd(
+        self,
+        account: AccountConfig,
+        args: list[str],
+    ) -> list[str]:
+        """Return the argv to launch a Codex worker for ``account``.
+
+        Phase C keeps the shape identical to the legacy adapter:
+        ``[binary, *args]``. The old ``pollypm.providers.codex.CodexAdapter``
+        builds a richer ``LaunchCommand`` (resume markers, env dict) for
+        the tmux launch path; that adapter is unaffected by this
+        refactor and remains the source of truth for worker launches.
+        The helper here exists so the Protocol-level callers have a
+        simple argv builder.
+        """
+        # Import locally to avoid importing the tmux-heavy module when
+        # callers only want the Protocol surface.
+        from .adapter import CodexAdapter as _LegacyBinaryProvider
+
+        return [_LegacyBinaryProvider.binary, *args]
+
+    def isolated_env(self, home: Path) -> dict[str, str]:
+        """Return ``{CODEX_HOME: <home>/.codex}``.
+
+        Matches the Protocol contract: the returned dict is purely
+        additive — callers layer it onto whatever env the runtime
+        already provides.
+        """
+        return _codex_isolated_env(home, base_env={})
+
+
+__all__ = ["CodexProvider"]

--- a/src/pollypm/providers/codex/usage_parse.py
+++ b/src/pollypm/providers/codex/usage_parse.py
@@ -1,0 +1,43 @@
+"""Codex usage / weekly-quota parsing — Phase C of #397.
+
+Codex does not expose a machine-readable usage endpoint; the supervisor
+learns about weekly quota by scraping the ``/status`` pane that Codex
+prints when it boots. This module owns the regex-level parsers that
+turn that scraped text into a ``(health, summary)`` tuple.
+
+Previously lived at ``pollypm.accounts._parse_codex_status_text``. The
+function is re-exported from ``pollypm.accounts`` as a back-compat shim
+so the existing call sites (state-store writers, TUI surfaces) keep
+working during the Phase D migration.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def parse_codex_status_text(text: str) -> tuple[str, str]:
+    """Extract ``(health, summary)`` from a Codex ``/status`` pane dump.
+
+    Codex prints a one-line summary like::
+
+        gpt-5.4 default · 100% left · /Users/sam/dev/pollypm
+
+    This parser looks for the ``<n>% left`` fragment and surfaces it as
+    the usage summary. When the pane mentions ``usage limit`` we
+    classify the account as ``capacity-exhausted`` so the controller
+    knows to failover. Otherwise the result is ``("unknown", "usage
+    unavailable")`` — the caller decides what to do with it.
+
+    The return shape is kept identical to the legacy
+    ``_parse_codex_status_text`` so the back-compat shim is literal.
+    """
+    summary_match = re.search(r"(\d+)% left", text)
+    if summary_match:
+        return ("healthy", f"{summary_match.group(1)}% left")
+    if "usage limit" in text.lower():
+        return ("capacity-exhausted", "usage limit reached")
+    return ("unknown", "usage unavailable")
+
+
+__all__ = ["parse_codex_status_text"]

--- a/tests/providers/test_codex_detect.py
+++ b/tests/providers/test_codex_detect.py
@@ -1,0 +1,125 @@
+"""Tests for ``pollypm.providers.codex.detect`` (Phase C of #397).
+
+Run with::
+
+    HOME=/tmp/pytest-providers-codex uv run --with pytest \\
+        pytest tests/providers/test_codex_detect.py -x
+
+These tests exercise the email-detection helpers directly — email from
+``auth.json`` (the primary source), email from the tmux pane
+scrollback (the onboarding fast-path), and the boolean login-state
+wrapper that callers use when they only need a presence check.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from pollypm.providers.codex.detect import (
+    detect_codex_email,
+    detect_email_from_pane,
+    detect_logged_in,
+)
+
+
+def _fake_id_token(claims: dict[str, object]) -> str:
+    """Build a well-formed JWT (unsigned) carrying ``claims`` as the payload.
+
+    The detect helpers only read the payload, so a three-segment token
+    with any header/signature bytes is sufficient.
+    """
+
+    def _b64(payload: dict[str, object] | str) -> str:
+        if isinstance(payload, dict):
+            data = json.dumps(payload).encode("utf-8")
+        else:
+            data = payload.encode("utf-8")
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+    header = _b64({"alg": "none", "typ": "JWT"})
+    body = _b64(claims)
+    signature = _b64("signature")
+    return f"{header}.{body}.{signature}"
+
+
+def _write_auth_json(home: Path, id_token: str) -> None:
+    codex_dir = home / ".codex"
+    codex_dir.mkdir(parents=True, exist_ok=True)
+    (codex_dir / "auth.json").write_text(
+        json.dumps({"tokens": {"id_token": id_token}})
+    )
+
+
+def test_detect_codex_email_returns_lowercased_email(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    _write_auth_json(home, _fake_id_token({"email": "User@Example.COM"}))
+
+    assert detect_codex_email(home) == "user@example.com"
+
+
+def test_detect_codex_email_returns_none_when_auth_missing(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    (home / ".codex").mkdir(parents=True)
+    # No auth.json at all.
+
+    assert detect_codex_email(home) is None
+
+
+def test_detect_codex_email_returns_none_for_malformed_token(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    _write_auth_json(home, "not-a-jwt")
+
+    assert detect_codex_email(home) is None
+
+
+def test_detect_codex_email_returns_none_when_email_claim_absent(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    _write_auth_json(home, _fake_id_token({"sub": "abc123"}))
+
+    assert detect_codex_email(home) is None
+
+
+def test_detect_logged_in_handles_none_home() -> None:
+    """Matches ``pollypm.accounts._account_logged_in``: None -> False."""
+    assert detect_logged_in(None) is False
+
+
+def test_detect_logged_in_returns_true_when_auth_present(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    _write_auth_json(home, _fake_id_token({"email": "s@example.com"}))
+
+    assert detect_logged_in(home) is True
+
+
+def test_detect_logged_in_returns_false_when_auth_missing(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+
+    assert detect_logged_in(home) is False
+
+
+def test_detect_email_from_pane_parses_codex_account_line() -> None:
+    pane = "\n".join(
+        [
+            "openai codex ready",
+            "Account: s@example.com",
+            "> ",
+        ]
+    )
+
+    assert detect_email_from_pane(pane) == "s@example.com"
+
+
+def test_detect_email_from_pane_lowercases_match() -> None:
+    pane = "Account: Sam@Example.COM"
+
+    assert detect_email_from_pane(pane) == "sam@example.com"
+
+
+def test_detect_email_from_pane_returns_none_when_marker_absent() -> None:
+    pane = "openai codex ready\n100% left\n"
+
+    assert detect_email_from_pane(pane) is None

--- a/tests/providers/test_codex_provider.py
+++ b/tests/providers/test_codex_provider.py
@@ -1,0 +1,174 @@
+"""Tests for ``pollypm.providers.codex.CodexProvider`` (Phase C of #397).
+
+Run with::
+
+    HOME=/tmp/pytest-providers-codex uv run --with pytest \\
+        pytest tests/providers/test_codex_provider.py -x
+
+Exercises the adapter surface: Protocol satisfaction, delegation to
+the sibling helpers, the entry-point registration, and the three-
+question-rule error messages on the surfaces that are not yet wired.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+
+from pollypm.acct import ProviderAdapter, get_provider
+from pollypm.acct.model import AccountConfig
+from pollypm.models import ProviderKind
+from pollypm.providers.codex import CodexProvider
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_cache():
+    """Clear the ``lru_cache`` so each test sees a fresh registry."""
+    get_provider.cache_clear()
+    yield
+    get_provider.cache_clear()
+
+
+def _fake_id_token(claims: dict[str, object]) -> str:
+    def _b64(payload: dict[str, object] | str) -> str:
+        data = (
+            json.dumps(payload).encode("utf-8")
+            if isinstance(payload, dict)
+            else payload.encode("utf-8")
+        )
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+    return ".".join([_b64({"alg": "none"}), _b64(claims), _b64("sig")])
+
+
+def _account(name: str, home: Path | None) -> AccountConfig:
+    return AccountConfig(
+        name=name,
+        provider=ProviderKind.CODEX,
+        email=None,
+        home=home,
+    )
+
+
+def test_codex_provider_name_matches_entry_point() -> None:
+    assert CodexProvider().name == "codex"
+
+
+def test_codex_provider_satisfies_protocol() -> None:
+    assert isinstance(CodexProvider(), ProviderAdapter)
+
+
+def test_entry_point_resolves_to_codex_provider() -> None:
+    """``get_provider("codex")`` returns a ``CodexProvider`` instance.
+
+    This guards against the pyproject.toml entry point regressing back
+    to the Phase A legacy adapter during a merge.
+    """
+    adapter = get_provider("codex")
+    assert isinstance(adapter, CodexProvider)
+
+
+def test_detect_logged_in_delegates_to_home(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    codex_dir = home / ".codex"
+    codex_dir.mkdir(parents=True)
+    (codex_dir / "auth.json").write_text(
+        json.dumps({"tokens": {"id_token": _fake_id_token({"email": "a@b.com"})}})
+    )
+    provider = CodexProvider()
+
+    assert provider.detect_logged_in(_account("codex_1", home)) is True
+
+
+def test_detect_logged_in_returns_false_for_unauthenticated_home(
+    tmp_path: Path,
+) -> None:
+    provider = CodexProvider()
+
+    assert provider.detect_logged_in(_account("codex_1", tmp_path / "empty")) is False
+
+
+def test_detect_logged_in_returns_false_when_home_is_none() -> None:
+    """Guards the null-home path — no filesystem work happens."""
+    provider = CodexProvider()
+
+    assert provider.detect_logged_in(_account("codex_1", None)) is False
+
+
+def test_detect_email_returns_authenticated_email(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    codex_dir = home / ".codex"
+    codex_dir.mkdir(parents=True)
+    (codex_dir / "auth.json").write_text(
+        json.dumps({"tokens": {"id_token": _fake_id_token({"email": "User@X.com"})}})
+    )
+    provider = CodexProvider()
+
+    assert provider.detect_email(_account("codex_1", home)) == "user@x.com"
+
+
+def test_detect_email_returns_none_when_home_is_none() -> None:
+    provider = CodexProvider()
+
+    assert provider.detect_email(_account("codex_1", None)) is None
+
+
+def test_isolated_env_sets_codex_home_additively(tmp_path: Path) -> None:
+    provider = CodexProvider()
+    env = provider.isolated_env(tmp_path / "home")
+
+    # Protocol contract: purely additive — no ambient env leaks in.
+    assert env == {"CODEX_HOME": str(tmp_path / "home" / ".codex")}
+
+
+def test_worker_launch_cmd_prepends_codex_binary() -> None:
+    provider = CodexProvider()
+    argv = provider.worker_launch_cmd(
+        _account("codex_1", None),
+        ["--resume", "foo"],
+    )
+
+    assert argv == ["codex", "--resume", "foo"]
+
+
+def test_run_login_flow_rejects_none_home_with_three_question_error() -> None:
+    """#240 three-question rule: what / why / how-to-fix in the message."""
+    provider = CodexProvider()
+
+    with pytest.raises(ValueError) as exc_info:
+        provider.run_login_flow(_account("codex_missing_home", None))
+
+    msg = str(exc_info.value)
+    # What happened
+    assert "'codex_missing_home'" in msg
+    # Why it matters
+    assert "Why:" in msg
+    # How to fix
+    assert "Fix:" in msg
+
+
+def test_probe_usage_surfaces_not_implemented_with_fix_line() -> None:
+    """Phase C leaves probe_usage stubbed — the error must point callers
+    at the legacy API that still works."""
+    provider = CodexProvider()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        provider.probe_usage(_account("codex_1", None))
+
+    msg = str(exc_info.value)
+    assert "Why:" in msg
+    assert "Fix:" in msg
+    assert "probe_account_usage" in msg
+
+
+def test_legacy_codex_adapter_symbol_still_imports() -> None:
+    """The old ``CodexAdapter`` launch-command class must still be
+    importable at its historical path so the ``core_codex`` built-in
+    plugin and the ``tests/test_runtime.py`` suite keep working."""
+    from pollypm.providers.codex import CodexAdapter
+
+    assert CodexAdapter().name == "codex"
+    assert CodexAdapter().binary == "codex"

--- a/tests/providers/test_codex_usage_parse.py
+++ b/tests/providers/test_codex_usage_parse.py
@@ -1,0 +1,80 @@
+"""Tests for ``pollypm.providers.codex.usage_parse`` (Phase C of #397).
+
+Run with::
+
+    HOME=/tmp/pytest-providers-codex uv run --with pytest \\
+        pytest tests/providers/test_codex_usage_parse.py -x
+
+Covers the weekly-quota parser that reads the Codex ``/status`` pane
+dump and returns ``(health, summary)``. The legacy test at
+``tests/test_account_usage.py::test_parse_codex_status_text`` exercises
+the back-compat shim; these tests pin the new module directly so the
+shim can be removed later without losing coverage.
+"""
+
+from __future__ import annotations
+
+from pollypm.providers.codex.usage_parse import parse_codex_status_text
+
+
+def test_parse_codex_status_text_extracts_percent_left() -> None:
+    text = (
+        "› Implement {feature}\n"
+        "\n"
+        "  gpt-5.4 default · 100% left · /Users/sam/dev/pollypm\n"
+    )
+
+    assert parse_codex_status_text(text) == ("healthy", "100% left")
+
+
+def test_parse_codex_status_text_keeps_single_digit_percent() -> None:
+    text = "gpt-5.4 default · 7% left · /tmp/foo"
+
+    assert parse_codex_status_text(text) == ("healthy", "7% left")
+
+
+def test_parse_codex_status_text_flags_capacity_exhausted() -> None:
+    text = "Codex error: usage limit reached. Please retry later."
+
+    assert parse_codex_status_text(text) == (
+        "capacity-exhausted",
+        "usage limit reached",
+    )
+
+
+def test_parse_codex_status_text_capacity_exhausted_is_case_insensitive() -> None:
+    text = "ERROR: USAGE LIMIT exceeded"
+
+    health, summary = parse_codex_status_text(text)
+    assert health == "capacity-exhausted"
+    assert summary == "usage limit reached"
+
+
+def test_parse_codex_status_text_returns_unknown_for_empty_pane() -> None:
+    assert parse_codex_status_text("") == ("unknown", "usage unavailable")
+
+
+def test_parse_codex_status_text_returns_unknown_when_no_marker() -> None:
+    text = "Welcome to Codex. Type your prompt below.\n"
+
+    assert parse_codex_status_text(text) == ("unknown", "usage unavailable")
+
+
+def test_parse_codex_status_text_percent_left_beats_usage_limit_marker() -> None:
+    """If Codex prints both markers, the fresh quota reading wins.
+
+    Guards against a regression where a stale ``usage limit`` fragment
+    elsewhere in the scrollback would override a live ``% left`` line.
+    """
+    text = "old: usage limit reached\nnew: 42% left"
+
+    assert parse_codex_status_text(text) == ("healthy", "42% left")
+
+
+def test_parse_codex_status_text_matches_legacy_shim() -> None:
+    """The back-compat shim at ``pollypm.accounts._parse_codex_status_text``
+    must return the same tuple so existing callers keep working."""
+    from pollypm.accounts import _parse_codex_status_text as _legacy_shim
+
+    text = "gpt-5.4 default · 33% left"
+    assert _legacy_shim(text) == parse_codex_status_text(text)

--- a/tests/test_acct_substrate.py
+++ b/tests/test_acct_substrate.py
@@ -24,7 +24,8 @@ from pollypm.acct import (
     get_provider,
     list_providers,
 )
-from pollypm.acct._legacy_adapters import LegacyClaudeAdapter, LegacyCodexAdapter
+from pollypm.acct._legacy_adapters import LegacyClaudeAdapter
+from pollypm.providers.codex import CodexProvider
 
 
 @pytest.fixture(autouse=True)
@@ -100,16 +101,16 @@ def test_legacy_claude_adapter_satisfies_protocol():
     assert adapter.name == "claude"
 
 
-def test_legacy_codex_adapter_satisfies_protocol():
-    """The Phase A Codex adapter runtime-checks as ``ProviderAdapter``."""
-    adapter = LegacyCodexAdapter()
+def test_codex_provider_satisfies_protocol():
+    """The Phase C Codex provider runtime-checks as ``ProviderAdapter``."""
+    adapter = CodexProvider()
     assert isinstance(adapter, ProviderAdapter)
     assert adapter.name == "codex"
 
 
-def test_legacy_adapters_have_required_method_names():
-    """All six Protocol methods are defined on the legacy adapters."""
-    for adapter_cls in (LegacyClaudeAdapter, LegacyCodexAdapter):
+def test_provider_adapters_have_required_method_names():
+    """All six Protocol methods are defined on every adapter."""
+    for adapter_cls in (LegacyClaudeAdapter, CodexProvider):
         adapter = adapter_cls()
         for method in (
             "detect_logged_in",


### PR DESCRIPTION
Phase C of #397. Codex provider now self-contained in `src/pollypm/providers/codex/`.

## Contents
- `CodexProvider` implements `pollypm.acct.protocol.ProviderAdapter`
- Detection / login / probe / usage-parse / env split into dedicated files
- Back-compat shims in `onboarding.py` + `accounts.py` delegate to the new package
- `pyproject.toml` entry-point `codex` now points to `pollypm.providers.codex:CodexProvider`
- `LegacyCodexAdapter` removed from `acct/_legacy_adapters.py`
- Claude still on legacy adapter until Phase B merges (no conflict)

## Test plan
- Required: 37/37 pass (tests/providers/test_codex_* + test_onboarding + test_accounts)
- Full regression minus interactive/e2e: 2902/2902 pass

Phase B (Claude extract) in flight separately.