### PR TITLE
Standardize CLI help examples

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -43,6 +43,7 @@ from pollypm.config import (
     render_example_config,
     write_example_config,
 )
+from pollypm.cli_help import help_with_examples
 from pollypm.errors import format_config_not_found_error
 from pollypm.cli_features.alerts import alert_app, heartbeat_app, session_app
 from pollypm.cli_features.issues import issue_app, itsalive_app, report_app
@@ -52,23 +53,76 @@ from pollypm.cli_features.ui import register_ui_commands
 from pollypm.cli_features.workers import register_worker_commands
 
 
-# wg05 / #242: every `pm ... --help` gains an Examples section so
-# first-time users see copy-paste-ready commands for the common flows
-# alongside the raw subcommand table. Bullet formatting survives
-# typer's rich re-flow (epilog does not).
-_APP_HELP = """PollyPM CLI.
+_APP_HELP = help_with_examples(
+    "PollyPM CLI.",
+    [
+        ("pm", "start or attach to the PollyPM tmux session"),
+        ("pm add-project ~/dev/my-app", "register a project in the workspace"),
+        ('pm send operator "Build a weather CLI"', "hand a request to Polly"),
+    ],
+    trailing=(
+        "Sub-help:  pm task --help, pm session --help, pm project --help, "
+        "pm plugins --help.\n"
+        "Role guides: pm help worker."
+    ),
+)
 
-Examples (primary flows):
+_UP_HELP = help_with_examples(
+    "Create or attach to the PollyPM tmux session and boot the cockpit.",
+    [
+        ("pm up", "start the tmux session or attach if it already exists"),
+        (
+            "pm up --config ~/.pollypm/pollypm.toml",
+            "boot a specific PollyPM config",
+        ),
+    ],
+)
 
-• pm                                — bring up / attach to the PollyPM session
-• pm task next                      — find the next queued task to work on
-• pm task claim shortlink_gen/1     — claim a queued task (provisions worktree)
-• pm worker-start --role architect <project>  — spawn the project's planner architect
-• pm projects                       — list registered projects
-• pm help worker                    — full worker onboarding guide
+_STATUS_HELP = help_with_examples(
+    "Show configured session state, runtime status, and open-alert counts.",
+    [
+        ("pm status", "show every configured session"),
+        ("pm status operator", "inspect one session by name"),
+        ("pm status --json", "emit structured status for scripts"),
+    ],
+)
 
-Sub-help:  pm task --help, pm session --help, pm project --help, pm plugins --help.
-"""
+_SEND_HELP = help_with_examples(
+    "Send input directly into a managed tmux pane.",
+    [
+        ('pm send operator "Build a weather CLI"', "ask Polly to start work"),
+        (
+            'pm send reviewer "Please rerun the tests" --owner human',
+            "post a human follow-up to the reviewer",
+        ),
+        (
+            'pm send worker_demo "continue" --force',
+            "bypass the worker guard for a manual nudge",
+        ),
+    ],
+)
+
+_NOTIFY_HELP = help_with_examples(
+    (
+        "Create a work-service inbox item for the human user.\n\n"
+        "This is PollyPM's canonical escalation channel for blockers, "
+        "handoffs, and status updates."
+    ),
+    [
+        (
+            'pm notify "Deploy blocked" "Needs verification email click."',
+            "open an immediate user-visible inbox item",
+        ),
+        (
+            'echo "Longer body" | pm notify "Status update" -',
+            "read the notification body from stdin",
+        ),
+        (
+            'pm notify "Plan ready" "Review the explainer" --priority immediate',
+            "create a high-priority review notification",
+        ),
+    ],
+)
 
 app = typer.Typer(help=_APP_HELP, invoke_without_command=True, no_args_is_help=False)
 app.add_typer(alert_app, name="alert")
