### PR TITLE
refactor(onboarding): finish provider adapter dispatch

### DIFF
--- a/src/pollypm/acct/protocol.py
+++ b/src/pollypm/acct/protocol.py
@@ -11,13 +11,13 @@ in — detect, login, probe, launch, warm-resume, and onboarding
 priming — plus the env shim that makes isolated-home execution
 possible. Two later waves extended the original six-method surface:
 #406 added ``prime_home`` / ``login_command`` / ``logout_command`` /
-``login_completion_marker_seen`` so provider-specific onboarding
-details can live in provider packages; the architect-lifecycle work
-added ``latest_session_id`` / ``resume_launch_cmd`` so idle-closed
-architects can warm-resume from their provider's session UUID.
-Third-party providers implement the full surface to participate in
-PollyPM's onboarding + recovery + lifecycle paths without editing
-core.
+``login_completion_marker_seen`` / ``detect_email_from_pane`` so
+provider-specific onboarding details can live in provider packages;
+the architect-lifecycle work added ``latest_session_id`` /
+``resume_launch_cmd`` so idle-closed architects can warm-resume from
+their provider's session UUID. Third-party providers implement the
+full surface to participate in PollyPM's onboarding + recovery +
+lifecycle paths without editing core.
 """
 
 from __future__ import annotations
@@ -211,6 +211,16 @@ class ProviderAdapter(Protocol):
         at the tail of the login shell so providers without a strong
         native signal can use the same marker. Providers with a richer
         signal (e.g. a CLI banner) are free to widen this check.
+        """
+        ...
+
+    def detect_email_from_pane(self, pane_text: str) -> str | None:
+        """Return the authenticated email scraped from ``pane_text``.
+
+        Used by the shared onboarding wait-loop to notice a completed
+        login before the provider's on-disk auth files are flushed.
+        Providers that never print the email in their pane output
+        return ``None``.
         """
         ...
 

--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -4,19 +4,11 @@ import base64
 import json
 import re
 import shlex
-import shutil
 import threading
 import time
-from dataclasses import dataclass
 from pathlib import Path
 
 import typer
-from rich import box
-from rich.columns import Columns
-from rich.console import Console
-from rich.panel import Panel
-from rich.table import Table
-from rich.text import Text
 
 from pollypm.plugins_builtin.core_agent_profiles.profiles import heartbeat_prompt, polly_prompt
 from pollypm.config import DEFAULT_CONFIG_PATH, load_config, write_config
