### PR TITLE
feat(cockpit): add project action bar

### DIFF
--- a/src/pollypm/cockpit_sections/action_bar.py
+++ b/src/pollypm/cockpit_sections/action_bar.py
@@ -1,0 +1,22 @@
+"""Sticky one-line attention summary for project dashboards."""
+
+from __future__ import annotations
+
+
+def render_project_action_bar(
+    *,
+    review_count: int,
+    alert_count: int,
+    inbox_count: int,
+) -> str:
+    """Return a compact summary of the project's actionable work."""
+    bits: list[str] = []
+    if review_count:
+        bits.append(f"{review_count} approval{'s' if review_count != 1 else ''}")
+    if alert_count:
+        bits.append(f"{alert_count} alert{'s' if alert_count != 1 else ''}")
+    if inbox_count:
+        bits.append(f"{inbox_count} new in inbox")
+    if not bits:
+        return "▸ Clear · no approvals, alerts, or inbox items"
+    return "▸ " + " · ".join(bits)

--- a/src/pollypm/cockpit_sections/project_dashboard.py
+++ b/src/pollypm/cockpit_sections/project_dashboard.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from pollypm.cockpit_sections.action_bar import render_project_action_bar
 from pollypm.cockpit_sections.activity import _section_activity
 from pollypm.cockpit_sections.base import (
     _DASHBOARD_BULLET,
@@ -101,9 +102,19 @@ def _render_project_dashboard(
 
     # Single SQLite open per render \u2014 every downstream section reuses
     # this hydrated task list and the counts map.
+    inbox_count = 0
     with SQLiteWorkService(db_path=db_path, project_path=project.path) as svc:
+        try:
+            from pollypm.work.inbox_view import inbox_tasks
+        except Exception:  # noqa: BLE001
+            inbox_tasks = None
         counts = svc.state_counts(project=project_key)
         tasks = svc.list_tasks(project=project_key)
+        if inbox_tasks is not None:
+            try:
+                inbox_count = len(inbox_tasks(svc, project=project_key))
+            except Exception:  # noqa: BLE001
+                inbox_count = 0
 
     tokens = _aggregate_project_tokens(db_path, project_key)
 
@@ -158,6 +169,12 @@ def _render_project_dashboard(
     out: list[str] = [
         _section_header(name, presence),
         _DASHBOARD_BULLET + "\u2500" * (_DASHBOARD_DIVIDER_WIDTH - 2),
+        _DASHBOARD_BULLET
+        + render_project_action_bar(
+            review_count=len(review),
+            alert_count=len(project_alerts),
+            inbox_count=inbox_count,
+        ),
         _section_summary(counts),
         format_project_health_scorecard(name, counts, tasks),
         "",

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -92,6 +92,7 @@ from pollypm.cockpit_palette import (
     _record_palette_command,
     _resolve_recent_commands,
 )
+from pollypm.cockpit_sections.action_bar import render_project_action_bar
 from pollypm.cockpit_settings_accounts import (
     SETTINGS_ACCOUNT_ACTIONS,
     render_settings_account_detail,
@@ -6702,6 +6703,23 @@ class PollyProjectDashboardApp(App[None]):
         color: #97a6b2;
         padding-top: 0;
     }
+    #proj-action-bar {
+        margin-top: 1;
+        padding: 0 1;
+        background: #16202a;
+        color: #6b7a88;
+        border: round #243241;
+    }
+    #proj-action-bar.-attention {
+        background: #3a2c08;
+        color: #f7d67a;
+        border: round #7a5a14;
+    }
+    #proj-action-bar.-critical {
+        background: #3a1719;
+        color: #ffd7d9;
+        border: round #8d3137;
+    }
     #proj-body {
         height: 1fr;
         padding: 1 0 0 0;
@@ -6793,6 +6811,7 @@ class PollyProjectDashboardApp(App[None]):
         self.project_key = project_key
         self.topbar = Static("", id="proj-topbar", markup=True)
         self.status_line = Static("", id="proj-status", markup=True)
+        self.action_bar = Static("", id="proj-action-bar", markup=True)
         self.now_title = Static(
             "[b]Current activity[/b]",
             classes="proj-section-title",
@@ -6854,6 +6873,7 @@ class PollyProjectDashboardApp(App[None]):
         with Vertical(id="proj-outer"):
             yield self.topbar
             yield self.status_line
+            yield self.action_bar
             with VerticalScroll(id="proj-body"):
                 with Vertical(classes="proj-section", id="proj-now-section"):
                     yield self.now_title
@@ -6918,6 +6938,7 @@ class PollyProjectDashboardApp(App[None]):
             f"[#97a6b2]{_escape(data.status_label)}[/]"
         )
         self.status_line.update(status_markup)
+        self._update_action_bar(data)
 
         # ── Current activity ──
         self.now_body.update(self._render_now_body(data))
@@ -6937,6 +6958,21 @@ class PollyProjectDashboardApp(App[None]):
         self.inbox_body.update(self._render_inbox_body(data))
 
         self.hint.update(self._DEFAULT_HINT)
+
+    def _update_action_bar(self, data: ProjectDashboardData) -> None:
+        review_count = int(data.task_counts.get("review", 0))
+        summary = render_project_action_bar(
+            review_count=review_count,
+            alert_count=data.alert_count,
+            inbox_count=data.inbox_count,
+        )
+        self.action_bar.remove_class("-attention")
+        self.action_bar.remove_class("-critical")
+        if data.alert_count:
+            self.action_bar.add_class("-critical")
+        elif review_count or data.inbox_count:
+            self.action_bar.add_class("-attention")
+        self.action_bar.update(f"[b]{_escape(summary)}[/b]")
 
     # ------------------------------------------------------------------
     # Section renderers — all return Rich-markup strings, all handle

--- a/tests/test_cockpit_project_dashboard.py
+++ b/tests/test_cockpit_project_dashboard.py
@@ -35,6 +35,7 @@ from pollypm.cockpit import (
     _task_cycle_minutes,
     _worker_presence,
 )
+from pollypm.cockpit_sections.action_bar import render_project_action_bar
 from pollypm.work.models import (
     Artifact,
     ArtifactKind,
@@ -716,6 +717,7 @@ def test_render_project_dashboard_integration(tmp_path: Path):
         assert heading in out, f"missing section: {heading}"
 
     # Content spot-checks.
+    assert "▸ Clear · no approvals, alerts, or inbox items" in out
     assert "shortlink-gen" in out
     assert "1 in progress" in out
     assert "1 done" in out
@@ -798,3 +800,14 @@ def test_dashboard_visual_structure_is_stable(tmp_path: Path):
         idx = out.find(heading, cursor)
         assert idx >= 0, f"section {heading!r} missing or out of order"
         cursor = idx
+
+
+def test_render_project_action_bar_summarizes_pending_counts() -> None:
+    assert (
+        render_project_action_bar(review_count=3, alert_count=1, inbox_count=5)
+        == "▸ 3 approvals · 1 alert · 5 new in inbox"
+    )
+    assert (
+        render_project_action_bar(review_count=0, alert_count=0, inbox_count=0)
+        == "▸ Clear · no approvals, alerts, or inbox items"
+    )


### PR DESCRIPTION
## Summary
- add a shared project-dashboard action bar summarizing approvals, alerts, and inbox work
- surface that bar as a sticky widget in the Textual project dashboard and in the legacy text render
- cover the new summary copy in project dashboard tests

Closes #502

## Testing
- HOME=/tmp/pytest-502 uv run --extra dev pytest tests/test_cockpit_project_dashboard.py tests/test_cockpit.py -q