### PR TITLE
feat(cockpit): surface rejection feedback

### DIFF
--- a/src/pollypm/cockpit_tasks.py
+++ b/src/pollypm/cockpit_tasks.py
@@ -22,6 +22,11 @@ from pollypm.cockpit_task_review import (
 from pollypm.cockpit_formatting import format_event_time
 from pollypm.cockpit_formatting import format_relative_age as _format_relative_age
 from pollypm.config import load_config
+from pollypm.rejection_feedback import (
+    RejectionFeedbackNotice,
+    is_rejection_feedback_task,
+    unread_rejection_feedback,
+)
 from pollypm.session_services import create_tmux_client
 from pollypm.tz import format_time as _fmt_time
 
@@ -161,7 +166,14 @@ def _task_matches_query(task, owner: str | None, query: str) -> bool:
     return query in haystack
 
 
-def _render_overview(task, *, owner: str | None, flow, active_session) -> str:
+def _render_overview(
+    task,
+    *,
+    owner: str | None,
+    flow,
+    active_session,
+    rejection_feedback: RejectionFeedbackNotice | None = None,
+) -> str:
     icon = PollyTasksApp._STATUS_ICONS.get(task.work_status.value, "·")
     lines = [
         f"{icon} #{task.task_number} {priority_glyph(task)} {task.title}",
@@ -193,6 +205,16 @@ def _render_overview(task, *, owner: str | None, flow, active_session) -> str:
         lines.append(line)
     if active_session is not None:
         lines.append(f"Session    {active_session.agent_name}")
+    if rejection_feedback is not None:
+        lines.extend(
+            [
+                "",
+                "Inbox Feedback",
+                "",
+                f"Status     Rejected — feedback in inbox ({rejection_feedback.inbox_task_id})",
+                f"Preview    {rejection_feedback.preview}",
+            ]
+        )
     if task.description:
         lines.extend(["", "Description", "", task.description])
     if task.acceptance_criteria:
@@ -438,6 +460,7 @@ class PollyTasksApp(App[None]):
         self.project_key = project_key
         self._tasks: list = []
         self._owner_by_task_id: dict[str, str | None] = {}
+        self._rejection_feedback_by_task_id: dict[str, RejectionFeedbackNotice] = {}
         self._selected_task_id: str | None = None
         self._status_filter = "active"
         self._search_query = ""
@@ -523,17 +546,24 @@ class PollyTasksApp(App[None]):
             return None
         return SQLiteWorkService(db_path=db_path, project_path=project.path)
 
-    def _load_tasks(self) -> tuple[list, dict[str, str | None]]:
+    def _load_tasks(
+        self,
+    ) -> tuple[list, dict[str, str | None], dict[str, RejectionFeedbackNotice]]:
         svc = self._get_svc()
         if svc is None:
-            return [], {}
+            return [], {}, {}
         try:
-            tasks = list(svc.list_tasks(project=self.project_key))
+            tasks = [
+                task
+                for task in svc.list_tasks(project=self.project_key)
+                if not is_rejection_feedback_task(task)
+            ]
             owners = {task.task_id: svc.derive_owner(task) for task in tasks}
+            feedback = unread_rejection_feedback(svc, project=self.project_key)
         finally:
             svc.close()
         tasks.sort(key=_task_sort_key)
-        return tasks, owners
+        return tasks, owners, feedback
 
     def _filtered_tasks(self) -> list:
         visible: list = []
@@ -607,12 +637,20 @@ class PollyTasksApp(App[None]):
             updated = _format_event_time(
                 getattr(task, "updated_at", None) or getattr(task, "created_at", None)
             )
+            feedback = self._rejection_feedback_by_task_id.get(task.task_id)
+            status = task.work_status.value
+            title = f"{priority_glyph(task)} {task.title}"
+            stage = task.current_node_id or "—"
+            if feedback is not None:
+                status = f"{status} · feedback"
+                title = f"🔄 {title}"
+                stage = f"{stage} · Rejected"
             self.task_table.add_row(
                 f"#{task.task_number}",
-                task.work_status.value,
-                f"{priority_glyph(task)} {task.title}",
+                status,
+                title,
                 owner,
-                task.current_node_id or "—",
+                stage,
                 updated or "—",
                 key=task.task_id,
             )
@@ -629,7 +667,9 @@ class PollyTasksApp(App[None]):
         self._show_detail(target_id)
 
     def _refresh_list(self, *, select_first: bool = False) -> None:
-        self._tasks, self._owner_by_task_id = self._load_tasks()
+        self._tasks, self._owner_by_task_id, self._rejection_feedback_by_task_id = (
+            self._load_tasks()
+        )
         self._render_table(select_first=select_first)
 
     def _render_timeline(self, executions: list) -> None:
@@ -680,10 +720,13 @@ class PollyTasksApp(App[None]):
 
     def _render_selected_task(self, task, *, owner: str | None, flow, active_session) -> None:
         icon = self._STATUS_ICONS.get(task.work_status.value, "·")
+        feedback = self._rejection_feedback_by_task_id.get(task.task_id)
         header_bits = [
-            f"{icon} #{task.task_number} {priority_glyph(task)} {task.title}",
+            f"{'🔄 ' if feedback is not None else ''}{icon} #{task.task_number} {priority_glyph(task)} {task.title}",
             f"{task.work_status.value} · {_format_relative_age(task.updated_at or task.created_at)}",
         ]
+        if feedback is not None:
+            header_bits.append("Rejected — feedback in inbox")
         self.detail_header.update("\n".join(header_bits))
         self.detail_overview.update(
             _render_overview(
@@ -691,6 +734,7 @@ class PollyTasksApp(App[None]):
                 owner=owner,
                 flow=flow,
                 active_session=active_session,
+                rejection_feedback=feedback,
             )
         )
         self.detail_context.update(_render_context(task))

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -97,6 +97,10 @@ from pollypm.cockpit_settings_accounts import (
     render_settings_account_detail,
 )
 from pollypm.cockpit_workers import PollyWorkerRosterApp
+from pollypm.rejection_feedback import (
+    feedback_target_task_id,
+    is_rejection_feedback_task,
+)
 from pollypm.session_services import create_tmux_client
 from pollypm.service_api import PollyPMService
 from pollypm.cockpit import build_cockpit_detail
@@ -3451,6 +3455,10 @@ def _format_inbox_row(
         text.append("\u25c6 ", style="#f0c45a")  # yellow diamond
     else:
         text.append("\u25cb ", style="#4a5568")  # dim circle
+    subject_prefix = ""
+    if is_rejection_feedback_task(task):
+        subject_prefix = "🔄 "
+        text.append(subject_prefix, style="#ffb454")
     subject = task.title or "(no subject)"
     reply_suffix = ""
     if reply_count:
@@ -3458,7 +3466,9 @@ def _format_inbox_row(
         reply_suffix = f" ({reply_count} {noun})"
     # Account for the 2-char marker glyph prefix so the total row still
     # fits the target list-pane width without wrapping.
-    max_subject = max(8, width - 2 - len(tree_marker) - len(reply_suffix))
+    max_subject = max(
+        8, width - 2 - len(tree_marker) - len(reply_suffix) - len(subject_prefix)
+    )
     if len(subject) > max_subject:
         subject = subject[: max_subject - 1] + "\u2026"
     subject_style = "bold #eef2f4" if is_unread else "bold #b8c4cf"
@@ -3473,6 +3483,10 @@ def _format_inbox_row(
     age = format_relative(iso) if iso else ""
     project = (task.project or "").strip() or "\u2014"
     meta_bits = [project]
+    if is_rejection_feedback_task(task):
+        target_task = feedback_target_task_id(task)
+        if target_task:
+            meta_bits.append(f"feedback for {target_task}")
     if age:
         meta_bits.append(age)
     meta_indent = " " * max(2, len(tree_marker) + 2)
@@ -4022,6 +4036,8 @@ class _InboxListItem(ListItem):
         super().__init__(self._body, classes=row_classes)
         if is_unread:
             self.add_class("unread")
+        if row.is_task and is_rejection_feedback_task(row.task):
+            self.add_class("rejection-feedback")
 
     def mark_read(self, row: InboxThreadRow | None = None) -> None:
         """Flip the row to read styling in place (no reflow of the list)."""
@@ -4076,12 +4092,23 @@ class PollyInboxApp(App[None]):
     #inbox-list > .inbox-row.reply-row {
         color: #97a6b2;
     }
+    #inbox-list > .inbox-row.rejection-feedback {
+        border-left: thick #ffb454;
+        background: #17110d;
+    }
     #inbox-list > .inbox-row.-highlight {
         background: #1e2730;
+    }
+    #inbox-list > .inbox-row.rejection-feedback.-highlight {
+        background: #23180f;
     }
     #inbox-list:focus > .inbox-row.-highlight {
         background: #253140;
         color: #f2f6f8;
+    }
+    #inbox-list:focus > .inbox-row.rejection-feedback.-highlight {
+        background: #2d1e10;
+        color: #fff3df;
     }
     #inbox-detail-wrap {
         height: 1fr;

