### PR TITLE
roles-4: wire role routing into session launches

### DIFF
--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -83,6 +83,7 @@ def default_session_args(
     *,
     open_permissions: bool = True,
     role: str = "",
+    model: str | None = None,
 ) -> list[str]:
     """Dispatch the role-to-CLI-flag mapping to the provider package.
 
@@ -96,11 +97,19 @@ def default_session_args(
     if provider is ProviderKind.CLAUDE:
         from pollypm.providers.claude.session_args import session_args
 
-        return session_args(open_permissions=open_permissions, role=role)
+        return session_args(
+            open_permissions=open_permissions,
+            role=role,
+            model=model,
+        )
     if provider is ProviderKind.CODEX:
         from pollypm.providers.codex.session_args import session_args
 
-        return session_args(open_permissions=open_permissions, role=role)
+        return session_args(
+            open_permissions=open_permissions,
+            role=role,
+            model=model,
+        )
     return []
 
 
@@ -109,8 +118,14 @@ def default_control_args(
     *,
     open_permissions: bool = True,
     role: str = "",
+    model: str | None = None,
 ) -> list[str]:
-    return default_session_args(provider, open_permissions=open_permissions, role=role)
+    return default_session_args(
+        provider,
+        open_permissions=open_permissions,
+        role=role,
+        model=model,
+    )
 
 
 def _prime_claude_home(home: Path) -> None:

--- a/src/pollypm/plugins_builtin/default_launch_planner/planner.py
+++ b/src/pollypm/plugins_builtin/default_launch_planner/planner.py
@@ -17,6 +17,7 @@ stays a clean seam we can swap later.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
+import logging
 from typing import TYPE_CHECKING, Callable
 
 from pollypm.models import AccountConfig, ProviderKind, SessionConfig, SessionLaunchSpec
@@ -24,6 +25,7 @@ from pollypm.projects import ensure_session_lock
 from pollypm.providers import get_provider
 from pollypm.providers.args import sanitize_provider_args
 from pollypm.providers.base import LaunchCommand
+from pollypm.role_routing import resolved_provider_kind, resolve_role_assignment
 from pollypm.runtimes import get_runtime
 
 if TYPE_CHECKING:
@@ -32,6 +34,45 @@ if TYPE_CHECKING:
 
 
 _CONTROL_ROLES = frozenset({"heartbeat-supervisor", "operator-pm", "triage", "reviewer"})
+_ROUTED_ROLES = frozenset({"operator-pm", "architect", "worker", "reviewer"})
+_log = logging.getLogger(__name__)
+
+
+def _preferred_account_names(
+    config: "PollyPMConfig",
+    *,
+    session: SessionConfig,
+    override_account: str | None,
+) -> list[str]:
+    names: list[str] = []
+    for name in (
+        override_account,
+        session.account,
+        config.pollypm.controller_account,
+        *config.pollypm.failover_accounts,
+        *config.accounts,
+    ):
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
+def _first_account_for_provider(
+    config: "PollyPMConfig",
+    *,
+    provider: ProviderKind,
+    session: SessionConfig,
+    override_account: str | None,
+) -> str | None:
+    for name in _preferred_account_names(
+        config,
+        session=session,
+        override_account=override_account,
+    ):
+        account = config.accounts.get(name)
+        if account is not None and account.provider is provider:
+            return name
+    return None
 
 
 @dataclass(slots=True)
@@ -159,6 +200,7 @@ class DefaultLaunchPlanner:
         from pollypm.onboarding import default_control_args, default_session_args
 
         effective = session
+        routed_assignment = None
         try:
             runtime = ctx.store.get_session_runtime(session.name)
         except Exception:  # noqa: BLE001
@@ -182,14 +224,74 @@ class DefaultLaunchPlanner:
                         ctx.store.set_session_runtime(session.name, effective_account="")
                     except Exception:  # noqa: BLE001
                         pass
-        if ctx.readonly_state:
-            return effective
+        if session.role in _ROUTED_ROLES:
+            project_key = None if session.role == "operator-pm" else session.project
+            routed_assignment = resolve_role_assignment(
+                session.role,
+                project_key,
+                config=ctx.config,
+            )
+            try:
+                routed_provider = resolved_provider_kind(routed_assignment)
+            except ValueError:
+                _log.warning(
+                    "Ignoring invalid routed provider %r for %s session %s.",
+                    routed_assignment.provider,
+                    session.role,
+                    session.name,
+                )
+            else:
+                if routed_assignment.source != "fallback":
+                    account_name = _first_account_for_provider(
+                        ctx.config,
+                        provider=routed_provider,
+                        session=effective,
+                        override_account=override_account,
+                    )
+                    if account_name is None:
+                        _log.warning(
+                            "Role routing resolved %s session %s to %s/%s from %s, but no compatible account is configured; "
+                            "keeping the existing provider/account.",
+                            session.role,
+                            session.name,
+                            routed_assignment.provider,
+                            routed_assignment.model,
+                            routed_assignment.source,
+                        )
+                        routed_assignment = None
+                    else:
+                        effective = replace(
+                            effective,
+                            provider=routed_provider,
+                            account=account_name,
+                        )
+                        _log.info(
+                            "Role routing resolved %s session %s to %s/%s from %s.",
+                            session.role,
+                            session.name,
+                            routed_assignment.provider,
+                            routed_assignment.model,
+                            routed_assignment.source,
+                        )
+                elif effective.provider is routed_provider:
+                    _log.info(
+                        "Role routing resolved %s session %s to %s/%s from %s.",
+                        session.role,
+                        session.name,
+                        routed_assignment.provider,
+                        routed_assignment.model,
+                        routed_assignment.source,
+                    )
+                else:
+                    routed_assignment = None
         if effective.account not in ctx.config.accounts:
             # Fall back to controller account if the session's account is missing
             if controller_account and controller_account in ctx.config.accounts:
                 effective = replace(effective, account=controller_account)
             else:
                 return effective
+        if ctx.readonly_state:
+            return effective
         account = ctx.config.accounts[effective.account]
         profile_prompt = ctx.resolve_profile_prompt(effective, account)
         if effective.role in _CONTROL_ROLES:
@@ -200,6 +302,7 @@ class DefaultLaunchPlanner:
                     account.provider,
                     open_permissions=ctx.config.pollypm.open_permissions_by_default,
                     role=effective.role,
+                    model=routed_assignment.model if routed_assignment is not None else None,
                 ),
             )
         else:
@@ -220,6 +323,17 @@ class DefaultLaunchPlanner:
                         account.provider,
                         open_permissions=ctx.config.pollypm.open_permissions_by_default,
                         role=effective.role,
+                        model=routed_assignment.model if routed_assignment is not None else None,
+                    ),
+                )
+            elif routed_assignment is not None:
+                effective = replace(
+                    effective,
+                    args=default_session_args(
+                        account.provider,
+                        open_permissions=ctx.config.pollypm.open_permissions_by_default,
+                        role=effective.role,
+                        model=routed_assignment.model,
                     ),
                 )
             else:

--- a/src/pollypm/providers/claude/session_args.py
+++ b/src/pollypm/providers/claude/session_args.py
@@ -22,7 +22,12 @@ _NO_WRITE_TOOLS = "Edit,Write,MultiEdit,NotebookEdit"
 _OPERATOR_DISALLOWED = "Agent,Edit,Write,MultiEdit,NotebookEdit"
 
 
-def session_args(*, open_permissions: bool = True, role: str = "") -> list[str]:
+def session_args(
+    *,
+    open_permissions: bool = True,
+    role: str = "",
+    model: str | None = None,
+) -> list[str]:
     """Return the Claude CLI argv tail for a session of ``role``.
 
     Behavior:
