### PR TITLE
feat(cockpit): show palette tip on first launch

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -314,6 +314,17 @@ class CockpitRouter:
         data["selected"] = key
         self._write_state(data)
 
+    def should_show_palette_tip(self) -> bool:
+        data = self._load_state()
+        return not bool(data.get("palette_tip_seen"))
+
+    def mark_palette_tip_seen(self) -> None:
+        data = self._load_state()
+        if data.get("palette_tip_seen") is True:
+            return
+        data["palette_tip_seen"] = True
+        self._write_state(data)
+
     def _load_state(self) -> dict[str, object]:
         path = self._state_path()
         if not path.exists():

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -247,6 +247,8 @@ POLLY_SLOGANS = [
     "Guide the chaos.\nShip the value.",
 ]
 
+_PALETTE_TIP_MESSAGE = "Tip: press `:` to open the command palette."
+
 
 def _wrap_alert_reason(reason: str, *, width: int = 28, max_lines: int = 4) -> list[str]:
     """Break ``reason`` into ≤``max_lines`` display lines of ≤``width`` chars.
@@ -603,9 +605,19 @@ class PollyCockpitApp(App[None]):
         self._start_core_rail()
         # Live alert toasts — non-intrusive bottom-right overlay.
         _setup_alert_notifier(self, bind_a=True)
+        self.call_after_refresh(self._show_palette_tip_once)
 
     def action_view_alerts(self) -> None:
         _action_view_alerts(self)
+
+    def _show_palette_tip_once(self) -> None:
+        try:
+            if not self.router.should_show_palette_tip():
+                return
+            self.router.mark_palette_tip_seen()
+            self.notify(_PALETTE_TIP_MESSAGE, timeout=10.0)
+        except Exception:  # noqa: BLE001
+            pass
 
     def _start_core_rail(self) -> None:
         """Start the process-wide HeartbeatRail via the supervisor, best-effort.

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -171,6 +171,21 @@ def test_cockpit_router_selected_key_clears_missing_right_pane_state(monkeypatch
     assert "mounted_session" not in state
 
 
+def test_cockpit_router_marks_palette_tip_seen(tmp_path: Path) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+    router = CockpitRouter(config_path)
+
+    assert router.should_show_palette_tip() is True
+
+    router.mark_palette_tip_seen()
+
+    assert router.should_show_palette_tip() is False
+    assert router._load_state()["palette_tip_seen"] is True
+
+
 def test_cockpit_router_selected_key_clears_dead_right_pane_state(monkeypatch, tmp_path: Path) -> None:
     config_path = tmp_path / "pollypm.toml"
     config_path.write_text(
@@ -1462,3 +1477,53 @@ def test_cockpit_app_tick_scheduler_is_noop(tmp_path: Path) -> None:
     """The scheduler tick is a no-op — heartbeat runs via cron, not the cockpit."""
     app = PollyCockpitApp(tmp_path / "pollypm.toml")
     app._tick_scheduler()  # should not raise or do anything
+
+
+def test_cockpit_app_shows_palette_tip_on_first_launch(monkeypatch, tmp_path: Path) -> None:
+    class FakeRouter:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+            self.marked = 0
+
+        def selected_key(self) -> str:
+            return "polly"
+
+        def build_items(self, *, spinner_index: int = 0):
+            from pollypm.cockpit_rail import CockpitItem
+
+            return [
+                CockpitItem("polly", "Polly", "ready"),
+                CockpitItem("inbox", "Inbox (0)", "clear"),
+                CockpitItem("settings", "Settings", "config"),
+            ]
+
+        def route_selected(self, key: str) -> None:
+            self.calls.append(key)
+
+        def create_worker_and_route(self, project_key: str) -> None:
+            self.calls.append(f"new:{project_key}")
+
+        def should_show_palette_tip(self) -> bool:
+            return self.marked == 0
+
+        def mark_palette_tip_seen(self) -> None:
+            self.marked += 1
+
+    app = PollyCockpitApp(tmp_path / "pollypm.toml")
+    app.router = FakeRouter()  # type: ignore[assignment]
+    notices: list[tuple[str, float | None]] = []
+    monkeypatch.setattr(
+        app,
+        "notify",
+        lambda message, **kwargs: notices.append((message, kwargs.get("timeout"))),
+    )
+
+    async def exercise() -> None:
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await pilot.pause()
+
+    asyncio.run(exercise())
+
+    assert notices == [("Tip: press `:` to open the command palette.", 10.0)]
+    assert app.router.marked == 1


### PR DESCRIPTION
Closes #500

## Summary
- persist a first-launch command-palette tip flag in cockpit router state
- show a one-time 10-second cockpit tip for the `:` command palette on first launch
- add router and Textual coverage for the seen-flag and first-launch notification path

## Testing
- HOME=/tmp/pytest-500 uv run --extra dev pytest tests/test_cockpit.py -q