--- a/src/pollypm/rejection_feedback.py
+++ b/src/pollypm/rejection_feedback.py
@@ -1,0 +1,179 @@
+"""Structured rejection-feedback artifacts for cockpit task/inbox surfaces.
+
+Contract:
+- Inputs: a rejected work task plus reviewer + reason strings, or a
+  work service that can list tasks and read task context.
+- Outputs: inbox-task payloads and unread-feedback indexes keyed by the
+  original task id.
+- Side effects: optional inbox-task creation via the passed work service.
+- Invariants: feedback artifacts are ordinary chat-flow inbox tasks
+  labeled with ``review_feedback`` and ``task:<project/number>`` so the
+  task UI and inbox UI can consume one stable contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+FEEDBACK_LABEL = "review_feedback"
+TASK_LABEL_PREFIX = "task:"
+PROJECT_LABEL_PREFIX = "project:"
+
+
+@dataclass(slots=True)
+class RejectionFeedbackNotice:
+    """Unread rejection feedback linked to one work task."""
+
+    task_id: str
+    inbox_task_id: str
+    preview: str
+    created_at: object | None = None
+
+
+def emit_rejection_feedback(work_service, *, task, reviewer: str, reason: str):
+    """Create a chat-flow inbox task capturing one rejection reason."""
+
+    reviewer_name = _reviewer_label(reviewer)
+    preview = rejection_feedback_preview_from_reason(reason)
+    body = "\n".join(
+        [
+            preview,
+            "",
+            f"Task `{task.task_id}` was rejected by `{reviewer_name}` and returned to rework.",
+            "",
+            f"Current stage: `{getattr(task, 'current_node_id', None) or 'unknown'}`",
+            "",
+            "Open the linked task in the task cockpit, or jump to the inbox thread to",
+            "review the full rejection note before the worker continues.",
+        ]
+    )
+    return work_service.create(
+        title=f"Rejected {task.task_id} — {getattr(task, 'title', '') or 'Untitled task'}",
+        description=body,
+        type="task",
+        project=getattr(task, "project", "") or "inbox",
+        flow_template="chat",
+        roles={"requester": reviewer_name, "operator": "user"},
+        priority="high",
+        created_by=reviewer_name,
+        labels=[
+            FEEDBACK_LABEL,
+            f"{TASK_LABEL_PREFIX}{task.task_id}",
+            f"{PROJECT_LABEL_PREFIX}{getattr(task, 'project', '') or 'inbox'}",
+        ],
+    )
+
+
+def unread_rejection_feedback(service, *, project: str | None = None) -> dict[str, RejectionFeedbackNotice]:
+    """Return latest unread rejection feedback, keyed by target task id."""
+
+    notices: dict[str, RejectionFeedbackNotice] = {}
+    for task in service.list_tasks(project=project):
+        if not is_rejection_feedback_task(task):
+            continue
+        if _task_has_read_marker(service, task.task_id):
+            continue
+        target_task_id = feedback_target_task_id(task)
+        if not target_task_id:
+            continue
+        notice = RejectionFeedbackNotice(
+            task_id=target_task_id,
+            inbox_task_id=task.task_id,
+            preview=rejection_feedback_preview(task),
+            created_at=getattr(task, "updated_at", None) or getattr(task, "created_at", None),
+        )
+        current = notices.get(target_task_id)
+        if current is None or _sort_timestamp(notice.created_at) >= _sort_timestamp(current.created_at):
+            notices[target_task_id] = notice
+    return notices
+
+
+def is_rejection_feedback_task(task) -> bool:
+    """True when ``task`` is a structured review-feedback inbox item."""
+
+    labels = list(getattr(task, "labels", []) or [])
+    return FEEDBACK_LABEL in labels and any(
+        label.startswith(TASK_LABEL_PREFIX) for label in labels
+    )
+
+
+def feedback_target_task_id(task) -> str | None:
+    """Extract the linked work-task id from a feedback inbox task."""
+
+    for label in list(getattr(task, "labels", []) or []):
+        if label.startswith(TASK_LABEL_PREFIX):
+            value = label[len(TASK_LABEL_PREFIX):].strip()
+            return value or None
+    return None
+
+
+def rejection_feedback_preview(task) -> str:
+    """Best-effort first-line preview for an inbox feedback artifact."""
+
+    description = (getattr(task, "description", "") or "").strip()
+    if description:
+        for line in description.splitlines():
+            line = line.strip()
+            if line:
+                return line
+    title = (getattr(task, "title", "") or "").strip()
+    if " — " in title:
+        return title.split(" — ", 1)[1].strip() or title
+    return title or "Rejected — feedback in inbox"
+
+
+def rejection_feedback_preview_from_reason(reason: str) -> str:
+    """First non-empty line of a rejection reason, normalized for UI use."""
+
+    for line in (reason or "").splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return "Rejected — feedback in inbox"
+
+
+def _reviewer_label(reviewer: str) -> str:
+    label = (reviewer or "").strip()
+    if not label or label == "user":
+        return "reviewer"
+    return label
+
+
+def _task_has_read_marker(service, task_id: str) -> bool:
+    try:
+        rows = service.get_context(task_id, entry_type="read", limit=1)
+    except TypeError:
+        try:
+            rows = service.get_context(task_id, limit=1)
+        except Exception:  # noqa: BLE001
+            return False
+    except Exception:  # noqa: BLE001
+        return False
+    return bool(rows)
+
+
+def _sort_timestamp(value: object | None) -> float:
+    if value is None:
+        return 0.0
+    try:
+        if hasattr(value, "timestamp"):
+            return float(value.timestamp())
+        from datetime import datetime as _dt
+
+        return float(_dt.fromisoformat(str(value)).timestamp())
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+__all__ = [
+    "FEEDBACK_LABEL",
+    "PROJECT_LABEL_PREFIX",
+    "RejectionFeedbackNotice",
+    "TASK_LABEL_PREFIX",
+    "emit_rejection_feedback",
+    "feedback_target_task_id",
+    "is_rejection_feedback_task",
+    "rejection_feedback_preview",
+    "rejection_feedback_preview_from_reason",
+    "unread_rejection_feedback",
+]

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+from pollypm.rejection_feedback import emit_rejection_feedback
 from pollypm.work.flow_engine import resolve_flow
 from pollypm.work.gates import GateRegistry, evaluate_gates, has_hard_failure
 from pollypm.work.models import (
@@ -1767,6 +1768,12 @@ class SQLiteWorkService:
 
         result = self.get(task_id)
         self._sync_transition(result, WorkStatus.REVIEW.value, WorkStatus.IN_PROGRESS.value)
+        try:
+            emit_rejection_feedback(self, task=result, reviewer=actor, reason=reason)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "emit_rejection_feedback failed for %s: %s", task_id, exc,
+            )
         # Notify the per-task worker session about the rejection
         if self._session_mgr is not None:
             try:

--- a/tests/test_cockpit_inbox_ui.py
+++ b/tests/test_cockpit_inbox_ui.py
@@ -186,6 +186,31 @@ def test_list_row_renders_title_on_line1_and_project_age_on_line2(
     _run(body())
 
 
+def test_inbox_row_marks_rejection_feedback_threads(inbox_env) -> None:
+    from pollypm.cockpit_ui import _format_inbox_row
+
+    db_path = inbox_env["project_path"] / ".pollypm" / "state.db"
+    svc = SQLiteWorkService(db_path=db_path, project_path=inbox_env["project_path"])
+    try:
+        task = svc.create(
+            title="Rejected demo/1 — Smoke subject",
+            description="Need better rollback coverage.\n\nReturned for rework.",
+            type="task",
+            project="demo",
+            flow_template="chat",
+            roles={"requester": "polly", "operator": "user"},
+            priority="high",
+            created_by="polly",
+            labels=["review_feedback", "task:demo/1", "project:demo"],
+        )
+    finally:
+        svc.close()
+
+    plain = _format_inbox_row(task, is_unread=True).plain.splitlines()
+    assert plain[0].startswith("◆ 🔄 Rejected demo/1")
+    assert "feedback for demo/1" in plain[1]
+
+
 def test_selecting_a_row_renders_detail_and_clears_unread(inbox_env, inbox_app) -> None:
     """Keyboard navigation opens the message and records a read marker."""
     async def body() -> None:

--- a/tests/test_flow_progression.py
+++ b/tests/test_flow_progression.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 import pytest
 
+from pollypm.rejection_feedback import (
+    feedback_target_task_id,
+    is_rejection_feedback_task,
+    rejection_feedback_preview,
+)
 from pollypm.work.models import (
     Artifact,
     ArtifactKind,
@@ -219,6 +224,23 @@ class TestReject:
 
         with pytest.raises(ValidationError, match="Reason is required"):
             svc.reject(task.task_id, "polly", "")
+
+    def test_reject_creates_feedback_inbox_item(self, svc):
+        task = _create_task(svc)
+        _claim_task(svc, task)
+        svc.node_done(task.task_id, "pete", _valid_work_output())
+
+        svc.reject(task.task_id, "polly", "Needs better rollback coverage")
+
+        feedback_tasks = [
+            candidate
+            for candidate in svc.list_tasks(project="proj")
+            if is_rejection_feedback_task(candidate)
+        ]
+        assert len(feedback_tasks) == 1
+        feedback = feedback_tasks[0]
+        assert feedback_target_task_id(feedback) == task.task_id
+        assert rejection_feedback_preview(feedback) == "Needs better rollback coverage"
 
     def test_full_rejection_cycle(self, svc):
         """implement(v1) -> review -> reject -> implement(v2) -> review -> approve -> done"""

--- a/tests/test_rejection_feedback.py
+++ b/tests/test_rejection_feedback.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pollypm.rejection_feedback import (
+    emit_rejection_feedback,
+    feedback_target_task_id,
+    is_rejection_feedback_task,
+    unread_rejection_feedback,
+)
+from pollypm.work.models import Priority, Task, TaskType, WorkStatus
+
+
+def _work_task() -> Task:
+    return Task(
+        project="demo",
+        task_number=7,
+        title="Ship rejection feedback",
+        type=TaskType.TASK,
+        work_status=WorkStatus.IN_PROGRESS,
+        flow_template_id="standard",
+        flow_template_version=1,
+        current_node_id="implement",
+        assignee="worker_demo",
+        priority=Priority.HIGH,
+        description="Tighten the reject loop.",
+        roles={"worker": "worker_demo", "operator": "polly"},
+        created_at=datetime(2026, 4, 20, 17, 0, tzinfo=UTC),
+        created_by="polly",
+        updated_at=datetime(2026, 4, 20, 17, 10, tzinfo=UTC),
+    )
+
+
+class _CreateSpy:
+    def __init__(self) -> None:
+        self.kwargs: dict | None = None
+
+    def create(self, **kwargs):
+        self.kwargs = kwargs
+        return kwargs
+
+
+class _ReadAwareSvc:
+    def __init__(self, tasks: list[Task], read_task_ids: set[str] | None = None) -> None:
+        self._tasks = tasks
+        self._read_task_ids = read_task_ids or set()
+
+    def list_tasks(self, *, project: str | None = None):
+        assert project == "demo"
+        return list(self._tasks)
+
+    def get_context(self, task_id: str, *, entry_type: str | None = None, limit: int = 1):
+        assert limit == 1
+        if entry_type == "read" and task_id in self._read_task_ids:
+            return [object()]
+        return []
+
+
+def test_emit_rejection_feedback_creates_structured_inbox_item() -> None:
+    spy = _CreateSpy()
+
+    emit_rejection_feedback(
+        spy,
+        task=_work_task(),
+        reviewer="polly",
+        reason="Need better rollback coverage.\nAnd a guard for stale reads.",
+    )
+
+    assert spy.kwargs is not None
+    assert spy.kwargs["title"] == "Rejected demo/7 — Ship rejection feedback"
+    assert spy.kwargs["flow_template"] == "chat"
+    assert spy.kwargs["project"] == "demo"
+    assert spy.kwargs["roles"] == {"requester": "polly", "operator": "user"}
+    assert "review_feedback" in spy.kwargs["labels"]
+    assert "task:demo/7" in spy.kwargs["labels"]
+    assert spy.kwargs["description"].splitlines()[0] == "Need better rollback coverage."
+
+
+def test_unread_rejection_feedback_returns_latest_unread_notice() -> None:
+    older = Task(
+        project="demo",
+        task_number=80,
+        title="Rejected demo/7 — older",
+        type=TaskType.TASK,
+        labels=["review_feedback", "task:demo/7", "project:demo"],
+        work_status=WorkStatus.DRAFT,
+        flow_template_id="chat",
+        flow_template_version=1,
+        current_node_id="chat",
+        priority=Priority.HIGH,
+        description="Older reason",
+        roles={"requester": "polly", "operator": "user"},
+        created_at=datetime(2026, 4, 20, 17, 10, tzinfo=UTC),
+        created_by="polly",
+        updated_at=datetime(2026, 4, 20, 17, 10, tzinfo=UTC),
+    )
+    newer = Task(
+        project="demo",
+        task_number=81,
+        title="Rejected demo/7 — newer",
+        type=TaskType.TASK,
+        labels=["review_feedback", "task:demo/7", "project:demo"],
+        work_status=WorkStatus.DRAFT,
+        flow_template_id="chat",
+        flow_template_version=1,
+        current_node_id="chat",
+        priority=Priority.HIGH,
+        description="Newest reason",
+        roles={"requester": "polly", "operator": "user"},
+        created_at=datetime(2026, 4, 20, 17, 20, tzinfo=UTC),
+        created_by="polly",
+        updated_at=datetime(2026, 4, 20, 17, 20, tzinfo=UTC),
+    )
+    svc = _ReadAwareSvc([older, newer], read_task_ids={"demo/80"})
+
+    notices = unread_rejection_feedback(svc, project="demo")
+
+    assert list(notices) == ["demo/7"]
+    assert notices["demo/7"].inbox_task_id == "demo/81"
+    assert notices["demo/7"].preview == "Newest reason"
+    assert is_rejection_feedback_task(newer) is True
+    assert feedback_target_task_id(newer) == "demo/7"

--- a/tests/test_tasks_ui.py
+++ b/tests/test_tasks_ui.py
@@ -12,6 +12,7 @@ from textual.widgets import DataTable, Static
 
 from pollypm.work.models import (
     ActorType,
+    ContextEntry,
     ExecutionStatus,
     FlowNode,
     FlowNodeExecution,
@@ -75,19 +76,23 @@ def _task(
     priority: Priority = Priority.HIGH,
     updated_at: datetime | None = None,
     executions: list[FlowNodeExecution] | None = None,
+    labels: list[str] | None = None,
+    flow_template_id: str = "plan_project",
+    description: str = "Make the live task detail useful.",
 ) -> Task:
     return Task(
         project="demo",
         task_number=task_number,
         title=title,
         type=TaskType.TASK,
+        labels=list(labels or []),
         work_status=status,
-        flow_template_id="plan_project",
+        flow_template_id=flow_template_id,
         flow_template_version=1,
         current_node_id=node_id,
         assignee="architect_demo",
         priority=priority,
-        description="Make the live task detail useful.",
+        description=description,
         roles={"architect": "architect_demo", "operator": "polly"},
         created_at=datetime(2026, 4, 20, 16, 0, tzinfo=UTC),
         created_by="polly",
@@ -149,11 +154,13 @@ class _FakeSvc:
         flow: FlowTemplate,
         worker_sessions: dict[str, WorkerSessionRecord | None] | None = None,
         owner_by_id: dict[str, str] | None = None,
+        context_by_id: dict[tuple[str, str | None], list] | None = None,
     ) -> None:
         self._tasks_factory = tasks_factory
         self._flow = flow
         self._worker_sessions = worker_sessions or {}
         self._owner_by_id = owner_by_id or {}
+        self._context_by_id = context_by_id or {}
         self.approvals: list[tuple[str, str, str]] = []
         self.rejections: list[tuple[str, str, str]] = []
 
@@ -167,10 +174,14 @@ class _FakeSvc:
                 return deepcopy(task)
         raise AssertionError(task_id)
 
-    def get_context(self, task_id: str, limit: int = 15):
+    def get_context(
+        self,
+        task_id: str,
+        limit: int = 15,
+        entry_type: str | None = None,
+    ):
         assert task_id.startswith("demo/")
-        assert limit == 15
-        return []
+        return list(self._context_by_id.get((task_id, entry_type), []))
 
     def get_execution(self, task_id: str):
         return list(self.get(task_id).executions)
@@ -505,6 +516,91 @@ def test_task_app_surfaces_priority_glyphs_and_sorts_critical_first(env, monkeyp
             assert rows[0][2] == "🔴 Critical fix"
             assert rows[1][2] == "🟢 Low follow-up"
             assert "Priority   🔴 critical" in overview
+
+    _run(body())
+
+
+def test_task_app_surfaces_unread_rejection_feedback(env, monkeypatch) -> None:
+    if not _load_config_compatible(env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_tasks import PollyTasksApp
+
+    work_task = _task(node_id="synthesize", title="Ship Notesy visibility")
+    feedback_task = _task(
+        task_number=99,
+        node_id="chat",
+        title="Rejected demo/1 — Ship Notesy visibility",
+        flow_template_id="chat",
+        labels=["review_feedback", "task:demo/1", "project:demo"],
+        description="Need better rollback coverage.\n\nReturned for rework.",
+    )
+    fake_svc = _FakeSvc(
+        tasks_factory=lambda: [work_task, feedback_task],
+        flow=_flow(),
+    )
+
+    monkeypatch.setattr("pollypm.cockpit_tasks.create_tmux_client", lambda: _FakeTmux([]))
+
+    app = PollyTasksApp(env["config_path"], "demo")
+    app._get_svc = lambda: fake_svc  # type: ignore[method-assign]
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 50)) as pilot:
+            await pilot.pause()
+            rows = _table_rows(app.query_one("#tasks-table", DataTable))
+            overview = str(app.query_one("#task-detail", Static).render())
+
+            assert len(rows) == 1
+            assert rows[0][1] == "in_progress · feedback"
+            assert rows[0][2] == "🔄 🟠 Ship Notesy visibility"
+            assert rows[0][4] == "synthesize · Rejected"
+            assert "Inbox Feedback" in overview
+            assert "Need better rollback coverage." in overview
+
+    _run(body())
+
+
+def test_task_app_clears_rejection_feedback_after_inbox_open(env, monkeypatch) -> None:
+    if not _load_config_compatible(env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_tasks import PollyTasksApp
+
+    work_task = _task(node_id="synthesize", title="Ship Notesy visibility")
+    feedback_task = _task(
+        task_number=99,
+        node_id="chat",
+        title="Rejected demo/1 — Ship Notesy visibility",
+        flow_template_id="chat",
+        labels=["review_feedback", "task:demo/1", "project:demo"],
+        description="Need better rollback coverage.\n\nReturned for rework.",
+    )
+    read_marker = ContextEntry(
+        actor="user",
+        timestamp=datetime(2026, 4, 20, 17, 30, tzinfo=UTC),
+        text="opened in cockpit inbox",
+        entry_type="read",
+    )
+    fake_svc = _FakeSvc(
+        tasks_factory=lambda: [work_task, feedback_task],
+        flow=_flow(),
+        context_by_id={("demo/99", "read"): [read_marker]},
+    )
+
+    monkeypatch.setattr("pollypm.cockpit_tasks.create_tmux_client", lambda: _FakeTmux([]))
+
+    app = PollyTasksApp(env["config_path"], "demo")
+    app._get_svc = lambda: fake_svc  # type: ignore[method-assign]
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 50)) as pilot:
+            await pilot.pause()
+            rows = _table_rows(app.query_one("#tasks-table", DataTable))
+            overview = str(app.query_one("#task-detail", Static).render())
+
+            assert len(rows) == 1
+            assert rows[0][1] == "in_progress"
+            assert rows[0][2] == "🟠 Ship Notesy visibility"
+            assert "Inbox Feedback" not in overview
 
     _run(body())
 


### PR DESCRIPTION
## Summary
- create structured review_feedback inbox artifacts when work-service tasks are rejected
- surface unread rejection feedback in the task cockpit and make rejection inbox rows stand out
- add focused helper, UI, and reject-path coverage

## Testing
- HOME=/tmp/pytest-516 uv run --extra dev pytest tests/test_rejection_feedback.py tests/test_tasks_ui.py tests/test_cockpit_inbox_ui.py tests/test_flow_progression.py -q

Closes #516
