### PR TITLE
docs: clarify archived notes boundary

### DIFF
--- a/docs/archive/notes/README.md
+++ b/docs/archive/notes/README.md
@@ -1,7 +1,15 @@
 # Archived Notes
 
-This directory holds internal working notes that are no longer part of the
-front-line documentation set.
+This directory holds historical internal working notes that were removed from
+the user-facing docs surface. They are preserved for reference only and should
+not be treated as current product documentation.
 
-- `to-discuss.md`
-- `ideas-overnight.md`
+Archived note files:
+
+- `to-discuss.md`: internal decision log and overnight testing notes that
+  previously lived at `docs/to-discuss.md`
+- `ideas-overnight.md`: brainstorming notes that previously lived at
+  `docs/ideas-overnight.md`
+
+If a note turns into real product guidance, move the stable guidance into the
+main docs set and keep the working-note history here or in the issue tracker.


### PR DESCRIPTION
## Summary
- clarify that `docs/archive/notes/` contains historical internal notes, not current docs
- document that `to-discuss.md` and `ideas-overnight.md` were intentionally moved out of the user-facing docs surface
- keep the write set limited to the archive notes README

## Context
Issue #433 is already functionally resolved on `main` because the public docs files were removed and archived. This follow-up makes the archive status explicit so those notes stay clearly out of the active documentation set.

Closes #433
