### PR TITLE
feat(cockpit): add per-session rail glyphs

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -2029,6 +2029,8 @@ class PollyCockpitRail:
 
     def _session_work_glyph(self, work_state: str) -> tuple[str, _C | None]:
         if work_state == "writing":
+            if not self.presence.should_animate():
+                return "…", PALETTE["live_indicator"]
             return self.presence.working_frame(self.spinner_index), PALETTE["live_indicator"]
         if work_state == "reviewing":
             return "✎", PALETTE["live_indicator"]

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -120,6 +120,7 @@ class CockpitPresence:
     _cached_attached: bool | None = None
     _cached_at: float = 0.0
     _cached_session: str | None = None
+    _heartbeat_states: dict[str, tuple[str | None, int]] = field(default_factory=dict)
 
     def _calm_mode(self) -> bool:
         value = os.environ.get("POLLY_CALM", "")
@@ -193,6 +194,25 @@ class CockpitPresence:
             return ARC_SPINNER[0]
         return ARC_SPINNER[spinner_index % len(ARC_SPINNER)]
 
+    def heartbeat_frame(self, spinner_index: int) -> str:
+        frames = ("♥", "♡")
+        if not self.should_animate():
+            return frames[0]
+        return frames[spinner_index % len(frames)]
+
+    def heartbeat_frame_for(
+        self,
+        session_name: str,
+        heartbeat_at: str | None,
+    ) -> str:
+        frames = ("♥", "♡")
+        if not self.should_animate():
+            return frames[0]
+        previous_at, frame_index = self._heartbeat_states.get(session_name, (None, 0))
+        if heartbeat_at and heartbeat_at != previous_at:
+            frame_index = (frame_index + 1) % len(frames)
+        self._heartbeat_states[session_name] = (heartbeat_at, frame_index)
+        return frames[frame_index]
 
 # ── Rail data model + router ─────────────────────────────────────────────
 #
@@ -209,6 +229,9 @@ class CockpitItem:
     label: str
     state: str
     selectable: bool = True
+    session_name: str | None = None
+    work_state: str | None = None
+    heartbeat_at: str | None = None
 
 
 def _selected_project_key(selected: object) -> str | None:
@@ -734,6 +757,7 @@ class CockpitRouter:
         collapsed_sections = self._collapsed_rail_sections_cached(config)
         grouped_registrations = self._grouped_rail_registrations(config, registry)
         grouped: dict[str, list[CockpitItem]] = {name: [] for name in RAIL_SECTIONS}
+        project_session_map = self._project_session_map(launches)
 
         for section, registrations in grouped_registrations.items():
             for reg in registrations:
@@ -746,6 +770,12 @@ class CockpitRouter:
                         label=row.label,
                         state=row.state,
                         selectable=row.selectable,
+                    )
+                    self._attach_session_metadata(
+                        item,
+                        launches=launches,
+                        supervisor=supervisor,
+                        project_session_map=project_session_map,
                     )
                     grouped.setdefault(section, []).append(item)
 
@@ -770,6 +800,55 @@ class CockpitRouter:
             items.extend(rows)
 
         return items
