### PR TITLE
feat(doctor): version check + update-available banner (#714)

### DIFF
--- a/src/pollypm/cli_features/maintenance.py
+++ b/src/pollypm/cli_features/maintenance.py
@@ -129,6 +129,12 @@ def register_maintenance_commands(app: typer.Typer) -> None:
         if json_output:
             typer.echo(render_json(report))
         else:
+            from pollypm.release_check import update_banner_line
+
+            banner = update_banner_line()
+            if banner:
+                typer.echo(banner)
+                typer.echo("")
             typer.echo(render_human(report))
             typer.echo("")
             typer.echo(setup_tag_line())

--- a/src/pollypm/release_check.py
+++ b/src/pollypm/release_check.py
@@ -1,0 +1,285 @@
+"""Release-channel update check for the ``pm doctor`` banner (#714).
+
+Queries GitHub releases for the PollyPM repo, filters by channel (stable
+→ non-prerelease only; beta → includes prereleases), and compares
+against the installed version. Never raises — a check that fails at the
+network, DNS, or parsing layer returns ``None`` so callers never need a
+try/except. Results are cached for 24h in ``~/.pollypm/release-check.json``
+so repeat invocations inside that window don't touch the network.
+
+This module is consumed by ``pm doctor`` (banner) and by the rail
+update-pill (#715). The actual upgrade path (``pm upgrade``) lives in
+#716 and consumes the same cache.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any
+
+from packaging.version import InvalidVersion, Version
+
+import pollypm
+
+
+_DEFAULT_OWNER = "samhotchkiss"
+_DEFAULT_REPO = "pollypm"
+_DEFAULT_TTL_SECONDS = 86_400
+_DEFAULT_TIMEOUT_SECONDS = 3.0
+
+
+@dataclass(slots=True)
+class ReleaseCheck:
+    """Outcome of a ``check_latest`` invocation.
+
+    ``upgrade_available`` is True only when ``Version(latest) > Version(current)``.
+    Callers should render a banner only when True; the struct is
+    returned in all non-offline cases so the rail can still show
+    "up-to-date on v1.3.2 (beta)" if it wants to.
+    """
+
+    current: str
+    latest: str
+    channel: str
+    upgrade_available: bool
+    cached_at: float
+
+
+def _cache_path() -> Path:
+    return Path.home() / ".pollypm" / "release-check.json"
+
+
+def _load_cached(path: Path, channel: str, ttl_seconds: int) -> ReleaseCheck | None:
+    try:
+        raw = path.read_text()
+    except (OSError, FileNotFoundError):
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get("channel") != channel:
+        # Channel changed since the cache was written — invalidate so
+        # the caller re-queries against the new filter.
+        return None
+    cached_at = data.get("cached_at")
+    if not isinstance(cached_at, (int, float)):
+        return None
+    if (time.time() - float(cached_at)) > ttl_seconds:
+        return None
+    try:
+        return ReleaseCheck(
+            current=str(data["current"]),
+            latest=str(data["latest"]),
+            channel=str(data["channel"]),
+            upgrade_available=bool(data["upgrade_available"]),
+            cached_at=float(cached_at),
+        )
+    except KeyError:
+        return None
+
+
+def _save_cache(path: Path, check: ReleaseCheck) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(asdict(check)))
+    except OSError:
+        # Cache-write failure shouldn't break the upgrade-check flow;
+        # the next invocation just pays the network cost again.
+        return
+
+
+def invalidate_cache(path: Path | None = None) -> None:
+    """Drop the cached release-check result.
+
+    Called when the user switches channels in settings (#713) so the
+    next check queries with the new filter rather than serving stale
+    data from the old channel.
+    """
+    target = path or _cache_path()
+    try:
+        target.unlink()
+    except FileNotFoundError:
+        return
+    except OSError:
+        return
+
+
+def _fetch_releases(
+    owner: str, repo: str, *, timeout: float
+) -> list[dict[str, Any]] | None:
+    url = f"https://api.github.com/repos/{owner}/{repo}/releases?per_page=30"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": f"pollypm/{pollypm.__version__}",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = resp.read()
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return None
+    try:
+        data = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, list):
+        return None
+    return data
+
+
+def _tag_version(tag: str) -> Version | None:
+    raw = tag.lstrip("v").strip()
+    if not raw:
+        return None
+    try:
+        return Version(raw)
+    except InvalidVersion:
+        return None
+
+
+def _select_latest(
+    releases: list[dict[str, Any]], channel: str,
+) -> tuple[str, Version] | None:
+    best: tuple[str, Version] | None = None
+    for release in releases:
+        if not isinstance(release, dict):
+            continue
+        if release.get("draft"):
+            continue
+        is_pre = bool(release.get("prerelease"))
+        if channel == "stable" and is_pre:
+            continue
+        # Beta picks the highest release regardless of prerelease flag —
+        # a stable release that lands after a beta is still the
+        # "latest" for beta users who want the newest bits.
+        tag = release.get("tag_name")
+        if not isinstance(tag, str):
+            continue
+        version = _tag_version(tag)
+        if version is None:
+            continue
+        if best is None or version > best[1]:
+            best = (tag.lstrip("v"), version)
+    return best
+
+
+def check_latest(
+    channel: str = "stable",
+    *,
+    owner: str = _DEFAULT_OWNER,
+    repo: str = _DEFAULT_REPO,
+    cache_path: Path | None = None,
+    ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+    timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+    force_refresh: bool = False,
+    network_fetch: Any | None = None,
+) -> ReleaseCheck | None:
+    """Return the latest-release comparison, or ``None`` when unknown.
+
+    ``channel`` picks the filter: ``"stable"`` drops prereleases;
+    ``"beta"`` keeps them. Unknown channels are treated as stable.
+
+    The ``network_fetch`` hook is a test seam — pass a callable that
+    returns a list of release dicts to skip the real HTTP path. The
+    production call site never supplies this.
+    """
+    if channel not in {"stable", "beta"}:
+        channel = "stable"
+    target_cache = cache_path or _cache_path()
+    if not force_refresh:
+        cached = _load_cached(target_cache, channel, ttl_seconds)
+        if cached is not None:
+            return cached
+
+    if network_fetch is not None:
+        releases = network_fetch()
+    else:
+        releases = _fetch_releases(owner, repo, timeout=timeout)
+    if not releases:
+        return None
+
+    selected = _select_latest(releases, channel)
+    if selected is None:
+        return None
+    latest_label, latest_version = selected
+
+    current_str = pollypm.__version__
+    current_version = _tag_version(current_str)
+    upgrade_available = (
+        current_version is not None and latest_version > current_version
+    )
+    check = ReleaseCheck(
+        current=current_str,
+        latest=latest_label,
+        channel=channel,
+        upgrade_available=upgrade_available,
+        cached_at=time.time(),
+    )
+    _save_cache(target_cache, check)
+    return check
+
+
+def banner_text(check: ReleaseCheck) -> str:
+    """Render the one-line banner shown by ``pm doctor`` and the rail.
+
+    Callers decide whether to show it (only when ``upgrade_available``).
+    """
+    channel_label = f" ({check.channel} channel)" if check.channel != "stable" else ""
+    return (
+        f"↑ PollyPM v{check.current} → v{check.latest} available"
+        f"{channel_label}. Run: pm upgrade"
+    )
+
+
+def _resolve_channel(config_path: Path | None) -> str:
+    """Read the active release channel from config with a safe fallback.
+
+    A missing / unparseable config returns ``"stable"`` rather than
+    raising — the update check is a nice-to-have signal, never a
+    startup blocker.
+    """
+    from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+
+    path = config_path or DEFAULT_CONFIG_PATH
+    if not path.exists():
+        return "stable"
+    try:
+        config = load_config(path)
+    except Exception:  # noqa: BLE001
+        return "stable"
+    channel = getattr(config.pollypm, "release_channel", "stable")
+    if channel not in {"stable", "beta"}:
+        return "stable"
+    return channel
+
+
+def update_banner_line(
+    config_path: Path | None = None,
+    *,
+    channel: str | None = None,
+    network_fetch: Any | None = None,
+) -> str:
+    """Return the ``pm doctor`` update-available banner line, or "".
+
+    Empty string means either no upgrade is available, the network was
+    unreachable, or a cache-miss hit a quiet failure. Callers should
+    only print the result when non-empty.
+
+    ``channel`` overrides the config lookup — used by tests and by the
+    rail pill to show a "what would I see on beta?" preview.
+    """
+    resolved = channel if channel is not None else _resolve_channel(config_path)
+    check = check_latest(resolved, network_fetch=network_fetch)
+    if check is None or not check.upgrade_available:
+        return ""
+    return banner_text(check)

--- a/tests/test_release_check.py
+++ b/tests/test_release_check.py
@@ -1,0 +1,268 @@
+"""Tests for the release-channel update check (#714).
+
+Covers the channel filter (stable drops prereleases; beta keeps them),
+the 24h cache (hit on repeat, miss on TTL expiry, invalidate on channel
+switch), offline behavior (returns None, never raises), and the banner
+string shape.
+
+The HTTP path is never exercised — every test uses the ``network_fetch``
+seam on ``check_latest`` to feed synthetic release payloads.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+from pollypm import release_check
+
+
+def _release(tag: str, *, prerelease: bool = False, draft: bool = False) -> dict:
+    return {"tag_name": tag, "prerelease": prerelease, "draft": draft}
+
+
+def _fixed_fetch(releases: list[dict]):
+    def _call() -> list[dict]:
+        return releases
+    return _call
+
+
+def test_stable_channel_filters_prereleases(tmp_path, monkeypatch):
+    monkeypatch.setattr(release_check.pollypm, "__version__", "0.1.0")
+    result = release_check.check_latest(
+        "stable",
+        cache_path=tmp_path / "cache.json",
+        network_fetch=_fixed_fetch([
+            _release("v0.3.0-beta.1", prerelease=True),
+            _release("v0.2.0"),
+            _release("v0.1.5"),
+        ]),
+    )
+    assert result is not None
+    assert result.latest == "0.2.0"
+    assert result.channel == "stable"
+    assert result.upgrade_available is True
+
+
+def test_beta_channel_includes_prereleases(tmp_path, monkeypatch):
+    monkeypatch.setattr(release_check.pollypm, "__version__", "0.1.0")
+    result = release_check.check_latest(
+        "beta",
+        cache_path=tmp_path / "cache.json",
+        network_fetch=_fixed_fetch([
+            _release("v0.3.0-beta.1", prerelease=True),
+            _release("v0.2.0"),
+        ]),
+    )
+    assert result is not None
+    assert result.latest == "0.3.0-beta.1"
+    assert result.channel == "beta"
+
+
+def test_no_upgrade_when_current_is_latest(tmp_path, monkeypatch):
+    monkeypatch.setattr(release_check.pollypm, "__version__", "0.2.0")
+    result = release_check.check_latest(
+        "stable",
+        cache_path=tmp_path / "cache.json",
+        network_fetch=_fixed_fetch([_release("v0.2.0")]),
+    )
+    assert result is not None
+    assert result.upgrade_available is False
+
+
+def test_offline_returns_none_without_raising(tmp_path, monkeypatch):
+    def _empty():
+        return []
+    monkeypatch.setattr(release_check.pollypm, "__version__", "0.1.0")
+    result = release_check.check_latest(
+        "stable",
+        cache_path=tmp_path / "cache.json",
+        network_fetch=_empty,
+    )
+    assert result is None
+
+
+def test_drafts_are_skipped(tmp_path, monkeypatch):
+    monkeypatch.setattr(release_check.pollypm, "__version__", "0.1.0")
+    result = release_check.check_latest(
+        "stable",
+        cache_path=tmp_path / "cache.json",
+        network_fetch=_fixed_fetch([
+            _release("v0.9.9", draft=True),
+            _release("v0.2.0"),
+        ]),
+    )
+    assert result is not None
+    assert result.latest == "0.2.0"
+
+
+def test_unknown_channel_falls_back_to_stable(tmp_path, monkeypatch):
+    monkeypatch.setattr(release_check.pollypm, "__version__", "0.1.0")
+    result = release_check.check_latest(
+        "nightly",
+        cache_path=tmp_path / "cache.json",
+        network_fetch=_fixed_fetch([
+            _release("v0.3.0-beta.1", prerelease=True),
+            _release("v0.2.0"),
+        ]),
+    )
+    assert result is not None
+    # Unknown channel maps to stable, which filters prereleases.
+    assert result.latest == "0.2.0"
+    assert result.channel == "stable"
+
+
+def test_cache_hit_avoids_second_network_call(tmp_path, monkeypatch):
+    monkeypatch.setattr(release_check.pollypm, "__version__", "0.1.0")
+    calls = {"n": 0}
+
+    def _counting():
+        calls["n"] += 1
+        return [_release("v0.2.0")]
+
+    cache_path = tmp_path / "cache.json"
+    first = release_check.check_latest(
+        "stable", cache_path=cache_path, network_fetch=_counting,
+    )
+    second = release_check.check_latest(
+        "stable", cache_path=cache_path, network_fetch=_counting,
+    )
+    assert first is not None and second is not None
+    assert first.latest == second.latest
+    assert calls["n"] == 1  # second call served from cache
+
+
+def test_cache_expires_after_ttl(tmp_path, monkeypatch):
+    monkeypatch.setattr(release_check.pollypm, "__version__", "0.1.0")
+    cache_path = tmp_path / "cache.json"
+    release_check.check_latest(
+        "stable", cache_path=cache_path,
+        network_fetch=_fixed_fetch([_release("v0.2.0")]),
+    )
+    # Rewrite the cached_at to the distant past.
+    data = json.loads(cache_path.read_text())
+    data["cached_at"] = time.time() - 10_000_000
+    cache_path.write_text(json.dumps(data))
+
+    calls = {"n": 0}
+
+    def _counting():
+        calls["n"] += 1
+        return [_release("v0.3.0")]
+
+    result = release_check.check_latest(
+        "stable", cache_path=cache_path, network_fetch=_counting,
+    )
+    assert calls["n"] == 1
+    assert result is not None and result.latest == "0.3.0"
+
+
+def test_channel_switch_invalidates_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(release_check.pollypm, "__version__", "0.1.0")
+    cache_path = tmp_path / "cache.json"
+    release_check.check_latest(
+        "stable", cache_path=cache_path,
+        network_fetch=_fixed_fetch([_release("v0.2.0")]),
+    )
+    # Switching to beta must re-query — previous cache was stable-scoped.
+    calls = {"n": 0}
+
+    def _counting():
+        calls["n"] += 1
+        return [
+            _release("v0.3.0-beta.1", prerelease=True),
+            _release("v0.2.0"),
+        ]
+
+    result = release_check.check_latest(
+        "beta", cache_path=cache_path, network_fetch=_counting,
+    )
+    assert calls["n"] == 1
+    assert result is not None and result.channel == "beta"
+
+
+def test_invalidate_cache_drops_file(tmp_path):
+    cache_path = tmp_path / "cache.json"
+    cache_path.write_text("{}")
+    release_check.invalidate_cache(cache_path)
+    assert not cache_path.exists()
+    # Idempotent — second call doesn't raise.
+    release_check.invalidate_cache(cache_path)
+
+
+def test_banner_text_stable_channel(tmp_path, monkeypatch):
+    monkeypatch.setattr(release_check.pollypm, "__version__", "0.1.0")
+    check = release_check.check_latest(
+        "stable", cache_path=tmp_path / "cache.json",
+        network_fetch=_fixed_fetch([_release("v0.2.0")]),
+    )
+    assert check is not None
+    text = release_check.banner_text(check)
+    assert "0.1.0" in text
+    assert "0.2.0" in text
+    assert "pm upgrade" in text
+    # Stable channel omits the channel label to keep the banner terse.
+    assert "channel" not in text
+
+
+def test_banner_text_beta_channel_labels(tmp_path, monkeypatch):
+    monkeypatch.setattr(release_check.pollypm, "__version__", "0.1.0")
+    check = release_check.check_latest(
+        "beta", cache_path=tmp_path / "cache.json",
+        network_fetch=_fixed_fetch([
+            _release("v0.3.0-beta.1", prerelease=True),
+        ]),
+    )
+    assert check is not None
+    text = release_check.banner_text(check)
+    assert "beta channel" in text
+
+
+def test_update_banner_line_empty_when_no_upgrade(tmp_path, monkeypatch):
+    monkeypatch.setattr(release_check.pollypm, "__version__", "0.2.0")
+    monkeypatch.setattr(
+        release_check, "_cache_path", lambda: tmp_path / "cache.json",
+    )
+    line = release_check.update_banner_line(
+        channel="stable",
+        network_fetch=_fixed_fetch([_release("v0.2.0")]),
+    )
+    assert line == ""
+
+
+def test_update_banner_line_shows_when_upgrade(tmp_path, monkeypatch):
+    monkeypatch.setattr(release_check.pollypm, "__version__", "0.1.0")
+    monkeypatch.setattr(
+        release_check, "_cache_path", lambda: tmp_path / "cache.json",
+    )
+    line = release_check.update_banner_line(
+        channel="stable",
+        network_fetch=_fixed_fetch([_release("v0.2.0")]),
+    )
+    assert "pm upgrade" in line
+    assert "0.2.0" in line
+
+
+def test_malformed_cache_is_discarded(tmp_path, monkeypatch):
+    monkeypatch.setattr(release_check.pollypm, "__version__", "0.1.0")
+    cache_path = tmp_path / "cache.json"
+    cache_path.write_text("not json")
+    result = release_check.check_latest(
+        "stable", cache_path=cache_path,
+        network_fetch=_fixed_fetch([_release("v0.2.0")]),
+    )
+    assert result is not None
+    assert result.latest == "0.2.0"
+
+
+def test_invalid_version_tag_skipped(tmp_path, monkeypatch):
+    monkeypatch.setattr(release_check.pollypm, "__version__", "0.1.0")
+    result = release_check.check_latest(
+        "stable", cache_path=tmp_path / "cache.json",
+        network_fetch=_fixed_fetch([
+            {"tag_name": "release-candidate", "prerelease": False, "draft": False},
+            _release("v0.2.0"),
+        ]),
+    )
+    assert result is not None
+    assert result.latest == "0.2.0"


### PR DESCRIPTION
Adds the passive update signal: `pm doctor` now prepends a one-line banner when a newer PollyPM release is available on the user's chosen channel. Part of the auto-upgrade-flow set (see #709 parent).

## What ships

- **`src/pollypm/release_check.py`** — new module that:
  - Queries GitHub releases API for the PollyPM repo.
  - Filters by channel: `stable` drops prereleases; `beta` keeps them.
  - Compares against `pollypm.__version__` using `packaging.version.Version`.
  - Caches results for 24h in `~/.pollypm/release-check.json`.
  - Never raises — offline / DNS / parse failures return `None`.
  - Cache is channel-keyed so channel switches auto-invalidate.

- **`pm doctor`** prepends the banner when an upgrade is available:
  `↑ PollyPM v0.1.0 → v0.2.0 available. Run: pm upgrade`
  Beta channel includes the label: `↑ PollyPM v0.1.0 → v0.3.0-beta.1 available (beta channel). Run: pm upgrade`.

- **`update_banner_line()`** — public helper consumed by `pm doctor` now, by the rail pill in #715, and by `pm upgrade` in #716.

## Validation

- 16 new unit tests in `tests/test_release_check.py` cover channel filter, cache hit/miss/TTL, offline fallback, draft skip, malformed cache, banner text shape.
- Uses a `network_fetch` injection seam instead of mocking HTTP — no real network in tests.
- Regression check: `tests/test_cli.py` still passes (30/30).

## Dependencies

- Reads `config.pollypm.release_channel` via `getattr` with a safe fallback. When #713 lands, the field exists natively; until then, callers can pass `channel=` explicitly.

Closes #714 · Refs #709