### PR TITLE
refactor(accounts): Phase D — centralized manager dispatches via ProviderAdapter Protocol (#397)

### DIFF
--- a/src/pollypm/accounts.py
+++ b/src/pollypm/accounts.py
@@ -117,9 +117,16 @@ def _account_usage_summary(account: AccountConfig) -> tuple[str, str, str]:
 
 
 def _account_logged_in(account: AccountConfig) -> bool:
-    if account.home is None:
-        return False
-    return _detect_account_email(account.provider, account.home) is not None
+    """Delegating shim — Phase D of #397 moved the live check to the manager.
+
+    Kept as a thin wrapper so existing callers (``pollypm.workers``,
+    internal ``_effective_logged_in``) continue to import the same
+    symbol while the real dispatch happens through the provider-agnostic
+    manager. Phase E removes this shim once call sites migrate.
+    """
+    from pollypm.acct import manager as _acct_manager
+
+    return _acct_manager.detect_logged_in(account)
 
 
 def _effective_logged_in(

--- a/src/pollypm/acct/__init__.py
+++ b/src/pollypm/acct/__init__.py
@@ -27,6 +27,16 @@ resolve during Phase A and will be deleted once Phases B/C land.
 from __future__ import annotations
 
 from .errors import AccountNotFound, AcctError, ProviderNotFound
+from .manager import (
+    choose_healthy_for_worker,
+    detect_email,
+    detect_logged_in,
+    isolated_env,
+    list_logged_in,
+    probe_usage,
+    run_login_flow,
+    worker_launch_cmd,
+)
 from .model import AccountConfig, AccountStatus, RuntimeStatus
 from .protocol import ProviderAdapter
 from .registry import get_provider, list_providers
@@ -39,6 +49,14 @@ __all__ = [
     "ProviderAdapter",
     "ProviderNotFound",
     "RuntimeStatus",
+    "choose_healthy_for_worker",
+    "detect_email",
+    "detect_logged_in",
     "get_provider",
+    "isolated_env",
+    "list_logged_in",
     "list_providers",
+    "probe_usage",
+    "run_login_flow",
+    "worker_launch_cmd",
 ]

--- a/src/pollypm/acct/manager.py
+++ b/src/pollypm/acct/manager.py
@@ -1,0 +1,162 @@
+"""Centralized account manager for the ``pollypm.acct`` substrate.
+
+Phase D of #397 introduces this module as the single provider-agnostic
+orchestrator for account life-cycle operations. Every public helper in
+this file takes an :class:`AccountConfig`, reads
+``account.provider.value`` to resolve the adapter from the
+entry-point-backed registry, and delegates to the
+:class:`ProviderAdapter` Protocol method of the same name.
+
+Import boundary (hard rule):
+    This module **must not** import from ``pollypm.providers.*``. The
+    manager is the consumer side of the Protocol; the provider packages
+    are the producer side. Phase E removes the remaining legacy
+    ``pollypm.accounts`` dispatcher once the last caller has migrated.
+
+Public surface (re-exported from ``pollypm.acct``):
+    * :func:`detect_logged_in` / :func:`detect_email`
+    * :func:`probe_usage`
+    * :func:`worker_launch_cmd` / :func:`isolated_env`
+    * :func:`run_login_flow`
+    * :func:`list_logged_in` / :func:`choose_healthy_for_worker`
+
+The "choose" helper encodes the preference logic that used to live in
+``pollypm.workers.auto_select_worker_account``: a caller-supplied
+``preferred`` account wins if it is currently logged in; otherwise the
+first healthy account in iteration order does; otherwise ``None``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+from .model import AccountConfig, AccountStatus
+from .registry import get_provider
+
+
+def _adapter_for(account: AccountConfig):
+    """Resolve the ``ProviderAdapter`` for ``account.provider``.
+
+    Thin internal helper that keeps the ``account.provider.value`` →
+    ``get_provider(name)`` dispatch in one place. Raises
+    :class:`pollypm.acct.errors.ProviderNotFound` when the provider
+    string has no registered adapter.
+    """
+    return get_provider(account.provider.value)
+
+
+def detect_logged_in(account: AccountConfig) -> bool:
+    """Return True iff ``account`` currently holds valid credentials.
+
+    Dispatches to the registered provider's
+    :meth:`ProviderAdapter.detect_logged_in`. Side-effect-free.
+    """
+    return _adapter_for(account).detect_logged_in(account)
+
+
+def detect_email(account: AccountConfig) -> str | None:
+    """Return the authenticated email address for ``account``, or None.
+
+    The return value is a presence check — for providers whose auth API
+    does not expose the email (Claude Max 2.x) the adapter returns a
+    stable non-None sentinel rather than leaking the raw ``null``.
+    """
+    return _adapter_for(account).detect_email(account)
+
+
+def probe_usage(account: AccountConfig) -> AccountStatus:
+    """Return a fresh :class:`AccountStatus` snapshot for ``account``.
+
+    Delegates to the registered provider's
+    :meth:`ProviderAdapter.probe_usage`. Callers that want cached data
+    should read from the state store directly.
+    """
+    return _adapter_for(account).probe_usage(account)
+
+
+def worker_launch_cmd(account: AccountConfig, args: list[str]) -> list[str]:
+    """Return the argv to launch a worker session for ``account``.
+
+    The returned list does not include env — env is delivered
+    separately via :func:`isolated_env` so the runtime layer can merge
+    it with its own env contributions.
+    """
+    return _adapter_for(account).worker_launch_cmd(account, args)
+
+
+def isolated_env(account: AccountConfig) -> dict[str, str]:
+    """Return the env vars that pin the provider binary to ``account.home``.
+
+    Returns an empty dict when ``account.home`` is ``None``. The
+    non-empty result is purely additive — callers layer it onto
+    whatever env the runtime provides.
+    """
+    if account.home is None:
+        return {}
+    return _adapter_for(account).isolated_env(account.home)
+
+
+def run_login_flow(account: AccountConfig) -> None:
+    """Drive the interactive login for ``account``.
+
+    Blocks until the user completes login or aborts. Idempotent on
+    already-logged-in accounts: running twice must not corrupt existing
+    credentials.
+    """
+    _adapter_for(account).run_login_flow(account)
+
+
+def list_logged_in(accounts: Iterable[AccountConfig]) -> list[AccountConfig]:
+    """Return the subset of ``accounts`` that are currently logged in.
+
+    Iteration order is preserved so callers can layer their own tiering
+    on top (controller-first, provider-rank, etc.) without re-sorting.
+    """
+    return [account for account in accounts if detect_logged_in(account)]
+
+
+def choose_healthy_for_worker(
+    accounts: Iterable[AccountConfig],
+    preferred: str | None = None,
+) -> AccountConfig | None:
+    """Pick a logged-in account to assign to a new worker session.
+
+    Resolution order:
+
+    1. If ``preferred`` names an account in ``accounts`` and that
+       account is logged in, return it.
+    2. Otherwise, return the first account in iteration order that is
+       logged in.
+    3. Otherwise, return ``None``.
+
+    The caller owns the fallback behavior — the manager does not raise
+    here because "no healthy account" is a routine condition during
+    onboarding, not an error.
+    """
+    # Materialize once so we can scan twice without re-running the
+    # upstream generator.
+    materialized = list(accounts)
+
+    if preferred is not None:
+        for account in materialized:
+            if account.name == preferred and detect_logged_in(account):
+                return account
+
+    for account in materialized:
+        if detect_logged_in(account):
+            return account
+
+    return None
+
+
+__all__ = [
+    "choose_healthy_for_worker",
+    "detect_email",
+    "detect_logged_in",
+    "isolated_env",
+    "list_logged_in",
+    "probe_usage",
+    "run_login_flow",
+    "worker_launch_cmd",
+]

--- a/tests/test_acct_manager.py
+++ b/tests/test_acct_manager.py
@@ -1,0 +1,322 @@
+"""Phase D manager tests for ``pollypm.acct.manager`` (#397).
+
+Run with::
+
+    HOME=/tmp/pytest-acct-manager uv run --with pytest \\
+        pytest tests/test_acct_manager.py -x
+
+These tests exercise the dispatch logic in the centralized manager:
+every public helper must route through the entry-point-backed registry,
+so this suite swaps in a ``FakeProvider`` at the registry layer and
+asserts the manager never touches the provider packages directly.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from pollypm.acct import (
+    AccountConfig,
+    AccountStatus,
+    ProviderNotFound,
+    get_provider,
+)
+from pollypm.acct import manager as acct_manager
+from pollypm.acct.model import RuntimeStatus  # noqa: F401 — imported to validate re-export
+from pollypm.models import ProviderKind, RuntimeKind
+
+
+class FakeProvider:
+    """Instrumented ``ProviderAdapter`` stand-in for dispatch tests.
+
+    Records every call and returns caller-supplied canned responses so
+    the manager-level assertions can check both "was the right method
+    called" and "did the return value propagate".
+    """
+
+    def __init__(self, name: str = "claude") -> None:
+        self.name = name
+        self.calls: list[tuple[str, tuple, dict]] = []
+        self.logged_in_map: dict[str, bool] = {}
+        self.email_map: dict[str, str | None] = {}
+        self.status: AccountStatus | None = None
+        self.login_invocations = 0
+
+    def _record(self, method: str, args: tuple, kwargs: dict) -> None:
+        self.calls.append((method, args, kwargs))
+
+    def detect_logged_in(self, account: AccountConfig) -> bool:
+        self._record("detect_logged_in", (account,), {})
+        return self.logged_in_map.get(account.name, False)
+
+    def detect_email(self, account: AccountConfig) -> str | None:
+        self._record("detect_email", (account,), {})
+        return self.email_map.get(account.name)
+
+    def run_login_flow(self, account: AccountConfig) -> None:
+        self._record("run_login_flow", (account,), {})
+        self.login_invocations += 1
+
+    def probe_usage(self, account: AccountConfig) -> AccountStatus:
+        self._record("probe_usage", (account,), {})
+        assert self.status is not None, "test must set FakeProvider.status"
+        return self.status
+
+    def worker_launch_cmd(self, account: AccountConfig, args: list[str]) -> list[str]:
+        self._record("worker_launch_cmd", (account, args), {})
+        return [f"fake-{self.name}", *args]
+
+    def isolated_env(self, home: Path) -> dict[str, str]:
+        self._record("isolated_env", (home,), {})
+        return {f"FAKE_{self.name.upper()}_HOME": str(home)}
+
+
+@pytest.fixture
+def fake_claude(monkeypatch) -> FakeProvider:
+    """Register a FakeProvider under the ``claude`` name via the registry."""
+    provider = FakeProvider(name="claude")
+    get_provider.cache_clear()
+
+    def _fake_get(name: str):
+        if name == "claude":
+            return provider
+        raise ProviderNotFound(name, available=["claude"])
+
+    monkeypatch.setattr("pollypm.acct.manager.get_provider", _fake_get)
+    return provider
+
+
+@pytest.fixture
+def fake_pair(monkeypatch) -> tuple[FakeProvider, FakeProvider]:
+    """Register separate FakeProviders for claude + codex."""
+    claude = FakeProvider(name="claude")
+    codex = FakeProvider(name="codex")
+    mapping = {"claude": claude, "codex": codex}
+    get_provider.cache_clear()
+
+    def _fake_get(name: str):
+        if name in mapping:
+            return mapping[name]
+        raise ProviderNotFound(name, available=sorted(mapping))
+
+    monkeypatch.setattr("pollypm.acct.manager.get_provider", _fake_get)
+    return claude, codex
+
+
+def _account(
+    name: str,
+    provider: ProviderKind = ProviderKind.CLAUDE,
+    home: Path | None = Path("/tmp/pollypm-fake"),
+) -> AccountConfig:
+    return AccountConfig(
+        name=name,
+        provider=provider,
+        email=f"{name}@example.com",
+        runtime=RuntimeKind.LOCAL,
+        home=home,
+    )
+
+
+def test_detect_logged_in_dispatches_to_registered_provider(fake_claude: FakeProvider) -> None:
+    account = _account("primary")
+    fake_claude.logged_in_map[account.name] = True
+
+    assert acct_manager.detect_logged_in(account) is True
+
+    assert fake_claude.calls[0][0] == "detect_logged_in"
+    assert fake_claude.calls[0][1][0] is account
+
+
+def test_detect_logged_in_routes_by_account_provider(fake_pair) -> None:
+    claude, codex = fake_pair
+    claude_acct = _account("claude_one", ProviderKind.CLAUDE)
+    codex_acct = _account("codex_one", ProviderKind.CODEX)
+    claude.logged_in_map[claude_acct.name] = True
+    codex.logged_in_map[codex_acct.name] = True
+
+    acct_manager.detect_logged_in(claude_acct)
+    acct_manager.detect_logged_in(codex_acct)
+
+    # Each adapter only sees its own account — no cross-talk.
+    assert len(claude.calls) == 1 and claude.calls[0][1][0] is claude_acct
+    assert len(codex.calls) == 1 and codex.calls[0][1][0] is codex_acct
+
+
+def test_detect_email_returns_adapter_result(fake_claude: FakeProvider) -> None:
+    account = _account("primary")
+    fake_claude.email_map[account.name] = "primary@example.com"
+
+    assert acct_manager.detect_email(account) == "primary@example.com"
+
+
+def test_detect_email_preserves_none_from_adapter(fake_claude: FakeProvider) -> None:
+    account = _account("primary")
+    # Adapter returns None (no email known); manager must not invent one.
+    assert acct_manager.detect_email(account) is None
+
+
+def test_probe_usage_returns_provider_account_status(fake_claude: FakeProvider) -> None:
+    account = _account("primary")
+    status = AccountStatus(
+        key=account.name,
+        provider=account.provider,
+        email=account.email or account.name,
+        home=account.home,
+        logged_in=True,
+        plan="max",
+        health="healthy",
+        usage_summary="max until 2030-01-01",
+    )
+    fake_claude.status = status
+
+    result = acct_manager.probe_usage(account)
+
+    assert result is status
+    assert fake_claude.calls[-1][0] == "probe_usage"
+
+
+def test_worker_launch_cmd_dispatches_with_args(fake_claude: FakeProvider) -> None:
+    account = _account("primary")
+
+    cmd = acct_manager.worker_launch_cmd(account, ["--foo", "--bar"])
+
+    assert cmd == ["fake-claude", "--foo", "--bar"]
+    recorded = fake_claude.calls[-1]
+    assert recorded[0] == "worker_launch_cmd"
+    assert recorded[1][1] == ["--foo", "--bar"]
+
+
+def test_isolated_env_returns_adapter_contribution(
+    fake_claude: FakeProvider, tmp_path: Path
+) -> None:
+    account = _account("primary", home=tmp_path)
+
+    env = acct_manager.isolated_env(account)
+
+    assert env == {"FAKE_CLAUDE_HOME": str(tmp_path)}
+
+
+def test_isolated_env_short_circuits_when_home_is_none(fake_claude: FakeProvider) -> None:
+    """No home = no env contribution, and the adapter should not be consulted."""
+    account = _account("primary", home=None)
+
+    env = acct_manager.isolated_env(account)
+
+    assert env == {}
+    assert not any(call[0] == "isolated_env" for call in fake_claude.calls)
+
+
+def test_run_login_flow_delegates(fake_claude: FakeProvider) -> None:
+    account = _account("primary")
+
+    acct_manager.run_login_flow(account)
+
+    assert fake_claude.login_invocations == 1
+    assert fake_claude.calls[-1][0] == "run_login_flow"
+
+
+def test_unknown_provider_raises_provider_not_found(monkeypatch) -> None:
+    """The registry error surfaces through the manager unchanged."""
+    get_provider.cache_clear()
+
+    def _always_missing(name: str):
+        raise ProviderNotFound(name, available=["claude", "codex"])
+
+    monkeypatch.setattr("pollypm.acct.manager.get_provider", _always_missing)
+
+    account = _account("primary", provider=ProviderKind.CLAUDE)
+    with pytest.raises(ProviderNotFound) as exc_info:
+        acct_manager.detect_logged_in(account)
+
+    message = str(exc_info.value)
+    assert "Why:" in message
+    assert "Fix:" in message
+
+
+def test_list_logged_in_preserves_iteration_order(fake_claude: FakeProvider) -> None:
+    alpha = _account("alpha")
+    bravo = _account("bravo")
+    charlie = _account("charlie")
+    fake_claude.logged_in_map = {"alpha": False, "bravo": True, "charlie": True}
+
+    result = acct_manager.list_logged_in([alpha, bravo, charlie])
+
+    assert result == [bravo, charlie]
+
+
+def test_choose_healthy_prefers_preferred_when_healthy(fake_claude: FakeProvider) -> None:
+    alpha = _account("alpha")
+    bravo = _account("bravo")
+    fake_claude.logged_in_map = {"alpha": True, "bravo": True}
+
+    choice = acct_manager.choose_healthy_for_worker([alpha, bravo], preferred="bravo")
+
+    assert choice is bravo
+
+
+def test_choose_healthy_falls_back_when_preferred_unhealthy(
+    fake_claude: FakeProvider,
+) -> None:
+    alpha = _account("alpha")
+    bravo = _account("bravo")
+    fake_claude.logged_in_map = {"alpha": True, "bravo": False}
+
+    choice = acct_manager.choose_healthy_for_worker([alpha, bravo], preferred="bravo")
+
+    assert choice is alpha
+
+
+def test_choose_healthy_returns_none_when_all_signed_out(
+    fake_claude: FakeProvider,
+) -> None:
+    alpha = _account("alpha")
+    bravo = _account("bravo")
+    fake_claude.logged_in_map = {"alpha": False, "bravo": False}
+
+    choice = acct_manager.choose_healthy_for_worker([alpha, bravo])
+
+    assert choice is None
+
+
+def test_choose_healthy_handles_unknown_preferred_name(fake_claude: FakeProvider) -> None:
+    alpha = _account("alpha")
+    bravo = _account("bravo")
+    fake_claude.logged_in_map = {"alpha": True, "bravo": True}
+
+    # Preferred name isn't in the list — should fall back to first healthy.
+    choice = acct_manager.choose_healthy_for_worker(
+        [alpha, bravo], preferred="not-configured"
+    )
+
+    assert choice is alpha
+
+
+def test_manager_does_not_import_provider_packages() -> None:
+    """Import-boundary guard: the manager must stay provider-agnostic.
+
+    Scans the manager's source for any actual ``import`` or
+    ``from ... import`` that references ``pollypm.providers``. Docstring
+    prose that names the module is allowed — the rule is on real imports.
+    This is the hard rule called out in the module docstring and in
+    #397's Phase D deliverable: manager imports must go through
+    ``pollypm.acct.protocol`` / ``registry`` / ``model`` only.
+    """
+    import re
+
+    source = inspect.getsource(acct_manager)
+    # Strip module + function docstrings so prose doesn't trip the check.
+    without_docstrings = re.sub(r'"""[\s\S]*?"""', "", source)
+    import_lines = [
+        line
+        for line in without_docstrings.splitlines()
+        if re.match(r"\s*(?:from\s+\S+\s+import|import\s+\S+)", line)
+    ]
+    for line in import_lines:
+        assert "pollypm.providers" not in line, (
+            f"pollypm.acct.manager imports from pollypm.providers.*: {line!r}; "
+            "the manager must route through the ProviderAdapter Protocol "
+            "registry only."
+        )


### PR DESCRIPTION
Phase D of #397. Provider-agnostic manager built; caller migration scoped to the single live dispatch site that matches the current Protocol surface.

## What shipped
- `src/pollypm/acct/manager.py` — orchestrator resolving adapters via `get_provider(account.provider.value)`
- `src/pollypm/acct/__init__.py` — exports 8 public manager functions
- `_account_logged_in` now delegates to `manager.detect_logged_in` (existing monkeypatches still work via re-export)
- 16 new manager tests including an import-boundary assertion that acct/ never imports providers/

## Scope note

The Phase D prompt sketched rewiring `pm worker-start` through `manager.worker_launch_cmd` / `isolated_env`. Doing that requires widening the acct Protocol to subsume the richer `pollypm.providers.*.adapter.build_launch_command` contract (resume markers, session config). That's a Phase D.5 Protocol widening, not a Phase D merge — agent intentionally scoped to the thin-Protocol dispatch that matches today's surface. Flagged for a follow-up.

## Test plan
- 90 pass across tests/test_acct_manager.py + tests/test_acct_substrate.py + tests/test_accounts.py + tests/providers/
- 19 pass sanity run of tests/test_workers.py + tests/test_account_usage.py + tests/test_onboarding.py + tests/test_provider_sdk.py
- `grep -rn 'from pollypm.providers' src/pollypm/acct/` → 0 hits (boundary held)