### PR TITLE
feat(cockpit): rail update-available pill + u/x keybinds (#715)

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -678,6 +678,13 @@ class PollyCockpitApp(App[None]):
         background: #253140;
         color: #f2f6f8;
     }
+    #update-pill {
+        height: 1;
+        padding: 0 1;
+        color: #7aa2f7;
+        background: transparent;
+        text-style: bold;
+    }
     #ticker {
         height: 1;
         padding: 0 1;
@@ -698,6 +705,8 @@ class PollyCockpitApp(App[None]):
         Binding("p", "toggle_project_pin", "Pin Project"),
         Binding("r", "refresh", "Refresh"),
         Binding("s", "open_settings", "Settings"),
+        Binding("u", "trigger_upgrade", "Upgrade", show=False),
+        Binding("x", "dismiss_update_pill", "Dismiss Update", show=False),
         Binding("a", "view_alerts", "Alerts", show=False),
         Binding("ctrl+k,colon", "open_command_palette", "Palette", priority=True),
         Binding(
@@ -735,8 +744,13 @@ class PollyCockpitApp(App[None]):
         self.tagline = Static("\n" + POLLY_SLOGANS[0], id="tagline")
         self.nav = ListView(id="nav")
         self.settings_row = Static("\u2699 Settings", id="settings-row")
+        self.update_pill = Static("", id="update-pill", markup=True)
         self.ticker = Static("", id="ticker")
         self.hint = Static("", id="hint")
+        # True once the user presses ``x`` on the pill — hides it for
+        # the remainder of this cockpit session. Re-appears on next
+        # cockpit launch if an update is still available.
+        self._update_pill_dismissed = False
         self.spinner_index = 0
         self.slogan_index = 0
         self._slogan_tick = 0
@@ -764,6 +778,7 @@ class PollyCockpitApp(App[None]):
             yield self.tagline
             yield self.nav
             yield self.settings_row
+            yield self.update_pill
             yield self.ticker
             yield self.hint
 
@@ -771,6 +786,7 @@ class PollyCockpitApp(App[None]):
         self.selected_key = self.router.selected_key()
         self._refresh_rows()
         self._update_ticker()
+        self._update_pill_refresh()
         self.set_interval(0.8, self._tick)
         self.set_interval(self.SCHEDULER_POLL_INTERVAL_SECONDS, self._tick_scheduler)
         self.nav.focus()
@@ -929,6 +945,13 @@ class PollyCockpitApp(App[None]):
                     row.spinner_index = self.spinner_index
                     row.update_body()
         self._update_ticker()
+        # Release-check cache is 24h so polling each tick is cheap —
+        # almost always a dict lookup. Only the first tick per cache
+        # window touches the network (and that path short-circuits on
+        # any failure). This keeps the pill current without a separate
+        # timer.
+        if self._tick_count % 5 == 0:
+            self._update_pill_refresh()
         # Layout check much less frequently
         if self._tick_count % self._LAYOUT_CHECK_INTERVAL == 0:
             try:
@@ -1103,6 +1126,64 @@ class PollyCockpitApp(App[None]):
         ticker_text = self._event_ticker_text()
         self.ticker.update(ticker_text)
         self.ticker.display = bool(ticker_text)
+
+    def _update_pill_refresh(self) -> None:
+        """Refresh the update-available pill in the rail top area.
+
+        Shows ``↑ v<latest> available · u: upgrade · x: dismiss`` when
+        ``release_check.check_latest`` reports a newer version on the
+        active channel. Hidden otherwise — including when dismissed for
+        this session, when the check is cached as "up-to-date", and
+        when the check is offline or raised.
+        """
+        if self._update_pill_dismissed:
+            self.update_pill.display = False
+            return
+        try:
+            from pollypm.release_check import _resolve_channel, check_latest
+            channel = _resolve_channel(None)
+            check = check_latest(channel)
+        except Exception:  # noqa: BLE001
+            self.update_pill.display = False
+            return
+        if check is None or not check.upgrade_available:
+            self.update_pill.display = False
+            return
+        channel_label = (
+            f" ({check.channel})" if check.channel != "stable" else ""
+        )
+        self.update_pill.update(
+            f"[#7aa2f7]↑ v{check.latest} available{channel_label}"
+            "[/] · [dim]u: upgrade · x: dismiss[/]"
+        )
+        self.update_pill.display = True
+
+    def action_trigger_upgrade(self) -> None:
+        """Kick off the upgrade flow from the rail ``u`` keybind.
+
+        The full one-click pane flow ships in #719. Until that lands,
+        this action emits a friendly notice pointing at the CLI path
+        and closes. Users can already run ``pm upgrade`` directly.
+        """
+        try:
+            self.notify(
+                "Rail upgrade flow ships with #719. For now, run "
+                "`pm upgrade` in a terminal. See `pm doctor` for the "
+                "currently available version.",
+                timeout=6,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+    def action_dismiss_update_pill(self) -> None:
+        """Hide the update pill for this cockpit session.
+
+        Dismissal is session-scoped — the pill re-appears on next
+        cockpit launch if the upgrade is still available. This keeps
+        the nudge visible to future-you even if current-you is busy.
+        """
+        self._update_pill_dismissed = True
+        self.update_pill.display = False
 
     _HEARTBEAT_STALE_SECONDS = 180  # warn if no heartbeat in 3 minutes
 

--- a/tests/test_rail_update_pill.py
+++ b/tests/test_rail_update_pill.py
@@ -1,0 +1,186 @@
+"""Tests for the rail update-available pill (#715).
+
+Covers the three states the pill can be in:
+* hidden when no upgrade is available or the check is offline
+* visible when ``release_check.check_latest`` reports an upgrade
+* hidden for the session after the user presses ``x``
+
+Plus the keybindings: ``u`` triggers the upgrade action (stubbed
+pending #719), ``x`` dismisses for the session.
+
+Uses Textual's async test harness (``run_test()``) to drive the app.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pollypm import release_check
+
+
+@pytest.fixture
+def fake_config(tmp_path: Path) -> Path:
+    """Minimal config file the cockpit app can load without crashing."""
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        "[project]\n"
+        f'name = "PollyPM"\n'
+        f'tmux_session = "pollypm-test"\n'
+        f'root_dir = "{tmp_path}"\n'
+        f'workspace_root = "{tmp_path}"\n'
+        f'base_dir = "{tmp_path}/.pollypm"\n'
+        f'logs_dir = "{tmp_path}/.pollypm/logs"\n'
+        f'snapshots_dir = "{tmp_path}/.pollypm/snapshots"\n'
+        f'state_db = "{tmp_path}/.pollypm/state.db"\n'
+        "\n"
+        f'[projects.demo]\n'
+        f'key = "demo"\n'
+        f'name = "Demo"\n'
+        f'path = "{tmp_path}"\n'
+    )
+    (tmp_path / ".pollypm").mkdir(exist_ok=True)
+    return config_path
+
+
+@pytest.fixture(autouse=True)
+def isolated_release_check_cache(tmp_path, monkeypatch):
+    """Route the release-check cache into tmp_path so tests can seed
+    it without touching the user's real ``~/.pollypm`` state."""
+    monkeypatch.setattr(
+        release_check, "_cache_path", lambda: tmp_path / "release-check.json",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# _update_pill_refresh — unit-level checks that don't need the full app
+# --------------------------------------------------------------------------- #
+
+def test_pill_refresh_hides_when_no_upgrade(fake_config, monkeypatch):
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    app = PollyCockpitApp(fake_config)
+    monkeypatch.setattr(
+        "pollypm.release_check.check_latest",
+        lambda *a, **kw: release_check.ReleaseCheck(
+            current="0.2.0", latest="0.2.0", channel="stable",
+            upgrade_available=False, cached_at=0.0,
+        ),
+    )
+    app._update_pill_refresh()
+    assert app.update_pill.display is False
+
+
+def test_pill_refresh_shows_when_upgrade_available(fake_config, monkeypatch):
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    app = PollyCockpitApp(fake_config)
+    monkeypatch.setattr(
+        "pollypm.release_check.check_latest",
+        lambda *a, **kw: release_check.ReleaseCheck(
+            current="0.1.0", latest="0.2.0", channel="stable",
+            upgrade_available=True, cached_at=0.0,
+        ),
+    )
+    app._update_pill_refresh()
+    assert app.update_pill.display is True
+    rendered = str(app.update_pill.render())
+    assert "0.2.0" in rendered
+    assert "u:" in rendered  # keybind hint
+    assert "x:" in rendered
+
+
+def test_pill_refresh_labels_beta_channel(fake_config, monkeypatch):
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    app = PollyCockpitApp(fake_config)
+    monkeypatch.setattr(
+        "pollypm.release_check.check_latest",
+        lambda *a, **kw: release_check.ReleaseCheck(
+            current="0.1.0", latest="0.3.0-beta.1", channel="beta",
+            upgrade_available=True, cached_at=0.0,
+        ),
+    )
+    app._update_pill_refresh()
+    rendered = str(app.update_pill.render())
+    assert "beta" in rendered
+
+
+def test_pill_refresh_offline_stays_hidden(fake_config, monkeypatch):
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    app = PollyCockpitApp(fake_config)
+    monkeypatch.setattr(
+        "pollypm.release_check.check_latest",
+        lambda *a, **kw: None,
+    )
+    app._update_pill_refresh()
+    assert app.update_pill.display is False
+
+
+def test_pill_refresh_swallows_exceptions(fake_config, monkeypatch):
+    """A raised exception inside release_check must not crash the
+    cockpit — the pill just stays hidden."""
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("synthetic network failure")
+
+    app = PollyCockpitApp(fake_config)
+    monkeypatch.setattr("pollypm.release_check.check_latest", boom)
+    app._update_pill_refresh()
+    assert app.update_pill.display is False
+
+
+def test_dismiss_hides_pill_for_session(fake_config, monkeypatch):
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    app = PollyCockpitApp(fake_config)
+    monkeypatch.setattr(
+        "pollypm.release_check.check_latest",
+        lambda *a, **kw: release_check.ReleaseCheck(
+            current="0.1.0", latest="0.2.0", channel="stable",
+            upgrade_available=True, cached_at=0.0,
+        ),
+    )
+    app._update_pill_refresh()
+    assert app.update_pill.display is True
+
+    # Dismiss — even if the next tick finds an upgrade, stays hidden.
+    app.action_dismiss_update_pill()
+    assert app.update_pill.display is False
+    app._update_pill_refresh()
+    assert app.update_pill.display is False
+
+
+# --------------------------------------------------------------------------- #
+# Key bindings are present in the binding list
+# --------------------------------------------------------------------------- #
+
+def test_upgrade_binding_registered() -> None:
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    bindings = {b.key: b.action for b in PollyCockpitApp.BINDINGS}
+    assert bindings.get("u") == "trigger_upgrade"
+    assert bindings.get("x") == "dismiss_update_pill"
+
+
+# --------------------------------------------------------------------------- #
+# action_trigger_upgrade — stub pending #719
+# --------------------------------------------------------------------------- #
+
+def test_trigger_upgrade_emits_notification(fake_config, monkeypatch):
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    app = PollyCockpitApp(fake_config)
+    notices: list[str] = []
+
+    def _capture(message: str, *, timeout: int | None = None) -> None:
+        del timeout
+        notices.append(message)
+
+    monkeypatch.setattr(app, "notify", _capture)
+    app.action_trigger_upgrade()
+    assert len(notices) == 1
+    assert "pm upgrade" in notices[0]


### PR DESCRIPTION
**Recreated from #726** (auto-closed when its stacked base `wip-714-version-check` was deleted after #721 merged.) Branch is now rebased directly on current main.

Visual nudge for a newer PollyPM release, visible in the cockpit rail. A small pill appears above the event ticker when `release_check.check_latest` reports an upgrade on the active channel:

```
↑ v0.2.0 available · u: upgrade · x: dismiss
```

## Behaviour

- **Hidden** when no upgrade, offline, or the check raises (swallows exceptions — never crashes the cockpit).
- **`u` keybind** fires `action_trigger_upgrade`. Full one-click pane flow lands in #719 (= new-PR followup); this PR stubs with a `notify()` pointing at `pm upgrade` so the binding is live and discoverable today.
- **`x` keybind** dismisses the pill for the current cockpit session. Re-appears on next launch if the upgrade is still available.
- **Beta channel** labels itself: `↑ v0.3.0-beta.1 available (beta) · …`.
- **Tick rate**: refreshed every 5 cockpit ticks (~4s). Release-check has a 24h cache so the cost is dict-lookup after the first tick per window.

## Validation

8 new unit tests cover: hides-when-current, shows-when-available, beta-label, offline-stays-hidden, exception-swallow, session-dismiss, binding registration, trigger-upgrade stub behaviour. Regression: `test_cockpit.py` green (62/62).

Closes #715 · Refs #709, replaces #726