### PR TITLE
Fix #1148 handle corrupt state db

### DIFF
--- a/src/pollypm/cli_features/migrate.py
+++ b/src/pollypm/cli_features/migrate.py
@@ -110,7 +110,10 @@ def register_migrate_commands(app: typer.Typer) -> None:
 def _run_check(db_path: Path) -> None:
     from pollypm.store import migrations as _migrations
 
-    status = _migrations.inspect(db_path)
+    try:
+        status = _migrations.inspect(db_path)
+    except _migrations.UnusableDatabaseError as exc:
+        _migrations.exit_unusable_database(exc)
     if status.up_to_date:
         typer.echo(f"All migrations up to date ({db_path}).")
         raise typer.Exit(code=0)
@@ -227,7 +230,10 @@ def _run_apply(db_path: Path, *, force: bool = False) -> None:
         if live:
             _refuse_live_processes(live)
 
-    outcome = _migrations.apply(db_path)
+    try:
+        outcome = _migrations.apply(db_path)
+    except _migrations.UnusableDatabaseError as exc:
+        _migrations.exit_unusable_database(exc)
     if outcome.already_up_to_date:
         typer.echo("All migrations up to date.")
     else:

--- a/src/pollypm/cli_features/session_runtime.py
+++ b/src/pollypm/cli_features/session_runtime.py
@@ -247,6 +247,7 @@ def register_session_runtime_commands(app: typer.Typer, *, helpers) -> None:
     ) -> None:
         if not helpers._config_option_was_explicit():
             config_path = helpers._discover_config_path(config_path)
+        helpers._enforce_migration_gate(config_path)
         from pollypm.service_api import PollyPMService
 
         payload = PollyPMService(config_path).session_status(session_name)

--- a/src/pollypm/store/migrations.py
+++ b/src/pollypm/store/migrations.py
@@ -45,6 +45,15 @@ NAMESPACE_STATE = "state"
 NAMESPACE_WORK = "work"
 
 
+class UnusableDatabaseError(RuntimeError):
+    """Raised when ``state.db`` exists but cannot be read as SQLite."""
+
+    def __init__(self, db_path: Path, detail: str) -> None:
+        self.db_path = db_path
+        self.detail = detail
+        super().__init__(f"{db_path}: {detail}")
+
+
 @dataclass(frozen=True)
 class PendingMigration:
     """One migration that has not yet been applied to a target DB."""
@@ -121,6 +130,27 @@ def _readonly_connect(db_path: Path) -> sqlite3.Connection | None:
         return None
 
 
+def _looks_like_unusable_database_error(exc: sqlite3.Error) -> bool:
+    detail = str(exc).lower()
+    return (
+        "file is not a database" in detail
+        or "database disk image is malformed" in detail
+        or "file is encrypted or is not a database" in detail
+    )
+
+
+def _ensure_readable_sqlite(conn: sqlite3.Connection, db_path: Path) -> None:
+    """Fail fast when an existing file is not a usable SQLite database."""
+    try:
+        row = conn.execute("PRAGMA quick_check").fetchone()
+    except sqlite3.Error as exc:
+        if _looks_like_unusable_database_error(exc):
+            raise UnusableDatabaseError(db_path, str(exc)) from exc
+        return
+    if row and str(row[0]).lower() != "ok":
+        raise UnusableDatabaseError(db_path, str(row[0]))
+
+
 def _applied_version(conn: sqlite3.Connection, table: str) -> int:
     """Return ``MAX(version)`` from a schema-tracking table, 0 if missing."""
     try:
@@ -163,6 +193,7 @@ def inspect(db_path: Path) -> MigrationStatus:
         )
 
     try:
