### PR TITLE
docs: clarify shipped plugin spec headers

### DIFF
--- a/docs/advisor-plugin-spec.md
+++ b/docs/advisor-plugin-spec.md
@@ -1,6 +1,8 @@
 # Advisor Plugin Specification
 
-**Status:** v1 shipped - implemented in `src/pollypm/plugins_builtin/advisor/plugin.py`. Depends on: planner plugin, work service, session service, roster/jobs APIs, inbox view.
+**Status:** v1 shipped. This spec describes the built-in advisor plugin that is already live in PollyPM.
+**Implementation:** Entry module: `src/pollypm/plugins_builtin/advisor/plugin.py`
+**Depends on:** planner plugin, work service, session service, roster/jobs APIs, inbox view.
 
 ## 1. Purpose
 

--- a/docs/downtime-plugin-spec.md
+++ b/docs/downtime-plugin-spec.md
@@ -1,6 +1,8 @@
 # Downtime Management Plugin Specification
 
-**Status:** v1 shipped - implemented in `src/pollypm/plugins_builtin/downtime/plugin.py`. Depends on: planner plugin, work service, session service, roster/jobs APIs, capacity subsystem, inbox view.
+**Status:** v1 shipped. This spec describes the built-in downtime plugin that is already live in PollyPM.
+**Implementation:** Entry module: `src/pollypm/plugins_builtin/downtime/plugin.py`
+**Depends on:** planner plugin, work service, session service, roster/jobs APIs, capacity subsystem, inbox view.
 
 ## 1. Purpose
 

--- a/docs/morning-briefing-plugin-spec.md
+++ b/docs/morning-briefing-plugin-spec.md
@@ -1,6 +1,8 @@
 # Morning Briefing Plugin Specification
 
-**Status:** v1 shipped - implemented in `src/pollypm/plugins_builtin/morning_briefing/plugin.py`. Depends on: work service, inbox view, roster/jobs APIs, advisor plugin (optional — briefing can include advisor insights if present).
+**Status:** v1 shipped. This spec describes the built-in morning briefing plugin that is already live in PollyPM.
+**Implementation:** Entry module: `src/pollypm/plugins_builtin/morning_briefing/plugin.py`
+**Depends on:** work service, inbox view, roster/jobs APIs, advisor plugin (optional - briefing can include advisor insights if present).
 
 ## 1. Purpose
 

--- a/docs/planner-plugin-spec.md
+++ b/docs/planner-plugin-spec.md
@@ -1,6 +1,8 @@
 # Project Planning Plugin Specification
 
-**Status:** v1 shipped - implemented in `src/pollypm/plugins_builtin/project_planning/plugin.py`. Depends on: plugin-discovery spec (`docs/plugin-discovery-spec.md`), work service, session service, roster/jobs APIs.
+**Status:** v1 shipped. This spec describes the built-in project planning plugin that is already live in PollyPM.
+**Implementation:** Entry module: `src/pollypm/plugins_builtin/project_planning/plugin.py`
+**Depends on:** plugin-discovery spec (`docs/plugin-discovery-spec.md`), work service, session service, roster/jobs APIs.
 
 ## 1. Purpose
 


### PR DESCRIPTION
## Summary\n- normalize the shipped-status header block across the planner, morning briefing, downtime, and advisor specs\n- add an explicit implementation pointer to each built-in plugin entry module\n- keep the write set limited to the four issue-targeted docs\n\nCloses #436