### PR TITLE
feat(ui): celebrate task approvals

### DIFF
--- a/src/pollypm/approval_notifications.py
+++ b/src/pollypm/approval_notifications.py
@@ -1,0 +1,109 @@
+"""Shared approval-notification helpers for human review surfaces.
+
+Contract:
+- Inputs: a reviewed ``Task`` plus a UI ``notify`` callback.
+- Outputs: a stable approval toast message, and best-effort macOS banner
+  delivery when Notification Center is available.
+- Side effects: emits a Textual toast immediately and may queue an OS
+  notification on Darwin hosts.
+- Invariants: approval flows format the same message everywhere and never
+  fail the underlying approval action when notification delivery flakes.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Callable
+
+from pollypm.plugins_builtin.human_notify.macos import MacOsNotifyAdapter
+
+if TYPE_CHECKING:
+    from pollypm.plugins_builtin.human_notify.protocol import HumanNotifyAdapter
+    from pollypm.work.models import Task
+
+
+NotifyCallback = Callable[..., None]
+_TOAST_TIMEOUT_SECONDS = 5.0
+
+
+def format_task_approval_message(
+    task: "Task",
+    *,
+    approved_at: datetime | None = None,
+) -> str:
+    """Build the shared celebratory approval message."""
+    shipped_in = _format_elapsed(
+        getattr(task, "created_at", None),
+        approved_at or datetime.now(UTC),
+    )
+    if shipped_in:
+        return f"\u2713 {task.task_id} approved - shipped in {shipped_in}"
+    return f"\u2713 {task.task_id} approved"
+
+
+def notify_task_approved(
+    task: "Task",
+    *,
+    notify: NotifyCallback,
+    approved_at: datetime | None = None,
+    os_adapter: "HumanNotifyAdapter | None" = None,
+) -> str:
+    """Emit the in-cockpit toast and best-effort macOS banner."""
+    message = format_task_approval_message(task, approved_at=approved_at)
+    notify(message, severity="information", timeout=_TOAST_TIMEOUT_SECONDS)
+
+    adapter = os_adapter or MacOsNotifyAdapter()
+    try:
+        available = adapter.is_available()
+    except Exception:  # noqa: BLE001
+        available = False
+    if available:
+        adapter.notify(
+            title="PollyPM: Task approved",
+            body=message,
+            task_id=task.task_id,
+            project=task.project,
+        )
+    return message
+
+
+def _format_elapsed(
+    started_at: datetime | None,
+    finished_at: datetime,
+) -> str | None:
+    """Render a compact elapsed duration like ``45m`` or ``2h 5m``."""
+    if started_at is None:
+        return None
+    start = _coerce_utc(started_at)
+    end = _coerce_utc(finished_at)
+    if start is None or end is None:
+        return None
+    total_seconds = int((end - start).total_seconds())
+    if total_seconds <= 0:
+        return None
+
+    days, rem = divmod(total_seconds, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes, seconds = divmod(rem, 60)
+
+    if days:
+        return f"{days}d {hours}h" if hours else f"{days}d"
+    if hours:
+        return f"{hours}h {minutes}m" if minutes else f"{hours}h"
+    if minutes:
+        return f"{minutes}m"
+    return f"{seconds}s"
+
+
+def _coerce_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+__all__ = [
+    "format_task_approval_message",
+    "notify_task_approved",
+]

--- a/src/pollypm/cockpit_tasks.py
+++ b/src/pollypm/cockpit_tasks.py
@@ -9,6 +9,7 @@ from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Button, DataTable, Input, Static, TabbedContent, TabPane
 
+from pollypm.approval_notifications import notify_task_approved
 from pollypm.cockpit_task_review import (
     load_task_review_artifact,
     render_task_review_artifact,
@@ -791,7 +792,7 @@ class PollyTasksApp(App[None]):
                 return
             if decision == "approve":
                 svc.approve(task_id, "user", reason or "Approved from task cockpit")
-                self.notify(f"Approved {task_id}", severity="information")
+                notify_task_approved(task, notify=self.notify)
             else:
                 svc.reject(task_id, "user", reason or "Rejected from task cockpit")
                 self.notify(f"Rejected {task_id}", severity="information")

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -50,6 +50,7 @@ from textual.widgets import (
     TabPane,
 )
 
+from pollypm.approval_notifications import notify_task_approved
 from pollypm.cockpit_formatting import format_event_time
 from pollypm.cockpit_formatting import format_relative_age as _format_relative_age
 from pollypm.models import ProviderKind
@@ -1857,7 +1858,7 @@ class PollyTasksApp(App[None]):
                 self.notify("Task is not in review state", severity="warning")
                 return
             svc.approve(self._selected_task_id, "user", "Approved from cockpit")
-            self.notify(f"Approved {self._selected_task_id}", severity="information")
+            notify_task_approved(task, notify=self.notify)
             self._show_detail(self._selected_task_id)
         except Exception as exc:  # noqa: BLE001
             self.notify(f"Approve failed: {exc}", severity="error")

--- a/tests/test_approval_notifications.py
+++ b/tests/test_approval_notifications.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from pollypm.approval_notifications import (
+    format_task_approval_message,
+    notify_task_approved,
+)
+from pollypm.work.models import Priority, Task, TaskType
+
+
+def _task(*, created_at: datetime | None) -> Task:
+    return Task(
+        project="notesy",
+        task_number=1,
+        title="Ship task review polish",
+        type=TaskType.TASK,
+        priority=Priority.HIGH,
+        created_at=created_at,
+    )
+
+
+def test_format_task_approval_message_includes_compact_ship_time() -> None:
+    approved_at = datetime(2026, 4, 21, 18, 45, tzinfo=UTC)
+    task = _task(created_at=approved_at - timedelta(minutes=45))
+
+    assert (
+        format_task_approval_message(task, approved_at=approved_at)
+        == "\u2713 notesy/1 approved - shipped in 45m"
+    )
+
+
+def test_notify_task_approved_emits_toast_and_macos_banner() -> None:
+    approved_at = datetime(2026, 4, 21, 18, 45, tzinfo=UTC)
+    task = _task(created_at=approved_at - timedelta(hours=2, minutes=5))
+    toast_calls: list[tuple[str, str, float]] = []
+    adapter_calls: list[tuple[str, str, str, str]] = []
+
+    class FakeAdapter:
+        def is_available(self) -> bool:
+            return True
+
+        def notify(
+            self,
+            *,
+            title: str,
+            body: str,
+            task_id: str,
+            project: str,
+        ) -> None:
+            adapter_calls.append((title, body, task_id, project))
+
+    message = notify_task_approved(
+        task,
+        notify=lambda msg, *, severity, timeout: toast_calls.append(
+            (msg, severity, timeout)
+        ),
+        approved_at=approved_at,
+        os_adapter=FakeAdapter(),
+    )
+
+    assert message == "\u2713 notesy/1 approved - shipped in 2h 5m"
+    assert toast_calls == [
+        ("\u2713 notesy/1 approved - shipped in 2h 5m", "information", 5.0)
+    ]
+    assert adapter_calls == [
+        (
+            "PollyPM: Task approved",
+            "\u2713 notesy/1 approved - shipped in 2h 5m",
+            "notesy/1",
+            "notesy",
+        )
+    ]

--- a/tests/test_tasks_ui.py
+++ b/tests/test_tasks_ui.py
@@ -153,6 +153,8 @@ class _FakeSvc:
         self._flow = flow
         self._worker_sessions = worker_sessions or {}
         self._owner_by_id = owner_by_id or {}
+        self.approvals: list[tuple[str, str, str]] = []
+        self.rejections: list[tuple[str, str, str]] = []
 
     def list_tasks(self, *, project: str):
         assert project == "demo"
@@ -190,6 +192,12 @@ class _FakeSvc:
         assert task_project == "demo"
         assert active_only is True
         return self._worker_sessions.get(f"{task_project}/{task_number}")
+
+    def approve(self, task_id: str, actor: str, reason: str) -> None:
+        self.approvals.append((task_id, actor, reason))
+
+    def reject(self, task_id: str, actor: str, reason: str) -> None:
+        self.rejections.append((task_id, actor, reason))
 
     def close(self) -> None:
         return None
@@ -457,3 +465,32 @@ def test_task_app_filters_drive_table_contents(env, monkeypatch) -> None:
             assert rows[0][2] == "Done already"
 
     _run(body())
+
+
+def test_task_app_approval_routes_through_shared_notification(env, monkeypatch) -> None:
+    if not _load_config_compatible(env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_tasks import PollyTasksApp
+
+    review_task = _task(node_id="critic_panel", status=WorkStatus.REVIEW)
+    fake_svc = _FakeSvc(
+        tasks_factory=lambda: [review_task],
+        flow=_flow(),
+    )
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        "pollypm.cockpit_tasks.notify_task_approved",
+        lambda task, *, notify: calls.append(task.task_id),
+    )
+
+    app = PollyTasksApp(env["config_path"], "demo")
+    app._get_svc = lambda: fake_svc  # type: ignore[method-assign]
+    app._refresh_list = lambda select_first=False: None  # type: ignore[method-assign]
+
+    app._review_task("demo/1", decision="approve")
+
+    assert fake_svc.approvals == [
+        ("demo/1", "user", "Approved from task cockpit")
+    ]
+    assert calls == ["demo/1"]


### PR DESCRIPTION
Closes #507

## Summary
- add a shared approval-notification helper so task approval flows format the same celebratory message
- upgrade task approvals to show a 5-second in-cockpit toast and best-effort macOS banner
- add regression coverage for approval message formatting and the task review approval path

## Testing
- HOME=/tmp/pytest-507 uv run --extra dev pytest tests/test_approval_notifications.py tests/test_tasks_ui.py tests/test_cockpit.py -q