### PR TITLE
feat(store): schema migration gate (pm migrate + refuse-start)

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -47,6 +47,7 @@ from pollypm.cli_help import help_with_examples
 from pollypm.cli_features.alerts import alert_app, heartbeat_app, session_app
 from pollypm.cli_features.issues import issue_app, itsalive_app, report_app
 from pollypm.cli_features.maintenance import debug_app, register_maintenance_commands
+from pollypm.cli_features.migrate import register_migrate_commands
 from pollypm.cli_features.projects import register_project_commands
 from pollypm.cli_features.session_runtime import register_session_runtime_commands
 from pollypm.cli_features.ui import register_ui_commands
@@ -172,6 +173,7 @@ register_ui_commands(app)
 register_project_commands(app)
 register_maintenance_commands(app)
 register_upgrade_commands(app)
+register_migrate_commands(app)
 register_worker_commands(app)
 register_session_runtime_commands(app, helpers=sys.modules[__name__])
 
@@ -248,6 +250,27 @@ def _load_supervisor(config_path: Path):
     from pollypm.service_api import PollyPMService
 
     return PollyPMService(config_path).load_supervisor()
+
+
+def _enforce_migration_gate(config_path: Path) -> None:
+    """Refuse-start guard: bail out if the workspace state.db is behind (#717).
+
+    Skipped when ``POLLYPM_SKIP_MIGRATION_GATE`` is set — ``pm migrate``
+    turns the bypass on explicitly so the apply path can itself open the
+    store. A config that cannot be loaded is treated as "no gate to
+    enforce yet" so onboarding / first-run paths keep working.
+    """
+    from pollypm.store import migrations as _migrations
+
+    if _migrations.bypass_env_is_set():
+        return
+    try:
+        from pollypm.config import load_config
+        config = load_config(config_path)
+        db_path = config.project.state_db
+    except Exception:  # noqa: BLE001
+        return
+    _migrations.require_no_pending_or_exit(db_path)
 
 
 def _account_label(supervisor, account_name: str) -> str:
@@ -423,6 +446,7 @@ def up(
         typer.echo(f"Config not found at {config_path}. Starting onboarding.")
         onboard(config_path=config_path, force=False)
         return
+    _enforce_migration_gate(config_path)
     supervisor = _load_supervisor(config_path)
     # CoreRail owns startup orchestration — it drives plugin host load,
     # state store readiness, and Supervisor boot (which runs ensure_layout,

--- a/src/pollypm/cli_features/migrate.py
+++ b/src/pollypm/cli_features/migrate.py
@@ -1,0 +1,126 @@
+"""`pm migrate` — schema migration gate CLI (#717).
+
+Contract:
+- Inputs: ``--check`` for dry-run, ``--apply`` for real upgrades, plus
+  the standard ``--config`` option so the workspace state.db resolves
+  exactly like every other ``pm`` command.
+- Outputs: human-readable progress lines on stdout, diagnostics on
+  stderr, standard exit codes (0 on success, 2 when a pending migration
+  would block, 3 on dry-run failure).
+- Side effects (``--check``): copies the workspace state.db to
+  ``~/.pollypm/migration-check.db`` and applies pending migrations
+  against the clone.
+- Side effects (``--apply``): opens the live state.db and runs pending
+  migrations atomically per-migration.
+- Invariants: never mutates the live DB during ``--check``. Sets
+  ``POLLYPM_SKIP_MIGRATION_GATE`` before opening the store so the gate
+  in ``pm up`` cannot loop on itself.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from pollypm.cli_help import help_with_examples
+from pollypm.config import DEFAULT_CONFIG_PATH, load_config, resolve_config_path
+
+
+_MIGRATE_HELP = help_with_examples(
+    "Apply or dry-run pending schema migrations on the workspace state DB.",
+    [
+        ("pm migrate --check", "dry-run pending migrations against a clone"),
+        ("pm migrate --apply", "apply pending migrations to the live DB"),
+    ],
+    trailing=(
+        "The cockpit refuses to start when migrations are pending. "
+        "Run --apply to clear the gate, or --check first to see what "
+        "would change."
+    ),
+)
+
+
+def _resolve_state_db(config_path: Path) -> Path:
+    """Return the workspace-scope state.db path from the resolved config."""
+    path = resolve_config_path(config_path)
+    if not path.exists():
+        raise typer.BadParameter(
+            f"Config not found at {path}. Run `pm onboard` first."
+        )
+    config = load_config(path)
+    return config.project.state_db
+
+
+def register_migrate_commands(app: typer.Typer) -> None:
+    @app.command("migrate", help=_MIGRATE_HELP)
+    def migrate(
+        check: bool = typer.Option(
+            False, "--check", help="Dry-run pending migrations on a DB clone."
+        ),
+        apply: bool = typer.Option(
+            False, "--apply", help="Apply pending migrations to the live DB."
+        ),
+        config_path: Path = typer.Option(
+            DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."
+        ),
+    ) -> None:
+        if check == apply:
+            raise typer.BadParameter(
+                "Specify exactly one of --check or --apply."
+            )
+
+        db_path = _resolve_state_db(config_path)
+
+        # Bypass the refuse-start gate — pm migrate is the designated
+        # tool that fixes the situation the gate protects against, so
+        # opening the store here must not trip the guard.
+        from pollypm.store import migrations as _migrations
+        _migrations.set_bypass(True)
+
+        if check:
+            _run_check(db_path)
+        else:
+            _run_apply(db_path)
+
+
+def _run_check(db_path: Path) -> None:
+    from pollypm.store import migrations as _migrations
+
+    status = _migrations.inspect(db_path)
+    if status.up_to_date:
+        typer.echo(f"All migrations up to date ({db_path}).")
+        raise typer.Exit(code=0)
+
+    typer.echo(f"Dry-run against clone of {db_path}")
+    typer.echo(_migrations.format_pending_summary(status))
+
+    outcome = _migrations.check_against_clone(db_path)
+    if not outcome.ok:
+        typer.echo(
+            f"Migration check FAILED — live DB untouched.\n  error: {outcome.error}",
+            err=True,
+        )
+        raise typer.Exit(code=3)
+
+    if outcome.tables_changed:
+        typer.echo("Schema changes on clone:")
+        for change in outcome.tables_changed:
+            typer.echo(f"  {change}")
+    else:
+        typer.echo("No table-level changes — migrations affect columns/indexes only.")
+    if outcome.clone_path is not None:
+        typer.echo(f"Clone retained at {outcome.clone_path} for inspection.")
+    typer.echo("Migration check OK. Run `pm migrate --apply` to upgrade the live DB.")
+
+
+def _run_apply(db_path: Path) -> None:
+    from pollypm.store import migrations as _migrations
+
+    outcome = _migrations.apply(db_path)
+    if outcome.already_up_to_date:
+        typer.echo("All migrations up to date.")
+        return
+    typer.echo(f"Applied {len(outcome.applied)} migration(s) to {db_path}:")
+    for item in outcome.applied:
+        typer.echo(f"  [{item.namespace}] v{item.version}: {item.description}")

--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -19,6 +19,21 @@ import typer
 from pollypm.config import DEFAULT_CONFIG_PATH
 
 
+def _enforce_migration_gate(config_path: Path) -> None:
+    """Refuse-start guard (#717). Best-effort — a missing config is not
+    a schema-migration problem and onboarding handles it elsewhere."""
+    from pollypm.store import migrations as _migrations
+
+    if _migrations.bypass_env_is_set():
+        return
+    try:
+        from pollypm.config import load_config
+        config = load_config(config_path)
+    except Exception:  # noqa: BLE001
+        return
+    _migrations.require_no_pending_or_exit(config.project.state_db)
+
+
 def register_ui_commands(app: typer.Typer) -> None:
     @app.command()
     def accounts_ui(
@@ -40,6 +55,7 @@ def register_ui_commands(app: typer.Typer) -> None:
     def cockpit(
         config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
     ) -> None:
+        _enforce_migration_gate(config_path)
         crash_log = config_path.parent / "cockpit_crash.log"
         debug_log = config_path.parent / "cockpit_debug.log"
         try:
@@ -74,6 +90,7 @@ def register_ui_commands(app: typer.Typer) -> None:
             ),
         ),
     ) -> None:
+        _enforce_migration_gate(config_path)
         if kind == "settings" and target:
             from pollypm.cockpit_ui import PollyProjectSettingsApp
 

--- a/src/pollypm/rail_daemon.py
+++ b/src/pollypm/rail_daemon.py
@@ -77,8 +77,13 @@ def run(config_path: Path, *, poll_interval: float = 60.0) -> int:
     """
     from pollypm.config import load_config, DEFAULT_CONFIG_PATH
     from pollypm.service_api import PollyPMService
+    from pollypm.store import migrations as _migrations
 
     cfg = load_config(config_path)
+    # Refuse-start gate (#717): the daemon opens the state store and
+    # would silently run migrations otherwise. Exit loudly so the
+    # operator runs ``pm migrate --apply`` from a terminal instead.
+    _migrations.require_no_pending_or_exit(cfg.project.state_db)
     pollypm_home = Path(DEFAULT_CONFIG_PATH).parent
     pid_path = _pid_file(pollypm_home)
     if not _claim_pid_file(pid_path):

--- a/src/pollypm/store/migrations.py
+++ b/src/pollypm/store/migrations.py
@@ -1,0 +1,417 @@
+"""Schema migration gate — dry-run check, apply, and refuse-start (#717).
+
+PollyPM ships schema migrations in two append-only lists:
+
+* :attr:`pollypm.storage.state.StateStore._MIGRATIONS` — the state-domain
+  migrations, tracked in the ``schema_version`` table.
+* :attr:`pollypm.work.schema._WORK_MIGRATIONS` — work-service migrations,
+  tracked in the ``work_schema_version`` table.
+
+Both tables live in the same workspace-scope ``state.db``. This module
+provides a unified façade:
+
+* :func:`inspect` reads those tables read-only and returns the pending /
+  applied migration set without touching the DB.
+* :func:`check_against_clone` copies the DB to ``~/.pollypm/migration-
+  check.db``, opens it read-write, replays every pending migration, and
+  reports or rolls back on failure. Never mutates the live DB.
+* :func:`apply` runs pending migrations on the real DB by instantiating
+  the existing writers (``StateStore`` + ``SQLiteWorkService``) whose
+  ``__init__`` already replays migrations idempotently. Recorded in a
+  unified ``schema_migrations`` audit table.
+* :func:`require_no_pending_or_exit` is the refuse-start gate: probes the
+  live DB read-only, prints recovery steps and exits non-zero if any
+  migration is pending.
+
+The unified ``schema_migrations`` audit table is additive — it mirrors
+the two underlying tables so operators have a single place to inspect
+migration history. It does not replace ``schema_version`` or
+``work_schema_version``; those stay authoritative for the runners.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+# Namespace identifiers — must stay stable; persisted in schema_migrations.
+NAMESPACE_STATE = "state"
+NAMESPACE_WORK = "work"
+
+
+@dataclass(frozen=True)
+class PendingMigration:
+    """One migration that has not yet been applied to a target DB."""
+
+    namespace: str
+    version: int
+    description: str
+
+
+@dataclass
+class MigrationStatus:
+    """Read-only snapshot of migration state for a single DB."""
+
+    db_path: Path
+    applied: dict[str, int] = field(default_factory=dict)
+    latest: dict[str, int] = field(default_factory=dict)
+    pending: list[PendingMigration] = field(default_factory=list)
+
+    @property
+    def up_to_date(self) -> bool:
+        return not self.pending
+
+
+@dataclass
+class CheckOutcome:
+    """Result of a ``pm migrate --check`` dry run against a clone."""
+
+    ok: bool
+    applied: list[PendingMigration] = field(default_factory=list)
+    tables_changed: list[str] = field(default_factory=list)
+    error: str | None = None
+    clone_path: Path | None = None
+
+
+@dataclass
+class ApplyOutcome:
+    """Result of a ``pm migrate --apply`` on the live DB."""
+
+    applied: list[PendingMigration] = field(default_factory=list)
+    already_up_to_date: bool = False
+
+
+_SCHEMA_MIGRATIONS_DDL = """
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    namespace TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    description TEXT NOT NULL,
+    applied_at TEXT NOT NULL,
+    PRIMARY KEY (namespace, version)
+)
+"""
+
+
+def _declared_state_migrations() -> list[tuple[int, str]]:
+    from pollypm.storage.state import StateStore
+
+    return [(version, desc) for version, desc, _ in StateStore._MIGRATIONS]
+
+
+def _declared_work_migrations() -> list[tuple[int, str]]:
+    from pollypm.work.schema import _WORK_MIGRATIONS
+
+    return [(version, desc) for version, desc, _ in _WORK_MIGRATIONS]
+
+
+def _readonly_connect(db_path: Path) -> sqlite3.Connection | None:
+    """Open a read-only SQLite connection, or ``None`` if the DB is absent."""
+    if not db_path.is_file():
+        return None
+    uri = f"file:{db_path}?mode=ro"
+    try:
+        return sqlite3.connect(uri, uri=True, timeout=1.0)
+    except sqlite3.Error:
+        return None
+
+
+def _applied_version(conn: sqlite3.Connection, table: str) -> int:
+    """Return ``MAX(version)`` from a schema-tracking table, 0 if missing."""
+    try:
+        row = conn.execute(
+            f"SELECT COALESCE(MAX(version), 0) FROM {table}"
+        ).fetchone()
+    except sqlite3.Error:
+        return 0
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+def inspect(db_path: Path) -> MigrationStatus:
+    """Compute pending / applied migrations for ``db_path`` without mutating it.
+
+    For a DB that does not yet exist, every declared migration is
+    considered pending — the caller is responsible for bootstrapping
+    via :func:`apply` (which creates the file on first open).
+    """
+    state_declared = _declared_state_migrations()
+    work_declared = _declared_work_migrations()
+
+    latest = {
+        NAMESPACE_STATE: max((v for v, _ in state_declared), default=0),
+        NAMESPACE_WORK: max((v for v, _ in work_declared), default=0),
+    }
+
+    conn = _readonly_connect(db_path)
+    if conn is None:
+        # Missing DB — all migrations are pending.
+        pending = [
+            PendingMigration(NAMESPACE_STATE, v, d) for v, d in state_declared
+        ] + [
+            PendingMigration(NAMESPACE_WORK, v, d) for v, d in work_declared
+        ]
+        return MigrationStatus(
+            db_path=db_path,
+            applied={NAMESPACE_STATE: 0, NAMESPACE_WORK: 0},
+            latest=latest,
+            pending=pending,
+        )
+
+    try:
+        applied = {
+            NAMESPACE_STATE: _applied_version(conn, "schema_version"),
+            NAMESPACE_WORK: _applied_version(conn, "work_schema_version"),
+        }
+    finally:
+        conn.close()
+
+    pending: list[PendingMigration] = []
+    for version, desc in state_declared:
+        if version > applied[NAMESPACE_STATE]:
+            pending.append(PendingMigration(NAMESPACE_STATE, version, desc))
+    for version, desc in work_declared:
+        if version > applied[NAMESPACE_WORK]:
+            pending.append(PendingMigration(NAMESPACE_WORK, version, desc))
+
+    return MigrationStatus(
+        db_path=db_path, applied=applied, latest=latest, pending=pending,
+    )
+
+
+def _table_set(db_path: Path) -> set[str]:
+    """Return the set of user table names in ``db_path`` (empty on failure)."""
+    if not db_path.is_file():
+        return set()
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=5.0)
+    except sqlite3.Error:
+        return set()
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        ).fetchall()
+        return {row[0] for row in rows}
+    finally:
+        conn.close()
+
+
+def _default_clone_path() -> Path:
+    """Location of the dry-run clone (~/.pollypm/migration-check.db)."""
+    home = Path(os.environ.get("POLLYPM_HOME", str(Path.home() / ".pollypm")))
+    return home / "migration-check.db"
+
+
+def check_against_clone(
+    db_path: Path,
+    clone_path: Path | None = None,
+) -> CheckOutcome:
+    """Dry-run: clone the DB, replay pending migrations, report or roll back.
+
+    On failure the clone is removed so the next ``--check`` starts from a
+    clean slate — stale sidecar DBs from a partial run would confuse
+    ``pm doctor``. On success the clone is kept so operators can inspect
+    the resulting schema if they want to.
+    """
+    status = inspect(db_path)
+    if not status.pending:
+        return CheckOutcome(
+            ok=True, applied=[], tables_changed=[], clone_path=None,
+        )
+
+    clone = clone_path or _default_clone_path()
+    clone.parent.mkdir(parents=True, exist_ok=True)
+    # Wipe any stale clone + its WAL / journal sidecars from a prior run.
+    for suffix in ("", "-wal", "-shm", "-journal"):
+        Path(str(clone) + suffix).unlink(missing_ok=True)
+
+    if db_path.is_file():
+        shutil.copy2(db_path, clone)
+
+    tables_before = _table_set(clone)
+
+    try:
+        _apply_all(clone)
+    except Exception as exc:  # noqa: BLE001
+        # Roll back by removing the clone — there is no live connection
+        # to issue a SQL rollback against (StateStore opens its own).
+        for suffix in ("", "-wal", "-shm", "-journal"):
+            Path(str(clone) + suffix).unlink(missing_ok=True)
+        return CheckOutcome(
+            ok=False,
+            applied=[],
+            tables_changed=[],
+            error=str(exc),
+            clone_path=None,
+        )
+
+    tables_after = _table_set(clone)
+    changes = sorted(
+        [f"+{name}" for name in tables_after - tables_before]
+        + [f"-{name}" for name in tables_before - tables_after]
+    )
+    return CheckOutcome(
+        ok=True,
+        applied=list(status.pending),
+        tables_changed=changes,
+        clone_path=clone,
+    )
+
+
+def _apply_all(db_path: Path) -> None:
+    """Replay every migration idempotently by opening the existing writers.
+
+    ``StateStore.__init__`` already replays ``_MIGRATIONS`` against the
+    DB; ``SQLiteWorkService.__init__`` (via ``create_work_tables``) does
+    the same for ``_WORK_MIGRATIONS``. We also mirror the applied set
+    into the unified ``schema_migrations`` audit table so operators have
+    a single pane of glass.
+    """
+    from pollypm.storage.state import StateStore
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    with StateStore(db_path) as _store:
+        pass
+
+    with SQLiteWorkService(db_path) as _svc:
+        pass
+
+    _record_schema_migrations(db_path)
+
+
+def _record_schema_migrations(db_path: Path) -> None:
+    """Mirror ``schema_version`` + ``work_schema_version`` into ``schema_migrations``.
+
+    Safe to call repeatedly — the table has a ``(namespace, version)``
+    primary key and we ``INSERT OR IGNORE`` so previously-recorded rows
+    are left alone. This is the retrofit path for DBs that predate the
+    unified audit table: the first call after upgrade back-fills every
+    already-applied migration.
+    """
+    conn = sqlite3.connect(str(db_path), timeout=5.0)
+    try:
+        conn.execute(_SCHEMA_MIGRATIONS_DDL)
+        now = datetime.now(UTC).isoformat()
+
+        try:
+            rows = conn.execute(
+                "SELECT version, description, applied_at FROM schema_version"
+            ).fetchall()
+        except sqlite3.Error:
+            rows = []
+        for version, description, applied_at in rows:
+            conn.execute(
+                "INSERT OR IGNORE INTO schema_migrations "
+                "(namespace, version, description, applied_at) "
+                "VALUES (?, ?, ?, ?)",
+                (NAMESPACE_STATE, int(version), str(description), applied_at or now),
+            )
+
+        try:
+            rows = conn.execute(
+                "SELECT version, description, applied_at FROM work_schema_version"
+            ).fetchall()
+        except sqlite3.Error:
+            rows = []
+        for version, description, applied_at in rows:
+            conn.execute(
+                "INSERT OR IGNORE INTO schema_migrations "
+                "(namespace, version, description, applied_at) "
+                "VALUES (?, ?, ?, ?)",
+                (NAMESPACE_WORK, int(version), str(description), applied_at or now),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def apply(db_path: Path) -> ApplyOutcome:
+    """Apply pending migrations to the live DB.
+
+    Idempotent: a second call after everything is up to date is a cheap
+    no-op that still touches the writers (to retrofit
+    ``schema_migrations``) but records nothing new.
+    """
+    status_before = inspect(db_path)
+    if not status_before.pending:
+        # Still record the audit table on first upgrade post-#717.
+        if db_path.is_file():
+            _record_schema_migrations(db_path)
+        return ApplyOutcome(applied=[], already_up_to_date=True)
+
+    _apply_all(db_path)
+    return ApplyOutcome(applied=list(status_before.pending), already_up_to_date=False)
+
+
+def format_pending_summary(status: MigrationStatus) -> str:
+    """Render pending migrations as a compact multi-line string."""
+    if not status.pending:
+        return "All migrations up to date."
+    lines = [f"{len(status.pending)} pending migration(s):"]
+    for item in status.pending:
+        lines.append(f"  [{item.namespace}] v{item.version}: {item.description}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Refuse-start gate
+# ---------------------------------------------------------------------------
+
+
+# Env var that lets ``pm migrate`` bypass the refuse-start gate so the
+# migration CLI can actually open the store to fix the situation. Also
+# useful for tests that want to exercise the raw store.
+_BYPASS_ENV = "POLLYPM_SKIP_MIGRATION_GATE"
+
+
+def bypass_env_is_set() -> bool:
+    return bool(os.environ.get(_BYPASS_ENV))
+
+
+def set_bypass(enabled: bool) -> None:
+    """Turn the refuse-start gate off (``pm migrate`` uses this)."""
+    if enabled:
+        os.environ[_BYPASS_ENV] = "1"
+    else:
+        os.environ.pop(_BYPASS_ENV, None)
+
+
+def _format_refuse_start_message(status: MigrationStatus) -> str:
+    lines = [
+        "PollyPM cannot start: unapplied schema migrations detected.",
+        f"  DB: {status.db_path}",
+        format_pending_summary(status),
+        "",
+        "Recovery:",
+        "  pm migrate --check    # dry-run the migrations against a DB clone",
+        "  pm migrate --apply    # apply them to the live DB",
+    ]
+    return "\n".join(lines)
+
+
+def require_no_pending_or_exit(db_path: Path) -> None:
+    """Refuse-start gate: exit non-zero if the DB has pending migrations.
+
+    Skipped when ``POLLYPM_SKIP_MIGRATION_GATE`` is set — ``pm migrate``
+    sets this internally so the apply path can itself open the store.
+
+    A missing DB file is NOT a gate violation: it's the legitimate
+    first-boot path where ``StateStore``/``SQLiteWorkService`` will
+    create the file and apply every migration from scratch. The gate
+    protects against the "installed new code, forgot to migrate" case,
+    which by definition requires an existing older DB.
+    """
+    if bypass_env_is_set():
+        return
+    if not db_path.is_file():
+        return
+    status = inspect(db_path)
+    if status.up_to_date:
+        return
+    sys.stderr.write(_format_refuse_start_message(status) + "\n")
+    raise SystemExit(2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,14 @@ def pytest_configure(config):  # noqa: ARG001
     want to exercise the daemon can clear the var in their own fixture.
     """
     os.environ.setdefault("POLLYPM_SKIP_RAIL_DAEMON", "1")
+    # Tests build their config in pytest tmp dirs but ``state_db``
+    # defaults to ``~/.pollypm/state.db`` on the dev machine — which
+    # may legitimately have pending migrations. Skip the refuse-start
+    # gate globally so CLI plumbing tests don't pick up the real DB's
+    # migration state. Tests that exercise the gate itself clear the
+    # env var in their own monkeypatch fixture (see
+    # ``tests/test_migration_gate.py``).
+    os.environ.setdefault("POLLYPM_SKIP_MIGRATION_GATE", "1")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_migration_gate.py
+++ b/tests/test_migration_gate.py
@@ -1,0 +1,288 @@
+"""Tests for the schema migration gate (#717).
+
+Covers ``pm migrate --check``, ``pm migrate --apply``, refuse-start
+behaviour, and the synthetic-failure safety net.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm.store import migrations as mig_mod
+from pollypm.storage.state import StateStore
+
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _clear_gate_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the refuse-start gate to be active during these tests.
+
+    ``tests/conftest.py`` sets ``POLLYPM_SKIP_MIGRATION_GATE`` so unrelated
+    CLI plumbing tests don't collide with the developer's real state.db.
+    The migration-gate suite exercises the gate itself, so we clear it.
+    """
+    monkeypatch.delenv("POLLYPM_SKIP_MIGRATION_GATE", raising=False)
+
+
+def _fresh_state_db(path: Path) -> Path:
+    """Bring ``path`` fully current by running both migration sets once.
+
+    ``StateStore.__init__`` replays state migrations; the work-service
+    migrations only run when ``SQLiteWorkService`` is instantiated.
+    A "fresh" DB for our tests means both have been applied.
+    """
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    with StateStore(path):
+        pass
+    with SQLiteWorkService(path):
+        pass
+    return path
+
+
+def _build_cli_app():
+    """Build a fresh Typer app with just the migrate command attached.
+
+    We avoid importing the root ``pollypm.cli`` module here because it
+    eagerly registers every CLI surface in the project — far more than
+    we need, and some carry heavy side-effectful imports.
+    """
+    import typer
+
+    from pollypm.cli_features.migrate import register_migrate_commands
+
+    app = typer.Typer()
+    register_migrate_commands(app)
+    return app
+
+
+def _write_minimal_config(tmp_path: Path) -> Path:
+    """Write a PollyPM config that points state_db at ``tmp_path/state.db``."""
+    config_path = tmp_path / "pollypm.toml"
+    state_db = tmp_path / "state.db"
+    config_path.write_text(
+        "[project]\n"
+        f'base_dir = "{tmp_path}"\n'
+        f'state_db = "{state_db}"\n'
+        f'workspace_root = "{tmp_path}"\n'
+    )
+    return config_path
+
+
+# ---------------------------------------------------------------------------
+# --check / --apply
+# ---------------------------------------------------------------------------
+
+
+def test_pm_migrate_check_on_clean_db(tmp_path: Path) -> None:
+    db_path = _fresh_state_db(tmp_path / "state.db")
+    status = mig_mod.inspect(db_path)
+    assert status.up_to_date
+    outcome = mig_mod.check_against_clone(db_path)
+    assert outcome.ok
+    assert outcome.applied == []
+
+
+def test_pm_migrate_apply_idempotent(tmp_path: Path) -> None:
+    db_path = _fresh_state_db(tmp_path / "state.db")
+    first = mig_mod.apply(db_path)
+    assert first.already_up_to_date
+
+    # Second call is still a no-op.
+    second = mig_mod.apply(db_path)
+    assert second.already_up_to_date
+
+    # And the unified audit table now mirrors every migration.
+    with sqlite3.connect(str(db_path)) as conn:
+        rows = conn.execute(
+            "SELECT namespace, version FROM schema_migrations"
+        ).fetchall()
+    seen = {(ns, ver) for ns, ver in rows}
+    assert (mig_mod.NAMESPACE_STATE, 1) in seen
+    assert (mig_mod.NAMESPACE_WORK, 1) in seen
+
+
+def test_pm_migrate_check_detects_pending(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db_path = _fresh_state_db(tmp_path / "state.db")
+
+    # Synthetic pending migration — registered only for the duration of
+    # this test. The runner replays whatever is declared on the class,
+    # so a single extra row is enough to drive the "pending" branch
+    # without mutating the production list on disk.
+    synthetic = list(StateStore._MIGRATIONS) + [
+        (
+            9001,
+            "Synthetic test-only migration — adds marker_table",
+            ["CREATE TABLE IF NOT EXISTS migration_gate_marker (id INTEGER)"],
+        ),
+    ]
+    monkeypatch.setattr(StateStore, "_MIGRATIONS", synthetic)
+
+    status = mig_mod.inspect(db_path)
+    assert not status.up_to_date
+    pending = [p for p in status.pending if p.version == 9001]
+    assert len(pending) == 1
+    assert pending[0].namespace == mig_mod.NAMESPACE_STATE
+    assert "marker_table" in pending[0].description
+
+    outcome = mig_mod.check_against_clone(db_path)
+    assert outcome.ok
+    assert any(change == "+migration_gate_marker" for change in outcome.tables_changed)
+
+    # Live DB must still be on the pre-synthetic schema.
+    with sqlite3.connect(str(db_path)) as conn:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='migration_gate_marker'"
+        ).fetchone()
+    assert row is None
+
+
+def test_synthetic_failing_migration_caught_by_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = _fresh_state_db(tmp_path / "state.db")
+
+    # Synthetic migration that intentionally fails — drops a table that
+    # doesn't exist without IF EXISTS. The real DB must stay untouched.
+    synthetic = list(StateStore._MIGRATIONS) + [
+        (
+            9002,
+            "Synthetic failing migration — drops a non-existent table",
+            ["DROP TABLE no_such_table_gate_test"],
+        ),
+    ]
+    monkeypatch.setattr(StateStore, "_MIGRATIONS", synthetic)
+
+    outcome = mig_mod.check_against_clone(db_path)
+    assert outcome.ok is False
+    assert outcome.error is not None
+    assert outcome.clone_path is None  # clone was cleaned up on failure
+
+    # The real DB still has the pre-synthetic schema — no stray tables
+    # or dropped rows from the failed check.
+    with sqlite3.connect(str(db_path)) as conn:
+        version = conn.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()[0]
+    assert version is not None
+    # MAX declared in the real list (not our synthetic fail).
+    expected = max(v for v, _, _ in StateStore._MIGRATIONS if v < 9000)
+    assert version == expected
+
+
+# ---------------------------------------------------------------------------
+# Refuse-start gate
+# ---------------------------------------------------------------------------
+
+
+def test_cockpit_refuses_start_on_pending_migration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = _fresh_state_db(tmp_path / "state.db")
+
+    # Declare a pending migration *after* the DB was brought current,
+    # so the inspector sees it as unapplied.
+    synthetic = list(StateStore._MIGRATIONS) + [
+        (9003, "pending — refuse-start gate test", []),
+    ]
+    monkeypatch.setattr(StateStore, "_MIGRATIONS", synthetic)
+    # Make sure the bypass env is not leaking in from the CLI entry.
+    monkeypatch.delenv(mig_mod._BYPASS_ENV, raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        mig_mod.require_no_pending_or_exit(db_path)
+    assert exc.value.code != 0
+
+
+def test_migration_gate_skipped_when_bypass_env_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bypass env var lets ``pm migrate`` itself open the store."""
+    db_path = _fresh_state_db(tmp_path / "state.db")
+    synthetic = list(StateStore._MIGRATIONS) + [
+        (9004, "pending — bypass test", []),
+    ]
+    monkeypatch.setattr(StateStore, "_MIGRATIONS", synthetic)
+    monkeypatch.setenv(mig_mod._BYPASS_ENV, "1")
+
+    # No exception — the gate short-circuits out.
+    mig_mod.require_no_pending_or_exit(db_path)
+
+
+def test_up_enforces_migration_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``pm up`` bails with a non-zero exit when migrations are pending."""
+    from pollypm import cli as _cli
+
+    # Make the bypass check return False and the gate itself raise so we
+    # can assert the entrypoint propagates the exit without needing a
+    # full config surface.
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text("# dummy\n")
+
+    def _boom(_db_path):
+        raise SystemExit(2)
+
+    monkeypatch.setattr(_cli, "_discover_config_path", lambda p: config_path)
+    monkeypatch.setattr(
+        "pollypm.store.migrations.bypass_env_is_set", lambda: False
+    )
+    monkeypatch.setattr(
+        "pollypm.store.migrations.require_no_pending_or_exit", _boom
+    )
+    # load_config must return an object with .project.state_db for the
+    # CLI helper to extract the path before calling the gate.
+    fake_cfg = mock.Mock()
+    fake_cfg.project.state_db = tmp_path / "state.db"
+    monkeypatch.setattr("pollypm.config.load_config", lambda _p: fake_cfg)
+
+    with pytest.raises(SystemExit) as exc:
+        _cli.up(config_path=config_path)
+    assert exc.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_cli_migrate_check_outputs_up_to_date(tmp_path: Path) -> None:
+    db_path = _fresh_state_db(tmp_path / "state.db")
+    config_path = _write_minimal_config(tmp_path)
+    # Point state_db to the DB we just fresh-built.
+    config_path.write_text(
+        "[project]\n"
+        f'base_dir = "{tmp_path}"\n'
+        f'state_db = "{db_path}"\n'
+        f'workspace_root = "{tmp_path}"\n'
+    )
+    app = _build_cli_app()
+    result = runner.invoke(app, ["--check", "--config", str(config_path)])
+    assert result.exit_code == 0
+    assert "up to date" in result.stdout.lower()
+
+
+def test_cli_migrate_apply_reports_applied(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No fresh DB this time — let --apply bootstrap it so the CLI prints
+    # a non-empty "applied" list.
+    config_path = _write_minimal_config(tmp_path)
+    app = _build_cli_app()
+    result = runner.invoke(app, ["--apply", "--config", str(config_path)])
+    assert result.exit_code == 0
+    combined = result.stdout + "\n" + (result.stderr or "")
+    # Either "Applied N migration(s)..." on the bootstrap path or the
+    # "All migrations up to date." fallback if some future refactor
+    # makes the DB self-bootstrap earlier. Both are acceptable; failure
+    # would be a non-zero exit.
+    assert "Applied" in combined or "up to date" in combined


### PR DESCRIPTION
## Summary
- Adds `pm migrate --check` (dry-run against `~/.pollypm/migration-check.db` clone) and `pm migrate --apply` (idempotent live upgrade) CLI surfaces, wired through the existing `StateStore._MIGRATIONS` and `_WORK_MIGRATIONS` runners.
- Adds a refuse-start gate: `pm up`, `pm cockpit`, `pm cockpit-pane`, and the headless rail daemon now check the workspace `state.db` read-only before opening the store. Pending migrations print a recovery message and exit non-zero instead of silently auto-migrating.
- New `pollypm.store.migrations` module exposes `inspect`, `check_against_clone`, `apply`, and `require_no_pending_or_exit` helpers plus a unified `schema_migrations` audit table that mirrors both `schema_version` and `work_schema_version`. Bypassable via `POLLYPM_SKIP_MIGRATION_GATE` so `pm migrate` can itself open the store.

Closes #717

## Test plan
- [x] `uv run pytest tests/test_migration_gate.py` — all 9 new tests pass (check on clean DB, apply idempotent, check detects pending, synthetic failing migration caught, cockpit refuses start, bypass env honored, `pm up` propagates the exit, CLI up-to-date, CLI apply reporting).
- [x] `uv run pytest tests/test_cli.py tests/test_state.py` — existing regressions (incl. `test_importing_cli_defers_heavy_runtime_modules` which pins SQLAlchemy-laziness at import time).
- [x] `uv run pm migrate --check` on the developer's live DB correctly reports a pending migration without mutating it.
- [ ] Apply path on a CI-style fresh DB (covered by test_cli_migrate_apply_reports_applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)