@@ -46,6 +51,8 @@ def session_args(*, open_permissions: bool = True, role: str = "") -> list[str]:
     elif role == "operator-pm":
         args.extend(["--allowedTools", _OPERATOR_TOOLS])
         args.extend(["--disallowedTools", _OPERATOR_DISALLOWED])
+    if model:
+        args.extend(["--model", model])
     return args
 
 

--- a/src/pollypm/providers/codex/session_args.py
+++ b/src/pollypm/providers/codex/session_args.py
@@ -10,7 +10,12 @@ know about either provider's flag vocabulary.
 from __future__ import annotations
 
 
-def session_args(*, open_permissions: bool = True, role: str = "") -> list[str]:
+def session_args(
+    *,
+    open_permissions: bool = True,
+    role: str = "",
+    model: str | None = None,
+) -> list[str]:
     """Return the Codex CLI argv tail for a session of ``role``.
 
     Behavior:
@@ -26,12 +31,16 @@ def session_args(*, open_permissions: bool = True, role: str = "") -> list[str]:
       default for ad-hoc launches).
     """
     if role in {"heartbeat-supervisor", "operator-pm"}:
-        return ["--sandbox", "read-only", "--ask-for-approval", "never"]
-    if role == "worker":
-        return ["--sandbox", "workspace-write", "--ask-for-approval", "never"]
-    if open_permissions:
-        return ["--dangerously-bypass-approvals-and-sandbox"]
-    return []
+        args = ["--sandbox", "read-only", "--ask-for-approval", "never"]
+    elif role == "worker":
+        args = ["--sandbox", "workspace-write", "--ask-for-approval", "never"]
+    elif open_permissions:
+        args = ["--dangerously-bypass-approvals-and-sandbox"]
+    else:
+        args = []
+    if model:
+        args.extend(["--model", model])
+    return args
 
 
 __all__ = ["session_args"]

