### PR TITLE
fix(cli): defer startup-heavy imports

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -18,10 +18,7 @@ Contract:
 
 from __future__ import annotations
 
-import json
 import logging
-import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -39,37 +36,19 @@ from pollypm.error_log import install as _install_error_log
 
 _install_error_log(process_label="cli")
 
-from pollypm.accounts import (
-    add_account_via_login,
-    list_account_statuses,
-    probe_account_usage,
-    relogin_account,
-    remove_account as remove_account_entry,
-)
 from pollypm.config import (
     DEFAULT_CONFIG_PATH,
-    load_config,
     resolve_config_path,
     render_example_config,
     write_example_config,
 )
 from pollypm.errors import format_config_not_found_error
-from pollypm.service_api import PollyPMService
-from pollypm.service_api import render_json
 from pollypm.cli_features.alerts import alert_app, heartbeat_app, session_app
 from pollypm.cli_features.issues import issue_app, itsalive_app, report_app
 from pollypm.cli_features.maintenance import register_maintenance_commands
 from pollypm.cli_features.projects import register_project_commands
 from pollypm.cli_features.ui import register_ui_commands
 from pollypm.cli_features.workers import register_worker_commands
-from pollypm.session_services import (
-    attach_existing_session,
-    current_session_name,
-    probe_session,
-    switch_client_to_session,
-)
-from pollypm.transcript_ingest import start_transcript_ingestion
-from pollypm.workers import create_worker_session, launch_worker_session
 
 
 # wg05 / #242: every `pm ... --help` gains an Examples section so
@@ -138,6 +117,48 @@ register_maintenance_commands(app)
 register_worker_commands(app)
 
 
+def attach_existing_session(session_name: str) -> int:
+    from pollypm.session_services import attach_existing_session as _attach_existing_session
+
+    return _attach_existing_session(session_name)
+
+
+def current_session_name() -> str | None:
+    from pollypm.session_services import current_session_name as _current_session_name
+
+    return _current_session_name()
+
+
+def probe_session(session_name: str) -> bool:
+    from pollypm.session_services import probe_session as _probe_session
+
+    return _probe_session(session_name)
+
+
+def switch_client_to_session(session_name: str) -> int:
+    from pollypm.session_services import switch_client_to_session as _switch_client_to_session
+
+    return _switch_client_to_session(session_name)
+
+
+def start_transcript_ingestion(config) -> None:
+    from pollypm.transcript_ingest import start_transcript_ingestion as _start_transcript_ingestion
+
+    _start_transcript_ingestion(config)
+
+
+def create_worker_session(*args, **kwargs):
+    from pollypm.workers import create_worker_session as _create_worker_session
+
+    return _create_worker_session(*args, **kwargs)
+
+
+def launch_worker_session(*args, **kwargs):
+    from pollypm.workers import launch_worker_session as _launch_worker_session
+
+    return _launch_worker_session(*args, **kwargs)
+
+
 def _session_name_candidates() -> list[str]:
     return ["pollypm", "pollypm-storage-closet"]
 
@@ -165,6 +186,8 @@ def _attach_existing_session_without_config() -> bool:
 
 def _load_supervisor(config_path: Path):
     """Return a full Supervisor via the service_api facade."""
+    from pollypm.service_api import PollyPMService
+
     return PollyPMService(config_path).load_supervisor()
 
 
@@ -181,6 +204,8 @@ def _cli_status(msg: str) -> None:
 
 
 def _emit_json(payload: object) -> None:
+    from pollypm.service_api import render_json
+
     typer.echo(render_json(payload), nl=False)
 
 
