### PR TITLE
fix(work): prune cancelled planner critic tasks

### DIFF
--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -1103,6 +1103,7 @@ class SQLiteWorkService:
                 )
         result = self.get(task_id)
         self._sync_transition(result, task.work_status.value, WorkStatus.CANCELLED.value)
+        self._prune_cancelled_critique_child(result)
         return result
 
     def hold(self, task_id: str, actor: str, reason: str | None = None) -> Task:
@@ -2100,6 +2101,85 @@ class SQLiteWorkService:
     def _check_auto_unblock(self, task_id: str) -> None:
         """After a task moves to done, auto-unblock any tasks it was blocking."""
         check_auto_unblock(self, task_id)
+
+    def _has_incoming_parent_link(self, task: Task) -> bool:
+        """Return True when ``task`` is linked as a child of another task."""
+        row = self._conn.execute(
+            "SELECT 1 FROM work_task_dependencies "
+            "WHERE to_project = ? AND to_task_number = ? AND kind = ? "
+            "LIMIT 1",
+            (
+                task.project,
+                task.task_number,
+                LinkKind.PARENT.value,
+            ),
+        ).fetchone()
+        return row is not None
+
+    def _prune_cancelled_critique_child(self, task: Task) -> None:
+        """Delete cancelled planner critic subtasks after side effects land.
+
+        Project-planning critic reviews are short-lived helper tasks that
+        exist only to fan work out to critic sessions during the planner's
+        stage-5 panel. Keeping their cancelled rows around pollutes
+        ``pm task list`` and shifts the visible numbering of the first real
+        implementation task. Only prune ``critique_flow`` tasks that are
+        linked as a parent/child subtask so standalone uses of the flow keep
+        normal cancelled-task semantics.
+        """
+        if task.flow_template_id != "critique_flow":
+            return
+        if not self._has_incoming_parent_link(task):
+            return
+
+        params = (task.project, task.task_number)
+        dep_params = (
+            task.project,
+            task.task_number,
+            task.project,
+            task.task_number,
+        )
+        try:
+            self._conn.execute(
+                "DELETE FROM work_sync_state "
+                "WHERE task_project = ? AND task_number = ?",
+                params,
+            )
+            self._conn.execute(
+                "DELETE FROM work_sessions "
+                "WHERE task_project = ? AND task_number = ?",
+                params,
+            )
+            self._conn.execute(
+                "DELETE FROM work_context_entries "
+                "WHERE task_project = ? AND task_number = ?",
+                params,
+            )
+            self._conn.execute(
+                "DELETE FROM work_transitions "
+                "WHERE task_project = ? AND task_number = ?",
+                params,
+            )
+            self._conn.execute(
+                "DELETE FROM work_node_executions "
+                "WHERE task_project = ? AND task_number = ?",
+                params,
+            )
+            self._conn.execute(
+                "DELETE FROM work_task_dependencies "
+                "WHERE (from_project = ? AND from_task_number = ?) "
+                "OR (to_project = ? AND to_task_number = ?)",
+                dep_params,
+            )
+            self._conn.execute(
+                "DELETE FROM work_tasks "
+                "WHERE project = ? AND task_number = ?",
+                params,
+            )
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
 
     def _on_cancelled(self, task_id: str) -> None:
         """After a task is cancelled, add context entries on blocked dependents."""

--- a/tests/test_work_service.py
+++ b/tests/test_work_service.py
@@ -46,6 +46,30 @@ def _create_standard_task(svc, project="proj", title="My task", description="Do 
     return svc.create(**defaults)
 
 
+def _create_critique_task(
+    svc,
+    *,
+    project="proj",
+    title="Critique",
+    critic="critic_simplicity",
+    description="Review the candidate plan",
+    **kwargs,
+):
+    """Helper to create a planner critic task on the ``critique_flow``."""
+    defaults = dict(
+        title=title,
+        description=description,
+        type="task",
+        project=project,
+        flow_template="critique_flow",
+        roles={"critic": critic, "requester": "architect"},
+        priority="high",
+        created_by="architect",
+    )
+    defaults.update(kwargs)
+    return svc.create(**defaults)
+
+
 # ---------------------------------------------------------------------------
 # Task creation
 # ---------------------------------------------------------------------------
@@ -381,6 +405,61 @@ class TestCancel:
         svc.cancel(task.task_id, "pm", "bye")
         with pytest.raises(InvalidTransitionError, match="terminal"):
             svc.cancel(task.task_id, "pm", "double cancel")
+
+    def test_cancel_prunes_critique_child_tasks_and_reuses_numbering(self, svc):
+        plan = svc.create(
+            title="Plan project demo",
+            description="Run the planner.",
+            type="task",
+            project="demo",
+            flow_template="plan_project",
+            roles={"architect": "architect"},
+            priority="high",
+            created_by="tester",
+        )
+        critic_names = (
+            "critic_simplicity",
+            "critic_maintainability",
+            "critic_user",
+            "critic_operational",
+            "critic_security",
+        )
+        critic_ids: list[str] = []
+        for critic in critic_names:
+            task = _create_critique_task(
+                svc,
+                project="demo",
+                title=f"{critic} panel review",
+                critic=critic,
+            )
+            svc.link(plan.task_id, task.task_id, "parent")
+            critic_ids.append(task.task_id)
+
+        for task_id in critic_ids:
+            cancelled = svc.cancel(task_id, "architect", "critic output collected")
+            assert cancelled.work_status == WorkStatus.CANCELLED
+            with pytest.raises(TaskNotFoundError):
+                svc.get(task_id)
+
+        remaining = [task.task_id for task in svc.list_tasks(project="demo")]
+        assert remaining == [plan.task_id]
+        assert svc.get(plan.task_id).children == []
+
+        implementation = _create_standard_task(
+            svc,
+            project="demo",
+            title="Implement module",
+            description="Build the first module.",
+        )
+        assert implementation.task_id == "demo/2"
+
+    def test_cancel_keeps_standalone_critique_flow_tasks(self, svc):
+        critic = _create_critique_task(svc)
+
+        cancelled = svc.cancel(critic.task_id, "architect", "no longer needed")
+
+        assert cancelled.work_status == WorkStatus.CANCELLED
+        assert svc.get(critic.task_id).work_status == WorkStatus.CANCELLED
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- prune cancelled linked critique_flow subtasks after cancel side effects land
- keep standalone critique_flow tasks behaving like normal cancelled tasks
- add regression coverage for planner critic cleanup and numbering reuse

## Testing
- HOME=/tmp/pytest-395 uv run --extra dev pytest tests/test_work_service.py::TestCancel tests/test_work_dependencies.py::TestLinkBlocks::test_link_parent tests/test_work_cli.py::TestCliList::test_cli_list -q