### PR TITLE
docs: mark plugin specs as shipped

### DIFF
--- a/docs/advisor-plugin-spec.md
+++ b/docs/advisor-plugin-spec.md
@@ -1,6 +1,6 @@
 # Advisor Plugin Specification
 
-**Status:** v1 target. Depends on: planner plugin, work service, session service, roster/jobs APIs, inbox view.
+**Status:** v1 shipped - implemented in `src/pollypm/plugins_builtin/advisor/plugin.py`. Depends on: planner plugin, work service, session service, roster/jobs APIs, inbox view.
 
 ## 1. Purpose
 

--- a/docs/downtime-plugin-spec.md
+++ b/docs/downtime-plugin-spec.md
@@ -1,6 +1,6 @@
 # Downtime Management Plugin Specification
 
-**Status:** v1 target. Depends on: planner plugin, work service, session service, roster/jobs APIs, capacity subsystem, inbox view.
+**Status:** v1 shipped - implemented in `src/pollypm/plugins_builtin/downtime/plugin.py`. Depends on: planner plugin, work service, session service, roster/jobs APIs, capacity subsystem, inbox view.
 
 ## 1. Purpose
 

--- a/docs/morning-briefing-plugin-spec.md
+++ b/docs/morning-briefing-plugin-spec.md
@@ -1,6 +1,6 @@
 # Morning Briefing Plugin Specification
 
-**Status:** v1 target. Depends on: work service, inbox view, roster/jobs APIs, advisor plugin (optional — briefing can include advisor insights if present).
+**Status:** v1 shipped - implemented in `src/pollypm/plugins_builtin/morning_briefing/plugin.py`. Depends on: work service, inbox view, roster/jobs APIs, advisor plugin (optional — briefing can include advisor insights if present).
 
 ## 1. Purpose
 

--- a/docs/planner-plugin-spec.md
+++ b/docs/planner-plugin-spec.md
@@ -1,6 +1,6 @@
 # Project Planning Plugin Specification
 
-**Status:** v1 target. Depends on: plugin-discovery spec (`docs/plugin-discovery-spec.md`), work service, session service, roster/jobs APIs.
+**Status:** v1 shipped - implemented in `src/pollypm/plugins_builtin/project_planning/plugin.py`. Depends on: plugin-discovery spec (`docs/plugin-discovery-spec.md`), work service, session service, roster/jobs APIs.
 
 ## 1. Purpose
 


### PR DESCRIPTION
Refs #436.\n\nUpdated the plugin spec headers to reflect shipped status and added pointers to the builtin implementation modules.