--- a/src/pollypm/role_routing.py
+++ b/src/pollypm/role_routing.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 from pollypm.config import DEFAULT_CONFIG_PATH, load_config
 from pollypm.model_registry import Registry, load_registry, resolve_alias
-from pollypm.models import ModelAssignment, PollyPMConfig
+from pollypm.models import ModelAssignment, PollyPMConfig, ProviderKind
 
 
 _log = logging.getLogger(__name__)
@@ -127,8 +127,13 @@ class RoleRoutingFacade:
         )
 
 
+def resolved_provider_kind(resolved: ResolvedAssignment) -> ProviderKind:
+    return ProviderKind(resolved.provider)
+
+
 __all__ = [
     "ResolvedAssignment",
     "RoleRoutingFacade",
+    "resolved_provider_kind",
     "resolve_role_assignment",
 ]

--- a/src/pollypm/work/session_manager.py
+++ b/src/pollypm/work/session_manager.py
@@ -85,6 +85,26 @@ def _now_dt() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _first_matching_account(
+    accounts: dict[str, object],
+    *,
+    provider: object,
+    preferred_names: list[str],
+) -> tuple[str, object] | tuple[None, None]:
+    ordered: list[str] = []
+    for name in preferred_names:
+        if name and name not in ordered:
+            ordered.append(name)
+    for name in accounts:
+        if name not in ordered:
+            ordered.append(name)
+    for name in ordered:
+        account = accounts.get(name)
+        if account is not None and getattr(account, "provider", None) is provider:
+            return name, account
+    return None, None
+
+
 # ---------------------------------------------------------------------------
 # SessionManager
 # ---------------------------------------------------------------------------
@@ -304,42 +324,81 @@ class SessionManager:
         from pollypm.onboarding import default_session_args
         from pollypm.providers import get_provider
         from pollypm.runtimes import get_runtime
+        from pollypm.role_routing import resolved_provider_kind, resolve_role_assignment
 
         config = self._config
         accounts = getattr(config, "accounts", {}) or {}
-        account_name = (
-            agent_name if agent_name in accounts
-            else getattr(getattr(config, "pollypm", None), "controller_account", "")
-        )
-        account = accounts.get(account_name)
+        routed_assignment = resolve_role_assignment("worker", project, config=config)
+        try:
+            routed_provider = resolved_provider_kind(routed_assignment)
+        except ValueError as exc:
+            raise ProvisionError(
+                f"Worker routing for project {project} resolved an unknown provider "
+                f"{routed_assignment.provider!r}: {exc}"
+            ) from exc
+        preferred_names = [
+            agent_name if agent_name in accounts else "",
+            getattr(getattr(config, "pollypm", None), "controller_account", ""),
+        ]
+        if routed_assignment.source == "fallback":
+            legacy_name = preferred_names[0] or preferred_names[1]
+            account_name = legacy_name
+            account = accounts.get(account_name)
+            if account is None and accounts:
+                account_name, account = next(iter(accounts.items()))
+        else:
+            account_name, account = _first_matching_account(
+                accounts,
+                provider=routed_provider,
+                preferred_names=preferred_names,
+            )
         if account is None:
             if accounts:
