### PR TITLE
fix(work): auto-merge approved task branches

### DIFF
--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -23,6 +23,7 @@ import hashlib
 import json
 import logging
 import sqlite3
+import subprocess
 from datetime import datetime
 from pathlib import Path
 
@@ -1621,6 +1622,9 @@ class SQLiteWorkService:
                     f"Gate check failed on node '{node.name}': {reasons}"
                 )
 
+        if task.current_node_id == "code_review" and node.next_node_id == "done":
+            self._auto_merge_approved_task_branch(task)
+
         now = _now()
 
         try:
@@ -2473,6 +2477,98 @@ class SQLiteWorkService:
             return candidate
 
         return self._project_path
+
+    def _auto_merge_approved_task_branch(self, task: Task) -> None:
+        """Merge an approved task branch into the repo's current branch.
+
+        Runs before the task flips to ``done`` so merge failures leave the task
+        parked at review and preserve the worker worktree for intervention.
+        """
+        project_path = self._resolve_project_path(task.project)
+        if project_path is None or not (project_path / ".git").exists():
+            return
+
+        task_branch = f"task/{task.project}-{task.task_number}"
+        current_branch = self._git_stdout(
+            project_path,
+            "rev-parse",
+            "--abbrev-ref",
+            "HEAD",
+            error_prefix="Cannot determine the canonical branch for auto-merge.",
+        )
+        if current_branch == task_branch:
+            return
+
+        status = self._git_run(project_path, "status", "--porcelain")
+        if status.returncode != 0:
+            detail = status.stderr.strip() or status.stdout.strip() or "git status failed"
+            raise ValidationError(
+                "Cannot auto-merge approved work right now. "
+                f"Git status failed in {project_path}: {detail}"
+            )
+        if status.stdout.strip():
+            raise ValidationError(
+                "Cannot auto-merge approved work because the project root has "
+                "uncommitted changes. Commit or stash them, then retry approve."
+            )
+
+        branch_exists = self._git_run(project_path, "rev-parse", "--verify", task_branch)
+        if branch_exists.returncode != 0:
+            raise ValidationError(
+                f"Cannot auto-merge approved work because branch `{task_branch}` "
+                "does not exist."
+            )
+
+        already_merged = self._git_run(
+            project_path,
+            "merge-base",
+            "--is-ancestor",
+            task_branch,
+            "HEAD",
+        )
+        if already_merged.returncode == 0:
+            return
+
+        ff_only = self._git_run(project_path, "merge", "--ff-only", task_branch)
+        if ff_only.returncode == 0:
+            return
+
+        merge = self._git_run(project_path, "merge", "--no-ff", "--no-edit", task_branch)
+        if merge.returncode == 0:
+            return
+
+        # Best-effort cleanup so retrying approve starts from a clean repo.
+        self._git_run(project_path, "merge", "--abort")
+        detail = (
+            merge.stderr.strip()
+            or merge.stdout.strip()
+            or ff_only.stderr.strip()
+            or "git merge failed"
+        )
+        raise ValidationError(
+            f"Could not auto-merge `{task_branch}` into `{current_branch}`. "
+            f"Resolve the repo state and retry approve. Git said: {detail}"
+        )
+
+    def _git_run(self, project_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", "-C", str(project_path), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def _git_stdout(
+        self,
+        project_path: Path,
+        *args: str,
+        error_prefix: str,
+    ) -> str:
+        result = self._git_run(project_path, *args)
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or "git command failed"
+            raise ValidationError(f"{error_prefix} {detail}")
+        return result.stdout.strip()
 
     def available_flows(self, project: str | None = None) -> list[FlowTemplate]:
         """List all available flows after override resolution.

--- a/tests/test_flow_progression.py
+++ b/tests/test_flow_progression.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import subprocess
+
 import pytest
+from unittest.mock import MagicMock
 
 from pollypm.rejection_feedback import (
     feedback_target_task_id,
@@ -84,6 +87,47 @@ def _claim_task(svc, task):
     """Queue and claim a task, returning the claimed task."""
     svc.queue(task.task_id, "pm")
     return svc.claim(task.task_id, "pete")
+
+
+def _git_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=repo, check=True)
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    return repo
+
+
+def _git_stdout(repo, *args):
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _create_review_task_on_git_repo(tmp_path):
+    repo = _git_repo(tmp_path)
+    svc = SQLiteWorkService(db_path=tmp_path / "work.db", project_path=repo)
+    task = _create_task(svc)
+    _claim_task(svc, task)
+
+    current_branch = _git_stdout(repo, "rev-parse", "--abbrev-ref", "HEAD")
+    task_branch = f"task/{task.project}-{task.task_number}"
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "-b", task_branch], check=True)
+    (repo / "feature.txt").write_text("done\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "feature.txt"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "feat: worker change"], check=True)
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", current_branch], check=True)
+
+    svc.node_done(task.task_id, "pete", _valid_work_output())
+    return repo, svc, task, task_branch
 
 
 # ---------------------------------------------------------------------------
@@ -192,6 +236,33 @@ class TestApprove:
         assert len(review_execs) == 1
         assert review_execs[0].decision == Decision.APPROVED
         assert review_execs[0].decision_reason == "LGTM"
+
+    def test_approve_auto_merges_task_branch_into_repo(self, tmp_path):
+        repo, svc, task, task_branch = _create_review_task_on_git_repo(tmp_path)
+
+        result = svc.approve(task.task_id, "polly")
+
+        assert result.work_status == WorkStatus.DONE
+        assert (repo / "feature.txt").read_text(encoding="utf-8") == "done\n"
+        merged = subprocess.run(
+            ["git", "-C", str(repo), "merge-base", "--is-ancestor", task_branch, "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert merged.returncode == 0
+
+    def test_approve_refuses_auto_merge_when_repo_dirty(self, tmp_path):
+        repo, svc, task, _task_branch = _create_review_task_on_git_repo(tmp_path)
+        (repo / "README.md").write_text("dirty\n", encoding="utf-8")
+        session_mgr = MagicMock()
+        svc.set_session_manager(session_mgr)
+
+        with pytest.raises(ValidationError, match="uncommitted changes"):
+            svc.approve(task.task_id, "polly")
+
+        assert svc.get(task.task_id).work_status == WorkStatus.REVIEW
+        session_mgr.teardown_worker.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #386

## Summary
- merge the approved task branch into the canonical repo branch before worker teardown
- refuse the approval transition when the repo is dirty, the task branch is missing, or the merge conflicts
- preserve the worker/worktree on merge failure so the operator can recover cleanly

## Testing
- HOME=/tmp/pytest-386 uv run --extra dev pytest tests/test_flow_progression.py tests/test_session_manager.py -q