### PR TITLE
Fix #1194 serialize heartbeat shutdown

### DIFF
--- a/src/pollypm/heartbeat/boot.py
+++ b/src/pollypm/heartbeat/boot.py
@@ -118,7 +118,7 @@ class HeartbeatRail:
 
     __slots__ = (
         "queue", "pool", "heartbeat", "roster", "_concurrency",
-        "_tick_interval", "_tick_thread", "_tick_stop",
+        "_tick_interval", "_tick_thread", "_tick_stop", "_tick_lock",
     )
 
     def __init__(
@@ -143,6 +143,7 @@ class HeartbeatRail:
         )
         self._tick_thread: threading.Thread | None = None
         self._tick_stop = threading.Event()
+        self._tick_lock = threading.RLock()
 
     # ------------------------------------------------------------------
     # Construction
@@ -318,7 +319,8 @@ class HeartbeatRail:
         try:
             self.pool.stop(timeout=timeout)
         finally:
-            self.queue.close()
+            with self._tick_lock:
+                self.queue.close()
 
     def tick(self, now: datetime | None = None):
         """Run one heartbeat tick — enqueue jobs for due roster entries.
@@ -334,10 +336,21 @@ class HeartbeatRail:
         ``boot.py:258 -> tick.py:143 -> queue.py:269``).
         """
         resolved = now or datetime.now(UTC)
-        return retry_on_database_locked(
-            lambda: self.heartbeat.tick(resolved),
-            label="HeartbeatRail.tick",
-        )
+        lock = getattr(self, "_tick_lock", None)
+
+        def _do_tick():
+            stop_event = getattr(self, "_tick_stop", None)
+            if stop_event is not None and stop_event.is_set():
+                return None
+            return retry_on_database_locked(
+                lambda: self.heartbeat.tick(resolved),
+                label="HeartbeatRail.tick",
+            )
+
+        if lock is None:
+            return _do_tick()
+        with lock:
+            return _do_tick()
 
     # Context manager sugar — mostly useful for tests.
     def __enter__(self) -> "HeartbeatRail":

--- a/tests/test_rail_ticker.py
+++ b/tests/test_rail_ticker.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import threading
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -115,6 +116,50 @@ class TestTickerThreadLifecycle:
         assert rail._tick_stop.is_set()
         assert not ticker.is_alive(), "ticker thread did not exit after stop()"
         assert rail._tick_thread is None
+
+    def test_stop_does_not_close_queue_during_active_tick(self, tmp_path: Path) -> None:
+        """#1194: shutdown must not close the queue under an in-flight tick."""
+
+        rail = _build_rail(tmp_path, tick_interval=0.05)
+        rail.roster.register(
+            schedule="@on_startup",
+            handler_name="noop",
+            payload={"source": "test"},
+            dedupe_key="heartbeat:test",
+        )
+        inner = rail.heartbeat
+        entered = threading.Event()
+        release = threading.Event()
+        errors: list[BaseException] = []
+
+        class _SlowHeartbeat:
+            def tick(self, now):
+                entered.set()
+                assert release.wait(2.0), "test did not release heartbeat tick"
+                return inner.tick(now)
+
+        rail.heartbeat = _SlowHeartbeat()  # type: ignore[assignment]
+
+        def run_tick() -> None:
+            try:
+                rail.tick(datetime.now(UTC))
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        tick_thread = threading.Thread(target=run_tick)
+        tick_thread.start()
+        assert entered.wait(2.0), "heartbeat tick did not start"
+
+        stop_thread = threading.Thread(target=lambda: rail.stop(timeout=0.01))
+        stop_thread.start()
+        release.set()
+
+        tick_thread.join(timeout=2.0)
+        stop_thread.join(timeout=2.0)
+
+        assert not tick_thread.is_alive(), "tick thread did not finish"
+        assert not stop_thread.is_alive(), "stop thread did not finish"
+        assert errors == []
 
     def test_tick_exception_does_not_kill_thread(self, tmp_path: Path) -> None:
         """One bad tick must not kill the ticker — next iteration keeps going."""


### PR DESCRIPTION
Closes #1194

Serializes HeartbeatRail.tick() against shutdown so stop() cannot close the JobQueue while a heartbeat tick is still enqueueing due roster entries. This prevents the shutdown race that surfaced as sqlite3.ProgrammingError: Cannot operate on a closed database in the rail daemon tick loop.

Self-audit: touched heartbeat lifecycle/domain code in src/pollypm/heartbeat/boot.py and focused lifecycle regression coverage in tests/test_rail_ticker.py; no UI, facade, store, or cross-layer imports added.