### PR TITLE
roles-5: add project-local role guide forking

### DIFF
--- a/src/pollypm/memory_prompts.py
+++ b/src/pollypm/memory_prompts.py
@@ -345,6 +345,7 @@ def build_worker_protocol_injection(
     *,
     session_role: str | None,
     guide_text: str | None = None,
+    guide_reference: str | None = None,
 ) -> str:
     """Render a short ``## Worker Protocol`` pointer for workers.
 
@@ -354,15 +355,16 @@ def build_worker_protocol_injection(
     existing memory-injection path is a no-op for those sessions.
 
     ``guide_text`` is accepted for compatibility with the old guide-
-    loading implementation, but the rendered prompt now points workers
-    at ``docs/worker-guide.md`` instead of inlining the whole guide.
+    loading implementation, but the rendered prompt points workers at
+    a guide path instead of inlining the whole guide.
     """
     if session_role != "worker":
         return ""
+    guide_ref = guide_reference or "docs/worker-guide.md"
     # Keep the kickoff compact: the full playbook lives in docs/worker-guide.md.
     return (
         f"{WORKER_PROTOCOL_HEADING}\n\n"
-        "Read `docs/worker-guide.md` for the worker playbook, including how to "
+        f"Read `{guide_ref}` for the worker playbook, including how to "
         "claim work, ship it, and recover."
     )
 

--- a/src/pollypm/plugins_builtin/core_agent_profiles/profiles.py
+++ b/src/pollypm/plugins_builtin/core_agent_profiles/profiles.py
@@ -22,7 +22,19 @@ class StaticPromptProfile(AgentProfile):
 
     def build_prompt(self, context: AgentProfileContext) -> str | None:
         project_root = _project_root(context)
-        parts: list[str] = [self.prompt]
+        prompt = self.prompt
+        if self.name == "russell":
+            project = context.config.projects.get(context.session.project)
+            if project is not None:
+                from pollypm.project_guides import resolve_project_guide_text
+
+                prompt = resolve_project_guide_text(
+                    project.path,
+                    "reviewer",
+                    fallback_text=prompt,
+                )
+
+        parts: list[str] = [prompt]
 
         # Inject behavioral rules from INSTRUCT.md directly — the agent should
         # never need to "choose" to read them.  Keep reference docs as pointers.

--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -37,15 +37,16 @@ from pollypm.config import (
     load_config,
     resolve_config_path,
 )
