### PR TITLE
feat(cockpit): celebrate recent worker shipments

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -25,6 +25,7 @@ callers + the test suite.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from pollypm.config import load_config
@@ -339,6 +340,8 @@ class WorkerRosterRow:
     last_heartbeat: str | None
     worktree_path: str | None
     branch_name: str | None
+    just_shipped: bool = False
+    shipment_token: str | None = None
 
 
 # Order used by the renderer + sort helpers. Lower = earlier in the table.
@@ -355,6 +358,23 @@ def _worker_roster_sort_key(row: "WorkerRosterRow") -> tuple[int, str]:
         _WORKER_ROSTER_STATUS_ORDER.get(row.status, 9),
         (row.project_name or row.project_key or "").lower(),
     )
+
+
+def _recent_worker_shipment(task) -> tuple[bool, str | None]:
+    work_status = getattr(getattr(task, "work_status", None), "value", "")
+    updated_at = getattr(task, "updated_at", None)
+    task_id = getattr(task, "task_id", None)
+    if work_status != "review" or not updated_at or not task_id:
+        return False, None
+    try:
+        updated_dt = datetime.fromisoformat(str(updated_at))
+    except (TypeError, ValueError):
+        return False, None
+    if updated_dt.tzinfo is None:
+        updated_dt = updated_dt.replace(tzinfo=UTC)
+    if updated_dt < datetime.now(UTC) - timedelta(seconds=20):
+        return False, None
+    return True, f"{task_id}:{updated_dt.isoformat()}"
 
 
 def _pane_text_shows_active_turn(pane_text: str) -> bool:
@@ -519,6 +539,7 @@ def _gather_worker_roster(config) -> list[WorkerRosterRow]:
                 getattr(task, "current_node_id", None)
                 if task is not None else None
             )
+            just_shipped, shipment_token = _recent_worker_shipment(task)
             window_name = f"task-{project_key}-{ws.task_number}"
             window = storage_windows.get(window_name)
             has_window = window is not None and not getattr(
@@ -597,6 +618,8 @@ def _gather_worker_roster(config) -> list[WorkerRosterRow]:
                     last_heartbeat=last_heartbeat_iso,
                     worktree_path=ws.worktree_path,
                     branch_name=ws.branch_name,
+                    just_shipped=just_shipped,
+                    shipment_token=shipment_token,
                 )
             )
 

--- a/src/pollypm/cockpit_workers.py
+++ b/src/pollypm/cockpit_workers.py
@@ -103,6 +103,7 @@ class PollyWorkerRosterApp(App[None]):
     ]
 
     AUTO_REFRESH_SECONDS = 5.0
