### PR TITLE
fix(planning): align critic verdict contract

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/profiles/critic_maintainability.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/critic_maintainability.md
@@ -40,7 +40,7 @@ Emit structured JSON via `pm task done --output`:
           "hidden_coupling": ["modules X and Y share config key foo.bar"],
           "rot_risks": ["Playwright test asserts on CSS class names — will break on styling churn"],
           "six_month_concerns": "The Baz plugin contract has no versioning strategy",
-          "verdict": "approve_with_changes"
+          "verdict": "approved"
         }
       ],
       "preferred_candidate": "A",
@@ -51,5 +51,5 @@ Emit structured JSON via `pm task done --output`:
   }]
 }
 ```
-Scores are 1–10 (higher = more maintainable). Verdict is `approve`, `approve_with_changes`, or `reject`.
+Scores are 1–10 (higher = more maintainable). Verdict uses the work-service decision strings: `approved` or `rejected`. Put non-blocking follow-ups in the issue lists and `objections_for_risk_ledger`, not a third verdict value.
 </output_contract>

--- a/src/pollypm/plugins_builtin/project_planning/profiles/critic_operational.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/critic_operational.md
@@ -42,7 +42,7 @@ Emit structured JSON via `pm task done --output`:
           "debug_gaps": ["Module Bar logs nothing at module boundary"],
           "state_migration_risks": ["Foo's SQLite schema has no migration strategy"],
           "failure_modes_unaddressed": ["Bar crashes on malformed input"],
-          "verdict": "approve_with_changes"
+          "verdict": "approved"
         }
       ],
       "preferred_candidate": "A",
@@ -53,5 +53,5 @@ Emit structured JSON via `pm task done --output`:
   }]
 }
 ```
-Scores 1–10 (higher = more operable). Verdict: `approve`, `approve_with_changes`, `reject`.
+Scores 1–10 (higher = more operable). Verdict uses the work-service decision strings: `approved` or `rejected`. Put non-blocking follow-ups in the issue lists and `objections_for_risk_ledger`, not a third verdict value.
 </output_contract>

--- a/src/pollypm/plugins_builtin/project_planning/profiles/critic_security.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/critic_security.md
@@ -42,7 +42,7 @@ Emit structured JSON via `pm task done --output`:
           "input_validation_gaps": ["Module Foo parses JSON from disk without schema validation"],
           "secret_handling_issues": ["API key policy unspecified for Module Bar"],
           "threat_model_note": "Local-only single-user tool — limited external attack surface",
-          "verdict": "approve_with_changes"
+          "verdict": "approved"
         }
       ],
       "preferred_candidate": "A",
@@ -53,5 +53,5 @@ Emit structured JSON via `pm task done --output`:
   }]
 }
 ```
-Scores 1–10 (higher = more secure). Verdict: `approve`, `approve_with_changes`, `reject`.
+Scores 1–10 (higher = more secure). Verdict uses the work-service decision strings: `approved` or `rejected`. Put non-blocking follow-ups in the issue lists and `objections_for_risk_ledger`, not a third verdict value.
 </output_contract>

--- a/src/pollypm/plugins_builtin/project_planning/profiles/critic_simplicity.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/critic_simplicity.md
@@ -39,7 +39,7 @@ Emit structured JSON via `pm task done --output`:
           "score": 7,
           "over_engineered_pieces": ["FooRegistryFactory", "BarProtocol"],
           "scope_shrink_proposal": "Replace FooRegistryFactory with module-level dict",
-          "verdict": "approve_with_changes"
+          "verdict": "approved"
         }
       ],
       "preferred_candidate": "A",
@@ -50,5 +50,5 @@ Emit structured JSON via `pm task done --output`:
   }]
 }
 ```
-Scores are 1–10 (higher = simpler). Verdict is one of `approve`, `approve_with_changes`, `reject`.
+Scores are 1–10 (higher = simpler). Verdict uses the work-service decision strings: `approved` or `rejected`. Put non-blocking follow-ups in the issue lists and `objections_for_risk_ledger`, not a third verdict value.
 </output_contract>

--- a/src/pollypm/plugins_builtin/project_planning/profiles/critic_user.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/critic_user.md
@@ -42,7 +42,7 @@ Emit structured JSON via `pm task done --output`:
           "imagined_personas": ["'power users' in Module X — user is a single indie dev"],
           "invisible_magic": ["Auto-retry logic the user will never see trigger"],
           "first_run_gaps": "No zero-config path — user must set three env vars before first run",
-          "verdict": "approve_with_changes"
+          "verdict": "approved"
         }
       ],
       "preferred_candidate": "A",
@@ -53,5 +53,5 @@ Emit structured JSON via `pm task done --output`:
   }]
 }
 ```
-Scores 1–10 (higher = better user alignment). Verdict: `approve`, `approve_with_changes`, `reject`.
+Scores 1–10 (higher = better user alignment). Verdict uses the work-service decision strings: `approved` or `rejected`. Put non-blocking follow-ups in the issue lists and `objections_for_risk_ledger`, not a third verdict value.
 </output_contract>

--- a/tests/test_project_planning_plugin.py
+++ b/tests/test_project_planning_plugin.py
@@ -32,6 +32,10 @@ EXPECTED_PROFILES = (
     "critic_security",
 )
 
+CRITIC_PROFILES = tuple(
+    name for name in EXPECTED_PROFILES if name.startswith("critic_")
+)
+
 
 def test_project_planning_plugin_loads(tmp_path: Path) -> None:
     host = ExtensionHost(tmp_path)
@@ -86,6 +90,26 @@ def test_profile_file_exists_at_shipped_path(profile_name: str) -> None:
     # Frontmatter is YAML-ish and starts with ---
     assert text.startswith("---\n"), f"{profile_name} missing frontmatter"
     assert "preferred_providers" in text
+
+
+@pytest.mark.parametrize("profile_name", CRITIC_PROFILES)
+def test_critic_profile_verdict_contract_matches_work_service(profile_name: str) -> None:
+    from pollypm.work.models import Decision
+
+    root = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "pollypm"
+        / "plugins_builtin"
+        / "project_planning"
+        / "profiles"
+    )
+    text = (root / f"{profile_name}.md").read_text(encoding="utf-8")
+    accepted = tuple(decision.value for decision in Decision)
+
+    assert '"approve_with_changes"' not in text
+    for value in accepted:
+        assert f"`{value}`" in text
 
 
 # ---------------------------------------------------------------------------
@@ -525,8 +549,8 @@ def test_critic_verdict_from_payload() -> None:
     )
     payload = {
         "candidates": [
-            {"id": "A", "score": 8, "verdict": "approve"},
-            {"id": "B", "score": 6, "verdict": "approve_with_changes"},
+            {"id": "A", "score": 8, "verdict": "approved"},
+            {"id": "B", "score": 6, "verdict": "rejected"},
         ],
         "preferred_candidate": "A",
         "objections_for_risk_ledger": [


### PR DESCRIPTION
Closes #482

## Summary
- align critic prompt templates with the real work-service decision enum
- remove stale `approve_with_changes` examples from critic surfaces
- add coverage that keeps shipped critic profiles in sync with the accepted decision values