### PR TITLE
Make review approvals and test receipt guidance explicit

### DIFF
--- a/docs/worker-guide.md
+++ b/docs/worker-guide.md
@@ -134,6 +134,17 @@ pm task done shortlink_gen/1 --output '{
 
 On success, the task moves to `review` and the reviewer is notified.
 
+If your task was emitted on the `implement_module` flow, review also expects a
+user-level test receipt on disk before approval succeeds. Write:
+
+```json
+{"passed": true, "details": "Playwright 5/5 passed; screenshot report.html"}
+```
+
+to `.pollypm/test-receipts/<project>-<number>.json` in the project root
+(example: `demo/1` → `.pollypm/test-receipts/demo-1.json`). Unit tests alone do
+not satisfy that gate.
+
 ### 6. If the reviewer rejects
 
 ```bash

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -55,6 +55,13 @@ def _normalize_session_prompt(session_name: str, prompt: str | None) -> str | No
 
 
 def _resolve_path(base: Path, raw_path: str) -> Path:
+    # Global configs live in ``~/.pollypm/pollypm.toml``. Older renders
+    # wrote sibling paths as ``.pollypm/...`` relative to that same
+    # directory, which reloads as a bogus nested ``~/.pollypm/.pollypm``.
+    if base.name == GLOBAL_CONFIG_DIR.name:
+        rel = Path(raw_path)
+        if not rel.is_absolute() and rel.parts[:1] == (GLOBAL_CONFIG_DIR.name,):
+            raw_path = str(Path(*rel.parts[1:])) if len(rel.parts) > 1 else "."
     path = Path(raw_path)
     if path.is_absolute():
         return path
@@ -73,6 +80,12 @@ def _toml_str(value: str) -> str:
 
 
 def _format_path(path: Path, root: Path) -> str:
+    if root.resolve().name == GLOBAL_CONFIG_DIR.name:
+        legacy_nested_root = root.resolve() / GLOBAL_CONFIG_DIR.name
+        try:
+            return str(path.resolve().relative_to(legacy_nested_root))
+        except ValueError:
+            pass
     try:
         return str(path.resolve().relative_to(root.resolve()))
     except ValueError:

--- a/src/pollypm/defaults/docs/reference/tasks.md
+++ b/src/pollypm/defaults/docs/reference/tasks.md
@@ -36,7 +36,9 @@ pm task blocked -p <project>       # tasks with unresolved blockers
 When a task reaches a review node:
 
 ```bash
+pm task approve <id>                         # auto-uses bound reviewer/human actor
 pm task approve <id> --actor polly --reason "looks good"
