### PR TITLE
perf(settings): reuse filtered section rows

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -2365,6 +2365,9 @@ class PollySettingsPaneApp(App[None]):
         self._nav_widgets: dict[str, Static] = {}
         self._selected_account_key: str | None = None
         self._selected_project_key: str | None = None
+        self._visible_account_rows: list[dict] = []
+        self._visible_project_rows: list[dict] = []
+        self._visible_plugin_rows: list[dict] = []
         self._nav_cursor: int = 0
         self._focus_target: str = "nav"  # nav | table
 
@@ -2541,11 +2544,20 @@ class PollySettingsPaneApp(App[None]):
             return
 
         if key == "accounts":
-            self._render_accounts(data)
+            rows = self._filtered_accounts(data)
+            self._visible_account_rows = rows
+            self._render_accounts(rows)
+            self._render_account_detail(rows)
         elif key == "projects":
-            self._render_projects(data)
+            rows = self._filtered_projects(data)
+            self._visible_project_rows = rows
+            self._render_projects(rows)
+            self._render_project_detail(rows)
         elif key == "plugins":
-            self._render_plugins(data)
+            rows = self._filtered_plugins(data)
+            self._visible_plugin_rows = rows
+            self._render_plugins(rows)
+            self._render_plugin_detail(rows)
         elif key == "heartbeat":
             self._render_kv("Heartbeat & recovery", data.heartbeat)
         elif key == "planner":
@@ -2587,9 +2599,8 @@ class PollySettingsPaneApp(App[None]):
             or q in a["plan"].lower()
         ]
 
-    def _render_accounts(self, data: SettingsData) -> None:
+    def _render_accounts(self, rows: list[dict]) -> None:
         self.accounts.clear()
-        rows = self._filtered_accounts(data)
         for a in rows:
             dot, colour = _settings_status_dot(a["health"], a["logged_in"])
             fo_mark = f"#{a['failover_pos']}" if a["failover_pos"] else ""
@@ -2615,10 +2626,8 @@ class PollySettingsPaneApp(App[None]):
                 pass
         elif self.accounts.row_count and self.accounts.cursor_row < 0:
             self.accounts.move_cursor(row=0)
-        self._render_account_detail(data)
 
-    def _render_account_detail(self, data: SettingsData) -> None:
-        rows = self._filtered_accounts(data)
+    def _render_account_detail(self, rows: list[dict]) -> None:
         if not rows:
             self.detail.update(
                 "[dim]No accounts match the current filter.[/dim]\n\n"
@@ -2669,9 +2678,8 @@ class PollySettingsPaneApp(App[None]):
             or q in p["path"].lower()
         ]
 
-    def _render_projects(self, data: SettingsData) -> None:
+    def _render_projects(self, rows: list[dict]) -> None:
         self.projects_table.clear()
-        rows = self._filtered_projects(data)
         for p in rows:
             dot_colour = "#3ddc84" if p["tracked"] else "#4a5568"
             dot = Text("\u25cf", style=dot_colour)
@@ -2703,10 +2711,8 @@ class PollySettingsPaneApp(App[None]):
             and self.projects_table.cursor_row < 0
         ):
             self.projects_table.move_cursor(row=0)
-        self._render_project_detail(data)
 
-    def _render_project_detail(self, data: SettingsData) -> None:
-        rows = self._filtered_projects(data)
+    def _render_project_detail(self, rows: list[dict]) -> None:
         if not rows:
             self.detail.update(
                 "[dim]No projects match the current filter.[/dim]"
@@ -2763,9 +2769,8 @@ class PollySettingsPaneApp(App[None]):
             or q in p["status"].lower()
         ]
 
-    def _render_plugins(self, data: SettingsData) -> None:
+    def _render_plugins(self, rows: list[dict]) -> None:
         self.plugins_table.clear()
-        rows = self._filtered_plugins(data)
         for p in rows:
             status = p["status"]
             if status == "loaded":
@@ -2787,10 +2792,8 @@ class PollySettingsPaneApp(App[None]):
             and self.plugins_table.cursor_row < 0
         ):
             self.plugins_table.move_cursor(row=0)
-        self._render_plugin_detail(data)
 
-    def _render_plugin_detail(self, data: SettingsData) -> None:
-        rows = self._filtered_plugins(data)
+    def _render_plugin_detail(self, rows: list[dict]) -> None:
         if not rows:
             self.detail.update(
                 "[dim]No plugins match the current filter.[/dim]"
@@ -3143,12 +3146,12 @@ class PollySettingsPaneApp(App[None]):
             return
         if self._active_section == "accounts":
             self._selected_account_key = self._current_accounts_key()
-            self._render_account_detail(data)
+            self._render_account_detail(self._visible_account_rows)
         elif self._active_section == "projects":
             self._selected_project_key = self._current_projects_key()
-            self._render_project_detail(data)
+            self._render_project_detail(self._visible_project_rows)
         elif self._active_section == "plugins":
-            self._render_plugin_detail(data)
+            self._render_plugin_detail(self._visible_plugin_rows)
 
     @on(DataTable.RowHighlighted, "#accounts")
     def on_account_highlighted(

--- a/tests/test_settings_ui.py
+++ b/tests/test_settings_ui.py
@@ -495,6 +495,32 @@ def test_search_filters_accounts(settings_env) -> None:
     _run(body())
 
 
+def test_accounts_section_reuses_filtered_rows_within_one_render(
+    settings_env, monkeypatch,
+) -> None:
+    app = settings_env["app"]
+    filtered_calls = 0
+    original = app._filtered_accounts
+
+    def _count_filtered(data):
+        nonlocal filtered_calls
+        filtered_calls += 1
+        return original(data)
+
+    monkeypatch.setattr(app, "_filtered_accounts", _count_filtered)
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            filtered_calls_before = filtered_calls
+            app._search_query = "claude"
+            app._render_section("accounts")
+            await pilot.pause()
+            assert filtered_calls - filtered_calls_before == 1
+
+    _run(body())
+
+
 # ---------------------------------------------------------------------------
 # 6. R refresh reloads live data (service.list_account_statuses called
 #    again)


### PR DESCRIPTION
Closes #470

## Summary
- cache filtered settings-section rows during section render
- reuse the same filtered snapshot for detail rendering and row-highlight sync
- add a regression test proving the accounts section does not refilter during a single render cycle

## Testing
- HOME=/tmp/pytest-470d uv run --extra dev pytest tests/test_settings_ui.py -q