+
+    def _attach_session_metadata(
+        self,
+        item: CockpitItem,
+        *,
+        launches,
+        supervisor,
+        project_session_map: dict[str, str],
+    ) -> None:
+        session_name = self._session_name_for_item(item, project_session_map)
+        if session_name is None:
+            return
+        item.session_name = session_name
+        launch = next((entry for entry in launches if entry.session.name == session_name), None)
+        if launch is None:
+            return
+        item.work_state = self._work_state_for_item_state(item.state, launch.session.role)
+        try:
+            heartbeat = supervisor.store.latest_heartbeat(session_name)
+        except Exception:  # noqa: BLE001
+            heartbeat = None
+        item.heartbeat_at = getattr(heartbeat, "created_at", None)
+
+    def _session_name_for_item(
+        self,
+        item: CockpitItem,
+        project_session_map: dict[str, str],
+    ) -> str | None:
+        if item.key == "polly":
+            return "operator"
+        if item.key == "russell":
+            return "reviewer"
+        if not item.key.startswith("project:") or item.key.count(":") != 1:
+            return None
+        project_key = item.key.split(":", 1)[1]
+        return project_session_map.get(project_key)
+
+    def _work_state_for_item_state(self, state: str, role: str) -> str | None:
+        if state == "dead":
+            return "exited"
+        if state.startswith("!"):
+            return "stuck"
+        if state.endswith("working"):
+            return "writing"
+        if role == "reviewer":
+            return "reviewing"
+        if state.endswith("live") or state in {"idle", "ready"}:
+            return "idle"
+        return None
 
     def _rail_registry(self):
         """Return the plugin-host rail registry for the active root dir."""
@@ -1861,7 +1940,8 @@ class PollyCockpitRail:
         # Build the text with gutter (2-char prefix for alignment)
         bar = "\u258c " if is_selected else "  "
         label = item.label
-        max_label = width - 6  # 2 bar + 1 indicator + 1 space + 2 margin
+        indicator_width = max(1, len(indicator))
+        max_label = width - (5 + indicator_width)
         if len(label) > max_label and max_label > 3:
             label = label[: max_label - 1] + "\u2026"
         text = f" {bar}{indicator} {label}"
@@ -1910,6 +1990,13 @@ class PollyCockpitRail:
         return row
 
     def _indicator(self, item: CockpitItem) -> tuple[str, _C | None]:
+        if item.session_name and item.work_state:
+            pulse = self.presence.heartbeat_frame_for(
+                item.session_name,
+                item.heartbeat_at,
+            )
+            work_glyph, color = self._session_work_glyph(item.work_state)
+            return f"{pulse}{work_glyph}", color
         # State-based indicators first (apply to any item type including projects)
         if item.state.endswith("working"):
             char = self.presence.working_frame(self.spinner_index)
@@ -1939,6 +2026,17 @@ class PollyCockpitRail:
         if item.state == "sub":
             return " ", None
         return "\u25cb", PALETTE["idle"]
+
+    def _session_work_glyph(self, work_state: str) -> tuple[str, _C | None]:
+        if work_state == "writing":
+            return self.presence.working_frame(self.spinner_index), PALETTE["live_indicator"]
+        if work_state == "reviewing":
+            return "✎", PALETTE["live_indicator"]
+        if work_state == "stuck":
+            return "⚠", PALETTE["alert_indicator"]
+        if work_state == "exited":
+            return "✕", PALETTE["dead"]
+        return "·", PALETTE["idle"]
 
     def _write(self, text: str) -> None:
         sys.stdout.write(text)

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -556,6 +556,8 @@ class RailItem(ListItem):
         presence = self.presence
         if work_state == "writing":
             if presence is not None:
+                if not presence.should_animate():
+                    return "…", "#3ddc84"
                 return presence.working_frame(self.spinner_index), "#3ddc84"
             return "\u25c6", "#3ddc84"
         if work_state == "reviewing":

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -112,7 +112,7 @@ from pollypm.rejection_feedback import (
 from pollypm.session_services import create_tmux_client
 from pollypm.service_api import PollyPMService
 from pollypm.cockpit import build_cockpit_detail
-from pollypm.cockpit_rail import CockpitItem, CockpitRouter
+from pollypm.cockpit_rail import CockpitItem, CockpitPresence, CockpitRouter
 
 
 import re as _re
@@ -414,18 +414,36 @@ class RailItem(ListItem):
         *,
         active_view: bool,
         first_project: bool = False,
+        presence: CockpitPresence | None = None,
+        spinner_index: int = 0,
     ) -> None:
         self.body = Static(classes="rail-item-body")
         self.item = item
