### PR TITLE
test(docs): audit live pm references

### DIFF
--- a/docs/advisor-plugin-spec.md
+++ b/docs/advisor-plugin-spec.md
@@ -152,7 +152,7 @@ Each emit creates an inbox entry with `kind=advisor_insight`. User actions:
 
 - `pm task approve <id>` — "acknowledged, factored in." Closes.
 - `pm task reject <id> --reason topic_cooldown` — "not this, not now." Records a soft signal in `.pollypm-state/advisor-state.json` that the advisor's next prompt-pack will mention ("user rejected topic X 30 minutes ago — weight accordingly"). **Not a system-enforced cooldown** — the persona is expected to respect it intelligently.
-- `pm task convert <id> --to-task` — convert insight to a full work-service task with default `flow=implement_module` or similar.
+- Convert the insight into a normal work-service task from the inbox/cockpit flow, or create one manually with `pm task create ...` using the insight as the task brief.
 - Silent no-action → auto-closes after 7 days.
 
 ## 8. Observability — `pm advisor history`

--- a/docs/downtime-plugin-spec.md
+++ b/docs/downtime-plugin-spec.md
@@ -111,7 +111,7 @@ When a downtime task reaches `awaiting_approval`, the handler:
 3. User sees in `pm inbox` / cockpit inbox panel. Actions:
    - `pm task approve <id>` → advance to `apply` node, which commits/merges per §6.
    - `pm task reject <id>` → advance to `apply` node, which archives per §6.
-   - `pm task comment <id> "..."` + approve → like approve, with user's note logged.
+   - `pm inbox reply <id> "..."` + approve → like approve, with the user's note logged.
 
 ## 8. Planner integration
 

--- a/docs/morning-briefing-plugin-spec.md
+++ b/docs/morning-briefing-plugin-spec.md
@@ -87,7 +87,7 @@ Herald tone: morning-coffee-briefing, not status-meeting. Direct, organized, no 
 
 Single inbox entry per day, kind=`morning_briefing`. Body is the herald's synthesized text. User actions:
 - Read it → auto-close after 24h (next briefing supersedes).
-- `pm task comment <id>` to note follow-ups against it.
+- `pm inbox reply <id> "..."` to note follow-ups against it.
 
 The briefing is a read-only informational message; no approve/reject semantics.
 

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -256,7 +256,7 @@ A restart of `pm` is required for newly installed plugins to take effect — no 
 
 ```
 $ pm plugins disable hello-world
-Disabled 'hello-world'. Restart pm for the change to take effect.
+Disabled 'hello-world'. Restart PollyPM for the change to take effect.
 ```
 
 This writes `[plugins].disabled = ["hello-world"]` in `~/.pollypm/pollypm.toml`. `pm plugins list` still shows the plugin with a `disabled` marker and reason.

--- a/docs/work-service-spec.md
+++ b/docs/work-service-spec.md
@@ -748,7 +748,7 @@ A GitHub API outage shouldn't block the work service. Mitigations:
 - Sync adapters are async, best-effort, eventually consistent
 - Failed syncs are queued for retry with backoff
 - The work service state is always authoritative — sync failure means the projection is stale, not that work is blocked
-- Sync status is queryable: `pm task sync-status <id>` shows per-adapter state
+- Operators can force a resync with `pm task sync`; per-task sync-state inspection is stored in `work_sync_state` and does not yet have its own dedicated CLI surface
 
 ### P-4: Gate Brittleness
 

--- a/docs/worker-guide.md
+++ b/docs/worker-guide.md
@@ -174,7 +174,7 @@ commit, and re-run `pm task done` with an updated payload.
 
 ### 1. "No such command 'show'"
 
-`pm task show` does not exist. Use:
+The old `task show` spelling does not exist. Use:
 
 ```bash
 pm task get shortlink_gen/1
@@ -184,7 +184,7 @@ pm task get shortlink_gen/1
 
 The hard gate `has_work_output` requires at least one artifact. Re-run
 `pm task done` with an artifact list — the examples above are copy-paste
-ready. You do **not** need a separate `pm task output` command; the artifacts
+ready. You do **not** need a separate output-registration command; the artifacts
 travel in `--output`.
 
 ### 3. "provision_worker failed … tmux new-session exit 1"
@@ -194,9 +194,9 @@ usually benign when the PM already claimed the task from an existing worker
 session — that session picks up the work. If you ran `pm task claim` from a
 fresh shell and see this, either:
 
-- Work inside the existing session (check `pm session list`), or
-- Run `pm task release <id>` and re-claim from inside an active worker
-  session.
+- Work inside the existing session (check the cockpit rail or `pm status`), or
+- If the claimant session is gone, ask Polly to recover the stale claim before
+  retrying from a fresh worker shell.
 
 ### 4. "Task already claimed by <other>"
 
@@ -204,13 +204,13 @@ Another worker (or a stale claim) owns the task. Check:
 
 ```bash
 pm task get shortlink_gen/1          # look for "assignee"
-pm session list                      # find the claimant's session
+pm status                            # confirm core session health
 ```
 
-If the claim is stale (session dead, worker gone), release and re-claim:
+If the claim is stale (session dead, worker gone), confirm the worker is
+actually gone and then re-claim once Polly has cleared the stale assignment:
 
 ```bash
