### PR TITLE
perf(activity): avoid duplicate feed scans

### DIFF
--- a/src/pollypm/cockpit_activity.py
+++ b/src/pollypm/cockpit_activity.py
@@ -338,6 +338,8 @@ class PollyActivityFeedApp(App[None]):
         return count
 
     def _render(self) -> None:
+        filtered_entries = self._filtered_entries()
+        events_last_24h = self._events_in_last_24h()
         title_bits = ["[b #eef6ff]Activity[/b #eef6ff]"]
         if self._filter_project:
             title_bits.append(
@@ -346,7 +348,7 @@ class PollyActivityFeedApp(App[None]):
         self.topbar.update("  ".join(title_bits))
 
         chips: list[str] = [
-            f"[b]{self._events_in_last_24h()}[/b] [dim]event{'s' if self._events_in_last_24h() != 1 else ''} in last 24h[/dim]"
+            f"[b]{events_last_24h}[/b] [dim]event{'s' if events_last_24h != 1 else ''} in last 24h[/dim]"
         ]
         filter_description = self._describe_filters()
         if filter_description:
@@ -356,7 +358,7 @@ class PollyActivityFeedApp(App[None]):
         )
         self.counters.update("  \u00b7  ".join(chips))
 
-        self._render_table()
+        self._render_table(filtered_entries)
         if self._open_entry_id is not None:
             self._render_detail()
         else:
@@ -374,9 +376,9 @@ class PollyActivityFeedApp(App[None]):
         else:
             self.hint.update(self._DEFAULT_HINT)
 
-    def _render_table(self) -> None:
+    def _render_table(self, rows: list) -> None:
         self.table.clear()
-        for entry in self._filtered_entries():
+        for entry in rows:
             time_text = Text(_format_activity_relative(entry.timestamp), style="#97a6b2")
             project_label = entry.project or "\u2014"
             if self._filter_project and (entry.project or "") == self._filter_project:

--- a/tests/test_activity_feed_ui.py
+++ b/tests/test_activity_feed_ui.py
@@ -239,6 +239,48 @@ def test_fuzzy_filter_matches_actor_and_summary(
     _run(body())
 
 
+def test_render_scans_filtered_rows_only_once_per_render(
+    activity_env, activity_app, monkeypatch,
+) -> None:
+    """The counters/table path should not rescan the same in-memory window."""
+
+    async def body() -> None:
+        entries = [
+            _make_entry(entry_id="evt:1", summary="one"),
+            _make_entry(entry_id="evt:2", summary="two"),
+        ]
+        activity_app._gather = lambda: entries  # type: ignore[method-assign]
+
+        filtered_calls = 0
+        last_24h_calls = 0
+        original_filtered = activity_app._filtered_entries
+        original_last_24h = activity_app._events_in_last_24h
+
+        def _count_filtered():
+            nonlocal filtered_calls
+            filtered_calls += 1
+            return original_filtered()
+
+        def _count_last_24h():
+            nonlocal last_24h_calls
+            last_24h_calls += 1
+            return original_last_24h()
+
+        monkeypatch.setattr(activity_app, "_filtered_entries", _count_filtered)
+        monkeypatch.setattr(activity_app, "_events_in_last_24h", _count_last_24h)
+
+        async with activity_app.run_test(size=(160, 40)) as pilot:
+            await pilot.pause()
+            filtered_calls = 0
+            last_24h_calls = 0
+            activity_app._render()
+            await pilot.pause()
+            assert filtered_calls == 1
+            assert last_24h_calls == 1
+
+    _run(body())
+
+
 # ---------------------------------------------------------------------------
 # 4. Follow mode toggles + refreshes.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #465

## Summary
- compute the filtered activity rows and 24h counter once per render
- pass the prefiltered rows into table rendering instead of rescanning
- add a UI regression test to enforce the single-pass render behavior

## Testing
- HOME=/tmp/pytest-465 uv run --extra dev pytest tests/test_activity_feed_ui.py -q