### PR TITLE
feat(cockpit): add worker health glyphs

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -330,12 +330,15 @@ class WorkerRosterRow:
     project_name: str
     session_name: str
     status: str  # "working" | "idle" | "stuck" | "offline"
+    health: str  # "alive" | "idle_warn" | "unresponsive"
+    health_tooltip: str
     task_id: str | None
     task_number: int | None
     task_title: str
     current_node: str | None
     turn_label: str
     last_commit_label: str
+    token_total: int
     tmux_window: str | None  # e.g. "task-<project>-<number>"
     last_heartbeat: str | None
     worktree_path: str | None
@@ -454,6 +457,64 @@ def _last_commit_age(project_path: Path, branch_name: str | None) -> str:
     return f"{total_s // (3600 * 24)}d ago"
 
 
+def _format_heartbeat_age(last_heartbeat_iso: str | None) -> str:
+    """Return a tooltip-friendly relative heartbeat age."""
+    if not last_heartbeat_iso:
+        return "unknown"
+    try:
+        dt = datetime.fromisoformat(last_heartbeat_iso)
+    except (TypeError, ValueError):
+        return "unknown"
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    delta = datetime.now(UTC) - dt
+    total_s = max(0, int(delta.total_seconds()))
+    if total_s < 60:
+        return "now"
+    if total_s < 3600:
+        return f"{total_s // 60}m ago"
+    if total_s < 3600 * 24:
+        return f"{total_s // 3600}h ago"
+    return f"{total_s // (3600 * 24)}d ago"
+
+
+def _format_token_total(total: int) -> str:
+    if total < 1_000:
+        return f"{total}"
+    if total < 1_000_000:
+        return f"{total / 1_000:.1f}K"
+    return f"{total / 1_000_000:.1f}M"
+
+
+def _worker_health_snapshot(
+    *,
+    status: str,
+    last_heartbeat_iso: str | None,
+    token_total: int,
+    session_name: str,
+) -> tuple[str, str]:
+    """Map worker state to a health bucket + tooltip."""
+    heartbeat_age = _format_heartbeat_age(last_heartbeat_iso)
+    if status in {"stuck", "offline"}:
+        health = "unresponsive"
+    elif status == "idle":
+        try:
+            dt = datetime.fromisoformat(last_heartbeat_iso) if last_heartbeat_iso else None
+        except (TypeError, ValueError):
+            dt = None
+        if dt is not None and dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        idle_long = dt is not None and dt <= datetime.now(UTC) - timedelta(minutes=5)
+        health = "idle_warn" if idle_long else "alive"
+    else:
+        health = "alive"
+    tooltip = (
+        f"last heartbeat {heartbeat_age} · {_format_token_total(token_total)} tokens"
+        f" · session: {session_name}"
+    )
+    return health, tooltip
+
+
 def _gather_worker_roster(config) -> list[WorkerRosterRow]:
     """Walk every tracked project's work-service + tmux state.
 
@@ -539,6 +600,12 @@ def _gather_worker_roster(config) -> list[WorkerRosterRow]:
                 getattr(task, "current_node_id", None)
                 if task is not None else None
             )
+            token_total = 0
+            if task is not None:
+                token_total = int(
+                    (getattr(task, "total_input_tokens", 0) or 0)
+                    + (getattr(task, "total_output_tokens", 0) or 0)
+                )
             just_shipped, shipment_token = _recent_worker_shipment(task)
             window_name = f"task-{project_key}-{ws.task_number}"
             window = storage_windows.get(window_name)
@@ -601,6 +668,12 @@ def _gather_worker_roster(config) -> list[WorkerRosterRow]:
                 is_turn_active=is_turn_active,
             )
             last_commit_label = _last_commit_age(project_path, ws.branch_name)
+            health, health_tooltip = _worker_health_snapshot(
+                status=status,
+                last_heartbeat_iso=last_heartbeat_iso,
+                token_total=token_total,
+                session_name=session_name,
+            )
 
             rows.append(
                 WorkerRosterRow(
@@ -608,12 +681,15 @@ def _gather_worker_roster(config) -> list[WorkerRosterRow]:
                     project_name=str(project_name),
                     session_name=session_name,
                     status=status,
+                    health=health,
+                    health_tooltip=health_tooltip,
                     task_id=task_id,
                     task_number=ws.task_number,
                     task_title=task_title,
                     current_node=current_node,
                     turn_label=turn_label,
                     last_commit_label=last_commit_label,
+                    token_total=token_total,
                     tmux_window=window_name,
                     last_heartbeat=last_heartbeat_iso,
                     worktree_path=ws.worktree_path,

--- a/src/pollypm/cockpit_workers.py
+++ b/src/pollypm/cockpit_workers.py
@@ -105,11 +105,10 @@ class PollyWorkerRosterApp(App[None]):
     AUTO_REFRESH_SECONDS = 5.0
     CELEBRATION_SECONDS = 0.8
 
-    _STATUS_DOTS: dict[str, tuple[str, str]] = {
-        "working": ("\u25cf", "#3ddc84"),
-        "idle": ("\u25cb", "#97a6b2"),
-        "stuck": ("\u25b2", "#ff5f6d"),
-        "offline": ("\u25cf", "#4a5568"),
+    _HEALTH_GLYPHS: dict[str, tuple[str, str]] = {
+        "alive": ("\U0001f7e2", "#3ddc84"),
+        "idle_warn": ("\U0001f7e1", "#f0c45a"),
+        "unresponsive": ("\U0001f534", "#ff5f6d"),
     }
 
     _DEFAULT_HINT = (
@@ -149,7 +148,7 @@ class PollyWorkerRosterApp(App[None]):
     def on_mount(self) -> None:
         self.table.cursor_type = "row"
         self.table.add_columns(
-            "Project", "Session", " ", "Task", "Node", "Turn", "Last commit",
+            "Project", "Session", "Health", "Task", "Node", "Turn", "Last commit",
         )
         self._refresh()
         _setup_alert_notifier(self, bind_a=False)
@@ -220,7 +219,10 @@ class PollyWorkerRosterApp(App[None]):
         self.hint.update(self._DEFAULT_HINT)
         for row in rows:
             celebrating = self._is_celebrating(row)
-            glyph, colour = self._STATUS_DOTS.get(row.status, ("\u25cb", "#6b7a88"))
+            glyph, colour = self._HEALTH_GLYPHS.get(
+                getattr(row, "health", ""),
+                ("\U0001f7e1", "#6b7a88"),
+            )
             if celebrating:
                 dot = Text("\u2713", style="bold #dcf4e6 on #173322")
                 project_style = "bold #dcf4e6 on #173322"
@@ -246,6 +248,7 @@ class PollyWorkerRosterApp(App[None]):
                 Text(row.last_commit_label, style=cell_style),
                 key=f"{row.project_key}:{row.session_name}",
             )
+        self._sync_health_tooltip()
 
     def _is_celebrating(self, row) -> bool:
         token = getattr(row, "shipment_token", None)
@@ -279,6 +282,22 @@ class PollyWorkerRosterApp(App[None]):
         if not (0 <= cursor < len(self._rows)):
             return None
         return self._rows[cursor]
+
+    def _sync_health_tooltip(self) -> None:
+        row = self._selected_row()
+        tooltip = getattr(row, "health_tooltip", "") if row is not None else ""
+        try:
+            self.table.tooltip = tooltip or None
+        except Exception:  # noqa: BLE001
+            pass
+        if row is None:
+            self.hint.update(self._DEFAULT_HINT)
+            return
+        self.hint.update(
+            f"[dim]{_escape(tooltip)}[/dim]  \u00b7  "
+            "R refresh \u00b7 A auto-refresh \u00b7 \u21b5 open project "
+            "\u00b7 d discuss \u00b7 q back"
+        )
 
     def action_refresh(self) -> None:
         self._refresh()
@@ -381,3 +400,7 @@ class PollyWorkerRosterApp(App[None]):
     def _on_row_selected(self, event: DataTable.RowSelected) -> None:
         """Enter on a row → jump to its project dashboard."""
         self.action_jump_to_project()
+
+    @on(DataTable.RowHighlighted, "#wr-table")
+    def _on_row_highlighted(self, _event: DataTable.RowHighlighted) -> None:
+        self._sync_health_tooltip()

--- a/tests/test_worker_roster_ui.py
+++ b/tests/test_worker_roster_ui.py
@@ -71,12 +71,15 @@ def _make_row(**overrides):
         project_name="Demo",
         session_name="worker_demo",
         status="working",
+        health="alive",
+        health_tooltip="last heartbeat now · 168 tokens · session: worker_demo",
         task_id="demo/1",
         task_number=1,
         task_title="Build favicon",
         current_node="implement",
         turn_label="active 2m",
         last_commit_label="5m ago",
+        token_total=168,
         tmux_window="task-demo-1",
         last_heartbeat="2026-04-17T00:00:00+00:00",
         worktree_path="/tmp/wt",
@@ -130,26 +133,21 @@ def test_roster_renders_all_configured_workers(roster_env, roster_app) -> None:
 
 
 def test_status_dots_for_each_category(roster_env, roster_app) -> None:
-    """Each status maps to a distinct dot glyph from ``_STATUS_DOTS``."""
+    """Health states map to the expected glyph set."""
     async def body() -> None:
         rows = [
-            _make_row(status="stuck", session_name="s"),
-            _make_row(status="working", session_name="w"),
-            _make_row(status="idle", session_name="i"),
-            _make_row(status="offline", session_name="o"),
+            _make_row(status="stuck", health="unresponsive", session_name="s"),
+            _make_row(status="working", health="alive", session_name="w"),
+            _make_row(status="idle", health="idle_warn", session_name="i"),
+            _make_row(status="offline", health="unresponsive", session_name="o"),
         ]
         roster_app._gather = lambda: rows  # type: ignore[method-assign]
         async with roster_app.run_test(size=(160, 40)) as pilot:
             await pilot.pause()
-            dots = roster_app._STATUS_DOTS
-            # Sanity: the four statuses are all represented.
-            assert "stuck" in dots
-            assert "working" in dots
-            assert "idle" in dots
-            assert "offline" in dots
-            # Dot glyphs distinguish stuck (triangle) from the circles.
-            assert dots["stuck"][0] != dots["working"][0]
-            assert dots["stuck"][0] != dots["idle"][0]
+            dots = roster_app._HEALTH_GLYPHS
+            assert dots["alive"][0] == "🟢"
+            assert dots["idle_warn"][0] == "🟡"
+            assert dots["unresponsive"][0] == "🔴"
             # Counters line reflects the group tallies.
             counter_text = str(roster_app.counters.render())
             assert "1" in counter_text  # at least one of each
@@ -281,7 +279,30 @@ def test_recent_shipment_flashes_checkmark_then_clears(
             assert _table_rows(roster_app.table)[0][2] == "✓"
             await asyncio.sleep(0.9)
             await pilot.pause()
-            assert _table_rows(roster_app.table)[0][2] == "○"
+            assert _table_rows(roster_app.table)[0][2] == "🟢"
+
+    _run(body())
+
+
+def test_row_highlight_updates_health_tooltip_hint(roster_env, roster_app) -> None:
+    async def body() -> None:
+        rows = [
+            _make_row(
+                status="idle",
+                health="idle_warn",
+                health_tooltip="last heartbeat 7m ago · 2.4M tokens · session: worker_demo",
+                token_total=2_400_000,
+            ),
+        ]
+        roster_app._gather = lambda: rows  # type: ignore[method-assign]
+        async with roster_app.run_test(size=(160, 40)) as pilot:
+            await pilot.pause()
+            roster_app.table.focus()
+            await pilot.pause()
+            hint_text = str(roster_app.hint.render())
+            assert "last heartbeat 7m ago" in hint_text
+            assert "2.4M tokens" in hint_text
+            assert "session: worker_demo" in hint_text
 
     _run(body())
 
@@ -365,6 +386,7 @@ def test_gather_worker_roster_picks_up_worker_session(tmp_path: Path) -> None:
     assert rows[0].session_name == "worker_demo"
     # No tmux server in tests → window is absent → status is "offline".
     assert rows[0].status == "offline"
+    assert rows[0].health == "unresponsive"
     assert rows[0].task_number == t.task_number
     assert "Build favicon" in rows[0].task_title
 
@@ -491,4 +513,6 @@ def test_gather_worker_roster_reuses_recent_heartbeat_snapshot(
     assert len(rows) == 1
     assert rows[0].session_name == "worker_demo"
     assert rows[0].status == "working"
+    assert rows[0].health == "alive"
+    assert "session: worker_demo" in rows[0].health_tooltip
     assert rows[0].turn_label.startswith("active")


### PR DESCRIPTION
Closes #508

## Summary
- add worker-health classification and tooltip data to the roster gather contract
- render a dedicated health glyph in the worker roster instead of overloading the old status dot
- surface heartbeat/tokens/session details on row highlight and cover the gather + UI behavior in tests

## Testing
- HOME=/tmp/pytest-508 uv run --extra dev pytest tests/test_worker_roster_ui.py -q