### PR TITLE
docs(api): add concrete examples to v1 plugin and service APIs

### DIFF
--- a/src/pollypm/plugin_api/v1.py
+++ b/src/pollypm/plugin_api/v1.py
@@ -1,3 +1,25 @@
+"""PollyPM Plugin API v1.
+
+Stable registration surface for plugin authors. The module is mostly type
+declarations, so keep a concrete example here to show the intended shape.
+
+Example:
+    from pollypm.plugin_api.v1 import Capability, PluginAPI, PollyPMPlugin
+
+    def initialize(api: PluginAPI) -> None:
+        for path in api.content_paths(kind="magic_skill"):
+            api.emit_event("content_path_seen", {"path": str(path)})
+
+    plugin = PollyPMPlugin(
+        name="example_plugin",
+        description="Minimal example plugin",
+        capabilities=(
+            Capability(kind="hook", name="example_plugin"),
+        ),
+        initialize=initialize,
+    )
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/src/pollypm/service_api/v1.py
+++ b/src/pollypm/service_api/v1.py
@@ -8,6 +8,16 @@ allow-list.
 
 The public surface is re-exported from :mod:`pollypm.service_api`. Anything
 underscore-prefixed is internal.
+
+Example:
+    from pathlib import Path
+    from pollypm.models import ProviderKind
+    from pollypm.service_api.v1 import PollyPMService
+
+    service = PollyPMService(Path("/path/to/pollypm.toml"))
+    sessions = service.session_status()["sessions"]
+    accounts = service.list_cached_account_statuses()
+    service.add_account(ProviderKind.CLAUDE)
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- add concrete top-level examples to `plugin_api/v1.py`
- add concrete top-level examples to `service_api/v1.py`
- keep the change docstring-only so it clarifies the API surface without changing behavior

## Validation
- python -m py_compile src/pollypm/plugin_api/v1.py src/pollypm/service_api/v1.py

Closes #424