### PR TITLE
perf(core): cache work-output decode and scan hot paths

### DIFF
--- a/src/pollypm/cockpit_activity.py
+++ b/src/pollypm/cockpit_activity.py
@@ -261,6 +261,7 @@ class PollyActivityFeedApp(App[None]):
     def __init__(self, config_path: Path, *, project_key: str | None = None) -> None:
         super().__init__()
         self.config_path = config_path
+        self._config = None
         self._initial_project_filter = project_key or None
         self.topbar = Static("", id="af-topbar", markup=True)
         self.counters = Static("", id="af-counters", markup=True)
@@ -280,6 +281,11 @@ class PollyActivityFeedApp(App[None]):
         self._open_entry_id: str | None = None
         self._follow_on: bool = False
         self._follow_timer = None
+
+    def _load_config(self):
+        if self._config is None:
+            self._config = load_config(self.config_path)
+        return self._config
 
     def compose(self) -> ComposeResult:
         with Vertical(id="af-outer"):
@@ -311,7 +317,7 @@ class PollyActivityFeedApp(App[None]):
         from pollypm.cockpit import _gather_activity_feed
 
         try:
-            config = load_config(self.config_path)
+            config = self._load_config()
         except Exception:  # noqa: BLE001
             return []
         return _gather_activity_feed(
@@ -545,8 +551,9 @@ class PollyActivityFeedApp(App[None]):
 
     def action_pick_project(self) -> None:
         keys = sorted({entry.project or "" for entry in self._entries if entry.project})
+        ellipsis = " …" if len(keys) > 6 else ""
         hint = (
-            f"project: {', '.join(keys[:6])}{' \u2026' if len(keys) > 6 else ''}"
+            f"project: {', '.join(keys[:6])}{ellipsis}"
             if keys
             else "project: (no projects in current window)"
         )
@@ -554,8 +561,9 @@ class PollyActivityFeedApp(App[None]):
 
     def action_pick_type(self) -> None:
         kinds = sorted({entry.kind or "" for entry in self._entries if entry.kind})
+        ellipsis = " …" if len(kinds) > 6 else ""
         hint = (
-            f"type: {', '.join(kinds[:6])}{' \u2026' if len(kinds) > 6 else ''}"
+            f"type: {', '.join(kinds[:6])}{ellipsis}"
             if kinds
             else "type: (no event types in current window)"
         )

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -117,6 +117,12 @@ from pollypm.cockpit_rail import CockpitItem, CockpitRouter
 import re as _re
 
 
+_INLINE_BOLD_RE = _re.compile(r"\*\*(.+?)\*\*")
+_INLINE_ITALIC_RE = _re.compile(r"\*(.+?)\*")
+_INLINE_CODE_RE = _re.compile(r"`(.+?)`")
+_ORDERED_LIST_RE = _re.compile(r"\s*\d+\.\s")
+
+
 def _md_to_rich(text: str) -> str:
     """Convert common markdown to Rich markup for Textual Static widgets."""
     lines: list[str] = []
@@ -138,15 +144,15 @@ def _md_to_rich(text: str) -> str:
             lines.append(f"\n[b u]{line[2:]}[/b u]")
         else:
             # Inline formatting first (applies to all non-code lines)
-            line = _re.sub(r"\*\*(.+?)\*\*", r"[b]\1[/b]", line)
-            line = _re.sub(r"\*(.+?)\*", r"[i]\1[/i]", line)
-            line = _re.sub(r"`(.+?)`", r"[dim]\1[/dim]", line)
+            line = _INLINE_BOLD_RE.sub(r"[b]\1[/b]", line)
+            line = _INLINE_ITALIC_RE.sub(r"[i]\1[/i]", line)
+            line = _INLINE_CODE_RE.sub(r"[dim]\1[/dim]", line)
             # Bullet points
             if line.strip().startswith("- "):
                 indent = len(line) - len(line.lstrip())
                 content = line.strip()[2:]
                 lines.append(f"{'  ' * (indent // 2)}  • {content}")
-            elif _re.match(r"\s*\d+\.\s", line):
+            elif _ORDERED_LIST_RE.match(line):
                 lines.append(f"  {line.strip()}")
             else:
                 lines.append(line)
@@ -3851,7 +3857,8 @@ class _RollupItem(ListItem):
             header += f"  [dim]{_escape(age)}[/dim]"
         lines = [header]
         if ref_bits:
-            lines.append(f"[dim]{_escape(' \u00b7 '.join(ref_bits))}[/dim]")
+            separator = " · "
+            lines.append(f"[dim]{_escape(separator.join(ref_bits))}[/dim]")
         if self.expanded:
             body = (self.item.get("body") or "").strip()
             if body:
@@ -3866,7 +3873,8 @@ class _RollupItem(ListItem):
                 meta_bits.append(source_project)
             if meta_bits:
                 lines.append("")
-                lines.append(f"[dim]{_escape(' \u00b7 '.join(meta_bits))}[/dim]")
+                meta_separator = " · "
+                lines.append(f"[dim]{_escape(meta_separator.join(meta_bits))}[/dim]")
         return "\n".join(lines)
 
 

--- a/src/pollypm/transcript_ingest.py
+++ b/src/pollypm/transcript_ingest.py
@@ -49,6 +49,7 @@ class TranscriptCursorState:
 class TranscriptSourceScanCache:
     known_files: tuple[str, ...] = ()
     dir_mtimes: dict[str, float] = field(default_factory=dict)
+    root_mtime_ns: int = 0
     last_full_scan_at: float = 0.0
 
 
@@ -549,9 +550,14 @@ def _build_source_scan_cache(root: Path, files: list[Path], *, now: float) -> Tr
             dir_mtimes[directory_key] = Path(directory_key).stat().st_mtime
         except OSError:
             continue
+    try:
+        root_mtime_ns = root.stat().st_mtime_ns
+    except OSError:
+        root_mtime_ns = 0
     return TranscriptSourceScanCache(
         known_files=tuple(str(path) for path in files),
         dir_mtimes=dir_mtimes,
+        root_mtime_ns=root_mtime_ns,
         last_full_scan_at=now,
     )
 
@@ -591,9 +597,18 @@ def _scan_paths_for_source(source: TranscriptSource, state: TranscriptCursorStat
     cache = _SOURCE_SCAN_CACHE.get(cache_key)
     if cache is None:
         return _full_scan_paths(source, now=now)
-    if now - cache.last_full_scan_at >= FULL_RESCAN_SECONDS:
+    try:
+        current_root_mtime_ns = source.root.stat().st_mtime_ns
+    except OSError:
         return _full_scan_paths(source, now=now)
     if _dir_snapshot_changed(cache):
+        return _full_scan_paths(source, now=now)
+    if (
+        now - cache.last_full_scan_at >= FULL_RESCAN_SECONDS
+        and current_root_mtime_ns == cache.root_mtime_ns
+    ):
+        return _incremental_scan_paths(cache, state, now=now)
+    if now - cache.last_full_scan_at >= FULL_RESCAN_SECONDS:
         return _full_scan_paths(source, now=now)
     return _incremental_scan_paths(cache, state, now=now)
 

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -26,6 +26,7 @@ import sqlite3
 import subprocess
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +131,7 @@ class SQLiteWorkService:
         create_work_tables(self._conn)
         self._gate_registry = GateRegistry(project_path=project_path)
         self._flow_cache: dict[tuple[str, int], FlowTemplate] = {}
+        self._work_output_cache: dict[str, dict[str, Any]] = {}
         self._dependency_mgr = WorkDependencyManager(self)
         self._transition_mgr = WorkTransitionManager(self)
         self._worker_session_mgr = WorkSessionManager(self)
@@ -150,6 +152,7 @@ class SQLiteWorkService:
     def close(self) -> None:
         """Close the database connection."""
         self._flow_cache.clear()
+        self._work_output_cache.clear()
         self._conn.close()
 
     def __enter__(self):
@@ -585,10 +588,20 @@ class SQLiteWorkService:
             "SELECT "
             "from_project, from_task_number, "
             "to_project, to_task_number, "
-            "kind "
+            "kind, "
+            "1 AS is_outgoing, "
+            "0 AS is_incoming "
             "FROM work_task_dependencies "
-            "WHERE (from_project = ? AND from_task_number = ?) "
-            "   OR (to_project = ? AND to_task_number = ?)",
+            "WHERE from_project = ? AND from_task_number = ? "
+            "UNION ALL "
+            "SELECT "
+            "from_project, from_task_number, "
+            "to_project, to_task_number, "
+            "kind, "
+            "0 AS is_outgoing, "
+            "1 AS is_incoming "
+            "FROM work_task_dependencies "
+            "WHERE to_project = ? AND to_task_number = ?",
             (project, task_number, project, task_number),
         ).fetchall()
 
@@ -603,13 +616,7 @@ class SQLiteWorkService:
 
         for r in rows:
             kind = r["kind"]
-            is_outgoing = (
-                r["from_project"] == project and r["from_task_number"] == task_number
-            )
-            is_incoming = (
-                r["to_project"] == project and r["to_task_number"] == task_number
-            )
-            if is_outgoing:
+            if r["is_outgoing"]:
                 target = (r["to_project"], r["to_task_number"])
                 if kind == LinkKind.BLOCKS.value:
                     rels["blocks"].append(target)
@@ -620,7 +627,7 @@ class SQLiteWorkService:
                 elif kind == LinkKind.SUPERSEDES.value:
                     # outgoing supersedes: this task supersedes target
                     pass  # stored in supersedes_project/supersedes_task_number columns
-            if is_incoming:
+            if r["is_incoming"]:
                 source = (r["from_project"], r["from_task_number"])
                 if kind == LinkKind.BLOCKS.value:
                     rels["blocked_by"].append(source)
@@ -666,24 +673,7 @@ class SQLiteWorkService:
         ).fetchall()
         result: list[FlowNodeExecution] = []
         for r in rows:
