### PR TITLE
Fix #1179 prevent foreign HOME tmux hijack

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -19,6 +19,7 @@ Contract:
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -230,6 +231,14 @@ def switch_client_to_session(session_name: str) -> int:
     return _switch_client_to_session(session_name)
 
 
+def session_environment_value(session_name: str, variable: str) -> str | None:
+    from pollypm.session_services import (
+        session_environment_value as _session_environment_value,
+    )
+
+    return _session_environment_value(session_name, variable)
+
+
 def start_transcript_ingestion(config) -> None:
     from pollypm.transcript_ingest import start_transcript_ingestion as _start_transcript_ingestion
 
@@ -265,12 +274,77 @@ def _attach_existing_session_without_config() -> bool:
     for session_name in _session_name_candidates():
         if not probe_session(session_name):
             continue
+        if _session_home_mismatch(_bootstrap_session_home(session_name)) is not None:
+            continue
         if current_tmux == session_name:
             return True
         if current_tmux:
             raise typer.Exit(code=switch_client_to_session(session_name))
         raise typer.Exit(code=attach_existing_session(session_name))
     return False
+
+
+def _normalize_path_for_compare(value: str | None) -> str | None:
+    if not value:
+        return None
+    try:
+        return str(Path(value).expanduser().resolve(strict=False))
+    except Exception:  # noqa: BLE001
+        return str(Path(value).expanduser())
+
+
+def _session_home_mismatch(owner_home: str | None) -> tuple[str, str] | None:
+    current_home = os.environ.get("HOME")
+    owner = _normalize_path_for_compare(owner_home)
+    current = _normalize_path_for_compare(current_home)
+    if not owner or not current or owner == current:
+        return None
+    return (owner, current)
+
+
+def _bootstrap_session_home(session_name: str) -> str | None:
+    try:
+        return session_environment_value(session_name, "HOME")
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _supervisor_session_home(supervisor, session_name: str) -> str | None:
+    tmux = getattr(supervisor, "tmux", None)
+    show_environment = getattr(tmux, "show_environment", None)
+    if not callable(show_environment):
+        return None
+    try:
+        return show_environment(session_name, "HOME")
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _refuse_foreign_tmux_sessions(
+    supervisor,
+    probe: LaunchProbe,
+    config_path: Path,
+) -> None:
+    """Fail closed before mutating a same-named session from another HOME."""
+    sessions = (
+        (probe.main_session_name, probe.main_session_alive),
+        (probe.closet_session_name, probe.closet_session_alive),
+    )
+    for session_name, alive in sessions:
+        if not session_name or not alive:
+            continue
+        mismatch = _session_home_mismatch(
+            _supervisor_session_home(supervisor, session_name)
+        )
+        if mismatch is None:
+            continue
+        owner_home, current_home = mismatch
+        raise typer.BadParameter(
+            f"tmux session '{session_name}' is in use by another HOME "
+            f"({owner_home}); current HOME is {current_home}. Set "
+            f"`project.tmux_session` in {config_path} to a unique name "
+            "before running `pm up`."
+        )
 
 
 def _load_supervisor(config_path: Path):
@@ -681,6 +755,7 @@ def up(
     # ambient state. The probe only reads tmux + config; building it
     # is side-effect-free.
     probe = _build_launch_probe(supervisor)
+    _refuse_foreign_tmux_sessions(supervisor, probe, config_path)
     plan = plan_launch(probe)
     typer.echo(f"[launch] {plan.state.value}: {plan.reason}")
     if plan.state is LaunchState.UNSUPPORTED:

--- a/src/pollypm/session_services/__init__.py
+++ b/src/pollypm/session_services/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     "current_session_name",
     "get_session_service",
     "probe_session",
+    "session_environment_value",
     "switch_client_to_session",
 ]
 
@@ -57,6 +58,11 @@ def create_tmux_client():
 def probe_session(name: str) -> bool:
     """Return True if a session with this name exists at the tmux layer."""
     return create_tmux_client().has_session(name)
+
+
+def session_environment_value(session_name: str, variable: str) -> str | None:
+    """Return a tmux session environment value before config is loaded."""
+    return create_tmux_client().show_environment(session_name, variable)
 
 
 def attach_existing_session(name: str) -> int:

--- a/src/pollypm/tmux/client.py
+++ b/src/pollypm/tmux/client.py
@@ -126,6 +126,31 @@ class TmuxClient:
         result = self.run("has-session", "-t", self._exact_target(name), check=False)
         return result.returncode == 0
 
