### PR TITLE
Fix cockpit Polly live route race

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -872,6 +872,44 @@ class CockpitRouter:
             self._state_cache_mtime_ns = None
         self._state_dirty_since = None
 
+    _LAYOUT_MUTATION_TOKEN = "_layout_mutation_token"
+    _LAYOUT_MUTATION_UNTIL = "_layout_mutating_until"
+    _LAYOUT_MUTATION_TTL_SECONDS = 30.0
+
+    def _begin_layout_mutation(self) -> str:
+        token = f"{os.getpid()}:{time.monotonic_ns()}"
+        self._active_layout_mutation_token = token
+        state = self._load_state()
+        state[self._LAYOUT_MUTATION_TOKEN] = token
+        state[self._LAYOUT_MUTATION_UNTIL] = time.time() + self._LAYOUT_MUTATION_TTL_SECONDS
+        self._write_state(state)
+        return token
+
+    def _end_layout_mutation(self, token: str) -> None:
+        try:
+            state = self._load_state()
+            if state.get(self._LAYOUT_MUTATION_TOKEN) == token:
+                state.pop(self._LAYOUT_MUTATION_TOKEN, None)
+                state.pop(self._LAYOUT_MUTATION_UNTIL, None)
+                self._write_state(state)
+        finally:
+            if getattr(self, "_active_layout_mutation_token", None) == token:
+                self._active_layout_mutation_token = None
+
+    def _layout_mutation_active_elsewhere(self) -> bool:
+        state = self._load_state()
+        token = state.get(self._LAYOUT_MUTATION_TOKEN)
+        if not isinstance(token, str) or not token:
+            return False
+        if token == getattr(self, "_active_layout_mutation_token", None):
+            return False
+        until = state.get(self._LAYOUT_MUTATION_UNTIL)
+        try:
+            deadline = float(until)
+        except (TypeError, ValueError):
+            return False
+        return deadline > time.time()
+
     def rail_width(self) -> int:
         """Return the persisted rail width, falling back to the default."""
         data = self._load_state()
