### PR TITLE
Refactor cockpit navigation and window modules

### DIFF
--- a/src/pollypm/cockpit_content.py
+++ b/src/pollypm/cockpit_content.py
@@ -1,0 +1,395 @@
+"""Pure right-pane content planning for cockpit rail selections.
+
+This module translates rail selection keys into data-only content plans.
+It intentionally does not import Textual apps, tmux clients, the service
+API, or supervisor code. Callers provide any project/session facts the
+resolver needs, then a separate window manager can turn the returned plan
+into tmux operations.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Literal
+
+from pollypm.cockpit_rail_routes import (
+    ProjectRoute,
+    resolve_live_session_route,
+    resolve_project_route,
+    resolve_static_view_route,
+)
+
+
+PaneContentKind = Literal[
+    "static_command",
+    "live_agent",
+    "loading",
+    "error",
+    "fallback",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class CockpitContentContext:
+    """Facts the pure resolver may use without loading a supervisor."""
+
+    project_keys: frozenset[str] | None = None
+    project_sessions: Mapping[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_projects(
+        cls,
+        projects: Iterable[str] | Mapping[str, object] | None = None,
+        *,
+        project_sessions: Mapping[str, str] | None = None,
+    ) -> "CockpitContentContext":
+        """Build a context from config-shaped project/session mappings."""
+        project_keys: frozenset[str] | None
+        if projects is None:
+            project_keys = None
+        elif isinstance(projects, Mapping):
+            project_keys = frozenset(str(key) for key in projects)
+        else:
+            project_keys = frozenset(str(key) for key in projects)
+        return cls(
+            project_keys=project_keys,
+            project_sessions=dict(project_sessions or {}),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TextualCommandPane:
+    """A static right-pane surface launched through ``pm cockpit-pane``."""
+
+    route_key: str
+    selected_key: str
+    pane_kind: str
+    command_args: tuple[str, ...]
+    project_key: str | None = None
+    task_id: str | None = None
+    content_kind: Literal["static_command"] = field(
+        default="static_command",
+        init=False,
+    )
+    right_pane_state: Literal["static"] = field(default="static", init=False)
+
+
+StaticCommandPane = TextualCommandPane
+
+
+@dataclass(frozen=True, slots=True)
+class LiveAgentPane:
+    """A live agent session to mount into the cockpit right pane."""
+
+    route_key: str
+    selected_key: str
+    session_name: str
+    project_key: str | None = None
+    fallback: TextualCommandPane | None = None
+    content_kind: Literal["live_agent"] = field(default="live_agent", init=False)
+    right_pane_state: Literal["live_agent"] = field(
+        default="live_agent",
+        init=False,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class LoadingPane:
+    """A placeholder pane while async route work is pending."""
+
+    route_key: str
+    selected_key: str
+    title: str
+    message: str
+    content_kind: Literal["loading"] = field(default="loading", init=False)
+    right_pane_state: Literal["loading"] = field(default="loading", init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ErrorPane:
+    """An explicit non-tmux error pane."""
+
+    route_key: str
+    selected_key: str
+    reason: str
+    title: str
+    message: str
+    content_kind: Literal["error"] = field(default="error", init=False)
+    right_pane_state: Literal["error"] = field(default="error", init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class FallbackPane:
+    """An explicit fallback plan with a safe static target."""
+
+    route_key: str
+    selected_key: str
+    reason: str
+    message: str
+    fallback: TextualCommandPane
+    content_kind: Literal["fallback"] = field(default="fallback", init=False)
+    right_pane_state: Literal["static"] = field(default="static", init=False)
+
+
+RightPaneContentPlan = (
+    TextualCommandPane
+    | LiveAgentPane
+    | LoadingPane
+    | ErrorPane
+    | FallbackPane
+)
+
+
+def loading_content_plan(
+    route_key: str,
+    *,
+    selected_key: str | None = None,
+    label: str | None = None,
+) -> LoadingPane:
+    """Return the optimistic loading plan for a pending route."""
+    clean_key = _normalize_route_key(route_key)
+    display = (label or clean_key).strip() or "selection"
+    return LoadingPane(
+        route_key=clean_key,
+        selected_key=selected_key or clean_key,
+        title="Loading",
+        message=f"Loading {display}...",
+    )
+
+
+def resolve_cockpit_content(
+    key: str,
+    context: CockpitContentContext | None = None,
+) -> RightPaneContentPlan:
+    """Resolve a rail key to a typed right-pane content plan."""
+    route_key = _normalize_route_key(key)
+    if not route_key:
+        return _error_plan(
+            route_key=route_key,
+            selected_key=route_key,
+            reason="empty_route",
+            message="Cockpit route key must not be empty.",
+        )
+
+    ctx = context or CockpitContentContext()
+
+    live_route = resolve_live_session_route(route_key)
+    if live_route is not None:
+        return LiveAgentPane(
+            route_key=route_key,
+            selected_key=route_key,
+            session_name=live_route.session_name,
+            fallback=_textual_command_pane(
+                route_key=route_key,
+                selected_key=route_key,
+                pane_kind=live_route.fallback_kind,
+            ),
+        )
+
+    static_route = resolve_static_view_route(route_key)
+    if static_route is not None:
+        project_key = static_route.project_key
+        if project_key is not None and not _project_exists(ctx, project_key):
+            return _missing_project_plan(route_key, project_key)
+        return _textual_command_pane(
+            route_key=route_key,
+            selected_key=static_route.selected_key or route_key,
+            pane_kind=static_route.kind,
+            project_key=project_key,
+        )
+
+    project_route = resolve_project_route(route_key)
+    if project_route is not None:
+        return _resolve_project_content(route_key, project_route, ctx)
+
+    reason = "invalid_project_route" if route_key.startswith("project:") else "unknown_route"
+    return _error_plan(
+        route_key=route_key,
+        selected_key=route_key,
+        reason=reason,
+        message=f"Unknown cockpit route: {route_key}",
+    )
+
+
+resolve_right_pane_content = resolve_cockpit_content
+
+
+def _resolve_project_content(
+    route_key: str,
+    route: ProjectRoute,
+    context: CockpitContentContext,
+) -> RightPaneContentPlan:
+    project_key = route.project_key
+    if not _project_exists(context, project_key):
+        return _missing_project_plan(route_key, project_key)
+
+    sub_view = route.sub_view
+    if sub_view is None or sub_view == "dashboard":
+        return _textual_command_pane(
+            route_key=route_key,
+            selected_key=f"project:{project_key}:dashboard",
+            pane_kind="project",
+            project_key=project_key,
+        )
+
+    if sub_view == "settings":
+        return _textual_command_pane(
+            route_key=route_key,
+            selected_key=route_key,
+            pane_kind="settings",
+            project_key=project_key,
+        )
+
+    if sub_view == "issues":
+        task_id = f"{project_key}/{route.task_num}" if route.task_num else None
+        return _textual_command_pane(
+            route_key=route_key,
+            selected_key=route_key,
+            pane_kind="issues",
+            project_key=project_key,
+            task_id=task_id,
+        )
+
+    if sub_view == "task" and route.task_num:
+        task_id = f"{project_key}/{route.task_num}"
+        return _textual_command_pane(
+            route_key=route_key,
+            selected_key=route_key,
+            pane_kind="issues",
+            project_key=project_key,
+            task_id=task_id,
+        )
+
+    if sub_view == "session":
+        session_name = _project_session(context, project_key)
+        if session_name is not None:
+            return LiveAgentPane(
+                route_key=route_key,
+                selected_key=route_key,
+                session_name=session_name,
+                project_key=project_key,
+                fallback=_textual_command_pane(
+                    route_key=route_key,
+                    selected_key=f"project:{project_key}:dashboard",
+                    pane_kind="project",
+                    project_key=project_key,
+                ),
+            )
+        fallback = _textual_command_pane(
+            route_key=route_key,
+            selected_key=f"project:{project_key}:dashboard",
+            pane_kind="project",
+            project_key=project_key,
+        )
+        return FallbackPane(
+            route_key=route_key,
+            selected_key=fallback.selected_key,
+            reason="missing_worker",
+            message=(
+                f"Project '{project_key}' has no mapped worker/PM session. "
+                "Showing the project dashboard instead."
+            ),
+            fallback=fallback,
+        )
+
+    return _error_plan(
+        route_key=route_key,
+        selected_key=route_key,
+        reason="unsupported_project_route",
+        message=f"Unsupported project route: {route_key}",
+    )
+
+
+def _textual_command_pane(
+    *,
+    route_key: str,
+    selected_key: str,
+    pane_kind: str,
+    project_key: str | None = None,
+    task_id: str | None = None,
+) -> TextualCommandPane:
+    return TextualCommandPane(
+        route_key=route_key,
+        selected_key=selected_key,
+        pane_kind=pane_kind,
+        project_key=project_key,
+        task_id=task_id,
+        command_args=_command_args(pane_kind, project_key, task_id),
+    )
+
+
+def _command_args(
+    pane_kind: str,
+    project_key: str | None,
+    task_id: str | None,
+) -> tuple[str, ...]:
+    args = ["cockpit-pane", pane_kind]
+    if project_key is not None:
+        if pane_kind in {"activity", "inbox"}:
+            args.extend(["--project", project_key])
+        else:
+            args.append(project_key)
+    if task_id is not None:
+        args.extend(["--task", task_id])
+    return tuple(args)
+
+
+def _project_exists(context: CockpitContentContext, project_key: str) -> bool:
+    return context.project_keys is None or project_key in context.project_keys
+
+
+def _project_session(
+    context: CockpitContentContext,
+    project_key: str,
+) -> str | None:
+    session_name = context.project_sessions.get(project_key)
+    if not isinstance(session_name, str):
+        return None
+    session_name = session_name.strip()
+    return session_name or None
+
+
+def _missing_project_plan(route_key: str, project_key: str) -> ErrorPane:
+    return _error_plan(
+        route_key=route_key,
+        selected_key=route_key,
+        reason="missing_project",
+        message=f"Project '{project_key}' is not registered in this workspace.",
+    )
+
+
+def _error_plan(
+    *,
+    route_key: str,
+    selected_key: str,
+    reason: str,
+    message: str,
+) -> ErrorPane:
+    return ErrorPane(
+        route_key=route_key,
+        selected_key=selected_key,
+        reason=reason,
+        title="Unable to open pane",
+        message=message,
+    )
+
+
+def _normalize_route_key(key: str) -> str:
+    return str(key or "").strip()
+
+
+__all__ = [
+    "CockpitContentContext",
+    "ErrorPane",
+    "FallbackPane",
+    "LiveAgentPane",
+    "LoadingPane",
+    "PaneContentKind",
+    "RightPaneContentPlan",
+    "StaticCommandPane",
+    "TextualCommandPane",
+    "loading_content_plan",
+    "resolve_cockpit_content",
+    "resolve_right_pane_content",
+]

--- a/src/pollypm/cockpit_contracts.py
+++ b/src/pollypm/cockpit_contracts.py
@@ -1,0 +1,255 @@
+"""Typed contracts for the modular cockpit refactor (#969).
+
+The target cockpit shape is:
+
+    rail UI -> navigation state machine -> content resolver -> window manager
+
+This module declares the typed records passed across those boundaries. It is
+intentionally pure: no tmux client construction, no Textual imports, no
+Supervisor imports, and no process IO. Runtime code can adopt these contracts
+incrementally without changing today's cockpit behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Mapping, Protocol
+
+
+class NavigationIntent(StrEnum):
+    """Why the rail is asking the cockpit to route."""
+
+    SELECT = "select"
+    REFRESH = "refresh"
+    FOCUS_RIGHT = "focus_right"
+    SEND_KEY = "send_key"
+    RESTORE = "restore"
+
+
+class NavigationOutcome(StrEnum):
+    """State-machine result before any terminal mutation occurs."""
+
+    NOOP = "noop"
+    SHOW_CONTENT = "show_content"
+    MOUNT_CONTENT = "mount_content"
+    FOCUS_RIGHT = "focus_right"
+    ERROR = "error"
+
+
+class ContentPlanKind(StrEnum):
+    """Kinds of right-pane content the resolver may request."""
+
+    STATIC_VIEW = "static_view"
+    LIVE_SESSION = "live_session"
+    PROJECT_VIEW = "project_view"
+    TASK_VIEW = "task_view"
+    LAUNCH_STREAM = "launch_stream"
+
+
+class RightPaneLifecycleState(StrEnum):
+    """Lifecycle states for the cockpit right pane.
+
+    These are deliberately higher-level than tmux. The window manager owns
+    translating lifecycle transitions into terminal operations.
+    """
+
+    UNMOUNTED = "unmounted"
+    INITIALIZING = "initializing"
+    STATIC_VIEW = "static_view"
+    LIVE_SESSION = "live_session"
+    LAUNCH_STREAM = "launch_stream"
+    STALE = "stale"
+    DETACHING = "detaching"
+    ERROR = "error"
+
+
+class MountDisposition(StrEnum):
+    """What the window manager did with a content plan."""
+
+    UNCHANGED = "unchanged"
+    MOUNTED = "mounted"
+    REMOUNTED = "remounted"
+    DETACHED = "detached"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class NavigationRequest:
+    """Rail/UI request entering the navigation state machine."""
+
+    selected_key: str
+    intent: NavigationIntent = NavigationIntent.SELECT
+    origin: str = "rail"
+    project_key: str | None = None
+    task_id: str | None = None
+    payload: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ContentPlan:
+    """Resolver output consumed by the cockpit window manager.
+
+    ``command`` is a declarative argv tuple. The resolver may name what should
+    be shown, but only the window manager may decide how to materialize it.
+    """
+
+    kind: ContentPlanKind
+    key: str
+    title: str
+    selected_key: str | None = None
+    session_name: str | None = None
+    project_key: str | None = None
+    task_id: str | None = None
+    command: tuple[str, ...] = ()
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class NavigationResult:
+    """State-machine response to a :class:`NavigationRequest`."""
+
+    request: NavigationRequest
+    outcome: NavigationOutcome
+    active_key: str | None = None
+    content_plan: ContentPlan | None = None
+    lifecycle_state: RightPaneLifecycleState | None = None
+    reason: str = ""
+    diagnostics: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class PaneSnapshot:
+    """Pure data snapshot of a pane inside a cockpit window."""
+
+    pane_id: str
+    command: str = ""
+    current_path: str | None = None
+    active: bool = False
+    is_dead: bool = False
+    left: int | None = None
+    top: int | None = None
+    width: int | None = None
+    height: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class WindowSnapshot:
+    """Pure data snapshot of the cockpit window shape."""
+
+    session_name: str
+    window_name: str
+    target: str
+    window_index: int | None = None
+    width: int | None = None
+    height: int | None = None
+    active_pane_id: str | None = None
+    right_pane_id: str | None = None
+    panes: tuple[PaneSnapshot, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class RightPaneLifecycle:
+    """Persistable lifecycle record for the cockpit right pane."""
+
+    state: RightPaneLifecycleState
+    content_key: str | None = None
+    plan_kind: ContentPlanKind | None = None
+    pane_id: str | None = None
+    mounted_session: str | None = None
+    project_key: str | None = None
+    task_id: str | None = None
+    updated_at: str | None = None
+    detail: str = ""
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class MountResult:
+    """Window-manager response after applying a :class:`ContentPlan`."""
+
+    disposition: MountDisposition
+    lifecycle: RightPaneLifecycle
+    plan: ContentPlan | None = None
+    snapshot: WindowSnapshot | None = None
+    right_pane_id: str | None = None
+    message: str = ""
+    error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None and self.disposition is not MountDisposition.FAILED
+
+
+class CockpitNavigationStateMachine(Protocol):
+    """Boundary between rail events and route decisions."""
+
+    def navigate(
+        self,
+        request: NavigationRequest,
+        *,
+        current: RightPaneLifecycle | None = None,
+    ) -> NavigationResult:
+        """Return the next navigation result without terminal side effects."""
+        ...
+
+
+class CockpitContentResolver(Protocol):
+    """Boundary between route decisions and right-pane content plans."""
+
+    def resolve_content(self, navigation: NavigationResult) -> ContentPlan:
+        """Convert a navigation result into a content plan."""
+        ...
+
+
+class CockpitWindowManager(Protocol):
+    """Boundary that owns cockpit window and right-pane mechanics."""
+
+    def capture(self) -> WindowSnapshot:
+        """Return the current cockpit window snapshot."""
+        ...
+
+    def mount_content(
+        self,
+        plan: ContentPlan,
+        *,
+        current: RightPaneLifecycle | None = None,
+    ) -> MountResult:
+        """Apply a content plan to the right pane."""
+        ...
+
+    def release_right_pane(self, *, reason: str = "") -> MountResult:
+        """Detach or reset the right pane according to implementation policy."""
+        ...
+
+
+class CockpitRightPaneLifecycleStore(Protocol):
+    """Persistence boundary for right-pane lifecycle state."""
+
+    def load_lifecycle(self) -> RightPaneLifecycle:
+        """Return the last persisted right-pane lifecycle record."""
+        ...
+
+    def save_lifecycle(self, lifecycle: RightPaneLifecycle) -> None:
+        """Persist a right-pane lifecycle record."""
+        ...
+
+
+__all__ = [
+    "CockpitContentResolver",
+    "CockpitNavigationStateMachine",
+    "CockpitRightPaneLifecycleStore",
+    "CockpitWindowManager",
+    "ContentPlan",
+    "ContentPlanKind",
+    "MountDisposition",
+    "MountResult",
+    "NavigationIntent",
+    "NavigationOutcome",
+    "NavigationRequest",
+    "NavigationResult",
+    "PaneSnapshot",
+    "RightPaneLifecycle",
+    "RightPaneLifecycleState",
+    "WindowSnapshot",
+]

--- a/src/pollypm/cockpit_navigation.py
+++ b/src/pollypm/cockpit_navigation.py
@@ -1,0 +1,317 @@
+"""Pure navigation state machine for cockpit rail selections.
+
+The rail should acknowledge clicks immediately, then let slower content
+resolution and pane/window work happen behind a request-id guard. This module
+keeps that sequencing independent of Textual, tmux, and the cockpit router so
+it can be tested directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+
+NavigationState = Literal[
+    "accepted",
+    "loading",
+    "applied",
+    "cancelled",
+    "timed_out",
+    "failed",
+    "stale",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class NavigationRequest:
+    request_id: int
+    key: str
+
+
+@dataclass(frozen=True, slots=True)
+class NavigationContent:
+    destination_key: str
+    payload: object | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class NavigationResult:
+    request_id: int
+    key: str
+    state: NavigationState
+    destination_key: str | None = None
+    content: object | None = None
+    window_result: object | None = None
+    message: str | None = None
+    error: str | None = None
+    superseded_by: int | None = None
+
+
+class NavigationStateStore(Protocol):
+    def record(self, result: NavigationResult) -> None:
+        ...
+
+
+class NavigationContentResolver(Protocol):
+    def resolve(self, request: NavigationRequest) -> object | Awaitable[object]:
+        ...
+
+
+class NavigationWindowManager(Protocol):
+    def apply(
+        self,
+        request: NavigationRequest,
+        content: object,
+    ) -> object | Awaitable[object]:
+        ...
+
+
+class InMemoryNavigationStateStore:
+    """Small default store useful for tests and simple integrations."""
+
+    def __init__(self) -> None:
+        self.history: list[NavigationResult] = []
+        self.by_request: dict[int, NavigationResult] = {}
+
+    def record(self, result: NavigationResult) -> None:
+        self.history.append(result)
+        self.by_request[result.request_id] = result
+
+
+class NavigationController:
+    """Accept rail clicks and apply only the newest request's completion."""
+
+    def __init__(
+        self,
+        *,
+        state_store: NavigationStateStore,
+        content_resolver: NavigationContentResolver,
+        window_manager: NavigationWindowManager,
+        timeout_seconds: float | None = None,
+    ) -> None:
+        if timeout_seconds is not None and timeout_seconds < 0:
+            raise ValueError("timeout_seconds must be non-negative")
+        self._state_store = state_store
+        self._content_resolver = content_resolver
+        self._window_manager = window_manager
+        self._timeout_seconds = timeout_seconds
+        self._next_request_id = 0
+        self._current_request_id: int | None = None
+        self._requests: dict[int, NavigationRequest] = {}
+        self._results: dict[int, NavigationResult] = {}
+
+    @property
+    def current_request_id(self) -> int | None:
+        return self._current_request_id
+
+    @property
+    def current_result(self) -> NavigationResult | None:
+        if self._current_request_id is None:
+            return None
+        return self._results.get(self._current_request_id)
+
+    def result_for(self, request_id: int) -> NavigationResult | None:
+        return self._results.get(request_id)
+
+    def accept(self, key: str) -> NavigationRequest:
+        """Synchronously acknowledge a rail click before slow work starts."""
+
+        self._next_request_id += 1
+        request = NavigationRequest(request_id=self._next_request_id, key=key)
+        previous_id = self._current_request_id
+
+        if previous_id is not None and self._is_active(previous_id):
+            previous = self._requests[previous_id]
+            self._record(
+                previous,
+                "cancelled",
+                destination_key=previous.key,
+                message=f"Superseded by request {request.request_id}.",
+                superseded_by=request.request_id,
+            )
+
+        self._requests[request.request_id] = request
+        self._current_request_id = request.request_id
+        self._record(request, "accepted", destination_key=key)
+        self._record(request, "loading", destination_key=key)
+        return request
+
+    def cancel(self, request_id: int | None = None) -> NavigationResult | None:
+        """Mark a pending request as cancelled.
+
+        Cancelling is separate from staleness: a newer accepted request marks
+        the old one cancelled immediately, and a late old completion is then
+        recorded as stale when it tries to finish.
+        """
+
+        resolved_request_id = request_id or self._current_request_id
+        if resolved_request_id is None:
+            return None
+        request = self._requests.get(resolved_request_id)
+        if request is None:
+            return None
+        existing = self._results.get(resolved_request_id)
+        if existing is not None and existing.state in {
+            "applied",
+            "timed_out",
+            "failed",
+            "stale",
+        }:
+            return existing
+        return self._record(
+            request,
+            "cancelled",
+            destination_key=request.key,
+            message="Navigation cancelled.",
+        )
+
+    async def navigate(self, key: str) -> NavigationResult:
+        """Accept, resolve, and apply a rail navigation request."""
+
+        request = self.accept(key)
+        return await self.resolve_and_apply(request)
+
+    async def resolve_and_apply(
+        self,
+        request: NavigationRequest,
+    ) -> NavigationResult:
+        """Resolve content and apply it if ``request`` is still newest."""
+
+        inactive = self._inactive_result(request)
+        if inactive is not None:
+            return inactive
+
+        try:
+            if self._timeout_seconds is None:
+                return await self._resolve_and_apply_without_timeout(request)
+            return await asyncio.wait_for(
+                self._resolve_and_apply_without_timeout(request),
+                timeout=self._timeout_seconds,
+            )
+        except TimeoutError:
+            return self._finish_or_stale(
+                request,
+                "timed_out",
+                destination_key=request.key,
+                message=f"Navigation to {request.key} timed out.",
+                error="timed out",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return self._finish_or_stale(
+                request,
+                "failed",
+                destination_key=request.key,
+                message=f"Navigation to {request.key} failed: {exc}",
+                error=str(exc),
+            )
+
+    async def _resolve_and_apply_without_timeout(
+        self,
+        request: NavigationRequest,
+    ) -> NavigationResult:
+        content = await _maybe_await(self._content_resolver.resolve(request))
+
+        inactive = self._inactive_result(request)
+        if inactive is not None:
+            return inactive
+
+        destination_key = _destination_key(request, content)
+        window_result = await _maybe_await(self._window_manager.apply(request, content))
+
+        inactive = self._inactive_result(request)
+        if inactive is not None:
+            return inactive
+
+        return self._record(
+            request,
+            "applied",
+            destination_key=destination_key,
+            content=content,
+            window_result=window_result,
+        )
+
+    def _inactive_result(self, request: NavigationRequest) -> NavigationResult | None:
+        existing = self._results.get(request.request_id)
+        if request.request_id != self._current_request_id:
+            return self._record(
+                request,
+                "stale",
+                destination_key=request.key,
+                message="Navigation completion ignored because a newer request exists.",
+                superseded_by=self._current_request_id,
+            )
+        if existing is not None and existing.state == "cancelled":
+            return existing
+        return None
+
+    def _finish_or_stale(
+        self,
+        request: NavigationRequest,
+        state: Literal["timed_out", "failed"],
+        *,
+        destination_key: str,
+        message: str,
+        error: str,
+    ) -> NavigationResult:
+        inactive = self._inactive_result(request)
+        if inactive is not None:
+            return inactive
+        return self._record(
+            request,
+            state,
+            destination_key=destination_key,
+            message=message,
+            error=error,
+        )
+
+    def _is_active(self, request_id: int) -> bool:
+        result = self._results.get(request_id)
+        return result is not None and result.state in {"accepted", "loading"}
+
+    def _record(
+        self,
+        request: NavigationRequest,
+        state: NavigationState,
+        *,
+        destination_key: str | None = None,
+        content: object | None = None,
+        window_result: object | None = None,
+        message: str | None = None,
+        error: str | None = None,
+        superseded_by: int | None = None,
+    ) -> NavigationResult:
+        result = NavigationResult(
+            request_id=request.request_id,
+            key=request.key,
+            state=state,
+            destination_key=destination_key,
+            content=content,
+            window_result=window_result,
+            message=message,
+            error=error,
+            superseded_by=superseded_by,
+        )
+        self._results[request.request_id] = result
+        self._state_store.record(result)
+        return result
+
+
+async def _maybe_await(value: object | Awaitable[object]) -> object:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _destination_key(request: NavigationRequest, content: object) -> str:
+    if isinstance(content, NavigationContent):
+        return content.destination_key
+    if isinstance(content, str):
+        return content
+    destination_key = getattr(content, "destination_key", None)
+    if isinstance(destination_key, str) and destination_key:
+        return destination_key
+    return request.key

--- a/src/pollypm/cockpit_navigation.py
+++ b/src/pollypm/cockpit_navigation.py
@@ -27,7 +27,7 @@ NavigationState = Literal[
 
 
 @dataclass(frozen=True, slots=True)
-class NavigationRequest:
+class NavigationCommand:
     request_id: int
     key: str
 
@@ -39,7 +39,7 @@ class NavigationContent:
 
 
 @dataclass(frozen=True, slots=True)
-class NavigationResult:
+class NavigationTransition:
     request_id: int
     key: str
     state: NavigationState
@@ -52,19 +52,19 @@ class NavigationResult:
 
 
 class NavigationStateStore(Protocol):
-    def record(self, result: NavigationResult) -> None:
+    def record(self, result: NavigationTransition) -> None:
         ...
 
 
 class NavigationContentResolver(Protocol):
-    def resolve(self, request: NavigationRequest) -> object | Awaitable[object]:
+    def resolve(self, request: NavigationCommand) -> object | Awaitable[object]:
         ...
 
 
 class NavigationWindowManager(Protocol):
     def apply(
         self,
-        request: NavigationRequest,
+        request: NavigationCommand,
         content: object,
     ) -> object | Awaitable[object]:
         ...
@@ -74,10 +74,10 @@ class InMemoryNavigationStateStore:
     """Small default store useful for tests and simple integrations."""
 
     def __init__(self) -> None:
-        self.history: list[NavigationResult] = []
-        self.by_request: dict[int, NavigationResult] = {}
+        self.history: list[NavigationTransition] = []
+        self.by_request: dict[int, NavigationTransition] = {}
 
-    def record(self, result: NavigationResult) -> None:
+    def record(self, result: NavigationTransition) -> None:
         self.history.append(result)
         self.by_request[result.request_id] = result
 
@@ -101,27 +101,27 @@ class NavigationController:
         self._timeout_seconds = timeout_seconds
         self._next_request_id = 0
         self._current_request_id: int | None = None
-        self._requests: dict[int, NavigationRequest] = {}
-        self._results: dict[int, NavigationResult] = {}
+        self._requests: dict[int, NavigationCommand] = {}
+        self._results: dict[int, NavigationTransition] = {}
 
     @property
     def current_request_id(self) -> int | None:
         return self._current_request_id
 
     @property
-    def current_result(self) -> NavigationResult | None:
+    def current_result(self) -> NavigationTransition | None:
         if self._current_request_id is None:
             return None
         return self._results.get(self._current_request_id)
 
-    def result_for(self, request_id: int) -> NavigationResult | None:
+    def result_for(self, request_id: int) -> NavigationTransition | None:
         return self._results.get(request_id)
 
-    def accept(self, key: str) -> NavigationRequest:
+    def accept(self, key: str) -> NavigationCommand:
         """Synchronously acknowledge a rail click before slow work starts."""
 
         self._next_request_id += 1
-        request = NavigationRequest(request_id=self._next_request_id, key=key)
+        request = NavigationCommand(request_id=self._next_request_id, key=key)
         previous_id = self._current_request_id
 
         if previous_id is not None and self._is_active(previous_id):
@@ -140,7 +140,7 @@ class NavigationController:
         self._record(request, "loading", destination_key=key)
         return request
 
-    def cancel(self, request_id: int | None = None) -> NavigationResult | None:
+    def cancel(self, request_id: int | None = None) -> NavigationTransition | None:
         """Mark a pending request as cancelled.
 
         Cancelling is separate from staleness: a newer accepted request marks
@@ -169,7 +169,7 @@ class NavigationController:
             message="Navigation cancelled.",
         )
 
-    async def navigate(self, key: str) -> NavigationResult:
+    async def navigate(self, key: str) -> NavigationTransition:
         """Accept, resolve, and apply a rail navigation request."""
 
         request = self.accept(key)
@@ -177,8 +177,8 @@ class NavigationController:
 
     async def resolve_and_apply(
         self,
-        request: NavigationRequest,
-    ) -> NavigationResult:
+        request: NavigationCommand,
+    ) -> NavigationTransition:
         """Resolve content and apply it if ``request`` is still newest."""
 
         inactive = self._inactive_result(request)
@@ -211,8 +211,8 @@ class NavigationController:
 
     async def _resolve_and_apply_without_timeout(
         self,
-        request: NavigationRequest,
-    ) -> NavigationResult:
+        request: NavigationCommand,
+    ) -> NavigationTransition:
         content = await _maybe_await(self._content_resolver.resolve(request))
 
         inactive = self._inactive_result(request)
@@ -234,7 +234,7 @@ class NavigationController:
             window_result=window_result,
         )
 
-    def _inactive_result(self, request: NavigationRequest) -> NavigationResult | None:
+    def _inactive_result(self, request: NavigationCommand) -> NavigationTransition | None:
         existing = self._results.get(request.request_id)
         if request.request_id != self._current_request_id:
             return self._record(
@@ -250,13 +250,13 @@ class NavigationController:
 
     def _finish_or_stale(
         self,
-        request: NavigationRequest,
+        request: NavigationCommand,
         state: Literal["timed_out", "failed"],
         *,
         destination_key: str,
         message: str,
         error: str,
-    ) -> NavigationResult:
+    ) -> NavigationTransition:
         inactive = self._inactive_result(request)
         if inactive is not None:
             return inactive
@@ -274,7 +274,7 @@ class NavigationController:
 
     def _record(
         self,
-        request: NavigationRequest,
+        request: NavigationCommand,
         state: NavigationState,
         *,
         destination_key: str | None = None,
@@ -283,8 +283,8 @@ class NavigationController:
         message: str | None = None,
         error: str | None = None,
         superseded_by: int | None = None,
-    ) -> NavigationResult:
-        result = NavigationResult(
+    ) -> NavigationTransition:
+        result = NavigationTransition(
             request_id=request.request_id,
             key=request.key,
             state=state,
@@ -306,7 +306,7 @@ async def _maybe_await(value: object | Awaitable[object]) -> object:
     return value
 
 
-def _destination_key(request: NavigationRequest, content: object) -> str:
+def _destination_key(request: NavigationCommand, content: object) -> str:
     if isinstance(content, NavigationContent):
         return content.destination_key
     if isinstance(content, str):
@@ -315,3 +315,16 @@ def _destination_key(request: NavigationRequest, content: object) -> str:
     if isinstance(destination_key, str) and destination_key:
         return destination_key
     return request.key
+
+
+__all__ = [
+    "InMemoryNavigationStateStore",
+    "NavigationCommand",
+    "NavigationContent",
+    "NavigationContentResolver",
+    "NavigationController",
+    "NavigationState",
+    "NavigationStateStore",
+    "NavigationTransition",
+    "NavigationWindowManager",
+]

--- a/src/pollypm/cockpit_navigation_client.py
+++ b/src/pollypm/cockpit_navigation_client.py
@@ -1,0 +1,542 @@
+"""Lightweight client for right-pane initiated cockpit navigation.
+
+Right-pane apps currently construct ``CockpitRouter`` directly for jumps such
+as ``inbox:<project>``, ``activity:<project>``, and
+``project:<project>:issues``. This module is the replacement boundary: apps can
+submit typed navigation requests to an active cockpit owner without importing
+Textual apps, creating a router, or touching tmux.
+
+Integration points for later wiring:
+
+* The cockpit owner can install :class:`DirectCockpitNavigationAdapter` with a
+  callback that hands ``request.navigation`` to the owner-side routing path.
+* Out-of-process right-pane apps can use :class:`FileCockpitNavigationQueue`;
+  the cockpit owner can poll :meth:`FileCockpitNavigationQueue.pending` and
+  apply the newest request through the same owner-side routing path.
+* Standalone pane processes can keep the default fallback and surface the
+  unsupported result instead of trying to create their own router.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Protocol, TypeAlias, cast
+
+from pollypm.atomic_io import atomic_write_json
+from pollypm.cockpit_contracts import NavigationIntent, NavigationRequest
+
+
+JsonValue: TypeAlias = (
+    str
+    | int
+    | float
+    | bool
+    | None
+    | list["JsonValue"]
+    | dict[str, "JsonValue"]
+)
+JsonObject: TypeAlias = dict[str, JsonValue]
+
+QUEUE_VERSION = 1
+QUEUE_FILE_NAME = "cockpit_navigation_queue.json"
+DEFAULT_CLIENT_ID = "right-pane"
+DEFAULT_ORIGIN = "right_pane"
+
+
+class CockpitNavigationClientOutcome(StrEnum):
+    """Submission outcome from the client boundary."""
+
+    SUBMITTED = "submitted"
+    QUEUED = "queued"
+    UNSUPPORTED = "unsupported"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class CockpitNavigationClientRequest:
+    """Monotonic envelope around the pure cockpit navigation request."""
+
+    request_id: str
+    sequence: int
+    navigation: NavigationRequest
+
+    @property
+    def selected_key(self) -> str:
+        return self.navigation.selected_key
+
+    @property
+    def origin(self) -> str:
+        return self.navigation.origin
+
+    @property
+    def project_key(self) -> str | None:
+        return self.navigation.project_key
+
+    @property
+    def task_id(self) -> str | None:
+        return self.navigation.task_id
+
+    @property
+    def payload(self) -> Mapping[str, object]:
+        return self.navigation.payload
+
+    def to_dict(self) -> JsonObject:
+        return {
+            "request_id": self.request_id,
+            "sequence": self.sequence,
+            "navigation": {
+                "selected_key": self.navigation.selected_key,
+                "intent": self.navigation.intent.value,
+                "origin": self.navigation.origin,
+                "project_key": self.navigation.project_key,
+                "task_id": self.navigation.task_id,
+                "payload": _json_object(self.navigation.payload, "payload"),
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, object]) -> "CockpitNavigationClientRequest":
+        request_id = _required_string(value.get("request_id"), "request_id")
+        sequence = _required_int(value.get("sequence"), "sequence")
+        navigation_value = value.get("navigation")
+        if not isinstance(navigation_value, Mapping):
+            raise ValueError("navigation must be an object")
+
+        intent_value = navigation_value.get("intent", NavigationIntent.SELECT.value)
+        try:
+            intent = NavigationIntent(str(intent_value))
+        except ValueError as exc:
+            raise ValueError(f"unknown navigation intent: {intent_value!r}") from exc
+
+        payload_value = navigation_value.get("payload", {})
+        if payload_value is None:
+            payload: JsonObject = {}
+        elif isinstance(payload_value, Mapping):
+            payload = _json_object(payload_value, "payload")
+        else:
+            raise ValueError("payload must be an object")
+
+        project_key = _optional_string(navigation_value.get("project_key"), "project_key")
+        task_id = _optional_string(navigation_value.get("task_id"), "task_id")
+        return cls(
+            request_id=request_id,
+            sequence=sequence,
+            navigation=NavigationRequest(
+                selected_key=_required_string(
+                    navigation_value.get("selected_key"),
+                    "selected_key",
+                ),
+                intent=intent,
+                origin=_required_string(
+                    navigation_value.get("origin", DEFAULT_ORIGIN),
+                    "origin",
+                ),
+                project_key=project_key,
+                task_id=task_id,
+                payload=payload,
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CockpitNavigationClientResult:
+    """Typed result returned to a right-pane navigation caller."""
+
+    request: CockpitNavigationClientRequest
+    outcome: CockpitNavigationClientOutcome
+    handled: bool
+    message: str
+    error: str | None = None
+    details: Mapping[str, object] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None and self.outcome in {
+            CockpitNavigationClientOutcome.SUBMITTED,
+            CockpitNavigationClientOutcome.QUEUED,
+        }
+
+
+class CockpitNavigationClientAdapter(Protocol):
+    """Adapter surface used by :class:`CockpitNavigationClient`."""
+
+    def submit_navigation_request(
+        self,
+        request: CockpitNavigationClientRequest,
+    ) -> CockpitNavigationClientResult:
+        """Submit a navigation request to a cockpit owner or queue."""
+        ...
+
+
+NavigationRequestHandler: TypeAlias = Callable[
+    [CockpitNavigationClientRequest],
+    CockpitNavigationClientResult | Mapping[str, object] | object | None,
+]
+
+
+class DirectCockpitNavigationAdapter:
+    """In-process adapter for the active cockpit owner."""
+
+    def __init__(self, handler: NavigationRequestHandler) -> None:
+        self._handler = handler
+
+    def submit_navigation_request(
+        self,
+        request: CockpitNavigationClientRequest,
+    ) -> CockpitNavigationClientResult:
+        response = self._handler(request)
+        if isinstance(response, CockpitNavigationClientResult):
+            return response
+        details = {"owner_result": response} if response is not None else {}
+        return CockpitNavigationClientResult(
+            request=request,
+            outcome=CockpitNavigationClientOutcome.SUBMITTED,
+            handled=True,
+            message=f"Navigation request submitted for {request.selected_key}.",
+            details=details,
+        )
+
+
+class StandaloneCockpitNavigationAdapter:
+    """Safe fallback when no cockpit owner is available."""
+
+    def __init__(self) -> None:
+        self.history: list[CockpitNavigationClientRequest] = []
+
+    def submit_navigation_request(
+        self,
+        request: CockpitNavigationClientRequest,
+    ) -> CockpitNavigationClientResult:
+        self.history.append(request)
+        return CockpitNavigationClientResult(
+            request=request,
+            outcome=CockpitNavigationClientOutcome.UNSUPPORTED,
+            handled=False,
+            message=(
+                "Cockpit navigation is unsupported because no active cockpit "
+                f"owner is connected for {request.selected_key}."
+            ),
+        )
+
+
+class FileCockpitNavigationQueue:
+    """JSON state-file backed queue for cross-process navigation requests."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def submit_navigation_request(
+        self,
+        request: CockpitNavigationClientRequest,
+    ) -> CockpitNavigationClientResult:
+        state = self._load_state()
+        requests = _request_dicts(state.get("requests", []))
+        requests.append(request.to_dict())
+        state["version"] = QUEUE_VERSION
+        state["last_sequence"] = max(
+            request.sequence,
+            _safe_int(state.get("last_sequence"), default=0),
+        )
+        state["requests"] = requests
+        atomic_write_json(self.path, state)
+        return CockpitNavigationClientResult(
+            request=request,
+            outcome=CockpitNavigationClientOutcome.QUEUED,
+            handled=True,
+            message=f"Navigation request queued for {request.selected_key}.",
+            details={"queue_path": str(self.path)},
+        )
+
+    def pending(self) -> tuple[CockpitNavigationClientRequest, ...]:
+        state = self._load_state()
+        requests: list[CockpitNavigationClientRequest] = []
+        for item in _request_dicts(state.get("requests", [])):
+            requests.append(CockpitNavigationClientRequest.from_dict(item))
+        return tuple(sorted(requests, key=lambda request: request.sequence))
+
+    def clear(self) -> None:
+        state = self._load_state()
+        state["version"] = QUEUE_VERSION
+        state["requests"] = []
+        atomic_write_json(self.path, state)
+
+    def _load_state(self) -> JsonObject:
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return {"version": QUEUE_VERSION, "requests": []}
+        if not isinstance(payload, dict):
+            return {"version": QUEUE_VERSION, "requests": []}
+        state = _json_object(payload, "navigation queue state")
+        state.setdefault("version", QUEUE_VERSION)
+        state.setdefault("requests", [])
+        return state
+
+
+class CockpitNavigationClient:
+    """Submit typed navigation requests from right-pane code."""
+
+    def __init__(
+        self,
+        adapter: CockpitNavigationClientAdapter | None = None,
+        *,
+        client_id: str = DEFAULT_CLIENT_ID,
+        origin: str = DEFAULT_ORIGIN,
+        sequence_start: int = 0,
+    ) -> None:
+        self.adapter = adapter or StandaloneCockpitNavigationAdapter()
+        self.client_id = _clean_token(client_id, "client_id")
+        self.origin = _required_string(origin, "origin")
+        if sequence_start < 0:
+            raise ValueError("sequence_start must be non-negative")
+        self._sequence = sequence_start
+        self.history: list[CockpitNavigationClientResult] = []
+
+    def navigate(
+        self,
+        selected_key: str,
+        *,
+        intent: NavigationIntent = NavigationIntent.SELECT,
+        origin: str | None = None,
+        project_key: str | None = None,
+        task_id: str | None = None,
+        payload: Mapping[str, object] | None = None,
+    ) -> CockpitNavigationClientResult:
+        """Submit an arbitrary cockpit selection key."""
+        request = self._build_request(
+            selected_key,
+            intent=intent,
+            origin=origin,
+            project_key=project_key,
+            task_id=task_id,
+            payload=payload,
+        )
+        try:
+            result = self.adapter.submit_navigation_request(request)
+        except Exception as exc:  # noqa: BLE001
+            result = CockpitNavigationClientResult(
+                request=request,
+                outcome=CockpitNavigationClientOutcome.FAILED,
+                handled=False,
+                message=(
+                    "Cockpit navigation request failed for "
+                    f"{request.selected_key}: {exc}"
+                ),
+                error=str(exc),
+            )
+        self.history.append(result)
+        return result
+
+    def jump_to_inbox(
+        self,
+        project_key: str | None = None,
+        *,
+        payload: Mapping[str, object] | None = None,
+    ) -> CockpitNavigationClientResult:
+        """Jump to the inbox, optionally scoped to a project."""
+        key = "inbox" if project_key is None else f"inbox:{_project_key(project_key)}"
+        return self.navigate(
+            key,
+            project_key=project_key,
+            payload=_with_action(payload, "jump_to_inbox"),
+        )
+
+    def jump_to_activity(
+        self,
+        project_key: str | None = None,
+        *,
+        payload: Mapping[str, object] | None = None,
+    ) -> CockpitNavigationClientResult:
+        """Jump to the activity feed, optionally scoped to a project."""
+        key = "activity" if project_key is None else f"activity:{_project_key(project_key)}"
+        return self.navigate(
+            key,
+            project_key=project_key,
+            payload=_with_action(payload, "jump_to_activity"),
+        )
+
+    def jump_to_project(
+        self,
+        project_key: str,
+        *,
+        view: str | None = "dashboard",
+        task_number: str | int | None = None,
+        payload: Mapping[str, object] | None = None,
+    ) -> CockpitNavigationClientResult:
+        """Jump to a project route such as dashboard, issues, or a task."""
+        clean_project = _project_key(project_key)
+        clean_view = None if view is None else _required_string(view, "view")
+        selected_key = _project_route_key(clean_project, clean_view, task_number)
+        task_id = (
+            f"{clean_project}/{task_number}"
+            if task_number is not None
+            else None
+        )
+        return self.navigate(
+            selected_key,
+            project_key=clean_project,
+            task_id=task_id,
+            payload=_with_action(payload, "jump_to_project"),
+        )
+
+    def _build_request(
+        self,
+        selected_key: str,
+        *,
+        intent: NavigationIntent,
+        origin: str | None,
+        project_key: str | None,
+        task_id: str | None,
+        payload: Mapping[str, object] | None,
+    ) -> CockpitNavigationClientRequest:
+        sequence = self._next_sequence()
+        navigation = NavigationRequest(
+            selected_key=_required_string(selected_key, "selected_key"),
+            intent=intent,
+            origin=_required_string(origin or self.origin, "origin"),
+            project_key=project_key,
+            task_id=task_id,
+            payload={} if payload is None else dict(payload),
+        )
+        return CockpitNavigationClientRequest(
+            request_id=f"{self.client_id}-{sequence:08d}",
+            sequence=sequence,
+            navigation=navigation,
+        )
+
+    def _next_sequence(self) -> int:
+        self._sequence += 1
+        return self._sequence
+
+
+def cockpit_navigation_queue_path(config_path: Path) -> Path:
+    """Return the project-local cross-process cockpit navigation queue path."""
+    from pollypm.config import load_config
+
+    config = load_config(config_path)
+    config.project.base_dir.mkdir(parents=True, exist_ok=True)
+    return config.project.base_dir / QUEUE_FILE_NAME
+
+
+def file_navigation_client(
+    config_path: Path,
+    *,
+    client_id: str = DEFAULT_CLIENT_ID,
+    origin: str = DEFAULT_ORIGIN,
+) -> CockpitNavigationClient:
+    """Build a file-queue backed client for right-pane cockpit apps."""
+    return CockpitNavigationClient(
+        FileCockpitNavigationQueue(cockpit_navigation_queue_path(config_path)),
+        client_id=client_id,
+        origin=origin,
+    )
+
+
+def _project_route_key(
+    project_key: str,
+    view: str | None,
+    task_number: str | int | None,
+) -> str:
+    if view is None:
+        return f"project:{project_key}"
+    if task_number is None:
+        return f"project:{project_key}:{view}"
+    clean_task = _required_string(str(task_number), "task_number")
+    if view == "issues":
+        return f"project:{project_key}:issues:task:{clean_task}"
+    if view == "task":
+        return f"project:{project_key}:task:{clean_task}"
+    return f"project:{project_key}:{view}:task:{clean_task}"
+
+
+def _with_action(
+    payload: Mapping[str, object] | None,
+    action: str,
+) -> Mapping[str, object]:
+    merged: dict[str, object] = dict(payload or {})
+    merged.setdefault("action", action)
+    return merged
+
+
+def _request_dicts(value: JsonValue) -> list[JsonObject]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _json_object(value: Mapping[str, object], label: str) -> JsonObject:
+    copied: JsonObject = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise TypeError(f"{label} keys must be strings")
+        if not _is_json_value(item):
+            raise TypeError(f"{label} contains a non-JSON value")
+        copied[key] = cast(JsonValue, item)
+    return copied
+
+
+def _is_json_value(value: object) -> bool:
+    if value is None or isinstance(value, str | bool | int):
+        return True
+    if isinstance(value, float):
+        return value == value and value not in {float("inf"), float("-inf")}
+    if isinstance(value, list):
+        return all(_is_json_value(item) for item in value)
+    if isinstance(value, dict):
+        return all(
+            isinstance(key, str) and _is_json_value(item)
+            for key, item in value.items()
+        )
+    return False
+
+
+def _required_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def _optional_string(value: object, label: str) -> str | None:
+    if value is None:
+        return None
+    return _required_string(value, label)
+
+
+def _required_int(value: object, label: str) -> int:
+    if not isinstance(value, int):
+        raise ValueError(f"{label} must be an int")
+    return value
+
+
+def _safe_int(value: object, *, default: int) -> int:
+    return value if isinstance(value, int) else default
+
+
+def _project_key(value: str) -> str:
+    project_key = _required_string(value, "project_key")
+    if ":" in project_key:
+        raise ValueError("project_key must not contain ':'")
+    return project_key
+
+
+def _clean_token(value: str, label: str) -> str:
+    token = _required_string(value, label)
+    return "".join(char if char.isalnum() or char in {"-", "_"} else "-" for char in token)
+
+
+__all__ = [
+    "CockpitNavigationClient",
+    "CockpitNavigationClientAdapter",
+    "CockpitNavigationClientOutcome",
+    "CockpitNavigationClientRequest",
+    "CockpitNavigationClientResult",
+    "DirectCockpitNavigationAdapter",
+    "FileCockpitNavigationQueue",
+    "StandaloneCockpitNavigationAdapter",
+    "cockpit_navigation_queue_path",
+    "file_navigation_client",
+]

--- a/src/pollypm/cockpit_navigation_client.py
+++ b/src/pollypm/cockpit_navigation_client.py
@@ -11,16 +11,18 @@ Integration points for later wiring:
 * The cockpit owner can install :class:`DirectCockpitNavigationAdapter` with a
   callback that hands ``request.navigation`` to the owner-side routing path.
 * Out-of-process right-pane apps can use :class:`FileCockpitNavigationQueue`;
-  the cockpit owner can poll :meth:`FileCockpitNavigationQueue.pending` and
-  apply the newest request through the same owner-side routing path.
+  the cockpit owner can call :meth:`FileCockpitNavigationQueue.drain` and
+  apply the queued requests through the same owner-side routing path.
 * Standalone pane processes can keep the default fallback and surface the
   unsupported result instead of trying to create their own router.
 """
 
 from __future__ import annotations
 
+import fcntl
 import json
 from collections.abc import Callable, Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
@@ -43,6 +45,7 @@ JsonObject: TypeAlias = dict[str, JsonValue]
 
 QUEUE_VERSION = 1
 QUEUE_FILE_NAME = "cockpit_navigation_queue.json"
+DEFAULT_QUEUE_MAX_ENTRIES = 100
 DEFAULT_CLIENT_ID = "right-pane"
 DEFAULT_ORIGIN = "right_pane"
 
@@ -224,47 +227,100 @@ class StandaloneCockpitNavigationAdapter:
 
 
 class FileCockpitNavigationQueue:
-    """JSON state-file backed queue for cross-process navigation requests."""
+    """JSON state-file backed queue for cross-process navigation requests.
 
-    def __init__(self, path: Path) -> None:
+    The queue is an owner-polled inbox. Requests are delivered in locked
+    append order when the cockpit owner drains the file. If the owner is unavailable
+    and the file exceeds ``max_entries``, the oldest queued requests are
+    dropped first so the state file stays bounded.
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        max_entries: int = DEFAULT_QUEUE_MAX_ENTRIES,
+    ) -> None:
+        if max_entries < 1:
+            raise ValueError("max_entries must be positive")
         self.path = path
+        self.max_entries = max_entries
 
     def submit_navigation_request(
         self,
         request: CockpitNavigationClientRequest,
     ) -> CockpitNavigationClientResult:
-        state = self._load_state()
-        requests = _request_dicts(state.get("requests", []))
-        requests.append(request.to_dict())
-        state["version"] = QUEUE_VERSION
-        state["last_sequence"] = max(
-            request.sequence,
-            _safe_int(state.get("last_sequence"), default=0),
-        )
-        state["requests"] = requests
-        atomic_write_json(self.path, state)
+        with self._locked_state(write=True) as state:
+            requests = _request_dicts(state.get("requests", []))
+            requests.append(request.to_dict())
+            dropped_count = max(0, len(requests) - self.max_entries)
+            if dropped_count:
+                requests = requests[dropped_count:]
+            state["version"] = QUEUE_VERSION
+            state["last_sequence"] = max(
+                request.sequence,
+                _safe_int(state.get("last_sequence"), default=0),
+            )
+            state["dropped_count"] = (
+                _safe_int(state.get("dropped_count"), default=0) + dropped_count
+            )
+            state["requests"] = requests
         return CockpitNavigationClientResult(
             request=request,
             outcome=CockpitNavigationClientOutcome.QUEUED,
             handled=True,
             message=f"Navigation request queued for {request.selected_key}.",
-            details={"queue_path": str(self.path)},
+            details={
+                "queue_path": str(self.path),
+                "dropped_count": dropped_count,
+                "max_entries": self.max_entries,
+            },
         )
 
     def pending(self) -> tuple[CockpitNavigationClientRequest, ...]:
-        state = self._load_state()
-        requests: list[CockpitNavigationClientRequest] = []
-        for item in _request_dicts(state.get("requests", [])):
-            requests.append(CockpitNavigationClientRequest.from_dict(item))
-        return tuple(sorted(requests, key=lambda request: request.sequence))
+        with self._locked_state(write=False) as state:
+            return self._requests_from_state(state)
+
+    def drain(self) -> tuple[CockpitNavigationClientRequest, ...]:
+        """Atomically read and remove all currently queued requests."""
+        with self._locked_state(write=True) as state:
+            requests = self._requests_from_state(state)
+            state["version"] = QUEUE_VERSION
+            state["requests"] = []
+            if requests:
+                state["last_drained_sequence"] = max(
+                    request.sequence for request in requests
+                )
+            return requests
 
     def clear(self) -> None:
-        state = self._load_state()
-        state["version"] = QUEUE_VERSION
-        state["requests"] = []
-        atomic_write_json(self.path, state)
+        with self._locked_state(write=True) as state:
+            state["version"] = QUEUE_VERSION
+            state["requests"] = []
 
     def _load_state(self) -> JsonObject:
+        with self._locked_state(write=False) as state:
+            return dict(state)
+
+    @contextmanager
+    def _locked_state(self, *, write: bool):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self._lock_path.open("a+", encoding="utf-8") as lock_file:
+            operation = fcntl.LOCK_EX if write else fcntl.LOCK_SH
+            fcntl.flock(lock_file.fileno(), operation)
+            try:
+                state = self._load_state_unlocked()
+                yield state
+                if write:
+                    atomic_write_json(self.path, state)
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    @property
+    def _lock_path(self) -> Path:
+        return self.path.with_name(f"{self.path.name}.lock")
+
+    def _load_state_unlocked(self) -> JsonObject:
         try:
             payload = json.loads(self.path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError, UnicodeDecodeError):
@@ -275,6 +331,15 @@ class FileCockpitNavigationQueue:
         state.setdefault("version", QUEUE_VERSION)
         state.setdefault("requests", [])
         return state
+
+    @staticmethod
+    def _requests_from_state(
+        state: Mapping[str, JsonValue],
+    ) -> tuple[CockpitNavigationClientRequest, ...]:
+        requests: list[CockpitNavigationClientRequest] = []
+        for item in _request_dicts(state.get("requests", [])):
+            requests.append(CockpitNavigationClientRequest.from_dict(item))
+        return tuple(requests)
 
 
 class CockpitNavigationClient:
@@ -306,7 +371,12 @@ class CockpitNavigationClient:
         task_id: str | None = None,
         payload: Mapping[str, object] | None = None,
     ) -> CockpitNavigationClientResult:
-        """Submit an arbitrary cockpit selection key."""
+        """Submit an arbitrary cockpit selection key.
+
+        File-backed submissions are queued for the cockpit owner to drain in
+        locked append order. If the owner is offline long enough for the queue to
+        exceed its cap, the oldest requests are dropped before newer requests.
+        """
         request = self._build_request(
             selected_key,
             intent=intent,
@@ -534,6 +604,7 @@ __all__ = [
     "CockpitNavigationClientOutcome",
     "CockpitNavigationClientRequest",
     "CockpitNavigationClientResult",
+    "DEFAULT_QUEUE_MAX_ENTRIES",
     "DirectCockpitNavigationAdapter",
     "FileCockpitNavigationQueue",
     "StandaloneCockpitNavigationAdapter",

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -39,9 +39,19 @@ from pollypm.cockpit_rail_routes import (
     LiveSessionRoute,
     ProjectRoute,
     StaticViewRoute,
-    resolve_live_session_route,
-    resolve_project_route,
-    resolve_static_view_route,
+)
+from pollypm.cockpit_content import (
+    CockpitContentContext,
+    ErrorPane,
+    FallbackPane,
+    LiveAgentPane,
+    TextualCommandPane,
+    resolve_cockpit_content,
+)
+from pollypm.cockpit_window_manager import (
+    CockpitWindowManager,
+    CockpitWindowSpec,
+    CockpitWindowState,
 )
 from pollypm.cockpit_project_state import (
     ProjectRailState,
@@ -1244,9 +1254,13 @@ class CockpitRouter:
 
         project_session_map: dict[str, str] = {}
         for launch in launches:
-            if launch.session.role in CONTROL_ROLES:
+            role = getattr(launch.session, "role", "")
+            if role in CONTROL_ROLES:
                 continue
-            project_session_map.setdefault(launch.session.project, launch.session.name)
+            project = getattr(launch.session, "project", None)
+            name = getattr(launch.session, "name", None)
+            if project and name:
+                project_session_map.setdefault(project, name)
         return project_session_map
 
     def _decorate_project_items(
@@ -2051,6 +2065,158 @@ class CockpitRouter:
         except Exception:  # noqa: BLE001
             return None
 
+    def _content_context(self, supervisor) -> CockpitContentContext:
+        """Return data-only facts for the pure right-pane content resolver."""
+        try:
+            launches = supervisor.plan_launches()
+        except Exception:  # noqa: BLE001
+            launches = []
+        try:
+            projects = supervisor.config.projects
+        except Exception:  # noqa: BLE001
+            projects = None
+        return CockpitContentContext.from_projects(
+            projects,
+            project_sessions=self._project_session_map(launches),
+        )
+
+    def _route_content_plan(self, supervisor, window_target: str, plan) -> None:
+        """Materialize a pure content plan using the legacy pane applicators.
+
+        This is the first integration step for the modular cockpit
+        architecture: route decisions now come from ``cockpit_content`` while
+        the still-existing tmux applicators keep live behavior stable.
+        """
+        if isinstance(plan, FallbackPane):
+            self.set_selected_key(plan.selected_key)
+            self._route_content_plan(supervisor, window_target, plan.fallback)
+            return
+
+        if isinstance(plan, TextualCommandPane):
+            self.set_selected_key(plan.selected_key)
+            if plan.task_id is None:
+                self._show_static_view(
+                    supervisor,
+                    window_target,
+                    plan.pane_kind,
+                    plan.project_key,
+                )
+                return
+            self._show_static_view(
+                supervisor,
+                window_target,
+                plan.pane_kind,
+                plan.project_key,
+                task_id=plan.task_id,
+            )
+            return
+
+        if isinstance(plan, LiveAgentPane):
+            self.set_selected_key(plan.selected_key)
+            self._route_live_agent_plan(supervisor, window_target, plan)
+            return
+
+        if isinstance(plan, ErrorPane):
+            self.set_selected_key(plan.selected_key)
+            self._show_message_view(supervisor, window_target, plan.title, plan.message)
+            return
+
+        raise RuntimeError(f"Unsupported cockpit content plan: {plan!r}")
+
+    def _route_live_agent_plan(
+        self,
+        supervisor,
+        window_target: str,
+        plan: LiveAgentPane,
+    ) -> None:
+        fallback_kind = plan.fallback.pane_kind if plan.fallback is not None else "polly"
+        if plan.session_name in {"operator", "reviewer"}:
+            self._route_live_session(
+                supervisor,
+                window_target,
+                LiveSessionRoute(
+                    session_name=plan.session_name,
+                    fallback_kind=fallback_kind,
+                ),
+            )
+            return
+
+        if not self._session_available_for_mount(
+            supervisor,
+            plan.session_name,
+            window_target,
+        ):
+            try:
+                supervisor.launch_session(plan.session_name)
+            except Exception:  # noqa: BLE001
+                pass
+        try:
+            self._show_live_session(supervisor, plan.session_name, window_target)
+        except Exception:  # noqa: BLE001
+            if plan.fallback is not None:
+                self._route_content_plan(supervisor, window_target, plan.fallback)
+            return
+        if plan.project_key:
+            self._maybe_prime_project_pm_session(
+                supervisor,
+                plan.project_key,
+                plan.session_name,
+                window_target,
+            )
+
+    def _window_manager(self, supervisor) -> CockpitWindowManager:
+        config = getattr(supervisor, "config", None) or self._load_config()
+        tmux_session = config.project.tmux_session
+        try:
+            rail_command = supervisor.console_command()
+        except Exception:  # noqa: BLE001
+            rail_command = None
+        return CockpitWindowManager(
+            CockpitWindowSpec(
+                tmux_session=tmux_session,
+                cockpit_window=self._COCKPIT_WINDOW,
+                rail_width=self.rail_width(),
+                default_content_command=self._right_pane_command("polly"),
+                rail_command=rail_command,
+            ),
+            self.tmux,
+        )
+
+    def _window_state_from_cockpit_state(
+        self,
+        supervisor,
+        state: dict[str, object] | None = None,
+    ) -> CockpitWindowState:
+        state = state or self._load_state()
+        right_pane_id = state.get("right_pane_id")
+        mounted_session = state.get("mounted_session")
+        mounted_window_name = None
+        if isinstance(mounted_session, str) and mounted_session:
+            mounted_window_name = self._mounted_window_name(supervisor, mounted_session)
+        return CockpitWindowState(
+            right_pane_id=right_pane_id if isinstance(right_pane_id, str) else None,
+            mounted_session=mounted_session if isinstance(mounted_session, str) else None,
+            mounted_window_name=mounted_window_name,
+        )
+
+    def _write_window_state(
+        self,
+        window_state: CockpitWindowState,
+        *,
+        base: dict[str, object] | None = None,
+    ) -> None:
+        state = dict(base or self._load_state())
+        if window_state.right_pane_id:
+            state["right_pane_id"] = window_state.right_pane_id
+        else:
+            state.pop("right_pane_id", None)
+        if window_state.mounted_session:
+            state["mounted_session"] = window_state.mounted_session
+        else:
+            state.pop("mounted_session", None)
+            state.pop("mounted_identity", None)
+        self._write_state(state)
+
     def route_selected(self, key: str) -> None:
         supervisor = self._load_supervisor()
         window_target = f"{supervisor.config.project.tmux_session}:{self._COCKPIT_WINDOW}"
@@ -2060,19 +2226,8 @@ class CockpitRouter:
             raise RuntimeError("Cockpit right pane is not available.")
 
         self.set_selected_key(key)
-        live_route = resolve_live_session_route(key)
-        if live_route is not None:
-            self._route_live_session(supervisor, window_target, live_route)
-            return
-        static_route = resolve_static_view_route(key)
-        if static_route is not None:
-            self._route_static_view(supervisor, window_target, static_route)
-            return
-        project_route = resolve_project_route(key)
-        if project_route is not None:
-            self._route_project_selection(supervisor, window_target, project_route)
-            return
-        raise RuntimeError(f"Unknown cockpit item: {key}")
+        plan = resolve_cockpit_content(key, self._content_context(supervisor))
+        self._route_content_plan(supervisor, window_target, plan)
 
     def focus_right_pane(self) -> None:
         config = self._load_config()
@@ -2711,30 +2866,45 @@ class CockpitRouter:
         project_key: str | None = None,
         task_id: str | None = None,
     ) -> None:
+        self._show_command_view(
+            supervisor,
+            window_target,
+            self._right_pane_command(kind, project_key, task_id=task_id),
+        )
+
+    def _show_message_view(
+        self,
+        supervisor,
+        window_target: str,
+        title: str,
+        message: str,
+    ) -> None:
+        body = f"{title}\n\n{message}\n\nSelect another rail item to continue."
+        script = f"printf '%s\\n' {shlex.quote(body)}; sleep 3600"
+        self._show_command_view(
+            supervisor,
+            window_target,
+            f"sh -lc {shlex.quote(script)}",
+        )
+
+    def _show_command_view(
+        self,
+        supervisor,
+        window_target: str,
+        command: str,
+    ) -> None:
         self._park_mounted_session(supervisor, window_target)
-        self._cleanup_extra_panes(window_target)
-        left_pane_id = self._left_pane_id(window_target)
-        if left_pane_id is None:
-            raise RuntimeError("Cockpit left pane is not available.")
-        right_pane_id = self._right_pane_id(window_target)
-        if right_pane_id is None:
-            right_pane_id = self.tmux.split_window(
-                left_pane_id,
-                self._right_pane_command(kind, project_key, task_id=task_id),
-                horizontal=True,
-                detached=True,
-                size=self._right_pane_size(window_target),
-            )
-        else:
-            self.tmux.respawn_pane(
-                right_pane_id,
-                self._right_pane_command(kind, project_key, task_id=task_id),
-            )
         state = self._load_state()
-        state.pop("mounted_session", None)
-        state.pop("mounted_identity", None)
-        state["right_pane_id"] = self._right_pane_id(window_target)
-        self._write_state(state)
+        result = self._window_manager(supervisor).show_static(
+            command,
+            self._window_state_from_cockpit_state(supervisor, state),
+        )
+        if not result.ok:
+            raise RuntimeError(
+                "Cockpit pane layout is invalid after static route: "
+                + "; ".join(result.postcondition.errors)
+            )
+        self._write_window_state(result.state, base=state)
 
     def _cleanup_extra_panes(self, window_target: str) -> None:
         """Kill any extra panes beyond the expected 2 (rail + right)."""

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -2880,7 +2880,7 @@ class CockpitRouter:
         message: str,
     ) -> None:
         body = f"{title}\n\n{message}\n\nSelect another rail item to continue."
-        script = f"printf '%s\\n' {shlex.quote(body)}; sleep 3600"
+        script = f"printf '%s\\n' {shlex.quote(body)}; while IFS= read -r _; do :; done"
         self._show_command_view(
             supervisor,
             window_target,

--- a/src/pollypm/cockpit_state_store.py
+++ b/src/pollypm/cockpit_state_store.py
@@ -1,0 +1,375 @@
+"""Typed persistence wrapper for ``cockpit_state.json``.
+
+This module owns only JSON state shape and validation. It intentionally
+does not know how to find a project config, talk to tmux, create tmux
+clients, or load supervisors; callers pass the exact state-file path.
+
+The #970 persisted right-pane state contract is local for now because it
+uses the explicit ``idle`` / ``loading`` / ``static`` / ``live_agent`` /
+``error`` states. When shared cockpit contracts adopt that exact persisted
+shape, ``RightPaneState`` and ``MountedIdentityPayload`` can move there (or
+be imported from there) so cockpit rail/router/UI code share one boundary.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Mapping, Union, cast
+
+from pollypm.atomic_io import atomic_write_json
+
+
+JsonValue = Union[
+    str,
+    int,
+    float,
+    bool,
+    None,
+    list["JsonValue"],
+    dict[str, "JsonValue"],
+]
+MountedIdentityPayload = dict[str, JsonValue]
+RightPaneState = Literal["idle", "loading", "static", "live_agent", "error"]
+
+STATE_FILE_NAME = "cockpit_state.json"
+DEFAULT_SELECTED_KEY = "polly"
+DEFAULT_RAIL_WIDTH = 30
+MIN_RAIL_WIDTH = 20
+MAX_RAIL_WIDTH = 120
+RIGHT_PANE_STATES: frozenset[str] = frozenset(
+    {"idle", "loading", "static", "live_agent", "error"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CockpitStateSnapshot:
+    selected_key: str
+    active_request_id: str | None
+    right_pane_state: RightPaneState
+    right_pane_id: str | None
+    mounted_identity: MountedIdentityPayload | None
+    rail_width: int
+    pinned_projects: tuple[str, ...]
+    palette_tip_seen: bool
+
+
+class CockpitStateStore:
+    """Read and write typed cockpit state with safe defaults.
+
+    Selection intent (``selected``) is deliberately separate from mounted
+    truth (``right_pane_*`` and ``mounted_identity``). Clearing a mounted
+    pane must not rewrite the user's current rail selection.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    @classmethod
+    def for_project_dir(cls, project_dir: Path) -> "CockpitStateStore":
+        return cls(project_dir / STATE_FILE_NAME)
+
+    def snapshot(self) -> CockpitStateSnapshot:
+        state = self._load_raw()
+        return CockpitStateSnapshot(
+            selected_key=self._selected_key_from(state),
+            active_request_id=self._active_request_id_from(state),
+            right_pane_state=self._right_pane_state_from(state),
+            right_pane_id=self._right_pane_id_from(state),
+            mounted_identity=self._mounted_identity_from(state),
+            rail_width=self._rail_width_from(state),
+            pinned_projects=tuple(self._pinned_projects_from(state)),
+            palette_tip_seen=self._palette_tip_seen_from(state),
+        )
+
+    def raw_state(self) -> dict[str, JsonValue]:
+        """Return the raw JSON object, or ``{}`` for missing/corrupt state."""
+        return self._load_raw()
+
+    def selected_key(self) -> str:
+        return self._selected_key_from(self._load_raw())
+
+    def set_selected_key(self, key: str) -> None:
+        self._require_non_empty_string(key, "selected key")
+        self._mutate({"selected": key})
+
+    def active_request_id(self) -> str | None:
+        return self._active_request_id_from(self._load_raw())
+
+    def set_active_request_id(self, request_id: str | None) -> None:
+        if request_id is None:
+            self.clear_active_request_id()
+            return
+        self._require_non_empty_string(request_id, "active request id")
+        self._mutate({"active_request_id": request_id})
+
+    def clear_active_request_id(self) -> None:
+        self._mutate(remove=("active_request_id",))
+
+    def right_pane_state(self) -> RightPaneState:
+        return self._right_pane_state_from(self._load_raw())
+
+    def set_right_pane_state(self, state: RightPaneState) -> None:
+        self._require_right_pane_state(state)
+        self._mutate({"right_pane_state": state})
+
+    def mark_right_pane_idle(self) -> None:
+        self._mutate({"right_pane_state": "idle"}, remove=("active_request_id", "right_pane_error"))
+
+    def mark_right_pane_loading(self, request_id: str | None = None) -> None:
+        update: dict[str, JsonValue] = {"right_pane_state": "loading"}
+        if request_id is not None:
+            self._require_non_empty_string(request_id, "active request id")
+            update["active_request_id"] = request_id
+        self._mutate(update, remove=("right_pane_error",))
+
+    def mark_right_pane_static(self) -> None:
+        self._mutate({"right_pane_state": "static"}, remove=("active_request_id", "right_pane_error"))
+
+    def mark_right_pane_live_agent(self) -> None:
+        self._mutate({"right_pane_state": "live_agent"}, remove=("active_request_id", "right_pane_error"))
+
+    def mark_right_pane_error(self, message: str | None = None) -> None:
+        update: dict[str, JsonValue] = {"right_pane_state": "error"}
+        if message:
+            update["right_pane_error"] = message
+        self._mutate(update, remove=("active_request_id",))
+
+    def right_pane_id(self) -> str | None:
+        return self._right_pane_id_from(self._load_raw())
+
+    def set_right_pane_id(self, pane_id: str | None) -> None:
+        if pane_id is None:
+            self.clear_right_pane_id()
+            return
+        self._require_non_empty_string(pane_id, "right pane id")
+        self._mutate({"right_pane_id": pane_id})
+
+    def clear_right_pane_id(self) -> None:
+        self._mutate(remove=("right_pane_id",))
+
+    def mounted_identity(self) -> MountedIdentityPayload | None:
+        return self._mounted_identity_from(self._load_raw())
+
+    def set_mounted_identity(
+        self,
+        payload: Mapping[str, JsonValue] | None,
+    ) -> None:
+        if payload is None:
+            self.clear_mounted_identity()
+            return
+        identity = self._copy_json_object(payload, "mounted identity payload")
+        if not identity:
+            raise ValueError("mounted identity payload must not be empty")
+        self._mutate({"mounted_identity": identity})
+
+    def clear_mounted_identity(self) -> None:
+        self._mutate(remove=("mounted_identity", "mounted_session"))
+
+    def clear_mounted_and_right_pane_state(self) -> None:
+        self._mutate(
+            {"right_pane_state": "idle"},
+            remove=(
+                "active_request_id",
+                "mounted_identity",
+                "mounted_session",
+                "right_pane_error",
+                "right_pane_id",
+            ),
+        )
+
+    def rail_width(self) -> int:
+        return self._rail_width_from(self._load_raw())
+
+    def set_rail_width(self, width: int) -> None:
+        if not isinstance(width, int):
+            raise TypeError("rail width must be an int")
+        self._mutate({"rail_width": self.clamp_rail_width(width)})
+
+    @staticmethod
+    def clamp_rail_width(width: int) -> int:
+        return max(MIN_RAIL_WIDTH, min(MAX_RAIL_WIDTH, width))
+
+    def pinned_projects(self) -> list[str]:
+        return self._pinned_projects_from(self._load_raw())
+
+    def pins(self) -> list[str]:
+        return self.pinned_projects()
+
+    def set_pinned_projects(self, project_keys: list[str]) -> None:
+        ordered = self._normalize_pins(project_keys)
+        self._mutate({"pinned_projects": ordered})
+
+    def is_project_pinned(self, project_key: str) -> bool:
+        return project_key in self.pinned_projects()
+
+    def pin_project(self, project_key: str) -> None:
+        self._require_non_empty_string(project_key, "project key")
+        current = self.pinned_projects()
+        if project_key in current:
+            current.remove(project_key)
+        current.insert(0, project_key)
+        self._mutate({"pinned_projects": current})
+
+    def unpin_project(self, project_key: str) -> None:
+        current = [key for key in self.pinned_projects() if key != project_key]
+        self._mutate({"pinned_projects": current})
+
+    def toggle_pinned_project(self, project_key: str) -> bool:
+        self._require_non_empty_string(project_key, "project key")
+        current = self.pinned_projects()
+        if project_key in current:
+            current.remove(project_key)
+            pinned = False
+        else:
+            current.insert(0, project_key)
+            pinned = True
+        self._mutate({"pinned_projects": current})
+        return pinned
+
+    def should_show_palette_tip(self) -> bool:
+        return not self._palette_tip_seen_from(self._load_raw())
+
+    def palette_tip_seen(self) -> bool:
+        return self._palette_tip_seen_from(self._load_raw())
+
+    def set_palette_tip_seen(self, seen: bool) -> None:
+        if not isinstance(seen, bool):
+            raise TypeError("palette tip flag must be a bool")
+        self._mutate({"palette_tip_seen": seen})
+
+    def mark_palette_tip_seen(self) -> None:
+        self.set_palette_tip_seen(True)
+
+    def _mutate(
+        self,
+        update: Mapping[str, JsonValue] | None = None,
+        *,
+        remove: tuple[str, ...] = (),
+    ) -> None:
+        state = self._load_raw()
+        for key in remove:
+            state.pop(key, None)
+        if update:
+            state.update(update)
+        self._write_raw(state)
+
+    def _load_raw(self) -> dict[str, JsonValue]:
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return {}
+        if not isinstance(payload, dict):
+            return {}
+        return {
+            str(key): value
+            for key, value in payload.items()
+            if isinstance(key, str) and self._is_json_value(value)
+        }
+
+    def _write_raw(self, state: Mapping[str, JsonValue]) -> None:
+        atomic_write_json(self.path, dict(state))
+
+    @staticmethod
+    def _selected_key_from(state: Mapping[str, JsonValue]) -> str:
+        value = state.get("selected")
+        return value if isinstance(value, str) and value else DEFAULT_SELECTED_KEY
+
+    @staticmethod
+    def _active_request_id_from(state: Mapping[str, JsonValue]) -> str | None:
+        value = state.get("active_request_id")
+        return value if isinstance(value, str) and value else None
+
+    @staticmethod
+    def _right_pane_state_from(state: Mapping[str, JsonValue]) -> RightPaneState:
+        value = state.get("right_pane_state")
+        if isinstance(value, str) and value in RIGHT_PANE_STATES:
+            return cast(RightPaneState, value)
+        return "idle"
+
+    @staticmethod
+    def _right_pane_id_from(state: Mapping[str, JsonValue]) -> str | None:
+        value = state.get("right_pane_id")
+        return value if isinstance(value, str) and value else None
+
+    @classmethod
+    def _mounted_identity_from(
+        cls, state: Mapping[str, JsonValue],
+    ) -> MountedIdentityPayload | None:
+        value = state.get("mounted_identity")
+        if not isinstance(value, dict):
+            return None
+        copied = cls._copy_json_object(value, "mounted identity payload")
+        return copied or None
+
+    @staticmethod
+    def _rail_width_from(state: Mapping[str, JsonValue]) -> int:
+        value = state.get("rail_width")
+        if isinstance(value, int) and MIN_RAIL_WIDTH <= value <= MAX_RAIL_WIDTH:
+            return value
+        return DEFAULT_RAIL_WIDTH
+
+    @classmethod
+    def _pinned_projects_from(cls, state: Mapping[str, JsonValue]) -> list[str]:
+        value = state.get("pinned_projects")
+        return cls._normalize_pins(value if isinstance(value, list) else [])
+
+    @staticmethod
+    def _palette_tip_seen_from(state: Mapping[str, JsonValue]) -> bool:
+        return state.get("palette_tip_seen") is True
+
+    @classmethod
+    def _normalize_pins(cls, value: list[JsonValue]) -> list[str]:
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for item in value:
+            if isinstance(item, str) and item and item not in seen:
+                seen.add(item)
+                ordered.append(item)
+        return ordered
+
+    @classmethod
+    def _copy_json_object(
+        cls,
+        value: Mapping[str, JsonValue],
+        label: str,
+    ) -> dict[str, JsonValue]:
+        copied: dict[str, JsonValue] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"{label} keys must be strings")
+            if not cls._is_json_value(item):
+                raise TypeError(f"{label} contains a non-JSON value")
+            copied[key] = item
+        return copied
+
+    @classmethod
+    def _is_json_value(cls, value: Any) -> bool:
+        if value is None or isinstance(value, str):
+            return True
+        if isinstance(value, bool):
+            return True
+        if isinstance(value, int):
+            return True
+        if isinstance(value, float):
+            return value == value and value not in {float("inf"), float("-inf")}
+        if isinstance(value, list):
+            return all(cls._is_json_value(item) for item in value)
+        if isinstance(value, dict):
+            return all(
+                isinstance(key, str) and cls._is_json_value(item)
+                for key, item in value.items()
+            )
+        return False
+
+    @staticmethod
+    def _require_non_empty_string(value: str, label: str) -> None:
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{label} must be a non-empty string")
+
+    @staticmethod
+    def _require_right_pane_state(value: str) -> None:
+        if value not in RIGHT_PANE_STATES:
+            allowed = ", ".join(sorted(RIGHT_PANE_STATES))
+            raise ValueError(f"right pane state must be one of: {allowed}")

--- a/src/pollypm/cockpit_state_store.py
+++ b/src/pollypm/cockpit_state_store.py
@@ -4,11 +4,10 @@ This module owns only JSON state shape and validation. It intentionally
 does not know how to find a project config, talk to tmux, create tmux
 clients, or load supervisors; callers pass the exact state-file path.
 
-The #970 persisted right-pane state contract is local for now because it
-uses the explicit ``idle`` / ``loading`` / ``static`` / ``live_agent`` /
-``error`` states. When shared cockpit contracts adopt that exact persisted
-shape, ``RightPaneState`` and ``MountedIdentityPayload`` can move there (or
-be imported from there) so cockpit rail/router/UI code share one boundary.
+The #970 persisted right-pane state contract intentionally uses compact
+``idle`` / ``loading`` / ``static`` / ``live_agent`` / ``error`` values in
+JSON. Public cockpit modules use ``RightPaneLifecycleState``; the explicit
+mapping functions in this module are the boundary between those shapes.
 """
 
 from __future__ import annotations
@@ -19,6 +18,7 @@ from pathlib import Path
 from typing import Any, Literal, Mapping, Union, cast
 
 from pollypm.atomic_io import atomic_write_json
+from pollypm.cockpit_contracts import RightPaneLifecycleState
 
 
 JsonValue = Union[
@@ -41,6 +41,40 @@ MAX_RAIL_WIDTH = 120
 RIGHT_PANE_STATES: frozenset[str] = frozenset(
     {"idle", "loading", "static", "live_agent", "error"}
 )
+RIGHT_PANE_STATE_TO_LIFECYCLE: dict[RightPaneState, RightPaneLifecycleState] = {
+    "idle": RightPaneLifecycleState.UNMOUNTED,
+    "loading": RightPaneLifecycleState.INITIALIZING,
+    "static": RightPaneLifecycleState.STATIC_VIEW,
+    "live_agent": RightPaneLifecycleState.LIVE_SESSION,
+    "error": RightPaneLifecycleState.ERROR,
+}
+LIFECYCLE_TO_RIGHT_PANE_STATE: dict[RightPaneLifecycleState, RightPaneState] = {
+    lifecycle: state for state, lifecycle in RIGHT_PANE_STATE_TO_LIFECYCLE.items()
+}
+
+
+def right_pane_state_to_lifecycle(state: RightPaneState) -> RightPaneLifecycleState:
+    """Translate the persisted JSON state into the public lifecycle contract."""
+    if state not in RIGHT_PANE_STATE_TO_LIFECYCLE:
+        _raise_invalid_right_pane_state(state)
+    return RIGHT_PANE_STATE_TO_LIFECYCLE[state]
+
+
+def lifecycle_to_right_pane_state(state: RightPaneLifecycleState) -> RightPaneState:
+    """Translate a public lifecycle state into the persisted JSON state."""
+    try:
+        return LIFECYCLE_TO_RIGHT_PANE_STATE[state]
+    except KeyError as exc:
+        allowed = ", ".join(item.value for item in RIGHT_PANE_STATE_TO_LIFECYCLE.values())
+        raise ValueError(
+            f"lifecycle state cannot be persisted as right-pane state: {state}"
+            f" (allowed: {allowed})"
+        ) from exc
+
+
+def _raise_invalid_right_pane_state(value: str) -> None:
+    allowed = ", ".join(sorted(RIGHT_PANE_STATES))
+    raise ValueError(f"right pane state must be one of: {allowed}")
 
 
 @dataclass(frozen=True, slots=True)
@@ -371,5 +405,22 @@ class CockpitStateStore:
     @staticmethod
     def _require_right_pane_state(value: str) -> None:
         if value not in RIGHT_PANE_STATES:
-            allowed = ", ".join(sorted(RIGHT_PANE_STATES))
-            raise ValueError(f"right pane state must be one of: {allowed}")
+            _raise_invalid_right_pane_state(value)
+
+
+__all__ = [
+    "CockpitStateSnapshot",
+    "CockpitStateStore",
+    "DEFAULT_RAIL_WIDTH",
+    "DEFAULT_SELECTED_KEY",
+    "LIFECYCLE_TO_RIGHT_PANE_STATE",
+    "MAX_RAIL_WIDTH",
+    "MIN_RAIL_WIDTH",
+    "MountedIdentityPayload",
+    "RIGHT_PANE_STATE_TO_LIFECYCLE",
+    "RIGHT_PANE_STATES",
+    "RightPaneState",
+    "STATE_FILE_NAME",
+    "lifecycle_to_right_pane_state",
+    "right_pane_state_to_lifecycle",
+]

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -20,6 +20,7 @@ Contract:
 from __future__ import annotations
 
 import gc
+import asyncio
 import json
 import os
 import resource
@@ -128,6 +129,17 @@ from pollypm.rejection_feedback import (
 if TYPE_CHECKING:
     from pollypm.service_api import PollyPMService  # noqa: F401
 from pollypm.cockpit import build_cockpit_detail
+from pollypm.cockpit_navigation import (
+    InMemoryNavigationStateStore,
+    NavigationContent,
+    NavigationController,
+    NavigationRequest,
+)
+from pollypm.cockpit_navigation_client import (
+    FileCockpitNavigationQueue,
+    cockpit_navigation_queue_path,
+    file_navigation_client,
+)
 from pollypm.cockpit_rail import CockpitItem, CockpitPresence, CockpitRouter
 
 
@@ -149,6 +161,25 @@ _PLAN_REVIEW_UNAVAILABLE_HINT_RE = _re.compile(
     r"d\s+to\s+discuss\s+with\s+the\s+PM,\s*A\s+to\s+approve\.?",
     _re.IGNORECASE,
 )
+
+
+class _CockpitRouteContentResolver:
+    """Navigation resolver for the root cockpit rail.
+
+    The router still owns full content resolution during this integration
+    step; the navigation controller owns acknowledgement/cancellation state.
+    """
+
+    def resolve(self, request: NavigationRequest) -> NavigationContent:
+        return NavigationContent(request.key)
+
+
+class _CockpitRouteWindowApplier:
+    def __init__(self, app: "PollyCockpitApp") -> None:
+        self._app = app
+
+    def apply(self, request: NavigationRequest, _content: object) -> str:
+        return self._app._route_selected_with_deadline(request.key)
 
 
 def _md_to_rich(text: str) -> str:
@@ -836,6 +867,12 @@ class PollyCockpitApp(App[None]):
         # (heartbeats + token samples commit ~10/sec) don't cause the
         # visible row flash Sam reported on 2026-04-20.
         self._last_refresh_tick = -10
+        self._navigation_store = InMemoryNavigationStateStore()
+        self._navigation_controller = NavigationController(
+            state_store=self._navigation_store,
+            content_resolver=_CockpitRouteContentResolver(),
+            window_manager=_CockpitRouteWindowApplier(self),
+        )
 
     def compose(self) -> ComposeResult:
         with Vertical():
@@ -972,6 +1009,34 @@ class PollyCockpitApp(App[None]):
         self._last_router_selected_key = external_key
         self.selected_key = external_key
 
+    def _cockpit_navigation_queue(self) -> FileCockpitNavigationQueue:
+        queue = getattr(self, "_navigation_queue", None)
+        if queue is not None:
+            return queue
+        queue = FileCockpitNavigationQueue(
+            cockpit_navigation_queue_path(self.config_path),
+        )
+        self._navigation_queue = queue
+        return queue
+
+    def _drain_cockpit_navigation_queue(self) -> None:
+        try:
+            queue = self._cockpit_navigation_queue()
+            pending = queue.pending()
+        except Exception:  # noqa: BLE001
+            return
+        if not pending:
+            return
+        try:
+            queue.clear()
+        except Exception:  # noqa: BLE001
+            pass
+        latest = pending[-1]
+        self._schedule_route_selected(
+            latest.selected_key,
+            label=latest.selected_key,
+        )
+
     # Layout check (pane recovery, rail width) — only every ~30s
     _LAYOUT_CHECK_INTERVAL = 38  # ~30s at 0.8s/tick
     # Force GC every ~2 minutes
@@ -980,6 +1045,7 @@ class PollyCockpitApp(App[None]):
     def _tick(self) -> None:
         self._tick_count += 1
         self.spinner_index = (self.spinner_index + 1) % 4
+        self._drain_cockpit_navigation_queue()
         # Periodic GC
         if self._tick_count % self._GC_INTERVAL == 0:
             gc.collect()
@@ -1551,6 +1617,36 @@ class PollyCockpitApp(App[None]):
 
     _ROUTE_SELECT_TIMEOUT_SECONDS: float = 20.0
 
+    # Monotonically-increasing click counter (#967). Each click bumps
+    # this; the value at click time is captured by the worker thread
+    # and re-checked before any post-route UI update is applied. A
+    # stale worker (whose value lags ``_route_click_seq``) is ignored
+    # so its late completion can't bounce ``selected_key`` back to the
+    # previous click.
+    #
+    # Why a counter and not Textual's ``exclusive=True`` cancellation
+    # alone: ``run_worker(thread=True, exclusive=True)`` cancels the
+    # *asyncio task* representing the worker, but the underlying OS
+    # thread is not asyncio-aware and runs to completion regardless.
+    # The thread then calls ``_post_route_success`` and overwrites
+    # ``selected_key`` with the OLD click's resolved key — which is the
+    # bounce reported in #967. The seq guard short-circuits that path.
+    _route_click_seq: int = 0
+
+    def _ensure_navigation_controller(self) -> NavigationController:
+        controller = getattr(self, "_navigation_controller", None)
+        if controller is not None:
+            return controller
+        store = InMemoryNavigationStateStore()
+        controller = NavigationController(
+            state_store=store,
+            content_resolver=_CockpitRouteContentResolver(),
+            window_manager=_CockpitRouteWindowApplier(self),
+        )
+        self._navigation_store = store
+        self._navigation_controller = controller
+        return controller
+
     def _schedule_route_selected(
         self,
         key: str,
@@ -1575,6 +1671,9 @@ class PollyCockpitApp(App[None]):
         # even starts. The router may correct this once it knows the
         # canonical selection (e.g. ``project:x`` → ``project:x:dashboard``).
         self.selected_key = key
+        request = self._ensure_navigation_controller().accept(key)
+        seq = request.request_id
+        self._route_click_seq = seq
         try:
             display = label or key
             self.hint.update(f"Connecting to {display}…"[:60])
@@ -1584,15 +1683,15 @@ class PollyCockpitApp(App[None]):
             self._refresh_rows()
         except Exception:  # noqa: BLE001
             pass
-        self._dispatch_route_in_worker(key)
+        self._dispatch_route_in_worker(key, seq)
 
-    def _dispatch_route_in_worker(self, key: str) -> None:
+    def _dispatch_route_in_worker(self, key: str, seq: int = 0) -> None:
         """Spawn the route worker. Falls back to inline execution when
         Textual's worker pool is unavailable (e.g. unit tests that
         bypass ``App.__init__`` and have no running event loop)."""
         try:
             self.run_worker(
-                lambda: self._route_selected_worker(key),
+                lambda: self._route_selected_worker(key, seq),
                 thread=True,
                 exclusive=True,
                 group="route_select",
@@ -1600,19 +1699,9 @@ class PollyCockpitApp(App[None]):
         except Exception:  # noqa: BLE001
             # No event loop — execute inline so unit tests still see
             # ``route_selected`` invoked. Production always has a loop.
-            self._route_selected_worker(key)
+            self._route_selected_worker(key, seq)
 
-    def _route_selected_worker(self, key: str) -> None:
-        """Worker-thread body: run ``route_selected`` with a deadline.
-
-        The deadline is enforced by running the route call in a
-        ``ThreadPoolExecutor`` task and waiting with a timeout. On
-        timeout the loading hint is replaced with a clear error and the
-        worker returns — the user can click another rail item without
-        the failed attach blocking the next click (each new click runs
-        in a new ``exclusive`` worker which Textual cancels the prior
-        task on).
-        """
+    def _route_selected_with_deadline(self, key: str) -> str:
         import concurrent.futures as _cf
 
         def _do_route() -> str:
@@ -1626,25 +1715,14 @@ class PollyCockpitApp(App[None]):
             executor = None
         try:
             if executor is None:
-                resolved = _do_route()
+                return _do_route()
             else:
                 future = executor.submit(_do_route)
                 try:
-                    resolved = future.result(
-                        timeout=self._ROUTE_SELECT_TIMEOUT_SECONDS,
-                    )
+                    return future.result(timeout=self._ROUTE_SELECT_TIMEOUT_SECONDS)
                 except _cf.TimeoutError:
-                    self._post_route_error(
-                        key, f"Routing to {key} timed out — try again.",
-                    )
-                    # Best-effort cancel; the underlying router call may
-                    # still finish in the executor but its result is
-                    # ignored. The next click spawns a fresh worker.
                     future.cancel()
-                    return
-        except Exception as exc:  # noqa: BLE001
-            self._post_route_error(key, f"Error: {exc}")
-            return
+                    raise TimeoutError(f"Routing to {key} timed out.") from None
         finally:
             if executor is not None:
                 try:
@@ -1652,11 +1730,50 @@ class PollyCockpitApp(App[None]):
                 except Exception:  # noqa: BLE001
                     pass
 
-        self._post_route_success(key, resolved)
+    def _route_selected_worker(self, key: str, seq: int = 0) -> None:
+        """Worker-thread body: run ``route_selected`` through the
+        navigation controller with the existing route deadline."""
+        controller = self._ensure_navigation_controller()
+        if not seq or controller.current_request_id != seq:
+            request = controller.accept(key)
+            seq = request.request_id
+            self._route_click_seq = seq
+        else:
+            request = NavigationRequest(seq, key)
 
-    def _post_route_success(self, key: str, resolved: str) -> None:
-        """UI update after a route completes. Safe to call from a worker."""
+        try:
+            result = asyncio.run(controller.resolve_and_apply(request))
+        except Exception as exc:  # noqa: BLE001
+            self._post_route_error(key, f"Error: {exc}", seq)
+            return
+
+        if result.state == "applied":
+            resolved = str(result.window_result or result.destination_key or key)
+            self._post_route_success(key, resolved, seq)
+        elif result.state == "timed_out":
+            self._post_route_error(key, f"Routing to {key} timed out — try again.", seq)
+        elif result.state == "failed":
+            self._post_route_error(key, f"Error: {result.error or result.message}", seq)
+
+    def _post_route_success(
+        self, key: str, resolved: str, seq: int = 0,
+    ) -> None:
+        """UI update after a route completes. Safe to call from a worker.
+
+        ``seq`` is the click-sequence value captured when the worker was
+        scheduled. When a newer click has bumped ``_route_click_seq``
+        past ``seq`` this update is dropped so a stale (cancelled or
+        late-completing) worker can't overwrite the user's most-recent
+        intent — see #967 for the symptom this guards against.
+        """
         def _apply() -> None:
+            # Drop late updates from superseded clicks (#967). The
+            # check runs on the UI thread (inside ``call_from_thread``)
+            # so it races nothing — by the time we read
+            # ``_route_click_seq`` here, every preceding click's
+            # synchronous bump has happened.
+            if seq and seq != self._route_click_seq:
+                return
             # The router may have rewritten the selection (e.g.
             # ``project:x`` → ``project:x:dashboard``); re-sync.
             self.selected_key = resolved or key
@@ -1676,9 +1793,19 @@ class PollyCockpitApp(App[None]):
             # No running app (unit tests) — apply directly.
             _apply()
 
-    def _post_route_error(self, key: str, message: str) -> None:
-        """UI update after a route fails. Safe to call from a worker."""
+    def _post_route_error(
+        self, key: str, message: str, seq: int = 0,
+    ) -> None:
+        """UI update after a route fails. Safe to call from a worker.
+
+        ``seq`` is the click-sequence value captured when the worker
+        was scheduled. Stale errors (a worker whose click was already
+        superseded) are dropped so the loading hint of a newer in-flight
+        click isn't clobbered with a stale error message (#967).
+        """
         def _apply() -> None:
+            if seq and seq != self._route_click_seq:
+                return
             try:
                 self.hint.update(message[:60])
             except Exception:  # noqa: BLE001
@@ -2266,8 +2393,10 @@ class PollyDashboardApp(App[None]):
             )
 
     def _route_to_inbox(self) -> None:
-        router = CockpitRouter(self.config_path)
-        router.route_selected("inbox")
+        file_navigation_client(
+            self.config_path,
+            client_id="polly-dashboard",
+        ).jump_to_inbox()
 
 
 class PollyCockpitPaneApp(App[None]):
@@ -12033,8 +12162,10 @@ class PollyProjectDashboardApp(App[None]):
             )
 
     def _route_to_home(self) -> None:
-        router = CockpitRouter(self.config_path)
-        router.route_selected("dashboard")
+        file_navigation_client(
+            self.config_path,
+            client_id="project-dashboard",
+        ).navigate("dashboard")
 
     def action_chat_pm(self) -> None:
         """Route the cockpit right-pane to this project's PM session.
@@ -12176,26 +12307,34 @@ class PollyProjectDashboardApp(App[None]):
             )
 
     def _route_to_inbox(self) -> None:
-        router = CockpitRouter(self.config_path)
         # #751 — scope the inbox to the current project on jump so the
         # user doesn't land in the global feed when they came from a
         # specific project. Router resolves ``inbox:<key>`` to a
         # scoped static-view route.
-        router.route_selected(f"inbox:{self.project_key}")
+        file_navigation_client(
+            self.config_path,
+            client_id="project-dashboard",
+        ).jump_to_inbox(self.project_key)
 
     def _route_to_task(self, task_id: str) -> None:
         match = _PROJECT_TASK_REF_RE.fullmatch(task_id)
         if match is None:
             self._route_to_inbox()
             return
-        router = CockpitRouter(self.config_path)
-        router.route_selected(
-            f"project:{match.group('project')}:issues:task:{match.group('number')}"
+        file_navigation_client(
+            self.config_path,
+            client_id="project-dashboard",
+        ).jump_to_project(
+            match.group("project"),
+            view="issues",
+            task_number=match.group("number"),
         )
 
     def _route_to_tasks(self) -> None:
-        router = CockpitRouter(self.config_path)
-        router.route_selected(f"project:{self.project_key}:issues")
+        file_navigation_client(
+            self.config_path,
+            client_id="project-dashboard",
+        ).jump_to_project(self.project_key, view="issues")
 
     def _route_to_current_activity(self) -> None:
         data = self.data
@@ -12367,8 +12506,10 @@ class PollyProjectDashboardApp(App[None]):
         filter through ``pm cockpit-pane activity --project <key>`` so
         the user lands on a scoped view, not the global firehose.
         """
-        router = CockpitRouter(self.config_path)
-        router.route_selected(f"activity:{self.project_key}")
+        file_navigation_client(
+            self.config_path,
+            client_id="project-dashboard",
+        ).jump_to_activity(self.project_key)
 
     def action_open_plan(self) -> None:
         """Toggle plan-view mode — plan.md takes over the body.

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -873,6 +873,7 @@ class PollyCockpitApp(App[None]):
             content_resolver=_CockpitRouteContentResolver(),
             window_manager=_CockpitRouteWindowApplier(self),
         )
+        self._route_status_hint: str | None = None
 
     def compose(self) -> ComposeResult:
         with Vertical():
@@ -1523,6 +1524,10 @@ class PollyCockpitApp(App[None]):
         # wrapping. Anything beyond j/k/\u21b5/?/q is discoverable via the
         # ``?`` overlay (#790). Width budget is roughly 28 chars after
         # the leading pad applied by Textual.
+        route_status_hint = getattr(self, "_route_status_hint", None)
+        if route_status_hint:
+            self.hint.update(route_status_hint)
+            return
         if self._right_pane_has_live_session():
             hint_text = "Tab detail \u00b7 j/k \u00b7 ? help"
         else:
@@ -1676,7 +1681,8 @@ class PollyCockpitApp(App[None]):
         self._route_click_seq = seq
         try:
             display = label or key
-            self.hint.update(f"Connecting to {display}…"[:60])
+            self._route_status_hint = f"Connecting to {display}…"[:60]
+            self.hint.update(self._route_status_hint)
         except Exception:  # noqa: BLE001
             pass
         try:
@@ -1778,6 +1784,7 @@ class PollyCockpitApp(App[None]):
             # ``project:x`` → ``project:x:dashboard``); re-sync.
             self.selected_key = resolved or key
             self._last_router_selected_key = resolved or key
+            self._route_status_hint = None
             try:
                 self.hint.update("")
             except Exception:  # noqa: BLE001
@@ -1806,8 +1813,9 @@ class PollyCockpitApp(App[None]):
         def _apply() -> None:
             if seq and seq != self._route_click_seq:
                 return
+            self._route_status_hint = message[:60]
             try:
-                self.hint.update(message[:60])
+                self.hint.update(self._route_status_hint)
             except Exception:  # noqa: BLE001
                 pass
             try:

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -131,9 +131,9 @@ if TYPE_CHECKING:
 from pollypm.cockpit import build_cockpit_detail
 from pollypm.cockpit_navigation import (
     InMemoryNavigationStateStore,
+    NavigationCommand,
     NavigationContent,
     NavigationController,
-    NavigationRequest,
 )
 from pollypm.cockpit_navigation_client import (
     FileCockpitNavigationQueue,
@@ -170,7 +170,7 @@ class _CockpitRouteContentResolver:
     step; the navigation controller owns acknowledgement/cancellation state.
     """
 
-    def resolve(self, request: NavigationRequest) -> NavigationContent:
+    def resolve(self, request: NavigationCommand) -> NavigationContent:
         return NavigationContent(request.key)
 
 
@@ -178,7 +178,7 @@ class _CockpitRouteWindowApplier:
     def __init__(self, app: "PollyCockpitApp") -> None:
         self._app = app
 
-    def apply(self, request: NavigationRequest, _content: object) -> str:
+    def apply(self, request: NavigationCommand, _content: object) -> str:
         return self._app._route_selected_with_deadline(request.key)
 
 
@@ -1023,20 +1023,16 @@ class PollyCockpitApp(App[None]):
     def _drain_cockpit_navigation_queue(self) -> None:
         try:
             queue = self._cockpit_navigation_queue()
-            pending = queue.pending()
+            pending = queue.drain()
         except Exception:  # noqa: BLE001
             return
         if not pending:
             return
-        try:
-            queue.clear()
-        except Exception:  # noqa: BLE001
-            pass
-        latest = pending[-1]
-        self._schedule_route_selected(
-            latest.selected_key,
-            label=latest.selected_key,
-        )
+        for request in pending:
+            self._schedule_route_selected(
+                request.selected_key,
+                label=request.selected_key,
+            )
 
     # Layout check (pane recovery, rail width) — only every ~30s
     _LAYOUT_CHECK_INTERVAL = 38  # ~30s at 0.8s/tick
@@ -1745,7 +1741,7 @@ class PollyCockpitApp(App[None]):
             seq = request.request_id
             self._route_click_seq = seq
         else:
-            request = NavigationRequest(seq, key)
+            request = NavigationCommand(seq, key)
 
         try:
             result = asyncio.run(controller.resolve_and_apply(request))

--- a/src/pollypm/cockpit_window_manager.py
+++ b/src/pollypm/cockpit_window_manager.py
@@ -1,0 +1,653 @@
+"""Terminal mechanics for the cockpit tmux window.
+
+This module is intentionally below the router/UI layer.  It does not
+resolve rail keys, build cockpit pane commands, import Textual apps, or
+inspect content modules.  Integration code should pass already-resolved
+commands and persist the returned :class:`CockpitWindowState` alongside
+the rest of cockpit state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, Sequence
+
+
+class TmuxWindowMechanics(Protocol):
+    """Small tmux surface required by :class:`CockpitWindowManager`.
+
+    ``pollypm.tmux.client.TmuxClient`` satisfies this protocol.  Tests use
+    a deterministic in-memory model so the manager can be verified without
+    a live tmux server.
+    """
+
+    def list_panes(self, target: str) -> list[Any]: ...
+
+    def list_windows(self, name: str) -> list[Any]: ...
+
+    def split_window(
+        self,
+        target: str,
+        command: str,
+        *,
+        horizontal: bool = True,
+        detached: bool = True,
+        percent: int | None = None,
+        size: int | None = None,
+    ) -> str: ...
+
+    def kill_pane(self, target: str) -> None: ...
+
+    def resize_pane_width(self, target: str, width: int) -> None: ...
+
+    def respawn_pane(self, target: str, command: str) -> None: ...
+
+    def join_pane(self, source: str, target: str, *, horizontal: bool = True) -> None: ...
+
+    def break_pane(self, source: str, target_session: str, window_name: str) -> None: ...
+
+    def rename_window(self, target: str, new_name: str) -> None: ...
+
+    def swap_pane(self, source: str, target: str) -> None: ...
+
+    def select_pane(self, target: str) -> None: ...
+
+    def set_pane_history_limit(self, target: str, limit: int) -> None: ...
+
+    def run(self, *args: str, check: bool = True) -> Any: ...
+
+
+@dataclass(slots=True, frozen=True)
+class CockpitWindowSpec:
+    """Static terminal layout configuration.
+
+    The command strings are integration points: the router/content layer
+    resolves them, while this manager only decides which pane receives
+    each command.
+    """
+
+    tmux_session: str
+    cockpit_window: str = "PollyPM"
+    rail_width: int = 30
+    min_content_width: int = 40
+    default_content_command: str = "pm cockpit-pane polly"
+    rail_command: str | None = None
+    rail_commands: tuple[str, ...] = ("uv",)
+    live_provider_commands: tuple[str, ...] = ("node", "claude", "codex")
+    mounted_history_limit: int = 200
+
+    @property
+    def window_target(self) -> str:
+        return f"{self.tmux_session}:{self.cockpit_window}"
+
+
+@dataclass(slots=True, frozen=True)
+class CockpitWindowState:
+    """Persistable cockpit pane state owned by integration code."""
+
+    right_pane_id: str | None = None
+    mounted_session: str | None = None
+    mounted_window_name: str | None = None
+
+    def cleared_mount(self) -> "CockpitWindowState":
+        return CockpitWindowState(right_pane_id=self.right_pane_id)
+
+    def with_right(self, right_pane_id: str | None) -> "CockpitWindowState":
+        return CockpitWindowState(
+            right_pane_id=right_pane_id,
+            mounted_session=self.mounted_session,
+            mounted_window_name=self.mounted_window_name,
+        )
+
+    def with_mount(
+        self,
+        *,
+        right_pane_id: str,
+        mounted_session: str,
+        mounted_window_name: str,
+    ) -> "CockpitWindowState":
+        return CockpitWindowState(
+            right_pane_id=right_pane_id,
+            mounted_session=mounted_session,
+            mounted_window_name=mounted_window_name,
+        )
+
+
+@dataclass(slots=True, frozen=True)
+class LivePaneSpec:
+    """A live session window that should be mounted into the cockpit."""
+
+    storage_session: str
+    window_name: str
+    mounted_session: str
+    history_limit: int | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class ParkPaneSpec:
+    """Where to park a currently mounted cockpit content pane."""
+
+    storage_session: str
+    window_name: str
+    mounted_session: str
+
+
+@dataclass(slots=True, frozen=True)
+class PaneClassification:
+    panes: tuple[Any, ...]
+    live_panes: tuple[Any, ...]
+    dead_panes: tuple[Any, ...]
+    left_pane: Any | None
+    right_pane: Any | None
+    rail_pane: Any | None
+    content_pane: Any | None
+    extra_panes: tuple[Any, ...]
+
+
+@dataclass(slots=True, frozen=True)
+class CockpitPostcondition:
+    valid: bool
+    errors: tuple[str, ...]
+    left_pane_id: str | None = None
+    right_pane_id: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class CockpitWindowResult:
+    state: CockpitWindowState
+    actions: tuple[str, ...]
+    postcondition: CockpitPostcondition
+
+    @property
+    def left_pane_id(self) -> str | None:
+        return self.postcondition.left_pane_id
+
+    @property
+    def right_pane_id(self) -> str | None:
+        return self.postcondition.right_pane_id
+
+    @property
+    def ok(self) -> bool:
+        return self.postcondition.valid
+
+
+def _pane_id(pane: Any | None) -> str | None:
+    value = getattr(pane, "pane_id", None)
+    return value if isinstance(value, str) and value else None
+
+
+def _pane_left(pane: Any) -> int:
+    try:
+        return int(getattr(pane, "pane_left", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _pane_width(pane: Any) -> int:
+    try:
+        return int(getattr(pane, "pane_width", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _pane_command(pane: Any | None) -> str:
+    value = getattr(pane, "pane_current_command", "")
+    return value if isinstance(value, str) else ""
+
+
+def _pane_dead(pane: Any | None) -> bool:
+    return bool(getattr(pane, "pane_dead", False))
+
+
+class CockpitWindowManager:
+    """Own tmux pane layout and movement for one cockpit window."""
+
+    def __init__(
+        self,
+        spec: CockpitWindowSpec,
+        tmux: TmuxWindowMechanics | None = None,
+    ) -> None:
+        self.spec = spec
+        if tmux is None:
+            from pollypm.tmux.client import TmuxClient
+
+            tmux = TmuxClient()
+        self.tmux = tmux
+
+    def classify_panes(self, panes: Sequence[Any] | None = None) -> PaneClassification:
+        if panes is None:
+            panes = self.tmux.list_panes(self.spec.window_target)
+        ordered = tuple(sorted(panes, key=lambda pane: (_pane_left(pane), _pane_id(pane) or "")))
+        dead = tuple(pane for pane in ordered if _pane_dead(pane))
+        live = tuple(pane for pane in ordered if not _pane_dead(pane))
+        left = live[0] if live else None
+        right = live[-1] if live else None
+        rail = next((pane for pane in live if self._is_rail_pane(pane)), None)
+        content: Any | None = None
+        if rail is not None:
+            content = next((pane for pane in reversed(live) if pane is not rail), None)
+        elif len(live) >= 2:
+            content = live[-1]
+        extras = tuple(pane for pane in live if pane is not rail and pane is not content)
+        return PaneClassification(
+            panes=ordered,
+            live_panes=live,
+            dead_panes=dead,
+            left_pane=left,
+            right_pane=right,
+            rail_pane=rail,
+            content_pane=content,
+            extra_panes=extras,
+        )
+
+    def validate_postcondition(self, panes: Sequence[Any] | None = None) -> CockpitPostcondition:
+        classification = self.classify_panes(panes)
+        errors: list[str] = []
+        if classification.dead_panes:
+            errors.append(
+                "dead panes present: "
+                + ", ".join(_pane_id(pane) or "?" for pane in classification.dead_panes)
+            )
+        if len(classification.live_panes) != 2:
+            errors.append(f"expected exactly 2 live panes, found {len(classification.live_panes)}")
+        if classification.rail_pane is None:
+            errors.append("rail pane missing")
+        elif classification.left_pane is not classification.rail_pane:
+            errors.append("rail pane is not leftmost")
+        if classification.content_pane is None:
+            errors.append("content pane missing")
+        elif classification.right_pane is not classification.content_pane:
+            errors.append("content pane is not rightmost")
+        return CockpitPostcondition(
+            valid=not errors,
+            errors=tuple(errors),
+            left_pane_id=_pane_id(classification.left_pane),
+            right_pane_id=_pane_id(classification.content_pane),
+        )
+
+    def ensure_layout(
+        self,
+        state: CockpitWindowState | None = None,
+    ) -> CockpitWindowResult:
+        state = state or CockpitWindowState()
+        actions: list[str] = []
+        panes = self.tmux.list_panes(self.spec.window_target)
+
+        state = self._repair_dead_panes(panes, state, actions)
+        panes = self.tmux.list_panes(self.spec.window_target)
+
+        classification = self.classify_panes(panes)
+        if len(classification.live_panes) == 1:
+            state = self._repair_single_pane(classification.live_panes[0], state, actions)
+            panes = self.tmux.list_panes(self.spec.window_target)
+            classification = self.classify_panes(panes)
+
+        if len(classification.live_panes) < 2 and classification.live_panes:
+            right_pane_id = self._split_content_pane(classification.live_panes[0], actions)
+            state = state.cleared_mount().with_right(right_pane_id)
+            panes = self.tmux.list_panes(self.spec.window_target)
+            classification = self.classify_panes(panes)
+
+        if len(classification.live_panes) > 2:
+            self._kill_extra_panes(classification, state, actions)
+            panes = self.tmux.list_panes(self.spec.window_target)
+            classification = self.classify_panes(panes)
+
+        if len(classification.live_panes) == 2:
+            if classification.rail_pane is None and self.spec.rail_command is not None:
+                left_id = _pane_id(classification.left_pane)
+                if left_id is not None:
+                    self.tmux.respawn_pane(left_id, self.spec.rail_command)
+                    actions.append(f"respawn_rail:{left_id}")
+                    state = state.cleared_mount()
+                    panes = self.tmux.list_panes(self.spec.window_target)
+                    classification = self.classify_panes(panes)
+            if (
+                classification.rail_pane is not None
+                and classification.left_pane is not classification.rail_pane
+            ):
+                source = _pane_id(classification.rail_pane)
+                target = _pane_id(classification.left_pane)
+                if source is not None and target is not None:
+                    self.tmux.swap_pane(source, target)
+                    actions.append(f"swap_rail_left:{source}->{target}")
+                    panes = self.tmux.list_panes(self.spec.window_target)
+                    classification = self.classify_panes(panes)
+
+        self._resize_rail(classification, actions)
+        postcondition = self.validate_postcondition()
+        if postcondition.right_pane_id is not None:
+            state = state.with_right(postcondition.right_pane_id)
+        return CockpitWindowResult(
+            state=state,
+            actions=tuple(actions),
+            postcondition=postcondition,
+        )
+
+    def show_static(
+        self,
+        command: str,
+        state: CockpitWindowState | None = None,
+        *,
+        park: ParkPaneSpec | None = None,
+    ) -> CockpitWindowResult:
+        state = state or CockpitWindowState()
+        actions: list[str] = []
+        if park is not None and state.mounted_session:
+            park_result = self.park_live_to_storage(state, park=park)
+            state = park_result.state
+            actions.extend(park_result.actions)
+        layout = self.ensure_layout(state)
+        state = layout.state
+        actions.extend(layout.actions)
+        right = self._right_pane()
+        right_id = _pane_id(right)
+        if right_id is None:
+            return self._result(state, actions)
+        self.tmux.respawn_pane(right_id, command)
+        actions.append(f"respawn_static:{right_id}")
+        state = state.cleared_mount().with_right(right_id)
+        return self._result(state, actions)
+
+    def join_live_from_storage(
+        self,
+        live: LivePaneSpec,
+        state: CockpitWindowState | None = None,
+    ) -> CockpitWindowResult:
+        state = state or CockpitWindowState()
+        actions: list[str] = []
+        layout = self.ensure_layout(state)
+        state = layout.state
+        actions.extend(layout.actions)
+
+        source_window = self._storage_window(live.storage_session, live.window_name)
+        if source_window is None:
+            actions.append(f"missing_storage_window:{live.storage_session}:{live.window_name}")
+            return self._result(state, actions)
+
+        left = self._left_pane()
+        right = self._right_pane()
+        left_id = _pane_id(left)
+        right_id = _pane_id(right)
+        if left_id is None:
+            return self._result(state, actions)
+        if right_id is not None:
+            self.tmux.kill_pane(right_id)
+            actions.append(f"kill_static_right:{right_id}")
+
+        source = f"{live.storage_session}:{getattr(source_window, 'index')}.0"
+        self.tmux.join_pane(source, left_id, horizontal=True)
+        actions.append(f"join_live:{source}->{left_id}")
+        panes = self.tmux.list_panes(self.spec.window_target)
+        classification = self.classify_panes(panes)
+        self._resize_rail(classification, actions)
+        right = self._right_pane()
+        right_id = _pane_id(right)
+        if right_id is not None:
+            limit = live.history_limit or self.spec.mounted_history_limit
+            self.tmux.set_pane_history_limit(right_id, limit)
+            actions.append(f"history_limit:{right_id}:{limit}")
+            state = state.with_mount(
+                right_pane_id=right_id,
+                mounted_session=live.mounted_session,
+                mounted_window_name=live.window_name,
+            )
+        return self._result(state, actions)
+
+    def park_live_to_storage(
+        self,
+        state: CockpitWindowState | None = None,
+        *,
+        park: ParkPaneSpec | None = None,
+    ) -> CockpitWindowResult:
+        state = state or CockpitWindowState()
+        actions: list[str] = []
+        if park is None:
+            if not state.mounted_session or not state.mounted_window_name:
+                return self._result(state.cleared_mount(), actions)
+            storage_session = f"{self.spec.tmux_session}-storage-closet"
+            park = ParkPaneSpec(
+                storage_session=storage_session,
+                window_name=state.mounted_window_name,
+                mounted_session=state.mounted_session,
+            )
+
+        right = self._right_pane(preferred_id=state.right_pane_id)
+        right_id = _pane_id(right)
+        if right_id is None or not self._is_live_provider_pane(right):
+            actions.append("clear_non_live_mount")
+            state = state.cleared_mount()
+            layout = self.ensure_layout(state)
+            actions.extend(layout.actions)
+            return CockpitWindowResult(
+                state=layout.state,
+                actions=tuple(actions),
+                postcondition=layout.postcondition,
+            )
+
+        before = self._window_key_set(park.storage_session)
+        self.tmux.break_pane(right_id, park.storage_session, park.window_name)
+        actions.append(f"break_live:{right_id}->{park.storage_session}:{park.window_name}")
+        self._rename_created_window(park.storage_session, before, park.window_name, actions)
+        state = state.cleared_mount()
+
+        panes = self.tmux.list_panes(self.spec.window_target)
+        if len([pane for pane in panes if not _pane_dead(pane)]) < 2:
+            classification = self.classify_panes(panes)
+            anchor = classification.rail_pane or classification.left_pane
+            if anchor is not None:
+                new_right = self._split_content_pane(anchor, actions)
+                state = state.with_right(new_right)
+        layout = self.ensure_layout(state)
+        actions.extend(layout.actions)
+        return CockpitWindowResult(
+            state=layout.state,
+            actions=tuple(actions),
+            postcondition=layout.postcondition,
+        )
+
+    def focus_right(self, state: CockpitWindowState | None = None) -> CockpitWindowResult:
+        actions: list[str] = []
+        layout = self.ensure_layout(state)
+        actions.extend(layout.actions)
+        right_id = layout.right_pane_id
+        if right_id is not None:
+            self.tmux.run(
+                "display-message",
+                "-t",
+                self.spec.window_target,
+                "PollyPM: Ctrl-b Left returns to the rail.",
+                check=False,
+            )
+            self.tmux.select_pane(right_id)
+            actions.append(f"focus_right:{right_id}")
+        return CockpitWindowResult(
+            state=layout.state,
+            actions=tuple(actions),
+            postcondition=layout.postcondition,
+        )
+
+    def send_key_right(
+        self,
+        key: str,
+        state: CockpitWindowState | None = None,
+    ) -> CockpitWindowResult:
+        actions: list[str] = []
+        layout = self.ensure_layout(state)
+        actions.extend(layout.actions)
+        right_id = layout.right_pane_id
+        if right_id is not None:
+            self.tmux.run("send-keys", "-t", right_id, key, check=False)
+            actions.append(f"send_key_right:{right_id}:{key}")
+        return CockpitWindowResult(
+            state=layout.state,
+            actions=tuple(actions),
+            postcondition=layout.postcondition,
+        )
+
+    def _result(
+        self,
+        state: CockpitWindowState,
+        actions: list[str],
+    ) -> CockpitWindowResult:
+        postcondition = self.validate_postcondition()
+        if postcondition.right_pane_id is not None:
+            state = state.with_right(postcondition.right_pane_id)
+        return CockpitWindowResult(
+            state=state,
+            actions=tuple(actions),
+            postcondition=postcondition,
+        )
+
+    def _repair_dead_panes(
+        self,
+        panes: Sequence[Any],
+        state: CockpitWindowState,
+        actions: list[str],
+    ) -> CockpitWindowState:
+        if not any(_pane_dead(pane) for pane in panes):
+            return state
+        ordered = sorted(panes, key=lambda pane: (_pane_left(pane), _pane_id(pane) or ""))
+        for pane in ordered:
+            if not _pane_dead(pane):
+                continue
+            pane_id = _pane_id(pane)
+            if pane_id is None:
+                continue
+            if pane_id == state.right_pane_id or pane is ordered[-1]:
+                self.tmux.respawn_pane(pane_id, self.spec.default_content_command)
+                actions.append(f"respawn_dead_content:{pane_id}")
+                state = state.cleared_mount().with_right(pane_id)
+            elif self.spec.rail_command is not None:
+                self.tmux.respawn_pane(pane_id, self.spec.rail_command)
+                actions.append(f"respawn_dead_rail:{pane_id}")
+            else:
+                self.tmux.kill_pane(pane_id)
+                actions.append(f"kill_dead:{pane_id}")
+        return state
+
+    def _repair_single_pane(
+        self,
+        pane: Any,
+        state: CockpitWindowState,
+        actions: list[str],
+    ) -> CockpitWindowState:
+        if self._is_rail_pane(pane):
+            return state
+        pane_id = _pane_id(pane)
+        if pane_id is not None and self.spec.rail_command is not None:
+            self.tmux.respawn_pane(pane_id, self.spec.rail_command)
+            actions.append(f"respawn_missing_rail:{pane_id}")
+            return state.cleared_mount()
+        return state
+
+    def _kill_extra_panes(
+        self,
+        classification: PaneClassification,
+        state: CockpitWindowState,
+        actions: list[str],
+    ) -> None:
+        preferred_content = None
+        if state.right_pane_id is not None:
+            preferred_content = next(
+                (
+                    pane
+                    for pane in classification.live_panes
+                    if _pane_id(pane) == state.right_pane_id
+                ),
+                None,
+            )
+        keep_ids = {
+            _pane_id(classification.rail_pane or classification.left_pane),
+            _pane_id(preferred_content or classification.content_pane or classification.right_pane),
+        }
+        for pane in classification.live_panes:
+            pane_id = _pane_id(pane)
+            if pane_id is None or pane_id in keep_ids:
+                continue
+            self.tmux.kill_pane(pane_id)
+            actions.append(f"kill_extra:{pane_id}")
+
+    def _split_content_pane(self, anchor: Any, actions: list[str]) -> str:
+        width = max((_pane_width(anchor) or 200) - self.spec.rail_width - 1, self.spec.min_content_width)
+        right_pane_id = self.tmux.split_window(
+            self.spec.window_target,
+            self.spec.default_content_command,
+            horizontal=True,
+            detached=True,
+            size=width,
+        )
+        actions.append(f"split_content:{right_pane_id}")
+        return right_pane_id
+
+    def _resize_rail(
+        self,
+        classification: PaneClassification,
+        actions: list[str],
+    ) -> None:
+        pane_id = _pane_id(classification.rail_pane)
+        if pane_id is None:
+            return
+        self.tmux.resize_pane_width(pane_id, self.spec.rail_width)
+        actions.append(f"resize_rail:{pane_id}:{self.spec.rail_width}")
+
+    def _left_pane(self) -> Any | None:
+        return self.classify_panes().left_pane
+
+    def _right_pane(self, *, preferred_id: str | None = None) -> Any | None:
+        panes = self.tmux.list_panes(self.spec.window_target)
+        if preferred_id:
+            preferred = next(
+                (pane for pane in panes if _pane_id(pane) == preferred_id and not _pane_dead(pane)),
+                None,
+            )
+            if preferred is not None:
+                return preferred
+        return self.classify_panes(panes).content_pane
+
+    def _storage_window(self, storage_session: str, window_name: str) -> Any | None:
+        matches = [
+            window
+            for window in self.tmux.list_windows(storage_session)
+            if getattr(window, "name", None) == window_name
+        ]
+        if not matches:
+            return None
+        return sorted(matches, key=lambda window: int(getattr(window, "index", 0)))[0]
+
+    def _window_key_set(self, storage_session: str) -> set[tuple[int, str]]:
+        return {
+            (int(getattr(window, "index", 0)), str(getattr(window, "name", "")))
+            for window in self.tmux.list_windows(storage_session)
+        }
+
+    def _rename_created_window(
+        self,
+        storage_session: str,
+        before: set[tuple[int, str]],
+        window_name: str,
+        actions: list[str],
+    ) -> None:
+        after = self.tmux.list_windows(storage_session)
+        created = [
+            window
+            for window in after
+            if (int(getattr(window, "index", 0)), str(getattr(window, "name", ""))) not in before
+        ]
+        if not created:
+            return
+        created.sort(key=lambda window: int(getattr(window, "index", 0)))
+        target = created[-1]
+        index = int(getattr(target, "index", 0))
+        if getattr(target, "name", None) != window_name:
+            self.tmux.rename_window(f"{storage_session}:{index}", window_name)
+            actions.append(f"rename_parked:{storage_session}:{index}:{window_name}")
+
+    def _is_rail_pane(self, pane: Any | None) -> bool:
+        return _pane_command(pane) in self.spec.rail_commands
+
+    def _is_live_provider_pane(self, pane: Any | None) -> bool:
+        command = _pane_command(pane)
+        if command in self.spec.live_provider_commands:
+            return True
+        return bool(command) and all(char.isdigit() or char == "." for char in command)

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -2688,12 +2688,15 @@ def test_cockpit_router_routes_idle_project_to_detail_pane(monkeypatch, tmp_path
     class FakeTmux:
         def list_panes(self, target: str):
             return [
-                type("Pane", (), {"pane_id": "%1", "active": True})(),
-                type("Pane", (), {"pane_id": "%2", "active": False})(),
+                type("Pane", (), {"pane_id": "%1", "active": True, "pane_left": 0, "pane_current_command": "uv"})(),
+                type("Pane", (), {"pane_id": "%2", "active": False, "pane_left": 30, "pane_current_command": "sh"})(),
             ]
 
         def respawn_pane(self, target: str, command: str):
             calls["respawn"] = (target, command)
+
+        def resize_pane_width(self, target: str, width: int):
+            calls["resize"] = (target, width)
 
     class FakeConfig:
         class Project:
@@ -2740,12 +2743,15 @@ def test_cockpit_router_routes_dashboard_home_to_static_pane(
     class FakeTmux:
         def list_panes(self, target: str):
             return [
-                type("Pane", (), {"pane_id": "%1", "active": True})(),
-                type("Pane", (), {"pane_id": "%2", "active": False})(),
+                type("Pane", (), {"pane_id": "%1", "active": True, "pane_left": 0, "pane_current_command": "uv"})(),
+                type("Pane", (), {"pane_id": "%2", "active": False, "pane_left": 30, "pane_current_command": "sh"})(),
             ]
 
         def respawn_pane(self, target: str, command: str):
             calls["respawn"] = (target, command)
+
+        def resize_pane_width(self, target: str, width: int):
+            calls["resize"] = (target, width)
 
     class FakeConfig:
         class Project:
@@ -3549,6 +3555,34 @@ def test_cockpit_app_adopts_external_router_selection_without_stomping_cursor() 
     app.selected_key = "inbox"
     app._adopt_router_selection_if_changed()
     assert app.selected_key == "inbox"
+
+
+def test_cockpit_app_drains_right_pane_navigation_queue_to_latest_request() -> None:
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+    scheduled: list[tuple[str, str | None]] = []
+
+    class _Queue:
+        cleared = False
+
+        def pending(self):
+            return (
+                SimpleNamespace(sequence=1, selected_key="inbox:demo"),
+                SimpleNamespace(sequence=2, selected_key="activity:demo"),
+            )
+
+        def clear(self) -> None:
+            self.cleared = True
+
+    queue = _Queue()
+    app._cockpit_navigation_queue = lambda: queue  # type: ignore[method-assign]
+    app._schedule_route_selected = (  # type: ignore[method-assign]
+        lambda key, *, label=None: scheduled.append((key, label))
+    )
+
+    app._drain_cockpit_navigation_queue()
+
+    assert queue.cleared is True
+    assert scheduled == [("activity:demo", "activity:demo")]
 
 
 def test_cockpit_app_routes_detail_hint_keys_from_rail() -> None:
@@ -4408,7 +4442,7 @@ def test_async_click_dispatches_via_run_worker_when_available() -> None:
     app, events = _make_async_click_app()
     dispatched: list[str] = []
 
-    def _spy_dispatch(key: str) -> None:
+    def _spy_dispatch(key: str, seq: int = 0) -> None:
         dispatched.append(key)
 
     app._dispatch_route_in_worker = _spy_dispatch  # type: ignore[assignment]
@@ -4488,3 +4522,131 @@ def test_async_click_resyncs_selected_key_from_router() -> None:
 
     assert app.selected_key == "project:demo:dashboard"
     assert app._last_router_selected_key == "project:demo:dashboard"
+
+
+# ── #967: rail click stability — second click must NOT bounce back ────────────
+
+def test_rapid_double_click_does_not_bounce_back_to_first_target() -> None:
+    """#967 — every rail click flashed the target then bounced to Home.
+
+    Root cause: ``_route_selected_worker`` runs on a thread spawned via
+    ``run_worker(thread=True, exclusive=True, group="route_select")``.
+    Textual cancels the *asyncio* task when a newer click arrives, but the
+    thread itself continues running to completion (Python threads are not
+    asyncio-aware). When the stale thread eventually returned, it called
+    ``_post_route_success`` which unconditionally overwrote
+    ``selected_key`` with the OLD click's resolved key — bouncing the
+    user back to wherever the first click had gone.
+
+    Repro: click ``project:demo`` then immediately click ``polly``. The
+    ``project:demo`` worker is still running in its executor when the
+    ``polly`` worker fires. After both complete, ``selected_key`` MUST
+    reflect ``polly`` — the user's most-recent intent — not the stale
+    ``project:demo:dashboard`` the first worker resolved.
+    """
+    import threading
+
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+
+    project_started = threading.Event()
+    project_unblock = threading.Event()
+
+    class _RaceRouter:
+        selected = "polly"
+
+        def route_selected(self, key: str) -> None:
+            if key == "project:demo":
+                # Simulate the slow PM-attach: signal we've entered the
+                # router, then block until the test releases us. While
+                # we're parked here, the second click will fire.
+                project_started.set()
+                project_unblock.wait(timeout=2.0)
+                self.selected = "project:demo:dashboard"
+            else:
+                self.selected = key
+
+        def selected_key(self) -> str:
+            return self.selected
+
+    class _Hint:
+        def update(self, _msg: str) -> None:
+            pass
+
+    app.router = _RaceRouter()  # type: ignore[assignment]
+    app.selected_key = "polly"
+    app._last_router_selected_key = "polly"
+    app._route_click_seq = 0
+    app.hint = _Hint()  # type: ignore[assignment]
+    app._unread_keys = set()
+    app._refresh_rows = lambda: None  # type: ignore[method-assign]
+    app._selected_row_key = lambda: app.selected_key  # type: ignore[method-assign]
+
+    # First click — manually drive the same sequence that
+    # ``_schedule_route_selected`` would: bump the click seq and run
+    # the worker on a real thread (so we can race a second click).
+    app.selected_key = "project:demo"
+    app._route_click_seq += 1
+    first_seq = app._route_click_seq
+    first = threading.Thread(
+        target=lambda: app._route_selected_worker("project:demo", first_seq),
+        daemon=True,
+    )
+    first.start()
+    assert project_started.wait(timeout=2.0), "first router never entered"
+
+    # Second click — registers optimistic state for ``polly`` and runs
+    # the (fast) ``polly`` worker inline (no event loop in tests). After
+    # this returns the user's intent is unambiguously ``polly``.
+    app._schedule_route_selected("polly", label="Home")
+    assert app.selected_key == "polly"
+
+    # Release the stalled first worker. It will now finish and call
+    # ``_post_route_success`` for ``project:demo``. Without the #967 fix,
+    # this overwrites ``selected_key`` back to ``project:demo:dashboard``.
+    project_unblock.set()
+    first.join(timeout=2.0)
+    assert not first.is_alive(), "stalled router never returned"
+
+    # The user's most-recent click must win.
+    assert app.selected_key == "polly", (
+        "stale route worker bounced selected_key back to the previous "
+        f"click; got {app.selected_key!r}"
+    )
+    assert app._last_router_selected_key == "polly"
+
+
+def test_rail_click_is_stable_across_multiple_targets() -> None:
+    """#967 — clicking each rail entry in succession must leave the
+    cockpit on the LAST clicked target, not on whatever earlier click
+    happened to win the post-route race.
+    """
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+
+    class _Router:
+        selected = "polly"
+
+        def route_selected(self, key: str) -> None:
+            self.selected = key
+
+        def selected_key(self) -> str:
+            return self.selected
+
+    class _Hint:
+        def update(self, _msg: str) -> None:
+            pass
+
+    app.router = _Router()  # type: ignore[assignment]
+    app.selected_key = "polly"
+    app._last_router_selected_key = "polly"
+    app._route_click_seq = 0
+    app.hint = _Hint()  # type: ignore[assignment]
+    app._unread_keys = set()
+    app._refresh_rows = lambda: None  # type: ignore[method-assign]
+    app._selected_row_key = lambda: app.selected_key  # type: ignore[method-assign]
+
+    targets = ["inbox", "polly", "workers", "project:demo", "metrics"]
+    for target in targets:
+        app._schedule_route_selected(target, label=target)
+        assert app.selected_key == target, (
+            f"click on {target!r} did not stick (got {app.selected_key!r})"
+        )

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -99,6 +99,25 @@ def test_cockpit_router_build_items_includes_core_entries(monkeypatch, tmp_path:
     assert "PollyPM" in project_labels
 
 
+def test_cockpit_router_message_view_does_not_spawn_bounded_sleep() -> None:
+    router = CockpitRouter.__new__(CockpitRouter)
+    commands: list[str] = []
+    router._show_command_view = (  # type: ignore[attr-defined]
+        lambda _supervisor, _window_target, command: commands.append(command)
+    )
+
+    CockpitRouter._show_message_view(
+        router,
+        object(),
+        "test-window",
+        "Unable to open pane",
+        "Mount failed",
+    )
+
+    assert "sleep 3600" not in commands[0]
+    assert "read -r" in commands[0]
+
+
 def test_cockpit_router_build_items_keeps_mounted_task_worker_visible(
     monkeypatch, tmp_path: Path,
 ) -> None:
@@ -3557,21 +3576,19 @@ def test_cockpit_app_adopts_external_router_selection_without_stomping_cursor() 
     assert app.selected_key == "inbox"
 
 
-def test_cockpit_app_drains_right_pane_navigation_queue_to_latest_request() -> None:
+def test_cockpit_app_drains_right_pane_navigation_queue_in_sequence() -> None:
     app = PollyCockpitApp.__new__(PollyCockpitApp)
     scheduled: list[tuple[str, str | None]] = []
 
     class _Queue:
-        cleared = False
+        drained = False
 
-        def pending(self):
+        def drain(self):
+            self.drained = True
             return (
                 SimpleNamespace(sequence=1, selected_key="inbox:demo"),
                 SimpleNamespace(sequence=2, selected_key="activity:demo"),
             )
-
-        def clear(self) -> None:
-            self.cleared = True
 
     queue = _Queue()
     app._cockpit_navigation_queue = lambda: queue  # type: ignore[method-assign]
@@ -3581,8 +3598,11 @@ def test_cockpit_app_drains_right_pane_navigation_queue_to_latest_request() -> N
 
     app._drain_cockpit_navigation_queue()
 
-    assert queue.cleared is True
-    assert scheduled == [("activity:demo", "activity:demo")]
+    assert queue.drained is True
+    assert scheduled == [
+        ("inbox:demo", "inbox:demo"),
+        ("activity:demo", "activity:demo"),
+    ]
 
 
 def test_cockpit_app_routes_detail_hint_keys_from_rail() -> None:

--- a/tests/test_cockpit_content.py
+++ b/tests/test_cockpit_content.py
@@ -1,0 +1,194 @@
+import subprocess
+import sys
+
+from pollypm.cockpit_content import (
+    CockpitContentContext,
+    ErrorPane,
+    FallbackPane,
+    LiveAgentPane,
+    LoadingPane,
+    TextualCommandPane,
+    loading_content_plan,
+    resolve_cockpit_content,
+)
+
+
+def _ctx() -> CockpitContentContext:
+    return CockpitContentContext.from_projects(
+        ["demo", "other"],
+        project_sessions={
+            "demo": "worker_demo",
+            "other": "worker_other",
+        },
+    )
+
+
+def test_importing_content_resolver_does_not_load_ui_or_supervisor() -> None:
+    code = "\n".join(
+        [
+            "import sys",
+            "import pollypm.cockpit_content",
+            "bad = [name for name in (",
+            "    'pollypm.cockpit_ui',",
+            "    'pollypm.cockpit_rail',",
+            "    'pollypm.service_api',",
+            "    'pollypm.supervisor',",
+            ") if name in sys.modules]",
+            "assert not bad, bad",
+        ]
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)
+
+
+def test_loading_content_plan_is_typed_placeholder() -> None:
+    plan = loading_content_plan("project:demo", label="Demo")
+
+    assert isinstance(plan, LoadingPane)
+    assert plan.content_kind == "loading"
+    assert plan.right_pane_state == "loading"
+    assert plan.selected_key == "project:demo"
+    assert plan.message == "Loading Demo..."
+
+
+def test_resolves_polly_and_russell_to_live_agent_panes() -> None:
+    polly = resolve_cockpit_content("polly", _ctx())
+    russell = resolve_cockpit_content("russell", _ctx())
+
+    assert isinstance(polly, LiveAgentPane)
+    assert polly.session_name == "operator"
+    assert polly.fallback is not None
+    assert polly.fallback.pane_kind == "polly"
+
+    assert isinstance(russell, LiveAgentPane)
+    assert russell.session_name == "reviewer"
+
+
+def test_resolves_global_static_textual_command_panes() -> None:
+    expected = {
+        "dashboard": ("dashboard", ("cockpit-pane", "dashboard")),
+        "inbox": ("inbox", ("cockpit-pane", "inbox")),
+        "settings": ("settings", ("cockpit-pane", "settings")),
+        "metrics": ("metrics", ("cockpit-pane", "metrics")),
+        "activity": ("activity", ("cockpit-pane", "activity")),
+    }
+
+    for route_key, (pane_kind, command_args) in expected.items():
+        plan = resolve_cockpit_content(route_key, _ctx())
+        assert isinstance(plan, TextualCommandPane)
+        assert plan.content_kind == "static_command"
+        assert plan.pane_kind == pane_kind
+        assert plan.command_args == command_args
+        assert plan.selected_key == route_key
+
+
+def test_resolves_scoped_inbox_and_activity_to_project_filtered_commands() -> None:
+    inbox = resolve_cockpit_content("inbox:demo", _ctx())
+    activity = resolve_cockpit_content("activity:demo", _ctx())
+
+    assert isinstance(inbox, TextualCommandPane)
+    assert inbox.pane_kind == "inbox"
+    assert inbox.project_key == "demo"
+    assert inbox.selected_key == "inbox"
+    assert inbox.command_args == ("cockpit-pane", "inbox", "--project", "demo")
+
+    assert isinstance(activity, TextualCommandPane)
+    assert activity.pane_kind == "activity"
+    assert activity.project_key == "demo"
+    assert activity.selected_key == "activity:demo"
+    assert activity.command_args == ("cockpit-pane", "activity", "--project", "demo")
+
+
+def test_resolves_project_dashboard_settings_issues_and_task_panes() -> None:
+    cases = {
+        "project:demo": (
+            "project",
+            "project:demo:dashboard",
+            ("cockpit-pane", "project", "demo"),
+            None,
+        ),
+        "project:demo:dashboard": (
+            "project",
+            "project:demo:dashboard",
+            ("cockpit-pane", "project", "demo"),
+            None,
+        ),
+        "project:demo:settings": (
+            "settings",
+            "project:demo:settings",
+            ("cockpit-pane", "settings", "demo"),
+            None,
+        ),
+        "project:demo:issues": (
+            "issues",
+            "project:demo:issues",
+            ("cockpit-pane", "issues", "demo"),
+            None,
+        ),
+        "project:demo:issues:task:7": (
+            "issues",
+            "project:demo:issues:task:7",
+            ("cockpit-pane", "issues", "demo", "--task", "demo/7"),
+            "demo/7",
+        ),
+        "project:demo:task:7": (
+            "issues",
+            "project:demo:task:7",
+            ("cockpit-pane", "issues", "demo", "--task", "demo/7"),
+            "demo/7",
+        ),
+    }
+
+    for route_key, (pane_kind, selected_key, command_args, task_id) in cases.items():
+        plan = resolve_cockpit_content(route_key, _ctx())
+        assert isinstance(plan, TextualCommandPane)
+        assert plan.project_key == "demo"
+        assert plan.pane_kind == pane_kind
+        assert plan.selected_key == selected_key
+        assert plan.command_args == command_args
+        assert plan.task_id == task_id
+
+
+def test_resolves_project_pm_chat_to_exact_project_session_mapping() -> None:
+    plan = resolve_cockpit_content("project:demo:session", _ctx())
+
+    assert isinstance(plan, LiveAgentPane)
+    assert plan.project_key == "demo"
+    assert plan.session_name == "worker_demo"
+    assert plan.fallback is not None
+    assert plan.fallback.pane_kind == "project"
+    assert plan.fallback.command_args == ("cockpit-pane", "project", "demo")
+
+
+def test_missing_worker_returns_explicit_fallback_not_another_worker() -> None:
+    context = CockpitContentContext.from_projects(
+        ["demo", "other"],
+        project_sessions={"other": "worker_other"},
+    )
+
+    plan = resolve_cockpit_content("project:demo:session", context)
+
+    assert isinstance(plan, FallbackPane)
+    assert plan.reason == "missing_worker"
+    assert not hasattr(plan, "session_name")
+    assert "worker_other" not in repr(plan)
+    assert plan.fallback.pane_kind == "project"
+    assert plan.fallback.project_key == "demo"
+    assert plan.fallback.command_args == ("cockpit-pane", "project", "demo")
+
+
+def test_missing_project_returns_error_content() -> None:
+    context = CockpitContentContext.from_projects(["demo"])
+
+    plan = resolve_cockpit_content("project:missing:dashboard", context)
+
+    assert isinstance(plan, ErrorPane)
+    assert plan.reason == "missing_project"
+    assert "missing" in plan.message
+
+
+def test_invalid_route_returns_error_content() -> None:
+    plan = resolve_cockpit_content("not-a-route", _ctx())
+
+    assert isinstance(plan, ErrorPane)
+    assert plan.reason == "unknown_route"
+    assert plan.right_pane_state == "error"

--- a/tests/test_cockpit_contract_boundaries.py
+++ b/tests/test_cockpit_contract_boundaries.py
@@ -1,0 +1,212 @@
+"""Cockpit modular-contract and tmux-boundary tests (#969).
+
+The refactor target is:
+
+    rail UI -> navigation state machine -> content resolver -> window manager
+
+Only the final window-manager boundary should need concrete tmux pane/window
+operations for cockpit right-pane work. The production allowlist below is
+pragmatic because today's legacy cockpit and session code still contain direct
+calls. The intended cockpit end-state is smaller:
+
+* ``src/pollypm/cockpit_window_manager.py`` owns cockpit right-pane mutation.
+* ``src/pollypm/tmux/client.py`` owns the low-level tmux command adapter.
+* Tests should use protocol fakes instead of introducing new production
+  call sites.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+from dataclasses import dataclass
+from pathlib import Path
+
+import pollypm.cockpit_contracts as contracts
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+TMUX_PANE_WINDOW_METHODS: frozenset[str] = frozenset(
+    {
+        "join_pane",
+        "split_window",
+        "kill_pane",
+        "respawn_pane",
+        "break_pane",
+        "swap_pane",
+        "list_panes",
+        "list_windows",
+    }
+)
+
+# Current production references. Each entry is temporary except the low-level
+# adapter; remove entries as cockpit code moves behind CockpitWindowManager.
+CURRENT_TMUX_BOUNDARY_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "src/pollypm/cli.py",
+        "src/pollypm/cli_features/session_runtime.py",
+        "src/pollypm/cockpit_inbox.py",
+        "src/pollypm/cockpit_rail.py",
+        "src/pollypm/cockpit_ui.py",
+        "src/pollypm/cockpit_window_manager.py",
+        "src/pollypm/core/console_window.py",
+        "src/pollypm/job_runner.py",
+        "src/pollypm/plugins_builtin/core_rail_items/plugin.py",
+        "src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py",
+        "src/pollypm/session_services/tmux.py",
+        "src/pollypm/supervisor.py",
+        "src/pollypm/tmux/client.py",
+        "src/pollypm/work/session_manager.py",
+    }
+)
+
+FORBIDDEN_CONTRACT_IMPORT_ROOTS: frozenset[str] = frozenset(
+    {
+        "pollypm.cockpit_ui",
+        "pollypm.cockpit_rail",
+        "pollypm.supervisor",
+        "pollypm.tmux",
+        "textual",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TmuxReference:
+    path: str
+    line: int
+    symbol: str
+    kind: str
+
+    @property
+    def summary(self) -> str:
+        return f"{self.path}:{self.line}: {self.kind} {self.symbol}"
+
+
+def _production_python_files() -> tuple[Path, ...]:
+    src_root = REPO_ROOT / "src" / "pollypm"
+    return tuple(sorted(src_root.rglob("*.py")))
+
+
+def _relative(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def _tmux_references(path: Path) -> tuple[TmuxReference, ...]:
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(path))
+    rel = _relative(path)
+    refs: list[TmuxReference] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr in TMUX_PANE_WINDOW_METHODS:
+            refs.append(TmuxReference(rel, node.lineno, node.attr, "attribute"))
+        elif (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name in TMUX_PANE_WINDOW_METHODS
+        ):
+            refs.append(TmuxReference(rel, node.lineno, node.name, "definition"))
+        elif (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and node.value in TMUX_PANE_WINDOW_METHODS
+        ):
+            refs.append(TmuxReference(rel, node.lineno, node.value, "string"))
+
+    return tuple(refs)
+
+
+def _imported_roots(path: Path) -> tuple[str, ...]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    roots: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            roots.append(node.module)
+    return tuple(roots)
+
+
+def test_contract_records_are_frozen_slot_dataclasses() -> None:
+    dataclass_types = (
+        contracts.NavigationRequest,
+        contracts.NavigationResult,
+        contracts.ContentPlan,
+        contracts.PaneSnapshot,
+        contracts.WindowSnapshot,
+        contracts.RightPaneLifecycle,
+        contracts.MountResult,
+    )
+
+    for cls in dataclass_types:
+        assert dataclasses.is_dataclass(cls), cls.__name__
+        assert getattr(cls, "__slots__", None), cls.__name__
+        assert cls.__dataclass_params__.frozen, cls.__name__
+
+
+def test_contracts_describe_the_four_modular_boundaries() -> None:
+    assert hasattr(contracts.CockpitNavigationStateMachine, "navigate")
+    assert hasattr(contracts.CockpitContentResolver, "resolve_content")
+    assert hasattr(contracts.CockpitWindowManager, "capture")
+    assert hasattr(contracts.CockpitWindowManager, "mount_content")
+    assert hasattr(contracts.CockpitRightPaneLifecycleStore, "load_lifecycle")
+    assert hasattr(contracts.CockpitRightPaneLifecycleStore, "save_lifecycle")
+
+
+def test_mount_result_ok_is_false_for_failed_disposition() -> None:
+    lifecycle = contracts.RightPaneLifecycle(
+        state=contracts.RightPaneLifecycleState.ERROR
+    )
+    result = contracts.MountResult(
+        disposition=contracts.MountDisposition.FAILED,
+        lifecycle=lifecycle,
+    )
+    assert result.ok is False
+
+
+def test_cockpit_contracts_keep_imports_light() -> None:
+    path = REPO_ROOT / "src" / "pollypm" / "cockpit_contracts.py"
+    imports = _imported_roots(path)
+
+    offenders = sorted(
+        imported
+        for imported in imports
+        for forbidden in FORBIDDEN_CONTRACT_IMPORT_ROOTS
+        if imported == forbidden or imported.startswith(f"{forbidden}.")
+    )
+    assert not offenders, (
+        "cockpit_contracts.py must stay pure and lightweight. "
+        "Forbidden imports:\n  - " + "\n  - ".join(offenders)
+    )
+
+
+def test_tmux_pane_window_methods_stay_inside_allowlist() -> None:
+    refs = [
+        ref
+        for path in _production_python_files()
+        for ref in _tmux_references(path)
+        if ref.path not in CURRENT_TMUX_BOUNDARY_ALLOWLIST
+    ]
+    assert not refs, (
+        "Concrete tmux pane/window methods must not spread to new production "
+        "files. Route cockpit use through CockpitWindowManager or update the "
+        "documented allowlist with a removal condition. Offenders:\n  - "
+        + "\n  - ".join(ref.summary for ref in refs)
+    )
+
+
+def test_tmux_boundary_allowlist_has_no_stale_entries() -> None:
+    stale: list[str] = []
+    for rel in sorted(CURRENT_TMUX_BOUNDARY_ALLOWLIST):
+        path = REPO_ROOT / rel
+        if not path.exists():
+            stale.append(f"{rel} (file missing)")
+            continue
+        if not _tmux_references(path):
+            stale.append(f"{rel} (no concrete tmux reference found)")
+
+    assert not stale, (
+        "Stale entries in CURRENT_TMUX_BOUNDARY_ALLOWLIST. Remove them so "
+        "the boundary tightens as the refactor lands:\n  - " + "\n  - ".join(stale)
+    )

--- a/tests/test_cockpit_contract_boundaries.py
+++ b/tests/test_cockpit_contract_boundaries.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import ast
 import dataclasses
+import importlib
+import inspect
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -128,6 +130,24 @@ def _imported_roots(path: Path) -> tuple[str, ...]:
     return tuple(roots)
 
 
+def _export_shape(obj: object) -> tuple[str, tuple[str, ...]] | None:
+    if dataclasses.is_dataclass(obj):
+        return ("dataclass", tuple(field.name for field in dataclasses.fields(obj)))
+    if inspect.isclass(obj) and hasattr(obj, "__members__"):
+        members = getattr(obj, "__members__")
+        return ("enum", tuple(sorted(members)))
+    if inspect.isclass(obj) and getattr(obj, "_is_protocol", False):
+        methods = tuple(
+            sorted(
+                name
+                for name, member in obj.__dict__.items()
+                if callable(member) and not name.startswith("_")
+            )
+        )
+        return ("protocol", methods)
+    return None
+
+
 def test_contract_records_are_frozen_slot_dataclasses() -> None:
     dataclass_types = (
         contracts.NavigationRequest,
@@ -163,6 +183,37 @@ def test_mount_result_ok_is_false_for_failed_disposition() -> None:
         lifecycle=lifecycle,
     )
     assert result.ok is False
+
+
+def test_cockpit_modules_do_not_export_conflicting_contract_names() -> None:
+    modules = [
+        contracts,
+        importlib.import_module("pollypm.cockpit_content"),
+        importlib.import_module("pollypm.cockpit_navigation"),
+        importlib.import_module("pollypm.cockpit_navigation_client"),
+        importlib.import_module("pollypm.cockpit_state_store"),
+    ]
+    seen: dict[str, tuple[str, tuple[str, tuple[str, ...]]]] = {}
+    conflicts: list[str] = []
+
+    for module in modules:
+        for name in getattr(module, "__all__", ()):
+            obj = getattr(module, name)
+            if getattr(obj, "__module__", module.__name__) != module.__name__:
+                continue
+            shape = _export_shape(obj)
+            if shape is None:
+                continue
+            previous = seen.get(name)
+            if previous is not None and previous[1] != shape:
+                conflicts.append(
+                    f"{name}: {previous[0]} {previous[1]} != "
+                    f"{module.__name__} {shape}"
+                )
+                continue
+            seen[name] = (module.__name__, shape)
+
+    assert conflicts == []
 
 
 def test_cockpit_contracts_keep_imports_light() -> None:

--- a/tests/test_cockpit_modular_verification.py
+++ b/tests/test_cockpit_modular_verification.py
@@ -1,0 +1,471 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from pathlib import Path
+
+from pollypm.cockpit_content import (
+    CockpitContentContext,
+    ErrorPane,
+    FallbackPane,
+    LiveAgentPane,
+    RightPaneContentPlan,
+    TextualCommandPane,
+    resolve_cockpit_content,
+)
+from pollypm.cockpit_contracts import PaneSnapshot, WindowSnapshot
+from pollypm.cockpit_navigation import (
+    NavigationController,
+    NavigationRequest,
+    NavigationResult,
+)
+from pollypm.cockpit_state_store import CockpitStateStore
+
+
+def _run(coro: Awaitable[None]) -> None:
+    asyncio.run(coro)
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedPaneContent:
+    route_key: str
+    destination_key: str
+    plan: RightPaneContentPlan
+
+
+@dataclass(frozen=True, slots=True)
+class VisiblePane:
+    request_id: int
+    destination_key: str
+    pane_kind: str
+    right_pane_state: str
+    title: str
+    message: str
+    command_args: tuple[str, ...] = ()
+    session_name: str | None = None
+
+
+class ManualContentResolver:
+    """Content resolver fake with manual completion for out-of-order clicks."""
+
+    def __init__(self, context: CockpitContentContext) -> None:
+        self.context = context
+        self.calls: list[tuple[int, str]] = []
+        self._futures: dict[int, asyncio.Future[str | BaseException | None]] = {}
+
+    async def resolve(self, request: NavigationRequest) -> ResolvedPaneContent:
+        self.calls.append((request.request_id, request.key))
+        future = asyncio.get_running_loop().create_future()
+        self._futures[request.request_id] = future
+        route_key_or_error = await future
+        if isinstance(route_key_or_error, BaseException):
+            raise route_key_or_error
+        route_key = route_key_or_error or request.key
+        plan = resolve_cockpit_content(route_key, self.context)
+        return ResolvedPaneContent(
+            route_key=route_key,
+            destination_key=getattr(plan, "selected_key", route_key),
+            plan=plan,
+        )
+
+    async def wait_for_request(self, request_id: int) -> None:
+        while request_id not in self._futures:
+            await asyncio.sleep(0)
+
+    def complete(
+        self,
+        request_id: int,
+        route_key: str | BaseException | None = None,
+    ) -> None:
+        self._futures[request_id].set_result(route_key)
+
+
+class ImmediateContentResolver:
+    def __init__(self, context: CockpitContentContext) -> None:
+        self.context = context
+
+    async def resolve(self, request: NavigationRequest) -> ResolvedPaneContent:
+        plan = resolve_cockpit_content(request.key, self.context)
+        return ResolvedPaneContent(
+            route_key=request.key,
+            destination_key=getattr(plan, "selected_key", request.key),
+            plan=plan,
+        )
+
+
+class ModularStateStore:
+    """Navigation history plus persisted right-pane state for the harness."""
+
+    def __init__(self, path: Path) -> None:
+        self.persisted = CockpitStateStore(path)
+        self.history: list[NavigationResult] = []
+        self.by_request: dict[int, NavigationResult] = {}
+
+    def record(self, result: NavigationResult) -> None:
+        self.history.append(result)
+        self.by_request[result.request_id] = result
+
+        request_id = str(result.request_id)
+        if result.state == "accepted":
+            self.persisted.set_selected_key(result.key)
+            self.persisted.set_active_request_id(request_id)
+        elif result.state == "loading":
+            self.persisted.mark_right_pane_loading(request_id)
+        elif result.state == "applied":
+            self._record_applied(result)
+        elif result.state in {"failed", "timed_out"}:
+            self.persisted.mark_right_pane_error(result.error or result.message)
+
+    def is_active(self, request_id: int) -> bool:
+        return self.persisted.active_request_id() == str(request_id)
+
+    def states_for(self, request_id: int) -> list[str]:
+        return [
+            result.state
+            for result in self.history
+            if result.request_id == request_id
+        ]
+
+    def _record_applied(self, result: NavigationResult) -> None:
+        content = result.content
+        plan = content.plan if isinstance(content, ResolvedPaneContent) else None
+        destination_key = result.destination_key or result.key
+        self.persisted.set_selected_key(destination_key)
+        if isinstance(plan, LiveAgentPane):
+            self.persisted.set_mounted_identity(
+                {
+                    "rail_key": result.key,
+                    "session_name": plan.session_name,
+                    "right_pane_id": "%right",
+                }
+            )
+            self.persisted.set_right_pane_id("%right")
+            self.persisted.mark_right_pane_live_agent()
+        elif isinstance(plan, ErrorPane):
+            self.persisted.mark_right_pane_error(plan.message)
+        else:
+            self.persisted.clear_mounted_identity()
+            self.persisted.set_right_pane_id("%right")
+            self.persisted.mark_right_pane_static()
+
+
+class DeterministicWindowManager:
+    """Non-tmux right-pane model used as the modular verification boundary."""
+
+    def __init__(self, state_store: ModularStateStore) -> None:
+        self.state_store = state_store
+        self.visible_pane: VisiblePane | None = None
+        self.applied_request_ids: list[int] = []
+        self.rejected_request_ids: list[int] = []
+        self._held: dict[int, asyncio.Future[None]] = {}
+
+    async def apply(
+        self,
+        request: NavigationRequest,
+        content: ResolvedPaneContent,
+    ) -> VisiblePane | str:
+        future = self._held.get(request.request_id)
+        if future is not None:
+            await future
+        if not self.state_store.is_active(request.request_id):
+            self.rejected_request_ids.append(request.request_id)
+            return "stale-window-worker"
+
+        visible = self._render(request, content)
+        self.visible_pane = visible
+        self.applied_request_ids.append(request.request_id)
+        self.assert_pane_invariants()
+        return visible
+
+    def hold(self, request_id: int) -> None:
+        self._held[request_id] = asyncio.get_running_loop().create_future()
+
+    def release(self, request_id: int) -> None:
+        self._held[request_id].set_result(None)
+
+    def snapshot(self) -> WindowSnapshot:
+        right_command = "pm"
+        if self.visible_pane and self.visible_pane.session_name:
+            right_command = "codex"
+        return WindowSnapshot(
+            session_name="pollypm-test",
+            window_name="PollyPM",
+            target="pollypm-test:PollyPM",
+            active_pane_id="%rail",
+            right_pane_id="%right",
+            panes=(
+                PaneSnapshot(
+                    pane_id="%rail",
+                    command="uv",
+                    active=True,
+                    left=0,
+                    top=0,
+                    width=30,
+                    height=40,
+                ),
+                PaneSnapshot(
+                    pane_id="%right",
+                    command=right_command,
+                    left=31,
+                    top=0,
+                    width=100,
+                    height=40,
+                ),
+            ),
+        )
+
+    def assert_pane_invariants(self) -> None:
+        snapshot = self.snapshot()
+        assert snapshot.right_pane_id == "%right"
+        assert len(snapshot.panes) == 2
+        rail, right = snapshot.panes
+        assert rail.pane_id == "%rail"
+        assert right.pane_id == "%right"
+        assert rail.left == 0
+        assert right.left is not None and right.left > (rail.left or 0)
+        assert rail.command == "uv"
+        assert right.command in {"pm", "codex"}
+
+    @staticmethod
+    def _render(
+        request: NavigationRequest,
+        content: ResolvedPaneContent,
+    ) -> VisiblePane:
+        plan = content.plan
+        if isinstance(plan, ErrorPane):
+            return VisiblePane(
+                request_id=request.request_id,
+                destination_key=content.destination_key,
+                pane_kind="error",
+                right_pane_state=plan.right_pane_state,
+                title=plan.title,
+                message=plan.message,
+            )
+        if isinstance(plan, FallbackPane):
+            return VisiblePane(
+                request_id=request.request_id,
+                destination_key=content.destination_key,
+                pane_kind="fallback",
+                right_pane_state=plan.right_pane_state,
+                title="Fallback",
+                message=plan.message,
+                command_args=plan.fallback.command_args,
+            )
+        if isinstance(plan, LiveAgentPane):
+            return VisiblePane(
+                request_id=request.request_id,
+                destination_key=content.destination_key,
+                pane_kind="live_agent",
+                right_pane_state=plan.right_pane_state,
+                title=plan.session_name,
+                message=f"Mounted live session {plan.session_name}.",
+                session_name=plan.session_name,
+            )
+        if isinstance(plan, TextualCommandPane):
+            return VisiblePane(
+                request_id=request.request_id,
+                destination_key=content.destination_key,
+                pane_kind=plan.pane_kind,
+                right_pane_state=plan.right_pane_state,
+                title=plan.pane_kind,
+                message="Rendered static cockpit pane.",
+                command_args=plan.command_args,
+            )
+        return VisiblePane(
+            request_id=request.request_id,
+            destination_key=content.destination_key,
+            pane_kind="loading",
+            right_pane_state="loading",
+            title="Loading",
+            message="Loading cockpit pane.",
+        )
+
+
+@dataclass(slots=True)
+class ModularHarness:
+    """Composable cockpit harness that does not require a live tmux server."""
+
+    state_store: ModularStateStore
+    content_resolver: ManualContentResolver | ImmediateContentResolver
+    window_manager: DeterministicWindowManager
+    navigation: NavigationController
+
+    @classmethod
+    def manual(
+        cls,
+        tmp_path: Path,
+        context: CockpitContentContext,
+    ) -> ModularHarness:
+        state_store = ModularStateStore(tmp_path / "cockpit_state.json")
+        content_resolver = ManualContentResolver(context)
+        window_manager = DeterministicWindowManager(state_store)
+        navigation = NavigationController(
+            state_store=state_store,
+            content_resolver=content_resolver,
+            window_manager=window_manager,
+        )
+        return cls(state_store, content_resolver, window_manager, navigation)
+
+    @classmethod
+    def immediate(
+        cls,
+        tmp_path: Path,
+        context: CockpitContentContext,
+    ) -> ModularHarness:
+        state_store = ModularStateStore(tmp_path / "cockpit_state.json")
+        content_resolver = ImmediateContentResolver(context)
+        window_manager = DeterministicWindowManager(state_store)
+        navigation = NavigationController(
+            state_store=state_store,
+            content_resolver=content_resolver,
+            window_manager=window_manager,
+        )
+        return cls(state_store, content_resolver, window_manager, navigation)
+
+
+def _context_with_worker() -> CockpitContentContext:
+    return CockpitContentContext.from_projects(
+        ["demo", "other"],
+        project_sessions={"demo": "worker_demo"},
+    )
+
+
+def test_rapid_clicks_commit_only_final_selection(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        harness = ModularHarness.manual(tmp_path, _context_with_worker())
+
+        first = harness.navigation.accept("project:demo:session")
+        first_task = asyncio.create_task(
+            harness.navigation.resolve_and_apply(first)
+        )
+        await harness.content_resolver.wait_for_request(first.request_id)
+
+        second = harness.navigation.accept("metrics")
+        second_task = asyncio.create_task(
+            harness.navigation.resolve_and_apply(second)
+        )
+        await harness.content_resolver.wait_for_request(second.request_id)
+
+        final = harness.navigation.accept("inbox")
+        final_task = asyncio.create_task(
+            harness.navigation.resolve_and_apply(final)
+        )
+        await harness.content_resolver.wait_for_request(final.request_id)
+
+        harness.content_resolver.complete(final.request_id)
+        final_result = await final_task
+        harness.content_resolver.complete(first.request_id)
+        harness.content_resolver.complete(second.request_id)
+        first_result = await first_task
+        second_result = await second_task
+
+        snapshot = harness.state_store.persisted.snapshot()
+        assert first_result.state == "stale"
+        assert second_result.state == "stale"
+        assert final_result.state == "applied"
+        assert snapshot.selected_key == "inbox"
+        assert snapshot.right_pane_state == "static"
+        assert snapshot.active_request_id is None
+        assert harness.window_manager.applied_request_ids == [final.request_id]
+        assert harness.window_manager.visible_pane is not None
+        assert harness.window_manager.visible_pane.destination_key == "inbox"
+        assert harness.state_store.states_for(first.request_id) == [
+            "accepted",
+            "loading",
+            "cancelled",
+            "stale",
+        ]
+
+    _run(exercise())
+
+
+def test_stale_window_worker_cannot_overwrite_newer_result(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        harness = ModularHarness.immediate(tmp_path, _context_with_worker())
+
+        first = harness.navigation.accept("project:demo:session")
+        harness.window_manager.hold(first.request_id)
+        first_task = asyncio.create_task(
+            harness.navigation.resolve_and_apply(first)
+        )
+        await asyncio.sleep(0)
+
+        second = harness.navigation.accept("dashboard")
+        harness.window_manager.hold(second.request_id)
+        second_task = asyncio.create_task(
+            harness.navigation.resolve_and_apply(second)
+        )
+        await asyncio.sleep(0)
+
+        harness.window_manager.release(second.request_id)
+        second_result = await second_task
+        harness.window_manager.release(first.request_id)
+        first_result = await first_task
+
+        snapshot = harness.state_store.persisted.snapshot()
+        assert second_result.state == "applied"
+        assert first_result.state == "stale"
+        assert snapshot.selected_key == "dashboard"
+        assert snapshot.right_pane_state == "static"
+        assert harness.window_manager.applied_request_ids == [second.request_id]
+        assert harness.window_manager.rejected_request_ids == [first.request_id]
+        assert harness.window_manager.visible_pane is not None
+        assert harness.window_manager.visible_pane.destination_key == "dashboard"
+
+    _run(exercise())
+
+
+def test_visible_error_and_fallback_are_rendered_without_tmux(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        context = CockpitContentContext.from_projects(["demo"])
+        harness = ModularHarness.immediate(tmp_path, context)
+
+        error_result = await harness.navigation.navigate("project:missing:dashboard")
+
+        assert error_result.state == "applied"
+        assert harness.window_manager.visible_pane is not None
+        assert harness.window_manager.visible_pane.pane_kind == "error"
+        assert "missing" in harness.window_manager.visible_pane.message
+        assert harness.state_store.persisted.right_pane_state() == "error"
+
+        fallback_result = await harness.navigation.navigate("project:demo:session")
+
+        assert fallback_result.state == "applied"
+        visible = harness.window_manager.visible_pane
+        assert visible is not None
+        assert visible.pane_kind == "fallback"
+        assert visible.destination_key == "project:demo:dashboard"
+        assert "Showing the project dashboard instead." in visible.message
+        assert visible.command_args == ("cockpit-pane", "project", "demo")
+        snapshot = harness.state_store.persisted.snapshot()
+        assert snapshot.selected_key == "project:demo:dashboard"
+        assert snapshot.right_pane_state == "static"
+
+    _run(exercise())
+
+
+def test_deterministic_fake_window_manager_pane_invariants(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        harness = ModularHarness.immediate(tmp_path, _context_with_worker())
+
+        for key in ("dashboard", "project:demo:session", "not-a-route"):
+            result = await harness.navigation.navigate(key)
+            assert result.state == "applied"
+            harness.window_manager.assert_pane_invariants()
+
+        snapshot = harness.window_manager.snapshot()
+        rail, right = snapshot.panes
+        assert snapshot.active_pane_id == "%rail"
+        assert snapshot.right_pane_id == "%right"
+        assert rail.pane_id == "%rail"
+        assert right.pane_id == "%right"
+        assert rail.width == 30
+        assert right.width == 100
+        assert harness.window_manager.applied_request_ids == [1, 2, 3]
+
+    _run(exercise())

--- a/tests/test_cockpit_modular_verification.py
+++ b/tests/test_cockpit_modular_verification.py
@@ -16,9 +16,9 @@ from pollypm.cockpit_content import (
 )
 from pollypm.cockpit_contracts import PaneSnapshot, WindowSnapshot
 from pollypm.cockpit_navigation import (
+    NavigationCommand,
     NavigationController,
-    NavigationRequest,
-    NavigationResult,
+    NavigationTransition,
 )
 from pollypm.cockpit_state_store import CockpitStateStore
 
@@ -54,7 +54,7 @@ class ManualContentResolver:
         self.calls: list[tuple[int, str]] = []
         self._futures: dict[int, asyncio.Future[str | BaseException | None]] = {}
 
-    async def resolve(self, request: NavigationRequest) -> ResolvedPaneContent:
+    async def resolve(self, request: NavigationCommand) -> ResolvedPaneContent:
         self.calls.append((request.request_id, request.key))
         future = asyncio.get_running_loop().create_future()
         self._futures[request.request_id] = future
@@ -85,7 +85,7 @@ class ImmediateContentResolver:
     def __init__(self, context: CockpitContentContext) -> None:
         self.context = context
 
-    async def resolve(self, request: NavigationRequest) -> ResolvedPaneContent:
+    async def resolve(self, request: NavigationCommand) -> ResolvedPaneContent:
         plan = resolve_cockpit_content(request.key, self.context)
         return ResolvedPaneContent(
             route_key=request.key,
@@ -99,10 +99,10 @@ class ModularStateStore:
 
     def __init__(self, path: Path) -> None:
         self.persisted = CockpitStateStore(path)
-        self.history: list[NavigationResult] = []
-        self.by_request: dict[int, NavigationResult] = {}
+        self.history: list[NavigationTransition] = []
+        self.by_request: dict[int, NavigationTransition] = {}
 
-    def record(self, result: NavigationResult) -> None:
+    def record(self, result: NavigationTransition) -> None:
         self.history.append(result)
         self.by_request[result.request_id] = result
 
@@ -127,7 +127,7 @@ class ModularStateStore:
             if result.request_id == request_id
         ]
 
-    def _record_applied(self, result: NavigationResult) -> None:
+    def _record_applied(self, result: NavigationTransition) -> None:
         content = result.content
         plan = content.plan if isinstance(content, ResolvedPaneContent) else None
         destination_key = result.destination_key or result.key
@@ -162,7 +162,7 @@ class DeterministicWindowManager:
 
     async def apply(
         self,
-        request: NavigationRequest,
+        request: NavigationCommand,
         content: ResolvedPaneContent,
     ) -> VisiblePane | str:
         future = self._held.get(request.request_id)
@@ -229,7 +229,7 @@ class DeterministicWindowManager:
 
     @staticmethod
     def _render(
-        request: NavigationRequest,
+        request: NavigationCommand,
         content: ResolvedPaneContent,
     ) -> VisiblePane:
         plan = content.plan

--- a/tests/test_cockpit_navigation.py
+++ b/tests/test_cockpit_navigation.py
@@ -1,0 +1,264 @@
+import asyncio
+
+from pollypm.cockpit_navigation import (
+    NavigationContent,
+    NavigationController,
+    NavigationRequest,
+    NavigationResult,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class FakeStateStore:
+    def __init__(self) -> None:
+        self.history: list[NavigationResult] = []
+        self.by_request: dict[int, NavigationResult] = {}
+
+    def record(self, result: NavigationResult) -> None:
+        self.history.append(result)
+        self.by_request[result.request_id] = result
+
+    def states_for(self, request_id: int) -> list[str]:
+        return [
+            result.state
+            for result in self.history
+            if result.request_id == request_id
+        ]
+
+
+class ManualResolver:
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, str]] = []
+        self._futures: dict[int, asyncio.Future[object]] = {}
+
+    async def resolve(self, request: NavigationRequest) -> object:
+        self.calls.append((request.request_id, request.key))
+        future = asyncio.get_running_loop().create_future()
+        self._futures[request.request_id] = future
+        return await future
+
+    async def wait_for_request(self, request_id: int) -> None:
+        while request_id not in self._futures:
+            await asyncio.sleep(0)
+
+    def complete(self, request_id: int, content: object) -> None:
+        self._futures[request_id].set_result(content)
+
+
+class StaticResolver:
+    def __init__(self, content: object | None = None) -> None:
+        self.content = content or NavigationContent("resolved")
+        self.calls: list[tuple[int, str]] = []
+
+    async def resolve(self, request: NavigationRequest) -> object:
+        self.calls.append((request.request_id, request.key))
+        return self.content
+
+
+class FailingResolver:
+    async def resolve(self, _request: NavigationRequest) -> object:
+        raise RuntimeError("resolver exploded")
+
+
+class NeverResolver:
+    async def resolve(self, _request: NavigationRequest) -> object:
+        await asyncio.Event().wait()
+        return NavigationContent("never")
+
+
+class FakeWindowManager:
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, str, str]] = []
+
+    async def apply(self, request: NavigationRequest, content: object) -> object:
+        destination = getattr(content, "destination_key", str(content))
+        self.calls.append((request.request_id, request.key, destination))
+        return {"shown": destination}
+
+
+class FailingWindowManager:
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, str]] = []
+
+    async def apply(self, request: NavigationRequest, _content: object) -> object:
+        self.calls.append((request.request_id, request.key))
+        raise RuntimeError("window exploded")
+
+
+def test_rapid_clicks_end_on_final_destination() -> None:
+    async def exercise() -> None:
+        store = FakeStateStore()
+        resolver = ManualResolver()
+        window = FakeWindowManager()
+        controller = NavigationController(
+            state_store=store,
+            content_resolver=resolver,
+            window_manager=window,
+        )
+
+        first = controller.accept("project:demo")
+        first_task = asyncio.create_task(controller.resolve_and_apply(first))
+        await resolver.wait_for_request(first.request_id)
+
+        second = controller.accept("polly")
+        second_task = asyncio.create_task(controller.resolve_and_apply(second))
+        await resolver.wait_for_request(second.request_id)
+
+        resolver.complete(second.request_id, NavigationContent("polly"))
+        second_result = await second_task
+        resolver.complete(first.request_id, NavigationContent("project:demo:dashboard"))
+        first_result = await first_task
+
+        assert first_result.state == "stale"
+        assert second_result.state == "applied"
+        assert second_result.destination_key == "polly"
+        assert controller.current_result == second_result
+        assert store.states_for(first.request_id) == [
+            "accepted",
+            "loading",
+            "cancelled",
+            "stale",
+        ]
+
+    _run(exercise())
+
+
+def test_older_completion_cannot_apply_after_newer_request() -> None:
+    async def exercise() -> None:
+        store = FakeStateStore()
+        resolver = ManualResolver()
+        window = FakeWindowManager()
+        controller = NavigationController(
+            state_store=store,
+            content_resolver=resolver,
+            window_manager=window,
+        )
+
+        first = controller.accept("inbox")
+        first_task = asyncio.create_task(controller.resolve_and_apply(first))
+        await resolver.wait_for_request(first.request_id)
+
+        second = controller.accept("workers")
+        second_task = asyncio.create_task(controller.resolve_and_apply(second))
+        await resolver.wait_for_request(second.request_id)
+
+        resolver.complete(first.request_id, NavigationContent("inbox"))
+        first_result = await first_task
+        resolver.complete(second.request_id, NavigationContent("workers"))
+        second_result = await second_task
+
+        assert first_result.state == "stale"
+        assert second_result.state == "applied"
+        assert window.calls == [(second.request_id, "workers", "workers")]
+
+    _run(exercise())
+
+
+def test_resolver_error_becomes_visible_error_result() -> None:
+    async def exercise() -> None:
+        store = FakeStateStore()
+        window = FakeWindowManager()
+        controller = NavigationController(
+            state_store=store,
+            content_resolver=FailingResolver(),
+            window_manager=window,
+        )
+
+        result = await controller.navigate("metrics")
+
+        assert result.state == "failed"
+        assert result.error == "resolver exploded"
+        assert result.message is not None
+        assert "resolver exploded" in result.message
+        assert controller.current_result == result
+        assert window.calls == []
+
+    _run(exercise())
+
+
+def test_window_error_becomes_visible_error_result() -> None:
+    async def exercise() -> None:
+        store = FakeStateStore()
+        window = FailingWindowManager()
+        controller = NavigationController(
+            state_store=store,
+            content_resolver=StaticResolver(NavigationContent("settings")),
+            window_manager=window,
+        )
+
+        result = await controller.navigate("settings")
+
+        assert result.state == "failed"
+        assert result.error == "window exploded"
+        assert result.message is not None
+        assert "window exploded" in result.message
+        assert controller.current_result == result
+        assert window.calls == [(result.request_id, "settings")]
+
+    _run(exercise())
+
+
+def test_timeout_produces_timed_out_result() -> None:
+    async def exercise() -> None:
+        store = FakeStateStore()
+        window = FakeWindowManager()
+        controller = NavigationController(
+            state_store=store,
+            content_resolver=NeverResolver(),
+            window_manager=window,
+            timeout_seconds=0.01,
+        )
+
+        result = await controller.navigate("activity")
+
+        assert result.state == "timed_out"
+        assert result.error == "timed out"
+        assert result.message is not None
+        assert "timed out" in result.message
+        assert controller.current_result == result
+        assert window.calls == []
+
+    _run(exercise())
+
+
+def test_acknowledgement_happens_before_resolver_and_window_work() -> None:
+    async def exercise() -> None:
+        store = FakeStateStore()
+        events: list[tuple[str, list[str]]] = []
+
+        class ObservingResolver:
+            async def resolve(self, _request: NavigationRequest) -> object:
+                events.append(("resolver", [result.state for result in store.history]))
+                return NavigationContent("dashboard")
+
+        class ObservingWindowManager:
+            async def apply(
+                self,
+                _request: NavigationRequest,
+                _content: object,
+            ) -> object:
+                events.append(("window", [result.state for result in store.history]))
+                return "shown"
+
+        controller = NavigationController(
+            state_store=store,
+            content_resolver=ObservingResolver(),
+            window_manager=ObservingWindowManager(),
+        )
+
+        request = controller.accept("dashboard")
+
+        assert store.states_for(request.request_id) == ["accepted", "loading"]
+
+        result = await controller.resolve_and_apply(request)
+
+        assert result.state == "applied"
+        assert events == [
+            ("resolver", ["accepted", "loading"]),
+            ("window", ["accepted", "loading"]),
+        ]
+
+    _run(exercise())

--- a/tests/test_cockpit_navigation.py
+++ b/tests/test_cockpit_navigation.py
@@ -1,10 +1,10 @@
 import asyncio
 
 from pollypm.cockpit_navigation import (
+    NavigationCommand,
     NavigationContent,
     NavigationController,
-    NavigationRequest,
-    NavigationResult,
+    NavigationTransition,
 )
 
 
@@ -14,10 +14,10 @@ def _run(coro):
 
 class FakeStateStore:
     def __init__(self) -> None:
-        self.history: list[NavigationResult] = []
-        self.by_request: dict[int, NavigationResult] = {}
+        self.history: list[NavigationTransition] = []
+        self.by_request: dict[int, NavigationTransition] = {}
 
-    def record(self, result: NavigationResult) -> None:
+    def record(self, result: NavigationTransition) -> None:
         self.history.append(result)
         self.by_request[result.request_id] = result
 
@@ -34,7 +34,7 @@ class ManualResolver:
         self.calls: list[tuple[int, str]] = []
         self._futures: dict[int, asyncio.Future[object]] = {}
 
-    async def resolve(self, request: NavigationRequest) -> object:
+    async def resolve(self, request: NavigationCommand) -> object:
         self.calls.append((request.request_id, request.key))
         future = asyncio.get_running_loop().create_future()
         self._futures[request.request_id] = future
@@ -53,18 +53,18 @@ class StaticResolver:
         self.content = content or NavigationContent("resolved")
         self.calls: list[tuple[int, str]] = []
 
-    async def resolve(self, request: NavigationRequest) -> object:
+    async def resolve(self, request: NavigationCommand) -> object:
         self.calls.append((request.request_id, request.key))
         return self.content
 
 
 class FailingResolver:
-    async def resolve(self, _request: NavigationRequest) -> object:
+    async def resolve(self, _request: NavigationCommand) -> object:
         raise RuntimeError("resolver exploded")
 
 
 class NeverResolver:
-    async def resolve(self, _request: NavigationRequest) -> object:
+    async def resolve(self, _request: NavigationCommand) -> object:
         await asyncio.Event().wait()
         return NavigationContent("never")
 
@@ -73,7 +73,7 @@ class FakeWindowManager:
     def __init__(self) -> None:
         self.calls: list[tuple[int, str, str]] = []
 
-    async def apply(self, request: NavigationRequest, content: object) -> object:
+    async def apply(self, request: NavigationCommand, content: object) -> object:
         destination = getattr(content, "destination_key", str(content))
         self.calls.append((request.request_id, request.key, destination))
         return {"shown": destination}
@@ -83,7 +83,7 @@ class FailingWindowManager:
     def __init__(self) -> None:
         self.calls: list[tuple[int, str]] = []
 
-    async def apply(self, request: NavigationRequest, _content: object) -> object:
+    async def apply(self, request: NavigationCommand, _content: object) -> object:
         self.calls.append((request.request_id, request.key))
         raise RuntimeError("window exploded")
 
@@ -230,14 +230,14 @@ def test_acknowledgement_happens_before_resolver_and_window_work() -> None:
         events: list[tuple[str, list[str]]] = []
 
         class ObservingResolver:
-            async def resolve(self, _request: NavigationRequest) -> object:
+            async def resolve(self, _request: NavigationCommand) -> object:
                 events.append(("resolver", [result.state for result in store.history]))
                 return NavigationContent("dashboard")
 
         class ObservingWindowManager:
             async def apply(
                 self,
-                _request: NavigationRequest,
+                _request: NavigationCommand,
                 _content: object,
             ) -> object:
                 events.append(("window", [result.state for result in store.history]))

--- a/tests/test_cockpit_navigation_client.py
+++ b/tests/test_cockpit_navigation_client.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from pollypm.cockpit_navigation_client import (
+    CockpitNavigationClient,
+    CockpitNavigationClientOutcome,
+    CockpitNavigationClientRequest,
+    DirectCockpitNavigationAdapter,
+    FileCockpitNavigationQueue,
+    StandaloneCockpitNavigationAdapter,
+    cockpit_navigation_queue_path,
+    file_navigation_client,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_direct_adapter_receives_navigation_requests() -> None:
+    received: list[CockpitNavigationClientRequest] = []
+
+    def handle(request: CockpitNavigationClientRequest) -> dict[str, object]:
+        received.append(request)
+        return {"accepted": True, "selected_key": request.selected_key}
+
+    client = CockpitNavigationClient(
+        DirectCockpitNavigationAdapter(handle),
+        client_id="pane-a",
+    )
+
+    result = client.jump_to_project("demo", view="issues")
+
+    assert result.outcome == CockpitNavigationClientOutcome.SUBMITTED
+    assert result.ok is True
+    assert result.handled is True
+    assert result.details["owner_result"] == {
+        "accepted": True,
+        "selected_key": "project:demo:issues",
+    }
+    assert [request.selected_key for request in received] == [
+        "project:demo:issues",
+    ]
+    assert received[0].navigation.origin == "right_pane"
+
+
+def test_standalone_fallback_records_and_returns_unsupported_result() -> None:
+    adapter = StandaloneCockpitNavigationAdapter()
+    client = CockpitNavigationClient(adapter)
+
+    result = client.jump_to_inbox("demo")
+
+    assert result.outcome == CockpitNavigationClientOutcome.UNSUPPORTED
+    assert result.ok is False
+    assert result.handled is False
+    assert "unsupported" in result.message
+    assert result.request.selected_key == "inbox:demo"
+    assert adapter.history == [result.request]
+    assert client.history == [result]
+
+
+def test_request_sequences_and_ids_are_monotonic() -> None:
+    client = CockpitNavigationClient(client_id="pane")
+
+    results = [
+        client.navigate("inbox"),
+        client.navigate("activity"),
+        client.jump_to_project("demo"),
+        client.jump_to_project("demo", view="issues", task_number=7),
+    ]
+
+    assert [result.request.sequence for result in results] == [1, 2, 3, 4]
+    assert [result.request.request_id for result in results] == [
+        "pane-00000001",
+        "pane-00000002",
+        "pane-00000003",
+        "pane-00000004",
+    ]
+
+
+def test_right_pane_jump_helpers_represent_existing_route_shapes() -> None:
+    received: list[CockpitNavigationClientRequest] = []
+    client = CockpitNavigationClient(
+        DirectCockpitNavigationAdapter(lambda request: received.append(request)),
+        client_id="pane",
+    )
+
+    client.jump_to_inbox("demo")
+    client.jump_to_activity("demo")
+    client.jump_to_project("demo")
+    client.jump_to_project("demo", view=None)
+    client.jump_to_project("demo", view="issues")
+    client.jump_to_project("demo", view="issues", task_number=7)
+
+    assert [request.selected_key for request in received] == [
+        "inbox:demo",
+        "activity:demo",
+        "project:demo:dashboard",
+        "project:demo",
+        "project:demo:issues",
+        "project:demo:issues:task:7",
+    ]
+    assert [request.project_key for request in received] == [
+        "demo",
+        "demo",
+        "demo",
+        "demo",
+        "demo",
+        "demo",
+    ]
+    assert received[-1].task_id == "demo/7"
+    assert received[0].payload["action"] == "jump_to_inbox"
+    assert received[1].payload["action"] == "jump_to_activity"
+    assert received[2].payload["action"] == "jump_to_project"
+
+
+def test_file_queue_records_pending_requests(tmp_path: Path) -> None:
+    queue_path = tmp_path / "cockpit_navigation_queue.json"
+    queue = FileCockpitNavigationQueue(queue_path)
+    client = CockpitNavigationClient(queue, client_id="pane")
+
+    result = client.jump_to_activity("demo", payload={"source": "project-dashboard"})
+
+    assert result.outcome == CockpitNavigationClientOutcome.QUEUED
+    assert result.ok is True
+    pending = queue.pending()
+    assert [request.selected_key for request in pending] == ["activity:demo"]
+    assert pending[0].payload == {
+        "action": "jump_to_activity",
+        "source": "project-dashboard",
+    }
+
+    raw = json.loads(queue_path.read_text(encoding="utf-8"))
+    assert raw["version"] == 1
+    assert raw["last_sequence"] == 1
+    assert raw["requests"][0]["request_id"] == "pane-00000001"
+
+    queue.clear()
+    assert queue.pending() == ()
+
+
+def test_file_navigation_client_uses_project_local_queue(tmp_path: Path) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    base_dir = tmp_path / ".pollypm"
+    config_path.write_text(
+        "[project]\n"
+        "name = \"PollyPM\"\n"
+        "tmux_session = \"pollypm\"\n"
+        f"base_dir = \"{base_dir}\"\n",
+        encoding="utf-8",
+    )
+
+    client = file_navigation_client(config_path, client_id="pane")
+    result = client.jump_to_inbox("demo")
+
+    queue_path = cockpit_navigation_queue_path(config_path)
+    assert result.outcome == CockpitNavigationClientOutcome.QUEUED
+    assert queue_path == base_dir / "cockpit_navigation_queue.json"
+    assert FileCockpitNavigationQueue(queue_path).pending()[0].selected_key == "inbox:demo"
+
+
+def test_adapter_failures_are_typed_results() -> None:
+    def explode(_request: CockpitNavigationClientRequest) -> None:
+        raise RuntimeError("owner unavailable")
+
+    client = CockpitNavigationClient(DirectCockpitNavigationAdapter(explode))
+
+    result = client.jump_to_activity("demo")
+
+    assert result.outcome == CockpitNavigationClientOutcome.FAILED
+    assert result.ok is False
+    assert result.handled is False
+    assert result.error == "owner unavailable"
+    assert "owner unavailable" in result.message
+    assert client.history == [result]
+
+
+def test_navigation_client_keeps_imports_light() -> None:
+    path = REPO_ROOT / "src" / "pollypm" / "cockpit_navigation_client.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+
+    forbidden_roots = {
+        "pollypm.cockpit_ui",
+        "pollypm.cockpit_rail",
+        "pollypm.tmux",
+        "textual",
+    }
+    offenders = sorted(
+        name
+        for name in imported
+        for root in forbidden_roots
+        if name == root or name.startswith(f"{root}.")
+    )
+    assert offenders == []

--- a/tests/test_cockpit_navigation_client.py
+++ b/tests/test_cockpit_navigation_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import json
+import multiprocessing
 from pathlib import Path
 
 from pollypm.cockpit_navigation_client import (
@@ -17,6 +18,21 @@ from pollypm.cockpit_navigation_client import (
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _submit_file_queue_request(
+    queue_path: str,
+    client_id: str,
+    key: str,
+    sequence_start: int,
+) -> None:
+    queue = FileCockpitNavigationQueue(Path(queue_path), max_entries=50)
+    client = CockpitNavigationClient(
+        queue,
+        client_id=client_id,
+        sequence_start=sequence_start,
+    )
+    client.navigate(key)
 
 
 def test_direct_adapter_receives_navigation_requests() -> None:
@@ -137,8 +153,77 @@ def test_file_queue_records_pending_requests(tmp_path: Path) -> None:
     assert raw["last_sequence"] == 1
     assert raw["requests"][0]["request_id"] == "pane-00000001"
 
-    queue.clear()
+    drained = queue.drain()
+    assert [request.selected_key for request in drained] == ["activity:demo"]
     assert queue.pending() == ()
+    assert json.loads(queue_path.read_text(encoding="utf-8"))[
+        "last_drained_sequence"
+    ] == 1
+
+
+def test_file_queue_drain_does_not_clear_later_submits(tmp_path: Path) -> None:
+    queue_path = tmp_path / "cockpit_navigation_queue.json"
+    queue = FileCockpitNavigationQueue(queue_path)
+    pane_a = CockpitNavigationClient(queue, client_id="pane-a")
+    pane_b = CockpitNavigationClient(queue, client_id="pane-b")
+
+    pane_a.navigate("inbox:demo")
+    drained = queue.drain()
+    pane_b.navigate("activity:demo")
+
+    assert [request.selected_key for request in drained] == ["inbox:demo"]
+    assert [request.selected_key for request in queue.pending()] == ["activity:demo"]
+
+
+def test_file_queue_serializes_concurrent_submitters(tmp_path: Path) -> None:
+    queue_path = tmp_path / "cockpit_navigation_queue.json"
+    processes: list[multiprocessing.Process] = []
+    context = multiprocessing.get_context("spawn")
+
+    for index in range(16):
+        process = context.Process(
+            target=_submit_file_queue_request,
+            args=(
+                str(queue_path),
+                f"pane-{index}",
+                f"project:demo:{index:02d}",
+                index,
+            ),
+        )
+        process.start()
+        processes.append(process)
+
+    for process in processes:
+        process.join(timeout=10)
+    for process in processes:
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=2)
+
+    exitcodes = [process.exitcode for process in processes]
+    assert exitcodes == [0] * len(processes)
+
+    pending = FileCockpitNavigationQueue(queue_path).pending()
+    assert sorted(request.selected_key for request in pending) == [
+        f"project:demo:{index:02d}" for index in range(16)
+    ]
+
+
+def test_file_queue_caps_oldest_entries(tmp_path: Path) -> None:
+    queue_path = tmp_path / "cockpit_navigation_queue.json"
+    queue = FileCockpitNavigationQueue(queue_path, max_entries=3)
+    client = CockpitNavigationClient(queue, client_id="pane")
+
+    for index in range(5):
+        result = client.navigate(f"project:demo:{index}")
+
+    assert result.details["dropped_count"] == 1
+    assert [request.selected_key for request in queue.pending()] == [
+        "project:demo:2",
+        "project:demo:3",
+        "project:demo:4",
+    ]
+    assert json.loads(queue_path.read_text(encoding="utf-8"))["dropped_count"] == 2
 
 
 def test_file_navigation_client_uses_project_local_queue(tmp_path: Path) -> None:

--- a/tests/test_cockpit_state_store.py
+++ b/tests/test_cockpit_state_store.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pollypm.cockpit_state_store import (
+    DEFAULT_RAIL_WIDTH,
+    DEFAULT_SELECTED_KEY,
+    MAX_RAIL_WIDTH,
+    MIN_RAIL_WIDTH,
+    CockpitStateStore,
+)
+
+
+def _store(tmp_path: Path) -> CockpitStateStore:
+    return CockpitStateStore(tmp_path / "cockpit_state.json")
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_missing_file_returns_safe_defaults(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+
+    assert store.raw_state() == {}
+    assert store.selected_key() == DEFAULT_SELECTED_KEY
+    assert store.active_request_id() is None
+    assert store.right_pane_state() == "idle"
+    assert store.right_pane_id() is None
+    assert store.mounted_identity() is None
+    assert store.rail_width() == DEFAULT_RAIL_WIDTH
+    assert store.pinned_projects() == []
+    assert store.should_show_palette_tip()
+
+    snapshot = store.snapshot()
+    assert snapshot.selected_key == DEFAULT_SELECTED_KEY
+    assert snapshot.right_pane_state == "idle"
+    assert snapshot.pinned_projects == ()
+
+
+def test_corrupt_file_returns_defaults_and_next_write_replaces_it(tmp_path: Path) -> None:
+    path = tmp_path / "cockpit_state.json"
+    path.write_text("{not valid json", encoding="utf-8")
+    store = CockpitStateStore(path)
+
+    assert store.selected_key() == DEFAULT_SELECTED_KEY
+    assert store.right_pane_state() == "idle"
+
+    store.set_selected_key("inbox")
+
+    assert _read_json(path) == {"selected": "inbox"}
+
+
+def test_writes_preserve_unrelated_state_keys(tmp_path: Path) -> None:
+    path = tmp_path / "cockpit_state.json"
+    path.write_text(
+        json.dumps({"selected": "polly", "custom_plugin_key": {"count": 2}}),
+        encoding="utf-8",
+    )
+    store = CockpitStateStore(path)
+
+    store.set_active_request_id("req-1")
+    store.mark_palette_tip_seen()
+
+    assert _read_json(path) == {
+        "active_request_id": "req-1",
+        "custom_plugin_key": {"count": 2},
+        "palette_tip_seen": True,
+        "selected": "polly",
+    }
+
+
+def test_selection_intent_is_separate_from_mounted_truth(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    mounted = {
+        "rail_key": "polly",
+        "session_name": "operator",
+        "role": "operator-pm",
+        "expected_window_name": "pm-operator",
+        "right_pane_id": "%7",
+        "window_index": 2,
+        "mounted_at": "2026-04-29T12:00:00+00:00",
+    }
+
+    store.set_selected_key("project:demo:dashboard")
+    store.set_right_pane_id("%7")
+    store.set_mounted_identity(mounted)
+    store.mark_right_pane_live_agent()
+
+    assert store.selected_key() == "project:demo:dashboard"
+    assert store.right_pane_state() == "live_agent"
+    assert store.mounted_identity() == mounted
+
+    store.clear_mounted_and_right_pane_state()
+
+    assert store.selected_key() == "project:demo:dashboard"
+    assert store.right_pane_state() == "idle"
+    assert store.right_pane_id() is None
+    assert store.mounted_identity() is None
+
+
+def test_defaults_reject_invalid_persisted_values(tmp_path: Path) -> None:
+    path = tmp_path / "cockpit_state.json"
+    path.write_text(
+        json.dumps(
+            {
+                "selected": "",
+                "active_request_id": 42,
+                "right_pane_state": "mounted",
+                "right_pane_id": "",
+                "mounted_identity": [],
+                "rail_width": 999,
+                "palette_tip_seen": "yes",
+                "pinned_projects": [None, "", "alpha", "alpha", "beta"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    store = CockpitStateStore(path)
+
+    assert store.selected_key() == DEFAULT_SELECTED_KEY
+    assert store.active_request_id() is None
+    assert store.right_pane_state() == "idle"
+    assert store.right_pane_id() is None
+    assert store.mounted_identity() is None
+    assert store.rail_width() == DEFAULT_RAIL_WIDTH
+    assert store.should_show_palette_tip()
+    assert store.pinned_projects() == ["alpha", "beta"]
+
+
+def test_right_pane_lifecycle_states_and_active_request_id(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+
+    store.mark_right_pane_loading("req-123")
+    assert store.right_pane_state() == "loading"
+    assert store.active_request_id() == "req-123"
+
+    store.mark_right_pane_static()
+    assert store.right_pane_state() == "static"
+    assert store.active_request_id() is None
+
+    store.mark_right_pane_live_agent()
+    assert store.right_pane_state() == "live_agent"
+
+    store.mark_right_pane_error("failed to mount")
+    assert store.right_pane_state() == "error"
+    assert _read_json(store.path)["right_pane_error"] == "failed to mount"
+
+    store.mark_right_pane_idle()
+    assert store.right_pane_state() == "idle"
+    assert "right_pane_error" not in _read_json(store.path)
+
+
+def test_active_request_id_can_be_set_and_cleared(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+
+    store.set_active_request_id("req-a")
+    assert store.active_request_id() == "req-a"
+
+    store.set_active_request_id(None)
+    assert store.active_request_id() is None
+    assert "active_request_id" not in _read_json(store.path)
+
+
+def test_right_pane_id_can_be_set_and_cleared(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+
+    store.set_right_pane_id("%11")
+    assert store.right_pane_id() == "%11"
+
+    store.set_right_pane_id(None)
+    assert store.right_pane_id() is None
+    assert "right_pane_id" not in _read_json(store.path)
+
+
+def test_rail_width_bounds_and_invalid_type(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+
+    store.set_rail_width(44)
+    assert store.rail_width() == 44
+
+    store.set_rail_width(MIN_RAIL_WIDTH - 5)
+    assert store.rail_width() == MIN_RAIL_WIDTH
+
+    store.set_rail_width(MAX_RAIL_WIDTH + 5)
+    assert store.rail_width() == MAX_RAIL_WIDTH
+
+    with pytest.raises(TypeError):
+        store.set_rail_width("wide")  # type: ignore[arg-type]
+
+
+def test_pins_ordering_dedupe_and_toggle(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+
+    store.set_pinned_projects(["alpha", "beta", "alpha", "", "gamma"])
+    assert store.pinned_projects() == ["alpha", "beta", "gamma"]
+
+    store.pin_project("beta")
+    assert store.pinned_projects() == ["beta", "alpha", "gamma"]
+
+    assert store.toggle_pinned_project("delta") is True
+    assert store.pinned_projects() == ["delta", "beta", "alpha", "gamma"]
+
+    assert store.toggle_pinned_project("beta") is False
+    assert store.pinned_projects() == ["delta", "alpha", "gamma"]
+
+
+def test_clearing_mounted_state_removes_legacy_and_typed_payloads(tmp_path: Path) -> None:
+    path = tmp_path / "cockpit_state.json"
+    path.write_text(
+        json.dumps(
+            {
+                "selected": "workers",
+                "mounted_session": "operator",
+                "mounted_identity": {"session_name": "operator"},
+                "right_pane_id": "%5",
+                "right_pane_state": "live_agent",
+                "active_request_id": "req-old",
+            }
+        ),
+        encoding="utf-8",
+    )
+    store = CockpitStateStore(path)
+
+    store.clear_mounted_and_right_pane_state()
+
+    assert _read_json(path) == {"right_pane_state": "idle", "selected": "workers"}

--- a/tests/test_cockpit_state_store.py
+++ b/tests/test_cockpit_state_store.py
@@ -8,10 +8,15 @@ import pytest
 from pollypm.cockpit_state_store import (
     DEFAULT_RAIL_WIDTH,
     DEFAULT_SELECTED_KEY,
+    LIFECYCLE_TO_RIGHT_PANE_STATE,
     MAX_RAIL_WIDTH,
     MIN_RAIL_WIDTH,
+    RIGHT_PANE_STATE_TO_LIFECYCLE,
     CockpitStateStore,
+    lifecycle_to_right_pane_state,
+    right_pane_state_to_lifecycle,
 )
+from pollypm.cockpit_contracts import RightPaneLifecycleState
 
 
 def _store(tmp_path: Path) -> CockpitStateStore:
@@ -152,6 +157,28 @@ def test_right_pane_lifecycle_states_and_active_request_id(tmp_path: Path) -> No
     store.mark_right_pane_idle()
     assert store.right_pane_state() == "idle"
     assert "right_pane_error" not in _read_json(store.path)
+
+
+def test_persisted_right_pane_state_maps_to_public_lifecycle_contract() -> None:
+    expected = {
+        "idle": RightPaneLifecycleState.UNMOUNTED,
+        "loading": RightPaneLifecycleState.INITIALIZING,
+        "static": RightPaneLifecycleState.STATIC_VIEW,
+        "live_agent": RightPaneLifecycleState.LIVE_SESSION,
+        "error": RightPaneLifecycleState.ERROR,
+    }
+
+    assert RIGHT_PANE_STATE_TO_LIFECYCLE == expected
+    assert LIFECYCLE_TO_RIGHT_PANE_STATE == {
+        lifecycle: state for state, lifecycle in expected.items()
+    }
+
+    for state, lifecycle in expected.items():
+        assert right_pane_state_to_lifecycle(state) is lifecycle
+        assert lifecycle_to_right_pane_state(lifecycle) == state
+
+    with pytest.raises(ValueError):
+        lifecycle_to_right_pane_state(RightPaneLifecycleState.STALE)
 
 
 def test_active_request_id_can_be_set_and_cleared(tmp_path: Path) -> None:

--- a/tests/test_cockpit_window_manager.py
+++ b/tests/test_cockpit_window_manager.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from pollypm.cockpit_window_manager import (
+    CockpitWindowManager,
+    CockpitWindowSpec,
+    CockpitWindowState,
+    LivePaneSpec,
+    ParkPaneSpec,
+)
+
+
+@dataclass(slots=True)
+class FakePane:
+    pane_id: str
+    pane_current_command: str
+    pane_left: int
+    pane_width: int = 100
+    pane_dead: bool = False
+    session: str = ""
+    window_index: int = 0
+    window_name: str = ""
+    pane_index: int = 0
+    active: bool = False
+    pane_current_path: str = "/tmp"
+
+
+@dataclass(slots=True)
+class FakeWindow:
+    session: str
+    index: int
+    name: str
+    panes: list[FakePane] = field(default_factory=list)
+    active: bool = False
+
+    @property
+    def pane_id(self) -> str:
+        return self.panes[0].pane_id if self.panes else ""
+
+    @property
+    def pane_current_command(self) -> str:
+        return self.panes[0].pane_current_command if self.panes else ""
+
+    @property
+    def pane_current_path(self) -> str:
+        return self.panes[0].pane_current_path if self.panes else ""
+
+    @property
+    def pane_dead(self) -> bool:
+        return self.panes[0].pane_dead if self.panes else False
+
+
+class FakeTmux:
+    def __init__(self) -> None:
+        self.sessions: dict[str, list[FakeWindow]] = {}
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+        self._next_pane = 1
+
+    def add_window(
+        self,
+        session: str,
+        name: str,
+        panes: list[tuple[str, int, int, bool]] | list[tuple[str, int]],
+        *,
+        index: int | None = None,
+    ) -> FakeWindow:
+        windows = self.sessions.setdefault(session, [])
+        if index is None:
+            index = max((window.index for window in windows), default=0) + 1
+        window = FakeWindow(session=session, index=index, name=name)
+        for raw in panes:
+            command, left = raw[0], raw[1]
+            width = raw[2] if len(raw) > 2 else 100
+            dead = raw[3] if len(raw) > 3 else False
+            window.panes.append(
+                FakePane(
+                    pane_id=self._new_pane_id(),
+                    pane_current_command=self._command_name(command),
+                    pane_left=left,
+                    pane_width=width,
+                    pane_dead=dead,
+                )
+            )
+        windows.append(window)
+        self._refresh_window(window)
+        return window
+
+    def list_panes(self, target: str) -> list[FakePane]:
+        window = self._window_for_target(target)
+        return sorted(window.panes, key=lambda pane: (pane.pane_left, pane.pane_id))
+
+    def list_windows(self, name: str) -> list[FakeWindow]:
+        return sorted(self.sessions.get(name, []), key=lambda window: window.index)
+
+    def split_window(
+        self,
+        target: str,
+        command: str,
+        *,
+        horizontal: bool = True,
+        detached: bool = True,
+        percent: int | None = None,
+        size: int | None = None,
+    ) -> str:
+        del horizontal, detached, percent
+        window = self._window_for_target(target)
+        left = max((pane.pane_left + pane.pane_width for pane in window.panes), default=0) + 1
+        pane = FakePane(
+            pane_id=self._new_pane_id(),
+            pane_current_command=self._command_name(command),
+            pane_left=left,
+            pane_width=size or 100,
+        )
+        window.panes.append(pane)
+        self._refresh_window(window)
+        self.calls.append(("split_window", (target, command, size, pane.pane_id)))
+        return pane.pane_id
+
+    def kill_pane(self, target: str) -> None:
+        window, pane = self._find_pane(target)
+        window.panes.remove(pane)
+        self._refresh_window(window)
+        self.calls.append(("kill_pane", (target,)))
+
+    def resize_pane_width(self, target: str, width: int) -> None:
+        _window, pane = self._find_pane(target)
+        pane.pane_width = width
+        self.calls.append(("resize_pane_width", (target, width)))
+
+    def respawn_pane(self, target: str, command: str) -> None:
+        _window, pane = self._find_pane(target)
+        pane.pane_current_command = self._command_name(command)
+        pane.pane_dead = False
+        self.calls.append(("respawn_pane", (target, command)))
+
+    def join_pane(self, source: str, target: str, *, horizontal: bool = True) -> None:
+        del horizontal
+        source_window, pane = self._find_source_pane(source)
+        target_window, target_pane = self._find_pane(target)
+        source_window.panes.remove(pane)
+        if not source_window.panes:
+            self.sessions[source_window.session].remove(source_window)
+        pane.pane_left = target_pane.pane_left + target_pane.pane_width + 1
+        target_window.panes.append(pane)
+        self._refresh_window(target_window)
+        self.calls.append(("join_pane", (source, target)))
+
+    def break_pane(self, source: str, target_session: str, window_name: str) -> None:
+        source_window, pane = self._find_pane(source)
+        source_window.panes.remove(pane)
+        self._refresh_window(source_window)
+        window = self.add_window(
+            target_session,
+            window_name,
+            [],
+            index=max((w.index for w in self.sessions.get(target_session, [])), default=0) + 1,
+        )
+        pane.pane_left = 0
+        window.panes.append(pane)
+        self._refresh_window(window)
+        self.calls.append(("break_pane", (source, target_session, window_name)))
+
+    def rename_window(self, target: str, new_name: str) -> None:
+        session, raw_index = target.split(":", 1)
+        index = int(raw_index)
+        for window in self.sessions.get(session, []):
+            if window.index == index:
+                window.name = new_name
+                self._refresh_window(window)
+                self.calls.append(("rename_window", (target, new_name)))
+                return
+        raise KeyError(target)
+
+    def swap_pane(self, source: str, target: str) -> None:
+        _source_window, source_pane = self._find_pane(source)
+        _target_window, target_pane = self._find_pane(target)
+        source_pane.pane_left, target_pane.pane_left = target_pane.pane_left, source_pane.pane_left
+        self.calls.append(("swap_pane", (source, target)))
+
+    def select_pane(self, target: str) -> None:
+        self.calls.append(("select_pane", (target,)))
+
+    def set_pane_history_limit(self, target: str, limit: int) -> None:
+        self.calls.append(("set_pane_history_limit", (target, limit)))
+
+    def run(self, *args: str, check: bool = True) -> None:
+        self.calls.append(("run", (*args, check)))
+
+    def _new_pane_id(self) -> str:
+        pane_id = f"%{self._next_pane}"
+        self._next_pane += 1
+        return pane_id
+
+    def _window_for_target(self, target: str) -> FakeWindow:
+        if target.startswith("%"):
+            return self._find_pane(target)[0]
+        session, name = target.split(":", 1)
+        for window in self.sessions.get(session, []):
+            if window.name == name or str(window.index) == name:
+                return window
+        raise KeyError(target)
+
+    def _find_pane(self, pane_id: str) -> tuple[FakeWindow, FakePane]:
+        for windows in self.sessions.values():
+            for window in windows:
+                for pane in window.panes:
+                    if pane.pane_id == pane_id:
+                        return window, pane
+        raise KeyError(pane_id)
+
+    def _find_source_pane(self, source: str) -> tuple[FakeWindow, FakePane]:
+        session, rest = source.split(":", 1)
+        raw_window, raw_pane = rest.split(".", 1)
+        window_index = int(raw_window)
+        pane_index = int(raw_pane)
+        for window in self.sessions.get(session, []):
+            if window.index == window_index:
+                self._refresh_window(window)
+                return window, window.panes[pane_index]
+        raise KeyError(source)
+
+    def _refresh_window(self, window: FakeWindow) -> None:
+        window.panes.sort(key=lambda pane: (pane.pane_left, pane.pane_id))
+        for index, pane in enumerate(window.panes):
+            pane.session = window.session
+            pane.window_index = window.index
+            pane.window_name = window.name
+            pane.pane_index = index
+            pane.active = index == 0
+
+    @staticmethod
+    def _command_name(command: str) -> str:
+        if command.startswith("uv"):
+            return "uv"
+        if command.startswith("node"):
+            return "node"
+        if command.startswith("claude"):
+            return "claude"
+        if command.startswith("codex"):
+            return "codex"
+        if command.startswith("pm"):
+            return "pm"
+        return command.split(" ", 1)[0] if command else ""
+
+
+def _manager(tmux: FakeTmux) -> CockpitWindowManager:
+    return CockpitWindowManager(
+        CockpitWindowSpec(
+            tmux_session="pollypm",
+            rail_width=30,
+            rail_command="uv run pm rail",
+            default_content_command="pm cockpit-pane polly",
+        ),
+        tmux,
+    )
+
+
+def test_classifies_left_right_and_rail_before_repair() -> None:
+    tmux = FakeTmux()
+    window = tmux.add_window("pollypm", "PollyPM", [("bash", 0), ("uv", 100)])
+    manager = _manager(tmux)
+
+    classification = manager.classify_panes()
+
+    assert classification.left_pane == window.panes[0]
+    assert classification.right_pane == window.panes[1]
+    assert classification.rail_pane == window.panes[1]
+    assert classification.content_pane == window.panes[0]
+    assert manager.validate_postcondition().errors == ("rail pane is not leftmost", "content pane is not rightmost")
+
+
+def test_ensure_layout_swaps_rail_left_and_validates_postcondition() -> None:
+    tmux = FakeTmux()
+    window = tmux.add_window("pollypm", "PollyPM", [("bash", 0), ("uv", 100)])
+    old_left_id = window.panes[0].pane_id
+    old_right_id = window.panes[1].pane_id
+    manager = _manager(tmux)
+
+    result = manager.ensure_layout(CockpitWindowState(right_pane_id=old_right_id))
+
+    assert result.ok
+    assert f"swap_rail_left:{old_right_id}->{old_left_id}" in result.actions
+    assert result.state.right_pane_id == old_left_id
+    assert manager.classify_panes().rail_pane.pane_id == old_right_id
+
+
+def test_ensure_layout_repairs_missing_content_by_splitting() -> None:
+    tmux = FakeTmux()
+    tmux.add_window("pollypm", "PollyPM", [("uv", 0, 200, False)])
+    manager = _manager(tmux)
+
+    result = manager.ensure_layout()
+
+    assert result.ok
+    assert any(action.startswith("split_content:%") for action in result.actions)
+    assert len(tmux.list_panes("pollypm:PollyPM")) == 2
+
+
+def test_ensure_layout_repairs_missing_rail_by_respawning_single_pane_then_splitting() -> None:
+    tmux = FakeTmux()
+    window = tmux.add_window("pollypm", "PollyPM", [("codex", 0, 180, False)])
+    original_id = window.panes[0].pane_id
+    manager = _manager(tmux)
+
+    result = manager.ensure_layout(
+        CockpitWindowState(
+            right_pane_id=original_id,
+            mounted_session="worker_demo",
+            mounted_window_name="worker-demo",
+        )
+    )
+
+    assert result.ok
+    assert f"respawn_missing_rail:{original_id}" in result.actions
+    assert any(action.startswith("split_content:%") for action in result.actions)
+    assert result.state.mounted_session is None
+
+
+def test_ensure_layout_respawns_dead_right_and_kills_extra_panes() -> None:
+    tmux = FakeTmux()
+    window = tmux.add_window(
+        "pollypm",
+        "PollyPM",
+        [("uv", 0, 30, False), ("node", 40, 80, True), ("bash", 130, 80, False)],
+    )
+    dead_right_id = window.panes[1].pane_id
+    extra_id = window.panes[2].pane_id
+    manager = _manager(tmux)
+
+    result = manager.ensure_layout(CockpitWindowState(right_pane_id=dead_right_id))
+
+    assert result.ok
+    assert f"respawn_dead_content:{dead_right_id}" in result.actions
+    assert f"kill_extra:{extra_id}" in result.actions
+    assert {pane.pane_id for pane in tmux.list_panes("pollypm:PollyPM")} == {
+        window.panes[0].pane_id,
+        dead_right_id,
+    }
+
+
+def test_show_static_respawns_right_and_clears_mounted_state() -> None:
+    tmux = FakeTmux()
+    window = tmux.add_window("pollypm", "PollyPM", [("uv", 0), ("node", 100)])
+    right_id = window.panes[1].pane_id
+    manager = _manager(tmux)
+
+    result = manager.show_static(
+        "pm cockpit-pane project demo",
+        CockpitWindowState(
+            right_pane_id=right_id,
+            mounted_session="worker_demo",
+            mounted_window_name="worker-demo",
+        ),
+    )
+
+    assert result.ok
+    assert f"respawn_static:{right_id}" in result.actions
+    assert result.state == CockpitWindowState(right_pane_id=right_id)
+    assert ("respawn_pane", (right_id, "pm cockpit-pane project demo")) in tmux.calls
+
+
+def test_join_live_from_storage_uses_window_index_and_sets_mount_state() -> None:
+    tmux = FakeTmux()
+    cockpit = tmux.add_window("pollypm", "PollyPM", [("uv", 0), ("pm", 100)])
+    left_id = cockpit.panes[0].pane_id
+    static_right_id = cockpit.panes[1].pane_id
+    tmux.add_window("pollypm-storage-closet", "worker-demo", [("codex", 0)], index=7)
+    manager = _manager(tmux)
+
+    result = manager.join_live_from_storage(
+        LivePaneSpec(
+            storage_session="pollypm-storage-closet",
+            window_name="worker-demo",
+            mounted_session="worker_demo",
+        ),
+        CockpitWindowState(right_pane_id=static_right_id),
+    )
+
+    assert result.ok
+    assert f"kill_static_right:{static_right_id}" in result.actions
+    assert f"join_live:pollypm-storage-closet:7.0->{left_id}" in result.actions
+    assert result.state.mounted_session == "worker_demo"
+    assert result.state.mounted_window_name == "worker-demo"
+    assert tmux.list_windows("pollypm-storage-closet") == []
+    assert ("set_pane_history_limit", (result.right_pane_id, 200)) in tmux.calls
+
+
+def test_join_live_from_storage_does_not_kill_right_when_source_missing() -> None:
+    tmux = FakeTmux()
+    cockpit = tmux.add_window("pollypm", "PollyPM", [("uv", 0), ("pm", 100)])
+    right_id = cockpit.panes[1].pane_id
+    manager = _manager(tmux)
+
+    result = manager.join_live_from_storage(
+        LivePaneSpec(
+            storage_session="pollypm-storage-closet",
+            window_name="worker-demo",
+            mounted_session="worker_demo",
+        ),
+        CockpitWindowState(right_pane_id=right_id),
+    )
+
+    assert result.ok
+    assert "missing_storage_window:pollypm-storage-closet:worker-demo" in result.actions
+    assert ("kill_pane", (right_id,)) not in tmux.calls
+    assert {pane.pane_id for pane in tmux.list_panes("pollypm:PollyPM")} == {
+        cockpit.panes[0].pane_id,
+        right_id,
+    }
+
+
+def test_park_live_to_storage_breaks_right_and_replaces_static_content() -> None:
+    tmux = FakeTmux()
+    cockpit = tmux.add_window("pollypm", "PollyPM", [("uv", 0), ("codex", 100)])
+    right_id = cockpit.panes[1].pane_id
+    manager = _manager(tmux)
+
+    result = manager.park_live_to_storage(
+        CockpitWindowState(
+            right_pane_id=right_id,
+            mounted_session="worker_demo",
+            mounted_window_name="worker-demo",
+        ),
+        park=ParkPaneSpec(
+            storage_session="pollypm-storage-closet",
+            window_name="worker-demo",
+            mounted_session="worker_demo",
+        ),
+    )
+
+    assert result.ok
+    assert f"break_live:{right_id}->pollypm-storage-closet:worker-demo" in result.actions
+    assert result.state.mounted_session is None
+    assert result.state.right_pane_id != right_id
+    storage_windows = tmux.list_windows("pollypm-storage-closet")
+    assert len(storage_windows) == 1
+    assert storage_windows[0].name == "worker-demo"
+    assert storage_windows[0].pane_id == right_id
+
+
+def test_focus_right_selects_content_pane_and_shows_hint() -> None:
+    tmux = FakeTmux()
+    cockpit = tmux.add_window("pollypm", "PollyPM", [("uv", 0), ("pm", 100)])
+    right_id = cockpit.panes[1].pane_id
+    manager = _manager(tmux)
+
+    result = manager.focus_right(CockpitWindowState(right_pane_id=right_id))
+
+    assert result.ok
+    assert ("select_pane", (right_id,)) in tmux.calls
+    assert any(call[0] == "run" and "display-message" in call[1] for call in tmux.calls)
+
+
+def test_send_key_right_forwards_key_to_content_pane() -> None:
+    tmux = FakeTmux()
+    cockpit = tmux.add_window("pollypm", "PollyPM", [("uv", 0), ("pm", 100)])
+    right_id = cockpit.panes[1].pane_id
+    manager = _manager(tmux)
+
+    result = manager.send_key_right("Tab", CockpitWindowState(right_pane_id=right_id))
+
+    assert result.ok
+    assert ("run", ("send-keys", "-t", right_id, "Tab", False)) in tmux.calls


### PR DESCRIPTION
## Summary
- Adds modular cockpit contracts, state store, content resolver, navigation controller/client, and tmux window manager modules.
- Routes `CockpitRouter.route_selected()` through the new content resolver.
- Routes static pane materialization through `CockpitWindowManager.show_static()`.
- Wires root rail clicks through `NavigationController` for immediate acknowledgement and stale-completion protection.
- Adds a file-queue navigation client path for simple right-pane initiated jumps, drained by the root cockpit owner.

## Verification
- `uv run pytest -q tests/test_cockpit_contract_boundaries.py tests/test_cockpit_state_store.py tests/test_cockpit_navigation.py tests/test_cockpit_navigation_client.py tests/test_cockpit_window_manager.py tests/test_cockpit_content.py tests/test_cockpit_modular_verification.py tests/test_cockpit.py`
- Result: 177 passed, 1 existing Textual coroutine warning.
- `uv run ruff check` on touched cockpit modules/tests passed.

## Notes
- PM/worker jump-and-inject-context flows remain direct for now because they are compound operations (`navigate` plus `send_keys`). They should move behind a typed payload handler in a follow-up slice.

Refs #968 #969 #970 #971 #972 #973 #974 #975 #976
