### PR TITLE
Fix #1180 add zero-project onboarding hints

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -3259,8 +3259,13 @@ class PollyDashboardApp(App[None]):
         # ── Footer ──
         sweep_word = "sweep" if data.sweep_count_24h == 1 else "sweeps"
         msg_word = "message" if data.message_count_24h == 1 else "messages"
+        footer_action = (
+            "Click Polly to connect"
+            if n_projects
+            else "Add a project: pm add-project"
+        )
         footer = (
-            "[dim]Click Polly to connect  \u00b7  "
+            f"[dim]{footer_action}  \u00b7  "
             f"{data.sweep_count_24h} {sweep_word} today  \u00b7  "
             f"{data.message_count_24h} {msg_word}"
         )

--- a/src/pollypm/plugins_builtin/core_rail_items/plugin.py
+++ b/src/pollypm/plugins_builtin/core_rail_items/plugin.py
@@ -343,7 +343,12 @@ def _project_rows(ctx: RailContext) -> list[RailRow]:
         return []
     active, inactive, has_working = _classify_projects(ctx)
     if not active and not inactive:
-        return []
+        return [RailRow(
+            key="projects_root",
+            label="Projects",
+            state="separator",
+            selectable=False,
+        )]
     selected = _selected_key(ctx)
     config = _config(ctx)
 

--- a/tests/test_core_rail_items.py
+++ b/tests/test_core_rail_items.py
@@ -34,14 +34,19 @@ def _write_config(tmp_path: Path) -> Path:
 
 
 class _FakeConfig:
-    def __init__(self, tmp_path: Path, *, sessions: dict | None = None) -> None:
+    def __init__(
+        self,
+        tmp_path: Path,
+        *,
+        sessions: dict | None = None,
+        projects: dict | None = None,
+    ) -> None:
         class Project:
             root_dir = tmp_path
             base_dir = tmp_path / ".pollypm"
             tmux_session = "pollypm"
 
-        self.project = Project()
-        self.projects = {
+        default_projects = {
             "pollypm": KnownProject(
                 key="pollypm", path=tmp_path, name="PollyPM",
                 persona_name="Pete", kind=ProjectKind.GIT,
@@ -51,6 +56,8 @@ class _FakeConfig:
                 persona_name="Dora", kind=ProjectKind.GIT,
             ),
         }
+        self.project = Project()
+        self.projects = default_projects if projects is None else projects
         # ``sessions`` is read by visibility predicates that gate rail
         # entries on whether a backing ``[sessions.<name>]`` block
         # exists (#962 — Russell · chat). Default to operator + reviewer
@@ -81,8 +88,13 @@ class _FakeWindow:
         self.pane_id = f"%{name}"
 
 
-def _fake_supervisor(tmp_path: Path, *, sessions: dict | None = None):
-    config = _FakeConfig(tmp_path, sessions=sessions)
+def _fake_supervisor(
+    tmp_path: Path,
+    *,
+    sessions: dict | None = None,
+    projects: dict | None = None,
+):
+    config = _FakeConfig(tmp_path, sessions=sessions, projects=projects)
 
     class FakeSupervisor:
         def __init__(self) -> None:
@@ -159,6 +171,29 @@ def test_build_items_identical_to_legacy_shape(monkeypatch, tmp_path: Path) -> N
     # _count_inbox_tasks_for_label monkey-patch reached the rail).
     inbox_item = next(item for item in items if item.key == "inbox")
     assert inbox_item.label == "Inbox (1)"
+
+
+def test_build_items_keeps_projects_section_when_empty(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        "pollypm.cockpit._count_inbox_tasks_for_label", lambda config: 0,
+    )
+    _write_config(tmp_path)
+    router = CockpitRouter(tmp_path / "pollypm.toml")
+    monkeypatch.setattr(
+        router,
+        "_load_supervisor",
+        lambda: _fake_supervisor(tmp_path, projects={}),
+    )
+
+    items = router.build_items(spinner_index=0)
+    keys = [item.key for item in items]
+    project_section = next(item for item in items if item.key == "projects_root")
+
+    assert project_section.label == "Projects"
+    assert project_section.selectable is False
+    assert keys.index("inbox") < keys.index("projects_root") < keys.index("settings")
 
 
 def test_russell_rail_entry_hidden_when_reviewer_session_unconfigured(

--- a/tests/test_polly_dashboard_ui.py
+++ b/tests/test_polly_dashboard_ui.py
@@ -158,6 +158,24 @@ def test_polly_dashboard_shows_inbox_count_without_recent_messages(tmp_path: Pat
     assert "Press I to jump to the inbox" in rendered
 
 
+def test_polly_dashboard_zero_project_footer_points_to_add_project(
+    tmp_path: Path,
+) -> None:
+    app = PollyDashboardApp(tmp_path / "pollypm.toml")
+    data = _fake_dashboard_data()
+    config = SimpleNamespace(
+        projects={},
+        sessions={"operator": object(), "reviewer": object()},
+    )
+
+    app._render_dashboard(config, data)
+
+    rendered = str(app.footer_w.render())
+    assert "Add a project" in rendered
+    assert "pm add-project" in rendered
+    assert "Click Polly to connect" not in rendered
+
+
 def test_polly_dashboard_renders_llm_quota_usage(tmp_path: Path) -> None:
     app = PollyDashboardApp(tmp_path / "pollypm.toml")
     data = _fake_dashboard_data()


### PR DESCRIPTION
Closes #1180

Summary:
- Keep the Projects rail section visible when no projects are registered by rendering a disabled Projects row.
- Show an actionable zero-project Home footer hint: `Add a project: pm add-project`.

Tests:
- `uv run --extra dev pytest tests/test_polly_dashboard_ui.py tests/test_core_rail_items.py -k 'empty or zero or project' -x`
- `uv run --extra dev pytest tests/test_polly_dashboard_ui.py tests/test_core_rail_items.py -x`

Layer self-audit:
- `src/pollypm/plugins_builtin/core_rail_items/plugin.py`: UI rail rendering only.
- `src/pollypm/cockpit_ui.py`: UI dashboard rendering only.
- Tests only in `tests/test_core_rail_items.py` and `tests/test_polly_dashboard_ui.py`.
- Bug layer: UI. No service/domain/store boundary changes; no boundary debt.
