### PR TITLE
Settings budget/rationale follow-up

### DIFF
--- a/src/pollypm/cockpit_project_settings.py
+++ b/src/pollypm/cockpit_project_settings.py
@@ -23,10 +23,12 @@ from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, Static
 
+from pollypm.account_usage_sampler import load_cached_account_usage
 from pollypm.config import load_config
 from pollypm.cockpit_settings_history import (
     UndoAction,
     consume_settings_history,
+    history_rationale_for_account,
     latest_settings_history_entry,
     make_undo_action,
     record_settings_history,
@@ -204,14 +206,27 @@ class PollyProjectSettingsApp(App[None]):
         return "\n".join(lines)
 
     def _build_preview(self, worker, *, account_label: str) -> str:
+        current_budget = self._budget_summary_for_account(worker.account)
         lines = [
             "[b]Diff preview[/b]",
             f"Current: [b]{worker.provider.value}[/b] on {account_label}",
+            f"Current budget: [b]{current_budget}[/b]",
         ]
         claude = self._target_account_for(ProviderKind.CLAUDE)
         codex = self._target_account_for(ProviderKind.CODEX)
-        lines.append(f"Claude target: {claude or '[dim]none available[/dim]'}")
-        lines.append(f"Codex target: {codex or '[dim]none available[/dim]'}")
+        lines.append(
+            f"Claude target: {claude or '[dim]none available[/dim]'}"
+            f" · budget: [b]{self._budget_summary_for_account(claude)}[/b]"
+        )
+        lines.append(
+            f"Codex target: {codex or '[dim]none available[/dim]'}"
+            f" · budget: [b]{self._budget_summary_for_account(codex)}[/b]"
+        )
+        rationale = history_rationale_for_account(
+            worker.account,
+            default_account=worker.account,
+        )
+        lines.append(f"Rationale: {rationale}")
         lines.append("[dim]Press Enter or click a switch button to apply. U undoes the last reversible switch for 24h.[/dim]")
         return "\n".join(lines)
 
@@ -221,6 +236,30 @@ class PollyProjectSettingsApp(App[None]):
             if account.provider is target_provider:
                 return name
         return None
+
+    def _budget_summary_for_account(self, account_key: str | None) -> str:
+        if not account_key:
+            return "budget unavailable"
+        try:
+            cached = load_cached_account_usage(self.config_path)
+        except Exception:  # noqa: BLE001
+            cached = {}
+        record = cached.get(account_key)
+        if record is None:
+            return "budget unavailable"
+        used_pct = getattr(record, "used_pct", None)
+        remaining_pct = getattr(record, "remaining_pct", None)
+        usage_summary = getattr(record, "usage_summary", "") or "usage unavailable"
+        if used_pct is not None and remaining_pct is not None:
+            summary = f"{used_pct}% used / {remaining_pct}% left"
+        elif remaining_pct is not None:
+            summary = f"{remaining_pct}% left"
+        else:
+            summary = usage_summary
+        updated_at = getattr(record, "updated_at", "") or ""
+        if updated_at:
+            summary = f"{summary} · updated {updated_at}"
+        return summary
 
     def _record_undo(
         self,

--- a/src/pollypm/cockpit_settings_history.py
+++ b/src/pollypm/cockpit_settings_history.py
@@ -178,6 +178,7 @@ def history_rationale_for_account(
     *,
     entries: Sequence[SettingsHistoryEntry] | None = None,
     path: Path | None = None,
+    default_account: str | None = None,
 ) -> str | None:
     if not account_key:
         return None
@@ -185,22 +186,26 @@ def history_rationale_for_account(
     for entry in reversed(history):
         payload = entry.payload
         stamp = entry.created_at.astimezone(timezone.utc).strftime("%H:%M UTC")
-        if entry.kind == "session.switch":
-            to_account = str(payload.get("to_account") or "")
-            from_account = str(payload.get("from_account") or "")
+        if entry.kind in {"session.switch", "manual_switch"}:
+            to_account = str(payload.get("to_account") or payload.get("account") or "")
+            from_account = str(payload.get("from_account") or payload.get("previous_account") or "")
             session_name = str(payload.get("session_name") or "session")
             if account_key == to_account:
-                return f"Recent switch: {session_name} moved to {to_account} at {stamp}."
+                return f"Recent manual switch: {session_name} moved to {to_account} at {stamp}."
             if account_key == from_account:
-                return f"Recent switch: {session_name} moved away from {from_account} at {stamp}."
-        if entry.kind == "account.failover":
+                return f"Recent manual switch: {session_name} moved away from {from_account} at {stamp}."
+        if entry.kind in {"account.failover", "failover"}:
             if account_key == str(payload.get("account") or ""):
                 state = "enabled" if bool(payload.get("enabled")) else "disabled"
-                return f"Failover {state} for {account_key} at {stamp}."
-        if entry.kind == "account.controller":
+                return f"Recent failover {state} for {account_key} at {stamp}."
+        if entry.kind in {"account.controller", "default", "account.default"}:
             if account_key == str(payload.get("account") or ""):
-                return f"Controller account set to {account_key} at {stamp}."
-    return None
+                return f"Default account set to {account_key} at {stamp}."
+    if default_account:
+        if account_key == default_account:
+            return f"Default account from config: {default_account}."
+        return f"Default account from config: {default_account}."
+    return "No recent manual-switch or failover event recorded."
 
 
 def history_rationale_for_project(

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -2255,6 +2255,7 @@ def _gather_settings_data(
                 "rationale": history_rationale_for_account(
                     status.key,
                     entries=history,
+                    default_account=ctrl or None,
                 )
                 or (
                     "Provider budgets come from the cached account_usage sampler so the UI stays offline-safe."

--- a/tests/test_project_settings_ui.py
+++ b/tests/test_project_settings_ui.py
@@ -45,6 +45,14 @@ class _FakeAccount:
         self.provider = provider
 
 
+class _FakeUsage:
+    def __init__(self, *, used_pct: int, remaining_pct: int, usage_summary: str, updated_at: str) -> None:
+        self.used_pct = used_pct
+        self.remaining_pct = remaining_pct
+        self.usage_summary = usage_summary
+        self.updated_at = updated_at
+
+
 class _FakeConfig:
     def __init__(self) -> None:
         self.projects = {"alpha": _FakeProject("alpha", name="Alpha Project")}
@@ -90,6 +98,23 @@ def project_settings_env(tmp_path: Path, monkeypatch):
         lambda _path: service,
     )
     monkeypatch.setattr(
+        "pollypm.cockpit_project_settings.load_cached_account_usage",
+        lambda _path: {
+            "claude_main": _FakeUsage(
+                used_pct=19,
+                remaining_pct=81,
+                usage_summary="81% left this week",
+                updated_at="2026-04-21T09:00:00+00:00",
+            ),
+            "codex_main": _FakeUsage(
+                used_pct=78,
+                remaining_pct=22,
+                usage_summary="22% left this week",
+                updated_at="2026-04-21T09:30:00+00:00",
+            ),
+        },
+    )
+    monkeypatch.setattr(
         "pollypm.cockpit_settings_history.Path.home",
         lambda: tmp_path / "home",
     )
@@ -128,7 +153,12 @@ def test_project_settings_renders_worker_and_account(project_settings_env) -> No
             assert "claude" in model_info
             preview = str(app.query_one("#preview").render())
             assert "Diff preview" in preview
-            assert "Undo" in preview or "undo" in preview.lower()
+            assert "Current budget" in preview
+            assert "19% used / 81% left" in preview
+            assert "Claude target" in preview
+            assert "22% left" in preview
+            assert "Codex target" in preview
+            assert "Default account" in preview
 
     _run(body())
 
@@ -160,6 +190,35 @@ def test_project_settings_reset_and_switch_provider(project_settings_env, monkey
             new_app.action_undo_recent_change()
             assert service.switched[-1] == ("worker-alpha", "claude_main")
             assert "Undid" in str(new_app.query_one("#message").render())
+
+    _run(body())
+
+
+def test_project_settings_preview_uses_latest_history_event(project_settings_env, monkeypatch, tmp_path: Path) -> None:
+    from pollypm.cockpit_settings_history import record_settings_history
+
+    monkeypatch.setattr(
+        "pollypm.cockpit_settings_history.Path.home",
+        lambda: tmp_path / "home",
+    )
+    record_settings_history(
+        "manual_switch",
+        "worker-alpha -> codex_main",
+        {
+            "session_name": "worker-alpha",
+            "from_account": "claude_main",
+            "to_account": "codex_main",
+        },
+    )
+
+    app = project_settings_env["app"]
+
+    async def body() -> None:
+        async with app.run_test(size=(120, 30)) as pilot:
+            await pilot.pause()
+            preview = str(app.query_one("#preview").render())
+            assert "Recent manual switch" in preview
+            assert "codex_main" in preview
 
     _run(body())
 

--- a/tests/test_settings_ui.py
+++ b/tests/test_settings_ui.py
@@ -604,14 +604,18 @@ def test_settings_data_uses_history_rationale(settings_env, monkeypatch, tmp_pat
     from pollypm.cockpit_settings_history import record_settings_history
 
     record_settings_history(
-        "account.failover",
-        "failover claude_demo on",
-        {"account": "claude_demo", "enabled": True},
+        "manual_switch",
+        "worker-alpha -> codex_demo",
+        {
+            "session_name": "worker-alpha",
+            "from_account": "claude_demo",
+            "to_account": "codex_demo",
+        },
     )
     record_settings_history(
-        "project.tracked",
-        "project alpha tracked off",
-        {"project_key": "alpha", "previous": True, "enabled": False},
+        "failover",
+        "failover claude_demo on",
+        {"account": "claude_demo", "enabled": True},
     )
 
     app = settings_env["app"]
@@ -619,10 +623,12 @@ def test_settings_data_uses_history_rationale(settings_env, monkeypatch, tmp_pat
     async def body() -> None:
         async with app.run_test(size=(140, 40)) as pilot:
             await pilot.pause()
-            account = next(a for a in app.data.accounts if a["key"] == "claude_demo")
-            assert "Failover enabled for claude_demo" in account["rationale"]
-            project = next(p for p in app.data.projects if p["key"] == "alpha")
-            assert "marked paused" in project["rationale"]
+            switched = next(a for a in app.data.accounts if a["key"] == "codex_demo")
+            assert "Recent manual switch" in switched["rationale"]
+            failed_over = next(a for a in app.data.accounts if a["key"] == "claude_demo")
+            assert "Recent failover enabled for claude_demo" in failed_over["rationale"]
+            defaulted = next(a for a in app.data.accounts if a["key"] == "claude_stale")
+            assert "Default account from config: claude_demo." in defaulted["rationale"]
 
     _run(body())
 


### PR DESCRIPTION
Tightens the remaining settings follow-up by surfacing cached provider budget context where switch decisions happen and by sourcing the rationale line from the latest manual-switch/failover/default history entry.

What this ships:
- project settings preview shows current + target provider budget summaries from cached account usage
- settings/account rationale now reads from persisted history events with a default-account fallback
- focused settings tests cover budget/rationale rendering in both the project settings pane and the broader settings data model

Validation:
- `python3 -m py_compile src/pollypm/cockpit_ui.py src/pollypm/cockpit_project_settings.py src/pollypm/cockpit_settings_history.py tests/test_settings_ui.py tests/test_project_settings_ui.py tests/test_command_palette.py`
- `uv run --with pytest python -m pytest tests/test_settings_ui.py tests/test_project_settings_ui.py tests/test_command_palette.py -q`
- `35 passed`

Closes #669
Closes #670