### PR TITLE
Fix cockpit rail and inbox key routing regressions

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -845,7 +845,7 @@ class CockpitRouter:
         self._validate_state()
         data = self._load_state()
         value = data.get("selected")
-        return str(value) if isinstance(value, str) and value else "polly"
+        return str(value) if isinstance(value, str) and value else "dashboard"
 
     def set_selected_key(self, key: str) -> None:
         data = self._load_state()
@@ -3481,7 +3481,16 @@ class CockpitRouter:
                 # while the actual mount finishes — every project sub
                 # route legitimately overlays the project dashboard.
                 return self._right_pane_command("project", project_key)
-        return self._right_pane_command("polly")
+        if isinstance(selected, str):
+            if selected in {"dashboard", "inbox", "workers", "metrics", "activity", "settings"}:
+                return self._right_pane_command(selected)
+            if selected.startswith("inbox:"):
+                return self._right_pane_command("inbox", selected.split(":", 1)[1])
+            if selected.startswith("activity:"):
+                return self._right_pane_command("activity", selected.split(":", 1)[1])
+            if selected == "polly":
+                return self._right_pane_command("polly")
+        return self._right_pane_command("dashboard")
 
     def _right_pane_command(
         self,

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -964,7 +964,7 @@ class PollyCockpitApp(App[None]):
     """
 
     BINDINGS = [
-        Binding("enter,o", "open_selected", "Open"),
+        Binding("enter,o", "open_selected", "Open", priority=True),
         Binding("n", "new_worker", "New Worker"),
         # #1089 — ``i`` from the rail used to fire ``open_inbox``, which
         # shadowed the project dashboard's advertised ``i inbox`` (the
@@ -979,7 +979,8 @@ class PollyCockpitApp(App[None]):
             "i", "forward_project_jump_inbox", "Inbox",
             show=False, priority=True,
         ),
-        Binding("I", "open_inbox", "Inbox"),
+        Binding("I", "open_inbox", "Inbox", priority=True),
+        Binding("H", "open_home", "Home", show=False, priority=True),
         Binding("t", "open_activity", "Activity"),
         # #1088 — ``p`` from the rail used to fire ``toggle_project_pin``,
         # which shadowed the project dashboard's advertised ``p plan``
@@ -994,7 +995,7 @@ class PollyCockpitApp(App[None]):
         ),
         Binding("P", "toggle_project_pin", "Pin Project"),
         Binding("r", "refresh", "Refresh"),
-        Binding("s", "open_settings", "Settings"),
+        Binding("s", "open_settings", "Settings", priority=True),
         Binding("tab", "forward_tab_to_right", "Right Pane", show=False, priority=True),
         Binding("A", "forward_workers_auto_refresh", "Workers Auto", show=False, priority=True),
         Binding("d", "forward_inbox_discuss", "Inbox discuss", show=False),
@@ -1074,6 +1075,10 @@ class PollyCockpitApp(App[None]):
     # wins over the modal's own priority binding for the same key.
     _HELP_MODAL_GATED_ACTIONS = frozenset({
         "request_quit",          # Q, ctrl+q (#1089 — q forwards instead)
+        "open_selected",         # enter/o
+        "open_home",             # H
+        "open_inbox",            # I
+        "open_settings",         # s
         "back_to_home",          # escape
         "show_keyboard_help",    # ?  (so reopening on top is suppressed,
                                  #     letting the modal close itself)
@@ -1103,6 +1108,10 @@ class PollyCockpitApp(App[None]):
     # — instead the existing one stays up and Esc still works.
     _PALETTE_MODAL_GATED_ACTIONS = frozenset({
         "request_quit",          # Q, ctrl+q (#1089 — q forwards instead)
+        "open_selected",         # enter/o
+        "open_home",             # H
+        "open_inbox",            # I
+        "open_settings",         # s
         "back_to_home",          # escape
         "open_command_palette",  # : / ctrl+k (no double-stack)
         "show_keyboard_help",    # ? (don't open help on top of palette)
@@ -1128,6 +1137,10 @@ class PollyCockpitApp(App[None]):
     # actions / dismiss without the rail eating the keystroke first.
     _ALERT_DETAIL_MODAL_GATED_ACTIONS = frozenset({
         "request_quit",          # Q, ctrl+q  (#1089 — q forwards instead)
+        "open_selected",         # enter/o
+        "open_home",             # H
+        "open_inbox",            # I
+        "open_settings",         # s
         "forward_project_home",  # q  (#1089 — modal binds it to dismiss)
         "back_to_home",          # escape
         "view_alert_detail",     # !  (no double-stack)
@@ -1196,8 +1209,8 @@ class PollyCockpitApp(App[None]):
         self._update_pill_dismissed = False
         self.spinner_index = 0
         self._ticker_started_at = time.monotonic()
-        self.selected_key = "polly"
-        self._last_router_selected_key = "polly"
+        self.selected_key = "dashboard"
+        self._last_router_selected_key = "dashboard"
         self._items: list[CockpitItem] = []
         self._row_widgets: dict[str, RailItem] = {}
         self._section_sep: ListItem | None = None
@@ -2440,6 +2453,9 @@ class PollyCockpitApp(App[None]):
     def action_open_activity(self) -> None:
         self._schedule_route_selected("activity", label="Activity")
 
+    def action_open_home(self) -> None:
+        self._navigate_home()
+
     # ------------------------------------------------------------------
     # Async routing (#959)
     #
@@ -2846,8 +2862,8 @@ class PollyCockpitApp(App[None]):
         )
 
     def _navigate_home(self) -> bool:
-        """Switch to the Home (dashboard / polly) surface. Return True on success."""
-        self._schedule_route_selected("polly", label="Home")
+        """Switch to the Home dashboard surface. Return True on success."""
+        self._schedule_route_selected("dashboard", label="Home")
         return True
 
     def action_back_to_home(self) -> None:
@@ -2890,7 +2906,7 @@ class PollyCockpitApp(App[None]):
         selections (#959) so a slow supervisor load can never block the
         click handler / freeze cockpit input.
         """
-        self._schedule_route_selected("polly", label="Home")
+        self._schedule_route_selected("dashboard", label="Home")
 
     def action_detach(self) -> None:
         self.router.tmux.run("detach-client", check=False)

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import gc
 import asyncio
 import json
-import logging
 import os
 import resource
 from pathlib import Path
@@ -998,6 +997,7 @@ class PollyCockpitApp(App[None]):
         Binding("s", "open_settings", "Settings"),
         Binding("tab", "forward_tab_to_right", "Right Pane", show=False, priority=True),
         Binding("A", "forward_workers_auto_refresh", "Workers Auto", show=False, priority=True),
+        Binding("d", "forward_inbox_discuss", "Inbox discuss", show=False),
         # Forward Action Needed numbered buttons (1/2/3) from the rail
         # to the right pane (#862). The cards advertise "Use 1/2/3 for
         # the buttons below"; without this forward, those keystrokes are
@@ -1270,6 +1270,9 @@ class PollyCockpitApp(App[None]):
         self.call_after_refresh(self._show_palette_tip_once)
 
     def action_view_alerts(self) -> None:
+        if self._on_inbox_surface():
+            self._send_key_to_inbox_pane("a")
+            return
         _action_view_alerts(self)
 
     def action_view_alert_detail(self) -> None:
@@ -1676,6 +1679,35 @@ class PollyCockpitApp(App[None]):
             self._send_key_to_right_pane(key)
         except Exception:  # noqa: BLE001
             pass
+
+    def _on_inbox_surface(self) -> bool:
+        key = getattr(self, "selected_key", None)
+        return isinstance(key, str) and (key == "inbox" or key.startswith("inbox:"))
+
+    def _send_key_to_inbox_pane(self, key: str) -> bool:
+        """Forward an Inbox-owned key to the right-pane Inbox app.
+
+        Prefer the pane's own input bridge so bridge-delivered keys do
+        not get reinterpreted by the rail. Fall back to tmux only when
+        the right pane is not a mounted live session; this preserves the
+        #918 guard against j/k bytes landing in an agent chat.
+        """
+        try:
+            from pollypm.cockpit_input_bridge import send_key_to_first_live
+            delivered = send_key_to_first_live(
+                self.config_path, key, kind="pane-inbox", timeout=0.2,
+            )
+        except Exception:  # noqa: BLE001
+            delivered = None
+        if delivered is not None:
+            return True
+        if self._right_pane_has_live_session():
+            return False
+        try:
+            self._send_key_to_right_pane(key)
+            return True
+        except Exception:  # noqa: BLE001
+            return False
 
     def _cancel_pending_route_selection(self) -> None:
         controller = getattr(self, "_navigation_controller", None)
@@ -2329,6 +2361,9 @@ class PollyCockpitApp(App[None]):
         if self.selected_key == "settings":
             self._send_key_to_settings_pane("j")
             return
+        if self._on_inbox_surface():
+            self._send_key_to_inbox_pane("j")
+            return
         self._align_nav_cursor_to_selected_key()
         last_idx = self._last_nav_index()
         # On the last selectable nav row + Settings is visible → step
@@ -2349,6 +2384,9 @@ class PollyCockpitApp(App[None]):
     def action_cursor_up(self) -> None:
         if self.selected_key == "settings":
             self._send_key_to_settings_pane("k")
+            return
+        if self._on_inbox_surface():
+            self._send_key_to_inbox_pane("k")
             return
         self._align_nav_cursor_to_selected_key()
         # Step up off the virtual Settings row onto the last
@@ -2628,10 +2666,17 @@ class PollyCockpitApp(App[None]):
         self._send_key_to_right_pane("Tab")
 
     def action_forward_workers_auto_refresh(self) -> None:
+        if self._on_inbox_surface():
+            self._send_key_to_inbox_pane("A")
+            return
         if self.selected_key == "workers":
             self._send_key_to_right_pane("A")
             return
         self._schedule_route_selected("workers", label="Workers")
+
+    def action_forward_inbox_discuss(self) -> None:
+        if self._on_inbox_surface():
+            self._send_key_to_inbox_pane("d")
 
     def action_forward_action_button_1(self) -> None:
         self._send_key_to_right_pane("1")
@@ -2732,6 +2777,9 @@ class PollyCockpitApp(App[None]):
         self._refresh_rows()
 
     def action_new_worker(self) -> None:
+        if self._on_inbox_surface():
+            self._send_key_to_inbox_pane("n")
+            return
         key = self._selected_row_key()
         if key is None or not key.startswith("project:"):
             self.hint.update("Select a project first, then press n to launch a worker.")
@@ -2758,6 +2806,9 @@ class PollyCockpitApp(App[None]):
         self.call_from_thread(self._refresh_rows)
 
     def action_refresh(self) -> None:
+        if self._on_inbox_surface():
+            self._send_key_to_inbox_pane("r")
+            return
         self._recover_cockpit_render(force_render=False)
 
     def on_resize(self, _event: events.Resize) -> None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -2286,6 +2286,17 @@ def test_cockpit_router_marks_palette_tip_seen(tmp_path: Path) -> None:
     assert router._load_state()["palette_tip_seen"] is True
 
 
+def test_cockpit_router_defaults_to_home_dashboard(tmp_path: Path) -> None:
+    """#1152: a fresh cockpit should land on Home, not Polly chat."""
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+    router = CockpitRouter(config_path)
+
+    assert router.selected_key() == "dashboard"
+
+
 def test_cockpit_router_selected_key_bumps_epoch(monkeypatch, tmp_path: Path) -> None:
     config_path = tmp_path / "pollypm.toml"
     config_path.write_text(
@@ -2825,7 +2836,7 @@ def test_cockpit_router_ensure_layout_splits_when_missing_right_pane(tmp_path: P
     router.ensure_cockpit_layout()
 
     assert calls["split"][0] == "pollypm:PollyPM"
-    assert "cockpit-pane polly" in calls["split"][1]
+    assert "cockpit-pane dashboard" in calls["split"][1]
 
 
 def test_ensure_cockpit_layout_project_selection_repairs_with_project_command(
@@ -4034,7 +4045,7 @@ def test_cockpit_ui_arrow_and_enter_route_selected(tmp_path: Path) -> None:
 
 
 def test_cockpit_send_key_inbox_shortcut_keeps_nav_cursor_on_inbox(tmp_path: Path) -> None:
-    """#1122: after global ``I``, bridge-delivered Down starts from Inbox."""
+    """#1122/#1137: after global ``I``, Down stays owned by Inbox."""
 
     class FakeRouter:
         def __init__(self) -> None:
@@ -4097,8 +4108,8 @@ def test_cockpit_send_key_inbox_shortcut_keeps_nav_cursor_on_inbox(tmp_path: Pat
 
             send_key(handle.socket_path, "<down>")
             await pilot.pause(0.4)
-            assert app.selected_key == "activity"
-            assert app._selected_row_key() == "activity"
+            assert app.selected_key == "inbox"
+            assert app._selected_row_key() == "inbox"
 
     asyncio.run(exercise())
 
@@ -4254,6 +4265,54 @@ def test_cockpit_enter_routes_visible_workers_selection_when_nav_cursor_lags() -
     app.action_open_selected()
 
     assert calls == [("workers", "workers")]
+
+
+def test_cockpit_enter_routes_visible_settings_selection_when_nav_has_focus(
+    tmp_path: Path,
+) -> None:
+    """#1172: Enter follows the visible Settings marker, not nav.index."""
+
+    class FakeRouter:
+        def selected_key(self) -> str:
+            return "dashboard"
+
+        def _load_state(self) -> dict:
+            return {}
+
+        def build_items(self, *, spinner_index: int = 0):
+            from pollypm.cockpit_rail import CockpitItem
+
+            return [
+                CockpitItem("dashboard", "Home", "home"),
+                CockpitItem("workers", "Workers", "idle"),
+                CockpitItem("settings", "Settings", "config"),
+            ]
+
+    app = PollyCockpitApp(tmp_path / "pollypm.toml")
+    app.router = FakeRouter()  # type: ignore[assignment]
+    app._start_core_rail = lambda: None  # type: ignore[method-assign]
+    app._show_palette_tip_once = lambda: None  # type: ignore[method-assign]
+    app._enforce_rail_width_once = lambda: None  # type: ignore[method-assign]
+    calls: list[tuple[str, str | None]] = []
+
+    async def exercise() -> None:
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            app.selected_key = "settings"
+            app._items = [
+                SimpleNamespace(key="dashboard", selectable=True),
+                SimpleNamespace(key="workers", selectable=True),
+                SimpleNamespace(key="settings", selectable=True),
+            ]
+            app._schedule_route_selected = (  # type: ignore[method-assign]
+                lambda key, *, label=None: calls.append((key, label))
+            )
+            await pilot.press("enter")
+            await pilot.pause()
+
+    asyncio.run(exercise())
+
+    assert calls == [("settings", "settings")]
 
 
 def test_cockpit_capital_a_opens_workers_then_forwards_auto_refresh() -> None:
@@ -4736,8 +4795,8 @@ def test_cockpit_q_from_settings_returns_to_home_not_quit() -> None:
 
     app.action_request_quit()
 
-    assert ("route", "polly") in calls
-    assert app.selected_key == "polly"
+    assert ("route", "dashboard") in calls
+    assert app.selected_key == "dashboard"
     assert confirm_called == [], "should not show quit confirm from a sub-surface"
 
 
@@ -4774,8 +4833,20 @@ def test_cockpit_escape_routes_back_to_home_from_settings() -> None:
 
     app.action_back_to_home()
 
-    assert ("route", "polly") in calls
-    assert app.selected_key == "polly"
+    assert ("route", "dashboard") in calls
+    assert app.selected_key == "dashboard"
+
+
+def test_cockpit_capital_h_routes_back_to_home() -> None:
+    """#1163: capital H is an explicit global Home jump."""
+    app, calls = _build_back_to_home_app()
+    app.selected_key = "project:demo"
+    app._last_router_selected_key = "project:demo"
+
+    app.action_open_home()
+
+    assert ("route", "dashboard") in calls
+    assert app.selected_key == "dashboard"
 
 
 def test_cockpit_escape_at_home_is_noop() -> None:
@@ -5396,6 +5467,21 @@ def test_cockpit_app_binds_action_button_digits_at_priority() -> None:
         )
 
 
+def test_cockpit_global_open_bindings_are_priority() -> None:
+    """#1131/#1174/#1176: global rail open keys must beat held panes."""
+    expected = {"enter,o", "I", "s", "H"}
+    bindings = {
+        binding.key: binding
+        for binding in PollyCockpitApp.BINDINGS
+        if binding.key in expected
+    }
+    assert set(bindings) == expected, f"missing open bindings: {bindings.keys()}"
+    for key, binding in bindings.items():
+        assert getattr(binding, "priority", False), (
+            f"{key!r} must be priority so a focused content pane cannot swallow it"
+        )
+
+
 # ── #959: render-then-load click handlers ────────────────────────────────────
 
 def _make_async_click_app() -> "tuple[PollyCockpitApp, list]":
@@ -5779,6 +5865,30 @@ def test_right_pane_command_uses_exec_to_avoid_orphans(tmp_path: Path) -> None:
         # of something else) — guards against an accidental refactor
         # that drops the cockpit-pane invocation entirely.
         assert "cockpit-pane" in command
+
+
+def test_default_repair_command_uses_home_dashboard(tmp_path: Path) -> None:
+    """#1152: cold/layout repair panes default to Home, not Polly chat."""
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\n"
+        f"base_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+    router = CockpitRouter(config_path)
+
+    assert "cockpit-pane dashboard" in router._default_repair_command({})
+    assert "cockpit-pane workers" in router._default_repair_command(
+        {"selected": "workers"}
+    )
+    assert "cockpit-pane settings" in router._default_repair_command(
+        {"selected": "settings"}
+    )
+    assert "cockpit-pane inbox --project demo" in router._default_repair_command(
+        {"selected": "inbox:demo"}
+    )
+    assert "cockpit-pane polly" in router._default_repair_command(
+        {"selected": "polly"}
+    )
 
 
 def test_cockpit_pane_subprocess_dies_with_shell_wrapper(tmp_path: Path) -> None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4257,7 +4257,7 @@ def test_cockpit_enter_routes_visible_workers_selection_when_nav_cursor_lags() -
 
 
 def test_cockpit_capital_a_opens_workers_then_forwards_auto_refresh() -> None:
-    """#1134: A is a rail shortcut to Workers; on Workers it reaches the pane."""
+    """#1134/#1158: A opens Workers except when Inbox owns the key."""
     app = PollyCockpitApp.__new__(PollyCockpitApp)
     calls: list[tuple[str, str]] = []
     app._schedule_route_selected = (  # type: ignore[method-assign]
@@ -4266,13 +4266,18 @@ def test_cockpit_capital_a_opens_workers_then_forwards_auto_refresh() -> None:
     app._send_key_to_right_pane = (  # type: ignore[method-assign]
         lambda key: calls.append(("send", key))
     )
+    app._send_key_to_inbox_pane = (  # type: ignore[method-assign]
+        lambda key: calls.append(("inbox", key)) or True
+    )
 
     app.selected_key = "dashboard"
     app.action_forward_workers_auto_refresh()
     app.selected_key = "workers"
     app.action_forward_workers_auto_refresh()
+    app.selected_key = "inbox"
+    app.action_forward_workers_auto_refresh()
 
-    assert calls == [("route", "workers"), ("send", "A")]
+    assert calls == [("route", "workers"), ("send", "A"), ("inbox", "A")]
 
 
 def test_cockpit_app_open_live_session_keeps_rail_focus_until_tab() -> None:
@@ -4975,14 +4980,14 @@ def test_cockpit_pin_toggle_round_trips_and_reports_state() -> None:
     )
 
 
-def test_cockpit_jk_navigates_rail_on_inbox_surface() -> None:
-    """j/k always advance the rail cursor — never tmux-forward to right pane (#918).
+def test_cockpit_jk_navigates_rail_outside_inbox_surface() -> None:
+    """j/k advance the rail cursor outside active right-pane Inbox (#918).
 
     Earlier (#856) the rail forwarded ``j``/``k`` to the right pane while
     on Inbox/Activity so list scrolling worked from the rail. That blindly
     invoked ``tmux send-keys`` against pane 1, so once the right pane held
-    a Polly/Claude Code chat the bytes ended up typed into the chat box.
-    The fix returns j/k to plain rail navigation across every surface.
+    a Polly/Claude Code chat the bytes ended up typed into the chat box;
+    non-Inbox surfaces keep plain rail navigation.
     """
     app = PollyCockpitApp.__new__(PollyCockpitApp)
     sent: list[str] = []
@@ -5001,7 +5006,7 @@ def test_cockpit_jk_navigates_rail_on_inbox_surface() -> None:
 
     app.nav = _Nav()  # type: ignore[assignment]
 
-    for surface in ("polly", "inbox", "activity"):
+    for surface in ("polly", "activity"):
         app.selected_key = surface
         moves.clear()
         sent.clear()
@@ -5018,6 +5023,83 @@ def test_cockpit_jk_navigates_rail_on_inbox_surface() -> None:
         app.action_cursor_up()
         assert moves == ["nav_up", "sync"]
         assert sent == []
+
+
+def test_cockpit_inbox_surface_forwards_footer_keys_to_inbox_pane() -> None:
+    """#1128/#1137/#1146/#1158/#1162: active Inbox owns its footer keys."""
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+    forwarded: list[str] = []
+    routes: list[str] = []
+    app.selected_key = "inbox"
+    app._send_key_to_inbox_pane = (  # type: ignore[method-assign]
+        lambda key: forwarded.append(key) or True
+    )
+    app._send_key_to_right_pane = (  # type: ignore[method-assign]
+        lambda key: forwarded.append(f"right:{key}")
+    )
+    app._schedule_route_selected = (  # type: ignore[method-assign]
+        lambda key, *, label=None: routes.append(key)
+    )
+    app.hint = _CaptureWidget()
+    app._selected_row_key = lambda: "project:demo"  # type: ignore[method-assign]
+
+    app.action_new_worker()
+    app.action_cursor_down()
+    app.action_cursor_up()
+    app.action_forward_inbox_discuss()
+    app.action_forward_workers_auto_refresh()
+    app.action_view_alerts()
+    app.action_refresh()
+
+    assert forwarded == ["n", "j", "k", "d", "A", "a", "r"]
+    assert routes == []
+
+
+def test_cockpit_inbox_forward_prefers_pane_bridge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bare cockpit bridge keys are relayed to the Inbox pane bridge first."""
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+    config_path = tmp_path / "pollypm.toml"
+    app.config_path = config_path
+    sent: list[str] = []
+    bridge_calls: list[tuple[Path, str, str | None]] = []
+
+    def fake_send_key_to_first_live(
+        config: Path, key: str, *, kind: str | None = None, timeout: float = 2.0,
+    ) -> Path | None:
+        bridge_calls.append((config, key, kind))
+        return tmp_path / "pane_inbox-123.sock"
+
+    monkeypatch.setattr(
+        "pollypm.cockpit_input_bridge.send_key_to_first_live",
+        fake_send_key_to_first_live,
+    )
+    app._send_key_to_right_pane = lambda key: sent.append(key)  # type: ignore[method-assign]
+    app._right_pane_has_live_session = lambda: False  # type: ignore[method-assign]
+
+    assert app._send_key_to_inbox_pane("n") is True
+
+    assert bridge_calls == [(config_path, "n", "pane-inbox")]
+    assert sent == []
+
+
+def test_cockpit_inbox_forward_does_not_tmux_forward_into_live_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the pane bridge is absent, do not type Inbox keys into live chats."""
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+    app.config_path = tmp_path / "pollypm.toml"
+    sent: list[str] = []
+    monkeypatch.setattr(
+        "pollypm.cockpit_input_bridge.send_key_to_first_live",
+        lambda *args, **kwargs: None,
+    )
+    app._right_pane_has_live_session = lambda: True  # type: ignore[method-assign]
+    app._send_key_to_right_pane = lambda key: sent.append(key)  # type: ignore[method-assign]
+
+    assert app._send_key_to_inbox_pane("j") is False
+    assert sent == []
 
 
 class _StubItem:
@@ -5069,14 +5151,8 @@ class _StubNav:
                 return
 
 
-def test_cockpit_j_from_inbox_steps_into_first_project() -> None:
-    """Pressing ``j`` from Inbox advances the cursor into the project list,
-    stepping over the disabled ``── projects ──`` divider (#918 facet 1).
-
-    Reproduces the rail layout: Inbox row, then a disabled divider row,
-    then the first project row. ``ListView.action_cursor_down`` skips
-    disabled items, so one ``j`` lands on the project.
-    """
+def test_cockpit_j_from_inbox_forwards_to_inbox_cursor() -> None:
+    """#1137: pressing ``j`` from active Inbox moves the inbox cursor."""
     app = PollyCockpitApp.__new__(PollyCockpitApp)
     items = [
         _StubItem("inbox"),
@@ -5101,16 +5177,13 @@ def test_cockpit_j_from_inbox_steps_into_first_project() -> None:
     app._selected_row_key = _selected_row_key  # type: ignore[method-assign]
 
     captured: list[str] = []
-    app._send_key_to_right_pane = lambda key: captured.append(key)  # type: ignore[method-assign]
+    app._send_key_to_inbox_pane = lambda key: captured.append(key) or True  # type: ignore[method-assign]
 
     app.action_cursor_down()
 
-    assert nav.index == 2, (
-        "j from Inbox must skip the divider and land on the first project; "
-        f"got index={nav.index}"
-    )
-    assert app.selected_key == "project:booktalk"
-    assert captured == [], "j must never be tmux-forwarded to the right pane"
+    assert nav.index == 0
+    assert app.selected_key == "inbox"
+    assert captured == ["j"]
 
 
 def test_cockpit_j_at_last_item_is_silent_noop() -> None:

--- a/tests/test_cockpit_inbox_ui.py
+++ b/tests/test_cockpit_inbox_ui.py
@@ -2341,6 +2341,101 @@ def test_inbox_filter_bridge_literal_slash_opens_input(inbox_env) -> None:
     _run(body())
 
 
+def test_inbox_bridge_n_keypress_toggles_notifications_visible(
+    inbox_env,
+) -> None:
+    """#1128: bridge-delivered ``n`` reaches the Inbox notification toggle."""
+    if not _load_config_compatible(inbox_env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    _seed_workspace_message(
+        inbox_env["project_path"].parent,
+        subject="Done: bridge-visible completion",
+        body="background completion FYI",
+        scope="demo",
+    )
+    from pollypm.cockpit_input_bridge import send_key
+    from pollypm.cockpit_ui import PollyInboxApp
+
+    app = PollyInboxApp(inbox_env["config_path"])
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            handle = getattr(app, "_input_bridge_handle", None)
+            assert handle is not None
+            assert not _has_title_substring(
+                _visible_titles(app),
+                "Done: bridge-visible completion",
+            )
+
+            send_key(handle.socket_path, "n")
+            await pilot.pause(0.2)
+
+            assert _has_title_substring(
+                _visible_titles(app),
+                "Done: bridge-visible completion",
+            )
+
+    _run(body())
+
+
+def test_inbox_bridge_jk_moves_list_cursor(inbox_env) -> None:
+    """#1137: bridge-delivered ``j``/``k`` navigate the Inbox list."""
+    if not _load_config_compatible(inbox_env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_input_bridge import send_key
+    from pollypm.cockpit_ui import PollyInboxApp
+
+    app = PollyInboxApp(inbox_env["config_path"])
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            handle = getattr(app, "_input_bridge_handle", None)
+            assert handle is not None
+            assert app.list_view.index == 0
+
+            send_key(handle.socket_path, "j")
+            await pilot.pause(0.2)
+            assert app.list_view.index == 1
+
+            send_key(handle.socket_path, "k")
+            await pilot.pause(0.2)
+            assert app.list_view.index == 0
+
+    _run(body())
+
+
+def test_inbox_bridge_dispatches_discuss_approve_archive_actions(
+    inbox_env, monkeypatch,
+) -> None:
+    """#1146/#1158/#1162: bridge keys invoke Inbox actions, not rail ones."""
+    if not _load_config_compatible(inbox_env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_input_bridge import send_key
+    from pollypm.cockpit_ui import PollyInboxApp
+
+    app = PollyInboxApp(inbox_env["config_path"])
+    calls: list[str] = []
+    monkeypatch.setattr(app, "action_jump_to_pm", lambda: calls.append("d"))
+    monkeypatch.setattr(app, "action_accept_proposal", lambda: calls.append("A"))
+    monkeypatch.setattr(app, "action_archive_selected", lambda: calls.append("a"))
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            handle = getattr(app, "_input_bridge_handle", None)
+            assert handle is not None
+
+            for key in ("d", "A", "a"):
+                send_key(handle.socket_path, key)
+                await pilot.pause(0.2)
+
+            assert calls == ["d", "A", "a"]
+
+    _run(body())
+
+
 def test_background_refresh_skips_when_content_unchanged(inbox_env, inbox_app) -> None:
     """The visible flash every ~8s was caused by the background refresh
     calling ListView.clear() and re-appending every row on every tick,
@@ -2444,7 +2539,6 @@ def test_inbox_ctrl_h_returns_focus_to_rail_without_exiting(
         async with inbox_app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
 
-            from pollypm import cockpit_ui as _ui_mod
             monkeypatch.setattr(
                 "pollypm.cockpit_rail.focus_cockpit_rail_pane",
                 lambda path: calls.append(path) or True,


### PR DESCRIPTION
Closes #1128
Closes #1131
Closes #1137
Closes #1146
Closes #1152
Closes #1158
Closes #1162
Closes #1163
Closes #1172
Closes #1174
Closes #1176

Routes Inbox-owned keys from the rail to the right-pane Inbox bridge when the Inbox surface is active, so j/k/n/a/A/d/r reach the Inbox app instead of triggering rail navigation or global shortcuts.

Also restores the Home/dashboard and rail-open paths: fresh cockpits and layout repair now default to the Home dashboard, H routes back home, and Enter/open, capital I, and s are priority + modal-gated rail commands so a held content pane cannot swallow Workers, Inbox, or Settings opens.

Tests:
- `uv run pytest tests/test_cockpit.py tests/test_cockpit_inbox_ui.py tests/test_inbox_filter.py tests/test_keyboard_help.py -q`
- `uv run ruff check src/pollypm/cockpit_ui.py src/pollypm/cockpit_rail.py tests/test_cockpit.py tests/test_cockpit_inbox_ui.py`

Self-audit: UI/router routing plus cockpit/inbox UI tests; no store/domain changes.
