### PR TITLE
Fix #1167 surface stopped worker panes

### DIFF
--- a/src/pollypm/heartbeats/api.py
+++ b/src/pollypm/heartbeats/api.py
@@ -308,10 +308,20 @@ class SupervisorHeartbeatAPI:
             pane_id: str | None = None
             pane_command: str | None = None
             pane_dead = False
+            pane_stopped = False
             if window is not None:
                 pane_id = window.pane_id
                 pane_command = window.pane_current_command
                 pane_dead = window.pane_dead
+                pane_pid = getattr(window, "pane_pid", None)
+                if pane_pid:
+                    try:
+                        pane_stopped = (
+                            self.supervisor.session_service.tmux
+                            .pane_has_stopped_descendant(pane_pid=int(pane_pid))
+                        )
+                    except Exception:  # noqa: BLE001
+                        pane_stopped = False
                 try:
                     raw_snapshot_path, pane_text = self.supervisor.write_snapshot(window, self.snapshot_lines)
                 except Exception:
@@ -344,6 +354,7 @@ class SupervisorHeartbeatAPI:
                     previous_log_bytes=previous.log_bytes if previous else None,
                     previous_snapshot_hash=previous.snapshot_hash if previous else None,
                     cursor=cursor,
+                    pane_stopped=pane_stopped,
                 )
             )
         return contexts

--- a/src/pollypm/heartbeats/base.py
+++ b/src/pollypm/heartbeats/base.py
@@ -38,6 +38,7 @@ class HeartbeatSessionContext:
     previous_log_bytes: int | None
     previous_snapshot_hash: str | None
     cursor: HeartbeatCursor | None = None
+    pane_stopped: bool = False
 
 
 @dataclass(slots=True)

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -793,6 +793,27 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         else:
             api.clear_alert(context.session_name, "shell_returned")
 
+        stopped_reason = "Pane process is stopped (SIGSTOP)"
+        if context.pane_stopped:
+            _emit_routed_alert(
+                api,
+                session_name=context.session_name,
+                alert_type="pane_stopped",
+                severity="error",
+                message=(
+                    f"{context.session_name} appears stuck: "
+                    f"{stopped_reason}. Open Workers and resume or "
+                    "restart the stopped session."
+                ),
+                subject=f"{context.session_name} process stopped",
+                suggested_action=(
+                    "Open Workers and resume or restart the stopped session."
+                ),
+            )
+            alerts.append("pane_stopped")
+        else:
+            api.clear_alert(context.session_name, "pane_stopped")
+
         # Sessions parked at a prompt are legitimately idle — not an alert condition.
         # Only the suspected_loop detector (below) alerts on sustained identical snapshots.
         api.clear_alert(context.session_name, "idle_output")
@@ -991,7 +1012,17 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         if context.pane_dead:
             status_locked = True
 
-        if mechanical_only:
+        if context.pane_stopped:
+            verdict, reason = ("stuck", stopped_reason)
+            api.clear_alert(context.session_name, "needs_followup")
+            if not status_locked:
+                self._set_session_status(
+                    api,
+                    context,
+                    "stuck",
+                    reason=reason,
+                )
+        elif mechanical_only:
             verdict, reason = ("healthy", "Heartbeat supervisor only checks mechanical session health")
             api.clear_alert(context.session_name, "needs_followup")
             if not status_locked:

--- a/src/pollypm/tmux/client.py
+++ b/src/pollypm/tmux/client.py
@@ -20,6 +20,7 @@ class TmuxWindow:
     pane_current_command: str
     pane_current_path: str
     pane_dead: bool
+    pane_pid: int | None = None
 
 
 @dataclass(slots=True)
@@ -412,12 +413,12 @@ class TmuxClient:
     def list_windows(self, name: str) -> list[TmuxWindow]:
         fmt = (
             "#{session_name}\t#{window_index}\t#{window_name}\t#{window_active}\t#{pane_id}\t"
-            "#{pane_current_command}\t#{pane_current_path}\t#{pane_dead}"
+            "#{pane_current_command}\t#{pane_current_path}\t#{pane_dead}\t#{pane_pid}"
         )
         result = self.run("list-windows", "-t", self._exact_target(name), "-F", fmt)
         windows: list[TmuxWindow] = []
         for line in result.stdout.splitlines():
-            parts = line.split("\t", 7)
+            parts = line.split("\t", 8)
             if len(parts) < 8:
                 continue
             (
@@ -429,7 +430,14 @@ class TmuxClient:
                 pane_current_command,
                 pane_current_path,
                 pane_dead,
+                *rest,
             ) = parts
