### PR TITLE
Fix #1171 clean up Tasks done-only view

### DIFF
--- a/src/pollypm/cockpit_tasks.py
+++ b/src/pollypm/cockpit_tasks.py
@@ -1128,7 +1128,17 @@ class PollyTasksApp(App[None]):
     }
     #tasks-search {
         width: 1fr;
+        height: 1;
+        min-height: 1;
         margin: 0 1 0 0;
+        padding: 0 1;
+        border: none;
+        background: #111820;
+        color: #d6dee5;
+    }
+    #tasks-search:focus {
+        border: none;
+        background: #14202a;
     }
     #tasks-filters {
         width: auto;
@@ -1138,6 +1148,10 @@ class PollyTasksApp(App[None]):
     #tasks-filters Button {
         margin-left: 1;
         min-width: 8;
+        height: 1;
+        min-height: 1;
+        border: none;
+        padding: 0 1;
     }
     #tasks-filter-chips {
         height: auto;
@@ -1146,13 +1160,17 @@ class PollyTasksApp(App[None]):
     }
     #tasks-filter-chips Button {
         margin-right: 1;
+        height: 1;
+        min-height: 1;
+        border: none;
+        padding: 0 1;
     }
     #tasks-body { height: 1fr; }
     #tasks-list-pane {
         width: 46;
         min-width: 38;
-        padding: 0 1;
-        border-right: tall #24303b;
+        padding: 0 2 0 1;
+        border-right: none;
     }
     #tasks-summary {
         height: auto;
@@ -1169,7 +1187,7 @@ class PollyTasksApp(App[None]):
     }
     #tasks-detail-pane {
         width: 1fr;
-        padding: 0 1;
+        padding: 0 1 0 2;
     }
     #task-header {
         height: auto;
@@ -1182,6 +1200,10 @@ class PollyTasksApp(App[None]):
     }
     #task-actions Button {
         margin-right: 1;
