### PR TITLE
fix: harden worktree branch component validation

### DIFF
--- a/src/pollypm/worktrees.py
+++ b/src/pollypm/worktrees.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
@@ -15,6 +16,13 @@ from pollypm.projects import (
 )
 from pollypm.storage.state import StateStore, WorktreeRecord
 
+_SAFE_WORKTREE_KEY_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def _validate_worktree_key(param_name: str, param_value: str) -> None:
+    if not _SAFE_WORKTREE_KEY_RE.fullmatch(param_value):
+        raise typer.BadParameter(f"{param_name} contains invalid characters: {param_value}")
+
 
 def ensure_worktree(
     config_path: Path,
@@ -25,11 +33,13 @@ def ensure_worktree(
     session_name: str | None = None,
     issue_key: str | None = None,
 ) -> WorktreeRecord | None:
-    import re
-    # Validate lane parameters to prevent path traversal
-    for param_name, param_value in [("lane_kind", lane_kind), ("lane_key", lane_key)]:
-        if not re.match(r"^[a-zA-Z0-9_-]+$", param_value):
-            raise typer.BadParameter(f"{param_name} contains invalid characters: {param_value}")
+    # Validate branch/path components before they reach git arguments.
+    for param_name, param_value in [
+        ("project_key", project_key),
+        ("lane_kind", lane_kind),
+        ("lane_key", lane_key),
+    ]:
+        _validate_worktree_key(param_name, param_value)
 
     config = load_config(config_path)
     project = config.projects.get(project_key)
@@ -52,7 +62,7 @@ def ensure_worktree(
     branch = f"pollypm/{project_key}/{lane_kind}/{lane_key}"
     if not path.exists():
         result = subprocess.run(
-            ["git", "-C", str(project.path), "worktree", "add", "-B", branch, str(path), "HEAD"],
+            ["git", "-C", str(project.path), "worktree", "add", "-B", branch, "--", str(path), "HEAD"],
             check=False,
             text=True,
             capture_output=True,
@@ -84,6 +94,13 @@ def cleanup_worktree(
     lane_key: str,
     force: bool = False,
 ) -> Path:
+    for param_name, param_value in [
+        ("project_key", project_key),
+        ("lane_kind", lane_kind),
+        ("lane_key", lane_key),
+    ]:
+        _validate_worktree_key(param_name, param_value)
+
     config = load_config(config_path)
     project = config.projects.get(project_key)
     if project is None:
@@ -103,9 +120,10 @@ def cleanup_worktree(
         )
         if status.stdout.strip():
             raise typer.BadParameter(f"Worktree {path} has uncommitted changes; use force to clean it up.")
-    remove_cmd = ["git", "-C", str(project.path), "worktree", "remove", str(path)]
+    remove_cmd = ["git", "-C", str(project.path), "worktree", "remove"]
     if force:
         remove_cmd.append("--force")
+    remove_cmd.extend(["--", str(path)])
     subprocess.run(remove_cmd, check=False, text=True, capture_output=True, timeout=300)
     subprocess.run(
         ["git", "-C", str(project.path), "worktree", "prune"],

--- a/tests/test_worktrees.py
+++ b/tests/test_worktrees.py
@@ -1,6 +1,9 @@
 import subprocess
 from pathlib import Path
 
+import pytest
+import typer
+
 from pollypm.config import write_config
 from pollypm.models import (
     AccountConfig,
@@ -11,6 +14,7 @@ from pollypm.models import (
     PollyPMSettings,
     ProviderKind,
 )
+from pollypm.storage.state import StateStore
 from pollypm.worktrees import cleanup_worktree, ensure_worktree, list_worktrees
 
 
@@ -26,9 +30,8 @@ def _git_project(tmp_path: Path) -> Path:
     return repo
 
 
-def test_worktree_lifecycle(tmp_path: Path) -> None:
-    repo = _git_project(tmp_path)
-    config = PollyPMConfig(
+def _config(tmp_path: Path, repo: Path, *, project_key: str = "demo") -> PollyPMConfig:
+    return PollyPMConfig(
         project=ProjectSettings(root_dir=tmp_path, base_dir=tmp_path / ".pollypm", logs_dir=tmp_path / ".pollypm/logs", snapshots_dir=tmp_path / ".pollypm/snapshots", state_db=tmp_path / ".pollypm/state.db"),
         pollypm=PollyPMSettings(controller_account="codex_primary"),
         accounts={
@@ -41,9 +44,20 @@ def test_worktree_lifecycle(tmp_path: Path) -> None:
         },
         sessions={},
         projects={
-            "demo": KnownProject(key="demo", path=repo, name="Demo", kind=ProjectKind.GIT, tracked=True)
+            project_key: KnownProject(
+                key=project_key,
+                path=repo,
+                name="Demo",
+                kind=ProjectKind.GIT,
+                tracked=True,
+            )
         },
     )
+
+
+def test_worktree_lifecycle(tmp_path: Path) -> None:
+    repo = _git_project(tmp_path)
+    config = _config(tmp_path, repo)
     config_path = tmp_path / "pollypm.toml"
     write_config(config, config_path, force=True)
 
@@ -62,3 +76,102 @@ def test_worktree_lifecycle(tmp_path: Path) -> None:
 
     removed = cleanup_worktree(config_path, project_key="demo", lane_kind="pa", lane_key="worker_demo", force=True)
     assert removed == Path(worktree.path)
+
+
+def test_ensure_worktree_rejects_invalid_project_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = _git_project(tmp_path)
+    config = _config(tmp_path, repo, project_key="demo/evil")
+    monkeypatch.setattr("pollypm.worktrees.load_config", lambda _: config)
+    monkeypatch.setattr(
+        "pollypm.worktrees.subprocess.run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("git should not be called")),
+    )
+
+    with pytest.raises(typer.BadParameter, match="project_key contains invalid characters"):
+        ensure_worktree(
+            tmp_path / "pollypm.toml",
+            project_key="demo/evil",
+            lane_kind="pa",
+            lane_key="worker_demo",
+            session_name="worker_demo",
+        )
+
+
+def test_ensure_worktree_adds_separator_before_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _git_project(tmp_path)
+    config = _config(tmp_path, repo)
+    commands: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(cmd)
+        Path(cmd[8]).mkdir(parents=True, exist_ok=True)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("pollypm.worktrees.load_config", lambda _: config)
+    monkeypatch.setattr("pollypm.worktrees.subprocess.run", fake_run)
+
+    worktree = ensure_worktree(
+        tmp_path / "pollypm.toml",
+        project_key="demo",
+        lane_kind="pa",
+        lane_key="worker_demo",
+        session_name="worker_demo",
+    )
+
+    assert worktree is not None
+    assert commands == [[
+        "git",
+        "-C",
+        str(repo),
+        "worktree",
+        "add",
+        "-B",
+        "pollypm/demo/pa/worker_demo",
+        "--",
+        worktree.path,
+        "HEAD",
+    ]]
+
+
+def test_cleanup_worktree_adds_separator_before_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _git_project(tmp_path)
+    config = _config(tmp_path, repo)
+    config_path = tmp_path / "pollypm.toml"
+    worktree_path = tmp_path / "worker_demo" / "demo-pa-worker_demo"
+    store = StateStore(config.project.state_db)
+    store.upsert_worktree(
+        project_key="demo",
+        lane_kind="pa",
+        lane_key="worker_demo",
+        session_name="worker_demo",
+        issue_key=None,
+        path=str(worktree_path),
+        branch="pollypm/demo/pa/worker_demo",
+        status="active",
+    )
+    commands: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("pollypm.worktrees.load_config", lambda _: config)
+    monkeypatch.setattr("pollypm.worktrees.subprocess.run", fake_run)
+
+    removed = cleanup_worktree(
+        config_path,
+        project_key="demo",
+        lane_kind="pa",
+        lane_key="worker_demo",
+        force=True,
+    )
+
+    assert removed == worktree_path
+    assert commands == [
+        ["git", "-C", str(repo), "worktree", "remove", "--force", "--", str(worktree_path)],
+        ["git", "-C", str(repo), "worktree", "prune"],
+    ]


### PR DESCRIPTION
## Summary
- validate `project_key` with the same safe-key contract as other worktree branch components
- add `--` separators to git worktree commands that take path-like arguments
- add focused tests for invalid keys and argument separator placement

## Testing
- uv run --extra dev pytest -q tests/test_worktrees.py

Closes #492