@@ -605,6 +630,8 @@ def status(
     json_output: bool = typer.Option(False, "--json", help="Emit structured JSON."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
+    from pollypm.service_api import PollyPMService
+
     if not _config_option_was_explicit():
         config_path = _discover_config_path(config_path)
     payload = PollyPMService(config_path).session_status(session_name)
@@ -674,6 +701,8 @@ def alerts(
     json_output: bool = typer.Option(False, "--json", help="Emit structured JSON."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
+    from pollypm.service_api import PollyPMService
+
     items = PollyPMService(config_path).list_alerts()
     if not items:
         typer.echo("No open alerts.")
@@ -690,6 +719,8 @@ def failover(
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
     """Show failover configuration: controller account and failover order."""
+    from pollypm.config import load_config
+
     config = load_config(config_path)
     typer.echo(f"Controller: {config.pollypm.controller_account}")
     typer.echo(f"Failover enabled: {'yes' if config.pollypm.failover_enabled else 'no'}")

--- a/src/pollypm/cli_features/alerts.py
+++ b/src/pollypm/cli_features/alerts.py
@@ -20,7 +20,6 @@ from pathlib import Path
 import typer
 
 from pollypm.config import DEFAULT_CONFIG_PATH
-from pollypm.service_api import PollyPMService
 
 
 alert_app = typer.Typer(
@@ -49,6 +48,12 @@ heartbeat_app = typer.Typer(
         "• pm heartbeat status                — show last heartbeat tick\n"
     )
 )
+
+
+def _service(config_path: Path):
+    from pollypm.service_api import PollyPMService
+
+    return PollyPMService(config_path)
 
 
 @heartbeat_app.callback(invoke_without_command=True)
@@ -87,7 +92,7 @@ def alert_raise(
 ) -> None:
     from pollypm import cli as cli_mod
 
-    alert = PollyPMService(config_path).raise_alert(
+    alert = _service(config_path).raise_alert(
         alert_type,
         session_name,
         message,
@@ -108,7 +113,7 @@ def alert_clear(
     from pollypm import cli as cli_mod
 
     try:
-        alert = PollyPMService(config_path).clear_alert(alert_id)
+        alert = _service(config_path).clear_alert(alert_id)
     except KeyError as exc:
         raise typer.BadParameter(str(exc)) from exc
     if json_output:
@@ -124,7 +129,7 @@ def alert_list(
 ) -> None:
     from pollypm import cli as cli_mod
 
-    items = PollyPMService(config_path).list_alerts()
+    items = _service(config_path).list_alerts()
     if json_output:
         cli_mod._emit_json({"alerts": items})
         return
@@ -148,7 +153,7 @@ def session_set_status(
 ) -> None:
     from pollypm import cli as cli_mod
 
-    runtime = PollyPMService(config_path).set_session_status(
+    runtime = _service(config_path).set_session_status(
         session_name,
         status,
         reason=reason,
@@ -234,9 +239,8 @@ def heartbeat_record(
         raise typer.BadParameter(f"Invalid heartbeat JSON: {exc}") from exc
     if not isinstance(payload, dict):
         raise typer.BadParameter("Heartbeat payload must be a JSON object.")
-    record = PollyPMService(config_path).record_heartbeat(session_name, payload)
+    record = _service(config_path).record_heartbeat(session_name, payload)
     if json_output:
         cli_mod._emit_json({"heartbeat": record})
         return
     typer.echo(f"Recorded heartbeat for {session_name}")
-

--- a/src/pollypm/cli_features/issues.py
+++ b/src/pollypm/cli_features/issues.py
@@ -16,7 +16,6 @@ from pathlib import Path
 import typer
 
 from pollypm.config import DEFAULT_CONFIG_PATH
-from pollypm.service_api import PollyPMService
 
 
 issue_app = typer.Typer(
@@ -47,13 +46,19 @@ itsalive_app = typer.Typer(
 )
 
 
+def _service(config_path: Path):
+    from pollypm.service_api import PollyPMService
+
+    return PollyPMService(config_path)
+
+
 @issue_app.command("list")
 def issue_list(
     project: str = typer.Option(..., "--project", help="Project key."),
     state: list[str] | None = typer.Option(None, "--state", help="Optional tracker state filter."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    service = PollyPMService(config_path)
+    service = _service(config_path)
     tasks = service.list_tasks(project, states=state)
     if not tasks:
         typer.echo("No issues found.")
@@ -68,7 +73,7 @@ def issue_info(
     project: str = typer.Option(..., "--project", help="Project key."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    service = PollyPMService(config_path)
+    service = _service(config_path)
     task = service.get_task(project, task_id)
     typer.echo(f"{task.task_id} [{task.state}] {task.title}")
 
@@ -78,7 +83,7 @@ def issue_next(
     project: str = typer.Option(..., "--project", help="Project key."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    service = PollyPMService(config_path)
+    service = _service(config_path)
     task = service.next_available_task(project)
     if task is None:
         typer.echo("No ready issue found.")
@@ -92,7 +97,7 @@ def issue_history(
     project: str = typer.Option(..., "--project", help="Project key."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    service = PollyPMService(config_path)
+    service = _service(config_path)
     entries = service.task_history(project, task_id)
     if not entries:
         typer.echo("No history found.")
@@ -109,7 +114,7 @@ def issue_create(
     state: str = typer.Option("01-ready", "--state", help="Initial tracker state."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    service = PollyPMService(config_path)
+    service = _service(config_path)
     task = service.create_task(project, title=title, body=body, state=state)
     typer.echo(f"Created issue {task.task_id} [{task.state}] {task.title}")
 
@@ -121,7 +126,7 @@ def issue_transition(
     project: str = typer.Option(..., "--project", help="Project key."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    service = PollyPMService(config_path)
+    service = _service(config_path)
     try:
         task = service.move_task(project, task_id, to_state=to_state)
     except ValueError as exc:
@@ -137,7 +142,7 @@ def issue_comment(
     project: str = typer.Option(..., "--project", help="Project key."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    service = PollyPMService(config_path)
+    service = _service(config_path)
     path = service.append_task_note(project, task_name, text=text)
     typer.echo(f"Updated {path}")
 
@@ -152,7 +157,7 @@ def issue_handoff(
     project: str = typer.Option(..., "--project", help="Project key."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    service = PollyPMService(config_path)
+    service = _service(config_path)
     path = service.append_task_handoff(
         project,
         task_name,
@@ -172,7 +177,7 @@ def issue_approve(
     project: str = typer.Option(..., "--project", help="Project key."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    service = PollyPMService(config_path)
+    service = _service(config_path)
     try:
         task = service.review_task(
             project,
@@ -196,7 +201,7 @@ def issue_request_changes(
     project: str = typer.Option(..., "--project", help="Project key."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    service = PollyPMService(config_path)
+    service = _service(config_path)
     try:
         task = service.review_task(
             project,
@@ -217,7 +222,7 @@ def issue_counts(
     project: str = typer.Option(..., "--project", help="Project key."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    service = PollyPMService(config_path)
+    service = _service(config_path)
     counts = service.task_state_counts(project)
     for state, count in counts.items():
         typer.echo(f"{state}: {count}")
@@ -247,7 +252,7 @@ def itsalive_deploy(
     publish_dir: str = typer.Option(".", "--dir", help="Directory to deploy relative to the project root."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    service = PollyPMService(config_path)
+    service = _service(config_path)
     outcome = service.itsalive_deploy(
         project_key=project,
         subdomain=subdomain,
@@ -270,7 +275,7 @@ def itsalive_status(
     project: str = typer.Option(..., "--project", help="Project key."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    service = PollyPMService(config_path)
+    service = _service(config_path)
     items = service.itsalive_pending(project_key=project)
     if not items:
         typer.echo("No pending itsalive deployments.")
@@ -287,7 +292,7 @@ def itsalive_sweep(
     project: str = typer.Option(..., "--project", help="Project key."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    service = PollyPMService(config_path)
+    service = _service(config_path)
     outcomes = service.itsalive_sweep(project_key=project)
     if not outcomes:
         typer.echo("No itsalive deployment updates.")
@@ -303,7 +308,7 @@ def issue_validate(
     project: str = typer.Option(..., "--project", help="Project key."),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    service = PollyPMService(config_path)
+    service = _service(config_path)
     result = service.validate_task_backend(project)
     if getattr(result, "passed", False):
         typer.echo("Task backend validation passed.")
@@ -315,4 +320,3 @@ def issue_validate(
         typer.echo(f"error: {error}")
     if not getattr(result, "passed", False):
         raise typer.Exit(code=1)
-

--- a/src/pollypm/cli_features/maintenance.py
+++ b/src/pollypm/cli_features/maintenance.py
@@ -17,13 +17,6 @@ from pathlib import Path
 
 import typer
 
-from pollypm.accounts import (
-    add_account_via_login,
-    list_account_statuses,
-    probe_account_usage,
-    relogin_account,
-    remove_account as remove_account_entry,
-)
 from pollypm.config import (
     DEFAULT_CONFIG_PATH,
     GLOBAL_CONFIG_DIR,
@@ -32,9 +25,44 @@ from pollypm.config import (
 from pollypm.doc_scaffold import repair_docs, verify_docs
 from pollypm.errors import format_config_not_found_error
 from pollypm.models import ProviderKind
-from pollypm.service_api import PollyPMService
 from pollypm.storage.state import StateStore
 from pollypm.worktrees import list_worktrees as list_project_worktrees
+
+
+def _service(config_path: Path):
+    from pollypm.service_api import PollyPMService
+
+    return PollyPMService(config_path)
+
+
+def _list_account_statuses(config_path: Path):
+    from pollypm.accounts import list_account_statuses
+
+    return list_account_statuses(config_path)
+
+
+def _probe_account_usage(config_path: Path, account: str):
+    from pollypm.accounts import probe_account_usage
+
+    return probe_account_usage(config_path, account)
+
+
+def _add_account_via_login(config_path: Path, provider_kind: ProviderKind):
+    from pollypm.accounts import add_account_via_login
+
+    return add_account_via_login(config_path, provider_kind)
+
+
+def _relogin_account(config_path: Path, account: str):
+    from pollypm.accounts import relogin_account
+
+    return relogin_account(config_path, account)
+
+
+def _remove_account_entry(config_path: Path, account: str, *, delete_home: bool = False):
+    from pollypm.accounts import remove_account as remove_account_entry
+
+    return remove_account_entry(config_path, account, delete_home=delete_home)
 
 
 def register_maintenance_commands(app: typer.Typer) -> None:
@@ -97,7 +125,7 @@ def register_maintenance_commands(app: typer.Typer) -> None:
     def accounts(
         config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
     ) -> None:
-        for account in list_account_statuses(config_path):
+        for account in _list_account_statuses(config_path):
             typer.echo(
                 f"- {account.key}: {account.email} [{account.provider.value}] "
                 f"logged_in={'yes' if account.logged_in else 'no'} "
@@ -177,7 +205,7 @@ def register_maintenance_commands(app: typer.Typer) -> None:
         config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
     ) -> None:
         config = load_config(config_path)
-        statuses = list_account_statuses(config_path)
+        statuses = _list_account_statuses(config_path)
         if not statuses:
             typer.echo("No configured accounts.")
             return
@@ -201,7 +229,7 @@ def register_maintenance_commands(app: typer.Typer) -> None:
         account: str = typer.Argument(..., help="Account key or email."),
         config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
     ) -> None:
-        status = probe_account_usage(config_path, account)
+        status = _probe_account_usage(config_path, account)
         typer.echo(
             f"{status.key}: plan={status.plan} health={status.health} "
             f"usage={status.usage_summary}"
@@ -212,7 +240,7 @@ def register_maintenance_commands(app: typer.Typer) -> None:
         account: str | None = typer.Option(None, "--account", help="Optional account key or email to limit scanning."),
         config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
     ) -> None:
-        service = PollyPMService(config_path)
+        service = _service(config_path)
         count = service.sync_token_ledger(account=account)
         typer.echo(f"Synced {count} transcript token sample(s).")
 
@@ -221,7 +249,7 @@ def register_maintenance_commands(app: typer.Typer) -> None:
         limit: int = typer.Option(10, "--limit", min=1, max=100, help="Maximum rows to show."),
         config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
     ) -> None:
-        service = PollyPMService(config_path)
+        service = _service(config_path)
         rows = service.recent_token_usage(limit=limit)
         if not rows:
             typer.echo("No token usage recorded yet.")
@@ -300,7 +328,7 @@ def register_maintenance_commands(app: typer.Typer) -> None:
         config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
     ) -> None:
         provider_kind = ProviderKind(provider.lower())
-        key, email = add_account_via_login(config_path, provider_kind)
+        key, email = _add_account_via_login(config_path, provider_kind)
         typer.echo(f"Added {email} as {key}")
 
     @app.command()
@@ -308,7 +336,7 @@ def register_maintenance_commands(app: typer.Typer) -> None:
         account: str = typer.Argument(..., help="Account key or email."),
         config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
     ) -> None:
-        key, email = relogin_account(config_path, account)
+        key, email = _relogin_account(config_path, account)
         typer.echo(f"Re-authenticated {email} ({key})")
 
     @app.command()
@@ -317,7 +345,7 @@ def register_maintenance_commands(app: typer.Typer) -> None:
         delete_home: bool = typer.Option(False, "--delete-home", help="Also delete the isolated account home."),
         config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
     ) -> None:
-        key, email = remove_account_entry(
+        key, email = _remove_account_entry(
             config_path,
             account,
             delete_home=delete_home,

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-from pollypm.plugins_builtin.core_agent_profiles.profiles import heartbeat_prompt, polly_prompt
 from pollypm.models import (
     AccountConfig,
     EventsRetentionSettings,
@@ -48,10 +47,22 @@ def _normalize_session_prompt(session_name: str, prompt: str | None) -> str | No
     if prompt is None:
         return None
     if session_name == "heartbeat" and "You are PollyPM session 0," in prompt:
-        return heartbeat_prompt()
+        return _heartbeat_prompt()
     if session_name == "operator" and "You are Polly, the PollyPM project manager, in session 1." in prompt:
-        return polly_prompt()
+        return _polly_prompt()
     return prompt
+
+
+def _heartbeat_prompt() -> str:
+    from pollypm.plugins_builtin.core_agent_profiles.profiles import heartbeat_prompt
+
+    return heartbeat_prompt()
+
+
+def _polly_prompt() -> str:
+    from pollypm.plugins_builtin.core_agent_profiles.profiles import polly_prompt
+
+    return polly_prompt()
 
 
 def _resolve_path(base: Path, raw_path: str) -> Path:
@@ -813,7 +824,7 @@ def _build_example_config(root: Path) -> PollyPMConfig:
                 cwd=root,
                 project="pollypm",
                 window_name="pm-heartbeat",
-                prompt=heartbeat_prompt(),
+                prompt=_heartbeat_prompt(),
                 agent_profile="heartbeat",
             ),
             "operator": SessionConfig(
@@ -824,7 +835,7 @@ def _build_example_config(root: Path) -> PollyPMConfig:
                 cwd=root,
                 project="pollypm",
                 window_name="pm-operator",
-                prompt=polly_prompt(),
+                prompt=_polly_prompt(),
                 agent_profile="polly",
             ),
             "worker_demo": SessionConfig(

--- a/src/pollypm/jobs/__init__.py
+++ b/src/pollypm/jobs/__init__.py
@@ -11,6 +11,8 @@ retries, and delayed visibility (``run_after``).
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pollypm.jobs.queue import (
     Job,
     JobId,
@@ -20,14 +22,40 @@ from pollypm.jobs.queue import (
     RetryPolicy,
     exponential_backoff,
 )
-from pollypm.jobs.registry import JobHandlerRegistry
-from pollypm.jobs.workers import (
-    HandlerRegistryProtocol,
-    HandlerSpec,
-    JobWorkerPool,
-    PoolMetrics,
-    WorkerMetrics,
-)
+
+if TYPE_CHECKING:
+    from pollypm.jobs.registry import JobHandlerRegistry
+    from pollypm.jobs.workers import (
+        HandlerRegistryProtocol,
+        HandlerSpec,
+        JobWorkerPool,
+        PoolMetrics,
+        WorkerMetrics,
+    )
+
+
+_WORKER_EXPORTS = {
+    "HandlerRegistryProtocol",
+    "HandlerSpec",
+    "JobWorkerPool",
+    "JobHandlerRegistry",
+    "PoolMetrics",
+    "WorkerMetrics",
+}
+
+
+def __getattr__(name: str):
+    if name in _WORKER_EXPORTS:
+        from importlib import import_module
+
+        if name == "JobHandlerRegistry":
+            _registry = import_module("pollypm.jobs.registry")
+            return getattr(_registry, name)
+
+        _workers = import_module("pollypm.jobs.workers")
+
+        return getattr(_workers, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = [
     "HandlerRegistryProtocol",

--- a/src/pollypm/jobs/cli.py
+++ b/src/pollypm/jobs/cli.py
@@ -26,7 +26,7 @@ from typing import Any, Callable
 import typer
 
 from pollypm.config import DEFAULT_CONFIG_PATH, load_config, resolve_config_path
-from pollypm.jobs import Job, JobQueue, JobStatus
+from pollypm.jobs.queue import Job, JobQueue, JobStatus
 
 
 __all__ = ["jobs_app", "build_queue_for_config"]

--- a/src/pollypm/plugins_builtin/activity_feed/cli.py
+++ b/src/pollypm/plugins_builtin/activity_feed/cli.py
@@ -23,19 +23,15 @@ import sys
 import time
 from datetime import timedelta
 from pathlib import Path
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
 import typer
 
 from pollypm.config import DEFAULT_CONFIG_PATH, load_config
-from pollypm.plugins_builtin.activity_feed.cockpit.feed_panel import (
-    FeedFilter,
-    format_entry_row,
-)
-from pollypm.plugins_builtin.activity_feed.handlers.event_projector import (
-    FeedEntry,
-)
-from pollypm.plugins_builtin.activity_feed.plugin import build_projector
+
+if TYPE_CHECKING:
+    from pollypm.plugins_builtin.activity_feed.cockpit.feed_panel import FeedFilter
+    from pollypm.plugins_builtin.activity_feed.handlers.event_projector import FeedEntry
 
 
 activity_app = typer.Typer(
@@ -89,6 +85,8 @@ def parse_duration(raw: str | None) -> timedelta | None:
 
 
 def _entries_as_text(entries: Iterable[FeedEntry]) -> str:
+    from pollypm.plugins_builtin.activity_feed.cockpit.feed_panel import format_entry_row
+
     return "\n".join(format_entry_row(e) for e in entries)
 
 
@@ -97,6 +95,8 @@ def _entries_as_json_lines(entries: Iterable[FeedEntry]) -> str:
 
 
 def _resolve_projector(config_path: Path):
+    from pollypm.plugins_builtin.activity_feed.plugin import build_projector
+
     config = load_config(config_path)
     return build_projector(config)
 
@@ -107,6 +107,8 @@ def _build_filter(
     actor: str | None,
     since: str | None,
 ) -> FeedFilter:
+    from pollypm.plugins_builtin.activity_feed.cockpit.feed_panel import FeedFilter
+
     f = FeedFilter()
     if project:
         f = f.with_project(project)

--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -6,17 +6,10 @@ Provides ``pm task ...`` and ``pm flow ...`` subcommands via Typer.
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 from typing import Optional
 
 import typer
-
-from pollypm.work.flow_engine import parse_flow_yaml
-from pollypm.work.sqlite_service import (
-    SQLiteWorkService,
-    WorkServiceError,
-)
 
 # Worked examples block — shown in `pm task --help` so a worker
 # hitting --help for the first time sees a copy-paste flow instead of
@@ -61,6 +54,8 @@ _JSON_OPTION = typer.Option(False, "--json", help="Output as JSON.")
 
 def _run(fn, *args, **kwargs):
     """Call a work service method, catching errors for clean CLI output."""
+    from pollypm.work.sqlite_service import WorkServiceError
+
     try:
         return fn(*args, **kwargs)
     except WorkServiceError as exc:
@@ -141,6 +136,7 @@ def _svc(db: str, project: str | None = None) -> SQLiteWorkService:
 
     from pollypm.work.sync import SyncManager
     from pollypm.work.sync_file import FileSyncAdapter
+    from pollypm.work.sqlite_service import SQLiteWorkService
 
     db_path = _resolve_db_path(db, project=project)
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1121,6 +1117,8 @@ def flow_validate(
 
     text = p.read_text(encoding="utf-8")
     try:
+        from pollypm.work.flow_engine import parse_flow_yaml
+
         template = parse_flow_yaml(text)
         if output_json:
             typer.echo(json.dumps({"valid": True, "name": template.name}))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,7 @@
+import json
 from pathlib import Path
+import subprocess
+import sys
 
 from typer.testing import CliRunner
 
@@ -73,6 +76,49 @@ def test_discover_config_path_returns_global_config(monkeypatch, tmp_path: Path)
     assert resolved == cli.DEFAULT_CONFIG_PATH.resolve()
 
 
+def test_importing_cli_defers_heavy_runtime_modules() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    script = """
+import json
+import sys
+import pollypm.cli
+
+payload = {
+    "sqlalchemy": any(m == "sqlalchemy" or m.startswith("sqlalchemy.") for m in sys.modules),
+    "plugin_host": "pollypm.plugin_host" in sys.modules,
+    "service_api": any(m == "pollypm.service_api" or m.startswith("pollypm.service_api.") for m in sys.modules),
+    "accounts": "pollypm.accounts" in sys.modules,
+    "activity_panel": "pollypm.plugins_builtin.activity_feed.cockpit.feed_panel" in sys.modules,
+    "activity_plugin": "pollypm.plugins_builtin.activity_feed.plugin" in sys.modules,
+    "activity_projector": "pollypm.plugins_builtin.activity_feed.handlers.event_projector" in sys.modules,
+    "jobs_workers": "pollypm.jobs.workers" in sys.modules,
+    "memory_store": "pollypm.store.sqlalchemy_store" in sys.modules,
+    "work_sqlite": "pollypm.work.sqlite_service" in sys.modules,
+}
+print(json.dumps(payload, sort_keys=True))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert json.loads(result.stdout) == {
+        "accounts": False,
+        "activity_panel": False,
+        "activity_plugin": False,
+        "activity_projector": False,
+        "jobs_workers": False,
+        "memory_store": False,
+        "plugin_host": False,
+        "service_api": False,
+        "sqlalchemy": False,
+        "work_sqlite": False,
+    }
+
+
 def test_root_command_attaches_existing_session_when_default_config_missing(monkeypatch, tmp_path: Path) -> None:
     called: dict[str, object] = {}
 
@@ -87,7 +133,6 @@ def test_root_command_attaches_existing_session_when_default_config_missing(monk
             called["attached"] = name
             return 0
 
-    from pollypm.config import GLOBAL_CONFIG_DIR
     fake_default = tmp_path / "no-such-dir" / "pollypm.toml"
     monkeypatch.setattr(cli, "DEFAULT_CONFIG_PATH", fake_default)
     monkeypatch.setattr(cli, "_discover_config_path", lambda p: fake_default)


### PR DESCRIPTION
Closes #467

## Summary
- defer startup-heavy imports from the root CLI path
- lazy-load jobs, activity, work, and service-adjacent modules behind command registration or call sites
- add regression coverage that `import pollypm.cli` does not drag in heavy runtime modules

## Testing
- HOME=/tmp/pytest-467 uv run --extra dev pytest tests/test_cli.py tests/test_cli_issue.py tests/test_activity_feed_cli.py tests/test_jobs_cli.py tests/test_memory_cli.py tests/test_work_cli.py tests/test_config.py tests/test_transcript_ingest.py tests/test_cli_help_examples.py tests/test_typer_typo_suggestions.py -q