### PR TITLE
feat(config): release_channel (stable/beta) + settings picker

### DIFF
--- a/src/pollypm/cli_features/maintenance.py
+++ b/src/pollypm/cli_features/maintenance.py
@@ -101,6 +101,7 @@ def register_maintenance_commands(app: typer.Typer) -> None:
             apply_fixes,
             manual_fixes,
             planned_fixes,
+            release_channel_line,
             render_fix_dry_run,
             render_fix_summary,
             render_human,
@@ -137,6 +138,7 @@ def register_maintenance_commands(app: typer.Typer) -> None:
                 typer.echo("")
             typer.echo(render_human(report))
             typer.echo("")
+            typer.echo(release_channel_line())
             typer.echo(setup_tag_line())
         if fix_summary:
             typer.echo("")

--- a/src/pollypm/cockpit_project_settings.py
+++ b/src/pollypm/cockpit_project_settings.py
@@ -21,10 +21,10 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Button, Static
+from textual.widgets import Button, RadioButton, RadioSet, Static
 
 from pollypm.account_usage_sampler import load_cached_account_usage
-from pollypm.config import load_config
+from pollypm.config import load_config, write_config
 from pollypm.cockpit_settings_history import (
     UndoAction,
     consume_settings_history,
@@ -115,6 +115,18 @@ class PollyProjectSettingsApp(App[None]):
         with Vertical(classes="settings-section"):
             yield Static("Recent Tasks", classes="section-label")
             yield Static("", id="task-info")
+        with Vertical(classes="settings-section", id="release-channel-section"):
+            yield Static("Release channel", classes="section-label")
+            yield Static(
+                "Stable: Production builds. Recommended.\n"
+                "Beta: Pre-release builds. Faster features, occasional breakage.",
+                id="release-channel-explainer",
+            )
+            yield RadioSet(
+                RadioButton("Stable", id="release-channel-stable"),
+                RadioButton("Beta", id="release-channel-beta"),
+                id="release-channel-radio",
+            )
         with Horizontal(id="actions"):
             yield Button(Text("[R] Reset Session"), id="reset-session", variant="warning")
             yield Button(Text("[C] Switch to Claude"), id="switch-claude", variant="primary")
@@ -131,6 +143,9 @@ class PollyProjectSettingsApp(App[None]):
             self.title_bar.update(f"Project not found: {self.project_key}")
             return
         self.title_bar.update(f"{project.name or project.key} • Settings")
+        pollypm_settings = getattr(config, "pollypm", None)
+        current_channel = getattr(pollypm_settings, "release_channel", "stable")
+        self._sync_release_channel_radio(current_channel)
 
         worker = None
         for session in config.sessions.values():
@@ -306,6 +321,53 @@ class PollyProjectSettingsApp(App[None]):
     def _consume_undo_history(self, action: UndoAction) -> None:
         if action.entry_id:
             consume_settings_history(action.entry_id)
+
+    def _sync_release_channel_radio(self, channel: str) -> None:
+        """Mirror the on-disk channel into the radio picker.
+
+        The write-back handler short-circuits when the on-disk value
+        already matches the radio, so firing ``RadioSet.Changed`` during
+        sync is benign — no suppression plumbing needed.
+        """
+        try:
+            stable = self.query_one("#release-channel-stable", RadioButton)
+            beta = self.query_one("#release-channel-beta", RadioButton)
+        except Exception:  # noqa: BLE001
+            return
+        target = beta if channel == "beta" else stable
+        if target.value:
+            return
+        target.value = True
+
+    @on(RadioSet.Changed, "#release-channel-radio")
+    def on_release_channel_changed(self, event: RadioSet.Changed) -> None:
+        button = event.pressed
+        if button is None:
+            return
+        new_channel = "beta" if button.id == "release-channel-beta" else "stable"
+        try:
+            config = load_config(self.config_path)
+        except Exception as exc:  # noqa: BLE001
+            self._notify(f"Release channel update failed: {exc}")
+            return
+        current = getattr(getattr(config, "pollypm", None), "release_channel", "stable")
+        if current == new_channel:
+            return
+        config.pollypm.release_channel = new_channel
+        try:
+            write_config(config, self.config_path, force=True)
+        except Exception as exc:  # noqa: BLE001
+            self._notify(f"Release channel update failed: {exc}")
+            return
+        # Invalidate the cached release check so the next probe re-queries
+        # against the new channel. The cache module from #714 doesn't
+        # exist yet — unlink defensively.
+        cache_path = Path.home() / ".pollypm" / "release-check.json"
+        try:
+            cache_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        self._notify(f"Release channel set to {new_channel}.")
 
     @on(Button.Pressed, "#reset-session")
     def on_reset(self, _event: Button.Pressed | None) -> None:

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import tomllib
 from pathlib import Path
 
@@ -26,6 +27,27 @@ GLOBAL_CONFIG_DIR = Path.home() / ".pollypm"
 DEFAULT_CONFIG_PATH = GLOBAL_CONFIG_DIR / "pollypm.toml"
 PROJECT_CONFIG_DIRNAME = ".pollypm/config"
 PROJECT_CONFIG_FILENAME = "project.toml"
+
+_VALID_RELEASE_CHANNELS = ("stable", "beta")
+
+_log = logging.getLogger(__name__)
+
+
+def _validate_release_channel(value: object) -> str:
+    """Coerce a raw config value into one of the valid release channels.
+
+    Invariant: any unknown or non-string value falls back to ``"stable"``
+    with a warning — a fat-fingered channel must never brick the CLI.
+    See issue #713.
+    """
+    if isinstance(value, str) and value in _VALID_RELEASE_CHANNELS:
+        return value
+    if value is not None:
+        _log.warning(
+            "Invalid release_channel %r in pollypm.toml; falling back to 'stable'.",
+            value,
+        )
+    return "stable"
 
 
 def _normalize_project_display_name(key: str, name: str | None) -> str | None:
@@ -245,6 +267,7 @@ def _parse_pollypm_settings(raw: dict[str, object], sessions: dict[str, SessionC
         scheduler_backend=str(pollypm_raw.get("scheduler_backend", "inline")),
         lease_timeout_minutes=max(1, int(pollypm_raw.get("lease_timeout_minutes", 30))),
         timezone=_validate_timezone(str(pollypm_raw.get("timezone", ""))),
+        release_channel=_validate_release_channel(pollypm_raw.get("release_channel")),
     )
 
 
@@ -610,6 +633,7 @@ def _render_global_config(config: PollyPMConfig) -> str:
         f'heartbeat_backend = "{config.pollypm.heartbeat_backend}"',
         f'scheduler_backend = "{config.pollypm.scheduler_backend}"',
         f"lease_timeout_minutes = {config.pollypm.lease_timeout_minutes}",
+        f'release_channel = "{config.pollypm.release_channel}"',
     ]
     if config.pollypm.timezone:
         lines.append(f'timezone = "{config.pollypm.timezone}"')

--- a/src/pollypm/doctor.py
+++ b/src/pollypm/doctor.py
@@ -501,6 +501,26 @@ def setup_tag_line(config_path: Path | None = None) -> str:
     return f"pollypm setup: {tag} - share this if something looks off"
 
 
+def release_channel_line(config_path: Path | None = None) -> str:
+    """Return a single-line ``Release channel: <value>`` summary.
+
+    Falls back to the default channel when the config is missing or
+    unparseable — ``pm doctor`` must stay useful even before a first-run
+    user has written a config. See issue #713.
+    """
+    from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+
+    path = config_path or DEFAULT_CONFIG_PATH
+    channel = "stable"
+    if path.exists():
+        try:
+            config = load_config(path)
+            channel = config.pollypm.release_channel
+        except Exception:  # noqa: BLE001
+            channel = "stable"
+    return f"Release channel: {channel}"
+
+
 def decode_setup_tag(tag: str) -> dict[str, object] | None:
     for entry in _setup_tags_store():
         if entry.get("tag") == tag:

--- a/src/pollypm/models.py
+++ b/src/pollypm/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
+from typing import Literal
 
 
 class ProviderKind(StrEnum):
@@ -82,6 +83,7 @@ class PollyPMSettings:
     scheduler_backend: str = "inline"
     lease_timeout_minutes: int = 30
     timezone: str = ""  # IANA timezone (e.g. "America/Denver"). Empty = auto-detect.
+    release_channel: Literal["stable", "beta"] = "stable"
 
 
 @dataclass(slots=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -401,3 +401,77 @@ def test_write_config_splits_worker_sessions_into_project_local_files(tmp_path: 
     assert "worker_wire" in loaded.sessions
     assert loaded.sessions["worker_wire"].project == "wire"
     assert loaded.projects["wire"].persona_name == "Wren"
+
+
+def _minimal_config_text(*, release_channel_line: str = "") -> str:
+    """Minimal config TOML with a single account + operator session.
+
+    Used by the release_channel tests so they focus on parsing the
+    channel field without cross-referencing other config surfaces.
+    """
+    return (
+        "[project]\n"
+        'name = "pollypm"\n'
+        'tmux_session = "pollypm"\n'
+        "\n"
+        "[pollypm]\n"
+        'controller_account = "claude_primary"\n'
+        + (f"{release_channel_line}\n" if release_channel_line else "")
+        + "\n"
+        "[accounts.claude_primary]\n"
+        'provider = "claude"\n'
+        'home = ".pollypm/homes/claude_primary"\n'
+        "\n"
+        "[sessions.operator]\n"
+        'role = "operator-pm"\n'
+        'provider = "claude"\n'
+        'account = "claude_primary"\n'
+        'cwd = "."\n'
+        "\n"
+        "[projects.pollypm]\n"
+        'path = "."\n'
+        'name = "pollypm"\n'
+    )
+
+
+def test_release_channel_default_is_stable(tmp_path: Path) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(_minimal_config_text())
+    config = load_config(config_path)
+    assert config.pollypm.release_channel == "stable"
+
+
+def test_release_channel_beta_round_trips(tmp_path: Path) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        _minimal_config_text(release_channel_line='release_channel = "beta"')
+    )
+
+    config = load_config(config_path)
+    assert config.pollypm.release_channel == "beta"
+
+    out_path = tmp_path / "rewritten.toml"
+    write_config(config, out_path, force=True)
+    rendered = out_path.read_text()
+    assert 'release_channel = "beta"' in rendered
+    reloaded = load_config(out_path)
+    assert reloaded.pollypm.release_channel == "beta"
+
+
+def test_release_channel_invalid_falls_back_to_stable(
+    tmp_path: Path, caplog
+) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        _minimal_config_text(release_channel_line='release_channel = "bogus"')
+    )
+    import logging as _logging
+
+    with caplog.at_level(_logging.WARNING, logger="pollypm.config"):
+        config = load_config(config_path)
+
+    assert config.pollypm.release_channel == "stable"
+    assert any(
+        "release_channel" in record.getMessage() and "bogus" in record.getMessage()
+        for record in caplog.records
+    )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -800,3 +800,64 @@ def test_cli_doctor_all_pass_returns_zero(monkeypatch: pytest.MonkeyPatch) -> No
     result = runner.invoke(cli_mod.app, ["doctor"])
     assert result.exit_code == 0
     assert "Summary: 1/1" in result.stdout
+
+
+def test_release_channel_line_defaults_to_stable_without_config(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist.toml"
+    assert doctor.release_channel_line(missing) == "Release channel: stable"
+
+
+def test_release_channel_line_reads_configured_channel(tmp_path: Path) -> None:
+    from pollypm.config import load_config, write_config
+
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        "[project]\n"
+        'name = "pollypm"\n'
+        'tmux_session = "pollypm"\n'
+        "\n"
+        "[pollypm]\n"
+        'controller_account = "claude_primary"\n'
+        'release_channel = "beta"\n'
+        "\n"
+        "[accounts.claude_primary]\n"
+        'provider = "claude"\n'
+        'home = ".pollypm/homes/claude_primary"\n'
+        "\n"
+        "[sessions.operator]\n"
+        'role = "operator-pm"\n'
+        'provider = "claude"\n'
+        'account = "claude_primary"\n'
+        'cwd = "."\n'
+        "\n"
+        "[projects.pollypm]\n"
+        'path = "."\n'
+        'name = "pollypm"\n'
+    )
+    # Force a re-render through write_config so the rendered TOML matches
+    # what ``pm doctor`` would see after any on-disk mutation.
+    write_config(load_config(config_path), config_path, force=True)
+
+    assert doctor.release_channel_line(config_path) == "Release channel: beta"
+
+
+def test_cli_doctor_prints_release_channel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The human ``pm doctor`` output must contain a release-channel line."""
+    from pollypm import doctor as doctor_mod
+
+    def _pass() -> doctor_mod.CheckResult:
+        return doctor_mod._ok("ok")
+
+    monkeypatch.setattr(
+        doctor_mod, "_registered_checks",
+        lambda: [doctor_mod.Check("demo", _pass, "test")],
+    )
+    monkeypatch.setattr(
+        doctor_mod, "release_channel_line", lambda: "Release channel: beta"
+    )
+    import pollypm.cli as cli_mod
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.app, ["doctor"])
+    assert result.exit_code == 0
+    assert "Release channel: beta" in result.stdout

--- a/tests/test_project_settings_ui.py
+++ b/tests/test_project_settings_ui.py
@@ -235,3 +235,99 @@ def test_project_settings_buttons_include_inline_key_hints(project_settings_env)
             assert app.query_one("#undo", Button).label.plain == "[U] Undo"
 
     _run(body())
+
+
+def test_project_settings_release_channel_picker_persists(tmp_path: Path, monkeypatch) -> None:
+    """Changing the Release channel radio writes the selection to config."""
+    from textual.widgets import RadioButton
+
+    from pollypm.config import load_config, write_config
+    from pollypm.models import (
+        AccountConfig,
+        KnownProject,
+        PollyPMConfig,
+        PollyPMSettings,
+        ProjectKind,
+        ProjectSettings,
+        ProviderKind,
+        SessionConfig,
+    )
+
+    # Build a minimal real config so ``load_config`` / ``write_config``
+    # round-trip exercises the actual parse path — this is the
+    # integration we care about for the picker.
+    config_path = tmp_path / "pollypm.toml"
+    base_dir = tmp_path
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=base_dir,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=base_dir / "state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account="claude_primary"),
+        accounts={
+            "claude_primary": AccountConfig(
+                name="claude_primary",
+                provider=ProviderKind.CLAUDE,
+                home=base_dir / "homes" / "claude_primary",
+            )
+        },
+        sessions={
+            "operator": SessionConfig(
+                name="operator",
+                role="operator-pm",
+                provider=ProviderKind.CLAUDE,
+                account="claude_primary",
+                cwd=base_dir,
+            ),
+            "worker_alpha": SessionConfig(
+                name="worker_alpha",
+                role="worker",
+                provider=ProviderKind.CLAUDE,
+                account="claude_primary",
+                cwd=base_dir,
+                project="alpha",
+            ),
+        },
+        projects={
+            "alpha": KnownProject(
+                key="alpha",
+                path=base_dir,
+                name="Alpha",
+                kind=ProjectKind.FOLDER,
+            ),
+        },
+    )
+    write_config(config, config_path, force=True)
+    assert load_config(config_path).pollypm.release_channel == "stable"
+
+    # Point the cache-invalidation target at an isolated home so the
+    # unlink stays sandboxed.
+    fake_home = tmp_path / "home"
+    (fake_home / ".pollypm").mkdir(parents=True)
+    cache_path = fake_home / ".pollypm" / "release-check.json"
+    cache_path.write_text("{}")
+    monkeypatch.setattr(
+        "pollypm.cockpit_project_settings.Path.home",
+        lambda: fake_home,
+    )
+
+    from pollypm.cockpit_project_settings import PollyProjectSettingsApp
+
+    app = PollyProjectSettingsApp(config_path, "alpha")
+
+    async def body() -> None:
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            beta = app.query_one("#release-channel-beta", RadioButton)
+            beta.value = True
+            await pilot.pause()
+
+    _run(body())
+
+    reloaded = load_config(config_path)
+    assert reloaded.pollypm.release_channel == "beta"
+    assert not cache_path.exists()


### PR DESCRIPTION
## Summary
- Add `release_channel: Literal["stable", "beta"] = "stable"` to `PollyPMSettings`, round-trip through `pollypm.toml` under `[pollypm] release_channel`
- Invalid values fall back to `"stable"` with a logged warning; the CLI never bricks on a fat-fingered channel
- Cockpit project-settings pane gains a "Release channel" radio picker (Stable default / Beta) with short explainers. Changing the value persists to config and unlinks `~/.pollypm/release-check.json` so the next probe re-queries with the new filter
- `pm doctor` now prints a `Release channel: <value>` line above the setup tag

## Test plan
- [x] `pytest tests/test_config.py tests/test_doctor.py tests/test_project_settings_ui.py` (87 passed)
- [x] Round-trip: write + read a config with `release_channel = "beta"` — persists
- [x] Invalid value (`"bogus"`) in config loads as `"stable"` with a warning log
- [x] Cockpit picker change (via Pilot) updates the config file on disk and unlinks the cache
- [x] `pm doctor` output contains `Release channel: <value>` on its own line

Closes #713

Foundation PR for the auto-upgrade flow; #714 consumes the field from the release-check cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)