### PR TITLE
docs: add a changelog for v1 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to PollyPM will be documented in this file.
+
+The format is based on Keep a Changelog, and this file also doubles as the
+template for user-visible PR descriptions: summarize user-facing changes under
+Added, Changed, and Removed.
+
+## [Unreleased]
+
+## [1.0.0] - 2026-04-20
+
+### Added
+- A stable v1 control plane built around tmux sessions, the Textual cockpit,
+  issue-driven task orchestration, threaded inbox handling, and recoverable
+  project state.
+- Plugin API v1 plus replaceable provider, runtime, scheduler, heartbeat,
+  agent-profile, task-backend, and memory-backend seams, with bundled defaults
+  for local tmux workflows.
+- Headless operations needed for daily use, including the rail daemon,
+  architect warm resume, persistent recovery checkpoints, and cached account
+  usage refresh.
+
+### Changed
+- Provider and account integration now run through the extracted adapter
+  substrate and entry-point registry so providers can ship as standalone
+  packages instead of core-only integrations.
+- Worker lifecycle is task-scoped: claiming work provisions a worker session,
+  and teardown happens through the work service instead of long-lived managed
+  worker sessions.
+- The stable release rolls up the `1.0.0rc1` and `1.0.0rc2` release-candidate
+  line into the supported v1 baseline.
+
+### Removed
+- `pm worker-start <project>` as the per-task worker launch path; use
+  `pm task claim <id>` so workers are provisioned and cleaned up through the
+  work service. `pm worker-start --role architect` remains supported for the
+  planner lane.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PollyPM is a tmux-first control plane for people who want multiple AI coding ses
 
 Architecturally, PollyPM is a modular monolith: one local system with explicit replaceable boundaries for providers, runtimes, storage backends, scheduler/heartbeat hooks, and cockpit panes. The current cockpit includes a real split-pane task review surface, live session peeks, and cached account-usage tracking so the UI can stay responsive without probing providers inline.
 
-**New here? Start with [docs/getting-started.md](docs/getting-started.md)** — a 15-minute walkthrough from install to your first completed task. The rest of this README is the module map and architecture reference for contributors.
+**New here? Start with [docs/getting-started.md](docs/getting-started.md)** — a 15-minute walkthrough from install to your first completed task. See [CHANGELOG.md](CHANGELOG.md) for release notes and migration notes. The rest of this README is the module map and architecture reference for contributors.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- add a root `CHANGELOG.md` in Keep a Changelog style for v1 release notes
- seed it with `Unreleased` and `1.0.0` sections covering the shipped release surface
- link the changelog from the README so release notes are discoverable

## Validation
- git diff --check -- README.md CHANGELOG.md

Closes #430