### PR TITLE
Fix #1195 tolerate tmux option failures during bootstrap

### DIFF
--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -53,6 +53,7 @@ import os
 import re
 import shlex
 import shutil
+import subprocess
 import sys
 import threading
 import time
@@ -859,8 +860,8 @@ class Supervisor:
             else:
                 self.session_service.tmux.create_window(storage_session, launch.window_name, launch.command, detached=True)
             target = f"{storage_session}:{launch.window_name}"
-            self.session_service.tmux.set_window_option(target, "allow-passthrough", "on")
-            self.session_service.tmux.set_window_option(target, "focus-events", "on")
+            self._set_window_option_best_effort(target, "allow-passthrough", "on")
+            self._set_window_option_best_effort(target, "focus-events", "on")
             self.session_service.tmux.pipe_pane(target, launch.log_path)
             self._record_launch(launch)
             created += 1
@@ -898,8 +899,8 @@ class Supervisor:
                 on_status(f"Creating {first.session.name}...")
             first_pane_id = self.session_service.tmux.create_session(storage_session, first.window_name, first.command)
             window_target = f"{storage_session}:{first.window_name}"
-            self.session_service.tmux.set_window_option(window_target, "allow-passthrough", "on")
-            self.session_service.tmux.set_window_option(window_target, "focus-events", "on")
+            self._set_window_option_best_effort(window_target, "allow-passthrough", "on")
+            self._set_window_option_best_effort(window_target, "focus-events", "on")
             self.session_service.tmux.pipe_pane(window_target, first.log_path)
             self._record_launch(first)
             # Use pane ID from create_session for unambiguous targeting
@@ -910,8 +911,8 @@ class Supervisor:
                     on_status(f"Creating {launch.session.name}...")
                 pane_id = self.session_service.tmux.create_window(storage_session, launch.window_name, launch.command, detached=True)
                 window_target = f"{storage_session}:{launch.window_name}"
-                self.session_service.tmux.set_window_option(window_target, "allow-passthrough", "on")
-                self.session_service.tmux.set_window_option(window_target, "focus-events", "on")
+                self._set_window_option_best_effort(window_target, "allow-passthrough", "on")
+                self._set_window_option_best_effort(window_target, "focus-events", "on")
                 self.session_service.tmux.pipe_pane(window_target, launch.log_path)
                 self._record_launch(launch)
                 # Use pane ID returned by create_window for unambiguous targeting
@@ -921,10 +922,10 @@ class Supervisor:
         # Phase 2: Create the cockpit session so the user can attach immediately.
         self.session_service.tmux.create_session(session_name, self._CONSOLE_WINDOW, self._console_command(), remain_on_exit=False)
         console_target = f"{session_name}:{self._CONSOLE_WINDOW}"
-        self.session_service.tmux.set_window_option(console_target, "allow-passthrough", "on")
-        self.session_service.tmux.set_window_option(console_target, "focus-events", "on")
-        self.session_service.tmux.set_window_option(console_target, "window-size", "latest")
-        self.session_service.tmux.set_window_option(console_target, "aggressive-resize", "on")
+        self._set_window_option_best_effort(console_target, "allow-passthrough", "on")
+        self._set_window_option_best_effort(console_target, "focus-events", "on")
+        self._set_window_option_best_effort(console_target, "window-size", "latest")
+        self._set_window_option_best_effort(console_target, "aggressive-resize", "on")
         self.focus_console()
 
         # Phase 3: Finish the slow provider bootstrap in the background.
@@ -938,6 +939,18 @@ class Supervisor:
         )
         coordinator.start()
         self._bootstrap_completion_thread = coordinator
+
+    def _set_window_option_best_effort(self, target: str, option: str, value: str) -> None:
+        try:
+            self.session_service.tmux.set_window_option(target, option, value)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            logger.warning(
+                "tmux set-window-option failed for %s %s=%s during bootstrap; continuing: %s",
+                target,
+                option,
+                value,
+                exc,
+            )
 
     def _finish_bootstrap_sessions(
         self,

--- a/tests/test_sessions_registration.py
+++ b/tests/test_sessions_registration.py
@@ -21,6 +21,7 @@ These tests exercise:
 
 from __future__ import annotations
 
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -202,6 +203,65 @@ def test_rebootstrap_is_idempotent(monkeypatch, tmp_path: Path) -> None:
     rows = sorted(s.name for s in supervisor.store.list_sessions())
     # No duplicates (PRIMARY KEY on name prevents duplicates anyway, but
     # verify the set is unchanged and not empty after reconcile).
+    assert rows == ["heartbeat", "operator", "pm-reviewer"]
+
+
+def test_reconcile_continues_when_window_option_fails(monkeypatch, tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    storage = supervisor.storage_closet_session_name()
+    cockpit = config.project.tmux_session
+
+    created_windows: list[tuple[str, str, bool]] = []
+    piped_targets: list[str] = []
+    window_options: list[tuple[str, str, str]] = []
+
+    monkeypatch.setattr(supervisor.tmux, "has_session", lambda name: name in {storage, cockpit})
+    monkeypatch.setattr(
+        supervisor.tmux,
+        "list_windows",
+        lambda name: [
+            TmuxWindow(
+                session=storage,
+                index=i,
+                name=w,
+                active=(i == 0),
+                pane_id=f"%{i + 10}",
+                pane_current_command="claude",
+                pane_current_path=str(tmp_path),
+                pane_dead=False,
+            )
+            for i, w in enumerate(["pm-heartbeat", "pm-operator"])
+        ] if name == storage else [],
+    )
+    monkeypatch.setattr(
+        supervisor.tmux,
+        "create_window",
+        lambda name, window_name, command, detached=False: created_windows.append(
+            (name, window_name, detached)
+        ),
+    )
+
+    def _set_window_option(target: str, option: str, value: str) -> None:
+        window_options.append((target, option, value))
+        if target == f"{storage}:pm-reviewer" and option == "allow-passthrough":
+            raise subprocess.CalledProcessError(
+                1,
+                ["tmux", "set-window-option", "-t", target, option, value],
+            )
+
+    monkeypatch.setattr(supervisor.tmux, "set_window_option", _set_window_option)
+    monkeypatch.setattr(supervisor.tmux, "pipe_pane", lambda target, path: piped_targets.append(target))
+    monkeypatch.setattr(supervisor, "ensure_heartbeat_schedule", lambda: None)
+    monkeypatch.setattr(supervisor, "ensure_knowledge_extraction_schedule", lambda: None)
+
+    controller = supervisor.bootstrap_tmux()
+
+    assert controller == "claude_controller"
+    assert created_windows == [(storage, "pm-reviewer", True)]
+    assert piped_targets == [f"{storage}:pm-reviewer"]
+    assert (f"{storage}:pm-reviewer", "focus-events", "on") in window_options
+    rows = sorted(s.name for s in supervisor.store.list_sessions())
     assert rows == ["heartbeat", "operator", "pm-reviewer"]
 
 


### PR DESCRIPTION
Closes #1195

Makes bootstrap tmux window-option setup best-effort for tmux non-zero exits and timeouts, so a transient `allow-passthrough` or related option failure logs and reconciliation continues. Adds regression coverage that a missing storage-closet window is still piped and registered after an option failure.

Self-audit: touched Supervisor bootstrap orchestration and session-registration tests only; no UI/store imports or layer crossings.