+        self.presence = presence
+        self.spinner_index = spinner_index
         super().__init__(self.body, classes="rail-row", disabled=not item.selectable)
-        self.apply_item(item, active_view=active_view, first_project=first_project)
+        self.apply_item(
+            item,
+            active_view=active_view,
+            first_project=first_project,
+            spinner_index=spinner_index,
+        )
 
     @property
     def cockpit_key(self) -> str:
         return self.item.key
 
-    def apply_item(self, item: CockpitItem, *, active_view: bool, first_project: bool) -> None:
+    def apply_item(
+        self,
+        item: CockpitItem,
+        *,
+        active_view: bool,
+        first_project: bool,
+        spinner_index: int | None = None,
+    ) -> None:
         self.item = item
+        if spinner_index is not None:
+            self.spinner_index = spinner_index
         self.disabled = not item.selectable
         for class_name in [
             "inbox-entry",
@@ -483,6 +501,20 @@ class RailItem(ListItem):
         self.body.update(text)
 
     def _indicator(self) -> tuple[str, str]:
+        presence = self.presence
+        if (
+            presence is not None
+            and self.item.session_name
+            and self.item.work_state
+        ):
+            pulse = presence.heartbeat_frame_for(
+                self.item.session_name,
+                self.item.heartbeat_at,
+            )
+            work_glyph, color = self._session_work_glyph(self.item.work_state)
+            return f"{pulse}{work_glyph}", color
+        if presence is not None and self.item.state in {"heartbeat", "watch"}:
+            return presence.heartbeat_frame(self.spinner_index), "#3ddc84"
         # Alerts (red triangle)
         if self.item.state.startswith("!"):
             return "\u25b2", "#ff5f6d"
@@ -514,9 +546,25 @@ class RailItem(ListItem):
         # Projects: yellow for active task, dim for idle
         if self.item.key.startswith("project:"):
             if "working" in self.item.state:
+                if presence is not None:
+                    return presence.working_frame(self.spinner_index), "#3ddc84"
                 return "\u25c6", "#f0c45a"  # yellow diamond — active task
             return "\u25cb", "#4a5568"  # dim circle — idle
         return "\u25cb", "#4a5568"
+
+    def _session_work_glyph(self, work_state: str) -> tuple[str, str]:
+        presence = self.presence
+        if work_state == "writing":
+            if presence is not None:
+                return presence.working_frame(self.spinner_index), "#3ddc84"
+            return "\u25c6", "#3ddc84"
+        if work_state == "reviewing":
+            return "\u270e", "#3ddc84"
+        if work_state == "stuck":
+            return "\u26a0", "#ff5f6d"
+        if work_state == "exited":
+            return "\u2715", "#4a5568"
+        return "\u00b7", "#4a5568"
 
 
 class PollyCockpitApp(App[None]):
@@ -630,7 +678,12 @@ class PollyCockpitApp(App[None]):
         Binding("s", "open_settings", "Settings"),
         Binding("a", "view_alerts", "Alerts", show=False),
         Binding("colon", "open_command_palette", "Palette", priority=True),
-        Binding("question_mark", "show_keyboard_help", "Help", priority=True),
+        Binding(
+            "question_mark",
+            "show_keyboard_help",
+            "Help: pulse ♥/♡, writing ◜◝◞◟, review ✎, idle ·, stuck ⚠, exited ✕",
+            priority=True,
+        ),
         Binding("j,down", "cursor_down", "Down", show=False),
         Binding("k,up", "cursor_up", "Up", show=False),
         Binding("g,home", "cursor_first", "First", show=False),
@@ -649,6 +702,7 @@ class PollyCockpitApp(App[None]):
         super().__init__()
         self.config_path = config_path
         self.router = CockpitRouter(config_path)
+        self.presence = CockpitPresence(self.router.tmux)
         self.service = PollyPMService(config_path)
         _lines = ASCII_POLLY.split("\n")
         self.brand = Static(
@@ -835,8 +889,18 @@ class PollyCockpitApp(App[None]):
                 if item.state.endswith("working"):
                     item.state = f"{frame} working"
             for key, row in self._row_widgets.items():
-                if row.item.state.endswith("working"):
-                    row.item.state = f"{frame} working"
+                should_animate = row.item.state.endswith("working")
+                rewrite_state = should_animate
+                if row.item.state in {"heartbeat", "watch"}:
+                    should_animate = True
+                    rewrite_state = False
+                if row.item.session_name and row.item.work_state == "writing":
+                    should_animate = True
+                    rewrite_state = False
+                if should_animate:
+                    if rewrite_state:
+                        row.item.state = f"{frame} working"
+                    row.spinner_index = self.spinner_index
                     row.update_body()
         # Layout check much less frequently
         if self._tick_count % self._LAYOUT_CHECK_INTERVAL == 0:
@@ -921,11 +985,18 @@ class PollyCockpitApp(App[None]):
                     item,
                     active_view=item.key == self.selected_key,
                     first_project=first_project,
+                    presence=self.presence,
+                    spinner_index=self.spinner_index,
                 )
                 self._row_widgets[item.key] = row
             else:
                 row = self._row_widgets[item.key]
-                row.apply_item(item, active_view=item.key == self.selected_key, first_project=first_project)
+                row.apply_item(
+                    item,
+                    active_view=item.key == self.selected_key,
+                    first_project=first_project,
+                    spinner_index=self.spinner_index,
+                )
             rows.append(row)
             if selected_key is not None and item.key == selected_key:
                 restore_index = nav_index

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from pollypm.cockpit import build_cockpit_detail
-from pollypm.cockpit_rail import CockpitPresence, CockpitRouter
+from pollypm.cockpit_rail import CockpitItem, CockpitPresence, CockpitRouter, PollyCockpitRail
 from pollypm.config import write_config
 from pollypm.cockpit_ui import PollyCockpitApp, PollySettingsPaneApp
 from pollypm.models import (
@@ -207,6 +207,83 @@ def test_cockpit_presence_calm_mode_disables_animation(monkeypatch) -> None:
 
     assert presence.should_animate() is False
     assert presence.working_frame(3) == "◜"
+
+
+def test_cockpit_presence_heartbeat_frame_advances_only_on_new_heartbeat() -> None:
+    class _FakeTmux:
+        def current_session_name(self) -> str | None:
+            return "pollypm"
+
+        def list_clients(self, session_name: str) -> str:
+            del session_name
+            return "client"
+
+    presence = CockpitPresence(_FakeTmux())
+
+    first = presence.heartbeat_frame_for("worker_demo", "2026-04-21T23:00:00+00:00")
+    second = presence.heartbeat_frame_for("worker_demo", "2026-04-21T23:00:00+00:00")
+    third = presence.heartbeat_frame_for("worker_demo", "2026-04-21T23:05:00+00:00")
+
+    assert first == "♡"
+    assert second == "♡"
+    assert third == "♥"
+
+
+def test_cockpit_rail_session_indicator_combines_pulse_and_work_glyph(monkeypatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+
+    class _FakeTmux:
+        def current_session_name(self) -> str | None:
+            return "pollypm"
+
+        def list_clients(self, session_name: str) -> str:
+            del session_name
+            return "client"
+
+    rail = PollyCockpitRail(config_path)
+    rail.router.tmux = _FakeTmux()  # type: ignore[assignment]
+    rail.presence = CockpitPresence(_FakeTmux())
+
+    writing = CockpitItem(
+        "project:demo",
+        "Demo",
+        "◜ working",
+        session_name="worker_demo",
+        work_state="writing",
+        heartbeat_at="2026-04-21T23:00:00+00:00",
+    )
+    reviewing = CockpitItem(
+        "russell",
+        "Russell",
+        "ready",
+        session_name="reviewer",
+        work_state="reviewing",
+        heartbeat_at="2026-04-21T23:00:00+00:00",
+    )
+    stuck = CockpitItem(
+        "project:demo",
+        "Demo",
+        "! pane dead",
+        session_name="worker_demo",
+        work_state="stuck",
+        heartbeat_at="2026-04-21T23:00:00+00:00",
+    )
+    exited = CockpitItem(
+        "project:demo",
+        "Demo",
+        "dead",
+        session_name="worker_demo",
+        work_state="exited",
+        heartbeat_at="2026-04-21T23:00:00+00:00",
+    )
+
+    assert rail._indicator(writing)[0] == "♡◜"
+    assert rail._indicator(reviewing)[0] == "♡✎"
+    assert rail._indicator(stuck)[0] == "♡⚠"
+    assert rail._indicator(exited)[0] == "♡✕"
 
 
 def test_cockpit_router_config_cache_reuses_loaded_config(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -209,6 +209,35 @@ def test_cockpit_presence_calm_mode_disables_animation(monkeypatch) -> None:
     assert presence.working_frame(3) == "◜"
 
 
+def test_cockpit_ui_rail_item_uses_static_ellipsis_in_calm_mode(monkeypatch) -> None:
+    monkeypatch.setattr(RailItem, "update_body", lambda self: None)
+
+    class _FakeTmux:
+        def current_session_name(self) -> str | None:
+            return "pollypm"
+
+        def list_clients(self, session_name: str) -> str:
+            del session_name
+            return "client"
+
+    monkeypatch.setenv("POLLY_CALM", "1")
+    presence = CockpitPresence(_FakeTmux())
+    item = RailItem(
+        CockpitItem(
+            "project:demo",
+            "Demo",
+            "ready",
+            session_name="worker_demo",
+            work_state="writing",
+            heartbeat_at="2026-04-21T23:00:00+00:00",
+        ),
+        active_view=False,
+        presence=presence,
+    )
+
+    assert item._indicator()[0] == "♥…"
+
+
 def test_cockpit_presence_heartbeat_frame_advances_only_on_new_heartbeat() -> None:
     class _FakeTmux:
         def current_session_name(self) -> str | None:
@@ -352,6 +381,40 @@ def test_cockpit_rail_session_indicator_combines_pulse_and_work_glyph(monkeypatc
     assert rail._indicator(reviewing)[0] == "♡✎"
     assert rail._indicator(stuck)[0] == "♡⚠"
     assert rail._indicator(exited)[0] == "♡✕"
+
+
+def test_cockpit_rail_session_indicator_uses_static_ellipsis_in_calm_mode(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("POLLY_CALM", "1")
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+
+    class _FakeTmux:
+        def current_session_name(self) -> str | None:
+            return "pollypm"
+
+        def list_clients(self, session_name: str) -> str:
+            del session_name
+            return "client"
+
+    rail = PollyCockpitRail(config_path)
+    rail.router.tmux = _FakeTmux()  # type: ignore[assignment]
+    rail.presence = CockpitPresence(_FakeTmux())
+
+    writing = CockpitItem(
+        "project:demo",
+        "Demo",
+        "◜ working",
+        session_name="worker_demo",
+        work_state="writing",
+        heartbeat_at="2026-04-21T23:00:00+00:00",
+    )
+
+    assert rail._indicator(writing)[0] == "♥…"
 
 
 def test_cockpit_ui_help_legend_mentions_glyph_alphabet() -> None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from pollypm.cockpit import build_cockpit_detail
 from pollypm.cockpit_rail import CockpitItem, CockpitPresence, CockpitRouter, PollyCockpitRail
 from pollypm.config import write_config
-from pollypm.cockpit_ui import PollyCockpitApp, PollySettingsPaneApp
+from pollypm.cockpit_ui import PollyCockpitApp, PollySettingsPaneApp, RailItem
 from pollypm.models import (
     AccountConfig,
     KnownProject,
@@ -229,6 +229,74 @@ def test_cockpit_presence_heartbeat_frame_advances_only_on_new_heartbeat() -> No
     assert third == "♥"
 
 
+def test_cockpit_ui_rail_item_indicator_combines_pulse_and_work_glyph(monkeypatch) -> None:
+    monkeypatch.setattr(RailItem, "update_body", lambda self: None)
+
+    class _FakeTmux:
+        def current_session_name(self) -> str | None:
+            return "pollypm"
+
+        def list_clients(self, session_name: str) -> str:
+            del session_name
+            return "client"
+
+    presence = CockpitPresence(_FakeTmux())
+
+    writing = RailItem(
+        CockpitItem(
+            "project:demo",
+            "Demo",
+            "ready",
+            session_name="worker_demo",
+            work_state="writing",
+            heartbeat_at="2026-04-21T23:00:00+00:00",
+        ),
+        active_view=False,
+        presence=presence,
+    )
+    reviewing = RailItem(
+        CockpitItem(
+            "russell",
+            "Russell",
+            "ready",
+            session_name="reviewer",
+            work_state="reviewing",
+            heartbeat_at="2026-04-21T23:00:00+00:00",
+        ),
+        active_view=False,
+        presence=presence,
+    )
+    stuck = RailItem(
+        CockpitItem(
+            "project:demo",
+            "Demo",
+            "! pane dead",
+            session_name="worker_demo",
+            work_state="stuck",
+            heartbeat_at="2026-04-21T23:00:00+00:00",
+        ),
+        active_view=False,
+        presence=presence,
+    )
+    exited = RailItem(
+        CockpitItem(
+            "project:demo",
+            "Demo",
+            "dead",
+            session_name="worker_demo",
+            work_state="exited",
+            heartbeat_at="2026-04-21T23:00:00+00:00",
+        ),
+        active_view=False,
+        presence=presence,
+    )
+
+    assert writing._indicator()[0] == "♡◜"
+    assert reviewing._indicator()[0] == "♡✎"
+    assert stuck._indicator()[0] == "♡⚠"
+    assert exited._indicator()[0] == "♡✕"
+
+
 def test_cockpit_rail_session_indicator_combines_pulse_and_work_glyph(monkeypatch, tmp_path: Path) -> None:
     config_path = tmp_path / "pollypm.toml"
     config_path.write_text(
@@ -284,6 +352,17 @@ def test_cockpit_rail_session_indicator_combines_pulse_and_work_glyph(monkeypatc
     assert rail._indicator(reviewing)[0] == "♡✎"
     assert rail._indicator(stuck)[0] == "♡⚠"
     assert rail._indicator(exited)[0] == "♡✕"
+
+
+def test_cockpit_ui_help_legend_mentions_glyph_alphabet() -> None:
+    binding = next(
+        binding for binding in PollyCockpitApp.BINDINGS if getattr(binding, "key", "") == "question_mark"
+    )
+
+    assert "pulse" in binding.description
+    assert "✎" in binding.description
+    assert "⚠" in binding.description
+    assert "✕" in binding.description
 
 
 def test_cockpit_router_config_cache_reuses_loaded_config(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
Builds the live rail pulse/work-state indicators on top of the merged perf cache work from #691.

Closes #659
Closes #660

Focused validation:
- `python3 -m py_compile src/pollypm/cockpit_rail.py src/pollypm/cockpit_ui.py tests/test_cockpit.py`
- `uv run --extra dev pytest -q tests/test_cockpit.py -k "calm_mode_disables_animation or rail_item_uses_static_ellipsis_in_calm_mode or rail_session_indicator_uses_static_ellipsis_in_calm_mode or rail_item_indicator_combines_pulse_and_work_glyph or cockpit_rail_session_indicator_combines_pulse_and_work_glyph or help_legend_mentions_glyph_alphabet"`