### PR TITLE
docs: replace deprecated per-task worker-start references

### DIFF
--- a/docs/live-integration-test-spec.md
+++ b/docs/live-integration-test-spec.md
@@ -35,7 +35,8 @@ before proceeding. The test is about the task flow, not session recovery.
 
 **Verify**:
 - [ ] Polly runs `pm add-project /Users/sam/dev/weather-cli` or equivalent
-- [ ] Polly runs `pm worker-start weather_cli`
+- [ ] Polly creates and queues the first task for `weather_cli`
+- [ ] Polly claims that task (`pm task claim <id>`) or otherwise dispatches it through the task system
 - [ ] A worker session appears in the storage closet
 - [ ] Project appears in the cockpit rail
 - [ ] Polly confirms the project is set up

--- a/docs/worker-guide.md
+++ b/docs/worker-guide.md
@@ -77,9 +77,9 @@ This:
 - Launches an interactive Claude session in a tmux window named
   `task-<project>-<number>`.
 
-If you are **already inside** a worker session that was started by
-`pm worker-start`, you do not need to run `claim` — the PM does that. You will
-simply see the task prompt land in your current window.
+If you are **already inside** the per-task worker session Polly opened for
+this claim, you do not need to run `claim` again — the PM already did it.
+You will simply see the task prompt land in your current window.
 
 ### 4. Build
 
@@ -163,9 +163,9 @@ travel in `--output`.
 ### 3. "provision_worker failed … tmux new-session exit 1"
 
 The storage-closet tmux session already exists. In the current build this is
-benign for workers launched via `pm worker-start` — your existing session
-picks up the work. If you ran `pm task claim` from a fresh shell and see this,
-either:
+usually benign when the PM already claimed the task from an existing worker
+session — that session picks up the work. If you ran `pm task claim` from a
+fresh shell and see this, either:
 
 - Work inside the existing session (check `pm session list`), or
 - Run `pm task release <id>` and re-claim from inside an active worker
@@ -198,8 +198,8 @@ pm task queue shortlink_gen/1
 
 ### 6. "No project '<name>' registered"
 
-`pm worker-start` or `pm task create` was given a project name that isn't
-registered. List what's available:
+`pm task create` or another project-scoped command was given a project name
+that isn't registered. List what's available:
 
 ```bash
 pm projects

--- a/docs/worker-onboarding-and-errors-spec.md
+++ b/docs/worker-onboarding-and-errors-spec.md
@@ -52,7 +52,7 @@ CLI-level entry point: `pm help worker` renders the guide (same content). Also `
 
 ### 4.1 Rules for every error
 
-Every error raised by `pm task`, `pm session`, `pm worker-start`, `pm project`, and friends must answer three questions:
+Every error raised by `pm task`, `pm session`, `pm project`, and related worker-management commands must answer three questions:
 
 1. **What happened** — one sentence.
 2. **Why** — one sentence where the cause is knowable.
@@ -81,12 +81,12 @@ See `pm task output --help` for other kinds (pr, file_change, action).
 Each of these gets the three-question treatment:
 
 - `pm task done` without output → §4.1 example above.
-- `pm task claim` with failing provision → "Claim recorded in DB but session provisioning failed: tmux session `pollypm-storage-closet` already exists / tmux exit <code>. If you're inside an already-running worker session, you're fine — continue working. Otherwise run `pm session list` and attach to an existing worker, or ask the PM to `pm worker-start <project>`."
+- `pm task claim` with failing provision → "Claim recorded in DB but session provisioning failed: tmux session `pollypm-storage-closet` already exists / tmux exit <code>. If you're inside an already-running worker session, you're fine — continue working. Otherwise run `pm session list` and attach to the active worker, or ask the PM to retry the claim from the task system."
 - `pm task show` typo → Typer-level "Did you mean `pm task get`?" with `--suggest-only` flag disabled by default so it's always on.
 - `pm project new` missing → "Command not registered. This usually means the pm binary hasn't been rebuilt since the project_planning plugin shipped. Fix: `cd /path/to/pollypm && uv pip install -e .` then try again. Workaround: `pm add-project <path> --name <name>`."
 - `pm task approve` on a draft task → "Task is in `draft` status; only `review` tasks can be approved. Did you mean `pm task queue <id>`?"
 - `pm task claim` on already-claimed task → "Task already claimed by <actor> at <time>. Use `pm task get <id>` to see current state, or `pm task release <id>` if the claim is stale."
-- `pm worker-start` on a non-existent project → "No project `<name>` registered. Run `pm projects` to see registered projects, or `pm add-project <path>` to register a new one."
+- `pm task create` or `pm task claim` on a non-existent project → "No project `<name>` registered. Run `pm projects` to see registered projects, or `pm add-project <path>` to register a new one."
 
 Every entry is a one-line code change (raise-with-better-message) plus a unit test asserting the guidance text is present.
 


### PR DESCRIPTION
## Summary
- replace deprecated per-task `pm worker-start <project>` guidance with the current task-system flow
- update the worker guide and live integration spec to point at `task create -> queue -> claim`
- scrub stale worker-start examples from the worker onboarding/error spec

## Validation
- rg -n "pm worker-start(?! --role architect)" docs/worker-guide.md docs/live-integration-test-spec.md docs/worker-onboarding-and-errors-spec.md -P

Closes #438