### PR TITLE
Fix #1140 carry round counters into launches

### DIFF
--- a/src/pollypm/plugins_builtin/default_launch_planner/planner.py
+++ b/src/pollypm/plugins_builtin/default_launch_planner/planner.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 import logging
+import os
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Callable
 
 from pollypm.models import AccountConfig, ProviderKind, SessionConfig, SessionLaunchSpec
@@ -37,6 +39,12 @@ if TYPE_CHECKING:
 from pollypm.models import CONTROL_ROLES as _CONTROL_ROLES
 
 _ROUTED_ROLES = frozenset({"operator-pm", "architect", "worker", "reviewer"})
+_ROUND_START_ENV_KEYS = (
+    "ROUND_START_ISO_TS",
+    "ROUND_START_ERRNO24",
+    "ROUND_START_HBFAIL",
+    "ROUND_START_MISSING_WINDOW",
+)
 _log = logging.getLogger(__name__)
 
 
@@ -64,6 +72,27 @@ def _write_codex_agents_md_to_disk(account: AccountConfig, content: str) -> None
     target = codex_home_dir(account.home) / "AGENTS.md"
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(content.rstrip() + "\n", encoding="utf-8")
+
+
+def _carry_round_start_env(
+    launch: LaunchCommand,
+    *,
+    ambient_env: Mapping[str, str] | None = None,
+) -> LaunchCommand:
+    env = dict(launch.env)
+    ambient = ambient_env if ambient_env is not None else os.environ
+    changed = False
+    for key in _ROUND_START_ENV_KEYS:
+        if key in env:
+            continue
+        value = ambient.get(key)
+        if not value:
+            continue
+        env[key] = value
+        changed = True
+    if not changed:
+        return launch
+    return replace(launch, env=env)
 
 
 def _preferred_account_names(
@@ -169,6 +198,7 @@ class DefaultLaunchPlanner:
                 )
             provider = get_provider(effective.provider, root_dir=ctx.config.project.root_dir)
             launch = provider.build_launch_command(effective, account)
+            launch = _carry_round_start_env(launch)
             launch = ctx.apply_role_launch_restrictions(effective, launch)
             # Architect warm-resume: when an architect was previously
             # idle-closed by the heartbeat sweep, swap its argv to the

--- a/tests/test_launch_planner.py
+++ b/tests/test_launch_planner.py
@@ -250,6 +250,29 @@ def test_planner_routes_operator_to_codex_when_compatible_account_exists(tmp_pat
     ]
 
 
+def test_planner_carries_round_start_env_into_launch_payload(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ROUND_START_ISO_TS", "2026-05-04T20:01:00Z")
+    monkeypatch.setenv("ROUND_START_ERRNO24", "983")
+    monkeypatch.setenv("ROUND_START_HBFAIL", "507")
+    monkeypatch.setenv("ROUND_START_MISSING_WINDOW", "0")
+    config = _config(tmp_path)
+    config.accounts["claude_controller"].env["ROUND_START_ERRNO24"] = "explicit"
+    sup = Supervisor(config)
+    sup.ensure_layout()
+
+    launch = next(item for item in sup.plan_launches() if item.session.name == "operator")
+    payload = _decode_launch_payload(launch.command)
+
+    env = payload["env"]
+    assert env["ROUND_START_ISO_TS"] == "2026-05-04T20:01:00Z"
+    assert env["ROUND_START_ERRNO24"] == "explicit"
+    assert env["ROUND_START_HBFAIL"] == "507"
+    assert env["ROUND_START_MISSING_WINDOW"] == "0"
+
+
 def test_supervisor_launch_planner_property_returns_default(tmp_path: Path) -> None:
     """Supervisor exposes the configured planner via the ``launch_planner`` property."""
     config = _config(tmp_path)


### PR DESCRIPTION
Closes #1140

Carries the explicit ROUND_START_* scenario context keys from the orchestrating process into each planned LaunchCommand env before runtime wrapping. This includes ROUND_START_ERRNO24, ROUND_START_HBFAIL, and ROUND_START_MISSING_WINDOW so counter-stability testers can compute round-local deltas.

Layer audit: touched the default launch planner in plugins_builtin/default_launch_planner and its planner test. No UI, store/IO, facade, or cross-layer imports were added.