### PR TITLE
fix(settings): expose account usage and actions

### DIFF
--- a/src/pollypm/accounts.py
+++ b/src/pollypm/accounts.py
@@ -44,6 +44,10 @@ class AccountStatus:
     access_expires_at: str | None = None
     usage_updated_at: str | None = None
     usage_raw_text: str = ""
+    used_pct: int | None = None
+    remaining_pct: int | None = None
+    reset_at: str | None = None
+    period_label: str | None = None
     isolation_status: str = "unknown"
     isolation_summary: str = "unknown"
     isolation_recommendation: str = ""
@@ -309,6 +313,10 @@ def probe_account_usage(config_path: Path, identifier: str) -> AccountStatus:
         access_expires_at=runtime.access_expires_at if runtime else None,
         usage_updated_at=(cached.updated_at if cached else None),
         usage_raw_text=(cached.raw_text if cached else ""),
+        used_pct=(cached.used_pct if cached else None),
+        remaining_pct=(cached.remaining_pct if cached else None),
+        reset_at=(cached.reset_at if cached else None),
+        period_label=(cached.period_label if cached else None),
         isolation_status=isolation_status,
         isolation_summary=isolation_summary,
         isolation_recommendation=isolation_recommendation,
@@ -348,6 +356,10 @@ def list_account_statuses(config_path: Path) -> list[AccountStatus]:
                     access_expires_at=runtime.access_expires_at if runtime else None,
                     usage_updated_at=cached.updated_at if cached else None,
                     usage_raw_text=cached.raw_text if cached else "",
+                    used_pct=cached.used_pct if cached else None,
+                    remaining_pct=cached.remaining_pct if cached else None,
+                    reset_at=cached.reset_at if cached else None,
+                    period_label=cached.period_label if cached else None,
                     isolation_status=isolation_status,
                     isolation_summary=isolation_summary,
                     isolation_recommendation=isolation_recommendation,
@@ -398,6 +410,10 @@ def list_cached_account_statuses(config_path: Path) -> list[AccountStatus]:
                     access_expires_at=runtime.access_expires_at if runtime else None,
                     usage_updated_at=cached.updated_at if cached else None,
                     usage_raw_text=cached.raw_text if cached else "",
+                    used_pct=cached.used_pct if cached else None,
+                    remaining_pct=cached.remaining_pct if cached else None,
+                    reset_at=cached.reset_at if cached else None,
+                    period_label=cached.period_label if cached else None,
                     isolation_status=isolation_status,
                     isolation_summary=isolation_summary,
                     isolation_recommendation=isolation_recommendation,

