### PR TITLE
feat(projects): detect drift in local role guides

### DIFF
--- a/src/pollypm/cockpit_project_settings.py
+++ b/src/pollypm/cockpit_project_settings.py
@@ -40,7 +40,6 @@ from pollypm.role_routing import resolve_role_assignment
 from pollypm.service_api import PollyPMService
 from pollypm.work.sqlite_service import SQLiteWorkService
 
-
 _PROJECT_ROLE_KEYS = ("architect", "worker", "reviewer")
 _ROLE_LABELS = {
     "operator_pm": "Operator PM",
@@ -133,6 +132,41 @@ def _build_project_role_rows(config, project_key: str, registry) -> list[dict]:
         )
     return rows
 
+_PROJECT_GUIDE_ROLES: tuple[str, ...] = ("architect", "worker", "reviewer")
+
+
+def _project_guides_dir(project_path: Path) -> Path:
+    return Path(project_path) / ".pollypm" / "project-guides"
+
+
+def _project_guide_path(project_path: Path, role: str) -> Path:
+    return _project_guides_dir(project_path) / f"{role}.md"
+
+
+def _drift_value(info: object, field: str, default: object = None) -> object:
+    if isinstance(info, dict):
+        return info.get(field, default)
+    return getattr(info, field, default)
+
+
+def _project_guide_drift_info(project_path: Path, role: str) -> object | None:
+    try:
+        from pollypm.project_guides import project_guide_drift_info as helper
+    except Exception:  # noqa: BLE001
+        helper = None
+    if callable(helper):
+        try:
+            return helper(project_path, role)
+        except Exception:  # noqa: BLE001
+            pass
+    try:
+        from pollypm import doctor as doctor_mod
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        return doctor_mod._project_guide_drift_info(project_path, role)
+    except Exception:  # noqa: BLE001
+        return None
 class PollyProjectSettingsApp(App[None]):
     TITLE = "PollyPM"
     SUB_TITLE = "Project Settings"
@@ -277,6 +311,9 @@ class PollyProjectSettingsApp(App[None]):
         with Vertical(classes="settings-section"):
             yield Static("Recent Tasks", classes="section-label")
             yield Static("", id="task-info")
+        with Vertical(classes="settings-section"):
+            yield Static("Project Guides", classes="section-label")
+            yield Static("", id="guide-info")
         with Vertical(classes="settings-section", id="release-channel-section"):
             yield Static("Release channel", classes="section-label")
             yield Static(
@@ -340,6 +377,8 @@ class PollyProjectSettingsApp(App[None]):
         worker_info = self.query_one("#worker-info", Static)
         model_info = self.query_one("#model-info", Static)
         task_info = self.query_one("#task-info", Static)
+        guide_info = self.query_one("#guide-info", Static)
+        guide_info.update(self._render_project_guides(getattr(project, "path", None)))
 
         if worker is None:
             worker_info.update("No worker session configured.\nPress N in the sidebar to create one.")
@@ -557,6 +596,29 @@ class PollyProjectSettingsApp(App[None]):
                 f"• [b]{task.task_id}[/b] [dim]{status}[/dim] "
                 f"[dim]{task.title}[/dim]"
             )
+        return "\n".join(lines)
+
+    def _render_project_guides(self, project_path: Path | None) -> str:
+        if project_path is None:
+            return "[dim]No project path available.[/dim]"
+        lines: list[str] = []
+        stale_count = 0
+        for role in _PROJECT_GUIDE_ROLES:
+            guide_path = _project_guide_path(project_path, role)
+            if not guide_path.is_file():
+                continue
+            info = _project_guide_drift_info(project_path, role)
+            drifted = bool(_drift_value(info, "drifted", False))
+            if drifted:
+                stale_count += 1
+            badge = " [#d7b75f]↑ upstream changed[/]" if drifted else ""
+            lines.append(
+                f"• [b]{role}[/b] [dim]{guide_path.name}[/dim]{badge}"
+            )
+        if not lines:
+            return "[dim]No project-local guides forked yet.[/dim]"
+        if stale_count:
+            lines.insert(0, f"[dim]{stale_count} guide fork(s) need refresh.[/dim]")
         return "\n".join(lines)
 
     def _build_preview(self, worker, *, account_label: str) -> str:

