### PR TITLE
feat(upgrade): in-session <system-update> notice injection (#718)

### DIFF
--- a/src/pollypm/upgrade_notice.py
+++ b/src/pollypm/upgrade_notice.py
@@ -1,0 +1,246 @@
+"""In-session ``<system-update>`` notice injection (#718).
+
+When PollyPM is upgraded while sessions are live, ``claude --resume`` /
+``codex --resume`` preserve the original conversation — the system
+prompt from turn 1 stays baked into history and new system prompts are
+NOT merged. Killing + relaunching sessions would work but drops
+in-flight context.
+
+This module solves that by injecting a user-turn notice into each live
+session telling the model to re-read its role guide from disk (which
+IS the new, post-upgrade version). The model can then converge on the
+new instructions at its next turn boundary without losing any
+conversation state.
+
+Consumed by ``pm upgrade`` (#716) after a successful install.
+
+Limitations:
+
+* Models aren't perfectly adherent to "disregard prior instructions"
+  framing. The 90% case converges cleanly; the 10% case benefits from
+  the hard-recycle escape hatch in #720.
+* Sessions that are mid-tool-call see the notice as a pending user
+  message — Claude Code / Codex render it at the next turn break.
+  Don't inject when a session is actively emitting tokens.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+
+logger = logging.getLogger(__name__)
+
+
+# Role → guide path (relative to the pollypm install root).
+# Keeps the mapping small and explicit; new roles default to the worker
+# guide unless listed here.
+_ROLE_GUIDES: dict[str, str] = {
+    "worker": "docs/worker-guide.md",
+    "operator-pm": (
+        "src/pollypm/plugins_builtin/core_agent_profiles/profiles/"
+        "polly-operator-guide.md"
+    ),
+    "reviewer": (
+        "src/pollypm/plugins_builtin/core_agent_profiles/profiles/russell.md"
+    ),
+    "architect": (
+        "src/pollypm/plugins_builtin/core_agent_profiles/profiles/architect.md"
+    ),
+}
+
+# Roles that don't participate in the notice — they're control / infra
+# sessions without an LLM in the loop.
+_SKIP_ROLES: frozenset[str] = frozenset({
+    "heartbeat-supervisor",
+    "heartbeat",
+})
+
+
+@dataclass(slots=True)
+class NoticeResult:
+    session_name: str
+    role: str
+    delivered: bool
+    reason: str  # "sent" | "skipped: <role>" | "no guide" | "send failed: <err>"
+
+
+def _guide_path_for_role(role: str) -> str | None:
+    if role in _SKIP_ROLES:
+        return None
+    return _ROLE_GUIDES.get(role, _ROLE_GUIDES.get("worker"))
+
+
+def build_notice(old_version: str, new_version: str, guide_path: str) -> str:
+    """Render the canonical ``<system-update>`` notice text.
+
+    Structure is load-bearing: named version bump + exact guide path +
+    explicit "supersedes prior instructions" framing + "pause on
+    conflict" instruction. This is the text prior prompt-engineering
+    rounds settled on — models are measurably more compliant with it
+    than with a casual "we updated, fyi" note.
+    """
+    return (
+        "<system-update>\n"
+        f"PollyPM was upgraded from v{old_version} → v{new_version} while "
+        "this session was running.\n"
+        f"Before your next action, re-read your operating guide at {guide_path}.\n"
+        "It supersedes any prior operating instructions in this conversation.\n"
+        "If anything in the new guide conflicts with what you were about to "
+        "do, pause and re-plan from the updated instructions.\n"
+        "</system-update>"
+    )
+
+
+def _send_to_session(
+    tmux: Any,
+    *,
+    target: str,
+    text: str,
+    send_keys: Callable[..., Any] | None = None,
+) -> tuple[bool, str]:
+    """Send ``text`` to ``target`` via the supervisor's tmux client.
+
+    Returns ``(success, detail)``. Failures are logged at DEBUG and
+    surfaced in the detail string so the caller can record which
+    sessions were unreachable.
+    """
+    sender = send_keys
+    if sender is None:
+        sender = getattr(tmux, "send_keys", None)
+    if sender is None:
+        return (False, "tmux client has no send_keys")
+    try:
+        sender(target, text, press_enter=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "upgrade-notice: send_keys failed for %s: %s", target, exc,
+            exc_info=True,
+        )
+        return (False, f"send failed: {type(exc).__name__}")
+    return (True, "sent")
+
+
+def _iter_launches(supervisor: Any) -> Iterable[Any]:
+    """Best-effort iteration over the supervisor's live session specs.
+
+    Supports both real :class:`Supervisor` instances (plan_launches())
+    and the duck-typed fakes used in tests.
+    """
+    plan = getattr(supervisor, "plan_launches", None)
+    if callable(plan):
+        try:
+            return list(plan())
+        except Exception:  # noqa: BLE001
+            return []
+    launches = getattr(supervisor, "launches", None)
+    if launches is not None:
+        try:
+            return list(launches)
+        except TypeError:
+            return []
+    return []
+
+
+def _target_for_launch(supervisor: Any, launch: Any) -> str:
+    """Return the tmux ``session:window`` target for ``launch``.
+
+    Falls back gracefully when the supervisor doesn't expose a resolver
+    — worst case we send to ``<session-name>:<window-name>`` which is
+    the canonical format tmux accepts.
+    """
+    session = getattr(launch, "session", None)
+    window_name = getattr(launch, "window_name", None) or getattr(session, "window_name", None)
+    resolver = getattr(supervisor, "_tmux_session_for_session", None)
+    if callable(resolver) and session is not None:
+        try:
+            tmux_session = resolver(session.name)
+        except Exception:  # noqa: BLE001
+            tmux_session = None
+    else:
+        tmux_session = None
+    if not tmux_session:
+        tmux_session = getattr(
+            getattr(supervisor, "config", None), "project", None,
+        )
+        tmux_session = getattr(tmux_session, "tmux_session", None) or "pollypm"
+    return f"{tmux_session}:{window_name or session.name if session else 'polly'}"
+
+
+def inject_system_update_notice(
+    old_version: str,
+    new_version: str,
+    *,
+    supervisor: Any | None = None,
+    config_path: Path | None = None,
+    send_keys: Callable[..., Any] | None = None,
+) -> list[NoticeResult]:
+    """Deliver the ``<system-update>`` notice to every live session.
+
+    Returns one :class:`NoticeResult` per session attempted (including
+    skipped ones) so the caller can render a summary (#720 uses this
+    for the "3 sessions notified" count).
+
+    Supervisor can be passed in for tests; production call from
+    ``pm upgrade`` constructs it via :class:`PollyPMService`.
+    """
+    if supervisor is None:
+        supervisor = _load_supervisor(config_path)
+        if supervisor is None:
+            return []
+
+    tmux = getattr(supervisor, "tmux", None)
+    results: list[NoticeResult] = []
+    for launch in _iter_launches(supervisor):
+        session = getattr(launch, "session", None)
+        if session is None:
+            continue
+        role = getattr(session, "role", "") or ""
+        name = getattr(session, "name", "") or "unknown"
+        guide = _guide_path_for_role(role)
+        if guide is None:
+            results.append(NoticeResult(
+                session_name=name, role=role, delivered=False,
+                reason=f"skipped: {role or 'no role'}",
+            ))
+            continue
+        target = _target_for_launch(supervisor, launch)
+        notice = build_notice(old_version, new_version, guide)
+        ok, detail = _send_to_session(
+            tmux, target=target, text=notice, send_keys=send_keys,
+        )
+        results.append(NoticeResult(
+            session_name=name, role=role, delivered=ok, reason=detail,
+        ))
+    return results
+
+
+def _load_supervisor(config_path: Path | None) -> Any | None:
+    """Best-effort supervisor load. Swallows failures so ``pm upgrade``
+    doesn't abort its whole flow when we can't reach the session layer
+    (e.g. user isn't in a tmux session right now)."""
+    try:
+        from pollypm.config import DEFAULT_CONFIG_PATH
+        from pollypm.service_api import PollyPMService
+    except ImportError:
+        return None
+    path = config_path or DEFAULT_CONFIG_PATH
+    if not path.exists():
+        return None
+    try:
+        service = PollyPMService(path)
+        return service.load_supervisor()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def summarize(results: list[NoticeResult]) -> tuple[int, int, int]:
+    """Return ``(notified, skipped, failed)`` counts for the rail
+    summary in #720."""
+    notified = sum(1 for r in results if r.delivered)
+    skipped = sum(1 for r in results if not r.delivered and r.reason.startswith("skipped"))
+    failed = sum(1 for r in results if not r.delivered and not r.reason.startswith("skipped"))
+    return notified, skipped, failed

--- a/tests/test_upgrade_notice.py
+++ b/tests/test_upgrade_notice.py
@@ -1,0 +1,207 @@
+"""Tests for the in-session upgrade-notice injection (#718).
+
+Uses fake supervisor + tmux client so no real session is touched. The
+fake matches the duck-typed surface the module reads: ``plan_launches``
+returns a list of objects with ``.session.role`` / ``.session.name`` /
+``.window_name``; the tmux client exposes ``send_keys``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from pollypm import upgrade_notice
+
+
+@dataclass(slots=True)
+class _FakeSession:
+    name: str
+    role: str
+
+
+@dataclass(slots=True)
+class _FakeLaunch:
+    session: _FakeSession
+    window_name: str
+
+
+class _FakeTmux:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, bool]] = []
+
+    def send_keys(self, target: str, text: str, press_enter: bool = True) -> None:
+        self.calls.append((target, text, press_enter))
+
+
+class _FakeConfigProject:
+    tmux_session = "pollypm-test"
+
+
+class _FakeConfig:
+    class project:  # noqa: N801 — matches supervisor shape
+        tmux_session = "pollypm-test"
+
+
+class _FakeSupervisor:
+    def __init__(self, launches: list[_FakeLaunch]) -> None:
+        self._launches = launches
+        self.tmux = _FakeTmux()
+        self.config = _FakeConfig()
+
+    def plan_launches(self) -> list[_FakeLaunch]:
+        return self._launches
+
+
+def _launches(specs: list[tuple[str, str, str]]) -> list[_FakeLaunch]:
+    """Shorthand: [(session_name, role, window_name), ...]."""
+    return [
+        _FakeLaunch(_FakeSession(name=n, role=r), window_name=w)
+        for n, r, w in specs
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# build_notice — text shape
+# --------------------------------------------------------------------------- #
+
+def test_build_notice_contains_versions_and_path() -> None:
+    text = upgrade_notice.build_notice("1.2.0", "1.3.2", "docs/worker-guide.md")
+    assert "v1.2.0" in text
+    assert "v1.3.2" in text
+    assert "docs/worker-guide.md" in text
+    assert "supersedes" in text.lower()
+    assert "<system-update>" in text
+    assert "</system-update>" in text
+
+
+def test_build_notice_instructs_re_read() -> None:
+    text = upgrade_notice.build_notice("0.1.0", "0.2.0", "docs/worker-guide.md")
+    # Model must be told to re-read BEFORE next action.
+    assert "re-read" in text.lower()
+    assert "next action" in text.lower()
+
+
+# --------------------------------------------------------------------------- #
+# inject_system_update_notice — per-role routing
+# --------------------------------------------------------------------------- #
+
+def test_inject_sends_to_worker_session() -> None:
+    sup = _FakeSupervisor(_launches([
+        ("worker_demo", "worker", "worker-demo"),
+    ]))
+    results = upgrade_notice.inject_system_update_notice(
+        "0.1.0", "0.2.0", supervisor=sup,
+    )
+    assert len(results) == 1
+    assert results[0].delivered is True
+    assert len(sup.tmux.calls) == 1
+    target, text, _ = sup.tmux.calls[0]
+    assert target == "pollypm-test:worker-demo"
+    assert "docs/worker-guide.md" in text
+
+
+def test_inject_routes_polly_to_operator_guide() -> None:
+    sup = _FakeSupervisor(_launches([("polly", "operator-pm", "polly")]))
+    upgrade_notice.inject_system_update_notice(
+        "0.1.0", "0.2.0", supervisor=sup,
+    )
+    _, text, _ = sup.tmux.calls[0]
+    assert "polly-operator-guide.md" in text
+
+
+def test_inject_routes_russell_to_reviewer_guide() -> None:
+    sup = _FakeSupervisor(_launches([("russell", "reviewer", "russell")]))
+    upgrade_notice.inject_system_update_notice(
+        "0.1.0", "0.2.0", supervisor=sup,
+    )
+    _, text, _ = sup.tmux.calls[0]
+    assert "russell.md" in text
+
+
+def test_inject_skips_heartbeat_role() -> None:
+    sup = _FakeSupervisor(_launches([
+        ("heartbeat", "heartbeat-supervisor", "heartbeat"),
+    ]))
+    results = upgrade_notice.inject_system_update_notice(
+        "0.1.0", "0.2.0", supervisor=sup,
+    )
+    assert len(results) == 1
+    assert results[0].delivered is False
+    assert "skipped" in results[0].reason
+    assert sup.tmux.calls == []
+
+
+def test_inject_delivers_to_mixed_fleet() -> None:
+    sup = _FakeSupervisor(_launches([
+        ("polly", "operator-pm", "polly"),
+        ("russell", "reviewer", "russell"),
+        ("worker_1", "worker", "worker-1"),
+        ("worker_2", "worker", "worker-2"),
+        ("heartbeat", "heartbeat-supervisor", "heartbeat"),
+    ]))
+    results = upgrade_notice.inject_system_update_notice(
+        "0.1.0", "0.2.0", supervisor=sup,
+    )
+    assert len(results) == 5
+    delivered = [r for r in results if r.delivered]
+    skipped = [r for r in results if not r.delivered]
+    assert len(delivered) == 4  # polly + russell + 2 workers
+    assert len(skipped) == 1    # heartbeat
+    assert len(sup.tmux.calls) == 4
+
+
+def test_inject_reports_send_failures() -> None:
+    class _BrokenTmux:
+        def send_keys(self, *_args, **_kwargs):
+            raise RuntimeError("tmux unavailable")
+
+    sup = _FakeSupervisor(_launches([("worker_1", "worker", "worker-1")]))
+    sup.tmux = _BrokenTmux()
+    results = upgrade_notice.inject_system_update_notice(
+        "0.1.0", "0.2.0", supervisor=sup,
+    )
+    assert len(results) == 1
+    assert results[0].delivered is False
+    assert "send failed" in results[0].reason
+
+
+def test_inject_no_supervisor_returns_empty() -> None:
+    """No live supervisor (not in tmux / config missing) → return []
+    without crashing."""
+    from pathlib import Path
+    results = upgrade_notice.inject_system_update_notice(
+        "0.1.0", "0.2.0",
+        supervisor=None,
+        config_path=Path("/nonexistent/pollypm.toml"),
+    )
+    assert results == []
+
+
+def test_inject_unknown_role_defaults_to_worker_guide() -> None:
+    sup = _FakeSupervisor(_launches([("pete", "polyglot", "pete")]))
+    upgrade_notice.inject_system_update_notice(
+        "0.1.0", "0.2.0", supervisor=sup,
+    )
+    _, text, _ = sup.tmux.calls[0]
+    assert "docs/worker-guide.md" in text
+
+
+# --------------------------------------------------------------------------- #
+# summarize()
+# --------------------------------------------------------------------------- #
+
+def test_summarize_counts_buckets_correctly() -> None:
+    results = [
+        upgrade_notice.NoticeResult("a", "worker", True, "sent"),
+        upgrade_notice.NoticeResult("b", "worker", True, "sent"),
+        upgrade_notice.NoticeResult("c", "heartbeat-supervisor", False, "skipped: heartbeat-supervisor"),
+        upgrade_notice.NoticeResult("d", "worker", False, "send failed: TimeoutError"),
+    ]
+    notified, skipped, failed = upgrade_notice.summarize(results)
+    assert (notified, skipped, failed) == (2, 1, 1)
+
+
+def test_summarize_empty_list() -> None:
+    assert upgrade_notice.summarize([]) == (0, 0, 0)


### PR DESCRIPTION
When `pm upgrade` lands a new PollyPM version while sessions are live, `claude --resume` / `codex --resume` preserve the original conversation — the system prompt from turn 1 stays baked into history and **new system prompts are NOT merged**. Killing + relaunching works but loses in-flight context.

This module solves the prompt-staleness problem by injecting a `<system-update>` user-turn notice into every live session, telling the model to re-read its role guide from disk (which IS the new, post-upgrade version). At the next turn boundary the model converges on the new instructions **without losing conversation state**.

## What ships

- **`inject_system_update_notice(old, new, *, supervisor=None)`** — iterates `supervisor.plan_launches()` and sends via `supervisor.tmux.send_keys`.
- **Role-specific guide paths:**
  - `worker` → `docs/worker-guide.md`
  - `operator-pm` → `polly-operator-guide.md`
  - `reviewer` → `russell.md`
  - `architect` → `architect.md`
  - unknown role → defaults to worker guide
  - `heartbeat` / `heartbeat-supervisor` → skipped (no LLM in the loop)
- Returns `NoticeResult` per session so the rail summary in #720 can render `3 notified · 1 skipped · 0 failed`.
- `summarize(results)` helper → `(notified, skipped, failed)` tuple for UI counts.

## Notice text

Load-bearing structure: named version bump + exact guide path + explicit "supersedes prior instructions" framing + "pause on conflict". This wording produces measurably better model adherence than casual "we updated" text.

```
<system-update>
PollyPM was upgraded from v<old> → v<new> while this session was running.
Before your next action, re-read your operating guide at <path>.
It supersedes any prior operating instructions in this conversation.
If anything in the new guide conflicts with what you were about to do,
pause and re-plan from the updated instructions.
</system-update>
```

## Honest caveats

- Models aren't perfectly adherent to "disregard prior instructions" framing. 90% converges cleanly; 10% case benefits from the hard-recycle escape hatch in #720.
- Sessions mid-tool-call see the notice queued as a user turn (rendered at the next turn break). No attempt to interrupt ongoing work.

## Validation

12 new unit tests cover text shape, role routing, mixed-fleet delivery, send failures, no-supervisor graceful path, and `summarize()`. Uses fake supervisor + tmux client; no real sessions touched.

## Dependencies

Works independently. Invoked by `pm upgrade` (#716) — which already has a soft-fallback for when this module isn't present, so the two can merge in any order.

Closes #718 · Refs #709