### PR TITLE
refactor(accounts): Phase E — remove legacy shims, add pm doctor providers check, close out #397

### DIFF
--- a/src/pollypm/accounts.py
+++ b/src/pollypm/accounts.py
@@ -116,56 +116,20 @@ def _account_usage_summary(account: AccountConfig) -> tuple[str, str, str]:
     return ("unknown", "unknown", "unknown")
 
 
-def _account_logged_in(account: AccountConfig) -> bool:
-    """Delegating shim — Phase D of #397 moved the live check to the manager.
-
-    Kept as a thin wrapper so existing callers (``pollypm.workers``,
-    internal ``_effective_logged_in``) continue to import the same
-    symbol while the real dispatch happens through the provider-agnostic
-    manager. Phase E removes this shim once call sites migrate.
-    """
-    from pollypm.acct import manager as _acct_manager
-
-    return _acct_manager.detect_logged_in(account)
-
-
 def _effective_logged_in(
     account: AccountConfig,
     *,
     cached_health: str | None = None,
     runtime_status: str | None = None,
 ) -> bool:
-    logged_in = _account_logged_in(account)
+    from pollypm.acct import detect_logged_in
+
+    logged_in = detect_logged_in(account)
     if runtime_status in {"auth-broken", "signed-out"}:
         return False
     if cached_health in {"auth-broken", "signed-out"}:
         return False
     return logged_in
-
-
-def _parse_claude_usage_text(text: str) -> tuple[str, str]:
-    """Deprecated — use :func:`pollypm.providers.claude.usage_parse.parse_claude_usage_text`.
-
-    Kept as a back-compat shim until Phase D of #397. The underlying
-    regex is unchanged.
-    """
-    from pollypm.providers.claude.usage_parse import parse_claude_usage_text
-
-    return parse_claude_usage_text(text)
-
-
-def _parse_codex_status_text(text: str) -> tuple[str, str]:
-    """Back-compat shim: Phase C of #397 moved this to the Codex package.
-
-    The real parser now lives at
-    :func:`pollypm.providers.codex.usage_parse.parse_codex_status_text`.
-    This shim preserves the legacy private import path so existing
-    tests (``tests/test_account_usage.py``) and the state-store writer
-    keep working; Phase D migrates callers and drops the shim.
-    """
-    from pollypm.providers.codex.usage_parse import parse_codex_status_text
-
-    return parse_codex_status_text(text)
 
 
 def _codex_credentials_store(home: Path) -> str:

--- a/src/pollypm/doctor.py
+++ b/src/pollypm/doctor.py
@@ -709,6 +709,79 @@ def check_storage_backend() -> CheckResult:
     )
 
 
+def check_registered_providers() -> CheckResult:
+    """Probe the ``pollypm.provider`` entry-point registry (issue #397).
+
+    Phase E of the account-management refactor introduced a
+    provider-agnostic substrate at :mod:`pollypm.acct`; each provider
+    (Claude, Codex, and any third-party plugin) registers its adapter
+    via the ``pollypm.provider`` entry-point group. Doctor walks the
+    registry and confirms every registered adapter can be imported and
+    instantiated — a misconfigured entry point or a broken adapter
+    class would otherwise only surface when an account tries to probe.
+
+    Mirrors the ``storage-backend`` check: one call to the registry,
+    per-provider try/except so a single broken adapter does not mask
+    the others.
+    """
+    from pollypm.acct import get_provider, list_providers
+
+    names = list_providers()
+    if not names:
+        return _fail(
+            "no providers registered",
+            why=(
+                "PollyPM resolves every account (Claude, Codex, plugin) "
+                "via the 'pollypm.provider' entry-point group; with no "
+                "entry points registered, no account can run and every "
+                "`pm account` command will fail."
+            ),
+            fix=(
+                "Reinstall PollyPM so the built-in 'claude' and 'codex' "
+                "entry points are registered —\n"
+                "  uv tool install --editable --reinstall .\n"
+                "If a third-party provider is expected, reinstall the "
+                "plugin package that ships it.\n"
+                "Recheck: pm doctor"
+            ),
+            data={"providers": []},
+        )
+
+    failures: dict[str, str] = {}
+    for name in names:
+        try:
+            get_provider(name)
+        except Exception as exc:  # noqa: BLE001
+            failures[name] = f"{type(exc).__name__}: {exc}"
+
+    if failures:
+        first_name = next(iter(failures))
+        first_error = failures[first_name]
+        return _fail(
+            f"{first_name} failed to load ({first_error})",
+            why=(
+                "A registered provider adapter raised on import or "
+                "instantiation. Every account whose provider string "
+                "maps to that adapter will fail before any subprocess "
+                "runs — the failure is silent until the user actually "
+                "probes an account."
+            ),
+            fix=(
+                "Inspect the error above, verify the provider plugin's "
+                "installation, and fix the import / constructor issue.\n"
+                f"Registered providers: {', '.join(names)}\n"
+                f"Failing: {', '.join(sorted(failures))}\n"
+                "Recheck: pm doctor"
+            ),
+            data={"providers": names, "failures": failures},
+        )
+
+    return _ok(
+        f"registered-providers: {', '.join(names)}",
+        data={"providers": names},
+    )
+
+
 # --------------------------------------------------------------------- #
 # Plugin health
 # --------------------------------------------------------------------- #
