### PR TITLE
fix(supervisor): resume claude sessions by recorded uuid

### DIFF
--- a/src/pollypm/providers/claude/adapter.py
+++ b/src/pollypm/providers/claude/adapter.py
@@ -28,10 +28,17 @@ from pollypm.provider_sdk import (
 from pollypm.runtime_env import claude_config_dir
 
 from .probe import collect_usage_snapshot as _collect_usage_snapshot
+from .resume import recorded_session_id as _recorded_session_id
+from .resume import resume_argv as _resume_argv
 from .usage_parse import parse_claude_usage_snapshot
 
 if TYPE_CHECKING:
     from pollypm.tmux.client import TmuxClient
+
+
+_RESUMABLE_CONTROL_ROLES = frozenset(
+    {"heartbeat-supervisor", "operator-pm", "reviewer", "triage"}
+)
 
 
 class ClaudeAdapter(ProviderAdapterBase):
@@ -57,14 +64,15 @@ class ClaudeAdapter(ProviderAdapterBase):
             fresh_launch_marker = (
                 account.home / ".pollypm" / "session-markers" / f"{session.name}.fresh"
             )
-        if (
-            session.role in {"heartbeat-supervisor", "operator-pm"}
-            and account.home is not None
-        ):
-            resume_argv = [self.binary, "--continue", *session.args]
+        if session.role in _RESUMABLE_CONTROL_ROLES and account.home is not None:
             resume_marker = (
                 account.home / ".pollypm" / "session-markers" / f"{session.name}.resume"
             )
+            session_id = _recorded_session_id(resume_marker)
+            if session_id:
+                resume_argv = _resume_argv(session_id, list(session.args))
+            else:
+                resume_argv = [self.binary, "--continue", *session.args]
         return LaunchCommand(
             argv=argv,
             env=dict(account.env),
@@ -81,7 +89,7 @@ class ClaudeAdapter(ProviderAdapterBase):
         account: AccountConfig,
     ) -> LaunchCommand | None:
         if (
-            session.role not in {"heartbeat-supervisor", "operator-pm"}
+            session.role not in _RESUMABLE_CONTROL_ROLES
             or account.home is None
         ):
             return None

--- a/src/pollypm/providers/claude/resume.py
+++ b/src/pollypm/providers/claude/resume.py
@@ -48,14 +48,40 @@ def latest_session_id(home: Path, cwd: Path) -> str | None:
     ``.jsonl``) is the session UUID Claude Code accepts via
     ``--resume``.
     """
+    ids = session_ids(home, cwd)
+    if not ids:
+        return None
+    return ids[0]
+
+
+def session_ids(home: Path, cwd: Path) -> list[str]:
+    """Return Claude transcript UUIDs for ``cwd`` newest-first.
+
+    The UUIDs are the ``.stem`` values of transcript ``*.jsonl`` files
+    under Claude's encoded-cwd bucket. Newest ``mtime`` wins so callers
+    can compare a pre-launch snapshot against the post-launch bucket and
+    detect the fresh transcript a new tmux window created.
+    """
     bucket = home / ".claude" / "projects" / _encoded_cwd(cwd)
     if not bucket.is_dir():
-        return None
+        return []
     candidates = [p for p in bucket.iterdir() if p.suffix == ".jsonl"]
-    if not candidates:
-        return None
     candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-    return candidates[0].stem
+    return [candidate.stem for candidate in candidates]
+
+
+def recorded_session_id(marker: Path) -> str | None:
+    """Read a previously-recorded Claude session UUID from ``marker``.
+
+    The marker is PollyPM-owned state under ``.pollypm/session-markers``.
+    When it contains a non-empty line, that line is the exact Claude
+    transcript UUID we should pass to ``claude --resume``.
+    """
+    try:
+        raw = marker.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return raw or None
 
 
 def resume_argv(session_id: str, extra_args: list[str] | None = None) -> list[str]:
@@ -78,5 +104,4 @@ def resume_argv(session_id: str, extra_args: list[str] | None = None) -> list[st
         *extra,
     ]
 
-
-__all__ = ["latest_session_id", "resume_argv"]
+__all__ = ["latest_session_id", "recorded_session_id", "resume_argv", "session_ids"]

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -76,6 +76,8 @@ from pollypm.models import AccountConfig, ProviderKind, SessionConfig, SessionLa
 from pollypm.onboarding import _prime_claude_home
 from pollypm.projects import ensure_project_scaffold
 from pollypm.projects import project_checkpoints_dir, project_transcripts_dir, project_worktrees_dir, release_session_lock
+from pollypm.providers.claude.resume import recorded_session_id as _recorded_claude_session_id
+from pollypm.providers.claude.resume import session_ids as _claude_session_ids
 from pollypm.schedulers import ScheduledJob, get_scheduler_backend
 from pollypm.store.registry import get_store
 from pollypm.transcript_ledger import sync_token_ledger_for_config
@@ -2576,6 +2578,15 @@ class Supervisor:
         window_map = self._window_map()
         if launch.window_name in window_map:
             return launch, None
+        existing_claude_ids: set[str] | None = None
+        if (
+            launch.session.provider is ProviderKind.CLAUDE
+            and launch.account.home is not None
+            and launch.resume_marker is not None
+        ):
+            existing_claude_ids = set(
+                _claude_session_ids(launch.account.home, launch.session.cwd)
+            )
 
         if on_status:
             on_status(f"Creating tmux window for {session_name}...")
@@ -2591,6 +2602,11 @@ class Supervisor:
         self.session_service.tmux.set_pane_history_limit(target, 200)
         self.session_service.tmux.pipe_pane(target, launch.log_path)
         self._record_launch(launch)
+        if existing_claude_ids is not None:
+            self._capture_claude_resume_session_id(
+                launch,
+                previous_ids=existing_claude_ids,
+            )
         return launch, target
 
     def stop_session(self, session_name: str) -> None:
@@ -2787,8 +2803,53 @@ class Supervisor:
         marker = launch.resume_marker
         if marker is None:
             return
+        if (
+            launch.session.provider is ProviderKind.CLAUDE
+            and _recorded_claude_session_id(marker) is not None
+        ):
+            return
         marker.parent.mkdir(parents=True, exist_ok=True)
         marker.write_text(datetime.now(UTC).isoformat().replace("+00:00", "Z") + "\n")
+
+    def _capture_claude_resume_session_id(
+        self,
+        launch: SessionLaunchSpec,
+        *,
+        previous_ids: set[str] | None = None,
+        poll_timeout_s: float = 10.0,
+    ) -> None:
+        """Persist the fresh Claude transcript UUID for ``launch``.
+
+        Claude control sessions on macOS share one auth home, so a bare
+        ``claude --continue`` can jump into a sibling session's transcript.
+        Capturing the UUID created for this tmux window lets later restarts
+        use ``claude --resume <uuid>`` instead.
+        """
+        marker = launch.resume_marker
+        home = launch.account.home
+        if (
+            marker is None
+            or home is None
+            or launch.session.provider is not ProviderKind.CLAUDE
+        ):
+            return
+
+        before = set(previous_ids or set())
+        deadline = time.monotonic() + poll_timeout_s
+        chosen: str | None = None
+        while time.monotonic() < deadline:
+            ids = _claude_session_ids(home, launch.session.cwd)
+            fresh = [sid for sid in ids if sid not in before]
+            if fresh:
+                chosen = fresh[0]
+                break
+            if ids:
+                chosen = ids[0]
+            time.sleep(0.2)
+        if chosen is None:
+            return
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(chosen + "\n", encoding="utf-8")
 
     def _send_initial_input_if_fresh(self, launch: SessionLaunchSpec, target: str) -> None:
         if launch.session.role not in self._INITIAL_INPUT_ROLES:

--- a/tests/test_provider_sdk.py
+++ b/tests/test_provider_sdk.py
@@ -55,6 +55,38 @@ def test_claude_provider_exposes_transcript_sources_and_usage_snapshot(tmp_path:
     assert adapter.build_resume_command(session, account) is not None
 
 
+def test_claude_provider_prefers_recorded_resume_session_id(tmp_path: Path) -> None:
+    adapter = ClaudeAdapter()
+    account = AccountConfig(
+        name="claude_primary",
+        provider=ProviderKind.CLAUDE,
+        home=tmp_path / "home",
+    )
+    session = SessionConfig(
+        name="operator",
+        role="operator-pm",
+        provider=ProviderKind.CLAUDE,
+        account="claude_primary",
+        cwd=tmp_path,
+        project="pollypm",
+        args=["--model", "sonnet"],
+    )
+    marker = account.home / ".pollypm" / "session-markers" / "operator.resume"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("claude-session-123\n", encoding="utf-8")
+
+    launch = adapter.build_launch_command(session, account)
+
+    assert launch.resume_argv == [
+        "claude",
+        "--dangerously-skip-permissions",
+        "--resume",
+        "claude-session-123",
+        "--model",
+        "sonnet",
+    ]
+
+
 def test_codex_provider_exposes_transcript_sources_and_usage_snapshot(tmp_path: Path) -> None:
     adapter = CodexAdapter()
     account = AccountConfig(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -540,6 +540,56 @@ def test_claude_control_sessions_use_original_account_home(tmp_path: Path) -> No
     assert operator_home == source_home
 
 
+def test_create_session_window_records_claude_resume_ids(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    source_home = config.accounts["claude_controller"].home
+    assert source_home is not None
+    (source_home / ".claude").mkdir(parents=True, exist_ok=True)
+    (source_home / ".claude" / "settings.json").write_text("{}\n")
+    (source_home / ".claude.json").write_text('{"hasCompletedOnboarding": true}\n')
+
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+
+    bucket = source_home / ".claude" / "projects" / str(tmp_path.resolve()).replace("/", "-")
+    created_tmux_sessions: set[str] = set()
+
+    def _write_transcript(session_name: str) -> None:
+        bucket.mkdir(parents=True, exist_ok=True)
+        session_id = f"{session_name}-uuid"
+        (bucket / f"{session_id}.jsonl").write_text('{"sessionId": "%s"}\n' % session_id)
+
+    def _create_session(tmux_session: str, window_name: str, command: str) -> str:
+        del command
+        created_tmux_sessions.add(tmux_session)
+        _write_transcript("heartbeat")
+        return "%1"
+
+    def _create_window(tmux_session: str, window_name: str, command: str, detached: bool = True) -> str:
+        del tmux_session, command, detached
+        _write_transcript("operator")
+        return "%2"
+
+    monkeypatch.setattr(supervisor, "_window_map", lambda: {})
+    monkeypatch.setattr(supervisor.tmux, "has_session", lambda name: name in created_tmux_sessions)
+    monkeypatch.setattr(supervisor.tmux, "create_session", _create_session)
+    monkeypatch.setattr(supervisor.tmux, "create_window", _create_window)
+    monkeypatch.setattr(supervisor.tmux, "set_window_option", lambda *args, **kwargs: None)
+    monkeypatch.setattr(supervisor.tmux, "set_pane_history_limit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(supervisor.tmux, "pipe_pane", lambda *args, **kwargs: None)
+
+    heartbeat_launch, heartbeat_target = supervisor.create_session_window("heartbeat")
+    operator_launch, operator_target = supervisor.create_session_window("operator")
+
+    storage_session = supervisor.storage_closet_session_name()
+    assert heartbeat_target == f"{storage_session}:0"
+    assert operator_target == f"{storage_session}:pm-operator"
+    assert heartbeat_launch.resume_marker is not None
+    assert operator_launch.resume_marker is not None
+    assert heartbeat_launch.resume_marker.read_text(encoding="utf-8").strip() == "heartbeat-uuid"
+    assert operator_launch.resume_marker.read_text(encoding="utf-8").strip() == "operator-uuid"
+
+
 def test_codex_control_home_syncs_global_state(tmp_path: Path) -> None:
     config = _config(tmp_path)
     config.accounts["codex_backup"] = AccountConfig(


### PR DESCRIPTION
## Summary
- capture the fresh Claude transcript UUID when Polly creates a new control-session window
- store that UUID in the per-session resume marker and prefer `claude --resume <uuid>` over bare `--continue`
- add focused coverage for recorded resume IDs in the Claude adapter and supervisor window creation

## Testing
- HOME=/tmp/pytest-309 uv run --extra dev pytest tests/test_provider_sdk.py tests/test_runtime.py tests/test_runtime_launcher.py tests/test_auth_integration.py::test_claude_control_sessions_keep_original_account_home tests/test_supervisor.py::test_claude_control_sessions_use_original_account_home tests/test_supervisor.py::test_create_session_window_records_claude_resume_ids -q