### PR TITLE
feat(tasks): inline review diff in cockpit Review tab

### DIFF
--- a/src/pollypm/cockpit_task_review.py
+++ b/src/pollypm/cockpit_task_review.py
@@ -11,8 +11,13 @@ Contract:
 from __future__ import annotations
 
 import re
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+
+from rich.console import Group
+from rich.syntax import Syntax
+from rich.text import Text
 
 
 @dataclass(slots=True)
@@ -30,6 +35,20 @@ class ReviewArtifact:
     confidence: int | None = None
 
 
+@dataclass(slots=True)
+class ReviewDiffFile:
+    path: str
+    patch: str
+    line_count: int
+
+
+@dataclass(slots=True)
+class ReviewDiffBundle:
+    source_label: str
+    files: list[ReviewDiffFile]
+    total_lines: int
+
+
 _PLAN_REVIEW_DEFAULTS: tuple[tuple[str, str], ...] = (
     ("Project Plan", "docs/project-plan.md"),
     ("Canonical Plan", "docs/plan/plan.md"),
@@ -38,6 +57,25 @@ _PLAN_REVIEW_DEFAULTS: tuple[tuple[str, str], ...] = (
 
 _CONFIDENCE_PATTERN = re.compile(
     r"(?im)\bconfidence\s*[:=-]?\s*(10|[0-9])\s*/\s*10\b"
+)
+_DIFF_FENCE_PATTERN = re.compile(r"```diff\s*\n(.*?)```", re.IGNORECASE | re.DOTALL)
+_DIFF_HEADING_PATTERN = re.compile(r"(?im)^(diff --git .+|--- .+\n\+\+\+ .+|@@ .+ @@)")
+_DIFF_PATH_PATTERN = re.compile(r"^diff --git a/(.+?) b/(.+)$")
+_DIFF_COLLAPSE_LINES = 500
+
+_DIFF_LINK_KEYS = (
+    "github_pr",
+    "github_pr_number",
+    "pull_request",
+    "pr_number",
+    "branch",
+    "branch_name",
+    "head_branch",
+    "head_ref",
+    "head_sha",
+    "base_branch",
+    "base_ref",
+    "base_sha",
 )
 
 
@@ -89,6 +127,40 @@ def load_task_review_artifact(task, project_path: Path | None) -> ReviewArtifact
     )
 
 
+def load_task_review_diff(
+    task,
+    project_path: Path | None,
+    *,
+    review_artifact: ReviewArtifact | None = None,
+    active_branch: str | None = None,
+) -> ReviewDiffBundle | None:
+    """Load a review diff, preferring captured review artifacts over git."""
+    artifact = review_artifact
+    if artifact is None and project_path is not None:
+        artifact = load_task_review_artifact(task, project_path)
+    artifact_diff = _artifact_review_diff(artifact)
+    if artifact_diff is not None:
+        return artifact_diff
+    refs = _linked_diff_refs(task, active_branch=active_branch)
+    if refs is None or project_path is None:
+        return None
+    base_ref, head_ref = refs
+    diff_text = _git_review_diff(project_path, base_ref=base_ref, head_ref=head_ref)
+    if not diff_text:
+        return None
+    return _bundle_from_diff_text(
+        diff_text,
+        source_label=f"git diff {base_ref}..{head_ref}",
+    )
+
+
+def load_task_review_inline_diff(
+    artifact: ReviewArtifact | None,
+) -> ReviewDiffBundle | None:
+    """Load inline review diff content from a captured review artifact only."""
+    return _artifact_review_diff(artifact)
+
+
 def render_task_review_artifact(artifact: ReviewArtifact | None) -> str:
     """Render a review artifact bundle as scrollable plain text."""
     if artifact is None:
@@ -107,6 +179,28 @@ def render_task_review_artifact(artifact: ReviewArtifact | None) -> str:
     return "\n".join(lines).rstrip()
 
 
+def render_task_review_inline_diff(bundle: ReviewDiffBundle | None):
+    """Render an inline review diff as syntax-highlighted rich content."""
+    if bundle is None:
+        return "No inline diff is available for this task yet."
+    renderables: list[object] = [Text(bundle.source_label, style="bold"), Text("")]
+    for diff_file in bundle.files:
+        renderables.append(Text(diff_file.path, style="cyan"))
+        renderables.append(
+            Syntax(
+                collapse_review_diff_file(diff_file),
+                "diff",
+                line_numbers=False,
+                word_wrap=False,
+            )
+        )
+        hidden_lines = review_diff_hidden_line_count(diff_file)
+        if hidden_lines:
+            renderables.append(Text(f"... {hidden_lines} more lines hidden", style="dim"))
+        renderables.append(Text(""))
+    return Group(*renderables)
+
+
 def _candidate_review_paths(
     task, project_path: Path,
 ) -> list[tuple[str, Path]]:
@@ -121,10 +215,220 @@ def _candidate_review_paths(
     return candidates
 
 
+def review_diff_is_large(bundle: ReviewDiffBundle | None) -> bool:
+    return bundle is not None and bundle.total_lines > _DIFF_COLLAPSE_LINES
+
+
+def collapse_review_diff_file(
+    diff_file: ReviewDiffFile,
+    *,
+    max_lines: int = _DIFF_COLLAPSE_LINES,
+) -> str:
+    lines = diff_file.patch.splitlines()
+    if len(lines) <= max_lines:
+        return diff_file.patch
+    return "\n".join(lines[:max_lines])
+
+
+def review_diff_hidden_line_count(
+    diff_file: ReviewDiffFile,
+    *,
+    max_lines: int = _DIFF_COLLAPSE_LINES,
+) -> int:
+    return max(0, diff_file.line_count - max_lines)
+
+
+def _artifact_review_diff(artifact: ReviewArtifact | None) -> ReviewDiffBundle | None:
+    if artifact is None:
+        return None
+    chunks: list[str] = []
+    for section in artifact.sections:
+        body = (section.body or "").strip()
+        if not body:
+            continue
+        suffix = section.path.suffix.lower()
+        if suffix in {".diff", ".patch"}:
+            chunks.append(body)
+            continue
+        fenced = [chunk.strip() for chunk in _DIFF_FENCE_PATTERN.findall(body) if chunk.strip()]
+        if fenced:
+            chunks.extend(fenced)
+            continue
+        if _looks_like_unified_diff(body):
+            chunks.append(body)
+    if not chunks:
+        return None
+    return _bundle_from_diff_text(
+        "\n".join(chunks),
+        source_label="Review Artifact Diff",
+    )
+
+
+def _looks_like_unified_diff(text: str) -> bool:
+    if not text:
+        return False
+    return _DIFF_HEADING_PATTERN.search(text) is not None
+
+
+def _bundle_from_diff_text(diff_text: str, *, source_label: str) -> ReviewDiffBundle | None:
+    files = _parse_diff_files(diff_text)
+    if not files:
+        return None
+    return ReviewDiffBundle(
+        source_label=source_label,
+        files=files,
+        total_lines=sum(item.line_count for item in files),
+    )
+
+
+def _parse_diff_files(diff_text: str) -> list[ReviewDiffFile]:
+    lines = diff_text.splitlines()
+    if not lines:
+        return []
+    chunks: list[list[str]] = []
+    start_indices = [index for index, line in enumerate(lines) if line.startswith("diff --git ")]
+    if start_indices:
+        for offset, start in enumerate(start_indices):
+            end = start_indices[offset + 1] if offset + 1 < len(start_indices) else len(lines)
+            chunk = lines[start:end]
+            if chunk:
+                chunks.append(chunk)
+    elif _looks_like_unified_diff(diff_text):
+        chunks.append(lines)
+    files: list[ReviewDiffFile] = []
+    for index, chunk_lines in enumerate(chunks, start=1):
+        patch = "\n".join(chunk_lines).rstrip()
+        if not patch:
+            continue
+        files.append(
+            ReviewDiffFile(
+                path=_diff_file_path(chunk_lines, index=index),
+                patch=patch,
+                line_count=len(chunk_lines),
+            )
+        )
+    return files
+
+
+def _diff_file_path(chunk_lines: list[str], *, index: int) -> str:
+    for line in chunk_lines:
+        match = _DIFF_PATH_PATTERN.match(line)
+        if match is None:
+            continue
+        before = _normalize_diff_path(match.group(1))
+        after = _normalize_diff_path(match.group(2))
+        return after or before or f"Diff {index}"
+    for line in chunk_lines:
+        if not line.startswith(("--- ", "+++ ")):
+            continue
+        path = _normalize_diff_path(line[4:].strip())
+        if path:
+            return path
+    return f"Diff {index}"
+
+
+def _normalize_diff_path(raw_path: str) -> str:
+    if raw_path in {"", "/dev/null"}:
+        return ""
+    if raw_path.startswith(("a/", "b/")):
+        return raw_path[2:]
+    return raw_path
+
+
+def _linked_diff_refs(task, *, active_branch: str | None = None) -> tuple[str, str] | None:
+    refs = getattr(task, "external_refs", {}) or {}
+    if not any(refs.get(key) for key in _DIFF_LINK_KEYS):
+        return None
+    base_ref = _first_ref(
+        refs,
+        "base_ref",
+        "base_branch",
+        "base_sha",
+        "base_commit",
+        "target_branch",
+        "default_branch",
+    )
+    head_ref = _first_ref(
+        refs,
+        "head_ref",
+        "head_branch",
+        "branch",
+        "branch_name",
+        "head_sha",
+    )
+    if head_ref is None and active_branch and _first_ref(
+        refs,
+        "github_pr",
+        "github_pr_number",
+        "pull_request",
+        "pr_number",
+    ):
+        head_ref = active_branch
+    if base_ref is None and head_ref is not None and _first_ref(
+        refs,
+        "github_pr",
+        "github_pr_number",
+        "pull_request",
+        "pr_number",
+    ):
+        base_ref = "origin/main"
+    if base_ref is None or head_ref is None:
+        return None
+    return str(base_ref), str(head_ref)
+
+
+def _first_ref(refs: dict[str, object], *keys: str) -> str | None:
+    for key in keys:
+        value = refs.get(key)
+        if value in (None, ""):
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _git_review_diff(
+    project_path: Path,
+    *,
+    base_ref: str,
+    head_ref: str,
+) -> str | None:
+    try:
+        completed = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(project_path),
+                "diff",
+                "--no-color",
+                "--no-ext-diff",
+                f"{base_ref}..{head_ref}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+    if completed.returncode not in {0, 1}:
+        return None
+    text = (completed.stdout or "").strip()
+    return text or None
+
+
 __all__ = [
     "ReviewArtifact",
+    "ReviewDiffBundle",
+    "ReviewDiffFile",
+    "collapse_review_diff_file",
     "ReviewSection",
     "extract_confidence_score",
+    "load_task_review_diff",
+    "load_task_review_inline_diff",
     "load_task_review_artifact",
     "render_task_review_artifact",
+    "render_task_review_inline_diff",
+    "review_diff_hidden_line_count",
+    "review_diff_is_large",
 ]

--- a/src/pollypm/cockpit_task_review.py
+++ b/src/pollypm/cockpit_task_review.py
@@ -15,10 +15,6 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-from rich.console import Group
-from rich.syntax import Syntax
-from rich.text import Text
-
 
 @dataclass(slots=True)
 class ReviewSection:
@@ -154,13 +150,6 @@ def load_task_review_diff(
     )
 
 
-def load_task_review_inline_diff(
-    artifact: ReviewArtifact | None,
-) -> ReviewDiffBundle | None:
-    """Load inline review diff content from a captured review artifact only."""
-    return _artifact_review_diff(artifact)
-
-
 def render_task_review_artifact(artifact: ReviewArtifact | None) -> str:
     """Render a review artifact bundle as scrollable plain text."""
     if artifact is None:
@@ -177,28 +166,6 @@ def render_task_review_artifact(artifact: ReviewArtifact | None) -> str:
             ]
         )
     return "\n".join(lines).rstrip()
