### PR TITLE
fix: retry and classify locked sqlite backups

### DIFF
--- a/src/pollypm/backup.py
+++ b/src/pollypm/backup.py
@@ -28,6 +28,7 @@ import shutil
 import sqlite3
 import tarfile
 import tempfile
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -43,6 +44,8 @@ _FULL_SNAPSHOT_SUFFIX = ".tar.gz"
 
 # Default retention for plain DB snapshots; keep the last N.
 DEFAULT_KEEP = 7
+BACKUP_LOCK_RETRY_MAX_SECONDS = 3.0
+BACKUP_LOCK_RETRY_INITIAL_SECONDS = 0.1
 
 
 # --------------------------------------------------------------------- #
@@ -73,6 +76,10 @@ class RestoreResult:
     live_db_path: Path
     safety_path: Path
     is_tar: bool
+
+
+class BackupLockedError(RuntimeError):
+    """Raised when the live SQLite DB stays locked across backup retries."""
 
 
 # --------------------------------------------------------------------- #
@@ -159,18 +166,37 @@ def _classify_snapshot(path: Path) -> str:
     raise ValueError(f"unrecognized snapshot format: {path}")
 
 
+def _is_locked_sqlite_error(exc: sqlite3.OperationalError) -> bool:
+    return "locked" in str(exc).lower()
+
+
 def _online_backup_to_plain_file(source_db: Path, dest: Path) -> None:
     """Use SQLite's online backup API to copy ``source_db`` -> ``dest``."""
     dest.parent.mkdir(parents=True, exist_ok=True)
-    src = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
-    try:
-        dst = sqlite3.connect(dest)
+    delay = BACKUP_LOCK_RETRY_INITIAL_SECONDS
+    deadline = time.monotonic() + BACKUP_LOCK_RETRY_MAX_SECONDS
+    while True:
         try:
-            src.backup(dst)
-        finally:
-            dst.close()
-    finally:
-        src.close()
+            src = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+            try:
+                dst = sqlite3.connect(dest)
+                try:
+                    src.backup(dst)
+                    return
+                finally:
+                    dst.close()
+            finally:
+                src.close()
+        except sqlite3.OperationalError as exc:
+            if not _is_locked_sqlite_error(exc):
+                raise
+            if time.monotonic() >= deadline:
+                raise BackupLockedError(
+                    "state.db is locked by an active writer. Wait for the cockpit or heartbeat "
+                    "to quiesce, then retry the backup."
+                ) from exc
+            time.sleep(delay)
+            delay = min(delay * 2, 1.0)
 
 
 def _gzip_file(src: Path, dest_gz: Path) -> None:
@@ -479,6 +505,7 @@ def humanize_bytes(n: int) -> str:
 
 
 __all__ = [
+    "BackupLockedError",
     "BackupResult",
     "RestorePlan",
     "RestoreResult",

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -406,6 +406,59 @@ def test_backup_module_retention_prunes_only_default_dir(
     assert len(remaining) == 3
 
 
+def test_backup_module_retries_locked_database_then_succeeds(
+    fake_home: Path, state_db: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_connect = backup_mod.sqlite3.connect
+    attempts = {"count": 0}
+    sleeps: list[float] = []
+
+    def flaky_connect(*args, **kwargs):
+        target = args[0]
+        if kwargs.get("uri") and isinstance(target, str) and "mode=ro" in target:
+            attempts["count"] += 1
+            if attempts["count"] < 3:
+                raise sqlite3.OperationalError("database is locked")
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(backup_mod.sqlite3, "connect", flaky_connect)
+    monkeypatch.setattr(backup_mod.time, "sleep", sleeps.append)
+
+    result = backup_mod.backup_state_db(
+        state_db,
+        base_dir=fake_home,
+        output=tmp_path / "custom" / "retry.db.gz",
+        full=False,
+        keep=7,
+    )
+
+    assert result.path.exists()
+    assert attempts["count"] == 3
+    assert sleeps == [0.1, 0.2]
+
+
+def test_backup_module_raises_named_error_when_database_stays_locked(
+    fake_home: Path, state_db: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        backup_mod.sqlite3,
+        "connect",
+        lambda *args, **kwargs: (_ for _ in ()).throw(sqlite3.OperationalError("database is locked")),
+    )
+    monkeypatch.setattr(backup_mod.time, "sleep", lambda _seconds: None)
+    monotonic_values = iter([0.0, 0.0, 0.1, 0.3, 0.7, 1.5, 3.1])
+    monkeypatch.setattr(backup_mod.time, "monotonic", lambda: next(monotonic_values))
+
+    with pytest.raises(backup_mod.BackupLockedError, match="quiesce"):
+        backup_mod.backup_state_db(
+            state_db,
+            base_dir=fake_home,
+            output=tmp_path / "custom" / "locked.db.gz",
+            full=False,
+            keep=7,
+        )
+
+
 def test_plan_restore_rejects_full_archive_missing_state_db(
     fake_home: Path, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- retry online SQLite backups when the live database is temporarily locked
- raise a named `BackupLockedError` with accurate operator guidance when the lock persists
- add focused tests for retry success and retry exhaustion

## Testing
- uv run --extra dev pytest -q tests/test_backup_restore.py

Closes #416