### PR TITLE
Fix #1145 add network-dead simulation

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -53,6 +53,7 @@ from pollypm.launch_state import (
     plan_launch,
 )
 from pollypm.cli_features.issues import issue_app, itsalive_app, report_app
+from pollypm.cli_features.dev import dev_app
 from pollypm.cli_features.maintenance import debug_app, register_maintenance_commands
 from pollypm.cli_features.migrate import register_migrate_commands
 from pollypm.cli_features.projects import register_project_commands
@@ -159,6 +160,7 @@ app.add_typer(issue_app, name="issue")
 app.add_typer(report_app, name="report")
 app.add_typer(itsalive_app, name="itsalive")
 app.add_typer(debug_app, name="debug")
+app.add_typer(dev_app, name="dev")
 
 from pollypm.work.cli import task_app, flow_app
 app.add_typer(task_app, name="task")

--- a/src/pollypm/cli_features/dev.py
+++ b/src/pollypm/cli_features/dev.py
@@ -1,0 +1,47 @@
+"""Developer/test-harness CLI controls."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from pollypm.config import DEFAULT_CONFIG_PATH
+
+
+dev_app = typer.Typer(
+    help=(
+        "Developer/test-harness controls for already-running PollyPM "
+        "processes."
+    )
+)
+
+
+@dev_app.command("simulate-network-dead")
+def simulate_network_dead(
+    config_path: Path = typer.Option(
+        DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."
+    ),
+) -> None:
+    """Make the next PollyPM live-chat dispatch fail as network-dead."""
+    from pollypm.dev_network_simulation import arm_network_dead
+
+    marker = arm_network_dead(config_path)
+    typer.echo(
+        "Armed simulated network-dead for the next PollyPM chat/API dispatch "
+        f"(connection refused). Marker: {marker}"
+    )
+
+
+@dev_app.command("simulate-network-clear")
+def simulate_network_clear(
+    config_path: Path = typer.Option(
+        DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."
+    ),
+) -> None:
+    """Clear a pending simulated network-dead failure."""
+    from pollypm.dev_network_simulation import clear_network_dead
+
+    marker = clear_network_dead(config_path)
+    typer.echo(f"Cleared simulated network-dead marker: {marker}")
+

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -2203,6 +2203,12 @@ class CockpitRouter:
         window_target: str,
         route: LiveSessionRoute,
     ) -> None:
+        from pollypm.dev_network_simulation import raise_if_network_dead
+
+        raise_if_network_dead(
+            self.config_path,
+            surface=f"live session route to {route.session_name}",
+        )
         launches = supervisor.plan_launches()
         storage_session = supervisor.storage_closet_session_name()
         launch = next((item for item in launches if item.session.name == route.session_name), None)

--- a/src/pollypm/dev_network_simulation.py
+++ b/src/pollypm/dev_network_simulation.py
@@ -1,0 +1,129 @@
+"""Dev-only network failure simulation controls.
+
+Contract:
+- Inputs: a PollyPM config path or base directory.
+- Outputs: a small marker file that long-lived PollyPM processes can
+  consume to simulate one connection-refused network failure.
+- Side effects: writes/removes ``dev_network_simulation.json`` under
+  the PollyPM base directory.
+- Invariants: file-backed so already-running cockpit/rail processes can
+  observe the flag without restart; one-shot unless explicitly re-armed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+_MARKER_FILENAME = "dev_network_simulation.json"
+
+
+class SimulatedNetworkDead(ConnectionRefusedError):
+    """Raised when the dev network-dead switch consumes a failure."""
+
+
+def marker_path_for_base_dir(base_dir: Path) -> Path:
+    """Return the marker path for a PollyPM base directory."""
+    return Path(base_dir) / _MARKER_FILENAME
+
+
+def marker_path_for_config(config_path: Path) -> Path:
+    """Return the marker path associated with ``config_path``.
+
+    Prefer the parsed ``project.base_dir`` so custom configs share the
+    same control location as the running cockpit. If the config is
+    missing or broken, fall back to the config's parent directory so the
+    dev CLI remains usable while diagnosing boot failures.
+    """
+    try:
+        from pollypm.config import load_config
+
+        config = load_config(config_path)
+        base_dir = getattr(getattr(config, "project", None), "base_dir", None)
+        if isinstance(base_dir, Path):
+            return marker_path_for_base_dir(base_dir)
+    except Exception:  # noqa: BLE001
+        pass
+    return marker_path_for_base_dir(Path(config_path).parent)
+
+
+def arm_network_dead(config_path: Path) -> Path:
+    """Arm one simulated network-dead failure for this PollyPM install."""
+    marker = marker_path_for_config(config_path)
+    payload = {
+        "network_dead_once": True,
+        "armed_at": datetime.now(UTC).isoformat(),
+        "reason": "pm dev simulate-network-dead",
+    }
+    _write_marker(marker, payload)
+    return marker
+
+
+def clear_network_dead(config_path: Path) -> Path:
+    """Clear any pending simulated network-dead failure."""
+    marker = marker_path_for_config(config_path)
+    marker.unlink(missing_ok=True)
+    return marker
+
+
+def network_dead_armed(config_path: Path) -> bool:
+    """Return True if a simulated network-dead failure is pending."""
+    return _marker_is_armed(marker_path_for_config(config_path))
+
+
+def network_dead_armed_for_base_dir(base_dir: Path) -> bool:
+    """Return True if a simulated network-dead failure is pending."""
+    return _marker_is_armed(marker_path_for_base_dir(base_dir))
+
+
+def raise_if_network_dead(config_path: Path, *, surface: str) -> None:
+    """Consume and raise when a config-scoped network simulation is armed."""
+    _raise_if_marker_armed(marker_path_for_config(config_path), surface=surface)
+
+
+def raise_if_network_dead_for_base_dir(base_dir: Path, *, surface: str) -> None:
+    """Consume and raise when a base-dir-scoped simulation is armed."""
+    _raise_if_marker_armed(marker_path_for_base_dir(base_dir), surface=surface)
+
+
+def _raise_if_marker_armed(marker: Path, *, surface: str) -> None:
+    if not _consume_marker(marker):
+        return
+    raise SimulatedNetworkDead(
+        f"network unreachable (simulated): connection refused for {surface}"
+    )
+
+
+def _marker_is_armed(marker: Path) -> bool:
+    payload = _read_marker(marker)
+    return bool(payload.get("network_dead_once"))
+
+
+def _consume_marker(marker: Path) -> bool:
+    payload = _read_marker(marker)
+    if not payload.get("network_dead_once"):
+        return False
+    marker.unlink(missing_ok=True)
+    return True
+
+
+def _read_marker(marker: Path) -> dict[str, object]:
+    try:
+        raw = marker.read_text(encoding="utf-8")
+        parsed = json.loads(raw)
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return parsed
+
+
+def _write_marker(marker: Path, payload: dict[str, object]) -> None:
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    tmp = marker.with_name(f".{marker.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(marker)
+

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -1945,6 +1945,12 @@ class Supervisor:
         self._assert_lease_available(session_name, owner=owner, force=force, action="send input to")
 
         target = self._resolve_send_target(launch)
+        from pollypm.dev_network_simulation import raise_if_network_dead_for_base_dir
+
+        raise_if_network_dead_for_base_dir(
+            self.config.project.base_dir,
+            surface=f"send input to {session_name}",
+        )
         prefixed = _prefix_for_owner(owner, text)
         self.session_service.tmux.send_keys(target, prefixed, press_enter=press_enter)
         # Codex CLI buffers input and requires a second Enter to submit.

--- a/tests/test_dev_network_simulation.py
+++ b/tests/test_dev_network_simulation.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm.cockpit_rail import CockpitRouter
+from pollypm.cockpit_rail_routes import LiveSessionRoute
+from pollypm.cli import app
+from pollypm.dev_network_simulation import (
+    SimulatedNetworkDead,
+    arm_network_dead,
+    clear_network_dead,
+    network_dead_armed,
+    raise_if_network_dead,
+)
+
+
+def test_network_dead_marker_is_consumed_once(tmp_path: Path) -> None:
+    config_path = tmp_path / "pollypm.toml"
+
+    arm_network_dead(config_path)
+
+    with pytest.raises(SimulatedNetworkDead) as raised:
+        raise_if_network_dead(config_path, surface="test dispatch")
+
+    message = str(raised.value)
+    assert "network unreachable" in message
+    assert "connection refused" in message
+    assert not network_dead_armed(config_path)
+
+    # One-shot: the next check should be a no-op unless re-armed.
+    raise_if_network_dead(config_path, surface="test dispatch")
+
+
+def test_network_dead_marker_can_be_cleared(tmp_path: Path) -> None:
+    config_path = tmp_path / "pollypm.toml"
+
+    arm_network_dead(config_path)
+    clear_network_dead(config_path)
+
+    assert not network_dead_armed(config_path)
+
+
+def test_dev_cli_arms_and_clears_network_dead_marker(tmp_path: Path) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    runner = CliRunner()
+
+    armed = runner.invoke(
+        app,
+        ["dev", "simulate-network-dead", "--config", str(config_path)],
+    )
+
+    assert armed.exit_code == 0, armed.output
+    assert "connection refused" in armed.output
+    assert network_dead_armed(config_path)
+
+    cleared = runner.invoke(
+        app,
+        ["dev", "simulate-network-clear", "--config", str(config_path)],
+    )
+
+    assert cleared.exit_code == 0, cleared.output
+    assert not network_dead_armed(config_path)
+
+
+def test_live_session_route_consumes_network_dead_marker(tmp_path: Path) -> None:
+    config_path = tmp_path / "pollypm.toml"
+    router = CockpitRouter.__new__(CockpitRouter)
+    router.config_path = config_path
+
+    arm_network_dead(config_path)
+
+    with pytest.raises(SimulatedNetworkDead):
+        router._route_live_session(
+            object(),
+            "pollypm:PollyPM",
+            LiveSessionRoute(session_name="operator"),
+        )
+
+    assert not network_dead_armed(config_path)
+


### PR DESCRIPTION
Closes #1145

Adds a dev-only network-dead simulation switch (`pm dev simulate-network-dead` / `pm dev simulate-network-clear`) backed by a one-shot marker file that already-running PollyPM processes can consume. Live cockpit chat routing and direct `send_input` now surface a simulated connection-refused/network-unreachable failure without host firewall or restart requirements.

Layer self-audit: CLI surface added under `cli_features/dev.py`; cockpit routing consumes the marker in `cockpit_rail.py`; supervisor session-send consumes the same marker after target resolution; shared file-backed helper stays in `dev_network_simulation.py`; no store/sqlite imports were added to UI code and no cross-layer reach into store/IO internals was introduced.
