### PR TITLE
roles-1: add per-role ModelAssignment config foundation

### DIFF
--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -9,6 +9,7 @@ from pollypm.models import (
     EventsRetentionSettings,
     LoggingSettings,
     MemorySettings,
+    ModelAssignment,
     KnownProject,
     PlannerSettings,
     PluginSettings,
@@ -29,6 +30,17 @@ PROJECT_CONFIG_DIRNAME = ".pollypm/config"
 PROJECT_CONFIG_FILENAME = "project.toml"
 
 _VALID_RELEASE_CHANNELS = ("stable", "beta")
+_GLOBAL_ROLE_ASSIGNMENT_KEYS = (
+    "operator_pm",
+    "architect",
+    "worker",
+    "reviewer",
+)
+_PROJECT_ROLE_ASSIGNMENT_KEYS = (
+    "architect",
+    "worker",
+    "reviewer",
+)
 
 _log = logging.getLogger(__name__)
 
@@ -110,6 +122,90 @@ def _resolve_path(base: Path, raw_path: str) -> Path:
 def _toml_str(value: str) -> str:
     """Escape a string for TOML double-quoted format."""
     return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _clean_optional_str(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _parse_role_assignments(
+    raw_roles: object,
+    *,
+    allowed_roles: tuple[str, ...],
+    scope_label: str,
+) -> dict[str, ModelAssignment]:
+    if not isinstance(raw_roles, dict):
+        return {}
+    assignments: dict[str, ModelAssignment] = {}
+    allowed = set(allowed_roles)
+    for role_name, role_raw in raw_roles.items():
+        if not isinstance(role_name, str):
+            _log.warning(
+                "Dropping invalid role assignment under %s: role key %r is not a string.",
+                scope_label,
+                role_name,
+            )
+            continue
+        if role_name not in allowed:
+            if role_name == "operator_pm" and "project" in scope_label:
+                reason = "operator_pm is global-only"
+            else:
+                reason = "unknown role"
+            _log.warning(
+                "Dropping invalid role assignment for %s.%s: %s.",
+                scope_label,
+                role_name,
+                reason,
+            )
+            continue
+        if not isinstance(role_raw, dict):
+            _log.warning(
+                "Dropping invalid role assignment for %s.%s: entry must be a table.",
+                scope_label,
+                role_name,
+            )
+            continue
+        alias = _clean_optional_str(role_raw.get("alias"))
+        provider = _clean_optional_str(role_raw.get("provider"))
+        model = _clean_optional_str(role_raw.get("model"))
+        if alias is not None and (provider is not None or model is not None):
+            _log.warning(
+                "Dropping invalid role assignment for %s.%s: alias and provider/model cannot both be set.",
+                scope_label,
+                role_name,
+            )
+            continue
+        if alias is None and provider is None and model is None:
+            _log.warning(
+                "Dropping invalid role assignment for %s.%s: empty assignment.",
+                scope_label,
+                role_name,
+            )
+            continue
+        if provider is None or model is None:
+            if alias is None:
+                _log.warning(
+                    "Dropping invalid role assignment for %s.%s: provider and model must both be set.",
+                    scope_label,
+                    role_name,
+                )
+                continue
+        try:
+            assignments[role_name] = ModelAssignment(
+                alias=alias,
+                provider=provider,
+                model=model,
+            )
+        except ValueError:
+            _log.warning(
+                "Dropping invalid role assignment for %s.%s: assignment must be alias-only or provider/model-only.",
+                scope_label,
+                role_name,
+            )
+    return assignments
 
 
 def _format_path(path: Path, root: Path) -> str:
@@ -268,6 +364,11 @@ def _parse_pollypm_settings(raw: dict[str, object], sessions: dict[str, SessionC
         lease_timeout_minutes=max(1, int(pollypm_raw.get("lease_timeout_minutes", 30))),
         timezone=_validate_timezone(str(pollypm_raw.get("timezone", ""))),
         release_channel=_validate_release_channel(pollypm_raw.get("release_channel")),
+        role_assignments=_parse_role_assignments(
+            pollypm_raw.get("roles", {}),
+            allowed_roles=_GLOBAL_ROLE_ASSIGNMENT_KEYS,
+            scope_label="pollypm.roles",
+        ),
     )
 
 
@@ -499,6 +600,11 @@ def _parse_known_projects(raw: dict[str, object], *, base: Path) -> dict[str, Kn
             persona_name=item_raw.get("persona_name") if isinstance(item_raw.get("persona_name"), str) else None,
             kind=ProjectKind(item_raw.get("kind", "folder")),
             tracked=bool(item_raw.get("tracked", False)),
+            role_assignments=_parse_role_assignments(
+                item_raw.get("roles", {}),
+                allowed_roles=_PROJECT_ROLE_ASSIGNMENT_KEYS,
+                scope_label=f"projects.{project_key}.roles",
+            ),
         )
     return projects
 
@@ -614,6 +720,34 @@ def load_config(path: Path = DEFAULT_CONFIG_PATH) -> PollyPMConfig:
     return config
 
 
+def _ordered_role_assignments(
+    assignments: dict[str, ModelAssignment],
+    allowed_roles: tuple[str, ...],
+) -> list[tuple[str, ModelAssignment]]:
+    return [
+        (role_name, assignments[role_name])
+        for role_name in allowed_roles
+        if role_name in assignments
+    ]
+
+
+def _append_role_assignment_tables(
+    lines: list[str],
+    *,
+    table_prefix: str,
+    assignments: dict[str, ModelAssignment],
+    allowed_roles: tuple[str, ...],
+) -> None:
+    for role_name, assignment in _ordered_role_assignments(assignments, allowed_roles):
+        lines.append(f"[{table_prefix}.{role_name}]")
+        if assignment.alias is not None:
+            lines.append(f'alias = "{_toml_str(assignment.alias)}"')
+        else:
+            lines.append(f'provider = "{_toml_str(assignment.provider or "")}"')
+            lines.append(f'model = "{_toml_str(assignment.model or "")}"')
+        lines.append("")
+
+
 def _render_global_config(config: PollyPMConfig) -> str:
     root = config.project.root_dir
     lines = [
@@ -641,6 +775,12 @@ def _render_global_config(config: PollyPMConfig) -> str:
         items = ", ".join(f'"{name}"' for name in config.pollypm.failover_accounts)
         lines.append(f"failover_accounts = [{items}]")
     lines.append("")
+    _append_role_assignment_tables(
+        lines,
+        table_prefix="pollypm.roles",
+        assignments=config.pollypm.role_assignments,
+        allowed_roles=_GLOBAL_ROLE_ASSIGNMENT_KEYS,
+    )
 
     lines.extend(
         [
@@ -758,6 +898,12 @@ def _render_global_config(config: PollyPMConfig) -> str:
         if project.tracked:
             lines.append("tracked = true")
         lines.append("")
+        _append_role_assignment_tables(
+            lines,
+            table_prefix=f"projects.{project_key}.roles",
+            assignments=project.role_assignments,
+            allowed_roles=_PROJECT_ROLE_ASSIGNMENT_KEYS,
+        )
 
     return "\n".join(lines).rstrip() + "\n"
 

--- a/src/pollypm/models.py
+++ b/src/pollypm/models.py
@@ -34,6 +34,26 @@ class ProjectSettings:
 
 
 @dataclass(slots=True)
+class ModelAssignment:
+    alias: str | None = None
+    provider: str | None = None
+    model: str | None = None
+
+    def __post_init__(self) -> None:
+        has_alias = isinstance(self.alias, str) and bool(self.alias.strip())
+        has_pair = (
+            isinstance(self.provider, str)
+            and bool(self.provider.strip())
+            and isinstance(self.model, str)
+            and bool(self.model.strip())
+        )
+        if has_alias == has_pair:
+            raise ValueError(
+                "ModelAssignment requires exactly one of alias or provider/model."
+            )
+
+
+@dataclass(slots=True)
 class KnownProject:
     key: str
     path: Path
@@ -41,9 +61,13 @@ class KnownProject:
     persona_name: str | None = None
     kind: ProjectKind = ProjectKind.FOLDER
     tracked: bool = False
+    role_assignments: dict[str, ModelAssignment] = field(default_factory=dict)
 
     def display_label(self) -> str:
         return self.name or self.key
+
+
+ProjectConfig = KnownProject
 
 
 @dataclass(slots=True)
@@ -84,6 +108,7 @@ class PollyPMSettings:
     lease_timeout_minutes: int = 30
     timezone: str = ""  # IANA timezone (e.g. "America/Denver"). Empty = auto-detect.
     release_channel: Literal["stable", "beta"] = "stable"
+    role_assignments: dict[str, ModelAssignment] = field(default_factory=dict)
 
 
 @dataclass(slots=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ from pollypm.config import load_config, project_config_path, render_example_conf
 from pollypm.models import (
     AccountConfig,
     KnownProject,
+    ModelAssignment,
     PollyPMConfig,
     PollyPMSettings,
     ProjectSettings,
@@ -475,3 +476,115 @@ def test_release_channel_invalid_falls_back_to_stable(
         "release_channel" in record.getMessage() and "bogus" in record.getMessage()
         for record in caplog.records
     )
+
+
+def test_role_assignments_round_trip_global_and_project_scope(tmp_path: Path) -> None:
+    project_root = tmp_path / "wire"
+    project_root.mkdir()
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            base_dir=tmp_path / ".pollypm",
+            logs_dir=tmp_path / ".pollypm" / "logs",
+            snapshots_dir=tmp_path / ".pollypm" / "snapshots",
+            state_db=tmp_path / ".pollypm" / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="claude_primary",
+            role_assignments={
+                "operator_pm": ModelAssignment(alias="opus-4.7"),
+                "architect": ModelAssignment(provider="claude", model="claude-opus-4-7"),
+                "worker": ModelAssignment(alias="codex-gpt-5.4"),
+                "reviewer": ModelAssignment(provider="codex", model="gpt-5.4"),
+            },
+        ),
+        accounts={
+            "claude_primary": AccountConfig(
+                name="claude_primary",
+                provider=ProviderKind.CLAUDE,
+                home=tmp_path / ".pollypm" / "homes" / "claude_primary",
+            )
+        },
+        sessions={
+            "operator": SessionConfig(
+                name="operator",
+                role="operator-pm",
+                provider=ProviderKind.CLAUDE,
+                account="claude_primary",
+                cwd=tmp_path,
+            )
+        },
+        projects={
+            "wire": KnownProject(
+                key="wire",
+                path=project_root,
+                role_assignments={
+                    "architect": ModelAssignment(alias="sonnet-4.6"),
+                    "worker": ModelAssignment(provider="codex", model="gpt-5.4"),
+                    "reviewer": ModelAssignment(alias="haiku-4.5"),
+                },
+            )
+        },
+    )
+
+    config_path = tmp_path / "pollypm.toml"
+    write_config(config, config_path, force=True)
+
+    loaded = load_config(config_path)
+
+    assert loaded.pollypm.role_assignments == config.pollypm.role_assignments
+    assert loaded.projects["wire"].role_assignments == config.projects["wire"].role_assignments
+
+
+def test_invalid_role_assignments_warn_and_drop_entries(tmp_path: Path, caplog) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        """
+[project]
+name = "pollypm"
+tmux_session = "pollypm"
+
+[pollypm]
+controller_account = "claude_primary"
+
+[pollypm.roles.architect]
+alias = "opus-4.7"
+provider = "claude"
+model = "claude-opus-4-7"
+
+[pollypm.roles.worker]
+
+[pollypm.roles.ghost]
+alias = "haiku-4.5"
+
+[accounts.claude_primary]
+provider = "claude"
+home = ".pollypm/homes/claude_primary"
+
+[sessions.operator]
+role = "operator-pm"
+provider = "claude"
+account = "claude_primary"
+cwd = "."
+
+[projects.demo]
+path = "demo"
+
+[projects.demo.roles.operator_pm]
+alias = "opus-4.7"
+"""
+    )
+    (tmp_path / "demo").mkdir()
+
+    import logging as _logging
+
+    with caplog.at_level(_logging.WARNING, logger="pollypm.config"):
+        config = load_config(config_path)
+
+    assert config.pollypm.role_assignments == {}
+    assert config.projects["demo"].role_assignments == {}
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("pollypm.roles.architect" in message for message in messages)
+    assert any("pollypm.roles.worker" in message for message in messages)
+    assert any("pollypm.roles.ghost" in message for message in messages)
+    assert any("projects.demo.roles.operator_pm" in message for message in messages)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,8 @@
+import pytest
+
 from pathlib import Path
 
-from pollypm.models import KnownProject, ProjectKind
+from pollypm.models import KnownProject, ModelAssignment, ProjectConfig, ProjectKind
 
 
 def test_known_project_display_label_prefers_name_without_persona() -> None:
@@ -24,3 +26,23 @@ def test_known_project_display_label_falls_back_to_key() -> None:
     )
 
     assert project.display_label() == "demo"
+
+
+def test_model_assignment_requires_exactly_one_variant() -> None:
+    assert ModelAssignment(alias="opus-4.7") == ModelAssignment(alias="opus-4.7")
+    assert ModelAssignment(provider="claude", model="claude-opus-4-7") == ModelAssignment(
+        provider="claude",
+        model="claude-opus-4-7",
+    )
+
+    with pytest.raises(ValueError):
+        ModelAssignment()
+
+    with pytest.raises(ValueError):
+        ModelAssignment(alias="opus-4.7", provider="claude", model="claude-opus-4-7")
+
+
+def test_project_config_alias_exposes_role_assignments_default() -> None:
+    project = ProjectConfig(key="demo", path=Path("/tmp/demo"))
+
+    assert project.role_assignments == {}


### PR DESCRIPTION
Closes #729

## Summary
- add `ModelAssignment` plus global/project `role_assignments` config fields
- round-trip role assignment tables through `pollypm.toml` and project blocks
- warn and drop invalid role entries instead of failing config load

## Verification
- `uv run pytest tests/test_models.py tests/test_config.py`
- `uv build`