### PR TITLE
fix(cockpit): avoid blocking settings reads

### DIFF
--- a/src/pollypm/cockpit_settings_projects.py
+++ b/src/pollypm/cockpit_settings_projects.py
@@ -1,0 +1,103 @@
+"""Non-blocking project snapshot helpers for the cockpit settings screen.
+
+Contract:
+- Inputs: the loaded PollyPM config plus a relative-age formatter.
+- Outputs: normalized project rows for the settings UI.
+- Side effects: reads project-path metadata and does read-only SQLite
+  queries with a very short timeout so busy project DBs do not stall UI
+  mount.
+- Invariants: callers get best-effort task totals; a locked DB surfaces
+  as ``task_total_label='busy'`` instead of blocking the screen.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime as _dt
+from pathlib import Path
+import sqlite3
+
+
+def collect_settings_projects(config, *, format_relative_age) -> list[dict]:
+    """Return settings-project rows without blocking on busy work DBs."""
+
+    rows: list[dict] = []
+    for key, project in (getattr(config, "projects", {}) or {}).items():
+        path = getattr(project, "path", None)
+        persona = getattr(project, "persona_name", None)
+        path_str = str(path) if path else ""
+        tracked = bool(getattr(project, "tracked", False))
+        path_exists = False
+        task_total_label = "0"
+        last_activity = ""
+        try:
+            if path is not None and path.exists():
+                path_exists = True
+                db_path = path / ".pollypm" / "state.db"
+                if db_path.exists():
+                    last_activity = _project_last_activity(
+                        db_path, format_relative_age=format_relative_age
+                    )
+                    task_total = _project_task_total(db_path, project_key=key)
+                    if task_total is None:
+                        task_total_label = "busy"
+                    else:
+                        task_total_label = str(task_total)
+        except OSError:
+            path_exists = False
+            task_total_label = "0"
+        rows.append(
+            {
+                "key": key,
+                "name": getattr(project, "name", None) or key,
+                "persona": (
+                    persona if isinstance(persona, str) and persona.strip() else "Polly"
+                ),
+                "path": path_str,
+                "path_exists": path_exists,
+                "tracked": tracked,
+                "task_total": task_total_label,
+                "task_total_label": task_total_label,
+                "last_activity": last_activity,
+                "project_obj": project,
+            }
+        )
+    return rows
+
+
+def _project_last_activity(db_path: Path, *, format_relative_age) -> str:
+    try:
+        mtime = db_path.stat().st_mtime
+    except OSError:
+        return ""
+    return format_relative_age(_dt.fromtimestamp(mtime).isoformat())
+
+
+def _project_task_total(db_path: Path, *, project_key: str) -> int | None:
+    """Return a task count quickly, or ``None`` if the DB is busy."""
+
+    conn: sqlite3.Connection | None = None
+    try:
+        conn = sqlite3.connect(
+            f"file:{db_path}?mode=ro",
+            uri=True,
+            timeout=0.05,
+        )
+        conn.execute("PRAGMA busy_timeout=50")
+        row = conn.execute(
+            "SELECT COUNT(*) FROM work_tasks WHERE project = ?",
+            (project_key,),
+        ).fetchone()
+        return int(row[0] or 0) if row is not None else 0
+    except sqlite3.OperationalError as exc:
+        message = str(exc).lower()
+        if "locked" in message or "busy" in message:
+            return None
+        return 0
+    except sqlite3.Error:
+        return 0
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+__all__ = ["collect_settings_projects"]

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -96,6 +96,7 @@ from pollypm.cockpit_settings_accounts import (
     SETTINGS_ACCOUNT_ACTIONS,
     render_settings_account_detail,
 )
+from pollypm.cockpit_settings_projects import collect_settings_projects
 from pollypm.cockpit_workers import PollyWorkerRosterApp
 from pollypm.session_services import create_tmux_client
 from pollypm.service_api import PollyPMService
@@ -2070,55 +2071,10 @@ def _gather_settings_data(
 
     projects: list[dict] = []
     if config is not None:
-        from datetime import datetime as _dt
-        for key, project in (getattr(config, "projects", {}) or {}).items():
-            path = getattr(project, "path", None)
-            persona = getattr(project, "persona_name", None)
-            path_str = str(path) if path else ""
-            tracked = bool(getattr(project, "tracked", False))
-            path_exists = False
-            task_total = 0
-            last_activity = ""
-            try:
-                if path is not None and path.exists():
-                    path_exists = True
-                    db_path = path / ".pollypm" / "state.db"
-                    if db_path.exists():
-                        try:
-                            mtime = db_path.stat().st_mtime
-                            last_activity = _format_relative_age(
-                                _dt.fromtimestamp(mtime).isoformat()
-                            )
-                        except OSError:
-                            last_activity = ""
-                        try:
-                            from pollypm.work.sqlite_service import SQLiteWorkService
-                            with SQLiteWorkService(
-                                db_path=db_path, project_path=path,
-                            ) as svc:
-                                counts = svc.state_counts(project=key)
-                                task_total = sum(counts.values())
-                        except Exception:  # noqa: BLE001
-                            task_total = 0
-            except OSError:
-                path_exists = False
-            projects.append(
-                {
-                    "key": key,
-                    "name": getattr(project, "name", None) or key,
-                    "persona": (
-                        persona
-                        if isinstance(persona, str) and persona.strip()
-                        else "Polly"
-                    ),
-                    "path": path_str,
-                    "path_exists": path_exists,
-                    "tracked": tracked,
-                    "task_total": task_total,
-                    "last_activity": last_activity,
-                    "project_obj": project,
-                }
-            )
+        projects = collect_settings_projects(
+            config,
+            format_relative_age=_format_relative_age,
+        )
 
     heartbeat: list[tuple[str, str]] = []
     if pp is not None:
@@ -2745,7 +2701,7 @@ class PollySettingsPaneApp(App[None]):
             path = p["path"] or "-"
             path_disp = path if len(path) <= 42 else ("\u2026" + path[-41:])
             path_cell = Text(path_disp, style="dim")
-            tasks_cell = Text(str(p["task_total"]))
+            tasks_cell = Text(str(p.get("task_total_label", p["task_total"])))
             last_cell = Text(p["last_activity"] or "-", style="dim")
             key_cell = Text(p["key"], style=name_style)
             persona_cell = Text(p["persona"], style="dim")
@@ -2793,7 +2749,7 @@ class PollySettingsPaneApp(App[None]):
             f"[dim]Path:[/dim]   {_escape(selected['path']) or '-'}  "
             f"{'' if selected['path_exists'] else '[#ff5f6d](missing)[/]'}",
             f"[dim]Status:[/dim] {tracked_line}",
-            f"[dim]Tasks:[/dim]  {selected['task_total']}",
+            f"[dim]Tasks:[/dim]  {selected.get('task_total_label', selected['task_total'])}",
             f"[dim]Last:[/dim]   {_escape(selected['last_activity']) or '-'}",
         ]
         self.detail.update("\n".join(lines))

--- a/tests/test_cockpit_settings_projects.py
+++ b/tests/test_cockpit_settings_projects.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+import time
+
+from pollypm.cockpit_settings_projects import collect_settings_projects
+
+
+class _FakeProject:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.name = "Demo"
+        self.persona_name = None
+        self.tracked = True
+
+
+class _FakeConfig:
+    def __init__(self, path: Path) -> None:
+        self.projects = {"demo": _FakeProject(path)}
+
+
+def _seed_work_db(project_path: Path) -> Path:
+    db_path = project_path / ".pollypm" / "state.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "CREATE TABLE work_tasks (project TEXT NOT NULL, task_number INTEGER NOT NULL)"
+        )
+        conn.executemany(
+            "INSERT INTO work_tasks (project, task_number) VALUES (?, ?)",
+            [("demo", 1), ("demo", 2), ("other", 1)],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path
+
+
+def test_collect_settings_projects_reads_fast_task_totals(tmp_path: Path) -> None:
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    _seed_work_db(project_path)
+
+    rows = collect_settings_projects(
+        _FakeConfig(project_path),
+        format_relative_age=lambda _value: "moments ago",
+    )
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["key"] == "demo"
+    assert row["name"] == "Demo"
+    assert row["persona"] == "Polly"
+    assert row["path"] == str(project_path)
+    assert row["path_exists"] is True
+    assert row["tracked"] is True
+    assert row["task_total"] == "2"
+    assert row["task_total_label"] == "2"
+    assert row["last_activity"] == "moments ago"
+
+
+def test_collect_settings_projects_marks_busy_db_without_blocking(tmp_path: Path) -> None:
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    db_path = _seed_work_db(project_path)
+    conn = sqlite3.connect(db_path, timeout=0.01)
+    try:
+        conn.execute("BEGIN EXCLUSIVE")
+        start = time.perf_counter()
+        rows = collect_settings_projects(
+            _FakeConfig(project_path),
+            format_relative_age=lambda _value: "moments ago",
+        )
+        elapsed = time.perf_counter() - start
+    finally:
+        conn.rollback()
+        conn.close()
+
+    assert elapsed < 1.0
+    assert rows[0]["task_total_label"] == "busy"
+    assert rows[0]["last_activity"] == "moments ago"


### PR DESCRIPTION
## Summary
- move settings-project snapshot reads into a dedicated helper module
- use short-timeout read-only SQLite queries so busy project DBs render as `busy` instead of blocking Settings mount
- add a regression test for locked project databases and keep the existing settings-pane slice green

## Testing
- HOME=/tmp/pytest-606 uv run --extra dev pytest tests/test_cockpit_settings_projects.py tests/test_settings_ui.py -q

Closes #606