@@ -2606,6 +2679,7 @@ def _registered_checks() -> list[Check]:
         Check("config-file", check_config_file, "install"),
         Check("provider-account", check_provider_account_configured, "install"),
         Check("storage-backend", check_storage_backend, "install"),
+        Check("registered-providers", check_registered_providers, "install"),
         # Plugins
         Check("builtin-plugin-manifests", check_builtin_plugin_manifests, "plugins"),
         Check("critical-plugins-enabled", check_no_critical_plugin_disabled, "plugins"),

--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import base64
 import json
-import os
 import re
 import shlex
 import shutil
@@ -505,85 +504,42 @@ def _decode_jwt_payload(token: str) -> dict[str, object]:
     return json.loads(base64.urlsafe_b64decode(payload))
 
 
-def _detect_codex_email(home: Path) -> str | None:
-    """Back-compat shim: Phase C of #397 moved this to the Codex package.
-
-    The real implementation now lives at
-    :func:`pollypm.providers.codex.detect.detect_codex_email`. Existing
-    call sites inside this module (and tests) import the shim name
-    unchanged; once Phase D migrates callers, this shim can be deleted.
-    """
-    from pollypm.providers.codex.detect import detect_codex_email
-
-    return detect_codex_email(home)
-
-
-def _isolated_env(provider: ProviderKind, home: Path) -> dict[str, str]:
-    """Return provider-pinned env vars layered onto ``os.environ``.
-
-    Phase B of #397: the Claude branch delegates to
-    :func:`pollypm.providers.claude.env.isolated_env`; the Codex branch
-    stays here until Phase C extracts it. The shape is unchanged.
-    """
-    if provider is ProviderKind.CLAUDE:
-        from pollypm.providers.claude.env import isolated_env_with_os_environ
-
-        return isolated_env_with_os_environ(home)
-    return provider_profile_env_for_provider(provider, home, base_env=os.environ)
-
-
-def _detect_claude_email(home: Path) -> str | None:
-    """Deprecated — use :func:`pollypm.providers.claude.detect.detect_claude_email`.
-
-    Kept as a thin shim so existing callers (and tests) that import
-    ``pollypm.onboarding._detect_claude_email`` keep working until the
-    Phase D removal window. Behavior preserves the #396 fix.
-    """
-    from pollypm.providers.claude.detect import detect_claude_email as _impl
-
-    return _impl(home)
-
-
 def _detect_account_email(provider: ProviderKind, home: Path) -> str | None:
+    """Dispatch email-from-home detection to the provider package.
+
+    Tiny glue for the login-window loop in this module — the real
+    detectors live in :mod:`pollypm.providers.claude.detect` and
+    :mod:`pollypm.providers.codex.detect`. Kept here so the loop's
+    provider-agnostic flow (capture pane → try email → try home) has a
+    single entry point tests can monkeypatch.
+    """
     if provider is ProviderKind.CODEX:
