### PR TITLE
Close out #709 — all main-suite tests green (22 → 0)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -829,8 +829,12 @@ class CockpitRouter:
             if not rows:
                 continue
             active_rows = [row for row in rows if self._row_is_active(row)]
+            # ``projects`` is the primary navigation surface — keep it
+            # visible even when no project has an active session, so the
+            # user can still click into a project from the rail. Only
+            # transient/dynamic sections get auto-collapsed when idle.
             if section in collapsed_sections or (
-                section not in {"top", "system"} and not active_rows
+                section not in {"top", "system", "projects"} and not active_rows
             ):
                 # Collapsed sections render as a disabled header row so
                 # the user can still see the section exists. Expansion

--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -220,15 +220,26 @@ def _has_work_tasks(
     project_key: str | None = None,
     config_path: Path | None = None,
 ) -> bool:
-    """Return True iff the project's work-service DB has ≥1 work_tasks row.
+    """Return True iff *this* project's DB has ≥1 work_tasks row.
 
     Reads the sqlite table directly — ``SQLiteWorkService`` is a heavier
     entrypoint and this path runs on the happy path for every
     ``pm project new`` invocation, so we keep it lean. Fails closed:
     any DB / IO error returns False so we don't accidentally flag a
     greenfield project as existing on a transient error.
+
+    Post-#339 the workspace-scope DB holds tasks for *every* registered
+    project — so counting "any row in the workspace DB" for an unkeyed
+    call would leak state from sibling projects into the classification
+    of a fresh directory. When ``project_key`` is None we therefore
+    look only at the project-local DB (``<path>/.pollypm/state.db``);
+    callers that know their key pass it through so the workspace DB
+    filter is safe.
     """
-    db_path = _planner_db_path(project_path, config_path=config_path)
+    if project_key:
+        db_path = _planner_db_path(project_path, config_path=config_path)
+    else:
+        db_path = project_path / ".pollypm" / "state.db"
     if not db_path.exists():
         return False
     try:

--- a/src/pollypm/rules.py
+++ b/src/pollypm/rules.py
@@ -241,7 +241,14 @@ def _render_compact_catalog(
     names = sorted(entries)
     for name in names[:_SESSION_SECTION_LIMIT]:
         entry = entries[name]
-        lines.append(f"- {entry.name}: {entry.description}")
+        # Include display_path so both project-local overrides
+        # (``.pollypm/rules/build.md``) and their builtin fallbacks
+        # (``pollypm/defaults/rules/build.md``) are unambiguous to the
+        # session. Workers need the exact file to read for any rule they
+        # invoke.
+        lines.append(
+            f"- {entry.name}: {entry.description} ({entry.display_path})"
+        )
     remaining = len(names) - _SESSION_SECTION_LIMIT
     if remaining > 0:
         lines.append(f"- … {remaining} more in `{_SESSION_MANIFEST_PATH.as_posix()}`")

--- a/tests/integration/test_magic_integration.py
+++ b/tests/integration/test_magic_integration.py
@@ -61,5 +61,9 @@ def test_project_magic_appears_in_worker_prompt_manifest(tmp_path: Path) -> None
     assert "Screenshot verification" in prompt
     assert "deploy-site" in prompt
     assert ".pollypm/MANIFEST.md" in prompt
-    assert "pollypm/defaults/magic/deploy-site.md" not in prompt
+    # Per #709 cluster 6, display_paths for both builtin and project-local
+    # catalog entries are now inlined so workers can resolve the exact
+    # file to read without grepping MANIFEST.md.
+    assert "pollypm/defaults/magic/deploy-site.md" in prompt
+    assert ".pollypm/magic/screenshot-verify.md" in prompt
     assert (project_root / ".pollypm" / "MANIFEST.md").exists()

--- a/tests/integration/test_rules_integration.py
+++ b/tests/integration/test_rules_integration.py
@@ -61,5 +61,9 @@ def test_project_rule_appears_in_worker_prompt_manifest(tmp_path: Path) -> None:
     assert "Project deploy process" in prompt
     assert "bugfix" in prompt
     assert ".pollypm/MANIFEST.md" in prompt
-    assert "pollypm/defaults/rules/bugfix.md" not in prompt
+    # Per #709 cluster 6, display_paths for both builtin and project-local
+    # catalog entries are now inlined so workers can resolve the exact
+    # file to read without grepping MANIFEST.md.
+    assert "pollypm/defaults/rules/bugfix.md" in prompt
+    assert ".pollypm/rules/deploy.md" in prompt
     assert (project_root / ".pollypm" / "MANIFEST.md").exists()

--- a/tests/test_architect_bootstrap.py
+++ b/tests/test_architect_bootstrap.py
@@ -61,6 +61,10 @@ def _write_minimal_config(
     config = PollyPMConfig(
         project=ProjectSettings(
             root_dir=tmp_path,
+            # Pin workspace_root to tmp_path so planner-created tasks
+            # land under the test's sandbox rather than the ambient
+            # ``~/dev`` default picked up by ``_planner_db_path``.
+            workspace_root=tmp_path,
             base_dir=tmp_path / ".pollypm",
             logs_dir=tmp_path / ".pollypm/logs",
             snapshots_dir=tmp_path / ".pollypm/snapshots",
@@ -249,8 +253,10 @@ def test_project_new_auto_spawns_architect_session(
     )
     assert result.exit_code == 0, result.stdout + result.stderr
     # Plan task was auto-created (regression guard against #255 breakage).
+    # Post-#339 planner tasks land in the workspace-scope DB
+    # (``workspace_root/.pollypm/state.db``), not the project-local path.
     with SQLiteWorkService(
-        db_path=repo / ".pollypm" / "state.db", project_path=repo,
+        db_path=tmp_path / ".pollypm" / "state.db", project_path=repo,
     ) as svc:
         tasks = svc.list_tasks(project="fresh")
     plan_tasks = [t for t in tasks if t.flow_template_id == "plan_project"]

--- a/tests/test_worktree_state_audit.py
+++ b/tests/test_worktree_state_audit.py
@@ -315,6 +315,7 @@ def _invoke_handler_with_fakes(
     swapped for fakes. Returns (result, store, work) so assertions can
     inspect side effects."""
     from pollypm.plugins_builtin.core_recurring import plugin as plugin_module
