### PR TITLE
perf(work): add hot-path task indexes

### DIFF
--- a/src/pollypm/work/schema.py
+++ b/src/pollypm/work/schema.py
@@ -101,6 +101,10 @@ CREATE INDEX IF NOT EXISTS idx_work_tasks_assignee
     ON work_tasks(assignee)
     WHERE assignee IS NOT NULL;
 
+CREATE INDEX IF NOT EXISTS idx_work_tasks_active
+    ON work_tasks(current_node_id)
+    WHERE current_node_id IS NOT NULL;
+
 CREATE INDEX IF NOT EXISTS idx_work_tasks_priority
     ON work_tasks(priority, work_status);
 
@@ -124,6 +128,9 @@ CREATE TABLE IF NOT EXISTS work_task_dependencies (
 
 CREATE INDEX IF NOT EXISTS idx_work_deps_to
     ON work_task_dependencies(to_project, to_task_number);
+
+CREATE INDEX IF NOT EXISTS idx_work_deps_from
+    ON work_task_dependencies(from_project, from_task_number, kind);
 
 -- -------------------------------------------------------------------
 -- Flow node executions
@@ -326,6 +333,21 @@ _WORK_MIGRATIONS: list[tuple[int, str, list[str]]] = [
             """
             CREATE INDEX IF NOT EXISTS idx_notification_staging_created
                 ON notification_staging(created_at)
+            """,
+        ],
+    ),
+    (
+        5,
+        "Add hot-path indexes for active-task and dependency-from queries",
+        [
+            """
+            CREATE INDEX IF NOT EXISTS idx_work_tasks_active
+                ON work_tasks(current_node_id)
+                WHERE current_node_id IS NOT NULL
+            """,
+            """
+            CREATE INDEX IF NOT EXISTS idx_work_deps_from
+                ON work_task_dependencies(from_project, from_task_number, kind)
             """,
         ],
     ),

--- a/tests/test_work_schema.py
+++ b/tests/test_work_schema.py
@@ -206,6 +206,15 @@ def _indexes(conn: sqlite3.Connection) -> set[str]:
     return {row[0] for row in cur.fetchall()}
 
 
+def _index_sql(conn: sqlite3.Connection, name: str) -> str:
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name = ?",
+        (name,),
+    ).fetchone()
+    assert row is not None and row[0] is not None
+    return row[0]
+
+
 class TestIndexes:
     def test_key_indexes_exist(self, conn):
         create_work_tables(conn)
@@ -214,11 +223,44 @@ class TestIndexes:
             "idx_work_tasks_status",
             "idx_work_tasks_project_status",
             "idx_work_tasks_assignee",
+            "idx_work_tasks_active",
             "idx_work_tasks_priority",
             "idx_work_deps_to",
+            "idx_work_deps_from",
             "idx_work_exec_task",
             "idx_work_context_task",
             "idx_work_transitions_task",
         }
         for name in expected:
             assert name in idxs, f"Missing index: {name}"
+
+    def test_active_tasks_index_is_partial(self, conn):
+        create_work_tables(conn)
+        sql = _index_sql(conn, "idx_work_tasks_active")
+        assert "current_node_id" in sql
+        assert "WHERE current_node_id IS NOT NULL" in sql
+
+
+def test_legacy_db_gets_hot_query_indexes_and_schema_bump(conn):
+    conn.executescript(
+        """
+        CREATE TABLE work_schema_version (
+            version INTEGER NOT NULL,
+            description TEXT NOT NULL,
+            applied_at TEXT NOT NULL
+        );
+        INSERT INTO work_schema_version (version, description, applied_at)
+        VALUES (4, 'old', '2026-01-01T00:00:00+00:00');
+        """
+    )
+
+    create_work_tables(conn)
+
+    idxs = _indexes(conn)
+    assert "idx_work_tasks_active" in idxs
+    assert "idx_work_deps_from" in idxs
+
+    version = conn.execute(
+        "SELECT COALESCE(MAX(version), 0) FROM work_schema_version"
+    ).fetchone()[0]
+    assert version == 5


### PR DESCRIPTION
Closes #461

## Summary
- add the missing active-task and dependency-from indexes to the work schema
- record the new work schema head so legacy DBs stop reading as behind after bootstrap
- cover the fresh-schema and legacy-upgrade paths in schema tests

## Testing
- HOME=/tmp/pytest-461 uv run --extra dev pytest tests/test_work_schema.py tests/test_doctor.py -q