### PR TITLE
perf(cockpit): cache dashboard refreshes off-thread

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -1263,6 +1263,10 @@ class PollyDashboardApp(App[None]):
         self.chart_title = Static("[b]Tokens[/b]", classes="section-title", markup=True)
         self.chart_body = Static("", classes="chart-section", markup=True)
         self.footer_w = Static("", classes="footer", markup=True)
+        self._dashboard_config = None
+        self._dashboard_data = None
+        self._refresh_running = False
+        self._refresh_error: str | None = None
 
     def compose(self) -> ComposeResult:
         yield self.header_w
@@ -1288,19 +1292,49 @@ class PollyDashboardApp(App[None]):
         return f"{int(seconds // 86400)}d ago"
 
     def _refresh(self) -> None:
-        try:
-            from pollypm.dashboard_data import gather
-            config = load_config(self.config_path)
-            from pollypm.storage.state import StateStore
-            store = StateStore(config.project.state_db)
-            try:
-                data = gather(config, store)
-            finally:
-                store.close()
-        except Exception as exc:  # noqa: BLE001
-            self.header_w.update(f"[dim]Error: {exc}[/dim]")
+        self._render_cached_dashboard()
+        if self._refresh_running:
             return
+        self._refresh_running = True
+        self.run_worker(
+            self._refresh_dashboard_sync,
+            thread=True,
+            exclusive=True,
+            group="polly_dashboard_refresh",
+        )
 
+    def _render_cached_dashboard(self) -> None:
+        if self._dashboard_config is not None and self._dashboard_data is not None:
+            self._render_dashboard(self._dashboard_config, self._dashboard_data)
+            return
+        if self._refresh_error:
+            self.header_w.update(f"[dim]Error: {_escape(self._refresh_error)}[/dim]")
+            return
+        self.header_w.update("[dim]Loading dashboard…[/dim]")
+
+    def _refresh_dashboard_sync(self) -> None:
+        try:
+            from pollypm.dashboard_data import load_dashboard
+
+            config, data = load_dashboard(self.config_path)
+        except Exception as exc:  # noqa: BLE001
+            self.call_from_thread(self._finish_dashboard_refresh_error, str(exc))
+            return
+        self.call_from_thread(self._finish_dashboard_refresh_success, config, data)
+
+    def _finish_dashboard_refresh_success(self, config, data) -> None:
+        self._dashboard_config = config
+        self._dashboard_data = data
+        self._refresh_running = False
+        self._refresh_error = None
+        self._render_dashboard(config, data)
+
+    def _finish_dashboard_refresh_error(self, error: str) -> None:
+        self._refresh_running = False
+        self._refresh_error = error
+        self._render_cached_dashboard()
+
+    def _render_dashboard(self, config, data) -> None:
         # ── Header ──
         parts = [f"[b]{len(config.projects)}[/b] projects", f"[b]{len(config.sessions)}[/b] agents"]
         if data.inbox_count:
@@ -1405,11 +1439,15 @@ class PollyDashboardApp(App[None]):
             self.chart_body.update("[dim]No token data yet[/dim]")
 
         # ── Footer ──
