### PR TITLE
feat(cockpit): read inbox notifications from store

### DIFF
--- a/src/pollypm/cockpit_inbox_items.py
+++ b/src/pollypm/cockpit_inbox_items.py
@@ -1,0 +1,188 @@
+"""Shared inbox item adapters for the cockpit inbox screen.
+
+Contract:
+- Inputs: loaded config objects, Store message rows, and work-service tasks.
+- Outputs: a single inbox-item surface that lets the Textual inbox render
+  Store-backed notifications and task-backed inbox rows together.
+- Side effects: opens and closes Store / SQLite readers while loading.
+- Invariants: item ids are stable across refreshes, message rows stay
+  read-only, and task-backed thread replies continue to flow through the
+  work-service path unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pollypm.cockpit_inbox import _inbox_db_sources
+from pollypm.store import SQLAlchemyStore
+from pollypm.work.inbox_view import inbox_tasks
+from pollypm.work.sqlite_service import SQLiteWorkService
+
+
+def message_item_id(source_key: str, row_id: object) -> str:
+    """Stable local id for a Store-backed inbox item."""
+    return f"msg:{source_key}:{row_id}"
+
+
+class InboxEntry:
+    """Thin adapter so tasks and Store messages share one inbox surface."""
+
+    def __init__(self, *, raw=None, **values: Any) -> None:
+        self._raw = raw
+        for key, value in values.items():
+            setattr(self, key, value)
+
+    def __getattr__(self, name: str):
+        raw = self.__dict__.get("_raw")
+        if raw is not None:
+            return getattr(raw, name)
+        raise AttributeError(name)
+
+
+def task_to_inbox_entry(task, *, db_path: Path | None) -> InboxEntry:
+    """Wrap a work-service task in the common inbox-item surface."""
+    return InboxEntry(
+        raw=task,
+        source="task",
+        task_id=task.task_id,
+        message_id=None,
+        message_type=None,
+        tier=None,
+        state="open",
+        sender=getattr(task, "sender", None),
+        project=getattr(task, "project", "") or "",
+        title=getattr(task, "title", "") or "",
+        description=getattr(task, "description", "") or "",
+        created_at=getattr(task, "created_at", None),
+        updated_at=getattr(task, "updated_at", None),
+        priority=getattr(task, "priority", None),
+        labels=list(getattr(task, "labels", []) or []),
+        roles=getattr(task, "roles", {}) or {},
+        created_by=getattr(task, "created_by", "") or "",
+        payload={},
+        recipient="user",
+        scope=getattr(task, "project", "") or "",
+        db_path=db_path,
+    )
+
+
+def message_row_to_inbox_entry(
+    row: dict[str, Any], *, source_key: str, db_path: Path,
+) -> InboxEntry:
+    """Project one Store message row into the common inbox-item surface."""
+    payload = row.get("payload") or {}
+    scope = (row.get("scope") or "").strip()
+    project = (
+        payload.get("project")
+        or scope
+        or ("inbox" if source_key == "__workspace__" else source_key)
+    )
+    tier = row.get("tier") or "immediate"
+    message_type = row.get("type") or "notify"
+    priority = "high" if tier == "immediate" and message_type == "alert" else "normal"
+    return InboxEntry(
+        source="message",
+        task_id=message_item_id(source_key, row.get("id")),
+        message_id=row.get("id"),
+        message_type=message_type,
+        tier=tier,
+        state=row.get("state") or "open",
+        sender=row.get("sender") or "polly",
+        project=project,
+        title=row.get("subject") or "(no subject)",
+        description=row.get("body") or "",
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at") or row.get("created_at"),
+        priority=priority,
+        labels=list(row.get("labels", []) or []),
+        roles={},
+        created_by=row.get("sender") or "polly",
+        payload=payload,
+        recipient=row.get("recipient") or "",
+        scope=scope,
+        db_path=db_path,
+    )
+
+
+def is_task_inbox_entry(item) -> bool:
+    """True when the inbox item is backed by a work-service task row."""
+    return getattr(item, "source", "task") == "task"
+
+
+def load_inbox_entries(
+    config,
+    *,
+    session_read_ids: set[str] | None = None,
+) -> tuple[list[InboxEntry], set[str], dict[str, list]]:
+    """Load Store-backed messages and task-backed inbox items together."""
+    session_read_ids = session_read_ids or set()
+    items: list[InboxEntry] = []
+    unread: set[str] = set()
+    replies_by_task: dict[str, list] = {}
+    seen_task_ids: set[str] = set()
+    for project_key, db_path, project_path in _inbox_db_sources(config):
+        if not db_path.exists():
+            continue
+        source_key = project_key or "__workspace__"
+        try:
+            store = SQLAlchemyStore(f"sqlite:///{db_path}")
+        except Exception:  # noqa: BLE001
+            store = None
+        if store is not None:
+            try:
+                try:
+                    rows = store.query_messages(
+                        recipient="user",
+                        state="open",
+                        type=["notify", "inbox_task", "alert"],
+                    )
+                except Exception:  # noqa: BLE001
+                    rows = []
+                for row in rows:
+                    item = message_row_to_inbox_entry(
+                        row,
+                        source_key=source_key,
+                        db_path=db_path,
+                    )
+                    items.append(item)
+                    if item.task_id not in session_read_ids:
+                        unread.add(item.task_id)
+            finally:
+                try:
+                    store.close()
+                except Exception:  # noqa: BLE001
+                    pass
+        try:
+            svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+        except Exception:  # noqa: BLE001
+            continue
+        try:
+            try:
+                project_tasks = inbox_tasks(svc, project=project_key)
+            except Exception:  # noqa: BLE001
+                project_tasks = []
+            for task in project_tasks:
+                if task.task_id in seen_task_ids:
+                    continue
+                seen_task_ids.add(task.task_id)
+                items.append(task_to_inbox_entry(task, db_path=db_path))
+                try:
+                    rows = svc.get_context(task.task_id, entry_type="read", limit=1)
+                except Exception:  # noqa: BLE001
+                    rows = []
+                if not rows:
+                    unread.add(task.task_id)
+                try:
+                    replies = svc.list_replies(task.task_id)
+                except Exception:  # noqa: BLE001
+                    replies = []
+                if replies:
+                    replies_by_task[task.task_id] = replies
+        finally:
+            try:
+                svc.close()
+            except Exception:  # noqa: BLE001
+                pass
+    return items, unread, replies_by_task

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -73,6 +73,10 @@ from pollypm.cockpit_inbox import (
     inbox_thread_left_action,
     inbox_thread_right_action,
 )
+from pollypm.cockpit_inbox_items import (
+    is_task_inbox_entry,
+    load_inbox_entries,
+)
 from pollypm.cockpit_metrics import (
     PollyMetricsApp,
     _MetricsDrillDownModal,
@@ -3428,6 +3432,9 @@ def _format_sender(task) -> str:
     from a worker's notify use ``operator`` too. When nothing resolves,
     fall back to ``created_by``.
     """
