### PR TITLE
refactor(state): retire legacy message side tables

### DIFF
--- a/src/pollypm/recovery/worker_turn_end.py
+++ b/src/pollypm/recovery/worker_turn_end.py
@@ -140,10 +140,11 @@ def _unfulfilled_pm_notify(tail: str, work_service: Any) -> bool:
 
     Best-effort: in v1 we simply check for the command-shaped text in
     the tail. If we see the intent and no corresponding
-    ``task_notifications`` row landed, we treat the turn-end as an
-    escalation attempt that the agent gave up on mid-flight. ``work_service``
-    is unused in v1 but the parameter stays so a v2 stricter match can
-    correlate on subject/body without changing callers.
+    task-assignment notification row landed in the unified messages
+    ledger, we treat the turn-end as an escalation attempt that the
+    agent gave up on mid-flight. ``work_service`` is unused in v1 but
+    the parameter stays so a v2 stricter match can correlate on
+    subject/body without changing callers.
     """
     _ = work_service
     lower = tail.lower()
@@ -165,7 +166,7 @@ def determine_worker_response(
     * Scan the last 2000 chars of the transcript for any phrase in
       ``_BLOCKER_PHRASES`` → blocking_question.
     * Otherwise, if the tail shows a ``pm notify`` / ``pm task block``
-      intent that has no matching row in ``task_notifications`` →
+      intent that has no matching task-assignment notification row →
       blocking_question.
     * Otherwise → reprompt.
 

--- a/src/pollypm/storage/state.py
+++ b/src/pollypm/storage/state.py
@@ -65,8 +65,8 @@ CREATE TABLE IF NOT EXISTS messages (
     body TEXT NOT NULL DEFAULT '',
     payload_json TEXT NOT NULL DEFAULT '{}',
     labels TEXT NOT NULL DEFAULT '[]',
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     closed_at TEXT
 );
 

--- a/src/pollypm/storage/state.py
+++ b/src/pollypm/storage/state.py
@@ -1,7 +1,10 @@
 """Legacy :class:`StateStore` — domain tables that haven't moved yet.
 
-#342 retired the event/alert/message-shaped surfaces that this module
-used to own (now on :class:`pollypm.store.SQLAlchemyStore`). What's
+#342 retired the message-shaped storage surfaces onto the unified
+``messages`` table. #411 finishes that retirement for the remaining
+compatibility APIs on this class: ``record_event()``, ``upsert_alert()``,
+and the task-assignment notification helpers still exist, but they now
+persist/read through ``messages`` rather than legacy side tables. What's
 left are the domain tables we didn't have time to port to SQLAlchemy
 Core Table defs in a single PR:
 
