### PR TITLE
Fix #1170 align PM Chat rail persona

### DIFF
--- a/src/pollypm/plugins_builtin/core_rail_items/plugin.py
+++ b/src/pollypm/plugins_builtin/core_rail_items/plugin.py
@@ -337,6 +337,24 @@ def _selected_key(ctx: RailContext) -> str:
     return str(value) if isinstance(value, str) and value else "polly"
 
 
+def _project_chat_persona(project: Any, session_role: Any) -> str | None:
+    if isinstance(session_role, str) and session_role.strip():
+        try:
+            from pollypm.role_contract import canonical_role, persona_for
+
+            if canonical_role(session_role) == "architect":
+                return persona_for("architect")
+        except ValueError:
+            pass
+
+    persona_raw = getattr(project, "persona_name", None)
+    return (
+        persona_raw.strip()
+        if isinstance(persona_raw, str) and persona_raw.strip()
+        else None
+    )
+
+
 def _project_rows(ctx: RailContext) -> list[RailRow]:
     router = _router(ctx)
     if router is None:
@@ -352,20 +370,25 @@ def _project_rows(ctx: RailContext) -> list[RailRow]:
     selected = _selected_key(ctx)
     config = _config(ctx)
 
-    # Map project -> session name for session_state fallback.
+    # Map project -> session name/role for session_state fallback and label copy.
     from pollypm.models import CONTROL_ROLES
 
-    project_session_map: dict[str, str] = {}
+    project_session_map: dict[str, tuple[str, str]] = {}
     for launch in _launches(ctx):
         role = getattr(launch.session, "role", "")
         if role in CONTROL_ROLES:
             continue
-        project_session_map.setdefault(launch.session.project, launch.session.name)
+        project_session_map.setdefault(
+            launch.session.project,
+            (launch.session.name, role),
+        )
 
     rows: list[RailRow] = []
 
     def _emit(project_key: str, project: Any) -> None:
-        session_name = project_session_map.get(project_key)
+        session_info = project_session_map.get(project_key)
+        session_name = session_info[0] if session_info is not None else None
+        session_role = session_info[1] if session_info is not None else None
         if has_working.get(project_key):
             state = "\u25c6 working"
         elif session_name is not None:
@@ -383,12 +406,7 @@ def _project_rows(ctx: RailContext) -> list[RailRow]:
                 label="  Dashboard",
                 state="sub",
             ))
-            persona_raw = getattr(project, "persona_name", None)
-            persona = (
-                persona_raw.strip()
-                if isinstance(persona_raw, str) and persona_raw.strip()
-                else None
-            )
+            persona = _project_chat_persona(project, session_role)
             label = f"  PM Chat ({persona})" if persona else "  PM Chat"
             rows.append(RailRow(
                 key=f"project:{project_key}:session",

--- a/tests/test_core_rail_items.py
+++ b/tests/test_core_rail_items.py
@@ -88,6 +88,59 @@ class _FakeWindow:
         self.pane_id = f"%{name}"
 
 
+@pytest.mark.parametrize(
+    ("session_role", "expected_label"),
+    [
+        ("architect", "  PM Chat (Archie)"),
+        ("worker", "  PM Chat (Bea)"),
+    ],
+)
+def test_pm_chat_label_matches_project_session_persona(
+    monkeypatch, tmp_path: Path, session_role: str, expected_label: str,
+) -> None:
+    project = KnownProject(
+        key="bikepath",
+        path=tmp_path,
+        name="Bikepath",
+        persona_name="Bea",
+        kind=ProjectKind.GIT,
+    )
+    config = type("Config", (), {"projects": {"bikepath": project}})()
+
+    class _Router:
+        def _session_state(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            return "idle"
+
+    monkeypatch.setattr(
+        core_rail_items_plugin,
+        "_classify_projects",
+        lambda ctx: ([("bikepath", project)], [], {"bikepath": False}),
+    )
+    monkeypatch.setattr(
+        core_rail_items_plugin,
+        "_active_task_numbers",
+        lambda project, *, config=None: [],
+    )
+    ctx = RailContext(
+        router=_Router(),
+        config=config,
+        launches=[
+            _FakeLaunch(
+                f"{session_role}_bikepath",
+                session_role,
+                "bikepath",
+                f"{session_role}-bikepath",
+            ),
+        ],
+        cockpit_state={"selected": "project:bikepath"},
+    )
+
+    rows = core_rail_items_plugin._project_rows(ctx)
+
+    session_row = next(row for row in rows if row.key == "project:bikepath:session")
+    assert session_row.label == expected_label
+
+
 def _fake_supervisor(
     tmp_path: Path,
     *,


### PR DESCRIPTION
Closes #1170

Summary:
- Align project PM Chat rail parentheticals with the session persona when the backing project session is the architect, so architect-backed chat shows Archie instead of the project PM alias.
- Preserve the existing project persona label for worker-backed PM Chat sessions.

Tests:
- uv run --extra dev pytest tests/test_core_rail_items.py tests/test_role_contract.py tests/test_architect_bootstrap.py -x

Layer self-audit:
- Bug layer: UI rail copy.
- Files touched: core_rail_items rail plugin (UI) and focused rail contract tests.
- Boundary audit: no store/IO access and no new UI-to-store reach; uses the existing role_contract identity contract for persona display.
