### PR TITLE
perf(work): cache flow template loads

### DIFF
--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -147,6 +147,7 @@ class SQLiteWorkService:
         self._conn.execute("PRAGMA busy_timeout=30000")
         create_work_tables(self._conn)
         self._gate_registry = GateRegistry(project_path=project_path)
+        self._flow_cache: dict[tuple[str, int], FlowTemplate] = {}
         # Last-provision-error breadcrumb — set by ``claim()`` when
         # ``provision_worker`` fails so the CLI can surface it instead
         # of reporting a silent success (#243).
@@ -163,6 +164,7 @@ class SQLiteWorkService:
 
     def close(self) -> None:
         """Close the database connection."""
+        self._flow_cache.clear()
         self._conn.close()
 
     def __enter__(self):
@@ -280,6 +282,7 @@ class SQLiteWorkService:
         self, template: FlowTemplate, version: int,
     ) -> None:
         """Persist ``template`` at ``version`` in work_flow_templates/nodes."""
+        self._invalidate_flow_cache(name=template.name, version=version)
         now = _now()
         self._conn.execute(
             "INSERT INTO work_flow_templates "
@@ -315,6 +318,22 @@ class SQLiteWorkService:
                     json.dumps(node.gates),
                 ),
             )
+
+    def _invalidate_flow_cache(
+        self,
+        *,
+        name: str | None = None,
+        version: int | None = None,
+    ) -> None:
+        if name is None:
+            self._flow_cache.clear()
+            return
+        if version is not None:
+            self._flow_cache.pop((name, version), None)
+            return
+        stale = [key for key in self._flow_cache if key[0] == name]
+        for key in stale:
+            self._flow_cache.pop(key, None)
 
     def _ensure_flow_in_db(self, name: str) -> FlowTemplate:
         """Load a flow via the engine and persist it, bumping version on change.
@@ -385,13 +404,19 @@ class SQLiteWorkService:
 
     def _load_flow_from_db(self, name: str, version: int) -> FlowTemplate:
         """Load a flow template from the database."""
+        cache_key = (name, version)
+        cached = self._flow_cache.get(cache_key)
+        if cached is not None:
+            return cached
         row = self._conn.execute(
             "SELECT * FROM work_flow_templates WHERE name = ? AND version = ?",
             (name, version),
         ).fetchone()
         if row is None:
             # Fall back to engine resolution
-            return resolve_flow(name, self._project_path)
+            flow = resolve_flow(name, self._project_path)
+            self._flow_cache[cache_key] = flow
+            return flow
 
         roles = json.loads(row["roles"])
         nodes: dict[str, FlowNode] = {}
@@ -418,7 +443,7 @@ class SQLiteWorkService:
                 gates=json.loads(nr["gates"]),
             )
 
-        return FlowTemplate(
+        flow = FlowTemplate(
             name=row["name"],
             description=row["description"],
             roles=roles,
@@ -427,6 +452,8 @@ class SQLiteWorkService:
             version=row["version"],
             is_current=bool(row["is_current"]),
         )
+        self._flow_cache[cache_key] = flow
+        return flow
 
     # ------------------------------------------------------------------
     # Internal: task reconstruction

--- a/tests/test_work_service.py
+++ b/tests/test_work_service.py
@@ -704,6 +704,38 @@ class TestFlowImmutability:
         t2 = self._make_task(svc)
         assert svc.get(t2.task_id).flow_template_version == 1
 
+    def test_load_flow_from_db_uses_cached_template_on_repeat_load(self, tmp_path, monkeypatch):
+        self._write_custom_standard(tmp_path, description="cached-body")
+        db = tmp_path / "work.db"
+        svc = SQLiteWorkService(db_path=db, project_path=tmp_path)
+
+        task = self._make_task(svc)
+        flow = svc._load_flow_from_db(
+            task.flow_template_id,
+            task.flow_template_version,
+        )
+
+        class GuardConn:
+            def __init__(self, conn):
+                self._conn = conn
+
+            def execute(self, sql, params=()):
+                if "work_flow_templates" in sql or "work_flow_nodes" in sql:
+                    raise AssertionError("flow template DB lookup should be served from cache")
+                return self._conn.execute(sql, params)
+
+            def __getattr__(self, name):
+                return getattr(self._conn, name)
+
+        monkeypatch.setattr(svc, "_conn", GuardConn(svc._conn))
+
+        cached = svc._load_flow_from_db(
+            task.flow_template_id,
+            task.flow_template_version,
+        )
+
+        assert cached is flow
+
 
 # ---------------------------------------------------------------------------
 # actor_type=agent — named agent resolution (#140)


### PR DESCRIPTION
Closes #459

## Summary
- cache flow templates per service instance by (name, version) instead of reloading them from SQLite on repeat reads
- invalidate the cached entry when a persisted flow version is written
- add a regression test that proves repeated loads do not hit the flow tables again

## Testing
- HOME=/tmp/pytest-459 uv run --extra dev pytest tests/test_work_service.py tests/test_work_queries.py -q