### PR TITLE
fix(heartbeat): dedupe repeated idle nudges

### DIFF
--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -911,7 +911,25 @@ class LocalHeartbeatBackend(HeartbeatBackend):
     # Rate limit nudges: max once per session per 10 minutes
     # Rate limits for worker nudges
     _NUDGE_COOLDOWN_SECONDS = 600
+    _NUDGE_ESCALATION_IDLE_CYCLES = 8
     _MAX_NUDGES_BEFORE_RECOVERY = 6
+
+    def _repeated_snapshot_count(
+        self,
+        api,
+        context: HeartbeatSessionContext,
+        *,
+        limit: int,
+    ) -> int:
+        hashes = api.recent_snapshot_hashes(context.session_name, limit=limit)
+        repeated = 0
+        if hashes:
+            for value in hashes:
+                if value == hashes[0]:
+                    repeated += 1
+                else:
+                    break
+        return repeated
 
     def _nudge_stalled_worker(self, api, context: HeartbeatSessionContext) -> None:
         """Send a targeted nudge to a stalled WORKER. Never targets the operator."""
@@ -929,6 +947,11 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                 limit=200,
             )
             now = datetime.now(UTC)
+            idle_cycles = self._repeated_snapshot_count(
+                api,
+                context,
+                limit=self._NUDGE_ESCALATION_IDLE_CYCLES,
+            )
 
             def _age_seconds(event: dict) -> float | None:
                 created_at = event.get("created_at")
@@ -957,8 +980,22 @@ class LocalHeartbeatBackend(HeartbeatBackend):
             # Rate limit + circuit breaker.
             nudge_count = 0
             most_recent_age: float | None = None
+            same_episode_nudge = False
+            same_episode_escalated = False
             for event in recent:
-                if event.get("subject") != "nudge":
+                payload = event.get("payload") or {}
+                subject = event.get("subject")
+                if (
+                    subject == "nudge"
+                    and payload.get("snapshot_hash") == context.snapshot_hash
+                ):
+                    same_episode_nudge = True
+                if (
+                    subject == "nudge_escalated"
+                    and payload.get("snapshot_hash") == context.snapshot_hash
+                ):
+                    same_episode_escalated = True
+                if subject != "nudge":
                     continue
                 age = _age_seconds(event)
                 if age is None:
@@ -967,6 +1004,29 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                     nudge_count += 1
                 if most_recent_age is None:
                     most_recent_age = age
+            if same_episode_escalated:
+                return
+            if same_episode_nudge:
+                if idle_cycles >= self._NUDGE_ESCALATION_IDLE_CYCLES:
+                    api.raise_alert(
+                        context.session_name,
+                        "stuck_session",
+                        "warn",
+                        (
+                            f"{context.session_name} stayed stalled after a heartbeat "
+                            f"nudge for {idle_cycles} identical heartbeats"
+                        ),
+                    )
+                    api.supervisor.msg_store.append_event(
+                        scope=context.session_name,
+                        sender=context.session_name,
+                        subject="nudge_escalated",
+                        payload={
+                            "snapshot_hash": context.snapshot_hash,
+                            "idle_cycles": idle_cycles,
+                        },
+                    )
+                return
             # Circuit breaker: too many nudges → recover the worker.
             if nudge_count >= self._MAX_NUDGES_BEFORE_RECOVERY:
                 self._recover_session(
@@ -1006,6 +1066,8 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                         verb="nudged",
                         subject=context.session_name,
                     ),
+                    "snapshot_hash": context.snapshot_hash,
+                    "idle_cycles": idle_cycles,
                 },
             )
         except Exception:  # noqa: BLE001

--- a/tests/test_heartbeat_plugin_api.py
+++ b/tests/test_heartbeat_plugin_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -116,6 +117,10 @@ class FakeHeartbeatAPI:
         self.recoveries: list[tuple[str, str, str]] = []
         self.account_marks: list[tuple[str, str, str]] = []
         self.messages: list[tuple[str, str, str]] = []
+        self.supervisor = SimpleNamespace(
+            config=SimpleNamespace(sessions={}, projects={}),
+            msg_store=_FakeMessageStore(),
+        )
 
     def list_sessions(self) -> list[HeartbeatSessionContext]:
         return list(self._contexts)
@@ -176,6 +181,52 @@ class FakeHeartbeatAPI:
 
     def queue_polly_followup(self, session_name: str, reason: str) -> None:
         self.messages.append(("operator", f"Heartbeat follow-up for {session_name}: {reason}", "heartbeat"))
