### PR TITLE
Fix #1192 expand project subitems on enter

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -2485,6 +2485,11 @@ class PollyCockpitApp(App[None]):
     # bounce reported in #967. The seq guard short-circuits that path.
     _route_click_seq: int = 0
 
+    def _optimistic_selected_key_for_route(self, key: str) -> str:
+        if key.startswith("project:") and key.count(":") == 1:
+            return f"{key}:dashboard"
+        return key
+
     def _ensure_navigation_controller(self) -> NavigationController:
         controller = getattr(self, "_navigation_controller", None)
         if controller is not None:
@@ -2522,7 +2527,13 @@ class PollyCockpitApp(App[None]):
         # rail highlight tracks the user's intent before the route work
         # even starts. The router may correct this once it knows the
         # canonical selection (e.g. ``project:x`` → ``project:x:dashboard``).
-        self.selected_key = key
+        optimistic_key = self._optimistic_selected_key_for_route(key)
+        self.selected_key = optimistic_key
+        if optimistic_key != key:
+            try:
+                self.router.set_selected_key(optimistic_key)
+            except Exception:  # noqa: BLE001
+                pass
         request = self._ensure_navigation_controller().accept(key)
         seq = request.request_id
         self._route_click_seq = seq

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -5020,6 +5020,52 @@ def test_cockpit_project_enter_advances_cursor_to_dashboard_subitem() -> None:
     assert app.selected_key == "project:demo:dashboard"
 
 
+def test_cockpit_project_enter_primes_subitems_before_route_worker() -> None:
+    """#1192: Enter on a project should expand its sub-items immediately."""
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+    events: list[tuple[str, str, str] | tuple[str, str]] = []
+
+    class _Router:
+        selected = "polly"
+
+        def set_selected_key(self, key: str) -> None:
+            events.append(("set", key))
+            self.selected = key
+
+        def selected_key(self) -> str:
+            return self.selected
+
+        def route_selected(self, key: str) -> None:
+            events.append(("route", key))
+            self.selected = f"{key}:dashboard"
+
+    router = _Router()
+    app.router = router  # type: ignore[assignment]
+    app.selected_key = "project:demo"
+    app._last_router_selected_key = "polly"
+    app._items = [SimpleNamespace(key="project:demo", selectable=True)]
+    app._selected_row_key = lambda: "project:demo"  # type: ignore[method-assign]
+    app.hint = _CaptureWidget()
+    app._refresh_rows = (  # type: ignore[method-assign]
+        lambda: events.append(("refresh", app.selected_key, router.selected_key()))
+    )
+
+    app.action_open_selected()
+
+    first_refresh_index = next(
+        index for index, event in enumerate(events) if event[0] == "refresh"
+    )
+    route_index = events.index(("route", "project:demo"))
+
+    assert events[0] == ("set", "project:demo:dashboard")
+    assert events[first_refresh_index] == (
+        "refresh",
+        "project:demo:dashboard",
+        "project:demo:dashboard",
+    )
+    assert first_refresh_index < route_index
+
+
 def test_cockpit_pin_toggle_round_trips_and_reports_state() -> None:
     """``p`` toggles the pin AND surfaces a hint about the new state (#858)."""
     app = PollyCockpitApp.__new__(PollyCockpitApp)


### PR DESCRIPTION
Closes #1192

Enter on a bare project rail row now primes the optimistic selection to the canonical project dashboard sub-item before the async route worker runs, so the project sub-items render immediately while the dashboard opens. Added a focused cockpit regression test for the first refresh before route work.

Layer self-audit: touched only cockpit UI routing behavior and its unit test; no store/domain/service boundary changes.