### PR TITLE
Fix #1149 restore Home quota indicator

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -3190,14 +3190,39 @@ class PollyDashboardApp(App[None]):
 
         self.done_body.update("\n".join(done_lines))
 
-        # ── Token chart ──
+        # ── Token chart + cached LLM account quota ──
+        chart_lines: list[str] = []
+        account_usages = getattr(data, "account_usages", [])
+        if account_usages:
+            chart_lines.append("[b]LLM account quota usage[/b]")
+            for usage in account_usages:
+                if usage.severity == "critical":
+                    marker = "[#f85149]▲[/#f85149]"
+                    suffix = " · over limit"
+                elif usage.severity == "warning":
+                    marker = "[#d29922]◆[/#d29922]"
+                    suffix = " · approaching ceiling"
+                else:
+                    marker = "[dim]·[/dim]"
+                    suffix = ""
+                label = usage.provider or usage.account_name
+                if usage.email:
+                    label = f"{label} ({usage.email})"
+                line = (
+                    f"{marker} {_escape(label)}  "
+                    f"[b]{usage.used_pct}%[/b] used of {_escape(usage.limit_label)}"
+                )
+                if usage.reset_at and usage.severity in {"warning", "critical"}:
+                    suffix += f" · resets {_escape(usage.reset_at)}"
+                chart_lines.append(line + suffix)
+            chart_lines.append("")
+
         if data.daily_tokens:
             values = [t for _, t in data.daily_tokens]
             max_val = max(values) or 1
             chart_height = 6
             bars = [max(0, min(chart_height, round(v / max_val * chart_height))) for v in values]
 
-            chart_lines: list[str] = []
             for row in range(chart_height, 0, -1):
                 line_chars: list[str] = []
                 for bar_h in bars:
@@ -3220,7 +3245,8 @@ class PollyDashboardApp(App[None]):
             )
             self.chart_body.update("\n".join(chart_lines))
         else:
-            self.chart_body.update("[dim]No token data yet[/dim]")
+            chart_lines.append("[dim]No token data yet[/dim]")
+            self.chart_body.update("\n".join(chart_lines))
 
         # ── Footer ──
         sweep_word = "sweep" if data.sweep_count_24h == 1 else "sweeps"

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import re
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -139,6 +139,18 @@ class InboxPreview:
 
 
 @dataclass(slots=True)
+class AccountQuotaUsage:
+    account_name: str
+    provider: str
+    email: str
+    used_pct: int
+    summary: str
+    severity: str
+    limit_label: str = "limit"
+    reset_at: str = ""
+
+
+@dataclass(slots=True)
 class DashboardData:
     active_sessions: list[SessionActivity]
     recent_commits: list[CommitInfo]
@@ -152,6 +164,7 @@ class DashboardData:
     recovery_count_24h: int
     inbox_count: int
     alert_count: int
+    account_usages: list[AccountQuotaUsage] = field(default_factory=list)
     briefing: str = ""  # morning briefing narrative (if user was away)
 
 
@@ -639,6 +652,80 @@ def _recent_inbox_messages(config: PollyPMConfig, *, limit: int = 3) -> list[Inb
     return previews[:limit]
 
 
+def _provider_label(provider: object) -> str:
+    raw = getattr(provider, "value", provider)
+    text = str(raw or "").strip().lower()
+    if text in {"claude", "anthropic"}:
+        return "Anthropic"
+    if text == "codex":
+        return "OpenAI"
+    if not text:
+        return ""
+    return text.capitalize()
+
+
+def _quota_severity(used_pct: int) -> str:
+    if used_pct >= 95:
+        return "critical"
+    if used_pct >= 80:
+        return "warning"
+    return "ok"
+
+
+def _quota_limit_label(period_label: object) -> str:
+    label = str(period_label or "").strip().lower()
+    if "week" in label:
+        return "weekly limit"
+    if "month" in label:
+        return "monthly limit"
+    if "day" in label:
+        return "daily limit"
+    return "limit"
+
+
+def _account_quota_usage(config: PollyPMConfig, store: StateStore) -> list[AccountQuotaUsage]:
+    """Return cached LLM account quota percentages for the Home dashboard."""
+    rows: list[AccountQuotaUsage] = []
+    seen_emails: set[str] = set()
+    for account_name, account in getattr(config, "accounts", {}).items():
+        email = (getattr(account, "email", None) or "").strip()
+        if email:
+            if email in seen_emails:
+                continue
+            seen_emails.add(email)
+        try:
+            usage = store.get_account_usage(account_name)
+        except Exception:  # noqa: BLE001
+            usage = None
+        used_pct = getattr(usage, "used_pct", None) if usage is not None else None
+        if used_pct is None:
+            continue
+        pct = int(used_pct)
+        rows.append(
+            AccountQuotaUsage(
+                account_name=account_name,
+                provider=_provider_label(
+                    getattr(account, "provider", None)
+                    or getattr(usage, "provider", "")
+                ),
+                email=email,
+                used_pct=pct,
+                summary=str(getattr(usage, "usage_summary", "") or f"{pct}% used"),
+                severity=_quota_severity(pct),
+                limit_label=_quota_limit_label(getattr(usage, "period_label", "")),
+                reset_at=str(getattr(usage, "reset_at", "") or ""),
+            )
+        )
+    rows.sort(
+        key=lambda row: (
+            -row.used_pct,
+            row.provider.lower(),
+            row.account_name,
+        )
+    )
+    return rows
+
+
 def load_dashboard(config_path: Path) -> tuple[PollyPMConfig, DashboardData]:
     """Load config + state store and gather one blocking dashboard snapshot."""
     config = load_config(config_path)
@@ -696,6 +783,7 @@ def gather(config: PollyPMConfig, store: StateStore) -> DashboardData:
     values = [t for _, t in daily]
     today_str = now.strftime("%Y-%m-%d")
     today_tokens = next((t for d, t in daily if d == today_str), 0)
+    account_usages = _account_quota_usage(config, store)
 
     commits = _recent_commits(config, hours=24)
     completed = _completed_issues(config, hours=72)
@@ -765,5 +853,6 @@ def gather(config: PollyPMConfig, store: StateStore) -> DashboardData:
         recovery_count_24h=recoveries,
         inbox_count=inbox_count,
         alert_count=alert_count,
+        account_usages=account_usages,
         briefing=briefing,
     )

