### PR TITLE
feat(cockpit): surface task priority glyphs

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -29,8 +29,21 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from pollypm.config import load_config
+from pollypm.cockpit_task_priority import priority_glyph, priority_rank
 from pollypm.cockpit_sections.base import _STATUS_ICONS
 from pollypm.heartbeats.snapshots import read_recent_heartbeat_snapshot
+
+
+def _timestamp_sort_value(value) -> float:
+    """Best-effort sortable timestamp for task list ordering."""
+    if not value:
+        return 0.0
+    try:
+        if hasattr(value, "timestamp"):
+            return float(value.timestamp())
+        return float(datetime.fromisoformat(str(value)).timestamp())
+    except Exception:  # noqa: BLE001
+        return 0.0
 
 
 def _render_work_service_issues(project: object) -> str:
@@ -62,12 +75,21 @@ def _render_work_service_issues(project: object) -> str:
     # Active tasks (non-terminal) — sorted by status priority
     _so = {"in_progress": 0, "review": 1, "queued": 2, "blocked": 3, "on_hold": 4, "draft": 5}
     active = [t for t in tasks if t.work_status.value not in ("done", "cancelled")]
-    active.sort(key=lambda t: _so.get(t.work_status.value, 9))
+    active.sort(
+        key=lambda t: (
+            _so.get(t.work_status.value, 9),
+            priority_rank(t),
+            -_timestamp_sort_value(getattr(t, "updated_at", None)),
+            int(getattr(t, "task_number", 0) or 0),
+        )
+    )
     if active:
         for t in active:
             icon = _STATUS_ICONS.get(t.work_status.value, "·")
             assignee = f" [{t.assignee}]" if t.assignee else ""
-            lines.append(f"  {icon} #{t.task_number} {t.title}{assignee}")
+            lines.append(
+                f"  {icon} {priority_glyph(t)} #{t.task_number} {t.title}{assignee}"
+            )
         lines.append("")
 
     # Recently completed (last 10)
@@ -77,7 +99,7 @@ def _render_work_service_issues(project: object) -> str:
         lines.append(f"─── completed ({len(completed)}) ───")
         for t in completed[:10]:
             icon = _STATUS_ICONS.get(t.work_status.value, "·")
-            lines.append(f"  {icon} #{t.task_number} {t.title}")
+            lines.append(f"  {icon} {priority_glyph(t)} #{t.task_number} {t.title}")
         lines.append("")
 
     if not tasks:

