### PR TITLE
docs(plugins): warn on third-party trust boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ plugin = PollyPMPlugin(
 )
 ```
 
-The plugin host discovers plugins from four sources (precedence low → high): built-in, Python entry_points under `pollypm.plugins`, user-global `~/.pollypm/plugins/`, and project-local `<project>/.pollypm/plugins/`. See [docs/plugin-discovery-spec.md](docs/plugin-discovery-spec.md) for the full specification, [docs/plugin-authoring.md](docs/plugin-authoring.md) for a from-scratch walkthrough, and [docs/plugin-boundaries.md](docs/plugin-boundaries.md) for boundary contracts between plugins.
+The plugin host discovers plugins from four sources (precedence low → high): built-in, Python entry_points under `pollypm.plugins`, user-global `~/.pollypm/plugins/`, and project-local `<project>/.pollypm/plugins/`. Third-party plugins and provider packages are not sandboxed; see [docs/plugin-trust.md](docs/plugin-trust.md) before installing one. For the full specification, see [docs/plugin-discovery-spec.md](docs/plugin-discovery-spec.md), [docs/plugin-authoring.md](docs/plugin-authoring.md), and [docs/plugin-boundaries.md](docs/plugin-boundaries.md).
 
 ## Session Roles
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@ and working design docs. If you are not sure where to start, start here:
   sessions.
 - [Plugin Authoring](plugin-authoring.md) — the shortest path to building and
   testing a PollyPM plugin.
+- [Plugin Trust Model](plugin-trust.md) — what installing a third-party
+  plugin or provider means in v1.
 
 ## User
 
@@ -30,6 +32,8 @@ and working design docs. If you are not sure where to start, start here:
 
 - [Plugin Authoring](plugin-authoring.md) — end-to-end walkthrough for writing,
   testing, and installing a plugin.
+- [Plugin Trust Model](plugin-trust.md) — the security boundary for external
+  plugins and provider packages.
 - [Provider Plugin SDK](provider-plugin-sdk.md) — stable adapter surface for
   adding a new CLI provider.
 - [Plugin Discovery Spec](plugin-discovery-spec.md) — manifests, capabilities,

--- a/docs/plugin-trust.md
+++ b/docs/plugin-trust.md
@@ -1,0 +1,3 @@
+# Plugin Trust Model
+
+PollyPM plugins, provider packages, and other extension entry points run in-process with the same user privileges as PollyPM itself. A third-party extension can read and write your files, inspect PollyPM state, spawn subprocesses, access the network, and change runtime behavior or prompts. PollyPM v1 does not sandbox, sign, or capability-restrict extensions, so only install plugins and providers you trust and review them like any other code dependency.

--- a/src/pollypm/acct/registry.py
+++ b/src/pollypm/acct/registry.py
@@ -20,8 +20,18 @@ from functools import lru_cache
 
 from .errors import ProviderNotFound
 from .protocol import ProviderAdapter
+from pollypm.plugin_trust import warn_third_party_extension_trust_once
 
 _ENTRY_POINT_GROUP = "pollypm.provider"
+
+
+def _is_builtin_provider_entry_point(ep: importlib.metadata.EntryPoint) -> bool:
+    """Return True when ``ep`` resolves to a PollyPM-shipped provider."""
+    module_name = getattr(ep, "module", None)
+    if not module_name:
+        value = getattr(ep, "value", "")
+        module_name = str(value).split(":", 1)[0]
+    return str(module_name).startswith("pollypm.")
 
 
 def _entry_points() -> list[importlib.metadata.EntryPoint]:
@@ -34,7 +44,10 @@ def _entry_points() -> list[importlib.metadata.EntryPoint]:
     # ``entry_points()`` returns an ``EntryPoints`` selectable view on
     # 3.10+ but iterating it yields ``EntryPoint``s — normalize to a
     # list so callers can cheaply len()/sort() the result.
-    return list(eps)
+    normalized = list(eps)
+    if any(not _is_builtin_provider_entry_point(ep) for ep in normalized):
+        warn_third_party_extension_trust_once()
+    return normalized
 
 
 @lru_cache(maxsize=None)

--- a/src/pollypm/defaults/docs/reference/plugins.md
+++ b/src/pollypm/defaults/docs/reference/plugins.md
@@ -2,6 +2,8 @@
 
 PollyPM uses a file-based plugin system. Plugins are directories containing a manifest (`pollypm-plugin.toml`) and a Python module. No pip install required — just drop the directory in the right location.
 
+Third-party plugins and provider packages are not sandboxed. They run with the same user privileges as PollyPM, so only install code you trust.
+
 ## Plugin Types
 
 | Type | What it provides | Example |

--- a/src/pollypm/plugin_host.py
+++ b/src/pollypm/plugin_host.py
@@ -40,6 +40,7 @@ from pollypm.plugin_api.v1 import (
     RosterAPI,
     check_requires_api,
 )
+from pollypm.plugin_trust import warn_third_party_extension_trust_once
 
 logger = logging.getLogger(__name__)
 
@@ -620,7 +621,12 @@ class ExtensionHost:
 
         # "repo" is a legacy alias for "project" used by older tests; we
         # accept both so internal call sites can transition gradually.
-        for manifest in self._discover_directory_manifests(sources=("user", "project", "repo")):
+        external_manifests = self._discover_directory_manifests(
+            sources=("user", "project", "repo"),
+        )
+        if external_manifests:
+            warn_third_party_extension_trust_once()
+        for manifest in external_manifests:
             _install_from_manifest(manifest)
 
         self._plugin_sources = sources  # exposed for doctor / CLI later
@@ -677,6 +683,8 @@ class ExtensionHost:
         except Exception as exc:  # noqa: BLE001
             self.errors.append(f"Failed to enumerate pollypm.plugins entry points: {exc}")
             return found
+        if eps:
+            warn_third_party_extension_trust_once()
         for ep in eps:
             try:
                 obj = ep.load()

--- a/src/pollypm/plugin_trust.py
+++ b/src/pollypm/plugin_trust.py
@@ -1,0 +1,24 @@
+"""Shared trust notice for third-party PollyPM extensions."""
+
+from __future__ import annotations
+
+import sys
+
+_THIRD_PARTY_EXTENSION_WARNING_EMITTED = False
+_THIRD_PARTY_EXTENSION_WARNING = (
+    "Warning: third-party PollyPM plugins and providers run with full user "
+    "privileges; review code before installing. See docs/plugin-trust.md."
+)
+
+
+def warn_third_party_extension_trust_once() -> bool:
+    """Print the third-party extension trust warning once per process."""
+    global _THIRD_PARTY_EXTENSION_WARNING_EMITTED
+    if _THIRD_PARTY_EXTENSION_WARNING_EMITTED:
+        return False
+    _THIRD_PARTY_EXTENSION_WARNING_EMITTED = True
+    print(_THIRD_PARTY_EXTENSION_WARNING, file=sys.stderr)
+    return True
+
+
+__all__ = ["warn_third_party_extension_trust_once"]

--- a/tests/test_acct_substrate.py
+++ b/tests/test_acct_substrate.py
@@ -87,6 +87,47 @@ def test_list_providers_returns_sorted_names():
     assert set(providers) >= {"claude", "codex"}
 
 
+def test_external_provider_entry_points_emit_trust_warning_once(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "pollypm.plugin_trust._THIRD_PARTY_EXTENSION_WARNING_EMITTED", False,
+    )
+
+    class FakeEntryPoint:
+        name = "external-provider"
+        value = "external_pkg.provider:ExternalProvider"
+
+    monkeypatch.setattr(
+        "pollypm.acct.registry.importlib.metadata.entry_points",
+        lambda *, group: [FakeEntryPoint()],
+    )
+
+    assert list_providers() == ["external-provider"]
+    assert "full user privileges" in capsys.readouterr().err
+
+    assert list_providers() == ["external-provider"]
+    assert capsys.readouterr().err == ""
+
+
+def test_builtin_provider_entry_points_do_not_emit_trust_warning(
+    monkeypatch, capsys,
+):
+    monkeypatch.setattr(
+        "pollypm.plugin_trust._THIRD_PARTY_EXTENSION_WARNING_EMITTED", False,
+    )
+
+    class FakeEntryPoint:
+        name = "claude"
+        value = "pollypm.providers.claude:ClaudeProvider"
+
+    monkeypatch.setattr(
+        "pollypm.acct.registry.importlib.metadata.entry_points",
+        lambda *, group: [FakeEntryPoint()],
+    )
+
+    assert list_providers() == ["claude"]
+    assert capsys.readouterr().err == ""
+
+
 def test_get_provider_caches_instances():
     """Repeated ``get_provider()`` calls return the same instance."""
     first = get_provider("claude")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -598,6 +598,32 @@ def test_entry_point_plugin_with_wrong_api_version_skipped(monkeypatch, tmp_path
     assert any("API version 99" in e for e in host.errors)
 
 
+def test_external_plugin_discovery_emits_trust_warning_once(
+    monkeypatch, tmp_path: Path, capsys,
+) -> None:
+    monkeypatch.setattr(
+        "pollypm.plugin_trust._THIRD_PARTY_EXTENSION_WARNING_EMITTED", False,
+    )
+    plugin_dir = tmp_path / ".pollypm" / "plugins" / "hello"
+    _write_plugin(
+        plugin_dir,
+        name="hello",
+        body=(
+            "from pollypm.plugin_api.v1 import PollyPMPlugin\n"
+            "plugin = PollyPMPlugin(name='hello')\n"
+        ),
+        capabilities=(),
+    )
+
+    host = ExtensionHost(tmp_path)
+    assert "hello" in host.plugins()
+    assert "full user privileges" in capsys.readouterr().err
+
+    host = ExtensionHost(tmp_path)
+    host.plugins()
+    assert capsys.readouterr().err == ""
+
+
 # ---------------------------------------------------------------------------
 # Issue #169 — content_paths(plugin, kind) helper
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #496

## Summary
- add a shared trust warning for third-party plugin and provider discovery
- document the trust model in dedicated plugin docs and link it from front-door docs
- cover both plugin and provider discovery paths with tests

## Testing
- uv run --with pytest pytest tests/test_plugins.py tests/test_acct_substrate.py