### PR TITLE
Preserve shell-wrapped cockpit rail panes

### DIFF
--- a/src/pollypm/cockpit_window_manager.py
+++ b/src/pollypm/cockpit_window_manager.py
@@ -223,6 +223,13 @@ class CockpitWindowManager:
         left = live[0] if live else None
         right = live[-1] if live else None
         rail = next((pane for pane in live if self._is_rail_pane(pane)), None)
+        if rail is None and len(live) >= 2:
+            # Real cockpit rail panes may report ``bash`` or ``python`` while
+            # the TUI is running through a shell wrapper. In a normal two-pane
+            # cockpit, position is the stronger signal: left is rail, right is
+            # content. Command matching is only used when it identifies the
+            # rail somewhere else and we need to swap it back left.
+            rail = left
         content: Any | None = None
         if rail is not None:
             content = next((pane for pane in reversed(live) if pane is not rail), None)
@@ -535,6 +542,14 @@ class CockpitWindowManager:
         if self._is_rail_pane(pane):
             return state
         pane_id = _pane_id(pane)
+        if pane_id is not None and pane_id != state.right_pane_id:
+            # After parking a live right pane back to storage, tmux leaves
+            # only the shell-wrapped rail pane in the cockpit window. Its
+            # foreground command may report as ``bash``/``zsh`` rather than
+            # ``uv``. If this lone pane is not the persisted right pane, keep
+            # it as rail and let the caller split a fresh content pane.
+            actions.append(f"assume_shell_wrapped_rail:{pane_id}")
+            return state.cleared_mount().with_right(None)
         if pane_id is not None and self.spec.rail_command is not None:
             self.tmux.respawn_pane(pane_id, self.spec.rail_command)
             actions.append(f"respawn_missing_rail:{pane_id}")

--- a/tests/test_cockpit_window_manager.py
+++ b/tests/test_cockpit_window_manager.py
@@ -271,6 +271,20 @@ def test_classifies_left_right_and_rail_before_repair() -> None:
     assert manager.validate_postcondition().errors == ("rail pane is not leftmost", "content pane is not rightmost")
 
 
+def test_classifies_left_pane_as_rail_when_shell_wrapper_hides_command() -> None:
+    tmux = FakeTmux()
+    window = tmux.add_window("pollypm", "PollyPM", [("bash", 0), ("pm", 100)])
+    manager = _manager(tmux)
+
+    classification = manager.classify_panes()
+
+    assert classification.left_pane == window.panes[0]
+    assert classification.right_pane == window.panes[1]
+    assert classification.rail_pane == window.panes[0]
+    assert classification.content_pane == window.panes[1]
+    assert manager.validate_postcondition().errors == ()
+
+
 def test_ensure_layout_swaps_rail_left_and_validates_postcondition() -> None:
     tmux = FakeTmux()
     window = tmux.add_window("pollypm", "PollyPM", [("bash", 0), ("uv", 100)])
@@ -284,6 +298,25 @@ def test_ensure_layout_swaps_rail_left_and_validates_postcondition() -> None:
     assert f"swap_rail_left:{old_right_id}->{old_left_id}" in result.actions
     assert result.state.right_pane_id == old_left_id
     assert manager.classify_panes().rail_pane.pane_id == old_right_id
+
+
+def test_show_static_does_not_respawn_live_shell_wrapped_rail() -> None:
+    tmux = FakeTmux()
+    window = tmux.add_window("pollypm", "PollyPM", [("bash", 0), ("pm", 100)])
+    left_id = window.panes[0].pane_id
+    right_id = window.panes[1].pane_id
+    manager = _manager(tmux)
+
+    result = manager.show_static(
+        "pm cockpit-pane settings",
+        CockpitWindowState(right_pane_id=right_id),
+    )
+
+    assert result.ok
+    assert result.left_pane_id == left_id
+    assert result.right_pane_id == right_id
+    assert ("respawn_pane", (left_id, "uv run pm rail")) not in tmux.calls
+    assert ("respawn_pane", (right_id, "pm cockpit-pane settings")) in tmux.calls
 
 
 def test_ensure_layout_repairs_missing_content_by_splitting() -> None:
@@ -314,6 +347,30 @@ def test_ensure_layout_repairs_missing_rail_by_respawning_single_pane_then_split
 
     assert result.ok
     assert f"respawn_missing_rail:{original_id}" in result.actions
+    assert any(action.startswith("split_content:%") for action in result.actions)
+    assert result.state.mounted_session is None
+
+
+def test_ensure_layout_keeps_single_shell_wrapped_rail_after_parking_live_pane() -> None:
+    tmux = FakeTmux()
+    window = tmux.add_window("pollypm", "PollyPM", [("bash", 0, 180, False)])
+    left_id = window.panes[0].pane_id
+    manager = _manager(tmux)
+
+    result = manager.ensure_layout(
+        CockpitWindowState(
+            right_pane_id="%old-right",
+            mounted_session="worker_demo",
+            mounted_window_name="worker-demo",
+        )
+    )
+
+    assert result.ok
+    assert f"assume_shell_wrapped_rail:{left_id}" in result.actions
+    assert not any(
+        call == ("respawn_pane", (left_id, "uv run pm rail"))
+        for call in tmux.calls
+    )
     assert any(action.startswith("split_content:%") for action in result.actions)
     assert result.state.mounted_session is None
 


### PR DESCRIPTION
## Summary
- Treat the left pane as the cockpit rail when tmux reports a shell wrapper instead of `uv`/`pm`.
- Preserve the shell-wrapped rail after parking a live PM Chat pane back to storage.
- Add window-manager regressions for the global Settings crash and the live-pane-to-static route path.

## Verification
- `uv run pytest -q tests/test_cockpit_window_manager.py` -> `14 passed in 0.13s`
- `uv run ruff check src/pollypm/cockpit_window_manager.py tests/test_cockpit_window_manager.py` -> `All checks passed!`
- Real tmux route walk against `pollypm:PollyPM`: 105 routes across 25 projects, dashboard/tasks/settings for all projects, PM Chat for the 5 existing project sessions, `summary_failures=0`.
- Explicit global Settings route after route walk: `selected=settings`, two live panes, left rail alive, right pane renders settings.
