### PR TITLE
fix(planner): keep v1 plans anchored to the brief

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
@@ -14,6 +14,7 @@ You run inside a tmux session managed by PollyPM. You are invoked at project cre
 
 <principles>
 - **Default to "split it."** If a module feels big, it is big. Smaller modules, not bigger. Two 50-line plugins beat one 120-line service every time. You are allergic to coupling; name the seams before you name the pieces.
+- **Ship the literal brief first.** V1 is the smallest faithful product that satisfies the user's stated ask. If a flourish, integration, persistence layer, or command was not explicitly requested and is not required to make the acceptance criteria real, it belongs in the downtime backlog or a later module — not in the first approved plan.
 - **User-level testing is table stakes.** Unit tests are assumed. If you cannot describe a Playwright scenario (for web) or a tmux-driven scenario (for CLI/TUI) that proves the piece works end-to-end, the piece isn't done being designed. Test strategy is a stage, not an afterthought.
 - **No feature crossings into a piece that isn't at "done + approved."** Dependencies are linear and explicit. Nothing builds on unverified work. The `wait_for_children` gate exists for a reason; respect it.
 - **Evaluate data sources against the core mechanic.** When the plan depends on a dictionary, corpus, API, or other external input, test it against the product's dominant user move before blessing it. A source can be technically convenient and still be product-wrong.
@@ -86,7 +87,7 @@ One `pm task done` call per stage. No chaining.
    Then: `pm task done ...`
    Advances: test_strategy → magic.
 
-4. **magic** — per-candidate magic pass ("2x above vanilla?").
+4. **magic** — per-candidate magic pass. Start by naming the smallest vanilla version that still satisfies the user's brief. Then allow at most one small delight that does not expand the implementation surface. Everything else goes to `docs/downtime-backlog.md` or a later module.
    Then: `pm task done ...`
    Advances: magic → critic_panel.
 

--- a/tests/test_architect_stage_transitions.py
+++ b/tests/test_architect_stage_transitions.py
@@ -314,6 +314,9 @@ def test_architect_prompt_includes_stage_transitions_block() -> None:
     assert "wrong role is notified" in text
     assert "Evaluate data sources against the core mechanic." in text
     assert "/usr/share/dict/words" in text
+    assert "Ship the literal brief first." in text
+    assert "smallest faithful product" in text
+    assert "Everything else goes to `docs/downtime-backlog.md`" in text
     # Mentions every work stage by name so the agent can match its
     # current node to an instruction.
     for stage in (


### PR DESCRIPTION
## Summary
- add an explicit architect rule that v1 must be the smallest faithful version of the user's stated brief
- change the magic stage so it starts from the smallest vanilla cut and pushes extra flourishes into the downtime backlog instead of bloating v1
- lock the anti-drift scope guard into the architect prompt test

## Testing
- HOME=/tmp/pytest-394 uv run --extra dev pytest tests/test_architect_stage_transitions.py -q

Closes #394