@@ -354,7 +408,7 @@ def onboard(
     typer.echo("Next step: run `pollypm up` or `uv run pm up` to create or attach to the PollyPM tmux session.")
 
 
-@app.command()
+@app.command(help=_UP_HELP)
 def up(
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
@@ -450,7 +504,7 @@ def up(
     raise typer.Exit(code=supervisor.tmux.attach_session(session_name))
 
 
-@app.command()
+@app.command(help=_UP_HELP)
 def launch(
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
@@ -631,7 +685,7 @@ def reset(
     typer.echo(f"Killed {len(sessions_to_kill)} session(s): {', '.join(sessions_to_kill)}")
 
 
-@app.command()
+@app.command(help=_STATUS_HELP)
 def status(
     session_name: str | None = typer.Argument(None, help="Optional session name from config."),
     json_output: bool = typer.Option(False, "--json", help="Emit structured JSON."),
@@ -821,7 +875,7 @@ def release(
     typer.echo(f"Lease released for {session_name}")
 
 
-@app.command()
+@app.command(help=_SEND_HELP)
 def send(
     session_name: str = typer.Argument(..., help="Session name from config."),
     text: str = typer.Argument(..., help="Text to send into the tmux pane."),
@@ -869,7 +923,7 @@ def send(
     typer.echo(f"Sent input to {session_name}")
 
 
-@app.command()
+@app.command(help=_NOTIFY_HELP)
 def notify(
     subject: str = typer.Argument(..., help="Short title for the inbox item."),
     body: str = typer.Argument(..., help="Message body. Pass '-' to read from stdin."),
@@ -921,26 +975,6 @@ def notify(
         help="Path to SQLite database (default: same resolution as `pm inbox`).",
     ),
 ) -> None:
-    """Create a work-service inbox item for the human user.
-
-    This is the canonical escalation channel referenced by the operator
-    runbook and control prompts. Polly (or any agent) uses ``pm notify``
-    to reach the user when something needs attention — a blocker, a
-    completed deliverable, a status update.
-
-    The notification is stored as a work-service task on the ``chat``
-    flow with ``roles.requester=user``, so it appears in ``pm inbox``
-    immediately.
-
-    Examples:
-
-    • pm notify "Deploy blocked" "Needs verification email click."
-    • pm notify "Done: homepage rewrite" "Review at https://…"
-    • echo "long body" | pm notify "Subject" -
-    • pm notify "Plan ready" "Review the plan" --priority immediate \\
-          --label plan_review --label "plan_task:demo/5" \\
-          --label "explainer:/abs/path/reports/plan-review.html"
-    """
     if not subject.strip():
         typer.echo("Error: subject must not be empty.", err=True)
         raise typer.Exit(code=1)

--- a/src/pollypm/cli_features/alerts.py
+++ b/src/pollypm/cli_features/alerts.py
@@ -19,33 +19,42 @@ from pathlib import Path
 
 import typer
 
+from pollypm.cli_help import help_with_examples
 from pollypm.config import DEFAULT_CONFIG_PATH
 
 
 alert_app = typer.Typer(
-    help=(
-        "Manage durable alerts.\n\n"
-        "Examples:\n\n"
-        "• pm alert list                      — show open alerts\n"
-        "• pm alert ack <id>                  — acknowledge one\n"
+    help=help_with_examples(
+        "Manage durable alerts.",
+        [
+            ("pm alert list", "show open alerts"),
+            ('pm alert raise blocked worker_demo "pane died"', "raise a manual alert"),
+            ("pm alert clear 12", "clear one alert by id"),
+        ],
     )
 )
 
 session_app = typer.Typer(
-    help=(
-        "Manage session runtime state.\n\n"
-        "Examples:\n\n"
-        "• pm session set-status <name> idle       — mark a session idle\n"
-        "• pm session set-status <name> working    — mark a session as working\n"
+    help=help_with_examples(
+        "Manage session runtime state.",
+        [
+            ("pm session set-status operator idle", "mark a session idle"),
+            (
+                'pm session set-status worker_demo working --reason "running tests"',
+                "record a working state with context",
+            ),
+        ],
     )
 )
 
 heartbeat_app = typer.Typer(
-    help=(
-        "Run or record heartbeat state.\n\n"
-        "Examples:\n\n"
-        "• pm heartbeat run                   — run the heartbeat loop once\n"
-        "• pm heartbeat status                — show last heartbeat tick\n"
+    help=help_with_examples(
+        "Run or record heartbeat state.",
+        [
+            ("pm heartbeat", "run one heartbeat sweep"),
+            ("pm heartbeat --json", "emit the sweep result as JSON"),
+            ("pm heartbeat install", "install the cron-based heartbeat runner"),
+        ],
     )
 )
 

--- a/src/pollypm/cli_features/issues.py
+++ b/src/pollypm/cli_features/issues.py
@@ -15,33 +15,48 @@ from pathlib import Path
 
 import typer
 
+from pollypm.cli_help import help_with_examples
 from pollypm.config import DEFAULT_CONFIG_PATH
 
 
 issue_app = typer.Typer(
-    help=(
-        "Manage project issues through the configured backend.\n\n"
-        "Examples:\n\n"
-        "• pm issue list                      — list issues for the active project\n"
-        "• pm issue show <id>                 — print a single issue\n"
+    help=help_with_examples(
+        "Manage project issues through the configured backend.",
+        [
+            ("pm issue list --project my_app", "list issues for one project"),
+            ("pm issue info my_app/1 --project my_app", "print one issue"),
+            (
+                "pm issue transition my_app/1 03-needs-review --project my_app",
+                "move an issue to its next tracker state",
+            ),
+        ],
     )
 )
 
 report_app = typer.Typer(
-    help=(
-        "Report project status summaries.\n\n"
-        "Examples:\n\n"
-        "• pm report status                   — summarize all projects\n"
-        "• pm report status --project <name>  — summarize one project\n"
+    help=help_with_examples(
+        "Report project status summaries.",
+        [
+            ("pm report status --project my_app", "summarize one project"),
+            (
+                "pm report status --project marketing_site",
+                "summarize a second project workspace",
+            ),
+        ],
     )
 )
 
 itsalive_app = typer.Typer(
-    help=(
-        "Manage itsalive deployments.\n\n"
-        "Examples:\n\n"
-        "• pm itsalive status                 — show deployment state\n"
-        "• pm itsalive deploy                 — deploy the project\n"
+    help=help_with_examples(
+        "Manage itsalive deployments.",
+        [
+            ("pm itsalive status --project marketing_site", "show deployment state"),
+            (
+                "pm itsalive deploy --project marketing_site --subdomain marketing-site --email ops@example.com",
+                "request or retry a deployment",
+            ),
+            ("pm itsalive sweep --project marketing_site", "poll pending deploys"),
+        ],
     )
 )
 

--- a/src/pollypm/cli_features/maintenance.py
+++ b/src/pollypm/cli_features/maintenance.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import typer
 
+from pollypm.cli_help import help_with_examples
 from pollypm.config import (
     DEFAULT_CONFIG_PATH,
     GLOBAL_CONFIG_DIR,
@@ -66,7 +67,16 @@ def _remove_account_entry(config_path: Path, account: str, *, delete_home: bool 
 
 
 def register_maintenance_commands(app: typer.Typer) -> None:
-    @app.command()
+    @app.command(
+        help=help_with_examples(
+            "Run the diagnostic checklist and optionally apply safe fixes.",
+            [
+                ("pm doctor", "show the full health checklist"),
+                ("pm doctor --fix", "apply safe automatic repairs"),
+                ("pm doctor --json", "emit the report as machine-readable JSON"),
+            ],
+        )
+    )
     def doctor(
         json_output: bool = typer.Option(
             False,

--- a/src/pollypm/cli_features/projects.py
+++ b/src/pollypm/cli_features/projects.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import typer
 
+from pollypm.cli_help import help_with_examples
 from pollypm.config import DEFAULT_CONFIG_PATH, load_config
 from pollypm.projects import (
     enable_tracked_project,
@@ -27,7 +28,18 @@ logger = logging.getLogger(__name__)
 
 
 def register_project_commands(app: typer.Typer) -> None:
-    @app.command()
+    @app.command(
+        help=help_with_examples(
+            "List the projects registered in the current PollyPM workspace.",
+            [
+                ("pm projects", "show every registered project"),
+                (
+                    "pm projects --config ~/.pollypm/pollypm.toml",
+                    "inspect a specific config file",
+                ),
+            ],
+        )
+    )
     def projects(
         config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
     ) -> None:
@@ -52,7 +64,22 @@ def register_project_commands(app: typer.Typer) -> None:
         for project in added:
             typer.echo(f"- {project.name or project.key}: {project.path}")
 
-    @app.command()
+    @app.command(
+        help=help_with_examples(
+            "Register a repository as a PollyPM project.",
+            [
+                ("pm add-project ~/dev/my-app", "register a repo and import its history"),
+                (
+                    'pm add-project ~/dev/my-app --name "My App"',
+                    "override the display name",
+                ),
+                (
+                    "pm add-project ~/dev/my-app --skip-plan",
+                    "register the repo without planner auto-fire",
+                ),
+            ],
+        )
+    )
     def add_project(
         repo_path: Path = typer.Argument(..., help="Path to the project folder."),
         name: str | None = typer.Option(None, "--name", help="Optional display name."),
@@ -176,4 +203,3 @@ def register_project_commands(app: typer.Typer) -> None:
     ) -> None:
         tracked = enable_tracked_project(config_path, project)
         typer.echo(f"Enabled tracked-project mode for {tracked.name or tracked.key}")
-

--- a/src/pollypm/cli_help.py
+++ b/src/pollypm/cli_help.py
@@ -1,0 +1,31 @@
+"""Shared helpers for CLI help text."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+Example = tuple[str, str]
+
+
+def examples_block(examples: Sequence[Example]) -> str:
+    """Render a uniform ``Examples:`` block for Typer help text."""
+    if not 2 <= len(examples) <= 3:
+        raise ValueError("CLI help examples must contain 2-3 entries.")
+    width = max(len(command) for command, _description in examples)
+    lines = ["Examples:", ""]
+    for command, description in examples:
+        lines.append(f"• {command.ljust(width)}  — {description}")
+    return "\n".join(lines)
+
+
+def help_with_examples(
+    summary: str,
+    examples: Sequence[Example],
+    *,
+    trailing: str | None = None,
+) -> str:
+    """Append a uniform examples block to a summary paragraph."""
+    parts = [summary.rstrip(), "", examples_block(examples)]
+    if trailing:
+        parts.extend(["", trailing.rstrip()])
+    return "\n".join(parts)

--- a/src/pollypm/jobs/cli.py
+++ b/src/pollypm/jobs/cli.py
@@ -25,6 +25,7 @@ from typing import Any, Callable
 
 import typer
 
+from pollypm.cli_help import help_with_examples
 from pollypm.config import DEFAULT_CONFIG_PATH, load_config, resolve_config_path
 from pollypm.jobs.queue import Job, JobQueue, JobStatus
 
@@ -33,12 +34,13 @@ __all__ = ["jobs_app", "build_queue_for_config"]
 
 
 jobs_app = typer.Typer(
-    help=(
-        "Inspect and manage the durable job queue.\n\n"
-        "Examples:\n\n"
-        "• pm jobs list                       — show queued / running jobs\n"
-        "• pm jobs show <id>                  — inspect one job\n"
-        "• pm jobs retry <id>                 — retry a failed job\n"
+    help=help_with_examples(
+        "Inspect and manage the durable job queue.",
+        [
+            ("pm jobs list", "show queued and running jobs"),
+            ("pm jobs show 42", "inspect one job"),
+            ("pm jobs retry 42", "retry a failed job"),
+        ],
     )
 )
 

--- a/src/pollypm/memory_cli.py
+++ b/src/pollypm/memory_cli.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import typer
 
+from pollypm.cli_help import help_with_examples
 from pollypm.config import DEFAULT_CONFIG_PATH, load_config, resolve_config_path
 from pollypm.memory_backends import FileMemoryBackend, MemoryEntry, get_memory_backend
 
@@ -29,12 +30,13 @@ __all__ = ["memory_app", "build_backend_for_config"]
 
 
 memory_app = typer.Typer(
-    help=(
-        "Inspect and manage the memory store.\n\n"
-        "Examples:\n\n"
-        "• pm memory list                     — show memories for the user\n"
-        "• pm memory show <id>                — print one memory's body\n"
-        "• pm memory search <query>           — full-text search across memories\n"
+    help=help_with_examples(
+        "Inspect and manage the memory store.",
+        [
+            ("pm memory list", "show recent memory entries"),
+            ('pm memory recall "deploy playbook"', "run a recall query"),
+            ("pm memory show 42", "print one memory entry in full"),
+        ],
     )
 )
 

--- a/src/pollypm/plugin_cli.py
+++ b/src/pollypm/plugin_cli.py
@@ -18,13 +18,16 @@ from typing import Any
 
 import typer
 
+from pollypm.cli_help import help_with_examples
+
 plugins_app = typer.Typer(
-    help=(
-        "Manage PollyPM plugins.\n\n"
-        "Examples:\n\n"
-        "• pm plugins list                    — show installed plugins\n"
-        "• pm plugins show <name>             — inspect one plugin's manifest\n"
-        "• pm plugins scaffold <name>         — scaffold a new plugin\n"
+    help=help_with_examples(
+        "Manage PollyPM plugins.",
+        [
+            ("pm plugins list", "show installed and disabled plugins"),
+            ("pm plugins show local_heartbeat", "inspect one plugin manifest"),
+            ("pm plugins install ~/dev/my-plugin", "install a local plugin"),
+        ],
     )
 )
 

--- a/src/pollypm/plugins_builtin/activity_feed/cli.py
+++ b/src/pollypm/plugins_builtin/activity_feed/cli.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Iterable
 
 import typer
 
+from pollypm.cli_help import help_with_examples
 from pollypm.config import DEFAULT_CONFIG_PATH, load_config
 
 if TYPE_CHECKING:
@@ -35,12 +36,16 @@ if TYPE_CHECKING:
 
 
 activity_app = typer.Typer(
-    help=(
-        "Live activity feed. `pm activity --follow` tails live events.\n\n"
-        "Examples:\n\n"
-        "• pm activity                        — print the most recent events\n"
-        "• pm activity --follow               — tail the event stream\n"
-        "• pm activity --since 15m            — events from the last 15 minutes\n"
+    help=help_with_examples(
+        "Live activity feed. `pm activity --follow` tails live events.",
+        [
+            ("pm activity", "print the most recent events"),
+            ("pm activity --follow", "tail the live event stream"),
+            (
+                "pm activity --project my_app --since 15m",
+                "filter to one project and a recent time window",
+            ),
+        ],
     ),
     invoke_without_command=True,
     no_args_is_help=False,

--- a/src/pollypm/plugins_builtin/advisor/cli/advisor_cli.py
+++ b/src/pollypm/plugins_builtin/advisor/cli/advisor_cli.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import typer
 
+from pollypm.cli_help import help_with_examples
 from pollypm.config import DEFAULT_CONFIG_PATH, load_config, resolve_config_path
 from pollypm.plugins_builtin.advisor.handlers.history_log import (
     HistoryEntry,
@@ -43,13 +44,13 @@ from pollypm.plugins_builtin.advisor.state import (
 
 
 advisor_app = typer.Typer(
-    help=(
-        "Manage the advisor (every-30m alignment coach).\n\n"
-        "Examples:\n\n"
-        "• pm advisor status                  — show advisor state and next run\n"
-        "• pm advisor enable                  — turn on the advisor\n"
-        "• pm advisor pause                   — stop runs without disabling\n"
-        "• pm advisor history                 — recent advisor decisions\n"
+    help=help_with_examples(
+        "Manage the advisor (every-30m alignment coach).",
+        [
+            ("pm advisor status", "show advisor state and next run"),
+            ("pm advisor pause", "stop runs without disabling the plugin"),
+            ("pm advisor history --since 7d", "inspect recent advisor decisions"),
+        ],
     ),
     no_args_is_help=True,
 )

--- a/src/pollypm/plugins_builtin/downtime/cli.py
+++ b/src/pollypm/plugins_builtin/downtime/cli.py
@@ -23,6 +23,7 @@ from typing import Any, Optional
 import typer
 
 from pollypm.atomic_io import atomic_write_text
+from pollypm.cli_help import help_with_examples
 from pollypm.config import DEFAULT_CONFIG_PATH, load_config, resolve_config_path
 from pollypm.plugins_builtin.downtime.handlers.pick_candidate import (
     USER_QUEUE_RELATIVE_PATH,
@@ -41,12 +42,16 @@ from pollypm.plugins_builtin.downtime.state import (
 
 
 downtime_app = typer.Typer(
-    help=(
-        "Manage the downtime exploration plugin (idle-LLM-budget tasks).\n\n"
-        "Examples:\n\n"
-        "• pm downtime status                 — show downtime state\n"
-        "• pm downtime enable                 — turn on downtime exploration\n"
-        "• pm downtime list                   — show exploration runs\n"
+    help=help_with_examples(
+        "Manage the downtime exploration plugin (idle-LLM-budget tasks).",
+        [
+            ("pm downtime status", "show downtime state"),
+            (
+                'pm downtime add "Profile the dashboard query"',
+                "queue a user-suggested exploration",
+            ),
+            ("pm downtime pause --until 2026-04-30", "pause downtime until a date"),
+        ],
     ),
     no_args_is_help=True,
 )

--- a/src/pollypm/plugins_builtin/morning_briefing/cli.py
+++ b/src/pollypm/plugins_builtin/morning_briefing/cli.py
@@ -28,6 +28,7 @@ from zoneinfo import ZoneInfo
 
 import typer
 
+from pollypm.cli_help import help_with_examples
 from pollypm.config import DEFAULT_CONFIG_PATH, load_config, resolve_config_path
 from pollypm.plugins_builtin.morning_briefing.handlers import briefing_tick as _tick
 from pollypm.plugins_builtin.morning_briefing.inbox import (
@@ -46,13 +47,13 @@ from pollypm.plugins_builtin.morning_briefing.state import (
 
 
 briefing_app = typer.Typer(
-    help=(
-        "Manage the morning briefing (daily inbox digest).\n\n"
-        "Examples:\n\n"
-        "• pm briefing status                 — show briefing configuration\n"
-        "• pm briefing enable                 — turn on the daily briefing\n"
-        "• pm briefing now                    — render today's briefing immediately\n"
-        "• pm briefing preview                — dry-run without delivering\n"
+    help=help_with_examples(
+        "Manage the morning briefing (daily inbox digest).",
+        [
+            ("pm briefing status", "show briefing configuration"),
+            ("pm briefing preview", "dry-run without delivering"),
+            ("pm briefing now", "render today's briefing immediately"),
+        ],
     ),
     no_args_is_help=True,
 )

--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -31,6 +31,7 @@ from typing import Any, Literal, Optional
 
 import typer
 
+from pollypm.cli_help import help_with_examples
 from pollypm.config import (
     DEFAULT_CONFIG_PATH,
     load_config,
@@ -39,12 +40,13 @@ from pollypm.config import (
 
 
 project_app = typer.Typer(
-    help=(
-        "Planner-backed project lifecycle (new / plan / replan).\n\n"
-        "Examples:\n\n"
-        "• pm project new <name>              — create a new planner-backed project\n"
-        "• pm project plan <name>             — (re)run the tree-of-plans planner\n"
-        "• pm project replan <name>           — regenerate the plan from current state\n"
+    help=help_with_examples(
+        "Planner-backed project lifecycle (new / plan / replan).",
+        [
+            ("pm project new ~/dev/my-app", "register a project and offer to plan it"),
+            ("pm project plan my_app", "queue a fresh planning task"),
+            ("pm project replan my_app", "run the drift-aware planner again"),
+        ],
     ),
     no_args_is_help=True,
 )

--- a/src/pollypm/rail_cli.py
+++ b/src/pollypm/rail_cli.py
@@ -16,13 +16,16 @@ from typing import Any
 
 import typer
 
+from pollypm.cli_help import help_with_examples
+
 rail_app = typer.Typer(
-    help=(
-        "Manage cockpit rail items.\n\n"
-        "Examples:\n\n"
-        "• pm rail list                       — show configured rail items\n"
-        "• pm rail add <plugin>               — add a plugin's rail item\n"
-        "• pm rail remove <plugin>            — remove a plugin's rail item\n"
+    help=help_with_examples(
+        "Manage cockpit rail items.",
+        [
+            ("pm rail list", "show configured rail items"),
+            ("pm rail hide tools.activity", "hide one rail item"),
+            ("pm rail show tools.activity", "restore a hidden rail item"),
+        ],
     )
 )
 

--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -12,17 +12,11 @@ from typing import Optional
 import typer
 
 from pollypm.cli_help import help_with_examples
-from pollypm.work.flow_engine import parse_flow_yaml
-from pollypm.work.sqlite_service import (
-    SQLiteWorkService,
-    WorkServiceError,
-)
 
 _TASK_APP_HELP = help_with_examples(
     "Manage work tasks.",
     [
         ("pm task next", "find work"),
-        ("pm task get shortlink_gen/1", "read the spec"),
         (
             "pm task claim shortlink_gen/1",
             "pick it up",

--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -11,35 +11,41 @@ from typing import Optional
 
 import typer
 
-# Worked examples block — shown in `pm task --help` so a worker
-# hitting --help for the first time sees a copy-paste flow instead of
-# just a table of subcommands. wg05 / #242.
-#
-# Typer's rich renderer collapses whitespace inside epilog, but
-# preserves bullet-formatted lines in the help text itself, so we
-# embed examples there.
-_TASK_APP_HELP = """Manage work tasks.
+from pollypm.cli_help import help_with_examples
+from pollypm.work.flow_engine import parse_flow_yaml
+from pollypm.work.sqlite_service import (
+    SQLiteWorkService,
+    WorkServiceError,
+)
 
-Examples (typical worker flow):
-
-• pm task next                                 — find work
-• pm task get shortlink_gen/1                  — read the spec
-• pm task claim shortlink_gen/1                — pick it up
-• pm task done shortlink_gen/1 --output '...'  — hand to review
-
-Run `pm help worker` for the full worker guide with --output payload
-templates and common failure modes.
-"""
+_TASK_APP_HELP = help_with_examples(
+    "Manage work tasks.",
+    [
+        ("pm task next", "find work"),
+        ("pm task get shortlink_gen/1", "read the spec"),
+        (
+            "pm task claim shortlink_gen/1",
+            "pick it up",
+        ),
+        (
+            "pm task done shortlink_gen/1 --output '{\"summary\":\"done\"}'",
+            "hand to review",
+        ),
+    ],
+    trailing=(
+        "Run `pm help worker` for the full worker guide with --output payload "
+        "templates and common failure modes."
+    ),
+)
 
 task_app = typer.Typer(help=_TASK_APP_HELP)
 flow_app = typer.Typer(
-    help=(
-        "Manage flow templates.\n"
-        "\n"
-        "Examples:\n"
-        "\n"
-        "• pm flow list                              — show registered flows\n"
-        "• pm flow validate standard                 — check a flow template\n"
+    help=help_with_examples(
+        "Manage flow templates.",
+        [
+            ("pm flow list", "show registered flows"),
+            ("pm flow validate standard", "check a flow template"),
+        ],
     )
 )
 

--- a/src/pollypm/work/inbox_cli.py
+++ b/src/pollypm/work/inbox_cli.py
@@ -16,6 +16,7 @@ from typing import Any, Optional
 
 import typer
 
+from pollypm.cli_help import help_with_examples
 from pollypm.work.cli import (
     _DB_OPTION,
     _JSON_OPTION,
@@ -30,11 +31,13 @@ from pollypm.work.inbox_view import inbox_tasks
 
 
 inbox_app = typer.Typer(
-    help=(
-        "Work assigned to the user.\n\n"
-        "Examples:\n\n"
-        "• pm inbox                           — list inbox items\n"
-        "• pm inbox show <id>                 — print one inbox item\n"
+    help=help_with_examples(
+        "Work assigned to the user.",
+        [
+            ("pm inbox", "list open inbox items"),
+            ("pm inbox show demo/1", "print one inbox task or message"),
+            ("pm inbox --json", "emit the merged inbox view as JSON"),
+        ],
     )
 )
 

--- a/tests/test_cli_help_examples.py
+++ b/tests/test_cli_help_examples.py
@@ -1,9 +1,9 @@
-"""Tests for wg05 / #242: every `pm ... --help` carries an Examples section.
+"""Tests for CLI help examples.
 
 Typer's rich renderer collapses whitespace in the epilog, so examples
 are embedded in the top-level help text itself (bullet format, which
-Typer preserves). This module asserts that every documented subgroup's
---help output mentions 'Examples' and contains at least 2 copy-paste
+Typer preserves). This module asserts that every documented help
+surface carries a literal ``Examples:`` block with 2-3 copy-paste
 invocations.
 
 It also exercises the new `pm help worker` meta-command.
@@ -23,10 +23,10 @@ def runner():
     return CliRunner()
 
 
-# Every group listed here must carry an "Examples:" section with at
-# least 2 `pm …` invocations. If a subgroup is deprecated or removed
-# in the future, drop it here (and mention why in the commit).
-_GROUPS_WITH_EXAMPLES = [
+# Every help surface listed here must carry an "Examples:" section with
+# 2-3 `• pm ...` invocations. If a subgroup is deprecated or removed in
+# the future, drop it here (and mention why in the commit).
+_SURFACES_WITH_EXAMPLES = [
     (),  # top-level pm --help
     ("task",),
     ("session",),
@@ -46,27 +46,36 @@ _GROUPS_WITH_EXAMPLES = [
     ("issue",),
     ("report",),
     ("itsalive",),
+    ("up",),
+    ("launch",),
+    ("status",),
+    ("send",),
+    ("notify",),
+    ("doctor",),
+    ("projects",),
+    ("add-project",),
 ]
 
 
-@pytest.mark.parametrize("group", _GROUPS_WITH_EXAMPLES)
-def test_group_help_has_examples_section(runner, group):
-    args = list(group) + ["--help"]
+@pytest.mark.parametrize("surface", _SURFACES_WITH_EXAMPLES)
+def test_help_surface_has_uniform_examples_block(runner, surface):
+    args = list(surface) + ["--help"]
     result = runner.invoke(app, args)
     # Help should render (exit 0 for --help)
     assert result.exit_code == 0, (
         f"`pm {' '.join(args)}` help did not render:\n{result.output}"
     )
-    # The literal word "Examples" — either "Examples:" or
-    # "Examples (typical worker flow):" qualifies.
-    assert "Examples" in result.output, (
-        f"`pm {' '.join(args)}` --help has no Examples section:\n{result.output}"
+    assert "Examples:" in result.output, (
+        f"`pm {' '.join(args)}` --help has no literal Examples: section:\n"
+        f"{result.output}"
     )
-    # At least two `pm ` invocations (copy-paste-ready commands).
-    pm_mentions = result.output.count("pm ")
-    assert pm_mentions >= 2, (
-        f"`pm {' '.join(args)}` --help has only {pm_mentions} "
-        f"`pm ` references; expected >= 2 concrete examples:\n"
+    example_lines = [
+        line for line in result.output.splitlines()
+        if "• pm " in line
+    ]
+    assert 2 <= len(example_lines) <= 3, (
+        f"`pm {' '.join(args)}` --help has {len(example_lines)} example lines; "
+        "expected 2-3 concrete examples:\n"
         f"{result.output}"
     )
 
@@ -104,7 +113,6 @@ def test_task_help_shows_typical_worker_flow(runner):
     assert result.exit_code == 0
     # The worker flow sequence should be readable top-to-bottom.
     assert "pm task next" in result.output
-    assert "pm task get" in result.output
     assert "pm task claim" in result.output
     assert "pm task done" in result.output
 
@@ -114,3 +122,33 @@ def test_top_level_help_points_to_worker_guide(runner):
     assert result.exit_code == 0
     # Users should see the help-worker meta-command prominently.
     assert "pm help worker" in result.output
+
+
+def test_memory_help_uses_recall_not_search(runner):
+    result = runner.invoke(app, ["memory", "--help"])
+    assert result.exit_code == 0
+    assert "pm memory recall" in result.output
+    assert "pm memory search" not in result.output
+
+
+def test_issue_help_uses_real_issue_commands(runner):
+    result = runner.invoke(app, ["issue", "--help"])
+    assert result.exit_code == 0
+    assert "pm issue info" in result.output
+    assert "pm issue transition" in result.output
+    assert "pm issue show" not in result.output
+
+
+def test_rail_help_uses_hide_and_show(runner):
+    result = runner.invoke(app, ["rail", "--help"])
+    assert result.exit_code == 0
+    assert "pm rail hide" in result.output
+    assert "pm rail show" in result.output
+    assert "pm rail add" not in result.output
+
+
+def test_plugins_help_uses_install_not_scaffold(runner):
+    result = runner.invoke(app, ["plugins", "--help"])
+    assert result.exit_code == 0
+    assert "pm plugins install" in result.output
+    assert "pm plugins scaffold" not in result.output


### PR DESCRIPTION
## Summary
- add a shared CLI help formatter so `Examples:` blocks render with one uniform bullet style
- audit the existing top-level/group help surfaces and replace stale examples with syntactically valid commands
- add example blocks to the golden-path root commands (`up`, `status`, `send`, `notify`, `doctor`, `projects`, `add-project`) and tighten the help tests

## Testing
- uv run --with pytest pytest tests/test_cli_help_examples.py tests/test_cli.py

Closes #518