+from pollypm.project_guides import init_project_guide, list_project_guides
 
 
 project_app = typer.Typer(
     help=help_with_examples(
-        "Planner-backed project lifecycle (new / plan / replan).",
+        "Planner-backed project lifecycle (new / plan / replan / guides).",
         [
             ("pm project new ~/dev/my-app", "register a project and offer to plan it"),
             ("pm project plan my_app", "queue a fresh planning task"),
-            ("pm project replan my_app", "run the drift-aware planner again"),
+            ("pm project init-guide architect --project my_app", "fork the architect guide into the project"),
         ],
     ),
     no_args_is_help=True,
@@ -336,6 +337,75 @@ def _plan_project_task(
             priority="high",
         )
     return task
+
+
+# ---------------------------------------------------------------------------
+# pm project init-guide / list-guides
+# ---------------------------------------------------------------------------
+
+
+@project_app.command("init-guide")
+def init_guide_cmd(
+    role: str = typer.Argument(
+        ...,
+        help="Role guide to fork: architect, reviewer, or worker.",
+    ),
+    project: Optional[str] = typer.Option(
+        None,
+        "--project",
+        help=(
+            "Project key, alias, or path. Defaults to the project whose "
+            "root matches the current directory."
+        ),
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Overwrite an existing project-local guide.",
+    ),
+    config_path: Path = typer.Option(
+        DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path.",
+    ),
+) -> None:
+    """Fork a built-in role guide into ``.pollypm/project-guides``."""
+    path = _require_config(config_path)
+    key, project_path = _resolve_project_key(path, project)
+    try:
+        guide = init_project_guide(project_path, role, force=force)
+    except (FileExistsError, RuntimeError, ValueError) as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+    typer.echo(
+        f"Wrote project-local {guide.role} guide for '{key}' at "
+        f"{guide.path} (forked_from: {guide.forked_from})."
+    )
+
+
+@project_app.command("list-guides")
+def list_guides_cmd(
+    project: Optional[str] = typer.Option(
+        None,
+        "--project",
+        help=(
+            "Project key, alias, or path. Defaults to the project whose "
+            "root matches the current directory."
+        ),
+    ),
+    config_path: Path = typer.Option(
+        DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path.",
+    ),
+) -> None:
+    """List project-local role guides for a project."""
+    path = _require_config(config_path)
+    key, project_path = _resolve_project_key(path, project)
+    guides = list_project_guides(project_path)
+    if not guides:
+        typer.echo(f"No project-local guides for '{key}'.")
+        return
+    typer.echo(f"Project-local guides for '{key}':")
+    for guide in guides:
+        forked = guide.forked_from or "unknown"
+        typer.echo(f"- {guide.role}: {guide.path} (forked_from: {forked})")
 
 
 # ---------------------------------------------------------------------------

--- a/src/pollypm/plugins_builtin/project_planning/plugin.py
+++ b/src/pollypm/plugins_builtin/project_planning/plugin.py
@@ -59,7 +59,18 @@ class MarkdownPromptProfile:
             text = self.path.read_text(encoding="utf-8")
         except OSError:
             return None
-        return text.strip() or None
+        prompt = text.strip()
+        if self.name == "architect" and context is not None:
+            project = context.config.projects.get(context.session.project)
+            if project is not None:
+                from pollypm.project_guides import resolve_project_guide_text
+
+                prompt = resolve_project_guide_text(
+                    project.path,
+                    "architect",
+                    fallback_text=prompt,
+                )
+        return prompt or None
 
 
 def _profile_factory(name: str):

--- a/src/pollypm/project_guides.py
+++ b/src/pollypm/project_guides.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from pollypm.projects import project_pollypm_dir
+
+PROJECT_GUIDES_DIRNAME = "project-guides"
+SUPPORTED_PROJECT_GUIDE_ROLES: tuple[str, ...] = (
+    "architect",
+    "reviewer",
+    "worker",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectGuideInfo:
+    role: str
+    path: Path
+    forked_from: str | None
+    body: str
+
+
+def normalize_project_guide_role(role: str) -> str:
+    return role.strip().lower().replace("-", "_")
+
+
+def validate_project_guide_role(role: str) -> str:
+    normalized = normalize_project_guide_role(role)
+    if normalized == "operator_pm":
+        raise ValueError(
+            "Project-local guides do not support operator_pm. "
+            "Polly always uses the built-in operator guide."
+        )
+    if normalized not in SUPPORTED_PROJECT_GUIDE_ROLES:
+        available = ", ".join(SUPPORTED_PROJECT_GUIDE_ROLES)
+        raise ValueError(
+            f"Unsupported role '{role}'. Available: {available}."
+        )
+    return normalized
+
+
+def project_guides_dir(project_path: Path) -> Path:
+    return project_pollypm_dir(project_path) / PROJECT_GUIDES_DIRNAME
+
+
+def project_guide_path(project_path: Path, role: str) -> Path:
+    normalized = validate_project_guide_role(role)
+    return project_guides_dir(project_path) / f"{normalized}.md"
+
+
+def init_project_guide(
+    project_path: Path,
+    role: str,
+    *,
+    force: bool = False,
+) -> ProjectGuideInfo:
+    normalized = validate_project_guide_role(role)
+    built_in = built_in_guide_text(normalized)
+    built_in_source = built_in_guide_source_path(normalized)
+    forked_from = built_in_guide_fork_ref(
+        normalized,
+        content=built_in,
+        source_path=built_in_source,
+    )
+    target = project_guide_path(project_path, normalized)
+    if target.exists() and not force:
+        raise FileExistsError(
+            f"{target} already exists. Re-run with --force to overwrite."
+        )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(_render_front_matter(forked_from) + built_in.rstrip() + "\n")
+    return read_project_guide(project_path, normalized)
+
+
+def list_project_guides(project_path: Path) -> list[ProjectGuideInfo]:
+    guide_dir = project_guides_dir(project_path)
+    if not guide_dir.exists():
+        return []
+    guides: list[ProjectGuideInfo] = []
+    for path in sorted(guide_dir.glob("*.md")):
+        guides.append(_read_project_guide_path(path))
+    return guides
+
+
+def read_project_guide(project_path: Path, role: str) -> ProjectGuideInfo:
+    normalized = validate_project_guide_role(role)
+    return _read_project_guide_path(project_guide_path(project_path, normalized))
+
+
+def resolve_project_guide_text(
+    project_path: Path,
+    role: str,
+    *,
+    fallback_text: str | None = None,
+) -> str:
+    normalized = validate_project_guide_role(role)
+    target = project_guides_dir(project_path) / f"{normalized}.md"
+    if target.exists():
+        return _read_project_guide_path(target).body
+    if fallback_text is not None:
+        return fallback_text.strip()
+    return built_in_guide_text(normalized).strip()
+
+
+def worker_guide_reference(project_path: Path) -> str:
+    target = project_guides_dir(project_path) / "worker.md"
+    if target.exists():
+        return str(target.resolve())
+    return "docs/worker-guide.md"
+
+
+def built_in_guide_text(role: str) -> str:
+    normalized = validate_project_guide_role(role)
+    if normalized == "architect":
+        path = built_in_guide_source_path(normalized)
+        if path is None:
+            raise RuntimeError("Could not locate the built-in architect guide.")
+        return path.read_text(encoding="utf-8")
+    if normalized == "reviewer":
+        from pollypm.plugins_builtin.core_agent_profiles.profiles import reviewer_prompt
+
+        return reviewer_prompt()
+    if normalized == "worker":
+        path = built_in_guide_source_path(normalized)
+        if path is None:
+            raise RuntimeError("Could not locate docs/worker-guide.md.")
+        return path.read_text(encoding="utf-8")
+    raise ValueError(f"Unsupported role '{role}'.")
+
+
+def built_in_guide_source_path(role: str) -> Path | None:
+    normalized = validate_project_guide_role(role)
+    if normalized == "architect":
+        return Path(__file__).resolve().parent / "plugins_builtin" / "project_planning" / "profiles" / "architect.md"
+    if normalized == "reviewer":
+        return Path(__file__).resolve().parent / "plugins_builtin" / "core_agent_profiles" / "profiles.py"
+    if normalized == "worker":
+        return _locate_repo_file("docs/worker-guide.md")
+    raise ValueError(f"Unsupported role '{role}'.")
+
+
+def built_in_guide_fork_ref(
+    role: str,
+    *,
+    content: str | None = None,
+    source_path: Path | None = None,
+) -> str:
+    normalized = validate_project_guide_role(role)
+    guide_content = content if content is not None else built_in_guide_text(normalized)
+    guide_source = source_path if source_path is not None else built_in_guide_source_path(normalized)
+    git_sha = _git_sha_for_path(guide_source)
+    if git_sha:
+        return git_sha
+    digest = hashlib.sha256(guide_content.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _locate_repo_file(relative_path: str) -> Path | None:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / relative_path
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _git_sha_for_path(path: Path | None) -> str | None:
+    if path is None or not path.exists():
+        return None
+    try:
+        repo = subprocess.run(
+            ["git", "-C", str(path.parent), "rev-parse", "--show-toplevel"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if repo.returncode != 0:
+        return None
+    repo_root = Path(repo.stdout.strip())
+    try:
+        relative = path.resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "log", "-n", "1", "--format=%H", "--", str(relative)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    sha = result.stdout.strip()
+    return sha or None
+
+
+def _read_project_guide_path(path: Path) -> ProjectGuideInfo:
+    text = path.read_text(encoding="utf-8")
+    header, body = _split_front_matter(text)
+    return ProjectGuideInfo(
+        role=path.stem,
+        path=path,
+        forked_from=header.get("forked_from"),
+        body=body.strip(),
+    )
+
+
+def _split_front_matter(text: str) -> tuple[dict[str, str], str]:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, text
+    for index in range(1, len(lines)):
+        if lines[index].strip() != "---":
+            continue
+        header: dict[str, str] = {}
+        for raw_line in lines[1:index]:
+            if ":" not in raw_line:
+                continue
+            key, value = raw_line.split(":", 1)
+            header[key.strip()] = value.strip()
+        body = "\n".join(lines[index + 1:])
+        return header, body
+    return {}, text
+
+
+def _render_front_matter(forked_from: str) -> str:
+    return f"---\nforked_from: {forked_from}\n---\n\n"

--- a/src/pollypm/session_services/tmux.py
+++ b/src/pollypm/session_services/tmux.py
@@ -111,6 +111,7 @@ class TmuxSessionService:
         session_role: str | None = None,
         task_title: str | None = None,
         task_description: str | None = None,
+        guide_reference: str | None = None,
         user_id: str = "operator",
     ) -> SessionHandle:
         wname = window_name or f"session-{name}"
@@ -197,6 +198,7 @@ class TmuxSessionService:
                     session_role=session_role,
                     task_title=task_title,
                     task_description=task_description,
+                    guide_reference=guide_reference,
                     user_id=user_id,
                 )
                 kickoff = self._prepare_initial_input(
@@ -813,6 +815,7 @@ class TmuxSessionService:
         session_role: str | None,
         task_title: str | None,
         task_description: str | None,
+        guide_reference: str | None = None,
         user_id: str,
     ) -> str:
         """Prepend memory recall + (for workers) the worker guide.
@@ -879,6 +882,7 @@ class TmuxSessionService:
         try:
             worker_injection = build_worker_protocol_injection(
                 session_role=session_role,
+                guide_reference=guide_reference,
             )
         except Exception:  # noqa: BLE001
             worker_injection = ""

--- a/src/pollypm/work/session_manager.py
+++ b/src/pollypm/work/session_manager.py
@@ -437,6 +437,8 @@ class SessionManager:
         self._kill_stale_task_window(session_name, window_name)
 
         if self._session_service is not None:
+            from pollypm.project_guides import worker_guide_reference
+
             # Use a fresh_launch_marker so SessionService.create() knows
             # to send the kickoff as initial input.
             marker_dir = self._project_path / ".pollypm" / "worker-markers"
@@ -460,6 +462,7 @@ class SessionManager:
                 initial_input=kickoff,
                 fresh_launch_marker=fresh_launch_marker,
                 session_role="worker",
+                guide_reference=worker_guide_reference(self._project_path),
             )
             return handle.pane_id or ""
 
@@ -932,6 +935,8 @@ class SessionManager:
 
     def _build_task_prompt(self, task_id: str, worktree_path: Path) -> str:
         """Build a clear operating prompt for a per-task worker session."""
+        from pollypm.project_guides import worker_guide_reference
+
         # Get task details from the work service
         task_info = ""
         try:
@@ -947,11 +952,16 @@ class SessionManager:
         except Exception:
             task_info = f"## Your Assignment\n\nTask ID: {task_id}\n\n"
 
+        guide_reference = worker_guide_reference(self._project_path)
+
         return (
             f"You are a PollyPM task worker. You have one job: complete the task below.\n\n"
             f"You are working in a git worktree at: {worktree_path}\n"
             f"This is an isolated branch — your changes won't affect other workers.\n\n"
             f"{task_info}"
+            f"## Worker Guide\n\n"
+            f"Read `{guide_reference}` first for the worker playbook. Use the "
+            f"project-local guide when present; otherwise use the built-in one.\n\n"
             f"## How to Work\n\n"
             f"1. Read the task description carefully\n"
             f"2. Implement the work: read code, write code, run tests, commit\n"

--- a/tests/test_project_planning_cli.py
+++ b/tests/test_project_planning_cli.py
@@ -73,6 +73,104 @@ def _write_minimal_config(
 
 
 # ---------------------------------------------------------------------------
+# init-guide / list-guides
+# ---------------------------------------------------------------------------
+
+
+class TestGuides:
+    def test_init_guide_worker_creates_project_local_copy(self, tmp_path: Path) -> None:
+        repo = _make_project_repo(tmp_path)
+        config_path = _write_minimal_config(tmp_path, projects={"demo": repo})
+
+        result = runner.invoke(
+            project_app,
+            ["init-guide", "worker", "--project", "demo", "--config", str(config_path)],
+        )
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        guide_path = repo / ".pollypm" / "project-guides" / "worker.md"
+        assert guide_path.exists()
+        text = guide_path.read_text()
+        assert "forked_from:" in text
+        assert "# Worker Guide" in text
+        assert "pm task done" in text
+
+    def test_init_guide_force_overwrites_existing_copy(self, tmp_path: Path) -> None:
+        repo = _make_project_repo(tmp_path)
+        config_path = _write_minimal_config(tmp_path, projects={"demo": repo})
+        guide_path = repo / ".pollypm" / "project-guides" / "worker.md"
+        guide_path.parent.mkdir(parents=True, exist_ok=True)
+        guide_path.write_text("custom old body\n")
+
+        result = runner.invoke(
+            project_app,
+            [
+                "init-guide",
+                "worker",
+                "--project",
+                "demo",
+                "--force",
+                "--config",
+                str(config_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        text = guide_path.read_text()
+        assert "custom old body" not in text
+        assert "forked_from:" in text
+        assert "# Worker Guide" in text
+
+    def test_list_guides_shows_role_path_and_fork_sha(self, tmp_path: Path) -> None:
+        repo = _make_project_repo(tmp_path)
+        config_path = _write_minimal_config(tmp_path, projects={"demo": repo})
+
+        for role in ("architect", "worker"):
+            result = runner.invoke(
+                project_app,
+                ["init-guide", role, "--project", "demo", "--config", str(config_path)],
+            )
+            assert result.exit_code == 0, result.stdout + result.stderr
+
+        result = runner.invoke(
+            project_app,
+            ["list-guides", "--project", "demo", "--config", str(config_path)],
+        )
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert "Project-local guides for 'demo':" in result.stdout
+        assert "architect:" in result.stdout
+        assert "worker:" in result.stdout
+        assert "forked_from:" in result.stdout
+        assert str(repo / ".pollypm" / "project-guides" / "architect.md") in result.stdout
+
+    def test_init_guide_rejects_operator_pm(self, tmp_path: Path) -> None:
+        repo = _make_project_repo(tmp_path)
+        config_path = _write_minimal_config(tmp_path, projects={"demo": repo})
+
+        result = runner.invoke(
+            project_app,
+            ["init-guide", "operator_pm", "--project", "demo", "--config", str(config_path)],
+        )
+
+        assert result.exit_code == 1
+        assert "operator_pm" in (result.stdout + result.stderr)
+        assert "built-in operator guide" in (result.stdout + result.stderr)
+
+    def test_init_guide_requires_role_argument(self, tmp_path: Path) -> None:
+        repo = _make_project_repo(tmp_path)
+        config_path = _write_minimal_config(tmp_path, projects={"demo": repo})
+
+        result = runner.invoke(
+            project_app,
+            ["init-guide", "--project", "demo", "--config", str(config_path)],
+        )
+
+        assert result.exit_code != 0
+        assert "Missing argument" in (result.stdout + result.stderr)
+
+
+# ---------------------------------------------------------------------------
 # plan
 # ---------------------------------------------------------------------------
 

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -257,6 +257,30 @@ def manager(mock_tmux, mock_svc, tmp_project):
     return SessionManager(mock_tmux, mock_svc, tmp_project)
 
 
+def test_build_task_prompt_points_at_builtin_worker_guide(manager, tmp_project) -> None:
+    prompt = manager._build_task_prompt(
+        "proj/1",
+        tmp_project / ".pollypm" / "worktrees" / "proj-1",
+    )
+
+    assert "## Worker Guide" in prompt
+    assert "docs/worker-guide.md" in prompt
+
+
+def test_build_task_prompt_prefers_project_local_worker_guide(manager, tmp_project) -> None:
+    guide_path = tmp_project / ".pollypm" / "project-guides" / "worker.md"
+    guide_path.parent.mkdir(parents=True, exist_ok=True)
+    guide_path.write_text("---\nforked_from: test-sha\n---\n\n# Custom worker guide\n")
+
+    prompt = manager._build_task_prompt(
+        "proj/1",
+        tmp_project / ".pollypm" / "worktrees" / "proj-1",
+    )
+
+    assert str(guide_path.resolve()) in prompt
+    assert "docs/worker-guide.md" not in prompt
+
+
 def _decode_local_runtime_payload(command: str) -> dict[str, object]:
     outer = shlex.split(command)
     assert outer[:2] == ["sh", "-lc"]

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -646,6 +646,48 @@ def test_control_sessions_use_agent_profiles_for_prompts(tmp_path: Path) -> None
     assert "heartbeat supervisor" in launches["heartbeat"].session.prompt
 
 
+def test_architect_launch_prefers_project_local_guide(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    config.sessions["architect"] = SessionConfig(
+        name="architect",
+        role="architect",
+        provider=ProviderKind.CLAUDE,
+        account="claude_controller",
+        cwd=tmp_path,
+        project="pollypm",
+        window_name="architect-pollypm",
+    )
+    guide_path = tmp_path / ".pollypm" / "project-guides" / "architect.md"
+    guide_path.parent.mkdir(parents=True, exist_ok=True)
+    guide_path.write_text("---\nforked_from: test-sha\n---\n\n# Custom architect guide\n")
+
+    supervisor = Supervisor(config)
+    launches = {launch.session.name: launch for launch in supervisor.plan_launches()}
+
+    assert launches["architect"].session.prompt == "# Custom architect guide"
+
+
+def test_reviewer_launch_prefers_project_local_guide(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    config.sessions["reviewer"] = SessionConfig(
+        name="reviewer",
+        role="reviewer",
+        provider=ProviderKind.CLAUDE,
+        account="claude_controller",
+        cwd=tmp_path,
+        project="pollypm",
+        window_name="reviewer-pollypm",
+    )
+    guide_path = tmp_path / ".pollypm" / "project-guides" / "reviewer.md"
+    guide_path.parent.mkdir(parents=True, exist_ok=True)
+    guide_path.write_text("---\nforked_from: test-sha\n---\n\n# Custom reviewer guide\n")
+
+    supervisor = Supervisor(config)
+    launches = {launch.session.name: launch for launch in supervisor.plan_launches()}
+
+    assert "# Custom reviewer guide" in launches["reviewer"].session.prompt
+
+
 def test_open_permissions_default_can_disable_launch_args(tmp_path: Path) -> None:
     config = _config(tmp_path)
     config.pollypm.open_permissions_by_default = False

--- a/tests/test_worker_protocol_injection.py
+++ b/tests/test_worker_protocol_injection.py
@@ -79,6 +79,15 @@ def test_injection_accepts_explicit_guide_text_for_isolation():
     assert "Body goes here." not in out
 
 
+def test_injection_uses_explicit_guide_reference_when_provided():
+    out = build_worker_protocol_injection(
+        session_role="worker",
+        guide_reference="/tmp/project/.pollypm/project-guides/worker.md",
+    )
+    assert "/tmp/project/.pollypm/project-guides/worker.md" in out
+    assert "docs/worker-guide.md" not in out
+
+
 def test_injection_uses_pointer_when_guide_missing():
     """Blank guide text no longer inlines the guide; it still points
     workers at docs/worker-guide.md."""
@@ -214,6 +223,20 @@ def test_tmux_service_injects_worker_protocol_for_worker(tmux_service):
     assert persona in out
     # Protocol appears above the persona.
     assert out.index(WORKER_PROTOCOL_HEADING) < out.index(persona)
+
+
+def test_tmux_service_uses_custom_worker_guide_reference(tmux_service):
+    persona = "You are a worker persona."
+    out = tmux_service._inject_memory_into_prompt(
+        initial_input=persona,
+        session_role="worker",
+        task_title=None,
+        task_description=None,
+        guide_reference="/tmp/project/.pollypm/project-guides/worker.md",
+        user_id="operator",
+    )
+    assert "/tmp/project/.pollypm/project-guides/worker.md" in out
+    assert persona in out
 
 
 @pytest.mark.parametrize("role", ["pm", "reviewer", "supervisor", "triage"])


### PR DESCRIPTION
Closes #733

## Summary
- add project-local guide helpers plus `pm project init-guide` and `pm project list-guides`
- prefer project-local architect/reviewer guides during prompt construction
- point task workers at a project-local worker guide when present

## Verification
- HOME="$(mktemp -d)" uv run --with pytest pytest tests/test_project_planning_cli.py tests/test_supervisor.py tests/test_session_manager.py tests/test_worker_protocol_injection.py -q
- HOME="$(mktemp -d)" uv run --with pytest pytest tests/test_launch_planner.py tests/test_project_planning_plugin.py tests/test_workers.py -q
- uv build