### PR TITLE
refactor(supervisor): extract alert helpers

### DIFF
--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -81,6 +81,7 @@ from pollypm.providers.claude.resume import session_ids as _claude_session_ids
 from pollypm.schedulers import ScheduledJob, get_scheduler_backend
 from pollypm.store.registry import get_store
 from pollypm.transcript_ledger import sync_token_ledger_for_config
+from pollypm import supervisor_alerts as _supervisor_alerts
 from pollypm.supervision import ControllerProbeService, ControlHomeManager, ProbeRunner
 from pollypm.storage.state import AlertRecord, LeaseRecord, StateStore
 from pollypm.tmux.client import TmuxWindow
@@ -126,41 +127,7 @@ def _prefix_for_owner(owner: str, text: str) -> str:
 # ``Supervisor._build_review_nudge``). Unchanged projects skip SQLite entirely
 # — mirrors ``_DASHBOARD_PROJECT_CACHE`` in cockpit.py and keeps the heartbeat
 # tick from scaling linearly with project count (see #174).
-_REVIEW_NUDGE_CACHE: dict[str, tuple[float, list[str]]] = {}
-
-
-def _review_tasks_for_project(project_key: str, db_path: Path) -> list[str]:
-    """Return nudge lines for a project's review-queue tasks.
-
-    Opens SQLite only when ``state.db`` mtime differs from the cached entry;
-    otherwise returns the cached lines. Mirrors ``_dashboard_project_tasks``.
-    """
-    try:
-        db_mtime = db_path.stat().st_mtime
-    except OSError:
-        _REVIEW_NUDGE_CACHE.pop(project_key, None)
-        return []
-    cached = _REVIEW_NUDGE_CACHE.get(project_key)
-    if cached is not None and cached[0] == db_mtime:
-        return cached[1]
-
-    from pollypm.work.sqlite_service import SQLiteWorkService
-
-    entries: list[str] = []
-    try:
-        with SQLiteWorkService(db_path=db_path) as svc:
-            tasks = svc.list_tasks(work_status="review", project=project_key)
-            for task in tasks:
-                # Skip human-review tasks — those need user approval.
-                if task.current_node_id and "human" in task.current_node_id:
-                    continue
-                entries.append(f"  - {task.task_id}: {task.title}")
-    except Exception:  # noqa: BLE001
-        # Don't poison the cache on transient errors; just return empty.
-        return []
-
-    _REVIEW_NUDGE_CACHE[project_key] = (db_mtime, entries)
-    return entries
+_REVIEW_NUDGE_CACHE = _supervisor_alerts._REVIEW_NUDGE_CACHE
 
 
 class Supervisor:
@@ -1396,240 +1363,28 @@ class Supervisor:
         current_log_bytes: int,
         current_snapshot_hash: str,
     ) -> list[str]:
