### PR TITLE
perf(cockpit): reuse heartbeat pane snapshots

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 from pollypm.config import load_config
 from pollypm.cockpit_sections.base import _STATUS_ICONS
+from pollypm.heartbeats.snapshots import read_recent_heartbeat_snapshot
 
 
 def _render_work_service_issues(project: object) -> str:
@@ -356,6 +357,15 @@ def _worker_roster_sort_key(row: "WorkerRosterRow") -> tuple[int, str]:
     )
 
 
+def _pane_text_shows_active_turn(pane_text: str) -> bool:
+    lowered = pane_text.lower()
+    return (
+        "\u23fa" in pane_text
+        or "working (" in lowered
+        or "esc to interrupt" in lowered
+    )
+
+
 def _format_worker_turn_label(
     *, last_heartbeat_iso: str | None, is_turn_active: bool,
 ) -> str:
@@ -517,20 +527,8 @@ def _gather_worker_roster(config) -> list[WorkerRosterRow]:
             session_name = ws.agent_name or window_name
 
             last_heartbeat_iso: str | None = None
+            heartbeat = None
             is_turn_active = False
-            if has_window and tmux is not None:
-                try:
-                    pane_text = tmux.capture_pane(window.pane_id, lines=15)
-                except Exception:  # noqa: BLE001
-                    pane_text = ""
-                lowered = pane_text.lower()
-                if "\u23fa" in pane_text or "working" in lowered:
-                    is_turn_active = True
-                if (
-                    "working (" in lowered
-                    and "esc to interrupt" in lowered
-                ):
-                    is_turn_active = True
 
             stuck = False
             if supervisor is not None:
@@ -552,11 +550,21 @@ def _gather_worker_roster(config) -> list[WorkerRosterRow]:
                         if drift_dt >= datetime.now(UTC) - timedelta(minutes=30):
                             stuck = True
                 try:
-                    hb = supervisor.store.latest_heartbeat(session_name)
+                    heartbeat = supervisor.store.latest_heartbeat(session_name)
                 except Exception:  # noqa: BLE001
-                    hb = None
-                if hb is not None:
-                    last_heartbeat_iso = getattr(hb, "created_at", None)
+                    heartbeat = None
+                if heartbeat is not None:
+                    last_heartbeat_iso = getattr(heartbeat, "created_at", None)
+
+            if has_window:
+                pane_text = read_recent_heartbeat_snapshot(heartbeat)
+                if pane_text is None and tmux is not None:
+                    try:
+                        pane_text = tmux.capture_pane(window.pane_id, lines=15)
+                    except Exception:  # noqa: BLE001
+                        pane_text = ""
+                if pane_text:
+                    is_turn_active = _pane_text_shows_active_turn(pane_text)
 
             if not has_window:
                 status = "offline"
@@ -760,4 +768,3 @@ def _register_worker_roster_rail_item(registry, router) -> None:
         registry.add(reg)
     except Exception:  # noqa: BLE001
         pass
-

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -36,6 +36,7 @@ from pathlib import Path
 
 from pollypm.atomic_io import atomic_write_json
 from pollypm.config import load_config
+from pollypm.heartbeats.snapshots import read_recent_heartbeat_snapshot
 from pollypm.providers import get_provider
 from pollypm.runtimes import get_runtime
 from pollypm.service_api import PollyPMService
@@ -604,7 +605,21 @@ class CockpitRouter:
             return "dead"
         spinners = ["\u25dc", "\u25dd", "\u25de", "\u25df"]
         if launch.session.role in ("worker", "operator-pm", "reviewer"):
-            working = self._is_pane_working(window, launch.session.provider)
+            heartbeat = None
+            try:
+                supervisor = self._load_supervisor()
+            except Exception:  # noqa: BLE001
+                supervisor = None
+            if supervisor is not None:
+                try:
+                    heartbeat = supervisor.store.latest_heartbeat(session_name)
+                except Exception:  # noqa: BLE001
+                    heartbeat = None
+            working = self._is_pane_working(
+                window,
+                launch.session.provider,
+                heartbeat=heartbeat,
+            )
             if working:
                 return spinners[spinner_index % 4] + " working"
             if launch.session.role == "worker":
@@ -641,17 +656,22 @@ class CockpitRouter:
         except Exception:  # noqa: BLE001
             return None
 
-    def _is_pane_working(self, window, provider) -> bool:
+    def _is_pane_working(self, window, provider, *, heartbeat=None) -> bool:
         """Check if a session pane has an active turn (agent is working, not idle at prompt)."""
