### PR TITLE
feat(onboarding): add modular demo repo fallback

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,6 +43,10 @@ pm
 
 On a fresh machine, `pm` runs onboarding: it writes a default config to `~/.pollypm/config.toml`, walks you through your first account login, and creates the PollyPM tmux session. When it finishes, you're attached to the cockpit — a tmux layout with Polly on one side and a project/session rail on the other.
 
+If onboarding can't find any recently active local git repos, it can also copy
+a small self-contained demo repo into your workspace so you can exercise PollyPM
+without any network dependency beyond the account login you already completed.
+
 If you're already inside tmux when you run `pm`, PollyPM prints the attach command instead of grabbing your client:
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,8 @@ pollypm = [
   "defaults/magic/*/LICENSE",
   "defaults/docs/*.template",
   "defaults/docs/reference/*.md",
+  "defaults/demo/*",
+  "defaults/demo/**/*",
   "work/flows/*.yaml",
 ]
 

--- a/src/pollypm/defaults/demo/.gitignore
+++ b/src/pollypm/defaults/demo/.gitignore
@@ -1,0 +1,3 @@
+.pollypm/
+__pycache__/
+.pytest_cache/

--- a/src/pollypm/defaults/demo/README.md
+++ b/src/pollypm/defaults/demo/README.md
@@ -1,0 +1,12 @@
+# PollyPM Demo Repo
+
+This repo is the offline fallback used by onboarding when no recent local
+projects are detected.
+
+## What To Try
+
+- Run `python -m unittest discover -s tests -p "test_*.py"`
+- Read `demo_app.py`
+- Ask Polly to explain, extend, or test the queue summary behavior
+
+Everything in this repo uses only the Python standard library.

--- a/src/pollypm/defaults/demo/README.md
+++ b/src/pollypm/defaults/demo/README.md
@@ -3,10 +3,18 @@
 This repo is the offline fallback used by onboarding when no recent local
 projects are detected.
 
+It is intentionally small, but self-contained:
+
+- `demo_app.py` contains a tiny queue-summary helper with one deliberate bug.
+- `tests/test_demo_app.py` contains the matching failing regression test.
+- `TASK.md` describes the seeded PollyPM task that onboarding can add to the
+  project database.
+
 ## What To Try
 
 - Run `python -m unittest discover -s tests -p "test_*.py"`
 - Read `demo_app.py`
+- Fix the queue estimate regression, then rerun the demo tests
 - Ask Polly to explain, extend, or test the queue summary behavior
 
 Everything in this repo uses only the Python standard library.

--- a/src/pollypm/defaults/demo/README.md
+++ b/src/pollypm/defaults/demo/README.md
@@ -5,15 +5,20 @@ projects are detected.
 
 It is intentionally small, but self-contained:
 
+- The shipped repo is a 12-file mini project with a replayable git history.
+
 - `demo_app.py` contains a tiny queue-summary helper with one deliberate bug.
 - `tests/test_demo_app.py` contains the matching failing regression test.
+- `demo_cli.py` is a tiny entrypoint that prints the demo queue summary.
+- `demo_data.py` holds sample task titles used by the CLI and tests.
+- `demo_history.md` explains the replayable git history seeded by onboarding.
 - `TASK.md` describes the seeded PollyPM task that onboarding can add to the
   project database.
 
 ## What To Try
 
 - Run `python -m unittest discover -s tests -p "test_*.py"`
-- Read `demo_app.py`
+- Read `TASK.md` and `demo_history.md`
 - Fix the queue estimate regression, then rerun the demo tests
 - Ask Polly to explain, extend, or test the queue summary behavior
 

--- a/src/pollypm/defaults/demo/TASK.md
+++ b/src/pollypm/defaults/demo/TASK.md
@@ -1,0 +1,9 @@
+# Demo Task
+
+Fix the queue estimate regression in `demo_app.py`.
+
+The follow-up is intentionally small:
+
+- `estimate_focus_minutes(1)` should reserve a 30-minute block.
+- The demo test suite already includes a failing regression test.
+- Keep the task in PollyPM if you want it to show up in the seeded inbox.

--- a/src/pollypm/defaults/demo/TASK.md
+++ b/src/pollypm/defaults/demo/TASK.md
@@ -6,4 +6,5 @@ The follow-up is intentionally small:
 
 - `estimate_focus_minutes(1)` should reserve a 30-minute block.
 - The demo test suite already includes a failing regression test.
+- The repo history is replayable so you can inspect the change in three commits.
 - Keep the task in PollyPM if you want it to show up in the seeded inbox.

--- a/src/pollypm/defaults/demo/demo_app.py
+++ b/src/pollypm/defaults/demo/demo_app.py
@@ -1,0 +1,21 @@
+"""Small offline demo for PollyPM onboarding."""
+
+from __future__ import annotations
+
+
+def summarize_queue(items: list[str]) -> str:
+    cleaned = [item.strip() for item in items if item.strip()]
+    if not cleaned:
+        return "No tasks queued."
+    if len(cleaned) == 1:
+        return f"1 task queued: {cleaned[0]}"
+    preview = ", ".join(cleaned[:2])
+    if len(cleaned) > 2:
+        preview += f", +{len(cleaned) - 2} more"
+    return f"{len(cleaned)} tasks queued: {preview}"
+
+
+def estimate_focus_minutes(task_count: int, *, per_task: int = 25) -> int:
+    if task_count <= 0:
+        return 0
+    return task_count * per_task

--- a/src/pollypm/defaults/demo/demo_app.py
+++ b/src/pollypm/defaults/demo/demo_app.py
@@ -16,6 +16,11 @@ def summarize_queue(items: list[str]) -> str:
 
 
 def estimate_focus_minutes(task_count: int, *, per_task: int = 25) -> int:
+    """Return a rough focus block estimate for the queue.
+
+    The demo task deliberately asks the user to fix the single-item
+    estimate bug in the follow-up regression test.
+    """
     if task_count <= 0:
         return 0
     return task_count * per_task

--- a/src/pollypm/defaults/demo/demo_cli.py
+++ b/src/pollypm/defaults/demo/demo_cli.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import argparse
+
+from demo_app import estimate_focus_minutes, summarize_queue
+from demo_data import demo_task_titles
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="demo-polly")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("summary", help="Print the queue summary.")
+    subparsers.add_parser("tasks", help="Print the sample demo tasks.")
+    subparsers.add_parser("focus", help="Print the focus estimate.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "summary":
+        print(summarize_queue(demo_task_titles()))
+        return 0
+    if args.command == "tasks":
+        for title in demo_task_titles():
+            print(f"- {title}")
+        return 0
+    if args.command == "focus":
+        print(f"{estimate_focus_minutes(len(demo_task_titles()))} minutes")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pollypm/defaults/demo/demo_data.py
+++ b/src/pollypm/defaults/demo/demo_data.py
@@ -1,0 +1,13 @@
+"""Sample tasks for the offline PollyPM demo."""
+
+from __future__ import annotations
+
+DEMO_TASKS: list[dict[str, str]] = [
+    {"title": "Fix the queue estimate bug", "kind": "bug"},
+    {"title": "Write a demo launch note", "kind": "docs"},
+    {"title": "Review the seeded git history", "kind": "ops"},
+]
+
+
+def demo_task_titles() -> list[str]:
+    return [item["title"] for item in DEMO_TASKS]

--- a/src/pollypm/defaults/demo/demo_history.md
+++ b/src/pollypm/defaults/demo/demo_history.md
@@ -1,0 +1,12 @@
+# Demo History
+
+This repo is replayable: onboarding seeds a short git history so the
+demo feels like a real project instead of a single snapshot.
+
+Three commits are seeded:
+
+1. scaffold the offline fallback
+2. introduce the queue bug
+3. add task notes and the replay guide
+
+Use `git log --oneline --reverse` to walk the change in order.

--- a/src/pollypm/defaults/demo/tests/test_demo_app.py
+++ b/src/pollypm/defaults/demo/tests/test_demo_app.py
@@ -14,6 +14,10 @@ class DemoAppTests(unittest.TestCase):
     def test_estimate_focus_minutes_uses_default_block(self) -> None:
         self.assertEqual(estimate_focus_minutes(3), 75)
 
+    def test_estimate_focus_minutes_reserves_a_half_hour_for_one_task(self) -> None:
+        """Intentional demo bug: the helper still underestimates a single task."""
+        self.assertEqual(estimate_focus_minutes(1), 30)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/pollypm/defaults/demo/tests/test_demo_app.py
+++ b/src/pollypm/defaults/demo/tests/test_demo_app.py
@@ -1,0 +1,19 @@
+import unittest
+
+from demo_app import estimate_focus_minutes, summarize_queue
+
+
+class DemoAppTests(unittest.TestCase):
+    def test_summarize_queue_handles_empty_input(self) -> None:
+        self.assertEqual(summarize_queue([]), "No tasks queued.")
+
+    def test_summarize_queue_shows_preview_and_count(self) -> None:
+        summary = summarize_queue(["plan onboarding", "write docs", "ship fallback"])
+        self.assertEqual(summary, "3 tasks queued: plan onboarding, write docs, +1 more")
+
+    def test_estimate_focus_minutes_uses_default_block(self) -> None:
+        self.assertEqual(estimate_focus_minutes(3), 75)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/pollypm/defaults/demo/tests/test_demo_cli.py
+++ b/src/pollypm/defaults/demo/tests/test_demo_cli.py
@@ -1,0 +1,13 @@
+from contextlib import redirect_stdout
+from io import StringIO
+
+from demo_cli import main
+
+
+def test_summary_command_prints_queue_summary() -> None:
+    buffer = StringIO()
+    with redirect_stdout(buffer):
+        assert main(["summary"]) == 0
+    output = buffer.getvalue()
+    assert "tasks queued" in output
+    assert "Fix the queue estimate bug" in output

--- a/src/pollypm/defaults/demo/tests/test_demo_data.py
+++ b/src/pollypm/defaults/demo/tests/test_demo_data.py
@@ -1,0 +1,6 @@
+from demo_data import DEMO_TASKS, demo_task_titles
+
+
+def test_demo_data_exposes_three_sample_tasks() -> None:
+    assert len(DEMO_TASKS) == 3
+    assert demo_task_titles()[0] == "Fix the queue estimate bug"

--- a/src/pollypm/defaults/demo/tests/test_demo_history.py
+++ b/src/pollypm/defaults/demo/tests/test_demo_history.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_demo_history_describes_the_seeded_git_log() -> None:
+    text = Path("demo_history.md").read_text(encoding="utf-8")
+    lowered = text.lower()
+    assert "replayable" in lowered
+    assert "three commits" in lowered or "3 commits" in lowered

--- a/src/pollypm/defaults/demo/tests/test_demo_task.py
+++ b/src/pollypm/defaults/demo/tests/test_demo_task.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_task_doc_points_at_the_seeded_bug_and_tests() -> None:
+    text = Path("TASK.md").read_text(encoding="utf-8")
+    assert "demo_app.py" in text
+    assert "tests/test_demo_app.py" in text
+    assert "30-minute block" in text

--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -57,6 +57,12 @@ if TYPE_CHECKING:
 DEMO_PROJECT_BASENAME = "pollypm-demo"
 DEMO_PROJECT_MARKER = ".pollypm-demo-fallback"
 DEMO_PROJECT_TEMPLATE_DIR = Path(__file__).resolve().parent / "defaults" / "demo"
+DEMO_PROJECT_TASK_TITLE = "Fix the demo queue estimate bug"
+DEMO_PROJECT_TASK_DESCRIPTION = (
+    "The offline demo intentionally ships a tiny regression in demo_app.py.\n"
+    "Open TASK.md and tests/test_demo_app.py, fix estimate_focus_minutes(), "
+    "and keep the seeded PollyPM task until you are done."
+)
 
 
 class LoginCancelled(Exception):
@@ -320,6 +326,33 @@ def _write_demo_project_files(target: Path) -> None:
         destination = target / relative_name
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source, destination)
+
+
+def seed_demo_project_task(project_path: Path, *, project_key: str) -> str:
+    """Seed one small PollyPM task into the demo project's work DB."""
+    from pollypm.projects import ensure_project_scaffold
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    ensure_project_scaffold(project_path)
+    db_path = project_path / ".pollypm" / "state.db"
+    with SQLiteWorkService(db_path=db_path, project_path=project_path) as svc:
+        existing = svc.list_tasks(project=project_key)
+        for task in existing:
+            if task.title == DEMO_PROJECT_TASK_TITLE:
+                return task.task_id
+        task = svc.create(
+            title=DEMO_PROJECT_TASK_TITLE,
+            description=DEMO_PROJECT_TASK_DESCRIPTION,
+            type="task",
+            project=project_key,
+            flow_template="standard",
+            roles={"worker": "demo_worker", "reviewer": "demo_reviewer"},
+            priority="normal",
+            created_by="onboarding",
+            labels=["demo", "onboarding"],
+        )
+        svc.queue(task.task_id, "onboarding", skip_gates=True)
+        return task.task_id
 
 
 def _init_demo_project_git(target: Path) -> None:

