### PR TITLE
refactor: extract shared cockpit formatting helpers

### DIFF
--- a/src/pollypm/cockpit_formatting.py
+++ b/src/pollypm/cockpit_formatting.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime as _dt
+
+from collections.abc import Callable
+
+from pollypm.tz import format_time as _default_fmt_time
+
+
+def format_relative_age(value) -> str:
+    """Relative-age formatting tolerant of missing or malformed inputs."""
+    if not value:
+        return ""
+    iso_str = value.isoformat() if isinstance(value, _dt) else str(value)
+    try:
+        from pollypm.tz import format_relative
+
+        return format_relative(iso_str)
+    except Exception:  # noqa: BLE001
+        return iso_str[:16]
+
+
+def format_event_time(value, *, formatter: Callable[[str], str] = _default_fmt_time) -> str:
+    """Stable local timestamp formatting for cockpit detail rows."""
+    if not value:
+        return ""
+    iso = value.isoformat() if hasattr(value, "isoformat") else str(value)
+    return formatter(iso)

--- a/src/pollypm/cockpit_tasks.py
+++ b/src/pollypm/cockpit_tasks.py
@@ -13,6 +13,8 @@ from pollypm.cockpit_task_review import (
     load_task_review_artifact,
     render_task_review_artifact,
 )
+from pollypm.cockpit_formatting import format_event_time
+from pollypm.cockpit_formatting import format_relative_age as _format_relative_age
 from pollypm.config import load_config
 from pollypm.session_services import create_tmux_client
 from pollypm.tz import format_time as _fmt_time
@@ -37,27 +39,8 @@ _FILTER_LABELS = {
 }
 
 
-def _format_relative_age(value) -> str:
-    """Render a human age from a datetime or ISO string."""
-    if not value:
-        return ""
-    from datetime import datetime as _dt
-
-    iso_str = value.isoformat() if isinstance(value, _dt) else str(value)
-    try:
-        from pollypm.tz import format_relative
-
-        return format_relative(iso_str)
-    except Exception:  # noqa: BLE001
-        return iso_str[:16]
-
-
 def _format_event_time(value) -> str:
-    """Stable local timestamp formatting for task detail rows."""
-    if not value:
-        return ""
-    iso = value.isoformat() if hasattr(value, "isoformat") else str(value)
-    return _fmt_time(iso)
+    return format_event_time(value, formatter=_fmt_time)
 
 
 def _timestamp_sort_value(value) -> float:

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -50,6 +50,8 @@ from textual.widgets import (
     TabPane,
 )
 
+from pollypm.cockpit_formatting import format_event_time
+from pollypm.cockpit_formatting import format_relative_age as _format_relative_age
 from pollypm.models import ProviderKind
 from pollypm.tz import format_time as _fmt_time
 from pollypm.cockpit_activity import (
@@ -1518,10 +1520,7 @@ class PollyTasksApp(App[None]):
         return " · ".join(parts)
 
     def _format_event_time(self, value) -> str:
-        if not value:
-            return ""
-        iso = value.isoformat() if hasattr(value, "isoformat") else str(value)
-        return _fmt_time(iso)
+        return format_event_time(value, formatter=_fmt_time)
 
     def _peek_session_tail(self, pane_id: str | None) -> list[str]:
         if not pane_id:
@@ -5820,27 +5819,6 @@ def _dashboard_plan_staleness(
     except Exception:  # noqa: BLE001
         return None
     return None
-
-
-def _format_relative_age(value) -> str:
-    """Relative-age formatting that tolerates missing / malformed inputs.
-
-    Accepts either an ISO-8601 string or a :class:`datetime` instance
-    (the work service surfaces both shapes depending on the call site).
-    """
-    if not value:
-        return ""
-    from datetime import datetime as _dt
-    iso_str: str
-    if isinstance(value, _dt):
-        iso_str = value.isoformat()
-    else:
-        iso_str = str(value)
-    try:
-        from pollypm.tz import format_relative
-        return format_relative(iso_str)
-    except Exception:  # noqa: BLE001
-        return iso_str[:16]
 
 
 def _dashboard_status(


### PR DESCRIPTION
## Summary
- extract shared cockpit time/age formatting helpers into `cockpit_formatting.py`
- route both the task UI and root cockpit UI through the shared implementation
- preserve the existing task UI monkeypatch seam while removing duplicate logic

## Testing
- uv run --extra dev pytest -q tests/test_tasks_ui.py tests/test_cockpit.py

Closes #420