-
-
-def render_task_review_inline_diff(bundle: ReviewDiffBundle | None):
-    """Render an inline review diff as syntax-highlighted rich content."""
-    if bundle is None:
-        return "No inline diff is available for this task yet."
-    renderables: list[object] = [Text(bundle.source_label, style="bold"), Text("")]
-    for diff_file in bundle.files:
-        renderables.append(Text(diff_file.path, style="cyan"))
-        renderables.append(
-            Syntax(
-                collapse_review_diff_file(diff_file),
-                "diff",
-                line_numbers=False,
-                word_wrap=False,
-            )
-        )
-        hidden_lines = review_diff_hidden_line_count(diff_file)
-        if hidden_lines:
-            renderables.append(Text(f"... {hidden_lines} more lines hidden", style="dim"))
-        renderables.append(Text(""))
-    return Group(*renderables)
 
 
 def _candidate_review_paths(
@@ -425,10 +392,8 @@ __all__ = [
     "ReviewSection",
     "extract_confidence_score",
     "load_task_review_diff",
-    "load_task_review_inline_diff",
     "load_task_review_artifact",
     "render_task_review_artifact",
-    "render_task_review_inline_diff",
     "review_diff_hidden_line_count",
     "review_diff_is_large",
 ]

--- a/src/pollypm/cockpit_tasks.py
+++ b/src/pollypm/cockpit_tasks.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from time import monotonic
 
+from rich.syntax import Syntax
 from textual import events, on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
@@ -21,9 +22,13 @@ from pollypm.cockpit_task_priority import (
     priority_rank,
 )
 from pollypm.cockpit_task_review import (
+    ReviewDiffBundle,
+    collapse_review_diff_file,
     extract_confidence_score,
+    load_task_review_diff,
     load_task_review_artifact,
     render_task_review_artifact,
+    review_diff_hidden_line_count,
 )
 from pollypm.cockpit_formatting import format_event_time
 from pollypm.cockpit_formatting import format_relative_age as _format_relative_age
@@ -789,6 +794,25 @@ class PollyTasksApp(App[None]):
         background: #18232d;
         color: #cfe1ff;
     }