--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -890,6 +890,77 @@ def build_onboarded_config(
         projects=dict(projects or {}),
     )
 
+def _seeded_demo_route(result: OnboardingResult) -> str | None:
+    project_key = result.seeded_demo_project_key
+    task_id = result.seeded_demo_task_id
+    if not project_key or not task_id:
+        return None
+    task_num = task_id.rsplit("/", 1)[-1].rsplit(":", 1)[-1].strip()
+    if not task_num:
+        return None
+    return f"project:{project_key}:task:{task_num}"
+
+
+def _launch_onboarding_experience(result: OnboardingResult) -> bool:
+    """Best-effort launch of the seeded demo cockpit after onboarding consent."""
+    from pollypm.cockpit_rail import CockpitRouter
+    from pollypm.service_api import PollyPMService
+    from pollypm.transcript_ingest import start_transcript_ingestion
+
+    service = PollyPMService(result.config_path)
+    supervisor = service.load_supervisor()
+    session_name = supervisor.config.project.tmux_session
+    launched = False
+
+    try:
+        if supervisor.tmux.has_session(session_name):
+            supervisor.ensure_layout()
+        else:
+            supervisor.bootstrap_tmux(skip_probe=True)
+    except Exception:  # noqa: BLE001
+        pass
+
+    try:
+        start_transcript_ingestion(supervisor.config)
+    except Exception:  # noqa: BLE001
+        pass
+
+    route_key = _seeded_demo_route(result)
+    if route_key is not None:
+        try:
+            CockpitRouter(result.config_path).route_selected(route_key)
+        except Exception:  # noqa: BLE001
+            pass
+
+    try:
+        subprocess.run(
+            ["uv", "tool", "install", "--editable", "--reinstall", str(result.parent)],
+            cwd=result.parent,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+    try:
+        current_tmux = create_tmux_client().current_session_name()
+    except Exception:  # noqa: BLE001
+        current_tmux = None
+    if current_tmux == session_name:
+        launched = True
+        try:
+            supervisor.focus_console()
+        except Exception:  # noqa: BLE001
+            pass
+        return launched
+    try:
+        supervisor.tmux.attach_session(session_name)
+        launched = True
+    except Exception:  # noqa: BLE001
+        pass
+    return launched
+
 
 def _account_ready_for_welcome_back(account: AccountConfig) -> bool:
     if account.home is None:
@@ -918,6 +989,8 @@ def run_onboarding(
     *,
     no_animation: bool = False,
 ) -> OnboardingResult:
+    from pollypm.onboarding_tui import run_onboarding_app
+
     if not force and config_path.exists():
         try:
             config = load_config(config_path)
@@ -932,18 +1005,25 @@ def run_onboarding(
             typer.echo("3. Re-run full onboarding")
             choice = typer.prompt("Choose", default="1")
             if choice == "1":
-                return OnboardingResult(config_path=config_path, launch_requested=True)
+                result = OnboardingResult(config_path=config_path, launch_requested=True)
+                if _launch_onboarding_experience(result):
+                    raise typer.Exit()
+                return result
             if choice == "2":
-                from pollypm.onboarding_tui import run_onboarding_app
-
-                return run_onboarding_app(config_path=config_path, force=False, no_animation=no_animation)
+                result = run_onboarding_app(config_path=config_path, force=False, no_animation=no_animation)
+                if result.launch_requested and _launch_onboarding_experience(result):
+                    raise typer.Exit()
+                return result
             if choice == "3":
-                from pollypm.onboarding_tui import run_onboarding_app
+                result = run_onboarding_app(config_path=config_path, force=True, no_animation=no_animation)
+                if result.launch_requested and _launch_onboarding_experience(result):
+                    raise typer.Exit()
+                return result
 
-                return run_onboarding_app(config_path=config_path, force=True, no_animation=no_animation)
-    from pollypm.onboarding_tui import run_onboarding_app
-
-    return run_onboarding_app(config_path=config_path, force=force, no_animation=no_animation)
+    result = run_onboarding_app(config_path=config_path, force=force, no_animation=no_animation)
+    if result.launch_requested and _launch_onboarding_experience(result):
+        raise typer.Exit()
+    return result
 
 
 def relogin_account(config_path: Path, identifier: str) -> tuple[str, str]:

--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -56,65 +56,7 @@ if TYPE_CHECKING:
 
 DEMO_PROJECT_BASENAME = "pollypm-demo"
 DEMO_PROJECT_MARKER = ".pollypm-demo-fallback"
-DEMO_PROJECT_FILES: dict[str, str] = {
-    DEMO_PROJECT_MARKER: "demo-fallback-v1\n",
-    ".gitignore": ".pollypm/\n__pycache__/\n.pytest_cache/\n",
-    "README.md": """# PollyPM Demo Repo
-
-This repo is the offline fallback used by onboarding when no recent local
-projects are detected.
-
-## What To Try
-
-- Run `python -m unittest discover -s tests -p "test_*.py"`
-- Read `demo_app.py`
-- Ask Polly to explain, extend, or test the queue summary behavior
-
-Everything in this repo uses only the Python standard library.
-""",
-    "demo_app.py": '''"""Small offline demo for PollyPM onboarding."""
-
-from __future__ import annotations
-
-
-def summarize_queue(items: list[str]) -> str:
-    cleaned = [item.strip() for item in items if item.strip()]
-    if not cleaned:
-        return "No tasks queued."
-    if len(cleaned) == 1:
-        return f"1 task queued: {cleaned[0]}"
-    preview = ", ".join(cleaned[:2])
-    if len(cleaned) > 2:
-        preview += f", +{len(cleaned) - 2} more"
-    return f"{len(cleaned)} tasks queued: {preview}"
-
-
-def estimate_focus_minutes(task_count: int, *, per_task: int = 25) -> int:
-    if task_count <= 0:
-        return 0
-    return task_count * per_task
-''',
-    "tests/test_demo_app.py": """import unittest
-
-from demo_app import estimate_focus_minutes, summarize_queue
-
-
-class DemoAppTests(unittest.TestCase):
-    def test_summarize_queue_handles_empty_input(self) -> None:
-        self.assertEqual(summarize_queue([]), "No tasks queued.")
-
-    def test_summarize_queue_shows_preview_and_count(self) -> None:
-        summary = summarize_queue(["plan onboarding", "write docs", "ship fallback"])
-        self.assertEqual(summary, "3 tasks queued: plan onboarding, write docs, +1 more")
-
-    def test_estimate_focus_minutes_uses_default_block(self) -> None:
-        self.assertEqual(estimate_focus_minutes(3), 75)
-
-
-if __name__ == "__main__":
-    unittest.main()
-""",
-}
+DEMO_PROJECT_TEMPLATE_DIR = Path(__file__).resolve().parent / "defaults" / "demo"
 
 
 class LoginCancelled(Exception):
@@ -368,10 +310,16 @@ def demo_project_fallback_destination(config_path: Path) -> Path:
 
 
 def _write_demo_project_files(target: Path) -> None:
-    for relative_name, content in DEMO_PROJECT_FILES.items():
+    marker_path = target / DEMO_PROJECT_MARKER
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    marker_path.write_text("demo-fallback-v1\n", encoding="utf-8")
+    for source in sorted(DEMO_PROJECT_TEMPLATE_DIR.rglob("*")):
+        if not source.is_file():
+            continue
+        relative_name = source.relative_to(DEMO_PROJECT_TEMPLATE_DIR)
         destination = target / relative_name
         destination.parent.mkdir(parents=True, exist_ok=True)
-        destination.write_text(content, encoding="utf-8")
+        shutil.copyfile(source, destination)
 
 
 def _init_demo_project_git(target: Path) -> None:

--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
     from pollypm.tmux.client import TmuxClient
 
 
-DEMO_PROJECT_BASENAME = "pollypm-demo"
+DEMO_PROJECT_BASENAME = "demo-polly"
 DEMO_PROJECT_MARKER = ".pollypm-demo-fallback"
 DEMO_PROJECT_TEMPLATE_DIR = Path(__file__).resolve().parent / "defaults" / "demo"
 DEMO_PROJECT_TASK_TITLE = "Fix the demo queue estimate bug"
@@ -63,6 +63,15 @@ DEMO_PROJECT_TASK_DESCRIPTION = (
     "Open TASK.md and tests/test_demo_app.py, fix estimate_focus_minutes(), "
     "and keep the seeded PollyPM task until you are done."
 )
+DEMO_PROJECT_REPLAY_COMMIT_COUNT = 3
+DEMO_PROJECT_REPLAY_HISTORY_FILES = {
+    "demo_history.md",
+}
+DEMO_PROJECT_REPLAY_TASK_FILES = {
+    "TASK.md",
+    "tests/test_demo_history.py",
+    "tests/test_demo_task.py",
+}
 
 
 class LoginCancelled(Exception):
@@ -304,7 +313,8 @@ def _workspace_root_for_onboarding(config_path: Path) -> Path:
 
 
 def demo_project_fallback_destination(config_path: Path) -> Path:
-    workspace_root = _workspace_root_for_onboarding(config_path)
+    del config_path
+    workspace_root = Path.home()
     for index in range(100):
         suffix = "" if index == 0 else f"-{index}"
         candidate = workspace_root / f"{DEMO_PROJECT_BASENAME}{suffix}"
@@ -326,6 +336,225 @@ def _write_demo_project_files(target: Path) -> None:
         destination = target / relative_name
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source, destination)
+
+
+def _demo_repo_stage_one_contents() -> dict[str, str]:
+    return {
+        "README.md": (
+            "# PollyPM Demo Repo\n\n"
+            "This offline fallback gives onboarding a tiny local project to copy.\n\n"
+            "It ships a queue-summary helper, a small CLI, sample data, and tests.\n"
+        ),
+        "demo_app.py": (
+            '"""Small offline demo for PollyPM onboarding."""\n\n'
+            "from __future__ import annotations\n\n\n"
+            "def summarize_queue(items: list[str]) -> str:\n"
+            "    cleaned = [item.strip() for item in items if item.strip()]\n"
+            "    if not cleaned:\n"
+            '        return "No tasks queued."\n'
+            "    if len(cleaned) == 1:\n"
+            '        return f"1 task queued: {cleaned[0]}"\n'
+            '    preview = ", ".join(cleaned[:2])\n'
+            "    if len(cleaned) > 2:\n"
+            '        preview += f", +{len(cleaned) - 2} more"\n'
+            '    return f"{len(cleaned)} tasks queued: {preview}"\n\n\n'
+            "def estimate_focus_minutes(task_count: int, *, per_task: int = 25) -> int:\n"
+            "    if task_count <= 0:\n"
+            "        return 0\n"
+            "    if task_count == 1:\n"
+            "        return 30\n"
+            "    return task_count * per_task\n"
+        ),
+        "demo_cli.py": (
+            "from __future__ import annotations\n\n"
+            "import argparse\n\n"
+            "from demo_app import estimate_focus_minutes, summarize_queue\n"
+            "from demo_data import demo_task_titles\n\n\n"
+            "def build_parser() -> argparse.ArgumentParser:\n"
+            '    parser = argparse.ArgumentParser(prog="demo-polly")\n'
+            "    subparsers = parser.add_subparsers(dest=\"command\", required=True)\n"
+            '    subparsers.add_parser("summary", help="Print the queue summary.")\n'
+            '    subparsers.add_parser("tasks", help="Print the sample demo tasks.")\n'
+            '    subparsers.add_parser("focus", help="Print the focus estimate.")\n'
+            "    return parser\n\n\n"
+            "def main(argv: list[str] | None = None) -> int:\n"
+            "    args = build_parser().parse_args(argv)\n"
+            "    if args.command == \"summary\":\n"
+            "        print(summarize_queue(demo_task_titles()))\n"
+            "        return 0\n"
+            "    if args.command == \"tasks\":\n"
+            "        for title in demo_task_titles():\n"
+            "            print(f\"- {title}\")\n"
+            "        return 0\n"
+            "    if args.command == \"focus\":\n"
+            "        print(f\"{estimate_focus_minutes(len(demo_task_titles()))} minutes\")\n"
+            "        return 0\n"
+            "    return 1\n\n\n"
+            "if __name__ == \"__main__\":\n"
+            "    raise SystemExit(main())\n"
+        ),
+        "demo_data.py": (
+            '"""Sample tasks for the offline PollyPM demo."""\n\n'
+            "from __future__ import annotations\n\n"
+            "DEMO_TASKS: list[dict[str, str]] = [\n"
+            '    {"title": "Fix the queue estimate bug", "kind": "bug"},\n'
+            '    {"title": "Write a demo launch note", "kind": "docs"},\n'
+            '    {"title": "Review the seeded git history", "kind": "ops"},\n'
+            "]\n\n\n"
+            "def demo_task_titles() -> list[str]:\n"
+            '    return [item["title"] for item in DEMO_TASKS]\n'
+        ),
+        "demo_history.md": (
+            "# Demo History\n\n"
+            "This repo is replayable: onboarding seeds a short git history so the\n"
+            "demo feels like a real project instead of a single snapshot.\n"
+        ),
+        ".gitignore": ".pollypm/\n__pycache__/\n.pytest_cache/\n",
+        "tests/test_demo_app.py": (
+            "import unittest\n\n"
+            "from demo_app import estimate_focus_minutes, summarize_queue\n\n\n"
+            "class DemoAppTests(unittest.TestCase):\n"
+            "    def test_summarize_queue_handles_empty_input(self) -> None:\n"
+            '        self.assertEqual(summarize_queue([]), "No tasks queued.")\n\n'
+            "    def test_summarize_queue_shows_preview_and_count(self) -> None:\n"
+            '        summary = summarize_queue(["plan onboarding", "write docs", "ship fallback"])\n'
+            '        self.assertEqual(summary, "3 tasks queued: plan onboarding, write docs, +1 more")\n\n'
+            "    def test_estimate_focus_minutes_uses_default_block(self) -> None:\n"
+            "        self.assertEqual(estimate_focus_minutes(3), 75)\n\n"
+            "    def test_estimate_focus_minutes_reserves_a_half_hour_for_one_task(self) -> None:\n"
+            "        self.assertEqual(estimate_focus_minutes(1), 30)\n\n\n"
+            "if __name__ == \"__main__\":\n"
+            "    unittest.main()\n"
+        ),
+        "tests/test_demo_cli.py": (
+            "from contextlib import redirect_stdout\n"
+            "from io import StringIO\n\n"
+            "from demo_cli import main\n\n\n"
+            "def test_summary_command_prints_queue_summary() -> None:\n"
+            "    buffer = StringIO()\n"
+            "    with redirect_stdout(buffer):\n"
+            '        assert main(["summary"]) == 0\n'
+            "    output = buffer.getvalue()\n"
+            '    assert "tasks queued" in output\n'
+            '    assert "Fix the queue estimate bug" in output\n'
+        ),
+        "tests/test_demo_data.py": (
+            "from demo_data import DEMO_TASKS, demo_task_titles\n\n\n"
+            "def test_demo_data_exposes_three_sample_tasks() -> None:\n"
+            "    assert len(DEMO_TASKS) == 3\n"
+            '    assert demo_task_titles()[0] == "Fix the queue estimate bug"\n'
+        ),
+    }
+
+
+def _demo_repo_stage_two_contents() -> dict[str, str]:
+    stage = _demo_repo_stage_one_contents()
+    stage["README.md"] = (
+        "# PollyPM Demo Repo\n\n"
+        "The offline demo intentionally carries a small queue-estimate regression.\n"
+        "Run the unit tests, fix the bug in `demo_app.py`, and keep the seeded task\n"
+        "while you work.\n"
+    )
+    stage["demo_app.py"] = (
+        '"""Small offline demo for PollyPM onboarding."""\n\n'
+        "from __future__ import annotations\n\n\n"
+        "def summarize_queue(items: list[str]) -> str:\n"
+        "    cleaned = [item.strip() for item in items if item.strip()]\n"
+        "    if not cleaned:\n"
+        '        return "No tasks queued."\n'
+        "    if len(cleaned) == 1:\n"
+        '        return f"1 task queued: {cleaned[0]}"\n'
+        '    preview = ", ".join(cleaned[:2])\n'
+        "    if len(cleaned) > 2:\n"
+        '        preview += f", +{len(cleaned) - 2} more"\n'
+        '    return f"{len(cleaned)} tasks queued: {preview}"\n\n\n'
+        "def estimate_focus_minutes(task_count: int, *, per_task: int = 25) -> int:\n"
+        '    """Intentional demo bug: a single task still underestimates by five minutes."""\n'
+        "    if task_count <= 0:\n"
+        "        return 0\n"
+        "    return task_count * per_task\n"
+    )
+    stage["tests/test_demo_app.py"] = (
+        "import unittest\n\n"
+        "from demo_app import estimate_focus_minutes, summarize_queue\n\n\n"
+        "class DemoAppTests(unittest.TestCase):\n"
+        "    def test_summarize_queue_handles_empty_input(self) -> None:\n"
+        '        self.assertEqual(summarize_queue([]), "No tasks queued.")\n\n'
+        "    def test_summarize_queue_shows_preview_and_count(self) -> None:\n"
+        '        summary = summarize_queue(["plan onboarding", "write docs", "ship fallback"])\n'
+        '        self.assertEqual(summary, "3 tasks queued: plan onboarding, write docs, +1 more")\n\n'
+        "    def test_estimate_focus_minutes_uses_default_block(self) -> None:\n"
+        "        self.assertEqual(estimate_focus_minutes(3), 75)\n\n"
+        "    def test_estimate_focus_minutes_reserves_a_half_hour_for_one_task(self) -> None:\n"
+        "        \"\"\"Intentional demo bug: the helper still underestimates a single task.\"\"\"\n"
+        "        self.assertEqual(estimate_focus_minutes(1), 30)\n\n\n"
+        "if __name__ == \"__main__\":\n"
+        "    unittest.main()\n"
+    )
+    return stage
+
+
+def _demo_repo_stage_three_contents() -> dict[str, str]:
+    stage = _demo_repo_stage_two_contents()
+    stage["README.md"] = (
+        "# PollyPM Demo Repo\n\n"
+        "This repo is the offline fallback used by onboarding when no recent local\n"
+        "projects are detected.\n\n"
+        "It is intentionally small, but self-contained:\n\n"
+        "- `demo_app.py` contains a tiny queue-summary helper with one deliberate bug.\n"
+        "- `tests/test_demo_app.py` contains the matching failing regression test.\n"
+        "- `demo_cli.py` is a tiny entrypoint that prints the demo queue summary.\n"
+        "- `demo_data.py` holds sample task titles used by the CLI and tests.\n"
+        "- `demo_history.md` explains the replayable git history seeded by onboarding.\n"
+        "- `TASK.md` describes the seeded PollyPM task that onboarding can add to the\n"
+        "  project database.\n\n"
+        "## What To Try\n\n"
+        "- Run `python -m unittest discover -s tests -p \"test_*.py\"`\n"
+        "- Read `TASK.md` and `demo_history.md`\n"
+        "- Fix the queue estimate regression, then rerun the demo tests\n"
+        "- Ask Polly to explain, extend, or test the queue summary behavior\n\n"
+        "Everything in this repo uses only the Python standard library.\n"
+    )
+    stage["TASK.md"] = (
+        "# Demo Task\n\n"
+        "Fix the queue estimate regression in `demo_app.py`.\n\n"
+        "The follow-up is intentionally small:\n\n"
+        "- `estimate_focus_minutes(1)` should reserve a 30-minute block.\n"
+        "- The demo test suite already includes a failing regression test.\n"
+        "- The repo history is replayable so you can inspect the change in three commits.\n"
+        "- Keep the task in PollyPM if you want it to show up in the seeded inbox.\n"
+    )
+    stage["tests/test_demo_history.py"] = (
+        "from pathlib import Path\n\n\n"
+        "def test_demo_history_describes_the_seeded_git_log() -> None:\n"
+        "    text = Path(\"demo_history.md\").read_text(encoding=\"utf-8\")\n"
+        "    lowered = text.lower()\n"
+        '    assert "replayable" in lowered\n'
+        '    assert "three commits" in lowered or "3 commits" in lowered\n'
+    )
+    stage["tests/test_demo_task.py"] = (
+        "from pathlib import Path\n\n\n"
+        "def test_task_doc_points_at_the_seeded_bug_and_tests() -> None:\n"
+        "    text = Path(\"TASK.md\").read_text(encoding=\"utf-8\")\n"
+        '    assert "demo_app.py" in text\n'
+        '    assert "tests/test_demo_app.py" in text\n'
+        '    assert "30-minute block" in text\n'
+    )
+    return stage
+
+
+def _write_demo_repo_files(target: Path, files: dict[str, str]) -> None:
+    for relative_name, contents in files.items():
+        destination = target / relative_name
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(contents, encoding="utf-8")
+
+
+def _remove_demo_repo_files(target: Path, relative_names: set[str]) -> None:
+    for relative_name in relative_names:
+        path = target / relative_name
+        if path.exists():
+            path.unlink()
 
 
 def seed_demo_project_task(project_path: Path, *, project_key: str) -> str:
@@ -366,6 +595,60 @@ def _init_demo_project_git(target: Path) -> None:
     )
 
 
