### PR TITLE
fix(projects): route planner tasks through workspace db

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -189,7 +189,37 @@ def _has_source_files(project_path: Path, *, max_scan: int = 2000) -> bool:
     return False
 
 
-def _has_work_tasks(project_path: Path) -> bool:
+def _planner_db_path(
+    project_path: Path,
+    *,
+    config_path: Path | None = None,
+    create_parent: bool = False,
+) -> Path:
+    """Return the planner/work-task DB for project-planning entry points.
+
+    Post-#339, planner-created tasks belong in the workspace-scope DB.
+    Fall back to the project-local path only when no config is available,
+    which keeps older isolated tests and recovery paths working.
+    """
+    db_path = project_path / ".pollypm" / "state.db"
+    try:
+        cfg = load_config(config_path) if config_path is not None else load_config()
+        workspace_root = getattr(cfg.project, "workspace_root", None)
+        if workspace_root is not None:
+            db_path = Path(workspace_root) / ".pollypm" / "state.db"
+    except Exception:  # noqa: BLE001
+        pass
+    if create_parent:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+    return db_path
+
+
+def _has_work_tasks(
+    project_path: Path,
+    *,
+    project_key: str | None = None,
+    config_path: Path | None = None,
+) -> bool:
     """Return True iff the project's work-service DB has ≥1 work_tasks row.
 
     Reads the sqlite table directly — ``SQLiteWorkService`` is a heavier
@@ -198,7 +228,7 @@ def _has_work_tasks(project_path: Path) -> bool:
     any DB / IO error returns False so we don't accidentally flag a
     greenfield project as existing on a transient error.
     """
-    db_path = project_path / ".pollypm" / "state.db"
+    db_path = _planner_db_path(project_path, config_path=config_path)
     if not db_path.exists():
         return False
     try:
@@ -211,7 +241,13 @@ def _has_work_tasks(project_path: Path) -> bool:
             )
             if cur.fetchone() is None:
                 return False
-            cur = conn.execute("SELECT 1 FROM work_tasks LIMIT 1")
+            if project_key:
+                cur = conn.execute(
+                    "SELECT 1 FROM work_tasks WHERE project = ? LIMIT 1",
+                    (project_key,),
+                )
+            else:
+                cur = conn.execute("SELECT 1 FROM work_tasks LIMIT 1")
             return cur.fetchone() is not None
     except Exception:  # noqa: BLE001
         return False
@@ -219,6 +255,8 @@ def _has_work_tasks(project_path: Path) -> bool:
 
 def _classify_project_state(
     project_path: Path,
+    project_key: str | None = None,
+    config_path: Path | None = None,
 ) -> Literal["greenfield", "existing"]:
     """Classify a project directory for the ``pm project new`` routing.
 
@@ -241,7 +279,11 @@ def _classify_project_state(
         return "existing"
     if _has_source_files(project_path):
         return "existing"
-    if _has_work_tasks(project_path):
+    if _has_work_tasks(
+        project_path,
+        project_key=project_key,
+        config_path=config_path,
+    ):
         return "existing"
     return "greenfield"
 
@@ -250,6 +292,7 @@ def _plan_project_task(
     project_key: str,
     project_path: Path,
     *,
+    config_path: Path | None = None,
     title_prefix: str = "Plan",
     description: str = "",
     actor: str = "architect",
@@ -262,8 +305,11 @@ def _plan_project_task(
     # a full SQLite environment yet.
     from pollypm.work.sqlite_service import SQLiteWorkService
 
-    db_path = project_path / ".pollypm" / "state.db"
-    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db_path = _planner_db_path(
+        project_path,
+        config_path=config_path,
+        create_parent=True,
+    )
 
     with SQLiteWorkService(db_path=db_path, project_path=project_path) as svc:
         task = svc.create(
@@ -310,7 +356,12 @@ def plan_cmd(
     """
     path = _require_config(config_path)
     key, project_path = _resolve_project_key(path, project)
