### PR TITLE
perf(work): collapse next-task blocker queries

### DIFF
--- a/src/pollypm/work/service_queries.py
+++ b/src/pollypm/work/service_queries.py
@@ -227,12 +227,42 @@ def update_task(service: "SQLiteWorkService", task_id: str, **fields: object) ->
     return task
 
 
+def _unresolved_blocked_task_keys(
+    service: "SQLiteWorkService",
+    *,
+    project: str | None = None,
+) -> set[tuple[str, int]]:
+    clauses = [
+        "d.kind = ?",
+        "t.work_status NOT IN (?, ?)",
+    ]
+    params: list[object] = [
+        "blocks",
+        WorkStatus.DONE.value,
+        WorkStatus.CANCELLED.value,
+    ]
+    if project is not None:
+        clauses.append("d.to_project = ?")
+        params.append(project)
+    rows = service._conn.execute(
+        "SELECT DISTINCT d.to_project, d.to_task_number "
+        "FROM work_task_dependencies d "
+        "JOIN work_tasks t "
+        "  ON t.project = d.from_project "
+        " AND t.task_number = d.from_task_number "
+        f"WHERE {' AND '.join(clauses)}",
+        params,
+    ).fetchall()
+    return {(row["to_project"], row["to_task_number"]) for row in rows}
+
+
 def next_task(
     service: "SQLiteWorkService",
     *,
     agent: str | None = None,
     project: str | None = None,
 ) -> Task | None:
+    blocked_keys = _unresolved_blocked_task_keys(service, project=project)
     clauses = ["t.work_status = ?"]
     params: list[object] = [WorkStatus.QUEUED.value]
     if project is not None:
@@ -254,12 +284,12 @@ def next_task(
     )
     rows = service._conn.execute(sql, params).fetchall()
     for row in rows:
-        task = service._row_to_task(row)
-        if service._has_unresolved_blockers(task.task_id):
+        task_key = (row["project"], row["task_number"])
+        if task_key in blocked_keys:
             continue
-        if agent is not None and task.roles.get("worker") != agent:
+        if agent is not None and json.loads(row["roles"]).get("worker") != agent:
             continue
-        return task
+        return service._row_to_task(row)
     return None
 
 

--- a/tests/test_work_queries.py
+++ b/tests/test_work_queries.py
@@ -123,6 +123,62 @@ class TestNext:
         _create_task(svc, title="Draft task")
         assert svc.next() is None
 
+    def test_next_does_not_call_per_task_blocker_lookup(self, svc, monkeypatch):
+        blocker = _create_task(svc, title="Blocker")
+        blocked = _create_task(svc, title="Blocked")
+        winner = _create_task(svc, title="Winner")
+
+        _queue_task(svc, blocked)
+        _queue_task(svc, winner)
+        svc.link(blocker.task_id, blocked.task_id, "blocks")
+
+        def _fail(_: str) -> bool:
+            raise AssertionError("next() should not call per-task blocker lookups")
+
+        monkeypatch.setattr(svc, "_has_unresolved_blockers", _fail)
+
+        result = svc.next()
+        assert result is not None
+        assert result.task_id == winner.task_id
+
+    def test_next_hydrates_only_selected_matching_task(self, svc, monkeypatch):
+        blocker = _create_task(svc, title="Blocker")
+        blocked = _create_task(
+            svc,
+            title="Blocked",
+            roles={"worker": "alice", "reviewer": "reviewer"},
+        )
+        wrong_agent = _create_task(
+            svc,
+            title="Wrong Agent",
+            roles={"worker": "bob", "reviewer": "reviewer"},
+        )
+        winner = _create_task(
+            svc,
+            title="Winner",
+            roles={"worker": "alice", "reviewer": "reviewer"},
+        )
+
+        _queue_task(svc, blocked)
+        _queue_task(svc, wrong_agent)
+        _queue_task(svc, winner)
+        svc.link(blocker.task_id, blocked.task_id, "blocks")
+
+        original = svc._row_to_task
+        hydrate_calls = 0
+
+        def _counting_row_to_task(*args, **kwargs):
+            nonlocal hydrate_calls
+            hydrate_calls += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(svc, "_row_to_task", _counting_row_to_task)
+
+        result = svc.next(agent="alice")
+        assert result is not None
+        assert result.task_id == winner.task_id
+        assert hydrate_calls == 1
+
 
 # ---------------------------------------------------------------------------
 # my_tasks() tests


### PR DESCRIPTION
Closes #457

## Summary
- precompute queued tasks blocked by unresolved dependencies in one joined query
- cheap-filter queued rows by blocker set and worker role before hydration
- add regression tests to prevent per-task blocker lookups and extra hydration

## Testing
- HOME=/tmp/pytest-457 uv run --extra dev pytest tests/test_work_queries.py -q