### PR TITLE
fix(flow): clarify worker review handoff

### DIFF
--- a/docs/worker-guide.md
+++ b/docs/worker-guide.md
@@ -37,6 +37,11 @@ Your scope is the `in_progress → review` edge. You:
 
 If the reviewer rejects, the task goes back to `in_progress` and you iterate.
 
+Some flows insert an extra worker-owned handoff step before review. If task
+status shows `review_handoff`, that does **not** mean a human takes over. It
+means you still need to run the user-level test, write the pass receipt, and
+then call `pm task done` to hand the task to Russell.
+
 ## The commands you need — copy-paste ready
 
 All commands below use `shortlink_gen/1` as an example task id. Yours will

--- a/src/pollypm/defaults/docs/reference/tasks.md
+++ b/src/pollypm/defaults/docs/reference/tasks.md
@@ -60,6 +60,7 @@ pm flow list                       # show available flows
 - **bug**: reproduce → fix → code_review → done
 - **spike**: research → done (no review)
 - **user-review**: implement → human_review → done (user must approve)
+- **implement_module**: build → review_handoff → code_review → done
 
 ## File Projection
 

--- a/src/pollypm/plugins_builtin/core_agent_profiles/profiles.py
+++ b/src/pollypm/plugins_builtin/core_agent_profiles/profiles.py
@@ -204,7 +204,10 @@ def worker_prompt() -> str:
         "1. `pm task claim <id>` — claim the task (starts the flow)\n"
         '2. `pm task context <id> "progress note"` — log what you\'re doing as you go\n'
         "3. Do the actual work: read code, write code, run tests, commit\n"
-        "4. When done: `pm task done <id> --output '<work-output-json>'`\n\n"
+        "4. When done: `pm task done <id> --output '<work-output-json>'`\n"
+        "   If the flow shows a worker-owned handoff node like `review_handoff`, "
+        "that is still your turn: run the user-level test, write the receipt, "
+        "and call `pm task done` again to release review.\n\n"
         "## Work output format (required when signaling done)\n"
         "Use the spelled `--output` form in prompts and docs. It takes a "
         "JSON string describing what you did:\n"

--- a/src/pollypm/plugins_builtin/project_planning/flows/implement_module.yaml
+++ b/src/pollypm/plugins_builtin/project_planning/flows/implement_module.yaml
@@ -23,13 +23,13 @@ nodes:
     type: work
     actor_type: role
     actor_role: worker
-    next_node: user_test
+    next_node: review_handoff
     gates: [has_assignee]
 
-  # User-test — worker runs the user-level test and writes the pass
-  # receipt. The user_level_tests_pass gate blocks advance from review
-  # until that receipt is present and reads passed=true.
-  user_test:
+  # Review handoff — still a worker-owned node. The worker runs the
+  # user-level test, writes the pass receipt, and then calls
+  # ``pm task done`` to release the task to review.
+  review_handoff:
     type: work
     actor_type: role
     actor_role: worker

--- a/tests/test_project_planning_plugin.py
+++ b/tests/test_project_planning_plugin.py
@@ -183,7 +183,12 @@ def test_critique_flow_has_output_present_gate() -> None:
 
 def test_implement_module_review_enforces_user_level_tests() -> None:
     template = resolve_flow("implement_module")
+    handoff = template.nodes["review_handoff"]
     review = template.nodes["code_review"]
+    assert handoff.type == NodeType.WORK
+    assert handoff.actor_type == ActorType.ROLE
+    assert handoff.actor_role == "worker"
+    assert handoff.next_node_id == "code_review"
     assert review.type == NodeType.REVIEW
     assert "user_level_tests_pass" in review.gates
 

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -212,6 +212,7 @@ def test_worker_prompt_requires_core_identity() -> None:
     assert "file_change" in prompt
     assert "operations with side effects" in prompt
     assert "decision, blocker, or observation" in prompt
+    assert "review_handoff" in prompt
 
 
 def test_operator_prompt_requires_delegation_instructions() -> None:


### PR DESCRIPTION
## Summary
- rename the worker-owned `implement_module` handoff node from `user_test` to `review_handoff` so task status no longer implies a human takes over
- teach worker-facing prompts/docs that `review_handoff` is still the worker's turn and must end with `pm task done`
- lock the new flow contract with targeted flow/template and prompt tests

## Testing
- HOME=/tmp/pytest-389 uv run --extra dev pytest tests/test_project_planning_plugin.py tests/test_workers.py -q

Closes #389