+            pane_pid: int | None = None
+            if rest:
+                try:
+                    pane_pid = int(rest[0])
+                except ValueError:
+                    pane_pid = None
             windows.append(
                 TmuxWindow(
                     session=session,
@@ -440,6 +448,7 @@ class TmuxClient:
                     pane_current_command=pane_current_command,
                     pane_current_path=pane_current_path,
                     pane_dead=pane_dead == "1",
+                    pane_pid=pane_pid,
                 )
             )
         return windows
@@ -448,17 +457,23 @@ class TmuxClient:
         """List windows across ALL tmux sessions in a single subprocess call."""
         fmt = (
             "#{session_name}\t#{window_index}\t#{window_name}\t#{window_active}\t#{pane_id}\t"
-            "#{pane_current_command}\t#{pane_current_path}\t#{pane_dead}"
+            "#{pane_current_command}\t#{pane_current_path}\t#{pane_dead}\t#{pane_pid}"
         )
         result = self.run("list-windows", "-a", "-F", fmt, check=False)
         if result.returncode != 0:
             return []
         windows: list[TmuxWindow] = []
         for line in result.stdout.splitlines():
-            parts = line.split("\t", 7)
+            parts = line.split("\t", 8)
             if len(parts) < 8:
                 continue
-            session, index, window_name, active, pane_id, pane_cmd, pane_path, pane_dead = parts
+            session, index, window_name, active, pane_id, pane_cmd, pane_path, pane_dead, *rest = parts
+            pane_pid: int | None = None
+            if rest:
+                try:
+                    pane_pid = int(rest[0])
+                except ValueError:
+                    pane_pid = None
             windows.append(
                 TmuxWindow(
                     session=session,
@@ -469,6 +484,7 @@ class TmuxClient:
                     pane_current_command=pane_cmd,
                     pane_current_path=pane_path,
                     pane_dead=pane_dead == "1",
+                    pane_pid=pane_pid,
                 )
             )
         return windows
@@ -644,6 +660,65 @@ class TmuxClient:
                 except ValueError:
                     return None
         return None
+
+    def pane_has_stopped_descendant(
+        self,
+        *,
+        pane_pid: int | None = None,
+        pane_id: str | None = None,
+    ) -> bool:
+        """Return True if the pane process or one of its children is stopped.
+
+        ``tmux`` keeps a pane alive when its foreground agent process is
+        suspended with SIGSTOP, so ``pane_dead`` stays false. The heartbeat
+        needs the OS process state to distinguish that wedged-but-live pane
+        from a legitimately idle worker.
+        """
+        root_pid = pane_pid
+        if root_pid is None and pane_id:
+            root_pid = self.get_pane_pid(pane_id)
+        if root_pid is None or root_pid <= 0:
+            return False
+
+        try:
+            result = subprocess.run(
+                ["ps", "-axo", "pid=,ppid=,stat="],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=2,
+            )
+        except Exception:  # noqa: BLE001
+            return False
+        if result.returncode != 0:
+            return False
+
+        statuses: dict[int, str] = {}
+        children: dict[int, list[int]] = {}
+        for line in result.stdout.splitlines():
+            parts = line.split(None, 2)
+            if len(parts) < 3:
+                continue
+            try:
+                pid = int(parts[0])
+                ppid = int(parts[1])
+            except ValueError:
+                continue
+            statuses[pid] = parts[2]
+            children.setdefault(ppid, []).append(pid)
+
+        stack = [root_pid]
+        seen: set[int] = set()
+        while stack:
+            pid = stack.pop()
+            if pid in seen:
+                continue
+            seen.add(pid)
+            stat = statuses.get(pid, "")
+            if "T" in stat:
+                return True
+            stack.extend(children.get(pid, []))
+        return False
 
     # -- Teardown helper -------------------------------------------------------
 

