### PR TITLE
Fix #1156 keep task-backed plan reviews

### DIFF
--- a/src/pollypm/cockpit_inbox_items.py
+++ b/src/pollypm/cockpit_inbox_items.py
@@ -545,6 +545,10 @@ def _filter_approved_plan_reviews(
     Logs the number of phantom rows filtered so we can measure inbox
     cleanup and decide when the proper sweeper is needed.
 
+    Task-backed plan-review rows are checked against their loaded task
+    state directly. Message-backed rows still resolve their
+    ``plan_task:<project/number>`` labels through the DB map.
+
     DB resolution: ``project_db_paths`` may carry both per-project
     entries (``project_key -> (db, project_path)``) AND a workspace-root
     entry under the ``__workspace__`` sentinel key. When a plan_review's
@@ -563,11 +567,15 @@ def _filter_approved_plan_reviews(
     refs_by_db: dict[str, set[tuple[str, int]]] = {}
     considered = 0
     refs_unparsed = 0
+    has_task_backed_plan_reviews = False
     for item in items:
         labels = {str(lbl) for lbl in (getattr(item, "labels", []) or [])}
         if "plan_review" not in labels:
             continue
         considered += 1
+        if getattr(item, "source", None) == "task":
+            has_task_backed_plan_reviews = True
+            continue
         ref = _plan_task_ref(item)
         if not ref or "/" not in ref:
             refs_unparsed += 1
@@ -597,17 +605,26 @@ def _filter_approved_plan_reviews(
                 considered,
                 refs_unparsed,
             )
-        return items
-    approved_refs = approved_plan_review_refs(
-        refs_by_db=refs_by_db,
-        project_db_paths=project_db_paths,
-        service_factory=SQLiteWorkService,
-    )
+        if not has_task_backed_plan_reviews:
+            return items
+        approved_refs = set()
+    else:
+        approved_refs = approved_plan_review_refs(
+            refs_by_db=refs_by_db,
+            project_db_paths=project_db_paths,
+            service_factory=SQLiteWorkService,
+        )
     kept: list[InboxEntry] = []
     dropped = 0
     for item in items:
         labels = {str(lbl) for lbl in (getattr(item, "labels", []) or [])}
         if "plan_review" in labels:
+            if getattr(item, "source", None) == "task":
+                if _task_user_approval_is_approved(item):
+                    dropped += 1
+                    continue
+                kept.append(item)
+                continue
             ref = _plan_task_ref(item)
             if ref and ref in approved_refs:
                 dropped += 1
@@ -716,14 +733,10 @@ def load_inbox_entries(
                     continue
                 seen_task_ids.add(task.task_id)
                 # Synth-source filter for plan_review (#1103, 4th
-                # attempt). The post-emission ``_filter_approved_plan_reviews``
-                # only catches notify-message rows that carry a
-                # ``plan_task:<project/number>`` ref label — task-backed
-                # synth rows (the ones produced here) don't carry that
-                # label, so the filter never sees them. Check the
-                # task's own user_approval execution directly: if it's
-                # COMPLETED + APPROVED, the plan review is already
-                # done and emitting the row would be a phantom action.
+                # attempt). Check the task's own user_approval
+                # execution directly: if it's COMPLETED + APPROVED,
+                # the plan review is already done and emitting the row
+                # would be a phantom action.
                 task_labels = {str(lbl) for lbl in (getattr(task, "labels", []) or [])}
                 if "plan_review" in task_labels:
                     emit = not _task_user_approval_is_approved(task)

--- a/tests/test_cockpit_inbox_ui.py
+++ b/tests/test_cockpit_inbox_ui.py
@@ -548,6 +548,71 @@ def test_filter_approved_plan_reviews_drops_completed_user_approval(
     assert "msg:bikepath:9" in kept_ids
 
 
+def test_filter_approved_plan_reviews_keeps_task_backed_pending_user_approval(
+    monkeypatch,
+) -> None:
+    """Task-backed plan_review rows use their loaded task approval state."""
+    from datetime import datetime
+    from pathlib import Path
+    from types import SimpleNamespace
+
+    from pollypm.cockpit_inbox_items import (
+        InboxEntry,
+        _filter_approved_plan_reviews,
+    )
+    from pollypm.work.models import Decision, ExecutionStatus
+
+    pending_exec = SimpleNamespace(
+        node_id="user_approval",
+        status=ExecutionStatus.ACTIVE,
+        decision=None,
+    )
+    approved_exec = SimpleNamespace(
+        node_id="user_approval",
+        status=ExecutionStatus.COMPLETED,
+        decision=Decision.APPROVED,
+    )
+    pending_item = InboxEntry(
+        raw=SimpleNamespace(executions=[pending_exec]),
+        source="task",
+        task_id="bikepath/7",
+        title="Plan ready for review: bikepath",
+        project="bikepath",
+        labels=["plan_review", "project:bikepath", "plan_task:bikepath/7"],
+        created_at=datetime(2026, 5, 5, 10, 0, 0),
+        updated_at=datetime(2026, 5, 5, 10, 0, 0),
+    )
+    approved_item = InboxEntry(
+        raw=SimpleNamespace(executions=[approved_exec]),
+        source="task",
+        task_id="smoketest/7",
+        title="Plan ready for review: smoketest",
+        project="smoketest",
+        labels=["plan_review", "project:smoketest", "plan_task:smoketest/7"],
+        created_at=datetime(2026, 5, 5, 10, 0, 0),
+        updated_at=datetime(2026, 5, 5, 10, 0, 0),
+    )
+
+    def fail_if_ref_filter_runs(**_kwargs):
+        raise AssertionError("task-backed plan reviews should not use ref lookup")
+
+    monkeypatch.setattr(
+        "pollypm.cockpit_inbox_items.approved_plan_review_refs",
+        fail_if_ref_filter_runs,
+    )
+
+    project_db_paths = {
+        "bikepath": (Path("/tmp/bikepath.db"), Path("/tmp/bikepath")),
+        "smoketest": (Path("/tmp/smoketest.db"), Path("/tmp/smoketest")),
+    }
+    kept = _filter_approved_plan_reviews(
+        [pending_item, approved_item],
+        project_db_paths=project_db_paths,
+    )
+
+    assert kept == [pending_item]
+
+
 def test_filter_approved_plan_reviews_no_op_without_project_paths() -> None:
     """No project_db_paths → filter is a no-op (defensive guard)."""
     from datetime import datetime


### PR DESCRIPTION
Closes #1156

Summary:
- Keep explicit task-backed plan_review rows on their loaded task approval state instead of routing them through the generic plan_task ref lookup after synth already emitted them as user_approval_pending.
- Preserve stale approved filtering: task-backed rows still drop when their loaded user_approval execution is COMPLETED+APPROVED, while message-backed rows continue using the DB ref filter.

Tests:
- uv run --extra dev pytest tests/test_cockpit_inbox_ui.py -k 'plan_review or user_approval or inbox' -x

Layer audit:
- src/pollypm/cockpit_inbox_items.py: UI inbox item synthesis/filtering.
- tests/test_cockpit_inbox_ui.py: focused UI regression coverage.
- Bug layer: UI inbox filtering/rendering.
- Boundary violation needed: false.