+    sender = getattr(task, "sender", None)
+    if sender and sender != "user":
+        return sender
     roles = getattr(task, "roles", {}) or {}
     op = roles.get("operator")
     if op and op != "user":
@@ -4316,6 +4323,7 @@ class PollyInboxApp(App[None]):
         self._selected_task_id: str | None = None
         self._selected_row_key: str | None = None
         self._unread_ids: set[str] = set()
+        self._session_read_ids: set[str] = set()
         self._replies_by_task: dict[str, list] = {}
         self._visible_rows: list[InboxThreadRow] = []
         self._thread_expanded_task_ids: set[str] = set()
@@ -4390,55 +4398,17 @@ class PollyInboxApp(App[None]):
     # ------------------------------------------------------------------
 
     def _load_inbox(self) -> tuple[list, set[str], dict[str, list]]:
-        """Open each project's work-service DB plus reply threads.
+        """Open each inbox DB source and merge messages with task threads.
 
         All services are closed before return — callers don't need to
         manage lifecycle. Per-task operations open a fresh svc via
         :meth:`_svc_for_task` so we never hold connections across ticks.
         """
-        from pollypm.work.inbox_view import inbox_tasks
-        from pollypm.work.sqlite_service import SQLiteWorkService
-
         config = load_config(self.config_path)
-        tasks: list = []
-        unread: set[str] = set()
-        replies_by_task: dict[str, list] = {}
-        for project_key, project in getattr(config, "projects", {}).items():
-            db_path = project.path / ".pollypm" / "state.db"
-            if not db_path.exists():
-                continue
-            try:
-                svc = SQLiteWorkService(
-                    db_path=db_path, project_path=project.path,
-                )
-            except Exception:  # noqa: BLE001
-                continue
-            try:
-                try:
-                    project_tasks = inbox_tasks(svc, project=project_key)
-                except Exception:  # noqa: BLE001
-                    project_tasks = []
-                for t in project_tasks:
-                    tasks.append(t)
-                    try:
-                        rows = svc.get_context(
-                            t.task_id, entry_type="read", limit=1,
-                        )
-                    except Exception:  # noqa: BLE001
-                        rows = []
-                    if not rows:
-                        unread.add(t.task_id)
-                    try:
-                        replies = svc.list_replies(t.task_id)
-                    except Exception:  # noqa: BLE001
-                        replies = []
-                    if replies:
-                        replies_by_task[t.task_id] = replies
-            finally:
-                try:
-                    svc.close()
-                except Exception:  # noqa: BLE001
-                    pass
+        tasks, unread, replies_by_task = load_inbox_entries(
+            config,
+            session_read_ids=self._session_read_ids,
+        )
         tasks.sort(key=_inbox_sort_key)
         return tasks, unread, replies_by_task
 
@@ -4650,8 +4620,10 @@ class PollyInboxApp(App[None]):
         return " ".join(
             [
                 task.title or "",
+                task.description or "",
                 task.project or "",
                 _format_sender(task),
+                " ".join(list(getattr(task, "labels", []) or [])),
             ]
         )
 
@@ -4794,7 +4766,91 @@ class PollyInboxApp(App[None]):
     # Detail rendering
     # ------------------------------------------------------------------
 
+    def _item_for_id(self, item_id: str | None):
+        if item_id is None:
+            return None
+        for item in self._tasks:
+            if item.task_id == item_id:
+                return item
+        return None
+
+    def _set_reply_mode_for_task(self) -> None:
+        self.reply_input.disabled = False
+        if self.reply_input.placeholder != "Why reject? (Enter to confirm, Esc to cancel)":
+            self.reply_input.placeholder = "Reply … (Enter to send, Esc back to list)"
+
+    def _set_reply_mode_for_message(self) -> None:
+        self._awaiting_rejection_task_id = None
+        self.reply_input.value = ""
+        self.reply_input.disabled = True
+        self.reply_input.placeholder = (
+            "Notifications are read-only — press d to discuss or a to archive"
+        )
+        if self.reply_input.has_focus:
+            self.list_view.focus()
+
+    def _render_message_detail(self, item) -> None:
+        from pollypm.tz import format_relative
+
+        updated_iso = (
+            item.updated_at.isoformat()
+            if hasattr(item.updated_at, "isoformat") else str(item.updated_at or "")
+        )
+        created_iso = (
+            item.created_at.isoformat()
+            if hasattr(item.created_at, "isoformat") else str(item.created_at or "")
+        )
+        when = _fmt_time(updated_iso or created_iso)
+        rel = format_relative(updated_iso or created_iso)
+
+        sender = _format_sender(item)
+        _session, pm_label = _resolve_pm_target(self.config_path, item.project)
+        sections: list[str] = []
+        sections.append(f"[b #eef2f4]{_escape(item.title or '(no subject)')}[/b #eef2f4]")
+        meta_bits = [f"[#5b8aff]{_escape(sender)}[/#5b8aff]"]
+        if when:
+            meta_bits.append(f"[#97a6b2]{_escape(when)}[/#97a6b2]")
+        if rel:
+            meta_bits.append(f"[dim]{_escape(rel)}[/dim]")
+        if item.project and item.project != "inbox":
+            meta_bits.append(f"[dim]· {_escape(item.project)}[/dim]")
+        prio = getattr(item.priority, "value", str(item.priority))
+        if prio and prio != "normal":
+            meta_bits.append(f"[#f0c45a]◆ {_escape(prio)}[/#f0c45a]")
+        meta_bits.append(f"[dim #6b7a88]PM: {_escape(pm_label)}[/dim #6b7a88]")
+        sections.append("  ·  ".join(meta_bits))
+        tags = [item.message_type or "notify", item.tier or "immediate"]
+        labels = list(getattr(item, "labels", []) or [])
+        tags.extend(labels)
+        sections.append(f"[dim]{_escape(' · '.join([tag for tag in tags if tag]))}[/dim]")
+        sections.append("")
+        sections.append(_md_to_rich(_escape_body(item.description or "(no body)")))
+        self.detail.update("\n".join(sections))
+        self._proposal_specs.pop(item.task_id, None)
+        self._plan_review_meta.pop(item.task_id, None)
+        self._plan_review_round_trip.pop(item.task_id, None)
+        self._blocking_question_meta.pop(item.task_id, None)
+        self._clear_rollup_items()
+        self._update_hint_for_message()
+        self._set_reply_mode_for_message()
+        try:
+            self.query_one("#inbox-detail-scroll", VerticalScroll).scroll_home(
+                animate=False,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
     def _render_detail(self, task_id: str) -> None:
+        item = self._item_for_id(task_id)
+        if item is None:
+            self.detail.update("[red]Inbox item is no longer available.[/red]")
+            self._clear_rollup_items()
+            self._set_reply_mode_for_task()
+            return
+        if not is_task_inbox_entry(item):
+            self._render_message_detail(item)
+            return
+        self._set_reply_mode_for_task()
         svc = self._svc_for_task(task_id)
         if svc is None:
             self.detail.update("[red]Could not open project database for this task.[/red]")
@@ -5190,6 +5246,24 @@ class PollyInboxApp(App[None]):
     def _mark_open_read(self, task_id: str) -> None:
         if task_id not in self._unread_ids:
             return
+        item = self._item_for_id(task_id)
+        if item is None:
+            return
+        if not is_task_inbox_entry(item):
+            self._session_read_ids.add(task_id)
+            self._unread_ids.discard(task_id)
+            try:
+                for row in self.list_view.children:
+                    if (
+                        isinstance(row, _InboxListItem)
+                        and row.row_ref.is_task
+                        and row.task_id == task_id
+                    ):
+                        row.mark_read()
+                        break
+            except Exception:  # noqa: BLE001
+                pass
+            return
         svc = self._svc_for_task(task_id)
         if svc is None:
             return
@@ -5225,6 +5299,32 @@ class PollyInboxApp(App[None]):
     def action_archive_selected(self) -> None:
         task_id = self._selected_task_id
         if task_id is None:
+            return
+        item = self._item_for_id(task_id)
+        if item is None:
+            return
+        if not is_task_inbox_entry(item):
+            try:
+                from pollypm.store import SQLAlchemyStore
+
+                store = SQLAlchemyStore(f"sqlite:///{item.db_path}")
+                try:
+                    store.close_message(int(item.message_id))
+                finally:
+                    store.close()
+            except Exception as exc:  # noqa: BLE001
+                self.notify(f"Archive failed: {exc}", severity="error")
+                return
+            self.notify(f"Archived {task_id}", severity="information", timeout=2.0)
+            self._tasks = [task for task in self._tasks if task.task_id != task_id]
+            self._unread_ids.discard(task_id)
+            self._session_read_ids.discard(task_id)
+            self._replies_by_task.pop(task_id, None)
+            self._thread_expanded_task_ids.discard(task_id)
+            if self._selected_task_id == task_id:
+                self._selected_task_id = None
+                self._selected_row_key = None
+            self._render_list(select_first=bool(self._tasks))
             return
         # Improvement proposals force an explicit Accept (A) or Reject
         # (X). Plain ``a`` must not silently archive them — the user
@@ -5271,6 +5371,15 @@ class PollyInboxApp(App[None]):
         task_id = self._selected_task_id
         if task_id is None:
             return
+        item = self._item_for_id(task_id)
+        if item is not None and not is_task_inbox_entry(item):
+            self.notify(
+                "Notifications are read-only — press d to discuss or a to archive.",
+                severity="warning",
+                timeout=2.5,
+            )
+            self.list_view.focus()
+            return
         self.reply_input.focus()
 
     # ------------------------------------------------------------------
@@ -5295,21 +5404,27 @@ class PollyInboxApp(App[None]):
         task_id = self._selected_task_id
         if task_id is None:
             return
-        svc = self._svc_for_task(task_id)
-        if svc is None:
-            self.notify("Could not open project database.", severity="error")
+        item = self._item_for_id(task_id)
+        if item is None:
             return
-        try:
-            task = svc.get(task_id)
-        except Exception as exc:  # noqa: BLE001
-            self.notify(f"Could not load task: {exc}", severity="error")
-            svc.close()
-            return
-        finally:
+        if is_task_inbox_entry(item):
+            svc = self._svc_for_task(task_id)
+            if svc is None:
+                self.notify("Could not open project database.", severity="error")
+                return
             try:
+                task = svc.get(task_id)
+            except Exception as exc:  # noqa: BLE001
+                self.notify(f"Could not load task: {exc}", severity="error")
                 svc.close()
-            except Exception:  # noqa: BLE001
-                pass
+                return
+            finally:
+                try:
+                    svc.close()
+                except Exception:  # noqa: BLE001
+                    pass
+        else:
+            task = item
 
         # Determine which item (rollup sub-item vs the rollup itself)
         # we're discussing, and derive the project the PM serves.
@@ -5529,6 +5644,7 @@ class PollyInboxApp(App[None]):
     def _on_reply_submitted(self, event: Input.Submitted) -> None:
         body = (event.value or "").strip()
         task_id = self._selected_task_id
+        item = self._item_for_id(task_id)
         # Rejection path: when the user pressed ``X`` on a proposal, the
         # shared reply input was repurposed to collect a rationale. Route
         # submission through the rejection flow instead of add_reply so
@@ -5549,6 +5665,15 @@ class PollyInboxApp(App[None]):
             return
         if not body or not task_id:
             # Empty submit — just hand focus back to the list.
+            self.reply_input.value = ""
+            self.list_view.focus()
+            return
+        if item is None or not is_task_inbox_entry(item):
+            self.notify(
+                "Notifications are read-only — press d to discuss or a to archive.",
+                severity="warning",
+                timeout=2.5,
+            )
             self.reply_input.value = ""
             self.list_view.focus()
             return
@@ -5597,6 +5722,10 @@ class PollyInboxApp(App[None]):
         "j/k move \u00b7 \u21b5 open \u00b7 r reply \u00b7 a archive "
         "\u00b7 d discuss \u00b7 / filter \u00b7 c clear \u00b7 q back"
     )
+    _MESSAGE_HINT = (
+        "j/k move \u00b7 \u21b5 open \u00b7 a archive "
+        "\u00b7 d discuss \u00b7 / filter \u00b7 c clear \u00b7 q back"
+    )
     _PROPOSAL_HINT = (
         "A accept \u00b7 X reject \u00b7 r reply \u00b7 q back"
     )
@@ -5623,6 +5752,12 @@ class PollyInboxApp(App[None]):
     def _update_hint_for_blocking_question(self) -> None:
         try:
             self.hint.update(self._BLOCKING_QUESTION_HINT)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _update_hint_for_message(self) -> None:
+        try:
+            self.hint.update(self._MESSAGE_HINT)
         except Exception:  # noqa: BLE001
             pass
 
@@ -5662,6 +5797,9 @@ class PollyInboxApp(App[None]):
         """Return (task, labels) for the current selection if it's a proposal."""
         task_id = self._selected_task_id
         if task_id is None:
+            return None, []
+        item = self._item_for_id(task_id)
+        if item is None or not is_task_inbox_entry(item):
             return None, []
         svc = self._svc_for_task(task_id)
         if svc is None:
@@ -5854,6 +5992,9 @@ class PollyInboxApp(App[None]):
         """
         task_id = self._selected_task_id
         if task_id is None:
+            return None, []
+        item = self._item_for_id(task_id)
+        if item is None or not is_task_inbox_entry(item):
             return None, []
         svc = self._svc_for_task(task_id)
         if svc is None:

--- a/tests/test_cockpit_inbox_ui.py
+++ b/tests/test_cockpit_inbox_ui.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import pytest
 
+from pollypm.store import SQLAlchemyStore
 from pollypm.work.sqlite_service import SQLiteWorkService
 
 
@@ -70,6 +71,34 @@ def _seed_project(project_path: Path) -> list[str]:
         return ids
     finally:
         svc.close()
+
+
+def _seed_workspace_message(
+    workspace_root: Path,
+    *,
+    subject: str = "Workspace notify",
+    body: str = "Fresh notification from Store.",
+    scope: str = "demo",
+    recipient: str = "user",
+    sender: str = "polly",
+    type: str = "notify",
+    tier: str = "immediate",
+) -> int:
+    db_path = workspace_root / ".pollypm" / "state.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    store = SQLAlchemyStore(f"sqlite:///{db_path}")
+    try:
+        return store.enqueue_message(
+            type=type,
+            tier=tier,
+            recipient=recipient,
+            sender=sender,
+            subject=subject,
+            body=body,
+            scope=scope,
+        )
+    finally:
+        store.close()
 
 
 def _seed_threaded_task(project_path: Path) -> str:
@@ -409,6 +438,75 @@ def test_archive_removes_row_and_flips_status(inbox_env, inbox_app) -> None:
             finally:
                 svc.close()
             assert task.work_status.value == "done"
+    _run(body())
+
+
+def test_workspace_store_notification_appears_in_inbox(inbox_env, inbox_app) -> None:
+    """Workspace-root Store rows are listed alongside task-backed inbox items."""
+    _seed_workspace_message(
+        inbox_env["project_path"].parent,
+        subject="Deploy blocked",
+        body="Needs verification email click.",
+    )
+
+    async def body() -> None:
+        async with inbox_app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            message_item = next(
+                (item for item in inbox_app._tasks if item.task_id.startswith("msg:")),
+                None,
+            )
+            assert message_item is not None
+            assert "Deploy blocked" in message_item.title
+            assert message_item.project == "demo"
+
+            inbox_app.list_view.index = inbox_app._tasks.index(message_item)
+            await pilot.press("enter")
+            await pilot.pause()
+
+            detail_text = str(inbox_app.detail.render())
+            assert "Deploy blocked" in detail_text
+            assert "Needs verification email click." in detail_text
+            assert inbox_app._selected_task_id == message_item.task_id
+            assert message_item.task_id not in inbox_app._unread_ids
+            assert inbox_app.reply_input.disabled is True
+    _run(body())
+
+
+def test_archive_closes_store_notification_and_removes_row(inbox_env, inbox_app) -> None:
+    """Archiving a Store-backed notification closes the message row."""
+    message_id = _seed_workspace_message(
+        inbox_env["project_path"].parent,
+        subject="Nightly report ready",
+        body="Open the run summary for details.",
+    )
+
+    async def body() -> None:
+        async with inbox_app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            message_item = next(
+                (item for item in inbox_app._tasks if item.message_id == message_id),
+                None,
+            )
+            assert message_item is not None
+
+            inbox_app.list_view.index = inbox_app._tasks.index(message_item)
+            await pilot.press("enter")
+            await pilot.pause()
+            await pilot.press("a")
+            await pilot.pause()
+
+            assert all(item.message_id != message_id for item in inbox_app._tasks)
+
+        db_path = inbox_env["project_path"].parent / ".pollypm" / "state.db"
+        store = SQLAlchemyStore(f"sqlite:///{db_path}")
+        try:
+            open_rows = store.query_messages(state="open", type="notify")
+            closed_rows = store.query_messages(state="closed", type="notify")
+        finally:
+            store.close()
+        assert all(row["id"] != message_id for row in open_rows)
+        assert any(row["id"] == message_id for row in closed_rows)
     _run(body())
 
 


### PR DESCRIPTION
## Summary\n- add a dedicated inbox-item adapter module that merges Store-backed notifications with task-backed inbox rows\n- teach the Textual inbox screen to render read-only Store notifications, track local read state, and archive them via Store\n- cover workspace-root notifications in the cockpit inbox UI tests\n\n## Testing\n- HOME=/tmp/pytest-372 uv run --extra dev pytest tests/test_cockpit_inbox_ui.py tests/test_plan_review_flow.py -q\n\nCloses #372