### PR TITLE
roles-3: add role-routing resolver with live inheritance

### DIFF
--- a/src/pollypm/role_routing.py
+++ b/src/pollypm/role_routing.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+from typing import Literal
+
+from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+from pollypm.model_registry import Registry, load_registry, resolve_alias
+from pollypm.models import ModelAssignment, PollyPMConfig
+
+
+_log = logging.getLogger(__name__)
+_ROLE_KEYS = ("operator_pm", "architect", "worker", "reviewer")
+_FALLBACK_ASSIGNMENTS: dict[str, ModelAssignment] = {
+    "operator_pm": ModelAssignment(alias="codex-gpt-5.4"),
+    "architect": ModelAssignment(alias="opus-4.7"),
+    "worker": ModelAssignment(alias="codex-gpt-5.4"),
+    "reviewer": ModelAssignment(alias="sonnet-4.6"),
+}
+
+
+@dataclass(slots=True, frozen=True)
+class ResolvedAssignment:
+    provider: str
+    model: str
+    alias: str | None
+    source: Literal["project", "global", "fallback"]
+
+
+def _canonical_role(role: str) -> str:
+    canonical = (role or "").strip().replace("-", "_")
+    if canonical not in _ROLE_KEYS:
+        raise ValueError(
+            f"Unknown role {role!r}. Expected one of: {', '.join(_ROLE_KEYS)}"
+        )
+    return canonical
+
+
+def _resolved_from_assignment(
+    role: str,
+    assignment: ModelAssignment,
+    *,
+    source: Literal["project", "global", "fallback"],
+    registry: Registry,
+) -> ResolvedAssignment | None:
+    if assignment.alias is not None:
+        resolved = resolve_alias(assignment.alias, registry=registry)
+        if resolved is None:
+            _log.warning(
+                "Unknown model alias %r for %s from %s scope; falling through.",
+                assignment.alias,
+                role,
+                source,
+            )
+            return None
+        return ResolvedAssignment(
+            provider=resolved.provider or "",
+            model=resolved.model or "",
+            alias=assignment.alias,
+            source=source,
+        )
+    return ResolvedAssignment(
+        provider=assignment.provider or "",
+        model=assignment.model or "",
+        alias=None,
+        source=source,
+    )
+
+
+def resolve_role_assignment(
+    role: str,
+    project_key: str | None = None,
+    *,
+    config: PollyPMConfig | None = None,
+    registry: Registry | None = None,
+) -> ResolvedAssignment:
+    canonical_role = _canonical_role(role)
+    resolved_registry = registry or load_registry()
+    current_config = config or load_config(DEFAULT_CONFIG_PATH)
+
+    if project_key is not None:
+        project = current_config.projects.get(project_key)
+        if project is not None:
+            project_assignment = project.role_assignments.get(canonical_role)
+            if project_assignment is not None:
+                resolved = _resolved_from_assignment(
+                    canonical_role,
+                    project_assignment,
+                    source="project",
+                    registry=resolved_registry,
+                )
+                if resolved is not None:
+                    return resolved
+
+    global_assignment = current_config.pollypm.role_assignments.get(canonical_role)
+    if global_assignment is not None:
+        resolved = _resolved_from_assignment(
+            canonical_role,
+            global_assignment,
+            source="global",
+            registry=resolved_registry,
+        )
+        if resolved is not None:
+            return resolved
+
+    fallback = _resolved_from_assignment(
+        canonical_role,
+        _FALLBACK_ASSIGNMENTS[canonical_role],
+        source="fallback",
+        registry=resolved_registry,
+    )
+    if fallback is None:
+        raise RuntimeError(f"Fallback role assignment for {canonical_role} is invalid")
+    return fallback
+
+
+class RoleRoutingFacade:
+    def __init__(self, config_path: Path) -> None:
+        self._config_path = config_path
+
+    def resolve(self, role: str, project_key: str | None = None) -> ResolvedAssignment:
+        return resolve_role_assignment(
+            role,
+            project_key,
+            config=load_config(self._config_path),
+        )
+
+
+__all__ = [
+    "ResolvedAssignment",
+    "RoleRoutingFacade",
+    "resolve_role_assignment",
+]

