### PR TITLE
Fix #1161 keep settings j/k in settings pane

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -3627,9 +3627,15 @@ class PollyCockpitRail:
         if key in {b"q", b"\x03"}:
             return False
         if key in {b"j", b"\x1b[B"}:
+            if self.selected_key == "settings":
+                self._send_key_to_settings_pane("j")
+                return True
             self._move(1, items)
             return True
         if key in {b"k", b"\x1b[A"}:
+            if self.selected_key == "settings":
+                self._send_key_to_settings_pane("k")
+                return True
             self._move(-1, items)
             return True
         if key in {b"g", b"\x1b[H"}:
@@ -3677,6 +3683,22 @@ class PollyCockpitRail:
             self.selected_key = "settings"
             return True
         return True
+
+    def _send_key_to_settings_pane(self, key: str) -> None:
+        delivered = None
+        try:
+            from pollypm.cockpit_input_bridge import send_key_to_first_live
+            delivered = send_key_to_first_live(
+                self.router.config_path, key, kind="settings", timeout=0.2,
+            )
+        except Exception:  # noqa: BLE001
+            delivered = None
+        if delivered is not None:
+            return
+        try:
+            self.router.send_key_to_right_pane(key)
+        except Exception:  # noqa: BLE001
+            pass
 
     # ── Navigation ───────────────────────────────────────────────────────
 

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4403,6 +4403,42 @@ def test_cockpit_rail_ctrl_k_routes_to_settings(monkeypatch, tmp_path: Path) -> 
     assert rail.selected_key == "settings"
 
 
+def test_cockpit_rail_jk_on_settings_forward_to_settings_pane(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    class FakeRouter:
+        def __init__(self, config_path: Path) -> None:
+            self.config_path = config_path
+            self.sent: list[str] = []
+            self.selected_updates: list[str] = []
+            self.tmux = None
+
+        def selected_key(self) -> str:
+            return "settings"
+
+        def send_key_to_right_pane(self, key: str) -> None:
+            self.sent.append(key)
+
+        def set_selected_key(self, key: str) -> None:
+            self.selected_updates.append(key)
+
+    monkeypatch.setattr("pollypm.cockpit_rail.CockpitRouter", FakeRouter)
+    from pollypm.cockpit_rail import CockpitItem, PollyCockpitRail
+
+    rail = PollyCockpitRail(tmp_path / "pollypm.toml")
+    items = [
+        CockpitItem("polly", "Polly", "ready"),
+        CockpitItem("settings", "Settings", "config"),
+    ]
+
+    assert rail._handle_key(b"j", items) is True
+    assert rail._handle_key(b"\x1b[A", items) is True
+
+    assert rail.selected_key == "settings"
+    assert rail.router.sent == ["j", "k"]
+    assert rail.router.selected_updates == []
+
+
 def test_cockpit_rail_forwards_detail_hint_keys(monkeypatch, tmp_path: Path) -> None:
     class FakeRouter:
         def __init__(self, _config_path: Path) -> None:


### PR DESCRIPTION
Closes #1161

Raw cockpit rail now forwards j/k from the active Settings row into the Settings pane instead of wrapping the rail selection back to Polly. Added a regression test for the raw rail path so Settings remains selected while the pane receives the nav keys.

Layer self-audit: touched only UI/CLI rail code and its cockpit unit test; no facade, domain, store, or IO boundary crossings.