-        session_name = launch.session.name
-        shell_commands = {"bash", "zsh", "sh", "fish"}
-        active_alerts: list[str] = []
-
-        if window.pane_dead:
-            self._msg_store.upsert_alert(
-                session_name,
-                "pane_dead",
-                "error",
-                f"Pane {window.pane_id} in window {window.name} has exited",
-            )
-            active_alerts.append("pane_dead")
-        else:
-            self._msg_store.clear_alert(session_name, "pane_dead")
-
-        if window.pane_current_command in shell_commands:
-            self._msg_store.upsert_alert(
-                session_name,
-                "shell_returned",
-                "warn",
-                f"Window {window.name} appears to be back at the shell prompt ({window.pane_current_command})",
-            )
-            active_alerts.append("shell_returned")
-        else:
-            self._msg_store.clear_alert(session_name, "shell_returned")
-
-        if previous_log_bytes is not None and current_log_bytes <= previous_log_bytes:
-            self._msg_store.upsert_alert(
-                session_name,
-                "idle_output",
-                "warn",
-                f"No new pane output since the previous heartbeat for window {window.name}",
-            )
-            active_alerts.append("idle_output")
-        else:
-            self._msg_store.clear_alert(session_name, "idle_output")
-
-        if previous_snapshot_hash and previous_snapshot_hash == current_snapshot_hash:
-            history = self.store.recent_heartbeats(session_name, limit=3)
-            recent_hashes = [item.snapshot_hash for item in history[:3]]
-            if len(recent_hashes) == 3 and len(set(recent_hashes)) == 1:
-                # Skip the ``suspected_loop`` alert for control-plane
-                # sessions that legitimately idle (operator / reviewer /
-                # worker_pollypm). Their pane reaches a steady state
-                # whenever the user isn't actively chatting, and
-                # re-alerting on every heartbeat (~30s) floods the
-                # cockpit with false positives that never signal real
-                # work stalls. Project-scoped workers / architects
-                # still fire the alert so the nudge path catches
-                # genuinely-stuck agents.
-                role = launch.session.role
-                if role in {"heartbeat-supervisor", "operator-pm", "reviewer"} or \
-                        launch.session.name in {"worker_pollypm"}:
-                    self._msg_store.clear_alert(session_name, "suspected_loop")
-                else:
-                    self._msg_store.upsert_alert(
-                        session_name,
-                        "suspected_loop",
-                        "warn",
-                        f"Window {window.name} has produced effectively the same snapshot for 3 heartbeats",
-                    )
-                    active_alerts.append("suspected_loop")
-                    longer_history = self.store.recent_heartbeats(session_name, limit=5)
-                    longer_hashes = [item.snapshot_hash for item in longer_history[:5]]
-                    if len(longer_hashes) == 5 and len(set(longer_hashes)) == 1:
-                        self._maybe_nudge_stalled_session(launch)
-            else:
-                self._msg_store.clear_alert(session_name, "suspected_loop")
-        else:
-            self._msg_store.clear_alert(session_name, "suspected_loop")
-
-        lower_pane = pane_text.lower()
-        if self._pane_has_auth_failure(lower_pane):
-            self._msg_store.upsert_alert(
-                session_name,
-                "auth_broken",
-                "error",
-                f"Window {window.name} reported authentication failure",
-            )
-            self.store.upsert_account_runtime(
-                account_name=launch.account.name,
-                provider=launch.account.provider.value,
-                status="auth_broken",
-                reason="live session reported authentication failure",
-            )
-            active_alerts.append("auth_broken")
-        else:
-            self._msg_store.clear_alert(session_name, "auth_broken")
-
-        if self._pane_has_capacity_failure(lower_pane):
-            self._msg_store.upsert_alert(
-                session_name,
-                "capacity_exhausted",
-                "error",
-                f"Window {window.name} reported a usage or quota limit",
-            )
-            self.store.upsert_account_runtime(
-                account_name=launch.account.name,
-                provider=launch.account.provider.value,
-                status="exhausted",
-                reason="live session reported capacity exhaustion",
-            )
-            active_alerts.append("capacity_exhausted")
-        else:
-            self._msg_store.clear_alert(session_name, "capacity_exhausted")
-
-        if self._pane_has_provider_outage(lower_pane):
-            self._msg_store.upsert_alert(
-                session_name,
-                "provider_outage",
-                "warn",
-                f"Window {window.name} appears to be hitting a provider outage",
-            )
-            self.store.upsert_account_runtime(
-                account_name=launch.account.name,
-                provider=launch.account.provider.value,
-                status="provider_outage",
-                reason="live session reported upstream provider instability",
-                available_at=(datetime.now(UTC) + timedelta(minutes=10)).isoformat(),
-            )
-            active_alerts.append("provider_outage")
-        else:
-            self._msg_store.clear_alert(session_name, "provider_outage")
-
-        return active_alerts
-
-    def _maybe_nudge_stalled_session(self, launch: SessionLaunchSpec) -> None:
-        if launch.session.role == "reviewer":
-            self._maybe_nudge_reviewer_review(launch)
-            return
-        if launch.session.role == "operator-pm":
-            return  # Polly no longer reviews — Russell handles it
-        if launch.session.role != "worker":
-            return
-        lease = self.store.get_lease(launch.session.name)
-        if lease is not None and lease.owner == "human":
-            # Sync path — operator-visible audit event tied to the
-            # nudge-skip decision (tested synchronously below).
-            self._msg_store.record_event(
-                scope=launch.session.name,
-                sender=launch.session.name,
-                subject="heartbeat_nudge_skipped",
-                payload={
-                    "message": (
-                        "Skipped stalled-worker nudge because session is "
-                        "leased to human"
-                    ),
-                },
-            )
-            return
-        # Check if there's a queued task the worker could pick up
-        nudge = self._build_task_nudge(launch)
-        self.send_input(
-            launch.session.name,
-            nudge or self._STALL_NUDGE_MESSAGE,
-            owner="heartbeat",
-            force=lease is not None and lease.owner != "human",
+        return _supervisor_alerts._update_alerts(
+            self,
+            launch,
+            window,
+            pane_text=pane_text,
+            previous_log_bytes=previous_log_bytes,
+            previous_snapshot_hash=previous_snapshot_hash,
+            current_log_bytes=current_log_bytes,
+            current_snapshot_hash=current_snapshot_hash,
         )
 
+    def _maybe_nudge_stalled_session(self, launch: SessionLaunchSpec) -> None:
+        _supervisor_alerts._maybe_nudge_stalled_session(self, launch)
+
     def _maybe_nudge_reviewer_review(self, launch: SessionLaunchSpec) -> None:
-        """Nudge the reviewer (Russell) if tasks are waiting for review."""
-        lease = self.store.get_lease(launch.session.name)
-        if lease is not None and lease.owner == "human":
-            return
-        nudge = self._build_review_nudge()
-        if nudge is None:
-            return
-        try:
-            self.send_input(
-                launch.session.name,
-                nudge,
-                owner="heartbeat",
-                force=lease is not None and lease.owner != "human",
-            )
-        except Exception:  # noqa: BLE001
-            pass
+        _supervisor_alerts._maybe_nudge_reviewer_review(self, launch)
 
     def _build_review_nudge(self) -> str | None:
-        """Check all projects for tasks in review state.
-
-        Per-project review-task lists are cached in ``_REVIEW_NUDGE_CACHE``
-        keyed by ``state.db`` mtime — unchanged projects skip SQLite entirely.
-        Mirrors the pattern used by ``_dashboard_project_tasks`` (cockpit.py)
-        so the heartbeat cost scales with changed projects, not total projects.
-        """
-        try:
-            from pollypm.work.cli import _resolve_db_path
-
-            review_tasks: list[str] = []
-            live_keys: set[str] = set()
-            for project_key in self.config.projects:
-                live_keys.add(project_key)
-                db_path = _resolve_db_path(".pollypm/state.db", project=project_key)
-                if not db_path.exists():
-                    _REVIEW_NUDGE_CACHE.pop(project_key, None)
-                    continue
-                entries = _review_tasks_for_project(project_key, db_path)
-                review_tasks.extend(entries)
-            # Evict cache entries for projects no longer in config.
-            for stale in set(_REVIEW_NUDGE_CACHE) - live_keys:
-                _REVIEW_NUDGE_CACHE.pop(stale, None)
-            if not review_tasks:
-                return None
-            lines = [
-                f"You have {len(review_tasks)} task(s) waiting for your review:",
-                *review_tasks,
-                "",
-                "Review with: pm task status <id>, then pm task approve <id> --actor russell or pm task reject <id> --actor russell --reason \"...\"",
-            ]
-            return "\n".join(lines)
-        except Exception:  # noqa: BLE001
-            return None
+        return _supervisor_alerts._build_review_nudge(self)
 
     def _build_task_nudge(self, launch: SessionLaunchSpec) -> str | None:
-        """Check for queued tasks assigned to this worker and build a nudge message."""
-        try:
-            from pollypm.work.cli import _resolve_db_path
-            from pollypm.work.sqlite_service import SQLiteWorkService
-
-            project = launch.session.project
-            db_path = _resolve_db_path(".pollypm/state.db", project=project)
-            if not db_path.exists():
-                return None
-            with SQLiteWorkService(db_path=db_path) as svc:
-                task = svc.next(project=project)
-                if task is None:
-                    return None
-                return (
-                    f"You have work waiting. Task {task.task_id} — \"{task.title}\" "
-                    f"is queued for your project. "
-                    f"Claim it: pm task claim {task.task_id}"
-                )
-        except Exception:
-            return None
+        return _supervisor_alerts._build_task_nudge(self, launch)
 
     def _lease_timeout(self) -> timedelta:
         return timedelta(minutes=self.config.pollypm.lease_timeout_minutes)

--- a/src/pollypm/supervisor_alerts.py
+++ b/src/pollypm/supervisor_alerts.py
@@ -1,0 +1,312 @@
+"""Supervisor alert-update and nudge boundary helpers.
+
+Contract:
+- Inputs: a supervisor-like boundary object plus live launch/window
+  state from :mod:`pollypm.supervisor`.
+- Outputs: alert updates, nudge decisions, and the review-task cache
+  used by the heartbeat path.
+- Side effects: writes alert rows, appends events, and sends heartbeat
+  nudges through the provided supervisor boundary.
+- Invariants: behavior mirrors the legacy ``Supervisor`` methods so the
+  public supervisor surface stays compatible while this seam is split
+  out for future decomposition.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Protocol
+
+from pollypm.config import PollyPMConfig
+from pollypm.models import SessionLaunchSpec
+from pollypm.storage.state import StateStore
+from pollypm.tmux.client import TmuxWindow
+
+
+class SupervisorAlertBoundary(Protocol):
+    config: PollyPMConfig
+    store: StateStore
+    _msg_store: object
+    _STALL_NUDGE_MESSAGE: str
+
+    def send_input(
+        self,
+        session_name: str,
+        text: str,
+        *,
+        owner: str = "pollypm",
+        force: bool = False,
+        press_enter: bool = True,
+    ) -> None: ...
+
+    def _pane_has_auth_failure(self, lowered_pane: str) -> bool: ...
+
+    def _pane_has_capacity_failure(self, lowered_pane: str) -> bool: ...
+
+    def _pane_has_provider_outage(self, lowered_pane: str) -> bool: ...
+
+
+_REVIEW_NUDGE_CACHE: dict[str, tuple[float, list[str]]] = {}
+
+
+def _review_tasks_for_project(project_key: str, db_path: Path) -> list[str]:
+    """Return nudge lines for a project's review-queue tasks."""
+    try:
+        db_mtime = db_path.stat().st_mtime
+    except OSError:
+        _REVIEW_NUDGE_CACHE.pop(project_key, None)
+        return []
+    cached = _REVIEW_NUDGE_CACHE.get(project_key)
+    if cached is not None and cached[0] == db_mtime:
+        return cached[1]
+
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    entries: list[str] = []
+    try:
+        with SQLiteWorkService(db_path=db_path) as svc:
+            tasks = svc.list_tasks(work_status="review", project=project_key)
+            for task in tasks:
+                if task.current_node_id and "human" in task.current_node_id:
+                    continue
+                entries.append(f"  - {task.task_id}: {task.title}")
+    except Exception:  # noqa: BLE001
+        return []
+
+    _REVIEW_NUDGE_CACHE[project_key] = (db_mtime, entries)
+    return entries
+
+
+def _update_alerts(
+    supervisor: SupervisorAlertBoundary,
+    launch: SessionLaunchSpec,
+    window: TmuxWindow,
+    *,
+    pane_text: str,
+    previous_log_bytes: int | None,
+    previous_snapshot_hash: str | None,
+    current_log_bytes: int,
+    current_snapshot_hash: str,
+) -> list[str]:
+    session_name = launch.session.name
+    shell_commands = {"bash", "zsh", "sh", "fish"}
+    active_alerts: list[str] = []
+
+    if window.pane_dead:
+        supervisor._msg_store.upsert_alert(
+            session_name,
+            "pane_dead",
+            "error",
+            f"Pane {window.pane_id} in window {window.name} has exited",
+        )
+        active_alerts.append("pane_dead")
+    else:
+        supervisor._msg_store.clear_alert(session_name, "pane_dead")
+
+    if window.pane_current_command in shell_commands:
+        supervisor._msg_store.upsert_alert(
+            session_name,
+            "shell_returned",
+            "warn",
+            f"Window {window.name} appears to be back at the shell prompt ({window.pane_current_command})",
+        )
+        active_alerts.append("shell_returned")
+    else:
+        supervisor._msg_store.clear_alert(session_name, "shell_returned")
+
+    if previous_log_bytes is not None and current_log_bytes <= previous_log_bytes:
+        supervisor._msg_store.upsert_alert(
+            session_name,
+            "idle_output",
+            "warn",
+            f"No new pane output since the previous heartbeat for window {window.name}",
+        )
+        active_alerts.append("idle_output")
+    else:
+        supervisor._msg_store.clear_alert(session_name, "idle_output")
+
+    if previous_snapshot_hash and previous_snapshot_hash == current_snapshot_hash:
+        history = supervisor.store.recent_heartbeats(session_name, limit=3)
+        recent_hashes = [item.snapshot_hash for item in history[:3]]
+        if len(recent_hashes) == 3 and len(set(recent_hashes)) == 1:
+            role = launch.session.role
+            if role in {"heartbeat-supervisor", "operator-pm", "reviewer"} or launch.session.name in {"worker_pollypm"}:
+                supervisor._msg_store.clear_alert(session_name, "suspected_loop")
+            else:
+                supervisor._msg_store.upsert_alert(
+                    session_name,
+                    "suspected_loop",
+                    "warn",
+                    f"Window {window.name} has produced effectively the same snapshot for 3 heartbeats",
+                )
+                active_alerts.append("suspected_loop")
+                longer_history = supervisor.store.recent_heartbeats(session_name, limit=5)
+                longer_hashes = [item.snapshot_hash for item in longer_history[:5]]
+                if len(longer_hashes) == 5 and len(set(longer_hashes)) == 1:
+                    _maybe_nudge_stalled_session(supervisor, launch)
+        else:
+            supervisor._msg_store.clear_alert(session_name, "suspected_loop")
+    else:
+        supervisor._msg_store.clear_alert(session_name, "suspected_loop")
+
+    lowered_pane = pane_text.lower()
+    if supervisor._pane_has_auth_failure(lowered_pane):
+        supervisor._msg_store.upsert_alert(
+            session_name,
+            "auth_broken",
+            "error",
+            f"Window {window.name} reported authentication failure",
+        )
+        supervisor.store.upsert_account_runtime(
+            account_name=launch.account.name,
+            provider=launch.account.provider.value,
+            status="auth_broken",
+            reason="live session reported authentication failure",
+        )
+        active_alerts.append("auth_broken")
+    else:
+        supervisor._msg_store.clear_alert(session_name, "auth_broken")
+
+    if supervisor._pane_has_capacity_failure(lowered_pane):
+        supervisor._msg_store.upsert_alert(
+            session_name,
+            "capacity_exhausted",
+            "error",
+            f"Window {window.name} reported a usage or quota limit",
+        )
+        supervisor.store.upsert_account_runtime(
+            account_name=launch.account.name,
+            provider=launch.account.provider.value,
+            status="exhausted",
+            reason="live session reported capacity exhaustion",
+        )
+        active_alerts.append("capacity_exhausted")
+    else:
+        supervisor._msg_store.clear_alert(session_name, "capacity_exhausted")
+
+    if supervisor._pane_has_provider_outage(lowered_pane):
+        supervisor._msg_store.upsert_alert(
+            session_name,
+            "provider_outage",
+            "warn",
+            f"Window {window.name} appears to be hitting a provider outage",
+        )
+        supervisor.store.upsert_account_runtime(
+            account_name=launch.account.name,
+            provider=launch.account.provider.value,
+            status="provider_outage",
+            reason="live session reported upstream provider instability",
+            available_at=(datetime.now(UTC) + timedelta(minutes=10)).isoformat(),
+        )
+        active_alerts.append("provider_outage")
+    else:
+        supervisor._msg_store.clear_alert(session_name, "provider_outage")
+
+    return active_alerts
+
+
+def _maybe_nudge_stalled_session(supervisor: SupervisorAlertBoundary, launch: SessionLaunchSpec) -> None:
+    if launch.session.role == "reviewer":
+        _maybe_nudge_reviewer_review(supervisor, launch)
+        return
+    if launch.session.role == "operator-pm":
+        return
+    if launch.session.role != "worker":
+        return
+    lease = supervisor.store.get_lease(launch.session.name)
+    if lease is not None and lease.owner == "human":
+        supervisor._msg_store.record_event(
+            scope=launch.session.name,
+            sender=launch.session.name,
+            subject="heartbeat_nudge_skipped",
+            payload={
+                "message": (
+                    "Skipped stalled-worker nudge because session is "
+                    "leased to human"
+                ),
+            },
+        )
+        return
+    nudge = _build_task_nudge(supervisor, launch)
+    supervisor.send_input(
+        launch.session.name,
+        nudge or supervisor._STALL_NUDGE_MESSAGE,
+        owner="heartbeat",
+        force=lease is not None and lease.owner != "human",
+    )
+
+
+def _maybe_nudge_reviewer_review(
+    supervisor: SupervisorAlertBoundary,
+    launch: SessionLaunchSpec,
+) -> None:
+    """Nudge the reviewer if tasks are waiting for review."""
+    lease = supervisor.store.get_lease(launch.session.name)
+    if lease is not None and lease.owner == "human":
+        return
+    nudge = _build_review_nudge(supervisor)
+    if nudge is None:
+        return
+    try:
+        supervisor.send_input(
+            launch.session.name,
+            nudge,
+            owner="heartbeat",
+            force=lease is not None and lease.owner != "human",
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _build_review_nudge(supervisor: SupervisorAlertBoundary) -> str | None:
+    """Check all projects for tasks in review state."""
+    try:
+        from pollypm.work.cli import _resolve_db_path
+
+        review_tasks: list[str] = []
+        live_keys: set[str] = set()
+        for project_key in supervisor.config.projects:
+            live_keys.add(project_key)
+            db_path = _resolve_db_path(".pollypm/state.db", project=project_key)
+            if not db_path.exists():
+                _REVIEW_NUDGE_CACHE.pop(project_key, None)
+                continue
+            entries = _review_tasks_for_project(project_key, db_path)
+            review_tasks.extend(entries)
+        for stale in set(_REVIEW_NUDGE_CACHE) - live_keys:
+            _REVIEW_NUDGE_CACHE.pop(stale, None)
+        if not review_tasks:
+            return None
+        lines = [
+            f"You have {len(review_tasks)} task(s) waiting for your review:",
+            *review_tasks,
+            "",
+            "Review with: pm task status <id>, then pm task approve <id> --actor russell or pm task reject <id> --actor russell --reason \"...\"",
+        ]
+        return "\n".join(lines)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _build_task_nudge(supervisor: SupervisorAlertBoundary, launch: SessionLaunchSpec) -> str | None:
+    """Check for queued tasks assigned to this worker and build a nudge message."""
+    try:
+        from pollypm.work.cli import _resolve_db_path
+        from pollypm.work.sqlite_service import SQLiteWorkService
+
+        project = launch.session.project
+        db_path = _resolve_db_path(".pollypm/state.db", project=project)
+        if not db_path.exists():
+            return None
+        with SQLiteWorkService(db_path=db_path) as svc:
+            task = svc.next(project=project)
+            if task is None:
+                return None
+            return (
+                f"You have work waiting. Task {task.task_id} — \"{task.title}\" "
+                f"is queued for your project. "
+                f"Claim it: pm task claim {task.task_id}"
+            )
+    except Exception:
+        return None

--- a/tests/test_supervisor_alerts.py
+++ b/tests/test_supervisor_alerts.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pollypm.supervisor_alerts as _supervisor_alerts
+from pollypm.models import (
+    AccountConfig,
+    KnownProject,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectKind,
+    ProjectSettings,
+    ProviderKind,
+    SessionConfig,
+)
+from pollypm.supervisor import Supervisor
+from pollypm.tmux.client import TmuxWindow
+
+
+def _config(tmp_path: Path) -> PollyPMConfig:
+    return PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            base_dir=tmp_path / ".pollypm",
+            logs_dir=tmp_path / ".pollypm/logs",
+            snapshots_dir=tmp_path / ".pollypm/snapshots",
+            state_db=tmp_path / ".pollypm/state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="claude_controller",
+            failover_enabled=True,
+            failover_accounts=["codex_backup"],
+        ),
+        accounts={
+            "claude_controller": AccountConfig(
+                name="claude_controller",
+                provider=ProviderKind.CLAUDE,
+                email="claude@example.com",
+                home=tmp_path / ".pollypm/homes/claude_controller",
+            ),
+            "codex_backup": AccountConfig(
+                name="codex_backup",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                home=tmp_path / ".pollypm/homes/codex_backup",
+            ),
+        },
+        sessions={
+            "worker": SessionConfig(
+                name="worker",
+                role="worker",
+                provider=ProviderKind.CODEX,
+                account="codex_backup",
+                cwd=tmp_path,
+                project="pollypm",
+                prompt="Ship the fix",
+                window_name="worker-pollypm",
+            ),
+        },
+        projects={
+            "pollypm": KnownProject(
+                key="pollypm",
+                path=tmp_path,
+                name="PollyPM",
+                kind=ProjectKind.FOLDER,
+            )
+        },
+    )
+
+
+def test_supervisor_alert_helper_updates_and_nudges(monkeypatch, tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+    launch = next(item for item in supervisor.plan_launches() if item.session.name == "worker")
+    window = TmuxWindow(
+        session=supervisor.storage_closet_session_name(),
+        index=1,
+        name="worker-pollypm",
+        active=False,
+        pane_id="%42",
+        pane_current_command="codex",
+        pane_current_path=str(tmp_path),
+        pane_dead=False,
+    )
+
+    for index in range(4):
+        supervisor.store.record_heartbeat(
+            session_name="worker",
+            tmux_window=window.name,
+            pane_id=window.pane_id,
+            pane_command=window.pane_current_command,
+            pane_dead=False,
+            log_bytes=100 + index,
+            snapshot_path=str(tmp_path / f"snapshot-{index}.txt"),
+            snapshot_hash="same-hash",
+        )
+    supervisor.store.record_heartbeat(
+        session_name="worker",
+        tmux_window=window.name,
+        pane_id=window.pane_id,
+        pane_command=window.pane_current_command,
+        pane_dead=False,
+        log_bytes=200,
+        snapshot_path=str(tmp_path / "snapshot-current.txt"),
+        snapshot_hash="same-hash",
+    )
+
+    sent: list[tuple[str, str, bool]] = []
+    monkeypatch.setattr(
+        supervisor,
+        "send_input",
+        lambda session_name, text, owner="pollypm", force=False, press_enter=True: sent.append(
+            (session_name, text, force)
+        ),
+    )
+
+    alerts = _supervisor_alerts._update_alerts(
+        supervisor,
+        launch,
+        window,
+        pane_text="Still stalled",
+        previous_log_bytes=150,
+        previous_snapshot_hash="same-hash",
+        current_log_bytes=200,
+        current_snapshot_hash="same-hash",
+    )
+
+    assert "suspected_loop" in alerts
+    assert sent == [("worker", Supervisor._STALL_NUDGE_MESSAGE, False)]
+
+
+def test_supervisor_wrapper_delegates_alert_helper(monkeypatch, tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+    launch = next(item for item in supervisor.plan_launches() if item.session.name == "worker")
+    window = TmuxWindow(
+        session=supervisor.storage_closet_session_name(),
+        index=1,
+        name="worker-pollypm",
+        active=False,
+        pane_id="%42",
+        pane_current_command="codex",
+        pane_current_path=str(tmp_path),
+        pane_dead=False,
+    )
+
+    monkeypatch.setattr(
+        _supervisor_alerts,
+        "_update_alerts",
+        lambda *args, **kwargs: ["delegated"],
+    )
+
+    alerts = supervisor._update_alerts(
+        launch,
+        window,
+        pane_text="ignore",
+        previous_log_bytes=None,
+        previous_snapshot_hash=None,
+        current_log_bytes=1,
+        current_snapshot_hash="hash",
+    )
+
+    assert alerts == ["delegated"]


### PR DESCRIPTION
Part of #366

## Summary
- move supervisor alert-update and heartbeat nudge helpers into a dedicated module
- keep Supervisor methods as thin delegations so the public surface stays stable
- add focused tests for the extracted helper seam and delegation path

## Testing
- HOME=/tmp/pytest-366 uv run --extra dev pytest tests/test_supervisor_alerts.py tests/test_supervisor.py -k 'stalled_worker_gets_heartbeat_nudge_after_five_identical_cycles or stalled_worker_nudge_skips_when_human_holds_lease or build_review_nudge' -q