### PR TITLE
roles-2: add shipped model registry and alias resolver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 pollypm = [
+  "model_registry.toml",
   "plugins_builtin/*/pollypm-plugin.toml",
   "plugins_builtin/*/profiles/*.md",
   "plugins_builtin/*/flows/*.yaml",

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -9,6 +9,7 @@ from pollypm.models import (
     EventsRetentionSettings,
     LoggingSettings,
     MemorySettings,
+    ModelAssignment,
     KnownProject,
     PlannerSettings,
     PluginSettings,
@@ -29,6 +30,17 @@ PROJECT_CONFIG_DIRNAME = ".pollypm/config"
 PROJECT_CONFIG_FILENAME = "project.toml"
 
 _VALID_RELEASE_CHANNELS = ("stable", "beta")
+_GLOBAL_ROLE_ASSIGNMENT_KEYS = (
+    "operator_pm",
+    "architect",
+    "worker",
+    "reviewer",
+)
+_PROJECT_ROLE_ASSIGNMENT_KEYS = (
+    "architect",
+    "worker",
+    "reviewer",
+)
 
 _log = logging.getLogger(__name__)
 
@@ -110,6 +122,90 @@ def _resolve_path(base: Path, raw_path: str) -> Path:
 def _toml_str(value: str) -> str:
     """Escape a string for TOML double-quoted format."""
     return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _clean_optional_str(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _parse_role_assignments(
+    raw_roles: object,
+    *,
+    allowed_roles: tuple[str, ...],
+    scope_label: str,
+) -> dict[str, ModelAssignment]:
+    if not isinstance(raw_roles, dict):
+        return {}
+    assignments: dict[str, ModelAssignment] = {}
+    allowed = set(allowed_roles)
+    for role_name, role_raw in raw_roles.items():
+        if not isinstance(role_name, str):
+            _log.warning(
+                "Dropping invalid role assignment under %s: role key %r is not a string.",
+                scope_label,
+                role_name,
+            )
+            continue
+        if role_name not in allowed:
+            if role_name == "operator_pm" and "project" in scope_label:
+                reason = "operator_pm is global-only"
+            else:
+                reason = "unknown role"
+            _log.warning(
+                "Dropping invalid role assignment for %s.%s: %s.",
+                scope_label,
+                role_name,
+                reason,
+            )
+            continue
+        if not isinstance(role_raw, dict):
+            _log.warning(
+                "Dropping invalid role assignment for %s.%s: entry must be a table.",
+                scope_label,
+                role_name,
+            )
+            continue
+        alias = _clean_optional_str(role_raw.get("alias"))
+        provider = _clean_optional_str(role_raw.get("provider"))
+        model = _clean_optional_str(role_raw.get("model"))
+        if alias is not None and (provider is not None or model is not None):
+            _log.warning(
+                "Dropping invalid role assignment for %s.%s: alias and provider/model cannot both be set.",
+                scope_label,
+                role_name,
+            )
+            continue
+        if alias is None and provider is None and model is None:
+            _log.warning(
+                "Dropping invalid role assignment for %s.%s: empty assignment.",
+                scope_label,
+                role_name,
+            )
+            continue
+        if provider is None or model is None:
+            if alias is None:
+                _log.warning(
+                    "Dropping invalid role assignment for %s.%s: provider and model must both be set.",
+                    scope_label,
+                    role_name,
+                )
+                continue
+        try:
+            assignments[role_name] = ModelAssignment(
+                alias=alias,
+                provider=provider,
+                model=model,
+            )
+        except ValueError:
+            _log.warning(
+                "Dropping invalid role assignment for %s.%s: assignment must be alias-only or provider/model-only.",
+                scope_label,
+                role_name,
+            )
+    return assignments
 
 
 def _format_path(path: Path, root: Path) -> str:
@@ -268,6 +364,11 @@ def _parse_pollypm_settings(raw: dict[str, object], sessions: dict[str, SessionC
         lease_timeout_minutes=max(1, int(pollypm_raw.get("lease_timeout_minutes", 30))),
         timezone=_validate_timezone(str(pollypm_raw.get("timezone", ""))),
         release_channel=_validate_release_channel(pollypm_raw.get("release_channel")),
+        role_assignments=_parse_role_assignments(
+            pollypm_raw.get("roles", {}),
+            allowed_roles=_GLOBAL_ROLE_ASSIGNMENT_KEYS,
+            scope_label="pollypm.roles",
+        ),
     )
 
 
@@ -499,6 +600,11 @@ def _parse_known_projects(raw: dict[str, object], *, base: Path) -> dict[str, Kn
             persona_name=item_raw.get("persona_name") if isinstance(item_raw.get("persona_name"), str) else None,
             kind=ProjectKind(item_raw.get("kind", "folder")),
             tracked=bool(item_raw.get("tracked", False)),
+            role_assignments=_parse_role_assignments(
+                item_raw.get("roles", {}),
+                allowed_roles=_PROJECT_ROLE_ASSIGNMENT_KEYS,
+                scope_label=f"projects.{project_key}.roles",
+            ),
         )
     return projects
 
@@ -614,6 +720,34 @@ def load_config(path: Path = DEFAULT_CONFIG_PATH) -> PollyPMConfig:
     return config
 
 
+def _ordered_role_assignments(
+    assignments: dict[str, ModelAssignment],
+    allowed_roles: tuple[str, ...],
+) -> list[tuple[str, ModelAssignment]]:
+    return [
+        (role_name, assignments[role_name])
+        for role_name in allowed_roles
+        if role_name in assignments
+    ]
+
+
+def _append_role_assignment_tables(
+    lines: list[str],
+    *,
+    table_prefix: str,
+    assignments: dict[str, ModelAssignment],
+    allowed_roles: tuple[str, ...],
+) -> None:
+    for role_name, assignment in _ordered_role_assignments(assignments, allowed_roles):
+        lines.append(f"[{table_prefix}.{role_name}]")
+        if assignment.alias is not None:
+            lines.append(f'alias = "{_toml_str(assignment.alias)}"')
+        else:
+            lines.append(f'provider = "{_toml_str(assignment.provider or "")}"')
+            lines.append(f'model = "{_toml_str(assignment.model or "")}"')
+        lines.append("")
+
+
 def _render_global_config(config: PollyPMConfig) -> str:
     root = config.project.root_dir
     lines = [
@@ -641,6 +775,12 @@ def _render_global_config(config: PollyPMConfig) -> str:
         items = ", ".join(f'"{name}"' for name in config.pollypm.failover_accounts)
         lines.append(f"failover_accounts = [{items}]")
     lines.append("")
+    _append_role_assignment_tables(
+        lines,
+        table_prefix="pollypm.roles",
+        assignments=config.pollypm.role_assignments,
+        allowed_roles=_GLOBAL_ROLE_ASSIGNMENT_KEYS,
+    )
 
     lines.extend(
         [
@@ -758,6 +898,12 @@ def _render_global_config(config: PollyPMConfig) -> str:
         if project.tracked:
             lines.append("tracked = true")
         lines.append("")
+        _append_role_assignment_tables(
+            lines,
+            table_prefix=f"projects.{project_key}.roles",
+            assignments=project.role_assignments,
+            allowed_roles=_PROJECT_ROLE_ASSIGNMENT_KEYS,
+        )
 
     return "\n".join(lines).rstrip() + "\n"
 

--- a/src/pollypm/model_registry.py
+++ b/src/pollypm/model_registry.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from importlib import resources
+import logging
+from pathlib import Path
+import tomllib
+
+from pollypm.models import ModelAssignment
+
+
+_log = logging.getLogger(__name__)
+_DEFAULT_OVERLAY_PATH = Path.home() / ".pollypm" / "model_registry.toml"
+
+
+@dataclass(slots=True, frozen=True)
+class AliasRecord:
+    provider: str
+    model: str
+    capabilities: tuple[str, ...] = ()
+
+
+@dataclass(slots=True, frozen=True)
+class RoleRequirements:
+    preferred: tuple[str, ...] = ()
+    discouraged: tuple[str, ...] = ()
+
+
+@dataclass(slots=True)
+class Registry:
+    aliases: dict[str, AliasRecord] = field(default_factory=dict)
+    role_requirements: dict[str, RoleRequirements] = field(default_factory=dict)
+
+
+def _fallback_registry() -> Registry:
+    return Registry(
+        aliases={
+            "opus-4.7": AliasRecord(
+                provider="claude",
+                model="claude-opus-4-7",
+                capabilities=(
+                    "reasoning",
+                    "tool_use",
+                    "long_context",
+                    "strong_planning",
+                ),
+            ),
+            "sonnet-4.6": AliasRecord(
+                provider="claude",
+                model="claude-sonnet-4-6",
+                capabilities=(
+                    "reasoning",
+                    "tool_use",
+                    "long_context",
+                    "balanced_planning",
+                ),
+            ),
+            "haiku-4.5": AliasRecord(
+                provider="claude",
+                model="claude-haiku-4-5-20251001",
+                capabilities=(
+                    "tool_use",
+                    "fast",
+                    "weak_planning",
+                ),
+            ),
+            "codex-gpt-5.4": AliasRecord(
+                provider="codex",
+                model="gpt-5.4",
+                capabilities=(
+                    "reasoning",
+                    "tool_use",
+                    "long_context",
+                    "strong_planning",
+                ),
+            ),
+        },
+        role_requirements={
+            "operator_pm": RoleRequirements(
+                preferred=("reasoning", "long_context"),
+                discouraged=("weak_planning",),
+            ),
+            "architect": RoleRequirements(
+                preferred=("strong_planning", "reasoning"),
+                discouraged=("weak_planning",),
+            ),
+            "worker": RoleRequirements(
+                preferred=("tool_use", "reasoning"),
+                discouraged=(),
+            ),
+            "reviewer": RoleRequirements(
+                preferred=("reasoning", "long_context"),
+                discouraged=("weak_planning",),
+            ),
+        },
+    )
+
+
+def _clean_str(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    cleaned: list[str] = []
+    for item in value:
+        entry = _clean_str(item)
+        if entry is not None:
+            cleaned.append(entry)
+    return tuple(dict.fromkeys(cleaned))
+
+
+def _iter_alias_tables(
+    raw_aliases: dict[str, object],
+    *,
+    prefix: str = "",
+):
+    for alias, alias_raw in raw_aliases.items():
+        if not isinstance(alias, str) or not isinstance(alias_raw, dict):
+            continue
+        full_alias = f"{prefix}.{alias}" if prefix else alias
+        provider = _clean_str(alias_raw.get("provider"))
+        model = _clean_str(alias_raw.get("model"))
+        if provider is not None and model is not None:
+            yield full_alias, alias_raw
+            continue
+        nested_tables = any(isinstance(value, dict) for value in alias_raw.values())
+        if nested_tables:
+            yield from _iter_alias_tables(alias_raw, prefix=full_alias)
+            continue
+        yield full_alias, alias_raw
+
+
+def _read_shipped_registry_text() -> str:
+    ref = resources.files("pollypm").joinpath("model_registry.toml")
+    return ref.read_text(encoding="utf-8")
+
+
+def _load_toml_text(text: str, *, source: str) -> dict[str, object] | None:
+    try:
+        raw = tomllib.loads(text)
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("Failed to parse %s: %s. Falling back to minimal registry.", source, exc)
+        return None
+    if not isinstance(raw, dict):
+        _log.warning("Failed to parse %s: top-level document must be a table.", source)
+        return None
+    return raw
+
+
+def _registry_from_raw(raw: dict[str, object], *, source: str) -> Registry:
+    registry = Registry()
+    aliases_raw = raw.get("aliases", {})
+    if isinstance(aliases_raw, dict):
+        for alias, alias_raw in _iter_alias_tables(aliases_raw):
+            provider = _clean_str(alias_raw.get("provider"))
+            model = _clean_str(alias_raw.get("model"))
+            if provider is None or model is None:
+                _log.warning(
+                    "Ignoring invalid alias %r in %s: provider/model required.",
+                    alias,
+                    source,
+                )
+                continue
+            registry.aliases[alias] = AliasRecord(
+                provider=provider,
+                model=model,
+                capabilities=_string_tuple(alias_raw.get("capabilities", [])),
+            )
+    requirements_raw = raw.get("role_requirements", {})
+    if isinstance(requirements_raw, dict):
+        for role, role_raw in requirements_raw.items():
+            if not isinstance(role, str) or not isinstance(role_raw, dict):
+                continue
+            registry.role_requirements[role] = RoleRequirements(
+                preferred=_string_tuple(role_raw.get("preferred", [])),
+                discouraged=_string_tuple(role_raw.get("discouraged", [])),
+            )
+    return registry
+
+
+def _merge_registry(base: Registry, overlay: Registry) -> Registry:
+    aliases = dict(base.aliases)
+    aliases.update(overlay.aliases)
+    role_requirements = dict(base.role_requirements)
+    role_requirements.update(overlay.role_requirements)
+    return Registry(aliases=aliases, role_requirements=role_requirements)
+
+
+def load_registry(overlay_path: Path | None = None) -> Registry:
+    registry = _fallback_registry()
+    shipped_raw = _load_toml_text(
+        _read_shipped_registry_text(),
+        source="shipped model registry",
+    )
+    if shipped_raw is not None:
+        registry = _merge_registry(
+            registry,
+            _registry_from_raw(shipped_raw, source="shipped model registry"),
+        )
+
+    candidate_overlay = _DEFAULT_OVERLAY_PATH if overlay_path is None else overlay_path
+    if candidate_overlay is None or not candidate_overlay.exists():
+        return registry
+
+    overlay_raw = _load_toml_text(
+        candidate_overlay.read_text(encoding="utf-8"),
+        source=str(candidate_overlay),
+    )
+    if overlay_raw is None:
+        return registry
+    return _merge_registry(
+        registry,
+        _registry_from_raw(overlay_raw, source=str(candidate_overlay)),
+    )
+
+
+def resolve_alias(
+    alias: str,
+    *,
+    registry: Registry | None = None,
+) -> ModelAssignment | None:
+    entry = (registry or load_registry()).aliases.get(alias)
+    if entry is None:
+        return None
+    return ModelAssignment(provider=entry.provider, model=entry.model)
+
+
+def _record_for_assignment(
+    assignment: ModelAssignment,
+    *,
+    registry: Registry,
+) -> AliasRecord | None:
+    if assignment.alias is not None:
+        return registry.aliases.get(assignment.alias)
+    for record in registry.aliases.values():
+        if record.provider == assignment.provider and record.model == assignment.model:
+            return record
+    return None
+
+
+def advisories_for(
+    role: str,
+    assignment: ModelAssignment,
+    *,
+    registry: Registry | None = None,
+) -> list[str]:
+    resolved_registry = registry or load_registry()
+    requirements = resolved_registry.role_requirements.get(role)
+    if requirements is None:
+        return []
+    record = _record_for_assignment(assignment, registry=resolved_registry)
+    if record is None:
+        return []
+
+    capabilities = set(record.capabilities)
+    advisories: list[str] = []
+    for discouraged in requirements.discouraged:
+        if discouraged in capabilities:
+            advisories.append(
+                f"{role} is not recommended for models tagged {discouraged}."
+            )
+    if advisories:
+        return advisories
+
+    missing = [
+        preferred
+        for preferred in requirements.preferred
+        if preferred not in capabilities
+    ]
+    if missing:
+        advisories.append(
+            f"{role} works best with {', '.join(missing)}; current model may be a weak match."
+        )
+    return advisories
+
+
+__all__ = [
+    "AliasRecord",
+    "Registry",
+    "RoleRequirements",
+    "advisories_for",
+    "load_registry",
+    "resolve_alias",
+]

--- a/src/pollypm/model_registry.toml
+++ b/src/pollypm/model_registry.toml
@@ -1,0 +1,35 @@
+[aliases."opus-4.7"]
+provider = "claude"
+model = "claude-opus-4-7"
+capabilities = ["reasoning", "tool_use", "long_context", "strong_planning"]
+
+[aliases."sonnet-4.6"]
+provider = "claude"
+model = "claude-sonnet-4-6"
+capabilities = ["reasoning", "tool_use", "long_context", "balanced_planning"]
+
+[aliases."haiku-4.5"]
+provider = "claude"
+model = "claude-haiku-4-5-20251001"
+capabilities = ["tool_use", "fast", "weak_planning"]
+
+[aliases."codex-gpt-5.4"]
+provider = "codex"
+model = "gpt-5.4"
+capabilities = ["reasoning", "tool_use", "long_context", "strong_planning"]
+
+[role_requirements.operator_pm]
+preferred = ["reasoning", "long_context"]
+discouraged = ["weak_planning"]
+
+[role_requirements.architect]
+preferred = ["strong_planning", "reasoning"]
+discouraged = ["weak_planning"]
+
+[role_requirements.worker]
+preferred = ["tool_use", "reasoning"]
+discouraged = []
+
+[role_requirements.reviewer]
+preferred = ["reasoning", "long_context"]
+discouraged = ["weak_planning"]

--- a/src/pollypm/models.py
+++ b/src/pollypm/models.py
@@ -34,6 +34,26 @@ class ProjectSettings:
 
 
 @dataclass(slots=True)
+class ModelAssignment:
+    alias: str | None = None
+    provider: str | None = None
+    model: str | None = None
+
+    def __post_init__(self) -> None:
+        has_alias = isinstance(self.alias, str) and bool(self.alias.strip())
+        has_pair = (
+            isinstance(self.provider, str)
+            and bool(self.provider.strip())
+            and isinstance(self.model, str)
+            and bool(self.model.strip())
+        )
+        if has_alias == has_pair:
+            raise ValueError(
+                "ModelAssignment requires exactly one of alias or provider/model."
+            )
+
+
+@dataclass(slots=True)
 class KnownProject:
     key: str
     path: Path
@@ -41,9 +61,13 @@ class KnownProject:
     persona_name: str | None = None
     kind: ProjectKind = ProjectKind.FOLDER
     tracked: bool = False
+    role_assignments: dict[str, ModelAssignment] = field(default_factory=dict)
 
     def display_label(self) -> str:
         return self.name or self.key
+
+
+ProjectConfig = KnownProject
 
 
 @dataclass(slots=True)
@@ -84,6 +108,7 @@ class PollyPMSettings:
     lease_timeout_minutes: int = 30
     timezone: str = ""  # IANA timezone (e.g. "America/Denver"). Empty = auto-detect.
     release_channel: Literal["stable", "beta"] = "stable"
+    role_assignments: dict[str, ModelAssignment] = field(default_factory=dict)
 
 
 @dataclass(slots=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ from pollypm.config import load_config, project_config_path, render_example_conf
 from pollypm.models import (
     AccountConfig,
     KnownProject,
+    ModelAssignment,
     PollyPMConfig,
     PollyPMSettings,
     ProjectSettings,
@@ -475,3 +476,115 @@ def test_release_channel_invalid_falls_back_to_stable(
         "release_channel" in record.getMessage() and "bogus" in record.getMessage()
         for record in caplog.records
     )
+
+
+def test_role_assignments_round_trip_global_and_project_scope(tmp_path: Path) -> None:
+    project_root = tmp_path / "wire"
+    project_root.mkdir()
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            base_dir=tmp_path / ".pollypm",
+            logs_dir=tmp_path / ".pollypm" / "logs",
+            snapshots_dir=tmp_path / ".pollypm" / "snapshots",
+            state_db=tmp_path / ".pollypm" / "state.db",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="claude_primary",
+            role_assignments={
+                "operator_pm": ModelAssignment(alias="opus-4.7"),
+                "architect": ModelAssignment(provider="claude", model="claude-opus-4-7"),
+                "worker": ModelAssignment(alias="codex-gpt-5.4"),
+                "reviewer": ModelAssignment(provider="codex", model="gpt-5.4"),
+            },
+        ),
+        accounts={
+            "claude_primary": AccountConfig(
+                name="claude_primary",
+                provider=ProviderKind.CLAUDE,
+                home=tmp_path / ".pollypm" / "homes" / "claude_primary",
+            )
+        },
+        sessions={
+            "operator": SessionConfig(
+                name="operator",
+                role="operator-pm",
+                provider=ProviderKind.CLAUDE,
+                account="claude_primary",
+                cwd=tmp_path,
+            )
+        },
+        projects={
+            "wire": KnownProject(
+                key="wire",
+                path=project_root,
+                role_assignments={
+                    "architect": ModelAssignment(alias="sonnet-4.6"),
+                    "worker": ModelAssignment(provider="codex", model="gpt-5.4"),
+                    "reviewer": ModelAssignment(alias="haiku-4.5"),
+                },
+            )
+        },
+    )
+
+    config_path = tmp_path / "pollypm.toml"
+    write_config(config, config_path, force=True)
+
+    loaded = load_config(config_path)
+
+    assert loaded.pollypm.role_assignments == config.pollypm.role_assignments
+    assert loaded.projects["wire"].role_assignments == config.projects["wire"].role_assignments
+
+
+def test_invalid_role_assignments_warn_and_drop_entries(tmp_path: Path, caplog) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        """
+[project]
+name = "pollypm"
+tmux_session = "pollypm"
+
+[pollypm]
+controller_account = "claude_primary"
+
+[pollypm.roles.architect]
+alias = "opus-4.7"
+provider = "claude"
+model = "claude-opus-4-7"
+
+[pollypm.roles.worker]
+
+[pollypm.roles.ghost]
+alias = "haiku-4.5"
+
+[accounts.claude_primary]
+provider = "claude"
+home = ".pollypm/homes/claude_primary"
+
+[sessions.operator]
+role = "operator-pm"
+provider = "claude"
+account = "claude_primary"
+cwd = "."
+
+[projects.demo]
+path = "demo"
+
+[projects.demo.roles.operator_pm]
+alias = "opus-4.7"
+"""
+    )
+    (tmp_path / "demo").mkdir()
+
+    import logging as _logging
+
+    with caplog.at_level(_logging.WARNING, logger="pollypm.config"):
+        config = load_config(config_path)
+
+    assert config.pollypm.role_assignments == {}
+    assert config.projects["demo"].role_assignments == {}
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("pollypm.roles.architect" in message for message in messages)
+    assert any("pollypm.roles.worker" in message for message in messages)
+    assert any("pollypm.roles.ghost" in message for message in messages)
+    assert any("projects.demo.roles.operator_pm" in message for message in messages)

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from importlib import resources
+import logging
+from pathlib import Path
+
+from pollypm.model_registry import (
+    AliasRecord,
+    Registry,
+    RoleRequirements,
+    advisories_for,
+    load_registry,
+    resolve_alias,
+)
+from pollypm.models import ModelAssignment
+
+
+def test_shipped_registry_includes_minimum_aliases() -> None:
+    registry = load_registry(overlay_path=Path("/tmp/does-not-exist"))
+
+    assert {
+        "opus-4.7",
+        "sonnet-4.6",
+        "haiku-4.5",
+        "codex-gpt-5.4",
+    }.issubset(registry.aliases)
+    shipped_text = resources.files("pollypm").joinpath("model_registry.toml").read_text(
+        encoding="utf-8"
+    )
+    assert "opus-4.7" in shipped_text
+
+
+def test_overlay_merge_adds_and_overrides_aliases(tmp_path: Path) -> None:
+    overlay_path = tmp_path / "model_registry.toml"
+    overlay_path.write_text(
+        """
+[aliases.opus-4.7]
+provider = "claude"
+model = "claude-opus-4-7-hotfix"
+capabilities = ["reasoning"]
+
+[aliases.custom-codex]
+provider = "codex"
+model = "gpt-5.4-mini"
+capabilities = ["tool_use"]
+"""
+    )
+
+    registry = load_registry(overlay_path=overlay_path)
+
+    assert registry.aliases["custom-codex"].model == "gpt-5.4-mini"
+    assert registry.aliases["opus-4.7"].model == "claude-opus-4-7-hotfix"
+
+
+def test_resolve_alias_returns_assignment_and_miss_none() -> None:
+    registry = load_registry(overlay_path=Path("/tmp/does-not-exist"))
+
+    assert resolve_alias("codex-gpt-5.4", registry=registry) == ModelAssignment(
+        provider="codex",
+        model="gpt-5.4",
+    )
+    assert resolve_alias("missing-alias", registry=registry) is None
+
+
+def test_advisories_cover_preferred_discouraged_and_unknown_capabilities() -> None:
+    registry = Registry(
+        aliases={
+            "good": AliasRecord(
+                provider="claude",
+                model="good-model",
+                capabilities=("strong_planning", "reasoning", "experimental"),
+            ),
+            "bad": AliasRecord(
+                provider="claude",
+                model="bad-model",
+                capabilities=("weak_planning",),
+            ),
+        },
+        role_requirements={
+            "architect": RoleRequirements(
+                preferred=("strong_planning", "reasoning"),
+                discouraged=("weak_planning",),
+            )
+        },
+    )
+
+    assert advisories_for("architect", ModelAssignment(alias="good"), registry=registry) == []
+    bad = advisories_for("architect", ModelAssignment(alias="bad"), registry=registry)
+    assert bad
+    assert "weak_planning" in bad[0]
+    assert advisories_for(
+        "architect",
+        ModelAssignment(provider="claude", model="good-model"),
+        registry=registry,
+    ) == []
+
+
+def test_malformed_registry_tolerates_bad_shipped_and_overlay(
+    tmp_path: Path,
+    monkeypatch,
+    caplog,
+) -> None:
+    overlay_path = tmp_path / "model_registry.toml"
+    overlay_path.write_text("[aliases.bad")
+    monkeypatch.setattr(
+        "pollypm.model_registry._read_shipped_registry_text",
+        lambda: "[aliases.broken",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="pollypm.model_registry"):
+        registry = load_registry(overlay_path=overlay_path)
+
+    assert "opus-4.7" in registry.aliases
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("shipped model registry" in message for message in messages)
+    assert any(str(overlay_path) in message for message in messages)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,8 @@
+import pytest
+
 from pathlib import Path
 
-from pollypm.models import KnownProject, ProjectKind
+from pollypm.models import KnownProject, ModelAssignment, ProjectConfig, ProjectKind
 
 
 def test_known_project_display_label_prefers_name_without_persona() -> None:
@@ -24,3 +26,23 @@ def test_known_project_display_label_falls_back_to_key() -> None:
     )
 
     assert project.display_label() == "demo"
+
+
+def test_model_assignment_requires_exactly_one_variant() -> None:
+    assert ModelAssignment(alias="opus-4.7") == ModelAssignment(alias="opus-4.7")
+    assert ModelAssignment(provider="claude", model="claude-opus-4-7") == ModelAssignment(
+        provider="claude",
+        model="claude-opus-4-7",
+    )
+
+    with pytest.raises(ValueError):
+        ModelAssignment()
+
+    with pytest.raises(ValueError):
+        ModelAssignment(alias="opus-4.7", provider="claude", model="claude-opus-4-7")
+
+
+def test_project_config_alias_exposes_role_assignments_default() -> None:
+    project = ProjectConfig(key="demo", path=Path("/tmp/demo"))
+
+    assert project.role_assignments == {}


### PR DESCRIPTION
## Summary
- add a shipped model registry with alias resolution and optional user overlay support
- expose role advisories for weak model-role matches
- package the registry file and cover the loader behavior with tests

## Testing
- uv run pytest tests/test_model_registry.py tests/test_models.py tests/test_config.py
- uv build