--- a/tests/test_heartbeat_plugin_api.py
+++ b/tests/test_heartbeat_plugin_api.py
@@ -299,6 +299,49 @@ def test_supervisor_heartbeat_api_persists_cursor_and_reads_incremental_delta(tm
     assert "operator" in cursor_path.read_text()
 
 
+def test_supervisor_heartbeat_api_marks_stopped_pane(
+    tmp_path: Path, monkeypatch
+) -> None:
+    supervisor = Supervisor(_config(tmp_path))
+    supervisor.ensure_layout()
+    launch = supervisor.plan_launches()[0]
+    launch.log_path.parent.mkdir(parents=True, exist_ok=True)
+    launch.log_path.write_text("")
+    snapshot_path = supervisor.config.project.snapshots_dir / "pm-operator-test.txt"
+    tmux_session = supervisor.tmux_session_for_launch(launch)
+    window = TmuxWindow(
+        session=tmux_session,
+        index=1,
+        name=launch.window_name,
+        active=True,
+        pane_id="%1",
+        pane_current_command="claude",
+        pane_current_path=str(tmp_path),
+        pane_dead=False,
+        pane_pid=12345,
+    )
+    monkeypatch.setattr(
+        supervisor,
+        "window_map",
+        lambda: {(tmux_session, launch.window_name): window},
+    )
+    monkeypatch.setattr(
+        supervisor,
+        "write_snapshot",
+        lambda _window, _lines: (snapshot_path, "snapshot\n"),
+    )
+    monkeypatch.setattr(
+        supervisor.session_service.tmux,
+        "pane_has_stopped_descendant",
+        lambda *, pane_pid=None, pane_id=None: pane_pid == 12345,
+    )
+
+    api = SupervisorHeartbeatAPI(supervisor)
+    context = api.list_sessions()[0]
+
+    assert context.pane_stopped is True
+
+
 def test_supervisor_heartbeat_api_lists_unmanaged_windows(tmp_path: Path, monkeypatch) -> None:
     supervisor = Supervisor(_config(tmp_path))
     supervisor.ensure_layout()
@@ -1007,6 +1050,27 @@ def test_local_heartbeat_backend_clears_stale_unmanaged_window_alerts() -> None:
     assert ("heartbeat", "unmanaged_window:pollypm:e2e-sandbox") not in api.alerts
 
 
+def test_local_heartbeat_backend_marks_stopped_pane_stuck() -> None:
+    api = FakeHeartbeatAPI([
+        _context(
+            transcript_delta="",
+            pane_text="still visible but process stopped",
+            pane_stopped=True,
+        )
+    ])
+
+    LocalHeartbeatBackend().run(api)
+
+    alert = api.alerts[("worker_pollypm", "pane_stopped")]
+    assert alert.severity == "error"
+    assert "SIGSTOP" in alert.message
+    assert api.statuses["worker_pollypm"] == (
+        "stuck",
+        "Pane process is stopped (SIGSTOP)",
+    )
+    assert api.cursor_updates[-1]["verdict"] == "stuck"
+
+
 def test_worker_nudge_skips_repeat_for_same_snapshot_episode(monkeypatch) -> None:
     backend = LocalHeartbeatBackend()
     api = FakeHeartbeatAPI(
@@ -1351,4 +1415,3 @@ def test_heartbeat_unmanaged_window_event_routes_through_signal_envelope(
     # Legacy persistence path still records the event.
     persisted_subjects = {event_type for (_session, event_type, _msg) in api.events}
     assert "unmanaged_window" in persisted_subjects
-

--- a/tests/test_tmux_hardening.py
+++ b/tests/test_tmux_hardening.py
@@ -232,6 +232,41 @@ class TestGetPanePid:
         assert client.get_pane_pid("%42") is None
 
 
+class TestPaneHasStoppedDescendant:
+    def test_detects_stopped_child_process(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = TmuxClient()
+
+        def fake_run(*args, **kwargs):
+            return _ok(
+                "100 1 Ss\n"
+                "101 100 S\n"
+                "102 101 T+\n"
+                "200 1 S\n"
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert client.pane_has_stopped_descendant(pane_pid=100) is True
+
+    def test_returns_false_when_process_tree_is_running(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = TmuxClient()
+
+        def fake_run(*args, **kwargs):
+            return _ok(
+                "100 1 Ss\n"
+                "101 100 S\n"
+                "102 101 S+\n"
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert client.pane_has_stopped_descendant(pane_pid=100) is False
+
+
 # ---------------------------------------------------------------------------
 # Teardown helper
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1167

Adds tmux process-tree detection for SIGSTOP'd pane descendants and carries that mechanical signal through heartbeat contexts. Stopped panes now raise a pane_stopped alert and mark the runtime status as stuck, so the Home dashboard shows a stuck indicator instead of refreshing as healthy.

Layer self-audit: touched store/IO-adjacent tmux probing in src/pollypm/tmux/client.py and domain heartbeat code in src/pollypm/heartbeats/*.py; no UI imports from store and no cross-layer imports added.