### PR TITLE
fix: harden backup restore sidecar cleanup

### DIFF
--- a/src/pollypm/backup.py
+++ b/src/pollypm/backup.py
@@ -24,6 +24,7 @@ Design notes:
 from __future__ import annotations
 
 import gzip
+import os
 import shutil
 import sqlite3
 import tarfile
@@ -209,6 +210,26 @@ def _gunzip_file(src_gz: Path, dest: Path) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
     with gzip.open(src_gz, "rb") as fin, dest.open("wb") as fout:
         shutil.copyfileobj(fin, fout)
+
+
+def _sqlite_sidecars(db_path: Path) -> tuple[Path, Path]:
+    return (
+        db_path.with_name(db_path.name + "-wal"),
+        db_path.with_name(db_path.name + "-shm"),
+    )
+
+
+def _remove_sqlite_sidecars(db_path: Path) -> None:
+    """Remove stale WAL/SHM sidecars before a restore swap."""
+    for sidecar in _sqlite_sidecars(db_path):
+        if not sidecar.exists():
+            continue
+        try:
+            sidecar.unlink()
+        except OSError as exc:
+            raise RuntimeError(
+                f"Could not remove SQLite sidecar {sidecar}: {exc}. Restore aborted."
+            ) from exc
 
 
 # --------------------------------------------------------------------- #
@@ -445,7 +466,7 @@ def execute_restore(plan: RestorePlan) -> RestoreResult:
     # 2. Materialize the snapshot into a plain file we can move into
     #    place.
     live_db.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory() as staging:
+    with tempfile.TemporaryDirectory(dir=live_db.parent, prefix=".restore-") as staging:
         staged_db = Path(staging) / "restored.db"
 
         if plan.is_tar:
@@ -461,23 +482,13 @@ def execute_restore(plan: RestorePlan) -> RestoreResult:
         else:
             shutil.copy2(snapshot, staged_db)
 
-        # 3. Atomic-ish replace. On POSIX ``os.replace`` is atomic on
-        #    the same filesystem; the tempdir is in /tmp which may
-        #    differ, so we copy into place instead.
-        shutil.copy2(staged_db, live_db)
+        # 3. Remove stale WAL/SHM sidecars from the old DB before we
+        #    atomically swap in the restored snapshot. If cleanup fails,
+        #    abort loudly instead of risking a mixed restore + stale WAL.
+        _remove_sqlite_sidecars(live_db)
 
-    # 4. Clean up WAL / SHM sidecars from the old DB — they belong to
-    #    the previous transaction log and would confuse SQLite after
-    #    we've swapped in a cold snapshot. Best-effort.
-    for sidecar in (
-        live_db.with_name(live_db.name + "-wal"),
-        live_db.with_name(live_db.name + "-shm"),
-    ):
-        try:
-            if sidecar.exists():
-                sidecar.unlink()
-        except OSError:
-            pass
+        # 4. Atomic replace on the same filesystem.
+        os.replace(staged_db, live_db)
 
     return RestoreResult(
         snapshot_path=snapshot,

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -459,6 +459,93 @@ def test_backup_module_raises_named_error_when_database_stays_locked(
         )
 
 
+def test_execute_restore_matches_snapshot_bytes_and_clears_sidecars(
+    fake_home: Path, state_db: Path, tmp_path: Path
+) -> None:
+    snapshot = backup_mod.backup_state_db(
+        state_db,
+        base_dir=fake_home,
+        output=tmp_path / "backups" / "snapshot.db.gz",
+        full=False,
+        keep=7,
+    ).path
+    expected_bytes = gzip.decompress(snapshot.read_bytes())
+
+    conn = sqlite3.connect(state_db)
+    try:
+        conn.execute("UPDATE probe SET v = ? WHERE k = ?", ("mutated", "hello"))
+        conn.commit()
+    finally:
+        conn.close()
+
+    wal = state_db.with_name(state_db.name + "-wal")
+    shm = state_db.with_name(state_db.name + "-shm")
+    wal.write_bytes(b"stale wal")
+    shm.write_bytes(b"stale shm")
+
+    plan = backup_mod.plan_restore(snapshot, state_db)
+    result = backup_mod.execute_restore(plan)
+
+    assert result.live_db_path == state_db
+    assert state_db.read_bytes() == expected_bytes
+    assert not wal.exists()
+    assert not shm.exists()
+
+
+def test_execute_restore_aborts_when_sidecar_cleanup_fails(
+    fake_home: Path, state_db: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    snapshot = backup_mod.backup_state_db(
+        state_db,
+        base_dir=fake_home,
+        output=tmp_path / "backups" / "snapshot.db.gz",
+        full=False,
+        keep=7,
+    ).path
+
+    conn = sqlite3.connect(state_db)
+    try:
+        conn.execute("UPDATE probe SET v = ? WHERE k = ?", ("mutated", "hello"))
+        conn.commit()
+    finally:
+        conn.close()
+
+    wal = state_db.with_name(state_db.name + "-wal")
+    wal.write_bytes(b"stale wal")
+
+    real_unlink = Path.unlink
+
+    def fail_wal_unlink(self: Path, *args, **kwargs):
+        if self == wal:
+            raise OSError("permission denied")
+        return real_unlink(self, *args, **kwargs)
+
+    replace_called = {"value": False}
+    real_replace = backup_mod.os.replace
+
+    def fail_if_replace(*args, **kwargs):
+        replace_called["value"] = True
+        return real_replace(*args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_wal_unlink)
+    monkeypatch.setattr(backup_mod.os, "replace", fail_if_replace)
+
+    plan = backup_mod.plan_restore(snapshot, state_db)
+    with pytest.raises(RuntimeError, match="Restore aborted"):
+        backup_mod.execute_restore(plan)
+
+    assert replace_called["value"] is False
+
+    conn = sqlite3.connect(state_db)
+    try:
+        row = conn.execute(
+            "SELECT v FROM probe WHERE k = ?", ("hello",)
+        ).fetchone()
+        assert row == ("mutated",)
+    finally:
+        conn.close()
+
+
 def test_plan_restore_rejects_full_archive_missing_state_db(
     fake_home: Path, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- stage restores on the live DB filesystem and use `os.replace` for the final swap
- abort loudly when stale SQLite `-wal` / `-shm` cleanup fails instead of silently risking a mixed restore
- add regressions for byte-accurate restore and sidecar-cleanup abort behavior

## Testing
- uv run --extra dev pytest -q tests/test_backup_restore.py

Closes #415