--- a/src/pollypm/cockpit_sections/in_flight.py
+++ b/src/pollypm/cockpit_sections/in_flight.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pollypm.cockpit_task_priority import priority_glyph, priority_rank
 from pollypm.cockpit_sections.base import (
     _DASHBOARD_BULLET,
     _STATUS_ICONS,
@@ -11,13 +12,23 @@ from pollypm.cockpit_sections.base import (
 )
 
 
+def _in_flight_sort_key(task) -> tuple[int, float, int]:
+    updated = _iso_to_dt(getattr(task, "updated_at", None))
+    return (
+        priority_rank(task),
+        -(updated.timestamp() if updated is not None else 0.0),
+        int(getattr(task, "task_number", 0) or 0),
+    )
+
+
 def _section_in_flight(in_progress: list) -> list[str]:
     """Tasks currently being worked on."""
     lines = [_dashboard_divider("In flight"), ""]
     if not in_progress:
         lines.extend([f"{_DASHBOARD_BULLET}(none)", ""])
         return lines
-    for t in in_progress:
+    ordered = sorted(in_progress, key=_in_flight_sort_key)
+    for t in ordered:
         icon = _STATUS_ICONS.get(t.work_status.value, "\u27f3")
         assignee = f" [{t.assignee}]" if getattr(t, "assignee", None) else ""
         node = (
@@ -28,7 +39,7 @@ def _section_in_flight(in_progress: list) -> list[str]:
         age = _age_from_dt(_iso_to_dt(getattr(t, "updated_at", None)))
         age_part = f" \u00b7 {age}" if age else ""
         lines.append(
-            f"{_DASHBOARD_BULLET}{icon} #{t.task_number} {t.title}"
+            f"{_DASHBOARD_BULLET}{icon} {priority_glyph(t)} #{t.task_number} {t.title}"
             f"{assignee}{node}{age_part}"
         )
     lines.append("")

--- a/src/pollypm/cockpit_task_priority.py
+++ b/src/pollypm/cockpit_task_priority.py
@@ -1,0 +1,51 @@
+"""Shared task-priority helpers for cockpit task surfaces.
+
+Contract:
+- Inputs: a priority string / enum or any task-like object with a
+  ``.priority`` field.
+- Outputs: stable glyphs, labels, and sort ranks for cockpit task lists.
+- Side effects: none.
+- Invariants: unknown priorities degrade gracefully to a neutral glyph
+  and lowest precedence so the UI never crashes on unexpected data.
+"""
+
+from __future__ import annotations
+
+_PRIORITY_ORDER = {
+    "critical": 0,
+    "high": 1,
+    "normal": 2,
+    "low": 3,
+}
+
+_PRIORITY_GLYPHS = {
+    "critical": "🔴",
+    "high": "🟠",
+    "normal": "🟡",
+    "low": "🟢",
+}
+
+
+def priority_value(priority_or_task: object) -> str:
+    """Normalize a priority enum / task / raw string to a lowercase value."""
+    raw = getattr(priority_or_task, "priority", priority_or_task)
+    value = getattr(raw, "value", raw)
+    if value in (None, ""):
+        return "normal"
+    return str(value).strip().lower() or "normal"
+
+
+def priority_rank(priority_or_task: object) -> int:
+    """Return the cockpit sort rank for a priority value."""
+    return _PRIORITY_ORDER.get(priority_value(priority_or_task), len(_PRIORITY_ORDER))
+
+
+def priority_glyph(priority_or_task: object) -> str:
+    """Return the colored glyph used in cockpit task lists."""
+    return _PRIORITY_GLYPHS.get(priority_value(priority_or_task), "⚪")
+
+
+def priority_label(priority_or_task: object) -> str:
+    """Return a human-readable priority label with the cockpit glyph."""
+    value = priority_value(priority_or_task)
+    return f"{priority_glyph(value)} {value}"

--- a/src/pollypm/cockpit_tasks.py
+++ b/src/pollypm/cockpit_tasks.py
@@ -10,6 +10,11 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, DataTable, Input, Static, TabbedContent, TabPane
 
 from pollypm.approval_notifications import notify_task_approved
+from pollypm.cockpit_task_priority import (
+    priority_glyph,
+    priority_label,
+    priority_rank,
+)
 from pollypm.cockpit_task_review import (
     load_task_review_artifact,
     render_task_review_artifact,
@@ -58,14 +63,15 @@ def _timestamp_sort_value(value) -> float:
         return 0.0
 
 
-def _task_sort_key(task) -> tuple[int, float, int]:
-    """Sort tasks by status priority, then newest activity, then task number."""
+def _task_sort_key(task) -> tuple[int, int, float, int]:
+    """Sort tasks by status, then task priority, then newest activity."""
     status = getattr(getattr(task, "work_status", None), "value", None) or str(
         getattr(task, "work_status", "") or ""
     )
     updated = getattr(task, "updated_at", None) or getattr(task, "created_at", None)
     return (
         _TASK_STATUS_ORDER.get(status, 99),
+        priority_rank(task),
         -_timestamp_sort_value(updated),
         int(getattr(task, "task_number", 0) or 0),
     )
@@ -158,10 +164,10 @@ def _task_matches_query(task, owner: str | None, query: str) -> bool:
 def _render_overview(task, *, owner: str | None, flow, active_session) -> str:
     icon = PollyTasksApp._STATUS_ICONS.get(task.work_status.value, "·")
     lines = [
-        f"{icon} #{task.task_number} {task.title}",
+        f"{icon} #{task.task_number} {priority_glyph(task)} {task.title}",
         "",
         f"Status     {task.work_status.value}",
-        f"Priority   {task.priority.value}",
+        f"Priority   {priority_label(task)}",
         f"Flow       {task.flow_template_id}",
         f"Stage      {_format_stage_label(task, flow)}",
         f"Owner      {owner or '—'}",
@@ -604,7 +610,7 @@ class PollyTasksApp(App[None]):
             self.task_table.add_row(
                 f"#{task.task_number}",
                 task.work_status.value,
-                task.title,
+                f"{priority_glyph(task)} {task.title}",
                 owner,
                 task.current_node_id or "—",
                 updated or "—",
@@ -675,7 +681,7 @@ class PollyTasksApp(App[None]):
     def _render_selected_task(self, task, *, owner: str | None, flow, active_session) -> None:
         icon = self._STATUS_ICONS.get(task.work_status.value, "·")
         header_bits = [
-            f"{icon} #{task.task_number} {task.title}",
+            f"{icon} #{task.task_number} {priority_glyph(task)} {task.title}",
             f"{task.work_status.value} · {_format_relative_age(task.updated_at or task.created_at)}",
         ]
         self.detail_header.update("\n".join(header_bits))

--- a/tests/test_cockpit_project_dashboard.py
+++ b/tests/test_cockpit_project_dashboard.py
@@ -39,6 +39,7 @@ from pollypm.work.models import (
     Artifact,
     ArtifactKind,
     OutputType,
+    Priority,
     WorkOutput,
     WorkStatus,
 )
@@ -83,6 +84,7 @@ class _FakeTask:
         task_number: int,
         title: str,
         status: str,
+        priority: str = "normal",
         updated_at: datetime | None = None,
         transitions: list | None = None,
         executions: list | None = None,
@@ -92,6 +94,7 @@ class _FakeTask:
         self.task_number = task_number
         self.title = title
         self.work_status = WorkStatus(status)
+        self.priority = Priority(priority)
         self.updated_at = updated_at
         self.transitions = transitions or []
         self.executions = executions or []
@@ -249,6 +252,26 @@ class TestSectionInFlight:
         assert "#2 Add favicon" in joined
         assert "[worker]" in joined
         assert "@ implement" in joined
+
+    def test_in_flight_surfaces_priority_glyphs_and_sorts_critical_first(self):
+        low = _FakeTask(
+            task_number=2,
+            title="Add favicon",
+            status="in_progress",
+            priority="low",
+            updated_at=datetime(2026, 4, 20, 16, 0, tzinfo=UTC),
+        )
+        critical = _FakeTask(
+            task_number=7,
+            title="Patch auth outage",
+            status="in_progress",
+            priority="critical",
+            updated_at=datetime(2026, 4, 20, 15, 0, tzinfo=UTC),
+        )
+        lines = _section_in_flight([low, critical])
+        task_lines = [line for line in lines if "#7" in line or "#2" in line]
+        assert task_lines[0].startswith("  ⟳ 🔴 #7 Patch auth outage")
+        assert task_lines[1].startswith("  ⟳ 🟢 #2 Add favicon")
 
 
 class TestSectionRecent:

--- a/tests/test_cockpit_task_priority.py
+++ b/tests/test_cockpit_task_priority.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pollypm.cockpit_task_priority import (
+    priority_glyph,
+    priority_label,
+    priority_rank,
+    priority_value,
+)
+from pollypm.work.models import Priority
+
+
+class _Task:
+    def __init__(self, priority):
+        self.priority = priority
+
+
+def test_priority_helpers_accept_strings_enums_and_tasks() -> None:
+    assert priority_value("critical") == "critical"
+    assert priority_value(Priority.HIGH) == "high"
+    assert priority_value(_Task(Priority.LOW)) == "low"
+
+
+def test_priority_helpers_surface_expected_order_and_glyphs() -> None:
+    assert priority_rank("critical") < priority_rank("high") < priority_rank("normal") < priority_rank("low")
+    assert priority_glyph("critical") == "🔴"
+    assert priority_glyph("high") == "🟠"
+    assert priority_glyph("normal") == "🟡"
+    assert priority_glyph("low") == "🟢"
+    assert priority_label("critical") == "🔴 critical"
+
+
+def test_priority_helpers_degrade_for_unknown_values() -> None:
+    assert priority_value("") == "normal"
+    assert priority_glyph("urgent") == "⚪"
+    assert priority_rank("urgent") == 4

--- a/tests/test_tasks_ui.py
+++ b/tests/test_tasks_ui.py
@@ -72,6 +72,7 @@ def _task(
     node_id: str,
     title: str = "Ship Notesy visibility",
     status: WorkStatus = WorkStatus.IN_PROGRESS,
+    priority: Priority = Priority.HIGH,
     updated_at: datetime | None = None,
     executions: list[FlowNodeExecution] | None = None,
 ) -> Task:
@@ -85,7 +86,7 @@ def _task(
         flow_template_version=1,
         current_node_id=node_id,
         assignee="architect_demo",
-        priority=Priority.HIGH,
+        priority=priority,
         description="Make the live task detail useful.",
         roles={"architect": "architect_demo", "operator": "polly"},
         created_at=datetime(2026, 4, 20, 16, 0, tzinfo=UTC),
@@ -462,7 +463,48 @@ def test_task_app_filters_drive_table_contents(env, monkeypatch) -> None:
             await pilot.pause()
             rows = _table_rows(table)
             assert table.row_count == 1
-            assert rows[0][2] == "Done already"
+            assert rows[0][2] == "🟠 Done already"
+
+    _run(body())
+
+
+def test_task_app_surfaces_priority_glyphs_and_sorts_critical_first(env, monkeypatch) -> None:
+    if not _load_config_compatible(env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_tasks import PollyTasksApp
+
+    critical = _task(
+        task_number=2,
+        node_id="research",
+        title="Critical fix",
+        priority=Priority.CRITICAL,
+        updated_at=datetime(2026, 4, 20, 17, 5, tzinfo=UTC),
+    )
+    low = _task(
+        task_number=1,
+        node_id="research",
+        title="Low follow-up",
+        priority=Priority.LOW,
+        updated_at=datetime(2026, 4, 20, 17, 20, tzinfo=UTC),
+    )
+    fake_svc = _FakeSvc(
+        tasks_factory=lambda: [low, critical],
+        flow=_flow(),
+    )
+
+    monkeypatch.setattr("pollypm.cockpit_tasks.create_tmux_client", lambda: _FakeTmux([]))
+
+    app = PollyTasksApp(env["config_path"], "demo")
+    app._get_svc = lambda: fake_svc  # type: ignore[method-assign]
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 50)) as pilot:
+            await pilot.pause()
+            rows = _table_rows(app.query_one("#tasks-table", DataTable))
+            overview = str(app.query_one("#task-detail", Static).render())
+            assert rows[0][2] == "🔴 Critical fix"
+            assert rows[1][2] == "🟢 Low follow-up"
+            assert "Priority   🔴 critical" in overview
 
     _run(body())
 


### PR DESCRIPTION
Closes #504

## Summary
- add a shared cockpit task-priority module with glyph and sort helpers
- prefix task titles with priority glyphs and float critical work to the top of its section
- apply the same priority treatment to the project dashboard in-flight/task-list renderers

## Testing
- HOME=/tmp/pytest-504 uv run --extra dev pytest tests/test_cockpit_task_priority.py tests/test_tasks_ui.py tests/test_cockpit_project_dashboard.py -q