-        self.footer_w.update(
+        footer = (
             "[dim]Click Polly to connect  \u00b7  "
             f"{data.sweep_count_24h} sweeps today  \u00b7  "
-            f"{data.message_count_24h} messages[/dim]"
+            f"{data.message_count_24h} messages"
         )
+        if self._refresh_error:
+            footer += "  \u00b7  stale cache"
+        footer += "[/dim]"
+        self.footer_w.update(footer)
 
 
 class PollyCockpitPaneApp(App[None]):

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+from pollypm.config import load_config
 from pollypm.config import PollyPMConfig
 from pollypm.storage.state import StateStore
 
@@ -202,6 +203,17 @@ def _count_inbox_tasks(config: PollyPMConfig) -> int:
         except Exception:  # noqa: BLE001
             continue
     return total
+
+
+def load_dashboard(config_path: Path) -> tuple[PollyPMConfig, DashboardData]:
+    """Load config + state store and gather one blocking dashboard snapshot."""
+    config = load_config(config_path)
+    store = StateStore(config.project.state_db)
+    try:
+        data = gather(config, store)
+    finally:
+        store.close()
+    return config, data
 
 
 def gather(config: PollyPMConfig, store: StateStore) -> DashboardData:

--- a/tests/test_polly_dashboard_ui.py
+++ b/tests/test_polly_dashboard_ui.py
@@ -1,0 +1,105 @@
+"""Focused tests for the async Polly dashboard refresh path (#464)."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+from pollypm.cockpit_ui import PollyDashboardApp
+from pollypm.dashboard_data import DashboardData, load_dashboard
+
+
+def _run(coro) -> None:
+    asyncio.run(coro)
+
+
+def _fake_dashboard_data() -> DashboardData:
+    return DashboardData(
+        active_sessions=[],
+        recent_commits=[],
+        completed_items=[],
+        daily_tokens=[],
+        today_tokens=0,
+        total_tokens=0,
+        sweep_count_24h=0,
+        message_count_24h=0,
+        recovery_count_24h=0,
+        inbox_count=0,
+        alert_count=0,
+    )
+
+
+def _fake_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        projects={"demo": object()},
+        sessions={"operator": object()},
+    )
+
+
+def test_load_dashboard_closes_store(monkeypatch, tmp_path: Path) -> None:
+    closed: list[bool] = []
+    sentinel_config = SimpleNamespace(project=SimpleNamespace(state_db=tmp_path / "state.db"))
+    sentinel_data = _fake_dashboard_data()
+
+    class FakeStore:
+        def __init__(self, db_path: Path) -> None:
+            self.db_path = db_path
+
+        def close(self) -> None:
+            closed.append(True)
+
+    monkeypatch.setattr("pollypm.dashboard_data.load_config", lambda path: sentinel_config)
+    monkeypatch.setattr("pollypm.dashboard_data.StateStore", FakeStore)
+    monkeypatch.setattr("pollypm.dashboard_data.gather", lambda config, store: sentinel_data)
+
+    config, data = load_dashboard(tmp_path / "pollypm.toml")
+
+    assert config is sentinel_config
+    assert data is sentinel_data
+    assert closed == [True]
+
+
+def test_polly_dashboard_refresh_runs_in_worker_thread(monkeypatch, tmp_path: Path) -> None:
+    thread_ids: list[int] = []
+    main_thread_id = threading.main_thread().ident
+
+    def fake_load_dashboard(config_path: Path):
+        thread_ids.append(threading.get_ident())
+        return _fake_config(), _fake_dashboard_data()
+
+    monkeypatch.setattr("pollypm.dashboard_data.load_dashboard", fake_load_dashboard)
+    monkeypatch.setattr("pollypm.cockpit_ui._setup_alert_notifier", lambda *args, **kwargs: None)
+
+    async def body() -> None:
+        app = PollyDashboardApp(tmp_path / "pollypm.toml")
+        async with app.run_test(size=(120, 30)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            assert app._dashboard_data is not None
+            assert thread_ids
+            assert all(tid != main_thread_id for tid in thread_ids)
+
+    _run(body())
+
+
+def test_polly_dashboard_refresh_error_keeps_cached_snapshot(monkeypatch, tmp_path: Path) -> None:
+    app = PollyDashboardApp(tmp_path / "pollypm.toml")
+    config = _fake_config()
+    data = _fake_dashboard_data()
+    rendered: list[tuple[object, object]] = []
+
+    app._finish_dashboard_refresh_success(config, data)
+    monkeypatch.setattr(
+        app,
+        "_render_dashboard",
+        lambda cfg, snapshot: rendered.append((cfg, snapshot)),
+    )
+
+    app._finish_dashboard_refresh_error("boom")
+
+    assert app._dashboard_config is config
+    assert app._dashboard_data is data
+    assert app._refresh_error == "boom"
+    assert rendered == [(config, data)]


### PR DESCRIPTION
Closes #464

## Summary
- move blocking dashboard data collection off the Textual UI thread
- render from the last-known cached snapshot while refreshes run or fail
- cover worker-thread refresh and cached-error fallback behavior with focused tests

## Testing
- uv run --with pytest pytest tests/test_polly_dashboard_ui.py