+def _seed_demo_project_git_history(target: Path) -> None:
+    git = ["git", "-C", str(target)]
+    subprocess.run([*git, "config", "user.name", "PollyPM Demo"], check=False, capture_output=True, text=True)
+    subprocess.run([*git, "config", "user.email", "demo@pollypm.local"], check=False, capture_output=True, text=True)
+
+    stage_one = _demo_repo_stage_one_contents()
+    _write_demo_repo_files(target, stage_one)
+    _remove_demo_repo_files(target, DEMO_PROJECT_REPLAY_TASK_FILES)
+    subprocess.run([*git, "add", "-A"], check=False, capture_output=True, text=True)
+    subprocess.run(
+        [*git, "commit", "-q", "-m", "demo: scaffold offline fallback"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    stage_two = _demo_repo_stage_two_contents()
+    _write_demo_repo_files(target, stage_two)
+    subprocess.run([*git, "add", "-A"], check=False, capture_output=True, text=True)
+    subprocess.run(
+        [*git, "commit", "-q", "-m", "demo: introduce the queue bug"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    stage_three = _demo_repo_stage_three_contents()
+    _write_demo_repo_files(target, stage_three)
+    subprocess.run([*git, "add", "-A"], check=False, capture_output=True, text=True)
+    subprocess.run(
+        [*git, "commit", "-q", "-m", "demo: add task notes and replay guide"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _demo_project_history_seeded(target: Path) -> bool:
+    if not (target / ".git").exists():
+        return False
+    result = subprocess.run(
+        ["git", "-C", str(target), "rev-list", "--count", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return False
+    try:
+        return int(result.stdout.strip() or "0") >= DEMO_PROJECT_REPLAY_COMMIT_COUNT
+    except ValueError:
+        return False
+
+
 def provision_demo_project_fallback(config_path: Path) -> Path:
     target = demo_project_fallback_destination(config_path)
     marker = target / DEMO_PROJECT_MARKER
@@ -373,6 +656,8 @@ def provision_demo_project_fallback(config_path: Path) -> Path:
         target.mkdir(parents=True, exist_ok=True)
         _write_demo_project_files(target)
     _init_demo_project_git(target)
+    if shutil.which("git") is not None and not _demo_project_history_seeded(target):
+        _seed_demo_project_git_history(target)
     ensure_project_scaffold(target)
     return target
 

--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -4,6 +4,7 @@ import base64
 import json
 import re
 import shlex
+import shutil
 import subprocess
 import threading
 import time
@@ -51,6 +52,71 @@ from pollypm.session_services import create_tmux_client
 
 if TYPE_CHECKING:
     from pollypm.tmux.client import TmuxClient
+
+
+DEMO_PROJECT_BASENAME = "pollypm-demo"
+DEMO_PROJECT_MARKER = ".pollypm-demo-fallback"
+DEMO_PROJECT_FILES: dict[str, str] = {
+    DEMO_PROJECT_MARKER: "demo-fallback-v1\n",
+    ".gitignore": ".pollypm/\n__pycache__/\n.pytest_cache/\n",
+    "README.md": """# PollyPM Demo Repo
+
+This repo is the offline fallback used by onboarding when no recent local
+projects are detected.
+
+## What To Try
+
+- Run `python -m unittest discover -s tests -p "test_*.py"`
+- Read `demo_app.py`
+- Ask Polly to explain, extend, or test the queue summary behavior
+
+Everything in this repo uses only the Python standard library.
+""",
+    "demo_app.py": '''"""Small offline demo for PollyPM onboarding."""
+
+from __future__ import annotations
+
+
+def summarize_queue(items: list[str]) -> str:
+    cleaned = [item.strip() for item in items if item.strip()]
+    if not cleaned:
+        return "No tasks queued."
+    if len(cleaned) == 1:
+        return f"1 task queued: {cleaned[0]}"
+    preview = ", ".join(cleaned[:2])
+    if len(cleaned) > 2:
+        preview += f", +{len(cleaned) - 2} more"
+    return f"{len(cleaned)} tasks queued: {preview}"
+
+
+def estimate_focus_minutes(task_count: int, *, per_task: int = 25) -> int:
+    if task_count <= 0:
+        return 0
+    return task_count * per_task
+''',
+    "tests/test_demo_app.py": """import unittest
+
+from demo_app import estimate_focus_minutes, summarize_queue
+
+
+class DemoAppTests(unittest.TestCase):
+    def test_summarize_queue_handles_empty_input(self) -> None:
+        self.assertEqual(summarize_queue([]), "No tasks queued.")
+
+    def test_summarize_queue_shows_preview_and_count(self) -> None:
+        summary = summarize_queue(["plan onboarding", "write docs", "ship fallback"])
+        self.assertEqual(summary, "3 tasks queued: plan onboarding, write docs, +1 more")
+
+    def test_estimate_focus_minutes_uses_default_block(self) -> None:
+        self.assertEqual(estimate_focus_minutes(3), 75)
+
+
+if __name__ == "__main__":
+    unittest.main()
+""",
+}
+
+
 class LoginCancelled(Exception):
     pass
 
@@ -242,6 +308,15 @@ def _scan_recent_projects(config_path: Path) -> list[KnownProject]:
     discovered = discover_recent_project_candidates(config_path)
     if not discovered:
         typer.echo("No recently active git repos were found in your home folder.")
+        demo_path = demo_project_fallback_destination(config_path)
+        typer.echo(
+            f"You can copy a self-contained demo repo to {demo_path} and use it offline."
+        )
+        if typer.confirm("Copy the demo repo and use it as your first project?", default=True):
+            return add_selected_projects(
+                config_path,
+                [provision_demo_project_fallback(config_path)],
+            )
         return []
 
     typer.echo("")
@@ -253,10 +328,72 @@ def _scan_recent_projects(config_path: Path) -> list[KnownProject]:
     return add_selected_projects(config_path, selected)
 
 
-def discover_recent_project_candidates(config_path: Path) -> list[Path]:
-    config = load_config(config_path)
-    known_paths = {project.path.resolve() for project in config.projects.values()}
-    return discover_recent_git_repositories(Path.home(), known_paths=known_paths, recent_days=14)
+def discover_recent_project_candidates(
+    config_path: Path,
+    *,
+    scan_root: Path | None = None,
+    recent_days: int = 14,
+) -> list[Path]:
+    try:
+        config = load_config(config_path)
+        known_paths = {project.path.resolve() for project in config.projects.values()}
+    except Exception:  # noqa: BLE001
+        known_paths = set()
+    return discover_recent_git_repositories(
+        scan_root or Path.home(),
+        known_paths=known_paths,
+        recent_days=recent_days,
+    )
+
+
+def _workspace_root_for_onboarding(config_path: Path) -> Path:
+    try:
+        config = load_config(config_path)
+        workspace_root = getattr(config.project, "workspace_root", DEFAULT_WORKSPACE_ROOT)
+    except Exception:  # noqa: BLE001
+        workspace_root = DEFAULT_WORKSPACE_ROOT
+    return Path(workspace_root).expanduser()
+
+
+def demo_project_fallback_destination(config_path: Path) -> Path:
+    workspace_root = _workspace_root_for_onboarding(config_path)
+    for index in range(100):
+        suffix = "" if index == 0 else f"-{index}"
+        candidate = workspace_root / f"{DEMO_PROJECT_BASENAME}{suffix}"
+        if (candidate / DEMO_PROJECT_MARKER).exists():
+            return candidate
+        if not candidate.exists():
+            return candidate
+    raise RuntimeError("Could not find a free path for the onboarding demo repo.")
+
+
+def _write_demo_project_files(target: Path) -> None:
+    for relative_name, content in DEMO_PROJECT_FILES.items():
+        destination = target / relative_name
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(content, encoding="utf-8")
+
+
+def _init_demo_project_git(target: Path) -> None:
+    if shutil.which("git") is None or (target / ".git").exists():
+        return
+    subprocess.run(
+        ["git", "init", "-q", str(target)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def provision_demo_project_fallback(config_path: Path) -> Path:
+    target = demo_project_fallback_destination(config_path)
+    marker = target / DEMO_PROJECT_MARKER
+    if not marker.exists():
+        target.mkdir(parents=True, exist_ok=True)
+        _write_demo_project_files(target)
+    _init_demo_project_git(target)
+    ensure_project_scaffold(target)
+    return target
 
 
 def add_selected_projects(config_path: Path, selected_paths: list[Path]) -> list[KnownProject]:

--- a/src/pollypm/onboarding_models.py
+++ b/src/pollypm/onboarding_models.py
@@ -38,6 +38,18 @@ class LoginPreferences:
 class OnboardingResult:
     config_path: Path
     launch_requested: bool = False
+    seeded_demo_project_key: str | None = None
+    seeded_demo_task_id: str | None = None
+
+    @property
+    def parent(self) -> Path:
+        return self.config_path.parent
+
+    def resolve(self) -> Path:
+        return self.config_path.resolve()
+
+    def __str__(self) -> str:
+        return str(self.config_path)
 
 
 __all__ = [

--- a/src/pollypm/onboarding_tui.py
+++ b/src/pollypm/onboarding_tui.py
@@ -156,6 +156,15 @@ class OnboardingState:
     scan_complete: bool = False
     scan_started: bool = False
 
+
+@dataclass(slots=True)
+class BlockingAutoFix:
+    button_id: str
+    label: str
+    summary: str
+    plan: AutoFixPlan
+
+
 class ExitModal(ModalScreen[None]):
     CSS = """
     ModalScreen {

--- a/src/pollypm/onboarding_tui.py
+++ b/src/pollypm/onboarding_tui.py
@@ -150,6 +150,7 @@ class OnboardingState:
     failover_enabled: bool = True
     recent_projects: list[Path] = field(default_factory=list)
     selected_project_paths: list[Path] = field(default_factory=list)
+    seeded_demo_task_id: str | None = None
     scan_complete: bool = False
     scan_started: bool = False
 
@@ -275,6 +276,59 @@ class CodexLoginModeModal(ModalScreen[str | None]):
             return
         if event.button.id == "codex-mode-remote":
             self.dismiss("remote")
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+class DemoTaskModal(ModalScreen[str | None]):
+    CSS = """
+    ModalScreen {
+        align: center middle;
+        background: rgba(0, 0, 0, 0.55);
+    }
+    #demo-task-dialog {
+        width: 78;
+        height: auto;
+        padding: 1 2;
+        background: #141a20;
+        border: heavy #3ddc84;
+    }
+    #demo-task-title {
+        text-style: bold;
+        color: #f0f4f8;
+        padding-bottom: 1;
+    }
+    #demo-task-actions {
+        height: auto;
+        padding-top: 1;
+        align-horizontal: right;
+    }
+    #demo-task-actions Button {
+        margin-left: 1;
+    }
+    """
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    def compose(self) -> ComposeResult:
+        with CenterMiddle():
+            with Vertical(id="demo-task-dialog"):
+                yield Static("Keep the seeded demo task?", id="demo-task-title")
+                yield Static(
+                    "The demo repo includes one PollyPM task pointing at the intentional bug in demo_app.py. "
+                    "Keeping it adds the task to the project DB so it shows up in the cockpit."
+                )
+                with Horizontal(id="demo-task-actions"):
+                    yield Button("Keep", id="demo-task-keep", variant="primary")
+                    yield Button("Forget", id="demo-task-forget", variant="warning")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "demo-task-keep":
+            self.dismiss("keep")
+            return
+        if event.button.id == "demo-task-forget":
+            self.dismiss("forget")
 
     def action_cancel(self) -> None:
         self.dismiss(None)
@@ -459,6 +513,7 @@ class OnboardingApp(App[OnboardingResult | None]):
         self.scan_loading_widget: Static | None = None
         self.scan_frame_index = 0
         self.launch_button: Button | None = None
+        self._pending_demo_repo_path: Path | None = None
 
     def _blocking_auto_fixes(self) -> list[BlockingAutoFix]:
         fixes: list[BlockingAutoFix] = []
@@ -1013,10 +1068,8 @@ class OnboardingApp(App[OnboardingResult | None]):
             except Exception as exc:  # noqa: BLE001
                 self._set_message(f"Could not prepare the demo repo: {exc}")
                 return
-            self.state.recent_projects = [demo_path]
-            self.state.selected_project_paths = [demo_path]
-            self._set_message(f"Demo repo ready at {demo_path}.")
-            self._render_current_step()
+            self._pending_demo_repo_path = demo_path
+            self.push_screen(DemoTaskModal(), self._handle_demo_task_choice)
             return
         if button_id == "projects-finish":
             if self.project_selection is not None:
@@ -1084,6 +1137,36 @@ class OnboardingApp(App[OnboardingResult | None]):
             self._set_message(
                 "No recent repos matched your local commit history. You can use the demo repo fallback or add projects later."
             )
+        self._render_current_step()
+
+    def _handle_demo_task_choice(self, choice: str | None) -> None:
+        demo_path = self._pending_demo_repo_path
+        self._pending_demo_repo_path = None
+        if demo_path is None:
+            return
+
+        self.state.recent_projects = [demo_path]
+        self.state.selected_project_paths = [demo_path]
+        if choice == "keep":
+            from pollypm.onboarding import seed_demo_project_task
+
+            project_key = make_project_key(demo_path, set(self.state.known_projects))
+            try:
+                task_id = seed_demo_project_task(demo_path, project_key=project_key)
+            except Exception as exc:  # noqa: BLE001
+                self.state.seeded_demo_task_id = None
+                self._set_message(f"Demo repo copied, but seeding the task failed: {exc}")
+            else:
+                self.state.seeded_demo_task_id = task_id
+                self._set_message(
+                    f"Demo repo ready at {demo_path}. Seeded task {task_id} is waiting in the cockpit."
+                )
+        elif choice == "forget":
+            self.state.seeded_demo_task_id = None
+            self._set_message(f"Demo repo ready at {demo_path}. No seeded task was kept.")
+        else:
+            self.state.seeded_demo_task_id = None
+            self._set_message(f"Demo repo ready at {demo_path}.")
         self._render_current_step()
 
 

--- a/src/pollypm/onboarding_tui.py
+++ b/src/pollypm/onboarding_tui.py
@@ -44,6 +44,7 @@ from pollypm.onboarding import (
     discover_recent_project_candidates,
     provision_demo_project_fallback,
 )
+from pollypm.onboarding_models import OnboardingResult
 from pollypm.projects import ensure_project_scaffold, make_project_key
 from pollypm.session_services import create_tmux_client
 
@@ -150,24 +151,10 @@ class OnboardingState:
     failover_enabled: bool = True
     recent_projects: list[Path] = field(default_factory=list)
     selected_project_paths: list[Path] = field(default_factory=list)
+    seeded_demo_project_key: str | None = None
     seeded_demo_task_id: str | None = None
     scan_complete: bool = False
     scan_started: bool = False
-
-
-@dataclass(slots=True)
-class OnboardingResult:
-    config_path: Path
-    launch_requested: bool = False
-
-
-@dataclass(slots=True)
-class BlockingAutoFix:
-    button_id: str
-    label: str
-    summary: str
-    plan: AutoFixPlan
-
 
 class ExitModal(ModalScreen[None]):
     CSS = """
@@ -1084,7 +1071,14 @@ class OnboardingApp(App[OnboardingResult | None]):
             self._render_current_step()
             return
         if button_id == "tour-launch":
-            self.exit(OnboardingResult(config_path=self.config_path, launch_requested=True))
+            self.exit(
+                OnboardingResult(
+                    config_path=self.config_path,
+                    launch_requested=True,
+                    seeded_demo_project_key=self.state.seeded_demo_project_key,
+                    seeded_demo_task_id=self.state.seeded_demo_task_id,
+                )
+            )
 
     @on(RadioSet.Changed)
     def on_controller_changed(self, event: RadioSet.Changed) -> None:
@@ -1157,14 +1151,17 @@ class OnboardingApp(App[OnboardingResult | None]):
                 self.state.seeded_demo_task_id = None
                 self._set_message(f"Demo repo copied, but seeding the task failed: {exc}")
             else:
+                self.state.seeded_demo_project_key = project_key
                 self.state.seeded_demo_task_id = task_id
                 self._set_message(
                     f"Demo repo ready at {demo_path}. Seeded task {task_id} is waiting in the cockpit."
                 )
         elif choice == "forget":
+            self.state.seeded_demo_project_key = None
             self.state.seeded_demo_task_id = None
             self._set_message(f"Demo repo ready at {demo_path}. No seeded task was kept.")
         else:
+            self.state.seeded_demo_project_key = None
             self.state.seeded_demo_task_id = None
             self._set_message(f"Demo repo ready at {demo_path}.")
         self._render_current_step()

--- a/src/pollypm/onboarding_tui.py
+++ b/src/pollypm/onboarding_tui.py
@@ -40,8 +40,11 @@ from pollypm.onboarding import (
     _detected_host_account,
     _recover_existing_accounts,
     build_onboarded_config,
+    demo_project_fallback_destination,
+    discover_recent_project_candidates,
+    provision_demo_project_fallback,
 )
-from pollypm.projects import discover_recent_git_repositories, ensure_project_scaffold, make_project_key
+from pollypm.projects import ensure_project_scaffold, make_project_key
 from pollypm.session_services import create_tmux_client
 
 ONBOARDING_STAGES = (
@@ -778,11 +781,19 @@ class OnboardingApp(App[OnboardingResult | None]):
             empty = Vertical(classes="section")
             stage.mount(empty)
             empty.mount(Static("Nothing Recent Found", classes="section-title"))
+            demo_target = demo_project_fallback_destination(self.config_path)
             empty.mount(
                 Static(
                     "No recently active git repos were found in your home folder.\n\n"
-                    "You can add projects later anytime from the control room."
+                    "You can copy a self-contained demo repo and exercise PollyPM locally without any network dependency, "
+                    "or skip this step and add projects later anytime from the control room.\n\n"
+                    f"[dim]Demo target: {demo_target}[/dim]"
                 )
+            )
+            demo_actions = Horizontal(classes="button-row")
+            empty.mount(demo_actions)
+            demo_actions.mount(
+                Button("Use Demo Repo", id="projects-use-demo", variant="primary")
             )
         else:
             selections = []
@@ -876,8 +887,7 @@ class OnboardingApp(App[OnboardingResult | None]):
             self.launch_button.focus()
 
     def _scan_recent_projects(self) -> list[Path]:
-        known_paths = {project.path.resolve() for project in self.state.known_projects.values()}
-        return discover_recent_git_repositories(Path.home(), known_paths=known_paths, recent_days=14)
+        return discover_recent_project_candidates(self.config_path)
 
     def _update_scan_loading(self) -> None:
         if self.scan_loading_widget is None:
@@ -997,6 +1007,17 @@ class OnboardingApp(App[OnboardingResult | None]):
             self.step = "controller"
             self._render_current_step()
             return
+        if button_id == "projects-use-demo":
+            try:
+                demo_path = provision_demo_project_fallback(self.config_path)
+            except Exception as exc:  # noqa: BLE001
+                self._set_message(f"Could not prepare the demo repo: {exc}")
+                return
+            self.state.recent_projects = [demo_path]
+            self.state.selected_project_paths = [demo_path]
+            self._set_message(f"Demo repo ready at {demo_path}.")
+            self._render_current_step()
+            return
         if button_id == "projects-finish":
             if self.project_selection is not None:
                 self.state.selected_project_paths = list(self.project_selection.selected)
@@ -1060,7 +1081,9 @@ class OnboardingApp(App[OnboardingResult | None]):
         if self.state.recent_projects:
             self._set_message(f"Found {len(self.state.recent_projects)} recently active repo suggestion(s).")
         else:
-            self._set_message("No recent repos matched your local commit history. You can add projects later.")
+            self._set_message(
+                "No recent repos matched your local commit history. You can use the demo repo fallback or add projects later."
+            )
         self._render_current_step()
 
 

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -3,13 +3,17 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from pollypm.cli import app as cli_app
+import pytest
+from click.exceptions import Exit as ClickExit
 from pollypm.config import load_config, write_config
 from pollypm.doctor import decode_setup_tag, setup_tag_line
 from pollypm.models import KnownProject, ProviderKind
 from pollypm.projects import DEFAULT_WORKSPACE_ROOT
 from pollypm.onboarding import (
     ConnectedAccount,
+    OnboardingResult,
     _scan_recent_projects,
+    _seeded_demo_route,
     build_onboarded_config,
     demo_project_fallback_destination,
     provision_demo_project_fallback,
@@ -255,3 +259,54 @@ def test_scan_recent_projects_offers_demo_repo_when_discovery_is_empty(
 
     assert [project.path for project in projects] == [demo_path]
     assert any("demo repo" in message.lower() for message in messages)
+
+
+def test_onboarding_result_keeps_path_compatibility(tmp_path: Path) -> None:
+    result = OnboardingResult(
+        config_path=tmp_path / "pollypm.toml",
+        launch_requested=True,
+        seeded_demo_project_key="pollypm_demo",
+        seeded_demo_task_id="demo/1",
+    )
+
+    assert result.parent == tmp_path
+    assert result.resolve() == (tmp_path / "pollypm.toml").resolve()
+    assert str(result) == str(tmp_path / "pollypm.toml")
+
+
+def test_run_onboarding_launches_seeded_demo_experience(monkeypatch, tmp_path: Path) -> None:
+    result = OnboardingResult(
+        config_path=tmp_path / "pollypm.toml",
+        launch_requested=True,
+        seeded_demo_project_key="pollypm_demo",
+        seeded_demo_task_id="demo/1",
+    )
+    launched: list[OnboardingResult] = []
+
+    monkeypatch.setattr(
+        "pollypm.onboarding_tui.run_onboarding_app",
+        lambda config_path, force=False: result,
+    )
+    monkeypatch.setattr(
+        "pollypm.onboarding._launch_onboarding_experience",
+        lambda launch_result: launched.append(launch_result) or True,
+    )
+
+    with pytest.raises(ClickExit):
+        __import__("pollypm.onboarding", fromlist=["run_onboarding"]).run_onboarding(
+            config_path=result.config_path,
+            force=True,
+        )
+
+    assert launched == [result]
+
+
+def test_seeded_demo_route_parses_project_and_task_number(tmp_path: Path) -> None:
+    result = OnboardingResult(
+        config_path=tmp_path / "pollypm.toml",
+        launch_requested=True,
+        seeded_demo_project_key="pollypm_demo",
+        seeded_demo_task_id="demo/17",
+    )
+
+    assert _seeded_demo_route(result) == "project:pollypm_demo:task:17"

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -304,7 +304,7 @@ def test_run_onboarding_launches_seeded_demo_experience(monkeypatch, tmp_path: P
 
     monkeypatch.setattr(
         "pollypm.onboarding_tui.run_onboarding_app",
-        lambda config_path, force=False: result,
+        lambda config_path, force=False, no_animation=False: result,
     )
     monkeypatch.setattr(
         "pollypm.onboarding._launch_onboarding_experience",

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import subprocess
 
 from typer.testing import CliRunner
 
@@ -11,6 +12,8 @@ from pollypm.models import KnownProject, ProviderKind
 from pollypm.projects import DEFAULT_WORKSPACE_ROOT
 from pollypm.onboarding import (
     ConnectedAccount,
+    DEMO_PROJECT_TEMPLATE_DIR,
+    DEMO_PROJECT_REPLAY_COMMIT_COUNT,
     OnboardingResult,
     _scan_recent_projects,
     _seeded_demo_route,
@@ -182,18 +185,9 @@ def test_provision_demo_project_fallback_creates_self_contained_repo(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    workspace_root = tmp_path / "workspace"
     config_path = tmp_path / "pollypm.toml"
-    git_calls: list[list[str]] = []
-
-    def _fake_run(command: list[str], **_kwargs):
-        git_calls.append(command)
-        (workspace_root / "pollypm-demo" / ".git").mkdir(parents=True, exist_ok=True)
-        return type("Result", (), {"returncode": 0})()
-
-    monkeypatch.setattr("pollypm.onboarding.DEFAULT_WORKSPACE_ROOT", workspace_root)
+    monkeypatch.setattr("pollypm.onboarding.Path.home", lambda: tmp_path)
     monkeypatch.setattr("pollypm.onboarding.shutil.which", lambda name: "/usr/bin/git" if name == "git" else None)
-    monkeypatch.setattr("pollypm.onboarding.subprocess.run", _fake_run)
 
     target = provision_demo_project_fallback(config_path)
 
@@ -201,27 +195,52 @@ def test_provision_demo_project_fallback_creates_self_contained_repo(
     assert (target / ".pollypm-demo-fallback").exists()
     assert (target / "README.md").exists()
     assert (target / "demo_app.py").exists()
+    assert (target / "demo_cli.py").exists()
+    assert (target / "demo_data.py").exists()
+    assert (target / "demo_history.md").exists()
     assert (target / "TASK.md").exists()
     assert (target / "tests" / "test_demo_app.py").exists()
+    assert (target / "tests" / "test_demo_cli.py").exists()
+    assert (target / "tests" / "test_demo_data.py").exists()
+    assert (target / "tests" / "test_demo_history.py").exists()
+    assert (target / "tests" / "test_demo_task.py").exists()
     assert (target / ".pollypm").exists()
-    assert git_calls == [["git", "init", "-q", str(target)]]
+
+    git_count = subprocess.run(
+        ["git", "-C", str(target), "rev-list", "--count", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert git_count.stdout.strip() == str(DEMO_PROJECT_REPLAY_COMMIT_COUNT)
+    template_files = [
+        path for path in DEMO_PROJECT_TEMPLATE_DIR.rglob("*")
+        if path.is_file() and "__pycache__" not in path.parts and not path.suffix == ".pyc"
+    ]
+    assert len(template_files) == 12
 
     same_target = provision_demo_project_fallback(config_path)
     assert same_target == target
-    assert git_calls == [["git", "init", "-q", str(target)]]
+    git_count_again = subprocess.run(
+        ["git", "-C", str(target), "rev-list", "--count", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert git_count_again.stdout.strip() == str(DEMO_PROJECT_REPLAY_COMMIT_COUNT)
 
 
 def test_seed_demo_project_task_creates_a_visible_queue_item(tmp_path: Path) -> None:
-    project_path = tmp_path / "pollypm-demo"
+    project_path = tmp_path / "demo-polly"
     project_path.mkdir()
 
-    task_id = seed_demo_project_task(project_path, project_key="pollypm_demo")
+    task_id = seed_demo_project_task(project_path, project_key="demo_polly")
 
     from pollypm.work.sqlite_service import SQLiteWorkService
 
     with SQLiteWorkService(db_path=project_path / ".pollypm" / "state.db", project_path=project_path) as svc:
         task = svc.get(task_id)
-        assert task.project == "pollypm_demo"
+        assert task.project == "demo_polly"
         assert task.work_status.value == "queued"
         assert task.title == "Fix the demo queue estimate bug"
 

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -13,6 +13,7 @@ from pollypm.onboarding import (
     build_onboarded_config,
     demo_project_fallback_destination,
     provision_demo_project_fallback,
+    seed_demo_project_task,
 )
 
 
@@ -196,6 +197,7 @@ def test_provision_demo_project_fallback_creates_self_contained_repo(
     assert (target / ".pollypm-demo-fallback").exists()
     assert (target / "README.md").exists()
     assert (target / "demo_app.py").exists()
+    assert (target / "TASK.md").exists()
     assert (target / "tests" / "test_demo_app.py").exists()
     assert (target / ".pollypm").exists()
     assert git_calls == [["git", "init", "-q", str(target)]]
@@ -203,6 +205,21 @@ def test_provision_demo_project_fallback_creates_self_contained_repo(
     same_target = provision_demo_project_fallback(config_path)
     assert same_target == target
     assert git_calls == [["git", "init", "-q", str(target)]]
+
+
+def test_seed_demo_project_task_creates_a_visible_queue_item(tmp_path: Path) -> None:
+    project_path = tmp_path / "pollypm-demo"
+    project_path.mkdir()
+
+    task_id = seed_demo_project_task(project_path, project_key="pollypm_demo")
+
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    with SQLiteWorkService(db_path=project_path / ".pollypm" / "state.db", project_path=project_path) as svc:
+        task = svc.get(task_id)
+        assert task.project == "pollypm_demo"
+        assert task.work_status.value == "queued"
+        assert task.title == "Fix the demo queue estimate bug"
 
 
 def test_scan_recent_projects_offers_demo_repo_when_discovery_is_empty(

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -7,7 +7,13 @@ from pollypm.config import load_config, write_config
 from pollypm.doctor import decode_setup_tag, setup_tag_line
 from pollypm.models import KnownProject, ProviderKind
 from pollypm.projects import DEFAULT_WORKSPACE_ROOT
-from pollypm.onboarding import ConnectedAccount, build_onboarded_config
+from pollypm.onboarding import (
+    ConnectedAccount,
+    _scan_recent_projects,
+    build_onboarded_config,
+    demo_project_fallback_destination,
+    provision_demo_project_fallback,
+)
 
 
 def test_build_onboarded_config_uses_controller_for_pollypm_sessions(tmp_path: Path) -> None:
@@ -165,3 +171,70 @@ def test_decode_setup_tag_cli_round_trips(monkeypatch, tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert '"accounts": 2' in result.output
+
+
+def test_provision_demo_project_fallback_creates_self_contained_repo(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    config_path = tmp_path / "pollypm.toml"
+    git_calls: list[list[str]] = []
+
+    def _fake_run(command: list[str], **_kwargs):
+        git_calls.append(command)
+        (workspace_root / "pollypm-demo" / ".git").mkdir(parents=True, exist_ok=True)
+        return type("Result", (), {"returncode": 0})()
+
+    monkeypatch.setattr("pollypm.onboarding.DEFAULT_WORKSPACE_ROOT", workspace_root)
+    monkeypatch.setattr("pollypm.onboarding.shutil.which", lambda name: "/usr/bin/git" if name == "git" else None)
+    monkeypatch.setattr("pollypm.onboarding.subprocess.run", _fake_run)
+
+    target = provision_demo_project_fallback(config_path)
+
+    assert target == demo_project_fallback_destination(config_path)
+    assert (target / ".pollypm-demo-fallback").exists()
+    assert (target / "README.md").exists()
+    assert (target / "demo_app.py").exists()
+    assert (target / "tests" / "test_demo_app.py").exists()
+    assert (target / ".pollypm").exists()
+    assert git_calls == [["git", "init", "-q", str(target)]]
+
+    same_target = provision_demo_project_fallback(config_path)
+    assert same_target == target
+    assert git_calls == [["git", "init", "-q", str(target)]]
+
+
+def test_scan_recent_projects_offers_demo_repo_when_discovery_is_empty(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    demo_path = tmp_path / "workspace" / "pollypm-demo"
+    messages: list[str] = []
+
+    monkeypatch.setattr(
+        "pollypm.onboarding.discover_recent_project_candidates",
+        lambda _config_path: [],
+    )
+    monkeypatch.setattr(
+        "pollypm.onboarding.demo_project_fallback_destination",
+        lambda _config_path: demo_path,
+    )
+    monkeypatch.setattr(
+        "pollypm.onboarding.provision_demo_project_fallback",
+        lambda _config_path: demo_path,
+    )
+    monkeypatch.setattr(
+        "pollypm.onboarding.add_selected_projects",
+        lambda _config_path, selected_paths: [
+            KnownProject(key="pollypm_demo", path=selected_paths[0], name="PollyPM Demo")
+        ],
+    )
+    monkeypatch.setattr("pollypm.onboarding.typer.confirm", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr("pollypm.onboarding.typer.echo", lambda message="": messages.append(message))
+
+    projects = _scan_recent_projects(config_path)
+
+    assert [project.path for project in projects] == [demo_path]
+    assert any("demo repo" in message.lower() for message in messages)

--- a/tests/test_onboarding_tui.py
+++ b/tests/test_onboarding_tui.py
@@ -348,6 +348,7 @@ def test_projects_step_can_offer_demo_repo_fallback(monkeypatch, tmp_path: Path)
 
             assert app.state.recent_projects == [demo_path]
             assert app.state.selected_project_paths == [demo_path]
+            assert app.state.seeded_demo_project_key == "pollypm_demo"
             assert app.state.seeded_demo_task_id == "demo/1"
             assert app.project_selection is not None
             assert list(app.project_selection.selected) == [demo_path]
@@ -377,6 +378,7 @@ def test_demo_task_choice_keeps_seeded_task(monkeypatch, tmp_path: Path) -> None
     assert seeded == [(demo_path, "pollypm_demo")]
     assert app.state.recent_projects == [demo_path]
     assert app.state.selected_project_paths == [demo_path]
+    assert app.state.seeded_demo_project_key == "pollypm_demo"
     assert app.state.seeded_demo_task_id == "demo/1"
     assert rendered == ["rendered"]
     assert "Seeded task demo/1" in messages[-1]
@@ -402,6 +404,7 @@ def test_demo_task_choice_can_forget_seeded_task(monkeypatch, tmp_path: Path) ->
 
     assert app.state.recent_projects == [demo_path]
     assert app.state.selected_project_paths == [demo_path]
+    assert app.state.seeded_demo_project_key is None
     assert app.state.seeded_demo_task_id is None
     assert rendered == ["rendered"]
     assert "No seeded task" in messages[-1]

--- a/tests/test_onboarding_tui.py
+++ b/tests/test_onboarding_tui.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from pollypm.models import KnownProject, ProviderKind
 from pollypm.onboarding import CliAvailability, ConnectedAccount
+from pollypm.projects import make_project_key
 from pollypm.onboarding_tui import (
     BlockingAutoFix,
     ONBOARDING_STAGES,
@@ -314,7 +315,7 @@ def test_onboarding_progress_lines_mark_done_current_and_up_next() -> None:
 
 def test_projects_step_can_offer_demo_repo_fallback(monkeypatch, tmp_path: Path) -> None:
     async def run() -> None:
-        demo_path = tmp_path / "workspace" / "pollypm-demo"
+        demo_path = tmp_path / "demo-polly"
         monkeypatch.setattr(
             "pollypm.onboarding_tui.demo_project_fallback_destination",
             lambda _config_path: demo_path,
@@ -348,7 +349,7 @@ def test_projects_step_can_offer_demo_repo_fallback(monkeypatch, tmp_path: Path)
 
             assert app.state.recent_projects == [demo_path]
             assert app.state.selected_project_paths == [demo_path]
-            assert app.state.seeded_demo_project_key == "pollypm_demo"
+            assert app.state.seeded_demo_project_key == make_project_key(demo_path, set())
             assert app.state.seeded_demo_task_id == "demo/1"
             assert app.project_selection is not None
             assert list(app.project_selection.selected) == [demo_path]
@@ -359,7 +360,7 @@ def test_projects_step_can_offer_demo_repo_fallback(monkeypatch, tmp_path: Path)
 
 def test_demo_task_choice_keeps_seeded_task(monkeypatch, tmp_path: Path) -> None:
     app = OnboardingApp(tmp_path / "pollypm.toml")
-    demo_path = tmp_path / "workspace" / "pollypm-demo"
+    demo_path = tmp_path / "demo-polly"
     app._pending_demo_repo_path = demo_path
     app.state.known_projects = {}
 
@@ -375,10 +376,10 @@ def test_demo_task_choice_keeps_seeded_task(monkeypatch, tmp_path: Path) -> None
 
     app._handle_demo_task_choice("keep")
 
-    assert seeded == [(demo_path, "pollypm_demo")]
+    assert seeded == [(demo_path, make_project_key(demo_path, set()))]
     assert app.state.recent_projects == [demo_path]
     assert app.state.selected_project_paths == [demo_path]
-    assert app.state.seeded_demo_project_key == "pollypm_demo"
+    assert app.state.seeded_demo_project_key == make_project_key(demo_path, set())
     assert app.state.seeded_demo_task_id == "demo/1"
     assert rendered == ["rendered"]
     assert "Seeded task demo/1" in messages[-1]
@@ -386,7 +387,7 @@ def test_demo_task_choice_keeps_seeded_task(monkeypatch, tmp_path: Path) -> None
 
 def test_demo_task_choice_can_forget_seeded_task(monkeypatch, tmp_path: Path) -> None:
     app = OnboardingApp(tmp_path / "pollypm.toml")
-    demo_path = tmp_path / "workspace" / "pollypm-demo"
+    demo_path = tmp_path / "demo-polly"
     app._pending_demo_repo_path = demo_path
     app.state.known_projects = {}
     app.state.seeded_demo_task_id = "demo/1"

--- a/tests/test_onboarding_tui.py
+++ b/tests/test_onboarding_tui.py
@@ -323,6 +323,10 @@ def test_projects_step_can_offer_demo_repo_fallback(monkeypatch, tmp_path: Path)
             "pollypm.onboarding_tui.provision_demo_project_fallback",
             lambda _config_path: demo_path,
         )
+        monkeypatch.setattr(
+            "pollypm.onboarding.seed_demo_project_task",
+            lambda project_path, *, project_key: "demo/1",
+        )
 
         app = OnboardingApp(tmp_path / "pollypm.toml")
         app.step = "projects"
@@ -330,6 +334,11 @@ def test_projects_step_can_offer_demo_repo_fallback(monkeypatch, tmp_path: Path)
         app.state.scan_complete = True
         app.state.recent_projects = []
         app.state.selected_project_paths = []
+        monkeypatch.setattr(
+            app,
+            "push_screen",
+            lambda _screen, callback: callback("keep"),
+        )
 
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
@@ -339,8 +348,60 @@ def test_projects_step_can_offer_demo_repo_fallback(monkeypatch, tmp_path: Path)
 
             assert app.state.recent_projects == [demo_path]
             assert app.state.selected_project_paths == [demo_path]
+            assert app.state.seeded_demo_task_id == "demo/1"
             assert app.project_selection is not None
             assert list(app.project_selection.selected) == [demo_path]
-            assert "Demo repo ready" in str(app.message_widget.render())
+            assert "Seeded task demo/1" in str(app.message_widget.render())
 
     asyncio.run(run())
+
+
+def test_demo_task_choice_keeps_seeded_task(monkeypatch, tmp_path: Path) -> None:
+    app = OnboardingApp(tmp_path / "pollypm.toml")
+    demo_path = tmp_path / "workspace" / "pollypm-demo"
+    app._pending_demo_repo_path = demo_path
+    app.state.known_projects = {}
+
+    seeded: list[tuple[Path, str]] = []
+    monkeypatch.setattr(
+        "pollypm.onboarding.seed_demo_project_task",
+        lambda project_path, *, project_key: seeded.append((project_path, project_key)) or "demo/1",
+    )
+    rendered: list[str] = []
+    monkeypatch.setattr(app, "_render_current_step", lambda: rendered.append("rendered"))
+    messages: list[str] = []
+    monkeypatch.setattr(app, "_set_message", lambda message="": messages.append(message))
+
+    app._handle_demo_task_choice("keep")
+
+    assert seeded == [(demo_path, "pollypm_demo")]
+    assert app.state.recent_projects == [demo_path]
+    assert app.state.selected_project_paths == [demo_path]
+    assert app.state.seeded_demo_task_id == "demo/1"
+    assert rendered == ["rendered"]
+    assert "Seeded task demo/1" in messages[-1]
+
+
+def test_demo_task_choice_can_forget_seeded_task(monkeypatch, tmp_path: Path) -> None:
+    app = OnboardingApp(tmp_path / "pollypm.toml")
+    demo_path = tmp_path / "workspace" / "pollypm-demo"
+    app._pending_demo_repo_path = demo_path
+    app.state.known_projects = {}
+    app.state.seeded_demo_task_id = "demo/1"
+
+    monkeypatch.setattr(
+        "pollypm.onboarding.seed_demo_project_task",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not seed")),
+    )
+    rendered: list[str] = []
+    monkeypatch.setattr(app, "_render_current_step", lambda: rendered.append("rendered"))
+    messages: list[str] = []
+    monkeypatch.setattr(app, "_set_message", lambda message="": messages.append(message))
+
+    app._handle_demo_task_choice("forget")
+
+    assert app.state.recent_projects == [demo_path]
+    assert app.state.selected_project_paths == [demo_path]
+    assert app.state.seeded_demo_task_id is None
+    assert rendered == ["rendered"]
+    assert "No seeded task" in messages[-1]

--- a/tests/test_onboarding_tui.py
+++ b/tests/test_onboarding_tui.py
@@ -310,3 +310,37 @@ def test_onboarding_progress_lines_mark_done_current_and_up_next() -> None:
     assert f"✓[/] [#3ddc84]{ONBOARDING_STAGES[0][1]}" in lines[0]
     assert f"◉[/] [#5b8aff bold]{ONBOARDING_STAGES[1][1]}" in lines[1]
     assert f"○[/] [#6b7a88]{ONBOARDING_STAGES[2][1]}" in lines[2]
+
+
+def test_projects_step_can_offer_demo_repo_fallback(monkeypatch, tmp_path: Path) -> None:
+    async def run() -> None:
+        demo_path = tmp_path / "workspace" / "pollypm-demo"
+        monkeypatch.setattr(
+            "pollypm.onboarding_tui.demo_project_fallback_destination",
+            lambda _config_path: demo_path,
+        )
+        monkeypatch.setattr(
+            "pollypm.onboarding_tui.provision_demo_project_fallback",
+            lambda _config_path: demo_path,
+        )
+
+        app = OnboardingApp(tmp_path / "pollypm.toml")
+        app.step = "projects"
+        app.state.scan_started = True
+        app.state.scan_complete = True
+        app.state.recent_projects = []
+        app.state.selected_project_paths = []
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            assert app.query_one("#projects-use-demo") is not None
+            await pilot.click("#projects-use-demo")
+            await pilot.pause()
+
+            assert app.state.recent_projects == [demo_path]
+            assert app.state.selected_project_paths == [demo_path]
+            assert app.project_selection is not None
+            assert list(app.project_selection.selected) == [demo_path]
+            assert "Demo repo ready" in str(app.message_widget.render())
+
+    asyncio.run(run())


### PR DESCRIPTION
Summary:
- offer a local demo project when onboarding finds no recent repos
- provision the demo idempotently and surface it in the onboarding TUI
- keep the demo repo contents in src/pollypm/defaults/demo so the fallback stays modular and replaceable

Testing:
- python -m py_compile src/pollypm/onboarding.py src/pollypm/onboarding_tui.py tests/test_onboarding.py tests/test_onboarding_tui.py
- uv run --with pytest python -m pytest tests/test_onboarding.py tests/test_onboarding_tui.py tests/test_onboarding_ux.py tests/test_onboarding_login_flow.py -q

Closes #653