### PR TITLE
Fix #1166 keep corrupt DB cockpit pane readable

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -3493,7 +3493,13 @@ class CockpitRouter:
         root = shlex.quote(str(self.config_path.parent.resolve()))
         import shutil
         pm_cmd = "pm" if shutil.which("pm") else "uv run pm"
-        args = [pm_cmd, "cockpit-pane", shlex.quote(kind)]
+        args = [
+            "env",
+            "POLLYPM_HOLD_UNUSABLE_DATABASE_SCREEN=1",
+            pm_cmd,
+            "cockpit-pane",
+            shlex.quote(kind),
+        ]
         if project_key is not None:
             # #751 — inbox and activity both use --project to scope
             # their view. Other views (settings/issues/project) use

--- a/src/pollypm/store/migrations.py
+++ b/src/pollypm/store/migrations.py
@@ -439,7 +439,21 @@ def format_unusable_database_message(error: UnusableDatabaseError) -> str:
 def exit_unusable_database(error: UnusableDatabaseError, *, code: int = 2) -> None:
     """Print the corruption message and exit with a non-zero CLI code."""
     sys.stderr.write(format_unusable_database_message(error) + "\n")
+    sys.stderr.flush()
+    if hold_unusable_database_screen_enabled():
+        _hold_unusable_database_screen(code=code)
     raise SystemExit(code)
+
+
+def _hold_unusable_database_screen(*, code: int) -> None:
+    """Keep a cockpit pane alive after rendering an unrecoverable DB error."""
+    import time
+
+    try:
+        while True:
+            time.sleep(3600)
+    except KeyboardInterrupt as exc:
+        raise SystemExit(code) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -451,10 +465,15 @@ def exit_unusable_database(error: UnusableDatabaseError, *, code: int = 2) -> No
 # migration CLI can actually open the store to fix the situation. Also
 # useful for tests that want to exercise the raw store.
 _BYPASS_ENV = "POLLYPM_SKIP_MIGRATION_GATE"
+_HOLD_UNUSABLE_DATABASE_ENV = "POLLYPM_HOLD_UNUSABLE_DATABASE_SCREEN"
 
 
 def bypass_env_is_set() -> bool:
     return bool(os.environ.get(_BYPASS_ENV))
+
+
+def hold_unusable_database_screen_enabled() -> bool:
+    return bool(os.environ.get(_HOLD_UNUSABLE_DATABASE_ENV))
 
 
 def set_bypass(enabled: bool) -> None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -5702,6 +5702,10 @@ def test_right_pane_command_uses_exec_to_avoid_orphans(tmp_path: Path) -> None:
             f"{kind!r} pane command missing ``exec`` keyword (would leak "
             f"orphan on respawn-pane -k): {command!r}"
         )
+        assert "env POLLYPM_HOLD_UNUSABLE_DATABASE_SCREEN=1" in command, (
+            f"{kind!r} pane command does not park on unrecoverable DB "
+            f"corruption: {command!r}"
+        )
         # Sanity: the command actually runs cockpit-pane (not just exec
         # of something else) — guards against an accidental refactor
         # that drops the cockpit-pane invocation entirely.

--- a/tests/test_migration_gate.py
+++ b/tests/test_migration_gate.py
@@ -29,6 +29,7 @@ def _clear_gate_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
     The migration-gate suite exercises the gate itself, so we clear it.
     """
     monkeypatch.delenv("POLLYPM_SKIP_MIGRATION_GATE", raising=False)
+    monkeypatch.delenv("POLLYPM_HOLD_UNUSABLE_DATABASE_SCREEN", raising=False)
 
 
 def _fresh_state_db(path: Path) -> Path:
@@ -294,6 +295,32 @@ def test_refuse_start_reports_corrupt_db_without_migration_advice(
     assert "pm restore" in captured.err
     assert "Cannot start" not in captured.err
     assert "Apply (recommended)" not in captured.err
+
+
+def test_unusable_db_hold_mode_parks_after_rendering_message(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    db_path = _write_corrupt_db(tmp_path / "state.db")
+    error = mig_mod.UnusableDatabaseError(db_path, "file is not a database")
+    held: list[int] = []
+
+    def fake_hold(*, code: int) -> None:
+        held.append(code)
+        raise SystemExit(99)
+
+    monkeypatch.setenv("POLLYPM_HOLD_UNUSABLE_DATABASE_SCREEN", "1")
+    monkeypatch.setattr(mig_mod, "_hold_unusable_database_screen", fake_hold)
+
+    with pytest.raises(SystemExit) as exc:
+        mig_mod.exit_unusable_database(error, code=2)
+
+    captured = capsys.readouterr()
+    assert exc.value.code == 99
+    assert held == [2]
+    assert "Cannot use state.db" in captured.err
+    assert "pm restore" in captured.err
 
 
 def test_migration_gate_skipped_when_bypass_env_set(


### PR DESCRIPTION
Closes #1166

When a cockpit right-pane launch hits unrecoverable state.db corruption, PollyPM now renders the existing recovery message and keeps the pane process alive so tmux does not churn through respawns. Normal CLI migration-gate callers still exit non-zero; only cockpit-pane launch commands opt into the hold behavior.

Layer self-audit: touched the store migration error exit path and cockpit right-pane launch command generation, plus focused regression tests. No inbox action/keymap behavior changed.