### PR TITLE
Fix #1139 carry round start env into launches

### DIFF
--- a/src/pollypm/runtime_env.py
+++ b/src/pollypm/runtime_env.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping
 from pathlib import Path
 
 from pollypm.models import AccountConfig, ProviderKind
+
+LAUNCH_CONTEXT_ENV_KEYS = ("ROUND_START_ISO_TS",)
 
 
 def claude_config_dir(home: Path) -> Path:
@@ -12,6 +15,23 @@ def claude_config_dir(home: Path) -> Path:
 
 def codex_home_dir(home: Path) -> Path:
     return home / ".codex"
+
+
+def launch_context_env(
+    *,
+    base_env: Mapping[str, str] | None = None,
+    ambient_env: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Carry explicit test/orchestration context into tmux-launched agents."""
+    env = dict(base_env or {})
+    ambient = ambient_env if ambient_env is not None else os.environ
+    for key in LAUNCH_CONTEXT_ENV_KEYS:
+        if key in env:
+            continue
+        value = ambient.get(key)
+        if value:
+            env[key] = value
+    return env
 
 
 def provider_profile_env_for_provider(

--- a/src/pollypm/runtimes/docker.py
+++ b/src/pollypm/runtimes/docker.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from pollypm.models import AccountConfig, ProjectSettings
 from pollypm.providers.base import LaunchCommand
-from pollypm.runtime_env import container_runtime_env_for_provider
+from pollypm.runtime_env import container_runtime_env_for_provider, launch_context_env
 from pollypm.runtimes.base import WrappedRuntimeCommand
 
 
@@ -49,7 +49,11 @@ class DockerRuntimeAdapter:
 
         account.home.mkdir(parents=True, exist_ok=True)
 
-        env = container_runtime_env_for_provider(account.provider, Path(self.home_mount), base_env=command.env)
+        env = container_runtime_env_for_provider(
+            account.provider,
+            Path(self.home_mount),
+            base_env=launch_context_env(base_env=command.env),
+        )
 
         inner_parts = [
             "mkdir -p \"$HOME\" \"$XDG_CONFIG_HOME\" \"$XDG_DATA_HOME\" \"$XDG_STATE_HOME\"",
@@ -135,7 +139,7 @@ class DockerRuntimeAdapter:
         env = container_runtime_env_for_provider(
             account.provider,
             Path(self.home_mount),
-            base_env=command.env,
+            base_env=launch_context_env(base_env=command.env),
         )
 
         inner_parts = [

--- a/src/pollypm/runtimes/local.py
+++ b/src/pollypm/runtimes/local.py
@@ -10,7 +10,7 @@ import subprocess
 
 from pollypm.models import AccountConfig, ProjectSettings
 from pollypm.providers.base import LaunchCommand
-from pollypm.runtime_env import provider_profile_env
+from pollypm.runtime_env import launch_context_env, provider_profile_env
 from pollypm.runtimes.base import WrappedRuntimeCommand
 
 logger = logging.getLogger(__name__)
@@ -156,7 +156,10 @@ class LocalRuntimeAdapter:
         account: AccountConfig,
         project: ProjectSettings,
     ) -> str:
-        env = provider_profile_env(account, base_env=command.env)
+        env = provider_profile_env(
+            account,
+            base_env=launch_context_env(base_env=command.env),
+        )
         # #965 — resolve agent binary to an absolute path so the
         # runtime_launcher's ``os.execvpe`` does not need to search a
         # sanitized child-process PATH (npm-global stripped under tmux).
@@ -204,7 +207,12 @@ class LocalRuntimeAdapter:
         project: ProjectSettings,
     ) -> WrappedRuntimeCommand:
         env = os.environ.copy()
-        env.update(provider_profile_env(account, base_env=command.env))
+        env.update(
+            provider_profile_env(
+                account,
+                base_env=launch_context_env(base_env=command.env),
+            )
+        )
         src_dir = (project.root_dir / "src").resolve()
         if src_dir.is_dir():
             existing = env.get("PYTHONPATH")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -38,6 +38,40 @@ def test_local_runtime_wraps_home_and_command(tmp_path: Path) -> None:
     assert "pollypm.runtime_launcher" in wrapped
 
 
+def test_local_runtime_payload_carries_round_start_env(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    round_start = "2026-05-04T15:14:55+00:00"
+    monkeypatch.setenv("ROUND_START_ISO_TS", round_start)
+    session = SessionConfig(
+        name="worker",
+        role="worker",
+        provider=ProviderKind.CODEX,
+        account="codex_primary",
+        cwd=tmp_path,
+        project="demo-project",
+        prompt="hello",
+    )
+    account = AccountConfig(
+        name="codex_primary",
+        provider=ProviderKind.CODEX,
+        email="codex@example.com",
+        runtime=RuntimeKind.LOCAL,
+        home=tmp_path / "home",
+    )
+
+    command = CodexAdapter().build_launch_command(session, account)
+    wrapped = LocalRuntimeAdapter().wrap_command(
+        command,
+        account,
+        ProjectSettings(root_dir=tmp_path),
+    )
+
+    payload = _decoded_payload(wrapped)
+    assert payload["env"]["ROUND_START_ISO_TS"] == round_start
+
+
 def test_docker_runtime_mounts_workspace_and_home(tmp_path: Path) -> None:
     project_root = tmp_path / "repo"
     cwd = project_root / "subdir"
@@ -72,6 +106,43 @@ def test_docker_runtime_mounts_workspace_and_home(tmp_path: Path) -> None:
     assert f"{project_root.resolve()}:/workspace" in wrapped
     assert f"{home.resolve()}:/home/pollypm" in wrapped
     assert "CODEX_HOME=/home/pollypm/.codex" in wrapped
+
+
+def test_docker_runtime_exports_round_start_env(tmp_path: Path, monkeypatch) -> None:
+    round_start = "2026-05-04T15:14:55+00:00"
+    monkeypatch.setenv("ROUND_START_ISO_TS", round_start)
+    project_root = tmp_path / "repo"
+    cwd = project_root / "subdir"
+    home = tmp_path / "home"
+    cwd.mkdir(parents=True)
+    home.mkdir(parents=True)
+
+    session = SessionConfig(
+        name="worker",
+        role="worker",
+        provider=ProviderKind.CODEX,
+        account="codex_primary",
+        cwd=cwd,
+        project="demo-project",
+        prompt="hello",
+    )
+    account = AccountConfig(
+        name="codex_primary",
+        provider=ProviderKind.CODEX,
+        email="codex@example.com",
+        runtime=RuntimeKind.DOCKER,
+        home=home,
+        docker_image="ghcr.io/example/pollypm-agent:latest",
+    )
+
+    command = CodexAdapter().build_launch_command(session, account)
+    wrapped = DockerRuntimeAdapter().wrap_command(
+        command,
+        account,
+        ProjectSettings(root_dir=project_root),
+    )
+
+    assert f"ROUND_START_ISO_TS={round_start}" in wrapped
 
 
 def test_claude_runtime_sets_provider_native_config_dir(tmp_path: Path) -> None:

--- a/tests/test_runtime_env.py
+++ b/tests/test_runtime_env.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 
 from pollypm.models import AccountConfig, ProviderKind
-from pollypm.runtime_env import container_runtime_env_for_provider, provider_profile_env
+from pollypm.runtime_env import (
+    container_runtime_env_for_provider,
+    launch_context_env,
+    provider_profile_env,
+)
 
 
 def test_provider_profile_env_sets_provider_specific_home_variable(tmp_path: Path) -> None:
@@ -31,3 +35,20 @@ def test_container_runtime_env_sets_xdg_and_provider_paths(tmp_path: Path) -> No
     assert env["XDG_DATA_HOME"] == str(tmp_path / "claude-home" / ".local/share")
     assert env["XDG_STATE_HOME"] == str(tmp_path / "claude-home" / ".local/state")
     assert env["CLAUDE_CONFIG_DIR"] == str(tmp_path / "claude-home" / ".claude")
+
+
+def test_launch_context_env_carries_round_start_without_overriding() -> None:
+    env = launch_context_env(
+        base_env={"KEEP": "1"},
+        ambient_env={"ROUND_START_ISO_TS": "2026-05-04T15:14:55+00:00"},
+    )
+
+    assert env["KEEP"] == "1"
+    assert env["ROUND_START_ISO_TS"] == "2026-05-04T15:14:55+00:00"
+
+    explicit = launch_context_env(
+        base_env={"ROUND_START_ISO_TS": "explicit"},
+        ambient_env={"ROUND_START_ISO_TS": "ambient"},
+    )
+
+    assert explicit["ROUND_START_ISO_TS"] == "explicit"


### PR DESCRIPTION
Closes #1139

Propagates ROUND_START_ISO_TS from the orchestrating process into local runtime launcher payloads and Docker runtime exports so spawned agent shells can bound scenario log checks to the current round.

Layer audit: touched runtime environment plumbing in src/pollypm/runtime_env.py and runtime wrappers in src/pollypm/runtimes/{local,docker}. No UI, store, or domain-layer imports were added.