@@ -39,46 +31,25 @@ from pollypm.projects import (
 from pollypm.runtime_env import provider_profile_env_for_provider
 from typing import TYPE_CHECKING
 
+from pollypm.onboarding_models import (
+    CliAvailability,
+    ConnectedAccount,
+    LoginPreferences,
+    OnboardingResult,
+    ProviderChoice,
+)
+from pollypm.onboarding_ui import (
+    available_clis as _available_clis,
+    provider_choices as _provider_choices,
+    render_account_step_intro as _render_account_step_intro,
+    render_connected_account as _render_connected_account,
+    render_intro as _render_intro,
+    render_provider_choices as _render_provider_choices,
+)
 from pollypm.session_services import create_tmux_client
 
 if TYPE_CHECKING:
     from pollypm.tmux.client import TmuxClient
-
-
-@dataclass(slots=True)
-class ConnectedAccount:
-    provider: ProviderKind
-    email: str
-    account_name: str
-    home: Path
-
-
-@dataclass(slots=True)
-class CliAvailability:
-    provider: ProviderKind
-    label: str
-    binary: str
-    installed: bool
-
-
-@dataclass(slots=True)
-class ProviderChoice:
-    key: str
-    label: str
-    provider: ProviderKind | None
-
-
-@dataclass(slots=True)
-class LoginPreferences:
-    codex_headless: bool = False
-
-
-@dataclass(slots=True)
-class OnboardingResult:
-    config_path: Path
-    launch_requested: bool = False
-
-
 class LoginCancelled(Exception):
     pass
 
@@ -130,135 +101,6 @@ def _prime_claude_home(home: Path) -> None:
     from pollypm.providers.claude.onboarding import prime_claude_home
 
     prime_claude_home(home)
-
-
-def _available_clis() -> list[CliAvailability]:
-    return [
-        CliAvailability(
-            provider=ProviderKind.CLAUDE,
-            label="Claude CLI",
-            binary="claude",
-            installed=shutil.which("claude") is not None,
-        ),
-        CliAvailability(
-            provider=ProviderKind.CODEX,
-            label="Codex CLI",
-            binary="codex",
-            installed=shutil.which("codex") is not None,
-        ),
-    ]
-
-
-def _render_intro(statuses: list[CliAvailability]) -> None:
-    console = Console()
-    hero_text = Text(justify="left")
-    hero_text.append("PollyPM\n", style="bold bright_white")
-    hero_text.append("Set up your CLI agents, detect active projects, and bring the control room online.", style="white")
-    hero = Panel(
-        hero_text,
-        border_style="grey70",
-        box=box.ROUNDED,
-        padding=(1, 2),
-    )
-    table = Table(show_header=False, box=None, pad_edge=False)
-    table.add_column("tool", style="bold")
-    table.add_column("status")
-    for item in statuses:
-        state = "[green]Ready[/green]" if item.installed else "[red]Missing[/red]"
-        table.add_row(item.label, state)
-    table.add_row("tmux", "[green]Ready[/green]" if shutil.which("tmux") else "[red]Missing[/red]")
-    machine_panel = Panel(table, title="Machine Check", border_style="grey50", box=box.ROUNDED)
-
-    flight_plan = Table(show_header=False, box=None, pad_edge=False)
-    flight_plan.add_column("step", style="bold cyan", width=4)
-    flight_plan.add_column("detail")
-    flight_plan.add_row("01", "Connect your first agent account")
-    flight_plan.add_row("02", "Detect projects with recent activity")
-    flight_plan.add_row("03", "Launch your control room")
-    plan_panel = Panel(
-        flight_plan,
-        title="Setup Flow",
-        subtitle="You can add more accounts later",
-        border_style="grey50",
-        box=box.ROUNDED,
-    )
-
-    console.print(hero)
-    console.print(Columns([machine_panel, plan_panel], equal=True, expand=True))
-    console.print()
-
-
-def _starting_provider_message(installed: list[CliAvailability]) -> str:
-    if len(installed) == 1:
-        return f"First, let's connect {installed[0].label}."
-    return "First, let's connect your agent accounts."
-
-
-def _provider_choices(installed: list[CliAvailability], accounts: dict[str, ConnectedAccount]) -> list[ProviderChoice]:
-    connected_by_provider = {item.provider: 0 for item in installed}
-    for account in accounts.values():
-        connected_by_provider[account.provider] = connected_by_provider.get(account.provider, 0) + 1
-
-    choices: list[ProviderChoice] = []
-    for index, item in enumerate(installed, start=1):
-        count = connected_by_provider.get(item.provider, 0)
-        suffix = f" ({count} connected)" if count else ""
-        choices.append(ProviderChoice(str(index), f"{item.label}{suffix}", item.provider))
-    if accounts:
-        choices.append(ProviderChoice(str(len(choices) + 1), "Continue", None))
-    return choices
-
-
-def _render_account_step_intro(installed: list[CliAvailability], accounts: dict[str, ConnectedAccount]) -> None:
-    console = Console()
-    body = Text()
-    body.append(_starting_provider_message(installed), style="bold white")
-    body.append("\n")
-    body.append(
-        "PollyPM opens a real login window, detects the account automatically, and saves it as a reusable profile.",
-        style="dim",
-    )
-    if not accounts:
-        body.append("\n\n")
-        body.append("Press Return to connect your first account.", style="bold bright_green")
-    else:
-        body.append("\n\n")
-        body.append("You can connect more now, or later anytime from the Accounts tab.", style="yellow")
-    console.print(Panel(body, title="Account Setup", border_style="grey50", box=box.ROUNDED))
-
-
-def _render_connected_account(account: ConnectedAccount, total_accounts: int) -> None:
-    console = Console()
-    table = Table(show_header=False, box=None, pad_edge=False)
-    table.add_column("field", style="bold")
-    table.add_column("value")
-    table.add_row("Connected", account.email)
-    table.add_row("Provider", account.provider.value)
-    table.add_row("Profile", account.account_name)
-    table.add_row("Accounts ready", str(total_accounts))
-    console.print(Panel(table, title="Account Ready", border_style="green", box=box.ROUNDED))
-
-
-def _provider_description(provider: ProviderKind) -> str:
-    if provider is ProviderKind.CLAUDE:
-        return "Strong for planning, review, and longer strategic loops."
-    if provider is ProviderKind.CODEX:
-        return "Strong for implementation, shell-heavy work, and fast coding loops."
-    return ""
-
-
-def _render_provider_choices(choices: list[ProviderChoice]) -> None:
-    console = Console()
-    table = Table(box=box.SIMPLE_HEAVY, expand=True, show_header=True, header_style="bold white")
-    table.add_column("Option", width=8, style="bold cyan")
-    table.add_column("Provider", width=18, style="bold")
-    table.add_column("Best For")
-    for item in choices:
-        if item.provider is None:
-            table.add_row(item.key, "Continue", "Move on to controller and project setup.")
-            continue
-        table.add_row(item.key, item.label, _provider_description(item.provider))
-    console.print(Panel(table, title="Choose a Provider", border_style="grey50", box=box.ROUNDED))
 
 
 def _select_provider_to_connect(installed: list[CliAvailability], accounts: dict[str, ConnectedAccount]) -> ProviderKind | None:
@@ -464,15 +306,11 @@ def _detect_account_email(provider: ProviderKind, home: Path) -> str | None:
     provider-agnostic flow (capture pane → try email → try home) has a
     single entry point tests can monkeypatch.
     """
-    if provider is ProviderKind.CODEX:
-        from pollypm.providers.codex.detect import detect_codex_email
+    from pollypm.acct.registry import get_provider
 
-        return detect_codex_email(home)
-    if provider is ProviderKind.CLAUDE:
-        from pollypm.providers.claude.detect import detect_claude_email
-
-        return detect_claude_email(home)
-    raise ValueError(f"Unsupported provider: {provider.value}")
+    return get_provider(provider.value).detect_email(
+        AccountConfig(name=f"{provider.value}_probe", provider=provider, home=home),
+    )
 
 
 def _detect_email_from_pane(provider: ProviderKind, pane_text: str) -> str | None:
@@ -482,15 +320,9 @@ def _detect_email_from_pane(provider: ProviderKind, pane_text: str) -> str | Non
     in the provider ``detect`` modules; this dispatcher exists so the
     login-window loop can stay provider-agnostic.
     """
-    if provider is ProviderKind.CODEX:
-        from pollypm.providers.codex.detect import detect_email_from_pane
+    from pollypm.acct.registry import get_provider
 
-        return detect_email_from_pane(pane_text)
-    if provider is ProviderKind.CLAUDE:
-        from pollypm.providers.claude.detect import detect_email_from_pane
-
-        return detect_email_from_pane(pane_text)
-    return None
+    return get_provider(provider.value).detect_email_from_pane(pane_text)
 
 
 def _login_completion_marker_seen(pane_text: str, provider: ProviderKind | None = None) -> bool:

--- a/src/pollypm/onboarding_models.py
+++ b/src/pollypm/onboarding_models.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from pollypm.models import ProviderKind
+
+
+@dataclass(slots=True)
+class ConnectedAccount:
+    provider: ProviderKind
+    email: str
+    account_name: str
+    home: Path
+
+
+@dataclass(slots=True)
+class CliAvailability:
+    provider: ProviderKind
+    label: str
+    binary: str
+    installed: bool
+
+
+@dataclass(slots=True)
+class ProviderChoice:
+    key: str
+    label: str
+    provider: ProviderKind | None
+
+
+@dataclass(slots=True)
+class LoginPreferences:
+    codex_headless: bool = False
+
+
+@dataclass(slots=True)
+class OnboardingResult:
+    config_path: Path
+    launch_requested: bool = False
+
+
+__all__ = [
+    "CliAvailability",
+    "ConnectedAccount",
+    "LoginPreferences",
+    "OnboardingResult",
+    "ProviderChoice",
+]

--- a/src/pollypm/onboarding_ui.py
+++ b/src/pollypm/onboarding_ui.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import shutil
+
+from rich import box
+from rich.columns import Columns
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from pollypm.models import ProviderKind
+
+from .onboarding_models import CliAvailability, ConnectedAccount, ProviderChoice
+
+
+def available_clis() -> list[CliAvailability]:
+    return [
+        CliAvailability(
+            provider=ProviderKind.CLAUDE,
+            label="Claude CLI",
+            binary="claude",
+            installed=shutil.which("claude") is not None,
+        ),
+        CliAvailability(
+            provider=ProviderKind.CODEX,
+            label="Codex CLI",
+            binary="codex",
+            installed=shutil.which("codex") is not None,
+        ),
+    ]
+
+
+def render_intro(statuses: list[CliAvailability]) -> None:
+    console = Console()
+    hero_text = Text(justify="left")
+    hero_text.append("PollyPM\n", style="bold bright_white")
+    hero_text.append(
+        "Set up your CLI agents, detect active projects, and bring the control room online.",
+        style="white",
+    )
+    hero = Panel(
+        hero_text,
+        border_style="grey70",
+        box=box.ROUNDED,
+        padding=(1, 2),
+    )
+    table = Table(show_header=False, box=None, pad_edge=False)
+    table.add_column("tool", style="bold")
+    table.add_column("status")
+    for item in statuses:
+        state = "[green]Ready[/green]" if item.installed else "[red]Missing[/red]"
+        table.add_row(item.label, state)
+    table.add_row(
+        "tmux",
+        "[green]Ready[/green]" if shutil.which("tmux") else "[red]Missing[/red]",
+    )
+    machine_panel = Panel(
+        table,
+        title="Machine Check",
+        border_style="grey50",
+        box=box.ROUNDED,
+    )
+
+    flight_plan = Table(show_header=False, box=None, pad_edge=False)
+    flight_plan.add_column("step", style="bold cyan", width=4)
+    flight_plan.add_column("detail")
+    flight_plan.add_row("01", "Connect your first agent account")
+    flight_plan.add_row("02", "Detect projects with recent activity")
+    flight_plan.add_row("03", "Launch your control room")
+    plan_panel = Panel(
+        flight_plan,
+        title="Setup Flow",
+        subtitle="You can add more accounts later",
+        border_style="grey50",
+        box=box.ROUNDED,
+    )
+
+    console.print(hero)
+    console.print(Columns([machine_panel, plan_panel], equal=True, expand=True))
+    console.print()
+
+
+def starting_provider_message(installed: list[CliAvailability]) -> str:
+    if len(installed) == 1:
+        return f"First, let's connect {installed[0].label}."
+    return "First, let's connect your agent accounts."
+
+
+def provider_choices(
+    installed: list[CliAvailability],
+    accounts: dict[str, ConnectedAccount],
+) -> list[ProviderChoice]:
+    connected_by_provider = {item.provider: 0 for item in installed}
+    for account in accounts.values():
+        connected_by_provider[account.provider] = (
+            connected_by_provider.get(account.provider, 0) + 1
+        )
+
+    choices: list[ProviderChoice] = []
+    for index, item in enumerate(installed, start=1):
+        count = connected_by_provider.get(item.provider, 0)
+        suffix = f" ({count} connected)" if count else ""
+        choices.append(ProviderChoice(str(index), f"{item.label}{suffix}", item.provider))
+    if accounts:
+        choices.append(ProviderChoice(str(len(choices) + 1), "Continue", None))
+    return choices
+
+
+def render_account_step_intro(
+    installed: list[CliAvailability],
+    accounts: dict[str, ConnectedAccount],
+) -> None:
+    console = Console()
+    body = Text()
+    body.append(starting_provider_message(installed), style="bold white")
+    body.append("\n")
+    body.append(
+        "PollyPM opens a real login window, detects the account automatically, and saves it as a reusable profile.",
+        style="dim",
+    )
+    if not accounts:
+        body.append("\n\n")
+        body.append("Press Return to connect your first account.", style="bold bright_green")
+    else:
+        body.append("\n\n")
+        body.append(
+            "You can connect more now, or later anytime from the Accounts tab.",
+            style="yellow",
+        )
+    console.print(
+        Panel(body, title="Account Setup", border_style="grey50", box=box.ROUNDED)
+    )
+
+
+def render_connected_account(account: ConnectedAccount, total_accounts: int) -> None:
+    console = Console()
+    table = Table(show_header=False, box=None, pad_edge=False)
+    table.add_column("field", style="bold")
+    table.add_column("value")
+    table.add_row("Connected", account.email)
+    table.add_row("Provider", account.provider.value)
+    table.add_row("Profile", account.account_name)
+    table.add_row("Accounts ready", str(total_accounts))
+    console.print(
+        Panel(table, title="Account Ready", border_style="green", box=box.ROUNDED)
+    )
+
+
+def provider_description(provider: ProviderKind) -> str:
+    if provider is ProviderKind.CLAUDE:
+        return "Strong for planning, review, and longer strategic loops."
+    if provider is ProviderKind.CODEX:
+        return "Strong for implementation, shell-heavy work, and fast coding loops."
+    return ""
+
+
+def render_provider_choices(choices: list[ProviderChoice]) -> None:
+    console = Console()
+    table = Table(
+        box=box.SIMPLE_HEAVY,
+        expand=True,
+        show_header=True,
+        header_style="bold white",
+    )
+    table.add_column("Option", width=8, style="bold cyan")
+    table.add_column("Provider", width=18, style="bold")
+    table.add_column("Best For")
+    for item in choices:
+        if item.provider is None:
+            table.add_row(
+                item.key,
+                "Continue",
+                "Move on to controller and project setup.",
+            )
+            continue
+        table.add_row(item.key, item.label, provider_description(item.provider))
+    console.print(
+        Panel(
+            table,
+            title="Choose a Provider",
+            border_style="grey50",
+            box=box.ROUNDED,
+        )
+    )
+
+
+__all__ = [
+    "available_clis",
+    "provider_choices",
+    "render_account_step_intro",
+    "render_connected_account",
+    "render_intro",
+    "render_provider_choices",
+]

--- a/src/pollypm/providers/claude/provider.py
+++ b/src/pollypm/providers/claude/provider.py
@@ -192,5 +192,9 @@ class ClaudeProvider:
         """Return True iff ``pane_text`` contains the PollyPM done-marker."""
         return _login.login_completion_marker_seen(pane_text)
 
+    def detect_email_from_pane(self, pane_text: str) -> str | None:
+        """Claude never surfaces the account email in pane output."""
+        return _detect.detect_email_from_pane(pane_text)
+
 
 __all__ = ["ClaudeProvider"]

--- a/src/pollypm/providers/codex/provider.py
+++ b/src/pollypm/providers/codex/provider.py
@@ -23,7 +23,7 @@ from pollypm.provider_sdk import ProviderUsageSnapshot
 
 from . import login as _login
 from .adapter import CodexAdapter as _RuntimeCodexAdapter
-from .detect import detect_codex_email, detect_logged_in
+from .detect import detect_codex_email, detect_email_from_pane, detect_logged_in
 from .env import isolated_env as _codex_isolated_env
 from .login import run_login_flow as _codex_run_login_flow
 from .probe import probe_usage as _codex_probe_usage
@@ -193,6 +193,10 @@ class CodexProvider:
     def login_completion_marker_seen(self, pane_text: str) -> bool:
         """Return True iff ``pane_text`` contains the PollyPM done-marker."""
         return _login.login_completion_marker_seen(pane_text)
+
+    def detect_email_from_pane(self, pane_text: str) -> str | None:
+        """Return the account email if the Codex login pane prints it."""
+        return detect_email_from_pane(pane_text)
 
 
 __all__ = ["CodexProvider"]

--- a/tests/providers/test_claude_provider.py
+++ b/tests/providers/test_claude_provider.py
@@ -103,6 +103,11 @@ def test_detect_email_preserves_issue_396_sentinel(monkeypatch, tmp_path: Path) 
     assert result == "claude.ai:max"
 
 
+def test_detect_email_from_pane_delegates_to_detect_helper() -> None:
+    provider = ClaudeProvider()
+    assert provider.detect_email_from_pane("Account: no-email-here") is None
+
+
 def test_isolated_env_returns_claude_config_dir(tmp_path: Path) -> None:
     provider = ClaudeProvider()
     env = provider.isolated_env(tmp_path)
@@ -151,5 +156,6 @@ def test_all_six_protocol_methods_are_present() -> None:
         "probe_usage",
         "worker_launch_cmd",
         "isolated_env",
+        "detect_email_from_pane",
     ):
         assert callable(getattr(provider, method)), f"missing {method}"