+        height: 1;
+        min-height: 1;
+        border: none;
+        padding: 0 1;
     }
     /* #767 — when a review action is pending undo, the morphed
        button gets a strong success tint so the click target reads
@@ -1245,6 +1267,12 @@ class PollyTasksApp(App[None]):
         background: #d93f3a;
     }
     #task-tabs { height: 1fr; }
+    #task-tabs ContentTabs {
+        height: 1;
+    }
+    #task-tabs Underline {
+        display: none;
+    }
     #task-detail-scroll,
     #task-review-scroll,
     #task-context-scroll,
@@ -1697,6 +1725,47 @@ class PollyTasksApp(App[None]):
             visible.append(task)
         return visible
 
+    def _done_task_count(self) -> int:
+        return sum(
+            1
+            for task in self._tasks
+            if _task_matches_status(
+                task,
+                "done",
+                plan_blocked=task.task_id in self._plan_blocked_task_ids,
+            )
+        )
+
+    def _active_task_count(self) -> int:
+        return sum(
+            1
+            for task in self._tasks
+            if _task_matches_status(
+                task,
+                "active",
+                plan_blocked=task.task_id in self._plan_blocked_task_ids,
+            )
+        )
+
+    def _use_done_filter_for_done_only_default(self) -> None:
+        if self._status_filter != "active" or self._search_query.strip():
+            return
+        if (
+            self._tasks
+            and self._active_task_count() == 0
+            and self._done_task_count() > 0
+        ):
+            self._status_filter = "done"
+            self._sync_filter_buttons()
+
+    def _empty_filter_message(self) -> str:
+        if self._status_filter == "active" and not self._search_query.strip():
+            done_count = self._done_task_count()
+            if done_count:
+                task_word = "task" if done_count == 1 else "tasks"
+                return f"No active tasks. {done_count} done {task_word} available."
+        return "No tasks match the current filter."
+
     def _summary_text(self, visible: list) -> str:
         counts = _task_counts(
             self._tasks,
@@ -1869,7 +1938,7 @@ class PollyTasksApp(App[None]):
         previous = self._selected_task_id
         self.task_table.clear()
         if not visible:
-            self._set_detail_empty("No tasks match the current filter.")
+            self._set_detail_empty(self._empty_filter_message())
             return
         for task in visible:
             owner = self._owner_by_task_id.get(task.task_id) or "—"
@@ -1955,6 +2024,8 @@ class PollyTasksApp(App[None]):
             self._plan_approval_task_id,
             self._recent_sweeper_ping_task_ids,
         ) = self._load_tasks()
+        if select_first:
+            self._use_done_filter_for_done_only_default()
         self._render_table(select_first=select_first)
 
     def _render_timeline(self, executions: list) -> None:

--- a/tests/test_tasks_ui.py
+++ b/tests/test_tasks_ui.py
@@ -1175,6 +1175,115 @@ def test_task_app_filters_drive_table_contents(env, monkeypatch) -> None:
     _run(body())
 
 
+def test_task_app_done_only_project_defaults_to_done_filter(env, monkeypatch) -> None:
+    """#1171 — done-only projects should not open to an empty Active view."""
+    if not _load_config_compatible(env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_tasks import PollyTasksApp
+
+    done_one = _task(
+        task_number=1,
+        node_id="research",
+        title="Done already",
+        status=WorkStatus.DONE,
+    )
+    done_two = _task(
+        task_number=2,
+        node_id="research",
+        title="Also done",
+        status=WorkStatus.DONE,
+    )
+    fake_svc = _FakeSvc(tasks_factory=lambda: [done_one, done_two], flow=_flow())
+
+    monkeypatch.setattr("pollypm.cockpit_tasks.create_tmux_client", lambda: _FakeTmux([]))
+
+    app = PollyTasksApp(env["config_path"], "demo")
+    app._get_svc = lambda: fake_svc  # type: ignore[method-assign]
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 50)) as pilot:
+            await pilot.pause()
+            table = app.query_one("#tasks-table", DataTable)
+            rows = _table_rows(table)
+            summary = str(app.query_one("#tasks-summary", Static).render())
+
+            assert app._status_filter == "done"
+            assert table.row_count == 2
+            assert [row[2] for row in rows] == ["🟠 Done already", "🟠 Also done"]
+            assert summary.startswith("2 tasks")
+            assert "0 of 2 shown" not in summary
+
+    _run(body())
+
+
+def test_task_app_active_empty_state_surfaces_done_count(env, monkeypatch) -> None:
+    """#1171 — explicit Active on done-only tasks explains where rows went."""
+    if not _load_config_compatible(env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_tasks import PollyTasksApp
+
+    done_task = _task(
+        task_number=1,
+        node_id="research",
+        title="Done already",
+        status=WorkStatus.DONE,
+    )
+    fake_svc = _FakeSvc(tasks_factory=lambda: [done_task], flow=_flow())
+
+    monkeypatch.setattr("pollypm.cockpit_tasks.create_tmux_client", lambda: _FakeTmux([]))
+
+    app = PollyTasksApp(env["config_path"], "demo")
+    app._get_svc = lambda: fake_svc  # type: ignore[method-assign]
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 50)) as pilot:
+            await pilot.pause()
+            app._status_filter = "active"
+            app._sync_filter_buttons()
+            app._render_table(select_first=True)
+            await pilot.pause()
+
+            table = app.query_one("#tasks-table", DataTable)
+            header = str(app.query_one("#task-header", Static).render())
+            assert table.row_count == 0
+            assert header == "No active tasks. 1 done task available."
+
+    _run(body())
+
+
+def test_task_app_chrome_omits_stray_rule_glyphs(env, monkeypatch) -> None:
+    """#1171 — the Tasks chrome should not render decorative rule shards."""
+    if not _load_config_compatible(env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_smoke import SmokeHarness
+    from pollypm.cockpit_tasks import PollyTasksApp
+
+    done_task = _task(
+        task_number=1,
+        node_id="research",
+        title="Done already",
+        status=WorkStatus.DONE,
+    )
+    fake_svc = _FakeSvc(tasks_factory=lambda: [done_task], flow=_flow())
+
+    monkeypatch.setattr("pollypm.cockpit_tasks.create_tmux_client", lambda: _FakeTmux([]))
+
+    app = PollyTasksApp(env["config_path"], "demo")
+    app._get_svc = lambda: fake_svc  # type: ignore[method-assign]
+
+    async def body() -> None:
+        async with SmokeHarness.mount(app, size=(220, 80)) as smoke:
+            capture = smoke.snapshot()
+            for glyph in ("▔", "▁", "▎", "╸", "╺", "━"):
+                assert glyph not in capture.rendered_text
+            heading_line = next(
+                line for line in capture.visible_lines if "Tasks · Demo" in line
+            )
+            assert "▊" not in heading_line
+
+    _run(body())
+
+
 def test_task_app_surfaces_priority_glyphs_and_sorts_critical_first(env, monkeypatch) -> None:
     if not _load_config_compatible(env["config_path"]):
         pytest.skip("minimal pollypm.toml fixture not supported by loader")


### PR DESCRIPTION
Closes #1171

Summary:
- Compact the Tasks toolbar, chips, actions, split-pane gutter, and tabs so Textual does not render decorative rule/border artifacts in the project Tasks view.
- When the initial Tasks load has no active rows but has done/cancelled rows, default to Done instead of a dead empty Active filter; explicit Active now reports the done count.

Tests:
- uv run --extra dev pytest tests/test_tasks_ui.py tests/test_project_dashboard_ui.py -k 'task or filter or done' -x\n- uv run --extra dev pytest tests/test_cockpit_smoke_render.py::test_tasks_app_smoke -q\n\nLayer self-audit:\n- Bug layer: UI rendering/filter behavior.\n- Files touched: src/pollypm/cockpit_tasks.py (UI), tests/test_tasks_ui.py (tests).\n- Boundary audit: no facade/domain/store changes, no new cross-layer imports, no boundary violation needed.