-        return _detect_codex_email(home)
+        from pollypm.providers.codex.detect import detect_codex_email
+
+        return detect_codex_email(home)
     if provider is ProviderKind.CLAUDE:
-        return _detect_claude_email(home)
+        from pollypm.providers.claude.detect import detect_claude_email
+
+        return detect_claude_email(home)
     raise ValueError(f"Unsupported provider: {provider.value}")
 
 
 def _detect_email_from_pane(provider: ProviderKind, pane_text: str) -> str | None:
-    """Dispatch Codex pane-scraping to the Codex package (Phase C of #397).
+    """Dispatch pane-scraping to the provider package.
 
-    The Codex branch lives at
-    :func:`pollypm.providers.codex.detect.detect_email_from_pane`; the
-    Claude branch stays here until Phase B extracts it. Returning None
-    for unrecognised providers preserves the pre-split behaviour.
+    Mirror of :func:`_detect_account_email` — the heavy lifting happens
+    in the provider ``detect`` modules; this dispatcher exists so the
+    login-window loop can stay provider-agnostic.
     """
     if provider is ProviderKind.CODEX:
-        from pollypm.providers.codex.detect import (
-            detect_email_from_pane as _codex_detect_email_from_pane,
-        )
+        from pollypm.providers.codex.detect import detect_email_from_pane
 
-        return _codex_detect_email_from_pane(pane_text)
+        return detect_email_from_pane(pane_text)
     if provider is ProviderKind.CLAUDE:
-        from pollypm.providers.claude.detect import (
-            detect_email_from_pane as _claude_detect_email_from_pane,
-        )
+        from pollypm.providers.claude.detect import detect_email_from_pane
 
-        return _claude_detect_email_from_pane(pane_text)
+        return detect_email_from_pane(pane_text)
     return None
-
-
-def _claude_prompt_ready(pane_text: str) -> bool:
-    """Deprecated — use :func:`pollypm.providers.claude.detect.claude_prompt_ready`.
-
-    Thin shim for back-compat; kept for callers that imported the
-    private helper before Phase B.
-    """
-    from pollypm.providers.claude.detect import claude_prompt_ready as _impl
-
-    return _impl(pane_text)
 
 
 def _login_completion_marker_seen(pane_text: str) -> bool:

--- a/src/pollypm/workers.py
+++ b/src/pollypm/workers.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import typer
 
-from pollypm.accounts import _account_logged_in
+from pollypm.acct import detect_logged_in
 from pollypm.config import load_config, write_config
 from pollypm.onboarding import default_session_args
 from pollypm.models import ProviderKind, SessionConfig
@@ -28,7 +28,7 @@ def _effective_control_accounts(config_path: Path) -> set[str]:
 def _account_is_available(config_path: Path, account_name: str) -> bool:
     config = load_config(config_path)
     account = config.accounts[account_name]
-    if not _account_logged_in(account):
+    if not detect_logged_in(account):
         return False
     store = StateStore(config.project.state_db)
     runtime = store.get_account_runtime(account_name)

--- a/tests/providers/test_claude_usage_parse.py
+++ b/tests/providers/test_claude_usage_parse.py
@@ -76,10 +76,3 @@ def test_parse_usage_snapshot_returns_raw_text_only_on_failure() -> None:
     assert snapshot.raw_text == "unrelated noise"
 
 
-def test_legacy_accounts_shim_still_routes_to_new_parser() -> None:
-    """The back-compat shim in :mod:`pollypm.accounts` must preserve behavior."""
-    from pollypm.accounts import _parse_claude_usage_text
-
-    assert _parse_claude_usage_text(WEEKLY_SAMPLE) == parse_claude_usage_text(
-        WEEKLY_SAMPLE
-    )

--- a/tests/providers/test_codex_usage_parse.py
+++ b/tests/providers/test_codex_usage_parse.py
@@ -6,10 +6,9 @@ Run with::
         pytest tests/providers/test_codex_usage_parse.py -x
 
 Covers the weekly-quota parser that reads the Codex ``/status`` pane
-dump and returns ``(health, summary)``. The legacy test at
-``tests/test_account_usage.py::test_parse_codex_status_text`` exercises
-the back-compat shim; these tests pin the new module directly so the
-shim can be removed later without losing coverage.
+dump and returns ``(health, summary)``. These tests pin the canonical
+module directly; Phase E of #397 removed the back-compat shim at
+``pollypm.accounts._parse_codex_status_text``.
 """
 
 from __future__ import annotations
