### PR TITLE
refactor(tui): centralize control routing tables

### DIFF
--- a/src/pollypm/control_tui.py
+++ b/src/pollypm/control_tui.py
@@ -27,6 +27,11 @@ from pollypm.accounts import (
     AccountStatus,
 )
 from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+from pollypm.control_tui_routes import (
+    focus_attr_for_tab,
+    resolve_button_route,
+    resolve_tab_shortcut,
+)
 from pollypm.models import ProviderKind
 from pollypm.projects import (
     discover_git_repositories,
@@ -1289,59 +1294,25 @@ class PollyPMApp(App[None]):
             self.action_focus_alert_session()
 
     def on_key(self, event: events.Key) -> None:
-        tab_map = {
-            "1": "dashboard-tab",
-            "2": "accounts-tab",
-            "3": "projects-tab",
-            "4": "sessions-tab",
-            "5": "alerts-tab",
-            "6": "events-tab",
-        }
         if event.key == "b":
             self.action_toggle_open_permissions()
             event.stop()
             return
-        tab_id = tab_map.get(event.key)
+        tab_id = resolve_tab_shortcut(event.key)
         if tab_id is None:
             return
         self._set_active_tab(tab_id)
         event.stop()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        actions = {
-            "dashboard-open": self.action_open_selected_session,
-            "dashboard-ensure": self.action_ensure_pollypm,
-            "dashboard-heartbeat": self.action_run_heartbeat,
-            "dashboard-permissions": self.action_toggle_open_permissions,
-            "accounts-add-codex": self.action_add_codex_account,
-            "accounts-add-claude": self.action_add_claude_account,
-            "accounts-usage": self.action_refresh_selected_account_usage,
-            "accounts-relogin": self.action_relogin_selected_account,
-            "accounts-switch-operator": self.action_switch_operator,
-            "accounts-controller": self.action_make_controller,
-            "accounts-failover": self.action_toggle_failover,
-            "accounts-remove": self.action_remove_selected_account,
-            "projects-scan": self.action_scan_projects,
-            "projects-add": self.action_add_project,
-            "projects-tracker": self.action_init_project_tracker,
-            "projects-root": self.action_set_workspace_root,
-            "projects-worker": self.action_new_worker,
-            "projects-remove": self.action_remove_selected_project,
-            "sessions-open": self.action_open_selected_session,
-            "sessions-send": self.action_send_input_selected,
-            "sessions-claim": self.action_claim_selected_session,
-            "sessions-release": self.action_release_selected_session,
-            "sessions-stop": self.action_stop_selected_session,
-            "sessions-remove": self.action_remove_selected_session,
-            "alerts-focus": self.action_focus_alert_session,
-        }
-        button_id = event.button.id or ""
-        if button_id.startswith("nav-"):
-            self._set_active_tab(button_id.removeprefix("nav-"))
+        route = resolve_button_route(event.button.id or "")
+        if route is None:
             return
-        action = actions.get(button_id)
-        if action is not None:
-            action()
+        if route.tab_id is not None:
+            self._set_active_tab(route.tab_id)
+            return
+        if route.action_name is not None:
+            getattr(self, route.action_name)()
 
     def _active_tab(self) -> str:
         try:
@@ -1351,15 +1322,8 @@ class PollyPMApp(App[None]):
 
     def _set_active_tab(self, tab_id: str) -> None:
         self.query_one("#tabs", TabbedContent).active = tab_id
-        focus_map = {
-            "dashboard-tab": self.cockpit_table,
-            "accounts-tab": self.accounts_table,
-            "projects-tab": self.projects_table,
-            "sessions-tab": self.sessions_table,
-            "alerts-tab": self.alerts_table,
-            "events-tab": self.events_table,
-        }
-        widget = focus_map.get(tab_id)
+        focus_attr = focus_attr_for_tab(tab_id)
+        widget = getattr(self, focus_attr, None) if focus_attr is not None else None
         if widget is not None:
             widget.focus()
         self.session_preview_cache = None

--- a/src/pollypm/control_tui_routes.py
+++ b/src/pollypm/control_tui_routes.py
@@ -1,0 +1,82 @@
+"""Pure routing tables for the legacy control TUI.
+
+Contract:
+- Inputs: keyboard shortcuts, button ids, and tab ids emitted by the
+  Textual control-room surface.
+- Outputs: immutable route specs and attribute names the app can
+  dispatch through.
+- Side effects: none.
+- Invariants: tab/button routing stays centralized here so adding a new
+  tab or action does not require editing scattered literal maps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ButtonRoute:
+    action_name: str | None = None
+    tab_id: str | None = None
+
+
+_TAB_SHORTCUTS: dict[str, str] = {
+    "1": "dashboard-tab",
+    "2": "accounts-tab",
+    "3": "projects-tab",
+    "4": "sessions-tab",
+    "5": "alerts-tab",
+    "6": "events-tab",
+}
+
+_TAB_FOCUS_ATTRS: dict[str, str] = {
+    "dashboard-tab": "cockpit_table",
+    "accounts-tab": "accounts_table",
+    "projects-tab": "projects_table",
+    "sessions-tab": "sessions_table",
+    "alerts-tab": "alerts_table",
+    "events-tab": "events_table",
+}
+
+_BUTTON_ROUTES: dict[str, ButtonRoute] = {
+    "dashboard-open": ButtonRoute(action_name="action_open_selected_session"),
+    "dashboard-ensure": ButtonRoute(action_name="action_ensure_pollypm"),
+    "dashboard-heartbeat": ButtonRoute(action_name="action_run_heartbeat"),
+    "dashboard-permissions": ButtonRoute(action_name="action_toggle_open_permissions"),
+    "accounts-add-codex": ButtonRoute(action_name="action_add_codex_account"),
+    "accounts-add-claude": ButtonRoute(action_name="action_add_claude_account"),
+    "accounts-usage": ButtonRoute(action_name="action_refresh_selected_account_usage"),
+    "accounts-relogin": ButtonRoute(action_name="action_relogin_selected_account"),
+    "accounts-switch-operator": ButtonRoute(action_name="action_switch_operator"),
+    "accounts-controller": ButtonRoute(action_name="action_make_controller"),
+    "accounts-failover": ButtonRoute(action_name="action_toggle_failover"),
+    "accounts-remove": ButtonRoute(action_name="action_remove_selected_account"),
+    "projects-scan": ButtonRoute(action_name="action_scan_projects"),
+    "projects-add": ButtonRoute(action_name="action_add_project"),
+    "projects-tracker": ButtonRoute(action_name="action_init_project_tracker"),
+    "projects-root": ButtonRoute(action_name="action_set_workspace_root"),
+    "projects-worker": ButtonRoute(action_name="action_new_worker"),
+    "projects-remove": ButtonRoute(action_name="action_remove_selected_project"),
+    "sessions-open": ButtonRoute(action_name="action_open_selected_session"),
+    "sessions-send": ButtonRoute(action_name="action_send_input_selected"),
+    "sessions-claim": ButtonRoute(action_name="action_claim_selected_session"),
+    "sessions-release": ButtonRoute(action_name="action_release_selected_session"),
+    "sessions-stop": ButtonRoute(action_name="action_stop_selected_session"),
+    "sessions-remove": ButtonRoute(action_name="action_remove_selected_session"),
+    "alerts-focus": ButtonRoute(action_name="action_focus_alert_session"),
+}
+
+
+def resolve_tab_shortcut(key: str) -> str | None:
+    return _TAB_SHORTCUTS.get(key)
+
+
+def focus_attr_for_tab(tab_id: str) -> str | None:
+    return _TAB_FOCUS_ATTRS.get(tab_id)
+
+
+def resolve_button_route(button_id: str) -> ButtonRoute | None:
+    if button_id.startswith("nav-"):
+        return ButtonRoute(tab_id=button_id.removeprefix("nav-"))
+    return _BUTTON_ROUTES.get(button_id)

--- a/tests/test_control_tui_routes.py
+++ b/tests/test_control_tui_routes.py
@@ -1,0 +1,33 @@
+from pollypm.control_tui_routes import (
+    ButtonRoute,
+    focus_attr_for_tab,
+    resolve_button_route,
+    resolve_tab_shortcut,
+)
+
+
+def test_resolve_tab_shortcut_returns_registered_tab_ids() -> None:
+    assert resolve_tab_shortcut("1") == "dashboard-tab"
+    assert resolve_tab_shortcut("6") == "events-tab"
+    assert resolve_tab_shortcut("x") is None
+
+
+def test_resolve_button_route_returns_action_routes() -> None:
+    assert resolve_button_route("accounts-remove") == ButtonRoute(
+        action_name="action_remove_selected_account",
+    )
+    assert resolve_button_route("alerts-focus") == ButtonRoute(
+        action_name="action_focus_alert_session",
+    )
+
+
+def test_resolve_button_route_handles_nav_buttons() -> None:
+    assert resolve_button_route("nav-dashboard-tab") == ButtonRoute(tab_id="dashboard-tab")
+    assert resolve_button_route("nav-alerts-tab") == ButtonRoute(tab_id="alerts-tab")
+    assert resolve_button_route("unknown-button") is None
+
+
+def test_focus_attr_for_tab_returns_table_attribute_names() -> None:
+    assert focus_attr_for_tab("dashboard-tab") == "cockpit_table"
+    assert focus_attr_for_tab("sessions-tab") == "sessions_table"
+    assert focus_attr_for_tab("missing") is None


### PR DESCRIPTION
## Summary
- extract control-TUI button/tab routing into a dedicated helper module
- drive keypresses, button dispatch, and tab focus through centralized registries
- add pure routing tests alongside the existing control-TUI regression suite

Closes #419

## Testing
- HOME=/tmp/pytest-419 uv run --extra dev pytest tests/test_control_tui_routes.py tests/test_control_tui.py -q