### PR TITLE
Fix project PM chat mounting

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -420,7 +420,12 @@ def _build_project_pm_primer(supervisor, project_key: str) -> str | None:
     project = supervisor.config.projects.get(project_key)
     if project is None:
         return None
-    persona = getattr(project, "persona_name", None) or "Polly"
+    persona_raw = getattr(project, "persona_name", None)
+    persona = (
+        persona_raw.strip()
+        if isinstance(persona_raw, str) and persona_raw.strip()
+        else None
+    )
     project_name = project.name or project_key
     project_path = str(project.path)
 
@@ -478,10 +483,21 @@ def _build_project_pm_primer(supervisor, project_key: str) -> str | None:
     except Exception:  # noqa: BLE001 — primer is best-effort
         pass
 
+    if persona is not None:
+        identity_line = (
+            f"You are {persona}, the PM for project '{project_name}' "
+            f"(key: {project_key}). Re-anchor on this identity for the "
+            "rest of this session."
+        )
+    else:
+        identity_line = (
+            f"You are the PM for project '{project_name}' "
+            f"(key: {project_key}). Re-anchor on this project identity "
+            "for the rest of this session."
+        )
+
     lines = [
-        f"You are {persona}, the PM for project '{project_name}' "
-        f"(key: {project_key}). Re-anchor on this identity for the "
-        "rest of this session.",
+        identity_line,
         f"Project root: {project_path}",
         (
             f"Tasks: {queued} queued, {in_progress} in progress, "
@@ -2197,6 +2213,14 @@ class CockpitRouter:
         the still-existing tmux applicators keep live behavior stable.
         """
         if isinstance(plan, FallbackPane):
+            if (
+                plan.reason == "missing_worker"
+                and plan.fallback.project_key is not None
+                and plan.route_key == f"project:{plan.fallback.project_key}:session"
+            ):
+                self.set_selected_key(plan.route_key)
+                self.create_worker_and_route(plan.fallback.project_key)
+                return
             self.set_selected_key(plan.selected_key)
             self._route_content_plan(supervisor, window_target, plan.fallback)
             return
@@ -2425,6 +2449,8 @@ class CockpitRouter:
         storage_windows = {w.name for w in self.tmux.list_windows(storage_session)}
 
         target: str | None = None
+        launch = None
+        should_stabilize_visible = False
         if session_name is not None:
             launch = next(
                 item for item in launches
@@ -2432,6 +2458,8 @@ class CockpitRouter:
             )
             if launch.window_name not in storage_windows:
                 _launch, target = supervisor.create_session_window(session_name, on_status=on_status)
+                launch = _launch
+                should_stabilize_visible = target is not None
         else:
             prompt = self.service.suggest_worker_prompt(project_key=project_key)
             self.service.create_and_launch_worker(
@@ -2446,12 +2474,21 @@ class CockpitRouter:
                     item for item in launches
                     if item.session.name == session_name
                 )
-                tmux_session = supervisor.tmux_session_for_launch(launch)
-                window_map = supervisor.window_map()
-                if launch.window_name in window_map:
-                    target_key = f"{tmux_session}:{launch.window_name}"
-                    # Window exists but hasn't been stabilized yet
-                    target = target_key
+                target_window = next(
+                    (
+                        window for window in self.tmux.list_windows(storage_session)
+                        if window.name == launch.window_name
+                    ),
+                    None,
+                )
+                if target_window is not None:
+                    source_pane_id = getattr(target_window, "pane_id", None)
+                    target = (
+                        source_pane_id
+                        if isinstance(source_pane_id, str) and source_pane_id
+                        else f"{storage_session}:{target_window.index}.0"
+                    )
+                    should_stabilize_visible = True
 
         # #964 — route to the project's PM Chat session when a worker is
         # known to exist (either pre-existing or freshly spawned above).
@@ -2463,17 +2500,50 @@ class CockpitRouter:
         # diagnoses the launch failure rather than surfacing a blank
         # right pane.
         if session_name is not None:
+            if should_stabilize_visible and launch is not None:
+                self._mount_created_worker_and_stabilize(
+                    supervisor,
+                    project_key=project_key,
+                    session_name=session_name,
+                    launch=launch,
+                    target=target,
+                    on_status=on_status,
+                )
+                return
             self.route_selected(f"project:{project_key}:session")
         else:
             self.route_selected(f"project:{project_key}")
 
-        # Stabilize in the background (dismisses prompts, waits for ready)
-        if target is not None and session_name is not None:
-            launch = next(
-                item for item in supervisor.plan_launches()
-                if item.session.name == session_name
+    def _mount_created_worker_and_stabilize(
+        self,
+        supervisor,
+        *,
+        project_key: str,
+        session_name: str,
+        launch,
+        target: str | None,
+        on_status: Callable[[str], None] | None = None,
+    ) -> None:
+        token = self._begin_layout_mutation()
+        try:
+            tmux_session = supervisor.config.project.tmux_session
+            window_target = f"{tmux_session}:{self._COCKPIT_WINDOW}"
+            self.ensure_cockpit_layout()
+            self.set_selected_key(f"project:{project_key}:session")
+            self._show_live_session(supervisor, session_name, window_target)
+            right_pane_id = self._right_pane_id(window_target)
+            stabilize_target = (
+                target
+                if isinstance(target, str) and target.startswith("%")
+                else right_pane_id
             )
-            supervisor.stabilize_launch(launch, target, on_status=on_status)
+            if stabilize_target is not None:
+                supervisor.stabilize_launch(launch, stabilize_target, on_status=on_status)
+            self._maybe_prime_project_pm_session(
+                supervisor, project_key, session_name, window_target,
+            )
+        finally:
+            self._end_layout_mutation(token)
 
     def _maybe_prime_operator_session(
         self,

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -5467,8 +5467,10 @@ def _resolve_pm_target(config_path: Path, project_key: str | None) -> tuple[str,
 
     * Project has a ``persona_name`` configured → dispatch to its PM Chat
       window (``project:<key>:session``) and surface the persona name.
-    * Otherwise (including ``project_key`` being empty or absent from
-      the config) → fall back to Polly (``polly`` → operator session).
+    * Project exists without a persona → dispatch to its PM Chat and
+      surface a neutral project-PM label.
+    * Empty or absent project keys still fall back to Polly's workspace
+      operator session.
     """
     fallback_key = "polly"
     fallback_name = "Polly"
@@ -5485,7 +5487,7 @@ def _resolve_pm_target(config_path: Path, project_key: str | None) -> tuple[str,
     persona = getattr(project, "persona_name", None)
     if isinstance(persona, str) and persona.strip():
         return f"project:{project_key}:session", persona.strip()
-    return fallback_key, fallback_name
+    return f"project:{project_key}:session", "Project PM"
 
 
 def _build_pm_context_line(
@@ -10411,7 +10413,11 @@ def _gather_project_dashboard(
         else (getattr(project, "name", None) or project_key)
     )
     persona = getattr(project, "persona_name", None)
-    pm_label = f"PM: {persona}" if (isinstance(persona, str) and persona.strip()) else "PM: Polly"
+    pm_label = (
+        f"PM: {persona.strip()}"
+        if isinstance(persona, str) and persona.strip()
+        else "PM: Project PM"
+    )
 
     exists_on_disk = bool(
         project_path is not None

--- a/src/pollypm/plugins_builtin/core_rail_items/plugin.py
+++ b/src/pollypm/plugins_builtin/core_rail_items/plugin.py
@@ -406,10 +406,16 @@ def _project_rows(ctx: RailContext) -> list[RailRow]:
                 label="  Dashboard",
                 state="sub",
             ))
-            persona = getattr(project, "persona_name", None) or "Polly"
+            persona_raw = getattr(project, "persona_name", None)
+            persona = (
+                persona_raw.strip()
+                if isinstance(persona_raw, str) and persona_raw.strip()
+                else None
+            )
+            label = f"  PM Chat ({persona})" if persona else "  PM Chat"
             rows.append(RailRow(
                 key=f"project:{project_key}:session",
-                label=f"  PM Chat ({persona})",
+                label=label,
                 state="sub",
             ))
             rows.append(RailRow(

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -1454,6 +1454,92 @@ def test_create_worker_and_route_targets_pm_chat_session_when_worker_exists() ->
     assert routed == ["project:demo:session"], routed
 
 
+def test_create_worker_and_route_mounts_new_worker_before_stabilizing() -> None:
+    """Fresh PM Chat creation should stabilize the pane that gets mounted.
+
+    Stabilizing by ``storage:window-name`` after a join races with tmux
+    because the storage window disappears once its pane moves into the
+    cockpit. Pane ids survive the join and keep the bootstrap attached to
+    the visible right pane.
+    """
+    calls: list[tuple[str, object]] = []
+
+    class _FakeSession:
+        name = "worker_demo"
+        role = "worker"
+        project = "demo"
+
+    class _FakeLaunch:
+        session = _FakeSession()
+        window_name = "worker-demo"
+
+    class _FakeSupervisor:
+        class _Config:
+            class _Project:
+                tmux_session = "pollypm"
+
+            project = _Project()
+
+        config = _Config()
+
+        def __init__(self, launches) -> None:
+            self._launches = launches
+
+        def plan_launches(self):
+            return list(self._launches)
+
+        def storage_closet_session_name(self) -> str:
+            return "pollypm-storage-closet"
+
+        def stabilize_launch(self, launch, target, on_status=None):  # noqa: ARG002
+            calls.append(("stabilize", target))
+
+    class _FakeTmux:
+        def list_windows(self, target: str):  # noqa: ARG002
+            return [SimpleNamespace(name="worker-demo", index=7, pane_id="%worker")]
+
+    class _FakeService:
+        def suggest_worker_prompt(self, *, project_key: str) -> str:  # noqa: ARG002
+            return ""
+
+        def create_and_launch_worker(self, **kwargs) -> None:
+            calls.append(("create", kwargs["project_key"]))
+
+    empty_supervisor = _FakeSupervisor([])
+    fresh_supervisor = _FakeSupervisor([_FakeLaunch()])
+    router = CockpitRouter.__new__(CockpitRouter)
+    router.tmux = _FakeTmux()
+    router.service = _FakeService()
+    router._load_supervisor = (  # type: ignore[assignment]
+        lambda fresh=False: fresh_supervisor if fresh else empty_supervisor
+    )
+    router._begin_layout_mutation = lambda: "token"  # type: ignore[assignment]
+    router._end_layout_mutation = (  # type: ignore[assignment]
+        lambda token: calls.append(("end", token))
+    )
+    router.ensure_cockpit_layout = (  # type: ignore[assignment]
+        lambda: calls.append(("ensure", None))
+    )
+    router.set_selected_key = (  # type: ignore[assignment]
+        lambda key: calls.append(("selected", key))
+    )
+    router._show_live_session = (  # type: ignore[assignment]
+        lambda supervisor, session_name, target: calls.append(("mount", session_name))
+    )
+    router._right_pane_id = lambda target: "%worker"  # type: ignore[assignment]
+    router._maybe_prime_project_pm_session = (  # type: ignore[assignment]
+        lambda *args: calls.append(("prime", args[2]))
+    )
+
+    router.create_worker_and_route("demo")
+
+    assert ("create", "demo") in calls
+    assert ("selected", "project:demo:session") in calls
+    assert ("mount", "worker_demo") in calls
+    assert ("stabilize", "%worker") in calls
+    assert ("prime", "worker_demo") in calls
+
+
 def test_create_worker_and_route_falls_back_to_project_dashboard_without_session() -> None:
     """If worker creation truly produces no session (launch failure,
     config gap), fall back to the project Dashboard so the cockpit
@@ -1488,6 +1574,41 @@ def test_create_worker_and_route_falls_back_to_project_dashboard_without_session
     router.create_worker_and_route("ghost")
 
     assert routed == ["project:ghost"], routed
+
+
+def test_missing_worker_pm_chat_route_creates_worker_from_modular_plan() -> None:
+    from pollypm.cockpit_content import FallbackPane, TextualCommandPane
+
+    calls: list[tuple[str, str]] = []
+    fallback = TextualCommandPane(
+        route_key="project:demo:session",
+        selected_key="project:demo:dashboard",
+        pane_kind="project",
+        command_args=("cockpit-pane", "project", "demo"),
+        project_key="demo",
+    )
+    plan = FallbackPane(
+        route_key="project:demo:session",
+        selected_key="project:demo:dashboard",
+        reason="missing_worker",
+        message="missing",
+        fallback=fallback,
+    )
+    router = CockpitRouter.__new__(CockpitRouter)
+    router.set_selected_key = lambda key: calls.append(("selected", key))  # type: ignore[assignment]
+    router.create_worker_and_route = (  # type: ignore[assignment]
+        lambda project_key: calls.append(("create", project_key))
+    )
+    router._show_static_view = (  # type: ignore[assignment]
+        lambda *args, **kwargs: calls.append(("static", "called"))
+    )
+
+    router._route_content_plan(SimpleNamespace(), "pollypm:PollyPM", plan)
+
+    assert calls == [
+        ("selected", "project:demo:session"),
+        ("create", "demo"),
+    ]
 
 
 def test_rail_listview_swallows_value_error_for_orphan_clicks() -> None:

--- a/tests/test_cockpit_inbox_ui.py
+++ b/tests/test_cockpit_inbox_ui.py
@@ -1321,12 +1321,16 @@ def test_d_key_dispatches_to_pm_with_context_line(inbox_env, inbox_app) -> None:
             # Fallback: drive the worker directly if the thread scheduler
             # didn't land inside the pilot pause budget.
             if not calls:
-                inbox_app._dispatch_to_pm_sync("polly", f're: inbox/{task_id} "stub"', "Polly")
+                inbox_app._dispatch_to_pm_sync(
+                    "project:demo:session",
+                    f're: inbox/{task_id} "stub"',
+                    "Project PM",
+                )
 
             assert calls, "expected _perform_pm_dispatch to be called"
             cockpit_key, context_line = calls[-1]
-            # Project has no persona → falls back to Polly.
-            assert cockpit_key == "polly"
+            # Project has no persona, but still routes to the project PM Chat.
+            assert cockpit_key == "project:demo:session"
             assert context_line.startswith(f're: inbox/{task_id} ')
             assert '"' in context_line
     _run(body())
@@ -1736,7 +1740,7 @@ def test_inbox_detail_includes_inline_review_artifact(tmp_path: Path) -> None:
                 f"expected review-artifact section; got {detail_text!r}"
             )
             assert "Ship the inbox review surface." in detail_text, (
-                f"plan body missing from rendered inbox detail"
+                "plan body missing from rendered inbox detail"
             )
 
     _run(body())

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -641,14 +641,13 @@ def _run(coro) -> None:
 
 
 def test_topbar_renders_name_and_default_pm(dashboard_env, dashboard_app) -> None:
-    """With no persona configured the top bar falls back to ``PM: Polly``."""
+    """With no persona configured the top bar uses a neutral PM label."""
     async def body() -> None:
         async with dashboard_app.run_test(size=(140, 50)) as pilot:
             await pilot.pause()
             topbar_text = str(dashboard_app.topbar.render())
             assert "Demo" in topbar_text
-            # Fallback persona because the fixture wrote no ``persona_name``.
-            assert "PM: Polly" in topbar_text
+            assert "PM: Project PM" in topbar_text
     _run(body())
 
 
@@ -3148,12 +3147,15 @@ def test_c_keybinding_dispatches_to_pm(dashboard_env, dashboard_app) -> None:
             # drive the worker body directly so the assertion is deterministic.
             if not calls:
                 dashboard_app._dispatch_to_pm_sync(
-                    "polly", 're: project/demo "dashboard discussion"', "Polly",
+                    "project:demo:session",
+                    're: project/demo "dashboard discussion"',
+                    "Project PM",
                 )
             assert calls, "expected _perform_pm_dispatch to be called"
             cockpit_key, context_line = calls[-1]
-            # No persona configured on the fixture → fall back to Polly.
-            assert cockpit_key == "polly"
+            # No persona configured on the fixture, but the project still has
+            # its own PM Chat route.
+            assert cockpit_key == "project:demo:session"
             assert "project/demo" in context_line
     _run(body())
 


### PR DESCRIPTION
## Summary
- create missing project PM Chat workers from the modular route path instead of falling back to the dashboard
- mount newly-created worker panes before stabilization and stabilize by pane id so bootstrap/input lands in the visible cockpit pane
- stop labeling projects without a persona as Polly; use neutral Project PM labels and PM Chat text

## Verification
- uv run ruff check src/pollypm/cockpit_rail.py src/pollypm/cockpit_ui.py src/pollypm/plugins_builtin/core_rail_items/plugin.py tests/test_cockpit.py tests/test_project_dashboard_ui.py tests/test_cockpit_inbox_ui.py
- uv run pytest -q tests/test_cockpit*.py tests/test_project_dashboard_ui.py tests/test_project_dashboard_signature.py
- live tmux route walk: top-level Polly/settings/inbox/activity; all 25 project dashboard/tasks/settings routes; 7 existing PM Chat mounts; final state mounted worker_coin_flip