### PR TITLE
feat(cockpit): add project health scorecards

### DIFF
--- a/src/pollypm/cockpit_sections/__init__.py
+++ b/src/pollypm/cockpit_sections/__init__.py
@@ -33,6 +33,12 @@ from pollypm.cockpit_sections.base import (
 from pollypm.cockpit_sections.dashboard import _build_dashboard
 from pollypm.cockpit_sections.downtime import _section_downtime
 from pollypm.cockpit_sections.header import _section_header, _worker_presence
+from pollypm.cockpit_sections.health import (
+    format_project_health_scorecard,
+    project_health_glyph,
+    project_health_rank,
+    stuck_task_count,
+)
 from pollypm.cockpit_sections.in_flight import _section_in_flight
 from pollypm.cockpit_sections.insights import _section_insights
 from pollypm.cockpit_sections.project_dashboard import (
@@ -63,6 +69,9 @@ __all__ = [
     "_format_tokens",
     "_iso_to_dt",
     "_render_project_dashboard",
+    "format_project_health_scorecard",
+    "project_health_glyph",
+    "project_health_rank",
     "_section_activity",
     "_section_downtime",
     "_section_header",
@@ -74,6 +83,7 @@ __all__ = [
     "_section_velocity",
     "_section_you_need_to",
     "_spark_bar",
+    "stuck_task_count",
     "_task_cycle_minutes",
     "_worker_presence",
 ]

--- a/src/pollypm/cockpit_sections/dashboard.py
+++ b/src/pollypm/cockpit_sections/dashboard.py
@@ -8,6 +8,10 @@ that ships when the user selects ``polly``/``dashboard`` in the rail.
 from __future__ import annotations
 
 from pollypm.cockpit_sections.base import _STATUS_ICONS
+from pollypm.cockpit_sections.health import (
+    format_project_health_scorecard,
+    project_health_rank,
+)
 from pollypm.cockpit_sections.project_dashboard import (
     _DASHBOARD_PROJECT_CACHE,
     _dashboard_project_tasks,
@@ -46,11 +50,13 @@ def _build_dashboard(supervisor, config) -> str:
     all_queued: list[tuple[str, object]] = []  # ready for pickup
     all_blocked: list[tuple[str, object]] = []
     all_done: list[tuple[str, object]] = []
+    project_scorecards: list[tuple[int, str, str]] = []
     total_counts: dict[str, int] = {}
     live_keys: set[str] = set()
     for pk, proj in config.projects.items():
         live_keys.add(pk)
         partitioned, counts = _dashboard_project_tasks(pk, proj.path)
+        tasks = [task for bucket in partitioned.values() for task in bucket]
         for s, n in counts.items():
             total_counts[s] = total_counts.get(s, 0) + n
         for t in partitioned.get("in_progress", ()):
@@ -63,6 +69,18 @@ def _build_dashboard(supervisor, config) -> str:
             all_blocked.append((pk, t))
         for t in partitioned.get("done", ()):
             all_done.append((pk, t))
+        label = (
+            proj.display_label()
+            if hasattr(proj, "display_label")
+            else getattr(proj, "name", None) or pk
+        )
+        project_scorecards.append(
+            (
+                project_health_rank(tasks, now=now),
+                str(label).lower(),
+                format_project_health_scorecard(label, counts, tasks, now=now),
+            )
+        )
     # Evict cache entries for projects no longer in config.
     for stale_key in list(_DASHBOARD_PROJECT_CACHE.keys()):
         if stale_key not in live_keys:
@@ -108,6 +126,13 @@ def _build_dashboard(supervisor, config) -> str:
     if count_parts:
         lines.append("  " + " · ".join(count_parts))
     lines.append("")
+
+    if project_scorecards:
+        lines.append("  ─── Projects ─────────────────────────────────────")
+        lines.append("")
+        for _rank, _label, line in sorted(project_scorecards):
+            lines.append(f"  {line}")
+        lines.append("")
 
     # ── What's happening right now ──
     if all_active or all_review:

--- a/src/pollypm/cockpit_sections/health.py
+++ b/src/pollypm/cockpit_sections/health.py
@@ -1,0 +1,97 @@
+"""Project-health scorecards for cockpit dashboard surfaces.
+
+Contract:
+- Inputs: per-project task counts, hydrated task rows, and an optional
+  ``now`` timestamp for deterministic tests.
+- Outputs: one-line scorecards plus sortable health ranks for global and
+  per-project cockpit dashboards.
+- Side effects: none.
+- Invariants: missing timestamps / transitions degrade to neutral values
+  instead of raising so dashboards remain readable on partial state.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from pollypm.cockpit_sections.base import _iso_to_dt, _task_cycle_minutes
+
+_ACTIVE_STATUSES = {"draft", "queued", "in_progress", "review", "blocked", "on_hold"}
+_STUCK_AFTER = timedelta(hours=6)
+
+
+def _project_cycle_minutes(tasks: list) -> int | None:
+    completed = [
+        task for task in tasks
+        if getattr(getattr(task, "work_status", None), "value", None) == "done"
+    ]
+    completed.sort(
+        key=lambda task: _iso_to_dt(getattr(task, "updated_at", None))
+        or datetime.min.replace(tzinfo=UTC),
+        reverse=True,
+    )
+    cycles = [
+        minutes for task in completed[:7]
+        if (minutes := _task_cycle_minutes(task)) is not None
+    ]
+    if not cycles:
+        return None
+    return sum(cycles) // len(cycles)
+
+
+def stuck_task_count(tasks: list, *, now: datetime | None = None) -> int:
+    """Count non-terminal tasks whose activity is stale beyond the threshold."""
+    now = now or datetime.now(UTC)
+    stuck = 0
+    for task in tasks:
+        status = getattr(getattr(task, "work_status", None), "value", None) or str(
+            getattr(task, "work_status", "") or ""
+        )
+        if status not in _ACTIVE_STATUSES:
+            continue
+        updated = _iso_to_dt(getattr(task, "updated_at", None))
+        if updated is None:
+            continue
+        if now - updated > _STUCK_AFTER:
+            stuck += 1
+    return stuck
+
+
+def project_health_glyph(tasks: list, *, now: datetime | None = None) -> str:
+    """Return the health glyph based on the number of stuck tasks."""
+    stuck = stuck_task_count(tasks, now=now)
+    if stuck > 2:
+        return "🔴"
+    if stuck >= 1:
+        return "🟡"
+    return "🟢"
+
+
+def project_health_rank(tasks: list, *, now: datetime | None = None) -> int:
+    """Sort worst health first so the cockpit surfaces stuck projects early."""
+    glyph = project_health_glyph(tasks, now=now)
+    if glyph == "🔴":
+        return 0
+    if glyph == "🟡":
+        return 1
+    return 2
+
+
+def format_project_health_scorecard(
+    project_name: str,
+    counts: dict[str, int],
+    tasks: list,
+    *,
+    now: datetime | None = None,
+) -> str:
+    """Format the cockpit one-line project health summary."""
+    cycle = _project_cycle_minutes(tasks)
+    cycle_part = f"{cycle}m cycle" if cycle is not None else "— cycle"
+    return (
+        f"{project_name} · "
+        f"{int(counts.get('in_progress', 0))} in progress · "
+        f"{int(counts.get('review', 0))} review · "
+        f"{int(counts.get('blocked', 0))} blocked · "
+        f"{cycle_part} · "
+        f"{project_health_glyph(tasks, now=now)}"
+    )

--- a/src/pollypm/cockpit_sections/project_dashboard.py
+++ b/src/pollypm/cockpit_sections/project_dashboard.py
@@ -20,6 +20,7 @@ from pollypm.cockpit_sections.base import (
 )
 from pollypm.cockpit_sections.downtime import _section_downtime
 from pollypm.cockpit_sections.header import _section_header, _worker_presence
+from pollypm.cockpit_sections.health import format_project_health_scorecard
 from pollypm.cockpit_sections.in_flight import _section_in_flight
 from pollypm.cockpit_sections.insights import _section_insights
 from pollypm.cockpit_sections.quick_actions import _section_quick_actions
@@ -158,6 +159,7 @@ def _render_project_dashboard(
         _section_header(name, presence),
         _DASHBOARD_BULLET + "\u2500" * (_DASHBOARD_DIVIDER_WIDTH - 2),
         _section_summary(counts),
+        format_project_health_scorecard(name, counts, tasks),
         "",
     ]
     velocity_lines = _section_velocity(tasks, tokens)

--- a/tests/test_cockpit_project_health.py
+++ b/tests/test_cockpit_project_health.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from pollypm.cockpit_sections.dashboard import _build_dashboard
+from pollypm.cockpit_sections.health import (
+    format_project_health_scorecard,
+    project_health_glyph,
+    project_health_rank,
+    stuck_task_count,
+)
+from pollypm.work.models import WorkStatus
+
+
+@dataclass
+class _Transition:
+    to_state: str
+    actor: str
+    timestamp: datetime
+
+
+class _Task:
+    def __init__(
+        self,
+        *,
+        title: str,
+        status: str,
+        updated_at: datetime,
+        transitions: list[_Transition] | None = None,
+        assignee: str | None = None,
+        current_node_id: str | None = None,
+    ) -> None:
+        self.title = title
+        self.work_status = WorkStatus(status)
+        self.updated_at = updated_at
+        self.transitions = transitions or []
+        self.assignee = assignee
+        self.current_node_id = current_node_id
+
+
+class _Project:
+    def __init__(self, key: str, name: str) -> None:
+        self.key = key
+        self.name = name
+        self.path = Path("/tmp") / key
+
+    def display_label(self) -> str:
+        return self.name
+
+
+class _Store:
+    def open_alerts(self):
+        return []
+
+    def recent_events(self, limit=300):
+        return []
+
+
+class _Supervisor:
+    store = _Store()
+
+
+class _Config:
+    def __init__(self, projects: dict[str, _Project]) -> None:
+        self.projects = projects
+
+
+def test_format_project_health_scorecard_includes_counts_cycle_and_health() -> None:
+    now = datetime(2026, 4, 21, 12, 0, tzinfo=UTC)
+    done = _Task(
+        title="Ship launch flow",
+        status="done",
+        updated_at=now - timedelta(hours=1),
+        transitions=[
+            _Transition("in_progress", "worker", now - timedelta(hours=2, minutes=15)),
+            _Transition("done", "reviewer", now - timedelta(hours=1, minutes=30)),
+        ],
+    )
+    active = _Task(
+        title="Polish account UI",
+        status="in_progress",
+        updated_at=now - timedelta(minutes=20),
+    )
+    line = format_project_health_scorecard(
+        "web-app",
+        {"in_progress": 1, "review": 0, "blocked": 0},
+        [done, active],
+        now=now,
+    )
+    assert line == "web-app · 1 in progress · 0 review · 0 blocked · 45m cycle · 🟢"
+
+
+def test_health_thresholds_track_stuck_tasks() -> None:
+    now = datetime(2026, 4, 21, 12, 0, tzinfo=UTC)
+    fresh = _Task(
+        title="Fresh",
+        status="in_progress",
+        updated_at=now - timedelta(minutes=10),
+    )
+    stale = _Task(
+        title="Stale",
+        status="review",
+        updated_at=now - timedelta(hours=7),
+    )
+    very_stale = _Task(
+        title="Very stale",
+        status="blocked",
+        updated_at=now - timedelta(hours=10),
+    )
+    assert stuck_task_count([fresh, stale], now=now) == 1
+    assert project_health_glyph([fresh, stale], now=now) == "🟡"
+    assert stuck_task_count([stale, very_stale, stale], now=now) == 3
+    assert project_health_glyph([stale, very_stale, stale], now=now) == "🔴"
+    assert project_health_rank([fresh], now=now) == 2
+
+
+def test_global_dashboard_surfaces_project_scorecards_sorted_by_health(monkeypatch) -> None:
+    now = datetime.now(UTC)
+    healthy_tasks = [
+        _Task(
+            title="Healthy",
+            status="in_progress",
+            updated_at=now - timedelta(minutes=15),
+        )
+    ]
+    stuck_tasks = [
+        _Task(
+            title=f"Stuck {index}",
+            status="review",
+            updated_at=now - timedelta(hours=7 + index),
+        )
+        for index in range(3)
+    ]
+
+    project_data = {
+        "red": (
+            {"in_progress": [], "review": stuck_tasks, "queued": [], "blocked": [], "done": []},
+            {"review": 3, "blocked": 0, "in_progress": 0},
+        ),
+        "green": (
+            {"in_progress": healthy_tasks, "review": [], "queued": [], "blocked": [], "done": []},
+            {"review": 0, "blocked": 0, "in_progress": 1},
+        ),
+    }
+
+    monkeypatch.setattr(
+        "pollypm.cockpit_sections.dashboard._dashboard_project_tasks",
+        lambda project_key, _path: project_data[project_key],
+    )
+
+    out = _build_dashboard(
+        _Supervisor(),
+        _Config(
+            {
+                "red": _Project("red", "api"),
+                "green": _Project("green", "notesy"),
+            }
+        ),
+    )
+
+    assert "Projects" in out
+    red_line = "api · 0 in progress · 3 review · 0 blocked · — cycle · 🔴"
+    green_line = "notesy · 1 in progress · 0 review · 0 blocked · — cycle · 🟢"
+    assert red_line in out
+    assert green_line in out
+    assert out.index(red_line) < out.index(green_line)


### PR DESCRIPTION
Closes #510

## Summary
- add a dedicated cockpit health-scorecard module for stuck-task health and cycle summaries
- surface per-project health lines in the global dashboard and per-project dashboard
- keep the health scoring logic independently testable with focused dashboard tests

## Testing
- HOME=/tmp/pytest-510 uv run --extra dev pytest tests/test_cockpit_project_health.py tests/test_cockpit_project_dashboard.py -q