+        pane_text = read_recent_heartbeat_snapshot(heartbeat)
+        if pane_text is None:
+            try:
+                pane_text = self.tmux.capture_pane(window.pane_id, lines=15)
+            except Exception:  # noqa: BLE001
+                return False
         try:
-            pane_text = self.tmux.capture_pane(window.pane_id, lines=15)
+            tail_lines = [
+                line.rstrip()
+                for line in pane_text.splitlines()
+                if line.strip()
+            ][-6:]
         except Exception:  # noqa: BLE001
             return False
-        tail_lines = [
-            line.rstrip()
-            for line in pane_text.splitlines()
-            if line.strip()
-        ][-6:]
         if not tail_lines:
             return False
         tail = "\n".join(tail_lines)

--- a/src/pollypm/heartbeats/snapshots.py
+++ b/src/pollypm/heartbeats/snapshots.py
@@ -1,0 +1,41 @@
+"""Helpers for reusing recent heartbeat pane snapshots across the UI."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from pollypm.storage.state import HeartbeatRecord
+
+RECENT_HEARTBEAT_MAX_AGE_SECONDS = 30
+
+
+def _heartbeat_created_at(record: HeartbeatRecord | None) -> datetime | None:
+    if record is None:
+        return None
+    try:
+        created_at = datetime.fromisoformat(record.created_at)
+    except (TypeError, ValueError):
+        return None
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=UTC)
+    return created_at
+
+
+def read_recent_heartbeat_snapshot(
+    record: HeartbeatRecord | None,
+    *,
+    max_age_seconds: int = RECENT_HEARTBEAT_MAX_AGE_SECONDS,
+) -> str | None:
+    """Return a recent heartbeat snapshot, or ``None`` when it is stale."""
+    if record is None or not record.snapshot_path:
+        return None
+    created_at = _heartbeat_created_at(record)
+    if created_at is None:
+        return None
+    if datetime.now(UTC) - created_at > timedelta(seconds=max_age_seconds):
+        return None
+    try:
+        return Path(record.snapshot_path).read_text(errors="ignore")
+    except (FileNotFoundError, OSError):
+        return None

--- a/tests/test_cockpit_idle_state.py
+++ b/tests/test_cockpit_idle_state.py
@@ -110,3 +110,76 @@ def test_worker_session_state_stays_working_when_codex_shows_interrupt_banner(
     router.tmux = FakeTmux()  # type: ignore[assignment]
 
     assert router._session_state("worker_demo", [launch], [window], [], 0).endswith("working")
+
+
+def test_worker_session_state_reuses_recent_heartbeat_snapshot(
+    tmp_path: Path,
+) -> None:
+    from datetime import UTC, datetime
+
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+    snapshot_path = tmp_path / "worker-snapshot.txt"
+    snapshot_path.write_text(
+        "\n".join(
+            [
+                "OpenAI Codex",
+                "• Working (12s • esc to interrupt)",
+                "› Implement {feature}",
+            ]
+        )
+    )
+
+    launch = type(
+        "Launch",
+        (),
+        {
+            "window_name": "worker-demo",
+            "session": type(
+                "Session",
+                (),
+                {
+                    "name": "worker_demo",
+                    "role": "worker",
+                    "project": "demo",
+                    "provider": type("P", (), {"value": "codex"})(),
+                },
+            )(),
+        },
+    )()
+    window = type(
+        "Window",
+        (),
+        {
+            "name": "worker-demo",
+            "pane_dead": False,
+            "pane_id": "%9",
+        },
+    )()
+
+    class FakeStore:
+        def latest_heartbeat(self, session_name: str):
+            assert session_name == "worker_demo"
+            return type(
+                "Heartbeat",
+                (),
+                {
+                    "snapshot_path": str(snapshot_path),
+                    "created_at": datetime.now(UTC).isoformat(),
+                },
+            )()
+
+    class FakeSupervisor:
+        store = FakeStore()
+
+    class FakeTmux:
+        def capture_pane(self, pane_id: str, lines: int = 15) -> str:
+            raise AssertionError("capture_pane should not run when heartbeat snapshot is fresh")
+
+    router = CockpitRouter(config_path)
+    router.tmux = FakeTmux()  # type: ignore[assignment]
+    router._load_supervisor = lambda fresh=False: FakeSupervisor()  # type: ignore[method-assign]
+
+    assert router._session_state("worker_demo", [launch], [window], [], 0).endswith("working")

--- a/tests/test_worker_roster_ui.py
+++ b/tests/test_worker_roster_ui.py
@@ -335,3 +335,128 @@ def test_gather_worker_roster_picks_up_worker_session(tmp_path: Path) -> None:
     assert rows[0].status == "offline"
     assert rows[0].task_number == t.task_number
     assert "Build favicon" in rows[0].task_title
+
+
+def test_gather_worker_roster_reuses_recent_heartbeat_snapshot(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Fresh heartbeat snapshots should satisfy turn-status checks without tmux capture."""
+    from datetime import UTC, datetime
+
+    import pollypm.cockpit_inbox as cockpit_inbox
+    import pollypm.session_services as session_services
+    from pollypm.cockpit import _gather_worker_roster
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    (project_path / ".pollypm").mkdir()
+    db_path = project_path / ".pollypm" / "state.db"
+
+    svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+    try:
+        task = svc.create(
+            title="Build favicon",
+            description="Fetch and cache site favicons for every shortlink.",
+            type="task",
+            project="demo",
+            flow_template="standard",
+            roles={"worker": "pete", "reviewer": "russell"},
+            priority="normal",
+            created_by="polly",
+        )
+        svc.queue(task.task_id, "polly")
+        svc.claim(task.task_id, "worker")
+        svc.ensure_worker_session_schema()
+        svc.upsert_worker_session(
+            task_project="demo",
+            task_number=task.task_number,
+            agent_name="worker_demo",
+            pane_id="%1",
+            worktree_path=str(tmp_path / "wt"),
+            branch_name="task/demo-1",
+            started_at=datetime.now(UTC).isoformat(),
+        )
+    finally:
+        svc.close()
+
+    snapshot_path = tmp_path / "worker-snapshot.txt"
+    snapshot_path.write_text(
+        "\n".join(
+            [
+                "OpenAI Codex",
+                "• Working (12s • esc to interrupt)",
+                "› Implement {feature}",
+            ]
+        )
+    )
+
+    class _Project:
+        def __init__(self, path: Path) -> None:
+            self.path = path
+            self.name = "Demo"
+            self.key = "demo"
+
+        def display_label(self) -> str:
+            return self.name
+
+    class _InnerProject:
+        tmux_session = "pollypm-test"
+
+    class _Config:
+        project = _InnerProject()
+
+        def __init__(self, project_path: Path) -> None:
+            self.projects = {"demo": _Project(project_path)}
+
+    class FakeStore:
+        def last_event_at(self, session_name: str, event_type: str):
+            assert session_name == "worker_demo"
+            assert event_type == "state_drift"
+            return None
+
+        def latest_heartbeat(self, session_name: str):
+            assert session_name == "worker_demo"
+            return type(
+                "Heartbeat",
+                (),
+                {
+                    "snapshot_path": str(snapshot_path),
+                    "created_at": datetime.now(UTC).isoformat(),
+                },
+            )()
+
+        def close(self) -> None:
+            return None
+
+    class FakeSupervisor:
+        store = FakeStore()
+
+    class FakeTmux:
+        def list_windows(self, session_name: str):
+            assert session_name == "pollypm-test-storage-closet"
+            return [
+                type(
+                    "Window",
+                    (),
+                    {
+                        "name": f"task-demo-{task.task_number}",
+                        "pane_id": "%1",
+                        "pane_dead": False,
+                    },
+                )()
+            ]
+
+        def capture_pane(self, pane_id: str, lines: int = 15) -> str:
+            raise AssertionError("capture_pane should not run when heartbeat snapshot is fresh")
+
+    monkeypatch.setattr(cockpit_inbox, "_try_load_supervisor_for_config", lambda config: FakeSupervisor())
+    monkeypatch.setattr(session_services, "create_tmux_client", lambda: FakeTmux())
+
+    rows = _gather_worker_roster(_Config(project_path))
+
+    assert len(rows) == 1
+    assert rows[0].session_name == "worker_demo"
+    assert rows[0].status == "working"
+    assert rows[0].turn_label.startswith("active")


### PR DESCRIPTION
Closes #469

## Summary
- reuse fresh heartbeat pane snapshots in cockpit status views before falling back to live tmux capture
- centralize the recent-snapshot freshness check in heartbeats.snapshot helpers
- add focused coverage proving fresh heartbeat snapshots avoid extra capture-pane calls

## Testing
- uv run --with pytest pytest tests/test_cockpit_idle_state.py tests/test_worker_roster_ui.py