@@ -49,13 +52,36 @@ CREATE TABLE IF NOT EXISTS sessions (
     window_name TEXT NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS events (
+CREATE TABLE IF NOT EXISTS messages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    session_name TEXT NOT NULL,
-    event_type TEXT NOT NULL,
-    message TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    scope TEXT NOT NULL,
+    type TEXT NOT NULL,
+    tier TEXT NOT NULL DEFAULT 'immediate',
+    recipient TEXT NOT NULL,
+    sender TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'open',
+    parent_id INTEGER REFERENCES messages(id) ON DELETE SET NULL,
+    subject TEXT NOT NULL,
+    body TEXT NOT NULL DEFAULT '',
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    labels TEXT NOT NULL DEFAULT '[]',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    closed_at TEXT
 );
+
+CREATE INDEX IF NOT EXISTS idx_messages_recipient_state
+ON messages(recipient, state);
+
+CREATE INDEX IF NOT EXISTS idx_messages_type_tier
+ON messages(type, tier);
+
+CREATE INDEX IF NOT EXISTS idx_messages_scope_created
+ON messages(scope, created_at);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_open_alert_unique
+ON messages(scope, sender)
+WHERE type = 'alert' AND state = 'open';
 
 CREATE TABLE IF NOT EXISTS heartbeats (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -69,21 +95,6 @@ CREATE TABLE IF NOT EXISTS heartbeats (
     snapshot_hash TEXT NOT NULL DEFAULT '',
     created_at TEXT NOT NULL
 );
-
-CREATE TABLE IF NOT EXISTS alerts (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    session_name TEXT NOT NULL,
-    alert_type TEXT NOT NULL,
-    severity TEXT NOT NULL,
-    message TEXT NOT NULL,
-    status TEXT NOT NULL,
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_alerts_open
-ON alerts(session_name, alert_type)
-WHERE status = 'open';
 
 CREATE TABLE IF NOT EXISTS leases (
     session_name TEXT PRIMARY KEY,
@@ -288,6 +299,43 @@ CREATE TABLE IF NOT EXISTS architect_resume_tokens (
     last_active_at TEXT NOT NULL
 );
 """
+
+
+def _json_object(raw: str | None) -> dict[str, object]:
+    if not raw:
+        return {}
+    try:
+        decoded = json.loads(raw)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _alert_message(subject: str, body: str) -> str:
+    text = (body or "").strip()
+    if text:
+        return text
+    title = (subject or "").strip()
+    if title.startswith("[Alert] "):
+        return title[len("[Alert] "):]
+    if title.startswith("[Alert]"):
+        return title[len("[Alert]"):].lstrip()
+    return title
+
+
+def _alert_status(state: str) -> str:
+    return "open" if state == "open" else "cleared"
+
+
+def _event_message(subject: str, body: str, payload_json: str | None) -> str:
+    text = (body or "").strip()
+    if text:
+        return text
+    payload = _json_object(payload_json)
+    candidate = payload.get("message")
+    if isinstance(candidate, str) and candidate.strip():
+        return candidate
+    return (subject or "").strip()
 
 
 @dataclass(slots=True)
@@ -511,9 +559,11 @@ class StateStore:
                 try:
                     self._conn.executescript(SCHEMA)
                 except sqlite3.IntegrityError:
-                    # Duplicates exist that conflict with a UNIQUE index.
-                    # Deduplicate and retry.
-                    self._deduplicate_alerts()
+                    # Old DBs can carry duplicate open alert rows in
+                    # ``messages`` from pre-index boots. Close the
+                    # duplicates, then retry the schema bootstrap so the
+                    # uniqueness contract lands cleanly.
+                    self._deduplicate_open_alert_messages()
                     self._conn.executescript(SCHEMA)
                 try:
                     self._migrate()
@@ -628,19 +678,6 @@ class StateStore:
             pass
         return deleted
 
-    def _deduplicate_alerts(self) -> None:
-        """Remove duplicate alerts, keeping the most recently updated row."""
-        try:
-            self._conn.execute("""
-                DELETE FROM alerts WHERE rowid NOT IN (
-                    SELECT MAX(rowid) FROM alerts
-                    GROUP BY session_name, alert_type
-                )
-            """)
-            self._conn.commit()
-        except Exception:  # noqa: BLE001
-            pass
-
     def __enter__(self):
         return self
 
@@ -675,6 +712,42 @@ class StateStore:
     def _now(self) -> str:
         return datetime.now(UTC).isoformat()
 
+    def _deduplicate_open_alert_messages(self) -> None:
+        """Close duplicate open alert rows, keeping the newest per key."""
+        try:
+            rows = self._conn.execute(
+                """
+                SELECT id, scope, sender
+                FROM messages
+                WHERE type = 'alert' AND state = 'open'
+                ORDER BY id DESC
+                """
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return
+        keep: set[tuple[str, str]] = set()
+        duplicate_ids: list[int] = []
+        for row_id, scope, sender in rows:
+            key = (str(scope or ""), str(sender or ""))
+            if key in keep:
+                duplicate_ids.append(int(row_id))
+                continue
+            keep.add(key)
+        if not duplicate_ids:
+            return
+        now = self._now()
+        self._conn.executemany(
+            """
+            UPDATE messages
+            SET state = 'closed',
+                closed_at = COALESCE(closed_at, updated_at, ?),
+                updated_at = COALESCE(updated_at, ?)
+            WHERE id = ?
+            """,
+            [(now, now, row_id) for row_id in duplicate_ids],
+        )
+        self._conn.commit()
+
     # ------------------------------------------------------------------
     # Schema migrations — append-only list.  Each entry is
     # (version, description, sql_statements).  The runner applies any
@@ -683,18 +756,15 @@ class StateStore:
     # so they are safe to replay on databases created before versioning.
     # ------------------------------------------------------------------
     _MIGRATIONS: list[tuple[int, str, list[str]]] = [
-        (1, "Rebuild alerts unique index", [
-            "DROP INDEX IF EXISTS idx_alerts_open",
-            """CREATE UNIQUE INDEX IF NOT EXISTS idx_alerts_open
-               ON alerts(session_name, alert_type) WHERE status = 'open'""",
-        ]),
+        # Legacy alerts table retired by migration 15. Keep the version
+        # marker so old databases still walk the same version sequence.
+        (1, "Rebuild alerts unique index", []),
         (2, "Add project column to sessions", [
             # Column-existence check is handled by _safe_add_column below.
         ]),
         (3, "Add snapshot_hash to heartbeats", []),
         (4, "Add cache_read_tokens to token_usage_hourly", []),
         (5, "Add indexes on events and heartbeats for heartbeat sweep performance", [
-            "CREATE INDEX IF NOT EXISTS idx_events_session_type ON events(session_name, event_type, id DESC)",
             "CREATE INDEX IF NOT EXISTS idx_heartbeats_session ON heartbeats(session_name, id DESC)",
         ]),
         (6, "Add work_jobs table for durable job queue", [
@@ -748,46 +818,16 @@ class StateStore:
             # it from SCHEMA). The index is created afterwards.
         ]),
         # --- Migration 11 ----------------------------------------------
-        # Task-assignment notification dedupe table (#244). Records
-        # every ping sent to a session about a given task so the notify
-        # handler can throttle re-sends to once per 30 minutes and the
-        # ``pm task pickup-log`` CLI can surface delivery history.
-        (11, "Task-assignment notifications dedupe table (#244)", [
-            """CREATE TABLE IF NOT EXISTS task_notifications (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                session_name TEXT NOT NULL,
-                task_id TEXT NOT NULL,
-                project TEXT NOT NULL DEFAULT '',
-                notified_at TEXT NOT NULL,
-                delivery_status TEXT NOT NULL DEFAULT 'sent',
-                message TEXT NOT NULL DEFAULT ''
-            )""",
-            """CREATE INDEX IF NOT EXISTS idx_task_notifications_recent
-               ON task_notifications(notified_at DESC)""",
-            """CREATE INDEX IF NOT EXISTS idx_task_notifications_session_task
-               ON task_notifications(session_name, task_id, notified_at DESC)""",
-        ]),
+        # Task-assignment notifications now live on ``messages`` (type
+        # ``task_notification``). Keep the version marker so pre-#411 DBs
+        # still advance through the historical sequence before migration 15
+        # copies/drops the legacy table.
+        (11, "Task-assignment notifications dedupe table (#244)", []),
         # --- Migration 12 ----------------------------------------------
-        # Reject-bounce retry fix (#279). The dedupe for task-assignment
-        # pings was keyed on ``(session_name, task_id)`` only, which
-        # meant a rejected worker couldn't be re-pinged when the task
-        # bounced back to ``implement`` — the 30-minute dedupe window
-        # kept the retry ping suppressed. We add an ``execution_version``
-        # column (the ``work_node_executions.visit`` counter for the
-        # task's current node at ping time) so the dedupe key becomes
-        # ``(session_name, task_id, execution_version)``. A reject that
-        # opens a fresh ``(node, visit=N+1)`` execution counts as a new
-        # ping opportunity; identical-state pings within the window are
-        # still suppressed. Existing rows default to ``0`` (column
-        # DEFAULT) — the same default a freshly-built event carries when
-        # the work service can't compute a visit — so pre-migration
-        # dedupe semantics survive the upgrade.
-        (12, "Dedupe includes execution_version (#279)", [
-            # Column addition + index creation handled via the dispatch
-            # block below (_safe_add_column + explicit CREATE INDEX) so
-            # the column is guaranteed to exist before the index touches
-            # it, and a fresh DB re-running the migration is idempotent.
-        ]),
+        # Historical marker only — migration 15 preserves the
+        # ``execution_version`` semantics when it copies any remaining
+        # ``task_notifications`` rows into ``messages``.
+        (12, "Dedupe includes execution_version (#279)", []),
         # --- Migration 13 ----------------------------------------------
         # Actually drop the ``inbox_messages`` table that migration 7
         # deprecated but left in place. No live callers remain after
@@ -802,6 +842,10 @@ class StateStore:
         (14, "Structured account_usage fields for sampler snapshots", [
             # Column additions handled in the dispatch block below.
         ]),
+        # --- Migration 15 ----------------------------------------------
+        # Move the remaining message-shaped legacy rows into the unified
+        # ``messages`` table, then retire the old tables outright.
+        (15, "Retire legacy events / alerts / task_notifications tables", []),
     ]
 
     def _migrate(self) -> None:
@@ -872,37 +916,135 @@ class StateStore:
                     "CREATE INDEX IF NOT EXISTS idx_memory_entries_tier "
                     "ON memory_entries(scope_tier, scope, id DESC)"
                 )
-            elif version == 12:
-                # Reject-bounce retry fix (#279). The dedupe key now
-                # includes the current node's execution version (the
-                # ``work_node_executions.visit`` counter at ping time).
-                # Existing rows back-fill to ``0`` via the column
-                # DEFAULT, which matches the default version emitted by
-                # freshly-rebuilt events whose work service can't
-                # compute a visit — so pre-migration dedupe semantics
-                # survive the upgrade intact.
-                self._safe_add_column(
-                    "task_notifications",
-                    "execution_version",
-                    "INTEGER NOT NULL DEFAULT 0",
-                )
-                # Composite index supports the new dedupe query path —
-                # ``WHERE session = ? AND task = ? AND version = ? AND
-                # notified_at >= ?``. The original per-session-task
-                # index (migration 11) stays in place for pickup-log
-                # filters that don't care about version.
-                self.execute(
-                    "CREATE INDEX IF NOT EXISTS "
-                    "idx_task_notifications_session_task_version "
-                    "ON task_notifications("
-                    "session_name, task_id, execution_version, "
-                    "notified_at DESC)"
-                )
             elif version == 14:
                 self._safe_add_column("account_usage", "used_pct", "INTEGER")
                 self._safe_add_column("account_usage", "remaining_pct", "INTEGER")
                 self._safe_add_column("account_usage", "reset_at", "TEXT")
                 self._safe_add_column("account_usage", "period_label", "TEXT")
+            elif version == 15:
+                if self._table_exists("events"):
+                    rows = self.execute(
+                        "SELECT session_name, event_type, message, created_at FROM events ORDER BY id"
+                    ).fetchall()
+                    for session_name, event_type, message, created_at in rows:
+                        self.execute(
+                            """
+                            INSERT INTO messages (
+                                scope, type, tier, recipient, sender, state,
+                                subject, body, payload_json, labels,
+                                created_at, updated_at
+                            )
+                            VALUES (?, 'event', 'immediate', '*', ?, 'open', ?, ?, ?, '[]', ?, ?)
+                            """,
+                            (
+                                session_name,
+                                event_type,
+                                event_type,
+                                message,
+                                json.dumps(
+                                    {
+                                        "session_name": session_name,
+                                        "event_type": event_type,
+                                    }
+                                ),
+                                created_at,
+                                created_at,
+                            ),
+                        )
+                if self._table_exists("alerts"):
+                    rows = self.execute(
+                        "SELECT id, session_name, alert_type, severity, message, status, created_at, updated_at "
+                        "FROM alerts ORDER BY id"
+                    ).fetchall()
+                    latest_open_by_key: dict[tuple[str, str], int] = {}
+                    for row in rows:
+                        if row[5] == "open":
+                            latest_open_by_key[(str(row[1]), str(row[2]))] = int(row[0])
+                    for row_id, session_name, alert_type, severity, message, status, created_at, updated_at in rows:
+                        if status == "open" and latest_open_by_key.get((str(session_name), str(alert_type))) != int(row_id):
+                            continue
+                        state = "open" if status == "open" else "closed"
+                        closed_at = None if state == "open" else updated_at
+                        self.execute(
+                            """
+                            INSERT INTO messages (
+                                scope, type, tier, recipient, sender, state,
+                                subject, body, payload_json, labels,
+                                created_at, updated_at, closed_at
+                            )
+                            VALUES (?, 'alert', 'immediate', 'user', ?, ?, ?, '', ?, '[]', ?, ?, ?)
+                            """,
+                            (
+                                session_name,
+                                alert_type,
+                                state,
+                                message,
+                                json.dumps(
+                                    {
+                                        "severity": severity,
+                                        "session_name": session_name,
+                                    }
+                                ),
+                                created_at,
+                                updated_at,
+                                closed_at,
+                            ),
+                        )
+                if self._table_exists("task_notifications"):
+                    has_execution_version = self._column_exists(
+                        self._conn, "task_notifications", "execution_version"
+                    )
+                    columns = (
+                        "session_name, task_id, project, notified_at, delivery_status, message, execution_version"
+                        if has_execution_version
+                        else "session_name, task_id, project, notified_at, delivery_status, message"
+                    )
+                    rows = self.execute(
+                        f"SELECT {columns} FROM task_notifications ORDER BY id"
+                    ).fetchall()
+                    for row in rows:
+                        session_name, task_id, project, notified_at, delivery_status, message, *rest = row
+                        execution_version = int(rest[0] or 0) if rest else 0
+                        self.execute(
+                            """
+                            INSERT INTO messages (
+                                scope, type, tier, recipient, sender, state,
+                                subject, body, payload_json, labels,
+                                created_at, updated_at
+                            )
+                            VALUES (?, 'task_notification', 'immediate', ?, ?, 'open', ?, ?, ?, '[]', ?, ?)
+                            """,
+                            (
+                                session_name,
+                                project,
+                                task_id,
+                                task_id,
+                                message,
+                                json.dumps(
+                                    {
+                                        "project": project,
+                                        "delivery_status": delivery_status,
+                                        "execution_version": execution_version,
+                                    }
+                                ),
+                                notified_at,
+                                notified_at,
+                            ),
+                        )
+                self._deduplicate_open_alert_messages()
+                self.execute(
+                    """CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_open_alert_unique
+                       ON messages(scope, sender)
+                       WHERE type = 'alert' AND state = 'open'"""
+                )
+                self.execute("DROP INDEX IF EXISTS idx_task_notifications_session_task_version")
+                self.execute("DROP INDEX IF EXISTS idx_task_notifications_recent")
+                self.execute("DROP INDEX IF EXISTS idx_task_notifications_session_task")
+                self.execute("DROP INDEX IF EXISTS idx_alerts_open")
+                self.execute("DROP INDEX IF EXISTS idx_events_session_type")
+                self.execute("DROP TABLE IF EXISTS task_notifications")
+                self.execute("DROP TABLE IF EXISTS alerts")
+                self.execute("DROP TABLE IF EXISTS events")
             self.execute(
                 "INSERT INTO schema_version (version, description, applied_at) VALUES (?, ?, ?)",
                 (version, description, datetime.now(UTC).isoformat()),
@@ -912,6 +1054,13 @@ class StateStore:
     def _column_exists(cursor, table: str, column: str) -> bool:
         cols = {row[1] for row in cursor.execute(f"PRAGMA table_info({table})").fetchall()}
         return column in cols
+
+    def _table_exists(self, table: str) -> bool:
+        row = self.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name = ?",
+            (table,),
+        ).fetchone()
+        return row is not None
 
     def _safe_add_column(self, table: str, column: str, typedef: str) -> None:
         if not self._column_exists(self._conn, table, column):
@@ -971,11 +1120,11 @@ class StateStore:
             )
             self.execute(
                 f"""
-                UPDATE alerts
-                SET status = 'cleared', updated_at = ?
-                WHERE status = 'open' AND session_name NOT IN ({placeholders})
+                UPDATE messages
+                SET state = 'closed', closed_at = ?, updated_at = ?
+                WHERE type = 'alert' AND state = 'open' AND scope NOT IN ({placeholders})
                 """,
-                (now, *sorted(valid_session_names)),
+                (now, now, *sorted(valid_session_names)),
             )
             # M03 (#232): session-tier memory entries auto-purge when
             # their session ends. The supervisor's session-reconciliation
@@ -997,11 +1146,11 @@ class StateStore:
             self.execute("DELETE FROM leases")
             self.execute(
                 """
-                UPDATE alerts
-                SET status = 'cleared', updated_at = ?
-                WHERE status = 'open'
+                UPDATE messages
+                SET state = 'closed', closed_at = ?, updated_at = ?
+                WHERE type = 'alert' AND state = 'open'
                 """,
-                (now,),
+                (now, now),
             )
             # No live sessions ⇒ all session-tier memory is orphaned.
             self.execute(
@@ -1019,17 +1168,35 @@ class StateStore:
     def record_event(self, session_name: str, event_type: str, message: str) -> None:
         self.execute(
             """
-            INSERT INTO events (session_name, event_type, message, created_at)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO messages (
+                scope, type, tier, recipient, sender, state,
+                subject, body, payload_json, labels, created_at, updated_at
+            )
+            VALUES (?, 'event', 'immediate', '*', ?, 'open', ?, ?, ?, '[]', ?, ?)
             """,
-            (session_name, event_type, message, self._now()),
+            (
+                session_name,
+                event_type,
+                event_type,
+                message,
+                json.dumps(
+                    {
+                        "session_name": session_name,
+                        "event_type": event_type,
+                    }
+                ),
+                self._now(),
+                self._now(),
+            ),
         )
         self.commit()
 
     def last_event_at(self, session_name: str, event_type: str) -> str | None:
         """Return the ISO timestamp of the most recent event of this type, or None."""
         row = self.execute(
-            "SELECT created_at FROM events WHERE session_name = ? AND event_type = ? ORDER BY id DESC LIMIT 1",
+            "SELECT created_at FROM messages "
+            "WHERE type = 'event' AND scope = ? AND subject = ? "
+            "ORDER BY id DESC LIMIT 1",
             (session_name, event_type),
         ).fetchone()
         return row[0] if row else None
@@ -1037,40 +1204,41 @@ class StateStore:
     def last_heartbeat_at(self) -> str | None:
         """Return the ISO timestamp of the most recent heartbeat sweep, or None.
 
-        Reads from the unified ``messages`` table where heartbeat
-        events have landed since #349. The legacy ``events`` table
-        receives no new heartbeat rows post-migration, so reading it
-        returns the pre-migration timestamp and surfaces in the
-        cockpit as a permanent "Heartbeat offline (NNNm)" warning
-        even though heartbeat is ticking happily on the new table.
-
-        Falls back to the legacy table when the unified lookup finds
-        nothing — covers installs that haven't yet generated a
-        post-migration heartbeat event.
+        #411 retires the legacy ``events`` table, so this is now a
+        straight lookup against unified ``messages`` rows with
+        ``type='event'`` / ``subject='heartbeat'``.
         """
         row = self.execute(
             "SELECT created_at FROM messages "
-            "WHERE type = 'event' AND scope = 'heartbeat' AND subject = 'heartbeat' "
+            "WHERE type = 'event' AND subject = 'heartbeat' "
             "ORDER BY id DESC LIMIT 1"
-        ).fetchone()
-        if row:
-            return row[0]
-        row = self.execute(
-            "SELECT created_at FROM events WHERE event_type = 'heartbeat' ORDER BY id DESC LIMIT 1"
         ).fetchone()
         return row[0] if row else None
 
     def recent_events(self, limit: int = 20) -> list[EventRecord]:
         rows = self.execute(
             """
-            SELECT session_name, event_type, message, created_at
-            FROM events
-            ORDER BY id DESC
+            SELECT scope, subject, body, payload_json, created_at
+            FROM messages
+            WHERE type = 'event'
+            ORDER BY created_at DESC, id DESC
             LIMIT ?
             """,
             (limit,),
         ).fetchall()
-        return [EventRecord(*row) for row in rows]
+        return [
+            EventRecord(
+                session_name=str(row[0] or ""),
+                event_type=str(row[1] or ""),
+                message=_event_message(
+                    str(row[1] or ""),
+                    str(row[2] or ""),
+                    row[3] if isinstance(row[3], str) else None,
+                ),
+                created_at=str(row[4] or ""),
+            )
+            for row in rows
+        ]
 
     def prune_old_data(self, *, event_days: int = 7, heartbeat_hours: int = 24) -> dict[str, int]:
         """Remove old events and heartbeat observations. Returns counts of pruned rows."""
@@ -1079,7 +1247,10 @@ class StateStore:
         event_cutoff = (now - timedelta(days=event_days)).isoformat()
         heartbeat_cutoff = (now - timedelta(hours=heartbeat_hours)).isoformat()
         with self._lock:
-            e_cursor = self._conn.execute("DELETE FROM events WHERE created_at < ?", (event_cutoff,))
+            e_cursor = self._conn.execute(
+                "DELETE FROM messages WHERE type = 'event' AND created_at < ?",
+                (event_cutoff,),
+            )
             events_pruned = e_cursor.rowcount
             h_cursor = self._conn.execute("DELETE FROM heartbeats WHERE created_at < ?", (heartbeat_cutoff,))
             heartbeats_pruned = h_cursor.rowcount
@@ -1175,35 +1346,48 @@ class StateStore:
 
     def upsert_alert(self, session_name: str, alert_type: str, severity: str, message: str) -> None:
         now = self._now()
-        # Use INSERT OR IGNORE + UPDATE to avoid check-then-act race
         with self._lock:
             existing = self._conn.execute(
                 """
-                SELECT id, message, severity
-                FROM alerts
-                WHERE session_name = ? AND alert_type = ? AND status = 'open'
+                SELECT id
+                FROM messages
+                WHERE type = 'alert' AND scope = ? AND sender = ? AND state = 'open'
+                ORDER BY id DESC
+                LIMIT 1
                 """,
                 (session_name, alert_type),
             ).fetchone()
             if existing is None:
-                try:
-                    self._conn.execute(
-                        """
-                        INSERT INTO alerts (session_name, alert_type, severity, message, status, created_at, updated_at)
-                        VALUES (?, ?, ?, ?, 'open', ?, ?)
-                        """,
-                        (session_name, alert_type, severity, message, now, now),
+                self._conn.execute(
+                    """
+                    INSERT INTO messages (
+                        scope, type, tier, recipient, sender, state,
+                        subject, body, payload_json, labels, created_at, updated_at, closed_at
                     )
-                except sqlite3.IntegrityError:
-                    pass  # Another process inserted first — that's fine
+                    VALUES (?, 'alert', 'immediate', 'user', ?, 'open', ?, '', ?, '[]', ?, ?, NULL)
+                    """,
+                    (
+                        session_name,
+                        alert_type,
+                        message,
+                        json.dumps({"severity": severity, "session_name": session_name}),
+                        now,
+                        now,
+                    ),
+                )
             else:
                 self._conn.execute(
                     """
-                    UPDATE alerts
-                    SET severity = ?, message = ?, updated_at = ?
+                    UPDATE messages
+                    SET subject = ?, body = '', payload_json = ?, updated_at = ?
                     WHERE id = ?
                     """,
-                    (severity, message, now, existing[0]),
+                    (
+                        message,
+                        json.dumps({"severity": severity, "session_name": session_name}),
+                        now,
+                        existing[0],
+                    ),
                 )
             self._conn.commit()
             try:
@@ -1215,32 +1399,32 @@ class StateStore:
     def clear_alert(self, session_name: str, alert_type: str) -> None:
         self.execute(
             """
-            UPDATE alerts
-            SET status = 'cleared', updated_at = ?
-            WHERE session_name = ? AND alert_type = ? AND status = 'open'
+            UPDATE messages
+            SET state = 'closed', closed_at = ?, updated_at = ?
+            WHERE type = 'alert' AND scope = ? AND sender = ? AND state = 'open'
             """,
-            (self._now(), session_name, alert_type),
+            (self._now(), self._now(), session_name, alert_type),
         )
         self.commit()
 
     def open_alerts(self) -> list[AlertRecord]:
         rows = self.execute(
             """
-            SELECT id, session_name, alert_type, severity, message, status, created_at, updated_at
-            FROM alerts
-            WHERE status = 'open'
-            ORDER BY updated_at DESC
+            SELECT id, scope, sender, payload_json, state, subject, body, created_at, updated_at
+            FROM messages
+            WHERE type = 'alert' AND state = 'open'
+            ORDER BY updated_at DESC, id DESC
             """
         ).fetchall()
         return [
             AlertRecord(
-                session_name=row[1],
-                alert_type=row[2],
-                severity=row[3],
-                message=row[4],
-                status=row[5],
-                created_at=row[6],
-                updated_at=row[7],
+                session_name=str(row[1] or ""),
+                alert_type=str(row[2] or ""),
+                severity=str(_json_object(row[3] if isinstance(row[3], str) else None).get("severity") or ""),
+                message=_alert_message(str(row[5] or ""), str(row[6] or "")),
+                status=_alert_status(str(row[4] or "")),
+                created_at=str(row[7] or ""),
+                updated_at=str(row[8] or ""),
                 alert_id=int(row[0]),
             )
             for row in rows
@@ -1249,22 +1433,22 @@ class StateStore:
     def get_alert(self, alert_id: int) -> AlertRecord | None:
         row = self.execute(
             """
-            SELECT id, session_name, alert_type, severity, message, status, created_at, updated_at
-            FROM alerts
-            WHERE id = ?
+            SELECT id, scope, sender, payload_json, state, subject, body, created_at, updated_at
+            FROM messages
+            WHERE type = 'alert' AND id = ?
             """,
             (alert_id,),
         ).fetchone()
         if row is None:
             return None
         return AlertRecord(
-            session_name=row[1],
-            alert_type=row[2],
-            severity=row[3],
-            message=row[4],
-            status=row[5],
-            created_at=row[6],
-            updated_at=row[7],
+            session_name=str(row[1] or ""),
+            alert_type=str(row[2] or ""),
+            severity=str(_json_object(row[3] if isinstance(row[3], str) else None).get("severity") or ""),
+            message=_alert_message(str(row[5] or ""), str(row[6] or "")),
+            status=_alert_status(str(row[4] or "")),
+            created_at=str(row[7] or ""),
+            updated_at=str(row[8] or ""),
             alert_id=int(row[0]),
         )
 
@@ -1274,11 +1458,11 @@ class StateStore:
             return None
         self.execute(
             """
-            UPDATE alerts
-            SET status = 'cleared', updated_at = ?
-            WHERE id = ? AND status = 'open'
+            UPDATE messages
+            SET state = 'closed', closed_at = ?, updated_at = ?
+            WHERE type = 'alert' AND id = ? AND state = 'open'
             """,
-            (self._now(), alert_id),
+            (self._now(), self._now(), alert_id),
         )
         self.commit()
         return self.get_alert(alert_id)
@@ -1309,21 +1493,30 @@ class StateStore:
         correctly treats as a new ping opportunity instead of a
         duplicate within the 30-minute window.
         """
+        now = self._now()
         self.execute(
             """
-            INSERT INTO task_notifications
-                (session_name, task_id, project, notified_at,
-                 delivery_status, message, execution_version)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO messages (
+                scope, type, tier, recipient, sender, state,
+                subject, body, payload_json, labels, created_at, updated_at
+            )
+            VALUES (?, 'task_notification', 'immediate', ?, ?, 'open', ?, ?, ?, '[]', ?, ?)
             """,
             (
                 session_name,
-                task_id,
                 project,
-                self._now(),
-                delivery_status,
+                task_id,
+                task_id,
                 message,
-                int(execution_version),
+                json.dumps(
+                    {
+                        "project": project,
+                        "delivery_status": delivery_status,
+                        "execution_version": int(execution_version),
+                    }
+                ),
+                now,
+                now,
             ),
         )
         self.commit()
@@ -1344,26 +1537,30 @@ class StateStore:
         ``execution_version`` (#279) is matched exactly. A reject-bounce
         that advances the task's current node execution to a fresh
         ``visit`` yields a different version, so the dedupe returns
-        ``False`` and the retry ping gets through. Pre-#279 notification
-        rows back-fill to ``0`` via the column DEFAULT; events built
-        when the work service can't compute a visit also emit ``0``, so
-        identical-state pings still dedupe correctly across the
-        migration boundary.
+        ``False`` and the retry ping gets through. Legacy
+        ``task_notifications`` rows migrate into ``messages`` with
+        version ``0`` when the old column was absent, so identical-state
+        pings still dedupe correctly across the migration boundary.
         """
         from datetime import timedelta
         cutoff = (datetime.now(UTC) - timedelta(seconds=window_seconds)).isoformat()
-        row = self.execute(
+        rows = self.execute(
             """
-            SELECT 1 FROM task_notifications
-            WHERE session_name = ?
-              AND task_id = ?
-              AND execution_version = ?
-              AND notified_at >= ?
-            LIMIT 1
+            SELECT payload_json
+            FROM messages
+            WHERE type = 'task_notification'
+              AND scope = ?
+              AND sender = ?
+              AND created_at >= ?
+            ORDER BY id DESC
             """,
-            (session_name, task_id, int(execution_version), cutoff),
-        ).fetchone()
-        return row is not None
+            (session_name, task_id, cutoff),
+        ).fetchall()
+        for (payload_json,) in rows:
+            payload = _json_object(payload_json if isinstance(payload_json, str) else None)
+            if int(payload.get("execution_version") or 0) == int(execution_version):
+                return True
+        return False
 
     def recent_notifications(
         self,
@@ -1377,25 +1574,24 @@ class StateStore:
 
         Backs ``pm task pickup-log``. Filters compose (AND).
         """
-        clauses: list[str] = []
+        clauses: list[str] = ["type = 'task_notification'"]
         params: list[object] = []
         if since_seconds is not None:
             from datetime import timedelta
             cutoff = (datetime.now(UTC) - timedelta(seconds=since_seconds)).isoformat()
-            clauses.append("notified_at >= ?")
+            clauses.append("created_at >= ?")
             params.append(cutoff)
         if project is not None:
-            clauses.append("project = ?")
+            clauses.append("recipient = ?")
             params.append(project)
         if task_id is not None:
-            clauses.append("task_id = ?")
+            clauses.append("sender = ?")
             params.append(task_id)
-        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        where = " WHERE " + " AND ".join(clauses)
         sql = (
-            "SELECT session_name, task_id, project, notified_at, "
-            "delivery_status, message, execution_version "
-            "FROM task_notifications"
-            f"{where} ORDER BY notified_at DESC LIMIT ?"
+            "SELECT scope, sender, recipient, payload_json, body, created_at "
+            "FROM messages"
+            f"{where} ORDER BY created_at DESC, id DESC LIMIT ?"
         )
         params.append(int(limit))
         rows = self.execute(sql, tuple(params)).fetchall()
@@ -1404,10 +1600,12 @@ class StateStore:
                 "session_name": r[0],
                 "task_id": r[1],
                 "project": r[2],
-                "notified_at": r[3],
-                "delivery_status": r[4],
-                "message": r[5],
-                "execution_version": r[6] if len(r) > 6 else 0,
+                "notified_at": r[5],
+                "delivery_status": _json_object(r[3] if isinstance(r[3], str) else None).get("delivery_status", ""),
+                "message": r[4],
+                "execution_version": int(
+                    _json_object(r[3] if isinstance(r[3], str) else None).get("execution_version") or 0
+                ),
             }
             for r in rows
         ]

--- a/src/pollypm/store/schema.py
+++ b/src/pollypm/store/schema.py
@@ -35,6 +35,7 @@ from sqlalchemy import (
     Table,
     Text,
     func,
+    text,
 )
 
 
@@ -98,10 +99,18 @@ messages = Table(
     ),
     Column("closed_at", DateTime(timezone=True), nullable=True),
     # Hot-path indexes: inbox list (recipient+state), firehose filter
-    # (type+tier), and per-scope recency scans.
+    # (type+tier), per-scope recency scans, and legacy alert upsert
+    # dedupe on open rows.
     Index("idx_messages_recipient_state", "recipient", "state"),
     Index("idx_messages_type_tier", "type", "tier"),
     Index("idx_messages_scope_created", "scope", "created_at"),
+    Index(
+        "idx_messages_open_alert_unique",
+        "scope",
+        "sender",
+        unique=True,
+        sqlite_where=text("type = 'alert' AND state = 'open'"),
+    ),
 )
 
 

--- a/src/pollypm/store/sqlalchemy_store.py
+++ b/src/pollypm/store/sqlalchemy_store.py
@@ -32,6 +32,7 @@ from typing import Any, Iterator
 
 from sqlalchemy import Executable, MetaData, and_, delete, insert, select, text, update
 from sqlalchemy.engine import Connection, CursorResult, Engine
+from sqlalchemy.exc import IntegrityError
 
 from pollypm.store.engine import make_engines
 from pollypm.store.event_buffer import EventBuffer
@@ -155,10 +156,49 @@ class SQLAlchemyStore:
         ``checkfirst=True`` default, and the FTS DDL uses ``IF NOT EXISTS``
         guards, so re-running on an already-bootstrapped DB is a no-op.
         """
-        metadata.create_all(self._write_engine)
+        try:
+            metadata.create_all(self._write_engine)
+        except IntegrityError:
+            self._deduplicate_open_alert_messages()
+            metadata.create_all(self._write_engine)
         with self.transaction() as conn:
             for stmt in FTS_DDL_STATEMENTS:
                 conn.execute(text(stmt))
+
+    def _deduplicate_open_alert_messages(self) -> None:
+        """Close duplicate open alert rows before the unique index lands."""
+        with self.transaction() as conn:
+            rows = conn.execute(
+                text(
+                    """
+                    SELECT id, scope, sender
+                    FROM messages
+                    WHERE type = 'alert' AND state = 'open'
+                    ORDER BY id DESC
+                    """
+                )
+            ).fetchall()
+            keep: set[tuple[str, str]] = set()
+            duplicate_ids: list[int] = []
+            for row_id, scope, sender in rows:
+                key = (str(scope or ""), str(sender or ""))
+                if key in keep:
+                    duplicate_ids.append(int(row_id))
+                    continue
+                keep.add(key)
+            if not duplicate_ids:
+                return
+            now = datetime.now(timezone.utc)
+            for row_id in duplicate_ids:
+                conn.execute(
+                    update(messages)
+                    .where(messages.c.id == row_id)
+                    .values(
+                        state="closed",
+                        closed_at=now,
+                        updated_at=now,
+                    )
+                )
 
     # ------------------------------------------------------------------
     # Event log — firehose ('event' type) entries.

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -1633,6 +1633,10 @@ class Supervisor:
     def leases(self) -> list[LeaseRecord]:
         return self.store.list_leases()
 
+    def pane_has_auth_failure(self, lowered_pane: str) -> bool:
+        """Public alert-boundary detector for authentication failures."""
+        return self._pane_has_auth_failure(lowered_pane)
+
     def _pane_has_auth_failure(self, lowered_pane: str) -> bool:
         patterns = [
             "please run /login",
@@ -1641,6 +1645,10 @@ class Supervisor:
             "not authenticated",
         ]
         return any(pattern in lowered_pane for pattern in patterns)
+
+    def pane_has_capacity_failure(self, lowered_pane: str) -> bool:
+        """Public alert-boundary detector for provider quota failures."""
+        return self._pane_has_capacity_failure(lowered_pane)
 
     def _pane_has_capacity_failure(self, lowered_pane: str) -> bool:
         patterns = [
@@ -1651,6 +1659,10 @@ class Supervisor:
             "credit balance is too low",
         ]
         return any(pattern in lowered_pane for pattern in patterns)
+
+    def pane_has_provider_outage(self, lowered_pane: str) -> bool:
+        """Public alert-boundary detector for upstream provider outages."""
+        return self._pane_has_provider_outage(lowered_pane)
 
     def _pane_has_provider_outage(self, lowered_pane: str) -> bool:
         patterns = [

--- a/src/pollypm/supervisor_alerts.py
+++ b/src/pollypm/supervisor_alerts.py
@@ -20,6 +20,7 @@ from typing import Protocol
 
 from pollypm.config import PollyPMConfig
 from pollypm.models import SessionLaunchSpec
+from pollypm.store.protocol import Store
 from pollypm.storage.state import StateStore
 from pollypm.tmux.client import TmuxWindow
 
@@ -27,7 +28,7 @@ from pollypm.tmux.client import TmuxWindow
 class SupervisorAlertBoundary(Protocol):
     config: PollyPMConfig
     store: StateStore
-    _msg_store: object
+    msg_store: Store
     _STALL_NUDGE_MESSAGE: str
 
     def send_input(
@@ -40,11 +41,11 @@ class SupervisorAlertBoundary(Protocol):
         press_enter: bool = True,
     ) -> None: ...
 
-    def _pane_has_auth_failure(self, lowered_pane: str) -> bool: ...
+    def pane_has_auth_failure(self, lowered_pane: str) -> bool: ...
 
-    def _pane_has_capacity_failure(self, lowered_pane: str) -> bool: ...
+    def pane_has_capacity_failure(self, lowered_pane: str) -> bool: ...
 
-    def _pane_has_provider_outage(self, lowered_pane: str) -> bool: ...
+    def pane_has_provider_outage(self, lowered_pane: str) -> bool: ...
 
 
 _REVIEW_NUDGE_CACHE: dict[str, tuple[float, list[str]]] = {}
@@ -94,7 +95,7 @@ def _update_alerts(
     active_alerts: list[str] = []
 
     if window.pane_dead:
-        supervisor._msg_store.upsert_alert(
+        supervisor.msg_store.upsert_alert(
             session_name,
             "pane_dead",
             "error",
@@ -102,10 +103,10 @@ def _update_alerts(
         )
         active_alerts.append("pane_dead")
     else:
-        supervisor._msg_store.clear_alert(session_name, "pane_dead")
+        supervisor.msg_store.clear_alert(session_name, "pane_dead")
 
     if window.pane_current_command in shell_commands:
-        supervisor._msg_store.upsert_alert(
+        supervisor.msg_store.upsert_alert(
             session_name,
             "shell_returned",
             "warn",
@@ -113,10 +114,10 @@ def _update_alerts(
         )
         active_alerts.append("shell_returned")
     else:
-        supervisor._msg_store.clear_alert(session_name, "shell_returned")
+        supervisor.msg_store.clear_alert(session_name, "shell_returned")
 
     if previous_log_bytes is not None and current_log_bytes <= previous_log_bytes:
-        supervisor._msg_store.upsert_alert(
+        supervisor.msg_store.upsert_alert(
             session_name,
             "idle_output",
             "warn",
@@ -124,7 +125,7 @@ def _update_alerts(
         )
         active_alerts.append("idle_output")
     else:
-        supervisor._msg_store.clear_alert(session_name, "idle_output")
+        supervisor.msg_store.clear_alert(session_name, "idle_output")
 
     if previous_snapshot_hash and previous_snapshot_hash == current_snapshot_hash:
         history = supervisor.store.recent_heartbeats(session_name, limit=3)
@@ -132,9 +133,9 @@ def _update_alerts(
         if len(recent_hashes) == 3 and len(set(recent_hashes)) == 1:
             role = launch.session.role
             if role in {"heartbeat-supervisor", "operator-pm", "reviewer"} or launch.session.name in {"worker_pollypm"}:
-                supervisor._msg_store.clear_alert(session_name, "suspected_loop")
+                supervisor.msg_store.clear_alert(session_name, "suspected_loop")
             else:
-                supervisor._msg_store.upsert_alert(
+                supervisor.msg_store.upsert_alert(
                     session_name,
                     "suspected_loop",
                     "warn",
@@ -146,13 +147,13 @@ def _update_alerts(
                 if len(longer_hashes) == 5 and len(set(longer_hashes)) == 1:
                     _maybe_nudge_stalled_session(supervisor, launch)
         else:
-            supervisor._msg_store.clear_alert(session_name, "suspected_loop")
+            supervisor.msg_store.clear_alert(session_name, "suspected_loop")
     else:
-        supervisor._msg_store.clear_alert(session_name, "suspected_loop")
+        supervisor.msg_store.clear_alert(session_name, "suspected_loop")
 
     lowered_pane = pane_text.lower()
-    if supervisor._pane_has_auth_failure(lowered_pane):
-        supervisor._msg_store.upsert_alert(
+    if supervisor.pane_has_auth_failure(lowered_pane):
+        supervisor.msg_store.upsert_alert(
             session_name,
             "auth_broken",
             "error",
@@ -166,10 +167,10 @@ def _update_alerts(
         )
         active_alerts.append("auth_broken")
     else:
-        supervisor._msg_store.clear_alert(session_name, "auth_broken")
+        supervisor.msg_store.clear_alert(session_name, "auth_broken")
 
-    if supervisor._pane_has_capacity_failure(lowered_pane):
-        supervisor._msg_store.upsert_alert(
+    if supervisor.pane_has_capacity_failure(lowered_pane):
+        supervisor.msg_store.upsert_alert(
             session_name,
             "capacity_exhausted",
             "error",
@@ -183,10 +184,10 @@ def _update_alerts(
         )
         active_alerts.append("capacity_exhausted")
     else:
-        supervisor._msg_store.clear_alert(session_name, "capacity_exhausted")
+        supervisor.msg_store.clear_alert(session_name, "capacity_exhausted")
 
-    if supervisor._pane_has_provider_outage(lowered_pane):
-        supervisor._msg_store.upsert_alert(
+    if supervisor.pane_has_provider_outage(lowered_pane):
+        supervisor.msg_store.upsert_alert(
             session_name,
             "provider_outage",
             "warn",
@@ -201,7 +202,7 @@ def _update_alerts(
         )
         active_alerts.append("provider_outage")
     else:
-        supervisor._msg_store.clear_alert(session_name, "provider_outage")
+        supervisor.msg_store.clear_alert(session_name, "provider_outage")
 
     return active_alerts
 
@@ -216,7 +217,7 @@ def _maybe_nudge_stalled_session(supervisor: SupervisorAlertBoundary, launch: Se
         return
     lease = supervisor.store.get_lease(launch.session.name)
     if lease is not None and lease.owner == "human":
-        supervisor._msg_store.record_event(
+        supervisor.msg_store.record_event(
             scope=launch.session.name,
             sender=launch.session.name,
             subject="heartbeat_nudge_skipped",

--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -1380,8 +1380,9 @@ def task_pickup_log(
 ) -> None:
     """Show task-assignment notifications (who got pinged about what, when).
 
-    Reads the ``task_notifications`` dedupe table written by the
-    ``task_assignment_notify`` plugin. Helpful for auditing worker /
+    Reads the unified ``messages`` ledger rows written by the
+    ``task_assignment_notify`` plugin (legacy ``task_notifications``
+    rows migrate there during #411). Helpful for auditing worker /
     reviewer pickup after the E2E gap closed by issue #244.
     """
     since_seconds = _parse_since(since)

--- a/src/pollypm/work/task_assignment.py
+++ b/src/pollypm/work/task_assignment.py
@@ -51,8 +51,9 @@ class TaskAssignmentEvent:
       event rather than suppressing it inside the 30-min window.
       Defaults to ``0`` for environments that can't compute a visit
       (bare test doubles, pre-#279 rehydrated events) — pre-migration
-      dedupe semantics survive the default because existing
-      ``task_notifications`` rows back-fill to ``0`` as well.
+      dedupe semantics survive the default because legacy
+      task-assignment notification rows migrate into the unified
+      ledger with ``execution_version=0`` as well.
     """
 
     task_id: str

--- a/tests/test_db_vacuum.py
+++ b/tests/test_db_vacuum.py
@@ -40,8 +40,8 @@ def test_incremental_vacuum_reclaims_space_after_bulk_delete(tmp_path: Path) -> 
     store = StateStore(tmp_path / "state.db")
     try:
         # Insert enough dummy rows to guarantee multiple pages land on the
-        # freelist after delete. ``events`` is a cheap table for this —
-        # no foreign keys, no triggers, no FTS. 2000 rows with a 1 KB
+        # freelist after delete. ``messages WHERE type='event'`` is the
+        # surviving event surface after #411; 2000 rows with a 1 KB
         # message is ~2 MB, plenty to exceed a single 4 KB page.
         big_message = "x" * 1024
         for i in range(2000):
@@ -55,7 +55,9 @@ def test_incremental_vacuum_reclaims_space_after_bulk_delete(tmp_path: Path) -> 
         # this, the "reclaimed" measurement is dominated by WAL mechanics
         # rather than freelist behaviour.
         store.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-        store.execute("DELETE FROM events WHERE event_type = 'bulk.test'")
+        store.execute(
+            "DELETE FROM messages WHERE type = 'event' AND subject = 'bulk.test'"
+        )
         store.commit()
         store.execute("PRAGMA wal_checkpoint(TRUNCATE)")
 

--- a/tests/test_task_assignment_notify.py
+++ b/tests/test_task_assignment_notify.py
@@ -513,23 +513,37 @@ def test_event_to_payload_round_trip():
 # ---------------------------------------------------------------------------
 
 
-def test_migration_creates_task_notifications(tmp_path):
+def test_fresh_db_retires_legacy_message_tables(tmp_path):
     store = StateStore(tmp_path / "state.db")
     try:
-        row = store.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='task_notifications'"
-        ).fetchone()
-        assert row is not None
-        # Indexes present
-        indexes = [
-            r[0] for r in store.execute(
-                "SELECT name FROM sqlite_master WHERE type='index' "
-                "AND tbl_name='task_notifications'"
+        tables = {
+            r[0]
+            for r in store.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name IN ('events', 'alerts', 'task_notifications')"
             ).fetchall()
-        ]
-        assert any("recent" in i for i in indexes)
-        assert any("session_task" in i for i in indexes)
-        # Round-trip a row.
+        }
+        assert tables == set()
+        indexes = {
+            r[0]
+            for r in store.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' "
+                "AND name='idx_messages_open_alert_unique'"
+            ).fetchall()
+        }
+        assert indexes == {"idx_messages_open_alert_unique"}
+
+        store.record_event("worker-demo", "heartbeat", "tick")
+        events = store.recent_events(limit=5)
+        assert events and events[0].event_type == "heartbeat"
+        assert events[0].message == "tick"
+
+        store.upsert_alert("worker-demo", "idle_output", "warn", "No new output")
+        alerts = store.open_alerts()
+        assert len(alerts) == 1
+        assert alerts[0].alert_type == "idle_output"
+        assert alerts[0].message == "No new output"
+
         store.record_notification(
             session_name="worker-demo", task_id="demo/1",
             project="demo", message="hi", delivery_status="sent",
@@ -537,6 +551,101 @@ def test_migration_creates_task_notifications(tmp_path):
         assert store.was_notified_within("worker-demo", "demo/1", 60)
         rows = store.recent_notifications(limit=10)
         assert rows and rows[0]["session_name"] == "worker-demo"
+    finally:
+        store.close()
+
+
+def test_migration_moves_legacy_message_rows_into_messages_and_drops_tables(tmp_path):
+    import sqlite3
+
+    p = tmp_path / "legacy.db"
+    conn = sqlite3.connect(p)
+    conn.executescript(
+        """
+        CREATE TABLE schema_version (
+            version INTEGER NOT NULL,
+            description TEXT NOT NULL,
+            applied_at TEXT NOT NULL
+        );
+        CREATE TABLE events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_name TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            message TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+        CREATE TABLE alerts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_name TEXT NOT NULL,
+            alert_type TEXT NOT NULL,
+            severity TEXT NOT NULL,
+            message TEXT NOT NULL,
+            status TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        CREATE TABLE task_notifications (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_name TEXT NOT NULL,
+            task_id TEXT NOT NULL,
+            project TEXT NOT NULL DEFAULT '',
+            notified_at TEXT NOT NULL,
+            delivery_status TEXT NOT NULL DEFAULT 'sent',
+            message TEXT NOT NULL DEFAULT '',
+            execution_version INTEGER NOT NULL DEFAULT 0
+        );
+        INSERT INTO schema_version VALUES
+            (14, 'v14 baseline', '2026-01-01T00:00:00+00:00');
+        INSERT INTO events (session_name, event_type, message, created_at)
+        VALUES ('worker-legacy', 'heartbeat', 'legacy event', '2026-04-21T01:00:00+00:00');
+        INSERT INTO alerts
+            (session_name, alert_type, severity, message, status, created_at, updated_at)
+        VALUES
+            ('task_assignment', 'legacy_alert', 'warning', 'legacy alert',
+             'open', '2026-04-21T01:01:00+00:00', '2026-04-21T01:01:00+00:00');
+        INSERT INTO task_notifications
+            (session_name, task_id, project, notified_at, delivery_status, message, execution_version)
+        VALUES
+            ('worker-legacy', 'legacy/1', 'demo',
+             '2026-04-21T01:02:00+00:00', 'sent', 'legacy ping', 3);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    store = StateStore(p)
+    try:
+        tables = {
+            r[0]
+            for r in store.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name IN ('events', 'alerts', 'task_notifications')"
+            ).fetchall()
+        }
+        assert tables == set()
+
+        events = store.recent_events(limit=10)
+        assert events and events[0].session_name == "worker-legacy"
+        assert events[0].event_type == "heartbeat"
+        assert events[0].message == "legacy event"
+
+        alerts = store.open_alerts()
+        assert len(alerts) == 1
+        assert alerts[0].alert_type == "legacy_alert"
+        assert alerts[0].message == "legacy alert"
+
+        rows = store.recent_notifications(limit=10)
+        assert rows and rows[0]["session_name"] == "worker-legacy"
+        assert rows[0]["task_id"] == "legacy/1"
+        assert rows[0]["execution_version"] == 3
+        assert store.was_notified_within(
+            "worker-legacy", "legacy/1", 3650 * 24 * 3600, execution_version=3,
+        )
+
+        version = store.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()[0]
+        assert version >= 15
     finally:
         store.close()
 
@@ -1338,29 +1447,17 @@ class TestRejectBounceDedupe:
         assert len(svc.sent) == 0
 
     def test_migration_adds_execution_version_column(self, tmp_path):
-        """Migration 12 adds ``execution_version`` with DEFAULT 0 and
-        creates the version-aware composite index. Fresh DBs get the
-        column from the migration runner; pre-#279 DBs back-fill
-        existing rows to ``0`` via the column DEFAULT."""
+        """Notification dedupe still keys on ``execution_version`` after #411."""
         store = StateStore(tmp_path / "state.db")
         try:
-            cols = {
-                r[1] for r in store.execute(
-                    "PRAGMA table_info(task_notifications)"
+            tables = {
+                r[0]
+                for r in store.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' "
+                    "AND name='task_notifications'"
                 ).fetchall()
             }
-            assert "execution_version" in cols
-            indexes = [
-                r[0] for r in store.execute(
-                    "SELECT name FROM sqlite_master WHERE type='index' "
-                    "AND tbl_name='task_notifications'"
-                ).fetchall()
-            ]
-            assert any("session_task_version" in i for i in indexes), (
-                f"version-aware dedupe index missing: {indexes!r}"
-            )
-            # Round-trip with + without the column: both forms work,
-            # and default rows dedupe at version=0.
+            assert tables == set()
             store.record_notification(
                 session_name="worker-demo", task_id="demo/1",
                 project="demo", message="default", delivery_status="sent",
@@ -1387,10 +1484,7 @@ class TestRejectBounceDedupe:
             store.close()
 
     def test_migration_upgrades_pre_existing_v11_database(self, tmp_path):
-        """A database that existed before #279 (schema v11) with
-        ``task_notifications`` rows must upgrade cleanly to v12 — the
-        new column appears, existing rows back-fill to 0, and the old
-        dedupe behaviour survives for any still-pending ping."""
+        """A schema-v11 DB upgrades directly onto messages and drops the table."""
         import sqlite3
         p = tmp_path / "legacy.db"
         # Hand-build a v11-shaped DB (no execution_version column).
@@ -1428,27 +1522,33 @@ class TestRejectBounceDedupe:
         # place without losing data.
         store = StateStore(p)
         try:
-            cols = {
-                r[1] for r in store.execute(
-                    "PRAGMA table_info(task_notifications)"
+            tables = {
+                r[0]
+                for r in store.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' "
+                    "AND name='task_notifications'"
                 ).fetchall()
             }
-            assert "execution_version" in cols, (
-                f"migration 12 did not add column: {cols!r}"
-            )
-            rows = store.execute(
-                "SELECT session_name, task_id, execution_version "
-                "FROM task_notifications"
-            ).fetchall()
-            assert rows == [("worker-legacy", "legacy/1", 0)], (
-                f"legacy row did not back-fill to version=0: {rows!r}"
+            assert tables == set()
+            rows = store.recent_notifications(limit=10)
+            assert rows == [
+                {
+                    "session_name": "worker-legacy",
+                    "task_id": "legacy/1",
+                    "project": "legacy",
+                    "notified_at": "2026-04-17T00:00:00+00:00",
+                    "delivery_status": "sent",
+                    "message": "legacy ping",
+                    "execution_version": 0,
+                }
+            ]
+            assert store.was_notified_within(
+                "worker-legacy", "legacy/1", 3650 * 24 * 3600, execution_version=0,
             )
             version = store.execute(
                 "SELECT MAX(version) FROM schema_version"
             ).fetchone()[0]
-            # The v11 fixture must upgrade through migration 12 and on
-            # to the current schema head.
-            assert version >= 12
+            assert version >= 15
         finally:
             store.close()
 


### PR DESCRIPTION
Summary:
- migrate legacy events / alerts / task_notifications rows into messages
- stop creating or querying those retired side tables on fresh databases
- route supervisor alert updates through the public msg_store boundary so import-boundary validation stays green

Note:
- notification_staging retirement is intentionally deferred; this PR does not close #411 by itself

Testing:
- .venv/bin/pytest -q tests/test_task_assignment_notify.py tests/test_messages_schema.py tests/test_import_boundary.py tests/test_db_vacuum.py