### PR TITLE
docs(memory): point workers to the guide

### DIFF
--- a/src/pollypm/memory_prompts.py
+++ b/src/pollypm/memory_prompts.py
@@ -321,27 +321,25 @@ def build_worker_protocol_injection(
     session_role: str | None,
     guide_text: str | None = None,
 ) -> str:
-    """Render a ``## Worker Protocol`` section containing the worker guide.
+    """Render a short ``## Worker Protocol`` pointer for workers.
 
     Returns an empty string when ``session_role`` is not exactly
     ``"worker"``. Non-worker roles (PM, reviewer, operator, supervisor)
     get nothing — this is intentional, so adding the injection to the
     existing memory-injection path is a no-op for those sessions.
 
-    ``guide_text`` overrides the on-disk lookup; tests use it to avoid
-    a filesystem dependency.
+    ``guide_text`` is accepted for compatibility with the old guide-
+    loading implementation, but the rendered prompt now points workers
+    at ``docs/worker-guide.md`` instead of inlining the whole guide.
     """
     if session_role != "worker":
         return ""
-    text = guide_text if guide_text is not None else load_worker_guide_text()
-    if not text.strip():
-        return ""
-    # The guide starts with its own "# Worker Guide" H1. We wrap it in
-    # an H2 section so the persona prompt keeps a consistent hierarchy
-    # (the memory section is also H2). Strip a trailing newline before
-    # re-wrapping so the final render has exactly one trailing newline.
-    body = text.rstrip("\n")
-    return f"{WORKER_PROTOCOL_HEADING}\n\n{body}\n"
+    # Keep the kickoff compact: the full playbook lives in docs/worker-guide.md.
+    return (
+        f"{WORKER_PROTOCOL_HEADING}\n\n"
+        "Read `docs/worker-guide.md` for the worker playbook, including how to "
+        "claim work, ship it, and recover."
+    )
 
 
 def prepend_worker_protocol(prompt: str, injection: str) -> str:

--- a/tests/test_worker_protocol_injection.py
+++ b/tests/test_worker_protocol_injection.py
@@ -60,41 +60,45 @@ def test_injection_empty_for_non_worker_roles():
 def test_injection_non_empty_for_worker_role():
     out = build_worker_protocol_injection(session_role="worker")
     assert out.startswith(WORKER_PROTOCOL_HEADING)
-    # Contains load-bearing signal strings from the guide.
-    assert "pm task claim" in out
-    assert "pm task done" in out
+    assert "docs/worker-guide.md" in out
+    assert "claim work" in out
+    assert "ship it" in out
+    assert "recover" in out
+    assert "pm task done" not in out
 
 
 def test_injection_accepts_explicit_guide_text_for_isolation():
-    """Tests pin a known payload without needing the real doc on disk."""
+    """The legacy ``guide_text`` hook should not inline the guide."""
     payload = "# Worker Guide\n\nBody goes here."
     out = build_worker_protocol_injection(
         session_role="worker",
         guide_text=payload,
     )
     assert out.startswith(WORKER_PROTOCOL_HEADING + "\n")
-    assert "Body goes here." in out
+    assert "docs/worker-guide.md" in out
+    assert "Body goes here." not in out
 
 
-def test_injection_empty_when_guide_missing():
-    """Blank guide text → empty injection. Session startup must not
-    choke on a missing doc in a slim install."""
+def test_injection_uses_pointer_when_guide_missing():
+    """Blank guide text no longer inlines the guide; it still points
+    workers at docs/worker-guide.md."""
     out = build_worker_protocol_injection(
         session_role="worker",
         guide_text="",
     )
-    assert out == ""
+    assert out.startswith(WORKER_PROTOCOL_HEADING)
+    assert "docs/worker-guide.md" in out
+    assert "Body goes here." not in out
 
 
-def test_injection_has_single_trailing_newline():
+def test_injection_has_no_trailing_newline():
     out = build_worker_protocol_injection(
         session_role="worker",
         guide_text="# Worker Guide\n\nBody.",
     )
-    # Exactly one trailing newline so prepend functions add exactly
-    # one blank line of separation.
-    assert out.endswith("\n")
-    assert not out.endswith("\n\n")
+    # The pointer prompt is compact; the prepend helper supplies the
+    # separator when composing with the persona prompt.
+    assert not out.endswith("\n")
 
 
 # ---------------------------------------------------------------------------
@@ -204,7 +208,7 @@ def test_tmux_service_injects_worker_protocol_for_worker(tmux_service):
         user_id="operator",
     )
     assert WORKER_PROTOCOL_HEADING in out
-    assert "pm task done" in out
+    assert "docs/worker-guide.md" in out
     assert persona in out
     # Protocol appears above the persona.
     assert out.index(WORKER_PROTOCOL_HEADING) < out.index(persona)
@@ -229,9 +233,9 @@ def test_tmux_service_skips_worker_protocol_for_other_roles(tmux_service, role):
     assert persona in out
 
 
-def test_tmux_service_injects_nothing_for_missing_guide(tmux_service, monkeypatch):
-    """If the guide can't be located, worker sessions still launch —
-    they just don't get the protocol section. Defensive resilience."""
+def test_tmux_service_injects_worker_protocol_even_without_guide_text(tmux_service, monkeypatch):
+    """The kickoff now points to docs/worker-guide.md directly, so a
+    missing on-disk guide_text hook must not suppress the pointer."""
     import pollypm.memory_prompts as mp
 
     monkeypatch.setattr(mp, "load_worker_guide_text", lambda: "")
@@ -244,6 +248,6 @@ def test_tmux_service_injects_nothing_for_missing_guide(tmux_service, monkeypatc
         task_description=None,
         user_id="operator",
     )
-    # No crash, no protocol, persona intact.
-    assert WORKER_PROTOCOL_HEADING not in out
+    assert WORKER_PROTOCOL_HEADING in out
+    assert "docs/worker-guide.md" in out
     assert persona in out


### PR DESCRIPTION
Refs #474.\n\nReplaces the duplicated kickoff worker-guide prose with a short pointer to docs/worker-guide.md and updates the focused regression test.