### PR TITLE
fix(memory): disclose truncated prompt recall

### DIFF
--- a/src/pollypm/memory_prompts.py
+++ b/src/pollypm/memory_prompts.py
@@ -189,9 +189,17 @@ def _render_injection(
     # a simple loop — the worst case is O(limit^2) entry renders, but
     # limit is small (default 15) so it's negligible.
     ordered = _flatten_for_budget(by_type)
+    total_entries = len(ordered)
 
     while True:
         rendered = _render_by_type(by_type)
+        shown_entries = sum(len(entries) for entries in by_type.values())
+        if shown_entries < total_entries:
+            rendered = _append_truncation_notice(
+                rendered,
+                shown_entries=shown_entries,
+                total_entries=total_entries,
+            )
         if len(rendered) <= budget_chars:
             return rendered
         if not ordered:
@@ -251,6 +259,23 @@ def _render_entry_bullet(entry: MemoryEntry) -> str:
     """
     raw = (entry.title or entry.body or "").strip()
     return " ".join(raw.split())
+
+
+def _append_truncation_notice(
+    rendered: str,
+    *,
+    shown_entries: int,
+    total_entries: int,
+) -> str:
+    if not rendered:
+        return rendered
+    notice = (
+        f"_[Memory truncated: {shown_entries} of {total_entries} entries shown. "
+        "Ask for more with `pm memory recall`.]_"
+    )
+    if rendered.endswith("\n"):
+        return f"{rendered}{notice}\n"
+    return f"{rendered}\n{notice}\n"
 
 
 def prepend_memory_injection(prompt: str, injection: str) -> str:

--- a/tests/test_memory_prompts.py
+++ b/tests/test_memory_prompts.py
@@ -232,6 +232,34 @@ def test_build_memory_injection_budget_override_works(seeded_backend: FileMemory
     assert len(tiny) <= 400
 
 
+def test_build_memory_injection_marks_when_entries_are_truncated(tmp_path: Path) -> None:
+    backend = FileMemoryBackend(tmp_path)
+    for i in range(12):
+        backend.write_entry(
+            ProjectMemory(
+                fact=f"Large fact {i:02d} " + ("z " * 80),
+                why="x " * 120,
+                how_to_apply="y " * 120,
+                scope="pollypm",
+                scope_tier="project",
+                importance=4,
+            )
+        )
+
+    injection = build_memory_injection(
+        backend,
+        user_id="operator",
+        project_name="pollypm",
+        task_context_summary="large corpus test",
+        limit=12,
+        budget_chars=300,
+    )
+
+    assert len(injection) <= 300
+    assert "Memory truncated:" in injection
+    assert "pm memory recall" in injection
+
+
 # ---------------------------------------------------------------------------
 # Importance filter — entries below the importance floor are excluded
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #483

## Summary
- append an explicit truncation note when memory injection drops entries for budget
- point agents at `pm memory recall` when they need more context
- add focused coverage for the truncated-output path