### PR TITLE
fix(prompt): explain worker override files

### DIFF
--- a/src/pollypm/plugins_builtin/core_agent_profiles/profiles.py
+++ b/src/pollypm/plugins_builtin/core_agent_profiles/profiles.py
@@ -34,6 +34,7 @@ class StaticPromptProfile(AgentProfile):
             parts.append(_render_operator_state_brief(context))
 
         if self.name == "worker":
+            parts.append(_worker_instruction_overrides_note())
             project = context.config.projects.get(context.session.project)
             if project and project.persona_name:
                 parts.append(
@@ -450,6 +451,18 @@ def _worker_context_parts(context: AgentProfileContext, project_root: Path) -> l
     if checkpoint:
         parts.append(checkpoint)
     return parts
+
+
+def _worker_instruction_overrides_note() -> str:
+    """Explain the optional PM-authored override files exposed to workers."""
+    return (
+        "<instruction-overrides>\n"
+        "`.pollypm/docs/SYSTEM.md` and `.pollypm/INSTRUCT.md` are optional "
+        "project-level overrides written by the PM. When either file is present, "
+        "it overrides the built-in defaults for this project. If one or both are "
+        "missing, the defaults still apply — continue without blocking.\n"
+        "</instruction-overrides>"
+    )
 
 
 def _read_instruct_rules(project_root: Path) -> str:

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from pollypm.agent_profiles.base import AgentProfileContext
 from pollypm.config import write_config
 from pollypm.models import (
     AccountConfig,
@@ -13,6 +14,7 @@ from pollypm.models import (
     KnownProject,
 )
 from pollypm.storage.state import StateStore
+from pollypm.plugins_builtin.core_agent_profiles.profiles import StaticPromptProfile
 from pollypm.plugins_builtin.core_agent_profiles.profiles import heartbeat_prompt
 from pollypm.plugins_builtin.core_agent_profiles.profiles import polly_prompt as operator_prompt
 from pollypm.plugins_builtin.core_agent_profiles.profiles import triage_prompt
@@ -212,6 +214,34 @@ def test_worker_prompt_requires_core_identity() -> None:
     assert "file_change" in prompt
     assert "operations with side effects" in prompt
     assert "decision, blocker, or observation" in prompt
+
+
+def test_worker_profile_explains_optional_instruction_overrides(tmp_path: Path) -> None:
+    config, _config_path = _config(tmp_path)
+    worker_session = SessionConfig(
+        name="worker-demo",
+        role="worker",
+        provider=ProviderKind.CLAUDE,
+        account="claude_worker",
+        cwd=tmp_path,
+        project="pollypm",
+        window_name="pm-worker-demo",
+    )
+    context = AgentProfileContext(
+        config=config,
+        session=worker_session,
+        account=config.accounts["claude_worker"],
+    )
+
+    prompt = StaticPromptProfile(name="worker", prompt=worker_prompt()).build_prompt(context)
+
+    assert prompt is not None
+    assert ".pollypm/docs/SYSTEM.md" in prompt
+    assert ".pollypm/INSTRUCT.md" in prompt
+    assert "optional project-level overrides" in prompt
+    assert "written by the PM" in prompt
+    assert "overrides the built-in defaults" in prompt
+    assert "continue without blocking" in prompt
 
 
 def test_operator_prompt_requires_delegation_instructions() -> None:


### PR DESCRIPTION
## Summary
- explain that `.pollypm/docs/SYSTEM.md` and `.pollypm/INSTRUCT.md` are optional PM-authored overrides
- tell workers that built-in defaults still apply when either file is missing
- pin the note in prompt assembly tests

Closes #485

## Testing
- HOME=/tmp/pytest-485 uv run --extra dev pytest tests/test_workers.py -q