### PR TITLE
Fix #1130 settings narrow nav keys

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -1656,6 +1656,22 @@ class PollyCockpitApp(App[None]):
         if callable(send_method):
             send_method(key)
 
+    def _send_key_to_settings_pane(self, key: str) -> None:
+        delivered = None
+        try:
+            from pollypm.cockpit_input_bridge import send_key_to_first_live
+            delivered = send_key_to_first_live(
+                self.config_path, key, kind="settings", timeout=0.2,
+            )
+        except Exception:  # noqa: BLE001
+            delivered = None
+        if delivered is not None:
+            return
+        try:
+            self._send_key_to_right_pane(key)
+        except Exception:  # noqa: BLE001
+            pass
+
     def _cancel_pending_route_selection(self) -> None:
         controller = getattr(self, "_navigation_controller", None)
         current_id = getattr(controller, "current_request_id", None)
@@ -2233,15 +2249,14 @@ class PollyCockpitApp(App[None]):
             self._last_nav_change = self._tick_count
             self._apply_active_view_to_rows()
 
-    # j/k always navigate the rail's own item list — including
+    # j/k normally navigate the rail's own item list — including
     # stepping over the ``── projects ──`` divider (which is a
     # ``disabled=True`` ListItem so Textual's ListView correctly
     # skips it) and remaining a no-op once the cursor reaches the
-    # first/last selectable row. The keys are claimed by the rail's
-    # priority binding regardless of cursor position; we never call
-    # ``tmux send-keys`` for j/k, which previously leaked the byte
-    # into whatever process owned the right-pane TTY (#918, reverts
-    # the right-pane forward added in #856).
+    # first/last selectable row. The one exception is Settings: its
+    # pane advertises j/k section browsing, so while Settings is active
+    # these keys are delivered to that pane instead of moving the rail
+    # cursor (#1130).
     #
     # ``⚙ Settings`` lives in a separate ``Static`` widget below the
     # nav ``ListView`` (so a long project list can scroll while the
@@ -2277,8 +2292,8 @@ class PollyCockpitApp(App[None]):
         self._apply_active_view_to_rows()
 
     def action_cursor_down(self) -> None:
-        # Already on the virtual Settings row — nothing below it.
         if self.selected_key == "settings":
+            self._send_key_to_settings_pane("j")
             return
         last_idx = self._last_nav_index()
         # On the last selectable nav row + Settings is visible → step
@@ -2297,14 +2312,11 @@ class PollyCockpitApp(App[None]):
         self._sync_selected_from_nav()
 
     def action_cursor_up(self) -> None:
+        if self.selected_key == "settings":
+            self._send_key_to_settings_pane("k")
+            return
         # Step up off the virtual Settings row onto the last
         # selectable nav row (#1080).
-        if self.selected_key == "settings":
-            last_idx = self._last_nav_index()
-            if last_idx is not None:
-                self.nav.index = last_idx
-                self._sync_selected_from_nav()
-            return
         if self.nav.index is None:
             self.nav.index = 0
         else:
@@ -4303,6 +4315,21 @@ class PollySettingsPaneApp(App[None]):
         # Alert toast surface removed in #956 — alerts still raise/clear
         # via the data layer; ``a`` opens the alert list in Metrics.
         self._apply_narrow_class()
+        try:
+            from pollypm.cockpit_input_bridge import start_input_bridge
+            self._input_bridge_handle = start_input_bridge(
+                self, kind="settings", config_path=self.config_path,
+            )
+        except Exception:  # noqa: BLE001
+            self._input_bridge_handle = None
+
+    def on_unmount(self) -> None:
+        bridge = getattr(self, "_input_bridge_handle", None)
+        if bridge is not None:
+            try:
+                bridge.stop()
+            except Exception:  # noqa: BLE001
+                pass
 
     # Threshold below which the side-by-side nav + content layout
     # collapses into letter-by-letter wrapping (#865). Empirically a

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -5081,27 +5081,30 @@ def test_cockpit_j_at_last_nav_row_steps_onto_settings() -> None:
         f"j from Activity should land on Settings; got {app.selected_key!r}"
     )
 
-    # Repeat j on Settings is a no-op (nothing below).
+    # Repeat j on Settings belongs to the Settings pane's own nav.
+    sent: list[str] = []
+    app._send_key_to_settings_pane = lambda key: sent.append(key)  # type: ignore[method-assign]
     app.action_cursor_down()
     assert app.selected_key == "settings"
+    assert sent == ["j"]
 
 
-def test_cockpit_k_off_settings_returns_to_last_nav_row() -> None:
-    """k from the virtual Settings row lands on the last selectable nav
-    row so the round-trip is symmetric (#1080)."""
+def test_cockpit_k_on_settings_forwards_to_settings_pane() -> None:
+    """k from Settings belongs to the Settings pane's own nav (#1130)."""
     items = [_StubItem("polly"), _StubItem("activity")]
     app, nav = _make_rail_app_with_settings(
         items,
         items_keys=["polly", "activity", "settings"],
         selected_key="settings",
     )
-    nav.index = 0  # cursor parked anywhere; k uses last_nav_index
+    nav.index = 0
+    sent: list[str] = []
+    app._send_key_to_settings_pane = lambda key: sent.append(key)  # type: ignore[method-assign]
 
     app.action_cursor_up()
-    assert app.selected_key == "activity", (
-        f"k from Settings should land on Activity; got {app.selected_key!r}"
-    )
-    assert nav.index == 1
+    assert app.selected_key == "settings"
+    assert nav.index == 0
+    assert sent == ["k"]
 
 
 def test_cockpit_G_lands_on_settings_when_visible() -> None:

--- a/tests/test_settings_ui.py
+++ b/tests/test_settings_ui.py
@@ -439,6 +439,35 @@ def test_settings_mounts_all_sections(settings_env) -> None:
     _run(body())
 
 
+def test_settings_pane_registers_input_bridge(settings_env, monkeypatch) -> None:
+    app = settings_env["app"]
+    calls: list[tuple[str, Path]] = []
+    stopped: list[bool] = []
+
+    class _Handle:
+        def stop(self) -> None:
+            stopped.append(True)
+
+    def _start_input_bridge(app_arg, *, kind: str, config_path: Path):  # noqa: ANN001
+        assert app_arg is app
+        calls.append((kind, config_path))
+        return _Handle()
+
+    monkeypatch.setattr(
+        "pollypm.cockpit_input_bridge.start_input_bridge",
+        _start_input_bridge,
+    )
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+
+    _run(body())
+
+    assert calls == [("settings", settings_env["config_path"])]
+    assert stopped == [True]
+
+
 def test_accounts_section_lists_configured_accounts(settings_env) -> None:
     app = settings_env["app"]
 


### PR DESCRIPTION
Closes #1130

Routes j/k from the cockpit rail into the Settings pane while Settings is active, so narrow-mode section browsing follows the pane hint instead of moving the rail. The Settings pane now registers its own input bridge so `pm cockpit-send-key` can deliver those forwarded keys in TTY-less runs.

Self-audit: touched UI-layer code only (`cockpit_ui.py`) plus UI regression tests; no facade, domain, or store changes.