### PR TITLE
feat(cli): add curated shortcuts cheatsheet

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -36,6 +36,7 @@ from pollypm.error_log import install as _install_error_log
 
 _install_error_log(process_label="cli")
 
+from pollypm.cli_shortcuts import render_shortcuts_text
 from pollypm.config import (
     DEFAULT_CONFIG_PATH,
     resolve_config_path,
@@ -265,6 +266,12 @@ def init(
 @app.command()
 def example_config() -> None:
     typer.echo(render_example_config())
+
+
+@app.command()
+def shortcuts() -> None:
+    """Print a curated cheatsheet of PollyPM commands."""
+    typer.echo(render_shortcuts_text())
 
 
 _ROLE_GUIDES = {

--- a/src/pollypm/cli_shortcuts.py
+++ b/src/pollypm/cli_shortcuts.py
@@ -1,0 +1,43 @@
+"""Shared curated CLI shortcuts for PollyPM surfaces.
+
+Contract:
+- Inputs: none; this module exposes a stable curated shortcut list.
+- Outputs: plain-text and row-oriented render helpers for CLI and UI use.
+- Side effects: none.
+- Invariants: shortcut content is defined once here so CLI and onboarding
+  surfaces do not drift.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ShortcutGroup:
+    name: str
+    commands: tuple[str, ...]
+
+
+_SHORTCUT_GROUPS: tuple[ShortcutGroup, ...] = (
+    ShortcutGroup("Create", ("pm task create", "pm issue create")),
+    ShortcutGroup("Monitor", ("pm activity --follow", "pm cockpit")),
+    ShortcutGroup("Review", ("pm inbox", "pm task approve")),
+    ShortcutGroup("Advanced", ("pm advisor", "pm briefing")),
+)
+
+
+def shortcut_groups() -> tuple[ShortcutGroup, ...]:
+    return _SHORTCUT_GROUPS
+
+
+def shortcut_rows() -> tuple[tuple[str, str], ...]:
+    return tuple((group.name, " | ".join(group.commands)) for group in _SHORTCUT_GROUPS)
+
+
+def render_shortcuts_text() -> str:
+    width = max(len(group.name) for group in _SHORTCUT_GROUPS)
+    lines = ["PollyPM shortcuts", ""]
+    for group in _SHORTCUT_GROUPS:
+        lines.append(f"{group.name.ljust(width)}: {' | '.join(group.commands)}")
+    return "\n".join(lines)

--- a/src/pollypm/onboarding_tui.py
+++ b/src/pollypm/onboarding_tui.py
@@ -15,6 +15,7 @@ from textual.screen import ModalScreen
 from textual.worker import Worker, WorkerState
 from textual.widgets import Button, Checkbox, Footer, RadioButton, RadioSet, SelectionList, Static
 
+from pollypm.cli_shortcuts import shortcut_rows
 from pollypm.config import write_config
 from pollypm.models import KnownProject, ProjectKind, PollyPMConfig, ProviderKind
 from pollypm.onboarding import (
@@ -721,12 +722,23 @@ class OnboardingApp(App[OnboardingResult | None]):
         keys_table.add_row("Ctrl-Q", "Shut down PollyPM and stop all agent sessions.")
         keys_section.mount(Static(Group(keys_table)))
 
+        shortcuts_section = Vertical(classes="section")
+        stage.mount(shortcuts_section)
+        shortcuts_section.mount(Static("Shortcut commands", classes="section-title"))
+        shortcuts_table = Table.grid(expand=True, padding=(0, 1))
+        shortcuts_table.add_column(style="bold #e0e8ef", width=14)
+        shortcuts_table.add_column(style="#a8b8c4")
+        for label, commands in shortcut_rows():
+            shortcuts_table.add_row(label, commands)
+        shortcuts_section.mount(Static(Group(shortcuts_table)))
+
         # ── Tips
         tips_section = Vertical(classes="section")
         stage.mount(tips_section)
         tips_section.mount(Static("Tips", classes="section-title"))
         tips_section.mount(Static(
             "[#a8b8c4]You can reopen PollyPM anytime with [bold #e0e8ef]pm[/] from any terminal.\n"
+            "Run [bold #e0e8ef]pm shortcuts[/] anytime for the same quick command list.\n"
             "Add more accounts or projects later from settings.\n"
             "PollyPM stores all state in [bold #e0e8ef]~/.pollypm/[/] — nothing is written to your project repos.[/]"
         ))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -261,6 +261,19 @@ def test_worker_start_no_role_is_deprecated(monkeypatch, tmp_path: Path) -> None
     assert "pm task claim" in result.output
 
 
+def test_shortcuts_command_prints_curated_cheatsheet() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli.app, ["shortcuts"])
+
+    assert result.exit_code == 0
+    assert "PollyPM shortcuts" in result.output
+    assert "Create" in result.output
+    assert "pm task create" in result.output
+    assert "pm activity --follow" in result.output
+    assert "pm briefing" in result.output
+
+
 def test_worker_start_role_architect_still_works(monkeypatch, tmp_path: Path) -> None:
     """``pm worker-start --role architect <project>`` remains supported.
 

--- a/tests/test_cli_shortcuts.py
+++ b/tests/test_cli_shortcuts.py
@@ -1,0 +1,19 @@
+from pollypm.cli_shortcuts import render_shortcuts_text, shortcut_rows
+
+
+def test_shortcut_rows_are_stable_for_shared_surfaces() -> None:
+    assert shortcut_rows() == (
+        ("Create", "pm task create | pm issue create"),
+        ("Monitor", "pm activity --follow | pm cockpit"),
+        ("Review", "pm inbox | pm task approve"),
+        ("Advanced", "pm advisor | pm briefing"),
+    )
+
+
+def test_render_shortcuts_text_uses_all_rows() -> None:
+    rendered = render_shortcuts_text()
+
+    assert rendered.startswith("PollyPM shortcuts")
+    for label, commands in shortcut_rows():
+        assert label in rendered
+        assert commands in rendered


### PR DESCRIPTION
Closes #506

## Summary
- add a shared shortcuts module so curated command groups live in one place
- add `pm shortcuts` for a categorized PollyPM cheatsheet
- surface the same shortcuts list on the onboarding launch screen

## Testing
- HOME=/tmp/pytest-506 uv run --extra dev pytest tests/test_cli.py tests/test_cli_shortcuts.py tests/test_onboarding_tui.py -q