+pm task reject <id> --reason "specific feedback"  # auto-uses bound reviewer/human actor
 pm task reject <id> --actor polly --reason "specific feedback"
 ```
 

--- a/src/pollypm/plugins_builtin/project_planning/gates/user_level_tests_pass.py
+++ b/src/pollypm/plugins_builtin/project_planning/gates/user_level_tests_pass.py
@@ -27,6 +27,9 @@ from pollypm.work.models import GateResult, Task
 
 
 RECEIPTS_DIR = ".pollypm/test-receipts"
+RECEIPT_SCHEMA_EXAMPLE = (
+    '{"passed": true, "details": "Playwright 5/5 passed; screenshot report.html"}'
+)
 
 
 class UserLevelTestsPass:
@@ -53,8 +56,9 @@ class UserLevelTestsPass:
                 passed=False,
                 reason=(
                     f"No user-level test receipt at {receipt_path}. "
-                    "Worker must run the Playwright/tmux scenario and "
-                    "write a pass receipt before code_review."
+                    f"Expected a JSON object like {RECEIPT_SCHEMA_EXAMPLE}. "
+                    "Fix: run the Playwright/tmux scenario, then write that "
+                    "exact file before asking the reviewer to approve."
                 ),
             )
 
@@ -63,7 +67,10 @@ class UserLevelTestsPass:
         except (OSError, json.JSONDecodeError) as exc:
             return GateResult(
                 passed=False,
-                reason=f"Receipt at {receipt_path} is not valid JSON: {exc}",
+                reason=(
+                    f"Receipt at {receipt_path} is not valid JSON: {exc}. "
+                    f"Expected {RECEIPT_SCHEMA_EXAMPLE}."
+                ),
             )
 
         if not isinstance(data, dict):
@@ -71,19 +78,44 @@ class UserLevelTestsPass:
                 passed=False,
                 reason=(
                     f"Receipt at {receipt_path} is not a JSON object "
-                    f"(got {type(data).__name__})."
+                    f"(got {type(data).__name__}). "
+                    f"Expected {RECEIPT_SCHEMA_EXAMPLE}."
                 ),
             )
 
         passed = data.get("passed")
+        details = data.get("details")
+        if not isinstance(passed, bool):
+            return GateResult(
+                passed=False,
+                reason=(
+                    f"Receipt at {receipt_path} has invalid schema. "
+                    "Expected boolean field 'passed' and optional string "
+                    f"'details'. Example: {RECEIPT_SCHEMA_EXAMPLE}."
+                ),
+            )
+        if details is not None and not isinstance(details, str):
+            return GateResult(
+                passed=False,
+                reason=(
+                    f"Receipt at {receipt_path} has invalid schema. "
+                    "Field 'details' must be a string when present. "
+                    f"Example: {RECEIPT_SCHEMA_EXAMPLE}."
+                ),
+            )
+
         if passed is True:
-            details = data.get("details", "")
+            detail_text = (details or "").strip()
             return GateResult(
                 passed=True,
-                reason=f"User-level tests pass. {details}".strip(),
+                reason=f"User-level tests pass. {detail_text}".strip(),
             )
-        details = data.get("details", "no details supplied")
+        detail_text = (details or "no details supplied").strip()
         return GateResult(
             passed=False,
-            reason=f"User-level tests did not pass: {details}",
+            reason=(
+                f"User-level tests did not pass per {receipt_path}: "
+                f"{detail_text}. Reviewer expects {RECEIPT_SCHEMA_EXAMPLE} "
+                "with passed=true before code_review can pass."
+            ),
         )

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 from pollypm.agent_profiles import get_agent_profile
 from pollypm.agent_profiles.base import AgentProfileContext
 from pollypm.checkpoints import record_checkpoint, snapshot_hash, write_mechanical_checkpoint
-from pollypm.config import PollyPMConfig
+from pollypm.config import GLOBAL_CONFIG_DIR, PollyPMConfig
 from pollypm.errors import _last_lines, format_probe_failure
 from pollypm.heartbeats import get_heartbeat_backend
 from pollypm.heartbeats.api import SupervisorHeartbeatAPI
@@ -952,7 +952,22 @@ class Supervisor:
         project.base_dir.mkdir(parents=True, exist_ok=True)
         project.logs_dir.mkdir(parents=True, exist_ok=True)
         project.snapshots_dir.mkdir(parents=True, exist_ok=True)
-        ensure_project_scaffold(project.root_dir)
+        root_dir = project.root_dir.resolve()
+        base_dir = project.base_dir.resolve()
+        # The user-global config lives under ``~/.pollypm``. That control
+        # root is not a real project checkout, so scaffolding it creates a
+        # fake ``~/.pollypm/.pollypm`` project tree. Skip the ambient-root
+        # scaffold for both the normalized shape (root == base) and the
+        # legacy nested-base shape written by older configs/onboarding.
+        should_scaffold_root = (
+            root_dir != base_dir
+            and not (
+                root_dir.name == GLOBAL_CONFIG_DIR.name
+                and base_dir == root_dir / GLOBAL_CONFIG_DIR.name
+            )
+        )
+        if should_scaffold_root:
+            ensure_project_scaffold(project.root_dir)
         for known_project in self.config.projects.values():
             ensure_project_scaffold(known_project.path)
         for account in self.config.accounts.values():

--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -192,6 +192,21 @@ def _svc(db: str, project: str | None = None) -> SQLiteWorkService:
     return svc
 
 
+def _resolve_actor_for_task(
+    svc: SQLiteWorkService,
+    task_id: str,
+    actor: str | None,
+) -> str:
+    """Use the task's bound actor when the CLI caller omits ``--actor``."""
+    if actor:
+        return actor
+    try:
+        task = svc.get(task_id)
+    except WorkServiceError:
+        return "cli"
+    return svc.derive_owner(task) or "cli"
+
+
 def _print_task(task, as_json: bool = False) -> None:
     """Print a single task."""
     if as_json:
@@ -681,13 +696,22 @@ def task_done(
 def task_approve(
     task_id: str = typer.Argument(..., help="Task ID (project/number)"),
     reason: Optional[str] = typer.Option(None, "--reason", help="Approval reason"),
-    actor: str = typer.Option("cli", "--actor", help="Actor approving"),
+    actor: Optional[str] = typer.Option(
+        None,
+        "--actor",
+        help="Actor approving (defaults to the task's bound reviewer/human approver)",
+    ),
     db: str = _DB_OPTION,
     output_json: bool = _JSON_OPTION,
 ) -> None:
     """Approve at a review node."""
     svc = _svc(db, project=_project_from_task_id(task_id))
-    task = _run(svc.approve, task_id, actor, reason)
+    task = _run(
+        svc.approve,
+        task_id,
+        _resolve_actor_for_task(svc, task_id, actor),
+        reason,
+    )
     if output_json:
         typer.echo(json.dumps(_task_to_dict(task), indent=2, default=str))
     else:
@@ -698,13 +722,22 @@ def task_approve(
 def task_reject(
     task_id: str = typer.Argument(..., help="Task ID (project/number)"),
     reason: str = typer.Option(..., "--reason", help="Rejection reason (required)"),
-    actor: str = typer.Option("cli", "--actor", help="Actor rejecting"),
+    actor: Optional[str] = typer.Option(
+        None,
+        "--actor",
+        help="Actor rejecting (defaults to the task's bound reviewer/human approver)",
+    ),
     db: str = _DB_OPTION,
     output_json: bool = _JSON_OPTION,
 ) -> None:
     """Reject at a review node."""
     svc = _svc(db, project=_project_from_task_id(task_id))
-    task = _run(svc.reject, task_id, actor, reason)
+    task = _run(
+        svc.reject,
+        task_id,
+        _resolve_actor_for_task(svc, task_id, actor),
+        reason,
+    )
     if output_json:
         typer.echo(json.dumps(_task_to_dict(task), indent=2, default=str))
     else:

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -719,6 +719,13 @@ class SQLiteWorkService:
         parts = [f"[skip-gates] {r.gate_name}: {r.reason}" for r in failures]
         return "; ".join(parts)
 
+    def _gate_kwargs(self) -> dict[str, object]:
+        """Build common kwargs for gate evaluation."""
+        kwargs: dict[str, object] = {"get_task": self.get}
+        if self._project_path is not None:
+            kwargs["project_root"] = self._project_path
+        return kwargs
+
     # ------------------------------------------------------------------
     # Owner derivation
     # ------------------------------------------------------------------
@@ -874,7 +881,7 @@ class SQLiteWorkService:
         # Gate: has_description
         gate_results = evaluate_gates(
             task, ["has_description"], self._gate_registry,
-            get_task=self.get,
+            **self._gate_kwargs(),
         )
         if not skip_gates and has_hard_failure(gate_results):
             failing = [r for r in gate_results if not r.passed]
@@ -1282,22 +1289,42 @@ class SQLiteWorkService:
     # Actors that are always treated as human for actor_type=HUMAN nodes.
     _HUMAN_ACTOR_NAMES = frozenset({"human", "user", "sam"})
 
+    @staticmethod
+    def _ordered_names(*names: str | None) -> list[str]:
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for name in names:
+            if not name or name in seen:
+                continue
+            ordered.append(name)
+            seen.add(name)
+        return ordered
+
     def _validate_actor_role(
         self, task: Task, node: FlowNode, actor: str
     ) -> None:
         """Validate that actor matches the node's expected role."""
         if node.actor_type == ActorType.HUMAN:
             # Accept well-known human names plus the assigned reviewer role value
-            allowed = set(self._HUMAN_ACTOR_NAMES)
+            reviewer = None
             if node.actor_role:
                 reviewer = task.roles.get(node.actor_role)
-                if reviewer:
-                    allowed.add(reviewer)
+            allowed = self._ordered_names(
+                reviewer, *sorted(self._HUMAN_ACTOR_NAMES),
+            )
             if actor not in allowed:
+                schema = "actor_type='human'"
+                if node.actor_role:
+                    schema += f", actor_role='{node.actor_role}'"
+                    if reviewer:
+                        schema += (
+                            f", task.roles['{node.actor_role}']='{reviewer}'"
+                        )
                 raise ValidationError(
-                    f"Node '{node.name}' requires human review. "
-                    f"Actor '{actor}' is not authorized — "
-                    f"accepted actors: {', '.join(sorted(allowed))}."
+                    f"Node '{node.name}' requires human review ({schema}). "
+                    f"Actor '{actor}' is not authorized. "
+                    f"Accepted actors: {', '.join(repr(name) for name in allowed)}. "
+                    f"Fix: rerun this action with --actor {allowed[0]}."
                 )
         elif node.actor_type == ActorType.ROLE and node.actor_role:
             expected_actor = task.roles.get(node.actor_role)
@@ -1306,13 +1333,32 @@ class SQLiteWorkService:
                 if actor != node.actor_role:
                     raise ValidationError(
                         f"Actor '{actor}' does not match role "
-                        f"'{node.actor_role}' (expected '{expected_actor}')."
+                        f"'{node.actor_role}' (expected '{expected_actor}'). "
+                        f"Node '{node.name}' uses actor_type='role', "
+                        f"actor_role='{node.actor_role}', "
+                        f"task.roles['{node.actor_role}']='{expected_actor}'. "
+                        f"Accepted actors: '{expected_actor}' or literal role "
+                        f"name '{node.actor_role}'. "
+                        f"Fix: rerun this action with --actor {expected_actor}."
                     )
+            elif expected_actor is None and actor != node.actor_role:
+                raise ValidationError(
+                    f"Actor '{actor}' does not match role '{node.actor_role}'. "
+                    f"Node '{node.name}' uses actor_type='role', "
+                    f"actor_role='{node.actor_role}', but this task has no "
+                    f"binding in task.roles['{node.actor_role}']. "
+                    f"Accepted actor: '{node.actor_role}'. "
+                    f"Fix: rerun this action with --actor {node.actor_role}, "
+                    f"or update the role binding."
+                )
         elif node.actor_type == ActorType.AGENT and node.agent_name:
             if actor != node.agent_name:
                 raise ValidationError(
                     f"Node '{node.name}' is pinned to agent "
-                    f"'{node.agent_name}'. Actor '{actor}' is not authorized."
+                    f"'{node.agent_name}' (actor_type='agent', "
+                    f"agent_name='{node.agent_name}'). Actor '{actor}' is not "
+                    f"authorized. Fix: rerun this action with --actor "
+                    f"{node.agent_name}."
                 )
 
     def _next_visit(
@@ -1382,7 +1428,7 @@ class SQLiteWorkService:
         if node.gates:
             gate_results = evaluate_gates(
                 task, node.gates, self._gate_registry,
-                get_task=self.get,
+                **self._gate_kwargs(),
             )
             if not skip_gates and has_hard_failure(gate_results):
                 failing = [r for r in gate_results if not r.passed and r.gate_type == "hard"]
@@ -1525,7 +1571,7 @@ class SQLiteWorkService:
         if node.gates:
             gate_results = evaluate_gates(
                 task, node.gates, self._gate_registry,
-                get_task=self.get,
+                **self._gate_kwargs(),
             )
             if not skip_gates and has_hard_failure(gate_results):
                 failing = [r for r in gate_results if not r.passed and r.gate_type == "hard"]
@@ -1937,7 +1983,7 @@ class SQLiteWorkService:
             results.extend(
                 evaluate_gates(
                     task, node.gates, self._gate_registry,
-                    get_task=self.get,
+                    **self._gate_kwargs(),
                 )
             )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -149,6 +149,104 @@ cwd = "."
     assert config.sessions["worker"].cwd == tmp_path
 
 
+def test_load_config_flattens_legacy_global_dot_pollypm_paths(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / ".pollypm"
+    config_dir.mkdir()
+    config_path = config_dir / "pollypm.toml"
+    config_path.write_text(
+        """
+[project]
+name = "pollypm"
+tmux_session = "pollypm"
+base_dir = ".pollypm"
+logs_dir = ".pollypm/logs"
+snapshots_dir = ".pollypm/snapshots"
+state_db = ".pollypm/state.db"
+
+[pollypm]
+controller_account = "claude_primary"
+
+[accounts.claude_primary]
+provider = "claude"
+home = ".pollypm/homes/claude_primary"
+
+[sessions.heartbeat]
+role = "heartbeat-supervisor"
+provider = "claude"
+account = "claude_primary"
+cwd = "."
+
+[sessions.operator]
+role = "operator-pm"
+provider = "claude"
+account = "claude_primary"
+cwd = "."
+"""
+    )
+
+    config = load_config(config_path)
+
+    assert config.project.root_dir == config_dir
+    assert config.project.base_dir == config_dir
+    assert config.project.logs_dir == config_dir / "logs"
+    assert config.project.snapshots_dir == config_dir / "snapshots"
+    assert config.project.state_db == config_dir / "state.db"
+    assert config.accounts["claude_primary"].home == (
+        config_dir / "homes" / "claude_primary"
+    )
+
+
+def test_write_config_flattens_global_dot_pollypm_paths(tmp_path: Path) -> None:
+    config_dir = tmp_path / ".pollypm"
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=config_dir,
+            base_dir=config_dir / ".pollypm",
+            logs_dir=config_dir / ".pollypm" / "logs",
+            snapshots_dir=config_dir / ".pollypm" / "snapshots",
+            state_db=config_dir / ".pollypm" / "state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account="claude_primary"),
+        accounts={
+            "claude_primary": AccountConfig(
+                name="claude_primary",
+                provider=ProviderKind.CLAUDE,
+                home=config_dir / ".pollypm" / "homes" / "claude_primary",
+            )
+        },
+        sessions={
+            "heartbeat": SessionConfig(
+                name="heartbeat",
+                role="heartbeat-supervisor",
+                provider=ProviderKind.CLAUDE,
+                account="claude_primary",
+                cwd=config_dir,
+            ),
+            "operator": SessionConfig(
+                name="operator",
+                role="operator-pm",
+                provider=ProviderKind.CLAUDE,
+                account="claude_primary",
+                cwd=config_dir,
+            ),
+        },
+        projects={},
+    )
+    config_path = config_dir / "pollypm.toml"
+
+    write_config(config, config_path, force=True)
+
+    rendered = config_path.read_text()
+    assert 'base_dir = "."' in rendered
+    assert 'logs_dir = "logs"' in rendered
+    assert 'snapshots_dir = "snapshots"' in rendered
+    assert 'state_db = "state.db"' in rendered
+    assert 'home = "homes/claude_primary"' in rendered
+
+
 def test_load_config_parses_custom_lease_timeout_minutes(tmp_path: Path) -> None:
     config_path = tmp_path / "pollypm.toml"
     config_path.write_text(

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -154,6 +154,66 @@ class TestApproveNonReviewTask:
         assert "worker" in msg.lower()
 
 
+class TestReviewActorGuidance:
+    def test_approve_wrong_actor_names_role_binding_and_fix(self, svc):
+        task = _queued_task(svc)
+        svc.claim(task.task_id, "agent-1")
+        svc.node_done(
+            task.task_id,
+            "agent-1",
+            {
+                "type": "code_change",
+                "summary": "did the thing",
+                "artifacts": [
+                    {"kind": "commit", "description": "impl", "ref": "HEAD"},
+                ],
+            },
+        )
+
+        with pytest.raises(ValidationError) as excinfo:
+            svc.approve(task.task_id, "agent-1")
+
+        msg = str(excinfo.value)
+        assert "does not match role 'reviewer'" in msg
+        assert "actor_type='role'" in msg
+        assert "task.roles['reviewer']='agent-2'" in msg
+        assert "--actor agent-2" in msg
+
+    def test_human_review_wrong_actor_names_expected_human_actor(self, svc):
+        task = svc.create(
+            title="t",
+            description="d",
+            type="task",
+            project="proj",
+            flow_template="user-review",
+            roles={"worker": "agent-1"},
+            priority="normal",
+            created_by="tester",
+        )
+        svc.queue(task.task_id, "pm")
+        svc.claim(task.task_id, "agent-1")
+        svc.node_done(
+            task.task_id,
+            "agent-1",
+            {
+                "type": "code_change",
+                "summary": "did the thing",
+                "artifacts": [
+                    {"kind": "commit", "description": "impl", "ref": "HEAD"},
+                ],
+            },
+        )
+
+        with pytest.raises(ValidationError) as excinfo:
+            svc.approve(task.task_id, "polly")
+
+        msg = str(excinfo.value)
+        assert "requires human review" in msg
+        assert "actor_type='human'" in msg
+        assert "'human'" in msg
+        assert "--actor human" in msg
+
+
 # ---------------------------------------------------------------------------
 # Catalog entry 6: `pm task claim` on already-claimed task
 # ---------------------------------------------------------------------------

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import textwrap
 
 import pytest
@@ -453,3 +454,54 @@ class TestValidateAdvance:
             if r.gate_name == "actor_role" and not r.passed
         ]
         assert actor_failures == []
+
+
+class TestProjectRootGateResolution:
+    def test_approve_uses_service_project_root_for_receipt_lookup(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        project_root = tmp_path / "demo"
+        project_root.mkdir()
+        db_path = project_root / ".pollypm" / "state.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        outside_cwd = tmp_path / "elsewhere"
+        outside_cwd.mkdir()
+
+        svc = SQLiteWorkService(db_path=db_path, project_path=project_root)
+        try:
+            task = svc.create(
+                title="Module task",
+                description="Implement module",
+                type="task",
+                project="demo",
+                flow_template="implement_module",
+                roles={"worker": "agent-1", "reviewer": "agent-2"},
+                priority="normal",
+                created_by="tester",
+            )
+            svc.queue(task.task_id, "pm")
+            svc.claim(task.task_id, "agent-1")
+            output = {
+                "type": "code_change",
+                "summary": "module implemented",
+                "artifacts": [
+                    {"kind": "commit", "description": "impl", "ref": "HEAD"},
+                ],
+            }
+            svc.node_done(task.task_id, "agent-1", output)
+            svc.node_done(task.task_id, "agent-1", output)
+
+            receipts = project_root / ".pollypm" / "test-receipts"
+            receipts.mkdir(parents=True)
+            receipts.joinpath("demo-1.json").write_text(
+                json.dumps({"passed": True, "details": "tmux 1/1"}),
+                encoding="utf-8",
+            )
+
+            monkeypatch.chdir(outside_cwd)
+            approved = svc.approve(task.task_id, "agent-2")
+            assert approved.work_status == WorkStatus.DONE
+        finally:
+            svc.close()

--- a/tests/test_project_planning_plugin.py
+++ b/tests/test_project_planning_plugin.py
@@ -351,6 +351,8 @@ def test_user_level_tests_pass_blocks_without_receipt(tmp_path: Path) -> None:
     gate = GateRegistry().get("user_level_tests_pass")
     result = gate.check(_make_task(), project_root=tmp_path)
     assert result.passed is False
+    assert ".pollypm/test-receipts/demo-1.json" in result.reason
+    assert '"passed": true' in result.reason
 
 
 def test_user_level_tests_pass_blocks_with_failing_receipt(tmp_path: Path) -> None:
@@ -367,6 +369,24 @@ def test_user_level_tests_pass_blocks_with_failing_receipt(tmp_path: Path) -> No
     result = gate.check(_make_task(), project_root=tmp_path)
     assert result.passed is False
     assert "3/5" in result.reason
+    assert '"passed": true' in result.reason
+
+
+def test_user_level_tests_pass_blocks_with_invalid_schema(tmp_path: Path) -> None:
+    import json as _json
+
+    from pollypm.work.gates import GateRegistry
+
+    gate = GateRegistry().get("user_level_tests_pass")
+    receipts = tmp_path / ".pollypm" / "test-receipts"
+    receipts.mkdir(parents=True)
+    receipts.joinpath("demo-1.json").write_text(
+        _json.dumps({"details": "Playwright 5/5"})
+    )
+    result = gate.check(_make_task(), project_root=tmp_path)
+    assert result.passed is False
+    assert "invalid schema" in result.reason
+    assert "boolean field 'passed'" in result.reason
 
 
 def test_user_level_tests_pass_passes_with_receipt(tmp_path: Path) -> None:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -120,6 +120,34 @@ def test_supervisor_failover_prefers_viable_backup(monkeypatch, tmp_path: Path) 
     }
 
 
+def test_ensure_layout_skips_scaffolding_global_control_root(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    config_root = tmp_path / ".pollypm"
+    config = _config(config_root)
+    real_project = tmp_path / "demo"
+    config.projects = {
+        "demo": KnownProject(
+            key="demo",
+            path=real_project,
+            name="Demo",
+            kind=ProjectKind.FOLDER,
+        ),
+    }
+    supervisor = Supervisor(config)
+    scaffolded: list[Path] = []
+
+    monkeypatch.setattr(
+        "pollypm.supervisor.ensure_project_scaffold",
+        lambda path: (scaffolded.append(Path(path)), Path(path))[1],
+    )
+
+    supervisor.ensure_layout()
+
+    assert config.project.root_dir not in scaffolded
+    assert real_project in scaffolded
+
+
 def test_human_input_creates_automatic_lease(monkeypatch, tmp_path: Path) -> None:
     config = _config(tmp_path)
     supervisor = Supervisor(config)

--- a/tests/test_work_cli.py
+++ b/tests/test_work_cli.py
@@ -103,6 +103,61 @@ class TestCliLifecycle:
         data = json.loads(result.output)
         assert data["work_status"] == "done"
 
+    def test_cli_approve_without_actor_uses_bound_reviewer(self, db_path):
+        _create_task(
+            db_path,
+            title="Auto approve",
+            roles=["worker=pete", "reviewer=polly"],
+        )
+        assert runner.invoke(task_app, ["queue", "proj/1", "--db", db_path]).exit_code == 0
+        assert runner.invoke(
+            task_app, ["claim", "proj/1", "--actor", "pete", "--db", db_path],
+        ).exit_code == 0
+        wo = json.dumps(
+            {
+                "type": "code_change",
+                "summary": "Implemented the feature",
+                "artifacts": [
+                    {"kind": "commit", "description": "abc123", "ref": "abc123"},
+                ],
+            }
+        )
+        assert runner.invoke(
+            task_app, ["done", "proj/1", "--output", wo, "--actor", "pete", "--db", db_path],
+        ).exit_code == 0
+
+        result = runner.invoke(task_app, ["approve", "proj/1", "--db", db_path])
+        assert result.exit_code == 0, result.output
+        assert "Approved proj/1" in result.output
+
+    def test_cli_approve_without_actor_uses_human_for_user_review(self, db_path):
+        _create_task(
+            db_path,
+            title="Human approve",
+            flow="user-review",
+            roles=["worker=pete"],
+        )
+        assert runner.invoke(task_app, ["queue", "proj/1", "--db", db_path]).exit_code == 0
+        assert runner.invoke(
+            task_app, ["claim", "proj/1", "--actor", "pete", "--db", db_path],
+        ).exit_code == 0
+        wo = json.dumps(
+            {
+                "type": "code_change",
+                "summary": "Implemented the feature",
+                "artifacts": [
+                    {"kind": "commit", "description": "abc123", "ref": "abc123"},
+                ],
+            }
+        )
+        assert runner.invoke(
+            task_app, ["done", "proj/1", "--output", wo, "--actor", "pete", "--db", db_path],
+        ).exit_code == 0
+
+        result = runner.invoke(task_app, ["approve", "proj/1", "--db", db_path])
+        assert result.exit_code == 0, result.output
+        assert "Approved proj/1" in result.output
+
 
 class TestCliNext:
     def test_cli_next(self, db_path):


### PR DESCRIPTION
Fixes #387 and #390.

## Summary
- default `pm task approve`/`pm task reject` to the task's bound reviewer or human approver when `--actor` is omitted
- expand review actor mismatch errors so they name the expected actor/schema and give an exact retry command
- make user-level test receipt failures explicit about file location/schema and resolve receipt lookups against the service project root

## Testing
- `uv run pytest tests/test_work_cli.py tests/test_error_messages.py tests/test_project_planning_plugin.py tests/test_gates.py -q`
- `uv run pytest tests/test_flow_progression.py tests/test_work_service.py -q`