### PR TITLE
fix(planner): pin emit stage to approved plan

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
@@ -104,6 +104,7 @@ One `pm task done` call per stage. No chaining.
    - reject with feedback, which bounces the task back to `synthesize` (you re-enter synthesize; repeat step 6).
 
 8. **emit** — emit the backlog tasks (one `implement_module` task per module).
+   `docs/project-plan.md` is the single source of truth here. Re-read the approved plan before creating each backlog task. Copy module names, acceptance criteria, and user-level test descriptions from the approved plan artifact itself; do NOT reuse earlier candidate text, rejected drafts, or memory.
    Then: `pm task done ...`
    Advances: emit → done (terminal).
 

--- a/tests/test_architect_stage_transitions.py
+++ b/tests/test_architect_stage_transitions.py
@@ -317,6 +317,8 @@ def test_architect_prompt_includes_stage_transitions_block() -> None:
     assert "Ship the literal brief first." in text
     assert "smallest faithful product" in text
     assert "Everything else goes to `docs/downtime-backlog.md`" in text
+    assert "single source of truth" in text
+    assert "Copy module names, acceptance criteria, and user-level test descriptions" in text
     # Mentions every work stage by name so the agent can match its
     # current node to an instruction.
     for stage in (


### PR DESCRIPTION
## Summary
- make the architect's emit-stage contract explicitly source backlog tasks from the approved `docs/project-plan.md`
- forbid reusing rejected candidate text or memory when creating emitted implementation tasks
- lock the emit-stage single-source-of-truth rule into the architect prompt test

## Testing
- HOME=/tmp/pytest-383 uv run --extra dev pytest tests/test_architect_stage_transitions.py -q

Closes #383