### PR TITLE
feat(cockpit): add project cost and commit trends

### DIFF
--- a/src/pollypm/cockpit_sections/project_dashboard.py
+++ b/src/pollypm/cockpit_sections/project_dashboard.py
@@ -26,6 +26,7 @@ from pollypm.cockpit_sections.in_flight import _section_in_flight
 from pollypm.cockpit_sections.insights import _section_insights
 from pollypm.cockpit_sections.quick_actions import _section_quick_actions
 from pollypm.cockpit_sections.recent import _section_recent
+from pollypm.cockpit_sections.recent_commits import _section_recent_commits
 from pollypm.cockpit_sections.summary import _section_summary
 from pollypm.cockpit_sections.velocity import _section_velocity
 from pollypm.cockpit_sections.you_need_to import _section_you_need_to
@@ -188,6 +189,7 @@ def _render_project_dashboard(
     out.extend(_section_you_need_to(review, project_alerts, 0))
     out.extend(_section_in_flight(in_progress, blocked))
     out.extend(_section_recent(completed))
+    out.extend(_section_recent_commits(project.path))
     out.extend(_section_activity(tasks, system_events))
     out.extend(_section_insights(project.path, project_key))
     out.extend(_section_downtime(project.path))

--- a/src/pollypm/cockpit_sections/recent_commits.py
+++ b/src/pollypm/cockpit_sections/recent_commits.py
@@ -1,0 +1,109 @@
+"""Recent git commit timeline for the per-project dashboard (#513)."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from pollypm.cockpit_sections.base import (
+    _DASHBOARD_BULLET,
+    _dashboard_divider,
+    _iso_to_dt,
+)
+
+
+@dataclass(slots=True)
+class RecentCommit:
+    sha: str
+    committed_at: str
+    subject: str
+
+
+def _compact_age(dt, *, now=None) -> str:
+    from datetime import UTC, datetime
+
+    if dt is None:
+        return "?"
+    current = now or datetime.now(UTC)
+    seconds = max(0, int((current - dt).total_seconds()))
+    if seconds < 60:
+        return "now"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86400}d"
+
+
+def _list_recent_commits(
+    project_path: Path,
+    *,
+    limit: int = 5,
+    timeout: float = 2.0,
+    runner=None,
+) -> list[RecentCommit]:
+    """Best-effort git log reader for the current project root."""
+    if limit <= 0 or not (project_path / ".git").exists():
+        return []
+    run = runner or subprocess.run
+    fmt = "%H%x1f%cI%x1f%s%x1e"
+    cmd = [
+        "git",
+        "log",
+        f"-{limit}",
+        f"--pretty=format:{fmt}",
+        "--no-merges",
+    ]
+    try:
+        result = run(
+            cmd,
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+
+    commits: list[RecentCommit] = []
+    for raw in result.stdout.split("\x1e"):
+        item = raw.strip()
+        if not item:
+            continue
+        parts = item.split("\x1f")
+        if len(parts) < 3:
+            continue
+        commits.append(
+            RecentCommit(
+                sha=parts[0].strip(),
+                committed_at=parts[1].strip(),
+                subject=parts[2].strip(),
+            )
+        )
+    return commits
+
+
+def _section_recent_commits(project_path: Path) -> list[str]:
+    from datetime import UTC, datetime
+
+    lines = [_dashboard_divider("Recent commits"), ""]
+    commits = _list_recent_commits(project_path)
+    if not commits:
+        lines.extend([f"{_DASHBOARD_BULLET}(none)", ""])
+        return lines
+
+    now = datetime.now(UTC)
+    for commit in commits:
+        age = _compact_age(_iso_to_dt(commit.committed_at), now=now)
+        subject = commit.subject or "(no subject)"
+        if len(subject) > 52:
+            subject = subject[:49] + "..."
+        lines.append(
+            f"{_DASHBOARD_BULLET}{commit.sha[:7]:<7}  {age:<4}  {subject}"
+        )
+    lines.append("")
+    return lines

--- a/src/pollypm/cockpit_sections/velocity.py
+++ b/src/pollypm/cockpit_sections/velocity.py
@@ -1,4 +1,4 @@
-"""Velocity / cycle-time / token aggregation rows (#403)."""
+"""Velocity / cycle-time / cost / token aggregation rows (#403, #501)."""
 
 from __future__ import annotations
 
@@ -11,8 +11,68 @@ from pollypm.cockpit_sections.base import (
 )
 
 
+_BLENDED_USD_PER_1K_TOKENS = 0.01
+
+
+def _done_tasks(tasks: list) -> list:
+    """Newest-first list of completed tasks that shipped work."""
+    from datetime import UTC, datetime
+
+    completed = [
+        t for t in tasks if getattr(t, "work_status", None) is not None
+        and t.work_status.value == "done"
+    ]
+    completed.sort(
+        key=lambda t: _iso_to_dt(t.updated_at)
+        or datetime.min.replace(tzinfo=UTC),
+        reverse=True,
+    )
+    return completed
+
+
+def _estimate_task_cost_usd(task) -> float | None:
+    """Blended token-cost estimate until model pricing lands in the ledger."""
+    total_tokens = (
+        int(getattr(task, "total_input_tokens", 0) or 0)
+        + int(getattr(task, "total_output_tokens", 0) or 0)
+    )
+    if total_tokens <= 0:
+        return None
+    return (total_tokens / 1000.0) * _BLENDED_USD_PER_1K_TOKENS
+
+
+def _format_usd(amount: float) -> str:
+    return f"${amount:.2f}"
+
+
+def _cost_delta_label(completed: list, now) -> str:
+    """Short this-week vs last-week summary for completed-task cost."""
+    this_week: list[float] = []
+    last_week: list[float] = []
+    for task in completed:
+        dt = _iso_to_dt(getattr(task, "updated_at", None))
+        cost = _estimate_task_cost_usd(task)
+        if dt is None or cost is None:
+            continue
+        age_days = (now - dt).days
+        if 0 <= age_days < 7:
+            this_week.append(cost)
+        elif 7 <= age_days < 14:
+            last_week.append(cost)
+    if not this_week or not last_week:
+        return ""
+    this_avg = sum(this_week) / len(this_week)
+    last_avg = sum(last_week) / len(last_week)
+    delta = this_avg - last_avg
+    if abs(delta) < 0.005:
+        return "this wk → flat vs last"
+    arrow = "↗" if delta > 0 else "↘"
+    sign = "+" if delta > 0 else "-"
+    return f"this wk {arrow} {sign}{_format_usd(abs(delta))} vs last"
+
+
 def _section_velocity(tasks: list, tokens: tuple[int, int] | None) -> list[str]:
-    """Velocity + cycle-time sparklines and token aggregation."""
+    """Velocity + cycle-time + cost sparklines and token aggregation."""
     from datetime import UTC, datetime
 
     lines: list[str] = []
@@ -50,15 +110,7 @@ def _section_velocity(tasks: list, tokens: tuple[int, int] | None) -> list[str]:
 
     # Cycle time sparkline: median minutes for each of the last 7 completed tasks.
     cycles: list[int] = []
-    completed = [
-        t for t in tasks if getattr(t, "work_status", None) is not None
-        and t.work_status.value == "done"
-    ]
-    completed.sort(
-        key=lambda t: _iso_to_dt(t.updated_at)
-        or datetime.min.replace(tzinfo=UTC),
-        reverse=True,
-    )
+    completed = _done_tasks(tasks)
     for t in completed[:7]:
         m = _task_cycle_minutes(t)
         if m is not None:
@@ -69,6 +121,24 @@ def _section_velocity(tasks: list, tokens: tuple[int, int] | None) -> list[str]:
         lines.append(
             f"{_DASHBOARD_BULLET}Cycle time  {_spark_bar(cycles_asc):<8}    "
             f"{avg_min}m avg"
+        )
+
+    # Cost sparkline: blended $ estimate from per-task token totals.
+    recent_costs_desc = [
+        cost for cost in (_estimate_task_cost_usd(task) for task in completed[:7])
+        if cost is not None
+    ]
+    if recent_costs_desc:
+        avg_cost = sum(recent_costs_desc) / len(recent_costs_desc)
+        cost_spark_values = [
+            max(1, int(round(cost * 100)))
+            for cost in reversed(recent_costs_desc)
+        ]
+        delta_label = _cost_delta_label(completed, now)
+        suffix = f" · {delta_label}" if delta_label else ""
+        lines.append(
+            f"{_DASHBOARD_BULLET}Cost/task  {_spark_bar(cost_spark_values):<8}    "
+            f"avg {_format_usd(avg_cost)}/task{suffix}"
         )
 
     # Token aggregation \u2014 drops the line entirely when unavailable.

--- a/tests/test_cockpit_project_dashboard.py
+++ b/tests/test_cockpit_project_dashboard.py
@@ -8,6 +8,8 @@ integration test that seeds a real SQLite-backed work service.
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 from datetime import UTC, datetime, timedelta
 from dataclasses import dataclass
 from pathlib import Path
@@ -36,6 +38,10 @@ from pollypm.cockpit import (
     _worker_presence,
 )
 from pollypm.cockpit_sections.action_bar import render_project_action_bar
+from pollypm.cockpit_sections.recent_commits import (
+    _list_recent_commits,
+    _section_recent_commits,
+)
 from pollypm.work.models import (
     Artifact,
     ArtifactKind,
@@ -92,6 +98,8 @@ class _FakeTask:
         assignee: str | None = None,
         current_node_id: str | None = None,
         blocked_by: list[tuple[str, int]] | None = None,
+        total_input_tokens: int = 0,
+        total_output_tokens: int = 0,
     ) -> None:
         self.task_number = task_number
         self.title = title
@@ -103,6 +111,8 @@ class _FakeTask:
         self.assignee = assignee
         self.current_node_id = current_node_id
         self.blocked_by = blocked_by or []
+        self.total_input_tokens = total_input_tokens
+        self.total_output_tokens = total_output_tokens
 
 
 class _FakeEvent:
@@ -205,6 +215,60 @@ class TestSectionVelocity:
         assert any("Cycle time" in l for l in lines)
         # 30m per task on average.
         assert any("30m avg" in l for l in lines)
+
+    def test_cost_sparkline_renders_from_completed_task_tokens(self):
+        now = datetime.now(UTC)
+        tasks = [
+            _FakeTask(
+                task_number=1,
+                title="this week expensive",
+                status="done",
+                updated_at=now - timedelta(days=2),
+                total_input_tokens=100_000,
+                total_output_tokens=0,
+            ),
+            _FakeTask(
+                task_number=2,
+                title="this week moderate",
+                status="done",
+                updated_at=now - timedelta(days=4),
+                total_input_tokens=80_000,
+                total_output_tokens=20_000,
+            ),
+            _FakeTask(
+                task_number=3,
+                title="last week cheaper",
+                status="done",
+                updated_at=now - timedelta(days=9),
+                total_input_tokens=40_000,
+                total_output_tokens=10_000,
+            ),
+            _FakeTask(
+                task_number=4,
+                title="last week cheaper too",
+                status="done",
+                updated_at=now - timedelta(days=11),
+                total_input_tokens=30_000,
+                total_output_tokens=20_000,
+            ),
+        ]
+        lines = _section_velocity(tasks, None)
+        cost_line = next((line for line in lines if "Cost/task" in line), "")
+        assert "avg $0.75/task" in cost_line
+        assert "this wk ↗ +$0.50 vs last" in cost_line
+
+    def test_cost_sparkline_skipped_when_no_task_tokens(self):
+        now = datetime.now(UTC)
+        tasks = [
+            _FakeTask(
+                task_number=1,
+                title="no usage",
+                status="done",
+                updated_at=now - timedelta(days=1),
+            )
+        ]
+        lines = _section_velocity(tasks, None)
+        assert not any("Cost/task" in line for line in lines)
 
     def test_tokens_line_present_when_tokens_supplied(self):
         lines = _section_velocity([], (45200, 12100))
@@ -351,6 +415,28 @@ class TestSectionRecent:
         assert "approved by russell" in joined
         assert "commit 237dfb0" in joined
         assert "25m cycle" in joined
+
+
+class TestSectionRecentCommits:
+    def test_recent_commits_without_git_repo(self, tmp_path: Path):
+        lines = _section_recent_commits(tmp_path)
+        assert any("(none)" in line for line in lines)
+
+    def test_recent_commits_renders_git_timeline(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        _init_git_repo(repo)
+        _git_commit(repo, "feat(router): wire cockpit rail", filename="router.txt")
+        _git_commit(repo, "fix(ingest): guard JSONL types", filename="ingest.txt")
+
+        lines = _section_recent_commits(repo)
+        joined = "\n".join(lines)
+        assert "Recent commits" in joined
+        assert "feat(router): wire cockpit rail" in joined
+        assert "fix(ingest): guard JSONL types" in joined
+
+        commits = _list_recent_commits(repo)
+        assert len(commits) == 2
+        assert commits[0].subject == "fix(ingest): guard JSONL types"
 
 
 class TestSectionActivity:
@@ -697,6 +783,36 @@ def _seed_project(tmp_path: Path) -> tuple[Path, str]:
     )
     svc.close()
     return proj_path, "shortlink-gen"
+
+
+def _git(project_path: Path, *args: str, env: dict[str, str] | None = None) -> None:
+    merged_env = None
+    if env is not None:
+        merged_env = dict(os.environ)
+        merged_env.update(env)
+    subprocess.run(
+        ["git", *args],
+        cwd=project_path,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=merged_env,
+    )
+
+
+def _init_git_repo(project_path: Path) -> None:
+    project_path.mkdir(parents=True, exist_ok=True)
+    _git(project_path, "init", "-q")
+    _git(project_path, "config", "user.email", "test@example.com")
+    _git(project_path, "config", "user.name", "Test User")
+    _git(project_path, "config", "commit.gpgsign", "false")
+
+
+def _git_commit(project_path: Path, subject: str, *, filename: str) -> None:
+    target = project_path / filename
+    target.write_text(subject + "\n", encoding="utf-8")
+    _git(project_path, "add", filename)
+    _git(project_path, "commit", "-q", "-m", subject)
 
 
 class _DashFakeProject:


### PR DESCRIPTION
## Summary
- add a per-project recent commits dashboard section
- add a blended cost-per-task sparkline alongside the existing velocity section
- cover both features with focused cockpit project dashboard tests

## Testing
- HOME=/tmp/pytest-dashboard uv run --extra dev pytest tests/test_cockpit_project_dashboard.py -q
- Note: tests/test_project_dashboard_ui.py currently has unrelated baseline fixture failures around git auto-merge setup on origin/main, so it was not used as a blocker for this slice.