### PR TITLE
feat(notify): surface critical errors as alerts

### DIFF
--- a/src/pollypm/error_log.py
+++ b/src/pollypm/error_log.py
@@ -36,6 +36,8 @@ import logging
 import os
 from pathlib import Path
 
+from pollypm.error_notifications import CriticalErrorNotificationHandler
+
 DEFAULT_LOG_FILENAME = "errors.log"
 DEFAULT_LEVEL = logging.WARNING
 _FORMAT = (
@@ -85,22 +87,25 @@ def install(
     root = logging.getLogger()
     # Don't stack handlers — a repeat install (cockpit boot after
     # ``pm up`` already installed for its CLI process) is a no-op.
-    if any(getattr(h, "_pollypm_error_handler", False) for h in root.handlers):
-        return
-    target = path or _log_path()
-    try:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        handler = logging.FileHandler(target, encoding="utf-8")
-    except Exception:  # noqa: BLE001
-        # Can't write the log file — don't take the whole process
-        # down over it. Callers still get stderr logging from their
-        # own basicConfig.
-        return
-    handler.setLevel(level)
-    handler.setFormatter(logging.Formatter(_FORMAT))
-    handler.addFilter(_ProcessTagFilter(process_label))
-    handler._pollypm_error_handler = True  # type: ignore[attr-defined]
-    root.addHandler(handler)
+    if not any(getattr(h, "_pollypm_error_handler", False) for h in root.handlers):
+        target = path or _log_path()
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            handler = logging.FileHandler(target, encoding="utf-8")
+        except Exception:  # noqa: BLE001
+            # Can't write the log file — don't take the whole process
+            # down over it. Callers still get stderr logging from their
+            # own basicConfig.
+            return
+        handler.setLevel(level)
+        handler.setFormatter(logging.Formatter(_FORMAT))
+        handler.addFilter(_ProcessTagFilter(process_label))
+        handler._pollypm_error_handler = True  # type: ignore[attr-defined]
+        root.addHandler(handler)
+    if not any(getattr(h, "_pollypm_error_notification_handler", False) for h in root.handlers):
+        alert_handler = CriticalErrorNotificationHandler()
+        alert_handler._pollypm_error_notification_handler = True  # type: ignore[attr-defined]
+        root.addHandler(alert_handler)
     if root.level > level:
         root.setLevel(level)
 

--- a/src/pollypm/error_notifications.py
+++ b/src/pollypm/error_notifications.py
@@ -1,0 +1,213 @@
+"""Critical error alert + desktop notification bridge.
+
+Contract:
+- Inputs: ``logging.LogRecord`` objects at ``ERROR`` or higher.
+- Outputs: durable ``error_log`` alerts in the store plus best-effort desktop
+  notifications on supported hosts.
+- Side effects: writes alert rows via the shared Store singleton and shells out
+  to platform notification tools when available.
+- Invariants: one module owns critical-error fanout; callers only install the
+  handler and keep logging normally.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import threading
+from typing import TYPE_CHECKING, Protocol, Sequence
+
+if TYPE_CHECKING:
+    from pollypm.store.protocol import Store
+
+
+_SESSION_NAME = "error_log"
+_ALERT_SEVERITY = "critical"
+_MAX_MESSAGE_LENGTH = 280
+
+
+@dataclass(frozen=True, slots=True)
+class CriticalErrorNotification:
+    """Normalized notification payload derived from one log record."""
+
+    alert_type: str
+    title: str
+    message: str
+
+
+class DesktopNotifier(Protocol):
+    """Narrow desktop-notification contract for critical errors."""
+
+    name: str
+
+    def is_available(self) -> bool: ...
+
+    def notify(self, *, title: str, body: str) -> None: ...
+
+
+class MacOsDesktopNotifier:
+    name = "macos"
+
+    def is_available(self) -> bool:
+        return sys.platform == "darwin" and shutil.which("osascript") is not None
+
+    def notify(self, *, title: str, body: str) -> None:
+        script = (
+            'display notification "' + _escape_applescript(body) + '" '
+            'with title "' + _escape_applescript(title) + '" '
+            'sound name "Glass"'
+        )
+        subprocess.run(
+            ["osascript", "-e", script],
+            check=False,
+            timeout=2.0,
+            capture_output=True,
+        )
+
+
+class LinuxNotifySendNotifier:
+    name = "notify-send"
+
+    def is_available(self) -> bool:
+        return sys.platform.startswith("linux") and shutil.which("notify-send") is not None
+
+    def notify(self, *, title: str, body: str) -> None:
+        subprocess.run(
+            ["notify-send", "--app-name", "PollyPM", title, body],
+            check=False,
+            timeout=2.0,
+            capture_output=True,
+        )
+
+
+def build_critical_error_notification(
+    record: logging.LogRecord,
+) -> CriticalErrorNotification | None:
+    """Convert an ``ERROR``/``CRITICAL`` log record into an alert payload."""
+    if record.levelno < logging.ERROR:
+        return None
+    message = _normalize_message(record.getMessage())
+    if not message:
+        return None
+    return CriticalErrorNotification(
+        alert_type=f"critical_error:{_record_signature(record, message)}",
+        title=_notification_title(message),
+        message=message,
+    )
+
+
+def load_critical_error_store(config_path: Path | None = None) -> "Store":
+    """Resolve the shared Store singleton for alert writes."""
+    from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+    from pollypm.store.registry import get_store
+
+    config = load_config(config_path or DEFAULT_CONFIG_PATH)
+    return get_store(config)
+
+
+class CriticalErrorNotificationHandler(logging.Handler):
+    """Mirror critical log records into durable alerts + desktop banners."""
+
+    def __init__(
+        self,
+        *,
+        config_path: Path | None = None,
+        store_loader=load_critical_error_store,
+        notifiers: Sequence[DesktopNotifier] | None = None,
+    ) -> None:
+        super().__init__(level=logging.ERROR)
+        self.config_path = config_path
+        self._store_loader = store_loader
+        self._notifiers = tuple(
+            notifiers
+            if notifiers is not None
+            else (MacOsDesktopNotifier(), LinuxNotifySendNotifier())
+        )
+        self._sent_signatures: set[str] = set()
+        self._sent_lock = threading.Lock()
+        self._emit_guard = threading.local()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if getattr(self._emit_guard, "active", False):
+            return
+        notification = build_critical_error_notification(record)
+        if notification is None:
+            return
+        self._emit_guard.active = True
+        try:
+            self._write_alert(notification)
+            if self._mark_first_delivery(notification.alert_type):
+                self._send_desktop(notification)
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            self._emit_guard.active = False
+
+    def _write_alert(self, notification: CriticalErrorNotification) -> None:
+        store = self._store_loader(self.config_path)
+        store.upsert_alert(
+            _SESSION_NAME,
+            notification.alert_type,
+            _ALERT_SEVERITY,
+            notification.message,
+        )
+
+    def _mark_first_delivery(self, alert_type: str) -> bool:
+        with self._sent_lock:
+            if alert_type in self._sent_signatures:
+                return False
+            self._sent_signatures.add(alert_type)
+            return True
+
+    def _send_desktop(self, notification: CriticalErrorNotification) -> None:
+        for notifier in self._notifiers:
+            try:
+                if not notifier.is_available():
+                    continue
+                notifier.notify(
+                    title=notification.title,
+                    body=notification.message,
+                )
+            except Exception:  # noqa: BLE001
+                continue
+
+
+def _notification_title(message: str) -> str:
+    lower = message.lower()
+    if any(token in lower for token in ("capacity", "exhausted", "auth", "signed out", "relogin")):
+        return "PollyPM: Account issue"
+    if any(token in lower for token in ("pane dead", "session died", "missing window", "worker died")):
+        return "PollyPM: Session issue"
+    return "PollyPM: Critical error"
+
+
+def _normalize_message(message: str) -> str:
+    text = " ".join((message or "").split())
+    if len(text) <= _MAX_MESSAGE_LENGTH:
+        return text
+    return text[: _MAX_MESSAGE_LENGTH - 1] + "..."
+
+
+def _record_signature(record: logging.LogRecord, message: str) -> str:
+    payload = f"{record.name}\n{message}".encode("utf-8", "replace")
+    return hashlib.sha1(payload).hexdigest()[:12]
+
+
+def _escape_applescript(raw: str) -> str:
+    return raw.replace("\\", "\\\\").replace('"', '\\"')
+
+
+__all__ = [
+    "CriticalErrorNotification",
+    "CriticalErrorNotificationHandler",
+    "DesktopNotifier",
+    "LinuxNotifySendNotifier",
+    "MacOsDesktopNotifier",
+    "build_critical_error_notification",
+    "load_critical_error_store",
+]

--- a/tests/test_error_notifications.py
+++ b/tests/test_error_notifications.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from pollypm.error_log import install
+from pollypm.error_notifications import (
+    CriticalErrorNotificationHandler,
+    build_critical_error_notification,
+)
+
+
+def test_build_critical_error_notification_ignores_warning() -> None:
+    record = logging.LogRecord(
+        name="demo",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=10,
+        msg="just a warning",
+        args=(),
+        exc_info=None,
+    )
+
+    assert build_critical_error_notification(record) is None
+
+
+def test_handler_upserts_alert_and_sends_desktop_notification() -> None:
+    store_calls: list[tuple[str, str, str, str]] = []
+    desktop_calls: list[tuple[str, str]] = []
+
+    class FakeStore:
+        def upsert_alert(
+            self,
+            session_name: str,
+            alert_type: str,
+            severity: str,
+            message: str,
+        ) -> None:
+            store_calls.append((session_name, alert_type, severity, message))
+
+    class FakeNotifier:
+        name = "fake"
+
+        def is_available(self) -> bool:
+            return True
+
+        def notify(self, *, title: str, body: str) -> None:
+            desktop_calls.append((title, body))
+
+    handler = CriticalErrorNotificationHandler(
+        store_loader=lambda _config_path=None: FakeStore(),
+        notifiers=(FakeNotifier(),),
+    )
+    record = logging.LogRecord(
+        name="pollypm.supervisor",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=23,
+        msg="Account main exhausted - switch to backup",
+        args=(),
+        exc_info=None,
+    )
+
+    handler.emit(record)
+
+    assert len(store_calls) == 1
+    session_name, alert_type, severity, message = store_calls[0]
+    assert session_name == "error_log"
+    assert alert_type.startswith("critical_error:")
+    assert severity == "critical"
+    assert message == "Account main exhausted - switch to backup"
+    assert desktop_calls == [
+        (
+            "PollyPM: Account issue",
+            "Account main exhausted - switch to backup",
+        )
+    ]
+
+
+def test_handler_dedupes_repeated_desktop_notifications() -> None:
+    desktop_calls: list[tuple[str, str]] = []
+
+    class FakeStore:
+        def upsert_alert(self, *_args) -> None:
+            return None
+
+    class FakeNotifier:
+        name = "fake"
+
+        def is_available(self) -> bool:
+            return True
+
+        def notify(self, *, title: str, body: str) -> None:
+            desktop_calls.append((title, body))
+
+    handler = CriticalErrorNotificationHandler(
+        store_loader=lambda _config_path=None: FakeStore(),
+        notifiers=(FakeNotifier(),),
+    )
+    record = logging.LogRecord(
+        name="pollypm.supervisor",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=54,
+        msg="worker session died while switching providers",
+        args=(),
+        exc_info=None,
+    )
+
+    handler.emit(record)
+    handler.emit(record)
+
+    assert desktop_calls == [
+        (
+            "PollyPM: Session issue",
+            "worker session died while switching providers",
+        )
+    ]
+
+
+def test_install_adds_notification_handler_once(tmp_path: Path) -> None:
+    root = logging.getLogger()
+    old_handlers = list(root.handlers)
+    old_level = root.level
+    try:
+        root.handlers = []
+        install(process_label="test", path=tmp_path / "errors.log")
+        install(process_label="test", path=tmp_path / "errors.log")
+        assert sum(
+            1
+            for handler in root.handlers
+            if getattr(handler, "_pollypm_error_handler", False)
+        ) == 1
+        assert sum(
+            1
+            for handler in root.handlers
+            if getattr(handler, "_pollypm_error_notification_handler", False)
+        ) == 1
+    finally:
+        for handler in list(root.handlers):
+            try:
+                handler.close()
+            except Exception:  # noqa: BLE001
+                pass
+        root.handlers = old_handlers
+        root.setLevel(old_level)


### PR DESCRIPTION
Closes #509

## Summary
- add a logging-side bridge that mirrors ERROR/CRITICAL records into durable `error_log` alerts
- send best-effort desktop notifications for first-seen critical errors on macOS and Linux
- cover the handler contract and idempotent install path with focused tests

## Testing
- HOME=/tmp/pytest-509 uv run --extra dev pytest tests/test_error_notifications.py tests/test_alert_toasts.py tests/test_human_notify.py -q