### PR TITLE
feat(cockpit): add stable worker avatars

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -32,6 +32,10 @@ from typing import Literal
 from pollypm.config import load_config
 from pollypm.cockpit_task_priority import priority_glyph, priority_rank
 from pollypm.cockpit_sections.base import _STATUS_ICONS
+from pollypm.cockpit_worker_identity import (
+    load_worker_color_overrides,
+    worker_identity,
+)
 from pollypm.heartbeats.snapshots import read_recent_heartbeat_snapshot
 
 
@@ -892,6 +896,7 @@ def _render_worker_roster_panel(config_path: Path) -> str:
             "No active worker sessions.\n\n"
             "Start one with `pm cockpit-pane project <key>` and press `w`."
         )
+    color_overrides = load_worker_color_overrides(config_path)
     lines = ["Workers", ""]
     dot_for = {
         "working": "\u25cf", "idle": "\u25cb",
@@ -899,13 +904,14 @@ def _render_worker_roster_panel(config_path: Path) -> str:
     }
     for row in rows:
         dot = dot_for.get(row.status, "\u25cb")
+        identity = worker_identity(row.session_name, color_overrides=color_overrides)
         task_part = (
             f"#{row.task_number} {row.task_title}"
             if row.task_number is not None else "(none)"
         )
         lines.append(
             f"  {dot} {row.status:<7}  {row.project_name:<18}  "
-            f"{row.session_name:<22}  {task_part}  @{row.current_node or '-'}  "
+            f"{(identity.avatar + ' ' + row.session_name):<22}  {task_part}  @{row.current_node or '-'}  "
             f"{row.turn_label}  {row.last_commit_label}"
         )
     return "\n".join(lines)

--- a/src/pollypm/cockpit_worker_identity.py
+++ b/src/pollypm/cockpit_worker_identity.py
@@ -1,0 +1,113 @@
+"""Worker identity helpers for cockpit worker/session surfaces.
+
+Contract:
+- Inputs: a session name plus optional ``[worker_colors]`` overrides
+  loaded from ``pollypm.toml``.
+- Outputs: stable ``WorkerIdentity`` records containing avatar and
+  colour values for rendering.
+- Side effects: optional best-effort config-file read for overrides.
+- Invariants: same session name yields the same identity across renders;
+  invalid override values are ignored.
+"""
+
+from __future__ import annotations
+
+import colorsys
+import hashlib
+import re
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+_HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+_TRAILING_DIGITS_RE = re.compile(r"(\d+)$")
+
+
+@dataclass(slots=True, frozen=True)
+class WorkerIdentity:
+    session_name: str
+    avatar: str
+    color: str
+
+
+def load_worker_color_overrides(config_path: Path) -> dict[str, str]:
+    """Return valid ``[worker_colors]`` overrides from ``config_path``."""
+    try:
+        raw = tomllib.loads(config_path.read_text())
+    except Exception:  # noqa: BLE001
+        return {}
+    section = raw.get("worker_colors", {})
+    if not isinstance(section, dict):
+        return {}
+    overrides: dict[str, str] = {}
+    for key, value in section.items():
+        normalized = _normalize_color(value)
+        if normalized is None:
+            continue
+        overrides[str(key).strip().lower()] = normalized
+    return overrides
+
+
+def worker_identity(
+    session_name: str,
+    *,
+    color_overrides: Mapping[str, str] | None = None,
+) -> WorkerIdentity:
+    """Return a stable avatar + colour for ``session_name``."""
+    lowered = session_name.strip().lower()
+    avatar = _avatar_for_session(session_name, lowered)
+    color = _override_color(session_name, lowered, color_overrides) or _hashed_color(lowered)
+    return WorkerIdentity(session_name=session_name, avatar=avatar, color=color)
+
+
+def _avatar_for_session(session_name: str, lowered: str) -> str:
+    if lowered in {"operator", "polly"} or lowered.startswith("polly"):
+        return "P"
+    if lowered in {"reviewer", "russell"} or lowered.startswith("russell"):
+        return "R"
+    match = _TRAILING_DIGITS_RE.search(session_name)
+    if match:
+        return f"W{match.group(1)}"
+    return "W"
+
+
+def _override_color(
+    session_name: str,
+    lowered: str,
+    color_overrides: Mapping[str, str] | None,
+) -> str | None:
+    if not color_overrides:
+        return None
+    keys = [lowered]
+    if lowered in {"operator", "polly"} or lowered.startswith("polly"):
+        keys.append("polly")
+    elif lowered in {"reviewer", "russell"} or lowered.startswith("russell"):
+        keys.append("russell")
+    else:
+        keys.append("worker")
+    for key in keys:
+        color = color_overrides.get(key)
+        if color:
+            return color
+    return None
+
+
+def _normalize_color(value: object) -> str | None:
+    text = str(value).strip()
+    if not _HEX_COLOR_RE.fullmatch(text):
+        return None
+    return text.upper()
+
+
+def _hashed_color(seed: str) -> str:
+    digest = hashlib.sha1(seed.encode("utf-8")).digest()
+    hue = int.from_bytes(digest[:2], "big") % 360
+    sat = 0.60 + (digest[2] / 255.0) * 0.15
+    light = 0.50 + (digest[3] / 255.0) * 0.12
+    red, green, blue = colorsys.hls_to_rgb(hue / 360.0, light, sat)
+    return "#{:02X}{:02X}{:02X}".format(
+        int(red * 255),
+        int(green * 255),
+        int(blue * 255),
+    )