-pm task release shortlink_gen/1
 pm task claim shortlink_gen/1
 ```
 
@@ -305,7 +305,7 @@ pm task done <id> --output '{            # hand to review
 }'
 
 pm task context <id> --text "..."        # leave a breadcrumb
-pm task release <id>                     # drop a claim
+pm status                                # check cockpit/core health
 pm task list --status <status>           # browse
 pm help worker                           # re-read this guide
 ```

--- a/tests/test_docs_command_references.py
+++ b/tests/test_docs_command_references.py
@@ -1,0 +1,135 @@
+"""Audit live ``pm ...`` references in maintained docs against the real CLI.
+
+This keeps the front-door docs from drifting onto renamed or removed
+commands. Historical/generated docs are excluded on purpose: they contain
+snapshots, archival transcripts, and background material rather than live
+operator guidance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+import click
+from typer.main import get_command
+
+from pollypm.cli import app
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DOCS_ROOT = PROJECT_ROOT / "docs"
+ROOT_COMMAND = get_command(app)
+COMMAND_REF_RE = re.compile(r"\bpm(?:\s+[a-z][a-z0-9-]*)+")
+INLINE_CODE_RE = re.compile(r"`([^`\n]*\bpm\b[^`\n]*)`")
+FENCED_BLOCK_RE = re.compile(r"```(?:bash|shell|sh)?\n(.*?)```", re.S)
+
+# These files are archival, generated, or snapshot-heavy rather than active
+# operator docs, so they are intentionally excluded from the live CLI drift
+# gate.
+EXCLUDED_TOP_LEVEL_DOCS = {
+    "activity-log.md",
+    "decisions.md",
+    "deprecated-facts.md",
+    "history.md",
+    "ideas.md",
+    "project-overview.md",
+    "status-report.md",
+    "system-state-2026-04-11.md",
+}
+
+
+@dataclass(frozen=True)
+class CommandReference:
+    path: Path
+    line_number: int
+    reference: str
+
+
+def _audited_paths() -> list[Path]:
+    docs = [
+        path
+        for path in sorted(DOCS_ROOT.glob("*.md"))
+        if path.name not in EXCLUDED_TOP_LEVEL_DOCS
+    ]
+    return [
+        PROJECT_ROOT / "README.md",
+        PROJECT_ROOT / "issues" / "instructions.md",
+        *docs,
+    ]
+
+
+def _iter_command_references(path: Path) -> list[CommandReference]:
+    text = path.read_text(encoding="utf-8")
+    refs: list[CommandReference] = []
+
+    for match in INLINE_CODE_RE.finditer(text):
+        refs.extend(
+            _refs_from_snippet(
+                path=path,
+                line_number=text.count("\n", 0, match.start()) + 1,
+                snippet=match.group(1),
+            )
+        )
+
+    for match in FENCED_BLOCK_RE.finditer(text):
+        block_start = text.count("\n", 0, match.start()) + 1
+        for offset, line in enumerate(match.group(1).splitlines()):
+            refs.extend(
+                _refs_from_snippet(
+                    path=path,
+                    line_number=block_start + offset + 1,
+                    snippet=line,
+                )
+            )
+
+    return refs
+
+
+def _refs_from_snippet(*, path: Path, line_number: int, snippet: str) -> list[CommandReference]:
+    return [
+        CommandReference(path=path, line_number=line_number, reference=match.group(0))
+        for match in COMMAND_REF_RE.finditer(snippet)
+    ]
+
+
+def _resolve_reference(reference: str) -> bool:
+    tokens = reference.split()[1:]
+    if not tokens:
+        return False
+
+    node: click.Command = ROOT_COMMAND
+    consumed_any = False
+
+    for token in tokens:
+        child = _lookup_child(node, token)
+        if child is not None:
+            node = child
+            consumed_any = True
+            continue
+
+        # If we are already at a concrete command, the remaining words are
+        # positional args like account names, session targets, or roles.
+        return consumed_any and not isinstance(node, click.Group)
+
+    return consumed_any
+
+
+def _lookup_child(node: click.Command, token: str) -> click.Command | None:
+    if not isinstance(node, click.Group):
+        return None
+    return node.commands.get(token)
+
+
+def test_live_doc_command_references_match_cli():
+    failures: list[str] = []
+
+    for path in _audited_paths():
+        for ref in _iter_command_references(path):
+            if _resolve_reference(ref.reference):
+                continue
+            relpath = ref.path.relative_to(PROJECT_ROOT)
+            failures.append(f"{relpath}:{ref.line_number} -> {ref.reference}")
+
+    assert not failures, "Invalid docs command references:\n" + "\n".join(failures)


### PR DESCRIPTION
## Summary
- add a docs command audit that checks maintained live `pm ...` references against the real Typer CLI tree
- fix stale maintained-doc references surfaced by the audit (`task comment`, `task convert`, `task show`, `task output`, `session list`, `task release`, `task sync-status`)
- tighten plugin-authoring wording so prose does not masquerade as a shell command

## Testing
- `HOME=/tmp/pytest-446 uv run --extra dev pytest tests/test_docs_command_references.py tests/test_cli_help_examples.py -q`

Closes #446