+        _ensure_readable_sqlite(conn, db_path)
         applied = {
             NAMESPACE_STATE: _applied_version(conn, "schema_version"),
             NAMESPACE_WORK: _applied_version(conn, "work_schema_version"),
@@ -372,6 +403,45 @@ def format_pending_summary(status: MigrationStatus) -> str:
     return "\n".join(lines)
 
 
+def format_unusable_database_message(error: UnusableDatabaseError) -> str:
+    """Render a friendly corruption/recovery message for CLI surfaces."""
+    from pollypm.structured_message import StructuredUserMessage
+
+    details = "\n".join([
+        f"DB: {error.db_path}",
+        f"SQLite error: {error.detail}",
+    ])
+    msg = StructuredUserMessage(
+        summary="Cannot use state.db — the file is not a valid SQLite database.",
+        why=(
+            "PollyPM could not read its central store. This is data-store "
+            "corruption, not a pending schema migration, so `pm migrate` "
+            "cannot repair it."
+        ),
+        next_action=(
+            "Run `pm doctor` to confirm the failure, then restore from a "
+            "recent backup with `pm restore <snapshot> --confirm` or move "
+            "the corrupt state.db aside before reinitializing."
+        ),
+        suggested_actions=(
+            ("Diagnose", "pm doctor"),
+            ("List backups", "ls ~/.pollypm/backups"),
+            (
+                "Restore backup",
+                "pm restore ~/.pollypm/backups/<snapshot>.db.gz --confirm",
+            ),
+        ),
+        details=details,
+    )
+    return msg.render_cli(show_details=True)
+
+
+def exit_unusable_database(error: UnusableDatabaseError, *, code: int = 2) -> None:
+    """Print the corruption message and exit with a non-zero CLI code."""
+    sys.stderr.write(format_unusable_database_message(error) + "\n")
+    raise SystemExit(code)
+
+
 # ---------------------------------------------------------------------------
 # Refuse-start gate
 # ---------------------------------------------------------------------------
@@ -456,7 +526,10 @@ def require_no_pending_or_exit(db_path: Path) -> None:
         return
     if not db_path.is_file():
         return
-    status = inspect(db_path)
+    try:
+        status = inspect(db_path)
+    except UnusableDatabaseError as exc:
+        exit_unusable_database(exc)
     if status.up_to_date:
         return
     sys.stderr.write(_format_refuse_start_message(status) + "\n")

--- a/tests/test_migration_gate.py
+++ b/tests/test_migration_gate.py
@@ -76,6 +76,11 @@ def _write_minimal_config(tmp_path: Path) -> Path:
     return config_path
 
 
+def _write_corrupt_db(path: Path) -> Path:
+    path.write_text("garbage", encoding="utf-8")
+    return path
+
+
 # ---------------------------------------------------------------------------
 # --check / --apply
 # ---------------------------------------------------------------------------
@@ -205,6 +210,16 @@ def test_synthetic_failing_migration_caught_by_check(
     assert version == expected
 
 
+def test_inspect_rejects_corrupt_state_db(tmp_path: Path) -> None:
+    db_path = _write_corrupt_db(tmp_path / "state.db")
+
+    with pytest.raises(mig_mod.UnusableDatabaseError) as exc:
+        mig_mod.inspect(db_path)
+
+    assert exc.value.db_path == db_path
+    assert "not a database" in exc.value.detail
+
+
 # ---------------------------------------------------------------------------
 # Refuse-start gate
 # ---------------------------------------------------------------------------
@@ -261,6 +276,24 @@ def test_cockpit_refuses_start_on_pending_migration(
     with pytest.raises(SystemExit) as exc:
         mig_mod.require_no_pending_or_exit(db_path)
     assert exc.value.code != 0
+
+
+def test_refuse_start_reports_corrupt_db_without_migration_advice(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    db_path = _write_corrupt_db(tmp_path / "state.db")
+
+    with pytest.raises(SystemExit) as exc:
+        mig_mod.require_no_pending_or_exit(db_path)
+
+    captured = capsys.readouterr()
+    assert exc.value.code == 2
+    assert "Cannot use state.db" in captured.err
+    assert "not a valid SQLite database" in captured.err
+    assert "pm doctor" in captured.err
+    assert "pm restore" in captured.err
+    assert "Cannot start" not in captured.err
+    assert "Apply (recommended)" not in captured.err
 
 
 def test_migration_gate_skipped_when_bypass_env_set(
@@ -332,6 +365,55 @@ def test_cli_migrate_check_outputs_up_to_date(tmp_path: Path) -> None:
     assert "up to date" in result.stdout.lower()
 
 
+def test_cli_migrate_check_reports_corrupt_db_without_traceback(tmp_path: Path) -> None:
+    config_path = _write_minimal_config(tmp_path)
+    _write_corrupt_db(tmp_path / "state.db")
+
+    app = _build_cli_app()
+    result = runner.invoke(app, ["--check", "--config", str(config_path)])
+
+    combined = result.stdout + "\n" + (result.stderr or "")
+    assert result.exit_code == 2, result.output
+    assert "Cannot use state.db" in combined
+    assert "not a valid SQLite database" in combined
+    assert "pm doctor" in combined
+    assert "Traceback" not in combined
+
+
+def test_cli_migrate_apply_reports_corrupt_db_without_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pollypm.cli_features import migrate as _migrate_mod
+
+    monkeypatch.setattr(_migrate_mod, "_live_pollypm_processes", lambda: [])
+    config_path = _write_minimal_config(tmp_path)
+    _write_corrupt_db(tmp_path / "state.db")
+
+    app = _build_cli_app()
+    result = runner.invoke(app, ["--apply", "--config", str(config_path)])
+
+    combined = result.stdout + "\n" + (result.stderr or "")
+    assert result.exit_code == 2, result.output
+    assert "Cannot use state.db" in combined
+    assert "pm migrate --apply" not in combined
+    assert "Traceback" not in combined
+
+
+def test_cli_status_reports_corrupt_db_without_traceback(tmp_path: Path) -> None:
+    from pollypm import cli as _cli
+
+    config_path = _write_minimal_config(tmp_path)
+    _write_corrupt_db(tmp_path / "state.db")
+
+    result = runner.invoke(_cli.app, ["status", "--config", str(config_path)])
+
+    combined = result.stdout + "\n" + (result.stderr or "")
+    assert result.exit_code == 2, result.output
+    assert "Cannot use state.db" in combined
+    assert "pm doctor" in combined
+    assert "Traceback" not in combined
+
+
 def test_cli_migrate_check_renders_failure_in_structured_shape(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -380,6 +462,9 @@ def test_cli_migrate_check_renders_failure_in_structured_shape(
 def test_cli_migrate_apply_reports_applied(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from pollypm.cli_features import migrate as _migrate_mod
+
+    monkeypatch.setattr(_migrate_mod, "_live_pollypm_processes", lambda: [])
     # No fresh DB this time — let --apply bootstrap it so the CLI prints
     # a non-empty "applied" list.
     config_path = _write_minimal_config(tmp_path)


### PR DESCRIPTION
Closes #1148

Detect existing state.db files that SQLite cannot read and render a structured corruption/recovery message instead of treating them as pending migrations or letting status/migrate crash.

Self-audit: touched the store migration facade for corruption classification and the CLI/migrate/status entrypoints that already route through the migration gate; no new cross-layer imports beyond the existing CLI-to-migration-gate path.