### PR TITLE
Fix #1183 filter CLI tips from Now

### DIFF
--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -330,6 +330,25 @@ _NOW_EVENT_SIGNATURES: tuple[re.Pattern[str], ...] = (
 )
 
 
+_UPSTREAM_CLI_TIP_SUBSTRINGS = (
+    "try the codex app",
+    "visit https://chatgpt.com",
+)
+_UPSTREAM_CLI_TIP_COMMAND_RE = re.compile(r"^(?:new\s+)?use\s+/[a-z]", re.IGNORECASE)
+
+
+def _is_upstream_cli_tip(line: str) -> bool:
+    text = line.strip()
+    if not text:
+        return False
+    lower = text.lower()
+    return (
+        lower.startswith("tip:")
+        or _UPSTREAM_CLI_TIP_COMMAND_RE.search(text) is not None
+        or any(marker in lower for marker in _UPSTREAM_CLI_TIP_SUBSTRINGS)
+    )
+
+
 def _scan_for_event_signature(clean_lines: list[str]) -> str | None:
     """Return the most-recent line matching a recognized event
     signature, or None if no such line exists in the trailing window.
@@ -357,6 +376,8 @@ def _scan_for_event_signature(clean_lines: list[str]) -> str | None:
         # Skip lines that the existing fall-through filter would
         # already drop — same prompt prefixes, same TUI chrome.
         if stripped.startswith(("❯", "›", ">", "$", "%", *_BOX_DRAWING_PREFIXES)):
+            continue
+        if _is_upstream_cli_tip(stripped):
             continue
         for pattern in _NOW_EVENT_SIGNATURES:
             if pattern.search(stripped):
@@ -454,6 +475,8 @@ def _session_description(status: str, role: str, snapshot_path: str | None) -> s
                     or "shift+tab to cycle" in lower
                     or line.startswith("⏵⏵")
                 ):
+                    continue
+                if _is_upstream_cli_tip(line):
                     continue
                 # Codex idle-input placeholder hints — defensive net in
                 # case the ``›`` prompt arrow gets stripped during pane

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -200,6 +200,45 @@ def test_session_description_skips_codex_idle_placeholder_without_arrow(
     assert desc == "idle"
 
 
+def test_session_description_skips_upstream_cli_tips(tmp_path) -> None:
+    """#1183: Codex tip-of-the-day banners are not project activity."""
+    from pollypm.dashboard_data import _session_description
+
+    tip_lines = (
+        "Tip: Use /compact when the conversation gets long to summarize…",
+        "Tip: Try the Codex App. Run 'codex app' or visit https://chatgpt.com/",
+        "Tip: New Use /fast to enable our fastest inference with increased…",
+        "Use /compact when the conversation gets long to summarize…",
+        "Use /fast to enable our fastest inference with increased…",
+        "Try the Codex App. Run 'codex app' or visit https://chatgpt.com/",
+    )
+    for tip in tip_lines:
+        snapshot = tmp_path / "snap.txt"
+        snapshot.write_text(f"{tip}\n")
+        desc = _session_description("healthy", "worker", str(snapshot))
+        assert "tip:" not in desc.lower()
+        assert "/compact" not in desc.lower()
+        assert "/fast" not in desc.lower()
+        assert "codex app" not in desc.lower()
+        assert "chatgpt.com" not in desc.lower()
+        assert desc == "idle"
+
+
+def test_session_description_uses_meaningful_line_before_cli_tip(tmp_path) -> None:
+    """A real activity line above a skipped tip should remain visible."""
+    from pollypm.dashboard_data import _session_description
+
+    snapshot = tmp_path / "snap.txt"
+    snapshot.write_text(
+        "Updated dashboard activity filtering tests.\n"
+        "Tip: Try the Codex App. Run 'codex app' or visit https://chatgpt.com/\n"
+    )
+
+    desc = _session_description("healthy", "worker", str(snapshot))
+
+    assert desc == "Updated dashboard activity filtering tests."
+
+
 def test_session_description_keeps_real_codex_working_status(tmp_path) -> None:
     """#994 negative: the fix must not regress working-session
     rendering. A pane snapshot showing Codex actively working (the


### PR DESCRIPTION
Closes #1183

Summary:
- Filter upstream CLI tip/banner lines from Home Now session descriptions, including Tip:, Try the Codex App, Use /compact, Use /fast, and chatgpt.com banners.
- Fall through to the existing idle/default description when only tip noise is present, while preserving meaningful activity above a skipped tip.

Tests:
- uv run --extra dev pytest tests/test_dashboard_data*.py tests/test_polly_dashboard_ui.py -k 'activity or now or tip or codex' -x
- uv run --extra dev pytest tests/test_dashboard_data_alert_dedup.py -x

Layer self-audit:
- Files touched: src/pollypm/dashboard_data.py (UI/data aggregation for Home dashboard), tests/test_dashboard_data_alert_dedup.py (focused dashboard-data regression tests).
- Bug layer: Home dashboard data-layer activity filtering.
- Boundary violation needed: false.