### PR TITLE
feat(cockpit): show blocked dependencies inline

### DIFF
--- a/src/pollypm/cockpit_sections/in_flight.py
+++ b/src/pollypm/cockpit_sections/in_flight.py
@@ -21,26 +21,74 @@ def _in_flight_sort_key(task) -> tuple[int, float, int]:
     )
 
 
-def _section_in_flight(in_progress: list) -> list[str]:
-    """Tasks currently being worked on."""
+def _task_dependency_numbers(task) -> list[int]:
+    deps = getattr(task, "blocked_by", None) or []
+    numbers: list[int] = []
+    for dep in deps:
+        if not isinstance(dep, tuple) or len(dep) != 2:
+            continue
+        try:
+            numbers.append(int(dep[1]))
+        except (TypeError, ValueError):
+            continue
+    return numbers
+
+
+def _render_in_flight_row(task, *, prefix: str = "") -> str:
+    icon = _STATUS_ICONS.get(task.work_status.value, "\u27f3")
+    assignee = f" [{task.assignee}]" if getattr(task, "assignee", None) else ""
+    node = (
+        f" @ {task.current_node_id}"
+        if getattr(task, "current_node_id", None)
+        else ""
+    )
+    age = _age_from_dt(_iso_to_dt(getattr(task, "updated_at", None)))
+    age_part = f" \u00b7 {age}" if age else ""
+    return (
+        f"{_DASHBOARD_BULLET}{prefix}{icon} {priority_glyph(task)} "
+        f"#{task.task_number} {task.title}{assignee}{node}{age_part}"
+    )
+
+
+def _section_in_flight(in_progress: list, blocked: list | None = None) -> list[str]:
+    """Tasks currently being worked on, with blocked dependents inline."""
     lines = [_dashboard_divider("In flight"), ""]
-    if not in_progress:
+    blocked = blocked or []
+    if not in_progress and not blocked:
         lines.extend([f"{_DASHBOARD_BULLET}(none)", ""])
         return lines
     ordered = sorted(in_progress, key=_in_flight_sort_key)
-    for t in ordered:
-        icon = _STATUS_ICONS.get(t.work_status.value, "\u27f3")
-        assignee = f" [{t.assignee}]" if getattr(t, "assignee", None) else ""
-        node = (
-            f" @ {t.current_node_id}"
-            if getattr(t, "current_node_id", None)
-            else ""
+    rendered_blocked: set[int] = set()
+    for task in ordered:
+        lines.append(_render_in_flight_row(task))
+        blocker_number = getattr(task, "task_number", None)
+        children = sorted(
+            [
+                blocked_task for blocked_task in blocked
+                if blocker_number is not None
+                and blocker_number in _task_dependency_numbers(blocked_task)
+            ],
+            key=_in_flight_sort_key,
         )
-        age = _age_from_dt(_iso_to_dt(getattr(t, "updated_at", None)))
-        age_part = f" \u00b7 {age}" if age else ""
-        lines.append(
-            f"{_DASHBOARD_BULLET}{icon} {priority_glyph(t)} #{t.task_number} {t.title}"
-            f"{assignee}{node}{age_part}"
+        for child in children:
+            rendered_blocked.add(id(child))
+            wait_numbers = ", ".join(
+                f"#{number}" for number in _task_dependency_numbers(child)
+            )
+            wait_suffix = (
+                f" \u00b7 waiting on {wait_numbers}" if wait_numbers else ""
+            )
+            lines.append(
+                _render_in_flight_row(child, prefix="  \u2514\u2500 ")
+                + wait_suffix
+            )
+    for task in sorted(blocked, key=_in_flight_sort_key):
+        if id(task) in rendered_blocked:
+            continue
+        wait_numbers = ", ".join(
+            f"#{number}" for number in _task_dependency_numbers(task)
         )
+        wait_suffix = f" \u00b7 waiting on {wait_numbers}" if wait_numbers else ""
+        lines.append(_render_in_flight_row(task) + wait_suffix)
     lines.append("")
     return lines

--- a/src/pollypm/cockpit_sections/project_dashboard.py
+++ b/src/pollypm/cockpit_sections/project_dashboard.py
@@ -124,6 +124,7 @@ def _render_project_dashboard(
     in_progress = [
         t for t in tasks if t.work_status.value == "in_progress"
     ]
+    blocked = [t for t in tasks if t.work_status.value == "blocked"]
     review = [t for t in tasks if t.work_status.value == "review"]
     completed = [t for t in tasks if t.work_status.value == "done"]
     completed.sort(
@@ -185,7 +186,7 @@ def _render_project_dashboard(
         out.append("")
 
     out.extend(_section_you_need_to(review, project_alerts, 0))
-    out.extend(_section_in_flight(in_progress))
+    out.extend(_section_in_flight(in_progress, blocked))
     out.extend(_section_recent(completed))
     out.extend(_section_activity(tasks, system_events))
     out.extend(_section_insights(project.path, project_key))

--- a/tests/test_cockpit_project_dashboard.py
+++ b/tests/test_cockpit_project_dashboard.py
@@ -91,6 +91,7 @@ class _FakeTask:
         executions: list | None = None,
         assignee: str | None = None,
         current_node_id: str | None = None,
+        blocked_by: list[tuple[str, int]] | None = None,
     ) -> None:
         self.task_number = task_number
         self.title = title
@@ -101,6 +102,7 @@ class _FakeTask:
         self.executions = executions or []
         self.assignee = assignee
         self.current_node_id = current_node_id
+        self.blocked_by = blocked_by or []
 
 
 class _FakeEvent:
@@ -273,6 +275,48 @@ class TestSectionInFlight:
         task_lines = [line for line in lines if "#7" in line or "#2" in line]
         assert task_lines[0].startswith("  ⟳ 🔴 #7 Patch auth outage")
         assert task_lines[1].startswith("  ⟳ 🟢 #2 Add favicon")
+
+    def test_blocked_tasks_render_nested_under_their_blocker(self):
+        blocker = _FakeTask(
+            task_number=2,
+            title="Ship router",
+            status="in_progress",
+            assignee="worker",
+            current_node_id="implement",
+            updated_at=datetime.now(UTC),
+        )
+        blocked = _FakeTask(
+            task_number=3,
+            title="Wire alerts",
+            status="blocked",
+            assignee="worker",
+            current_node_id="implement",
+            updated_at=datetime.now(UTC),
+            blocked_by=[("proj", 2)],
+        )
+
+        lines = _section_in_flight([blocker], [blocked])
+        joined = "\n".join(lines)
+
+        assert "#2 Ship router" in joined
+        assert "└─ ⊘" in joined
+        assert "#3 Wire alerts" in joined
+        assert "waiting on #2" in joined
+
+    def test_orphan_blocked_tasks_render_with_wait_reason(self):
+        blocked = _FakeTask(
+            task_number=8,
+            title="Retry sync",
+            status="blocked",
+            updated_at=datetime.now(UTC),
+            blocked_by=[("proj", 1), ("proj", 4)],
+        )
+
+        lines = _section_in_flight([], [blocked])
+        joined = "\n".join(lines)
+
+        assert "#8 Retry sync" in joined
+        assert "waiting on #1, #4" in joined
 
 
 class TestSectionRecent:


### PR DESCRIPTION
Closes #499

## Summary
- extend the per-project dashboard in-flight section to show blocked tasks under the active task they depend on
- keep unmatched blocked tasks visible with explicit `waiting on #...` hints
- cover nested-blocker rendering in the project-dashboard test suite

## Testing
- HOME=/tmp/pytest-499 uv run --extra dev pytest tests/test_cockpit_project_dashboard.py -q