-                account_name, account = next(iter(accounts.items()))
-            else:
                 raise ProvisionError(
                     "Could not provision a worker because no configured account "
-                    "is available for provider/runtime launch planning. "
-                    "Why it matters: the worker session has no provider or "
-                    "runtime to start under. "
-                    "Fix: add at least one account to PollyPM config, then "
-                    "retry the claim."
+                    f"is available for routed provider {routed_provider.value}. "
+                    "Why it matters: the worker session has no compatible "
+                    "provider/runtime to start under. "
+                    f"Fix: add at least one {routed_provider.value} account to "
+                    "PollyPM config, then retry the claim."
                 )
+            raise ProvisionError(
+                "Could not provision a worker because no configured account "
+                "is available for provider/runtime launch planning. "
+                "Why it matters: the worker session has no provider or "
+                "runtime to start under. "
+                "Fix: add at least one account to PollyPM config, then "
+                "retry the claim."
+            )
+        session_provider = account.provider
+        session_model: str | None = None
+        if account.provider is routed_provider:
+            session_provider = routed_provider
+            session_model = routed_assignment.model
+            logger.info(
+                "Role routing resolved worker for %s to %s/%s from %s.",
+                project,
+                routed_assignment.provider,
+                routed_assignment.model,
+                routed_assignment.source,
+            )
 
         session = SessionConfig(
             name=window_name,
             role="worker",
-            provider=account.provider,
+            provider=session_provider,
             account=account_name,
             cwd=worktree_path,
             project=project,
             window_name=window_name,
             args=default_session_args(
-                account.provider,
+                session_provider,
                 open_permissions=config.pollypm.open_permissions_by_default,
                 role="worker",
+                model=session_model,
             ),
         )
-        provider = get_provider(account.provider, root_dir=config.project.root_dir)
+        provider = get_provider(session_provider, root_dir=config.project.root_dir)
         runtime = get_runtime(account.runtime, root_dir=config.project.root_dir)
         launch = provider.build_launch_command(session, account)
         command = runtime.wrap_command(launch, account, config.project)

--- a/src/pollypm/workers.py
+++ b/src/pollypm/workers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import logging
 from pathlib import Path
 
 import typer
@@ -9,9 +10,13 @@ from pollypm.acct import detect_logged_in
 from pollypm.config import load_config, write_config
 from pollypm.onboarding import default_session_args
 from pollypm.models import ProviderKind, SessionConfig
+from pollypm.role_routing import resolved_provider_kind, resolve_role_assignment
 from pollypm.supervisor import Supervisor
 from pollypm.storage.state import StateStore
 from pollypm.worktrees import ensure_worktree
+
+
+_log = logging.getLogger(__name__)
 
 
 def _effective_control_accounts(config_path: Path) -> set[str]:
@@ -104,15 +109,94 @@ def create_worker_session(
         )
 
     role = (role or "worker").strip() or "worker"
+    routed_assignment = resolve_role_assignment(role, project_key, config=config)
+    routed_provider: ProviderKind | None
+    try:
+        routed_provider = resolved_provider_kind(routed_assignment)
+    except ValueError:
+        _log.warning(
+            "Ignoring invalid routed provider %r for %s on %s.",
+            routed_assignment.provider,
+            role,
+            project_key,
+        )
+        routed_provider = None
 
     if account_name is None:
-        account_name = auto_select_worker_account(config_path, provider=provider)
+        preferred_provider = (
+            routed_provider
+            if routed_provider is not None and routed_assignment.source != "fallback"
+            else provider
+        )
+        try:
+            account_name = auto_select_worker_account(
+                config_path,
+                provider=preferred_provider,
+            )
+        except typer.BadParameter:
+            if (
+                routed_provider is None
+                or provider is not None
+                or routed_assignment.source == "fallback"
+            ):
+                raise
+            _log.warning(
+                "Role routing resolved %s for %s to %s/%s from %s, but no matching account is available; "
+                "falling back to the legacy worker account selection.",
+                role,
+                project_key,
+                routed_assignment.provider,
+                routed_assignment.model,
+                routed_assignment.source,
+            )
+            account_name = auto_select_worker_account(config_path, provider=provider)
     if account_name not in config.accounts:
         raise typer.BadParameter(f"Unknown account: {account_name}")
     account = config.accounts[account_name]
     if provider is not None and account.provider is not provider:
         raise typer.BadParameter(
             f"Account {account_name} uses provider {account.provider.value}, not {provider.value}"
+        )
+    active_provider = account.provider
+    active_model: str | None = None
+    if routed_provider is not None and (
+        routed_assignment.source != "fallback"
+        or account.provider is routed_provider
+    ):
+        if account.provider is not routed_provider:
+            _log.warning(
+                "Role routing resolved %s for %s to %s/%s from %s, but account %s uses %s; "
+                "keeping the session on the account provider.",
+                role,
+                project_key,
+                routed_assignment.provider,
+                routed_assignment.model,
+                routed_assignment.source,
+                account_name,
+                account.provider.value,
+            )
+        else:
+            active_provider = routed_provider
+            active_model = routed_assignment.model
+            _log.info(
+                "Role routing resolved %s for %s to %s/%s from %s.",
+                role,
+                project_key,
+                routed_assignment.provider,
+                routed_assignment.model,
+                routed_assignment.source,
+            )
+    elif routed_provider is not None and routed_assignment.source != "fallback":
+        _log.warning(
+            "Role routing resolved %s for %s to %s/%s from %s, but account %s uses %s; "
+            "keeping the session on the account provider.",
+            role,
+            project_key,
+            routed_assignment.provider,
+            routed_assignment.model,
+            routed_assignment.source,
+            account_name,
+            account.provider.value,
         )
     if not prompt or not prompt.strip():
         prompt = suggest_worker_prompt(config_path, project_key=project_key)