-    task = _plan_project_task(key, project_path, title_prefix="Plan project")
+    task = _plan_project_task(
+        key,
+        project_path,
+        config_path=path,
+        title_prefix="Plan project",
+    )
 
     if as_json:
         typer.echo(json.dumps({
@@ -361,7 +412,10 @@ def replan_cmd(
     path = _require_config(config_path)
     key, project_path = _resolve_project_key(path, project)
     task = _plan_project_task(
-        key, project_path, title_prefix="Replan project",
+        key,
+        project_path,
+        config_path=path,
+        title_prefix="Replan project",
         description=(
             f"Re-run the architecture planner on {key}. Stage-0 research "
             "should read the existing plan and produce a drift analysis "
@@ -491,7 +545,11 @@ def new_cmd(
         mode = "greenfield"
         typer.echo("Fresh project — running cold-start planner.")
     else:
-        mode = _classify_project_state(project.path)
+        mode = _classify_project_state(
+            project.path,
+            project.key,
+            path,
+        )
         if mode == "existing":
             typer.echo(
                 "Detected existing project — running drift-aware replan."
@@ -542,7 +600,11 @@ def new_cmd(
             # task on the project's work service. If it did, the
             # interactive prompt below becomes redundant — auto-fire
             # already satisfied the user's "plan this project" intent.
-            auto_fired = _plan_task_exists(project.path, project.key)
+            auto_fired = _plan_task_exists(
+                project.path,
+                project.key,
+                config_path=path,
+            )
         except Exception as exc:  # noqa: BLE001
             # Auto-fire is best-effort, but a silent swallow meant users
             # couldn't tell when the planner failed to boot. Emit a
@@ -591,6 +653,7 @@ def new_cmd(
     if mode == "existing":
         task = _plan_project_task(
             project.key, project.path,
+            config_path=path,
             title_prefix="Replan project",
             description=(
                 f"Re-run the architecture planner on {project.key}. Stage-0 "
@@ -600,7 +663,10 @@ def new_cmd(
         )
     else:
         task = _plan_project_task(
-            project.key, project.path, title_prefix="Plan project",
+            project.key,
+            project.path,
+            config_path=path,
+            title_prefix="Plan project",
         )
     typer.echo(
         f"Created planning task {task.task_id} on project "
@@ -689,7 +755,12 @@ def _auto_spawn_architect(config_path: Path, project_key: str) -> None:
         )
 
 
-def _plan_task_exists(project_path: Path, project_key: str) -> bool:
+def _plan_task_exists(
+    project_path: Path,
+    project_key: str,
+    *,
+    config_path: Path | None = None,
+) -> bool:
     """Return True if a ``plan_project`` task already exists on the
     project's work service.
 
@@ -698,7 +769,7 @@ def _plan_task_exists(project_path: Path, project_key: str) -> bool:
     interactive prompt becomes redundant. Safe to call on a project
     that never opened its work DB (returns False without creating one).
     """
-    db_path = project_path / ".pollypm" / "state.db"
+    db_path = _planner_db_path(project_path, config_path=config_path)
     if not db_path.exists():
         return False
     try:

--- a/src/pollypm/plugins_builtin/project_planning/plugin.py
+++ b/src/pollypm/plugins_builtin/project_planning/plugin.py
@@ -122,6 +122,7 @@ def _on_project_created(context) -> None:
         # config (fresh install, or a test ExtensionHost with no
         # pollypm.toml) means default ``auto_on_project_created=True``.
         auto_fire = True
+        workspace_db_path = None
         try:
             from pathlib import Path as _Path2
             from pollypm.config import DEFAULT_CONFIG_PATH, load_config, resolve_config_path
@@ -135,6 +136,9 @@ def _on_project_created(context) -> None:
             if cfg_path.exists():
                 cfg = load_config(cfg_path)
                 auto_fire = bool(cfg.planner.auto_on_project_created)
+                workspace_root = getattr(cfg.project, "workspace_root", None)
+                if workspace_root is not None:
+                    workspace_db_path = _Path2(workspace_root) / ".pollypm" / "state.db"
         except Exception as exc:  # noqa: BLE001
             log.debug(
                 "project_planning: config read failed, defaulting auto_fire=True (%s)",
@@ -168,7 +172,7 @@ def _on_project_created(context) -> None:
         from pollypm.work.sqlite_service import SQLiteWorkService
 
         project_path = _Path(project_path_raw)
-        db_path = project_path / ".pollypm" / "state.db"
+        db_path = workspace_db_path or (project_path / ".pollypm" / "state.db")
         db_path.parent.mkdir(parents=True, exist_ok=True)
         if is_replan:
             title = f"Replan project {project_key}"

--- a/tests/test_project_new_replan_routing.py
+++ b/tests/test_project_new_replan_routing.py
@@ -73,6 +73,7 @@ def _write_minimal_config(
     config = PollyPMConfig(
         project=ProjectSettings(
             root_dir=tmp_path,
+            workspace_root=tmp_path,
             base_dir=tmp_path / ".pollypm",
             logs_dir=tmp_path / ".pollypm/logs",
             snapshots_dir=tmp_path / ".pollypm/snapshots",
@@ -97,13 +98,13 @@ def _write_minimal_config(
     return config_path
 
 
-def _only_plan_task(repo: Path, project_key: str):
-    """Return the single plan_project task on ``repo``, failing clearly."""
+def _only_plan_task(workspace_root: Path, project_key: str):
+    """Return the single plan_project task in the workspace DB."""
     from pollypm.work.sqlite_service import SQLiteWorkService
 
-    db_path = repo / ".pollypm" / "state.db"
+    db_path = workspace_root / ".pollypm" / "state.db"
     assert db_path.exists(), "auto-fire should have opened the work DB"
-    with SQLiteWorkService(db_path=db_path, project_path=repo) as svc:
+    with SQLiteWorkService(db_path=db_path, project_path=workspace_root) as svc:
         tasks = [
             t for t in svc.list_tasks(project=project_key)
             if t.flow_template_id == "plan_project"
@@ -146,7 +147,7 @@ class TestProjectNewReplanRouting:
         assert "cold-start planner" in result.stdout
         # Auto-fired task is a plan (not replan).
         assert "Auto-created plan_project task" in result.stdout
-        task = _only_plan_task(repo, "fresh")
+        task = _only_plan_task(tmp_path, "fresh")
         assert task.title.startswith("Plan project")
         assert "Re-run" not in (task.description or "")
 
@@ -176,7 +177,7 @@ class TestProjectNewReplanRouting:
         assert "Detected existing project" in result.stdout
         assert "drift-aware replan" in result.stdout
         assert "Auto-created replan task" in result.stdout
-        task = _only_plan_task(repo, "existing")
+        task = _only_plan_task(tmp_path, "existing")
         assert task.title.startswith("Replan project")
         assert "drift" in (task.description or "").lower()
 
@@ -208,7 +209,7 @@ class TestProjectNewReplanRouting:
         )
         assert result.exit_code == 0, result.stdout + result.stderr
         assert "Detected existing project" in result.stdout
-        task = _only_plan_task(repo, "planned")
+        task = _only_plan_task(tmp_path, "planned")
         assert task.title.startswith("Replan project")
 
     def test_existing_py_files_classifies_existing_replan(
@@ -236,8 +237,66 @@ class TestProjectNewReplanRouting:
         )
         assert result.exit_code == 0, result.stdout + result.stderr
         assert "Detected existing project" in result.stdout
-        task = _only_plan_task(repo, "pycode")
+        task = _only_plan_task(tmp_path, "pycode")
         assert task.title.startswith("Replan project")
+
+    def test_existing_workspace_tasks_classify_existing_replan(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """Existing rows in the workspace DB should classify as replan."""
+        from pollypm.work.sqlite_service import SQLiteWorkService
+
+        repo = tmp_path / "existing_tasks"
+        repo.mkdir()
+        _git_init(repo, commits=0)
+        config_path = _write_minimal_config(tmp_path)
+        (tmp_path / ".pollypm").mkdir(parents=True, exist_ok=True)
+
+        with SQLiteWorkService(
+            db_path=tmp_path / ".pollypm" / "state.db",
+            project_path=tmp_path,
+        ) as svc:
+            svc.create(
+                title="Plan project existing_tasks",
+                description="seed existing task",
+                type="task",
+                project="existing_tasks",
+                flow_template="plan_project",
+                roles={"architect": "architect"},
+                priority="high",
+            )
+
+        assert project_cli._classify_project_state(
+            repo,
+            "existing_tasks",
+            config_path,
+        ) == "existing"
+
+        monkeypatch.setattr(
+            project_cli, "_prompt_run_planner",
+            lambda default_yes=True: (_ for _ in ()).throw(
+                AssertionError("prompt should not fire"),
+            ),
+        )
+
+        result = runner.invoke(
+            project_app,
+            ["new", str(repo), "--config", str(config_path)],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert "Detected existing project" in result.stdout
+        from pollypm.work.sqlite_service import SQLiteWorkService
+
+        with SQLiteWorkService(
+            db_path=tmp_path / ".pollypm" / "state.db",
+            project_path=tmp_path,
+        ) as svc:
+            tasks = [
+                t for t in svc.list_tasks(project="existing_tasks")
+                if t.flow_template_id == "plan_project"
+            ]
+        assert len(tasks) == 2
+        assert tasks[-1].title.startswith("Replan project")
 
     def test_skip_planner_suppresses_both_paths(
         self, tmp_path: Path, monkeypatch,
@@ -269,7 +328,7 @@ class TestProjectNewReplanRouting:
         assert "Detected existing project" not in result.stdout
         assert "Fresh project" not in result.stdout
         # No plan task (no DB at all).
-        assert not (repo / ".pollypm" / "state.db").exists()
+        assert not (tmp_path / ".pollypm" / "state.db").exists()
 
     def test_force_cold_start_overrides_existing_classification(
         self, tmp_path: Path, monkeypatch,
@@ -301,6 +360,6 @@ class TestProjectNewReplanRouting:
         assert "Fresh project" in result.stdout
         assert "Detected existing project" not in result.stdout
         assert "Auto-created plan_project task" in result.stdout
-        task = _only_plan_task(repo, "override")
+        task = _only_plan_task(tmp_path, "override")
         assert task.title.startswith("Plan project")
         assert "drift" not in (task.description or "").lower()

--- a/tests/test_project_planning_cli.py
+++ b/tests/test_project_planning_cli.py
@@ -47,6 +47,7 @@ def _write_minimal_config(
     config = PollyPMConfig(
         project=ProjectSettings(
             root_dir=tmp_path,
+            workspace_root=tmp_path,
             base_dir=tmp_path / ".pollypm",
             logs_dir=tmp_path / ".pollypm/logs",
             snapshots_dir=tmp_path / ".pollypm/snapshots",
@@ -90,8 +91,9 @@ class TestPlan:
         assert payload["project"] == "demo"
         assert payload["flow"] == "plan_project"
         assert payload["task_id"].startswith("demo/")
-        # Work-service DB created at the expected location.
-        assert (repo / ".pollypm" / "state.db").exists()
+        # Work-service DB is workspace-scoped, not project-local.
+        assert (tmp_path / ".pollypm" / "state.db").exists()
+        assert not (repo / ".pollypm" / "state.db").exists()
 
     def test_plan_text_output(self, tmp_path: Path) -> None:
         repo = _make_project_repo(tmp_path)
@@ -163,8 +165,8 @@ class TestReplan:
         # Title prefix differs from plan — assert via the created task.
         from pollypm.work.sqlite_service import SQLiteWorkService
         with SQLiteWorkService(
-            db_path=repo / ".pollypm" / "state.db",
-            project_path=repo,
+            db_path=tmp_path / ".pollypm" / "state.db",
+            project_path=tmp_path,
         ) as svc:
             task = svc.get(payload["task_id"])
             assert "Replan" in task.title
@@ -211,8 +213,9 @@ class TestNew:
         # Auto-fire branch produces this message; the explicit-prompt
         # branch produces "Created planning task …".
         assert "Auto-created plan_project task" in result.stdout
-        # DB was created by the observer.
-        assert (repo / ".pollypm" / "state.db").exists()
+        # DB was created at workspace scope by the observer.
+        assert (tmp_path / ".pollypm" / "state.db").exists()
+        assert not (repo / ".pollypm" / "state.db").exists()
 
     def test_new_declines_does_not_create_task(
         self, tmp_path: Path, monkeypatch
@@ -238,7 +241,7 @@ class TestNew:
         assert "Created planning task" not in result.stdout
         assert "Auto-created plan_project task" not in result.stdout
         # No work-service DB means no task was created.
-        assert not (repo / ".pollypm" / "state.db").exists()
+        assert not (tmp_path / ".pollypm" / "state.db").exists()
 
     def test_new_skip_planner_flag_bypasses_prompt(
         self, tmp_path: Path, monkeypatch
@@ -330,7 +333,8 @@ class TestNew:
         assert result.exit_code == 0, result.stdout + result.stderr
 
         with SQLiteWorkService(
-            db_path=repo / ".pollypm" / "state.db", project_path=repo,
+            db_path=tmp_path / ".pollypm" / "state.db",
+            project_path=tmp_path,
         ) as svc:
             tasks = svc.list_tasks(project="fresh")
         plan_tasks = [t for t in tasks if t.flow_template_id == "plan_project"]
@@ -357,7 +361,7 @@ class TestNew:
         )
         assert result.exit_code == 0, result.stdout + result.stderr
         # No plan_project task was created (no DB at all).
-        assert not (repo / ".pollypm" / "state.db").exists()
+        assert not (tmp_path / ".pollypm" / "state.db").exists()
         assert "Auto-created plan_project task" not in result.stdout
 
     def test_new_config_disable_suppresses_auto_fire(
@@ -377,7 +381,7 @@ class TestNew:
             ["new", str(repo), "--config", str(config_path)],
         )
         assert result.exit_code == 0, result.stdout + result.stderr
-        assert not (repo / ".pollypm" / "state.db").exists()
+        assert not (tmp_path / ".pollypm" / "state.db").exists()
         assert "Auto-created plan_project task" not in result.stdout
 
 
@@ -426,9 +430,9 @@ class TestAddProjectAutoFire:
         result = self._invoke_add_project(repo=repo, config_path=config_path)
         assert result.exit_code == 0, result.stdout + result.stderr
 
-        db_path = repo / ".pollypm" / "state.db"
+        db_path = tmp_path / ".pollypm" / "state.db"
         assert db_path.exists(), "auto-fire should have opened the work DB"
-        with SQLiteWorkService(db_path=db_path, project_path=repo) as svc:
+        with SQLiteWorkService(db_path=db_path, project_path=tmp_path) as svc:
             tasks = svc.list_tasks(project="fresh")
         plan_tasks = [t for t in tasks if t.flow_template_id == "plan_project"]
         assert len(plan_tasks) == 1
@@ -445,7 +449,7 @@ class TestAddProjectAutoFire:
         )
         assert result.exit_code == 0, result.stdout + result.stderr
         # --skip-plan means no observer-driven task, so no DB either.
-        assert not (repo / ".pollypm" / "state.db").exists()
+        assert not (tmp_path / ".pollypm" / "state.db").exists()
 
     def test_add_project_config_disabled_suppresses_auto_fire(
         self, tmp_path: Path
@@ -455,7 +459,7 @@ class TestAddProjectAutoFire:
 
         result = self._invoke_add_project(repo=repo, config_path=config_path)
         assert result.exit_code == 0, result.stdout + result.stderr
-        assert not (repo / ".pollypm" / "state.db").exists()
+        assert not (tmp_path / ".pollypm" / "state.db").exists()
 
     def test_add_project_re_add_does_not_double_fire(
         self, tmp_path: Path
@@ -472,7 +476,8 @@ class TestAddProjectAutoFire:
         result = self._invoke_add_project(repo=repo, config_path=config_path)
         assert result.exit_code == 0, result.stdout + result.stderr
         with SQLiteWorkService(
-            db_path=repo / ".pollypm" / "state.db", project_path=repo,
+            db_path=tmp_path / ".pollypm" / "state.db",
+            project_path=tmp_path,
         ) as svc:
             first_tasks = svc.list_tasks(project="fresh")
         assert len([t for t in first_tasks if t.flow_template_id == "plan_project"]) == 1
@@ -481,7 +486,8 @@ class TestAddProjectAutoFire:
         result = self._invoke_add_project(repo=repo, config_path=config_path)
         assert result.exit_code == 0, result.stdout + result.stderr
         with SQLiteWorkService(
-            db_path=repo / ".pollypm" / "state.db", project_path=repo,
+            db_path=tmp_path / ".pollypm" / "state.db",
+            project_path=tmp_path,
         ) as svc:
             second_tasks = svc.list_tasks(project="fresh")
         plan_tasks = [t for t in second_tasks if t.flow_template_id == "plan_project"]


### PR DESCRIPTION
## Summary
- route `pm project new/plan/replan` planner tasks through the workspace-scope work DB instead of per-project `state.db` files
- make the `project.created` observer use the same workspace DB so auto-fired planning tasks are visible to `pm task ...` immediately
- cover both the direct CLI path and the observer path with regression tests, including classification from existing workspace work-task rows

## Testing
- HOME=/tmp/pytest-377 uv run --extra dev pytest tests/test_project_new_replan_routing.py tests/test_project_planning_cli.py -q

Closes #377