### PR TITLE
docs: clarify provider-policy persona scope

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -20,6 +20,11 @@ Defaults for the built-in personas:
 | ``architect`` (planner) | ``[claude, codex]`` | Planning is a reading/reasoning task. |
 | Each critic (``critic_*``) | ``[claude, codex]`` | Planner-plugin diversity resolver may override one critic to Codex for real model diversity (pp06). |
 
+``architect`` and each ``critic_*`` persona are contributed by the
+``project_planning`` plugin; they are only available when that plugin is
+loaded. Core personas shipped in v1 are ``polly``, ``russell``, and
+``worker``.
+
 **Overrides.** Users override per-persona in ``pollypm.toml``:
 
 ```toml


### PR DESCRIPTION
Closes #439

## Summary
- document that `architect` and `critic_*` personas come from the `project_planning` plugin
- keep the provider-policy table from implying those personas are part of the always-shipped core set

## Testing
- git diff --check