--- a/tests/test_polly_dashboard_ui.py
+++ b/tests/test_polly_dashboard_ui.py
@@ -8,7 +8,13 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from pollypm.cockpit_ui import PollyDashboardApp
-from pollypm.dashboard_data import DashboardData, InboxPreview, load_dashboard
+from pollypm.dashboard_data import (
+    AccountQuotaUsage,
+    DashboardData,
+    InboxPreview,
+    load_dashboard,
+)
+from pollypm.storage.state import AccountUsageRecord
 
 
 def _run(coro) -> None:
@@ -152,6 +158,31 @@ def test_polly_dashboard_shows_inbox_count_without_recent_messages(tmp_path: Pat
     assert "Press I to jump to the inbox" in rendered
 
 
+def test_polly_dashboard_renders_llm_quota_usage(tmp_path: Path) -> None:
+    app = PollyDashboardApp(tmp_path / "pollypm.toml")
+    data = _fake_dashboard_data()
+    data.account_usages = [
+        AccountQuotaUsage(
+            account_name="claude_main",
+            provider="Anthropic",
+            email="claude@swh.me",
+            used_pct=84,
+            summary="16% left this week",
+            severity="warning",
+            limit_label="weekly limit",
+            reset_at="Apr 24 01:00",
+        )
+    ]
+
+    app._render_dashboard(_fake_config(), data)
+
+    rendered = str(app.chart_body.render())
+    assert "LLM account quota usage" in rendered
+    assert "84% used of weekly limit" in rendered
+    assert "approaching ceiling" in rendered
+    assert "No token data yet" in rendered
+
+
 def test_dashboard_gather_uses_rail_inbox_counter(monkeypatch, tmp_path: Path) -> None:
     """Home inbox count must match the rail, including untracked projects."""
     from pollypm.dashboard_data import gather
@@ -204,6 +235,71 @@ def test_dashboard_gather_uses_rail_inbox_counter(monkeypatch, tmp_path: Path) -
     assert seen == [config]
     assert data.inbox_count == 13
     assert "13 inbox items waiting" in data.briefing
+
+
+def test_dashboard_gather_includes_cached_llm_quota_usage(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    from pollypm.dashboard_data import gather
+
+    config = SimpleNamespace(
+        projects={},
+        accounts={
+            "claude_main": SimpleNamespace(
+                provider="claude",
+                email="claude@swh.me",
+            )
+        },
+    )
+
+    class FakeStore:
+        def list_session_runtimes(self):
+            return []
+
+        def recent_events(self, *, limit: int):
+            del limit
+            return []
+
+        def daily_token_usage(self, *, days: int):
+            del days
+            return []
+
+        def get_account_usage(self, account_name: str):
+            assert account_name == "claude_main"
+            return AccountUsageRecord(
+                account_name="claude_main",
+                provider="claude",
+                plan="max",
+                health="near-limit",
+                usage_summary="21% left this week",
+                raw_text="",
+                updated_at="2026-04-21T14:10:00+00:00",
+                used_pct=79,
+                remaining_pct=21,
+                reset_at="Apr 24 01:00",
+                period_label="current week",
+            )
+
+        def open_alerts(self):
+            return []
+
+    monkeypatch.setattr(
+        "pollypm.service_api.plan_launches_readonly",
+        lambda _config, _store: [],
+    )
+    monkeypatch.setattr("pollypm.dashboard_data._recent_commits", lambda *_a, **_kw: [])
+    monkeypatch.setattr("pollypm.dashboard_data._completed_issues", lambda *_a, **_kw: [])
+    monkeypatch.setattr("pollypm.dashboard_data._recent_inbox_messages", lambda *_a, **_kw: [])
+    monkeypatch.setattr("pollypm.dashboard_data._count_dashboard_inbox_items", lambda _config: 0)
+
+    data = gather(config, FakeStore())
+
+    assert len(data.account_usages) == 1
+    usage = data.account_usages[0]
+    assert usage.provider == "Anthropic"
+    assert usage.email == "claude@swh.me"
+    assert usage.used_pct == 79
+    assert usage.limit_label == "weekly limit"
 
 
 def test_polly_dashboard_i_key_routes_to_inbox(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1149

Restores the Textual Home dashboard quota signal by carrying cached account_usage percentages into DashboardData and rendering an LLM account quota usage block above the token sparkline.

Self-audit: touched Home dashboard data gathering and Textual UI rendering only; no store writes, no UI-to-store import, no module boundary debt.