### PR TITLE
Fix #1127 restore inbox filter bridge

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -7150,6 +7150,25 @@ class PollyInboxApp(App[None]):
         # paint on a narrow pane is already vertical (no flash of the
         # unreadable side-by-side split before the first resize).
         self._apply_stacked_layout()
+        # #1127 — the interactive Inbox is a separate right-pane
+        # Textual app, so it needs its own TTY-less bridge. Without it,
+        # `pm cockpit-send-key /` falls back to the rail's `cockpit-*`
+        # socket and never reaches the Inbox filter binding.
+        try:
+            from pollypm.cockpit_input_bridge import start_input_bridge
+            self._input_bridge_handle = start_input_bridge(
+                self, kind="pane-inbox", config_path=self.config_path,
+            )
+        except Exception:  # noqa: BLE001
+            self._input_bridge_handle = None
+
+    def on_unmount(self) -> None:
+        bridge = getattr(self, "_input_bridge_handle", None)
+        if bridge is not None:
+            try:
+                bridge.stop()
+            except Exception:  # noqa: BLE001
+                pass
 
     # #1078 — switch to stacked (detail-below-list) layout when the
     # detail column would otherwise drop below this many cols of usable
@@ -7200,6 +7219,21 @@ class PollyInboxApp(App[None]):
             focused is self.reply_input and not self.reply_input.value
         ):
             self.list_view.focus()
+
+    def on_key(self, event: events.Key) -> None:
+        """Treat bridge-delivered literal `/` like the terminal slash key.
+
+        ``App.simulate_key("/")`` preserves the character so focused
+        Inputs can type it, but Textual bindings listen for the named
+        ``slash`` key. The bridge path needs to open filtering from list
+        focus without stealing literal slash input once a text field owns
+        focus.
+        """
+        if self.reply_input.has_focus or self.filter_input.has_focus:
+            return
+        if event.key == "/" or getattr(event, "character", None) == "/":
+            event.stop()
+            self.action_start_filter()
 
     # ------------------------------------------------------------------
     # Data loading

--- a/tests/test_cockpit_inbox_ui.py
+++ b/tests/test_cockpit_inbox_ui.py
@@ -2163,6 +2163,42 @@ def test_inbox_filter_mode_shows_prompt_before_typing(inbox_env) -> None:
     _run(body())
 
 
+def test_inbox_filter_bridge_literal_slash_opens_input(inbox_env) -> None:
+    """#1127: `pm cockpit-send-key /` opens the right-pane Inbox filter."""
+    if not _load_config_compatible(inbox_env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_input_bridge import send_key
+    from pollypm.cockpit_ui import PollyInboxApp
+
+    app = PollyInboxApp(inbox_env["config_path"])
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            initial_count = len(_visible_titles(app))
+            assert initial_count > 1
+            handle = getattr(app, "_input_bridge_handle", None)
+            assert handle is not None
+            assert handle.socket_path.name.startswith("pane_inbox-")
+
+            send_key(handle.socket_path, "/")
+            await pilot.pause(0.2)
+
+            assert app.filter_bar.display is True
+            assert app.filter_input.display is True
+            assert app.filter_input.has_focus
+
+            for key in ("V", "C", "L"):
+                send_key(handle.socket_path, key)
+            await pilot.pause(0.3)
+
+            assert app.filter_input.value == "VCL"
+            assert _visible_titles(app) == ["Deploy blocked"]
+            assert len(_visible_titles(app)) < initial_count
+
+    _run(body())
+
+
 def test_background_refresh_skips_when_content_unchanged(inbox_env, inbox_app) -> None:
     """The visible flash every ~8s was caused by the background refresh
     calling ListView.clear() and re-appending every row on every tick,


### PR DESCRIPTION
Closes #1127

Restores TTY-less `pm cockpit-send-key /` behavior for the right-pane Inbox by starting an Inbox-scoped input bridge and handling the bridge's literal slash key as the filter shortcut. Adds a regression test that sends `/VCL` through the bridge and verifies the filter narrows the list.

Layer audit: UI only (`PollyInboxApp` and its Textual test); no facade, domain, or store/IO changes.