### PR TITLE
Avoid scaffolding a fake ~/.pollypm/.pollypm tree

### DIFF
--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -55,6 +55,13 @@ def _normalize_session_prompt(session_name: str, prompt: str | None) -> str | No
 
 
 def _resolve_path(base: Path, raw_path: str) -> Path:
+    # Global configs live in ``~/.pollypm/pollypm.toml``. Older renders
+    # wrote sibling paths as ``.pollypm/...`` relative to that same
+    # directory, which reloads as a bogus nested ``~/.pollypm/.pollypm``.
+    if base.name == GLOBAL_CONFIG_DIR.name:
+        rel = Path(raw_path)
+        if not rel.is_absolute() and rel.parts[:1] == (GLOBAL_CONFIG_DIR.name,):
+            raw_path = str(Path(*rel.parts[1:])) if len(rel.parts) > 1 else "."
     path = Path(raw_path)
     if path.is_absolute():
         return path
@@ -73,6 +80,12 @@ def _toml_str(value: str) -> str:
 
 
 def _format_path(path: Path, root: Path) -> str:
+    if root.resolve().name == GLOBAL_CONFIG_DIR.name:
+        legacy_nested_root = root.resolve() / GLOBAL_CONFIG_DIR.name
+        try:
+            return str(path.resolve().relative_to(legacy_nested_root))
+        except ValueError:
+            pass
     try:
         return str(path.resolve().relative_to(root.resolve()))
     except ValueError:

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 from pollypm.agent_profiles import get_agent_profile
 from pollypm.agent_profiles.base import AgentProfileContext
 from pollypm.checkpoints import record_checkpoint, snapshot_hash, write_mechanical_checkpoint
-from pollypm.config import PollyPMConfig
+from pollypm.config import GLOBAL_CONFIG_DIR, PollyPMConfig
 from pollypm.errors import _last_lines, format_probe_failure
 from pollypm.heartbeats import get_heartbeat_backend
 from pollypm.heartbeats.api import SupervisorHeartbeatAPI
@@ -952,7 +952,22 @@ class Supervisor:
         project.base_dir.mkdir(parents=True, exist_ok=True)
         project.logs_dir.mkdir(parents=True, exist_ok=True)
         project.snapshots_dir.mkdir(parents=True, exist_ok=True)
-        ensure_project_scaffold(project.root_dir)
+        root_dir = project.root_dir.resolve()
+        base_dir = project.base_dir.resolve()
+        # The user-global config lives under ``~/.pollypm``. That control
+        # root is not a real project checkout, so scaffolding it creates a
+        # fake ``~/.pollypm/.pollypm`` project tree. Skip the ambient-root
+        # scaffold for both the normalized shape (root == base) and the
+        # legacy nested-base shape written by older configs/onboarding.
+        should_scaffold_root = (
+            root_dir != base_dir
+            and not (
+                root_dir.name == GLOBAL_CONFIG_DIR.name
+                and base_dir == root_dir / GLOBAL_CONFIG_DIR.name
+            )
+        )
+        if should_scaffold_root:
+            ensure_project_scaffold(project.root_dir)
         for known_project in self.config.projects.values():
             ensure_project_scaffold(known_project.path)
         for account in self.config.accounts.values():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -149,6 +149,104 @@ cwd = "."
     assert config.sessions["worker"].cwd == tmp_path
 
 