+    #task-review-inline-diff-header {
+        height: auto;
+        padding: 0 1;
+        margin: 0 0 1 0;
+        border-left: thick #36536b;
+        color: #d7e8ff;
+    }
+    #task-review-inline-diff-expand {
+        width: auto;
+        margin: 0 0 1 1;
+    }
+    #task-review-inline-diff {
+        height: auto;
+        margin-top: 1;
+        padding: 0 1;
+        border: round #3d4d60;
+        background: #0f161d;
+        color: #d8e4ef;
+    }
     #task-review-diff {
         height: auto;
         margin-top: 1;
@@ -865,6 +889,13 @@ class PollyTasksApp(App[None]):
         self.detail_overview = Static("", id="task-detail")
         self.detail_review = Static("", id="task-review")
         self.review_confidence = Static("", id="task-review-confidence-chip")
+        self.review_inline_diff_header = Static("", id="task-review-inline-diff-header")
+        self.review_inline_diff_expand = Button(
+            "Expand",
+            id="task-review-inline-diff-expand",
+            variant="default",
+        )
+        self.review_inline_diff = Static("", id="task-review-inline-diff")
         self.review_diff_toggle = Button(
             "Diff Since Rejection: Off [D]",
             id="task-review-diff-toggle",
@@ -897,6 +928,10 @@ class PollyTasksApp(App[None]):
         self._active_reject_modal: _TaskRejectReasonModal | None = None
         self._selected_task_ids: set[str] = set()
         self._show_resubmission_diff = False
+        self._review_inline_diff: ReviewDiffBundle | None = None
+        self._review_inline_diff_file_index = 0
+        self._review_inline_diff_expanded = False
+        self._review_nav_prefix: str | None = None
 
     def compose(self) -> ComposeResult:
         with Vertical(id="tasks-root"):
@@ -929,9 +964,12 @@ class PollyTasksApp(App[None]):
                         with TabPane("Review", id="task-tab-review"):
                             with Vertical(id="task-review-panel"):
                                 yield self.review_confidence
+                                yield self.review_inline_diff_header
+                                yield self.review_inline_diff_expand
                                 yield self.review_diff_toggle
                                 with VerticalScroll(id="task-review-scroll"):
                                     yield self.detail_review
+                                    yield self.review_inline_diff
                                     yield self.review_diff
                         with TabPane("Timeline", id="task-tab-timeline"):
                             yield self.timeline
@@ -1094,6 +1132,11 @@ class PollyTasksApp(App[None]):
         self.detail_review.update("")
         self.review_confidence.update("")
         self.review_confidence.display = False
+        self.review_inline_diff_header.update("")
+        self.review_inline_diff_header.display = False
+        self.review_inline_diff_expand.display = False
+        self.review_inline_diff.update("")
+        self.review_inline_diff.display = False
         self.review_diff_toggle.display = False
         self.review_diff.update("")
         self.review_diff.display = False
@@ -1105,6 +1148,10 @@ class PollyTasksApp(App[None]):
         self.bulk_approve_button.disabled = True
         self.refresh_live_button.disabled = True
         self._set_live_tail_paused(False)
+        self._review_inline_diff = None
+        self._review_inline_diff_file_index = 0
+        self._review_inline_diff_expanded = False
+        self._review_nav_prefix = None
 
     def _render_table(self, *, select_first: bool) -> None:
         visible = self._filtered_tasks()
@@ -1263,7 +1310,7 @@ class PollyTasksApp(App[None]):
         if active_session is not None and not self._live_tail_paused:
             self.call_after_refresh(self._tail_live_scroll_to_end)
 
-    def _sync_review_panel(self, task, review_artifact) -> None:
+    def _sync_review_panel(self, task, review_artifact, review_diff_bundle) -> None:
         self.detail_review.update(render_task_review_artifact(review_artifact))
         score = _review_confidence_score(task, review_artifact)
         if score is None:
@@ -1272,6 +1319,8 @@ class PollyTasksApp(App[None]):
         else:
             self.review_confidence.update(_review_confidence_markup(score))
             self.review_confidence.display = True
+        self._review_inline_diff = review_diff_bundle
+        self._sync_inline_review_diff()
         diff_available = _task_has_resubmission_diff(task)
         self.review_diff_toggle.display = diff_available
         self.review_diff_toggle.disabled = not diff_available
@@ -1292,6 +1341,87 @@ class PollyTasksApp(App[None]):
                 "[dim]Press [D] to compare this submission against the last rejected attempt.[/dim]"
             )
         self.review_diff.display = True
