### PR TITLE
docs: clarify cockpit rail surface ownership

### DIFF
--- a/.github/ISSUE_TEMPLATE/rail-change.yml
+++ b/.github/ISSUE_TEMPLATE/rail-change.yml
@@ -1,0 +1,45 @@
+name: Rail change
+description: File a rail or cockpit-rail issue with explicit dual-surface review.
+title: "[rail] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Rail work spans two live surfaces on `main`:
+
+        - `src/pollypm/cockpit_ui.py` — the Textual cockpit users see when they run `pm`
+        - `src/pollypm/cockpit_rail.py` — shared rail/router/runtime plumbing; the legacy `PollyCockpitRail` class still lives here
+
+        Default to auditing both surfaces unless you can prove one is unaffected.
+  - type: checkboxes
+    id: surfaces
+    attributes:
+      label: Surfaces
+      description: Both surfaces must be reviewed before the issue is filed.
+      options:
+        - label: "`src/pollypm/cockpit_ui.py` reviewed"
+          required: true
+        - label: "`src/pollypm/cockpit_rail.py` reviewed"
+          required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: State the user-visible acceptance criteria for the rail change.
+      placeholder: |
+        - ...
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence / Audit
+      description: Note the commands, code paths, or docs that show why both surfaces do or do not need changes.
+      placeholder: |
+        - `pm` launches ...
+        - `pm rail` / `rail-daemon` use ...
+    validations:
+      required: true

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -1,6 +1,7 @@
-"""Rail rendering + routing for the cockpit left pane (#404).
+"""Shared rail data/routing plus a legacy renderer for cockpit surfaces (#404).
 
-This module owns every piece of the cockpit *rail* contract:
+This module owns the shared cockpit *rail* contract used across both
+``cockpit_ui.py`` and the rail-oriented CLI/runtime helpers:
 
 * :class:`CockpitItem` — the dataclass every row is built from.
 * :class:`CockpitRouter` — the orchestrator that loads state, persists
@@ -10,8 +11,9 @@ This module owns every piece of the cockpit *rail* contract:
   (``_selected_project_key``, ``_hidden_rail_items``,
   ``_collapsed_rail_sections``, ``_visibility_passes``,
   ``_rows_for_registration``).
-* :class:`PollyCockpitRail` — the text-only renderer used by ``pm rail``
-  when the user wants the pre-Textual surface.
+* :class:`PollyCockpitRail` — a legacy text-only renderer kept in-tree,
+  but not launched by the default ``pm`` Textual cockpit, ``pm rail``,
+  or ``rail-daemon`` on current ``main``.
 
 Splitting the rail out of ``cockpit.py`` keeps that module focused on
 the dashboard + detail-pane renderers; importers that still reach into


### PR DESCRIPTION
## Summary
- clarify in `src/pollypm/cockpit_rail.py` that the module is shared rail plumbing and that `PollyCockpitRail` is a legacy renderer, not the default `pm` surface
- add a rail issue form that requires explicit review of both `src/pollypm/cockpit_ui.py` and `src/pollypm/cockpit_rail.py`
- annotate the open rail issues (#656, #659, #660, #666, #667, #668, #677) with a dual-surface note outside the repo

## Audit evidence
- `pm` launches `PollyCockpitApp` from `src/pollypm/cli_features/ui.py`
- `pm up` still auto-spawns `pollypm.rail_daemon`, and `pm reset` stops it (`src/pollypm/cli.py`, `src/pollypm/cli_features/session_runtime.py`, `README.md`)
- `pm rail` is still documented and tested as a live CLI surface (`src/pollypm/rail_cli.py`, `docs/extensible-rail-spec.md`, `tests/test_rail_cli.py`)
- `PollyCockpitRail` the class has no call sites on current `main` beyond `run_cockpit_rail()` in the same module, so the removal candidate is the class, not the whole `cockpit_rail.py` module or the rail runtime/CLI surface

## Checks
- `git diff --check`
- verified the updated GitHub issue bodies with `gh issue view`

Closes #701
