### PR TITLE
fix: surface infrastructure errors creating session locks

### DIFF
--- a/src/pollypm/projects.py
+++ b/src/pollypm/projects.py
@@ -185,6 +185,14 @@ def ensure_session_lock(base_dir: Path, session_id: str) -> Path:
             raise RuntimeError(
                 f"Session lock conflict at {base_dir}: owned by {existing_session or 'unknown'}"
             ) from exc
+        except OSError as exc:
+            raise RuntimeError(
+                f"Could not create session lock at {base_dir}: {exc}"
+            ) from exc
+    except OSError as exc:
+        raise RuntimeError(
+            f"Could not create session lock at {base_dir}: {exc}"
+        ) from exc
     with os.fdopen(fd, "w", encoding="utf-8") as handle:
         json.dump(payload, handle, indent=2)
         handle.write("\n")

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -325,3 +325,17 @@ def test_session_lock_stale_unlink_race_surfaces_new_owner(
 
     with pytest.raises(RuntimeError, match="owned by fresh-owner"):
         ensure_session_lock(lock_root, "worker")
+
+
+def test_session_lock_surfaces_infrastructure_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    lock_root = tmp_path / "locks" / "worker"
+
+    def boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("pollypm.projects.os.open", boom)
+
+    with pytest.raises(RuntimeError, match="Could not create session lock"):
+        ensure_session_lock(lock_root, "worker")


### PR DESCRIPTION
## Summary
- distinguish session-lock race handling from infrastructure failures like disk-full or permission errors
- convert raw `OSError` lock-creation failures into user-facing runtime errors
- add a regression test covering the infrastructure-error path

## Testing
- uv run --extra dev pytest -q tests/test_projects.py

Closes #417