### PR TITLE
perf(work): collapse relationship load queries

### DIFF
--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -569,17 +569,15 @@ class SQLiteWorkService:
         self, project: str, task_number: int
     ) -> dict:
         """Load dependency relationships for a task from work_task_dependencies."""
-        # Outgoing edges: this task is from_id
-        out_rows = self._conn.execute(
-            "SELECT to_project, to_task_number, kind FROM work_task_dependencies "
-            "WHERE from_project = ? AND from_task_number = ?",
-            (project, task_number),
-        ).fetchall()
-        # Incoming edges: this task is to_id
-        in_rows = self._conn.execute(
-            "SELECT from_project, from_task_number, kind FROM work_task_dependencies "
-            "WHERE to_project = ? AND to_task_number = ?",
-            (project, task_number),
+        rows = self._conn.execute(
+            "SELECT "
+            "from_project, from_task_number, "
+            "to_project, to_task_number, "
+            "kind "
+            "FROM work_task_dependencies "
+            "WHERE (from_project = ? AND from_task_number = ?) "
+            "   OR (to_project = ? AND to_task_number = ?)",
+            (project, task_number, project, task_number),
         ).fetchall()
 
         rels: dict = {
@@ -591,36 +589,41 @@ class SQLiteWorkService:
             "superseded_by_task_number": None,
         }
 
-        for r in out_rows:
+        for r in rows:
             kind = r["kind"]
-            target = (r["to_project"], r["to_task_number"])
-            if kind == LinkKind.BLOCKS.value:
-                rels["blocks"].append(target)
-            elif kind == LinkKind.RELATES_TO.value:
-                rels["relates_to"].append(target)
-            elif kind == LinkKind.PARENT.value:
-                rels["children"].append(target)
-            elif kind == LinkKind.SUPERSEDES.value:
-                # outgoing supersedes: this task supersedes target
-                pass  # stored in supersedes_project/supersedes_task_number columns
-
-        for r in in_rows:
-            kind = r["kind"]
-            source = (r["from_project"], r["from_task_number"])
-            if kind == LinkKind.BLOCKS.value:
-                rels["blocked_by"].append(source)
-            elif kind == LinkKind.RELATES_TO.value:
-                # relates_to is bidirectional
-                if source not in rels["relates_to"]:
-                    rels["relates_to"].append(source)
-            elif kind == LinkKind.PARENT.value:
-                # incoming parent: source is parent of this task
-                # update parent fields (override column-based values)
-                pass  # parent is set via from_id=parent, to_id=child
-            elif kind == LinkKind.SUPERSEDES.value:
-                # incoming supersedes: source supersedes this task
-                rels["superseded_by_project"] = r["from_project"]
-                rels["superseded_by_task_number"] = r["from_task_number"]
+            is_outgoing = (
+                r["from_project"] == project and r["from_task_number"] == task_number
+            )
+            is_incoming = (
+                r["to_project"] == project and r["to_task_number"] == task_number
+            )
+            if is_outgoing:
+                target = (r["to_project"], r["to_task_number"])
+                if kind == LinkKind.BLOCKS.value:
+                    rels["blocks"].append(target)
+                elif kind == LinkKind.RELATES_TO.value:
+                    rels["relates_to"].append(target)
+                elif kind == LinkKind.PARENT.value:
+                    rels["children"].append(target)
+                elif kind == LinkKind.SUPERSEDES.value:
+                    # outgoing supersedes: this task supersedes target
+                    pass  # stored in supersedes_project/supersedes_task_number columns
+            if is_incoming:
+                source = (r["from_project"], r["from_task_number"])
+                if kind == LinkKind.BLOCKS.value:
+                    rels["blocked_by"].append(source)
+                elif kind == LinkKind.RELATES_TO.value:
+                    # relates_to is bidirectional
+                    if source not in rels["relates_to"]:
+                        rels["relates_to"].append(source)
+                elif kind == LinkKind.PARENT.value:
+                    # incoming parent: source is parent of this task
+                    # update parent fields (override column-based values)
+                    pass  # parent is set via from_id=parent, to_id=child
+                elif kind == LinkKind.SUPERSEDES.value:
+                    # incoming supersedes: source supersedes this task
+                    rels["superseded_by_project"] = r["from_project"]
+                    rels["superseded_by_task_number"] = r["from_task_number"]
 
         return rels
 

--- a/tests/test_work_service.py
+++ b/tests/test_work_service.py
@@ -705,6 +705,38 @@ class TestFlowImmutability:
         assert svc.get(t2.task_id).flow_template_version == 1
 
 
+def test_load_relationships_uses_one_dependency_query(svc, monkeypatch):
+    blocker = _create_standard_task(svc, title="Blocker")
+    target = _create_standard_task(svc, title="Target")
+    related = _create_standard_task(svc, title="Related")
+
+    svc.link(blocker.task_id, target.task_id, "blocks")
+    svc.link(target.task_id, related.task_id, "relates_to")
+
+    dependency_queries = 0
+
+    class GuardConn:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def execute(self, sql, params=()):
+            nonlocal dependency_queries
+            if "FROM work_task_dependencies" in sql:
+                dependency_queries += 1
+            return self._conn.execute(sql, params)
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+    monkeypatch.setattr(svc, "_conn", GuardConn(svc._conn))
+
+    rels = svc._load_relationships(target.project, target.task_number)
+
+    assert dependency_queries == 1
+    assert rels["blocked_by"] == [(blocker.project, blocker.task_number)]
+    assert rels["relates_to"] == [(related.project, related.task_number)]
+
+
 # ---------------------------------------------------------------------------
 # actor_type=agent — named agent resolution (#140)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #460

## Summary
- load task relationships from one scoped dependency query instead of separate incoming/outgoing queries
- preserve the existing relationship shape while reducing query amplification on task hydration
- add a regression test that counts dependency-table hits during relationship loading

## Testing
- HOME=/tmp/pytest-460 uv run --extra dev pytest tests/test_work_service.py tests/test_work_dependencies.py tests/test_flow_progression.py -q