### PR TITLE
Fix #1142 bootstrap fresh DB migrations

### DIFF
--- a/src/pollypm/store/migrations.py
+++ b/src/pollypm/store/migrations.py
@@ -446,15 +446,17 @@ def require_no_pending_or_exit(db_path: Path) -> None:
     Skipped when ``POLLYPM_SKIP_MIGRATION_GATE`` is set — ``pm migrate``
     sets this internally so the apply path can itself open the store.
 
-    A missing DB file is NOT a gate violation: it's the legitimate
-    first-boot path where ``StateStore``/``SQLiteWorkService`` will
-    create the file and apply every migration from scratch. The gate
-    protects against the "installed new code, forgot to migrate" case,
-    which by definition requires an existing older DB.
+    A missing DB file is the legitimate first-boot path. Bootstrap it
+    fully here so startup cannot create only the ``StateStore`` half of
+    the shared database and leave work-service migrations pending for
+    the next launch. The gate protects against the "installed new code,
+    forgot to migrate" case, which by definition requires an existing
+    older DB.
     """
     if bypass_env_is_set():
         return
     if not db_path.is_file():
+        _apply_all(db_path)
         return
     status = inspect(db_path)
     if status.up_to_date:

--- a/tests/test_migration_gate.py
+++ b/tests/test_migration_gate.py
@@ -278,6 +278,31 @@ def test_migration_gate_skipped_when_bypass_env_set(
     mig_mod.require_no_pending_or_exit(db_path)
 
 
+def test_refuse_start_gate_bootstraps_missing_db_fully(tmp_path: Path) -> None:
+    """Fresh startup must not leave only work migrations pending (#1142).
+
+    ``pm init`` writes config but no DB. The first bare ``pm`` reaches
+    the migration gate before Supervisor/StateStore startup. If the gate
+    simply returns, Supervisor can create a state-migrated DB without
+    opening the work service; the second ``pm`` then refuses to start on
+    pending ``[work]`` migrations.
+    """
+    db_path = tmp_path / "state.db"
+
+    mig_mod.require_no_pending_or_exit(db_path)
+
+    status = mig_mod.inspect(db_path)
+    assert status.up_to_date
+    assert (
+        status.applied[mig_mod.NAMESPACE_STATE]
+        == status.latest[mig_mod.NAMESPACE_STATE]
+    )
+    assert (
+        status.applied[mig_mod.NAMESPACE_WORK]
+        == status.latest[mig_mod.NAMESPACE_WORK]
+    )
+
+
 def test_up_enforces_migration_gate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Closes #1142

Bootstraps a missing workspace state.db through the migration gate so first startup applies both state and work migration families before any partial StateStore-only initialization can occur. Added a regression test that verifies the fresh missing-DB gate path leaves both migration namespaces fully current.

Self-audit: touched only the store migration gate and its focused migration-gate tests; no UI, facade, domain, or store boundary expansion beyond existing migration-runner behavior.