### PR TITLE
Fix #1132 restore bridge help key

### DIFF
--- a/src/pollypm/cockpit_input_bridge.py
+++ b/src/pollypm/cockpit_input_bridge.py
@@ -85,6 +85,14 @@ _SPECIAL_TOKENS: dict[str, str] = {
     "<end>": "end",
 }
 
+# `simulate_key("?")` creates a literal-character event whose key is
+# `"?"`; Textual's keyboard bindings for the physical ? key are named
+# `question_mark`. Normalize that one user-facing token so
+# `pm cockpit-send-key '?'` follows the same path as a real keypress.
+_CHAR_KEY_ALIASES: dict[str, str] = {
+    "?": "question_mark",
+}
+
 
 def _normalize_token(raw: str) -> str | None:
     """Map a wire-format token to the form ``simulate_key`` expects."""
@@ -94,6 +102,8 @@ def _normalize_token(raw: str) -> str | None:
     lowered = token.lower()
     if lowered in _SPECIAL_TOKENS:
         return _SPECIAL_TOKENS[lowered]
+    if token in _CHAR_KEY_ALIASES:
+        return _CHAR_KEY_ALIASES[token]
     # Allow ``ctrl+x`` / ``shift+a`` style modifiers verbatim — Textual
     # already understands those.
     return token

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -137,6 +137,19 @@ def test_special_tokens_normalize_to_textual_key_names(fake_config: Path) -> Non
         handle.stop()
 
 
+def test_literal_question_mark_normalizes_to_textual_key_name(
+    fake_config: Path,
+) -> None:
+    app = _FakeApp()
+    handle = start_input_bridge(app, kind="cockpit", config_path=fake_config)
+    assert handle is not None
+    try:
+        send_key(handle.socket_path, "?")
+        assert _wait_for(lambda: app.keys == ["question_mark"])
+    finally:
+        handle.stop()
+
+
 def test_modifier_tokens_pass_through(fake_config: Path) -> None:
     app = _FakeApp()
     handle = start_input_bridge(app, kind="cockpit", config_path=fake_config)

--- a/tests/test_keyboard_help.py
+++ b/tests/test_keyboard_help.py
@@ -153,6 +153,34 @@ def test_question_mark_opens_help_modal(
     _run(body())
 
 
+@pytest.mark.parametrize("app_factory_name", ["PollyCockpitApp", "PollyInboxApp"])
+def test_bridge_literal_question_mark_opens_help_modal(
+    single_project_env, app_factory_name,
+) -> None:
+    """``pm cockpit-send-key '?'`` opens help from rail and inbox surfaces."""
+    if not _load_config_compatible(single_project_env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm import cockpit_ui
+    from pollypm.cockpit_input_bridge import send_key
+
+    cls = getattr(cockpit_ui, app_factory_name)
+    app = cls(single_project_env["config_path"])
+
+    async def body() -> None:
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            assert _find_help_modal(app) is None
+            handle = getattr(app, "_input_bridge_handle", None)
+            assert handle is not None
+
+            send_key(handle.socket_path, "?")
+            await pilot.pause(0.2)
+
+            assert _find_help_modal(app) is not None
+
+    _run(body())
+
+
 def test_question_mark_opens_help_modal_project_dashboard(
     single_project_env,
 ) -> None:


### PR DESCRIPTION
Closes #1132

Normalizes bridge-delivered literal `?` to Textual's `question_mark` key name so `pm cockpit-send-key '?'` triggers the existing help bindings from the cockpit rail and inbox pane. Added tests for bridge normalization and help modal opening via the bridge.

Self-audit: UI input bridge and UI tests only; no service facade, domain, or store changes; no cross-layer imports.