--- a/src/pollypm/cockpit_settings_accounts.py
+++ b/src/pollypm/cockpit_settings_accounts.py
@@ -1,0 +1,127 @@
+"""Settings/accounts section helpers for the cockpit UI.
+
+Contract:
+- Input: one normalized account row from ``SettingsData.accounts``.
+- Output: account-detail markup plus the explicit action-button contract for
+  the Settings -> Accounts section.
+- Invariants: this module owns account-section rendering; ``cockpit_ui``
+  owns event wiring and service calls.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from rich.markup import escape as _escape
+
+from pollypm.tz import format_relative, format_time
+
+
+@dataclass(frozen=True, slots=True)
+class SettingsAccountAction:
+    button_id: str
+    label: str
+    variant: str = "default"
+
+
+SETTINGS_ACCOUNT_ACTIONS: tuple[SettingsAccountAction, ...] = (
+    SettingsAccountAction(
+        button_id="settings-account-add-claude",
+        label="Add Claude",
+        variant="primary",
+    ),
+    SettingsAccountAction(
+        button_id="settings-account-add-codex",
+        label="Add Codex",
+    ),
+    SettingsAccountAction(
+        button_id="settings-account-refresh-usage",
+        label="Refresh Usage",
+    ),
+    SettingsAccountAction(
+        button_id="settings-account-remove",
+        label="Remove",
+        variant="error",
+    ),
+)
+
+
+def render_settings_account_detail(selected: Mapping[str, object]) -> str:
+    sep = "[dim]" + "\u2500" * 40 + "[/dim]"
+    dot = str(selected.get("status_dot") or "\u25cf")
+    colour = str(selected.get("status_colour") or "#6b7a88")
+    lines = [
+        f"[{colour}]{dot}[/{colour}] [b]{_escape(str(selected.get('key') or ''))}[/b]"
+        f"  [dim]({_escape(str(selected.get('provider') or ''))})[/dim]",
+        sep,
+        f"[dim]Email:[/dim]      {_escape(str(selected.get('email') or '-'))}",
+        f"[dim]Logged in:[/dim]  {'yes' if selected.get('logged_in') else 'no'}",
+        f"[dim]Health:[/dim]     {_escape(str(selected.get('health') or '-'))}",
+        f"[dim]Plan:[/dim]       {_escape(str(selected.get('plan') or '-'))}",
+        f"[dim]Usage:[/dim]      {_escape(str(selected.get('usage_summary') or '-'))}",
+        f"[dim]Controller:[/dim] {'yes' if selected.get('is_controller') else 'no'}",
+        f"[dim]Failover:[/dim]   {_render_failover(selected.get('failover_pos'))}",
+        f"[dim]Home:[/dim]       {_escape(str(selected.get('home') or '-'))}",
+        f"[dim]Isolation:[/dim]  {_escape(str(selected.get('isolation_status') or '-'))}",
+        f"[dim]Storage:[/dim]    {_escape(str(selected.get('auth_storage') or '-'))}",
+    ]
+    if selected.get("remaining_pct") is not None:
+        lines.append(f"[dim]Remaining:[/dim]  {selected['remaining_pct']}%")
+    if selected.get("used_pct") is not None:
+        lines.append(f"[dim]Used:[/dim]       {selected['used_pct']}%")
+    if selected.get("period_label"):
+        lines.append(
+            f"[dim]Window:[/dim]     {_escape(str(selected['period_label']))}"
+        )
+    if selected.get("reset_at"):
+        lines.append(
+            f"[dim]Resets:[/dim]     {_escape(str(selected['reset_at']))}"
+        )
+    sampled = _render_usage_updated_at(selected.get("usage_updated_at"))
+    if sampled:
+        lines.append(f"[dim]Sampled:[/dim]    {sampled}")
+    if selected.get("available_at"):
+        lines.append(
+            f"[dim]Available:[/dim]  {_escape(str(selected['available_at']))}"
+        )
+    if selected.get("access_expires_at"):
+        lines.append(
+            f"[dim]Expires:[/dim]    {_escape(str(selected['access_expires_at']))}"
+        )
+    if selected.get("reason"):
+        lines.extend(
+            [sep, f"[dim]Reason:[/dim]     {_escape(str(selected['reason']))}"]
+        )
+    usage_raw_text = str(selected.get("usage_raw_text") or "").strip()
+    if usage_raw_text:
+        snippet = usage_raw_text.splitlines()[:6]
+        if snippet:
+            lines.append(sep)
+            lines.append("[dim]Latest usage snapshot:[/dim]")
+            lines.extend(f"  {_escape(line)}" for line in snippet)
+    return "\n".join(lines)
+
+
+def _render_usage_updated_at(value: object) -> str:
+    if not value:
+        return ""
+    iso = str(value)
+    absolute = format_time(iso)
+    relative = format_relative(iso)
+    if absolute and relative:
+        return f"{absolute} · {relative}"
+    return absolute or relative
+
+
+def _render_failover(value: object) -> str:
+    if value in (None, "", 0):
+        return "no"
+    return f"#{value}"
+
+
+__all__ = [
+    "SETTINGS_ACCOUNT_ACTIONS",
+    "SettingsAccountAction",
+    "render_settings_account_detail",
+]

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -83,6 +83,10 @@ from pollypm.cockpit_palette import (
     _record_palette_command,
     _resolve_recent_commands,
 )
+from pollypm.cockpit_settings_accounts import (
+    SETTINGS_ACCOUNT_ACTIONS,
+    render_settings_account_detail,
+)
 from pollypm.cockpit_workers import PollyWorkerRosterApp
 from pollypm.session_services import create_tmux_client
 from pollypm.service_api import PollyPMService
@@ -1993,6 +1997,11 @@ def _gather_settings_data(
                 "plan": getattr(status, "plan", "") or "",
                 "usage_summary": getattr(status, "usage_summary", "") or "",
                 "usage_raw_text": getattr(status, "usage_raw_text", "") or "",
+                "usage_updated_at": getattr(status, "usage_updated_at", "") or "",
+                "used_pct": getattr(status, "used_pct", None),
+                "remaining_pct": getattr(status, "remaining_pct", None),
+                "reset_at": getattr(status, "reset_at", "") or "",
+                "period_label": getattr(status, "period_label", "") or "",
                 "reason": getattr(status, "reason", "") or "",
                 "available_at": getattr(status, "available_at", "") or "",
                 "access_expires_at": getattr(status, "access_expires_at", "") or "",
@@ -2213,6 +2222,13 @@ class PollySettingsPaneApp(App[None]):
         height: auto;
         padding-bottom: 1;
     }
+    #settings-account-actions {
+        height: auto;
+        padding-bottom: 1;
+    }
+    #settings-account-actions Button {
+        margin-right: 1;
+    }
     #settings-reload-cockpit {
         min-width: 18;
     }
@@ -2374,6 +2390,13 @@ class PollySettingsPaneApp(App[None]):
                             id="settings-actions-note",
                         )
                     yield self.section_title
+                    with Horizontal(id="settings-account-actions"):
+                        for spec in SETTINGS_ACCOUNT_ACTIONS:
+                            yield Button(
+                                spec.label,
+                                id=spec.button_id,
+                                variant=spec.variant,
+                            )
                     with Vertical(id="settings-table-wrap"):
                         yield self.accounts
                         yield self.projects_table
@@ -2507,6 +2530,7 @@ class PollySettingsPaneApp(App[None]):
         self.plugins_table.display = key == "plugins"
         self.kv_static.display = key in {"heartbeat", "planner", "inbox", "about"}
         self.detail.display = key in {"accounts", "projects", "plugins"}
+        self.query_one("#settings-account-actions").display = key == "accounts"
 
         title_map = dict(_SETTINGS_SECTIONS)
         self.section_title.update(
@@ -2608,45 +2632,18 @@ class PollySettingsPaneApp(App[None]):
             or rows[0]["key"]
         )
         selected = next((a for a in rows if a["key"] == key), rows[0])
-        sep = "[dim]" + "\u2500" * 40 + "[/dim]"
         dot, colour = _settings_status_dot(
             selected["health"], selected["logged_in"],
         )
-        lines = [
-            f"[{colour}]{dot}[/{colour}] [b]{_escape(selected['key'])}[/b]"
-            f"  [dim]({_escape(selected['provider'])})[/dim]",
-            sep,
-            f"[dim]Email:[/dim]      {_escape(selected['email'])}",
-            f"[dim]Logged in:[/dim]  {'yes' if selected['logged_in'] else 'no'}",
-            f"[dim]Health:[/dim]     {_escape(selected['health']) or '-'}",
-            f"[dim]Plan:[/dim]       {_escape(selected['plan']) or '-'}",
-            f"[dim]Usage:[/dim]      {_escape(selected['usage_summary']) or '-'}",
-            f"[dim]Controller:[/dim] {'yes' if selected['is_controller'] else 'no'}",
-            f"[dim]Failover:[/dim]   "
-            f"{'#' + str(selected['failover_pos']) if selected['failover_pos'] else 'no'}",
-            f"[dim]Home:[/dim]       {_escape(selected['home']) or '-'}",
-            f"[dim]Isolation:[/dim]  {_escape(selected['isolation_status']) or '-'}",
-            f"[dim]Storage:[/dim]    {_escape(selected['auth_storage']) or '-'}",
-        ]
-        if selected["available_at"]:
-            lines.append(
-                f"[dim]Available:[/dim]  {_escape(selected['available_at'])}"
+        self.detail.update(
+            render_settings_account_detail(
+                {
+                    **selected,
+                    "status_dot": dot,
+                    "status_colour": colour,
+                }
             )
-        if selected["access_expires_at"]:
-            lines.append(
-                f"[dim]Expires:[/dim]    {_escape(selected['access_expires_at'])}"
-            )
-        if selected["reason"]:
-            lines.extend(
-                [sep, f"[dim]Reason:[/dim]     {_escape(selected['reason'])}"]
-            )
-        if selected["usage_raw_text"]:
-            snippet = selected["usage_raw_text"].strip().splitlines()[:6]
-            if snippet:
-                lines.append(sep)
-                lines.append("[dim]Latest usage snapshot:[/dim]")
-                lines.extend(f"  {_escape(line)}" for line in snippet)
-        self.detail.update("\n".join(lines))
+        )
 
     def _current_accounts_key(self) -> str | None:
         if self.accounts.row_count == 0 or self.accounts.cursor_row < 0:
@@ -3027,6 +3024,61 @@ class PollySettingsPaneApp(App[None]):
             return
         self._refresh()
 
+    def action_add_claude_account(self) -> None:
+        self._add_account(ProviderKind.CLAUDE)
+
+    def action_add_codex_account(self) -> None:
+        self._add_account(ProviderKind.CODEX)
+
+    def action_refresh_selected_account_usage(self) -> None:
+        if self._active_section != "accounts":
+            return
+        key = self._current_accounts_key()
+        if not key:
+            try:
+                self.notify("No account selected.", severity="warning")
+            except Exception:  # noqa: BLE001
+                pass
+            return
+        refresher = getattr(self.service, "refresh_account_usage", None)
+        if refresher is None:
+            return
+        try:
+            refresher(key)
+            self._selected_account_key = key
+        except Exception as exc:  # noqa: BLE001
+            try:
+                self.notify(
+                    f"Usage refresh failed: {exc}", severity="error",
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            return
+        self._refresh()
+        try:
+            self.notify(f"Refreshed usage for {key}.", timeout=1.5)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def action_remove_selected_account(self) -> None:
+        if self._active_section != "accounts":
+            return
+        key = self._current_accounts_key()
+        if not key:
+            try:
+                self.notify("No account selected.", severity="warning")
+            except Exception:  # noqa: BLE001
+                pass
+            return
+        self.push_screen(
+            _SettingsConfirmModal(
+                title="Remove account",
+                prompt=f"Remove account {key} from PollyPM config?",
+                confirm_label="Remove",
+            ),
+            lambda confirmed: self._confirm_remove_account(key, confirmed),
+        )
+
     def action_back_or_cancel(self) -> None:
         if self.search_input.has_class("-active"):
             self.search_input.remove_class("-active")
@@ -3121,11 +3173,125 @@ class PollySettingsPaneApp(App[None]):
     def on_reload_cockpit_pressed(self, _event: Button.Pressed) -> None:
         self.action_reload_cockpit()
 
+    @on(Button.Pressed, "#settings-account-add-claude")
+    def on_add_claude_account_pressed(self, _event: Button.Pressed) -> None:
+        self.action_add_claude_account()
+
+    @on(Button.Pressed, "#settings-account-add-codex")
+    def on_add_codex_account_pressed(self, _event: Button.Pressed) -> None:
+        self.action_add_codex_account()
+
+    @on(Button.Pressed, "#settings-account-refresh-usage")
+    def on_refresh_account_usage_pressed(self, _event: Button.Pressed) -> None:
+        self.action_refresh_selected_account_usage()
+
+    @on(Button.Pressed, "#settings-account-remove")
+    def on_remove_account_pressed(self, _event: Button.Pressed) -> None:
+        self.action_remove_selected_account()
+
     @on(DataTable.RowSelected, "#accounts")
     def on_account_selected(self, _event: DataTable.RowSelected) -> None:
         self._selected_account_key = self._current_accounts_key()
         if self.data is not None:
             self._render_account_detail(self.data)
+
+    def _add_account(self, provider: ProviderKind) -> None:
+        adder = getattr(self.service, "add_account", None)
+        if adder is None:
+            return
+        try:
+            key, _email = adder(provider)
+            self._selected_account_key = key
+        except Exception as exc:  # noqa: BLE001
+            try:
+                self.notify(f"Add account failed: {exc}", severity="error")
+            except Exception:  # noqa: BLE001
+                pass
+            return
+        self._refresh()
+        try:
+            self.notify(f"Added {provider.value} account {key}.", timeout=1.5)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _confirm_remove_account(self, key: str, confirmed: bool) -> None:
+        if not confirmed:
+            return
+        remover = getattr(self.service, "remove_account", None)
+        if remover is None:
+            return
+        try:
+            remover(key, delete_home=False)
+            if self._selected_account_key == key:
+                self._selected_account_key = None
+        except Exception as exc:  # noqa: BLE001
+            try:
+                self.notify(f"Remove account failed: {exc}", severity="error")
+            except Exception:  # noqa: BLE001
+                pass
+            return
+        self._refresh()
+        try:
+            self.notify(f"Removed account {key}.", timeout=1.5)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+class _SettingsConfirmModal(ModalScreen[bool]):
+    CSS = """
+    Screen {
+        align: center middle;
+    }
+    #settings-confirm {
+        width: 72;
+        height: auto;
+        padding: 1 2;
+        background: $panel;
+        border: heavy $warning;
+    }
+    #settings-confirm-title {
+        padding-bottom: 1;
+        text-style: bold;
+    }
+    #settings-confirm-buttons {
+        height: auto;
+        align-horizontal: right;
+        padding-top: 1;
+    }
+    #settings-confirm-buttons Button {
+        margin-left: 1;
+    }
+    """
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    def __init__(
+        self,
+        *,
+        title: str,
+        prompt: str,
+        confirm_label: str = "Confirm",
+        cancel_label: str = "Cancel",
+    ) -> None:
+        super().__init__()
+        self._title = title
+        self._prompt = prompt
+        self._confirm_label = confirm_label
+        self._cancel_label = cancel_label
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="settings-confirm"):
+            yield Static(self._title, id="settings-confirm-title")
+            yield Static(self._prompt)
+            with Horizontal(id="settings-confirm-buttons"):
+                yield Button(self._cancel_label, id="cancel")
+                yield Button(self._confirm_label, variant="primary", id="confirm")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "confirm")
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)
 
 
 # ---------------------------------------------------------------------------

--- a/src/pollypm/service_api/v1.py
+++ b/src/pollypm/service_api/v1.py
@@ -139,6 +139,10 @@ class PollyPMService:
         """Return cached account status for fast interactive views."""
         return list_cached_account_statuses(self.config_path)
 
+    def refresh_account_usage(self, identifier: str) -> AccountStatus:
+        """Refresh one account usage snapshot and return the updated status."""
+        return probe_account_usage(self.config_path, identifier)
+
     def create_and_launch_worker(
         self,
         *,

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -10,6 +10,7 @@ from pollypm.config import write_config
 from pollypm.models import AccountConfig, ProjectSettings, PollyPMConfig, PollyPMSettings, ProviderKind, RuntimeKind
 from pollypm.providers.claude.usage_parse import parse_claude_usage_text
 from pollypm.providers.codex.usage_parse import parse_codex_status_text
+from pollypm.storage.state import StateStore
 
 
 def test_parse_claude_usage_text() -> None:
@@ -274,3 +275,53 @@ def test_list_cached_account_statuses_avoids_live_probes(monkeypatch, tmp_path: 
 
     assert len(statuses) == 1
     assert probe_flags == [False]
+
+
+def test_list_cached_account_statuses_exposes_structured_usage_fields(tmp_path: Path) -> None:
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            base_dir=tmp_path / ".pollypm",
+            logs_dir=tmp_path / ".pollypm/logs",
+            snapshots_dir=tmp_path / ".pollypm/snapshots",
+            state_db=tmp_path / ".pollypm" / "state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account="claude_primary"),
+        accounts={
+            "claude_primary": AccountConfig(
+                name="claude_primary",
+                provider=ProviderKind.CLAUDE,
+                email="claude@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=tmp_path / ".pollypm/homes/claude_primary",
+            )
+        },
+        sessions={},
+        projects={},
+    )
+    config_path = tmp_path / "pollypm.toml"
+    write_config(config, config_path)
+
+    with StateStore(config.project.state_db) as store:
+        store.upsert_account_usage(
+            account_name="claude_primary",
+            provider="claude",
+            plan="max",
+            health="healthy",
+            usage_summary="79% left this week",
+            raw_text="Current week (all models)",
+            used_pct=21,
+            remaining_pct=79,
+            reset_at="Apr 24 at 1am",
+            period_label="current week",
+        )
+
+    statuses = list_cached_account_statuses(config_path)
+
+    assert len(statuses) == 1
+    status = statuses[0]
+    assert status.used_pct == 21
+    assert status.remaining_pct == 79
+    assert status.reset_at == "Apr 24 at 1am"
+    assert status.period_label == "current week"
+    assert status.usage_updated_at is not None

--- a/tests/test_settings_ui.py
+++ b/tests/test_settings_ui.py
@@ -21,6 +21,7 @@ import time
 from pathlib import Path
 
 import pytest
+from textual.widgets import Button
 
 from pollypm.models import ProviderKind
 
@@ -39,6 +40,11 @@ def _fake_status(
     usage: str = "80% left",
     plan: str = "max",
     logged_in: bool = True,
+    usage_updated_at: str | None = "2026-04-21T16:45:00+00:00",
+    used_pct: int | None = 20,
+    remaining_pct: int | None = 80,
+    reset_at: str | None = "Apr 24 at 1am",
+    period_label: str | None = "current week",
 ) -> object:
     class _Status:
         pass
@@ -54,12 +60,16 @@ def _fake_status(
     s.reason = ""
     s.available_at = None
     s.access_expires_at = None
-    s.usage_updated_at = None
+    s.usage_updated_at = usage_updated_at
     s.isolation_status = "host-profile"
     s.isolation_summary = ""
     s.isolation_recommendation = ""
     s.auth_storage = "file"
     s.profile_root = None
+    s.used_pct = used_pct
+    s.remaining_pct = remaining_pct
+    s.reset_at = reset_at
+    s.period_label = period_label
     s.home = Path("/tmp") / key
     return s
 
@@ -126,6 +136,9 @@ class _FakeService:
         self.permissions_calls: list[bool] = []
         self.tracked_calls: list[tuple[str, bool]] = []
         self.controller_calls: list[str] = []
+        self.add_account_calls: list[ProviderKind] = []
+        self.remove_account_calls: list[tuple[str, bool]] = []
+        self.refresh_usage_calls: list[str] = []
         self.cached_calls = 0
         self.live_calls = 0
 
@@ -150,6 +163,41 @@ class _FakeService:
 
     def set_controller_account(self, key: str) -> None:
         self.controller_calls.append(key)
+
+    def add_account(self, provider: ProviderKind) -> tuple[str, str]:
+        self.add_account_calls.append(provider)
+        key = f"{provider.value}_new"
+        email = f"{key}@example.com"
+        self._statuses.append(
+            _fake_status(
+                key,
+                provider=provider,
+                email=email,
+                usage="93% left this week",
+                used_pct=7,
+                remaining_pct=93,
+                reset_at="Apr 28 at 1am",
+            )
+        )
+        return key, email
+
+    def refresh_account_usage(self, key: str):
+        self.refresh_usage_calls.append(key)
+        for status in self._statuses:
+            if status.key == key:
+                status.usage_summary = "92% left this week"
+                status.used_pct = 8
+                status.remaining_pct = 92
+                status.reset_at = "Apr 28 at 1am"
+                status.period_label = "current week"
+                status.usage_updated_at = "2026-04-21T17:00:00+00:00"
+                return status
+        raise KeyError(key)
+
+    def remove_account(self, key: str, *, delete_home: bool = False) -> tuple[str, str]:
+        self.remove_account_calls.append((key, delete_home))
+        self._statuses = [status for status in self._statuses if status.key != key]
+        return key, "removed"
 
 
 # ---------------------------------------------------------------------------
@@ -253,6 +301,92 @@ def test_accounts_section_lists_configured_accounts(settings_env) -> None:
             # accounts too — even though the detail only shows one.
             keys = [a["key"] for a in app.data.accounts]
             assert keys == ["claude_demo", "codex_demo", "claude_stale"]
+
+    _run(body())
+
+
+def test_accounts_detail_shows_cached_usage_snapshot_fields(settings_env) -> None:
+    app = settings_env["app"]
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            detail_text = str(app.detail.render())
+            assert "Remaining:" in detail_text
+            assert "80%" in detail_text
+            assert "Used:" in detail_text
+            assert "Window:" in detail_text
+            assert "current week" in detail_text
+            assert "Resets:" in detail_text
+            assert "Sampled:" in detail_text
+
+    _run(body())
+
+
+def test_accounts_section_exposes_account_action_buttons(settings_env) -> None:
+    app = settings_env["app"]
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            assert app.query_one("#settings-account-add-claude", Button) is not None
+            assert app.query_one("#settings-account-add-codex", Button) is not None
+            assert app.query_one("#settings-account-refresh-usage", Button) is not None
+            assert app.query_one("#settings-account-remove", Button) is not None
+
+    _run(body())
+
+
+def test_add_account_actions_refresh_the_accounts_snapshot(settings_env) -> None:
+    app = settings_env["app"]
+    service = settings_env["service"]
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            app.action_add_codex_account()
+            await pilot.pause()
+            keys = [a["key"] for a in app.data.accounts]
+            assert service.add_account_calls == [ProviderKind.CODEX]
+            assert "codex_new" in keys
+
+    _run(body())
+
+
+def test_refresh_usage_action_updates_cached_account_detail(settings_env) -> None:
+    app = settings_env["app"]
+    service = settings_env["service"]
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            app.action_refresh_selected_account_usage()
+            await pilot.pause()
+            assert service.refresh_usage_calls == ["claude_demo"]
+            detail_text = str(app.detail.render())
+            assert "92%" in detail_text
+            assert "Sampled:" in detail_text
+
+    _run(body())
+
+
+def test_remove_account_action_confirms_and_refreshes_snapshot(settings_env, monkeypatch) -> None:
+    app = settings_env["app"]
+    service = settings_env["service"]
+
+    def _auto_confirm(_screen, callback):
+        callback(True)
+
+    monkeypatch.setattr(app, "push_screen", _auto_confirm)
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            app.action_remove_selected_account()
+            await pilot.pause()
+            keys = [a["key"] for a in app.data.accounts]
+            assert service.remove_account_calls == [("claude_demo", False)]
+            assert "claude_demo" not in keys
 
     _run(body())
 


### PR DESCRIPTION
Closes #539

## Summary
- expose cached account usage fields through the account-status contract
- add visible Settings -> Accounts controls for add, remove, and refresh usage
- split account detail rendering into a dedicated settings/accounts helper module with focused coverage