### PR TITLE
fix: validate plugin names at the host boundary

### DIFF
--- a/src/pollypm/plugin_host.py
+++ b/src/pollypm/plugin_host.py
@@ -19,6 +19,7 @@ Contract:
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from functools import lru_cache
 from importlib.util import module_from_spec, spec_from_file_location
@@ -44,6 +45,16 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_MANIFEST = "pollypm-plugin.toml"
 PLUGIN_API_VERSION = "1"
+PLUGIN_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*$")
+
+
+def _validate_plugin_name(plugin_name: str) -> str:
+    """Reject ambiguous or path-like plugin names at the host boundary."""
+    if not PLUGIN_NAME_PATTERN.fullmatch(plugin_name):
+        raise ValueError(
+            f"plugin name {plugin_name!r} must match {PLUGIN_NAME_PATTERN.pattern!r}"
+        )
+    return plugin_name
 
 
 def _emit_plugin_lifecycle_event(
@@ -206,6 +217,7 @@ class ExtensionHost:
         Directories are returned even if they don't exist yet; callers
         filter with ``path.is_dir()`` and mkdir-on-write as needed.
         """
+        plugin_name = _validate_plugin_name(plugin_name)
         if self._plugins is None:
             self.plugins()
 
@@ -710,7 +722,7 @@ class ExtensionHost:
 
     def _read_manifest(self, manifest_path: Path, source: str) -> PluginManifest:
         raw = tomllib.loads(manifest_path.read_text())
-        name = str(raw["name"])
+        name = _validate_plugin_name(str(raw["name"]))
         capabilities = self._parse_capability_entries(raw.get("capabilities", []), plugin_name=name)
         content = self._parse_content_declaration(raw.get("content"), plugin_name=name)
         reserved_flag = bool(raw.get("contributes_to_reserved_section", False))

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 import shutil
 
+import pytest
+
 from pollypm.models import ProviderKind, RuntimeKind
 from pollypm.plugin_api.v1 import Capability, HookFilterResult
 from pollypm.plugin_host import ExtensionHost
@@ -100,6 +102,26 @@ def test_extension_host_rejects_wrong_api_version(tmp_path: Path) -> None:
 
     assert "bad" not in host.plugins()
     assert any("API version 99" in item for item in host.errors)
+
+
+@pytest.mark.parametrize("plugin_name", ["../escape", "BadName"])
+def test_extension_host_rejects_invalid_plugin_name_at_manifest_boundary(
+    tmp_path: Path, plugin_name: str,
+) -> None:
+    plugin_dir = tmp_path / ".pollypm" / "plugins" / "invalid_name"
+    _write_plugin(
+        plugin_dir,
+        name=plugin_name,
+        body=(
+            "from pollypm.plugin_api.v1 import PollyPMPlugin\n"
+            "plugin = PollyPMPlugin(name='invalid_name')\n"
+        ),
+    )
+
+    host = ExtensionHost(tmp_path)
+
+    assert plugin_name not in host.plugins()
+    assert any(f"plugin name {plugin_name!r}" in item for item in host.errors)
 
 
 def test_extension_host_runs_observers_and_filters_safely(tmp_path: Path) -> None:
@@ -631,6 +653,14 @@ def test_content_paths_missing_directories_are_not_errors(tmp_path: Path) -> Non
     # No raised exceptions; directories don't need to exist.
     for path in paths:
         assert not path.exists() or path.is_dir()
+
+
+@pytest.mark.parametrize("plugin_name", ["../escape", "/tmp/escape"])
+def test_content_paths_reject_invalid_plugin_names(tmp_path: Path, plugin_name: str) -> None:
+    host = ExtensionHost(tmp_path)
+
+    with pytest.raises(ValueError, match="plugin name"):
+        host.content_paths(plugin_name, kind="magic_skill")
 
 
 def test_content_paths_precedence_order(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- reject invalid plugin names with a strict host-level regex
- enforce the same validation when resolving plugin content paths so traversal-like names cannot escape content roots
- add focused regressions for invalid manifest names and invalid `content_paths()` input

## Testing
- uv run --extra dev pytest -q tests/test_plugins.py

Closes #494