+    from pollypm.plugins_builtin.core_recurring import sweeps as sweeps_module
 
     fake_store = _FakeStore()
     fake_work = _FakeWork(sessions)
@@ -329,9 +330,18 @@ def _invoke_handler_with_fakes(
 
     cfg = _FakeConfig(project=_FakeProject(root_dir=project_root))
 
+    # ``worktree_state_audit_handler`` lives in ``sweeps`` and imports
+    # the shared helpers by name from ``.shared`` — patching those names
+    # in the ``plugin`` module alone would no-op, so route both.
     monkeypatch.setattr(
-        plugin_module, "_load_config_and_store",
+        sweeps_module, "_load_config_and_store",
         _fake_load_cm(cfg, fake_store),
+    )
+    monkeypatch.setattr(
+        sweeps_module, "_open_msg_store", lambda _config: fake_store,
+    )
+    monkeypatch.setattr(
+        sweeps_module, "_close_msg_store", lambda _store: None,
     )
     # Patch SQLiteWorkService to return our fake regardless of args.
     import pollypm.work.sqlite_service as sqlite_service_mod
@@ -465,6 +475,7 @@ class TestHandler:
         ]
         # Prime the store with a stale open alert simulating a prior sweep.
         from pollypm.plugins_builtin.core_recurring import plugin as plugin_module
+        from pollypm.plugins_builtin.core_recurring import sweeps as sweeps_module
 
         fake_store = _FakeStore()
         fake_work = _FakeWork(sessions)
@@ -484,18 +495,21 @@ class TestHandler:
             project: _FakeProject
 
         cfg = _FakeConfig(project=_FakeProject(root_dir=repo))
+        # The handler lives in ``sweeps`` and pulls shared helpers
+        # directly from ``.shared``; patch the names on the sweeps
+        # module so the in-handler references resolve to the fake.
         monkeypatch.setattr(
-            plugin_module, "_load_config_and_store",
+            sweeps_module, "_load_config_and_store",
             _fake_load_cm(cfg, fake_store),
         )
         # #342: handler reads/writes alerts through the unified Store;
         # point ``_open_msg_store`` at the fake so existence probes hit
         # the same in-memory dict the upsert/clear writes land on.
         monkeypatch.setattr(
-            plugin_module, "_open_msg_store", lambda _config: fake_store,
+            sweeps_module, "_open_msg_store", lambda _config: fake_store,
         )
         monkeypatch.setattr(
-            plugin_module, "_close_msg_store", lambda _store: None,
+            sweeps_module, "_close_msg_store", lambda _store: None,
         )
         import pollypm.work.sqlite_service as sqlite_service_mod
 


### PR DESCRIPTION
Tackles every remaining cluster from the #709 test audit. After this patch the full pytest suite is **3290/3290 green** (was 22 red on the original audit).

## Clusters fixed

- **Cluster 9** (`test_worktree_state_audit`, 3 tests): the handler lives in `core_recurring/sweeps.py` and pulls `_open_msg_store` / `_close_msg_store` / `_load_config_and_store` directly from `.shared`, so the tests' patches on the `plugin` module alone were no-ops. Patches now hit the `sweeps` module, so alert upsert/clear calls actually land on the fake store.

- **Cluster 6** (rules-not-in-worker-prompt, 1 test): `_render_compact_catalog` now includes each entry's `display_path` so project-local overrides (`.pollypm/rules/build.md`) and their builtin fallbacks (`pollypm/defaults/rules/build.md`) are unambiguous to the session. The older rules/magic integration tests had asserted the opposite (`pollypm/defaults/... not in prompt`) — updated them to match the new inlined-path behavior.

- **Cluster 8** (project classifier, 1 test): `_has_work_tasks(project_path, project_key=None)` was falling through to the workspace-scope DB and counting rows from *any* sibling project as proof the target directory had tasks. Now an unkeyed call looks only at the project-local `<path>/.pollypm/state.db`; keyed calls continue to use the workspace DB.

- **Cluster 7** (architect auto-spawn, 2 tests): fixture didn't set `workspace_root`, so post-#339 planner tasks were going to the ambient `~/dev/.pollypm/state.db`. Pinned `workspace_root=tmp_path` and pointed the post-invoke read at the workspace DB instead of the project-local path.

- **Bonus** (`test_register_project_persists_persona_and_shows_it_in_left_rail`): the `projects` rail section was auto-collapsing when no project had an active session (added by #696), hiding the primary navigation surface. Exempted `projects` from the no-active-rows collapse rule.

## Validation

Before (per #709): `22 failed, 3261 passed`
After this PR + prior #711: `3290 passed, 0 failed` in 337 s

Closes #709