+    CELEBRATION_SECONDS = 0.8
 
     _STATUS_DOTS: dict[str, tuple[str, str]] = {
         "working": ("\u25cf", "#3ddc84"),
@@ -134,6 +135,8 @@ class PollyWorkerRosterApp(App[None]):
         self._rows: list = []
         self._auto_refresh: bool = False
         self._auto_refresh_timer = None
+        self._active_shipments: set[str] = set()
+        self._seen_shipments: set[str] = set()
 
     def compose(self) -> ComposeResult:
         with Vertical(id="wr-outer"):
@@ -216,10 +219,18 @@ class PollyWorkerRosterApp(App[None]):
 
         self.hint.update(self._DEFAULT_HINT)
         for row in rows:
+            celebrating = self._is_celebrating(row)
             glyph, colour = self._STATUS_DOTS.get(row.status, ("\u25cb", "#6b7a88"))
-            dot = Text.assemble((glyph, colour))
-            project_cell = Text(row.project_name or row.project_key, style="#5b8aff")
-            session_cell = Text(row.session_name, style="#d6dee5")
+            if celebrating:
+                dot = Text("\u2713", style="bold #dcf4e6 on #173322")
+                project_style = "bold #dcf4e6 on #173322"
+                cell_style = "bold #dcf4e6 on #173322"
+            else:
+                dot = Text.assemble((glyph, colour))
+                project_style = "#5b8aff"
+                cell_style = "#d6dee5"
+            project_cell = Text(row.project_name or row.project_key, style=project_style)
+            session_cell = Text(row.session_name, style=cell_style)
             task_text = (
                 f"#{row.task_number} {row.task_title}".rstrip()
                 if row.task_number is not None
@@ -229,12 +240,31 @@ class PollyWorkerRosterApp(App[None]):
                 project_cell,
                 session_cell,
                 dot,
-                Text(task_text, style="#d6dee5"),
-                Text(row.current_node or "\u2014", style="#97a6b2"),
-                Text(row.turn_label, style="#97a6b2"),
-                Text(row.last_commit_label, style="#6b7a88"),
+                Text(task_text, style=cell_style),
+                Text(row.current_node or "\u2014", style=cell_style),
+                Text(row.turn_label, style=cell_style),
+                Text(row.last_commit_label, style=cell_style),
                 key=f"{row.project_key}:{row.session_name}",
             )
+
+    def _is_celebrating(self, row) -> bool:
+        token = getattr(row, "shipment_token", None)
+        if not getattr(row, "just_shipped", False) or not token:
+            return False
+        if token not in self._seen_shipments:
+            self._seen_shipments.add(token)
+            self._active_shipments.add(token)
+            self.set_timer(
+                self.CELEBRATION_SECONDS,
+                lambda token=token: self._clear_celebration(token),
+            )
+        return token in self._active_shipments
+
+    def _clear_celebration(self, token: str) -> None:
+        if token not in self._active_shipments:
+            return
+        self._active_shipments.remove(token)
+        self._render()
 
     def _selected_row(self):
         """Return the row currently under the cursor, or ``None``."""

--- a/tests/test_worker_roster_ui.py
+++ b/tests/test_worker_roster_ui.py
@@ -22,6 +22,7 @@ import asyncio
 from pathlib import Path
 
 import pytest
+from textual.widgets import DataTable
 
 
 # ---------------------------------------------------------------------------
@@ -80,6 +81,8 @@ def _make_row(**overrides):
         last_heartbeat="2026-04-17T00:00:00+00:00",
         worktree_path="/tmp/wt",
         branch_name="task/demo-1",
+        just_shipped=False,
+        shipment_token=None,
     )
     defaults.update(overrides)
     return WorkerRosterRow(**defaults)
@@ -87,6 +90,13 @@ def _make_row(**overrides):
 
 def _run(coro) -> None:
     asyncio.run(coro)
+
+
+def _table_rows(table: DataTable) -> list[list[str]]:
+    return [
+        [str(cell) for cell in table.get_row_at(row_index)]
+        for row_index in range(table.row_count)
+    ]
 
 
 @pytest.fixture
@@ -251,6 +261,28 @@ def test_d_dispatches_to_worker_tmux_window(roster_env, roster_app) -> None:
                 roster_app._dispatch_to_worker_sync(rows[0])
             assert targets, "expected _perform_worker_dispatch to be called"
             assert targets[-1] == ("gamma", 42)
+    _run(body())
+
+
+def test_recent_shipment_flashes_checkmark_then_clears(
+    roster_env, roster_app,
+) -> None:
+    async def body() -> None:
+        rows = [
+            _make_row(
+                status="idle",
+                just_shipped=True,
+                shipment_token="demo/1:2026-04-21T16:00:00+00:00",
+            ),
+        ]
+        roster_app._gather = lambda: rows  # type: ignore[method-assign]
+        async with roster_app.run_test(size=(160, 40)) as pilot:
+            await pilot.pause()
+            assert _table_rows(roster_app.table)[0][2] == "✓"
+            await asyncio.sleep(0.9)
+            await pilot.pause()
+            assert _table_rows(roster_app.table)[0][2] == "○"
+
     _run(body())
 
 


### PR DESCRIPTION
Closes #497

## Summary
- mark freshly shipped worker tasks in the roster gather layer when a task has just moved into review
- flash the roster row green with a subtle checkmark for 800ms on a new shipment token
- add UI coverage for the one-shot celebration behavior

## Testing
- HOME=/tmp/pytest-497 uv run --extra dev pytest tests/test_worker_roster_ui.py -q