--- a/src/pollypm/service_api/v1.py
+++ b/src/pollypm/service_api/v1.py
@@ -52,6 +52,7 @@ from pollypm.projects import (
     remove_project,
     set_workspace_root,
 )
+from pollypm.role_routing import RoleRoutingFacade
 from pollypm.schedulers.base import ScheduledJob
 from pollypm.storage.state import AlertRecord, StateStore
 from pollypm.supervisor import Supervisor
@@ -86,6 +87,7 @@ class PollyPMService:
     def __init__(self, config_path: Path) -> None:
         """Bind the service to a config file; all calls use this path."""
         self.config_path = config_path
+        self.role_routing = RoleRoutingFacade(config_path)
 
     def load_supervisor(self, *, readonly_state: bool = False) -> Supervisor:
         """Construct a fresh Supervisor from the bound config (internal helper)."""

--- a/tests/test_role_routing.py
+++ b/tests/test_role_routing.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from pollypm.model_registry import Registry
+from pollypm.models import (
+    AccountConfig,
+    KnownProject,
+    ModelAssignment,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectKind,
+    ProjectSettings,
+    ProviderKind,
+)
+from pollypm.role_routing import resolve_role_assignment
+
+
+def _config(tmp_path: Path) -> PollyPMConfig:
+    return PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            base_dir=tmp_path / ".pollypm",
+            logs_dir=tmp_path / ".pollypm/logs",
+            snapshots_dir=tmp_path / ".pollypm/snapshots",
+            state_db=tmp_path / ".pollypm/state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account="claude_main"),
+        accounts={
+            "claude_main": AccountConfig(
+                name="claude_main",
+                provider=ProviderKind.CLAUDE,
+                home=tmp_path / ".pollypm" / "homes" / "claude_main",
+            )
+        },
+        sessions={},
+        projects={
+            "demo": KnownProject(
+                key="demo",
+                path=tmp_path / "demo",
+                kind=ProjectKind.FOLDER,
+            )
+        },
+    )
+
+
+def test_project_override_wins_over_global(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    config.pollypm.role_assignments["architect"] = ModelAssignment(alias="opus-4.7")
+    config.projects["demo"].role_assignments["architect"] = ModelAssignment(
+        alias="sonnet-4.6"
+    )
+
+    resolved = resolve_role_assignment("architect", "demo", config=config)
+
+    assert resolved.alias == "sonnet-4.6"
+    assert resolved.provider == "claude"
+    assert resolved.source == "project"
+
+
+def test_global_assignment_used_when_project_has_no_override(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    config.pollypm.role_assignments["worker"] = ModelAssignment(alias="codex-gpt-5.4")
+
+    resolved = resolve_role_assignment("worker", "demo", config=config)
+
+    assert resolved.alias == "codex-gpt-5.4"
+    assert resolved.provider == "codex"
+    assert resolved.source == "global"
+
+
+def test_fallback_assignment_used_when_no_configured_assignment(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+
+    resolved = resolve_role_assignment("reviewer", "demo", config=config)
+
+    assert resolved.alias == "sonnet-4.6"
+    assert resolved.provider == "claude"
+    assert resolved.source == "fallback"
+
+
+def test_unknown_alias_falls_through_to_next_precedence_level(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    config = _config(tmp_path)
+    config.projects["demo"].role_assignments["architect"] = ModelAssignment(alias="missing")
+    config.pollypm.role_assignments["architect"] = ModelAssignment(alias="opus-4.7")
+
+    with caplog.at_level(logging.WARNING, logger="pollypm.role_routing"):
+        resolved = resolve_role_assignment("architect", "demo", config=config)
+
+    assert resolved.alias == "opus-4.7"
+    assert resolved.source == "global"
+    assert any("missing" in record.getMessage() for record in caplog.records)
+
+
+def test_explicit_pair_bypasses_registry_lookup(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    config.pollypm.role_assignments["reviewer"] = ModelAssignment(
+        provider="claude",
+        model="claude-review-custom",
+    )
+
+    resolved = resolve_role_assignment(
+        "reviewer",
+        "demo",
+        config=config,
+        registry=Registry(),
+    )
+
+    assert resolved.alias is None
+    assert resolved.provider == "claude"
+    assert resolved.model == "claude-review-custom"
+    assert resolved.source == "global"
+
+
+def test_live_inheritance_reflects_global_changes_without_project_copy(
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    config.pollypm.role_assignments["worker"] = ModelAssignment(alias="codex-gpt-5.4")
+
+    first = resolve_role_assignment("worker", "demo", config=config)
+    config.pollypm.role_assignments["worker"] = ModelAssignment(alias="sonnet-4.6")
+    second = resolve_role_assignment("worker", "demo", config=config)
+
+    assert first.alias == "codex-gpt-5.4"
+    assert second.alias == "sonnet-4.6"
+    assert second.source == "global"

--- a/tests/test_service_api.py
+++ b/tests/test_service_api.py
@@ -4,7 +4,16 @@ from pathlib import Path
 import subprocess
 
 from pollypm.config import write_config
-from pollypm.models import AccountConfig, KnownProject, PollyPMConfig, PollyPMSettings, ProjectKind, ProjectSettings, ProviderKind
+from pollypm.models import (
+    AccountConfig,
+    KnownProject,
+    ModelAssignment,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectKind,
+    ProjectSettings,
+    ProviderKind,
+)
 from pollypm.service_api import PollyPMService, render_json
 from pollypm.storage.state import StateStore
 from pollypm.task_backends.github import GitHubTaskBackendValidation
@@ -59,6 +68,41 @@ def test_service_suggest_worker_prompt_uses_worker_api(monkeypatch, tmp_path: Pa
     )
 
     assert service.suggest_worker_prompt(project_key="pollypm") == "Kick off pollypm"
+
+
+def test_service_role_routing_resolves_against_bound_config(tmp_path: Path) -> None:
+    project_root = tmp_path / "demo"
+    project_root.mkdir()
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            base_dir=tmp_path / ".pollypm",
+            logs_dir=tmp_path / ".pollypm/logs",
+            snapshots_dir=tmp_path / ".pollypm/snapshots",
+            state_db=tmp_path / ".pollypm/state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="claude_main",
+            role_assignments={"worker": ModelAssignment(alias="codex-gpt-5.4")},
+        ),
+        accounts={
+            "claude_main": AccountConfig(
+                name="claude_main",
+                provider=ProviderKind.CLAUDE,
+                home=tmp_path / ".pollypm" / "homes" / "claude_main",
+            )
+        },
+        sessions={},
+        projects={"demo": KnownProject(key="demo", path=project_root, kind=ProjectKind.FOLDER)},
+    )
+    config_path = tmp_path / "pollypm.toml"
+    write_config(config, config_path, force=True)
+
+    resolved = PollyPMService(config_path).role_routing.resolve("worker", "demo")
+
+    assert resolved.alias == "codex-gpt-5.4"
+    assert resolved.provider == "codex"
+    assert resolved.source == "global"
 
 
 def test_service_focus_and_send_input_use_supervisor(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
**Recreated from #739** (auto-closed when its stacked base `issue-730-model-registry` was deleted after #740 merged.) Now rebased onto current main.

Closes #731

## Summary
- add a central role-routing resolver with project, global, and fallback precedence
- expose bound role resolution through the PollyPM service facade
- cover live inheritance, alias fallback, and service binding with tests

## Testing
- `uv run pytest tests/test_role_routing.py tests/test_service_api.py tests/test_model_registry.py tests/test_models.py tests/test_config.py` — 47/47 pass