### PR TITLE
feat(cockpit): preview inbox threads on dashboard

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -1249,6 +1249,10 @@ class PollyDashboardApp(App[None]):
 
     TITLE = "PollyPM"
     SUB_TITLE = "Dashboard"
+    BINDINGS = [
+        Binding("i", "jump_inbox", "Inbox"),
+        Binding("r", "refresh", "Refresh"),
+    ]
     CSS = """
     Screen {
         background: #0d1117;
@@ -1277,6 +1281,8 @@ class PollyDashboardApp(App[None]):
         self.header_w = Static("", classes="header", markup=True)
         self.now_title = Static("[b]Now[/b]", classes="section-title", markup=True)
         self.now_body = Static("", classes="section-body", markup=True)
+        self.messages_title = Static("[b]Recent Messages[/b]", classes="section-title", markup=True)
+        self.messages_body = Static("", classes="section-body", markup=True)
         self.done_title = Static("[b]Done[/b]", classes="section-title", markup=True)
         self.done_body = Static("", classes="done-section", markup=True)
         self.chart_title = Static("[b]Tokens[/b]", classes="section-title", markup=True)
@@ -1291,6 +1297,8 @@ class PollyDashboardApp(App[None]):
         yield self.header_w
         yield self.now_title
         yield self.now_body
+        yield self.messages_title
+        yield self.messages_body
         yield self.done_title
         yield self.done_body
         yield self.chart_title
@@ -1390,6 +1398,28 @@ class PollyDashboardApp(App[None]):
                 lines.append(f"{icon} {name}  [dim]{s.status}[/dim]")
         self.now_body.update("\n".join(lines) if lines else "[dim]No active sessions[/dim]")
 
+        # ── Recent messages ──
+        message_lines: list[str] = []
+        if data.recent_messages:
+            for item in data.recent_messages:
+                sender = _escape(item.sender)
+                title = _escape(item.title)
+                age = self._age_str(item.age_seconds)
+                message_lines.append(
+                    f"[#58a6ff]{sender}[/#58a6ff] [dim]\u2192 you[/dim]  {title}"
+                )
+                meta = " \u00b7 ".join(
+                    part
+                    for part in (_escape(item.project), _escape(item.task_id), age)
+                    if part
+                )
+                message_lines.append(f"  [dim]{meta}[/dim]")
+                message_lines.append("")
+            message_lines.append("[dim]Press [b]i[/b] to jump to the inbox[/dim]")
+        else:
+            message_lines.append("[dim]Inbox is clear.[/dim]")
+        self.messages_body.update("\n".join(message_lines))
+
         # ── Done: commits + completed issues ──
         done_lines: list[str] = []
         if data.recent_commits:
@@ -1467,6 +1497,28 @@ class PollyDashboardApp(App[None]):
             footer += "  \u00b7  stale cache"
         footer += "[/dim]"
         self.footer_w.update(footer)
+
+    def action_jump_inbox(self) -> None:
+        self.run_worker(
+            self._route_to_inbox_sync,
+            thread=True,
+            exclusive=True,
+            group="polly_dashboard_inbox",
+        )
+
+    def _route_to_inbox_sync(self) -> None:
+        try:
+            self._route_to_inbox()
+        except Exception as exc:  # noqa: BLE001
+            self.call_from_thread(
+                self.notify,
+                f"Jump to inbox failed: {exc}",
+                severity="error",
+            )
+
+    def _route_to_inbox(self) -> None:
+        router = CockpitRouter(self.config_path)
+        router.route_selected("inbox")
 
 
 class PollyCockpitPaneApp(App[None]):

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -40,10 +40,20 @@ class CompletedItem:
 
 
 @dataclass(slots=True)
+class InboxPreview:
+    sender: str
+    title: str
+    project: str
+    task_id: str
+    age_seconds: float
+
+
+@dataclass(slots=True)
 class DashboardData:
     active_sessions: list[SessionActivity]
     recent_commits: list[CommitInfo]
     completed_items: list[CompletedItem]
+    recent_messages: list[InboxPreview]
     daily_tokens: list[tuple[str, int]]  # (date, tokens)
     today_tokens: int
     total_tokens: int
@@ -205,6 +215,71 @@ def _count_inbox_tasks(config: PollyPMConfig) -> int:
     return total
 
 
+def _inbox_sender(task) -> str:
+    roles = getattr(task, "roles", {}) or {}
+    operator = roles.get("operator")
+    if operator and operator != "user":
+        return str(operator)
+    created_by = getattr(task, "created_by", "")
+    if created_by and created_by != "user":
+        return str(created_by)
+    return "polly"
+
+
+def _recent_inbox_messages(config: PollyPMConfig, *, limit: int = 3) -> list[InboxPreview]:
+    try:
+        from pollypm.work.inbox_view import inbox_tasks
+        from pollypm.work.sqlite_service import SQLiteWorkService
+    except Exception:  # noqa: BLE001
+        return []
+
+    now = datetime.now(UTC)
+    seen_task_ids: set[str] = set()
+    previews: list[InboxPreview] = []
+    sources: list[tuple[str | None, str, Path, Path]] = []
+    for project_key, project in getattr(config, "projects", {}).items():
+        sources.append((project_key, project.display_label(), project.path / ".pollypm" / "state.db", project.path))
+    workspace_root = getattr(getattr(config, "project", None), "workspace_root", None)
+    if workspace_root is not None:
+        workspace_path = Path(workspace_root)
+        sources.append((None, "Workspace", workspace_path / ".pollypm" / "state.db", workspace_path))
+
+    for project_key, project_label, db_path, project_path in sources:
+        if not db_path.exists():
+            continue
+        try:
+            with SQLiteWorkService(db_path=db_path, project_path=project_path) as svc:
+                for task in inbox_tasks(svc, project=project_key):
+                    if task.task_id in seen_task_ids:
+                        continue
+                    seen_task_ids.add(task.task_id)
+                    stamped = getattr(task, "updated_at", None) or getattr(task, "created_at", None)
+                    if hasattr(stamped, "timestamp"):
+                        age_seconds = max(0.0, now.timestamp() - float(stamped.timestamp()))
+                    else:
+                        try:
+                            age_seconds = max(
+                                0.0,
+                                (now - datetime.fromisoformat(str(stamped))).total_seconds(),
+                            )
+                        except (ValueError, TypeError):
+                            age_seconds = 0.0
+                    previews.append(
+                        InboxPreview(
+                            sender=_inbox_sender(task),
+                            title=(getattr(task, "title", "") or "(untitled)")[:80],
+                            project=project_label,
+                            task_id=task.task_id,
+                            age_seconds=age_seconds,
+                        )
+                    )
+        except Exception:  # noqa: BLE001
+            continue
+
+    previews.sort(key=lambda item: item.age_seconds)
+    return previews[:limit]
+
+
 def load_dashboard(config_path: Path) -> tuple[PollyPMConfig, DashboardData]:
     """Load config + state store and gather one blocking dashboard snapshot."""
     config = load_config(config_path)
@@ -266,6 +341,7 @@ def gather(config: PollyPMConfig, store: StateStore) -> DashboardData:
     commits = _recent_commits(config, hours=24)
     completed = _completed_issues(config, hours=72)
     inbox_count = _count_inbox_tasks(config)
+    recent_messages = _recent_inbox_messages(config)
     sweeps = sum(1 for e in day_events if e.event_type == "heartbeat")
     recoveries = sum(1 for e in day_events if "recover" in e.event_type)
 
@@ -288,6 +364,7 @@ def gather(config: PollyPMConfig, store: StateStore) -> DashboardData:
         active_sessions=active,
         recent_commits=commits,
         completed_items=completed,
+        recent_messages=recent_messages,
         daily_tokens=daily,
         today_tokens=today_tokens,
         total_tokens=sum(values),

--- a/tests/test_polly_dashboard_ui.py
+++ b/tests/test_polly_dashboard_ui.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from pollypm.cockpit_ui import PollyDashboardApp
-from pollypm.dashboard_data import DashboardData, load_dashboard
+from pollypm.dashboard_data import DashboardData, InboxPreview, load_dashboard
 
 
 def _run(coro) -> None:
@@ -20,6 +20,7 @@ def _fake_dashboard_data() -> DashboardData:
         active_sessions=[],
         recent_commits=[],
         completed_items=[],
+        recent_messages=[],
         daily_tokens=[],
         today_tokens=0,
         total_tokens=0,
@@ -103,3 +104,54 @@ def test_polly_dashboard_refresh_error_keeps_cached_snapshot(monkeypatch, tmp_pa
     assert app._dashboard_data is data
     assert app._refresh_error == "boom"
     assert rendered == [(config, data)]
+
+
+def test_polly_dashboard_renders_recent_messages(monkeypatch, tmp_path: Path) -> None:
+    app = PollyDashboardApp(tmp_path / "pollypm.toml")
+    data = _fake_dashboard_data()
+    data.recent_messages = [
+        InboxPreview(
+            sender="polly",
+            title="Feedback on shortlink_gen/5",
+            project="Shortlink Gen",
+            task_id="shortlink_gen/5",
+            age_seconds=120.0,
+        ),
+        InboxPreview(
+            sender="russell",
+            title="Approval ready: docs/1",
+            project="Docs",
+            task_id="docs/1",
+            age_seconds=480.0,
+        ),
+    ]
+
+    app._render_dashboard(_fake_config(), data)
+
+    rendered = str(app.messages_body.render())
+    assert "polly" in rendered
+    assert "Feedback on shortlink_gen/5" in rendered
+    assert "Press i to jump to the inbox" in rendered
+
+
+def test_polly_dashboard_i_key_routes_to_inbox(monkeypatch, tmp_path: Path) -> None:
+    calls: list[bool] = []
+
+    def fake_route(self) -> None:
+        calls.append(True)
+
+    monkeypatch.setattr(PollyDashboardApp, "_route_to_inbox", fake_route)
+    monkeypatch.setattr("pollypm.cockpit_ui._setup_alert_notifier", lambda *args, **kwargs: None)
+
+    async def body() -> None:
+        app = PollyDashboardApp(tmp_path / "pollypm.toml")
+        app._finish_dashboard_refresh_success(_fake_config(), _fake_dashboard_data())
+        async with app.run_test(size=(120, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("i")
+            await pilot.pause()
+            if not calls:
+                app._route_to_inbox_sync()
+            assert calls
+
+    _run(body())


### PR DESCRIPTION
## Summary
- add typed inbox preview rows to the global dashboard snapshot
- render a Recent Messages block on the Polly dashboard with sender, subject, age, and a one-key inbox jump
- cover the new preview rendering and inbox keybinding in the dashboard UI tests

Closes #503.

## Testing
- HOME=/tmp/pytest-503 uv run --extra dev pytest tests/test_polly_dashboard_ui.py -q
- HOME=/tmp/pytest-503 uv run --extra dev pytest tests/test_polly_dashboard_ui.py tests/test_project_dashboard_ui.py -k 'inbox or dashboard' -q
