### PR TITLE
perf(cockpit): cache rail hot paths and gate idle animation

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -193,12 +193,6 @@ class CockpitPresence:
             return ARC_SPINNER[0]
         return ARC_SPINNER[spinner_index % len(ARC_SPINNER)]
 
-    def heartbeat_frame(self, spinner_index: int) -> str:
-        frames = ("♥", "♡")
-        if not self.should_animate():
-            return frames[0]
-        return frames[spinner_index % len(frames)]
-
 
 # ── Rail data model + router ─────────────────────────────────────────────
 #
@@ -870,7 +864,7 @@ class CockpitRouter:
                 return "\u25cf live"
             return "ready"
         if launch.session.role == "heartbeat-supervisor":
-            return "heartbeat"
+            return "watch"
         if launch.session.role == "triage":
             return "triage"
         return "live"
@@ -1916,8 +1910,8 @@ class PollyCockpitRail:
             return "\u25b2", PALETTE["alert_indicator"]
         if item.state == "dead":
             return "\u2715", PALETTE["dead"]
-        if item.state in {"heartbeat", "watch"}:
-            return self.presence.heartbeat_frame(self.spinner_index), PALETTE["live_indicator"]
+        if item.state == "watch":
+            return "\u25ce", PALETTE["live_indicator"]
         if item.state == "ready":
             return "\u25cf", PALETTE["sel_accent"]
         # Key-based fallbacks for items with no meaningful state

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -357,6 +357,7 @@ class CockpitRouter:
         self.config_path = config_path
         self.service = PollyPMService(config_path)
         self.tmux = create_tmux_client()
+        self.presence = CockpitPresence(self.tmux)
         self._supervisor = None
         self._config_cache: object | None = None
         self._config_cache_mtime_ns: int | None = None
@@ -374,6 +375,15 @@ class CockpitRouter:
         # value: (db_mtime, git_mtime, is_active, has_working_task)
         # Skips re-opening SQLite on every 0.8s cockpit tick when nothing changed.
         self._project_activity_cache: dict[str, tuple[float, float, bool, bool]] = {}
+
+    def _presence(self) -> CockpitPresence:
+        presence = getattr(self, "presence", None)
+        if not isinstance(presence, CockpitPresence):
+            presence = CockpitPresence(self.tmux)
+            self.presence = presence
+        elif presence.tmux is not self.tmux:
+            presence.tmux = self.tmux
+        return presence
 
     def _load_config(self):
         try:
@@ -859,7 +869,7 @@ class CockpitRouter:
                 heartbeat=heartbeat,
             )
             if working:
-                return f"{self.presence.working_frame(spinner_index)} working"
+                return f"{self._presence().working_frame(spinner_index)} working"
             if launch.session.role == "worker":
                 return "\u25cf live"
             return "ready"

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -111,6 +111,95 @@ POLLY_SLOGANS = [
 GUTTER = 2
 
 
+@dataclass(slots=True)
+class CockpitPresence:
+    """Presence-aware glyph helper for the rail renderer."""
+
+    tmux: object
+    _cache_ttl_seconds: float = 2.0
+    _cached_attached: bool | None = None
+    _cached_at: float = 0.0
+    _cached_session: str | None = None
+
+    def _calm_mode(self) -> bool:
+        value = os.environ.get("POLLY_CALM", "")
+        return value not in {"", "0", "false", "False", "no", "NO"}
+
+    def is_tmux_attached(self) -> bool:
+        """Return True when animation should behave as if tmux is attached."""
+        if self._calm_mode():
+            return False
+        session_name = self._current_session_name()
+        if session_name is None:
+            return True
+        now = time.monotonic()
+        if (
+            self._cached_session == session_name
+            and self._cached_attached is not None
+            and now - self._cached_at < self._cache_ttl_seconds
+        ):
+            return self._cached_attached
+        attached = self._probe_attached(session_name)
+        self._cached_session = session_name
+        self._cached_attached = attached
+        self._cached_at = now
+        return attached
+
+    def _current_session_name(self) -> str | None:
+        getter = getattr(self.tmux, "current_session_name", None)
+        if not callable(getter):
+            return None
+        try:
+            value = getter()
+            return str(value) if value else None
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _probe_attached(self, session_name: str) -> bool:
+        list_clients = getattr(self.tmux, "list_clients", None)
+        if callable(list_clients):
+            try:
+                result = list_clients(session_name)
+            except Exception:  # noqa: BLE001
+                return True
+            if isinstance(result, str):
+                return bool(result.strip())
+            try:
+                return bool(list(result))
+            except TypeError:
+                return True
+        run = getattr(self.tmux, "run", None)
+        if not callable(run):
+            return True
+        try:
+            result = run(
+                "list-clients",
+                "-t",
+                session_name,
+                "-F",
+                "#{client_tty}",
+                check=False,
+            )
+        except Exception:  # noqa: BLE001
+            return True
+        stdout = getattr(result, "stdout", "") or ""
+        return bool(str(stdout).strip())
+
+    def should_animate(self) -> bool:
+        return self.is_tmux_attached()
+
+    def working_frame(self, spinner_index: int) -> str:
+        if not self.should_animate():
+            return ARC_SPINNER[0]
+        return ARC_SPINNER[spinner_index % len(ARC_SPINNER)]
+
+    def heartbeat_frame(self, spinner_index: int) -> str:
+        frames = ("♥", "♡")
+        if not self.should_animate():
+            return frames[0]
+        return frames[spinner_index % len(frames)]
+
+
 # ── Rail data model + router ─────────────────────────────────────────────
 #
 # Moved out of pollypm.cockpit in #404 so the routing concern (which rail
@@ -268,16 +357,95 @@ class CockpitRouter:
     _STATE_FILE = "cockpit_state.json"
     _COCKPIT_WINDOW = "PollyPM"
     _LEFT_PANE_WIDTH = 30  # default; actual value persisted in cockpit state.
+    _STATE_WRITE_DEBOUNCE_SECONDS = 0.25
 
     def __init__(self, config_path: Path) -> None:
         self.config_path = config_path
         self.service = PollyPMService(config_path)
         self.tmux = create_tmux_client()
         self._supervisor = None
+        self._config_cache: object | None = None
+        self._config_cache_mtime_ns: int | None = None
+        self._state_cache: dict[str, object] | None = None
+        self._state_cache_mtime_ns: int | None = None
+        self._state_cache_path: Path | None = None
+        self._state_dirty_since: float | None = None
+        self._hidden_items_cache_key: int | None = None
+        self._hidden_items_cache: frozenset[str] | None = None
+        self._collapsed_sections_cache_key: int | None = None
+        self._collapsed_sections_cache: frozenset[str] | None = None
+        self._grouped_rail_cache_key: int | None = None
+        self._grouped_rail_cache: dict[str, tuple[object, ...]] | None = None
         # Per-project activity cache keyed by project key.
         # value: (db_mtime, git_mtime, is_active, has_working_task)
         # Skips re-opening SQLite on every 0.8s cockpit tick when nothing changed.
         self._project_activity_cache: dict[str, tuple[float, float, bool, bool]] = {}
+
+    def _load_config(self):
+        try:
+            mtime_ns = self.config_path.stat().st_mtime_ns
+        except OSError:
+            mtime_ns = None
+        if self._config_cache is not None and self._config_cache_mtime_ns == mtime_ns:
+            return self._config_cache
+        self._clear_rail_caches()
+        config = load_config(self.config_path)
+        self._config_cache = config
+        self._config_cache_mtime_ns = mtime_ns
+        return config
+
+    def _clear_rail_caches(self) -> None:
+        self._hidden_items_cache_key = None
+        self._hidden_items_cache = None
+        self._collapsed_sections_cache_key = None
+        self._collapsed_sections_cache = None
+        self._grouped_rail_cache_key = None
+        self._grouped_rail_cache = None
+
+    def _config_identity(self, config: object) -> int:
+        return id(config)
+
+    def _hidden_rail_items_cached(self, config: object) -> frozenset[str]:
+        cache_key = self._config_identity(config)
+        if self._hidden_items_cache_key == cache_key and self._hidden_items_cache is not None:
+            return self._hidden_items_cache
+        hidden = _hidden_rail_items(config)
+        self._hidden_items_cache_key = cache_key
+        self._hidden_items_cache = hidden
+        return hidden
+
+    def _collapsed_rail_sections_cached(self, config: object) -> frozenset[str]:
+        cache_key = self._config_identity(config)
+        if (
+            self._collapsed_sections_cache_key == cache_key
+            and self._collapsed_sections_cache is not None
+        ):
+            return self._collapsed_sections_cache
+        collapsed = _collapsed_rail_sections(config)
+        self._collapsed_sections_cache_key = cache_key
+        self._collapsed_sections_cache = collapsed
+        return collapsed
+
+    def _grouped_rail_registrations(
+        self,
+        config: object,
+        registry,
+    ) -> dict[str, tuple[object, ...]]:
+        cache_key = self._config_identity(config)
+        if self._grouped_rail_cache_key == cache_key and self._grouped_rail_cache is not None:
+            return self._grouped_rail_cache
+        from pollypm.plugin_api.v1 import RAIL_SECTIONS
+
+        hidden_keys = self._hidden_rail_items_cached(config)
+        grouped: dict[str, list[object]] = {name: [] for name in RAIL_SECTIONS}
+        for reg in registry.items():
+            if reg.item_key in hidden_keys:
+                continue
+            grouped.setdefault(reg.section, []).append(reg)
+        cache_value = {section: tuple(rows) for section, rows in grouped.items()}
+        self._grouped_rail_cache_key = cache_key
+        self._grouped_rail_cache = cache_value
+        return cache_value
 
     def _load_supervisor(self, *, fresh: bool = False):
         # Reload config if the file changed (picks up new projects, sessions, etc.)
@@ -292,6 +460,9 @@ class CockpitRouter:
         if fresh or self._supervisor is None:
             if self._supervisor is not None:
                 self._supervisor.store.close()
+            self._clear_rail_caches()
+            self._config_cache = None
+            self._config_cache_mtime_ns = None
             self._supervisor = self.service.load_supervisor()
             self._supervisor.ensure_layout()
             try:
@@ -307,7 +478,7 @@ class CockpitRouter:
         return self._supervisor
 
     def _state_path(self) -> Path:
-        config = load_config(self.config_path)
+        config = self._load_config()
         config.project.base_dir.mkdir(parents=True, exist_ok=True)
         return config.project.base_dir / self._STATE_FILE
 
@@ -336,16 +507,59 @@ class CockpitRouter:
 
     def _load_state(self) -> dict[str, object]:
         path = self._state_path()
+        if self._state_cache is not None and self._state_cache_path == path:
+            if self._state_dirty_since is not None:
+                self._maybe_flush_state()
+                return dict(self._state_cache)
+            try:
+                mtime_ns = path.stat().st_mtime_ns
+            except OSError:
+                self._state_cache = {}
+                self._state_cache_mtime_ns = None
+                self._state_dirty_since = None
+                return {}
+            if self._state_cache_mtime_ns == mtime_ns:
+                return dict(self._state_cache)
         if not path.exists():
+            self._state_cache = {}
+            self._state_cache_path = path
+            self._state_cache_mtime_ns = None
+            self._state_dirty_since = None
             return {}
         try:
             payload = json.loads(path.read_text())
         except json.JSONDecodeError:
-            return {}
-        return payload if isinstance(payload, dict) else {}
+            payload = {}
+        state = payload if isinstance(payload, dict) else {}
+        self._state_cache = dict(state)
+        self._state_cache_path = path
+        try:
+            self._state_cache_mtime_ns = path.stat().st_mtime_ns
+        except OSError:
+            self._state_cache_mtime_ns = None
+        self._state_dirty_since = None
+        return dict(self._state_cache)
 
     def _write_state(self, data: dict[str, object]) -> None:
-        atomic_write_json(self._state_path(), data)
+        path = self._state_path()
+        if (
+            self._state_cache is not None
+            and self._state_cache_path == path
+            and self._state_dirty_since is not None
+        ):
+            merged = dict(self._state_cache)
+            merged.update(data)
+            data = merged
+        else:
+            data = dict(data)
+        atomic_write_json(path, data)
+        self._state_cache = dict(data)
+        self._state_cache_path = path
+        try:
+            self._state_cache_mtime_ns = path.stat().st_mtime_ns
+        except OSError:
+            self._state_cache_mtime_ns = None
+        self._state_dirty_since = None
 
     def rail_width(self) -> int:
         """Return the persisted rail width, falling back to the default."""
@@ -363,7 +577,21 @@ class CockpitRouter:
         if data.get("rail_width") == width:
             return
         data["rail_width"] = width
-        self._write_state(data)
+        self._state_cache = dict(data)
+        self._state_cache_path = self._state_path()
+        self._state_dirty_since = time.monotonic()
+        self._maybe_flush_state()
+
+    def _maybe_flush_state(self) -> None:
+        if (
+            self._state_dirty_since is None
+            or self._state_cache is None
+            or self._state_cache_path is None
+        ):
+            return
+        if time.monotonic() - self._state_dirty_since < self._STATE_WRITE_DEBOUNCE_SECONDS:
+            return
+        self._write_state(self._state_cache)
 
     def _validate_state(self, *, panes: list | None = None, target: str | None = None) -> list:
         """Clear stale entries from cockpit_state.json.
@@ -378,7 +606,7 @@ class CockpitRouter:
         state = self._load_state()
         dirty = False
         if target is None:
-            config = load_config(self.config_path)
+            config = self._load_config()
             target = f"{config.project.tmux_session}:{self._COCKPIT_WINDOW}"
         if panes is None:
             panes = self._safe_list_panes(target)
@@ -499,25 +727,23 @@ class CockpitRouter:
         # Hidden items + visibility predicates land in er03 / er04. The
         # renderer here runs them every tick — badge providers likewise
         # (a crash falls back to no-badge).
-        hidden_keys = _hidden_rail_items(config)
-        collapsed_sections = _collapsed_rail_sections(config)
-
+        collapsed_sections = self._collapsed_rail_sections_cached(config)
+        grouped_registrations = self._grouped_rail_registrations(config, registry)
         grouped: dict[str, list[CockpitItem]] = {name: [] for name in RAIL_SECTIONS}
 
-        for reg in registry.items():
-            if reg.item_key in hidden_keys:
-                continue
-            if not _visibility_passes(reg, ctx):
-                continue
-            rows = _rows_for_registration(reg, ctx)
-            for row in rows:
-                item = CockpitItem(
-                    key=row.key,
-                    label=row.label,
-                    state=row.state,
-                    selectable=row.selectable,
-                )
-                grouped.setdefault(reg.section, []).append(item)
+        for section, registrations in grouped_registrations.items():
+            for reg in registrations:
+                if not _visibility_passes(reg, ctx):
+                    continue
+                rows = _rows_for_registration(reg, ctx)
+                for row in rows:
+                    item = CockpitItem(
+                        key=row.key,
+                        label=row.label,
+                        state=row.state,
+                        selectable=row.selectable,
+                    )
+                    grouped.setdefault(section, []).append(item)
 
         items: list[CockpitItem] = []
         for section in RAIL_SECTIONS:
@@ -531,7 +757,7 @@ class CockpitRouter:
                 items.append(
                     CockpitItem(
                         key=f"_section:{section}",
-                        label=f"{section.upper()} (collapsed)",
+                        label=f"{section.upper()} ({len(rows)})",
                         state="separator",
                         selectable=False,
                     )
@@ -545,7 +771,7 @@ class CockpitRouter:
         """Return the plugin-host rail registry for the active root dir."""
         from pollypm.plugin_host import extension_host_for_root
 
-        config = load_config(self.config_path)
+        config = self._load_config()
         host = extension_host_for_root(str(config.project.root_dir.resolve()))
         # Initialize plugins so the rail registry is populated. Safe to
         # call repeatedly — it tracks which plugins have been init'd.
@@ -622,7 +848,6 @@ class CockpitRouter:
             return "idle"
         if window.pane_dead:
             return "dead"
-        spinners = ["\u25dc", "\u25dd", "\u25de", "\u25df"]
         if launch.session.role in ("worker", "operator-pm", "reviewer"):
             heartbeat = None
             try:
@@ -640,12 +865,12 @@ class CockpitRouter:
                 heartbeat=heartbeat,
             )
             if working:
-                return spinners[spinner_index % 4] + " working"
+                return f"{self.presence.working_frame(spinner_index)} working"
             if launch.session.role == "worker":
                 return "\u25cf live"
             return "ready"
         if launch.session.role == "heartbeat-supervisor":
-            return "watch"
+            return "heartbeat"
         if launch.session.role == "triage":
             return "triage"
         return "live"
@@ -738,7 +963,7 @@ class CockpitRouter:
                 seen[window.name] = window.index
 
     def ensure_cockpit_layout(self) -> None:
-        config = load_config(self.config_path)
+        config = self._load_config()
         target = f"{config.project.tmux_session}:{self._COCKPIT_WINDOW}"
         # Single list-panes baseline shared with ``_validate_state``. See
         # #175: subsequent list-panes calls only run after a mutation that
@@ -1006,7 +1231,7 @@ class CockpitRouter:
         raise RuntimeError(f"Unknown cockpit item: {key}")
 
     def focus_right_pane(self) -> None:
-        config = load_config(self.config_path)
+        config = self._load_config()
         window_target = f"{config.project.tmux_session}:{self._COCKPIT_WINDOW}"
         self.ensure_cockpit_layout()
         right_pane = self._right_pane_id(window_target)
@@ -1426,6 +1651,7 @@ def _sgr(row: RenderRow) -> str:
 class PollyCockpitRail:
     def __init__(self, config_path: Path) -> None:
         self.router = CockpitRouter(config_path)
+        self.presence = CockpitPresence(self.router.tmux)
         self.selected_key = self.router.selected_key()
         self.spinner_index = 0
         self.slogan_started_at = time.time()
@@ -1444,7 +1670,8 @@ class PollyCockpitRail:
                 self._last_items = items
                 self._clamp_selection(items)
                 self._render(items)
-                self.spinner_index = (self.spinner_index + 1) % 4
+                if self.presence.should_animate():
+                    self.spinner_index = (self.spinner_index + 1) % 4
                 self._tick_slogan()
                 ready, _, _ = select.select([sys.stdin], [], [], 1.0)
                 if not ready:
@@ -1681,7 +1908,7 @@ class PollyCockpitRail:
     def _indicator(self, item: CockpitItem) -> tuple[str, _C | None]:
         # State-based indicators first (apply to any item type including projects)
         if item.state.endswith("working"):
-            char = ARC_SPINNER[self.spinner_index]
+            char = self.presence.working_frame(self.spinner_index)
             return char, PALETTE["live_indicator"]
         if item.state.endswith("live"):
             return "\u25cf", PALETTE["live_indicator"]
@@ -1689,8 +1916,8 @@ class PollyCockpitRail:
             return "\u25b2", PALETTE["alert_indicator"]
         if item.state == "dead":
             return "\u2715", PALETTE["dead"]
-        if item.state == "watch":
-            return "\u25ce", PALETTE["live_indicator"]
+        if item.state in {"heartbeat", "watch"}:
+            return self.presence.heartbeat_frame(self.spinner_index), PALETTE["live_indicator"]
         if item.state == "ready":
             return "\u25cf", PALETTE["sel_accent"]
         # Key-based fallbacks for items with no meaningful state

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -142,7 +142,7 @@ def test_cockpit_router_session_state_uses_heartbeat_state(tmp_path: Path) -> No
             self.pane_current_command = "python"
 
     router = CockpitRouter(config_path)
-    assert router._session_state("heartbeat", [FakeLaunch()], [FakeWindow()], [], 0) == "heartbeat"
+    assert router._session_state("heartbeat", [FakeLaunch()], [FakeWindow()], [], 0) == "watch"
 
 
 def test_cockpit_presence_treats_outside_tmux_as_attached() -> None:
@@ -207,7 +207,6 @@ def test_cockpit_presence_calm_mode_disables_animation(monkeypatch) -> None:
 
     assert presence.should_animate() is False
     assert presence.working_frame(3) == "◜"
-    assert presence.heartbeat_frame(1) == "♥"
 
 
 def test_cockpit_router_config_cache_reuses_loaded_config(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from pollypm.cockpit import build_cockpit_detail
-from pollypm.cockpit_rail import CockpitRouter
+from pollypm.cockpit_rail import CockpitPresence, CockpitRouter
 from pollypm.config import write_config
 from pollypm.cockpit_ui import PollyCockpitApp, PollySettingsPaneApp
 from pollypm.models import (
@@ -113,6 +113,242 @@ def test_cockpit_router_session_state_ignores_silent_alerts(tmp_path: Path) -> N
 
     assert router._session_state("worker_demo", launches, windows, [make_alert("needs_followup")], 0).endswith("live")
     assert router._session_state("worker_demo", launches, windows, [make_alert("pane_dead")], 0) == "! pane dead"
+
+
+def test_cockpit_router_session_state_uses_heartbeat_state(tmp_path: Path) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+
+    class FakeLaunch:
+        def __init__(self) -> None:
+            self.window_name = "heartbeat"
+            self.session = type(
+                "Session",
+                (),
+                {
+                    "name": "heartbeat",
+                    "role": "heartbeat-supervisor",
+                    "project": "pollypm",
+                    "provider": type("P", (), {"value": "claude"})(),
+                },
+            )()
+
+    class FakeWindow:
+        def __init__(self) -> None:
+            self.name = "heartbeat"
+            self.pane_dead = False
+            self.pane_current_command = "python"
+
+    router = CockpitRouter(config_path)
+    assert router._session_state("heartbeat", [FakeLaunch()], [FakeWindow()], [], 0) == "heartbeat"
+
+
+def test_cockpit_presence_treats_outside_tmux_as_attached() -> None:
+    class _FakeTmux:
+        def current_session_name(self) -> str | None:
+            return None
+
+    presence = CockpitPresence(_FakeTmux())
+
+    assert presence.is_tmux_attached() is True
+    assert presence.should_animate() is True
+
+
+def test_cockpit_presence_caches_attached_result_for_about_two_seconds(monkeypatch) -> None:
+    class _FakeTmux:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def current_session_name(self) -> str | None:
+            return "pollypm"
+
+        def list_clients(self, session_name: str) -> str:
+            del session_name
+            self.calls += 1
+            return ""
+
+    tmux = _FakeTmux()
+    presence = CockpitPresence(tmux)
+    times = iter([10.0, 10.5, 12.5])
+    monkeypatch.setattr("pollypm.cockpit_rail.time.monotonic", lambda: next(times))
+
+    assert presence.is_tmux_attached() is False
+    assert presence.is_tmux_attached() is False
+    assert presence.is_tmux_attached() is False
+    assert tmux.calls == 2
+
+
+def test_cockpit_presence_defaults_to_attached_on_detection_failure() -> None:
+    class _BrokenTmux:
+        def current_session_name(self) -> str | None:
+            return "pollypm"
+
+        def run(self, *args, **kwargs):  # noqa: ANN001
+            raise RuntimeError("boom")
+
+    presence = CockpitPresence(_BrokenTmux())
+
+    assert presence.is_tmux_attached() is True
+
+
+def test_cockpit_presence_calm_mode_disables_animation(monkeypatch) -> None:
+    class _FakeTmux:
+        def current_session_name(self) -> str | None:
+            return "pollypm"
+
+        def list_clients(self, session_name: str) -> str:
+            del session_name
+            return "client"
+
+    monkeypatch.setenv("POLLY_CALM", "1")
+    presence = CockpitPresence(_FakeTmux())
+
+    assert presence.should_animate() is False
+    assert presence.working_frame(3) == "◜"
+    assert presence.heartbeat_frame(1) == "♥"
+
+
+def test_cockpit_router_config_cache_reuses_loaded_config(monkeypatch, tmp_path: Path) -> None:
+    class _Config:
+        class Project:
+            root_dir = tmp_path
+            base_dir = tmp_path / ".pollypm"
+            tmux_session = "pollypm"
+
+        project = Project()
+
+    calls: list[Path] = []
+    monkeypatch.setattr("pollypm.cockpit_rail.load_config", lambda path: calls.append(path) or _Config())
+
+    router = CockpitRouter(tmp_path / "pollypm.toml")
+
+    first = router._load_config()
+    second = router._load_config()
+
+    assert first is second
+    assert len(calls) == 1
+
+
+def test_cockpit_router_state_cache_reuses_loaded_dict(monkeypatch, tmp_path: Path) -> None:
+    class _Config:
+        class Project:
+            root_dir = tmp_path
+            base_dir = tmp_path / ".pollypm"
+            tmux_session = "pollypm"
+
+        project = Project()
+
+    monkeypatch.setattr("pollypm.cockpit_rail.load_config", lambda path: _Config())
+
+    config_path = tmp_path / "pollypm.toml"
+    router = CockpitRouter(config_path)
+    router._write_state({"selected": "polly", "rail_width": 44})
+
+    reader = CockpitRouter(config_path)
+    reads: list[Path] = []
+    original_read_text = Path.read_text
+    state_path = reader._state_path()
+
+    def counting_read_text(self: Path, *args, **kwargs):
+        if self == state_path:
+            reads.append(self)
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", counting_read_text)
+
+    first = reader._load_state()
+    second = reader._load_state()
+
+    assert first == second == {"selected": "polly", "rail_width": 44}
+    assert len(reads) == 1
+
+
+def test_cockpit_router_debounces_rail_width_writes(monkeypatch, tmp_path: Path) -> None:
+    class _Config:
+        class Project:
+            root_dir = tmp_path
+            base_dir = tmp_path / ".pollypm"
+            tmux_session = "pollypm"
+
+        project = Project()
+
+    monkeypatch.setattr("pollypm.cockpit_rail.load_config", lambda path: _Config())
+
+    config_path = tmp_path / "pollypm.toml"
+    router = CockpitRouter(config_path)
+    router._write_state({"rail_width": 30})
+
+    writes: list[dict[str, object]] = []
+    from pollypm import cockpit_rail as cockpit_rail_module
+
+    original_atomic_write_json = cockpit_rail_module.atomic_write_json
+
+    def counting_atomic_write_json(path: Path, data: dict[str, object]) -> None:
+        writes.append(dict(data))
+        original_atomic_write_json(path, data)
+
+    times = iter([0.0, 0.0, 0.1, 0.1, 0.5])
+    monkeypatch.setattr("pollypm.cockpit_rail.atomic_write_json", counting_atomic_write_json)
+    monkeypatch.setattr("pollypm.cockpit_rail.time.monotonic", lambda: next(times))
+
+    router.set_rail_width(42)
+    router.set_rail_width(44)
+    router._maybe_flush_state()
+
+    assert writes == [{"rail_width": 44}]
+    assert router.rail_width() == 44
+
+
+def test_cockpit_router_caches_hidden_collapsed_and_grouped_registrations(monkeypatch, tmp_path: Path) -> None:
+    router = CockpitRouter.__new__(CockpitRouter)
+    router._hidden_items_cache_key = None
+    router._hidden_items_cache = None
+    router._collapsed_sections_cache_key = None
+    router._collapsed_sections_cache = None
+    router._grouped_rail_cache_key = None
+    router._grouped_rail_cache = None
+
+    calls = {"hidden": 0, "collapsed": 0, "registry": 0}
+
+    def _hidden(config):
+        del config
+        calls["hidden"] += 1
+        return frozenset({"top.Hidden"})
+
+    def _collapsed(config):
+        del config
+        calls["collapsed"] += 1
+        return frozenset({"system"})
+
+    monkeypatch.setattr("pollypm.cockpit_rail._hidden_rail_items", _hidden)
+    monkeypatch.setattr("pollypm.cockpit_rail._collapsed_rail_sections", _collapsed)
+
+    class _Reg:
+        def __init__(self, item_key: str, section: str) -> None:
+            self.item_key = item_key
+            self.section = section
+
+    class _Registry:
+        def items(self):
+            calls["registry"] += 1
+            return [_Reg("top.Inbox", "top"), _Reg("system.Settings", "system")]
+
+    config = object()
+    registry = _Registry()
+
+    hidden_first = router._hidden_rail_items_cached(config)
+    hidden_second = router._hidden_rail_items_cached(config)
+    collapsed_first = router._collapsed_rail_sections_cached(config)
+    collapsed_second = router._collapsed_rail_sections_cached(config)
+    grouped_first = router._grouped_rail_registrations(config, registry)
+    grouped_second = router._grouped_rail_registrations(config, registry)
+
+    assert hidden_first == hidden_second == frozenset({"top.Hidden"})
+    assert collapsed_first == collapsed_second == frozenset({"system"})
+    assert grouped_first == grouped_second
+    assert calls == {"hidden": 1, "collapsed": 1, "registry": 1}
 
 
 def test_cockpit_router_selected_key_clears_missing_right_pane_state(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_core_rail_items.py
+++ b/tests/test_core_rail_items.py
@@ -123,6 +123,29 @@ def test_build_items_identical_to_legacy_shape(monkeypatch, tmp_path: Path) -> N
     assert items[-1].key == "settings"
 
 
+def test_build_items_preserves_working_project_session_state(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Working sessions must not silently fall back to idle in rail rows."""
+    monkeypatch.setattr(
+        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 0,
+    )
+    _write_config(tmp_path)
+    router = CockpitRouter(tmp_path / "pollypm.toml")
+    monkeypatch.setattr(router, "_load_supervisor", lambda: _fake_supervisor(tmp_path))
+    monkeypatch.setattr(
+        router,
+        "_is_pane_working",
+        lambda window, provider, *, heartbeat=None: True,
+    )
+
+    items = router.build_items(spinner_index=1)
+    demo_item = next(item for item in items if item.key == "project:demo")
+
+    assert demo_item.state.endswith("working")
+    assert demo_item.state != "idle"
+
+
 def test_removing_core_rail_items_yields_empty_rail(monkeypatch, tmp_path: Path) -> None:
     """Acceptance: if `core_rail_items` is removed, the rail is empty.
 

--- a/tests/test_rail_cli.py
+++ b/tests/test_rail_cli.py
@@ -158,8 +158,10 @@ def test_build_items_collapses_sections(monkeypatch, tmp_path: Path) -> None:
     items = router.build_items(spinner_index=0)
     # Settings section should be rendered as a collapsed marker row.
     keys = [i.key for i in items]
+    header = next(i for i in items if i.key.startswith("_section:system"))
     assert "settings" not in keys
     assert any(k.startswith("_section:system") for k in keys)
+    assert header.label == "SYSTEM (1)"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #656
Closes #679
Closes #680
Closes #681
Closes #682
Closes #684

Scope note: #659 and #660 were split into stacked follow-up PR #699 so this branch stays perf-only.

Focused validation:
- `/Users/sam/dev/pollypm/.venv/bin/pytest -q tests/test_cockpit.py tests/test_rail_cli.py tests/test_core_rail_items.py`
- `python3 -m py_compile src/pollypm/cockpit_rail.py tests/test_cockpit.py`