--- a/src/pollypm/cockpit_workers.py
+++ b/src/pollypm/cockpit_workers.py
@@ -26,6 +26,10 @@ from textual.widgets import DataTable, Static
 from pollypm.cockpit_rail import CockpitRouter
 from pollypm.cockpit_alerts import _setup_alert_notifier
 from pollypm.cockpit_palette import _open_command_palette, _open_keyboard_help
+from pollypm.cockpit_worker_identity import (
+    load_worker_color_overrides,
+    worker_identity,
+)
 from pollypm.config import load_config
 
 
@@ -136,6 +140,7 @@ class PollyWorkerRosterApp(App[None]):
         self._auto_refresh_timer = None
         self._active_shipments: set[str] = set()
         self._seen_shipments: set[str] = set()
+        self._worker_color_overrides = load_worker_color_overrides(config_path)
 
     def compose(self) -> ComposeResult:
         with Vertical(id="wr-outer"):
@@ -174,6 +179,7 @@ class PollyWorkerRosterApp(App[None]):
 
     def _refresh(self) -> None:
         try:
+            self._worker_color_overrides = load_worker_color_overrides(self.config_path)
             rows = self._gather()
         except Exception as exc:  # noqa: BLE001
             self.topbar.update(
@@ -219,6 +225,10 @@ class PollyWorkerRosterApp(App[None]):
         self.hint.update(self._DEFAULT_HINT)
         for row in rows:
             celebrating = self._is_celebrating(row)
+            identity = worker_identity(
+                row.session_name,
+                color_overrides=self._worker_color_overrides,
+            )
             glyph, colour = self._HEALTH_GLYPHS.get(
                 getattr(row, "health", ""),
                 ("\U0001f7e1", "#6b7a88"),
@@ -227,12 +237,20 @@ class PollyWorkerRosterApp(App[None]):
                 dot = Text("\u2713", style="bold #dcf4e6 on #173322")
                 project_style = "bold #dcf4e6 on #173322"
                 cell_style = "bold #dcf4e6 on #173322"
+                session_style = project_style
+                avatar_style = project_style
             else:
                 dot = Text.assemble((glyph, colour))
                 project_style = "#5b8aff"
                 cell_style = "#d6dee5"
+                session_style = f"bold {identity.color}"
+                avatar_style = f"bold {identity.color}"
             project_cell = Text(row.project_name or row.project_key, style=project_style)
-            session_cell = Text(row.session_name, style=cell_style)
+            session_cell = Text.assemble(
+                (identity.avatar, avatar_style),
+                (" ", cell_style),
+                (row.session_name, session_style),
+            )
             task_text = (
                 f"#{row.task_number} {row.task_title}".rstrip()
                 if row.task_number is not None

--- a/tests/test_worker_identity.py
+++ b/tests/test_worker_identity.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from pollypm.cockpit_worker_identity import (
+    load_worker_color_overrides,
+    worker_identity,
+)
+
+
+def test_worker_identity_is_stable_and_role_aware() -> None:
+    first = worker_identity("task-demo-42")
+    second = worker_identity("task-demo-42")
+
+    assert first == second
+    assert first.avatar == "W42"
+    assert worker_identity("polly").avatar == "P"
+    assert worker_identity("russell").avatar == "R"
+    assert first.color.startswith("#")
+    assert len(first.color) == 7
+
+
+def test_worker_identity_honors_config_overrides(tmp_path: Path) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        "[worker_colors]\n"
+        'polly = "#7FDBFF"\n'
+        'russell = "#FFDC00"\n'
+        'worker = "#00AA88"\n'
+        'invalid = "blue"\n'
+    )
+
+    overrides = load_worker_color_overrides(config_path)
+
+    assert overrides == {
+        "polly": "#7FDBFF",
+        "russell": "#FFDC00",
+        "worker": "#00AA88",
+    }
+    assert worker_identity("operator", color_overrides=overrides).color == "#7FDBFF"
+    assert worker_identity("russell-review", color_overrides=overrides).color == "#FFDC00"
+    assert worker_identity("task-demo-7", color_overrides=overrides).color == "#00AA88"

--- a/tests/test_worker_roster_ui.py
+++ b/tests/test_worker_roster_ui.py
@@ -154,6 +154,18 @@ def test_status_dots_for_each_category(roster_env, roster_app) -> None:
     _run(body())
 
 
+def test_session_column_prefixes_avatar(roster_env, roster_app) -> None:
+    async def body() -> None:
+        rows = [_make_row(session_name="task-demo-42")]
+        roster_app._gather = lambda: rows  # type: ignore[method-assign]
+        async with roster_app.run_test(size=(160, 40)) as pilot:
+            await pilot.pause()
+            session_cell = roster_app.table.get_row_at(0)[1]
+            assert getattr(session_cell, "plain", str(session_cell)) == "W42 task-demo-42"
+
+    _run(body())
+
+
 def test_sort_order_stuck_then_working_then_idle_then_offline(
     roster_env, roster_app,
 ) -> None:


### PR DESCRIPTION
## Summary
- add a shared `cockpit_worker_identity` helper for stable avatar/color assignment plus optional `[worker_colors]` config overrides
- prefix roster session cells with deterministic avatars and use the shared color in the Textual worker roster
- mirror the avatar prefix in the fallback text roster and add regression coverage for identity stability and roster rendering

Closes #498.

## Testing
- HOME=/tmp/pytest-498 uv run --extra dev pytest tests/test_worker_identity.py tests/test_worker_roster_ui.py -q
- HOME=/tmp/pytest-498 uv run --extra dev pytest tests/test_worker_identity.py tests/test_worker_roster_ui.py tests/test_command_palette.py -k 'WorkerRosterApp or worker_roster' -q
