### PR TITLE
refactor(providers): move Claude-specific onboarding helpers to providers/claude/ (#406)

### DIFF
--- a/src/pollypm/acct/protocol.py
+++ b/src/pollypm/acct/protocol.py
@@ -94,5 +94,57 @@ class ProviderAdapter(Protocol):
         """
         ...
 
+    def prime_home(self, home: Path) -> None:
+        """Seed any provider state that must exist before first launch.
+
+        Issue #406 added this to lift the last Claude-specific dispatch
+        out of :mod:`pollypm.onboarding`. Claude pre-populates
+        ``.claude.json`` and ``settings.json`` so the welcome wizard
+        does not block unattended launches; providers that need no
+        seeding (Codex) implement this as a no-op.
+
+        Idempotent: callers may invoke ``prime_home`` repeatedly during
+        onboarding, control-home sync, and supervisor bootstrap.
+        """
+        ...
+
+    def login_command(
+        self,
+        *,
+        interactive: bool = False,
+        headless: bool = False,
+    ) -> str:
+        """Return the shell snippet that launches the provider login.
+
+        ``interactive`` and ``headless`` are the two flags the shared
+        login loop in :mod:`pollypm.onboarding` understands today.
+        Providers ignore flags they do not care about — Claude reads
+        ``interactive``; Codex reads ``headless``. Adding a new flag
+        here is the only path that lets a third-party provider expose
+        a new launch mode without editing onboarding.
+        """
+        ...
+
+    def logout_command(self) -> str:
+        """Return the shell snippet that clears provider credentials.
+
+        Used by the ``force_fresh_auth=True`` path of the shared login
+        loop (e.g. ``pm accounts relogin``) so the next launch starts
+        from a clean credential store. Implementations should suffix
+        their command with ``|| true`` so a "not currently logged in"
+        exit code does not abort the shell pipeline.
+        """
+        ...
+
+    def login_completion_marker_seen(self, pane_text: str) -> bool:
+        """Return True iff ``pane_text`` shows the provider's done-marker.
+
+        The shared login loop writes ``PollyPM: login window complete.``
+        at the tail of the login shell so providers without a strong
+        native signal can use the same marker. Providers with a richer
+        signal (e.g. a CLI banner) are free to widen this check.
+        """
+        ...
+
 
 __all__ = ["ProviderAdapter"]

--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -5,11 +5,9 @@ import json
 import re
 import shlex
 import shutil
-import subprocess
 import threading
 import time
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 
 import typer
@@ -85,37 +83,30 @@ class LoginCancelled(Exception):
     pass
 
 
-_CLAUDE_OPERATOR_TOOLS = "Read,Glob,Grep,LS,Bash,WebFetch,WebSearch,TodoWrite,Task"
-_CLAUDE_HEARTBEAT_TOOLS = "Read,Glob,Grep,LS,WebFetch,WebSearch,TodoWrite,Task"
-_CLAUDE_NO_WRITE_TOOLS = "Edit,Write,MultiEdit,NotebookEdit"
-_CLAUDE_OPERATOR_DISALLOWED = "Agent,Edit,Write,MultiEdit,NotebookEdit"  # PM delegates — never writes files
-
-
 def default_session_args(
     provider: ProviderKind,
     *,
     open_permissions: bool = True,
     role: str = "",
 ) -> list[str]:
-    args: list[str] = []
+    """Dispatch the role-to-CLI-flag mapping to the provider package.
+
+    Each provider owns its own flag vocabulary (Claude uses
+    ``--allowedTools``; Codex uses ``--sandbox``) — see
+    :mod:`pollypm.providers.claude.session_args` and
+    :mod:`pollypm.providers.codex.session_args`. Onboarding stays out
+    of the per-flag details so a third-party provider can ship its
+    own ``session_args`` without patching this module.
+    """
     if provider is ProviderKind.CLAUDE:
-        if open_permissions and role not in {"heartbeat-supervisor", "operator-pm"}:
-            args.append("--dangerously-skip-permissions")
-        if role == "heartbeat-supervisor":
-            args.extend(["--allowedTools", _CLAUDE_HEARTBEAT_TOOLS])
-            args.extend(["--disallowedTools", _CLAUDE_NO_WRITE_TOOLS])
-        elif role == "operator-pm":
-            args.extend(["--allowedTools", _CLAUDE_OPERATOR_TOOLS])
-            args.extend(["--disallowedTools", _CLAUDE_OPERATOR_DISALLOWED])
-        return args
+        from pollypm.providers.claude.session_args import session_args
+
+        return session_args(open_permissions=open_permissions, role=role)
     if provider is ProviderKind.CODEX:
-        if role in {"heartbeat-supervisor", "operator-pm"}:
-            return ["--sandbox", "read-only", "--ask-for-approval", "never"]
-        if role == "worker":
-            return ["--sandbox", "workspace-write", "--ask-for-approval", "never"]
-        if open_permissions:
-            return ["--dangerously-bypass-approvals-and-sandbox"]
-    return args
+        from pollypm.providers.codex.session_args import session_args
+
+        return session_args(open_permissions=open_permissions, role=role)
+    return []
 
 
 def default_control_args(
@@ -127,62 +118,18 @@ def default_control_args(
     return default_session_args(provider, open_permissions=open_permissions, role=role)
 
 
-def _detected_claude_version() -> str:
-    try:
-        result = subprocess.run(
-            ["claude", "--version"],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-    except OSError:
-        return "2.1.92"
-    match = re.search(r"(\d+\.\d+\.\d+)", result.stdout)
-    if match:
-        return match.group(1)
-    return "2.1.92"
-
-
 def _prime_claude_home(home: Path) -> None:
-    home.mkdir(parents=True, exist_ok=True, mode=0o700)
-    claude_dir = home / ".claude"
-    claude_dir.mkdir(parents=True, exist_ok=True)
+    """Back-compat shim — real impl lives in the Claude provider package.
 
-    # Claude Code reads .claude.json from INSIDE CLAUDE_CONFIG_DIR (home/.claude/)
-    state_path = claude_dir / ".claude.json"
-    data: dict[str, object] = {}
-    if state_path.exists():
-        try:
-            data = json.loads(state_path.read_text())
-        except json.JSONDecodeError:
-            data = {}
+    Tests and a handful of legacy callers (``supervisor``, ``accounts``,
+    ``supervision.control_home``) still import this name; #406 moved
+    the body into :func:`pollypm.providers.claude.onboarding.prime_claude_home`
+    and kept this dispatcher so monkeypatching
+    ``pollypm.onboarding._prime_claude_home`` still works.
+    """
+    from pollypm.providers.claude.onboarding import prime_claude_home
 
-    if "firstStartTime" not in data:
-        data["firstStartTime"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
-    if not isinstance(data.get("numStartups"), int):
-        data["numStartups"] = 0
-    data["hasCompletedOnboarding"] = True
-    data["lastOnboardingVersion"] = str(data.get("lastOnboardingVersion") or _detected_claude_version())
-
-    state_path.write_text(json.dumps(data, indent=2) + "\n")
-
-    # Ensure settings.json has the flags needed for unattended operation:
-    # - skipDangerousModePermissionPrompt: skip the "are you sure?" dialog
-    # - bypassWorkspaceTrust: skip the "is this a project you trust?" dialog
-    # - permissions.dangerouslySkipPermissions: match the --dangerously-skip-permissions flag
-    settings_path = claude_dir / "settings.json"
-    settings: dict[str, object] = {}
-    if settings_path.exists():
-        try:
-            settings = json.loads(settings_path.read_text())
-        except json.JSONDecodeError:
-            settings = {}
-    settings["skipDangerousModePermissionPrompt"] = True
-    settings["bypassWorkspaceTrust"] = True
-    if not isinstance(settings.get("permissions"), dict):
-        settings["permissions"] = {}
-    settings["permissions"]["dangerouslySkipPermissions"] = True  # type: ignore[index]
-    settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+    prime_claude_home(home)
 
 
 def _available_clis() -> list[CliAvailability]:
@@ -455,15 +402,20 @@ def _login_command(
     interactive: bool = False,
     preferences: LoginPreferences | None = None,
 ) -> str:
-    if provider is ProviderKind.CODEX:
-        if preferences is not None and preferences.codex_headless:
-            return "codex login --device-auth"
-        return "codex login"
-    if provider is ProviderKind.CLAUDE:
-        if interactive:
-            return "claude"
-        return "claude auth login --claudeai"
-    raise ValueError(f"Unsupported provider: {provider.value}")
+    """Dispatch the login shell snippet to the provider package.
+
+    Onboarding stays provider-agnostic: it folds the Codex-only
+    ``codex_headless`` preference into the generic ``headless`` kwarg
+    the Protocol exposes, then asks the registered adapter to render
+    its own command.
+    """
+    from pollypm.acct.registry import get_provider
+
+    headless = preferences is not None and preferences.codex_headless
+    return get_provider(provider.value).login_command(
+        interactive=interactive,
+        headless=headless,
+    )
 
 
 def _build_login_shell(
@@ -484,10 +436,9 @@ def _build_login_shell(
     for key, value in env.items():
         parts.append(f"export {key}={shlex.quote(value)}")
     if force_fresh_auth:
-        if provider is ProviderKind.CLAUDE:
-            parts.append("claude auth logout || true")
-        elif provider is ProviderKind.CODEX:
-            parts.append("codex logout || true")
+        from pollypm.acct.registry import get_provider
+
+        parts.append(get_provider(provider.value).logout_command())
     parts.append(_login_command(provider, interactive=interactive, preferences=preferences))
     if return_to_caller:
         parts.append('printf "\\nPollyPM: login window complete. Returning to onboarding...\\n"')
@@ -542,8 +493,21 @@ def _detect_email_from_pane(provider: ProviderKind, pane_text: str) -> str | Non
     return None
 
 
-def _login_completion_marker_seen(pane_text: str) -> bool:
-    return "PollyPM: login window complete." in pane_text
+def _login_completion_marker_seen(pane_text: str, provider: ProviderKind | None = None) -> bool:
+    """Dispatch the pane-marker check to the provider package.
+
+    ``provider`` is optional so the legacy single-arg call shape kept
+    by tests (and the default ``PollyPM: login window complete.``
+    marker) continues to work. When ``provider`` is omitted we fall
+    back to the shared marker — both built-in providers accept it,
+    and a third-party provider that needs a richer check will be
+    asked through its registered adapter from the wait loop below.
+    """
+    if provider is None:
+        return "PollyPM: login window complete." in pane_text
+    from pollypm.acct.registry import get_provider
+
+    return get_provider(provider.value).login_completion_marker_seen(pane_text)
 
 
 def _wait_for_login_completion(
@@ -564,7 +528,7 @@ def _wait_for_login_completion(
         except Exception:  # noqa: BLE001
             last_pane = ""
 
-        if _login_completion_marker_seen(last_pane):
+        if _login_completion_marker_seen(last_pane, provider):
             return True, last_pane
 
         if _detect_email_from_pane(provider, last_pane):
@@ -623,8 +587,11 @@ def _recover_existing_accounts(root_dir: Path) -> dict[str, ConnectedAccount]:
         actual_home = entry
         if entry.name.startswith("onboarding_"):
             actual_home = _promote_onboarding_home(entry, final_home)
-        if provider is ProviderKind.CLAUDE:
-            _prime_claude_home(actual_home if actual_home.exists() else final_home)
+        from pollypm.acct.registry import get_provider
+
+        get_provider(provider.value).prime_home(
+            actual_home if actual_home.exists() else final_home,
+        )
         connected[account_name] = ConnectedAccount(
             provider=provider,
             email=email,

--- a/src/pollypm/providers/claude/login.py
+++ b/src/pollypm/providers/claude/login.py
@@ -1,26 +1,58 @@
 """Claude login-flow orchestration.
 
-Phase B of #397 consolidates the Claude-specific bits of the login flow
-into this module. The *full* login flow still lives in
-:mod:`pollypm.onboarding` because it threads a tmux window label, a
-preferences object, and the cross-provider completion detector — none
-of which belong to Claude alone. What moves here:
+Phase B of #397 consolidated the Claude-specific bits of the login
+flow into this module. Issue #406 extends it with the small shell
+fragments (``login_command``, ``logout_command``,
+``login_completion_marker_seen``) that the cross-provider login loop
+in :mod:`pollypm.onboarding` needs to dispatch through the provider
+package instead of branching on ``ProviderKind``.
 
-* :func:`run_login_flow` — the Protocol-shaped entry point. Phase B
-  keeps the implementation thin: it documents that the real interactive
-  flow requires a tmux context not available on the Protocol and
-  points callers at the existing top-level helpers. Phase D will widen
-  the Protocol with a context object; until then the Phase A NotImplementedError
-  phrasing is preserved here behind the Claude adapter.
-
-Callers that want the detection + env helpers in isolation should
-import them directly from :mod:`pollypm.providers.claude.detect` and
-:mod:`pollypm.providers.claude.env`.
+The high-level interactive flow still lives in
+:mod:`pollypm.onboarding` because it threads a ``TmuxClient`` and a
+window label that the Phase A Protocol does not yet model — see
+:func:`run_login_flow` below.
 """
 
 from __future__ import annotations
 
-from pollypm.models import AccountConfig
+from pollypm.acct.model import AccountConfig
+
+
+def login_command(*, interactive: bool = False) -> str:
+    """Return the shell snippet that launches Claude's login flow.
+
+    ``interactive=True`` opens the Claude REPL itself (the user signs
+    in via the in-app ``/login`` flow); otherwise we kick off the
+    headless ``claude auth login --claudeai`` browser flow.
+    """
+    if interactive:
+        return "claude"
+    return "claude auth login --claudeai"
+
+
+def logout_command() -> str:
+    """Return the shell snippet that clears Claude credentials.
+
+    Used when the caller passes ``force_fresh_auth=True`` to the login
+    flow (e.g. ``pm accounts relogin``) so the next ``claude`` launch
+    starts from a clean keychain entry. Suffixed with ``|| true`` so a
+    "not currently logged in" exit code does not abort the shell
+    pipeline.
+    """
+    return "claude auth logout || true"
+
+
+def login_completion_marker_seen(pane_text: str) -> bool:
+    """Return True iff the Claude login pane shows the completion marker.
+
+    The shared login loop in :mod:`pollypm.onboarding` writes a
+    ``PollyPM: login window complete.`` line at the end of the login
+    shell so it can detect completion without parsing provider output.
+    Claude does not have a stronger marker (the welcome banner can
+    appear before auth completes), so this is the only signal we
+    consume.
+    """
+    return "PollyPM: login window complete." in pane_text
 
 
 def run_login_flow(account: AccountConfig) -> None:
@@ -53,4 +85,9 @@ def run_login_flow(account: AccountConfig) -> None:
     )
 
 
-__all__ = ["run_login_flow"]
+__all__ = [
+    "login_command",
+    "login_completion_marker_seen",
+    "logout_command",
+    "run_login_flow",
+]

--- a/src/pollypm/providers/claude/onboarding.py
+++ b/src/pollypm/providers/claude/onboarding.py
@@ -1,0 +1,115 @@
+"""Claude onboarding-side helpers — issue #406.
+
+Phase E of #397 closed the provider Protocol; #406 follows up by
+moving the last Claude-specific helpers out of
+:mod:`pollypm.onboarding` into the provider package so a third-party
+provider can ship login support without patching onboarding.
+
+Two public helpers live here:
+
+* :func:`detected_claude_version` — read ``claude --version`` and
+  return a stable semver string (with a hard-coded fallback used when
+  the binary is unavailable, so onboarding can still write a valid
+  ``.claude.json`` during dry-runs).
+* :func:`prime_claude_home` — populate the managed
+  ``CLAUDE_CONFIG_DIR`` profile so the first launch of ``claude`` does
+  not stop at the welcome wizard. Idempotent.
+
+The legacy ``pollypm.onboarding._detected_claude_version`` and
+``pollypm.onboarding._prime_claude_home`` symbols now delegate here
+and remain importable for back-compat with tests / plugins.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+_CLAUDE_VERSION_FALLBACK = "2.1.92"
+
+
+def detected_claude_version() -> str:
+    """Return the installed Claude CLI version, or a stable fallback.
+
+    Why the fallback: onboarding writes ``lastOnboardingVersion`` into
+    the seeded ``.claude.json`` so the wizard does not re-fire on the
+    first launch. When the binary is missing (CI, dry-run installs) we
+    still need a value that *looks like* a real version so the Claude
+    CLI accepts it. The fallback is chosen to be the lowest release
+    that supports the keys we write.
+    """
+    try:
+        result = subprocess.run(
+            ["claude", "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return _CLAUDE_VERSION_FALLBACK
+    match = re.search(r"(\d+\.\d+\.\d+)", result.stdout)
+    if match:
+        return match.group(1)
+    return _CLAUDE_VERSION_FALLBACK
+
+
+def prime_claude_home(home: Path) -> None:
+    """Seed the managed Claude profile so launches run unattended.
+
+    Claude Code reads ``.claude.json`` from inside ``CLAUDE_CONFIG_DIR``
+    (``home/.claude/``) — onboarding pre-populates it with the keys the
+    welcome wizard would otherwise prompt for. Also writes
+    ``settings.json`` with the flags that suppress the
+    ``--dangerously-skip-permissions`` / workspace-trust prompts so
+    PollyPM-launched panes don't block on confirmation dialogs.
+
+    Idempotent: existing values are preserved; missing values are
+    filled in. Safe to call repeatedly during onboarding, control-home
+    sync, and supervisor bootstrap.
+    """
+    home.mkdir(parents=True, exist_ok=True, mode=0o700)
+    claude_dir = home / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+
+    # Claude Code reads .claude.json from INSIDE CLAUDE_CONFIG_DIR (home/.claude/)
+    state_path = claude_dir / ".claude.json"
+    data: dict[str, object] = {}
+    if state_path.exists():
+        try:
+            data = json.loads(state_path.read_text())
+        except json.JSONDecodeError:
+            data = {}
+
+    if "firstStartTime" not in data:
+        data["firstStartTime"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    if not isinstance(data.get("numStartups"), int):
+        data["numStartups"] = 0
+    data["hasCompletedOnboarding"] = True
+    data["lastOnboardingVersion"] = str(data.get("lastOnboardingVersion") or detected_claude_version())
+
+    state_path.write_text(json.dumps(data, indent=2) + "\n")
+
+    # Ensure settings.json has the flags needed for unattended operation:
+    # - skipDangerousModePermissionPrompt: skip the "are you sure?" dialog
+    # - bypassWorkspaceTrust: skip the "is this a project you trust?" dialog
+    # - permissions.dangerouslySkipPermissions: match the --dangerously-skip-permissions flag
+    settings_path = claude_dir / "settings.json"
+    settings: dict[str, object] = {}
+    if settings_path.exists():
+        try:
+            settings = json.loads(settings_path.read_text())
+        except json.JSONDecodeError:
+            settings = {}
+    settings["skipDangerousModePermissionPrompt"] = True
+    settings["bypassWorkspaceTrust"] = True
+    if not isinstance(settings.get("permissions"), dict):
+        settings["permissions"] = {}
+    settings["permissions"]["dangerouslySkipPermissions"] = True  # type: ignore[index]
+    settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+
+
+__all__ = ["detected_claude_version", "prime_claude_home"]

--- a/src/pollypm/providers/claude/provider.py
+++ b/src/pollypm/providers/claude/provider.py
@@ -25,6 +25,7 @@ from pollypm.acct.model import AccountConfig, AccountStatus
 from . import detect as _detect
 from . import env as _env
 from . import login as _login
+from . import onboarding as _onboarding
 from . import probe as _probe
 
 
@@ -107,6 +108,38 @@ class ClaudeProvider:
         :func:`pollypm.providers.claude.env.isolated_env`.
         """
         return _env.isolated_env(home)
+
+    def prime_home(self, home: Path) -> None:
+        """Seed ``.claude.json`` + ``settings.json`` so launches run unattended.
+
+        Delegates to
+        :func:`pollypm.providers.claude.onboarding.prime_claude_home`.
+        Idempotent.
+        """
+        _onboarding.prime_claude_home(home)
+
+    def login_command(
+        self,
+        *,
+        interactive: bool = False,
+        headless: bool = False,
+    ) -> str:
+        """Return ``"claude"`` (interactive) or ``"claude auth login --claudeai"``.
+
+        ``headless`` is accepted for Protocol-shape parity with Codex
+        and intentionally ignored — Claude has no headless equivalent
+        of the browser auth flow today.
+        """
+        del headless  # Protocol-shape parity; Claude has no headless flow
+        return _login.login_command(interactive=interactive)
+
+    def logout_command(self) -> str:
+        """Return ``"claude auth logout || true"``."""
+        return _login.logout_command()
+
+    def login_completion_marker_seen(self, pane_text: str) -> bool:
+        """Return True iff ``pane_text`` contains the PollyPM done-marker."""
+        return _login.login_completion_marker_seen(pane_text)
 
 
 __all__ = ["ClaudeProvider"]

--- a/src/pollypm/providers/claude/session_args.py
+++ b/src/pollypm/providers/claude/session_args.py
@@ -1,0 +1,52 @@
+"""Claude-specific tmux session argv assembly — issue #406.
+
+The PollyPM launcher chooses Claude CLI flags based on the role of
+the session being launched (operator-pm, heartbeat-supervisor,
+worker, …). Those role-to-flag mappings are Claude-specific — they
+list Claude tool names — so they live in the provider package
+instead of leaking into :mod:`pollypm.onboarding`.
+
+Public API:
+    :func:`session_args` — returns the argv list to append to
+    ``["claude", *user_args]`` for a session with the given role and
+    permissions posture.
+"""
+
+from __future__ import annotations
+
+
+_OPERATOR_TOOLS = "Read,Glob,Grep,LS,Bash,WebFetch,WebSearch,TodoWrite,Task"
+_HEARTBEAT_TOOLS = "Read,Glob,Grep,LS,WebFetch,WebSearch,TodoWrite,Task"
+_NO_WRITE_TOOLS = "Edit,Write,MultiEdit,NotebookEdit"
+# PM delegates — never writes files itself.
+_OPERATOR_DISALLOWED = "Agent,Edit,Write,MultiEdit,NotebookEdit"
+
+
+def session_args(*, open_permissions: bool = True, role: str = "") -> list[str]:
+    """Return the Claude CLI argv tail for a session of ``role``.
+
+    Behavior:
+
+    * Worker / unrecognised role + ``open_permissions=True`` →
+      ``["--dangerously-skip-permissions"]`` so the worker pane never
+      blocks on permission prompts.
+    * ``heartbeat-supervisor`` → narrow read-only tool list with
+      writes explicitly disallowed.
+    * ``operator-pm`` → operator tool list (adds ``Bash``) with
+      writes + sub-Agent delegation explicitly disallowed.
+    * Control roles never get ``--dangerously-skip-permissions`` —
+      the role-locked tool lists are the safer expression of intent.
+    """
+    args: list[str] = []
+    if open_permissions and role not in {"heartbeat-supervisor", "operator-pm"}:
+        args.append("--dangerously-skip-permissions")
+    if role == "heartbeat-supervisor":
+        args.extend(["--allowedTools", _HEARTBEAT_TOOLS])
+        args.extend(["--disallowedTools", _NO_WRITE_TOOLS])
+    elif role == "operator-pm":
+        args.extend(["--allowedTools", _OPERATOR_TOOLS])
+        args.extend(["--disallowedTools", _OPERATOR_DISALLOWED])
+    return args
+
+
+__all__ = ["session_args"]

--- a/src/pollypm/providers/codex/login.py
+++ b/src/pollypm/providers/codex/login.py
@@ -6,6 +6,12 @@ and a window label the Phase A Protocol does not yet model. Until the
 Protocol carries that context (Phase D introduces the manager that
 will), this module delegates to the existing onboarding helper.
 
+Issue #406 adds the small shell-fragment helpers
+(``login_command``, ``logout_command``,
+``login_completion_marker_seen``) that the cross-provider login loop
+needs to dispatch through the provider package instead of branching
+on ``ProviderKind`` inside ``onboarding.py``.
+
 Keeping the delegation in one place means Phase D can rewrite the
 flow without a scavenger hunt: replace :func:`run_login_flow` here and
 every caller that already routes through the substrate picks up the
@@ -15,6 +21,40 @@ new implementation.
 from __future__ import annotations
 
 from pathlib import Path
+
+
+def login_command(*, headless: bool = False) -> str:
+    """Return the shell snippet that launches Codex's login flow.
+
+    ``headless=True`` switches to ``codex login --device-auth`` for
+    callers that opted into the device-flow preference (no browser on
+    the host). Otherwise ``codex login`` opens the standard browser
+    auth flow.
+    """
+    if headless:
+        return "codex login --device-auth"
+    return "codex login"
+
+
+def logout_command() -> str:
+    """Return the shell snippet that clears Codex credentials.
+
+    Used when the caller passes ``force_fresh_auth=True`` so the next
+    ``codex login`` starts from a clean ``auth.json``. Suffixed with
+    ``|| true`` so a "not currently logged in" exit code does not
+    abort the shell pipeline.
+    """
+    return "codex logout || true"
+
+
+def login_completion_marker_seen(pane_text: str) -> bool:
+    """Return True iff the Codex login pane shows the completion marker.
+
+    The shared login loop writes ``PollyPM: login window complete.``
+    at the tail of the login shell — Codex does not provide a more
+    specific signal, so we use the same marker as Claude.
+    """
+    return "PollyPM: login window complete." in pane_text
 
 
 def run_login_flow(home: Path, *, window_label: str | None = None) -> str:
@@ -44,4 +84,9 @@ def run_login_flow(home: Path, *, window_label: str | None = None) -> str:
     )
 
 
-__all__ = ["run_login_flow"]
+__all__ = [
+    "login_command",
+    "login_completion_marker_seen",
+    "logout_command",
+    "run_login_flow",
+]

--- a/src/pollypm/providers/codex/provider.py
+++ b/src/pollypm/providers/codex/provider.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 from pollypm.acct.model import AccountConfig, AccountStatus
 
+from . import login as _login
 from .detect import detect_codex_email, detect_logged_in
 from .env import isolated_env as _codex_isolated_env
 from .login import run_login_flow as _codex_run_login_flow
@@ -107,6 +108,39 @@ class CodexProvider:
         already provides.
         """
         return _codex_isolated_env(home, base_env={})
+
+    def prime_home(self, home: Path) -> None:
+        """No-op for Codex.
+
+        Codex writes its own state on first launch — there is no
+        equivalent of the Claude welcome wizard to skip. Implemented
+        so the cross-provider dispatch in :mod:`pollypm.onboarding`
+        does not need to special-case the provider kind.
+        """
+        del home  # nothing to seed for Codex
+
+    def login_command(
+        self,
+        *,
+        interactive: bool = False,
+        headless: bool = False,
+    ) -> str:
+        """Return ``"codex login"`` (or ``"codex login --device-auth"``).
+
+        ``interactive`` is accepted for Protocol-shape parity with
+        Claude and ignored — Codex has no interactive REPL login
+        equivalent.
+        """
+        del interactive  # Protocol-shape parity; Codex has no REPL login
+        return _login.login_command(headless=headless)
+
+    def logout_command(self) -> str:
+        """Return ``"codex logout || true"``."""
+        return _login.logout_command()
+
+    def login_completion_marker_seen(self, pane_text: str) -> bool:
+        """Return True iff ``pane_text`` contains the PollyPM done-marker."""
+        return _login.login_completion_marker_seen(pane_text)
 
 
 __all__ = ["CodexProvider"]

--- a/src/pollypm/providers/codex/session_args.py
+++ b/src/pollypm/providers/codex/session_args.py
@@ -1,0 +1,37 @@
+"""Codex-specific tmux session argv assembly — issue #406.
+
+Mirror of :mod:`pollypm.providers.claude.session_args`. The Codex CLI
+uses sandbox + approval flags rather than tool allow/deny lists, so
+the role-to-flag mapping is entirely different — keeping it in the
+Codex provider package means onboarding's launcher does not need to
+know about either provider's flag vocabulary.
+"""
+
+from __future__ import annotations
+
+
+def session_args(*, open_permissions: bool = True, role: str = "") -> list[str]:
+    """Return the Codex CLI argv tail for a session of ``role``.
+
+    Behavior:
+
+    * Control roles (``heartbeat-supervisor``, ``operator-pm``) →
+      ``--sandbox read-only --ask-for-approval never`` so the PM
+      pane is non-mutating and runs unattended.
+    * ``worker`` → ``--sandbox workspace-write --ask-for-approval never``
+      so workers can edit files inside their workspace without
+      blocking on prompts.
+    * Anything else with ``open_permissions=True`` →
+      ``--dangerously-bypass-approvals-and-sandbox`` (the historical
+      default for ad-hoc launches).
+    """
+    if role in {"heartbeat-supervisor", "operator-pm"}:
+        return ["--sandbox", "read-only", "--ask-for-approval", "never"]
+    if role == "worker":
+        return ["--sandbox", "workspace-write", "--ask-for-approval", "never"]
+    if open_permissions:
+        return ["--dangerously-bypass-approvals-and-sandbox"]
+    return []
+
+
+__all__ = ["session_args"]


### PR DESCRIPTION
## Summary

After the #397 refactor, `providers/claude/` and `providers/codex/` were clean packages — but `onboarding.py` (925 lines) still carried Claude-specific helpers. The boundary was leaky: a third-party provider could not have added login support without patching `onboarding.py`.

This PR completes that boundary. Every Claude-specific login helper now lives inside the Claude provider package, and `onboarding.py` dispatches through the `ProviderAdapter` Protocol.

## What moved

- **`_detected_claude_version` + `_prime_claude_home`** → new `providers/claude/onboarding.py`
- **`claude auth login --claudeai` / `claude auth logout`** → `providers/claude/login.py::login_command()` / `logout_command()`
- **Claude-pane completion marker** → `providers/claude/login.py::login_completion_marker_seen()`
- **`_CLAUDE_*_TOOLS` constants + Claude branch of `default_session_args`** → `providers/claude/session_args.py`
- **Codex equivalents** for symmetry: `codex login` / `codex logout` → `providers/codex/login.py`; `--sandbox` / `--ask-for-approval` → `providers/codex/session_args.py`

## Protocol additions

`ProviderAdapter` now carries four new methods so onboarding can dispatch without branching on `ProviderKind`:

- `prime_home(home)` — Claude seeds `.claude.json` / `settings.json`; Codex no-op
- `login_command(*, interactive, headless)` — returns the provider's login shell snippet
- `logout_command()` — returns the force-fresh-auth logout snippet
- `login_completion_marker_seen(pane_text)` — pane marker check

`_prime_claude_home` remains in `onboarding.py` as a thin shim so existing monkeypatches in tests (`pollypm.onboarding._prime_claude_home`, `pollypm.accounts._prime_claude_home`) and legacy callers (`supervisor`, `control_home`) keep working.

## Acceptance

**Grep acceptance (the leaky-string check):**
```
$ grep -n 'claude auth\|claudeai\|claude login\|--claudeai' src/pollypm/onboarding.py
# (no output — 0 hits)
```

**LOC delta:**
- Before: `src/pollypm/onboarding.py` = **925 lines**
- After: `src/pollypm/onboarding.py` = **892 lines** (−33)

The original brief targeted <800 lines. The enumerated specific helpers have all been relocated; the residual LOC is cross-provider orchestration (tmux login-window loop, rendering, failover UI) that would not benefit from further splitting. If more trimming is desired in a follow-up, the largest remaining blocks are the Rich/Textual rendering helpers (`_render_intro`, `_render_account_step_intro`, etc.) which are not Claude-specific.

**Third-party-pluggability:** A new provider can now add login support by registering a `ProviderAdapter` under the `pollypm.provider` entry-point group and implementing the four new Protocol methods. Zero edits to `onboarding.py` needed.

## Test plan

- [x] `uv run --with pytest pytest tests/test_onboarding.py tests/test_accounts.py -x` — 6 pass
- [x] Targeted suite (203 tests across all changed/dependent modules): `uv run pytest tests/test_onboarding.py tests/test_accounts.py tests/test_onboarding_ux.py tests/test_onboarding_login_flow.py tests/test_auth_integration.py tests/providers/ tests/test_acct_manager.py tests/test_supervisor.py tests/test_workers.py tests/test_job_workers.py tests/test_launch_planner.py tests/test_session_manager.py tests/test_runtime_launcher.py` — all pass
- [x] Broader sweeps (cli/cockpit/doctor, flow/event, project, memory, rail, session, work, etc.) — all pass when run in chunks. Two pre-existing flaky timing tests (`test_toast_auto_dismisses_after_timeout`, `test_ten_thousand_appends_land_under_two_seconds`) occasionally fail under full-suite load; both pass in isolation and both fail the same way on `main` — not related to this refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)