### PR TITLE
feat(cockpit): add rail activity ticker and project pinning

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -215,13 +215,6 @@ class CockpitPresence:
         return frames[frame_index]
 
 
-def _viewer_attached() -> bool:
-    """Best-effort check for a live terminal viewer."""
-    try:
-        return sys.stdin.isatty() and sys.stdout.isatty()
-    except Exception:  # noqa: BLE001
-        return False
-
 # ── Rail data model + router ─────────────────────────────────────────────
 #
 # Moved out of pollypm.cockpit in #404 so the routing concern (which rail
@@ -722,12 +715,25 @@ class CockpitRouter:
         data["ui_initialized_sessions"] = items
         self._write_state(data)
 
-    def pinned_projects(self) -> set[str]:
+    def pinned_projects(self) -> list[str]:
+        """Return pinned project keys in most-recently-pinned-first order.
+
+        Persisted as a JSON list so the insertion order survives restarts
+        (#677 acceptance: "Multiple pins maintain their relative pin
+        order (most recently pinned first)").
+        """
         data = self._load_state()
         value = data.get("pinned_projects")
         if not isinstance(value, list):
-            return set()
-        return {item for item in value if isinstance(item, str) and item}
+            return []
+        # Dedupe while preserving first-seen order.
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for item in value:
+            if isinstance(item, str) and item and item not in seen:
+                seen.add(item)
+                ordered.append(item)
+        return ordered
 
     def is_project_pinned(self, project_key: str) -> bool:
         return project_key in self.pinned_projects()
@@ -739,9 +745,11 @@ class CockpitRouter:
             current.remove(project_key)
             pinned = False
         else:
-            current.add(project_key)
+            # Most-recently-pinned first — prepend so the newest pin
+            # sorts to the top.
+            current.insert(0, project_key)
             pinned = True
-        data["pinned_projects"] = sorted(current)
+        data["pinned_projects"] = current
         self._write_state(data)
         return pinned
 
@@ -1009,11 +1017,18 @@ class CockpitRouter:
 
         project_region: list[CockpitItem] = []
         if project_blocks:
+            # Pinned projects sort first, ordered by most-recently-pinned
+            # (pinned_projects() returns newest-first, see #677). The
+            # selected project bubbles ahead of unpinned; unpinned
+            # projects sort alphabetically.
+            pin_order = self.pinned_projects()
+            pin_rank = {key: idx for idx, key in enumerate(pin_order)}
             project_blocks.sort(
                 key=lambda row: (
-                    not row[2],
-                    not row[3],
-                    row[0].lower(),
+                    not row[2],  # pinned ahead of unpinned
+                    pin_rank.get(row[0], 0),  # pinned: by recency
+                    not row[3],  # selected ahead of other unpinned
+                    row[0].lower(),  # unpinned: alphabetical
                 ),
             )
             for _key, block, _pinned, _selected in project_blocks:
@@ -2120,20 +2135,31 @@ class PollyCockpitRail:
                 self._write(clear_line + "\r\n")
 
     def _event_ticker_text(self) -> str:
-        if not _viewer_attached():
-            return ""
+        # #656 gate: use the router's CockpitPresence so tmux detach
+        # actually pauses the ticker. ``sys.stdin.isatty()`` stays True
+        # across detach and was burning CPU with no viewer.
+        try:
+            if not self.router._presence().is_tmux_attached():
+                return ""
+        except Exception:  # noqa: BLE001
+            pass
         try:
             supervisor = self.router._load_supervisor()
-            events = list(supervisor.store.recent_events(limit=4))
+            events = list(supervisor.store.recent_events(limit=12))
         except Exception:  # noqa: BLE001
             return ""
         if not events:
             return ""