@@ -914,6 +952,8 @@ class CockpitRouter:
         Returns the list of panes fetched (or the list passed in) so
         callers can avoid re-issuing ``list_panes`` — see #175.
         """
+        if self._layout_mutation_active_elsewhere():
+            return panes if panes is not None else []
         state = self._load_state()
         dirty = False
         if target is None:
@@ -1778,15 +1818,12 @@ class CockpitRouter:
                 seen[window.name] = window.index
 
     def ensure_cockpit_layout(self) -> None:
+        if self._layout_mutation_active_elsewhere():
+            return
         config = self._load_config()
         target = f"{config.project.tmux_session}:{self._COCKPIT_WINDOW}"
-        # Single list-panes baseline shared with ``_validate_state``. See
-        # #175: subsequent list-panes calls only run after a mutation that
-        # invalidates the cached view (split/kill); pure swaps preserve
-        # pane IDs so we update order locally.
         panes = self._safe_list_panes(target)
         self._validate_state(panes=panes, target=target)
-        # Clean up duplicate windows in the storage closet before layout setup
         try:
             supervisor = self._load_supervisor()
             self._cleanup_duplicate_windows(supervisor.storage_closet_session_name())
@@ -1835,8 +1872,23 @@ class CockpitRouter:
             self._write_state(state)
             panes = self.tmux.list_panes(target)  # split added a pane
         elif len(panes) > 2:
-            for pane in panes:
-                if pane.pane_id == panes[0].pane_id:
+            ordered = sorted(panes, key=self._pane_left)
+            left_pane = ordered[0]
+            preferred_right = None
+            if isinstance(right_pane_id, str):
+                preferred_right = next(
+                    (
+                        pane for pane in ordered
+                        if pane.pane_id == right_pane_id
+                        and not getattr(pane, "pane_dead", False)
+                    ),
+                    None,
+                )
+            if preferred_right is None or preferred_right.pane_id == left_pane.pane_id:
+                preferred_right = ordered[-1]
+            keep_ids = {left_pane.pane_id, preferred_right.pane_id}
+            for pane in ordered:
+                if pane.pane_id in keep_ids:
                     continue
                 try:
                     self.tmux.kill_pane(pane.pane_id)
@@ -1896,6 +1948,55 @@ class CockpitRouter:
         except Exception:  # noqa: BLE001
             pass
         return None
+
+    def _join_storage_pane_into_cockpit(
+        self,
+        *,
+        source: str,
+        source_pane_id: str | None,
+        left_pane_id: str,
+        previous_right_pane_id: str | None,
+        window_target: str,
+    ):
+        """Join a storage pane without exposing a one-pane cockpit layout.
+
+        The old sequence killed the static right pane first, then joined the
+        live pane. A concurrent rail layout tick could observe that one-pane
+        gap and split a fresh static dashboard, which then raced the live
+        join. Join first, then remove stale panes while keeping the known
+        source pane.
+        """
+        self.tmux.join_pane(source, left_pane_id, horizontal=True)
+        if (
+            previous_right_pane_id is not None
+            and previous_right_pane_id != source_pane_id
+        ):
+            try:
+                self.tmux.kill_pane(previous_right_pane_id)
+            except Exception:  # noqa: BLE001
+                pass
+        panes = self.tmux.list_panes(window_target)
+        if source_pane_id is not None:
+            keep = {left_pane_id, source_pane_id}
+            for pane in panes:
+                pane_id = getattr(pane, "pane_id", None)
+                if pane_id is None or pane_id in keep:
+                    continue
+                try:
+                    self.tmux.kill_pane(pane_id)
+                except Exception:  # noqa: BLE001
+                    pass
+            panes = self.tmux.list_panes(window_target)
+            right_pane = next(
+                (
+                    pane for pane in panes
+                    if getattr(pane, "pane_id", None) == source_pane_id
+                ),
+                None,
+            )
+            if right_pane is not None:
+                return right_pane
+        return max(panes, key=self._pane_left)
 
     def _normalize_layout(self, target: str, panes) -> None:
         if len(panes) != 2:
@@ -1999,14 +2100,22 @@ class CockpitRouter:
                     self._cleanup_extra_panes(window_target)
                     left_pane = self._left_pane_id(window_target)
                     right_pane_id = self._right_pane_id(window_target)
-                    if right_pane_id is not None:
-                        self.tmux.kill_pane(right_pane_id)
-                    source = f"{storage}:{target_win.index}.0"
-                    self.tmux.join_pane(source, left_pane, horizontal=True)
+                    source_pane_id = getattr(target_win, "pane_id", None)
+                    source = (
+                        source_pane_id
+                        if isinstance(source_pane_id, str) and source_pane_id
+                        else f"{storage}:{target_win.index}.0"
+                    )
+                    right_p = self._join_storage_pane_into_cockpit(
+                        source=source,
+                        source_pane_id=source_pane_id,
+                        left_pane_id=left_pane,
+                        previous_right_pane_id=right_pane_id,
+                        window_target=window_target,
+                    )
                     panes = self.tmux.list_panes(window_target)
                     left_p = min(panes, key=self._pane_left)
                     self._try_resize_rail(left_p.pane_id)
-                    right_p = max(panes, key=self._pane_left)
                     self.tmux.set_pane_history_limit(right_p.pane_id, 200)
                     state = self._load_state()
                     state["mounted_session"] = window_name
@@ -2218,16 +2327,20 @@ class CockpitRouter:
         self._write_state(state)
 
     def route_selected(self, key: str) -> None:
-        supervisor = self._load_supervisor()
-        window_target = f"{supervisor.config.project.tmux_session}:{self._COCKPIT_WINDOW}"
-        self.ensure_cockpit_layout()
-        right_pane = self._right_pane_id(window_target)
-        if right_pane is None:
-            raise RuntimeError("Cockpit right pane is not available.")
+        token = self._begin_layout_mutation()
+        try:
+            supervisor = self._load_supervisor()
+            window_target = f"{supervisor.config.project.tmux_session}:{self._COCKPIT_WINDOW}"
+            self.ensure_cockpit_layout()
+            right_pane = self._right_pane_id(window_target)
+            if right_pane is None:
+                raise RuntimeError("Cockpit right pane is not available.")
 
-        self.set_selected_key(key)
-        plan = resolve_cockpit_content(key, self._content_context(supervisor))
-        self._route_content_plan(supervisor, window_target, plan)
+            self.set_selected_key(key)
+            plan = resolve_cockpit_content(key, self._content_context(supervisor))
+            self._route_content_plan(supervisor, window_target, plan)
+        finally:
+            self._end_layout_mutation(token)
 
     def focus_right_pane(self) -> None:
         config = self._load_config()
@@ -2502,8 +2615,6 @@ class CockpitRouter:
                     supervisor.launch_session(session_name)
                     storage_windows = {w.name for w in self.tmux.list_windows(storage_session)}
                     if launch.window_name in storage_windows:
-                        if right_pane_id is not None:
-                            self.tmux.kill_pane(right_pane_id)
                         # Look up the freshly-spawned window's index so
                         # the persisted identity records the
                         # disambiguating index, not just the name.
@@ -2512,7 +2623,16 @@ class CockpitRouter:
                             (w for w in live_windows if w.name == launch.window_name),
                             None,
                         )
-                        source = f"{storage_session}:{launch.window_name}.0"
+                        source_pane_id = (
+                            getattr(target_window_for_identity, "pane_id", None)
+                            if target_window_for_identity is not None
+                            else None
+                        )
+                        source = (
+                            source_pane_id
+                            if isinstance(source_pane_id, str) and source_pane_id
+                            else f"{storage_session}:{launch.window_name}.0"
+                        )
                         # #934 follow-up — fifth-layer rail-mount guard.
                         # If the source pane already shows another role's
                         # canonical banner (e.g. a long-running rail
@@ -2529,11 +2649,16 @@ class CockpitRouter:
                                 "shows another role's banner — refusing "
                                 "to join into cockpit."
                             )
-                        self.tmux.join_pane(source, left_pane_id, horizontal=True)
+                        right_pane = self._join_storage_pane_into_cockpit(
+                            source=source,
+                            source_pane_id=source_pane_id,
+                            left_pane_id=left_pane_id,
+                            previous_right_pane_id=right_pane_id,
+                            window_target=window_target,
+                        )
                         panes = self.tmux.list_panes(window_target)
                         left_pane = min(panes, key=self._pane_left)
                         self._try_resize_rail(left_pane.pane_id)
-                        right_pane = max(panes, key=self._pane_left)
                         self.tmux.set_pane_history_limit(right_pane.pane_id, 200)
                         state = self._load_state()
                         state["mounted_session"] = session_name
@@ -2584,7 +2709,12 @@ class CockpitRouter:
             fallback_target = launch.session.project if fallback_kind == "project" else None
             self._show_static_view(supervisor, window_target, fallback_kind, fallback_target)
             return
-        source = f"{storage_session}:{target_window.index}.0"
+        source_pane_id = getattr(target_window, "pane_id", None)
+        source = (
+            source_pane_id
+            if isinstance(source_pane_id, str) and source_pane_id
+            else f"{storage_session}:{target_window.index}.0"
+        )
         # #934 follow-up — fifth-layer rail-mount guard. Even after the
         # supervisor's four crossing guards, a stale storage-closet pane
         # can carry another role's banner (e.g. an old rail-daemon
@@ -2599,13 +2729,16 @@ class CockpitRouter:
             fallback_target = launch.session.project if fallback_kind == "project" else None
             self._show_static_view(supervisor, window_target, fallback_kind, fallback_target)
             return
-        if right_pane_id is not None:
-            self.tmux.kill_pane(right_pane_id)
-        self.tmux.join_pane(source, left_pane_id, horizontal=True)
+        right_pane = self._join_storage_pane_into_cockpit(
+            source=source,
+            source_pane_id=source_pane_id,
+            left_pane_id=left_pane_id,
+            previous_right_pane_id=right_pane_id,
+            window_target=window_target,
+        )
         panes = self.tmux.list_panes(window_target)
         left_pane = min(panes, key=self._pane_left)
         self._try_resize_rail(left_pane.pane_id)
-        right_pane = max(panes, key=self._pane_left)
         self.tmux.set_pane_history_limit(right_pane.pane_id, 200)
         state = self._load_state()
         # Persist both the legacy bare-string ``mounted_session`` (for

--- a/src/pollypm/cockpit_window_manager.py
+++ b/src/pollypm/cockpit_window_manager.py
@@ -378,17 +378,38 @@ class CockpitWindowManager:
         right_id = _pane_id(right)
         if left_id is None:
             return self._result(state, actions)
-        if right_id is not None:
-            self.tmux.kill_pane(right_id)
-            actions.append(f"kill_static_right:{right_id}")
 
-        source = f"{live.storage_session}:{getattr(source_window, 'index')}.0"
+        source_id = _pane_id(source_window)
+        source = source_id or f"{live.storage_session}:{getattr(source_window, 'index')}.0"
         self.tmux.join_pane(source, left_id, horizontal=True)
         actions.append(f"join_live:{source}->{left_id}")
+        if right_id is not None and right_id != source_id:
+            self.tmux.kill_pane(right_id)
+            actions.append(f"kill_static_right:{right_id}")
         panes = self.tmux.list_panes(self.spec.window_target)
         classification = self.classify_panes(panes)
+        if source_id is not None:
+            keep_ids = {left_id, source_id}
+            for pane in classification.live_panes:
+                pane_id = _pane_id(pane)
+                if pane_id is None or pane_id in keep_ids:
+                    continue
+                self.tmux.kill_pane(pane_id)
+                actions.append(f"kill_extra:{pane_id}")
+            panes = self.tmux.list_panes(self.spec.window_target)
+            classification = self.classify_panes(panes)
         self._resize_rail(classification, actions)
-        right = self._right_pane()
+        right = (
+            next(
+                (
+                    pane for pane in classification.live_panes
+                    if _pane_id(pane) == source_id
+                ),
+                None,
+            )
+            if source_id is not None
+            else self._right_pane()
+        )
         right_id = _pane_id(right)
         if right_id is not None:
             limit = live.history_limit or self.spec.mounted_history_limit

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -2584,6 +2584,58 @@ def test_cockpit_router_ensure_layout_resizes_existing_left_pane(tmp_path: Path)
     assert calls["resize"] == ("%1", router._LEFT_PANE_WIDTH)
 
 
+def test_cockpit_router_ensure_layout_keeps_persisted_right_when_extra_pane_appears(tmp_path: Path) -> None:
+    class FakePane:
+        def __init__(self, pane_id: str, pane_left: int, command: str, pane_width: int = 80) -> None:
+            self.pane_id = pane_id
+            self.pane_left = pane_left
+            self.pane_current_command = command
+            self.pane_width = pane_width
+            self.active = True
+
+    class FakeTmux:
+        def __init__(self) -> None:
+            self.panes = [
+                FakePane("%1", 0, "zsh", pane_width=30),
+                FakePane("%2", 31, "bash", pane_width=80),
+                FakePane("%3", 112, "2.1.123", pane_width=100),
+            ]
+            self.killed: list[str] = []
+
+        def list_panes(self, target: str):
+            return list(self.panes)
+
+        def kill_pane(self, target: str) -> None:
+            self.killed.append(target)
+            self.panes = [pane for pane in self.panes if pane.pane_id != target]
+
+        def resize_pane_width(self, target: str, width: int):
+            pass
+
+        def run(self, *args, **kwargs):
+            pass
+
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+    router = CockpitRouter(config_path)
+    tmux = FakeTmux()
+    router.tmux = tmux  # type: ignore[assignment]
+    router._write_state(
+        {
+            "right_pane_id": "%3",
+        }
+    )
+
+    router.ensure_cockpit_layout()
+
+    assert tmux.killed == ["%2"]
+    assert {pane.pane_id for pane in tmux.panes} == {"%1", "%3"}
+    state = router._load_state()
+    assert state["right_pane_id"] == "%3"
+
+
 def test_cockpit_router_ensure_layout_steady_state_issues_one_list_panes(tmp_path: Path) -> None:
     """Steady-state ``ensure_cockpit_layout`` must invoke ``list_panes`` once (#175).
 
@@ -2944,6 +2996,35 @@ def test_cockpit_router_reload_shell_respawns_rail_and_settings(
     state = router._load_state()
     assert state["selected"] == "settings"
     assert state["right_pane_id"] == "%2"
+
+
+def test_cockpit_router_layout_repair_skips_during_external_route(tmp_path: Path) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+
+    class FakeTmux:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def list_panes(self, target: str):
+            self.calls.append(f"list_panes:{target}")
+            return []
+
+    router = CockpitRouter(config_path)
+    tmux = FakeTmux()
+    router.tmux = tmux  # type: ignore[assignment]
+    router._write_state(
+        {
+            "_layout_mutation_token": "other-process",
+            "_layout_mutating_until": 9_999_999_999.0,
+        }
+    )
+
+    router.ensure_cockpit_layout()
+
+    assert tmux.calls == []
 
 
 def test_cockpit_router_joins_session_from_storage(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_cockpit_window_manager.py
+++ b/tests/test_cockpit_window_manager.py
@@ -211,6 +211,8 @@ class FakeTmux:
         raise KeyError(pane_id)
 
     def _find_source_pane(self, source: str) -> tuple[FakeWindow, FakePane]:
+        if source.startswith("%"):
+            return self._find_pane(source)
         session, rest = source.split(":", 1)
         raw_window, raw_pane = rest.split(".", 1)
         window_index = int(raw_window)
@@ -397,6 +399,37 @@ def test_ensure_layout_respawns_dead_right_and_kills_extra_panes() -> None:
     }
 
 
+def test_ensure_layout_keeps_persisted_live_right_when_extra_static_pane_appears() -> None:
+    tmux = FakeTmux()
+    window = tmux.add_window(
+        "pollypm",
+        "PollyPM",
+        [("bash", 0, 30, False), ("pm", 40, 80, False), ("2.1.123", 130, 80, False)],
+    )
+    left_id = window.panes[0].pane_id
+    static_extra_id = window.panes[1].pane_id
+    live_right_id = window.panes[2].pane_id
+    manager = _manager(tmux)
+
+    result = manager.ensure_layout(
+        CockpitWindowState(
+            right_pane_id=live_right_id,
+            mounted_session="operator",
+            mounted_window_name="pm-operator",
+        )
+    )
+
+    assert result.ok
+    assert f"kill_extra:{static_extra_id}" in result.actions
+    assert ("kill_pane", (live_right_id,)) not in tmux.calls
+    assert {pane.pane_id for pane in tmux.list_panes("pollypm:PollyPM")} == {
+        left_id,
+        live_right_id,
+    }
+    assert result.state.right_pane_id == live_right_id
+    assert result.state.mounted_session == "operator"
+
+
 def test_show_static_respawns_right_and_clears_mounted_state() -> None:
     tmux = FakeTmux()
     window = tmux.add_window("pollypm", "PollyPM", [("uv", 0), ("node", 100)])
@@ -423,7 +456,8 @@ def test_join_live_from_storage_uses_window_index_and_sets_mount_state() -> None
     cockpit = tmux.add_window("pollypm", "PollyPM", [("uv", 0), ("pm", 100)])
     left_id = cockpit.panes[0].pane_id
     static_right_id = cockpit.panes[1].pane_id
-    tmux.add_window("pollypm-storage-closet", "worker-demo", [("codex", 0)], index=7)
+    source_window = tmux.add_window("pollypm-storage-closet", "worker-demo", [("codex", 0)], index=7)
+    source_pane_id = source_window.pane_id
     manager = _manager(tmux)
 
     result = manager.join_live_from_storage(
@@ -437,7 +471,7 @@ def test_join_live_from_storage_uses_window_index_and_sets_mount_state() -> None
 
     assert result.ok
     assert f"kill_static_right:{static_right_id}" in result.actions
-    assert f"join_live:pollypm-storage-closet:7.0->{left_id}" in result.actions
+    assert f"join_live:{source_pane_id}->{left_id}" in result.actions
     assert result.state.mounted_session == "worker_demo"
     assert result.state.mounted_window_name == "worker-demo"
     assert tmux.list_windows("pollypm-storage-closet") == []


### PR DESCRIPTION
## Summary
- guard route mutations so layout repair skips while another cockpit process is mounting a pane
- preserve the persisted/right live pane when transient three-pane layouts appear
- join live storage panes before killing the old static pane so failed joins do not blank the cockpit

## Verification
- uv run ruff check src/pollypm/cockpit_rail.py src/pollypm/cockpit_window_manager.py tests/test_cockpit.py tests/test_cockpit_window_manager.py
- uv run pytest -q tests/test_cockpit_content.py tests/test_cockpit_modular_verification.py tests/test_cockpit_mount_identity.py tests/test_cockpit_window_manager.py tests/test_cockpit.py -q
- uv run pytest -q tests/test_cockpit*.py
- live tmux route walk: 108 cockpit routes, 0 failures; final state mounted_session=operator