### PR TITLE
Fix #1156 keep task-backed plan reviews visible

### DIFF
--- a/src/pollypm/cockpit_inbox_items.py
+++ b/src/pollypm/cockpit_inbox_items.py
@@ -402,30 +402,33 @@ def _dedupe_message_vs_task_plan_reviews(
     higher-fidelity surface — drop the bare task row when a message
     with ``plan_task:<task_id>`` already covers it.
     """
-    # Build the set of task_ids that a notify-message already covers.
-    message_covered_task_ids: set[str] = set()
+    # Build refs to plan tasks already covered by a richer handoff row.
+    message_covered_task_ids: dict[str, set[str]] = {}
     for item in items:
         labels = {str(lbl) for lbl in (getattr(item, "labels", []) or [])}
         if "plan_review" not in labels:
             continue
-        # Task-based entries also carry ``plan_review`` via annotation,
-        # but they don't carry the ``plan_task:<id>`` reference label
-        # the architect's notify includes. Only message rows have it.
+        # Task-backed notify rows can also carry ``plan_task:<id>``.
+        # Track who provides the coverage so a self-referential row
+        # never dedupes itself out of the rendered inbox.
         for label in labels:
             if label.startswith("plan_task:"):
                 ref = label.split(":", 1)[1].strip()
                 if ref:
-                    message_covered_task_ids.add(ref)
+                    coverer_id = str(getattr(item, "task_id", "") or "")
+                    message_covered_task_ids.setdefault(ref, set()).add(coverer_id)
                 break
     if not message_covered_task_ids:
         return items
     kept: list[InboxEntry] = []
     for item in items:
-        # Only drop task-based entries — message rows we keep no matter
-        # what (they may be the source of the coverage).
+        # Only drop task-based entries when a different row covers the
+        # same plan task — message rows and self-referential task rows
+        # remain visible.
         if is_task_inbox_entry(item):
             task_id = str(getattr(item, "task_id", "") or "")
-            if task_id in message_covered_task_ids:
+            coverers = message_covered_task_ids.get(task_id, set())
+            if any(coverer_id != task_id for coverer_id in coverers):
                 continue
         kept.append(item)
     return kept

--- a/tests/test_cockpit_inbox_ui.py
+++ b/tests/test_cockpit_inbox_ui.py
@@ -124,6 +124,37 @@ def _seed_threaded_task(project_path: Path) -> str:
         svc.close()
 
 
+def _seed_self_referential_plan_review(project_path: Path) -> str:
+    """Create a task-backed plan_review row whose plan_task label is itself."""
+    db_path = project_path / ".pollypm" / "state.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+    try:
+        task = svc.create(
+            title="Plan ready for review: demo",
+            description="Review the proposed demo plan.",
+            type="task",
+            project="demo",
+            flow_template="chat",
+            roles={"requester": "user", "operator": "architect"},
+            priority="normal",
+            created_by="architect",
+            labels=["plan_review", "notify", "project:demo"],
+        )
+        task = svc.update(
+            task.task_id,
+            labels=[
+                "plan_review",
+                "notify",
+                "project:demo",
+                f"plan_task:{task.task_id}",
+            ],
+        )
+        return task.task_id
+    finally:
+        svc.close()
+
+
 @pytest.fixture
 def inbox_env(tmp_path: Path):
     project_path = tmp_path / "demo"
@@ -373,6 +404,32 @@ def test_message_plan_review_dedupes_against_task_entry() -> None:
     # Message row kept; unrelated row kept.
     assert "msg:booktalk:1" in deduped_ids
     assert "msg:polly_remote:12" in deduped_ids
+
+
+def test_task_backed_plan_review_does_not_dedupe_itself() -> None:
+    """A task-backed plan_review can carry its own plan_task sidecar.
+
+    The dedupe pass should only drop the bare plan task when a different
+    row covers it. If the only covering row is the task itself, keep it.
+    """
+    from datetime import datetime
+
+    from pollypm.cockpit_inbox_items import (
+        InboxEntry,
+        _dedupe_message_vs_task_plan_reviews,
+    )
+
+    item = InboxEntry(
+        source="task",
+        task_id="demo/7",
+        title="Plan ready for review: demo",
+        project="demo",
+        labels=["plan_review", "project:demo", "plan_task:demo/7"],
+        created_at=datetime(2026, 5, 5, 10, 0, 0),
+        updated_at=datetime(2026, 5, 5, 10, 0, 0),
+    )
+
+    assert _dedupe_message_vs_task_plan_reviews([item]) == [item]
 
 
 def test_task_backed_inbox_entries_default_to_action() -> None:
@@ -1019,6 +1076,26 @@ def test_action_items_sort_ahead_of_completed_updates(
             assert titles.index("[Action] Fly.io setup needed for demo") < titles.index(
                 "[Action] Demo shipped cleanly"
             )
+
+    _run(body())
+
+
+def test_self_referential_plan_review_row_is_visible(
+    inbox_env, inbox_app,
+) -> None:
+    """Plan-review task rows must survive dedupe and render in the inbox."""
+    title = "Plan ready for review: demo"
+    plan_review_id = _seed_self_referential_plan_review(inbox_env["project_path"])
+
+    async def body() -> None:
+        async with inbox_app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            assert any(t.task_id == plan_review_id for t in inbox_app._tasks)
+            assert title in _visible_titles(inbox_app)
+
+            await pilot.press("m")
+            await pilot.pause()
+            assert title in _visible_titles(inbox_app)
 
     _run(body())
 


### PR DESCRIPTION
Closes #1156

Keeps task-backed plan_review rows visible when their plan_task sidecar points at the same task, while still deduping a bare plan task when a different handoff row covers it. Adds regressions for the self-referential dedupe case and the rendered cockpit inbox list.

Self-audit of layers touched: UI/CLI inbox adapter and cockpit inbox UI tests only; no facade, domain, or store boundary changes.