### PR TITLE
fix(heartbeat): stop nudging review-only workers

### DIFF
--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -273,6 +273,7 @@ def _select_intervention(
 class LocalHeartbeatBackend(HeartbeatBackend):
     name = "local"
     _UNMANAGED_WINDOW_ALERT_PREFIX = "unmanaged_window:"
+    _WORKER_ACTIONABLE_STATUSES = frozenset({"queued", "in_progress", "blocked"})
     _MUTATING_SESSION_ROLES = frozenset(
         {
             "architect",
@@ -1090,8 +1091,9 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                 tasks = backend.list_tasks(states=["01-ready", "02-in-progress"])
                 if tasks:
                     return True
-            # Check the work service for non-terminal tasks assigned to this
-            # worker's project.
+            # Check the work service for worker-actionable tasks on this
+            # worker's project. Review / on_hold / done are idle-by-design
+            # for workers — the reviewer or user owns the next step there.
             try:
                 from pollypm.work.sqlite_service import SQLiteWorkService
 
@@ -1102,7 +1104,7 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                     ) as svc:
                         tasks = svc.list_tasks(project=session.project)
                     for t in tasks:
-                        if t.work_status.value not in ("done", "cancelled"):
+                        if t.work_status.value in self._WORKER_ACTIONABLE_STATUSES:
                             return True
             except Exception:  # noqa: BLE001
                 pass

--- a/tests/test_heartbeat_plugin_api.py
+++ b/tests/test_heartbeat_plugin_api.py
@@ -547,6 +547,86 @@ def test_collect_work_service_signals_reads_registered_worktree_commit_via_proje
     ]
 
 
+def test_has_pending_work_skips_review_only_tasks(tmp_path: Path, monkeypatch) -> None:
+    api = _work_signal_api(tmp_path)
+    context = _context()
+    backend = LocalHeartbeatBackend()
+
+    class _NoTaskBackend:
+        def exists(self) -> bool:
+            return False
+
+    class FakeSQLiteWorkService:
+        def __init__(self, *, db_path: Path, project_path: Path) -> None:
+            self.db_path = db_path
+            self.project_path = project_path
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def list_tasks(self, *, project: str):
+            return [
+                SimpleNamespace(
+                    task_id=f"{project}/1",
+                    work_status=SimpleNamespace(value="review"),
+                )
+            ]
+
+    monkeypatch.setattr(
+        "pollypm.task_backends.get_task_backend",
+        lambda _path: _NoTaskBackend(),
+    )
+    monkeypatch.setattr(
+        "pollypm.work.sqlite_service.SQLiteWorkService",
+        FakeSQLiteWorkService,
+    )
+
+    assert backend._has_pending_work(api, context) is False
+
+
+def test_has_pending_work_keeps_in_progress_tasks_actionable(tmp_path: Path, monkeypatch) -> None:
+    api = _work_signal_api(tmp_path)
+    context = _context()
+    backend = LocalHeartbeatBackend()
+
+    class _NoTaskBackend:
+        def exists(self) -> bool:
+            return False
+
+    class FakeSQLiteWorkService:
+        def __init__(self, *, db_path: Path, project_path: Path) -> None:
+            self.db_path = db_path
+            self.project_path = project_path
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def list_tasks(self, *, project: str):
+            return [
+                SimpleNamespace(
+                    task_id=f"{project}/1",
+                    work_status=SimpleNamespace(value="in_progress"),
+                )
+            ]
+
+    monkeypatch.setattr(
+        "pollypm.task_backends.get_task_backend",
+        lambda _path: _NoTaskBackend(),
+    )
+    monkeypatch.setattr(
+        "pollypm.work.sqlite_service.SQLiteWorkService",
+        FakeSQLiteWorkService,
+    )
+
+    assert backend._has_pending_work(api, context) is True
+
+
 def test_local_heartbeat_backend_marks_followup_when_work_remains() -> None:
     api = FakeHeartbeatAPI([_context(transcript_delta="Implemented the parser. Next step: add coverage.")])
 


### PR DESCRIPTION
## Summary
- treat only worker-actionable states as pending work for heartbeat nudges
- stop treating review-only tasks as evidence the worker should still be acting
- add heartbeat regression tests for review-only vs in-progress task states

## Testing
- HOME=/tmp/pytest-393 uv run --extra dev pytest tests/test_heartbeat_plugin_api.py -q

Closes #393