@@ -140,14 +224,19 @@ def create_worker_session(
     worker = SessionConfig(
         name=session_key,
         role=role,
-        provider=account.provider,
+        provider=active_provider,
         account=account_name,
         cwd=Path(worktree.path) if worktree is not None else project.path,
         project=project_key,
         window_name=f"{window_prefix}-{project_key}",
         prompt=prompt,
         agent_profile=agent_profile,
-        args=default_session_args(account.provider, open_permissions=config.pollypm.open_permissions_by_default),
+        args=default_session_args(
+            active_provider,
+            open_permissions=config.pollypm.open_permissions_by_default,
+            role=role,
+            model=active_model,
+        ),
     )
     config.sessions[session_key] = worker
     try:

--- a/tests/test_launch_planner.py
+++ b/tests/test_launch_planner.py
@@ -7,12 +7,16 @@ did, and the Supervisor's public methods correctly delegate to it.
 
 from __future__ import annotations
 
+import base64
+import json
 from pathlib import Path
+import shlex
 
 from pollypm.launch_planner import LaunchPlanner, get_launch_planner
 from pollypm.models import (
     AccountConfig,
     KnownProject,
+    ModelAssignment,
     PollyPMConfig,
     PollyPMSettings,
     ProjectKind,
@@ -25,6 +29,15 @@ from pollypm.plugins_builtin.default_launch_planner.planner import (
     DefaultLaunchPlannerContext,
 )
 from pollypm.supervisor import Supervisor
+
+
+def _decode_launch_payload(command: str) -> dict[str, object]:
+    parts = shlex.split(command)
+    if parts[0] == "sh" and "-lc" in parts:
+        parts = shlex.split(parts[-1])
+    payload = parts[-1]
+    raw = base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
+    return json.loads(raw.decode("utf-8"))
 
 
 def _config(tmp_path: Path) -> PollyPMConfig:
@@ -170,6 +183,65 @@ def test_default_planner_controller_override_matches(tmp_path: Path) -> None:
         for l in standalone.plan_launches(controller_account="codex_backup")
     ]
     assert via_standalone == via_supervisor
+
+
+def test_planner_routes_architect_launch_to_project_override(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    config.projects["pollypm"].role_assignments["architect"] = ModelAssignment(
+        alias="sonnet-4.6"
+    )
+    config.sessions["architect"] = SessionConfig(
+        name="architect",
+        role="architect",
+        provider=ProviderKind.CLAUDE,
+        account="claude_controller",
+        cwd=tmp_path,
+        project="pollypm",
+        window_name="architect-pollypm",
+    )
+    sup = Supervisor(config)
+    sup.ensure_layout()
+
+    launch = next(item for item in sup.plan_launches() if item.session.name == "architect")
+    payload = _decode_launch_payload(launch.command)
+
+    assert launch.session.provider is ProviderKind.CLAUDE
+    assert payload["argv"] == [
+        "claude",
+        "--dangerously-skip-permissions",
+        "--model",
+        "claude-sonnet-4-6",
+    ]
+
+
+def test_planner_routes_operator_to_codex_when_compatible_account_exists(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    config.pollypm.role_assignments["operator_pm"] = ModelAssignment(
+        alias="codex-gpt-5.4"
+    )
+    config.accounts["codex_backup"] = AccountConfig(
+        name="codex_backup",
+        provider=ProviderKind.CODEX,
+        email="codex@example.com",
+        home=tmp_path / ".pollypm/homes/codex_backup",
+    )
+    sup = Supervisor(config)
+    sup.ensure_layout()
+
+    launch = next(item for item in sup.plan_launches() if item.session.name == "operator")
+    payload = _decode_launch_payload(launch.command)
+
+    assert launch.session.provider is ProviderKind.CODEX
+    assert launch.session.account == "codex_backup"
+    assert payload["argv"] == [
+        "codex",
+        "--sandbox",
+        "read-only",
+        "--ask-for-approval",
+        "never",
+        "--model",
+        "gpt-5.4",
+    ]
 
 
 def test_supervisor_launch_planner_property_returns_default(tmp_path: Path) -> None:

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -606,6 +606,8 @@ class TestProvisionWorker:
             "workspace-write",
             "--ask-for-approval",
             "never",
+            "--model",
+            "gpt-5.4",
         ]
 
     def test_provision_worker_aborts_when_prompt_write_fails(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -512,11 +512,24 @@ def test_control_session_args_follow_override_provider(tmp_path: Path) -> None:
     config.sessions["operator"].args = ["--dangerously-skip-permissions"]
     supervisor = Supervisor(config)
 
-    launches = supervisor.plan_launches(controller_account="codex_backup")
+    launches = {launch.session.name: launch for launch in supervisor.plan_launches(controller_account="codex_backup")}
 
-    for launch in launches:
-        assert launch.session.provider is ProviderKind.CODEX
-        assert launch.session.args == ["--sandbox", "read-only", "--ask-for-approval", "never"]
+    assert launches["heartbeat"].session.provider is ProviderKind.CODEX
+    assert launches["heartbeat"].session.args == [
+        "--sandbox",
+        "read-only",
+        "--ask-for-approval",
+        "never",
+    ]
+    assert launches["operator"].session.provider is ProviderKind.CODEX
+    assert launches["operator"].session.args == [
+        "--sandbox",
+        "read-only",
+        "--ask-for-approval",
+        "never",
+        "--model",
+        "gpt-5.4",
+    ]
 
 
 def test_claude_control_sessions_use_original_account_home(tmp_path: Path) -> None:
@@ -657,7 +670,14 @@ def test_open_permissions_default_can_disable_launch_args(tmp_path: Path) -> Non
     assert "--disallowedTools" in launches["operator"].session.args
     assert "--dangerously-skip-permissions" not in launches["heartbeat"].session.args
     assert "--dangerously-skip-permissions" not in launches["operator"].session.args
-    assert launches["worker"].session.args == ["--sandbox", "workspace-write", "--ask-for-approval", "never"]
+    assert launches["worker"].session.args == [
+        "--sandbox",
+        "workspace-write",
+        "--ask-for-approval",
+        "never",
+        "--model",
+        "gpt-5.4",
+    ]
 
 
 def test_run_heartbeat_delegates_to_configured_backend(monkeypatch, tmp_path: Path) -> None:
@@ -740,7 +760,15 @@ def test_codex_control_launches_use_agents_md_instead_of_visible_prompt(tmp_path
     argv = decoded["argv"]
     env = decoded["env"]
 
-    assert argv == ["codex", "--sandbox", "read-only", "--ask-for-approval", "never"]
+    assert argv == [
+        "codex",
+        "--sandbox",
+        "read-only",
+        "--ask-for-approval",
+        "never",
+        "--model",
+        "gpt-5.4",
+    ]
     assert "PM_CODEX_HOME_AGENTS_MD" in env
     assert "Polly" in env["PM_CODEX_HOME_AGENTS_MD"]
     assert launch.initial_input is None
@@ -765,7 +793,15 @@ def test_codex_worker_launches_do_not_auto_send_prompt(tmp_path: Path) -> None:
 
     # Worker prompt should NOT be baked into argv
     assert not any("do some work" in arg for arg in decoded["argv"])
-    assert decoded["argv"] == ["codex", "--sandbox", "workspace-write", "--ask-for-approval", "never"]
+    assert decoded["argv"] == [
+        "codex",
+        "--sandbox",
+        "workspace-write",
+        "--ask-for-approval",
+        "never",
+        "--model",
+        "gpt-5.4",
+    ]
     shim_path = Path(decoded["env"]["PATH"].split(":")[0])
     assert shim_path.name == "worker"
     assert (shim_path / "tmux").exists()

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -5,6 +5,7 @@ from pollypm.models import (
     AccountConfig,
     ProjectKind,
     ProjectSettings,
+    ModelAssignment,
     PollyPMConfig,
     PollyPMSettings,
     ProviderKind,
@@ -17,7 +18,7 @@ from pollypm.plugins_builtin.core_agent_profiles.profiles import heartbeat_promp
 from pollypm.plugins_builtin.core_agent_profiles.profiles import polly_prompt as operator_prompt
 from pollypm.plugins_builtin.core_agent_profiles.profiles import triage_prompt
 from pollypm.plugins_builtin.core_agent_profiles.profiles import reviewer_prompt
-from pollypm.workers import auto_select_worker_account, suggest_worker_prompt
+from pollypm.workers import auto_select_worker_account, create_worker_session, suggest_worker_prompt
 from pollypm.plugins_builtin.core_agent_profiles.profiles import worker_prompt
 
 
@@ -198,6 +199,73 @@ def test_suggest_worker_prompt_returns_empty(tmp_path: Path) -> None:
     prompt = suggest_worker_prompt(config_path, project_key="pollypm")
 
     assert prompt == ""
+
+
+def test_create_worker_session_routes_architect_model_assignment(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config, config_path = _config(tmp_path)
+    config.projects["pollypm"].role_assignments["architect"] = ModelAssignment(
+        alias="sonnet-4.6"
+    )
+    write_config(config, config_path, force=True)
+    monkeypatch.setattr("pollypm.workers.detect_logged_in", lambda account: True)
+    monkeypatch.setattr(
+        "pollypm.workers.ensure_worktree",
+        lambda *args, **kwargs: type(
+            "Worktree",
+            (),
+            {"path": str(tmp_path / "architect-worktree")},
+        )(),
+    )
+
+    session = create_worker_session(
+        config_path,
+        project_key="pollypm",
+        prompt=None,
+        role="architect",
+        agent_profile="architect",
+    )
+
+    assert session.provider is ProviderKind.CLAUDE
+    assert session.args == [
+        "--dangerously-skip-permissions",
+        "--model",
+        "claude-sonnet-4-6",
+    ]
+
+
+def test_create_worker_session_keeps_legacy_selection_when_fallback_provider_has_no_account(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config, config_path = _config(tmp_path)
+    config.accounts = {
+        "claude_controller": config.accounts["claude_controller"],
+    }
+    config.pollypm.failover_enabled = False
+    config.pollypm.failover_accounts = []
+    write_config(config, config_path, force=True)
+    monkeypatch.setattr("pollypm.workers.detect_logged_in", lambda account: True)
+    monkeypatch.setattr(
+        "pollypm.workers.ensure_worktree",
+        lambda *args, **kwargs: type(
+            "Worktree",
+            (),
+            {"path": str(tmp_path / "worker-worktree")},
+        )(),
+    )
+
+    session = create_worker_session(
+        config_path,
+        project_key="pollypm",
+        prompt=None,
+        role="worker",
+    )
+
+    assert session.provider is ProviderKind.CLAUDE
+    assert session.args == ["--dangerously-skip-permissions"]
 
 
 def test_worker_prompt_requires_core_identity() -> None:


### PR DESCRIPTION
**Recreated from #744** (auto-closed when its stacked base `issue-731-role-routing` was deleted after #741 merged.) Now rebased onto current main.

Closes #732

## Summary
- route architect, worker, reviewer, and operator launches through the role resolver
- pass resolved models into provider-specific session args while preserving legacy fallback boot behavior
- cover planner, worker creation, task-worker provisioning, and launch payloads with tests

## Testing
- `uv run pytest tests/test_workers.py tests/test_launch_planner.py tests/test_session_manager.py tests/test_supervisor.py tests/test_role_routing.py tests/test_service_api.py tests/test_provider_sdk.py tests/test_model_registry.py tests/test_models.py tests/test_config.py` — 151/151 pass