+    def show_environment(self, session_name: str, variable: str) -> str | None:
+        """Return one tmux session environment value, if it is visible.
+
+        tmux prints hidden/unset variables as ``-NAME`` and regular
+        variables as ``NAME=value``. Treat hidden, unset, malformed, and
+        failed probes as missing so callers can stay conservative.
+        """
+        self._validate_name(session_name, "session name")
+        result = self.run(
+            "show-environment",
+            "-t",
+            self._exact_target(session_name),
+            variable,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        line = result.stdout.strip()
+        if not line or line.startswith(f"-{variable}"):
+            return None
+        prefix = f"{variable}="
+        if not line.startswith(prefix):
+            return None
+        return line[len(prefix):]
+
     def _spawn_env_args(self) -> list[str]:
         args: list[str] = []
         for name in _SPAWN_ENV_VARS:

--- a/tests/test_cli_up_state_machine.py
+++ b/tests/test_cli_up_state_machine.py
@@ -253,6 +253,77 @@ def test_up_unsupported_short_circuits_before_side_effects(
     )
 
 
+def test_up_refuses_foreign_home_tmux_session_before_side_effects(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """#1179: a fresh HOME must not hijack another HOME's pollypm tmux session."""
+    fresh_home = tmp_path / "fresh-home"
+    fresh_home.mkdir()
+    monkeypatch.setenv("HOME", str(fresh_home))
+    config_path = fresh_home / ".pollypm" / "pollypm.toml"
+    config_path.parent.mkdir()
+    config_path.write_text("[project]\nname = \"pollypm\"\n")
+    side_effects: list[str] = []
+
+    class _FakeTmux:
+        def has_session(self, name: str) -> bool:
+            return name == "pollypm"
+
+        def current_session_name(self) -> None:
+            return None
+
+        def show_environment(self, session_name: str, variable: str) -> str | None:
+            assert session_name == "pollypm"
+            assert variable == "HOME"
+            return "/Users/sam"
+
+    class _FakeCoreRail:
+        def start(self) -> None:
+            side_effects.append("core_rail.start")
+
+    class _FakeSupervisor:
+        def __init__(self) -> None:
+            self.tmux = _FakeTmux()
+            self.config = type(
+                "Config",
+                (),
+                {
+                    "project": type(
+                        "Project",
+                        (),
+                        {
+                            "tmux_session": "pollypm",
+                            "base_dir": config_path.parent,
+                        },
+                    )(),
+                    "accounts": {},
+                    "projects": {},
+                },
+            )()
+            self.core_rail = _FakeCoreRail()
+
+        def ensure_layout(self) -> None:
+            side_effects.append("ensure_layout")
+
+        def start_cockpit_tui(self, _session_name: str) -> None:
+            side_effects.append("start_cockpit_tui")
+
+    monkeypatch.setattr(cli, "_load_supervisor", lambda _path: _FakeSupervisor())
+    monkeypatch.setattr(
+        cli,
+        "start_transcript_ingestion",
+        lambda _config: side_effects.append("transcript_ingest"),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["up", "--config", str(config_path)])
+
+    assert result.exit_code != 0
+    assert "tmux session 'pollypm' is in use by another HOME" in result.output
+    assert "project.tmux_session" in result.output
+    assert side_effects == []
+
+
 def test_probe_detects_dead_console_pane() -> None:
     """#906 — when ``list_panes`` reports the console pane as dead,
     the probe must surface ``console_pane_alive=False`` so the

--- a/tests/test_tmux_client.py
+++ b/tests/test_tmux_client.py
@@ -89,6 +89,47 @@ def test_has_session_returns_false_when_tmux_hangs(monkeypatch) -> None:
     assert client.has_session("pollypm") is False
 
 
+def test_show_environment_reads_session_scoped_value(monkeypatch) -> None:
+    captured: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        captured.append(list(args))
+
+        class Result:
+            returncode = 0
+            stdout = "HOME=/tmp/polly-fresh\n"
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    client = TmuxClient()
+
+    assert client.show_environment("pollypm", "HOME") == "/tmp/polly-fresh"
+    assert captured[0] == [
+        "tmux",
+        "show-environment",
+        "-t",
+        "=pollypm",
+        "HOME",
+    ]
+
+
+def test_show_environment_treats_hidden_value_as_missing(monkeypatch) -> None:
+    def fake_run(args, **kwargs):
+        class Result:
+            returncode = 0
+            stdout = "-HOME\n"
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    client = TmuxClient()
+
+    assert client.show_environment("pollypm", "HOME") is None
+
+
 def test_send_keys_long_text_uses_per_call_named_buffer(monkeypatch, tmp_path) -> None:
     """#808: long sends must use a per-call named tmux paste buffer so
     two concurrent sends can't paste each other's text. Two


### PR DESCRIPTION
Closes #1179

Adds a pre-mutation launch guard that checks the tmux session HOME for the configured main/storage sessions and refuses to attach or recover when a same-named session belongs to another HOME. This prevents a fresh install from respawning its isolated cockpit rail inside an existing prod pollypm tmux session.

Self-audit: touched CLI/pre-config bootstrap and tmux client helpers only; no domain, store, or service-facade boundary crossings.