### PR TITLE
docs: add a v1.1 warning banner to the plugin discovery spec

### DIFF
--- a/docs/plugin-discovery-spec.md
+++ b/docs/plugin-discovery-spec.md
@@ -2,6 +2,13 @@
 
 **Status:** draft — target for v1.1. Supersedes ad-hoc discovery in `plugin_host.py`.
 
+> **Warning:** This document is still a draft target for v1.1, and some
+> sections may describe behavior that is not yet shipped or not yet
+> stable in the current v1 release.
+> If you're authoring a plugin today, start with
+> [`plugin-authoring.md`](plugin-authoring.md) and confirm details
+> against the current `pm plugins` behavior.
+
 This spec defines how PollyPM finds plugins, how plugins advertise what they provide, and how users add, disable, and inspect plugins. It also codifies the distinction between *plugins* (code that extends the rail) and *content* (data that extends what a plugin already provides).
 
 ---


### PR DESCRIPTION
## Summary
- add a top-of-file warning banner to `docs/plugin-discovery-spec.md`
- make it explicit that the document targets v1.1 and may not match shipped v1 behavior
- point readers at the current authoring/docs surface instead of treating the spec as live behavior

## Validation
- git diff --check -- docs/plugin-discovery-spec.md

Closes #435