-            wo_raw = r["work_output"]
-            work_output: WorkOutput | None = None
-            if wo_raw:
-                wo_dict = json.loads(wo_raw)
-                work_output = WorkOutput(
-                    type=OutputType(wo_dict["type"]),
-                    summary=wo_dict["summary"],
-                    artifacts=[
-                        Artifact(
-                            kind=ArtifactKind(a["kind"]),
-                            description=a.get("description", ""),
-                            ref=a.get("ref"),
-                            path=a.get("path"),
-                            external_ref=a.get("external_ref"),
-                        )
-                        for a in wo_dict.get("artifacts", [])
-                    ],
-                )
+            work_output = self._decode_work_output(r["work_output"])
             result.append(
                 FlowNodeExecution(
                     task_id=f"{r['task_project']}/{r['task_number']}",
@@ -708,6 +698,31 @@ class SQLiteWorkService:
                 )
             )
         return result
+
+    def _decode_work_output(self, raw: str | None) -> WorkOutput | None:
+        if not raw:
+            return None
+        wo_dict = self._work_output_cache.get(raw)
+        if wo_dict is None:
+            parsed = json.loads(raw)
+            if not isinstance(parsed, dict):
+                return None
+            wo_dict = parsed
+            self._work_output_cache[raw] = wo_dict
+        return WorkOutput(
+            type=OutputType(wo_dict["type"]),
+            summary=wo_dict["summary"],
+            artifacts=[
+                Artifact(
+                    kind=ArtifactKind(a["kind"]),
+                    description=a.get("description", ""),
+                    ref=a.get("ref"),
+                    path=a.get("path"),
+                    external_ref=a.get("external_ref"),
+                )
+                for a in wo_dict.get("artifacts", [])
+            ],
+        )
 
     def _record_transition(
         self,
@@ -1238,24 +1253,7 @@ class SQLiteWorkService:
 
         result: list[FlowNodeExecution] = []
         for r in rows:
-            wo_raw = r["work_output"]
-            wo: WorkOutput | None = None
-            if wo_raw:
-                wo_dict = json.loads(wo_raw)
-                wo = WorkOutput(
-                    type=OutputType(wo_dict["type"]),
-                    summary=wo_dict["summary"],
-                    artifacts=[
-                        Artifact(
-                            kind=ArtifactKind(a["kind"]),
-                            description=a.get("description", ""),
-                            ref=a.get("ref"),
-                            path=a.get("path"),
-                            external_ref=a.get("external_ref"),
-                        )
-                        for a in wo_dict.get("artifacts", [])
-                    ],
-                )
+            wo = self._decode_work_output(r["work_output"])
             result.append(
                 FlowNodeExecution(
                     task_id=f"{r['task_project']}/{r['task_number']}",

--- a/tests/test_activity_feed_ui.py
+++ b/tests/test_activity_feed_ui.py
@@ -350,6 +350,33 @@ def test_render_scans_filtered_rows_only_once_per_render(
     _run(body())
 
 
+def test_activity_panel_caches_loaded_config(activity_env, monkeypatch) -> None:
+    """The panel should load config once per app instance."""
+    if not _load_config_compatible(activity_env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+
+    from pollypm.cockpit_ui import PollyActivityFeedApp
+
+    calls = 0
+    fake_config = object()
+
+    def fake_load(_path):
+        nonlocal calls
+        calls += 1
+        return fake_config
+
+    monkeypatch.setattr("pollypm.cockpit_activity.load_config", fake_load)
+    monkeypatch.setattr(
+        "pollypm.cockpit._gather_activity_feed",
+        lambda config, **_kwargs: [config],
+    )
+
+    app = PollyActivityFeedApp(activity_env["config_path"])
+    assert app._gather() == [fake_config]
+    assert app._gather() == [fake_config]
+    assert calls == 1
+
+
 # ---------------------------------------------------------------------------
 # 4. Follow mode toggles + refreshes.
 # ---------------------------------------------------------------------------

--- a/tests/test_flow_progression.py
+++ b/tests/test_flow_progression.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 
 import pytest
@@ -539,6 +540,33 @@ class TestGetExecution:
         assert stored.artifacts[0].kind == ArtifactKind.COMMIT
         assert stored.artifacts[0].ref == "sha123"
         assert stored.artifacts[1].path == "src/main.py"
+
+    def test_get_execution_reuses_decoded_work_output(self, svc, monkeypatch):
+        task = _create_task(svc)
+        _claim_task(svc, task)
+
+        wo = _valid_work_output()
+        svc.node_done(task.task_id, "pete", wo)
+        svc.reject(task.task_id, "polly", "Redo it")
+        svc.node_done(task.task_id, "pete", wo)
+        svc._work_output_cache.clear()
+
+        loads = 0
+        original_loads = json.loads
+
+        def counting_loads(raw, *args, **kwargs):
+            nonlocal loads
+            loads += 1
+            return original_loads(raw, *args, **kwargs)
+
+        monkeypatch.setattr("pollypm.work.sqlite_service.json.loads", counting_loads)
+
+        first = svc.get_execution(task.task_id, node_id="implement")
+        second = svc.get_execution(task.task_id, node_id="implement")
+
+        assert len(first) == 2
+        assert len(second) == 2
+        assert loads == 1
 
     def test_get_execution_filters(self, svc):
         task = _create_task(svc)

--- a/tests/test_project_dashboard_plan_viewer.py
+++ b/tests/test_project_dashboard_plan_viewer.py
@@ -161,6 +161,19 @@ def test_plan_content_empty_when_no_file(env, app) -> None:
     _run(body())
 
 
+def test_md_to_rich_preserves_inline_markdown_helpers() -> None:
+    """The markdown-to-rich helper should keep its inline formatting."""
+    from pollypm.cockpit_ui import _md_to_rich
+
+    rendered = _md_to_rich("**bold** *italic* `code`\n1. item\n- bullet")
+
+    assert "[b]bold[/b]" in rendered
+    assert "[i]italic[/i]" in rendered
+    assert "[dim]code[/dim]" in rendered
+    assert "1. item" in rendered
+    assert "• bullet" in rendered
+
+
 # ---------------------------------------------------------------------------
 # 3. TOC lists H2 sections
 # ---------------------------------------------------------------------------

--- a/tests/test_transcript_ingest.py
+++ b/tests/test_transcript_ingest.py
@@ -363,6 +363,51 @@ def test_sync_transcripts_once_reads_live_append_without_fresh_rglob(monkeypatch
     assert [event["payload"]["text"] for event in events if event["event_type"] == "assistant_turn"] == ["First", "Second"]
 
 
+def test_sync_transcripts_once_skips_full_rescan_when_root_mtime_stable(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config, _config_path = _config(tmp_path)
+    claude_root = config.accounts["claude_main"].home / ".claude/projects/demo"
+    live_file = claude_root / "session-stable.jsonl"
+    live_file.parent.mkdir(parents=True, exist_ok=True)
+    live_file.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-10T00:00:00Z",
+                "type": "assistant",
+                "sessionId": "session-stable",
+                "cwd": str(config.project.root_dir),
+                "message": {"content": [{"type": "text", "text": "First"}], "usage": {"total_tokens": 1}},
+            }
+        )
+        + "\n"
+    )
+
+    sync_transcripts_once(config)
+    from pollypm import transcript_ingest as ingest
+
+    for cache in ingest._SOURCE_SCAN_CACHE.values():
+        cache.last_full_scan_at = time.time() - ingest.FULL_RESCAN_SECONDS - 5
+
+    full_scan_calls = 0
+    original_full_scan = ingest._full_scan_paths
+
+    def counting_full_scan(source, *, now):
+        nonlocal full_scan_calls
+        full_scan_calls += 1
+        return original_full_scan(source, now=now)
+
+    monkeypatch.setattr("pollypm.transcript_ingest._full_scan_paths", counting_full_scan)
+    sync_transcripts_once(config)
+
+    events = [
+        json.loads(line)
+        for line in (config.project.root_dir / ".pollypm/transcripts/session-stable/events.jsonl").read_text().splitlines()
+    ]
+    assert full_scan_calls == 0
+    assert [event["payload"]["text"] for event in events if event["event_type"] == "assistant_turn"] == ["First"]
+
+
 def test_service_load_supervisor_does_not_start_transcript_ingestion(monkeypatch, tmp_path: Path) -> None:
     _loaded_config, config_path = _config(tmp_path)
     calls: list[str] = []


### PR DESCRIPTION
Summary:
- cache decoded work_output payloads and collapse relationship loading into one UNION query
- cache the activity feed config and precompile markdown-to-rich regexes
- skip transcript rescans when the transcript root has not changed

Testing:
- python -m py_compile src/pollypm/work/sqlite_service.py src/pollypm/transcript_ingest.py src/pollypm/cockpit_activity.py src/pollypm/cockpit_ui.py tests/test_flow_progression.py tests/test_transcript_ingest.py tests/test_activity_feed_ui.py tests/test_project_dashboard_plan_viewer.py
- uv run --with pytest python -m pytest tests/test_flow_progression.py tests/test_work_dependencies.py -q
- uv run --with pytest python -m pytest tests/test_transcript_ingest.py -q
- uv run --with pytest python -m pytest tests/test_activity_feed_ui.py tests/test_project_dashboard_plan_viewer.py -q

Closes #683
Closes #685
Closes #686
Closes #687
Closes #688