### PR TITLE
feat(cockpit): one-click rail upgrade + post-upgrade restart nudge (#719)

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -20,6 +20,7 @@ Contract:
 from __future__ import annotations
 
 import gc
+import json
 import os
 import resource
 from collections import deque
@@ -952,6 +953,11 @@ class PollyCockpitApp(App[None]):
         # timer.
         if self._tick_count % 5 == 0:
             self._update_pill_refresh()
+        # Post-upgrade flag lands when ``pm upgrade`` finishes — switch
+        # the pill to a restart nudge. Check on every tick so the
+        # feedback loop from "upgrade complete" → visible notice is
+        # sub-second.
+        self._check_post_upgrade_flag()
         # Layout check much less frequently
         if self._tick_count % self._LAYOUT_CHECK_INTERVAL == 0:
             try:
@@ -1159,21 +1165,90 @@ class PollyCockpitApp(App[None]):
         self.update_pill.display = True
 
     def action_trigger_upgrade(self) -> None:
-        """Kick off the upgrade flow from the rail ``u`` keybind.
+        """Spawn ``pm upgrade`` in a new tmux window.
 
-        The full one-click pane flow ships in #719. Until that lands,
-        this action emits a friendly notice pointing at the CLI path
-        and closes. Users can already run ``pm upgrade`` directly.
+        Runs in its own window so the rail stays usable during install.
+        When the upgrade finishes, ``pm upgrade`` writes a sentinel at
+        ``~/.pollypm/post-upgrade.flag`` that ``_tick`` watches for —
+        on detection the pill swaps to a "Restart cockpit to pick up
+        v<new>" nudge. Auto-restart of the rail + daemons ships in
+        #720; for now the user presses ctrl+q to relaunch.
+
+        Non-blocking: a failed spawn falls back to a ``notify()``
+        pointing at the CLI path.
         """
+        tmux_session = "pollypm"
+        try:
+            supervisor = self.router._load_supervisor()
+            tmux_session = supervisor.config.project.tmux_session
+        except Exception:  # noqa: BLE001
+            pass
+
+        try:
+            self.router.tmux.create_window(
+                tmux_session,
+                "pm-upgrade",
+                "pm upgrade; echo; echo '(press enter to close)'; read",
+                detached=False,
+            )
+        except Exception:  # noqa: BLE001
+            try:
+                self.notify(
+                    "Could not open a new tmux window. Run "
+                    "`pm upgrade` directly in a terminal.",
+                    timeout=6,
+                )
+            except Exception:  # noqa: BLE001
+                pass
+            return
+
+        self.update_pill.update(
+            "[#e0af68]Upgrading… see window `pm-upgrade`[/]"
+        )
+        self.update_pill.display = True
         try:
             self.notify(
-                "Rail upgrade flow ships with #719. For now, run "
-                "`pm upgrade` in a terminal. See `pm doctor` for the "
-                "currently available version.",
-                timeout=6,
+                "Upgrade started in window `pm-upgrade`. Keep working; "
+                "the rail will tell you when it's done.",
+                timeout=5,
             )
         except Exception:  # noqa: BLE001
             pass
+
+    def _post_upgrade_flag_path(self) -> Path:
+        """Sentinel written by ``pm upgrade`` on success.
+
+        Content is JSON:
+        ``{"from": "0.1.0", "to": "0.2.0", "at": 1234567890.0}``.
+        The rail reads it to update the pill. ``pm upgrade`` writes it
+        atomically (tempfile + rename) so we never see a partial read.
+        Cleanup lives in #720's post-upgrade summary flow — the flag
+        sticks until the user dismisses the summary.
+        """
+        return Path.home() / ".pollypm" / "post-upgrade.flag"
+
+    def _check_post_upgrade_flag(self) -> None:
+        """Swap the pill to "restart to pick up new code" when the
+        sentinel appears.
+
+        Only updates the pill; does NOT delete the flag so a cockpit
+        restart can pick up where we left off.
+        """
+        if self._update_pill_dismissed:
+            return
+        flag = self._post_upgrade_flag_path()
+        if not flag.exists():
+            return
+        try:
+            payload = json.loads(flag.read_text())
+        except (OSError, json.JSONDecodeError):
+            return
+        new_version = str(payload.get("to") or "?")
+        self.update_pill.update(
+            f"[#9ece6a]✓ Upgraded to v{new_version} · "
+            "restart cockpit (ctrl+q) to pick up new code[/]"
+        )
+        self.update_pill.display = True
 
     def action_dismiss_update_pill(self) -> None:
         """Hide the update pill for this cockpit session.

--- a/tests/test_rail_oneclick_upgrade.py
+++ b/tests/test_rail_oneclick_upgrade.py
@@ -1,0 +1,201 @@
+"""Tests for the one-click rail upgrade flow (#719).
+
+Covers:
+* ``action_trigger_upgrade`` spawns ``pm upgrade`` in a new tmux window
+  (via the existing ``TmuxClient.create_window`` primitive).
+* The pill swaps to "Upgrading…" while the window is active.
+* ``_check_post_upgrade_flag`` reads ``~/.pollypm/post-upgrade.flag``
+  and swaps the pill to a "restart to pick up new code" nudge.
+* Failure modes degrade gracefully — no tmux, no window creation, no
+  flag — without crashing the cockpit.
+
+The actual ``pm upgrade`` subprocess never runs; we fake the tmux
+client and assert on the ``create_window`` args.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def fake_config(tmp_path: Path) -> Path:
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        "[project]\n"
+        f'name = "PollyPM"\n'
+        f'tmux_session = "pollypm-test"\n'
+        f'root_dir = "{tmp_path}"\n'
+        f'workspace_root = "{tmp_path}"\n'
+        f'base_dir = "{tmp_path}/.pollypm"\n'
+        f'logs_dir = "{tmp_path}/.pollypm/logs"\n'
+        f'snapshots_dir = "{tmp_path}/.pollypm/snapshots"\n'
+        f'state_db = "{tmp_path}/.pollypm/state.db"\n'
+        "\n"
+        f'[projects.demo]\n'
+        f'key = "demo"\n'
+        f'name = "Demo"\n'
+        f'path = "{tmp_path}"\n'
+    )
+    (tmp_path / ".pollypm").mkdir(exist_ok=True)
+    return config_path
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path, monkeypatch):
+    """Route ``Path.home()`` into the sandbox so the post-upgrade flag
+    read/write doesn't touch the developer's real ``~/.pollypm``."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    (fake_home / ".pollypm").mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+
+# --------------------------------------------------------------------------- #
+# action_trigger_upgrade — spawns the window
+# --------------------------------------------------------------------------- #
+
+def test_trigger_upgrade_spawns_pm_upgrade_window(fake_config, monkeypatch):
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    app = PollyCockpitApp(fake_config)
+    fake_tmux = MagicMock()
+    app.router.tmux = fake_tmux
+    monkeypatch.setattr(
+        app.router, "_load_supervisor",
+        lambda fresh=False: SimpleNamespace(
+            config=SimpleNamespace(
+                project=SimpleNamespace(tmux_session="pollypm-test"),
+            ),
+        ),
+    )
+
+    app.action_trigger_upgrade()
+
+    fake_tmux.create_window.assert_called_once()
+    args, kwargs = fake_tmux.create_window.call_args
+    assert args[0] == "pollypm-test"
+    assert args[1] == "pm-upgrade"
+    assert "pm upgrade" in args[2]
+    assert kwargs.get("detached") is False
+
+
+def test_trigger_upgrade_updates_pill_to_upgrading_state(fake_config):
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    app = PollyCockpitApp(fake_config)
+    app.router.tmux = MagicMock()
+
+    app.action_trigger_upgrade()
+
+    rendered = str(app.update_pill.render())
+    assert "Upgrading" in rendered
+    assert "pm-upgrade" in rendered
+    assert app.update_pill.display is True
+
+
+def test_trigger_upgrade_handles_tmux_failure(fake_config, monkeypatch):
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    class _BrokenTmux:
+        def create_window(self, *_args, **_kwargs):
+            raise RuntimeError("tmux unavailable")
+
+    app = PollyCockpitApp(fake_config)
+    app.router.tmux = _BrokenTmux()
+    notices: list[str] = []
+    monkeypatch.setattr(
+        app, "notify", lambda msg, *, timeout=None: notices.append(msg),
+    )
+
+    app.action_trigger_upgrade()
+
+    assert len(notices) == 1
+    assert "pm upgrade" in notices[0]
+    assert "terminal" in notices[0]
+
+
+def test_trigger_upgrade_falls_back_when_supervisor_missing(fake_config, monkeypatch):
+    """No supervisor (e.g. not yet booted) → use the default tmux
+    session name rather than crashing."""
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    app = PollyCockpitApp(fake_config)
+    fake_tmux = MagicMock()
+    app.router.tmux = fake_tmux
+    monkeypatch.setattr(
+        app.router, "_load_supervisor",
+        lambda fresh=False: (_ for _ in ()).throw(RuntimeError("no supervisor")),
+    )
+
+    app.action_trigger_upgrade()
+
+    fake_tmux.create_window.assert_called_once()
+    args, _kwargs = fake_tmux.create_window.call_args
+    # Default fallback tmux session name.
+    assert args[0] == "pollypm"
+
+
+# --------------------------------------------------------------------------- #
+# _check_post_upgrade_flag — picks up the sentinel
+# --------------------------------------------------------------------------- #
+
+def test_check_flag_switches_pill_to_restart_nudge(fake_config):
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    app = PollyCockpitApp(fake_config)
+    flag = Path.home() / ".pollypm" / "post-upgrade.flag"
+    flag.write_text(json.dumps({"from": "0.1.0", "to": "0.2.0", "at": 1.0}))
+
+    app._check_post_upgrade_flag()
+
+    rendered = str(app.update_pill.render())
+    assert "Upgraded" in rendered
+    assert "v0.2.0" in rendered
+    assert "restart" in rendered.lower()
+    assert app.update_pill.display is True
+
+
+def test_check_flag_no_op_when_absent(fake_config):
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    app = PollyCockpitApp(fake_config)
+    # update_pill starts hidden — this must stay that way.
+    app._check_post_upgrade_flag()
+    # Not asserting display here because it's whatever Textual inits to;
+    # we're checking the method doesn't crash and doesn't render a label.
+    rendered = str(app.update_pill.render())
+    assert "Upgraded" not in rendered
+
+
+def test_check_flag_handles_malformed_json(fake_config):
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    app = PollyCockpitApp(fake_config)
+    flag = Path.home() / ".pollypm" / "post-upgrade.flag"
+    flag.write_text("not-json")
+
+    # Should not raise.
+    app._check_post_upgrade_flag()
+
+
+def test_check_flag_respects_dismiss(fake_config):
+    """A dismissed pill must not render "Upgraded" content even when
+    the flag appears — the user explicitly opted out of the nudge for
+    this session."""
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    app = PollyCockpitApp(fake_config)
+    app._update_pill_dismissed = True
+    flag = Path.home() / ".pollypm" / "post-upgrade.flag"
+    flag.write_text(json.dumps({"from": "0.1.0", "to": "0.2.0", "at": 1.0}))
+
+    app._check_post_upgrade_flag()
+    rendered = str(app.update_pill.render())
+    assert "Upgraded" not in rendered
+    assert "restart" not in rendered.lower()


### PR DESCRIPTION
Replaces the #715 stubbed `action_trigger_upgrade` with the real one-click flow.

## Flow

1. Press `u` on the update pill → `pm upgrade` spawns in a new tmux window (`pm-upgrade`). Rail stays usable during install.
2. Pill swaps to yellow: `Upgrading… see window \`pm-upgrade\``.
3. When `pm upgrade` finishes, it writes `~/.pollypm/post-upgrade.flag` with the version bump (`{"from": "0.1.0", "to": "0.2.0", "at": ...}`).
4. `_check_post_upgrade_flag` runs every tick; on detection the pill turns green: `✓ Upgraded to v0.2.0 · restart cockpit (ctrl+q) to pick up new code`.

## Scope limits — deferred to #720

- **Auto-restart** of rail + heartbeat + rail-daemon. For now the user presses ctrl+q and relaunches.
- **Sentinel cleanup**. The flag lives in `~/.pollypm` until #720's post-upgrade summary dismisses it.
- **Sentinel writer** lives in `pm upgrade` (#716 branch). This PR ships only the rail-side reader, so the two can merge in either order.

## Safety

- Pill switch respects dismiss state — if the user pressed `x` earlier, the "Upgraded" notice doesn't reappear mid-session.
- tmux failures fall back to a `notify()` pointing at the CLI path. Cockpit never crashes.
- Malformed JSON is swallowed rather than surfaced.
- Tick-rate cost: one `Path.exists()` stat per tick plus at most one JSON read after upgrade.

## Validation

8 new tests cover window spawn args, pill state transitions, tmux-failure fallback, supervisor-missing fallback, flag pickup, absent/malformed flag handling, dismiss respect. Regression: 16/16 pass (8 new + 8 inherited from #715).

## Stack

Branch → `wip-715-rail-pill` → `wip-714-version-check` → main. Rebases cleanly once #721 and #726 merge.

Closes #719 · Refs #709