@@ -71,10 +70,3 @@ def test_parse_codex_status_text_percent_left_beats_usage_limit_marker() -> None
     assert parse_codex_status_text(text) == ("healthy", "42% left")
 
 
-def test_parse_codex_status_text_matches_legacy_shim() -> None:
-    """The back-compat shim at ``pollypm.accounts._parse_codex_status_text``
-    must return the same tuple so existing callers keep working."""
-    from pollypm.accounts import _parse_codex_status_text as _legacy_shim
-
-    text = "gpt-5.4 default · 33% left"
-    assert _legacy_shim(text) == parse_codex_status_text(text)

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -1,17 +1,17 @@
 from pathlib import Path
 
 from pollypm.accounts import (
-    _parse_claude_usage_text,
-    _parse_codex_status_text,
     inspect_account_isolation,
     probe_account_usage,
 )
 from pollypm.config import write_config
 from pollypm.models import AccountConfig, ProjectSettings, PollyPMConfig, PollyPMSettings, ProviderKind, RuntimeKind
+from pollypm.providers.claude.usage_parse import parse_claude_usage_text
+from pollypm.providers.codex.usage_parse import parse_codex_status_text
 
 
 def test_parse_claude_usage_text() -> None:
-    health, summary = _parse_claude_usage_text(
+    health, summary = parse_claude_usage_text(
         """
         Status   Config   Usage   Stats
 
@@ -26,7 +26,7 @@ def test_parse_claude_usage_text() -> None:
 
 
 def test_parse_codex_status_text() -> None:
-    health, summary = _parse_codex_status_text(
+    health, summary = parse_codex_status_text(
         """
         › Implement {feature}
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -280,6 +280,66 @@ def test_check_provider_account_ok(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
 
 
 # --------------------------------------------------------------------- #
+# Registered providers (#397 Phase E)
+# --------------------------------------------------------------------- #
+
+
+def test_check_registered_providers_passes_with_builtins() -> None:
+    """Every installed PollyPM ships with 'claude' + 'codex' registered.
+
+    The check walks the real entry-point registry; if this fails, the
+    package is installed without its own entry points — reinstall.
+    """
+    result = doctor.check_registered_providers()
+    assert result.passed, result.status
+    providers = result.data.get("providers", [])
+    assert "claude" in providers
+    assert "codex" in providers
+    assert "registered-providers:" in result.status
+
+
+def test_check_registered_providers_fails_when_registry_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pollypm.acct import registry as registry_mod
+
+    monkeypatch.setattr(registry_mod, "list_providers", lambda: [])
+    # Force the doctor module to resolve the patched symbol.
+    monkeypatch.setattr(
+        "pollypm.acct.list_providers", lambda: [], raising=False
+    )
+    result = doctor.check_registered_providers()
+    assert not result.passed
+    assert "no providers registered" in result.status
+    assert "uv tool install" in result.fix
+
+
+def test_check_registered_providers_reports_per_provider_load_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single broken adapter is reported by name without masking others."""
+
+    def _broken_get(name: str):
+        if name == "bogus":
+            raise ImportError("module 'bogus' has no attribute 'Adapter'")
+        return object()
+
+    monkeypatch.setattr(
+        "pollypm.acct.list_providers",
+        lambda: ["claude", "bogus"],
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "pollypm.acct.get_provider", _broken_get, raising=False
+    )
+    result = doctor.check_registered_providers()
+    assert not result.passed
+    assert "bogus failed to load" in result.status
+    assert "ImportError" in result.status
+    assert "bogus" in result.data.get("failures", {})
+
+
+# --------------------------------------------------------------------- #
 # Plugins
 # --------------------------------------------------------------------- #
 

--- a/tests/test_onboarding_ux.py
+++ b/tests/test_onboarding_ux.py
@@ -5,9 +5,7 @@ from pathlib import Path
 from pollypm.models import ProviderKind
 from pollypm.onboarding import (
     _build_login_shell,
-    _detect_claude_email,
     _connect_account_via_tmux,
-    _detect_codex_email,
     _detect_email_from_pane,
     _login_completion_marker_seen,
     _provider_choices,
@@ -16,6 +14,8 @@ from pollypm.onboarding import (
     ConnectedAccount,
     LoginPreferences,
 )
+from pollypm.providers.claude.detect import detect_claude_email
+from pollypm.providers.codex.detect import detect_codex_email
 
 
 def test_slugify_email_generates_stable_account_name() -> None:
@@ -30,7 +30,7 @@ def test_detect_codex_email_reads_isolated_codex_auth_file(tmp_path: Path) -> No
     auth_path.parent.mkdir(parents=True)
     auth_path.write_text(json.dumps({"tokens": {"id_token": token}}))
 
-    assert _detect_codex_email(tmp_path) == "jane@example.com"
+    assert detect_codex_email(tmp_path) == "jane@example.com"
 
 
 def test_detect_codex_email_from_status_pane() -> None:
@@ -112,7 +112,7 @@ def test_detect_claude_email_requires_logged_in_flag(monkeypatch, tmp_path: Path
         lambda *args, **kwargs: Result('{"loggedIn": false, "email": "pearl@swh.me"}'),
     )
 
-    assert _detect_claude_email(tmp_path) is None
+    assert detect_claude_email(tmp_path) is None
 
 
 def test_provider_choices_hide_continue_before_first_account(tmp_path: Path) -> None:

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -108,7 +108,7 @@ def test_auto_select_worker_avoids_effective_live_controller(tmp_path: Path, mon
         effective_provider=ProviderKind.CODEX.value,
     )
 
-    monkeypatch.setattr("pollypm.workers._account_logged_in", lambda account: True)
+    monkeypatch.setattr("pollypm.workers.detect_logged_in", lambda account: True)
 
     selected = auto_select_worker_account(config_path)
 
@@ -125,7 +125,7 @@ def test_auto_select_worker_skips_runtime_unhealthy_account(tmp_path: Path, monk
         reason="failed auth",
     )
 
-    monkeypatch.setattr("pollypm.workers._account_logged_in", lambda account: True)
+    monkeypatch.setattr("pollypm.workers.detect_logged_in", lambda account: True)
 
     selected = auto_select_worker_account(config_path)
 
@@ -146,7 +146,7 @@ def test_auto_select_worker_uses_control_plane_account_before_controller_last_re
     del config.accounts["claude_worker"]
     write_config(config, config_path, force=True)
 
-    monkeypatch.setattr("pollypm.workers._account_logged_in", lambda account: True)
+    monkeypatch.setattr("pollypm.workers.detect_logged_in", lambda account: True)
 
     selected = auto_select_worker_account(config_path)
 


### PR DESCRIPTION
Final phase of #397 refactor. Shims removed; pm doctor gets a registered-providers check; #397 closes.

## Changes
- Removed shims from onboarding.py (_detect_claude_email, _detect_codex_email, _claude_prompt_ready, _isolated_env) and accounts.py (_account_logged_in, _parse_claude_usage_text, _parse_codex_status_text). _effective_logged_in now calls pollypm.acct.detect_logged_in directly.
- workers.py migrated to `from pollypm.acct import detect_logged_in`
- test_workers / test_account_usage / test_onboarding_ux monkey-patches retargeted to canonical locations
- Added `check_registered_providers` in pm doctor (mirrors storage-backend check; three-question-rule errors)
- provider_sdk.py kept — still has live callers for ProviderAdapterBase, ProviderUsageSnapshot, TranscriptSource (not in scope for #397)
- One-line close-out entry in docs/decisions.md

## Test plan
- 2950 pass (23 → 0 live shim imports in src/)
- test_acct_manager.py::test_manager_does_not_import_provider_packages holds

Grep: `grep -rn 'from pollypm.onboarding import _detect_claude_email\|_detect_codex_email' src/` → 0 hits.