### PR TITLE
fix: point triage prompt at pm inbox

### DIFF
--- a/src/pollypm/plugins_builtin/core_agent_profiles/profiles.py
+++ b/src/pollypm/plugins_builtin/core_agent_profiles/profiles.py
@@ -181,7 +181,7 @@ def triage_prompt() -> str:
         "(tier 1 — clear alerts, create tasks) or notify the operator via inbox.\n"
         "</system>\n\n"
         "<principles>\n"
-        "- Check `pm mail` for unanswered inbox items owned by this project.\n"
+        "- Check `pm inbox` for unanswered inbox items owned by this project.\n"
         "- Check `pm status` for worker and session health.\n"
         "- Check `pm task list` for task states and progress.\n"
         "- If a user replied to an inbox thread, create a task or notify the operator to act on it.\n"

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -14,6 +14,7 @@ from pollypm.models import (
 )
 from pollypm.storage.state import StateStore
 from pollypm.plugins_builtin.core_agent_profiles.profiles import polly_prompt as operator_prompt
+from pollypm.plugins_builtin.core_agent_profiles.profiles import triage_prompt
 from pollypm.workers import auto_select_worker_account, suggest_worker_prompt
 from pollypm.plugins_builtin.core_agent_profiles.profiles import worker_prompt
 
@@ -212,3 +213,10 @@ def test_operator_prompt_requires_delegation_instructions() -> None:
     assert "delegate" in prompt.lower()
     assert "pm" in prompt  # references pm commands
     assert "<principles>" in prompt
+
+
+def test_triage_prompt_points_at_inbox_cli() -> None:
+    prompt = triage_prompt()
+
+    assert "`pm inbox`" in prompt
+    assert "`pm mail`" not in prompt


### PR DESCRIPTION
## Summary
- replace the stale `pm mail` instruction in the triage prompt with the real `pm inbox` CLI
- add a regression test covering the triage prompt command reference

## Testing
- uv run --extra dev pytest -q tests/test_workers.py

Closes #471