--- a/src/pollypm/doctor.py
+++ b/src/pollypm/doctor.py
@@ -43,6 +43,7 @@ import sys
 import time
 import tomllib
 from dataclasses import dataclass, field
+from functools import lru_cache
 from importlib.metadata import PackageNotFoundError, version as _package_version
 from pathlib import Path
 from typing import Any, Callable, Iterable
@@ -1377,6 +1378,18 @@ _EXPECTED_SCHEDULED_HANDLERS: tuple[str, ...] = (
     "work.progress_sweep",
     "task_assignment.sweep",
 )
+_PROJECT_GUIDE_ROLES: tuple[str, ...] = ("architect", "worker", "reviewer")
+
+
+@dataclass(slots=True, frozen=True)
+class _LocalGuideDriftInfo:
+    role: str
+    path: Path
+    forked_from: str
+    current_ref: str
+    drifted: bool
+    body: str
+    upstream_body: str
 
 
 def _safe_load_config():
@@ -1779,6 +1792,199 @@ def _role_assignment_checks() -> list[Check]:
     return checks
 
 
+def _drift_value(info: object, field: str, default: object = None) -> object:
+    if isinstance(info, dict):
+        return info.get(field, default)
+    return getattr(info, field, default)
+
+
+@lru_cache(maxsize=1)
+def _project_guides_module():
+    try:
+        import pollypm.project_guides as project_guides
+    except Exception:  # noqa: BLE001
+        return None
+    return project_guides
+
+
+def _project_guides_dir(project_path: Path) -> Path:
+    return Path(project_path) / ".pollypm" / "project-guides"
+
+
+def _project_guide_path(project_path: Path, role: str) -> Path:
+    return _project_guides_dir(project_path) / f"{role}.md"
+
+
+def _parse_guide_front_matter(text: str) -> tuple[dict[str, str], str]:
+    normalized = text.replace("\r\n", "\n")
+    if not normalized.startswith("---\n"):
+        return {}, normalized
+    marker = "\n---\n"
+    end = normalized.find(marker, 4)
+    if end == -1:
+        return {}, normalized
+    raw_header = normalized[4:end]
+    body = normalized[end + len(marker):]
+    header: dict[str, str] = {}
+    for line in raw_header.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        header[key.strip()] = value.strip().strip('"').strip("'")
+    return header, body
+
+
+def _guide_source_path(role: str) -> Path | None:
+    here = Path(__file__).resolve().parent
+    if role == "architect":
+        return here / "plugins_builtin" / "project_planning" / "profiles" / "architect.md"
+    if role in {"worker", "reviewer"}:
+        return here / "plugins_builtin" / "core_agent_profiles" / "profiles.py"
+    return None
+
+
+def _looks_like_hash(value: str, *, min_len: int = 7, max_len: int = 64) -> bool:
+    return bool(re.fullmatch(rf"[0-9a-f]{{{min_len},{max_len}}}", value))
+
+
+def _git_last_change_ref(path: Path | None) -> str | None:
+    if path is None or not path.exists():
+        return None
+    rc, out = _run_cmd(
+        ["git", "-C", str(path.parent), "rev-parse", "--show-toplevel"],
+        timeout=1.0,
+    )
+    if rc != 0:
+        return None
+    repo_root = Path(out.strip())
+    try:
+        relative = path.resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        return None
+    rc, out = _run_cmd(
+        ["git", "-C", str(repo_root), "log", "-n", "1", "--format=%H", "--", str(relative)],
+        timeout=1.5,
+    )
+    if rc != 0:
+        return None
+    sha = (out.splitlines() or [""])[0].strip().lower()
+    return sha if _looks_like_hash(sha, min_len=40, max_len=40) else None
+
+
+@lru_cache(maxsize=None)
+def _built_in_guide_body(role: str) -> str:
+    if role == "architect":
+        source = _guide_source_path(role)
+        if source is None:
+            raise ValueError(f"unknown guide role: {role}")
+        return source.read_text(encoding="utf-8")
+    if role == "worker":
+        from pollypm.plugins_builtin.core_agent_profiles.profiles import worker_prompt
+
+        return worker_prompt()
+    if role == "reviewer":
+        from pollypm.plugins_builtin.core_agent_profiles.profiles import reviewer_prompt
+
+        return reviewer_prompt()
+    raise ValueError(f"unknown guide role: {role}")
+
+
+@lru_cache(maxsize=None)
+def _built_in_guide_ref(role: str) -> str:
+    body = _built_in_guide_body(role)
+    git_ref = _git_last_change_ref(_guide_source_path(role))
+    if git_ref:
+        return git_ref
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _reference_aliases(value: str) -> set[str]:
+    cleaned = (value or "").strip().lower()
+    if not cleaned:
+        return set()
+    aliases = {cleaned}
+    if cleaned.startswith("sha256:"):
+        aliases.add(cleaned.split(":", 1)[1])
+    elif _looks_like_hash(cleaned, min_len=64, max_len=64):
+        aliases.add(f"sha256:{cleaned}")
+    return aliases
+
+
+def _forked_from_matches_current(forked_from: str, current_ref: str, *, upstream_body: str) -> bool:
+    left = _reference_aliases(forked_from)
+    right = _reference_aliases(current_ref)
+    digest = hashlib.sha256(upstream_body.encode("utf-8")).hexdigest()
+    right.add(digest)
+    right.add(f"sha256:{digest}")
+    if left & right:
+        return True
+    forked = (forked_from or "").strip().lower()
+    current = (current_ref or "").strip().lower()
+    if _looks_like_hash(forked) and _looks_like_hash(current):
+        return forked.startswith(current) or current.startswith(forked)
+    return False
+
+
+def _fallback_project_guide_drift_info(project_path: Path, role: str) -> _LocalGuideDriftInfo | None:
+    if role not in _PROJECT_GUIDE_ROLES:
+        return None
+    path = _project_guide_path(project_path, role)
+    if not path.is_file():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    header, body = _parse_guide_front_matter(text)
+    upstream_body = _built_in_guide_body(role)
+    current_ref = _built_in_guide_ref(role)
+    forked_from = str(header.get("forked_from") or "").strip()
+    drifted = bool(forked_from) and not _forked_from_matches_current(
+        forked_from,
+        current_ref,
+        upstream_body=upstream_body,
+    )
+    return _LocalGuideDriftInfo(
+        role=role,
+        path=path,
+        forked_from=forked_from,
+        current_ref=current_ref,
+        drifted=drifted,
+        body=body,
+        upstream_body=upstream_body,
+    )
+
+
+def _project_guide_drift_info(project_path: Path, role: str) -> object | None:
+    project_guides = _project_guides_module()
+    if project_guides is not None:
+        helper = getattr(project_guides, "project_guide_drift_info", None)
+        if callable(helper):
+            try:
+                return helper(project_path, role)
+            except Exception:  # noqa: BLE001
+                pass
+    return _fallback_project_guide_drift_info(project_path, role)
+
+
+def _list_drifted_project_guides(project_path: Path) -> list[object]:
+    project_guides = _project_guides_module()
+    if project_guides is not None:
+        helper = getattr(project_guides, "list_drifted_project_guides", None)
+        if callable(helper):
+            try:
+                return list(helper(project_path) or [])
+            except Exception:  # noqa: BLE001
+                pass
+    drifted: list[object] = []
+    for role in _PROJECT_GUIDE_ROLES:
+        info = _fallback_project_guide_drift_info(project_path, role)
+        if info is not None and info.drifted:
+            drifted.append(info)
+    return drifted
+
+
 def _rewrite_planner_enforce_plan(config_path: Path) -> tuple[bool, str]:
     """Flip ``[planner].enforce_plan`` to true in ``config_path``.
 
@@ -1953,6 +2159,70 @@ def check_visual_explainer_skill() -> CheckResult:
     return _ok(
         "visual-explainer skill present",
         data={"path": str(skill_dir)},
+    )
+
+
+def check_project_local_guide_drift() -> CheckResult:
+    """Warn when a project-local role guide has drifted from upstream."""
+    _path, config = _safe_load_config()
+    if config is None:
+        return _skip("project-guide drift check skipped (no config)")
+    projects = getattr(config, "projects", {}) or {}
+    if not projects:
+        return _skip("project-guide drift check skipped (no projects)")
+
+    stale: list[dict[str, object]] = []
+    for project_key, project in projects.items():
+        project_path = getattr(project, "path", None)
+        if project_path is None:
+            continue
+        for info in _list_drifted_project_guides(Path(project_path)):
+            role = str(_drift_value(info, "role") or "")
+            stale.append(
+                {
+                    "project": project_key,
+                    "project_name": getattr(project, "name", None) or project_key,
+                    "role": role,
+                    "path": str(_drift_value(info, "path") or _project_guide_path(Path(project_path), role)),
+                    "forked_from": str(_drift_value(info, "forked_from") or ""),
+                    "current_ref": str(_drift_value(info, "current_ref") or ""),
+                }
+            )
+
+    if not stale:
+        return _ok(
+            "no stale project-local guides detected",
+            data={"count": 0, "projects": 0, "stale": []},
+        )
+
+    projects_with_drift = len({item["project"] for item in stale})
+    sample = ", ".join(
+        f"{item['project']}:{item['role']}"
+        for item in stale[:4]
+    )
+    fix_lines = ["Refresh each stale guide from the current built-in prompt:"]
+    for item in stale[:4]:
+        fix_lines.append(
+            f"  pm project init-guide {item['role']} --project {item['project']} --force"
+        )
+    if len(stale) > 4:
+        fix_lines.append(f"  ... and {len(stale) - 4} more")
+    fix_lines.append("Review local edits before overwriting if needed.")
+    fix_lines.append("Recheck: pm doctor")
+    return _fail(
+        f"{len(stale)} stale project-local guide(s) across {projects_with_drift} project(s): {sample}",
+        why=(
+            "Project-local role guides stop inheriting upstream prompt updates "
+            "after they are forked. Stale guides can launch sessions with "
+            "outdated instructions until they are refreshed."
+        ),
+        fix="\n".join(fix_lines),
+        severity="warning",
+        data={
+            "count": len(stale),
+            "projects": projects_with_drift,
+            "stale": stale,
+        },
     )
 
 
@@ -3021,6 +3291,8 @@ def _registered_checks() -> list[Check]:
         Check("visual-explainer-skill", check_visual_explainer_skill, "pipeline"),
         Check("task-assignment-sweeper-dbs", check_task_assignment_sweeper_dbs, "pipeline", severity="warning"),
         Check("sessions-table-populated", check_sessions_table_populated, "pipeline", severity="warning"),
+        # Guide drift
+        Check("project-guide-drift", check_project_local_guide_drift, "guides", severity="warning"),
         # Schedulers
         Check("scheduler-handlers", check_scheduler_roster_handlers, "schedulers"),
         Check("scheduler-cadence", check_scheduler_last_fired, "schedulers", severity="warning"),

--- a/src/pollypm/doctor/rendering.py
+++ b/src/pollypm/doctor/rendering.py
@@ -22,6 +22,7 @@ _CATEGORY_LABELS: dict[str, str] = {
     "network": "Network",
     "roles": "Roles",
     "pipeline": "Pipeline",
+    "guides": "Guide Drift",
     "schedulers": "Schedulers",
     "resources": "Resources",
     "inbox": "Inbox",

--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -37,7 +37,11 @@ from pollypm.config import (
     load_config,
     resolve_config_path,
 )
-from pollypm.project_guides import init_project_guide, list_project_guides
+from pollypm.project_guides import (
+    init_project_guide,
+    list_project_guides,
+    render_project_guide_diff,
+)
 
 
 project_app = typer.Typer(
@@ -406,6 +410,38 @@ def list_guides_cmd(
     for guide in guides:
         forked = guide.forked_from or "unknown"
         typer.echo(f"- {guide.role}: {guide.path} (forked_from: {forked})")
+
+
+@project_app.command("guide-diff")
+def guide_diff_cmd(
+    role: str = typer.Argument(
+        ...,
+        help="Role guide to diff: architect, reviewer, or worker.",
+    ),
+    project: Optional[str] = typer.Option(
+        None,
+        "--project",
+        help=(
+            "Project key, alias, or path. Defaults to the project whose "
+            "root matches the current directory."
+        ),
+    ),
+    config_path: Path = typer.Option(
+        DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path.",
+    ),
+) -> None:
+    """Print a unified diff between the local guide and current built-in."""
+    path = _require_config(config_path)
+    _key, project_path = _resolve_project_key(path, project)
+    try:
+        diff_text = render_project_guide_diff(project_path, role)
+    except (FileExistsError, RuntimeError, ValueError, FileNotFoundError) as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+    if not diff_text:
+        typer.echo("No drift detected; the project-local guide matches the current built-in.")
+        return
+    typer.echo(diff_text)
 
 
 # ---------------------------------------------------------------------------

--- a/src/pollypm/project_guides.py
+++ b/src/pollypm/project_guides.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import difflib
 import hashlib
 import subprocess
 from dataclasses import dataclass
@@ -21,6 +22,17 @@ class ProjectGuideInfo:
     path: Path
     forked_from: str | None
     body: str
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectGuideDriftInfo:
+    role: str
+    path: Path
+    forked_from: str | None
+    current_ref: str
+    drifted: bool
+    body: str
+    upstream_body: str
 
 
 def normalize_project_guide_role(role: str) -> str:
@@ -83,6 +95,59 @@ def list_project_guides(project_path: Path) -> list[ProjectGuideInfo]:
     for path in sorted(guide_dir.glob("*.md")):
         guides.append(_read_project_guide_path(path))
     return guides
+
+
+def project_guide_drift_info(
+    project_path: Path,
+    role: str,
+) -> ProjectGuideDriftInfo | None:
+    normalized = validate_project_guide_role(role)
+    target = project_guide_path(project_path, normalized)
+    if not target.exists():
+        return None
+    guide = _read_project_guide_path(target)
+    upstream_body = built_in_guide_text(normalized).strip()
+    current_ref = built_in_guide_fork_ref(
+        normalized,
+        content=upstream_body,
+        source_path=built_in_guide_source_path(normalized),
+    )
+    return ProjectGuideDriftInfo(
+        role=guide.role,
+        path=guide.path,
+        forked_from=guide.forked_from,
+        current_ref=current_ref,
+        drifted=(guide.forked_from != current_ref),
+        body=guide.body,
+        upstream_body=upstream_body,
+    )
+
+
+def list_drifted_project_guides(project_path: Path) -> list[ProjectGuideDriftInfo]:
+    drifted: list[ProjectGuideDriftInfo] = []
+    for guide in list_project_guides(project_path):
+        info = project_guide_drift_info(project_path, guide.role)
+        if info is not None and info.drifted:
+            drifted.append(info)
+    return drifted
+
+
+def render_project_guide_diff(project_path: Path, role: str) -> str:
+    info = project_guide_drift_info(project_path, role)
+    if info is None:
+        raise FileNotFoundError(
+            f"No project-local {validate_project_guide_role(role)} guide exists."
+        )
+    from_label = f"project-local/{info.role}.md (forked_from {info.forked_from or 'unknown'})"
+    to_label = f"built-in/{info.role}.md (current {info.current_ref})"
+    diff = difflib.unified_diff(
+        info.body.splitlines(),
+        info.upstream_body.splitlines(),
+        fromfile=from_label,
+        tofile=to_label,
+        lineterm="",
+    )
+    return "\n".join(diff)
 
 
 def read_project_guide(project_path: Path, role: str) -> ProjectGuideInfo:

--- a/tests/test_doctor_enhancements.py
+++ b/tests/test_doctor_enhancements.py
@@ -445,6 +445,54 @@ def test_sessions_table_populated_skip_without_db(monkeypatch: pytest.MonkeyPatc
     assert result.passed and result.skipped
 
 
+def test_project_local_guide_drift_pass(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    project_path = tmp_path / "proj-a"
+    project_path.mkdir()
+    fake_project = type("P", (), {"path": project_path, "name": "Project A"})
+    fake_config = type("C", (), {"projects": {"proj-a": fake_project}})
+    monkeypatch.setattr(doctor, "_safe_load_config", lambda: (Path("/tmp/x"), fake_config))
+    monkeypatch.setattr(doctor, "_list_drifted_project_guides", lambda _path: [])
+    result = doctor.check_project_local_guide_drift()
+    assert result.passed
+    assert "no stale project-local guides" in result.status
+
+
+def test_project_local_guide_drift_warns_when_stale(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    project_path = tmp_path / "proj-b"
+    project_path.mkdir()
+    fake_project = type("P", (), {"path": project_path, "name": "Project B"})
+    fake_config = type("C", (), {"projects": {"proj-b": fake_project}})
+    guide_path = project_path / ".pollypm" / "project-guides" / "worker.md"
+    monkeypatch.setattr(doctor, "_safe_load_config", lambda: (Path("/tmp/x"), fake_config))
+    monkeypatch.setattr(
+        doctor,
+        "_list_drifted_project_guides",
+        lambda _path: [
+            {
+                "role": "worker",
+                "path": guide_path,
+                "forked_from": "deadbeef",
+                "current_ref": "cafebabe",
+                "drifted": True,
+            }
+        ],
+    )
+    result = doctor.check_project_local_guide_drift()
+    assert not result.passed
+    assert result.severity == "warning"
+    assert "proj-b:worker" in result.status
+    assert "pm project init-guide worker --project proj-b --force" in result.fix
+    assert result.data["stale"][0]["project"] == "proj-b"
+
+
+def test_project_local_guide_drift_skip_without_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(doctor, "_safe_load_config", lambda: (None, None))
+    result = doctor.check_project_local_guide_drift()
+    assert result.passed and result.skipped
+
+
 # --------------------------------------------------------------------- #
 # Scheduler checks
 # --------------------------------------------------------------------- #
@@ -777,6 +825,14 @@ def test_summary_counts_are_accurate() -> None:
     assert "4 checks · 2 passed · 1 warnings · 1 errors" in text
 
 
+def test_render_human_labels_guide_drift_section() -> None:
+    report = doctor.run_checks([
+        doctor.Check("guide-x", lambda: doctor._ok("ok"), "guides"),
+    ])
+    text = doctor.render_human(report)
+    assert "-- Guide Drift --" in text
+
+
 # --------------------------------------------------------------------- #
 # JSON output validity
 # --------------------------------------------------------------------- #
@@ -788,15 +844,16 @@ def test_json_output_is_valid_for_new_categories() -> None:
 
     report = doctor.run_checks([
         doctor.Check("pipeline-x", _pass, "pipeline"),
+        doctor.Check("guide-x", _pass, "guides"),
         doctor.Check("resource-x", _pass, "resources"),
         doctor.Check("inbox-x", _pass, "inbox"),
     ])
     payload = json.loads(doctor.render_json(report))
     assert payload["ok"] is True
     categories = {c["category"] for c in payload["checks"]}
-    assert categories == {"pipeline", "resources", "inbox"}
-    assert payload["summary"]["total"] == 3
-    assert payload["summary"]["passed"] == 3
+    assert categories == {"pipeline", "guides", "resources", "inbox"}
+    assert payload["summary"]["total"] == 4
+    assert payload["summary"]["passed"] == 4
 
 
 def test_cli_doctor_json_with_new_checks() -> None:
@@ -809,7 +866,7 @@ def test_cli_doctor_json_with_new_checks() -> None:
     payload = json.loads(result.stdout)
     categories = {c["category"] for c in payload["checks"]}
     # Confirm every new category appears.
-    for expected in ("roles", "pipeline", "schedulers", "resources", "inbox", "sessions"):
+    for expected in ("roles", "pipeline", "guides", "schedulers", "resources", "inbox", "sessions"):
         assert expected in categories, f"{expected} missing from {categories}"
 
 

--- a/tests/test_project_planning_cli.py
+++ b/tests/test_project_planning_cli.py
@@ -169,6 +169,59 @@ class TestGuides:
         assert result.exit_code != 0
         assert "Missing argument" in (result.stdout + result.stderr)
 
+    def test_guide_diff_shows_unified_diff_when_upstream_changes(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import pollypm.project_guides as project_guides
+
+        repo = _make_project_repo(tmp_path)
+        config_path = _write_minimal_config(tmp_path, projects={"demo": repo})
+
+        result = runner.invoke(
+            project_app,
+            ["init-guide", "worker", "--project", "demo", "--config", str(config_path)],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+
+        original_text = project_guides.built_in_guide_text
+        original_ref = project_guides.built_in_guide_fork_ref
+        monkeypatch.setattr(
+            "pollypm.project_guides.built_in_guide_text",
+            lambda role: "# Worker Guide\n\nNew upstream guidance\n"
+            if role == "worker"
+            else original_text(role),
+        )
+        monkeypatch.setattr(
+            "pollypm.project_guides.built_in_guide_fork_ref",
+            lambda role, **kwargs: "new-upstream-sha"
+            if role == "worker"
+            else original_ref(role, **kwargs),
+        )
+
+        result = runner.invoke(
+            project_app,
+            ["guide-diff", "worker", "--project", "demo", "--config", str(config_path)],
+        )
+
+        assert result.exit_code == 0, result.stdout + result.stderr
+        assert "--- project-local/worker.md" in result.stdout
+        assert "+++ built-in/worker.md" in result.stdout
+        assert "+New upstream guidance" in result.stdout
+
+    def test_guide_diff_requires_existing_local_guide(self, tmp_path: Path) -> None:
+        repo = _make_project_repo(tmp_path)
+        config_path = _write_minimal_config(tmp_path, projects={"demo": repo})
+
+        result = runner.invoke(
+            project_app,
+            ["guide-diff", "worker", "--project", "demo", "--config", str(config_path)],
+        )
+
+        assert result.exit_code == 1
+        assert "No project-local worker guide exists" in (result.stdout + result.stderr)
+
 
 # ---------------------------------------------------------------------------
 # plan

--- a/tests/test_project_settings_ui.py
+++ b/tests/test_project_settings_ui.py
@@ -55,8 +55,9 @@ def _fake_role_registry() -> Registry:
 
 
 class _FakeProject:
-    def __init__(self, key: str, *, name: str | None = None) -> None:
+    def __init__(self, key: str, *, path: Path, name: str | None = None) -> None:
         self.key = key
+        self.path = path
         self.name = name or key.title()
         self.role_assignments: dict[str, ModelAssignment] = {}
 
@@ -106,9 +107,9 @@ class _FakeUsage:
 
 
 class _FakeConfig:
-    def __init__(self) -> None:
+    def __init__(self, project_path: Path) -> None:
         self.pollypm = _FakePollyPM()
-        self.projects = {"alpha": _FakeProject("alpha", name="Alpha Project")}
+        self.projects = {"alpha": _FakeProject("alpha", path=project_path, name="Alpha Project")}
         self.sessions = {
             "worker-alpha": _FakeSession(
                 "worker-alpha",
@@ -140,7 +141,9 @@ class _FakeService:
 def project_settings_env(tmp_path: Path, monkeypatch):
     config_path = tmp_path / "pollypm.toml"
     config_path.write_text("# test config\n")
-    fake_config = _FakeConfig()
+    project_path = tmp_path / "alpha"
+    project_path.mkdir()
+    fake_config = _FakeConfig(project_path)
     service = _FakeService()
     monkeypatch.setattr(
         "pollypm.cockpit_project_settings.load_config",
@@ -180,6 +183,7 @@ def project_settings_env(tmp_path: Path, monkeypatch):
     return {
         "app": PollyProjectSettingsApp(config_path, "alpha"),
         "config_path": config_path,
+        "project_path": project_path,
         "service": service,
     }
 
@@ -308,7 +312,6 @@ def test_project_settings_buttons_include_inline_key_hints(project_settings_env)
 
     _run(body())
 
-
 def test_project_settings_role_editor_persists_override_custom_and_inherit(
     tmp_path: Path,
     monkeypatch,
@@ -423,6 +426,34 @@ def test_project_settings_role_editor_persists_override_custom_and_inherit(
             assert "architect" not in reloaded.projects["alpha"].role_assignments
             detail = str(app.query_one("#project-role-detail").render())
             assert "inherited global" in detail
+
+    _run(body())
+
+
+def test_project_settings_shows_prompt_drift_badge(project_settings_env, monkeypatch) -> None:
+    app = project_settings_env["app"]
+    guide_path = project_settings_env["project_path"] / ".pollypm" / "project-guides" / "worker.md"
+    guide_path.parent.mkdir(parents=True)
+    guide_path.write_text("---\nforked_from: deadbeef\n---\nlocal worker guide\n")
+    monkeypatch.setattr(
+        "pollypm.cockpit_project_settings._project_guide_drift_info",
+        lambda _project_path, role: {
+            "role": role,
+            "path": guide_path,
+            "forked_from": "deadbeef",
+            "current_ref": "cafebabe",
+            "drifted": role == "worker",
+            "body": "local worker guide\n",
+            "upstream_body": "upstream worker guide\n",
+        },
+    )
+
+    async def body() -> None:
+        async with app.run_test(size=(120, 30)) as pilot:
+            await pilot.pause()
+            guide_info = str(app.query_one("#guide-info").render())
+            assert "worker" in guide_info
+            assert "upstream changed" in guide_info
 
     _run(body())
 


### PR DESCRIPTION
Closes #734

## Summary
- add project-guide drift helpers plus `pm project guide-diff` for inspecting stale local forks
- surface upstream-change badges in project settings for stale project-local guides
- add a `guides` doctor category with refresh guidance for stale role guides

## Verification
- `HOME="$(mktemp -d)" uv run --with pytest pytest tests/test_project_planning_cli.py tests/test_supervisor.py tests/test_session_manager.py tests/test_worker_protocol_injection.py tests/test_project_settings_ui.py tests/test_doctor.py tests/test_doctor_enhancements.py -q`
- `HOME="$(mktemp -d)" uv run --with pytest pytest tests/test_launch_planner.py tests/test_project_planning_plugin.py tests/test_workers.py -q`
- `uv build`