### PR TITLE
docs: define the front-door doc flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Architecturally, PollyPM is a modular monolith: one local system with explicit r
 
 **New here? Start with [docs/getting-started.md](docs/getting-started.md)** — a 15-minute walkthrough from install to your first completed task. See [CHANGELOG.md](CHANGELOG.md) for release notes and migration notes. The rest of this README is the module map and architecture reference for contributors.
 
+## Document Map
+
+Use the front-door docs in this order:
+
+- `README.md` — what PollyPM is, how the system is shaped, and where the major modules live.
+- [`docs/getting-started.md`](docs/getting-started.md) — install, first-run, first-project, first-task walkthrough.
+- [`docs/project-overview.md`](docs/project-overview.md) — deep project context and regenerated background material; not the best first read.
+
 ## Architecture
 
 ```mermaid

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,6 +4,12 @@ PollyPM is a tmux-first control plane for running multiple AI coding agents in p
 
 This guide gets you from zero to a first completed task in under 15 minutes.
 
+Use the docs in this order:
+
+- [README.md](../README.md) for the high-level module map and architecture.
+- `docs/getting-started.md` for the install and first-run walkthrough.
+- [docs/project-overview.md](project-overview.md) only when you want the deeper generated background and historical context.
+
 ## Install
 
 PollyPM needs Python 3.13+, `tmux`, `git`, and at least one of the `claude` or `codex` CLIs on your PATH. Install those first if you don't have them.
@@ -137,6 +143,7 @@ Rejection sends the task back to `in_progress` with your feedback attached — t
 
 ## Where to go next
 
+- **[README.md](../README.md)** — architecture map, module boundaries, and the current system shape.
 - **[docs/worker-guide.md](worker-guide.md)** — the worker lifecycle, `pm task` commands, and the output format workers use to hand off.
 - **[docs/planner-plugin-spec.md](planner-plugin-spec.md)** — how `pm project plan` decomposes work through an architect + 5-critic pipeline.
 - **[docs/downtime-plugin-spec.md](downtime-plugin-spec.md)** — the downtime plugin for scheduled background work.
@@ -146,5 +153,6 @@ Rejection sends the task back to `in_progress` with your feedback attached — t
 - **`pm memory --help`** — the memory plugin for long-term context.
 - **[docs/plugin-authoring.md](plugin-authoring.md)** and **[docs/plugin-discovery-spec.md](plugin-discovery-spec.md)** — author your own provider, runtime, or profile plugin.
 - **[docs/magic-skills-catalog.md](magic-skills-catalog.md)** — the starter catalog of reusable agent skills.
+- **[docs/project-overview.md](project-overview.md)** — the long-form generated project context after you already know your way around.
 
 If something doesn't match what you're seeing, run `pm debug` for a one-screen snapshot of sessions, alerts, and recent events — that's the right thing to paste into a bug report.

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -2,6 +2,11 @@
 
 # PollyPM Overview
 
+This document is the deep context dump for contributors who already know the
+basics. Start with [README.md](../README.md) for the system map and
+[docs/getting-started.md](getting-started.md) for install and first-run
+instructions; this file is intentionally the third stop, not the front door.
+
 ## Summary
 - Goals: ✓ CRITICAL-EMERGENCY: Recovered from 270+ minute catastrophic failure
 - Architecture Changes: Start with issue #1 (global/project-local config split).


### PR DESCRIPTION
Closes #444

## Summary
- make `README.md` the explicit front door for architecture and module-map context
- position `docs/getting-started.md` as the install/first-run walkthrough
- mark `docs/project-overview.md` as the deeper third-stop context doc

## Testing
- git diff --check