### PR TITLE
perf(heartbeat): avoid deep copy for primitive payloads

### DIFF
--- a/src/pollypm/heartbeat/tick.py
+++ b/src/pollypm/heartbeat/tick.py
@@ -38,6 +38,29 @@ from pollypm.heartbeat.roster import (
 __all__ = ["Heartbeat", "JobQueueProtocol", "TickResult", "EnqueuedJob"]
 
 
+def _is_immutable_payload_value(value: Any) -> bool:
+    """Return True when a payload value is safe to reuse without deep copy."""
+    if value is None or isinstance(value, (str, bytes, int, float, bool)):
+        return True
+    if isinstance(value, tuple):
+        return all(_is_immutable_payload_value(item) for item in value)
+    if isinstance(value, frozenset):
+        return all(_is_immutable_payload_value(item) for item in value)
+    if isinstance(value, dict):
+        return all(
+            _is_immutable_payload_value(key) and _is_immutable_payload_value(item)
+            for key, item in value.items()
+        )
+    return False
+
+
+def _snapshot_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Take the cheapest safe snapshot for an enqueued heartbeat payload."""
+    if _is_immutable_payload_value(payload):
+        return dict(payload)
+    return copy.deepcopy(payload)
+
+
 class JobQueueProtocol(Protocol):
     """Structural interface for the queue dependency.
 
@@ -116,7 +139,7 @@ class Heartbeat:
                 entry.first_seen_at = now
 
             if self._is_due(entry, now, prev):
-                payload_snapshot = copy.deepcopy(entry.payload)
+                payload_snapshot = _snapshot_payload(entry.payload)
                 job_id = self.queue.enqueue(
                     entry.handler_name,
                     payload_snapshot,

--- a/tests/test_heartbeat_tick.py
+++ b/tests/test_heartbeat_tick.py
@@ -372,6 +372,29 @@ class TestHeartbeatTick:
         roster.entries[0].payload["items"].append(99)
         assert queue.enqueued[0]["payload"] == {"items": [1, 2, 3]}
 
+    def test_primitive_payload_avoids_deepcopy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        roster = Roster()
+        roster.register(
+            schedule="@on_startup",
+            handler_name="boot",
+            payload={"project": "pollypm", "count": 3, "enabled": True},
+        )
+        queue = FakeQueue()
+        hb = Heartbeat(roster, queue)
+
+        def _boom(_value):
+            raise AssertionError("deepcopy should not run for primitive payloads")
+
+        monkeypatch.setattr("pollypm.heartbeat.tick.copy.deepcopy", _boom)
+
+        result = hb.tick(_utc())
+        assert result.enqueued_count == 1
+        assert result.enqueued[0].payload == {
+            "project": "pollypm",
+            "count": 3,
+            "enabled": True,
+        }
+
 
 # ---------------------------------------------------------------------------
 # Performance


### PR DESCRIPTION
Closes #466

## Summary
- add a heartbeat payload snapshot helper with a primitive-value fast path
- keep deepcopy for nested mutable payloads so enqueue isolation stays intact
- add a regression test proving primitive-only payloads bypass deepcopy

## Testing
- HOME=/tmp/pytest-466 uv run --extra dev pytest tests/test_heartbeat_tick.py -q