### PR TITLE
Fix #1159 tighten inbox filter matching

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -6300,17 +6300,22 @@ def _task_is_rollup(task) -> bool:
 
 
 def _fuzzy_subseq_match(query: str, hay: str) -> bool:
-    """Subsequence fuzzy match: every char in ``query`` appears in ``hay`` in order.
+    """Inbox text match with fuzzy affordance for short abbreviations.
 
-    ``"shp"`` matches ``"shipped"`` (s, h, p land in order). Substring
-    matches are a subset, so a plain ``"deploy"`` query against
-    ``"deploy blocked"`` still matches via the same algorithm.
+    Literal substring matches always win. Short abbreviations like
+    ``"shp"`` can still match ``"shipped"`` as a subsequence, but
+    longer queries stay literal so a word like ``"recovery"`` does not
+    match rows where those letters are merely scattered across metadata.
     Empty query matches everything; case is folded before compare so
     the call site doesn't have to.
     """
     if not query:
         return True
     if not hay:
+        return False
+    if query in hay:
+        return True
+    if len(query) > 3:
         return False
     qi = 0
     q = query

--- a/tests/test_inbox_filter.py
+++ b/tests/test_inbox_filter.py
@@ -230,6 +230,54 @@ def test_fuzzy_subsequence_match(filter_env, filter_app) -> None:
     _run(body())
 
 
+def test_long_filter_query_requires_literal_substring(tmp_path: Path) -> None:
+    """#1159: long terms must not match letters scattered across metadata."""
+
+    async def body() -> None:
+        project_path = tmp_path / "demo"
+        project_path.mkdir()
+        (project_path / ".git").mkdir()
+        config_path = tmp_path / "pollypm.toml"
+        _write_minimal_config(project_path, config_path)
+        _seed_project(
+            project_path,
+            items=[
+                ("RECOVERY MODE injection burst", "actual literal match", None),
+                (
+                    "Refine estimate, confirm options, verify edge replies yesterday",
+                    "letters are in order but not contiguous",
+                    None,
+                ),
+            ],
+        )
+        if not _load_config_compatible(config_path):
+            pytest.skip("minimal pollypm.toml fixture not supported by loader")
+
+        from pollypm.cockpit_input_bridge import send_key
+        from pollypm.cockpit_ui import PollyInboxApp
+
+        app = PollyInboxApp(config_path)
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            initial_count = len(_visible_titles(app))
+            assert initial_count == 2
+            handle = getattr(app, "_input_bridge_handle", None)
+            assert handle is not None
+
+            send_key(handle.socket_path, "/")
+            await pilot.pause(0.2)
+            for key in "RECOVERY":
+                send_key(handle.socket_path, key)
+            await pilot.pause(0.3)
+
+            assert app.filter_input.value == "RECOVERY"
+            visible = _visible_titles(app)
+            assert visible == ["RECOVERY MODE injection burst"]
+            assert len(visible) < initial_count
+
+    _run(body())
+
+
 # ---------------------------------------------------------------------------
 # 3. Unread-only chip narrows the list
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1159

Tightens Inbox text filtering so literal long terms like RECOVERY only match rows containing that substring, while preserving short fuzzy abbreviations such as shp/VCL. Adds a pane-bridge regression test for the RECOVERY narrowing case.

Layer self-audit: UI-only change in src/pollypm/cockpit_ui.py plus focused UI tests in tests/test_inbox_filter.py; no facade, domain, or store imports changed and no boundary crossing.