### PR TITLE
Fix #1143 tmux panes honor launcher HOME

### DIFF
--- a/src/pollypm/tmux/client.py
+++ b/src/pollypm/tmux/client.py
@@ -43,6 +43,15 @@ import re as _re
 _NAME_RE = _re.compile(r"^[a-zA-Z0-9_.-]+$")
 # Safe characters for tmux targets (session:window.pane or %pane_id)
 _TARGET_RE = _re.compile(r"^[a-zA-Z0-9_:.%-]+$")
+_SPAWN_ENV_VARS = (
+    "HOME",
+    "PATH",
+    "POLLYPM_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "XDG_STATE_HOME",
+    "XDG_CACHE_HOME",
+)
 
 
 class DeadPaneError(RuntimeError):
@@ -116,6 +125,15 @@ class TmuxClient:
         result = self.run("has-session", "-t", self._exact_target(name), check=False)
         return result.returncode == 0
 
+    def _spawn_env_args(self) -> list[str]:
+        args: list[str] = []
+        for name in _SPAWN_ENV_VARS:
+            value = os.environ.get(name)
+            if value is None:
+                continue
+            args.extend(["-e", f"{name}={value}"])
+        return args
+
     def current_session_name(self) -> str | None:
         if not self._inside_tmux():
             return None
@@ -171,11 +189,13 @@ class TmuxClient:
             # Phase 1: empty pane (default shell). Resolves immediately.
             result = self.run(
                 "new-session", "-d", "-P", "-F", "#{pane_id}",
+                *self._spawn_env_args(),
                 "-s", name, "-n", window_name,
             )
         else:
             result = self.run(
                 "new-session", "-d", "-P", "-F", "#{pane_id}",
+                *self._spawn_env_args(),
                 "-s", name, "-n", window_name, command,
             )
         pane_id = result.stdout.strip()
@@ -224,7 +244,17 @@ class TmuxClient:
                     return None
             except subprocess.CalledProcessError:
                 pass  # Session may have vanished; proceed with creation attempt
-        args = ["new-window", "-P", "-F", "#{pane_id}", "-t", self._exact_target(name), "-n", window_name]
+        args = [
+            "new-window",
+            "-P",
+            "-F",
+            "#{pane_id}",
+            *self._spawn_env_args(),
+            "-t",
+            self._exact_target(name),
+            "-n",
+            window_name,
+        ]
         if detached:
             args.append("-d")
         if not two_phase:
@@ -290,7 +320,7 @@ class TmuxClient:
             "send_launch_command: respawn-pane -t %s argv0=%r argc=%d",
             resolved, argv[0], len(argv),
         )
-        self.run("respawn-pane", "-k", "-t", resolved, *argv)
+        self.run("respawn-pane", "-k", *self._spawn_env_args(), "-t", resolved, *argv)
 
     def split_window(
         self,
@@ -302,7 +332,15 @@ class TmuxClient:
         percent: int | None = None,
         size: int | None = None,
     ) -> str:
-        args = ["split-window", "-P", "-F", "#{pane_id}", "-t", self._exact_target(target)]
+        args = [
+            "split-window",
+            "-P",
+            "-F",
+            "#{pane_id}",
+            *self._spawn_env_args(),
+            "-t",
+            self._exact_target(target),
+        ]
         args.append("-h" if horizontal else "-v")
         if detached:
             args.append("-d")
@@ -480,7 +518,14 @@ class TmuxClient:
         self.run("rename-window", "-t", self._exact_target(target), new_name)
 
     def respawn_pane(self, target: str, command: str) -> None:
-        self.run("respawn-pane", "-k", "-t", self._exact_target(target), command)
+        self.run(
+            "respawn-pane",
+            "-k",
+            *self._spawn_env_args(),
+            "-t",
+            self._exact_target(target),
+            command,
+        )
 
     def set_option(self, target: str, option: str, value: str) -> None:
         normalized = target if ":" in target or target.startswith(("=", "%", "@")) else f"{target}:"

--- a/tests/test_tmux_client.py
+++ b/tests/test_tmux_client.py
@@ -203,6 +203,58 @@ def test_create_window_two_phase_default_omits_command(monkeypatch) -> None:
     assert not any("send-keys" in c for c in captured)
 
 
+def test_spawn_commands_propagate_launcher_workspace_env(monkeypatch) -> None:
+    """#1143: tmux pane processes must honor the launcher's HOME/PATH.
+
+    An existing tmux server keeps its own global environment. Without
+    explicit per-spawn env, ``HOME=/tmp/isolated pm up`` can still spawn
+    cockpit panes with the server's canonical HOME.
+    """
+    captured: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        captured.append(list(args))
+
+        class Result:
+            returncode = 0
+            stdout = "%42"
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setenv("HOME", "/tmp/polly-empty-state")
+    monkeypatch.setenv("PATH", "/tmp/polly-bin:/usr/bin:/bin")
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/tmp/polly-empty-state/.config")
+    monkeypatch.setenv("UNRELATED_SECRET", "do-not-forward")
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    client = TmuxClient()
+    monkeypatch.setattr(client, "has_session", lambda name: False)
+
+    client.create_session("storage", "main", "codex --resume abc")
+    client.create_window("storage", "task-foo-1", "claude --resume xyz")
+    client.split_window("pollypm:PollyPM", "pm cockpit-pane polly")
+    client.respawn_pane("%42", "pm cockpit")
+
+    spawn_calls = [
+        call
+        for call in captured
+        if len(call) > 1
+        and call[1] in {"new-session", "new-window", "split-window", "respawn-pane"}
+    ]
+    assert spawn_calls
+    for call in spawn_calls:
+        env_values = [
+            call[index + 1]
+            for index, arg in enumerate(call)
+            if arg == "-e" and index + 1 < len(call)
+        ]
+        assert "HOME=/tmp/polly-empty-state" in env_values
+        assert "PATH=/tmp/polly-bin:/usr/bin:/bin" in env_values
+        assert "XDG_CONFIG_HOME=/tmp/polly-empty-state/.config" in env_values
+        assert "UNRELATED_SECRET=do-not-forward" not in env_values
+
+
 def test_create_window_two_phase_false_inlines_command(monkeypatch) -> None:
     """The legacy single-call form is preserved behind ``two_phase=False``
     for callers that need it (none currently — but keeps the door open


### PR DESCRIPTION
Closes #1143

Propagate a small launcher environment allowlist into tmux new-session, new-window, split-window, and respawn-pane calls so cockpit panes inherit the HOME/XDG workspace selected by `pm up` instead of tmux server globals. Added a tmux client regression test covering HOME/PATH/XDG propagation and avoiding unrelated env leakage.

Layer self-audit: touched only the tmux IO adapter (`src/pollypm/tmux/client.py`) and its focused unit test; no UI/store cross-layer imports or boundary debt.