### PR TITLE
fix(prompts): compact session manifest injection

### DIFF
--- a/src/pollypm/rules.py
+++ b/src/pollypm/rules.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
 
+_SESSION_MANIFEST_PATH = Path(".pollypm/MANIFEST.md")
+_SESSION_SECTION_LIMIT = 6
+
 
 @dataclass(slots=True)
 class CatalogFile:
@@ -208,6 +211,69 @@ def render_magic_manifest(project_root: Path) -> str:
     return "\n".join(lines)
 
 
+def _write_project_manifest(project_root: Path) -> None:
+    full_manifest = "\n\n".join(
+        part
+        for part in (
+            render_rules_manifest(project_root),
+            render_magic_manifest(project_root),
+        )
+        if part
+    )
+    if not full_manifest:
+        return
+    try:
+        dest = project_root / _SESSION_MANIFEST_PATH
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if not dest.exists() or dest.read_text() != full_manifest:
+            dest.write_text(full_manifest)
+    except Exception:  # noqa: BLE001
+        return
+
+
+def _render_compact_catalog(
+    title: str,
+    entries: dict[str, CatalogFile],
+    *,
+    intro: str,
+) -> str:
+    lines = [title, intro]
+    names = sorted(entries)
+    for name in names[:_SESSION_SECTION_LIMIT]:
+        entry = entries[name]
+        lines.append(f"- {entry.name}: {entry.description}")
+    remaining = len(names) - _SESSION_SECTION_LIMIT
+    if remaining > 0:
+        lines.append(f"- … {remaining} more in `{_SESSION_MANIFEST_PATH.as_posix()}`")
+    return "\n".join(lines)
+
+
 def render_session_manifest(project_root: Path) -> str:
-    parts = [render_rules_manifest(project_root), render_magic_manifest(project_root)]
-    return "\n\n".join(part for part in parts if part)
+    _write_project_manifest(project_root)
+    rules = discover_rules(project_root)
+    magic = discover_magic(project_root)
+    parts: list[str] = []
+    if rules:
+        parts.append(
+            _render_compact_catalog(
+                "## Available Rules",
+                rules,
+                intro=(
+                    "Rules and available magic skills are summarized in "
+                    f"`{_SESSION_MANIFEST_PATH.as_posix()}` (auto-regenerated). "
+                    "Read it when you need one."
+                ),
+            )
+        )
+    if magic:
+        parts.append(
+            _render_compact_catalog(
+                "## Available Magic",
+                magic,
+                intro=(
+                    f"See `{_SESSION_MANIFEST_PATH.as_posix()}` for the full "
+                    "catalog with paths and trigger details."
+                ),
+            )
+        )
+    return "\n\n".join(parts)

--- a/tests/integration/test_magic_integration.py
+++ b/tests/integration/test_magic_integration.py
@@ -58,6 +58,8 @@ def test_project_magic_appears_in_worker_prompt_manifest(tmp_path: Path) -> None
     prompt = launches["worker_demo"].session.prompt or ""
 
     assert "## Available Magic" in prompt
-    assert ".pollypm/magic/screenshot-verify.md" in prompt
     assert "Screenshot verification" in prompt
-    assert "pollypm/defaults/magic/deploy-site.md" in prompt
+    assert "deploy-site" in prompt
+    assert ".pollypm/MANIFEST.md" in prompt
+    assert "pollypm/defaults/magic/deploy-site.md" not in prompt
+    assert (project_root / ".pollypm" / "MANIFEST.md").exists()

