### PR TITLE
docs(project-planning): explain --actor architect

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
@@ -58,7 +58,7 @@ The single command you use at every stage boundary is:
       ]
     }'
 
-`<task_id>` is the `project/number` you claimed in step 1 of `<kickoff>`. Always pass `--actor architect` so the work-service knows it's you driving the transition.
+`<task_id>` is the `project/number` you claimed in step 1 of `<kickoff>`. Always pass `--actor architect` so the work-service knows it's you driving the transition; if you omit it, the action is recorded as a worker and the wrong role is notified.
 
 ## When to advance
 

--- a/tests/test_architect_stage_transitions.py
+++ b/tests/test_architect_stage_transitions.py
@@ -309,6 +309,9 @@ def test_architect_prompt_includes_stage_transitions_block() -> None:
     assert "<stage_transitions>" in text
     assert "</stage_transitions>" in text
     assert "pm task done" in text
+    assert "--actor architect" in text
+    assert "recorded as a worker" in text
+    assert "wrong role is notified" in text
     # Mentions every work stage by name so the agent can match its
     # current node to an instruction.
     for stage in (


### PR DESCRIPTION
Refs #477.\n\nAdds a single explanatory sentence to the architect prompt and a regression assertion that the prompt explains why `--actor architect` is required.