### PR TITLE
Fix #1138 align rail nav cursor

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -2285,6 +2285,35 @@ class PollyCockpitApp(App[None]):
                 return i
         return None
 
+    def _nav_index_for_key(self, key: str) -> int | None:
+        try:
+            children = list(self.nav.children)
+        except AttributeError:
+            return None
+        for i, child in enumerate(children):
+            if getattr(child, "disabled", False):
+                continue
+            if isinstance(child, RailItem):
+                child_key = child.cockpit_key
+            else:
+                child_key = getattr(child, "cockpit_key", None)
+            if child_key == key:
+                return i
+        return None
+
+    def _align_nav_cursor_to_selected_key(self) -> None:
+        """Make the hidden ListView cursor match the visible rail marker."""
+        if not isinstance(self.selected_key, str) or self.selected_key == "settings":
+            return
+        index = self._nav_index_for_key(self.selected_key)
+        if index is None or self.nav.index == index:
+            return
+        self._suspend_selection_events = True
+        try:
+            self.nav.index = index
+        finally:
+            self._suspend_selection_events = False
+
     def _select_settings_row(self) -> None:
         self._cancel_pending_route_selection()
         self.selected_key = "settings"
@@ -2295,6 +2324,7 @@ class PollyCockpitApp(App[None]):
         if self.selected_key == "settings":
             self._send_key_to_settings_pane("j")
             return
+        self._align_nav_cursor_to_selected_key()
         last_idx = self._last_nav_index()
         # On the last selectable nav row + Settings is visible → step
         # down onto Settings instead of stalling at Activity (#1080).
@@ -2315,6 +2345,7 @@ class PollyCockpitApp(App[None]):
         if self.selected_key == "settings":
             self._send_key_to_settings_pane("k")
             return
+        self._align_nav_cursor_to_selected_key()
         # Step up off the virtual Settings row onto the last
         # selectable nav row (#1080).
         if self.nav.index is None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -5133,6 +5133,35 @@ def _make_rail_app_with_settings(
     return app, nav
 
 
+def test_cockpit_down_starts_from_visible_project_subtab_after_pane_swap() -> None:
+    """#1138: a stale hidden nav cursor must not make Down look like a no-op.
+
+    A right-pane route can update ``selected_key`` to the PM sub-tab while
+    the ListView cursor still points at Dashboard. The next Down should
+    start from the visible PM marker and land on Tasks in one press.
+    """
+    items = [
+        _StubItem("project:demo"),
+        _StubItem("project:demo:dashboard"),
+        _StubItem("project:demo:session"),
+        _StubItem("project:demo:issues"),
+        _StubItem("project:demo:settings"),
+    ]
+    keys = [item.cockpit_key for item in items if item.cockpit_key is not None]
+    app, nav = _make_rail_app_with_settings(
+        items,
+        items_keys=keys,
+        selected_key="project:demo:session",
+    )
+    app._suspend_selection_events = False
+    nav.index = 1  # stale Dashboard cursor; visible marker is PM Chat.
+
+    app.action_cursor_down()
+
+    assert nav.index == 3
+    assert app.selected_key == "project:demo:issues"
+
+
 def test_cockpit_j_at_last_nav_row_steps_onto_settings() -> None:
     """j on the last nav row (Activity) lands on Settings when the gear
     row is visible — the blank gap between Activity and Settings must


### PR DESCRIPTION
Closes #1138

Aligns the rail ListView cursor to the visible selected project sub-tab before applying j/k or arrow navigation, so the first Down press after a right-pane pane swap moves from PM Chat to Tasks instead of appearing to do nothing.

Self-audit: touched only the UI layer (src/pollypm/cockpit_ui.py) plus a focused cockpit regression test; no facade, domain, store, IO, or boundary-crossing imports changed.