### PR TITLE
feat(onboarding): show visible step progress

### DIFF
--- a/src/pollypm/onboarding_tui.py
+++ b/src/pollypm/onboarding_tui.py
@@ -33,6 +33,13 @@ from pollypm.onboarding import (
 from pollypm.projects import discover_recent_git_repositories, ensure_project_scaffold, make_project_key
 from pollypm.session_services import create_tmux_client
 
+ONBOARDING_STAGES = (
+    ("accounts", "Connect account"),
+    ("controller", "Choose controller"),
+    ("projects", "Add projects"),
+    ("tour", "Launch PollyPM"),
+)
+
 
 def installed_provider_statuses(statuses: list[CliAvailability]) -> list[CliAvailability]:
     return [status for status in statuses if status.installed]
@@ -66,6 +73,42 @@ def merge_selected_projects(
         existing_paths.add(normalized)
         keys_in_use.add(project.key)
     return merged
+
+
+def onboarding_step_header(step: str) -> str:
+    """Return the visible step counter + progress bar for ``step``."""
+    stage_ids = [stage_id for stage_id, _label in ONBOARDING_STAGES]
+    total = len(stage_ids)
+    try:
+        index = stage_ids.index(step)
+    except ValueError:
+        index = 0
+    current = index + 1
+    done = min(total, current)
+    bar = "[#3ddc84]" + ("█" * done) + "[/][#253140]" + ("█" * (total - done)) + "[/]"
+    label = ONBOARDING_STAGES[index][1]
+    return f"[#5b8aff bold]Step {current} of {total}[/]  {bar}  [dim]{label}[/]"
+
+
+def onboarding_progress_lines(step: str) -> list[str]:
+    """Return the rail-friendly progress checklist for ``step``."""
+    stage_ids = [stage_id for stage_id, _label in ONBOARDING_STAGES]
+    try:
+        current_index = stage_ids.index(step)
+    except ValueError:
+        current_index = 0
+
+    lines: list[str] = []
+    for index, (_stage_id, label) in enumerate(ONBOARDING_STAGES):
+        if index < current_index:
+            lines.append(f"[#3ddc84]✓[/] [#3ddc84]{label}[/]")
+        elif index == current_index:
+            lines.append(f"[#5b8aff]◉[/] [#5b8aff bold]{label}[/]")
+        else:
+            lines.append(f"[#6b7a88]○[/] [#6b7a88]{label}[/]")
+    lines.append("")
+    lines.append("[dim]Mouse is enabled. Click buttons, choices, and project selections directly.[/dim]")
+    return lines
 
 
 @dataclass(slots=True)
@@ -448,27 +491,11 @@ class OnboardingApp(App[OnboardingResult | None]):
         return Panel("\n".join(lines), title="Connected Accounts", border_style="#253140")
 
     def _progress_panel(self) -> Panel:
-        stages = [
-            ("accounts", "Connect agent accounts"),
-            ("controller", "Choose Polly's control account"),
-            ("projects", "Review suggested projects"),
-        ]
-        step_order = [s[0] for s in stages]
-        current_index = step_order.index(self.step) if self.step in step_order else -1
-        lines = []
-        for i, (step_id, label) in enumerate(stages):
-            if i < current_index:
-                marker = "[#3ddc84]━[/]"
-                lines.append(f"{marker} [#3ddc84]{label}[/]")
-            elif step_id == self.step:
-                marker = "[#5b8aff]►[/]"
-                lines.append(f"{marker} [#5b8aff bold]{label}[/]")
-            else:
-                marker = "[#3e4c5a]─[/]"
-                lines.append(f"{marker} [#3e4c5a]{label}[/]")
-        lines.append("")
-        lines.append("[dim]Mouse is enabled. Click buttons, choices, and project selections directly.[/dim]")
-        return Panel("\n".join(lines), title="Setup", border_style="#253140")
+        return Panel(
+            "\n".join(onboarding_progress_lines(self.step)),
+            title="Setup Progress",
+            border_style="#253140",
+        )
 
     def _tmux_ready(self) -> bool:
         return shutil.which("tmux") is not None
@@ -490,7 +517,7 @@ class OnboardingApp(App[OnboardingResult | None]):
 
     def _render_accounts_step(self) -> None:
         installed = installed_provider_statuses(self.state.statuses)
-        self.eyebrow_widget.update("Setup Step 1")
+        self.eyebrow_widget.update(onboarding_step_header("accounts"))
         self.title_widget.update("Connect your first agent account")
         self.intro_widget.update(
             "PollyPM opens the real Claude or Codex login flow, waits for it to finish, and saves the result "
@@ -563,7 +590,7 @@ class OnboardingApp(App[OnboardingResult | None]):
         return "Connect Codex\nImplementation, shell-heavy work, fast coding loops"
 
     def _render_controller_step(self) -> None:
-        self.eyebrow_widget.update("Setup Step 2")
+        self.eyebrow_widget.update(onboarding_step_header("controller"))
         self.title_widget.update("Choose the account that runs PollyPM")
         self.intro_widget.update(
             "This account runs Polly and heartbeat. If it becomes unavailable, PollyPM can fail over to another "
@@ -621,7 +648,7 @@ class OnboardingApp(App[OnboardingResult | None]):
         actions.mount(Button("Continue", id="controller-next", variant="success"))
 
     def _render_projects_step(self) -> None:
-        self.eyebrow_widget.update("Setup Step 3")
+        self.eyebrow_widget.update(onboarding_step_header("projects"))
         self.title_widget.update("Add active projects")
         self.intro_widget.update(
             "PollyPM looked through your home folder for git repos where your local git identity authored a commit "
@@ -688,7 +715,7 @@ class OnboardingApp(App[OnboardingResult | None]):
         actions.mount(Button(finish_label, id="projects-finish", variant="success"))
 
     def _render_tour_step(self) -> None:
-        self.eyebrow_widget.update("Ready to launch")
+        self.eyebrow_widget.update(onboarding_step_header("tour"))
         self.title_widget.update("Your cockpit is ready")
         self.intro_widget.update("")
         stage = Vertical(classes="stage")

--- a/tests/test_onboarding_tui.py
+++ b/tests/test_onboarding_tui.py
@@ -4,10 +4,13 @@ from pathlib import Path
 from pollypm.models import KnownProject, ProviderKind
 from pollypm.onboarding import CliAvailability, ConnectedAccount
 from pollypm.onboarding_tui import (
+    ONBOARDING_STAGES,
     OnboardingApp,
     default_controller_account,
     installed_provider_statuses,
     merge_selected_projects,
+    onboarding_progress_lines,
+    onboarding_step_header,
     run_onboarding_app,
 )
 
@@ -196,3 +199,19 @@ def test_connect_provider_cancel_returns_to_onboarding(monkeypatch, tmp_path: Pa
 
     assert rendered == ["rendered"]
     assert messages[-1] == "Login cancelled. Returned to onboarding."
+
+
+def test_onboarding_progress_header_shows_step_count_and_bar() -> None:
+    header = onboarding_step_header("projects")
+
+    assert "Step 3 of 4" in header
+    assert "Add projects" in header
+    assert "█" in header
+
+
+def test_onboarding_progress_lines_mark_done_current_and_up_next() -> None:
+    lines = onboarding_progress_lines("controller")
+
+    assert f"✓[/] [#3ddc84]{ONBOARDING_STAGES[0][1]}" in lines[0]
+    assert f"◉[/] [#5b8aff bold]{ONBOARDING_STAGES[1][1]}" in lines[1]
+    assert f"○[/] [#6b7a88]{ONBOARDING_STAGES[2][1]}" in lines[2]


### PR DESCRIPTION
Closes #517

## Summary
- promote onboarding progress into a clearer shared stage model
- show a visible `Step X of Y` progress header with a progress bar in the main pane
- upgrade the left rail progress block to a done/current/up-next checklist

## Testing
- HOME=/tmp/pytest-517 uv run --extra dev pytest tests/test_onboarding_tui.py -q