### PR TITLE
Fix #1122 rail navigation after Inbox shortcut

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -1656,6 +1656,20 @@ class PollyCockpitApp(App[None]):
         if callable(send_method):
             send_method(key)
 
+    def _cancel_pending_route_selection(self) -> None:
+        controller = getattr(self, "_navigation_controller", None)
+        current_id = getattr(controller, "current_request_id", None)
+        if controller is None or current_id is None:
+            return
+        try:
+            controller.cancel(current_id)
+        except Exception:  # noqa: BLE001
+            pass
+        self._route_click_seq = max(
+            getattr(self, "_route_click_seq", 0),
+            int(current_id) + 1,
+        )
+
     def _adopt_router_selection_if_changed(self) -> None:
         try:
             external_key = self.router.selected_key()
@@ -1816,11 +1830,16 @@ class PollyCockpitApp(App[None]):
                 item.state = "unread"
         nav_items = self._nav_items()
         previous_key = self._selected_row_key()
-        selected_key = None if self.selected_key == "settings" else (previous_key or self.selected_key)
         # #797: keep selected_key valid against the visible items so
         # the focus marker doesn't drop off when a previously-selected
         # row (e.g. an expanded project sub-row) leaves the list.
         keys = [item.key for item in nav_items]
+        if self.selected_key == "settings":
+            selected_key = None
+        elif self.selected_key in keys:
+            selected_key = self.selected_key
+        else:
+            selected_key = previous_key or self.selected_key
         if self.selected_key not in keys and self.selected_key != "settings":
             for item in nav_items:
                 if item.selectable:
@@ -2209,6 +2228,7 @@ class PollyCockpitApp(App[None]):
         """Update selected_key from the current ListView cursor position."""
         key = self._selected_row_key()
         if key is not None:
+            self._cancel_pending_route_selection()
             self.selected_key = key
             self._last_nav_change = self._tick_count
             self._apply_active_view_to_rows()
@@ -2251,6 +2271,7 @@ class PollyCockpitApp(App[None]):
         return None
 
     def _select_settings_row(self) -> None:
+        self._cancel_pending_route_selection()
         self.selected_key = "settings"
         self._last_nav_change = self._tick_count
         self._apply_active_view_to_rows()

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4031,6 +4031,76 @@ def test_cockpit_ui_arrow_and_enter_route_selected(tmp_path: Path) -> None:
     asyncio.run(exercise())
 
 
+def test_cockpit_send_key_inbox_shortcut_keeps_nav_cursor_on_inbox(tmp_path: Path) -> None:
+    """#1122: after global ``I``, bridge-delivered Down starts from Inbox."""
+
+    class FakeRouter:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+            self._selected = "polly"
+
+        @property
+        def tmux(self):
+            class _Tmux:
+                pass
+
+            return _Tmux()
+
+        def selected_key(self) -> str:
+            return self._selected
+
+        def _load_state(self) -> dict:
+            return {}
+
+        def build_items(self, *, spinner_index: int = 0):
+            from pollypm.cockpit_rail import CockpitItem
+
+            return [
+                CockpitItem("dashboard", "Home", "home"),
+                CockpitItem("polly", "Polly", "ready"),
+                CockpitItem("workers", "Workers", "idle"),
+                CockpitItem("metrics", "Metrics", "watch"),
+                CockpitItem("inbox", "Inbox (33)", "ready"),
+                CockpitItem("activity", "Activity", "ready"),
+                CockpitItem("project:demo", "demo", "idle"),
+                CockpitItem("settings", "Settings", "config"),
+            ]
+
+        def route_selected(self, key: str) -> None:
+            self.calls.append(key)
+            self._selected = key
+
+        def create_worker_and_route(self, project_key: str) -> None:
+            self.calls.append(f"new:{project_key}")
+
+    app = PollyCockpitApp(tmp_path / "pollypm.toml")
+    app.router = FakeRouter()  # type: ignore[assignment]
+    app._start_core_rail = lambda: None  # type: ignore[method-assign]
+    app._show_palette_tip_once = lambda: None  # type: ignore[method-assign]
+    app._enforce_rail_width_once = lambda: None  # type: ignore[method-assign]
+
+    async def exercise() -> None:
+        from pollypm.cockpit_input_bridge import send_key
+
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause(0.2)
+            assert app._selected_row_key() == "polly"
+
+            handle = getattr(app, "_input_bridge_handle", None)
+            assert handle is not None
+            send_key(handle.socket_path, "I")
+            await pilot.pause(0.4)
+            assert app.selected_key == "inbox"
+            assert app._selected_row_key() == "inbox"
+
+            send_key(handle.socket_path, "<down>")
+            await pilot.pause(0.4)
+            assert app.selected_key == "activity"
+            assert app._selected_row_key() == "activity"
+
+    asyncio.run(exercise())
+
+
 def test_cockpit_cursor_sync_moves_visible_marker_without_full_refresh() -> None:
     app = PollyCockpitApp.__new__(PollyCockpitApp)
     app.selected_key = "polly"


### PR DESCRIPTION
Closes #1122

Align the cockpit rail ListView cursor with visible route shortcuts such as global Inbox so bridge-delivered Down/Up starts from the row the rail marker shows. Cancel pending route completion updates when the user navigates the rail so an older route worker cannot snap the marker back.

Self-audit: touched only the Textual cockpit UI layer and cockpit tests; no store/domain/facade imports or boundary crossings.