### PR TITLE
Fix #1125 default cockpit-send-key routing

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -272,14 +272,14 @@ def register_ui_commands(app: typer.Typer) -> None:
         config_path: Path = typer.Option(
             DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."
         ),
-        kind: str | None = typer.Option(
-            None,
+        kind: str = typer.Option(
+            "cockpit",
             "--kind",
             "-k",
             help=(
                 "Restrict delivery to a specific cockpit surface "
-                "(`cockpit`, `dashboard`, `pane-inbox`, …). Omit to "
-                "target the most recently bound bridge socket."
+                "(`cockpit`, `dashboard`, `pane-inbox`, …). Defaults to "
+                "`cockpit` so stale dashboard sockets cannot steal rail input."
             ),
         ),
     ) -> None:

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -190,6 +190,41 @@ def test_list_bridge_sockets_filters_by_kind(fake_config: Path) -> None:
         dashboard.stop()
 
 
+def test_cockpit_send_key_defaults_to_cockpit_socket(fake_config: Path) -> None:
+    import typer
+    from typer.testing import CliRunner
+
+    from pollypm.cli_features.ui import register_ui_commands
+
+    cockpit_app = _FakeApp()
+    dashboard_app = _FakeApp()
+    cockpit = start_input_bridge(cockpit_app, kind="cockpit", config_path=fake_config)
+    assert cockpit is not None
+    dashboard = start_input_bridge(
+        dashboard_app, kind="dashboard", config_path=fake_config
+    )
+    assert dashboard is not None
+    try:
+        # Simulate issue #1125: a dashboard bridge has the newest socket
+        # timestamp, but bare `pm cockpit-send-key` should still target
+        # the rail cockpit unless the caller explicitly passes `--kind`.
+        future = time.time() + 5
+        os.utime(dashboard.socket_path, (future, future))
+
+        app = typer.Typer()
+        register_ui_commands(app)
+        result = CliRunner().invoke(
+            app, ["cockpit-send-key", "I", "--config", str(fake_config)]
+        )
+        assert result.exit_code == 0, result.output
+        assert f"via {cockpit.socket_path}" in result.output
+        assert _wait_for(lambda: cockpit_app.keys == ["I"])
+        assert dashboard_app.keys == []
+    finally:
+        cockpit.stop()
+        dashboard.stop()
+
+
 def test_send_key_to_first_live_skips_stale_sockets(fake_config: Path, tmp_path: Path) -> None:
     bridge_dir = fake_config.parent / "cockpit_inputs"
     bridge_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Closes #1125

Bare `pm cockpit-send-key` now defaults to the `cockpit` bridge kind instead of considering every bridge socket by mtime, so newer stale `dashboard-*` sockets cannot steal rail input. Added a regression test that makes a dashboard socket newer and verifies the CLI still delivers to the cockpit socket.

Layer audit: touched only CLI/UI command routing and focused bridge tests; no store/domain/facade boundary changes.