### PR TITLE
test(prompts): audit CLI references and align prompt contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ pm cockpit          # Open the main Textual cockpit
 pm ui               # Open the legacy control palette
 pm status           # System overview
 pm send operator …  # Send work to Polly
-pm down             # Shut everything down
+pm reset            # Shut everything down
 ```
 
 Usage is refreshed automatically in the background every 5 minutes. Run

--- a/src/pollypm/plugins_builtin/core_agent_profiles/profiles.py
+++ b/src/pollypm/plugins_builtin/core_agent_profiles/profiles.py
@@ -246,9 +246,10 @@ def worker_prompt() -> str:
         "1. `pm task claim <id>` — claim the task (starts the flow)\n"
         '2. `pm task context <id> "progress note"` — log what you\'re doing as you go\n'
         "3. Do the actual work: read code, write code, run tests, commit\n"
-        "4. When done: `pm task done <id> -o '<work-output-json>'`\n\n"
+        "4. When done: `pm task done <id> --output '<work-output-json>'`\n\n"
         "## Work output format (required when signaling done)\n"
-        "The --output/-o flag takes a JSON string describing what you did:\n"
+        "Use the spelled `--output` form in prompts and docs. It takes a "
+        "JSON string describing what you did:\n"
         "```json\n"
         '{"type": "code_change", "summary": "Implemented X by doing Y", '
         '"artifacts": [{"kind": "commit", "ref": "<hash>", "description": "commit message"}, '
@@ -282,8 +283,9 @@ def reviewer_prompt() -> str:
         "You run in your own tmux session managed by PollyPM. The heartbeat "
         "notifies you when tasks land at the `code_review` node. You read "
         "the diff, verify the acceptance criteria, and call approve or "
-        "reject. The stage transitions fire automatically from those CLI "
-        "calls — don't hand-hold.\n"
+        "reject. At `code_review`, `pm task approve` moves the task to "
+        "`done`, `pm task reject` sends it back to `implement`, and if "
+        "you emit neither command the task stays parked at `code_review`.\n"
         "</system>\n\n"
         "<operating_loop>\n"
         "Every turn:\n"

--- a/tests/test_prompt_command_references.py
+++ b/tests/test_prompt_command_references.py
@@ -1,0 +1,90 @@
+"""Audit `pm ...` command references across prompt/documentation surfaces."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from typer.main import get_command
+from typer.testing import CliRunner
+
+from pollypm.cli import app
+
+_PM_INLINE_RE = re.compile(r"`(pm[^`\n]+)`")
+_PM_LINE_RE = re.compile(r"^(?:[-*•]\s+)?(pm[^\n]+)$")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _prompt_command_surfaces() -> list[Path]:
+    repo_root = _repo_root()
+    builtin_profiles = sorted(
+        (repo_root / "src/pollypm/plugins_builtin").glob("*/profiles/*.md")
+    )
+    return [
+        repo_root / "README.md",
+        repo_root / "docs/worker-guide.md",
+        repo_root / "docs/getting-started.md",
+        repo_root / "src/pollypm/memory_prompts.py",
+        repo_root / "src/pollypm/recovery_prompt.py",
+        repo_root / "src/pollypm/plugins_builtin/core_agent_profiles/profiles.py",
+        *builtin_profiles,
+    ]
+
+
+def _resolve_command_path(command_text: str) -> tuple[str, ...] | None:
+    tokens = re.findall(r"[a-z][a-z0-9-]*", command_text)[1:]
+    if not tokens:
+        return ()
+    current = get_command(app)
+    resolved: list[str] = []
+    for token in tokens:
+        commands = getattr(current, "commands", None) or {}
+        next_command = commands.get(token)
+        if next_command is None:
+            break
+        resolved.append(token)
+        current = next_command
+    if not resolved:
+        return None
+    return tuple(resolved)
+
+
+def _extract_command_references(text: str) -> set[str]:
+    commands = set(_PM_INLINE_RE.findall(text))
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        match = _PM_LINE_RE.match(line)
+        if match:
+            command_text = match.group(1).split("#", 1)[0].strip()
+            if command_text:
+                commands.add(command_text)
+    return commands
+
+
+def test_prompt_command_references_resolve_against_real_cli() -> None:
+    runner = CliRunner()
+    repo_root = _repo_root()
+    broken: list[str] = []
+
+    for path in _prompt_command_surfaces():
+        text = path.read_text(encoding="utf-8")
+        commands = sorted(_extract_command_references(text))
+        for command_text in commands:
+            resolved = _resolve_command_path(command_text)
+            if resolved is None:
+                broken.append(
+                    f"{path.relative_to(repo_root)}: unknown `{command_text}`"
+                )
+                continue
+            help_args = ["--help"] if not resolved else [*resolved, "--help"]
+            result = runner.invoke(app, help_args)
+            if result.exit_code != 0:
+                broken.append(
+                    f"{path.relative_to(repo_root)}: `{command_text}` "
+                    f"help failed with exit {result.exit_code}"
+                )
+
+    assert not broken, "\n".join(broken)

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -16,6 +16,7 @@ from pollypm.storage.state import StateStore
 from pollypm.plugins_builtin.core_agent_profiles.profiles import heartbeat_prompt
 from pollypm.plugins_builtin.core_agent_profiles.profiles import polly_prompt as operator_prompt
 from pollypm.plugins_builtin.core_agent_profiles.profiles import triage_prompt
+from pollypm.plugins_builtin.core_agent_profiles.profiles import reviewer_prompt
 from pollypm.workers import auto_select_worker_account, suggest_worker_prompt
 from pollypm.plugins_builtin.core_agent_profiles.profiles import worker_prompt
 
@@ -205,6 +206,8 @@ def test_worker_prompt_requires_core_identity() -> None:
     assert "<identity>" in prompt
     assert "worker" in prompt.lower()
     assert "<principles>" in prompt
+    assert "--output" in prompt
+    assert " -o " not in prompt
 
 
 def test_operator_prompt_requires_delegation_instructions() -> None:
@@ -213,8 +216,9 @@ def test_operator_prompt_requires_delegation_instructions() -> None:
     assert "<identity>" in prompt
     assert "delegate" in prompt.lower()
     assert "pm" in prompt  # references pm commands
+    assert "pm inbox" in prompt
+    assert "pm mail" not in prompt
     assert "<principles>" in prompt
-
 
 def test_heartbeat_prompt_describes_recovery_protocol() -> None:
     prompt = heartbeat_prompt()
@@ -234,3 +238,12 @@ def test_triage_prompt_points_at_inbox_cli() -> None:
 
     assert "`pm inbox`" in prompt
     assert "`pm mail`" not in prompt
+
+
+def test_reviewer_prompt_states_code_review_gate_semantics() -> None:
+    prompt = reviewer_prompt()
+
+    assert "`code_review`" in prompt
+    assert "`done`" in prompt
+    assert "`implement`" in prompt
+    assert "stays parked at `code_review`" in prompt


### PR DESCRIPTION
Closes #490
Closes #489
Closes #481

## Summary
- add a prompt/doc surface test that resolves documented `pm ...` references against the real CLI
- replace stale `pm mail` and `pm down` references with current commands
- standardize worker prompt examples on `--output` and state reviewer gate semantics explicitly