+
+    def _sync_inline_review_diff(self) -> None:
+        bundle = self._review_inline_diff
+        if bundle is None or not bundle.files:
+            self.review_inline_diff_header.update("")
+            self.review_inline_diff_header.display = False
+            self.review_inline_diff_expand.display = False
+            self.review_inline_diff.update("")
+            self.review_inline_diff.display = False
+            return
+        self._review_inline_diff_file_index = max(
+            0,
+            min(self._review_inline_diff_file_index, len(bundle.files) - 1),
+        )
+        diff_file = bundle.files[self._review_inline_diff_file_index]
+        current_file = self._review_inline_diff_file_index + 1
+        self.review_inline_diff_header.update(
+            "\n".join(
+                [
+                    (
+                        f"[b]Code Diff[/b] · {bundle.source_label}"
+                        f" · {current_file}/{len(bundle.files)} files"
+                    ),
+                    (
+                        f"{diff_file.path}"
+                        + (
+                            " [dim]· [f prev · ]f next[/dim]"
+                            if len(bundle.files) > 1
+                            else ""
+                        )
+                    ),
+                ]
+            )
+        )
+        self.review_inline_diff_header.display = True
+        hidden_lines = review_diff_hidden_line_count(diff_file)
+        collapsed = hidden_lines > 0 and not self._review_inline_diff_expanded
+        if hidden_lines > 0:
+            self.review_inline_diff_expand.label = (
+                "Collapse"
+                if self._review_inline_diff_expanded
+                else f"Expand (+{hidden_lines} lines)"
+            )
+            self.review_inline_diff_expand.display = True
+        else:
+            self.review_inline_diff_expand.display = False
+        self.review_inline_diff.update(
+            Syntax(
+                diff_file.patch if not collapsed else collapse_review_diff_file(diff_file),
+                "diff",
+                line_numbers=True,
+                word_wrap=False,
+                background_color="default",
+            )
+        )
+        self.review_inline_diff.display = True
+
+    def _review_tab_is_active(self) -> bool:
+        try:
+            tabs = self.query_one("#task-tabs", TabbedContent)
+        except Exception:  # noqa: BLE001
+            return False
+        return tabs.active == "task-tab-review"
+
+    def _scroll_review_panel_home(self) -> None:
+        try:
+            review_scroll = self.query_one("#task-review-scroll", VerticalScroll)
+        except Exception:  # noqa: BLE001
+            return
+        review_scroll.scroll_home(animate=False)
+
+    def _jump_review_diff_file(self, step: int) -> None:
+        bundle = self._review_inline_diff
+        if bundle is None or len(bundle.files) < 2:
+            return
+        self._review_inline_diff_file_index = (
+            self._review_inline_diff_file_index + step
+        ) % len(bundle.files)
+        self._review_inline_diff_expanded = False
+        self._sync_inline_review_diff()
+        self.call_after_refresh(self._scroll_review_panel_home)
 
     def _project_path(self) -> Path | None:
         try:
@@ -1336,22 +1466,38 @@ class PollyTasksApp(App[None]):
                 pass
         self._selected_task_id = task_id
         self._owner_by_task_id[task.task_id] = owner
-        review_artifact = load_task_review_artifact(task, self._project_path())
+        project_path = self._project_path()
+        review_artifact = load_task_review_artifact(task, project_path)
         if task_id != previous_task_id:
             self._set_live_tail_paused(False)
             self._show_resubmission_diff = False
+            self._review_inline_diff_file_index = 0
+            self._review_inline_diff_expanded = False
+        review_diff_bundle = load_task_review_diff(
+            task,
+            project_path,
+            review_artifact=review_artifact,
+            active_branch=getattr(active_session, "branch_name", None),
+        )
+        if review_diff_bundle is None:
+            self._review_inline_diff_file_index = 0
+            self._review_inline_diff_expanded = False
+        elif self._review_inline_diff_file_index >= len(review_diff_bundle.files):
+            self._review_inline_diff_file_index = 0
+            self._review_inline_diff_expanded = False
         self._render_selected_task(
             task,
             owner=owner,
             flow=flow,
             active_session=active_session,
         )
-        self._sync_review_panel(task, review_artifact)
+        self._sync_review_panel(task, review_artifact, review_diff_bundle)
         tabs = self.query_one("#task-tabs", TabbedContent)
         if task_id != previous_task_id:
             tabs.active = (
                 "task-tab-review"
-                if task.work_status.value == "review" and review_artifact is not None
+                if task.work_status.value == "review"
+                and (review_artifact is not None or review_diff_bundle is not None)
                 else "task-tab-overview"
             )
         if active_session is not None and not self._live_tail_paused:
@@ -1704,11 +1850,24 @@ class PollyTasksApp(App[None]):
     def _on_press_review_diff_toggle(self) -> None:
         self.action_toggle_resubmission_diff()
 
+    @on(Button.Pressed, "#task-review-inline-diff-expand")
+    def _on_press_review_inline_diff_expand(self) -> None:
+        bundle = self._review_inline_diff
+        if bundle is None:
+            return
+        diff_file = bundle.files[self._review_inline_diff_file_index]
+        if review_diff_hidden_line_count(diff_file) == 0:
+            return
+        self._review_inline_diff_expanded = not self._review_inline_diff_expanded
+        self._sync_inline_review_diff()
+        self.call_after_refresh(self._scroll_review_panel_home)
+
     @on(Button.Pressed, "#task-refresh-live")
     def _on_press_refresh_live(self) -> None:
         self.action_refresh_live()
 
     def on_key(self, event: events.Key) -> None:
+        self._review_nav_prefix = self._handle_review_diff_key(event)
         modal = self._active_reject_modal
         if modal is None:
             return
@@ -1724,6 +1883,22 @@ class PollyTasksApp(App[None]):
         elif event.key == "4":
             event.stop()
             modal.action_pick_other()
+
+    def _handle_review_diff_key(self, event: events.Key) -> str | None:
+        if isinstance(getattr(self, "focused", None), Input):
+            return None
+        if not self._review_tab_is_active():
+            return None
+        bundle = self._review_inline_diff
+        if bundle is None or len(bundle.files) < 2:
+            return None
+        key_char = event.character or ""
+        if key_char in {"[", "]"}:
+            return key_char
+        if key_char == "f" and self._review_nav_prefix in {"[", "]"}:
+            event.stop()
+            self._jump_review_diff_file(1 if self._review_nav_prefix == "]" else -1)
+        return None
 
     @on(DataTable.RowHighlighted, "#tasks-table")
     def _on_task_highlighted(self) -> None:

--- a/tests/test_tasks_ui.py
+++ b/tests/test_tasks_ui.py
@@ -531,11 +531,13 @@ def test_task_review_tab_shows_resubmission_diff_and_confidence_chip(
             await pilot.pause()
             review = str(app.query_one("#task-review", Static).render())
             confidence = str(app.query_one("#task-review-confidence-chip", Static).render())
+            inline_diff = app.query_one("#task-review-inline-diff", Static)
             toggle = app.query_one("#task-review-diff-toggle", Button)
             diff = str(app.query_one("#task-review-diff", Static).render())
 
             assert "Review Artifact" in review
             assert "Russell: 8/10" in confidence
+            assert not inline_diff.display
             assert toggle.display
             assert "last rejected attempt" in diff
 
@@ -547,6 +549,275 @@ def test_task_review_tab_shows_resubmission_diff_and_confidence_chip(
             assert "Resubmission Diff" in diff
             assert "-Summary: Implemented the feature" in diff
             assert "+Summary: Implemented the feature with review fixes" in diff
+
+    _run(body())
+
+
+def test_task_review_diff_prefers_artifact_over_git_fallback(tmp_path, monkeypatch) -> None:
+    from pollypm.cockpit_task_review import (
+        ReviewArtifact,
+        ReviewSection,
+        load_task_review_diff,
+    )
+
+    artifact = ReviewArtifact(
+        title="Review Artifact",
+        summary="Review the change before approving it.",
+        sections=[
+            ReviewSection(
+                title="Project Plan",
+                path=Path("docs/project-plan.md"),
+                body=(
+                    "Plan notes.\n\n"
+                    "```diff\n"
+                    "--- a/src/app.py\n"
+                    "+++ b/src/app.py\n"
+                    "@@ -1 +1 @@\n"
+                    "-print('old')\n"
+                    "+print('new')\n"
+                    "```\n"
+                ),
+            )
+        ],
+    )
+    task = _task(
+        node_id="critic_panel",
+        status=WorkStatus.REVIEW,
+        flow_template_id="chat",
+        external_refs={
+            "github_pr": "123",
+            "base_branch": "origin/main",
+            "head_branch": "issue-663-inline-review-diff",
+        },
+    )
+
+    def _unexpected_git_diff(*args, **kwargs):
+        raise AssertionError("captured artifact diff should win before git fallback")
+
+    monkeypatch.setattr(
+        "pollypm.cockpit_task_review.subprocess.run",
+        _unexpected_git_diff,
+    )
+
+    bundle = load_task_review_diff(task, tmp_path, review_artifact=artifact)
+    assert bundle is not None
+    assert bundle.source_label == "Review Artifact Diff"
+    assert len(bundle.files) == 1
+    assert bundle.files[0].path == "src/app.py"
+    assert "-print('old')" in bundle.files[0].patch
+    assert "+print('new')" in bundle.files[0].patch
+
+
+def test_task_review_diff_falls_back_to_git_for_pr_linked_tasks(tmp_path, monkeypatch) -> None:
+    from pollypm.cockpit_task_review import load_task_review_diff
+
+    task = _task(
+        node_id="critic_panel",
+        status=WorkStatus.REVIEW,
+        flow_template_id="chat",
+        external_refs={"github_pr": "123"},
+    )
+
+    def fake_run(cmd, *, capture_output, text, check):  # noqa: ANN001
+        assert cmd[-1] == "origin/main..feature/notesy"
+        assert capture_output is True
+        assert text is True
+        assert check is False
+        return type(
+            "Proc",
+            (),
+            {
+                "returncode": 0,
+                "stdout": (
+                    "diff --git a/src/app.py b/src/app.py\n"
+                    "--- a/src/app.py\n"
+                    "+++ b/src/app.py\n"
+                    "@@ -1 +1 @@\n"
+                    "-print('old')\n"
+                    "+print('new')\n"
+                ),
+                "stderr": "",
+            },
+        )()
+
+    monkeypatch.setattr("pollypm.cockpit_task_review.subprocess.run", fake_run)
+
+    bundle = load_task_review_diff(
+        task,
+        tmp_path,
+        review_artifact=None,
+        active_branch="feature/notesy",
+    )
+
+    assert bundle is not None
+    assert bundle.source_label == "git diff origin/main..feature/notesy"
+    assert len(bundle.files) == 1
+    assert bundle.files[0].path == "src/app.py"
+    assert "+print('new')" in bundle.files[0].patch
+
+
+def test_task_review_tab_shows_inline_review_diff_without_resubmission_toggle(
+    env, monkeypatch,
+) -> None:
+    if not _load_config_compatible(env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_tasks import PollyTasksApp
+    from rich.syntax import Syntax
+    from textual.widgets import TabbedContent
+
+    plan_path = env["project_path"] / "docs" / "project-plan.md"
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+    plan_path.write_text(
+        "# Notesy Plan\n\n"
+        "Review the embedded diff inline.\n\n"
+        "```diff\n"
+        "--- a/src/app.py\n"
+        "+++ b/src/app.py\n"
+        "@@ -1 +1 @@\n"
+        "-print('old')\n"
+        "+print('new')\n"
+        "```\n"
+    )
+
+    review_task = _task(
+        node_id="critic_panel",
+        status=WorkStatus.REVIEW,
+        title="Review Notesy plan",
+    )
+    fake_svc = _FakeSvc(
+        tasks_factory=lambda: [review_task],
+        flow=_flow(),
+    )
+
+    monkeypatch.setattr("pollypm.cockpit_tasks.create_tmux_client", lambda: _FakeTmux([]))
+
+    app = PollyTasksApp(env["config_path"], "demo")
+    app._get_svc = lambda: fake_svc  # type: ignore[method-assign]
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 50)) as pilot:
+            await pilot.pause()
+            tabs = app.query_one("#task-tabs", TabbedContent)
+            review = str(app.query_one("#task-review", Static).render())
+            inline_diff_header = app.query_one("#task-review-inline-diff-header", Static)
+            inline_diff_expand = app.query_one("#task-review-inline-diff-expand", Button)
+            inline_diff = app.query_one("#task-review-inline-diff", Static)
+            toggle = app.query_one("#task-review-diff-toggle", Button)
+            renderable = inline_diff.content
+
+            assert tabs.active == "task-tab-review"
+            assert "Review Artifact" in review
+            assert inline_diff_header.display
+            assert "Code Diff" in str(inline_diff_header.render())
+            assert "src/app.py" in str(inline_diff_header.render())
+            assert inline_diff.display
+            assert isinstance(renderable, Syntax)
+            assert renderable.line_numbers
+            assert "-print('old')" in renderable.code
+            assert "+print('new')" in renderable.code
+            assert not inline_diff_expand.display
+            assert not toggle.display
+
+    _run(body())
+
+
+def test_task_review_tab_uses_git_diff_navigation_and_expand(env, monkeypatch) -> None:
+    if not _load_config_compatible(env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_tasks import PollyTasksApp
+    from rich.syntax import Syntax
+    from textual.widgets import TabbedContent
+
+    git_calls: list[list[str]] = []
+    large_lines = "\n".join(f"+big line {idx}" for idx in range(520))
+    git_diff = (
+        "diff --git a/src/app.py b/src/app.py\n"
+        "index 1111111..2222222 100644\n"
+        "--- a/src/app.py\n"
+        "+++ b/src/app.py\n"
+        "@@ -1 +1 @@\n"
+        "-print('old')\n"
+        "+print('new')\n"
+        "diff --git a/src/big.py b/src/big.py\n"
+        "index 3333333..4444444 100644\n"
+        "--- a/src/big.py\n"
+        "+++ b/src/big.py\n"
+        "@@ -0,0 +1,520 @@\n"
+        f"{large_lines}\n"
+    )
+
+    def _fake_git_diff(cmd, **kwargs):
+        git_calls.append(list(cmd))
+        return type(
+            "Proc",
+            (),
+            {"returncode": 0, "stdout": git_diff, "stderr": ""},
+        )()
+
+    review_task = _task(
+        node_id="critic_panel",
+        status=WorkStatus.REVIEW,
+        title="Review git-backed diff",
+        flow_template_id="chat",
+        external_refs={
+            "github_pr": "123",
+            "base_branch": "origin/main",
+            "head_branch": "issue-663-inline-review-diff",
+        },
+    )
+    fake_svc = _FakeSvc(tasks_factory=lambda: [review_task], flow=_flow())
+
+    monkeypatch.setattr("pollypm.cockpit_tasks.create_tmux_client", lambda: _FakeTmux([]))
+    monkeypatch.setattr("pollypm.cockpit_task_review.subprocess.run", _fake_git_diff)
+
+    app = PollyTasksApp(env["config_path"], "demo")
+    app._get_svc = lambda: fake_svc  # type: ignore[method-assign]
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 50)) as pilot:
+            await pilot.pause()
+            tabs = app.query_one("#task-tabs", TabbedContent)
+            inline_diff_header = app.query_one("#task-review-inline-diff-header", Static)
+            inline_diff_expand = app.query_one("#task-review-inline-diff-expand", Button)
+            inline_diff = app.query_one("#task-review-inline-diff", Static)
+
+            assert tabs.active == "task-tab-review"
+            assert git_calls
+            assert git_calls[0][-1] == "origin/main..issue-663-inline-review-diff"
+            assert "src/app.py" in str(inline_diff_header.render())
+
+            renderable = inline_diff.content
+            assert isinstance(renderable, Syntax)
+            assert renderable.line_numbers
+            assert "+print('new')" in renderable.code
+            assert not inline_diff_expand.display
+
+            await pilot.press("]")
+            await pilot.press("f")
+            await pilot.pause()
+
+            header_text = str(inline_diff_header.render())
+            assert "git diff origin/main..issue-663-inline-review-diff" in header_text
+            assert "src/big.py" in header_text
+            assert inline_diff_expand.display
+            assert "Expand (+" in str(inline_diff_expand.label)
+
+            renderable = inline_diff.content
+            assert isinstance(renderable, Syntax)
+            assert "+big line 494" in renderable.code
+            assert "+big line 519" not in renderable.code
+
+            inline_diff_expand.press()
+            await pilot.pause()
+            renderable = inline_diff.content
+            assert isinstance(renderable, Syntax)
+            assert "+big line 519" in renderable.code
+            assert str(inline_diff_expand.label) == "Collapse"
+
+            await pilot.press("[")
+            await pilot.press("f")
+            await pilot.pause()
+            assert "src/app.py" in str(inline_diff_header.render())
 
     _run(body())
 


### PR DESCRIPTION
Adds a dedicated inline review-diff surface to the cockpit task Review tab without reusing the resubmission-diff flow.

What this ships:
- review tab shows syntax-highlighted diffs sourced from captured review artifacts when available
- PR-linked tasks fall back to `git diff <base>..<head>` when no captured artifact diff exists
- multi-file diffs support `[f` / `]f` navigation plus collapse/expand for large files
- focused task UI coverage for artifact precedence, git fallback, and review-tab interaction

Validation:
- `python3 -m py_compile src/pollypm/cockpit_task_review.py src/pollypm/cockpit_tasks.py tests/test_tasks_ui.py`
- `uv run --with pytest python -m pytest tests/test_tasks_ui.py -q`
- result: `18 passed`

Closes #663