### PR TITLE
docs: tighten pm doctor intro

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,7 +33,7 @@ Verify your environment:
 pm doctor
 ```
 
-You should see JSON reporting that `tmux`, `claude` (or `codex`), and optionally `docker` are found. Run `pm doctor` — it reports tmux, git, provider auth, and storage health. Fix anything that comes back red before continuing.
+Run `pm doctor` — it reports tmux, git, provider auth, and storage health. Fix anything that comes back red before continuing.
 
 Now launch PollyPM:
 


### PR DESCRIPTION
Closes #442.\n\nReplaced the conditional onboarding phrasing with the shipped -- Environment --
✓ python-version: Python 3.13.11 (>= 3.13.0)
✓ tmux: tmux 3.6.0 (>= 3.3)
✓ git: git 2.50.1 (>= 2.40)
✓ gh-installed: gh CLI installed
✓ gh-authenticated: gh authenticated
✓ uv: uv installed
! terminal-color: terminal likely lacks color support (TERM='dumb')

-- Install --
✓ pm-binary: pm binary at /Users/sam/.local/bin/pm
✓ pollypm-version-matches: pollypm 1.0.0rc2 matches pyproject
✓ config-file: config present at /Users/sam/.pollypm/pollypm.toml
✓ provider-account: 1 provider account(s) configured
✓ storage-backend: storage backend 'sqlite' active at sqlite:////Users/sam/.pollypm/state.db
✓ registered-providers: registered-providers: claude, codex

-- Plugins --
✓ builtin-plugin-manifests: 22 builtin plugin manifest(s) parse
✓ critical-plugins-enabled: no critical plugin disabled
✓ plugin-capability-shapes: no deprecated capability shapes in builtin plugins

-- Migrations --
- state-migrations: state migration check skipped (no tracked project DBs)
- work-migrations: work migration check skipped (no tracked project DBs)

-- Filesystem --
✓ pollypm-home-writable: /Users/sam/.pollypm writable
✓ pollypm-plugins-dir: /Users/sam/.pollypm/plugins exists
✓ tracked-project-paths: tracked project paths exist
! db-layout-canonical: legacy .pollypm-state/ directories present: /Users/sam/dev/itsalive/.pollypm-state, /Users/sam/dev/otter-camp/.pollypm-state, /Users/sam/dev/news/.pollypm-state, /Users/sam/dev/health-coach/.pollypm-state, /Users/sam/dev/booktalk/.pollypm-state
✓ disk-space: 812.4 GB free on $HOME

-- Tmux --
✓ tmux-daemon: tmux daemon running
✓ storage-closet: pollypm-storage-closet session exists
✓ stale-dead-panes: no stale dead panes in storage closet
✓ rail-daemon-alive: rail daemon alive (pid 67503)

-- Network --
✓ network-github: github.com reachable
✓ network-anthropic: claude.ai + api.anthropic.com reachable
- network-openai: openai reachability skipped (no codex account)

-- Pipeline --
✓ plan-gate: plan-presence gate enabled (plan_dir='docs/plan')
✓ architect-profile: architect profile present (13616B)
✓ visual-explainer-skill: visual-explainer skill present
✓ task-assignment-sweeper-dbs: 0 tracked project(s) have reachable state.db
- sessions-table-populated: sessions-table check skipped (no state.db)

-- Schedulers --
✓ scheduler-handlers: all 7 scheduled handler(s) registered
- scheduler-cadence: scheduler-cadence check skipped (no state.db)

-- Resources --
- state-db-size: state.db size check skipped (no tracked DBs)
✓ agent-worktree-count: 7 agent worktree(s) under .claude/worktrees/
✓ logs-dir-size: logs dir 363.8 MB (/Users/sam/.pollypm/logs)
✓ session-memory: 5 session(s), largest 278 MB RSS

-- Inbox --
✓ inbox-aggregator-path: pm notify default → /Users/sam/dev/.pollypm/state.db
✓ inbox-open-count: 13 open inbox item(s)

-- Sessions --
- session-drift: session-drift check skipped (no state.db)
✓ persona-swap-defense: persona-swap assertion wired in supervisor.py

Summary: 43/45 passed, 2 warning(s), 0 error(s), 7 skipped (0.87s)
45 checks · 43 passed · 2 warnings · 0 errors

Failures:

! terminal-color: terminal likely lacks color support (TERM='dumb')

  Why: PollyPM's cockpit and rail rely on 256-color / true-color ANSI escapes. A 'dumb' or missing TERM renders them as garbage.

  Use a modern terminal:
    macOS:  iTerm2 (https://iterm2.com) or Terminal.app
    Linux:  kitty, WezTerm, Ghostty, gnome-terminal
  Or set:  export TERM=xterm-256color
  Recheck: pm doctor

! db-layout-canonical: legacy .pollypm-state/ directories present: /Users/sam/dev/itsalive/.pollypm-state, /Users/sam/dev/otter-camp/.pollypm-state, /Users/sam/dev/news/.pollypm-state, /Users/sam/dev/health-coach/.pollypm-state, /Users/sam/dev/booktalk/.pollypm-state

  Why: #339 collapsed PollyPM storage to two scopes — ~/.pollypm/state.db (user) and <workspace_root>/.pollypm/state.db (workspace). A leftover .pollypm-state/ tree is not read by any code path; it just wastes disk and can confuse grep when debugging.

  Remove the stray directories once you've confirmed nothing under them is needed —
    rm -rf /Users/sam/dev/itsalive/.pollypm-state /Users/sam/dev/otter-camp/.pollypm-state /Users/sam/dev/news/.pollypm-state /Users/sam/dev/health-coach/.pollypm-state /Users/sam/dev/booktalk/.pollypm-state
  Recheck: pm doctor description and removed the stale availability-era sentence.