--- a/tests/providers/test_codex_provider.py
+++ b/tests/providers/test_codex_provider.py
@@ -116,6 +116,13 @@ def test_detect_email_returns_none_when_home_is_none() -> None:
     assert provider.detect_email(_account("codex_1", None)) is None
 
 
+def test_detect_email_from_pane_reads_codex_status_line() -> None:
+    provider = CodexProvider()
+    pane = "Account:                     s@swh.me (Pro)"
+
+    assert provider.detect_email_from_pane(pane) == "s@swh.me"
+
+
 def test_isolated_env_sets_codex_home_additively(tmp_path: Path) -> None:
     provider = CodexProvider()
     env = provider.isolated_env(tmp_path / "home")

--- a/tests/test_acct_substrate.py
+++ b/tests/test_acct_substrate.py
@@ -167,6 +167,7 @@ def test_registered_adapters_have_required_method_names():
             "login_command",
             "logout_command",
             "login_completion_marker_seen",
+            "detect_email_from_pane",
         ):
             assert hasattr(adapter, method), f"{adapter_cls.__name__} missing {method}"
             assert callable(getattr(adapter, method))

--- a/tests/test_claude_onboarding.py
+++ b/tests/test_claude_onboarding.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pollypm.providers.claude.onboarding import detected_claude_version, prime_claude_home
+from pollypm.providers.claude.provider import ClaudeProvider
+
+
+def test_claude_provider_login_helpers() -> None:
+    provider = ClaudeProvider()
+
+    assert provider.login_command(interactive=True) == "claude"
+    assert provider.login_command() == "claude auth login --claudeai"
+    assert provider.logout_command() == "claude auth logout || true"
+    assert provider.login_completion_marker_seen("PollyPM: login window complete.")
+    assert provider.detect_email_from_pane("Logged in as pearl@example.com") is None
+
+
+def test_prime_claude_home_writes_state_inside_config_dir(tmp_path: Path) -> None:
+    home = tmp_path / "homes" / "claude_test"
+
+    prime_claude_home(home)
+
+    state_path = home / ".claude" / ".claude.json"
+    settings_path = home / ".claude" / "settings.json"
+
+    assert state_path.exists()
+    assert settings_path.exists()
+
+    state = json.loads(state_path.read_text())
+    settings = json.loads(settings_path.read_text())
+
+    assert state["hasCompletedOnboarding"] is True
+    assert settings["skipDangerousModePermissionPrompt"] is True
+    assert settings["bypassWorkspaceTrust"] is True
+    assert settings["permissions"]["dangerouslySkipPermissions"] is True
+
+
+def test_detected_claude_version_uses_binary_output(monkeypatch) -> None:
+    class Result:
+        def __init__(self, stdout: str) -> None:
+            self.stdout = stdout
+
+    monkeypatch.setattr(
+        "pollypm.providers.claude.onboarding.subprocess.run",
+        lambda *args, **kwargs: Result("Claude Code 3.2.1\n"),
+    )
+
+    assert detected_claude_version() == "3.2.1"


### PR DESCRIPTION
Closes #406.

## Summary
- move onboarding account/ui dataclasses into `onboarding_models.py`
- move Rich onboarding render helpers into `onboarding_ui.py` so `onboarding.py` drops below the review target size
- finish provider-adapter dispatch for pane/email detection so Claude-specific onboarding behavior stays in provider packages

## Testing
- `python -m py_compile src/pollypm/onboarding.py src/pollypm/onboarding_models.py src/pollypm/onboarding_ui.py src/pollypm/acct/protocol.py src/pollypm/providers/claude/provider.py src/pollypm/providers/codex/provider.py`
- `HOME=/tmp/pytest-406 uv run --extra dev pytest -q tests/test_claude_onboarding.py tests/test_onboarding_ux.py tests/test_onboarding_tui.py tests/test_onboarding_login_flow.py tests/test_auth_integration.py tests/test_acct_substrate.py tests/providers/test_claude_provider.py tests/providers/test_codex_provider.py`
