### PR TITLE
fix: handle stale session lock re-create races

### DIFF
--- a/src/pollypm/projects.py
+++ b/src/pollypm/projects.py
@@ -147,6 +147,14 @@ def session_lock_path(base_dir: Path, session_id: str) -> Path:
 _LOCK_STALE_SECONDS = 1800  # 30 minutes — locks older than this are considered stale
 
 
+def _read_session_lock_payload(lock_path: Path) -> dict[str, object]:
+    try:
+        payload = json.loads(lock_path.read_text())
+    except Exception:  # noqa: BLE001
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
 def ensure_session_lock(base_dir: Path, session_id: str) -> Path:
     base_dir.mkdir(parents=True, exist_ok=True)
     lock_path = session_lock_path(base_dir, session_id)
@@ -154,10 +162,7 @@ def ensure_session_lock(base_dir: Path, session_id: str) -> Path:
     try:
         fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
     except FileExistsError:
-        try:
-            existing = json.loads(lock_path.read_text())
-        except Exception:  # noqa: BLE001
-            existing = {}
+        existing = _read_session_lock_payload(lock_path)
         existing_session = existing.get("session_id")
         if isinstance(existing_session, str) and existing_session == session_id:
             return lock_path
@@ -170,7 +175,16 @@ def ensure_session_lock(base_dir: Path, session_id: str) -> Path:
             lock_path.unlink(missing_ok=True)
         else:
             raise RuntimeError(f"Session lock conflict at {base_dir}: owned by {existing_session or 'unknown'}")
-        fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+        try:
+            fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+        except FileExistsError as exc:
+            existing = _read_session_lock_payload(lock_path)
+            existing_session = existing.get("session_id")
+            if isinstance(existing_session, str) and existing_session == session_id:
+                return lock_path
+            raise RuntimeError(
+                f"Session lock conflict at {base_dir}: owned by {existing_session or 'unknown'}"
+            ) from exc
     with os.fdopen(fd, "w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2)
         handle.write("\n")

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -292,3 +292,36 @@ def test_session_lock_is_scoped_to_session_id(tmp_path: Path) -> None:
     assert other_lock.name == ".session.other.lock"
     assert worker_lock.exists()
     assert other_lock.exists()
+
+
+def test_session_lock_stale_unlink_race_surfaces_new_owner(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    lock_root = tmp_path / "locks" / "worker"
+    lock_root.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_root / ".session.worker.lock"
+    stale_created_at = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+    lock_path.write_text(
+        f'{{"session_id": "stale-owner", "created_at": "{stale_created_at}"}}\n'
+    )
+
+    real_open = __import__("os").open
+    calls = {"count": 0}
+
+    def fake_open(path, flags, mode=0o777):
+        if Path(path) != lock_path:
+            return real_open(path, flags, mode)
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise FileExistsError
+        if calls["count"] == 2:
+            lock_path.write_text(
+                f'{{"session_id": "fresh-owner", "created_at": "{datetime.now(UTC).isoformat()}"}}\n'
+            )
+            raise FileExistsError
+        return real_open(path, flags, mode)
+
+    monkeypatch.setattr("pollypm.projects.os.open", fake_open)
+
+    with pytest.raises(RuntimeError, match="owned by fresh-owner"):
+        ensure_session_lock(lock_root, "worker")


### PR DESCRIPTION
## Summary
- re-read the session lock after stale-lock unlink races instead of leaking FileExistsError
- keep same-session idempotence intact if another process recreated the same lock
- add a regression test for the stale-unlink/new-owner interleaving

## Testing
- uv run --extra dev pytest -q tests/test_projects.py

Closes #414