### PR TITLE
feat(cli): pm upgrade wrapper — detect installer + delegate (#716)

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -50,6 +50,7 @@ from pollypm.cli_features.maintenance import debug_app, register_maintenance_com
 from pollypm.cli_features.projects import register_project_commands
 from pollypm.cli_features.session_runtime import register_session_runtime_commands
 from pollypm.cli_features.ui import register_ui_commands
+from pollypm.cli_features.upgrade import register_upgrade_commands
 from pollypm.cli_features.workers import register_worker_commands
 
 
@@ -170,6 +171,7 @@ app.add_typer(downtime_app, name="downtime")
 register_ui_commands(app)
 register_project_commands(app)
 register_maintenance_commands(app)
+register_upgrade_commands(app)
 register_worker_commands(app)
 register_session_runtime_commands(app, helpers=sys.modules[__name__])
 

--- a/src/pollypm/cli_features/upgrade.py
+++ b/src/pollypm/cli_features/upgrade.py
@@ -1,0 +1,87 @@
+"""``pm upgrade`` command registration (#716).
+
+Thin Typer shim over :mod:`pollypm.upgrade`. All logic lives there so
+the rail one-click (#719) can invoke the same entry point.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from pollypm.cli_help import help_with_examples
+
+
+def register_upgrade_commands(app: typer.Typer) -> None:
+    @app.command(
+        help=help_with_examples(
+            "Upgrade PollyPM to the latest release on the current channel.",
+            [
+                ("pm upgrade", "install the latest release on the active channel"),
+                ("pm upgrade --check-only", "report what would happen, don't install"),
+                ("pm upgrade --channel beta", "one-off beta upgrade (config channel wins otherwise)"),
+            ],
+        )
+    )
+    def upgrade(
+        channel: str = typer.Option(
+            "",
+            "--channel",
+            help="stable | beta. Empty = read release_channel from config.",
+        ),
+        check_only: bool = typer.Option(
+            False,
+            "--check-only",
+            help="Show what would happen — run the migration check, fetch target version, exit without installing.",
+        ),
+        recycle_all: bool = typer.Option(
+            False,
+            "--recycle-all",
+            help="After install, tear down and respawn every live session (Polly, Russell, workers). Use for prompt-critical releases where the in-conversation notice isn't enough.",
+        ),
+        recycle_idle: bool = typer.Option(
+            False,
+            "--recycle-idle",
+            help="After install, respawn only sessions with no active turn in the last 30 minutes. Active work continues untouched.",
+        ),
+    ) -> None:
+        """Detect the install method and delegate to the right package manager."""
+        from pollypm.upgrade import read_changelog_diff, upgrade as run_upgrade
+
+        # ``release_check._resolve_channel`` is the canonical reader for
+        # ``config.pollypm.release_channel`` (from #713/#714). Until both
+        # land, fall back to stable if the helper isn't importable —
+        # never crash on a fresh checkout just because the config field
+        # is missing.
+        try:
+            from pollypm.release_check import _resolve_channel
+            default_channel = _resolve_channel(None)
+        except ImportError:
+            default_channel = "stable"
+        resolved_channel = channel or default_channel
+        result = run_upgrade(
+            channel=resolved_channel,
+            check_only=check_only,
+            recycle_all=recycle_all,
+            recycle_idle=recycle_idle,
+            emit=typer.echo,
+        )
+
+        typer.echo("")
+        typer.echo(f"installer: {result.installer}")
+        typer.echo(f"version:   {result.old_version} → {result.new_version}")
+        typer.echo(f"migration: {'checked' if result.migration_checked else 'skipped'}")
+        typer.echo(f"notified:  {'yes' if result.notified else 'no'}")
+        typer.echo(f"status:    {result.message}")
+
+        if not result.ok:
+            if result.stderr:
+                typer.echo("")
+                typer.echo(result.stderr)
+            raise typer.Exit(code=1)
+
+        if not check_only and result.old_version != result.new_version:
+            diff = read_changelog_diff(result.new_version)
+            if diff:
+                typer.echo("")
+                typer.echo("-- CHANGELOG --")
+                typer.echo(diff)

--- a/src/pollypm/upgrade.py
+++ b/src/pollypm/upgrade.py
@@ -1,0 +1,452 @@
+"""``pm upgrade`` — detect the install method, delegate to the right
+package manager, and wire the migration / notice-injection hooks (#716).
+
+Design goals:
+
+* **One command everywhere.** `pm upgrade` works whether the user
+  installed via ``uv tool install``, ``pip``, ``brew``, or ``npm -g``.
+  The wrapper detects which (in priority order) and shells out.
+* **Safe-by-default.** Before any mutation, the migration check from
+  #717 runs. On failure, upgrade aborts with a specific error — the
+  user is never left on a half-upgraded install.
+* **Observable.** Each step streams to stdout with a ``[step]`` prefix
+  so a log / pane can show progress. The caller (rail one-click in
+  #719) reads these markers.
+* **No new dependencies.** Detection uses ``shutil.which`` and
+  ``subprocess.run``; no external libraries.
+
+The dependent issues (#717 migration gate, #718 notice injection) are
+invoked via import-if-available so this module works on a system where
+either hasn't landed yet — we log "skipped: not yet implemented" and
+carry on. Once those merge, the stubs become real calls without
+touching this module.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import pollypm
+
+
+Installer = str  # "uv" | "pip" | "brew" | "npm" | "unknown"
+
+
+@dataclass(slots=True)
+class UpgradePlan:
+    """Resolved upgrade strategy for a specific install method.
+
+    ``command`` is the exact argv that will be run; ``notes`` is a
+    user-visible explanation of what's happening (shown in the pane).
+    """
+
+    installer: Installer
+    command: list[str]
+    channel: str
+    notes: str
+
+
+@dataclass(slots=True)
+class UpgradeResult:
+    ok: bool
+    installer: Installer
+    old_version: str
+    new_version: str
+    migration_checked: bool
+    notified: bool
+    stdout: str
+    stderr: str
+    message: str
+
+
+class Step:
+    """Tiny stdout-marker helper so the rail pane can tail progress."""
+
+    def __init__(self, emit: Callable[[str], None]) -> None:
+        self._emit = emit
+
+    def __call__(self, text: str) -> None:
+        self._emit(f"[step] {text}")
+
+
+def _runs_ok(cmd: list[str], *, timeout: float = 5.0) -> bool:
+    """True iff ``cmd`` exits 0 within the timeout."""
+    try:
+        result = subprocess.run(
+            cmd, check=False, capture_output=True, text=True, timeout=timeout,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def _uv_installed() -> bool:
+    return _runs_ok(["uv", "tool", "list"]) and _uv_has_pollypm()
+
+
+def _uv_has_pollypm() -> bool:
+    try:
+        result = subprocess.run(
+            ["uv", "tool", "list"],
+            check=False, capture_output=True, text=True, timeout=5.0,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    if result.returncode != 0:
+        return False
+    return "pollypm" in result.stdout
+
+
+def _pip_has_pollypm() -> bool:
+    return _runs_ok(["pip", "show", "pollypm"], timeout=3.0)
+
+
+def _brew_has_pollypm() -> bool:
+    return _runs_ok(["brew", "list", "pollypm"], timeout=3.0)
+
+
+def _npm_has_pollypm() -> bool:
+    try:
+        result = subprocess.run(
+            ["npm", "list", "-g", "--depth=0"],
+            check=False, capture_output=True, text=True, timeout=5.0,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    if result.returncode != 0:
+        return False
+    return "pollypm" in result.stdout
+
+
+def detect_installer(
+    *, overrides: dict[str, bool] | None = None,
+) -> Installer:
+    """Return the name of the package manager that installed PollyPM.
+
+    Priority order: uv → pip → brew → npm → unknown. The ``overrides``
+    kwarg is a test seam: pass ``{"uv": True, "pip": False, ...}`` to
+    skip the real shell probes.
+    """
+    if overrides is None:
+        overrides = {}
+
+    def probe(name: str, real: Callable[[], bool]) -> bool:
+        if name in overrides:
+            return overrides[name]
+        return real()
+
+    if probe("uv", _uv_installed):
+        return "uv"
+    if probe("pip", _pip_has_pollypm):
+        return "pip"
+    if probe("brew", _brew_has_pollypm):
+        return "brew"
+    if probe("npm", _npm_has_pollypm):
+        return "npm"
+    return "unknown"
+
+
+def plan_upgrade(installer: Installer, channel: str) -> UpgradePlan:
+    """Produce the exact argv + notes for a given installer + channel.
+
+    ``unknown`` returns a plan whose ``command`` is empty — the CLI
+    must treat that as an error, not execute it.
+    """
+    if channel not in {"stable", "beta"}:
+        channel = "stable"
+    if installer == "uv":
+        if channel == "beta":
+            cmd = [
+                "uv", "tool", "install", "--reinstall", "--prerelease", "allow",
+                "pollypm",
+            ]
+            notes = "uv tool install --reinstall --prerelease allow pollypm (beta)"
+        else:
+            cmd = ["uv", "tool", "upgrade", "pollypm"]
+            notes = "uv tool upgrade pollypm (stable)"
+        return UpgradePlan(installer, cmd, channel, notes)
+    if installer == "pip":
+        if channel == "beta":
+            cmd = ["pip", "install", "-U", "--pre", "pollypm"]
+            notes = "pip install -U --pre pollypm (beta)"
+        else:
+            cmd = ["pip", "install", "-U", "pollypm"]
+            notes = "pip install -U pollypm (stable)"
+        return UpgradePlan(installer, cmd, channel, notes)
+    if installer == "brew":
+        # brew doesn't distinguish stable/beta on this channel; beta is
+        # no-op and we warn the caller.
+        cmd = ["brew", "upgrade", "pollypm"]
+        notes = (
+            "brew upgrade pollypm — brew does not expose pre-release "
+            "channels; stable-only."
+        )
+        return UpgradePlan(installer, cmd, "stable", notes)
+    if installer == "npm":
+        if channel == "beta":
+            cmd = ["npm", "install", "-g", "pollypm@beta"]
+            notes = "npm install -g pollypm@beta"
+        else:
+            cmd = ["npm", "update", "-g", "pollypm"]
+            notes = "npm update -g pollypm"
+        return UpgradePlan(installer, cmd, channel, notes)
+    return UpgradePlan("unknown", [], channel, "no supported installer detected")
+
+
+def unsupported_installer_help() -> str:
+    """User-facing text shown when no installer is detected.
+
+    The text is deliberately specific — users see the exact command
+    per tool and can pick the one matching their install.
+    """
+    return (
+        "Could not detect how PollyPM was installed.\n"
+        "Try one of these manually:\n"
+        "  uv tool upgrade pollypm\n"
+        "  pip install -U pollypm\n"
+        "  brew upgrade pollypm\n"
+        "  npm update -g pollypm\n"
+        "For pre-release builds, add --pre (pip) / --prerelease allow (uv) "
+        "/ @beta (npm)."
+    )
+
+
+def run_migration_check() -> tuple[bool, str]:
+    """Run ``pm migrate --check`` if the migration gate (#717) is
+    present. Returns ``(ok, message)``.
+
+    Until #717 lands, this is a no-op that returns ``(True, "skipped:
+    migration gate not yet implemented")``. Once the gate ships, this
+    function will delegate to its entry point.
+    """
+    try:
+        from pollypm.store import migrations as _migrations  # noqa: F401
+    except ImportError:
+        return (True, "skipped: migration gate not yet implemented (#717)")
+    try:
+        from pollypm.store.migrations import check_pending
+    except ImportError:
+        return (True, "skipped: migrations module present but check_pending() absent")
+    try:
+        ok, detail = check_pending()
+    except Exception as exc:  # noqa: BLE001
+        return (False, f"migration check raised {type(exc).__name__}: {exc}")
+    return (ok, detail or "migration check ok")
+
+
+def inject_notice(old_version: str, new_version: str) -> tuple[bool, str]:
+    """Inject the `<system-update>` notice into every live session.
+
+    Delegates to the helper in #718. Until that lands, this is a no-op
+    returning ``(True, "skipped: notice injection not yet
+    implemented")``.
+    """
+    try:
+        from pollypm.upgrade_notice import inject_system_update_notice
+    except ImportError:
+        return (True, "skipped: notice injection not yet implemented (#718)")
+    try:
+        inject_system_update_notice(old_version, new_version)
+    except Exception as exc:  # noqa: BLE001
+        return (False, f"notice injection raised {type(exc).__name__}: {exc}")
+    return (True, "notified live sessions")
+
+
+def _read_new_version() -> str:
+    """Return the version string after install.
+
+    ``pollypm.__version__`` is cached in the old Python process — we
+    can't just re-read it. Shell out to ``pip show pollypm`` as the
+    canonical source. Returns "" on any failure.
+    """
+    try:
+        result = subprocess.run(
+            ["pip", "show", "pollypm"],
+            check=False, capture_output=True, text=True, timeout=3.0,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return ""
+    if result.returncode != 0:
+        return ""
+    for line in result.stdout.splitlines():
+        if line.lower().startswith("version:"):
+            return line.split(":", 1)[1].strip()
+    return ""
+
+
+def upgrade(
+    *,
+    channel: str = "stable",
+    check_only: bool = False,
+    recycle_all: bool = False,
+    recycle_idle: bool = False,
+    emit: Callable[[str], None] | None = None,
+    installer_overrides: dict[str, bool] | None = None,
+    plan_only: bool = False,
+) -> UpgradeResult:
+    """Execute the full upgrade flow and return a structured result.
+
+    The ``plan_only`` flag is for tests — compose the plan, don't run
+    it. Production paths never set it.
+
+    ``recycle_all`` / ``recycle_idle`` are wired here so the CLI flags
+    are stable, but the actual recycling behavior ships in #720. For
+    now they're recorded on the result for the caller to inspect.
+    """
+    step = Step(emit or print)
+    old_version = pollypm.__version__
+
+    installer = detect_installer(overrides=installer_overrides)
+    plan = plan_upgrade(installer, channel)
+    step(f"installer={installer} channel={plan.channel}")
+
+    if installer == "unknown":
+        return UpgradeResult(
+            ok=False,
+            installer="unknown",
+            old_version=old_version,
+            new_version=old_version,
+            migration_checked=False,
+            notified=False,
+            stdout="",
+            stderr=unsupported_installer_help(),
+            message="no supported installer",
+        )
+
+    # Migration check runs for both check-only and full upgrade — even
+    # check-only users want to know if they'd hit a blocker.
+    step("migration check")
+    mig_ok, mig_detail = run_migration_check()
+    step(f"migration: {mig_detail}")
+    if not mig_ok:
+        return UpgradeResult(
+            ok=False,
+            installer=installer,
+            old_version=old_version,
+            new_version=old_version,
+            migration_checked=True,
+            notified=False,
+            stdout="",
+            stderr=mig_detail,
+            message="migration check failed — upgrade aborted",
+        )
+
+    if check_only:
+        step(f"check-only: would run `{' '.join(plan.command)}`")
+        return UpgradeResult(
+            ok=True,
+            installer=installer,
+            old_version=old_version,
+            new_version=old_version,
+            migration_checked=True,
+            notified=False,
+            stdout="",
+            stderr="",
+            message=f"check-only: {plan.notes}",
+        )
+
+    if plan_only:
+        return UpgradeResult(
+            ok=True,
+            installer=installer,
+            old_version=old_version,
+            new_version=old_version,
+            migration_checked=True,
+            notified=False,
+            stdout="",
+            stderr="",
+            message=f"plan-only: {plan.notes}",
+        )
+
+    step(f"installing: {plan.notes}")
+    try:
+        result = subprocess.run(
+            plan.command,
+            check=False, capture_output=True, text=True, timeout=600.0,
+        )
+    except FileNotFoundError as exc:
+        return UpgradeResult(
+            ok=False,
+            installer=installer,
+            old_version=old_version,
+            new_version=old_version,
+            migration_checked=True,
+            notified=False,
+            stdout="",
+            stderr=str(exc),
+            message=f"installer binary not on PATH: {plan.command[0]}",
+        )
+    except subprocess.TimeoutExpired:
+        return UpgradeResult(
+            ok=False,
+            installer=installer,
+            old_version=old_version,
+            new_version=old_version,
+            migration_checked=True,
+            notified=False,
+            stdout="",
+            stderr="install timed out after 10m",
+            message="install timed out — network, or installer hung",
+        )
+    if result.returncode != 0:
+        return UpgradeResult(
+            ok=False,
+            installer=installer,
+            old_version=old_version,
+            new_version=old_version,
+            migration_checked=True,
+            notified=False,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            message=f"install failed (exit {result.returncode})",
+        )
+
+    new_version = _read_new_version() or old_version
+    step(f"installed {new_version}")
+
+    step("notifying live sessions")
+    notify_ok, notify_detail = inject_notice(old_version, new_version)
+    step(f"notify: {notify_detail}")
+
+    if recycle_all or recycle_idle:
+        # Wired in #720; for now just echo the intent.
+        scope = "all" if recycle_all else "idle"
+        step(f"recycle ({scope}): deferred to #720")
+
+    return UpgradeResult(
+        ok=True,
+        installer=installer,
+        old_version=old_version,
+        new_version=new_version,
+        migration_checked=True,
+        notified=notify_ok,
+        stdout=result.stdout,
+        stderr=result.stderr,
+        message=f"upgraded {old_version} → {new_version}",
+    )
+
+
+def read_changelog_diff(since: str, *, path: Path | None = None) -> str:
+    """Return the CHANGELOG.md section(s) above ``since`` version.
+
+    Best-effort scraping — we don't enforce strict changelog format.
+    If ``since`` appears as a heading in the file, return everything
+    above it (exclusive). Otherwise return an empty string.
+    """
+    changelog = path or Path.cwd() / "CHANGELOG.md"
+    try:
+        text = changelog.read_text()
+    except (OSError, FileNotFoundError):
+        return ""
+    lines = text.splitlines()
+    cut_at: int | None = None
+    for idx, line in enumerate(lines):
+        if line.startswith("#") and since in line:
+            cut_at = idx
+            break
+    if cut_at is None:
+        return ""
+    return "\n".join(lines[:cut_at]).rstrip()

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,0 +1,256 @@
+"""Tests for `pm upgrade` (#716).
+
+Exercises the installer-detection priority, per-installer plan shape,
+channel routing, migration-check gating, and the CLI wiring.
+
+Every test that would otherwise touch the real system uses the
+``installer_overrides`` / ``emit`` / ``plan_only`` seams on
+``upgrade()`` — no real ``uv``/``pip``/``brew``/``npm`` shells fire.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm.cli import app as cli_app
+from pollypm import upgrade as upgrade_mod
+
+
+runner = CliRunner()
+
+
+# --------------------------------------------------------------------------- #
+# detect_installer priority order
+# --------------------------------------------------------------------------- #
+
+def test_detect_uv_wins_over_everything() -> None:
+    assert upgrade_mod.detect_installer(
+        overrides={"uv": True, "pip": True, "brew": True, "npm": True},
+    ) == "uv"
+
+
+def test_detect_pip_when_no_uv() -> None:
+    assert upgrade_mod.detect_installer(
+        overrides={"uv": False, "pip": True, "brew": True, "npm": True},
+    ) == "pip"
+
+
+def test_detect_brew_when_no_uv_no_pip() -> None:
+    assert upgrade_mod.detect_installer(
+        overrides={"uv": False, "pip": False, "brew": True, "npm": True},
+    ) == "brew"
+
+
+def test_detect_npm_when_only_npm() -> None:
+    assert upgrade_mod.detect_installer(
+        overrides={"uv": False, "pip": False, "brew": False, "npm": True},
+    ) == "npm"
+
+
+def test_detect_unknown_when_none() -> None:
+    assert upgrade_mod.detect_installer(
+        overrides={"uv": False, "pip": False, "brew": False, "npm": False},
+    ) == "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# plan_upgrade — per-installer + channel routing
+# --------------------------------------------------------------------------- #
+
+def test_plan_uv_stable() -> None:
+    plan = upgrade_mod.plan_upgrade("uv", "stable")
+    assert plan.command == ["uv", "tool", "upgrade", "pollypm"]
+    assert plan.channel == "stable"
+
+
+def test_plan_uv_beta_uses_prerelease_flag() -> None:
+    plan = upgrade_mod.plan_upgrade("uv", "beta")
+    assert "--prerelease" in plan.command
+    assert plan.channel == "beta"
+
+
+def test_plan_pip_stable() -> None:
+    plan = upgrade_mod.plan_upgrade("pip", "stable")
+    assert plan.command == ["pip", "install", "-U", "pollypm"]
+
+
+def test_plan_pip_beta_uses_pre_flag() -> None:
+    plan = upgrade_mod.plan_upgrade("pip", "beta")
+    assert "--pre" in plan.command
+
+
+def test_plan_brew_downgrades_beta_to_stable() -> None:
+    # brew doesn't expose pre-release channels; explicit stable.
+    plan = upgrade_mod.plan_upgrade("brew", "beta")
+    assert plan.command == ["brew", "upgrade", "pollypm"]
+    assert plan.channel == "stable"
+
+
+def test_plan_npm_stable() -> None:
+    plan = upgrade_mod.plan_upgrade("npm", "stable")
+    assert plan.command == ["npm", "update", "-g", "pollypm"]
+
+
+def test_plan_npm_beta_uses_beta_tag() -> None:
+    plan = upgrade_mod.plan_upgrade("npm", "beta")
+    assert plan.command == ["npm", "install", "-g", "pollypm@beta"]
+
+
+def test_plan_unknown_returns_empty_command() -> None:
+    plan = upgrade_mod.plan_upgrade("unknown", "stable")
+    assert plan.command == []
+
+
+def test_plan_unknown_channel_falls_back_to_stable() -> None:
+    plan = upgrade_mod.plan_upgrade("uv", "nightly")
+    assert plan.channel == "stable"
+
+
+# --------------------------------------------------------------------------- #
+# upgrade() flow
+# --------------------------------------------------------------------------- #
+
+def test_upgrade_aborts_on_unknown_installer() -> None:
+    result = upgrade_mod.upgrade(
+        channel="stable",
+        installer_overrides={"uv": False, "pip": False, "brew": False, "npm": False},
+    )
+    assert result.ok is False
+    assert result.installer == "unknown"
+    assert "installer" in result.message.lower()
+    assert "uv tool upgrade pollypm" in result.stderr  # help text
+
+
+def test_upgrade_check_only_does_not_install() -> None:
+    """check_only runs the migration gate and reports the plan without
+    ever invoking the real subprocess."""
+    result = upgrade_mod.upgrade(
+        channel="stable",
+        check_only=True,
+        installer_overrides={"uv": True},
+    )
+    assert result.ok is True
+    assert result.old_version == result.new_version
+    assert "check-only" in result.message
+
+
+def test_upgrade_aborts_when_migration_check_fails(monkeypatch) -> None:
+    monkeypatch.setattr(
+        upgrade_mod, "run_migration_check",
+        lambda: (False, "synthetic failure"),
+    )
+    result = upgrade_mod.upgrade(
+        channel="stable",
+        installer_overrides={"uv": True},
+    )
+    assert result.ok is False
+    assert "migration" in result.message.lower()
+    assert result.stderr == "synthetic failure"
+    # Never called the installer; version unchanged.
+    assert result.old_version == result.new_version
+
+
+def test_upgrade_plan_only_stops_before_exec(monkeypatch) -> None:
+    """plan_only is the test seam for composing without running."""
+    result = upgrade_mod.upgrade(
+        channel="beta",
+        plan_only=True,
+        installer_overrides={"uv": True},
+    )
+    assert result.ok is True
+    assert "plan-only" in result.message
+
+
+def test_upgrade_records_recycle_flags(monkeypatch) -> None:
+    """recycle flags are accepted but defer behavior to #720."""
+    captured: list[str] = []
+    monkeypatch.setattr(
+        upgrade_mod, "run_migration_check",
+        lambda: (True, "ok"),
+    )
+    upgrade_mod.upgrade(
+        channel="stable",
+        plan_only=True,
+        recycle_all=True,
+        installer_overrides={"uv": True},
+        emit=captured.append,
+    )
+    # plan_only returns before the recycle step runs, so this is just
+    # a no-crash check — the flag plumbing is exercised.
+
+
+# --------------------------------------------------------------------------- #
+# Migration / notice injection stubs
+# --------------------------------------------------------------------------- #
+
+def test_run_migration_check_no_module_is_soft_pass() -> None:
+    """Until #717 lands, the check returns OK with a 'not yet' note."""
+    ok, detail = upgrade_mod.run_migration_check()
+    assert ok is True  # soft pass — #717 not wired yet
+    assert "not yet implemented" in detail or "ok" in detail
+
+
+def test_inject_notice_no_module_is_soft_pass() -> None:
+    ok, detail = upgrade_mod.inject_notice("0.1.0", "0.2.0")
+    assert ok is True
+    assert "not yet" in detail or "notif" in detail.lower()
+
+
+# --------------------------------------------------------------------------- #
+# read_changelog_diff
+# --------------------------------------------------------------------------- #
+
+def test_changelog_diff_returns_empty_when_missing(tmp_path) -> None:
+    assert upgrade_mod.read_changelog_diff(
+        "1.0.0", path=tmp_path / "CHANGELOG.md",
+    ) == ""
+
+
+def test_changelog_diff_returns_above_version(tmp_path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# CHANGELOG\n"
+        "\n"
+        "## 0.3.0\n"
+        "\n"
+        "- new thing\n"
+        "\n"
+        "## 0.2.0\n"
+        "\n"
+        "- older thing\n"
+    )
+    diff = upgrade_mod.read_changelog_diff("0.2.0", path=changelog)
+    assert "0.3.0" in diff
+    assert "new thing" in diff
+    assert "older thing" not in diff
+
+
+# --------------------------------------------------------------------------- #
+# CLI wiring
+# --------------------------------------------------------------------------- #
+
+def test_cli_upgrade_unknown_installer_exits_nonzero(monkeypatch) -> None:
+    """CLI surfaces the 'no installer' error from the library with a
+    non-zero exit code."""
+    monkeypatch.setattr(
+        upgrade_mod, "detect_installer", lambda overrides=None: "unknown",
+    )
+    result = runner.invoke(cli_app, ["upgrade", "--check-only"])
+    assert result.exit_code == 1
+    assert "installer" in result.stdout.lower()
+
+
+def test_cli_upgrade_check_only_succeeds(monkeypatch) -> None:
+    monkeypatch.setattr(
+        upgrade_mod, "detect_installer", lambda overrides=None: "uv",
+    )
+    monkeypatch.setattr(
+        upgrade_mod, "run_migration_check", lambda: (True, "ok"),
+    )
+    result = runner.invoke(cli_app, ["upgrade", "--check-only", "--channel", "stable"])
+    assert result.exit_code == 0
+    assert "installer: uv" in result.stdout
+    assert "check-only" in result.stdout


### PR DESCRIPTION
Adds the canonical upgrade command. `pm upgrade` detects how PollyPM was installed (uv tool → pip → brew → npm, in that priority order) and shells out to the right package manager, with channel-aware flags for beta.

## Flow

1. **Detect installer** via `shutil.which`-style probes against each package manager's list output.
2. **Migration gate** — runs the `pm migrate --check` from #717 before any mutation. Soft-passes with a "not yet implemented" note until #717 ships so the flow works on a fresh checkout.
3. **Check-only** (`--check-only`) prints the plan and exits. Otherwise runs the installer (10-min timeout).
4. **Read new version** via `pip show pollypm` (the old Python process's `__version__` is cached and can't be re-read in-place).
5. **Notice injection** — calls #718's `inject_system_update_notice` (soft-passes similarly until that lands).
6. **Changelog diff** — prints `CHANGELOG.md` section above the new version if present.

## Flags

- `--channel stable|beta` — one-off override (config's `release_channel` wins otherwise).
- `--check-only` — run the migration check + plan the command, don't install.
- `--recycle-all` / `--recycle-idle` — wired now so the CLI surface is stable; actual recycling ships in #720.

## Design notes

- **Never crashes on a fresh install.** Unknown installer prints the four manual commands and exits 1, never mutates anything.
- **Streams `[step] ...` markers** so the rail one-click pane in #719 can tail progress.
- `installer_overrides` / `plan_only` / `emit` are test seams — no real `uv`/`pip`/`brew`/`npm` fire in unit tests.
- **Release-channel defaults safely.** Reads `config.pollypm.release_channel` via `release_check._resolve_channel` when #714 is present; otherwise falls back to `"stable"`. No hard dep across branches.

## Validation

25 new unit tests cover detection priority, per-installer plan shape, channel routing (stable vs beta), migration-check gate behavior, plan-only seam, CLI wiring (exit codes + output shape), changelog-diff scraping. Regression spot-check on `test_cli.py` and `test_work_cli.py` (58/58 passing).

## Dependencies

Works independently. Integrates with #714 (channel resolution), #717 (migration gate), #718 (notice injection), #720 (recycle behavior) once those land.

Closes #716 · Refs #709