--- a/tests/integration/test_prompt_assembly_integration.py
+++ b/tests/integration/test_prompt_assembly_integration.py
@@ -89,11 +89,13 @@ def test_worker_prompt_assembles_overview_manifest_issue_and_checkpoint(tmp_path
     # The critical invariant is that all sections exist, not their relative order.
     assert all(idx >= 0 for idx in [overview_index, rules_index, magic_index, issue_index, checkpoint_index])
     assert "Current architecture summary." in prompt
-    assert ".pollypm/rules/deploy.md" in prompt
-    assert ".pollypm/magic/ship.md" in prompt
+    assert "Project deploy process" in prompt
+    assert "Release helper" in prompt
+    assert ".pollypm/MANIFEST.md" in prompt
     assert "Source: `issues/02-in-progress/0007-fix-deploy.md`" in prompt
     assert "Ship the deployment fix." in prompt
     assert "Recent handoff notes." in prompt
+    assert (project_root / ".pollypm" / "MANIFEST.md").exists()
 
 
 def test_worker_prompt_reads_active_issue_from_github_backend(monkeypatch, tmp_path: Path) -> None:

--- a/tests/integration/test_rules_integration.py
+++ b/tests/integration/test_rules_integration.py
@@ -58,6 +58,8 @@ def test_project_rule_appears_in_worker_prompt_manifest(tmp_path: Path) -> None:
     prompt = launches["worker_demo"].session.prompt or ""
 
     assert "## Available Rules" in prompt
-    assert ".pollypm/rules/deploy.md" in prompt
     assert "Project deploy process" in prompt
-    assert "pollypm/defaults/rules/bugfix.md" in prompt
+    assert "bugfix" in prompt
+    assert ".pollypm/MANIFEST.md" in prompt
+    assert "pollypm/defaults/rules/bugfix.md" not in prompt
+    assert (project_root / ".pollypm" / "MANIFEST.md").exists()

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,6 +1,12 @@
 from pathlib import Path
 
-from pollypm.rules import discover_magic, discover_rules, render_magic_manifest, render_rules_manifest
+from pollypm.rules import (
+    discover_magic,
+    discover_rules,
+    render_magic_manifest,
+    render_rules_manifest,
+    render_session_manifest,
+)
 
 
 def test_discover_rules_includes_packaged_defaults(tmp_path: Path) -> None:
@@ -84,3 +90,28 @@ def test_magic_manifest_lists_merged_magic(monkeypatch, tmp_path: Path) -> None:
     assert "## Available Magic" in manifest
     assert "- screenshot-verify: Screenshot verification -> .pollypm/magic/screenshot-verify.md (when checking UI output visually)" in manifest
     assert "- deploy-site: Deploy a site and verify it works -> pollypm/defaults/magic/deploy-site.md" in manifest
+
+
+def test_session_manifest_is_compact_and_writes_full_manifest(monkeypatch, tmp_path: Path) -> None:
+    fake_home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    (tmp_path / ".pollypm" / "rules").mkdir(parents=True)
+    (tmp_path / ".pollypm" / "rules" / "audit.md").write_text(
+        "Description: Project audit flow\nTrigger: when reviewing code in this project\n"
+    )
+    (tmp_path / ".pollypm" / "magic").mkdir(parents=True)
+    (tmp_path / ".pollypm" / "magic" / "screenshot-verify.md").write_text(
+        "Description: Screenshot verification\nTrigger: when checking UI output visually\n"
+    )
+
+    manifest = render_session_manifest(tmp_path)
+
+    assert "## Available Rules" in manifest
+    assert "## Available Magic" in manifest
+    assert ".pollypm/MANIFEST.md" in manifest
+    assert "-> .pollypm/rules/audit.md" not in manifest
+    assert "(when checking UI output visually)" not in manifest
+
+    written = (tmp_path / ".pollypm" / "MANIFEST.md").read_text()
+    assert "-> .pollypm/rules/audit.md" in written
+    assert "-> .pollypm/magic/screenshot-verify.md" in written


### PR DESCRIPTION
Closes #472

## Summary
- keep full rules/magic detail in `.pollypm/MANIFEST.md`
- switch prompt injection to compact rules/magic summaries with the same section headings
- update prompt/rules integration tests to assert the new compact manifest behavior

## Testing
- HOME=/tmp/pytest-472 uv run --extra dev pytest tests/test_rules.py tests/integration/test_magic_integration.py tests/integration/test_rules_integration.py tests/integration/test_prompt_assembly_integration.py -q