### PR TITLE
fix(work): filter my_tasks by assignee

### DIFF
--- a/src/pollypm/work/service_queries.py
+++ b/src/pollypm/work/service_queries.py
@@ -265,14 +265,12 @@ def next_task(
 
 def my_tasks(service: "SQLiteWorkService", agent: str) -> list[Task]:
     rows = service._conn.execute(
-        "SELECT * FROM work_tasks WHERE current_node_id IS NOT NULL",
+        "SELECT * FROM work_tasks "
+        "WHERE current_node_id IS NOT NULL AND assignee = ? "
+        "ORDER BY project, task_number",
+        (agent,),
     ).fetchall()
-    result: list[Task] = []
-    for row in rows:
-        task = service._row_to_task(row)
-        if service.derive_owner(task) == agent:
-            result.append(task)
-    return result
+    return [service._row_to_task(row) for row in rows]
 
 
 def state_counts(service: "SQLiteWorkService", project: str | None = None) -> dict[str, int]:

--- a/src/pollypm/work/service_transitions.py
+++ b/src/pollypm/work/service_transitions.py
@@ -77,11 +77,19 @@ def advance_to_node(
     new_status = (
         WorkStatus.REVIEW if next_node.type == NodeType.REVIEW else WorkStatus.IN_PROGRESS
     )
+    next_assignee = service._resolve_node_assignee(task, next_node)
     visit = next_visit(service, task.project, task.task_number, next_node_id)
     service._conn.execute(
-        "UPDATE work_tasks SET work_status = ?, current_node_id = ?, updated_at = ? "
+        "UPDATE work_tasks SET work_status = ?, assignee = ?, current_node_id = ?, updated_at = ? "
         "WHERE project = ? AND task_number = ?",
-        (new_status.value, next_node_id, now, task.project, task.task_number),
+        (
+            new_status.value,
+            next_assignee,
+            next_node_id,
+            now,
+            task.project,
+            task.task_number,
+        ),
     )
     service._conn.execute(
         "INSERT INTO work_node_executions "

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -723,6 +723,25 @@ class SQLiteWorkService:
     # Owner derivation
     # ------------------------------------------------------------------
 
+    def _resolve_node_assignee(
+        self, task: Task, node: FlowNode | None
+    ) -> str | None:
+        """Return the effective owner for ``node`` using ``task`` roles."""
+        if node is None:
+            return task.assignee
+
+        if node.actor_type == ActorType.ROLE:
+            return task.roles.get(node.actor_role or "", task.assignee)
+        if node.actor_type == ActorType.HUMAN:
+            return "human"
+        if node.actor_type == ActorType.PROJECT_MANAGER:
+            return "project_manager"
+        if node.actor_type == ActorType.AGENT:
+            # Fall back to the prior assignee only for legacy rows that
+            # predate stricter flow validation.
+            return node.agent_name or task.assignee
+        return task.assignee
+
     def derive_owner(self, task: Task) -> str | None:
         """Derive the current owner from the flow node's actor configuration."""
         if task.current_node_id is None:
@@ -742,18 +761,7 @@ class SQLiteWorkService:
         if node is None:
             return task.assignee
 
-        if node.actor_type == ActorType.ROLE:
-            return task.roles.get(node.actor_role or "", task.assignee)
-        elif node.actor_type == ActorType.HUMAN:
-            return "human"
-        elif node.actor_type == ActorType.PROJECT_MANAGER:
-            return "project_manager"
-        elif node.actor_type == ActorType.AGENT:
-            # Return the specific named agent from the flow YAML. Fall back
-            # to the assignee only if no agent_name was configured (which
-            # validate_flow now rejects, but guard anyway for legacy DBs).
-            return node.agent_name or task.assignee
-        return task.assignee
+        return self._resolve_node_assignee(task, node)
 
     # ------------------------------------------------------------------
     # Task CRUD
@@ -955,6 +963,8 @@ class SQLiteWorkService:
             task.flow_template_id, task.flow_template_version,
         )
         start_node = flow.start_node
+        start_node_cfg = flow.nodes.get(start_node)
+        assignee = self._resolve_node_assignee(task, start_node_cfg) or actor
         now = _now()
 
         try:
@@ -965,7 +975,7 @@ class SQLiteWorkService:
                 "WHERE project = ? AND task_number = ?",
                 (
                     WorkStatus.IN_PROGRESS.value,
-                    actor,
+                    assignee,
                     start_node,
                     now,
                     task.project,
@@ -1682,12 +1692,14 @@ class SQLiteWorkService:
             next_visit = max_visit_row["max_v"] + 1
 
             # Set status back to in_progress at the reject target
+            reject_assignee = self._resolve_node_assignee(task, reject_target)
             self._conn.execute(
-                "UPDATE work_tasks SET work_status = ?, "
+                "UPDATE work_tasks SET work_status = ?, assignee = ?, "
                 "current_node_id = ?, updated_at = ? "
                 "WHERE project = ? AND task_number = ?",
                 (
                     WorkStatus.IN_PROGRESS.value,
+                    reject_assignee,
                     node.reject_node_id,
                     now,
                     task.project,

--- a/tests/test_work_queries.py
+++ b/tests/test_work_queries.py
@@ -40,6 +40,14 @@ def _queue_task(svc, task):
     return svc.queue(task.task_id, "tester")
 
 
+def _work_output_payload(summary="done"):
+    return {
+        "type": "code_change",
+        "summary": summary,
+        "artifacts": [{"kind": "note", "description": summary}],
+    }
+
+
 # ---------------------------------------------------------------------------
 # next() tests
 # ---------------------------------------------------------------------------
@@ -151,6 +159,82 @@ class TestMyTasks:
         bob_tasks = svc.my_tasks("bob")
         assert len(bob_tasks) == 1
         assert bob_tasks[0].title == "Worker2 task"
+
+    def test_my_tasks_hands_off_to_reviewer_after_node_done(self, svc):
+        task = _create_task(
+            svc,
+            title="Handoff task",
+            roles={"worker": "alice", "reviewer": "bob"},
+        )
+        _queue_task(svc, task)
+        svc.claim(task.task_id, "alice")
+
+        svc.node_done(task.task_id, "alice", work_output=_work_output_payload("worker complete"))
+
+        reloaded = svc.get(task.task_id)
+        assert reloaded.current_node_id == "code_review"
+        assert reloaded.assignee == "bob"
+        assert [t.task_id for t in svc.my_tasks("alice")] == []
+        assert [t.task_id for t in svc.my_tasks("bob")] == [task.task_id]
+
+    def test_my_tasks_hands_back_to_worker_after_reject(self, svc):
+        task = _create_task(
+            svc,
+            title="Reject loop task",
+            roles={"worker": "alice", "reviewer": "bob"},
+        )
+        _queue_task(svc, task)
+        svc.claim(task.task_id, "alice")
+        svc.node_done(task.task_id, "alice", work_output=_work_output_payload("ready for review"))
+
+        svc.reject(task.task_id, "bob", "needs changes")
+
+        reloaded = svc.get(task.task_id)
+        assert reloaded.current_node_id == "implement"
+        assert reloaded.assignee == "alice"
+        assert [t.task_id for t in svc.my_tasks("alice")] == [task.task_id]
+        assert [t.task_id for t in svc.my_tasks("bob")] == []
+
+    def test_my_tasks_filters_rows_before_hydration(self, svc, monkeypatch):
+        tasks = [
+            _create_task(
+                svc,
+                title="Alice task",
+                roles={"worker": "alice", "reviewer": "reviewer-a"},
+            ),
+            _create_task(
+                svc,
+                title="Bob task",
+                roles={"worker": "bob", "reviewer": "reviewer-b"},
+            ),
+            _create_task(
+                svc,
+                title="Carol task",
+                roles={"worker": "carol", "reviewer": "reviewer-c"},
+            ),
+        ]
+        for task, actor in zip(tasks, ("alice", "bob", "carol"), strict=True):
+            _queue_task(svc, task)
+            svc.claim(task.task_id, actor)
+
+        hydrated: list[str] = []
+        original_row_to_task = svc._row_to_task
+
+        def counting_row_to_task(row, *args, **kwargs):
+            hydrated.append(f"{row['project']}/{row['task_number']}")
+            return original_row_to_task(row, *args, **kwargs)
+
+        monkeypatch.setattr(svc, "_row_to_task", counting_row_to_task)
+        monkeypatch.setattr(
+            svc,
+            "derive_owner",
+            lambda task: (_ for _ in ()).throw(AssertionError("derive_owner should not run")),
+        )
+
+        alice_tasks = svc.my_tasks("alice")
+
+        assert [task.task_id for task in alice_tasks] == [tasks[0].task_id]
+        assert hydrated == [tasks[0].task_id]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #458

## Summary
- keep assignee ownership aligned when tasks hand off between worker and reviewer nodes
- let my_tasks query active rows by assignee instead of hydrating every active task
- add regression coverage for handoff, reject-loop reassignment, and pre-hydration filtering

## Testing
- uv run --extra dev python -m pytest tests/test_work_queries.py tests/test_flow_progression.py