### PR TITLE
Fix #1151 let Esc leave live chat

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -1644,6 +1644,11 @@ class PollyCockpitApp(App[None]):
         if callable(focus_method):
             focus_method()
 
+    def _focus_rail_pane(self) -> None:
+        focus_method = getattr(self.router, "focus_rail_pane", None)
+        if callable(focus_method):
+            focus_method()
+
     def _right_pane_has_live_session(self) -> bool:
         try:
             state = self.router._load_state()
@@ -2795,6 +2800,9 @@ class PollyCockpitApp(App[None]):
         return True
 
     def action_back_to_home(self) -> None:
+        if self._right_pane_has_live_session():
+            self._focus_rail_pane()
+            return
         if self._is_on_home():
             return
         self._navigate_home()

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4782,6 +4782,19 @@ def test_cockpit_escape_at_home_is_noop() -> None:
     assert calls == [], f"expected no-op at home but saw {calls}"
 
 
+def test_cockpit_escape_from_live_chat_focuses_rail_pane() -> None:
+    """#1151: Esc from a mounted chat returns tmux focus to the rail."""
+    app, calls = _build_back_to_home_app()
+    app.selected_key = "polly"
+    app._last_router_selected_key = "polly"
+    app.router._load_state = lambda: {"mounted_session": "operator"}  # type: ignore[attr-defined]
+    app.router.focus_rail_pane = lambda: calls.append("focus_rail")  # type: ignore[attr-defined]
+
+    app.action_back_to_home()
+
+    assert calls == ["focus_rail"]
+
+
 def test_cockpit_action_button_digits_forward_from_rail() -> None:
     """1/2/3 from rail forwards to the right pane so Action Needed buttons fire (#862)."""
     app = PollyCockpitApp.__new__(PollyCockpitApp)


### PR DESCRIPTION
Closes #1151

Esc in the cockpit root now detects when the right pane hosts a mounted live session and hands tmux focus back to the rail instead of treating Polly chat as a Home no-op. Added a regression test for the mounted-chat escape path.

Layer self-audit: UI layer only (src/pollypm/cockpit_ui.py and tests/test_cockpit.py); no facade, domain, or store imports; no boundary changes.

Tests: uv run --extra dev pytest tests/test_cockpit.py -k "escape_from_live_chat or escape_at_home or escape_routes_back_to_home or open_live_session". Full tests/test_cockpit.py currently also exposes an existing current-main test-stub failure in test_cockpit_router_primes_workspace_operator_on_attach where CockpitRouter.__new__ lacks config_path.