### PR TITLE
docs(rail): define dual-surface contract

### DIFF
--- a/.github/ISSUE_TEMPLATE/rail-surface.yml
+++ b/.github/ISSUE_TEMPLATE/rail-surface.yml
@@ -1,0 +1,42 @@
+name: Rail Surface Work
+description: Feature or bug report for the cockpit rail / rail daemon surfaces
+title: "rail: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        PollyPM has two live rail surfaces:
+
+        - `src/pollypm/cockpit_ui.py` — the Textual cockpit users see when they run `pm`
+        - `src/pollypm/cockpit_rail.py` + `src/pollypm/rail_daemon.py` — the text/daemon rail path
+
+        If this issue changes rendering, indicators, keyboard bindings, tickers, or section behavior, assume **both** surfaces are in scope unless you explicitly limit it below.
+  - type: checkboxes
+    id: surfaces
+    attributes:
+      label: Surfaces
+      description: Select every surface this issue is expected to touch.
+      options:
+        - label: `src/pollypm/cockpit_ui.py` (Textual cockpit)
+        - label: `src/pollypm/cockpit_rail.py` (text rail)
+        - label: `src/pollypm/rail_daemon.py` (headless rail daemon)
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope note
+      description: If this intentionally touches only one surface, explain why.
+      placeholder: "Example: Textual-only because this is a modal dialog that does not exist in the daemon/text rail."
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: Include visibility checks for every selected surface.
+      placeholder: |
+        - Textual cockpit shows ...
+        - text/daemon rail shows ...
+    validations:
+      required: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ PollyPM is a tmux-first control plane for people who want multiple AI coding ses
 
 Architecturally, PollyPM is a modular monolith: one local system with explicit replaceable boundaries for providers, runtimes, storage backends, scheduler/heartbeat hooks, and cockpit panes. The current cockpit includes a real split-pane task review surface, live session peeks, and cached account-usage tracking so the UI can stay responsive without probing providers inline.
 
+One important contributor constraint: the "rail" is not a single file.
+User-visible rail work usually spans both the Textual cockpit surface in
+`src/pollypm/cockpit_ui.py` and the text/daemon rail path in
+`src/pollypm/cockpit_rail.py` plus `src/pollypm/rail_daemon.py`. Rail
+issues should call out their intended surface coverage explicitly.
+
 **New here? Start with [docs/getting-started.md](docs/getting-started.md)** — a 15-minute walkthrough from install to your first completed task. See [CHANGELOG.md](CHANGELOG.md) for release notes and migration notes. The rest of this README is the module map and architecture reference for contributors.
 
 ## Document Map

--- a/docs/extensible-rail-spec.md
+++ b/docs/extensible-rail-spec.md
@@ -2,6 +2,22 @@
 
 **Status:** v1 target. Depends on: plugin-api v1, cockpit.
 
+## 0. Surface contract
+
+PollyPM has **two live rail surfaces** and rail-facing issues must say
+which one they affect:
+
+- `src/pollypm/cockpit_ui.py` — the Textual cockpit launched by `pm`
+  and used for the normal interactive UI.
+- `src/pollypm/cockpit_rail.py` plus `src/pollypm/rail_daemon.py` —
+  the text/daemon rail path that keeps heartbeat and recovery work
+  alive when the cockpit is closed.
+
+If a rail feature changes row rendering, indicators, keyboard
+bindings, footer/ticker content, or section collapse behavior, the
+default expectation is that **both surfaces** are updated. An issue may
+scope itself to only one surface, but it must say so explicitly.
+
 ## 1. Purpose
 
 Today the cockpit's left rail is a hardcoded list (Projects, Tasks, Settings, etc.). Plugins that want to add a visible surface — the Live Activity Feed, a Magic Skills explorer, a Downtime Backlog viewer — can't do it without editing cockpit code.


### PR DESCRIPTION
Documents the decision behind issue #701: PollyPM keeps both the Textual cockpit rail and the headless/text rail path, so rail issues must declare their intended surface coverage instead of implicitly targeting only one file.

What this ships:
- adds the rail surface contract to `docs/extensible-rail-spec.md`
- adds a focused GitHub issue template requiring surface + acceptance declarations
- calls the same constraint out in the contributor-facing README

Closes #700