-        index = int((time.monotonic() - self._ticker_started_at) // 10)
-        event = events[index % len(events)]
-        event_type = getattr(event, "event_type", "event")
-        session_name = getattr(event, "session_name", "") or "system"
-        return f"events · {event_type}:{session_name}"
+        # #667 acceptance: cycle a window of the 3 newest events.
+        window_size = min(3, len(events))
+        offset = int((time.monotonic() - self._ticker_started_at) // 10)
+        cycled = [events[(offset + i) % len(events)] for i in range(window_size)]
+        labels = []
+        for event in cycled:
+            event_type = getattr(event, "event_type", "event")
+            session_name = getattr(event, "session_name", "") or "system"
+            labels.append(f"{event_type}:{session_name}")
+        return "events · " + " · ".join(labels)
 
     def _section_header(self, label: str, width: int) -> RenderRow:
         pad = " " * GUTTER

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -120,6 +120,7 @@ class CockpitPresence:
     _cached_attached: bool | None = None
     _cached_at: float = 0.0
     _cached_session: str | None = None
+    _heartbeat_states: dict[str, tuple[str | None, int]] = field(default_factory=dict)
 
     def _calm_mode(self) -> bool:
         value = os.environ.get("POLLY_CALM", "")
@@ -193,19 +194,33 @@ class CockpitPresence:
             return ARC_SPINNER[0]
         return ARC_SPINNER[spinner_index % len(ARC_SPINNER)]
 
+    def heartbeat_frame(self, spinner_index: int) -> str:
+        frames = ("♥", "♡")
+        if not self.should_animate():
+            return frames[0]
+        return frames[spinner_index % len(frames)]
+
+    def heartbeat_frame_for(
+        self,
+        session_name: str,
+        heartbeat_at: str | None,
+    ) -> str:
+        frames = ("♥", "♡")
+        if not self.should_animate():
+            return frames[0]
+        previous_at, frame_index = self._heartbeat_states.get(session_name, (None, 0))
+        if heartbeat_at and heartbeat_at != previous_at:
+            frame_index = (frame_index + 1) % len(frames)
+        self._heartbeat_states[session_name] = (heartbeat_at, frame_index)
+        return frames[frame_index]
+
 
 def _viewer_attached() -> bool:
-    """Best-effort check for a live terminal viewer.
-
-    The legacy rail is a direct TTY renderer, so this stays local to the
-    rail module rather than depending on the newer cockpit presence
-    stack.
-    """
+    """Best-effort check for a live terminal viewer."""
     try:
         return sys.stdin.isatty() and sys.stdout.isatty()
     except Exception:  # noqa: BLE001
         return False
-
 
 # ── Rail data model + router ─────────────────────────────────────────────
 #
@@ -222,6 +237,9 @@ class CockpitItem:
     label: str
     state: str
     selectable: bool = True
+    session_name: str | None = None
+    work_state: str | None = None
+    heartbeat_at: str | None = None
 
 
 def _selected_project_key(selected: object) -> str | None:
@@ -388,7 +406,6 @@ class CockpitRouter:
         # value: (db_mtime, git_mtime, is_active, has_working_task)
         # Skips re-opening SQLite on every 0.8s cockpit tick when nothing changed.
         self._project_activity_cache: dict[str, tuple[float, float, bool, bool]] = {}
-        self._pinned_projects_cache: set[str] | None = None
 
     def _presence(self) -> CockpitPresence:
         presence = getattr(self, "presence", None)
@@ -579,29 +596,6 @@ class CockpitRouter:
             self._state_cache_mtime_ns = None
         self._state_dirty_since = None
 
-    def pinned_projects(self) -> set[str]:
-        data = self._load_state()
-        value = data.get("pinned_projects")
-        if not isinstance(value, list):
-            return set()
-        return {item for item in value if isinstance(item, str) and item}
-
-    def is_project_pinned(self, project_key: str) -> bool:
-        return project_key in self.pinned_projects()
-
-    def toggle_pinned_project(self, project_key: str) -> bool:
-        data = self._load_state()
-        current = self.pinned_projects()
-        if project_key in current:
-            current.remove(project_key)
-            pinned = False
-        else:
-            current.add(project_key)
-            pinned = True
-        data["pinned_projects"] = sorted(current)
-        self._write_state(data)
-        return pinned
-
     def rail_width(self) -> int:
         """Return the persisted rail width, falling back to the default."""
         data = self._load_state()
@@ -728,6 +722,29 @@ class CockpitRouter:
         data["ui_initialized_sessions"] = items
         self._write_state(data)
 
+    def pinned_projects(self) -> set[str]:
+        data = self._load_state()
+        value = data.get("pinned_projects")
+        if not isinstance(value, list):
+            return set()
+        return {item for item in value if isinstance(item, str) and item}
+
+    def is_project_pinned(self, project_key: str) -> bool:
+        return project_key in self.pinned_projects()
+
+    def toggle_pinned_project(self, project_key: str) -> bool:
+        data = self._load_state()
+        current = self.pinned_projects()
+        if project_key in current:
+            current.remove(project_key)
+            pinned = False
+        else:
+            current.add(project_key)
+            pinned = True
+        data["pinned_projects"] = sorted(current)
+        self._write_state(data)
+        return pinned
+
     def build_items(self, *, spinner_index: int = 0) -> list[CockpitItem]:
         """Build rail rows by walking the plugin-host rail registry.
 
@@ -776,6 +793,7 @@ class CockpitRouter:
         collapsed_sections = self._collapsed_rail_sections_cached(config)
         grouped_registrations = self._grouped_rail_registrations(config, registry)
         grouped: dict[str, list[CockpitItem]] = {name: [] for name in RAIL_SECTIONS}
+        project_session_map = self._project_session_map(launches)
 
         for section, registrations in grouped_registrations.items():
             for reg in registrations:
@@ -788,6 +806,12 @@ class CockpitRouter:
                         label=row.label,
                         state=row.state,
                         selectable=row.selectable,
+                    )
+                    self._attach_session_metadata(
+                        item,
+                        launches=launches,
+                        supervisor=supervisor,
+                        project_session_map=project_session_map,
                     )
                     grouped.setdefault(section, []).append(item)
 
@@ -814,12 +838,6 @@ class CockpitRouter:
                 continue
             items.extend(rows)
 
-        project_session_map: dict[str, str] = {}
-        for launch in launches:
-            if launch.session.role in {"operator-pm", "heartbeat-supervisor", "triage", "reviewer"}:
-                continue
-            project_session_map.setdefault(launch.session.project, launch.session.name)
-
         return self._decorate_project_items(
             items,
             selected_project=_selected_project_key(cockpit_state.get("selected")),
@@ -827,6 +845,104 @@ class CockpitRouter:
             recent_events=recent_events,
             project_session_map=project_session_map,
         )
+
+    def _attach_session_metadata(
+        self,
+        item: CockpitItem,
+        *,
+        launches,
+        supervisor,
+        project_session_map: dict[str, str],
+    ) -> None:
+        session_name = self._session_name_for_item(item, project_session_map)
+        if session_name is None:
+            return
+        item.session_name = session_name
+        launch = next((entry for entry in launches if entry.session.name == session_name), None)
+        if launch is None:
+            return
+        item.work_state = self._work_state_for_item_state(item.state, launch.session.role)
+        try:
+            heartbeat = supervisor.store.latest_heartbeat(session_name)
+        except Exception:  # noqa: BLE001
+            heartbeat = None
+        item.heartbeat_at = getattr(heartbeat, "created_at", None)
+
+    def _session_name_for_item(
+        self,
+        item: CockpitItem,
+        project_session_map: dict[str, str],
+    ) -> str | None:
+        if item.key == "polly":
+            return "operator"
+        if item.key == "russell":
+            return "reviewer"
+        if not item.key.startswith("project:") or item.key.count(":") != 1:
+            return None
+        project_key = item.key.split(":", 1)[1]
+        return project_session_map.get(project_key)
+
+    def _work_state_for_item_state(self, state: str, role: str) -> str | None:
+        if state == "dead":
+            return "exited"
+        if state.startswith("!"):
+            return "stuck"
+        if state.endswith("working"):
+            return "writing"
+        if role == "reviewer":
+            return "reviewing"
+        if state.endswith("live") or state in {"idle", "ready"}:
+            return "idle"
+        return None
+
+    def _rail_registry(self):
+        """Return the plugin-host rail registry for the active root dir."""
+        from pollypm.plugin_host import extension_host_for_root
+
+        config = self._load_config()
+        host = extension_host_for_root(str(config.project.root_dir.resolve()))
+        # Initialize plugins so the rail registry is populated. Safe to
+        # call repeatedly — it tracks which plugins have been init'd.
+        try:
+            host.initialize_plugins(config=config)
+        except Exception:  # noqa: BLE001
+            # Plugin init failures surface via degraded_plugins; don't
+            # block the rail rendering.
+            pass
+        registry = host.rail_registry()
+        # Worker roster top-rail entry. Registered here (not in
+        # ``core_rail_items``) so the cockpit router + roster Textual
+        # app land in one feature drop — the rail row, the route handler
+        # (``route_selected("workers")``), and the panel renderer all
+        # live alongside each other. The registration is gated on
+        # ``core_rail_items`` being active so disabling the core plugin
+        # still yields an empty rail (see
+        # ``test_removing_core_rail_items_yields_empty_rail``).
+        try:
+            core_enabled = "core_rail_items" in host.plugins()
+        except Exception:  # noqa: BLE001
+            core_enabled = True
+        if core_enabled:
+            # Deferred imports: the worker roster + metrics registrations
+            # live in ``pollypm.cockpit`` alongside the gather helpers
+            # they call into. Importing them at module load time would
+            # create a cycle (cockpit imports cockpit_rail to re-export
+            # the router), so we resolve them per-tick instead.
+            from pollypm.cockpit import (
+                _register_metrics_rail_item,
+                _register_worker_roster_rail_item,
+            )
+            _register_worker_roster_rail_item(registry, self)
+            _register_metrics_rail_item(registry, self)
+        return registry
+
+    def _project_session_map(self, launches) -> dict[str, str]:
+        project_session_map: dict[str, str] = {}
+        for launch in launches:
+            if launch.session.role in {"operator-pm", "heartbeat-supervisor", "triage", "reviewer"}:
+                continue
+            project_session_map.setdefault(launch.session.project, launch.session.name)
+        return project_session_map
 
     def _decorate_project_items(
         self,
@@ -837,7 +953,6 @@ class CockpitRouter:
         recent_events: list,
         project_session_map: dict[str, str],
     ) -> list[CockpitItem]:
-        """Keep project rows together while decorating their presentation."""
         from pollypm.cockpit_sections.base import _iso_to_dt, _spark_bar
 
         first_project = next((idx for idx, item in enumerate(items) if item.key.startswith("project:")), None)
@@ -853,7 +968,6 @@ class CockpitRouter:
         prefix = list(items[:first_project])
         region = list(items[first_project : last_project + 1])
         suffix = list(items[last_project + 1 :])
-
         project_event_spark = self._project_activity_sparkline(
             project_session_map,
             recent_events,
@@ -947,19 +1061,10 @@ class CockpitRouter:
         result: dict[str, str] = {}
         for project_key, values in buckets.items():
             if any(values):
-                result[project_key] = self._sparkline(values)
+                result[project_key] = _spark_bar(values)
             else:
                 result[project_key] = "·" * len(values)
         return result
-
-    def _sparkline(self, values: list[int]) -> str:
-        from pollypm.cockpit_sections.base import _spark_bar
-
-        if not values:
-            return ""
-        if max(values) <= 0:
-            return "·" * len(values)
-        return _spark_bar(values)
 
     def _row_is_active(self, item: CockpitItem) -> bool:
         state = item.state.strip().lower()
@@ -969,55 +1074,6 @@ class CockpitRouter:
             marker in state
             for marker in ("working", "live", "watch", "ready", "alert", "active")
         ) or state.startswith("!")
-
-    def _rail_registry(self):
-        """Return the plugin-host rail registry for the active root dir."""
-        from pollypm.plugin_host import extension_host_for_root
-
-        config = self._load_config()
-        host = extension_host_for_root(str(config.project.root_dir.resolve()))
-        # Initialize plugins so the rail registry is populated. Safe to
-        # call repeatedly — it tracks which plugins have been init'd.
-        try:
-            host.initialize_plugins(config=config)
-        except Exception:  # noqa: BLE001
-            # Plugin init failures surface via degraded_plugins; don't
-            # block the rail rendering.
-            pass
-        registry = host.rail_registry()
-        # Worker roster top-rail entry. Registered here (not in
-        # ``core_rail_items``) so the cockpit router + roster Textual
-        # app land in one feature drop — the rail row, the route handler
-        # (``route_selected("workers")``), and the panel renderer all
-        # live alongside each other. The registration is gated on
-        # ``core_rail_items`` being active so disabling the core plugin
-        # still yields an empty rail (see
-        # ``test_removing_core_rail_items_yields_empty_rail``).
-        try:
-            core_enabled = "core_rail_items" in host.plugins()
-        except Exception:  # noqa: BLE001
-            core_enabled = True
-        if core_enabled:
-            # Deferred imports: the worker roster + metrics registrations
-            # live in ``pollypm.cockpit`` alongside the gather helpers
-            # they call into. Importing them at module load time would
-            # create a cycle (cockpit imports cockpit_rail to re-export
-            # the router), so we resolve them per-tick instead.
-            from pollypm.cockpit import (
-                _register_metrics_rail_item,
-                _register_worker_roster_rail_item,
-            )
-            _register_worker_roster_rail_item(registry, self)
-            _register_metrics_rail_item(registry, self)
-        return registry
-
-    def _project_session_map(self, launches) -> dict[str, str]:
-        project_session_map: dict[str, str] = {}
-        for launch in launches:
-            if launch.session.role in {"operator-pm", "heartbeat-supervisor", "triage", "reviewer"}:
-                continue
-            project_session_map.setdefault(launch.session.project, launch.session.name)
-        return project_session_map
 
     # Alert types that are informational / auto-managed — don't show red triangle
     _SILENT_ALERT_TYPES = frozenset({
@@ -1926,6 +1982,12 @@ class PollyCockpitRail:
             project_key = self.selected_key.split(":", 2)[1]
             self.router.toggle_pinned_project(project_key)
             return True
+        if key in {b"\x0b"}:
+            # Raw rail has no palette UI of its own; jump to settings so
+            # the user's ctrl-k habit still lands in the palette-enabled pane.
+            self.router.route_selected("settings")
+            self.selected_key = "settings"
+            return True
         return True
 
     # ── Navigation ───────────────────────────────────────────────────────
@@ -2024,7 +2086,7 @@ class PollyCockpitRail:
 
         # ── Spacer + settings at bottom
         if settings_item is not None:
-            target_lines = len(lines) + 5  # section header + blank + item + ticker + footer
+            target_lines = len(lines) + 4  # section header + blank + item + hint
             while len(lines) < height - target_lines + len(lines):
                 if len(lines) >= height - 4:
                     break
@@ -2033,13 +2095,13 @@ class PollyCockpitRail:
             lines.append(self._section_header("system", width))
             lines.append(self._item_row(settings_item, width, active_view))
 
-        # ── Bottom ticker + hint/footer
         ticker_text = self._event_ticker_text()
-        while len(lines) < height - 3:
+        reserve = 3 if ticker_text else 2
+        while len(lines) < height - reserve:
             lines.append(RenderRow(""))
+        lines.append(RenderRow(""))
         if ticker_text:
-            lines.append(RenderRow(""))
-            lines.append(RenderRow(f"{pad}{ticker_text}"[:width], fg=PALETTE["hint"]))
+            lines.append(RenderRow(ticker_text[:width], fg=PALETTE["hint"]))
         hint = f"{pad}j/k move \u00b7 \u21b5 open \u00b7 n new \u00b7 t activity \u00b7 p pin"
         lines.append(RenderRow(hint[:width], fg=PALETTE["hint"]))
 
@@ -2057,19 +2119,12 @@ class PollyCockpitRail:
             else:
                 self._write(clear_line + "\r\n")
 
-    def _section_header(self, label: str, width: int) -> RenderRow:
-        pad = " " * GUTTER
-        prefix = f"{pad}\u2500\u2500 {label.upper()} "
-        remaining = width - len(prefix)
-        rule = "\u2500" * max(0, remaining)
-        return RenderRow((prefix + rule)[:width], fg=PALETTE["section_label"])
-
     def _event_ticker_text(self) -> str:
         if not _viewer_attached():
             return ""
         try:
             supervisor = self.router._load_supervisor()
-            events = list(supervisor.store.recent_events(limit=12))
+            events = list(supervisor.store.recent_events(limit=4))
         except Exception:  # noqa: BLE001
             return ""
         if not events:
@@ -2080,6 +2135,13 @@ class PollyCockpitRail:
         session_name = getattr(event, "session_name", "") or "system"
         return f"events · {event_type}:{session_name}"
 
+    def _section_header(self, label: str, width: int) -> RenderRow:
+        pad = " " * GUTTER
+        prefix = f"{pad}\u2500\u2500 {label.upper()} "
+        remaining = width - len(prefix)
+        rule = "\u2500" * max(0, remaining)
+        return RenderRow((prefix + rule)[:width], fg=PALETTE["section_label"])
+
     def _item_row(self, item: CockpitItem, width: int, active_view: str) -> RenderRow:
         is_selected = item.key == self.selected_key
         is_active = item.key == active_view
@@ -2088,7 +2150,8 @@ class PollyCockpitRail:
         # Build the text with gutter (2-char prefix for alignment)
         bar = "\u258c " if is_selected else "  "
         label = item.label
-        max_label = width - 6  # 2 bar + 1 indicator + 1 space + 2 margin
+        indicator_width = max(1, len(indicator))
+        max_label = width - (5 + indicator_width)
         if len(label) > max_label and max_label > 3:
             label = label[: max_label - 1] + "\u2026"
         text = f" {bar}{indicator} {label}"
@@ -2137,6 +2200,13 @@ class PollyCockpitRail:
         return row
 
     def _indicator(self, item: CockpitItem) -> tuple[str, _C | None]:
+        if item.session_name and item.work_state:
+            pulse = self.presence.heartbeat_frame_for(
+                item.session_name,
+                item.heartbeat_at,
+            )
+            work_glyph, color = self._session_work_glyph(item.work_state)
+            return f"{pulse}{work_glyph}", color
         # State-based indicators first (apply to any item type including projects)
         if item.state.endswith("working"):
             char = self.presence.working_frame(self.spinner_index)
@@ -2166,6 +2236,19 @@ class PollyCockpitRail:
         if item.state == "sub":
             return " ", None
         return "\u25cb", PALETTE["idle"]
+
+    def _session_work_glyph(self, work_state: str) -> tuple[str, _C | None]:
+        if work_state == "writing":
+            if not self.presence.should_animate():
+                return "…", PALETTE["live_indicator"]
+            return self.presence.working_frame(self.spinner_index), PALETTE["live_indicator"]
+        if work_state == "reviewing":
+            return "✎", PALETTE["live_indicator"]
+        if work_state == "stuck":
+            return "⚠", PALETTE["alert_indicator"]
+        if work_state == "exited":
+            return "✕", PALETTE["dead"]
+        return "·", PALETTE["idle"]
 
     def _write(self, text: str) -> None:
         sys.stdout.write(text)

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -120,7 +120,6 @@ class CockpitPresence:
     _cached_attached: bool | None = None
     _cached_at: float = 0.0
     _cached_session: str | None = None
-    _heartbeat_states: dict[str, tuple[str | None, int]] = field(default_factory=dict)
 
     def _calm_mode(self) -> bool:
         value = os.environ.get("POLLY_CALM", "")
@@ -194,25 +193,19 @@ class CockpitPresence:
             return ARC_SPINNER[0]
         return ARC_SPINNER[spinner_index % len(ARC_SPINNER)]
 
-    def heartbeat_frame(self, spinner_index: int) -> str:
-        frames = ("♥", "♡")
-        if not self.should_animate():
-            return frames[0]
-        return frames[spinner_index % len(frames)]
 
-    def heartbeat_frame_for(
-        self,
-        session_name: str,
-        heartbeat_at: str | None,
-    ) -> str:
-        frames = ("♥", "♡")
-        if not self.should_animate():
-            return frames[0]
-        previous_at, frame_index = self._heartbeat_states.get(session_name, (None, 0))
-        if heartbeat_at and heartbeat_at != previous_at:
-            frame_index = (frame_index + 1) % len(frames)
-        self._heartbeat_states[session_name] = (heartbeat_at, frame_index)
-        return frames[frame_index]
+def _viewer_attached() -> bool:
+    """Best-effort check for a live terminal viewer.
+
+    The legacy rail is a direct TTY renderer, so this stays local to the
+    rail module rather than depending on the newer cockpit presence
+    stack.
+    """
+    try:
+        return sys.stdin.isatty() and sys.stdout.isatty()
+    except Exception:  # noqa: BLE001
+        return False
+
 
 # ── Rail data model + router ─────────────────────────────────────────────
 #
@@ -229,9 +222,6 @@ class CockpitItem:
     label: str
     state: str
     selectable: bool = True
-    session_name: str | None = None
-    work_state: str | None = None
-    heartbeat_at: str | None = None
 
 
 def _selected_project_key(selected: object) -> str | None:
@@ -398,6 +388,7 @@ class CockpitRouter:
         # value: (db_mtime, git_mtime, is_active, has_working_task)
         # Skips re-opening SQLite on every 0.8s cockpit tick when nothing changed.
         self._project_activity_cache: dict[str, tuple[float, float, bool, bool]] = {}
+        self._pinned_projects_cache: set[str] | None = None
 
     def _presence(self) -> CockpitPresence:
         presence = getattr(self, "presence", None)
@@ -588,6 +579,29 @@ class CockpitRouter:
             self._state_cache_mtime_ns = None
         self._state_dirty_since = None
 
+    def pinned_projects(self) -> set[str]:
+        data = self._load_state()
+        value = data.get("pinned_projects")
+        if not isinstance(value, list):
+            return set()
+        return {item for item in value if isinstance(item, str) and item}
+
+    def is_project_pinned(self, project_key: str) -> bool:
+        return project_key in self.pinned_projects()
+
+    def toggle_pinned_project(self, project_key: str) -> bool:
+        data = self._load_state()
+        current = self.pinned_projects()
+        if project_key in current:
+            current.remove(project_key)
+            pinned = False
+        else:
+            current.add(project_key)
+            pinned = True
+        data["pinned_projects"] = sorted(current)
+        self._write_state(data)
+        return pinned
+
     def rail_width(self) -> int:
         """Return the persisted rail width, falling back to the default."""
         data = self._load_state()
@@ -733,6 +747,11 @@ class CockpitRouter:
         supervisor = self._load_supervisor()
         config = supervisor.config
         launches, windows, alerts, _leases, _errors = supervisor.status()
+        recent_events = []
+        try:
+            recent_events = list(supervisor.store.recent_events(limit=300))
+        except Exception:  # noqa: BLE001
+            recent_events = []
 
         cockpit_state = self._load_state()
         ctx = RailContext(
@@ -757,7 +776,6 @@ class CockpitRouter:
         collapsed_sections = self._collapsed_rail_sections_cached(config)
         grouped_registrations = self._grouped_rail_registrations(config, registry)
         grouped: dict[str, list[CockpitItem]] = {name: [] for name in RAIL_SECTIONS}
-        project_session_map = self._project_session_map(launches)
 
         for section, registrations in grouped_registrations.items():
             for reg in registrations:
@@ -771,12 +789,6 @@ class CockpitRouter:
                         state=row.state,
                         selectable=row.selectable,
                     )
-                    self._attach_session_metadata(
-                        item,
-                        launches=launches,
-                        supervisor=supervisor,
-                        project_session_map=project_session_map,
-                    )
                     grouped.setdefault(section, []).append(item)
 
         items: list[CockpitItem] = []
@@ -784,7 +796,10 @@ class CockpitRouter:
             rows = grouped.get(section) or []
             if not rows:
                 continue
-            if section in collapsed_sections:
+            active_rows = [row for row in rows if self._row_is_active(row)]
+            if section in collapsed_sections or (
+                section not in {"top", "system"} and not active_rows
+            ):
                 # Collapsed sections render as a disabled header row so
                 # the user can still see the section exists. Expansion
                 # is a runtime concept tracked via set_selected_key.
@@ -799,56 +814,161 @@ class CockpitRouter:
                 continue
             items.extend(rows)
 
-        return items
+        project_session_map: dict[str, str] = {}
+        for launch in launches:
+            if launch.session.role in {"operator-pm", "heartbeat-supervisor", "triage", "reviewer"}:
+                continue
+            project_session_map.setdefault(launch.session.project, launch.session.name)
 
-    def _attach_session_metadata(
+        return self._decorate_project_items(
+            items,
+            selected_project=_selected_project_key(cockpit_state.get("selected")),
+            launches=launches,
+            recent_events=recent_events,
+            project_session_map=project_session_map,
+        )
+
+    def _decorate_project_items(
         self,
-        item: CockpitItem,
+        items: list[CockpitItem],
         *,
+        selected_project: str | None,
         launches,
-        supervisor,
+        recent_events: list,
         project_session_map: dict[str, str],
-    ) -> None:
-        session_name = self._session_name_for_item(item, project_session_map)
-        if session_name is None:
-            return
-        item.session_name = session_name
-        launch = next((entry for entry in launches if entry.session.name == session_name), None)
-        if launch is None:
-            return
-        item.work_state = self._work_state_for_item_state(item.state, launch.session.role)
-        try:
-            heartbeat = supervisor.store.latest_heartbeat(session_name)
-        except Exception:  # noqa: BLE001
-            heartbeat = None
-        item.heartbeat_at = getattr(heartbeat, "created_at", None)
+    ) -> list[CockpitItem]:
+        """Keep project rows together while decorating their presentation."""
+        from pollypm.cockpit_sections.base import _iso_to_dt, _spark_bar
 
-    def _session_name_for_item(
+        first_project = next((idx for idx, item in enumerate(items) if item.key.startswith("project:")), None)
+        if first_project is None:
+            return items
+        last_project = max(
+            (idx for idx, item in enumerate(items) if item.key.startswith("project:")),
+            default=None,
+        )
+        if last_project is None:
+            return items
+
+        prefix = list(items[:first_project])
+        region = list(items[first_project : last_project + 1])
+        suffix = list(items[last_project + 1 :])
+
+        project_event_spark = self._project_activity_sparkline(
+            project_session_map,
+            recent_events,
+            _iso_to_dt=_iso_to_dt,
+            _spark_bar=_spark_bar,
+        )
+
+        project_blocks: list[tuple[str, list[CockpitItem], bool, bool]] = []
+        current_key: str | None = None
+        current_block: list[CockpitItem] = []
+        current_pinned = False
+        current_selected = False
+
+        def flush_block() -> None:
+            nonlocal current_key, current_block, current_pinned, current_selected
+            if current_key is not None and current_block:
+                project_blocks.append((current_key, current_block, current_pinned, current_selected))
+            current_key = None
+            current_block = []
+            current_pinned = False
+            current_selected = False
+
+        for item in region:
+            if item.key.startswith("project:"):
+                parts = item.key.split(":")
+                if len(parts) == 2:
+                    flush_block()
+                    current_key = parts[1]
+                    current_selected = current_key == selected_project
+                    current_pinned = self.is_project_pinned(current_key)
+                    current_block = [self._decorate_project_row(item, project_event_spark.get(current_key))]
+                    continue
+                if current_key is not None and len(parts) > 2 and parts[1] == current_key:
+                    current_block.append(item)
+                    continue
+            flush_block()
+            prefix.append(item)
+        flush_block()
+
+        project_region: list[CockpitItem] = []
+        if project_blocks:
+            project_blocks.sort(
+                key=lambda row: (
+                    not row[2],
+                    not row[3],
+                    row[0].lower(),
+                ),
+            )
+            for _key, block, _pinned, _selected in project_blocks:
+                project_region.extend(block)
+        return [*prefix, *project_region, *suffix]
+
+    def _decorate_project_row(self, item: CockpitItem, sparkline: str | None) -> CockpitItem:
+        label = item.label
+        if self.is_project_pinned(item.key.split(":", 1)[1]):
+            label = f"📌 {label}"
+        if sparkline:
+            label = f"{label} {sparkline}"
+        return replace(item, label=label)
+
+    def _project_activity_sparkline(
         self,
-        item: CockpitItem,
         project_session_map: dict[str, str],
-    ) -> str | None:
-        if item.key == "polly":
-            return "operator"
-        if item.key == "russell":
-            return "reviewer"
-        if not item.key.startswith("project:") or item.key.count(":") != 1:
-            return None
-        project_key = item.key.split(":", 1)[1]
-        return project_session_map.get(project_key)
+        recent_events: list,
+        *,
+        _iso_to_dt,
+        _spark_bar,
+    ) -> dict[str, str]:
+        from datetime import UTC, datetime
 
-    def _work_state_for_item_state(self, state: str, role: str) -> str | None:
-        if state == "dead":
-            return "exited"
-        if state.startswith("!"):
-            return "stuck"
-        if state.endswith("working"):
-            return "writing"
-        if role == "reviewer":
-            return "reviewing"
-        if state.endswith("live") or state in {"idle", "ready"}:
-            return "idle"
-        return None
+        if not recent_events:
+            return {}
+        now = datetime.now(UTC)
+        buckets: dict[str, list[int]] = {key: [0] * 10 for key in project_session_map}
+        session_to_project = {
+            session_name: project_key
+            for project_key, session_name in project_session_map.items()
+        }
+        for event in recent_events:
+            project_key = session_to_project.get(getattr(event, "session_name", ""))
+            if project_key is None:
+                continue
+            dt = _iso_to_dt(getattr(event, "created_at", None))
+            if dt is None:
+                continue
+            age_minutes = int((now - dt).total_seconds() // 60)
+            if age_minutes < 0 or age_minutes >= 60:
+                continue
+            bucket = 9 - (age_minutes // 6)
+            buckets[project_key][bucket] += 1
+        result: dict[str, str] = {}
+        for project_key, values in buckets.items():
+            if any(values):
+                result[project_key] = self._sparkline(values)
+            else:
+                result[project_key] = "·" * len(values)
+        return result
+
+    def _sparkline(self, values: list[int]) -> str:
+        from pollypm.cockpit_sections.base import _spark_bar
+
+        if not values:
+            return ""
+        if max(values) <= 0:
+            return "·" * len(values)
+        return _spark_bar(values)
+
+    def _row_is_active(self, item: CockpitItem) -> bool:
+        state = item.state.strip().lower()
+        if not state or state in {"idle", "separator", "sub"}:
+            return False
+        return any(
+            marker in state
+            for marker in ("working", "live", "watch", "ready", "alert", "active")
+        ) or state.startswith("!")
 
     def _rail_registry(self):
         """Return the plugin-host rail registry for the active root dir."""
@@ -1738,6 +1858,7 @@ class PollyCockpitRail:
         self.selected_key = self.router.selected_key()
         self.spinner_index = 0
         self.slogan_started_at = time.time()
+        self._ticker_started_at = time.monotonic()
         self._last_items: list[CockpitItem] = []
         self._slogan_phase = 0
 
@@ -1797,11 +1918,13 @@ class PollyCockpitRail:
             self.router.route_selected("inbox")
             self.selected_key = "inbox"
             return True
-        if key in {b"\x0b"}:
-            # Raw rail has no palette UI of its own; jump to settings so
-            # the user's ctrl-k habit still lands in the palette-enabled pane.
-            self.router.route_selected("settings")
-            self.selected_key = "settings"
+        if key in {b"t", b"T"}:
+            self.router.route_selected("activity")
+            self.selected_key = "activity"
+            return True
+        if key in {b"p", b"P"} and self.selected_key.startswith("project:"):
+            project_key = self.selected_key.split(":", 2)[1]
+            self.router.toggle_pinned_project(project_key)
             return True
         return True
 
@@ -1901,7 +2024,7 @@ class PollyCockpitRail:
 
         # ── Spacer + settings at bottom
         if settings_item is not None:
-            target_lines = len(lines) + 4  # section header + blank + item + hint
+            target_lines = len(lines) + 5  # section header + blank + item + ticker + footer
             while len(lines) < height - target_lines + len(lines):
                 if len(lines) >= height - 4:
                     break
@@ -1910,11 +2033,14 @@ class PollyCockpitRail:
             lines.append(self._section_header("system", width))
             lines.append(self._item_row(settings_item, width, active_view))
 
-        # ── Hint line
-        while len(lines) < height - 2:
+        # ── Bottom ticker + hint/footer
+        ticker_text = self._event_ticker_text()
+        while len(lines) < height - 3:
             lines.append(RenderRow(""))
-        lines.append(RenderRow(""))
-        hint = f"{pad}j/k move \u00b7 \u21b5 open \u00b7 n new"
+        if ticker_text:
+            lines.append(RenderRow(""))
+            lines.append(RenderRow(f"{pad}{ticker_text}"[:width], fg=PALETTE["hint"]))
+        hint = f"{pad}j/k move \u00b7 \u21b5 open \u00b7 n new \u00b7 t activity \u00b7 p pin"
         lines.append(RenderRow(hint[:width], fg=PALETTE["hint"]))
 
         # ── Flush
@@ -1938,6 +2064,22 @@ class PollyCockpitRail:
         rule = "\u2500" * max(0, remaining)
         return RenderRow((prefix + rule)[:width], fg=PALETTE["section_label"])
 
+    def _event_ticker_text(self) -> str:
+        if not _viewer_attached():
+            return ""
+        try:
+            supervisor = self.router._load_supervisor()
+            events = list(supervisor.store.recent_events(limit=12))
+        except Exception:  # noqa: BLE001
+            return ""
+        if not events:
+            return ""
+        index = int((time.monotonic() - self._ticker_started_at) // 10)
+        event = events[index % len(events)]
+        event_type = getattr(event, "event_type", "event")
+        session_name = getattr(event, "session_name", "") or "system"
+        return f"events · {event_type}:{session_name}"
+
     def _item_row(self, item: CockpitItem, width: int, active_view: str) -> RenderRow:
         is_selected = item.key == self.selected_key
         is_active = item.key == active_view
@@ -1946,8 +2088,7 @@ class PollyCockpitRail:
         # Build the text with gutter (2-char prefix for alignment)
         bar = "\u258c " if is_selected else "  "
         label = item.label
-        indicator_width = max(1, len(indicator))
-        max_label = width - (5 + indicator_width)
+        max_label = width - 6  # 2 bar + 1 indicator + 1 space + 2 margin
         if len(label) > max_label and max_label > 3:
             label = label[: max_label - 1] + "\u2026"
         text = f" {bar}{indicator} {label}"
@@ -1996,13 +2137,6 @@ class PollyCockpitRail:
         return row
 
     def _indicator(self, item: CockpitItem) -> tuple[str, _C | None]:
-        if item.session_name and item.work_state:
-            pulse = self.presence.heartbeat_frame_for(
-                item.session_name,
-                item.heartbeat_at,
-            )
-            work_glyph, color = self._session_work_glyph(item.work_state)
-            return f"{pulse}{work_glyph}", color
         # State-based indicators first (apply to any item type including projects)
         if item.state.endswith("working"):
             char = self.presence.working_frame(self.spinner_index)
@@ -2032,19 +2166,6 @@ class PollyCockpitRail:
         if item.state == "sub":
             return " ", None
         return "\u25cb", PALETTE["idle"]
-
-    def _session_work_glyph(self, work_state: str) -> tuple[str, _C | None]:
-        if work_state == "writing":
-            if not self.presence.should_animate():
-                return "…", PALETTE["live_indicator"]
-            return self.presence.working_frame(self.spinner_index), PALETTE["live_indicator"]
-        if work_state == "reviewing":
-            return "✎", PALETTE["live_indicator"]
-        if work_state == "stuck":
-            return "⚠", PALETTE["alert_indicator"]
-        if work_state == "exited":
-            return "✕", PALETTE["dead"]
-        return "·", PALETTE["idle"]
 
     def _write(self, text: str) -> None:
         sys.stdout.write(text)

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -26,6 +26,7 @@ from collections import deque
 from pathlib import Path
 import subprocess
 import time
+from typing import Callable
 
 # Raise FD limit early — the cockpit opens many subprocesses and file handles.
 try:
@@ -56,6 +57,7 @@ from pollypm.approval_notifications import notify_task_approved
 from pollypm.cockpit_formatting import format_event_time
 from pollypm.cockpit_formatting import format_relative_age as _format_relative_age
 from pollypm.models import ProviderKind
+from pollypm.account_usage_sampler import load_cached_account_usage
 from pollypm.tz import format_time as _fmt_time
 from pollypm.cockpit_activity import (
     PollyActivityFeedApp,
@@ -100,9 +102,18 @@ from pollypm.cockpit_palette import (
 )
 from pollypm.cockpit_project_settings import PollyProjectSettingsApp
 from pollypm.cockpit_sections.action_bar import render_project_action_bar
-from pollypm.cockpit_settings_accounts import (
-    SETTINGS_ACCOUNT_ACTIONS,
-    render_settings_account_detail,
+from pollypm.cockpit_settings_accounts import SETTINGS_ACCOUNT_ACTIONS
+from pollypm.cockpit_settings_history import (
+    UndoAction,
+    consume_settings_history,
+    history_rationale_for_account,
+    history_rationale_for_project,
+    latest_settings_history_entry,
+    load_settings_history,
+    make_undo_action,
+    record_settings_history,
+    undo_expired,
+    undo_expires_text,
 )
 from pollypm.cockpit_settings_projects import collect_settings_projects
 from pollypm.cockpit_workers import PollyWorkerRosterApp
@@ -113,7 +124,7 @@ from pollypm.rejection_feedback import (
 from pollypm.session_services import create_tmux_client
 from pollypm.service_api import PollyPMService
 from pollypm.cockpit import build_cockpit_detail
-from pollypm.cockpit_rail import CockpitItem, CockpitRouter, _viewer_attached
+from pollypm.cockpit_rail import CockpitItem, CockpitPresence, CockpitRouter, _viewer_attached
 
 
 import re as _re
@@ -415,31 +426,46 @@ class RailItem(ListItem):
         *,
         active_view: bool,
         first_project: bool = False,
+        presence: CockpitPresence | None = None,
+        spinner_index: int = 0,
     ) -> None:
         self.body = Static(classes="rail-item-body")
         self.item = item
+        self.presence = presence
+        self.spinner_index = spinner_index
         super().__init__(self.body, classes="rail-row", disabled=not item.selectable)
-        self.apply_item(item, active_view=active_view, first_project=first_project)
+        self.apply_item(
+            item,
+            active_view=active_view,
+            first_project=first_project,
+            spinner_index=spinner_index,
+        )
 
     @property
     def cockpit_key(self) -> str:
         return self.item.key
 
-    def apply_item(self, item: CockpitItem, *, active_view: bool, first_project: bool) -> None:
+    def apply_item(
+        self,
+        item: CockpitItem,
+        *,
+        active_view: bool,
+        first_project: bool,
+        spinner_index: int | None = None,
+    ) -> None:
         self.item = item
+        if spinner_index is not None:
+            self.spinner_index = spinner_index
         self.disabled = not item.selectable
         for class_name in [
             "inbox-entry",
             "project-start",
             "project-row",
-            "section-sep",
             "needs-user",
             "live",
             "active-view",
         ]:
             self.remove_class(class_name)
-        if item.state == "separator":
-            self.add_class("section-sep")
         if item.key == "inbox":
             self.add_class("inbox-entry")
         if first_project:
@@ -487,6 +513,20 @@ class RailItem(ListItem):
         self.body.update(text)
 
     def _indicator(self) -> tuple[str, str]:
+        presence = self.presence
+        if (
+            presence is not None
+            and self.item.session_name
+            and self.item.work_state
+        ):
+            pulse = presence.heartbeat_frame_for(
+                self.item.session_name,
+                self.item.heartbeat_at,
+            )
+            work_glyph, color = self._session_work_glyph(self.item.work_state)
+            return f"{pulse}{work_glyph}", color
+        if presence is not None and self.item.state in {"heartbeat", "watch"}:
+            return presence.heartbeat_frame(self.spinner_index), "#3ddc84"
         # Alerts (red triangle)
         if self.item.state.startswith("!"):
             return "\u25b2", "#ff5f6d"
@@ -518,9 +558,27 @@ class RailItem(ListItem):
         # Projects: yellow for active task, dim for idle
         if self.item.key.startswith("project:"):
             if "working" in self.item.state:
+                if presence is not None:
+                    return presence.working_frame(self.spinner_index), "#3ddc84"
                 return "\u25c6", "#f0c45a"  # yellow diamond — active task
             return "\u25cb", "#4a5568"  # dim circle — idle
         return "\u25cb", "#4a5568"
+
+    def _session_work_glyph(self, work_state: str) -> tuple[str, str]:
+        presence = self.presence
+        if work_state == "writing":
+            if presence is not None:
+                if not presence.should_animate():
+                    return "…", "#3ddc84"
+                return presence.working_frame(self.spinner_index), "#3ddc84"
+            return "\u25c6", "#3ddc84"
+        if work_state == "reviewing":
+            return "\u270e", "#3ddc84"
+        if work_state == "stuck":
+            return "\u26a0", "#ff5f6d"
+        if work_state == "exited":
+            return "\u2715", "#4a5568"
+        return "\u00b7", "#4a5568"
 
 
 class PollyCockpitApp(App[None]):
@@ -574,13 +632,6 @@ class PollyCockpitApp(App[None]):
         color: #4a5568;
         background: transparent;
         margin-top: 1;
-        text-style: bold;
-    }
-    #ticker {
-        height: 1;
-        padding: 0 1;
-        color: #4a5568;
-        background: transparent;
     }
     #nav > .rail-row.-highlight {
         background: #1e2730;
@@ -627,6 +678,12 @@ class PollyCockpitApp(App[None]):
         background: #253140;
         color: #f2f6f8;
     }
+    #ticker {
+        height: 1;
+        padding: 0 1;
+        color: #4a5568;
+        background: transparent;
+    }
     #hint {
         height: 3;
         color: #3e4c5a;
@@ -642,8 +699,13 @@ class PollyCockpitApp(App[None]):
         Binding("r", "refresh", "Refresh"),
         Binding("s", "open_settings", "Settings"),
         Binding("a", "view_alerts", "Alerts", show=False),
-        Binding("colon", "open_command_palette", "Palette", priority=True),
-        Binding("question_mark", "show_keyboard_help", "Help", priority=True),
+        Binding("ctrl+k,colon", "open_command_palette", "Palette", priority=True),
+        Binding(
+            "question_mark",
+            "show_keyboard_help",
+            "Help: pulse ♥/♡, writing ◜◝◞◟, review ✎, idle ·, stuck ⚠, exited ✕",
+            priority=True,
+        ),
         Binding("j,down", "cursor_down", "Down", show=False),
         Binding("k,up", "cursor_up", "Up", show=False),
         Binding("g,home", "cursor_first", "First", show=False),
@@ -662,6 +724,7 @@ class PollyCockpitApp(App[None]):
         super().__init__()
         self.config_path = config_path
         self.router = CockpitRouter(config_path)
+        self.presence = CockpitPresence(self.router.tmux)
         self.service = PollyPMService(config_path)
         _lines = ASCII_POLLY.split("\n")
         self.brand = Static(
@@ -852,8 +915,18 @@ class PollyCockpitApp(App[None]):
                 if item.state.endswith("working"):
                     item.state = f"{frame} working"
             for key, row in self._row_widgets.items():
-                if row.item.state.endswith("working"):
-                    row.item.state = f"{frame} working"
+                should_animate = row.item.state.endswith("working")
+                rewrite_state = should_animate
+                if row.item.state in {"heartbeat", "watch"}:
+                    should_animate = True
+                    rewrite_state = False
+                if row.item.session_name and row.item.work_state == "writing":
+                    should_animate = True
+                    rewrite_state = False
+                if should_animate:
+                    if rewrite_state:
+                        row.item.state = f"{frame} working"
+                    row.spinner_index = self.spinner_index
                     row.update_body()
         self._update_ticker()
         # Layout check much less frequently
@@ -939,11 +1012,18 @@ class PollyCockpitApp(App[None]):
                     item,
                     active_view=item.key == self.selected_key,
                     first_project=first_project,
+                    presence=self.presence,
+                    spinner_index=self.spinner_index,
                 )
                 self._row_widgets[item.key] = row
             else:
                 row = self._row_widgets[item.key]
-                row.apply_item(item, active_view=item.key == self.selected_key, first_project=first_project)
+                row.apply_item(
+                    item,
+                    active_view=item.key == self.selected_key,
+                    first_project=first_project,
+                    spinner_index=self.spinner_index,
+                )
             rows.append(row)
             if selected_key is not None and item.key == selected_key:
                 restore_index = nav_index
@@ -1006,11 +1086,8 @@ class PollyCockpitApp(App[None]):
 
     def _update_ticker(self) -> None:
         ticker_text = self._event_ticker_text()
-        ticker = getattr(self, "ticker", None)
-        if ticker is None:
-            return
-        ticker.update(ticker_text)
-        ticker.display = bool(ticker_text)
+        self.ticker.update(ticker_text)
+        self.ticker.display = bool(ticker_text)
 
     _HEARTBEAT_STALE_SECONDS = 180  # warn if no heartbeat in 3 minutes
 
@@ -2000,6 +2077,54 @@ def _humanize_bytes(n: int) -> str:
     return f"{n} B"
 
 
+def _budget_level(summary: str) -> str:
+    match = _re.search(r"(\d{1,3})\s*%", summary or "")
+    if not match:
+        lowered = (summary or "").lower()
+        if any(token in lowered for token in ("offline", "unavailable", "error")):
+            return "error"
+        return "unknown"
+    pct = int(match.group(1))
+    if pct <= 20:
+        return "error"
+    if pct <= 50:
+        return "warn"
+    return "ok"
+
+
+def _budget_fields_from_cached_usage(record: object | None) -> tuple[str, str, str]:
+    if record is None:
+        return ("budget unavailable", "unknown", "No cached usage yet.")
+    used_pct = getattr(record, "used_pct", None)
+    remaining_pct = getattr(record, "remaining_pct", None)
+    usage_summary = getattr(record, "usage_summary", "") or "usage unavailable"
+    if used_pct is not None and remaining_pct is not None:
+        budget_summary = f"{used_pct}% used / {remaining_pct}% left"
+    elif remaining_pct is not None:
+        budget_summary = f"{remaining_pct}% left"
+    else:
+        budget_summary = usage_summary
+    updated_at = getattr(record, "updated_at", "") or ""
+    if updated_at:
+        budget_summary = f"{budget_summary} · updated {updated_at}"
+    return (budget_summary, _budget_level(budget_summary), "Cached from account_usage")
+
+
+def _format_recent_task(task: object) -> str:
+    task_id = str(getattr(task, "task_id", ""))
+    title = str(getattr(task, "title", "") or "(untitled)")
+    project = str(getattr(task, "project", "") or "")
+    status_obj = getattr(task, "work_status", getattr(task, "status", ""))
+    status = getattr(status_obj, "value", status_obj)
+    bits = [f"[b]{_escape(task_id)}[/b]"]
+    if project:
+        bits.append(f"[dim]{_escape(project)}[/dim]")
+    if status:
+        bits.append(f"[dim]{_escape(str(status))}[/dim]")
+    bits.append(f"[dim]{_escape(title)}[/dim]")
+    return " · ".join(bits)
+
+
 class SettingsData:
     """Snapshot of everything the settings screen renders — gathered once."""
 
@@ -2034,6 +2159,67 @@ class SettingsData:
         self.inbox = inbox
         self.about = about
         self.errors = errors
+
+
+def _collect_recent_tasks_by_account(
+    config,
+    account_statuses: list,
+    *,
+    max_per_account: int = 3,
+) -> dict[str, list[dict[str, str]]]:
+    recent: dict[str, list[dict[str, str]]] = {
+        str(getattr(status, "key", "")): [] for status in account_statuses
+    }
+    projects = getattr(config, "projects", {}) or {}
+    for project_key, project in projects.items():
+        path = getattr(project, "path", None)
+        if path is None:
+            continue
+        project_path = Path(path)
+        if not project_path.exists():
+            continue
+        db_path = project_path / ".pollypm" / "state.db"
+        if not db_path.exists():
+            continue
+        try:
+            from pollypm.work.sqlite_service import SQLiteWorkService
+
+            with SQLiteWorkService(db_path=db_path, project_path=project_path) as svc:
+                for status in account_statuses:
+                    key = str(getattr(status, "key", ""))
+                    if not key:
+                        continue
+                    try:
+                        tasks = svc.list_tasks(assignee=key, limit=max_per_account)
+                    except Exception:  # noqa: BLE001
+                        continue
+                    for task in tasks:
+                        recent[key].append(
+                            {
+                                "task_id": str(getattr(task, "task_id", "")),
+                                "project": str(getattr(task, "project", project_key) or project_key),
+                                "title": str(getattr(task, "title", "") or "(untitled)"),
+                                "work_status": getattr(
+                                    getattr(task, "work_status", None),
+                                    "value",
+                                    str(getattr(task, "work_status", "")),
+                                ),
+                                "updated_at": (
+                                    getattr(task, "updated_at", None).isoformat()
+                                    if hasattr(getattr(task, "updated_at", None), "isoformat")
+                                    else str(getattr(task, "updated_at", "") or "")
+                                ),
+                            }
+                        )
+        except Exception:  # noqa: BLE001
+            continue
+    for key, rows in recent.items():
+        rows.sort(
+            key=lambda row: (_iso_sort_weight(row["updated_at"]), row["task_id"]),
+            reverse=True,
+        )
+        recent[key] = rows[:max_per_account]
+    return recent
 
 
 def _gather_settings_data(
@@ -2075,6 +2261,14 @@ def _gather_settings_data(
         list(getattr(pp, "failover_accounts", []) or [])
         if pp is not None else []
     )
+    try:
+        cached_usages = load_cached_account_usage(config_path) if config is not None else {}
+    except Exception:  # noqa: BLE001
+        cached_usages = {}
+    try:
+        history = load_settings_history()
+    except Exception:  # noqa: BLE001
+        history = []
     for idx, status in enumerate(account_statuses):
         provider = getattr(status, "provider", None)
         provider_name = (
@@ -2083,6 +2277,10 @@ def _gather_settings_data(
         home = getattr(status, "home", None)
         failover_pos = (
             (fo_list.index(status.key) + 1) if status.key in fo_list else None
+        )
+        usage_record = cached_usages.get(status.key)
+        budget_summary, budget_level, budget_rationale = _budget_fields_from_cached_usage(
+            usage_record,
         )
         accounts.append(
             {
@@ -2129,6 +2327,28 @@ def _gather_settings_data(
             config,
             format_relative_age=_format_relative_age,
         )
+        for project in projects:
+            project.setdefault(
+                "rationale",
+                "Tracked projects stay visible in the cockpit and feed task counts.",
+            )
+            history_rationale = history_rationale_for_project(
+                project["key"],
+                entries=history,
+            )
+            if history_rationale:
+                project["rationale"] = history_rationale
+
+    if config is not None and accounts:
+        recent_by_account = _collect_recent_tasks_by_account(
+            config,
+            account_statuses or [],
+        )
+        for account in accounts:
+            account["recent_tasks"] = recent_by_account.get(account["key"], [])
+    else:
+        for account in accounts:
+            account["recent_tasks"] = []
 
     heartbeat: list[tuple[str, str]] = []
     if pp is not None:
@@ -2295,6 +2515,10 @@ class PollySettingsPaneApp(App[None]):
     #settings-account-actions Button {
         margin-right: 1;
     }
+    #settings-account-actions-note {
+        color: #97a6b2;
+        content-align: left middle;
+    }
     #settings-reload-cockpit {
         min-width: 18;
     }
@@ -2337,6 +2561,15 @@ class PollySettingsPaneApp(App[None]):
         text-style: bold;
         padding-bottom: 1;
         height: 1;
+    }
+    #settings-preview {
+        height: auto;
+        min-height: 6;
+        color: #d6dee5;
+        background: #111820;
+        border: round #253140;
+        padding: 1;
+        margin-bottom: 1;
     }
     #settings-table-wrap {
         height: 1fr;
@@ -2386,22 +2619,31 @@ class PollySettingsPaneApp(App[None]):
         Binding("[", "section_prev", "Prev section", show=False),
         Binding("enter", "activate_row", "Open", show=False),
         Binding("slash", "start_search", "Search", show=False),
-        Binding("r,u", "refresh", "Refresh"),
+        Binding("ctrl+k,colon", "open_command_palette", "Palette", priority=True),
+        Binding("r", "refresh", "Refresh"),
         Binding("b", "toggle_permissions", "Permissions"),
+        Binding("c", "add_claude_account", "Add Claude", show=False),
+        Binding("o", "add_codex_account", "Add Codex", show=False),
+        Binding("x", "remove_account", "Remove account", show=False),
         Binding("t", "toggle_project_tracked", "Toggle project", show=False),
         Binding("m", "make_controller", "Controller", show=False),
         Binding("v", "toggle_failover", "Failover", show=False),
         Binding("a", "view_alerts", "Alerts", show=False),
+        Binding("u", "undo_recent_change", "Undo", show=False),
         Binding("question_mark", "show_keyboard_help", "Help", priority=True),
         Binding("q,escape", "back_or_cancel", "Back"),
     ]
+
+    def action_open_command_palette(self) -> None:
+        _open_command_palette(self)
 
     def action_show_keyboard_help(self) -> None:
         _open_keyboard_help(self)
 
     _DEFAULT_HINT = (
-        "j/k move \u00b7 Tab section \u00b7 / search \u00b7 R refresh \u00b7 "
-        "b permissions \u00b7 t toggle project \u00b7 q back"
+        "j/k move \u00b7 Tab section \u00b7 / search \u00b7 r refresh \u00b7 "
+        "b permissions \u00b7 c/o add account \u00b7 x remove \u00b7 "
+        "t project \u00b7 m controller \u00b7 v failover \u00b7 u undo \u00b7 q back"
     )
 
     def __init__(self, config_path: Path) -> None:
@@ -2414,6 +2656,7 @@ class PollySettingsPaneApp(App[None]):
         self.section_title = Static(
             "", id="settings-section-title", markup=True,
         )
+        self.preview = Static("", id="settings-preview", markup=True)
         self.accounts = DataTable(id="accounts")  # backwards-compat name
         self.projects_table = DataTable(id="projects-table")
         self.plugins_table = DataTable(id="plugins-table")
@@ -2437,6 +2680,7 @@ class PollySettingsPaneApp(App[None]):
         self._visible_plugin_rows: list[dict] = []
         self._nav_cursor: int = 0
         self._focus_target: str = "nav"  # nav | table
+        self._undo_action: UndoAction | None = None
 
     # ------------------------------------------------------------------
     # Layout
@@ -2459,6 +2703,7 @@ class PollySettingsPaneApp(App[None]):
                             id="settings-actions-note",
                         )
                     yield self.section_title
+                    yield self.preview
                     with Horizontal(id="settings-account-actions"):
                         for spec in SETTINGS_ACCOUNT_ACTIONS:
                             yield Button(
@@ -2466,6 +2711,10 @@ class PollySettingsPaneApp(App[None]):
                                 id=spec.button_id,
                                 variant=spec.variant,
                             )
+                        yield Static(
+                            "c/o add \u00b7 x remove \u00b7 u undo",
+                            id="settings-account-actions-note",
+                        )
                     with Vertical(id="settings-table-wrap"):
                         yield self.accounts
                         yield self.projects_table
@@ -2480,7 +2729,7 @@ class PollySettingsPaneApp(App[None]):
         self.accounts.cursor_type = "row"
         self.accounts.zebra_stripes = True
         self.accounts.add_columns(
-            "", "Key", "Email", "Provider", "Ctrl", "FO", "Usage",
+            "", "Key", "Email", "Provider", "Budget", "Ctrl", "FO", "Usage",
         )
         self.projects_table.cursor_type = "row"
         self.projects_table.zebra_stripes = True
@@ -2528,6 +2777,7 @@ class PollySettingsPaneApp(App[None]):
         self._render_topbar()
         self._render_nav()
         self._render_section(self._active_section)
+        self._render_preview(self._active_section)
 
     def _render_topbar(self) -> None:
         data = self.data
@@ -2581,6 +2831,230 @@ class PollySettingsPaneApp(App[None]):
         cnt = f"  [dim]{count}[/dim]" if count is not None else ""
         return f"{marker} {_escape(label)}{cnt}"
 
+    def _clear_expired_undo(self) -> None:
+        if undo_expired(self._undo_action):
+            self._undo_action = None
+
+    def _record_undo(
+        self,
+        label: str,
+        apply: Callable[[], None],
+        *,
+        kind: str = "",
+        payload: dict[str, object] | None = None,
+    ) -> None:
+        entry = None
+        if kind:
+            entry = record_settings_history(kind, label, payload)
+        self._undo_action = make_undo_action(
+            label,
+            apply,
+            entry_id=entry.entry_id if entry is not None else "",
+            kind=kind,
+            payload=payload,
+        )
+
+    def _undo_action_from_history(self) -> UndoAction | None:
+        entry = latest_settings_history_entry()
+        if entry is None:
+            return None
+        config = load_config(self.config_path)
+
+        if entry.kind == "account.failover":
+            account = str(entry.payload.get("account") or "")
+            enabled = bool(entry.payload.get("enabled"))
+            if not account:
+                return None
+            setter = getattr(self.service, "toggle_failover_account", None)
+            if setter is None:
+                return None
+
+            def _apply() -> None:
+                current = account in (getattr(config.pollypm, "failover_accounts", []) or [])
+                if current != enabled:
+                    setter(account)
+
+            return make_undo_action(
+                entry.label,
+                _apply,
+                entry_id=entry.entry_id,
+                kind=entry.kind,
+                payload=entry.payload,
+            )
+
+        if entry.kind == "account.controller":
+            account = str(entry.payload.get("account") or "")
+            previous = str(entry.payload.get("previous_account") or "")
+            if not account or not previous:
+                return None
+            setter = getattr(self.service, "set_controller_account", None)
+            if setter is None:
+                return None
+
+            def _apply() -> None:
+                setter(previous)
+
+            return make_undo_action(
+                entry.label,
+                _apply,
+                entry_id=entry.entry_id,
+                kind=entry.kind,
+                payload=entry.payload,
+            )
+
+        if entry.kind == "project.tracked":
+            project_key = str(entry.payload.get("project_key") or "")
+            previous = bool(entry.payload.get("previous"))
+            if not project_key:
+                return None
+            setter = getattr(self.service, "set_project_tracked", None)
+            if setter is None:
+                return None
+
+            def _apply() -> None:
+                setter(project_key, previous)
+
+            return make_undo_action(
+                entry.label,
+                _apply,
+                entry_id=entry.entry_id,
+                kind=entry.kind,
+                payload=entry.payload,
+            )
+
+        if entry.kind == "permissions.toggle":
+            previous = bool(entry.payload.get("previous"))
+            setter = getattr(self.service, "set_open_permissions_default", None)
+            if setter is None:
+                return None
+
+            def _apply() -> None:
+                setter(previous)
+
+            return make_undo_action(
+                entry.label,
+                _apply,
+                entry_id=entry.entry_id,
+                kind=entry.kind,
+                payload=entry.payload,
+            )
+
+        return None
+
+    def _current_undo_action(self) -> UndoAction | None:
+        self._clear_expired_undo()
+        if self._undo_action is not None:
+            return self._undo_action
+        self._undo_action = self._undo_action_from_history()
+        return self._undo_action
+
+    def _consume_undo_history(self, action: UndoAction) -> None:
+        if action.entry_id:
+            consume_settings_history(action.entry_id)
+
+    def _render_preview(self, key: str) -> None:
+        self._clear_expired_undo()
+        data = self.data
+        if data is None:
+            self.preview.update("")
+            return
+        if key == "accounts":
+            self.preview.update(self._account_preview_text())
+            return
+        if key == "projects":
+            self.preview.update(self._project_preview_text())
+            return
+        if key == "plugins":
+            self.preview.update(
+                "[b]Preview[/b]\n"
+                "[dim]Plugin state is read-only in settings. Loaded, degraded, and disabled entries are summarized here.[/dim]"
+            )
+            return
+        if key == "heartbeat":
+            self.preview.update(
+                "[b]Preview[/b]\n"
+                "[dim]Heartbeat controls controller leasing and background scheduling. These values are shown for quick audit before changing account or project defaults.[/dim]"
+            )
+            return
+        if key == "planner":
+            self.preview.update(
+                "[b]Preview[/b]\n"
+                "[dim]Planner settings determine when new projects get work automatically and whether the plan gate stays enforced.[/dim]"
+            )
+            return
+        if key == "inbox":
+            self.preview.update(
+                "[b]Preview[/b]\n"
+                "[dim]Inbox paths point at the shared state database and logs directory for this workspace.[/dim]"
+            )
+            return
+        if key == "about":
+            lines = [
+                "[b]Preview[/b]",
+                "[dim]About is a quick diff-free summary of the install and disk footprint.[/dim]",
+            ]
+            undo_action = self._current_undo_action()
+            if undo_action is not None:
+                lines.append(
+                    f"[dim]Undo available for {_escape(undo_action.label)} "
+                    f"until {undo_expires_text(undo_action)}[/dim]"
+                )
+            self.preview.update("\n".join(lines))
+            return
+        self.preview.update("")
+
+    def _account_preview_text(self) -> str:
+        rows = self._visible_account_rows
+        if not rows:
+            return "[b]Preview[/b]\n[dim]No accounts match the current filter.[/dim]"
+        key = self._selected_account_key or self._current_accounts_key() or rows[0]["key"]
+        selected = next((a for a in rows if a["key"] == key), rows[0])
+        lines = [
+            "[b]Diff preview[/b]",
+            f"Current provider: [b]{_escape(selected['provider'])}[/b]",
+            f"Budget indicator: [b]{_escape(selected.get('budget_summary') or '-')}[/b] "
+            f"([dim]{selected.get('budget_level', 'unknown')}[/dim])",
+            f"Rationale: {_escape(selected.get('rationale') or 'No rationale available.')}",
+            f"[dim]Actions:[/] c add Claude · o add Codex · x remove selected",
+            "[dim]Keyboard:[/] b permissions · m controller · v failover · u undo",
+        ]
+        undo_action = self._current_undo_action()
+        if undo_action is not None:
+            lines.append(
+                f"[dim]Undo available:[/] {_escape(undo_action.label)} "
+                f"until {undo_expires_text(undo_action)}"
+            )
+        recent = selected.get("recent_tasks") or []
+        if recent:
+            lines.append("[dim]Recent tasks:[/dim]")
+            for task in recent[:3]:
+                lines.append("  " + _format_recent_task(type("TaskPreview", (), task)()))
+        else:
+            lines.append("[dim]Recent tasks: none recorded for this account yet.[/dim]")
+        return "\n".join(lines)
+
+    def _project_preview_text(self) -> str:
+        rows = self._visible_project_rows
+        if not rows:
+            return "[b]Preview[/b]\n[dim]No projects match the current filter.[/dim]"
+        key = self._selected_project_key or self._current_projects_key() or rows[0]["key"]
+        selected = next((p for p in rows if p["key"] == key), rows[0])
+        current = "tracked" if selected["tracked"] else "paused"
+        next_state = "paused" if selected["tracked"] else "tracked"
+        lines = [
+            "[b]Diff preview[/b]",
+            f"Current status: [b]{current}[/b] -> [b]{next_state}[/b] via [b]t[/b]",
+            f"Rationale: {_escape(selected.get('rationale') or 'No rationale available.')}",
+            "[dim]Keyboard:[/] t toggle project · u undo",
+        ]
+        undo_action = self._current_undo_action()
+        if undo_action is not None:
+            lines.append(
+                f"[dim]Undo available:[/] {_escape(undo_action.label)} "
+                f"until {undo_expires_text(undo_action)}"
+            )
+        return "\n".join(lines)
+
     # ------------------------------------------------------------------
     # Section switching / rendering
     # ------------------------------------------------------------------
@@ -2592,6 +3066,7 @@ class PollySettingsPaneApp(App[None]):
         self.search_input.value = ""
         self._render_nav()
         self._render_section(key)
+        self._render_preview(key)
 
     def _render_section(self, key: str) -> None:
         self.accounts.display = key == "accounts"
@@ -2599,7 +3074,10 @@ class PollySettingsPaneApp(App[None]):
         self.plugins_table.display = key == "plugins"
         self.kv_static.display = key in {"heartbeat", "planner", "inbox", "about"}
         self.detail.display = key in {"accounts", "projects", "plugins"}
-        self.query_one("#settings-account-actions").display = key == "accounts"
+        try:
+            self.query_one("#settings-account-actions").display = key == "accounts"
+        except Exception:  # noqa: BLE001
+            pass
 
         title_map = dict(_SETTINGS_SECTIONS)
         self.section_title.update(
@@ -2634,6 +3112,7 @@ class PollySettingsPaneApp(App[None]):
         elif key == "about":
             self._ensure_about_section_loaded()
             self._render_kv("About", data.about)
+        self._render_preview(key)
 
     def _ensure_about_section_loaded(self) -> None:
         data = self.data
@@ -2672,11 +3151,19 @@ class PollySettingsPaneApp(App[None]):
             dot, colour = _settings_status_dot(a["health"], a["logged_in"])
             fo_mark = f"#{a['failover_pos']}" if a["failover_pos"] else ""
             ctrl_mark = "\u2713" if a["is_controller"] else ""
+            budget_level = a.get("budget_level", "unknown")
+            budget_style = {
+                "ok": "#3ddc84",
+                "warn": "#f0c45a",
+                "error": "#ff5f6d",
+            }.get(budget_level, "#97a6b2")
+            budget_cell = Text(a.get("budget_summary") or "-", style=budget_style)
             self.accounts.add_row(
                 Text(dot, style=colour),
                 a["key"],
                 a["email"],
                 a["provider"],
+                budget_cell,
                 ctrl_mark,
                 fo_mark,
                 a["usage_summary"] or "-",
@@ -2710,15 +3197,66 @@ class PollySettingsPaneApp(App[None]):
         dot, colour = _settings_status_dot(
             selected["health"], selected["logged_in"],
         )
-        self.detail.update(
-            render_settings_account_detail(
-                {
-                    **selected,
-                    "status_dot": dot,
-                    "status_colour": colour,
-                }
+        sep = "[dim]" + "\u2500" * 40 + "[/dim]"
+        lines = [
+            f"[{colour}]{dot}[/{colour}] [b]{_escape(selected['key'])}[/b]"
+            f"  [dim]({_escape(selected['provider'])})[/dim]",
+            sep,
+            f"[dim]Email:[/dim]      {_escape(selected['email'])}",
+            f"[dim]Budget:[/dim]     {_escape(selected.get('budget_summary') or '-')}",
+            f"[dim]Logged in:[/dim]  {'yes' if selected['logged_in'] else 'no'}",
+            f"[dim]Health:[/dim]     {_escape(selected['health']) or '-'}",
+            f"[dim]Plan:[/dim]       {_escape(selected['plan']) or '-'}",
+            f"[dim]Usage:[/dim]      {_escape(selected['usage_summary']) or '-'}",
+            f"[dim]Remaining:[/dim]  "
+            f"{selected['remaining_pct']}%" if selected.get("remaining_pct") is not None
+            else "[dim]Remaining:[/dim]  -",
+            f"[dim]Used:[/dim]       "
+            f"{selected['used_pct']}%" if selected.get("used_pct") is not None
+            else "[dim]Used:[/dim]       -",
+            f"[dim]Window:[/dim]     {_escape(selected.get('period_label') or '-')}",
+            f"[dim]Resets:[/dim]     {_escape(selected.get('reset_at') or '-')}",
+            f"[dim]Sampled:[/dim]    {_escape(selected.get('usage_updated_at') or '-')}",
+            f"[dim]Controller:[/dim] {'yes' if selected['is_controller'] else 'no'}",
+            f"[dim]Failover:[/dim]   "
+            f"{'#' + str(selected['failover_pos']) if selected['failover_pos'] else 'no'}",
+            f"[dim]Home:[/dim]       {_escape(selected['home']) or '-'}",
+            f"[dim]Isolation:[/dim]  {_escape(selected['isolation_status']) or '-'}",
+            f"[dim]Storage:[/dim]    {_escape(selected['auth_storage']) or '-'}",
+            f"[dim]Budget note:[/dim] {_escape(selected.get('budget_rationale', 'Cached from account_usage'))}",
+        ]
+        if selected["available_at"]:
+            lines.append(
+                f"[dim]Available:[/dim]  {_escape(selected['available_at'])}"
             )
+        if selected["access_expires_at"]:
+            lines.append(
+                f"[dim]Expires:[/dim]    {_escape(selected['access_expires_at'])}"
+            )
+        if selected["reason"]:
+            lines.extend([sep, f"[dim]Reason:[/dim]     {_escape(selected['reason'])}"])
+        lines.extend(
+            [
+                sep,
+                f"[dim]Rationale:[/dim]  {_escape(selected.get('rationale') or 'No rationale available.')}",
+                f"[dim]Actions:[/dim]    c add Claude · o add Codex · x remove selected · u undo",
+            ]
         )
+        if selected["usage_raw_text"]:
+            snippet = selected["usage_raw_text"].strip().splitlines()[:6]
+            if snippet:
+                lines.append(sep)
+                lines.append("[dim]Latest usage snapshot:[/dim]")
+                lines.extend(f"  {_escape(line)}" for line in snippet)
+        recent = selected.get("recent_tasks") or []
+        lines.append(sep)
+        if recent:
+            lines.append("[dim]Recent tasks:[/dim]")
+            for task in recent[:3]:
+                lines.append("  " + _format_recent_task(type("TaskPreview", (), task)()))
+        else:
+            lines.append("[dim]Recent tasks: none recorded for this account yet.[/dim]")
+        self.detail.update("\n".join(lines))
 
     def _current_accounts_key(self) -> str | None:
         if self.accounts.row_count == 0 or self.accounts.cursor_row < 0:
@@ -2805,6 +3343,7 @@ class PollySettingsPaneApp(App[None]):
             f"[dim]Status:[/dim] {tracked_line}",
             f"[dim]Tasks:[/dim]  {selected.get('task_total_label', selected['task_total'])}",
             f"[dim]Last:[/dim]   {_escape(selected['last_activity']) or '-'}",
+            f"[dim]Rationale:[/dim] {_escape(selected.get('rationale') or 'No rationale available.')}",
         ]
         self.detail.update("\n".join(lines))
 
@@ -3003,8 +3542,18 @@ class PollySettingsPaneApp(App[None]):
     def action_toggle_permissions(self) -> None:
         try:
             config = load_config(self.config_path)
+            previous = bool(getattr(config.pollypm, "open_permissions_by_default", False))
             enabled = not config.pollypm.open_permissions_by_default
             self.service.set_open_permissions_default(enabled)
+            self._record_undo(
+                f"permissions {'on' if previous else 'off'}",
+                lambda: self.service.set_open_permissions_default(previous),
+                kind="permissions.toggle",
+                payload={
+                    "previous": previous,
+                    "enabled": enabled,
+                },
+            )
         except Exception as exc:  # noqa: BLE001
             try:
                 self.notify(
@@ -3042,7 +3591,18 @@ class PollySettingsPaneApp(App[None]):
             )
             if current is None:
                 return
+            previous = bool(current["tracked"])
             setter(key, not current["tracked"])
+            self._record_undo(
+                f"project {key} tracked {'on' if previous else 'off'}",
+                lambda: setter(key, previous),
+                kind="project.tracked",
+                payload={
+                    "project_key": key,
+                    "previous": previous,
+                    "enabled": not previous,
+                },
+            )
         except Exception as exc:  # noqa: BLE001
             try:
                 self.notify(f"Toggle failed: {exc}", severity="error")
@@ -3061,7 +3621,19 @@ class PollySettingsPaneApp(App[None]):
         if setter is None:
             return
         try:
+            config = load_config(self.config_path)
+            previous = getattr(config.pollypm, "controller_account", "")
             setter(key)
+            if previous:
+                self._record_undo(
+                    f"controller {previous}",
+                    lambda: setter(previous),
+                    kind="account.controller",
+                    payload={
+                        "account": key,
+                        "previous_account": previous,
+                    },
+                )
         except Exception as exc:  # noqa: BLE001
             try:
                 self.notify(
@@ -3082,7 +3654,18 @@ class PollySettingsPaneApp(App[None]):
         if setter is None:
             return
         try:
+            config = load_config(self.config_path)
+            previous = key in (getattr(config.pollypm, "failover_accounts", []) or [])
             setter(key)
+            self._record_undo(
+                f"failover {key} {'on' if previous else 'off'}",
+                lambda: setter(key),
+                kind="account.failover",
+                payload={
+                    "account": key,
+                    "enabled": not previous,
+                },
+            )
         except Exception as exc:  # noqa: BLE001
             try:
                 self.notify(
@@ -3129,6 +3712,9 @@ class PollySettingsPaneApp(App[None]):
         except Exception:  # noqa: BLE001
             pass
 
+    def action_remove_account(self) -> None:
+        self.action_remove_selected_account()
+
     def action_remove_selected_account(self) -> None:
         if self._active_section != "accounts":
             return
@@ -3147,6 +3733,27 @@ class PollySettingsPaneApp(App[None]):
             ),
             lambda confirmed: self._confirm_remove_account(key, confirmed),
         )
+
+    def action_undo_recent_change(self) -> None:
+        action = self._current_undo_action()
+        if action is None:
+            try:
+                self.notify("Nothing recent to undo.", timeout=1.2)
+            except Exception:  # noqa: BLE001
+                pass
+            return
+        try:
+            action.apply()
+            self._consume_undo_history(action)
+            self.notify(f"Undid {action.label}.", timeout=1.5)
+        except Exception as exc:  # noqa: BLE001
+            try:
+                self.notify(f"Undo failed: {exc}", severity="error")
+            except Exception:  # noqa: BLE001
+                pass
+        finally:
+            self._undo_action = None
+        self._refresh()
 
     def action_back_or_cancel(self) -> None:
         if self.search_input.has_class("-active"):
@@ -3219,6 +3826,7 @@ class PollySettingsPaneApp(App[None]):
             self._render_project_detail(self._visible_project_rows)
         elif self._active_section == "plugins":
             self._render_plugin_detail(self._visible_plugin_rows)
+        self._render_preview(self._active_section)
 
     @on(DataTable.RowHighlighted, "#accounts")
     def on_account_highlighted(
@@ -3262,15 +3870,21 @@ class PollySettingsPaneApp(App[None]):
     def on_account_selected(self, _event: DataTable.RowSelected) -> None:
         self._selected_account_key = self._current_accounts_key()
         if self.data is not None:
-            self._render_account_detail(self.data)
+            self._render_account_detail(self._visible_account_rows)
+            self._render_preview(self._active_section)
 
     def _add_account(self, provider: ProviderKind) -> None:
         adder = getattr(self.service, "add_account", None)
-        if adder is None:
+        remover = getattr(self.service, "remove_account", None)
+        if adder is None or remover is None:
             return
         try:
-            key, _email = adder(provider)
+            key, email = adder(provider)
             self._selected_account_key = key
+            self._record_undo(
+                f"add account {key}",
+                lambda: remover(key, delete_home=False),
+            )
         except Exception as exc:  # noqa: BLE001
             try:
                 self.notify(f"Add account failed: {exc}", severity="error")
@@ -3279,7 +3893,10 @@ class PollySettingsPaneApp(App[None]):
             return
         self._refresh()
         try:
-            self.notify(f"Added {provider.value} account {key}.", timeout=1.5)
+            self.notify(
+                f"Added {provider.value} account {key} ({email}).",
+                timeout=1.5,
+            )
         except Exception:  # noqa: BLE001
             pass
 
@@ -4266,7 +4883,7 @@ class PollyInboxApp(App[None]):
         # Refresh: ``u`` re-bound to filter, so refresh moves to ``ctrl+r``
         # (palette 'session.refresh' still works from any screen).
         Binding("ctrl+r", "refresh", "Refresh", show=False),
-        Binding("colon", "open_command_palette", "Palette", priority=True),
+        Binding("ctrl+k,colon", "open_command_palette", "Palette", priority=True),
         Binding("question_mark", "show_keyboard_help", "Help", priority=True),
         Binding("q,escape", "back_or_cancel", "Back"),
     ]
@@ -6924,7 +7541,7 @@ class PollyProjectDashboardApp(App[None]):
         Binding("G", "plan_scroll_bottom", "Bottom", show=False),
         Binding("u,r", "refresh", "Refresh", show=False),
         Binding("a", "view_alerts", "Alerts", show=False),
-        Binding("colon", "open_command_palette", "Palette", priority=True),
+        Binding("ctrl+k,colon", "open_command_palette", "Palette", priority=True),
         Binding("question_mark", "show_keyboard_help", "Help", priority=True),
         Binding("q,escape", "back", "Back"),
     ]

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -124,7 +124,7 @@ from pollypm.rejection_feedback import (
 from pollypm.session_services import create_tmux_client
 from pollypm.service_api import PollyPMService
 from pollypm.cockpit import build_cockpit_detail
-from pollypm.cockpit_rail import CockpitItem, CockpitPresence, CockpitRouter, _viewer_attached
+from pollypm.cockpit_rail import CockpitItem, CockpitPresence, CockpitRouter
 
 
 import re as _re
@@ -1069,8 +1069,13 @@ class PollyCockpitApp(App[None]):
         return None
 
     def _event_ticker_text(self) -> str:
-        if not _viewer_attached():
-            return ""
+        # Gate on real tmux-client attachment (not just isatty). When the
+        # user detaches from tmux, animation should stop — see #656.
+        try:
+            if not self.router._presence().is_tmux_attached():
+                return ""
+        except Exception:  # noqa: BLE001
+            pass  # fall through — render as if attached if gate fails
         try:
             supervisor = self.router._load_supervisor()
             events = list(supervisor.store.recent_events(limit=12))
@@ -1078,11 +1083,21 @@ class PollyCockpitApp(App[None]):
             return ""
         if not events:
             return ""
-        index = int((time.monotonic() - self._ticker_started_at) // 10)
-        event = events[index % len(events)]
-        event_type = getattr(event, "event_type", "event")
-        session_name = getattr(event, "session_name", "") or "system"
-        return f"events · {event_type}:{session_name}"
+        # #667 acceptance: show the 3 newest events, cycle the window so
+        # a re-glance sees a different set. supervisor.recent_events()
+        # returns rows in arbitrary order — newest-first comes from the
+        # created_at column, which the store already sorts descending.
+        window_size = min(3, len(events))
+        # Advance one event per 10s so the user sees motion without the
+        # header flickering on every cockpit tick.
+        offset = int((time.monotonic() - self._ticker_started_at) // 10)
+        cycled = [events[(offset + i) % len(events)] for i in range(window_size)]
+        labels = []
+        for event in cycled:
+            event_type = getattr(event, "event_type", "event")
+            session_name = getattr(event, "session_name", "") or "system"
+            labels.append(f"{event_type}:{session_name}")
+        return "events · " + " · ".join(labels)
 
     def _update_ticker(self) -> None:
         ticker_text = self._event_ticker_text()
@@ -1092,7 +1107,7 @@ class PollyCockpitApp(App[None]):
     _HEARTBEAT_STALE_SECONDS = 180  # warn if no heartbeat in 3 minutes
 
     def _update_hint(self) -> None:
-        hint_text = "j/k move \u00b7 \u21b5 open \u00b7 n new"
+        hint_text = "j/k move \u00b7 \u21b5 open \u00b7 n new \u00b7 t activity \u00b7 p pin"
         try:
             supervisor = self.router._load_supervisor()
             last_hb = supervisor.store.last_heartbeat_at()

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -25,7 +25,7 @@ import resource
 from collections import deque
 from pathlib import Path
 import subprocess
-from typing import Callable
+import time
 
 # Raise FD limit early — the cockpit opens many subprocesses and file handles.
 try:
@@ -56,7 +56,6 @@ from pollypm.approval_notifications import notify_task_approved
 from pollypm.cockpit_formatting import format_event_time
 from pollypm.cockpit_formatting import format_relative_age as _format_relative_age
 from pollypm.models import ProviderKind
-from pollypm.account_usage_sampler import load_cached_account_usage
 from pollypm.tz import format_time as _fmt_time
 from pollypm.cockpit_activity import (
     PollyActivityFeedApp,
@@ -101,18 +100,9 @@ from pollypm.cockpit_palette import (
 )
 from pollypm.cockpit_project_settings import PollyProjectSettingsApp
 from pollypm.cockpit_sections.action_bar import render_project_action_bar
-from pollypm.cockpit_settings_accounts import SETTINGS_ACCOUNT_ACTIONS
-from pollypm.cockpit_settings_history import (
-    UndoAction,
-    consume_settings_history,
-    history_rationale_for_account,
-    history_rationale_for_project,
-    latest_settings_history_entry,
-    load_settings_history,
-    make_undo_action,
-    record_settings_history,
-    undo_expired,
-    undo_expires_text,
+from pollypm.cockpit_settings_accounts import (
+    SETTINGS_ACCOUNT_ACTIONS,
+    render_settings_account_detail,
 )
 from pollypm.cockpit_settings_projects import collect_settings_projects
 from pollypm.cockpit_workers import PollyWorkerRosterApp
@@ -123,7 +113,7 @@ from pollypm.rejection_feedback import (
 from pollypm.session_services import create_tmux_client
 from pollypm.service_api import PollyPMService
 from pollypm.cockpit import build_cockpit_detail
-from pollypm.cockpit_rail import CockpitItem, CockpitPresence, CockpitRouter
+from pollypm.cockpit_rail import CockpitItem, CockpitRouter, _viewer_attached
 
 
 import re as _re
@@ -425,46 +415,31 @@ class RailItem(ListItem):
         *,
         active_view: bool,
         first_project: bool = False,
-        presence: CockpitPresence | None = None,
-        spinner_index: int = 0,
     ) -> None:
         self.body = Static(classes="rail-item-body")
         self.item = item
-        self.presence = presence
-        self.spinner_index = spinner_index
         super().__init__(self.body, classes="rail-row", disabled=not item.selectable)
-        self.apply_item(
-            item,
-            active_view=active_view,
-            first_project=first_project,
-            spinner_index=spinner_index,
-        )
+        self.apply_item(item, active_view=active_view, first_project=first_project)
 
     @property
     def cockpit_key(self) -> str:
         return self.item.key
 
-    def apply_item(
-        self,
-        item: CockpitItem,
-        *,
-        active_view: bool,
-        first_project: bool,
-        spinner_index: int | None = None,
-    ) -> None:
+    def apply_item(self, item: CockpitItem, *, active_view: bool, first_project: bool) -> None:
         self.item = item
-        if spinner_index is not None:
-            self.spinner_index = spinner_index
         self.disabled = not item.selectable
         for class_name in [
             "inbox-entry",
             "project-start",
             "project-row",
+            "section-sep",
             "needs-user",
             "live",
             "active-view",
         ]:
             self.remove_class(class_name)
+        if item.state == "separator":
+            self.add_class("section-sep")
         if item.key == "inbox":
             self.add_class("inbox-entry")
         if first_project:
@@ -512,20 +487,6 @@ class RailItem(ListItem):
         self.body.update(text)
 
     def _indicator(self) -> tuple[str, str]:
-        presence = self.presence
-        if (
-            presence is not None
-            and self.item.session_name
-            and self.item.work_state
-        ):
-            pulse = presence.heartbeat_frame_for(
-                self.item.session_name,
-                self.item.heartbeat_at,
-            )
-            work_glyph, color = self._session_work_glyph(self.item.work_state)
-            return f"{pulse}{work_glyph}", color
-        if presence is not None and self.item.state in {"heartbeat", "watch"}:
-            return presence.heartbeat_frame(self.spinner_index), "#3ddc84"
         # Alerts (red triangle)
         if self.item.state.startswith("!"):
             return "\u25b2", "#ff5f6d"
@@ -557,27 +518,9 @@ class RailItem(ListItem):
         # Projects: yellow for active task, dim for idle
         if self.item.key.startswith("project:"):
             if "working" in self.item.state:
-                if presence is not None:
-                    return presence.working_frame(self.spinner_index), "#3ddc84"
                 return "\u25c6", "#f0c45a"  # yellow diamond — active task
             return "\u25cb", "#4a5568"  # dim circle — idle
         return "\u25cb", "#4a5568"
-
-    def _session_work_glyph(self, work_state: str) -> tuple[str, str]:
-        presence = self.presence
-        if work_state == "writing":
-            if presence is not None:
-                if not presence.should_animate():
-                    return "…", "#3ddc84"
-                return presence.working_frame(self.spinner_index), "#3ddc84"
-            return "\u25c6", "#3ddc84"
-        if work_state == "reviewing":
-            return "\u270e", "#3ddc84"
-        if work_state == "stuck":
-            return "\u26a0", "#ff5f6d"
-        if work_state == "exited":
-            return "\u2715", "#4a5568"
-        return "\u00b7", "#4a5568"
 
 
 class PollyCockpitApp(App[None]):
@@ -631,6 +574,13 @@ class PollyCockpitApp(App[None]):
         color: #4a5568;
         background: transparent;
         margin-top: 1;
+        text-style: bold;
+    }
+    #ticker {
+        height: 1;
+        padding: 0 1;
+        color: #4a5568;
+        background: transparent;
     }
     #nav > .rail-row.-highlight {
         background: #1e2730;
@@ -687,16 +637,13 @@ class PollyCockpitApp(App[None]):
     BINDINGS = [
         Binding("enter,o", "open_selected", "Open"),
         Binding("n", "new_worker", "New Worker"),
+        Binding("t", "open_activity", "Activity"),
+        Binding("p", "toggle_project_pin", "Pin Project"),
         Binding("r", "refresh", "Refresh"),
         Binding("s", "open_settings", "Settings"),
         Binding("a", "view_alerts", "Alerts", show=False),
-        Binding("ctrl+k,colon", "open_command_palette", "Palette", priority=True),
-        Binding(
-            "question_mark",
-            "show_keyboard_help",
-            "Help: pulse ♥/♡, writing ◜◝◞◟, review ✎, idle ·, stuck ⚠, exited ✕",
-            priority=True,
-        ),
+        Binding("colon", "open_command_palette", "Palette", priority=True),
+        Binding("question_mark", "show_keyboard_help", "Help", priority=True),
         Binding("j,down", "cursor_down", "Down", show=False),
         Binding("k,up", "cursor_up", "Up", show=False),
         Binding("g,home", "cursor_first", "First", show=False),
@@ -715,7 +662,6 @@ class PollyCockpitApp(App[None]):
         super().__init__()
         self.config_path = config_path
         self.router = CockpitRouter(config_path)
-        self.presence = CockpitPresence(self.router.tmux)
         self.service = PollyPMService(config_path)
         _lines = ASCII_POLLY.split("\n")
         self.brand = Static(
@@ -726,10 +672,12 @@ class PollyCockpitApp(App[None]):
         self.tagline = Static("\n" + POLLY_SLOGANS[0], id="tagline")
         self.nav = ListView(id="nav")
         self.settings_row = Static("\u2699 Settings", id="settings-row")
+        self.ticker = Static("", id="ticker")
         self.hint = Static("", id="hint")
         self.spinner_index = 0
         self.slogan_index = 0
         self._slogan_tick = 0
+        self._ticker_started_at = time.monotonic()
         self.selected_key = "polly"
         self._items: list[CockpitItem] = []
         self._row_widgets: dict[str, RailItem] = {}
@@ -753,11 +701,13 @@ class PollyCockpitApp(App[None]):
             yield self.tagline
             yield self.nav
             yield self.settings_row
+            yield self.ticker
             yield self.hint
 
     def on_mount(self) -> None:
         self.selected_key = self.router.selected_key()
         self._refresh_rows()
+        self._update_ticker()
         self.set_interval(0.8, self._tick)
         self.set_interval(self.SCHEDULER_POLL_INTERVAL_SECONDS, self._tick_scheduler)
         self.nav.focus()
@@ -902,19 +852,10 @@ class PollyCockpitApp(App[None]):
                 if item.state.endswith("working"):
                     item.state = f"{frame} working"
             for key, row in self._row_widgets.items():
-                should_animate = row.item.state.endswith("working")
-                rewrite_state = should_animate
-                if row.item.state in {"heartbeat", "watch"}:
-                    should_animate = True
-                    rewrite_state = False
-                if row.item.session_name and row.item.work_state == "writing":
-                    should_animate = True
-                    rewrite_state = False
-                if should_animate:
-                    if rewrite_state:
-                        row.item.state = f"{frame} working"
-                    row.spinner_index = self.spinner_index
+                if row.item.state.endswith("working"):
+                    row.item.state = f"{frame} working"
                     row.update_body()
+        self._update_ticker()
         # Layout check much less frequently
         if self._tick_count % self._LAYOUT_CHECK_INTERVAL == 0:
             try:
@@ -998,18 +939,11 @@ class PollyCockpitApp(App[None]):
                     item,
                     active_view=item.key == self.selected_key,
                     first_project=first_project,
-                    presence=self.presence,
-                    spinner_index=self.spinner_index,
                 )
                 self._row_widgets[item.key] = row
             else:
                 row = self._row_widgets[item.key]
-                row.apply_item(
-                    item,
-                    active_view=item.key == self.selected_key,
-                    first_project=first_project,
-                    spinner_index=self.spinner_index,
-                )
+                row.apply_item(item, active_view=item.key == self.selected_key, first_project=first_project)
             rows.append(row)
             if selected_key is not None and item.key == selected_key:
                 restore_index = nav_index
@@ -1039,6 +973,7 @@ class PollyCockpitApp(App[None]):
             self.settings_row.display = True
         else:
             self.settings_row.display = False
+        self._update_ticker()
         self._update_hint()
 
     def _selected_row_key(self) -> str | None:
@@ -1052,6 +987,30 @@ class PollyCockpitApp(App[None]):
         if isinstance(child, RailItem):
             return child.cockpit_key
         return None
+
+    def _event_ticker_text(self) -> str:
+        if not _viewer_attached():
+            return ""
+        try:
+            supervisor = self.router._load_supervisor()
+            events = list(supervisor.store.recent_events(limit=12))
+        except Exception:  # noqa: BLE001
+            return ""
+        if not events:
+            return ""
+        index = int((time.monotonic() - self._ticker_started_at) // 10)
+        event = events[index % len(events)]
+        event_type = getattr(event, "event_type", "event")
+        session_name = getattr(event, "session_name", "") or "system"
+        return f"events · {event_type}:{session_name}"
+
+    def _update_ticker(self) -> None:
+        ticker_text = self._event_ticker_text()
+        ticker = getattr(self, "ticker", None)
+        if ticker is None:
+            return
+        ticker.update(ticker_text)
+        ticker.display = bool(ticker_text)
 
     _HEARTBEAT_STALE_SECONDS = 180  # warn if no heartbeat in 3 minutes
 
@@ -1134,6 +1093,25 @@ class PollyCockpitApp(App[None]):
             self.router.route_selected("settings")
         except Exception as exc:  # noqa: BLE001
             self.hint.update(f"Error: {exc}"[:60])
+        self._refresh_rows()
+
+    def action_open_activity(self) -> None:
+        self.selected_key = "activity"
+        try:
+            self.router.route_selected("activity")
+        except Exception as exc:  # noqa: BLE001
+            self.hint.update(f"Error: {exc}"[:60])
+        self._refresh_rows()
+
+    def action_toggle_project_pin(self) -> None:
+        key = self._selected_row_key()
+        if key is None or not key.startswith("project:"):
+            return
+        try:
+            self.router.toggle_pinned_project(key.split(":", 1)[1])
+        except Exception as exc:  # noqa: BLE001
+            self.hint.update(f"Error: {exc}"[:60])
+            return
         self._refresh_rows()
 
     def action_new_worker(self) -> None:
@@ -2022,54 +2000,6 @@ def _humanize_bytes(n: int) -> str:
     return f"{n} B"
 
 
-def _budget_level(summary: str) -> str:
-    match = _re.search(r"(\d{1,3})\s*%", summary or "")
-    if not match:
-        lowered = (summary or "").lower()
-        if any(token in lowered for token in ("offline", "unavailable", "error")):
-            return "error"
-        return "unknown"
-    pct = int(match.group(1))
-    if pct <= 20:
-        return "error"
-    if pct <= 50:
-        return "warn"
-    return "ok"
-
-
-def _budget_fields_from_cached_usage(record: object | None) -> tuple[str, str, str]:
-    if record is None:
-        return ("budget unavailable", "unknown", "No cached usage yet.")
-    used_pct = getattr(record, "used_pct", None)
-    remaining_pct = getattr(record, "remaining_pct", None)
-    usage_summary = getattr(record, "usage_summary", "") or "usage unavailable"
-    if used_pct is not None and remaining_pct is not None:
-        budget_summary = f"{used_pct}% used / {remaining_pct}% left"
-    elif remaining_pct is not None:
-        budget_summary = f"{remaining_pct}% left"
-    else:
-        budget_summary = usage_summary
-    updated_at = getattr(record, "updated_at", "") or ""
-    if updated_at:
-        budget_summary = f"{budget_summary} · updated {updated_at}"
-    return (budget_summary, _budget_level(budget_summary), "Cached from account_usage")
-
-
-def _format_recent_task(task: object) -> str:
-    task_id = str(getattr(task, "task_id", ""))
-    title = str(getattr(task, "title", "") or "(untitled)")
-    project = str(getattr(task, "project", "") or "")
-    status_obj = getattr(task, "work_status", getattr(task, "status", ""))
-    status = getattr(status_obj, "value", status_obj)
-    bits = [f"[b]{_escape(task_id)}[/b]"]
-    if project:
-        bits.append(f"[dim]{_escape(project)}[/dim]")
-    if status:
-        bits.append(f"[dim]{_escape(str(status))}[/dim]")
-    bits.append(f"[dim]{_escape(title)}[/dim]")
-    return " · ".join(bits)
-
-
 class SettingsData:
     """Snapshot of everything the settings screen renders — gathered once."""
 
@@ -2104,67 +2034,6 @@ class SettingsData:
         self.inbox = inbox
         self.about = about
         self.errors = errors
-
-
-def _collect_recent_tasks_by_account(
-    config,
-    account_statuses: list,
-    *,
-    max_per_account: int = 3,
-) -> dict[str, list[dict[str, str]]]:
-    recent: dict[str, list[dict[str, str]]] = {
-        str(getattr(status, "key", "")): [] for status in account_statuses
-    }
-    projects = getattr(config, "projects", {}) or {}
-    for project_key, project in projects.items():
-        path = getattr(project, "path", None)
-        if path is None:
-            continue
-        project_path = Path(path)
-        if not project_path.exists():
-            continue
-        db_path = project_path / ".pollypm" / "state.db"
-        if not db_path.exists():
-            continue
-        try:
-            from pollypm.work.sqlite_service import SQLiteWorkService
-
-            with SQLiteWorkService(db_path=db_path, project_path=project_path) as svc:
-                for status in account_statuses:
-                    key = str(getattr(status, "key", ""))
-                    if not key:
-                        continue
-                    try:
-                        tasks = svc.list_tasks(assignee=key, limit=max_per_account)
-                    except Exception:  # noqa: BLE001
-                        continue
-                    for task in tasks:
-                        recent[key].append(
-                            {
-                                "task_id": str(getattr(task, "task_id", "")),
-                                "project": str(getattr(task, "project", project_key) or project_key),
-                                "title": str(getattr(task, "title", "") or "(untitled)"),
-                                "work_status": getattr(
-                                    getattr(task, "work_status", None),
-                                    "value",
-                                    str(getattr(task, "work_status", "")),
-                                ),
-                                "updated_at": (
-                                    getattr(task, "updated_at", None).isoformat()
-                                    if hasattr(getattr(task, "updated_at", None), "isoformat")
-                                    else str(getattr(task, "updated_at", "") or "")
-                                ),
-                            }
-                        )
-        except Exception:  # noqa: BLE001
-            continue
-    for key, rows in recent.items():
-        rows.sort(
-            key=lambda row: (_iso_sort_weight(row["updated_at"]), row["task_id"]),
-            reverse=True,
-        )
-        recent[key] = rows[:max_per_account]
-    return recent
 
 
 def _gather_settings_data(
@@ -2206,14 +2075,6 @@ def _gather_settings_data(
         list(getattr(pp, "failover_accounts", []) or [])
         if pp is not None else []
     )
-    try:
-        cached_usages = load_cached_account_usage(config_path) if config is not None else {}
-    except Exception:  # noqa: BLE001
-        cached_usages = {}
-    try:
-        history = load_settings_history()
-    except Exception:  # noqa: BLE001
-        history = []
     for idx, status in enumerate(account_statuses):
         provider = getattr(status, "provider", None)
         provider_name = (
@@ -2222,10 +2083,6 @@ def _gather_settings_data(
         home = getattr(status, "home", None)
         failover_pos = (
             (fo_list.index(status.key) + 1) if status.key in fo_list else None
-        )
-        usage_record = cached_usages.get(status.key)
-        budget_summary, budget_level, budget_rationale = _budget_fields_from_cached_usage(
-            usage_record,
         )
         accounts.append(
             {
@@ -2272,28 +2129,6 @@ def _gather_settings_data(
             config,
             format_relative_age=_format_relative_age,
         )
-        for project in projects:
-            project.setdefault(
-                "rationale",
-                "Tracked projects stay visible in the cockpit and feed task counts.",
-            )
-            history_rationale = history_rationale_for_project(
-                project["key"],
-                entries=history,
-            )
-            if history_rationale:
-                project["rationale"] = history_rationale
-
-    if config is not None and accounts:
-        recent_by_account = _collect_recent_tasks_by_account(
-            config,
-            account_statuses or [],
-        )
-        for account in accounts:
-            account["recent_tasks"] = recent_by_account.get(account["key"], [])
-    else:
-        for account in accounts:
-            account["recent_tasks"] = []
 
     heartbeat: list[tuple[str, str]] = []
     if pp is not None:
@@ -2460,10 +2295,6 @@ class PollySettingsPaneApp(App[None]):
     #settings-account-actions Button {
         margin-right: 1;
     }
-    #settings-account-actions-note {
-        color: #97a6b2;
-        content-align: left middle;
-    }
     #settings-reload-cockpit {
         min-width: 18;
     }
@@ -2506,15 +2337,6 @@ class PollySettingsPaneApp(App[None]):
         text-style: bold;
         padding-bottom: 1;
         height: 1;
-    }
-    #settings-preview {
-        height: auto;
-        min-height: 6;
-        color: #d6dee5;
-        background: #111820;
-        border: round #253140;
-        padding: 1;
-        margin-bottom: 1;
     }
     #settings-table-wrap {
         height: 1fr;
@@ -2564,31 +2386,22 @@ class PollySettingsPaneApp(App[None]):
         Binding("[", "section_prev", "Prev section", show=False),
         Binding("enter", "activate_row", "Open", show=False),
         Binding("slash", "start_search", "Search", show=False),
-        Binding("ctrl+k,colon", "open_command_palette", "Palette", priority=True),
-        Binding("r", "refresh", "Refresh"),
+        Binding("r,u", "refresh", "Refresh"),
         Binding("b", "toggle_permissions", "Permissions"),
-        Binding("c", "add_claude_account", "Add Claude", show=False),
-        Binding("o", "add_codex_account", "Add Codex", show=False),
-        Binding("x", "remove_account", "Remove account", show=False),
         Binding("t", "toggle_project_tracked", "Toggle project", show=False),
         Binding("m", "make_controller", "Controller", show=False),
         Binding("v", "toggle_failover", "Failover", show=False),
         Binding("a", "view_alerts", "Alerts", show=False),
-        Binding("u", "undo_recent_change", "Undo", show=False),
         Binding("question_mark", "show_keyboard_help", "Help", priority=True),
         Binding("q,escape", "back_or_cancel", "Back"),
     ]
-
-    def action_open_command_palette(self) -> None:
-        _open_command_palette(self)
 
     def action_show_keyboard_help(self) -> None:
         _open_keyboard_help(self)
 
     _DEFAULT_HINT = (
-        "j/k move \u00b7 Tab section \u00b7 / search \u00b7 r refresh \u00b7 "
-        "b permissions \u00b7 c/o add account \u00b7 x remove \u00b7 "
-        "t project \u00b7 m controller \u00b7 v failover \u00b7 u undo \u00b7 q back"
+        "j/k move \u00b7 Tab section \u00b7 / search \u00b7 R refresh \u00b7 "
+        "b permissions \u00b7 t toggle project \u00b7 q back"
     )
 
     def __init__(self, config_path: Path) -> None:
@@ -2601,7 +2414,6 @@ class PollySettingsPaneApp(App[None]):
         self.section_title = Static(
             "", id="settings-section-title", markup=True,
         )
-        self.preview = Static("", id="settings-preview", markup=True)
         self.accounts = DataTable(id="accounts")  # backwards-compat name
         self.projects_table = DataTable(id="projects-table")
         self.plugins_table = DataTable(id="plugins-table")
@@ -2625,7 +2437,6 @@ class PollySettingsPaneApp(App[None]):
         self._visible_plugin_rows: list[dict] = []
         self._nav_cursor: int = 0
         self._focus_target: str = "nav"  # nav | table
-        self._undo_action: UndoAction | None = None
 
     # ------------------------------------------------------------------
     # Layout
@@ -2648,7 +2459,6 @@ class PollySettingsPaneApp(App[None]):
                             id="settings-actions-note",
                         )
                     yield self.section_title
-                    yield self.preview
                     with Horizontal(id="settings-account-actions"):
                         for spec in SETTINGS_ACCOUNT_ACTIONS:
                             yield Button(
@@ -2656,10 +2466,6 @@ class PollySettingsPaneApp(App[None]):
                                 id=spec.button_id,
                                 variant=spec.variant,
                             )
-                        yield Static(
-                            "c/o add \u00b7 x remove \u00b7 u undo",
-                            id="settings-account-actions-note",
-                        )
                     with Vertical(id="settings-table-wrap"):
                         yield self.accounts
                         yield self.projects_table
@@ -2674,7 +2480,7 @@ class PollySettingsPaneApp(App[None]):
         self.accounts.cursor_type = "row"
         self.accounts.zebra_stripes = True
         self.accounts.add_columns(
-            "", "Key", "Email", "Provider", "Budget", "Ctrl", "FO", "Usage",
+            "", "Key", "Email", "Provider", "Ctrl", "FO", "Usage",
         )
         self.projects_table.cursor_type = "row"
         self.projects_table.zebra_stripes = True
@@ -2722,7 +2528,6 @@ class PollySettingsPaneApp(App[None]):
         self._render_topbar()
         self._render_nav()
         self._render_section(self._active_section)
-        self._render_preview(self._active_section)
 
     def _render_topbar(self) -> None:
         data = self.data
@@ -2776,230 +2581,6 @@ class PollySettingsPaneApp(App[None]):
         cnt = f"  [dim]{count}[/dim]" if count is not None else ""
         return f"{marker} {_escape(label)}{cnt}"
 
-    def _clear_expired_undo(self) -> None:
-        if undo_expired(self._undo_action):
-            self._undo_action = None
-
-    def _record_undo(
-        self,
-        label: str,
-        apply: Callable[[], None],
-        *,
-        kind: str = "",
-        payload: dict[str, object] | None = None,
-    ) -> None:
-        entry = None
-        if kind:
-            entry = record_settings_history(kind, label, payload)
-        self._undo_action = make_undo_action(
-            label,
-            apply,
-            entry_id=entry.entry_id if entry is not None else "",
-            kind=kind,
-            payload=payload,
-        )
-
-    def _undo_action_from_history(self) -> UndoAction | None:
-        entry = latest_settings_history_entry()
-        if entry is None:
-            return None
-        config = load_config(self.config_path)
-
-        if entry.kind == "account.failover":
-            account = str(entry.payload.get("account") or "")
-            enabled = bool(entry.payload.get("enabled"))
-            if not account:
-                return None
-            setter = getattr(self.service, "toggle_failover_account", None)
-            if setter is None:
-                return None
-
-            def _apply() -> None:
-                current = account in (getattr(config.pollypm, "failover_accounts", []) or [])
-                if current != enabled:
-                    setter(account)
-
-            return make_undo_action(
-                entry.label,
-                _apply,
-                entry_id=entry.entry_id,
-                kind=entry.kind,
-                payload=entry.payload,
-            )
-
-        if entry.kind == "account.controller":
-            account = str(entry.payload.get("account") or "")
-            previous = str(entry.payload.get("previous_account") or "")
-            if not account or not previous:
-                return None
-            setter = getattr(self.service, "set_controller_account", None)
-            if setter is None:
-                return None
-
-            def _apply() -> None:
-                setter(previous)
-
-            return make_undo_action(
-                entry.label,
-                _apply,
-                entry_id=entry.entry_id,
-                kind=entry.kind,
-                payload=entry.payload,
-            )
-
-        if entry.kind == "project.tracked":
-            project_key = str(entry.payload.get("project_key") or "")
-            previous = bool(entry.payload.get("previous"))
-            if not project_key:
-                return None
-            setter = getattr(self.service, "set_project_tracked", None)
-            if setter is None:
-                return None
-
-            def _apply() -> None:
-                setter(project_key, previous)
-
-            return make_undo_action(
-                entry.label,
-                _apply,
-                entry_id=entry.entry_id,
-                kind=entry.kind,
-                payload=entry.payload,
-            )
-
-        if entry.kind == "permissions.toggle":
-            previous = bool(entry.payload.get("previous"))
-            setter = getattr(self.service, "set_open_permissions_default", None)
-            if setter is None:
-                return None
-
-            def _apply() -> None:
-                setter(previous)
-
-            return make_undo_action(
-                entry.label,
-                _apply,
-                entry_id=entry.entry_id,
-                kind=entry.kind,
-                payload=entry.payload,
-            )
-
-        return None
-
-    def _current_undo_action(self) -> UndoAction | None:
-        self._clear_expired_undo()
-        if self._undo_action is not None:
-            return self._undo_action
-        self._undo_action = self._undo_action_from_history()
-        return self._undo_action
-
-    def _consume_undo_history(self, action: UndoAction) -> None:
-        if action.entry_id:
-            consume_settings_history(action.entry_id)
-
-    def _render_preview(self, key: str) -> None:
-        self._clear_expired_undo()
-        data = self.data
-        if data is None:
-            self.preview.update("")
-            return
-        if key == "accounts":
-            self.preview.update(self._account_preview_text())
-            return
-        if key == "projects":
-            self.preview.update(self._project_preview_text())
-            return
-        if key == "plugins":
-            self.preview.update(
-                "[b]Preview[/b]\n"
-                "[dim]Plugin state is read-only in settings. Loaded, degraded, and disabled entries are summarized here.[/dim]"
-            )
-            return
-        if key == "heartbeat":
-            self.preview.update(
-                "[b]Preview[/b]\n"
-                "[dim]Heartbeat controls controller leasing and background scheduling. These values are shown for quick audit before changing account or project defaults.[/dim]"
-            )
-            return
-        if key == "planner":
-            self.preview.update(
-                "[b]Preview[/b]\n"
-                "[dim]Planner settings determine when new projects get work automatically and whether the plan gate stays enforced.[/dim]"
-            )
-            return
-        if key == "inbox":
-            self.preview.update(
-                "[b]Preview[/b]\n"
-                "[dim]Inbox paths point at the shared state database and logs directory for this workspace.[/dim]"
-            )
-            return
-        if key == "about":
-            lines = [
-                "[b]Preview[/b]",
-                "[dim]About is a quick diff-free summary of the install and disk footprint.[/dim]",
-            ]
-            undo_action = self._current_undo_action()
-            if undo_action is not None:
-                lines.append(
-                    f"[dim]Undo available for {_escape(undo_action.label)} "
-                    f"until {undo_expires_text(undo_action)}[/dim]"
-                )
-            self.preview.update("\n".join(lines))
-            return
-        self.preview.update("")
-
-    def _account_preview_text(self) -> str:
-        rows = self._visible_account_rows
-        if not rows:
-            return "[b]Preview[/b]\n[dim]No accounts match the current filter.[/dim]"
-        key = self._selected_account_key or self._current_accounts_key() or rows[0]["key"]
-        selected = next((a for a in rows if a["key"] == key), rows[0])
-        lines = [
-            "[b]Diff preview[/b]",
-            f"Current provider: [b]{_escape(selected['provider'])}[/b]",
-            f"Budget indicator: [b]{_escape(selected.get('budget_summary') or '-')}[/b] "
-            f"([dim]{selected.get('budget_level', 'unknown')}[/dim])",
-            f"Rationale: {_escape(selected.get('rationale') or 'No rationale available.')}",
-            f"[dim]Actions:[/] c add Claude · o add Codex · x remove selected",
-            "[dim]Keyboard:[/] b permissions · m controller · v failover · u undo",
-        ]
-        undo_action = self._current_undo_action()
-        if undo_action is not None:
-            lines.append(
-                f"[dim]Undo available:[/] {_escape(undo_action.label)} "
-                f"until {undo_expires_text(undo_action)}"
-            )
-        recent = selected.get("recent_tasks") or []
-        if recent:
-            lines.append("[dim]Recent tasks:[/dim]")
-            for task in recent[:3]:
-                lines.append("  " + _format_recent_task(type("TaskPreview", (), task)()))
-        else:
-            lines.append("[dim]Recent tasks: none recorded for this account yet.[/dim]")
-        return "\n".join(lines)
-
-    def _project_preview_text(self) -> str:
-        rows = self._visible_project_rows
-        if not rows:
-            return "[b]Preview[/b]\n[dim]No projects match the current filter.[/dim]"
-        key = self._selected_project_key or self._current_projects_key() or rows[0]["key"]
-        selected = next((p for p in rows if p["key"] == key), rows[0])
-        current = "tracked" if selected["tracked"] else "paused"
-        next_state = "paused" if selected["tracked"] else "tracked"
-        lines = [
-            "[b]Diff preview[/b]",
-            f"Current status: [b]{current}[/b] -> [b]{next_state}[/b] via [b]t[/b]",
-            f"Rationale: {_escape(selected.get('rationale') or 'No rationale available.')}",
-            "[dim]Keyboard:[/] t toggle project · u undo",
-        ]
-        undo_action = self._current_undo_action()
-        if undo_action is not None:
-            lines.append(
-                f"[dim]Undo available:[/] {_escape(undo_action.label)} "
-                f"until {undo_expires_text(undo_action)}"
-            )
-        return "\n".join(lines)
-
     # ------------------------------------------------------------------
     # Section switching / rendering
     # ------------------------------------------------------------------
@@ -3011,7 +2592,6 @@ class PollySettingsPaneApp(App[None]):
         self.search_input.value = ""
         self._render_nav()
         self._render_section(key)
-        self._render_preview(key)
 
     def _render_section(self, key: str) -> None:
         self.accounts.display = key == "accounts"
@@ -3019,10 +2599,7 @@ class PollySettingsPaneApp(App[None]):
         self.plugins_table.display = key == "plugins"
         self.kv_static.display = key in {"heartbeat", "planner", "inbox", "about"}
         self.detail.display = key in {"accounts", "projects", "plugins"}
-        try:
-            self.query_one("#settings-account-actions").display = key == "accounts"
-        except Exception:  # noqa: BLE001
-            pass
+        self.query_one("#settings-account-actions").display = key == "accounts"
 
         title_map = dict(_SETTINGS_SECTIONS)
         self.section_title.update(
@@ -3057,7 +2634,6 @@ class PollySettingsPaneApp(App[None]):
         elif key == "about":
             self._ensure_about_section_loaded()
             self._render_kv("About", data.about)
-        self._render_preview(key)
 
     def _ensure_about_section_loaded(self) -> None:
         data = self.data
@@ -3096,19 +2672,11 @@ class PollySettingsPaneApp(App[None]):
             dot, colour = _settings_status_dot(a["health"], a["logged_in"])
             fo_mark = f"#{a['failover_pos']}" if a["failover_pos"] else ""
             ctrl_mark = "\u2713" if a["is_controller"] else ""
-            budget_level = a.get("budget_level", "unknown")
-            budget_style = {
-                "ok": "#3ddc84",
-                "warn": "#f0c45a",
-                "error": "#ff5f6d",
-            }.get(budget_level, "#97a6b2")
-            budget_cell = Text(a.get("budget_summary") or "-", style=budget_style)
             self.accounts.add_row(
                 Text(dot, style=colour),
                 a["key"],
                 a["email"],
                 a["provider"],
-                budget_cell,
                 ctrl_mark,
                 fo_mark,
                 a["usage_summary"] or "-",
@@ -3142,66 +2710,15 @@ class PollySettingsPaneApp(App[None]):
         dot, colour = _settings_status_dot(
             selected["health"], selected["logged_in"],
         )
-        sep = "[dim]" + "\u2500" * 40 + "[/dim]"
-        lines = [
-            f"[{colour}]{dot}[/{colour}] [b]{_escape(selected['key'])}[/b]"
-            f"  [dim]({_escape(selected['provider'])})[/dim]",
-            sep,
-            f"[dim]Email:[/dim]      {_escape(selected['email'])}",
-            f"[dim]Budget:[/dim]     {_escape(selected.get('budget_summary') or '-')}",
-            f"[dim]Logged in:[/dim]  {'yes' if selected['logged_in'] else 'no'}",
-            f"[dim]Health:[/dim]     {_escape(selected['health']) or '-'}",
-            f"[dim]Plan:[/dim]       {_escape(selected['plan']) or '-'}",
-            f"[dim]Usage:[/dim]      {_escape(selected['usage_summary']) or '-'}",
-            f"[dim]Remaining:[/dim]  "
-            f"{selected['remaining_pct']}%" if selected.get("remaining_pct") is not None
-            else "[dim]Remaining:[/dim]  -",
-            f"[dim]Used:[/dim]       "
-            f"{selected['used_pct']}%" if selected.get("used_pct") is not None
-            else "[dim]Used:[/dim]       -",
-            f"[dim]Window:[/dim]     {_escape(selected.get('period_label') or '-')}",
-            f"[dim]Resets:[/dim]     {_escape(selected.get('reset_at') or '-')}",
-            f"[dim]Sampled:[/dim]    {_escape(selected.get('usage_updated_at') or '-')}",
-            f"[dim]Controller:[/dim] {'yes' if selected['is_controller'] else 'no'}",
-            f"[dim]Failover:[/dim]   "
-            f"{'#' + str(selected['failover_pos']) if selected['failover_pos'] else 'no'}",
-            f"[dim]Home:[/dim]       {_escape(selected['home']) or '-'}",
-            f"[dim]Isolation:[/dim]  {_escape(selected['isolation_status']) or '-'}",
-            f"[dim]Storage:[/dim]    {_escape(selected['auth_storage']) or '-'}",
-            f"[dim]Budget note:[/dim] {_escape(selected.get('budget_rationale', 'Cached from account_usage'))}",
-        ]
-        if selected["available_at"]:
-            lines.append(
-                f"[dim]Available:[/dim]  {_escape(selected['available_at'])}"
+        self.detail.update(
+            render_settings_account_detail(
+                {
+                    **selected,
+                    "status_dot": dot,
+                    "status_colour": colour,
+                }
             )
-        if selected["access_expires_at"]:
-            lines.append(
-                f"[dim]Expires:[/dim]    {_escape(selected['access_expires_at'])}"
-            )
-        if selected["reason"]:
-            lines.extend([sep, f"[dim]Reason:[/dim]     {_escape(selected['reason'])}"])
-        lines.extend(
-            [
-                sep,
-                f"[dim]Rationale:[/dim]  {_escape(selected.get('rationale') or 'No rationale available.')}",
-                f"[dim]Actions:[/dim]    c add Claude · o add Codex · x remove selected · u undo",
-            ]
         )
-        if selected["usage_raw_text"]:
-            snippet = selected["usage_raw_text"].strip().splitlines()[:6]
-            if snippet:
-                lines.append(sep)
-                lines.append("[dim]Latest usage snapshot:[/dim]")
-                lines.extend(f"  {_escape(line)}" for line in snippet)
-        recent = selected.get("recent_tasks") or []
-        lines.append(sep)
-        if recent:
-            lines.append("[dim]Recent tasks:[/dim]")
-            for task in recent[:3]:
-                lines.append("  " + _format_recent_task(type("TaskPreview", (), task)()))
-        else:
-            lines.append("[dim]Recent tasks: none recorded for this account yet.[/dim]")
-        self.detail.update("\n".join(lines))
 
     def _current_accounts_key(self) -> str | None:
         if self.accounts.row_count == 0 or self.accounts.cursor_row < 0:
@@ -3288,7 +2805,6 @@ class PollySettingsPaneApp(App[None]):
             f"[dim]Status:[/dim] {tracked_line}",
             f"[dim]Tasks:[/dim]  {selected.get('task_total_label', selected['task_total'])}",
             f"[dim]Last:[/dim]   {_escape(selected['last_activity']) or '-'}",
-            f"[dim]Rationale:[/dim] {_escape(selected.get('rationale') or 'No rationale available.')}",
         ]
         self.detail.update("\n".join(lines))
 
@@ -3487,18 +3003,8 @@ class PollySettingsPaneApp(App[None]):
     def action_toggle_permissions(self) -> None:
         try:
             config = load_config(self.config_path)
-            previous = bool(getattr(config.pollypm, "open_permissions_by_default", False))
             enabled = not config.pollypm.open_permissions_by_default
             self.service.set_open_permissions_default(enabled)
-            self._record_undo(
-                f"permissions {'on' if previous else 'off'}",
-                lambda: self.service.set_open_permissions_default(previous),
-                kind="permissions.toggle",
-                payload={
-                    "previous": previous,
-                    "enabled": enabled,
-                },
-            )
         except Exception as exc:  # noqa: BLE001
             try:
                 self.notify(
@@ -3536,18 +3042,7 @@ class PollySettingsPaneApp(App[None]):
             )
             if current is None:
                 return
-            previous = bool(current["tracked"])
             setter(key, not current["tracked"])
-            self._record_undo(
-                f"project {key} tracked {'on' if previous else 'off'}",
-                lambda: setter(key, previous),
-                kind="project.tracked",
-                payload={
-                    "project_key": key,
-                    "previous": previous,
-                    "enabled": not previous,
-                },
-            )
         except Exception as exc:  # noqa: BLE001
             try:
                 self.notify(f"Toggle failed: {exc}", severity="error")
@@ -3566,19 +3061,7 @@ class PollySettingsPaneApp(App[None]):
         if setter is None:
             return
         try:
-            config = load_config(self.config_path)
-            previous = getattr(config.pollypm, "controller_account", "")
             setter(key)
-            if previous:
-                self._record_undo(
-                    f"controller {previous}",
-                    lambda: setter(previous),
-                    kind="account.controller",
-                    payload={
-                        "account": key,
-                        "previous_account": previous,
-                    },
-                )
         except Exception as exc:  # noqa: BLE001
             try:
                 self.notify(
@@ -3599,18 +3082,7 @@ class PollySettingsPaneApp(App[None]):
         if setter is None:
             return
         try:
-            config = load_config(self.config_path)
-            previous = key in (getattr(config.pollypm, "failover_accounts", []) or [])
             setter(key)
-            self._record_undo(
-                f"failover {key} {'on' if previous else 'off'}",
-                lambda: setter(key),
-                kind="account.failover",
-                payload={
-                    "account": key,
-                    "enabled": not previous,
-                },
-            )
         except Exception as exc:  # noqa: BLE001
             try:
                 self.notify(
@@ -3657,9 +3129,6 @@ class PollySettingsPaneApp(App[None]):
         except Exception:  # noqa: BLE001
             pass
 
-    def action_remove_account(self) -> None:
-        self.action_remove_selected_account()
-
     def action_remove_selected_account(self) -> None:
         if self._active_section != "accounts":
             return
@@ -3678,27 +3147,6 @@ class PollySettingsPaneApp(App[None]):
             ),
             lambda confirmed: self._confirm_remove_account(key, confirmed),
         )
-
-    def action_undo_recent_change(self) -> None:
-        action = self._current_undo_action()
-        if action is None:
-            try:
-                self.notify("Nothing recent to undo.", timeout=1.2)
-            except Exception:  # noqa: BLE001
-                pass
-            return
-        try:
-            action.apply()
-            self._consume_undo_history(action)
-            self.notify(f"Undid {action.label}.", timeout=1.5)
-        except Exception as exc:  # noqa: BLE001
-            try:
-                self.notify(f"Undo failed: {exc}", severity="error")
-            except Exception:  # noqa: BLE001
-                pass
-        finally:
-            self._undo_action = None
-        self._refresh()
 
     def action_back_or_cancel(self) -> None:
         if self.search_input.has_class("-active"):
@@ -3771,7 +3219,6 @@ class PollySettingsPaneApp(App[None]):
             self._render_project_detail(self._visible_project_rows)
         elif self._active_section == "plugins":
             self._render_plugin_detail(self._visible_plugin_rows)
-        self._render_preview(self._active_section)
 
     @on(DataTable.RowHighlighted, "#accounts")
     def on_account_highlighted(
@@ -3815,21 +3262,15 @@ class PollySettingsPaneApp(App[None]):
     def on_account_selected(self, _event: DataTable.RowSelected) -> None:
         self._selected_account_key = self._current_accounts_key()
         if self.data is not None:
-            self._render_account_detail(self._visible_account_rows)
-            self._render_preview(self._active_section)
+            self._render_account_detail(self.data)
 
     def _add_account(self, provider: ProviderKind) -> None:
         adder = getattr(self.service, "add_account", None)
-        remover = getattr(self.service, "remove_account", None)
-        if adder is None or remover is None:
+        if adder is None:
             return
         try:
-            key, email = adder(provider)
+            key, _email = adder(provider)
             self._selected_account_key = key
-            self._record_undo(
-                f"add account {key}",
-                lambda: remover(key, delete_home=False),
-            )
         except Exception as exc:  # noqa: BLE001
             try:
                 self.notify(f"Add account failed: {exc}", severity="error")
@@ -3838,10 +3279,7 @@ class PollySettingsPaneApp(App[None]):
             return
         self._refresh()
         try:
-            self.notify(
-                f"Added {provider.value} account {key} ({email}).",
-                timeout=1.5,
-            )
+            self.notify(f"Added {provider.value} account {key}.", timeout=1.5)
         except Exception:  # noqa: BLE001
             pass
 
@@ -4828,7 +4266,7 @@ class PollyInboxApp(App[None]):
         # Refresh: ``u`` re-bound to filter, so refresh moves to ``ctrl+r``
         # (palette 'session.refresh' still works from any screen).
         Binding("ctrl+r", "refresh", "Refresh", show=False),
-        Binding("ctrl+k,colon", "open_command_palette", "Palette", priority=True),
+        Binding("colon", "open_command_palette", "Palette", priority=True),
         Binding("question_mark", "show_keyboard_help", "Help", priority=True),
         Binding("q,escape", "back_or_cancel", "Back"),
     ]
@@ -7486,7 +6924,7 @@ class PollyProjectDashboardApp(App[None]):
         Binding("G", "plan_scroll_bottom", "Bottom", show=False),
         Binding("u,r", "refresh", "Refresh", show=False),
         Binding("a", "view_alerts", "Alerts", show=False),
-        Binding("ctrl+k,colon", "open_command_palette", "Palette", priority=True),
+        Binding("colon", "open_command_palette", "Palette", priority=True),
         Binding("question_mark", "show_keyboard_help", "Help", priority=True),
         Binding("q,escape", "back", "Back"),
     ]

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -6,15 +6,9 @@ from types import SimpleNamespace
 import pytest
 
 from pollypm.cockpit import build_cockpit_detail
-from pollypm.cockpit_rail import (
-    CockpitItem,
-    CockpitPresence,
-    CockpitRouter,
-    PALETTE,
-    PollyCockpitRail,
-)
-from pollypm.config import write_config
+from pollypm.cockpit_rail import CockpitItem, CockpitPresence, CockpitRouter, PALETTE, PollyCockpitRail
 from pollypm.cockpit_ui import PollyCockpitApp, PollyDashboardApp, PollySettingsPaneApp, RailItem
+from pollypm.config import write_config
 from pollypm.dashboard_data import DashboardData, SessionActivity
 from pollypm.models import (
     AccountConfig,
@@ -27,7 +21,6 @@ from pollypm.models import (
     SessionConfig,
 )
 from pollypm.recovery.base import SessionHealth
-from pollypm.plugin_api.v1 import RailRow
 
 
 class _CaptureWidget:
@@ -253,59 +246,6 @@ def test_cockpit_router_session_state_uses_heartbeat_state(tmp_path: Path) -> No
     assert router._session_state("heartbeat", [FakeLaunch()], [FakeWindow()], [], 0) == "watch"
 
 
-def test_cockpit_router_decorates_project_items_with_sparkline_and_pin() -> None:
-    router = CockpitRouter.__new__(CockpitRouter)
-
-    class _Launch:
-        def __init__(self, session_name: str, project: str) -> None:
-            self.session = type(
-                "Session",
-                (),
-                {
-                    "name": session_name,
-                    "role": "worker",
-                    "project": project,
-                },
-            )()
-
-    class _Event:
-        def __init__(self, session_name: str, created_at) -> None:
-            self.session_name = session_name
-            self.created_at = created_at
-
-    items = [
-        CockpitItem(key="top", label="Top", state="idle"),
-        CockpitItem(key="project:alpha", label="Alpha", state="idle"),
-        CockpitItem(key="project:alpha:dashboard", label="Dashboard", state="sub", selectable=False),
-        CockpitItem(key="project:demo", label="Demo", state="◜ working"),
-        CockpitItem(key="project:demo:dashboard", label="Dashboard", state="sub", selectable=False),
-        CockpitItem(key="system", label="Settings", state="idle"),
-    ]
-    launches = [_Launch("worker_alpha", "alpha"), _Launch("worker_demo", "demo")]
-    recent_events = [
-        _Event("worker_alpha", datetime.now(UTC) - timedelta(minutes=4)),
-        _Event("worker_demo", datetime.now(UTC) - timedelta(minutes=15)),
-        _Event("worker_demo", datetime.now(UTC) - timedelta(minutes=28)),
-    ]
-    router.is_project_pinned = lambda key: key == "alpha"  # type: ignore[assignment]
-
-    decorated = router._decorate_project_items(
-        items,
-        selected_project="demo",
-        launches=launches,
-        recent_events=recent_events,
-        project_session_map={"alpha": "worker_alpha", "demo": "worker_demo"},
-    )
-
-    project_rows = [item for item in decorated if item.key.startswith("project:") and item.key.count(":") == 1]
-    assert project_rows[0].key == "project:alpha"
-    assert project_rows[0].label.startswith("📌 Alpha ")
-    assert len(project_rows[0].label[len("📌 Alpha "):]) == 10
-    assert project_rows[1].key == "project:demo"
-    assert project_rows[1].label != "Demo"
-    assert decorated[-1].key == "system"
-
-
 def test_cockpit_presence_treats_outside_tmux_as_attached() -> None:
     class _FakeTmux:
         def current_session_name(self) -> str | None:
@@ -368,6 +308,225 @@ def test_cockpit_presence_calm_mode_disables_animation(monkeypatch) -> None:
 
     assert presence.should_animate() is False
     assert presence.working_frame(3) == "◜"
+
+
+def test_cockpit_ui_rail_item_uses_static_ellipsis_in_calm_mode(monkeypatch) -> None:
+    monkeypatch.setattr(RailItem, "update_body", lambda self: None)
+
+    class _FakeTmux:
+        def current_session_name(self) -> str | None:
+            return "pollypm"
+
+        def list_clients(self, session_name: str) -> str:
+            del session_name
+            return "client"
+
+    monkeypatch.setenv("POLLY_CALM", "1")
+    presence = CockpitPresence(_FakeTmux())
+    item = RailItem(
+        CockpitItem(
+            "project:demo",
+            "Demo",
+            "ready",
+            session_name="worker_demo",
+            work_state="writing",
+            heartbeat_at="2026-04-21T23:00:00+00:00",
+        ),
+        active_view=False,
+        presence=presence,
+    )
+
+    assert item._indicator()[0] == "♥…"
+
+
+def test_cockpit_presence_heartbeat_frame_advances_only_on_new_heartbeat() -> None:
+    class _FakeTmux:
+        def current_session_name(self) -> str | None:
+            return "pollypm"
+
+        def list_clients(self, session_name: str) -> str:
+            del session_name
+            return "client"
+
+    presence = CockpitPresence(_FakeTmux())
+
+    first = presence.heartbeat_frame_for("worker_demo", "2026-04-21T23:00:00+00:00")
+    second = presence.heartbeat_frame_for("worker_demo", "2026-04-21T23:00:00+00:00")
+    third = presence.heartbeat_frame_for("worker_demo", "2026-04-21T23:05:00+00:00")
+
+    assert first == "♡"
+    assert second == "♡"
+    assert third == "♥"
+
+
+def test_cockpit_ui_rail_item_indicator_combines_pulse_and_work_glyph(monkeypatch) -> None:
+    monkeypatch.setattr(RailItem, "update_body", lambda self: None)
+
+    class _FakeTmux:
+        def current_session_name(self) -> str | None:
+            return "pollypm"
+
+        def list_clients(self, session_name: str) -> str:
+            del session_name
+            return "client"
+
+    presence = CockpitPresence(_FakeTmux())
+
+    writing = RailItem(
+        CockpitItem(
+            "project:demo",
+            "Demo",
+            "ready",
+            session_name="worker_demo",
+            work_state="writing",
+            heartbeat_at="2026-04-21T23:00:00+00:00",
+        ),
+        active_view=False,
+        presence=presence,
+    )
+    reviewing = RailItem(
+        CockpitItem(
+            "russell",
+            "Russell",
+            "ready",
+            session_name="reviewer",
+            work_state="reviewing",
+            heartbeat_at="2026-04-21T23:00:00+00:00",
+        ),
+        active_view=False,
+        presence=presence,
+    )
+    stuck = RailItem(
+        CockpitItem(
+            "project:demo",
+            "Demo",
+            "! pane dead",
+            session_name="worker_demo",
+            work_state="stuck",
+            heartbeat_at="2026-04-21T23:00:00+00:00",
+        ),
+        active_view=False,
+        presence=presence,
+    )
+    exited = RailItem(
+        CockpitItem(
+            "project:demo",
+            "Demo",
+            "dead",
+            session_name="worker_demo",
+            work_state="exited",
+            heartbeat_at="2026-04-21T23:00:00+00:00",
+        ),
+        active_view=False,
+        presence=presence,
+    )
+
+    assert writing._indicator()[0] == "♡◜"
+    assert reviewing._indicator()[0] == "♡✎"
+    assert stuck._indicator()[0] == "♡⚠"
+    assert exited._indicator()[0] == "♡✕"
+
+
+def test_cockpit_rail_session_indicator_combines_pulse_and_work_glyph(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+
+    class _FakeTmux:
+        def current_session_name(self) -> str | None:
+            return "pollypm"
+
+        def list_clients(self, session_name: str) -> str:
+            del session_name
+            return "client"
+
+    rail = PollyCockpitRail(config_path)
+    rail.router.tmux = _FakeTmux()  # type: ignore[assignment]
+    rail.presence = CockpitPresence(_FakeTmux())
+
+    writing = CockpitItem(
+        "project:demo",
+        "Demo",
+        "◜ working",
+        session_name="worker_demo",
+        work_state="writing",
+        heartbeat_at="2026-04-21T23:00:00+00:00",
+    )
+    reviewing = CockpitItem(
+        "russell",
+        "Russell",
+        "ready",
+        session_name="reviewer",
+        work_state="reviewing",
+        heartbeat_at="2026-04-21T23:00:00+00:00",
+    )
+    stuck = CockpitItem(
+        "project:demo",
+        "Demo",
+        "! pane dead",
+        session_name="worker_demo",
+        work_state="stuck",
+        heartbeat_at="2026-04-21T23:00:00+00:00",
+    )
+    exited = CockpitItem(
+        "project:demo",
+        "Demo",
+        "dead",
+        session_name="worker_demo",
+        work_state="exited",
+        heartbeat_at="2026-04-21T23:00:00+00:00",
+    )
+
+    assert rail._indicator(writing)[0] == "♡◜"
+    assert rail._indicator(reviewing)[0] == "♡✎"
+    assert rail._indicator(stuck)[0] == "♡⚠"
+    assert rail._indicator(exited)[0] == "♡✕"
+
+
+def test_cockpit_rail_session_indicator_uses_static_ellipsis_in_calm_mode(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("POLLY_CALM", "1")
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+
+    class _FakeTmux:
+        def current_session_name(self) -> str | None:
+            return "pollypm"
+
+        def list_clients(self, session_name: str) -> str:
+            del session_name
+            return "client"
+
+    rail = PollyCockpitRail(config_path)
+    rail.router.tmux = _FakeTmux()  # type: ignore[assignment]
+    rail.presence = CockpitPresence(_FakeTmux())
+
+    writing = CockpitItem(
+        "project:demo",
+        "Demo",
+        "◜ working",
+        session_name="worker_demo",
+        work_state="writing",
+        heartbeat_at="2026-04-21T23:00:00+00:00",
+    )
+
+    assert rail._indicator(writing)[0] == "♥…"
+
+
+def test_cockpit_ui_help_legend_mentions_glyph_alphabet() -> None:
+    binding = next(
+        binding for binding in PollyCockpitApp.BINDINGS if getattr(binding, "key", "") == "question_mark"
+    )
+
+    assert "pulse" in binding.description
+    assert "✎" in binding.description
+    assert "⚠" in binding.description
+    assert "✕" in binding.description
 
 
 def test_cockpit_router_config_cache_reuses_loaded_config(monkeypatch, tmp_path: Path) -> None:
@@ -510,6 +669,60 @@ def test_cockpit_router_caches_hidden_collapsed_and_grouped_registrations(monkey
     assert grouped_first == grouped_second
     assert calls == {"hidden": 1, "collapsed": 1, "registry": 1}
 
+
+def test_cockpit_router_decorates_project_items_with_sparkline_and_pin() -> None:
+    router = CockpitRouter.__new__(CockpitRouter)
+
+    class _Launch:
+        def __init__(self, session_name: str, project: str) -> None:
+            self.session = type(
+                "Session",
+                (),
+                {
+                    "name": session_name,
+                    "role": "worker",
+                    "project": project,
+                },
+            )()
+
+    class _Event:
+        def __init__(self, session_name: str, created_at) -> None:
+            self.session_name = session_name
+            self.created_at = created_at
+
+    items = [
+        CockpitItem(key="top", label="Top", state="idle"),
+        CockpitItem(key="project:alpha", label="Alpha", state="idle"),
+        CockpitItem(key="project:alpha:dashboard", label="Dashboard", state="sub", selectable=False),
+        CockpitItem(key="project:demo", label="Demo", state="◜ working"),
+        CockpitItem(key="project:demo:dashboard", label="Dashboard", state="sub", selectable=False),
+        CockpitItem(key="system", label="Settings", state="idle"),
+    ]
+    launches = [_Launch("worker_alpha", "alpha"), _Launch("worker_demo", "demo")]
+    recent_events = [
+        _Event("worker_alpha", datetime.now(UTC) - timedelta(minutes=4)),
+        _Event("worker_demo", datetime.now(UTC) - timedelta(minutes=15)),
+        _Event("worker_demo", datetime.now(UTC) - timedelta(minutes=28)),
+    ]
+    router.is_project_pinned = lambda key: key == "alpha"  # type: ignore[assignment]
+
+    decorated = router._decorate_project_items(
+        items,
+        selected_project="demo",
+        launches=launches,
+        recent_events=recent_events,
+        project_session_map={"alpha": "worker_alpha", "demo": "worker_demo"},
+    )
+
+    project_rows = [item for item in decorated if item.key.startswith("project:") and item.key.count(":") == 1]
+    assert project_rows[0].key == "project:alpha"
+    assert project_rows[0].label.startswith("📌 Alpha ")
+    assert len(project_rows[0].label[len("📌 Alpha "):]) == 10
+    assert project_rows[1].key == "project:demo"
+    assert project_rows[1].label != "Demo"
+    assert decorated[-1].key == "system"
+
+
 def test_cockpit_rail_render_includes_event_ticker(monkeypatch) -> None:
     class _Event:
         def __init__(self, event_type: str, session_name: str, created_at) -> None:
@@ -585,28 +798,6 @@ def test_cockpit_rail_hides_event_ticker_when_empty(monkeypatch) -> None:
     assert rail._event_ticker_text() == ""
 
 
-def test_cockpit_rail_keybinds_activity_and_pin(monkeypatch) -> None:
-    calls: list[tuple[str, str | None]] = []
-
-    class _Router:
-        def route_selected(self, key: str) -> None:
-            calls.append(("route", key))
-
-        def toggle_pinned_project(self, project_key: str) -> None:
-            calls.append(("pin", project_key))
-
-    rail = PollyCockpitRail.__new__(PollyCockpitRail)
-    rail.router = _Router()
-    rail.selected_key = "project:demo"
-
-    assert rail._handle_key(b"t", []) is True
-    rail.selected_key = "project:demo"
-    assert rail._handle_key(b"p", []) is True
-
-    assert ("route", "activity") in calls
-    assert ("pin", "demo") in calls
-
-
 def test_cockpit_ui_event_ticker_cycles_and_hides_when_empty(monkeypatch, tmp_path: Path) -> None:
     class _Event:
         def __init__(self, event_type: str, session_name: str) -> None:
@@ -668,9 +859,6 @@ def test_cockpit_ui_activity_and_pin_actions_route_live_rail(monkeypatch, tmp_pa
     calls: list[tuple[str, str]] = []
 
     class _Router:
-        def selected_key(self) -> str:
-            return "project:demo"
-
         def route_selected(self, key: str) -> None:
             calls.append(("route", key))
 
@@ -688,18 +876,6 @@ def test_cockpit_ui_activity_and_pin_actions_route_live_rail(monkeypatch, tmp_pa
     assert ("route", "activity") in calls
     assert ("pin", "demo") in calls
     assert ("refresh", "yes") in calls
-
-
-def test_cockpit_ui_section_separator_rows_use_section_style(monkeypatch) -> None:
-    monkeypatch.setattr(RailItem, "update_body", lambda self: None)
-
-    row = RailItem(
-        CockpitItem("_section:projects", "PROJECTS (3)", "separator", selectable=False),
-        active_view=False,
-    )
-
-    assert row.has_class("section-sep")
-    assert row.disabled is True
 
 
 def test_cockpit_router_selected_key_clears_missing_right_pane_state(monkeypatch, tmp_path: Path) -> None:
@@ -1997,6 +2173,32 @@ def test_cockpit_ui_arrow_and_enter_route_selected(tmp_path: Path) -> None:
             assert app.router.calls == ["inbox"]
 
     asyncio.run(exercise())
+
+
+def test_cockpit_rail_ctrl_k_routes_to_settings(monkeypatch, tmp_path: Path) -> None:
+    class FakeRouter:
+        def __init__(self, _config_path: Path) -> None:
+            self.calls: list[str] = []
+            self.tmux = None
+
+        def selected_key(self) -> str:
+            return "polly"
+
+        def route_selected(self, key: str) -> None:
+            self.calls.append(key)
+
+    monkeypatch.setattr("pollypm.cockpit_rail.CockpitRouter", FakeRouter)
+    from pollypm.cockpit_rail import CockpitItem, PollyCockpitRail
+
+    rail = PollyCockpitRail(tmp_path / "pollypm.toml")
+    items = [
+        CockpitItem("polly", "Polly", "ready"),
+        CockpitItem("settings", "Settings", "config"),
+    ]
+
+    assert rail._handle_key(b"\x0b", items) is True
+    assert rail.router.calls == ["settings"]
+    assert rail.selected_key == "settings"
 
 
 def test_settings_pane_renders_accounts_and_toggles_permissions(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -705,6 +705,7 @@ def test_cockpit_router_decorates_project_items_with_sparkline_and_pin() -> None
         _Event("worker_demo", datetime.now(UTC) - timedelta(minutes=28)),
     ]
     router.is_project_pinned = lambda key: key == "alpha"  # type: ignore[assignment]
+    router.pinned_projects = lambda: ["alpha"]  # type: ignore[assignment]
 
     decorated = router._decorate_project_items(
         items,
@@ -762,7 +763,6 @@ def test_cockpit_rail_render_includes_event_ticker(monkeypatch) -> None:
 
     captured: list[str] = []
     rail._write = lambda text: captured.append(text)
-    monkeypatch.setattr("pollypm.cockpit_rail._viewer_attached", lambda: True)
     monkeypatch.setattr("pollypm.cockpit_rail.time.monotonic", lambda: 11.0)
     monkeypatch.setattr(
         "pollypm.cockpit_rail.shutil.get_terminal_size",
@@ -771,7 +771,10 @@ def test_cockpit_rail_render_includes_event_ticker(monkeypatch) -> None:
 
     rail._render([CockpitItem(key="polly", label="Polly", state="idle"), CockpitItem(key="settings", label="Settings", state="idle")])
 
-    assert rail._event_ticker_text() == "events · heartbeat:heartbeat"
+    # offset=11//10=1; window_size=min(3, 2)=2; cycled = events[1], events[0]
+    assert rail._event_ticker_text() == (
+        "events · heartbeat:heartbeat · session.started:polly"
+    )
     assert captured
 
 
@@ -794,7 +797,8 @@ def test_cockpit_rail_hides_event_ticker_when_empty(monkeypatch) -> None:
     rail = PollyCockpitRail.__new__(PollyCockpitRail)
     rail.router = _Router()
     rail._ticker_started_at = 0.0
-    monkeypatch.setattr("pollypm.cockpit_rail._viewer_attached", lambda: True)
+    # Router has no ``_presence`` → gate silently passes (render as if
+    # attached), and an empty event list yields empty ticker.
     assert rail._event_ticker_text() == ""
 
 
@@ -833,18 +837,37 @@ def test_cockpit_ui_event_ticker_cycles_and_hides_when_empty(monkeypatch, tmp_pa
                 CockpitItem("settings", "Settings", "config"),
             ]
 
+    class _FakePresence:
+        def __init__(self, attached: bool = True) -> None:
+            self._attached = attached
+
+        def is_tmux_attached(self) -> bool:
+            return self._attached
+
+    # Extend the router with a ``_presence`` hook the production code
+    # calls to gate the ticker on tmux-client attachment.
+    def _make_router(events, *, attached: bool = True):
+        router = _Router(events)
+        router._presence = lambda: _FakePresence(attached)
+        return router
+
     app = PollyCockpitApp(tmp_path / "pollypm.toml")
-    app.router = _Router([_Event("commit", "worker_demo"), _Event("review", "system")])  # type: ignore[assignment]
+    app.router = _make_router([_Event("commit", "worker_demo"), _Event("review", "system")])  # type: ignore[assignment]
     app._ticker_started_at = 0.0
-    monkeypatch.setattr("pollypm.cockpit_ui._viewer_attached", lambda: True)
     monkeypatch.setattr("pollypm.cockpit_ui.time.monotonic", lambda: 11.0)
 
-    assert app._event_ticker_text() == "events · review:system"
+    # offset=11//10=1; window_size=min(3, 2)=2; cycled = events[1], events[0]
+    assert app._event_ticker_text() == (
+        "events · review:system · commit:worker_demo"
+    )
 
-    app.router = _Router([])  # type: ignore[assignment]
+    app.router = _make_router([])  # type: ignore[assignment]
     assert app._event_ticker_text() == ""
 
-    monkeypatch.setattr("pollypm.cockpit_ui._viewer_attached", lambda: False)
+    # Gate closed → ticker empty even with events available.
+    app.router = _make_router(
+        [_Event("commit", "worker_demo")], attached=False,
+    )  # type: ignore[assignment]
     assert app._event_ticker_text() == ""
 
 
@@ -853,6 +876,32 @@ def test_cockpit_ui_bindings_expose_activity_and_pin_legend() -> None:
 
     assert bindings["t"] == "Activity"
     assert bindings["p"] == "Pin Project"
+
+
+def test_toggle_pinned_project_preserves_insertion_recency(tmp_path: Path) -> None:
+    """#677 acceptance: most-recently-pinned sorts first. Each new pin
+    prepends so it beats older pins in rail ordering."""
+    from pollypm.cockpit_rail import CockpitRouter
+
+    router = CockpitRouter.__new__(CockpitRouter)
+    state: dict[str, object] = {}
+    router._load_state = lambda: dict(state)
+    router._write_state = lambda data: state.update(data)
+
+    router.toggle_pinned_project("alpha")
+    router.toggle_pinned_project("beta")
+    router.toggle_pinned_project("gamma")
+
+    # Most-recently pinned first.
+    assert router.pinned_projects() == ["gamma", "beta", "alpha"]
+
+    # Toggling off removes without reordering the rest.
+    router.toggle_pinned_project("beta")
+    assert router.pinned_projects() == ["gamma", "alpha"]
+
+    # Re-pinning moves to front.
+    router.toggle_pinned_project("beta")
+    assert router.pinned_projects() == ["beta", "gamma", "alpha"]
 
 
 def test_cockpit_ui_activity_and_pin_actions_route_live_rail(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -6,9 +6,15 @@ from types import SimpleNamespace
 import pytest
 
 from pollypm.cockpit import build_cockpit_detail
-from pollypm.cockpit_rail import CockpitItem, CockpitPresence, CockpitRouter, PollyCockpitRail
-from pollypm.cockpit_ui import PollyCockpitApp, PollyDashboardApp, PollySettingsPaneApp, RailItem
+from pollypm.cockpit_rail import (
+    CockpitItem,
+    CockpitPresence,
+    CockpitRouter,
+    PALETTE,
+    PollyCockpitRail,
+)
 from pollypm.config import write_config
+from pollypm.cockpit_ui import PollyCockpitApp, PollyDashboardApp, PollySettingsPaneApp, RailItem
 from pollypm.dashboard_data import DashboardData, SessionActivity
 from pollypm.models import (
     AccountConfig,
@@ -21,6 +27,7 @@ from pollypm.models import (
     SessionConfig,
 )
 from pollypm.recovery.base import SessionHealth
+from pollypm.plugin_api.v1 import RailRow
 
 
 class _CaptureWidget:
@@ -246,6 +253,59 @@ def test_cockpit_router_session_state_uses_heartbeat_state(tmp_path: Path) -> No
     assert router._session_state("heartbeat", [FakeLaunch()], [FakeWindow()], [], 0) == "watch"
 
 
+def test_cockpit_router_decorates_project_items_with_sparkline_and_pin() -> None:
+    router = CockpitRouter.__new__(CockpitRouter)
+
+    class _Launch:
+        def __init__(self, session_name: str, project: str) -> None:
+            self.session = type(
+                "Session",
+                (),
+                {
+                    "name": session_name,
+                    "role": "worker",
+                    "project": project,
+                },
+            )()
+
+    class _Event:
+        def __init__(self, session_name: str, created_at) -> None:
+            self.session_name = session_name
+            self.created_at = created_at
+
+    items = [
+        CockpitItem(key="top", label="Top", state="idle"),
+        CockpitItem(key="project:alpha", label="Alpha", state="idle"),
+        CockpitItem(key="project:alpha:dashboard", label="Dashboard", state="sub", selectable=False),
+        CockpitItem(key="project:demo", label="Demo", state="◜ working"),
+        CockpitItem(key="project:demo:dashboard", label="Dashboard", state="sub", selectable=False),
+        CockpitItem(key="system", label="Settings", state="idle"),
+    ]
+    launches = [_Launch("worker_alpha", "alpha"), _Launch("worker_demo", "demo")]
+    recent_events = [
+        _Event("worker_alpha", datetime.now(UTC) - timedelta(minutes=4)),
+        _Event("worker_demo", datetime.now(UTC) - timedelta(minutes=15)),
+        _Event("worker_demo", datetime.now(UTC) - timedelta(minutes=28)),
+    ]
+    router.is_project_pinned = lambda key: key == "alpha"  # type: ignore[assignment]
+
+    decorated = router._decorate_project_items(
+        items,
+        selected_project="demo",
+        launches=launches,
+        recent_events=recent_events,
+        project_session_map={"alpha": "worker_alpha", "demo": "worker_demo"},
+    )
+
+    project_rows = [item for item in decorated if item.key.startswith("project:") and item.key.count(":") == 1]
+    assert project_rows[0].key == "project:alpha"
+    assert project_rows[0].label.startswith("📌 Alpha ")
+    assert len(project_rows[0].label[len("📌 Alpha "):]) == 10
+    assert project_rows[1].key == "project:demo"
+    assert project_rows[1].label != "Demo"
+    assert decorated[-1].key == "system"
+
+
 def test_cockpit_presence_treats_outside_tmux_as_attached() -> None:
     class _FakeTmux:
         def current_session_name(self) -> str | None:
@@ -308,225 +368,6 @@ def test_cockpit_presence_calm_mode_disables_animation(monkeypatch) -> None:
 
     assert presence.should_animate() is False
     assert presence.working_frame(3) == "◜"
-
-
-def test_cockpit_ui_rail_item_uses_static_ellipsis_in_calm_mode(monkeypatch) -> None:
-    monkeypatch.setattr(RailItem, "update_body", lambda self: None)
-
-    class _FakeTmux:
-        def current_session_name(self) -> str | None:
-            return "pollypm"
-
-        def list_clients(self, session_name: str) -> str:
-            del session_name
-            return "client"
-
-    monkeypatch.setenv("POLLY_CALM", "1")
-    presence = CockpitPresence(_FakeTmux())
-    item = RailItem(
-        CockpitItem(
-            "project:demo",
-            "Demo",
-            "ready",
-            session_name="worker_demo",
-            work_state="writing",
-            heartbeat_at="2026-04-21T23:00:00+00:00",
-        ),
-        active_view=False,
-        presence=presence,
-    )
-
-    assert item._indicator()[0] == "♥…"
-
-
-def test_cockpit_presence_heartbeat_frame_advances_only_on_new_heartbeat() -> None:
-    class _FakeTmux:
-        def current_session_name(self) -> str | None:
-            return "pollypm"
-
-        def list_clients(self, session_name: str) -> str:
-            del session_name
-            return "client"
-
-    presence = CockpitPresence(_FakeTmux())
-
-    first = presence.heartbeat_frame_for("worker_demo", "2026-04-21T23:00:00+00:00")
-    second = presence.heartbeat_frame_for("worker_demo", "2026-04-21T23:00:00+00:00")
-    third = presence.heartbeat_frame_for("worker_demo", "2026-04-21T23:05:00+00:00")
-
-    assert first == "♡"
-    assert second == "♡"
-    assert third == "♥"
-
-
-def test_cockpit_ui_rail_item_indicator_combines_pulse_and_work_glyph(monkeypatch) -> None:
-    monkeypatch.setattr(RailItem, "update_body", lambda self: None)
-
-    class _FakeTmux:
-        def current_session_name(self) -> str | None:
-            return "pollypm"
-
-        def list_clients(self, session_name: str) -> str:
-            del session_name
-            return "client"
-
-    presence = CockpitPresence(_FakeTmux())
-
-    writing = RailItem(
-        CockpitItem(
-            "project:demo",
-            "Demo",
-            "ready",
-            session_name="worker_demo",
-            work_state="writing",
-            heartbeat_at="2026-04-21T23:00:00+00:00",
-        ),
-        active_view=False,
-        presence=presence,
-    )
-    reviewing = RailItem(
-        CockpitItem(
-            "russell",
-            "Russell",
-            "ready",
-            session_name="reviewer",
-            work_state="reviewing",
-            heartbeat_at="2026-04-21T23:00:00+00:00",
-        ),
-        active_view=False,
-        presence=presence,
-    )
-    stuck = RailItem(
-        CockpitItem(
-            "project:demo",
-            "Demo",
-            "! pane dead",
-            session_name="worker_demo",
-            work_state="stuck",
-            heartbeat_at="2026-04-21T23:00:00+00:00",
-        ),
-        active_view=False,
-        presence=presence,
-    )
-    exited = RailItem(
-        CockpitItem(
-            "project:demo",
-            "Demo",
-            "dead",
-            session_name="worker_demo",
-            work_state="exited",
-            heartbeat_at="2026-04-21T23:00:00+00:00",
-        ),
-        active_view=False,
-        presence=presence,
-    )
-
-    assert writing._indicator()[0] == "♡◜"
-    assert reviewing._indicator()[0] == "♡✎"
-    assert stuck._indicator()[0] == "♡⚠"
-    assert exited._indicator()[0] == "♡✕"
-
-
-def test_cockpit_rail_session_indicator_combines_pulse_and_work_glyph(monkeypatch, tmp_path: Path) -> None:
-    config_path = tmp_path / "pollypm.toml"
-    config_path.write_text(
-        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
-    )
-
-    class _FakeTmux:
-        def current_session_name(self) -> str | None:
-            return "pollypm"
-
-        def list_clients(self, session_name: str) -> str:
-            del session_name
-            return "client"
-
-    rail = PollyCockpitRail(config_path)
-    rail.router.tmux = _FakeTmux()  # type: ignore[assignment]
-    rail.presence = CockpitPresence(_FakeTmux())
-
-    writing = CockpitItem(
-        "project:demo",
-        "Demo",
-        "◜ working",
-        session_name="worker_demo",
-        work_state="writing",
-        heartbeat_at="2026-04-21T23:00:00+00:00",
-    )
-    reviewing = CockpitItem(
-        "russell",
-        "Russell",
-        "ready",
-        session_name="reviewer",
-        work_state="reviewing",
-        heartbeat_at="2026-04-21T23:00:00+00:00",
-    )
-    stuck = CockpitItem(
-        "project:demo",
-        "Demo",
-        "! pane dead",
-        session_name="worker_demo",
-        work_state="stuck",
-        heartbeat_at="2026-04-21T23:00:00+00:00",
-    )
-    exited = CockpitItem(
-        "project:demo",
-        "Demo",
-        "dead",
-        session_name="worker_demo",
-        work_state="exited",
-        heartbeat_at="2026-04-21T23:00:00+00:00",
-    )
-
-    assert rail._indicator(writing)[0] == "♡◜"
-    assert rail._indicator(reviewing)[0] == "♡✎"
-    assert rail._indicator(stuck)[0] == "♡⚠"
-    assert rail._indicator(exited)[0] == "♡✕"
-
-
-def test_cockpit_rail_session_indicator_uses_static_ellipsis_in_calm_mode(
-    monkeypatch,
-    tmp_path: Path,
-) -> None:
-    monkeypatch.setenv("POLLY_CALM", "1")
-    config_path = tmp_path / "pollypm.toml"
-    config_path.write_text(
-        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
-    )
-
-    class _FakeTmux:
-        def current_session_name(self) -> str | None:
-            return "pollypm"
-
-        def list_clients(self, session_name: str) -> str:
-            del session_name
-            return "client"
-
-    rail = PollyCockpitRail(config_path)
-    rail.router.tmux = _FakeTmux()  # type: ignore[assignment]
-    rail.presence = CockpitPresence(_FakeTmux())
-
-    writing = CockpitItem(
-        "project:demo",
-        "Demo",
-        "◜ working",
-        session_name="worker_demo",
-        work_state="writing",
-        heartbeat_at="2026-04-21T23:00:00+00:00",
-    )
-
-    assert rail._indicator(writing)[0] == "♥…"
-
-
-def test_cockpit_ui_help_legend_mentions_glyph_alphabet() -> None:
-    binding = next(
-        binding for binding in PollyCockpitApp.BINDINGS if getattr(binding, "key", "") == "question_mark"
-    )
-
-    assert "pulse" in binding.description
-    assert "✎" in binding.description
-    assert "⚠" in binding.description
-    assert "✕" in binding.description
 
 
 def test_cockpit_router_config_cache_reuses_loaded_config(monkeypatch, tmp_path: Path) -> None:
@@ -668,6 +509,197 @@ def test_cockpit_router_caches_hidden_collapsed_and_grouped_registrations(monkey
     assert collapsed_first == collapsed_second == frozenset({"system"})
     assert grouped_first == grouped_second
     assert calls == {"hidden": 1, "collapsed": 1, "registry": 1}
+
+def test_cockpit_rail_render_includes_event_ticker(monkeypatch) -> None:
+    class _Event:
+        def __init__(self, event_type: str, session_name: str, created_at) -> None:
+            self.event_type = event_type
+            self.session_name = session_name
+            self.created_at = created_at
+
+    class _Store:
+        def recent_events(self, limit: int = 4):
+            del limit
+            now = datetime.now(UTC)
+            return [
+                _Event("session.started", "polly", now - timedelta(minutes=1)),
+                _Event("heartbeat", "heartbeat", now - timedelta(minutes=2)),
+            ]
+
+    class _Supervisor:
+        store = _Store()
+
+    class _Router:
+        def selected_key(self) -> str:
+            return "polly"
+
+        def _load_supervisor(self):
+            return _Supervisor()
+
+    rail = PollyCockpitRail.__new__(PollyCockpitRail)
+    rail.router = _Router()
+    rail.selected_key = "polly"
+    rail.spinner_index = 1
+    rail.slogan_started_at = 0.0
+    rail._ticker_started_at = 0.0
+    rail._last_items = []
+    rail._slogan_phase = 0
+    rail._current_slogan = lambda: ("Line one", "Line two")
+    rail._slogan_color = lambda: PALETTE["slogan"]
+
+    captured: list[str] = []
+    rail._write = lambda text: captured.append(text)
+    monkeypatch.setattr("pollypm.cockpit_rail._viewer_attached", lambda: True)
+    monkeypatch.setattr("pollypm.cockpit_rail.time.monotonic", lambda: 11.0)
+    monkeypatch.setattr(
+        "pollypm.cockpit_rail.shutil.get_terminal_size",
+        lambda fallback=(30, 24): type("Size", (), {"columns": 120, "lines": 20})(),
+    )
+
+    rail._render([CockpitItem(key="polly", label="Polly", state="idle"), CockpitItem(key="settings", label="Settings", state="idle")])
+
+    assert rail._event_ticker_text() == "events · heartbeat:heartbeat"
+    assert captured
+
+
+def test_cockpit_rail_hides_event_ticker_when_empty(monkeypatch) -> None:
+    class _Store:
+        def recent_events(self, limit: int = 12):
+            del limit
+            return []
+
+    class _Supervisor:
+        store = _Store()
+
+    class _Router:
+        def selected_key(self) -> str:
+            return "polly"
+
+        def _load_supervisor(self):
+            return _Supervisor()
+
+    rail = PollyCockpitRail.__new__(PollyCockpitRail)
+    rail.router = _Router()
+    rail._ticker_started_at = 0.0
+    monkeypatch.setattr("pollypm.cockpit_rail._viewer_attached", lambda: True)
+    assert rail._event_ticker_text() == ""
+
+
+def test_cockpit_rail_keybinds_activity_and_pin(monkeypatch) -> None:
+    calls: list[tuple[str, str | None]] = []
+
+    class _Router:
+        def route_selected(self, key: str) -> None:
+            calls.append(("route", key))
+
+        def toggle_pinned_project(self, project_key: str) -> None:
+            calls.append(("pin", project_key))
+
+    rail = PollyCockpitRail.__new__(PollyCockpitRail)
+    rail.router = _Router()
+    rail.selected_key = "project:demo"
+
+    assert rail._handle_key(b"t", []) is True
+    rail.selected_key = "project:demo"
+    assert rail._handle_key(b"p", []) is True
+
+    assert ("route", "activity") in calls
+    assert ("pin", "demo") in calls
+
+
+def test_cockpit_ui_event_ticker_cycles_and_hides_when_empty(monkeypatch, tmp_path: Path) -> None:
+    class _Event:
+        def __init__(self, event_type: str, session_name: str) -> None:
+            self.event_type = event_type
+            self.session_name = session_name
+
+    class _Store:
+        def __init__(self, events: list[_Event]) -> None:
+            self._events = events
+
+        def recent_events(self, limit: int = 12):
+            del limit
+            return self._events
+
+    class _Supervisor:
+        def __init__(self, events: list[_Event]) -> None:
+            self.store = _Store(events)
+
+    class _Router:
+        def __init__(self, events: list[_Event]) -> None:
+            self._supervisor = _Supervisor(events)
+
+        def selected_key(self) -> str:
+            return "polly"
+
+        def _load_supervisor(self):
+            return self._supervisor
+
+        def build_items(self, *, spinner_index: int = 0):
+            del spinner_index
+            return [
+                CockpitItem("polly", "Polly", "ready"),
+                CockpitItem("settings", "Settings", "config"),
+            ]
+
+    app = PollyCockpitApp(tmp_path / "pollypm.toml")
+    app.router = _Router([_Event("commit", "worker_demo"), _Event("review", "system")])  # type: ignore[assignment]
+    app._ticker_started_at = 0.0
+    monkeypatch.setattr("pollypm.cockpit_ui._viewer_attached", lambda: True)
+    monkeypatch.setattr("pollypm.cockpit_ui.time.monotonic", lambda: 11.0)
+
+    assert app._event_ticker_text() == "events · review:system"
+
+    app.router = _Router([])  # type: ignore[assignment]
+    assert app._event_ticker_text() == ""
+
+    monkeypatch.setattr("pollypm.cockpit_ui._viewer_attached", lambda: False)
+    assert app._event_ticker_text() == ""
+
+
+def test_cockpit_ui_bindings_expose_activity_and_pin_legend() -> None:
+    bindings = {binding.key: binding.description for binding in PollyCockpitApp.BINDINGS}
+
+    assert bindings["t"] == "Activity"
+    assert bindings["p"] == "Pin Project"
+
+
+def test_cockpit_ui_activity_and_pin_actions_route_live_rail(monkeypatch, tmp_path: Path) -> None:
+    calls: list[tuple[str, str]] = []
+
+    class _Router:
+        def selected_key(self) -> str:
+            return "project:demo"
+
+        def route_selected(self, key: str) -> None:
+            calls.append(("route", key))
+
+        def toggle_pinned_project(self, project_key: str) -> None:
+            calls.append(("pin", project_key))
+
+    app = PollyCockpitApp(tmp_path / "pollypm.toml")
+    app.router = _Router()  # type: ignore[assignment]
+    monkeypatch.setattr(app, "_refresh_rows", lambda: calls.append(("refresh", "yes")))
+    monkeypatch.setattr(app, "_selected_row_key", lambda: "project:demo")
+
+    app.action_open_activity()
+    app.action_toggle_project_pin()
+
+    assert ("route", "activity") in calls
+    assert ("pin", "demo") in calls
+    assert ("refresh", "yes") in calls
+
+
+def test_cockpit_ui_section_separator_rows_use_section_style(monkeypatch) -> None:
+    monkeypatch.setattr(RailItem, "update_body", lambda self: None)
+
+    row = RailItem(
+        CockpitItem("_section:projects", "PROJECTS (3)", "separator", selectable=False),
+        active_view=False,
+    )
+
+    assert row.has_class("section-sep")
+    assert row.disabled is True
 
 
 def test_cockpit_router_selected_key_clears_missing_right_pane_state(monkeypatch, tmp_path: Path) -> None:
@@ -1965,32 +1997,6 @@ def test_cockpit_ui_arrow_and_enter_route_selected(tmp_path: Path) -> None:
             assert app.router.calls == ["inbox"]
 
     asyncio.run(exercise())
-
-
-def test_cockpit_rail_ctrl_k_routes_to_settings(monkeypatch, tmp_path: Path) -> None:
-    class FakeRouter:
-        def __init__(self, _config_path: Path) -> None:
-            self.calls: list[str] = []
-            self.tmux = None
-
-        def selected_key(self) -> str:
-            return "polly"
-
-        def route_selected(self, key: str) -> None:
-            self.calls.append(key)
-
-    monkeypatch.setattr("pollypm.cockpit_rail.CockpitRouter", FakeRouter)
-    from pollypm.cockpit_rail import CockpitItem, PollyCockpitRail
-
-    rail = PollyCockpitRail(tmp_path / "pollypm.toml")
-    items = [
-        CockpitItem("polly", "Polly", "ready"),
-        CockpitItem("settings", "Settings", "config"),
-    ]
-
-    assert rail._handle_key(b"\x0b", items) is True
-    assert rail.router.calls == ["settings"]
-    assert rail.selected_key == "settings"
 
 
 def test_settings_pane_renders_accounts_and_toggles_permissions(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_rail_cli.py
+++ b/tests/test_rail_cli.py
@@ -164,69 +164,6 @@ def test_build_items_collapses_sections(monkeypatch, tmp_path: Path) -> None:
     assert header.label == "SYSTEM (1)"
 
 
-def test_build_items_auto_collapses_empty_sections(monkeypatch, tmp_path: Path) -> None:
-    from pollypm.cockpit_rail import CockpitRouter
-    from pollypm.models import KnownProject, ProjectKind
-    from pollypm.plugin_api.v1 import RailRow
-
-    class _FakeConfig:
-        def __init__(self, tmp_path: Path) -> None:
-            class Project:
-                root_dir = tmp_path
-                base_dir = tmp_path / ".pollypm"
-                tmux_session = "pollypm"
-
-            self.project = Project()
-            self.projects = {
-                "demo": KnownProject(key="demo", path=tmp_path / "demo", name="Demo", kind=ProjectKind.GIT),
-            }
-            self.rail = RailSettings()
-
-    class FakeSupervisor:
-        def __init__(self, cfg) -> None:
-            self.config = cfg
-
-        def status(self):
-            return [], [], [], [], []
-
-    class _Reg:
-        section = "workflows"
-        item_key = "workflows.empty"
-        visibility = "always"
-        rows_provider = None
-        label_provider = None
-        state_provider = None
-        badge_provider = None
-
-    class _Registry:
-        def items(self):
-            return [_Reg()]
-
-    monkeypatch.setattr(
-        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 0,
-    )
-    monkeypatch.setattr(
-        "pollypm.cockpit_rail.load_config", lambda path: _FakeConfig(tmp_path),
-    )
-    cfg = _FakeConfig(tmp_path)
-    cfg_path = tmp_path / "pollypm.toml"
-    cfg_path.write_text(f"[project]\nname = \"P\"\nbase_dir = \"{tmp_path}\"\n")
-    router = CockpitRouter(cfg_path)
-    monkeypatch.setattr(router, "_load_supervisor", lambda: FakeSupervisor(cfg))
-    monkeypatch.setattr(router, "_rail_registry", lambda: _Registry())
-    monkeypatch.setattr(
-        "pollypm.cockpit_rail._rows_for_registration",
-        lambda reg, ctx: [RailRow(key="workflows.empty", label="Empty", state="idle")],
-    )
-
-    items = router.build_items(spinner_index=0)
-    keys = [i.key for i in items]
-    assert any(k.startswith("_section:workflows") for k in keys)
-    header = next(i for i in items if i.key.startswith("_section:workflows"))
-    assert header.label == "WORKFLOWS (1)"
-    assert "workflows.empty" not in keys
-
-
 # ---------------------------------------------------------------------------
 # CLI — list / hide / show
 # ---------------------------------------------------------------------------

--- a/tests/test_rail_cli.py
+++ b/tests/test_rail_cli.py
@@ -164,6 +164,69 @@ def test_build_items_collapses_sections(monkeypatch, tmp_path: Path) -> None:
     assert header.label == "SYSTEM (1)"
 
 
+def test_build_items_auto_collapses_empty_sections(monkeypatch, tmp_path: Path) -> None:
+    from pollypm.cockpit_rail import CockpitRouter
+    from pollypm.models import KnownProject, ProjectKind
+    from pollypm.plugin_api.v1 import RailRow
+
+    class _FakeConfig:
+        def __init__(self, tmp_path: Path) -> None:
+            class Project:
+                root_dir = tmp_path
+                base_dir = tmp_path / ".pollypm"
+                tmux_session = "pollypm"
+
+            self.project = Project()
+            self.projects = {
+                "demo": KnownProject(key="demo", path=tmp_path / "demo", name="Demo", kind=ProjectKind.GIT),
+            }
+            self.rail = RailSettings()
+
+    class FakeSupervisor:
+        def __init__(self, cfg) -> None:
+            self.config = cfg
+
+        def status(self):
+            return [], [], [], [], []
+
+    class _Reg:
+        section = "workflows"
+        item_key = "workflows.empty"
+        visibility = "always"
+        rows_provider = None
+        label_provider = None
+        state_provider = None
+        badge_provider = None
+
+    class _Registry:
+        def items(self):
+            return [_Reg()]
+
+    monkeypatch.setattr(
+        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 0,
+    )
+    monkeypatch.setattr(
+        "pollypm.cockpit_rail.load_config", lambda path: _FakeConfig(tmp_path),
+    )
+    cfg = _FakeConfig(tmp_path)
+    cfg_path = tmp_path / "pollypm.toml"
+    cfg_path.write_text(f"[project]\nname = \"P\"\nbase_dir = \"{tmp_path}\"\n")
+    router = CockpitRouter(cfg_path)
+    monkeypatch.setattr(router, "_load_supervisor", lambda: FakeSupervisor(cfg))
+    monkeypatch.setattr(router, "_rail_registry", lambda: _Registry())
+    monkeypatch.setattr(
+        "pollypm.cockpit_rail._rows_for_registration",
+        lambda reg, ctx: [RailRow(key="workflows.empty", label="Empty", state="idle")],
+    )
+
+    items = router.build_items(spinner_index=0)
+    keys = [i.key for i in items]
+    assert any(k.startswith("_section:workflows") for k in keys)
+    header = next(i for i in items if i.key.startswith("_section:workflows"))
+    assert header.label == "WORKFLOWS (1)"
+    assert "workflows.empty" not in keys
+
+
 # ---------------------------------------------------------------------------
 # CLI — list / hide / show
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
- add smart rail section collapsing with counts and auto-expand behavior
- add a bottom event ticker plus per-project activity sparklines
- support pinning priority projects to the top of the rail

Testing:
- uv run --with pytest python -m pytest -q tests/test_cockpit.py tests/test_rail_cli.py tests/test_core_rail_items.py
- python -m compileall -q src/pollypm/cockpit_rail.py tests/test_cockpit.py tests/test_rail_cli.py

Closes #666
Closes #667
Closes #668
Closes #677