+
+
+class _FakeMessageStore:
+    def __init__(self) -> None:
+        self._events: list[dict[str, object]] = []
+
+    def query_messages(
+        self,
+        *,
+        type: str | None = None,
+        scope: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, object]]:
+        rows = [
+            event
+            for event in self._events
+            if (type is None or event.get("type") == type)
+            and (scope is None or event.get("scope") == scope)
+        ]
+        rows.sort(key=lambda row: row["created_at"], reverse=True)
+        if limit is not None:
+            rows = rows[:limit]
+        return rows
+
+    def append_event(
+        self,
+        *,
+        scope: str,
+        sender: str,
+        subject: str,
+        payload: dict[str, object],
+        created_at: datetime | None = None,
+    ) -> None:
+        self._events.append(
+            {
+                "type": "event",
+                "scope": scope,
+                "sender": sender,
+                "subject": subject,
+                "payload": payload,
+                "created_at": created_at or datetime.now(timezone.utc),
+            }
+        )
+
+    def upsert_alert(self, *_args, **_kwargs) -> None:
+        return None
 
 
 def _work_signal_api(tmp_path: Path, session_name: str = "worker_pollypm") -> SimpleNamespace:
@@ -645,3 +696,77 @@ def test_local_heartbeat_backend_clears_stale_unmanaged_window_alerts() -> None:
     LocalHeartbeatBackend().run(api)
 
     assert ("heartbeat", "unmanaged_window:pollypm:e2e-sandbox") not in api.alerts
+
+
+def test_worker_nudge_skips_repeat_for_same_snapshot_episode(monkeypatch) -> None:
+    backend = LocalHeartbeatBackend()
+    api = FakeHeartbeatAPI(
+        [],
+        hashes={"worker_pollypm": ["hash-1"] * 7},
+    )
+    context = _context(
+        transcript_delta="",
+        pane_text="Still stalled",
+        previous_snapshot_hash="hash-1",
+        snapshot_hash="hash-1",
+    )
+    monkeypatch.setattr(backend, "_has_pending_work", lambda *_args: True)
+    api.supervisor.msg_store.append_event(
+        scope=context.session_name,
+        sender=context.session_name,
+        subject="nudge",
+        payload={"snapshot_hash": "hash-1"},
+        created_at=datetime.now(timezone.utc) - timedelta(seconds=601),
+    )
+
+    backend._nudge_stalled_worker(api, context)
+
+    assert api.messages == []
+    nudge_events = [
+        event
+        for event in api.supervisor.msg_store.query_messages(
+            type="event",
+            scope=context.session_name,
+            limit=20,
+        )
+        if event.get("subject") == "nudge"
+    ]
+    assert len(nudge_events) == 1
+
+
+def test_worker_nudge_escalates_when_same_episode_keeps_repeating(monkeypatch) -> None:
+    backend = LocalHeartbeatBackend()
+    api = FakeHeartbeatAPI(
+        [],
+        hashes={"worker_pollypm": ["hash-1"] * 8},
+    )
+    context = _context(
+        transcript_delta="",
+        pane_text="Still stalled",
+        previous_snapshot_hash="hash-1",
+        snapshot_hash="hash-1",
+    )
+    monkeypatch.setattr(backend, "_has_pending_work", lambda *_args: True)
+    api.supervisor.msg_store.append_event(
+        scope=context.session_name,
+        sender=context.session_name,
+        subject="nudge",
+        payload={"snapshot_hash": "hash-1"},
+        created_at=datetime.now(timezone.utc) - timedelta(seconds=601),
+    )
+
+    backend._nudge_stalled_worker(api, context)
+
+    assert api.messages == []
+    assert ("worker_pollypm", "stuck_session") in api.alerts
+    escalations = [
+        event
+        for event in api.supervisor.msg_store.query_messages(
+            type="event",
+            scope=context.session_name,
+            limit=20,
+        )
+        if event.get("subject") == "nudge_escalated"
+    ]
+    assert len(escalations) == 1
+    assert escalations[0]["payload"]["snapshot_hash"] == "hash-1"


### PR DESCRIPTION
Closes #478

## Summary
- treat repeated identical stalled snapshots as one idle episode for heartbeat nudges
- suppress repeat nudges for the same snapshot episode even after the cooldown window
- escalate to a stuck-session alert when the same episode keeps repeating, and record that escalation in the event stream

## Testing
- HOME=/tmp/pytest-478 uv run --extra dev pytest tests/test_heartbeat_plugin_api.py tests/test_supervisor.py -q