### PR TITLE
feat(cockpit): add just shipped dashboard panel

### DIFF
--- a/src/pollypm/cockpit_sections/__init__.py
+++ b/src/pollypm/cockpit_sections/__init__.py
@@ -41,6 +41,7 @@ from pollypm.cockpit_sections.health import (
 )
 from pollypm.cockpit_sections.in_flight import _section_in_flight
 from pollypm.cockpit_sections.insights import _section_insights
+from pollypm.cockpit_sections.just_shipped import _section_just_shipped
 from pollypm.cockpit_sections.project_dashboard import (
     _DASHBOARD_PROJECT_CACHE,
     _dashboard_project_tasks,
@@ -77,6 +78,7 @@ __all__ = [
     "_section_header",
     "_section_in_flight",
     "_section_insights",
+    "_section_just_shipped",
     "_section_quick_actions",
     "_section_recent",
     "_section_summary",

--- a/src/pollypm/cockpit_sections/dashboard.py
+++ b/src/pollypm/cockpit_sections/dashboard.py
@@ -12,6 +12,7 @@ from pollypm.cockpit_sections.health import (
     format_project_health_scorecard,
     project_health_rank,
 )
+from pollypm.cockpit_sections.just_shipped import _section_just_shipped
 from pollypm.cockpit_sections.project_dashboard import (
     _DASHBOARD_PROJECT_CACHE,
     _dashboard_project_tasks,
@@ -179,6 +180,8 @@ def _build_dashboard(supervisor, config) -> str:
         if len(all_done) > 8:
             lines.append(f"    + {len(all_done) - 8} more completed")
         lines.append("")
+
+    lines.extend(_section_just_shipped(all_done, now=now))
 
     # ── System activity ──
     lines.append("  ─── Activity ──────────────────────────────────────")

--- a/src/pollypm/cockpit_sections/just_shipped.py
+++ b/src/pollypm/cockpit_sections/just_shipped.py
@@ -1,0 +1,58 @@
+"""Celebratory dashboard section for recently approved work."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from pollypm.cockpit_sections.base import (
+    _DASHBOARD_BULLET,
+    _dashboard_divider,
+    _iso_to_dt,
+    _task_cycle_minutes,
+)
+
+
+def _relative_age(value, *, now: datetime) -> str:
+    dt = _iso_to_dt(value)
+    if dt is None:
+        return ""
+    delta = now - dt
+    if delta < timedelta(minutes=1):
+        return "just now"
+    if delta < timedelta(hours=1):
+        return f"{int(delta.total_seconds() // 60)}m ago"
+    if delta < timedelta(days=1):
+        return f"{int(delta.total_seconds() // 3600)}h ago"
+    return f"{delta.days}d ago"
+
+
+def _section_just_shipped(
+    completed: list[tuple[str, object]],
+    *,
+    now: datetime | None = None,
+) -> list[str]:
+    """Render the last three approved tasks from the last 24 hours."""
+    now = now or datetime.now(UTC)
+    shipped: list[tuple[str, object]] = []
+    cutoff = now - timedelta(hours=24)
+    for project_key, task in completed:
+        updated = _iso_to_dt(getattr(task, "updated_at", None))
+        if updated is None or updated < cutoff:
+            continue
+        shipped.append((project_key, task))
+        if len(shipped) == 3:
+            break
+    if not shipped:
+        return []
+
+    lines = [_dashboard_divider("🎉 Just shipped"), ""]
+    for project_key, task in shipped:
+        cycle = _task_cycle_minutes(task)
+        cycle_part = f"{cycle}m cycle" if cycle is not None else "— cycle"
+        age = _relative_age(getattr(task, "updated_at", None), now=now)
+        lines.append(
+            f"{_DASHBOARD_BULLET}{project_key}/{task.task_number}  "
+            f"{cycle_part:<9}  {age}"
+        )
+    lines.append("")
+    return lines

--- a/tests/test_cockpit_just_shipped.py
+++ b/tests/test_cockpit_just_shipped.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from pollypm.cockpit_sections.dashboard import _build_dashboard
+from pollypm.cockpit_sections.just_shipped import _section_just_shipped
+from pollypm.work.models import WorkStatus
+
+
+@dataclass
+class _Transition:
+    to_state: str
+    actor: str
+    timestamp: datetime
+
+
+class _Task:
+    def __init__(
+        self,
+        *,
+        task_number: int,
+        title: str,
+        updated_at: datetime,
+        transitions: list[_Transition],
+    ) -> None:
+        self.task_number = task_number
+        self.title = title
+        self.work_status = WorkStatus.DONE
+        self.updated_at = updated_at
+        self.transitions = transitions
+
+
+class _Project:
+    def __init__(self, key: str, name: str) -> None:
+        self.key = key
+        self.name = name
+        self.path = Path("/tmp") / key
+
+    def display_label(self) -> str:
+        return self.name
+
+
+class _Store:
+    def open_alerts(self):
+        return []
+
+    def recent_events(self, limit=300):
+        return []
+
+
+class _Supervisor:
+    store = _Store()
+
+
+class _Config:
+    def __init__(self, projects: dict[str, _Project]) -> None:
+        self.projects = projects
+
+
+def _done_task(task_number: int, *, now: datetime, age_hours: int, cycle_minutes: int) -> _Task:
+    end = now - timedelta(hours=age_hours)
+    start = end - timedelta(minutes=cycle_minutes)
+    return _Task(
+        task_number=task_number,
+        title=f"Task {task_number}",
+        updated_at=end,
+        transitions=[
+            _Transition("in_progress", "worker", start),
+            _Transition("done", "russell", end),
+        ],
+    )
+
+
+def test_section_just_shipped_shows_recent_approvals_only() -> None:
+    now = datetime(2026, 4, 21, 12, 0, tzinfo=UTC)
+    recent = _done_task(1, now=now, age_hours=2, cycle_minutes=45)
+    older = _done_task(2, now=now, age_hours=30, cycle_minutes=20)
+    lines = _section_just_shipped(
+        [("notesy", recent), ("notesy", older)],
+        now=now,
+    )
+    joined = "\n".join(lines)
+    assert "🎉 Just shipped" in joined
+    assert "notesy/1  45m cycle" in joined
+    assert "2h ago" in joined
+    assert "notesy/2" not in joined
+
+
+def test_global_dashboard_includes_just_shipped_panel(monkeypatch) -> None:
+    now = datetime.now(UTC)
+    shipped = _done_task(3, now=now, age_hours=4, cycle_minutes=20)
+    project_data = {
+        "notesy": (
+            {"in_progress": [], "review": [], "queued": [], "blocked": [], "done": [shipped]},
+            {"done": 1},
+        )
+    }
+
+    monkeypatch.setattr(
+        "pollypm.cockpit_sections.dashboard._dashboard_project_tasks",
+        lambda project_key, _path: project_data[project_key],
+    )
+
+    out = _build_dashboard(
+        _Supervisor(),
+        _Config({"notesy": _Project("notesy", "Notesy")}),
+    )
+
+    assert "🎉 Just shipped" in out
+    assert "notesy/3  20m cycle" in out


### PR DESCRIPTION
Closes #521

## Summary
- add a dedicated cockpit dashboard section for recently approved work
- surface the last three shipped tasks from the last 24 hours with cycle time and age
- keep the panel hidden when nothing shipped recently

## Testing
- HOME=/tmp/pytest-521 uv run --extra dev pytest tests/test_cockpit_just_shipped.py tests/test_cockpit_project_dashboard.py -q