+def test_load_config_flattens_legacy_global_dot_pollypm_paths(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / ".pollypm"
+    config_dir.mkdir()
+    config_path = config_dir / "pollypm.toml"
+    config_path.write_text(
+        """
+[project]
+name = "pollypm"
+tmux_session = "pollypm"
+base_dir = ".pollypm"
+logs_dir = ".pollypm/logs"
+snapshots_dir = ".pollypm/snapshots"
+state_db = ".pollypm/state.db"
+
+[pollypm]
+controller_account = "claude_primary"
+
+[accounts.claude_primary]
+provider = "claude"
+home = ".pollypm/homes/claude_primary"
+
+[sessions.heartbeat]
+role = "heartbeat-supervisor"
+provider = "claude"
+account = "claude_primary"
+cwd = "."
+
+[sessions.operator]
+role = "operator-pm"
+provider = "claude"
+account = "claude_primary"
+cwd = "."
+"""
+    )
+
+    config = load_config(config_path)
+
+    assert config.project.root_dir == config_dir
+    assert config.project.base_dir == config_dir
+    assert config.project.logs_dir == config_dir / "logs"
+    assert config.project.snapshots_dir == config_dir / "snapshots"
+    assert config.project.state_db == config_dir / "state.db"
+    assert config.accounts["claude_primary"].home == (
+        config_dir / "homes" / "claude_primary"
+    )
+
+
+def test_write_config_flattens_global_dot_pollypm_paths(tmp_path: Path) -> None:
+    config_dir = tmp_path / ".pollypm"
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=config_dir,
+            base_dir=config_dir / ".pollypm",
+            logs_dir=config_dir / ".pollypm" / "logs",
+            snapshots_dir=config_dir / ".pollypm" / "snapshots",
+            state_db=config_dir / ".pollypm" / "state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account="claude_primary"),
+        accounts={
+            "claude_primary": AccountConfig(
+                name="claude_primary",
+                provider=ProviderKind.CLAUDE,
+                home=config_dir / ".pollypm" / "homes" / "claude_primary",
+            )
+        },
+        sessions={
+            "heartbeat": SessionConfig(
+                name="heartbeat",
+                role="heartbeat-supervisor",
+                provider=ProviderKind.CLAUDE,
+                account="claude_primary",
+                cwd=config_dir,
+            ),
+            "operator": SessionConfig(
+                name="operator",
+                role="operator-pm",
+                provider=ProviderKind.CLAUDE,
+                account="claude_primary",
+                cwd=config_dir,
+            ),
+        },
+        projects={},
+    )
+    config_path = config_dir / "pollypm.toml"
+
+    write_config(config, config_path, force=True)
+
+    rendered = config_path.read_text()
+    assert 'base_dir = "."' in rendered
+    assert 'logs_dir = "logs"' in rendered
+    assert 'snapshots_dir = "snapshots"' in rendered
+    assert 'state_db = "state.db"' in rendered
+    assert 'home = "homes/claude_primary"' in rendered
+
+
 def test_load_config_parses_custom_lease_timeout_minutes(tmp_path: Path) -> None:
     config_path = tmp_path / "pollypm.toml"
     config_path.write_text(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -120,6 +120,34 @@ def test_supervisor_failover_prefers_viable_backup(monkeypatch, tmp_path: Path) 
     }
 
 
+def test_ensure_layout_skips_scaffolding_global_control_root(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    config_root = tmp_path / ".pollypm"
+    config = _config(config_root)
+    real_project = tmp_path / "demo"
+    config.projects = {
+        "demo": KnownProject(
+            key="demo",
+            path=real_project,
+            name="Demo",
+            kind=ProjectKind.FOLDER,
+        ),
+    }
+    supervisor = Supervisor(config)
+    scaffolded: list[Path] = []
+
+    monkeypatch.setattr(
+        "pollypm.supervisor.ensure_project_scaffold",
+        lambda path: (scaffolded.append(Path(path)), Path(path))[1],
+    )
+
+    supervisor.ensure_layout()
+
+    assert config.project.root_dir not in scaffolded
+    assert real_project in scaffolded
+
+
 def test_human_input_creates_automatic_lease(monkeypatch, tmp_path: Path) -> None:
     config = _config(tmp_path)
     supervisor = Supervisor(config)


### PR DESCRIPTION
## Summary
- normalize legacy global-config `".pollypm/..."` paths so they reload flat under the control/config root instead of nesting another `.pollypm` directory
- skip `ensure_project_scaffold()` for the ambient global control root while still scaffolding real tracked projects
- add focused regression coverage for config round-trip and supervisor bootstrap/layout behavior

## Testing
- `uv run pytest tests/test_config.py::test_control_sessions_use_workspace_root_for_dot_cwd tests/test_config.py::test_load_config_flattens_legacy_global_dot_pollypm_paths tests/test_config.py::test_write_config_flattens_global_dot_pollypm_paths tests/test_onboarding.py::test_rendered_onboarding_config_round_trips tests/test_supervisor.py::test_ensure_layout_skips_scaffolding_global_control_root`
- `uv run pytest tests/test_config.py::test_load_example_config tests/test_supervisor.py::test_claim_lease_rejects_conflicting_owner`

Closes #379.