### PR TITLE
Fix #1199 return from architect chat to inbox

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -863,6 +863,45 @@ class CockpitRouter:
         except Exception:  # noqa: BLE001
             pass
 
+    def _return_key_for_live_mount(self, previous_key: object) -> str | None:
+        """Return the static cockpit route to restore after a live mount."""
+        if not isinstance(previous_key, str) or not previous_key:
+            return None
+        if previous_key in {
+            "dashboard",
+            "inbox",
+            "workers",
+            "metrics",
+            "settings",
+            "activity",
+        }:
+            return previous_key
+        if previous_key.startswith(("inbox:", "activity:")):
+            return previous_key
+        if previous_key.startswith("project:"):
+            parts = previous_key.split(":")
+            if len(parts) == 2:
+                return f"{previous_key}:dashboard"
+            if len(parts) >= 3 and parts[2] in {"dashboard", "settings", "issues"}:
+                return previous_key
+        return None
+
+    def _record_live_mount_return_key(
+        self,
+        plan,
+        previous_key: object,
+    ) -> None:
+        state = self._load_state()
+        if isinstance(plan, LiveAgentPane):
+            return_key = self._return_key_for_live_mount(previous_key)
+            if return_key:
+                state["mounted_return_key"] = return_key
+            else:
+                state.pop("mounted_return_key", None)
+        else:
+            state.pop("mounted_return_key", None)
+        self._write_state(state)
+
     def should_show_palette_tip(self) -> bool:
         data = self._load_state()
         return not bool(data.get("palette_tip_seen"))
@@ -2552,6 +2591,8 @@ class CockpitRouter:
         # right pane to the stale prior selection. Writing the new key
         # to disk first keeps the rail aligned with the user's intent
         # even when downstream work raises.
+        state_before_route = self._load_state()
+        previous_key = state_before_route.get("selected")
         self.set_selected_key(key)
         token = self._begin_layout_mutation()
         try:
@@ -2563,6 +2604,7 @@ class CockpitRouter:
                 raise RuntimeError("Cockpit right pane is not available.")
 
             plan = resolve_cockpit_content(key, self._content_context(supervisor))
+            self._record_live_mount_return_key(plan, previous_key)
             self._route_content_plan(supervisor, window_target, plan)
         finally:
             # #995 — guarantee a two-pane cockpit on every rail click.
@@ -3408,6 +3450,7 @@ class CockpitRouter:
     ) -> None:
         self._park_mounted_session(supervisor, window_target)
         state = self._load_state()
+        state.pop("mounted_return_key", None)
         result = self._window_manager(supervisor).show_static(
             command,
             self._window_state_from_cockpit_state(supervisor, state),

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -1672,6 +1672,14 @@ class PollyCockpitApp(App[None]):
             return False
         return bool(state.get("mounted_session"))
 
+    def _mounted_return_key(self) -> str | None:
+        try:
+            state = self.router._load_state()
+        except Exception:  # noqa: BLE001
+            return None
+        value = state.get("mounted_return_key")
+        return value if isinstance(value, str) and value else None
+
     def _send_key_to_right_pane(self, key: str) -> None:
         send_method = getattr(self.router, "send_key_to_right_pane", None)
         if callable(send_method):
@@ -2879,6 +2887,10 @@ class PollyCockpitApp(App[None]):
 
     def action_back_to_home(self) -> None:
         if self._right_pane_has_live_session():
+            return_key = self._mounted_return_key()
+            if return_key:
+                self._schedule_route_selected(return_key, label=return_key)
+                return
             self._focus_rail_pane()
             return
         if self._is_on_home():

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4873,6 +4873,25 @@ def test_cockpit_escape_from_live_chat_focuses_rail_pane() -> None:
     assert calls == ["focus_rail"]
 
 
+def test_cockpit_escape_from_inbox_opened_chat_routes_back_to_inbox() -> None:
+    """#1199: Esc from an Inbox-started chat returns to Inbox content."""
+    app, calls = _build_back_to_home_app()
+    app.selected_key = "project:demo:session"
+    app._last_router_selected_key = "project:demo:session"
+    app.router._load_state = lambda: {  # type: ignore[attr-defined]
+        "mounted_session": "architect_demo",
+        "mounted_return_key": "inbox",
+    }
+    app.router.focus_rail_pane = lambda: calls.append("focus_rail")  # type: ignore[attr-defined]
+    app._schedule_route_selected = (  # type: ignore[method-assign]
+        lambda key, *, label=None: calls.append(("route", key, label))
+    )
+
+    app.action_back_to_home()
+
+    assert calls == [("route", "inbox", "inbox")]
+
+
 def test_cockpit_action_button_digits_forward_from_rail() -> None:
     """1/2/3 from rail forwards to the right pane so Action Needed buttons fire (#862)."""
     app = PollyCockpitApp.__new__(PollyCockpitApp)
@@ -5867,6 +5886,47 @@ def test_route_selected_persists_intent_before_layout_work(
         "next periodic _refresh_rows will bounce the cursor back to the "
         f"stale state[\"selected\"]={state.get('selected')!r} (#967)."
     )
+
+
+def test_route_selected_records_return_key_for_live_mount(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """#1199: live chats opened from Inbox remember how to get back."""
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\n"
+        f"tmux_session = \"pollypm\"\n"
+        f"base_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+
+    class FakeSupervisor:
+        class Config:
+            class Project:
+                tmux_session = "pollypm"
+                base_dir = tmp_path / ".pollypm"
+                root_dir = tmp_path
+
+            project = Project()
+            projects = {}
+
+        config = Config()
+
+        def plan_launches(self):
+            return []
+
+    router = CockpitRouter(config_path)
+    router._write_state({"selected": "inbox", "right_pane_id": "%2"})
+    monkeypatch.setattr(router, "_load_supervisor", lambda: FakeSupervisor())
+    monkeypatch.setattr(router, "ensure_cockpit_layout", lambda: None)
+    monkeypatch.setattr(router, "_right_pane_id", lambda target: "%2")
+    monkeypatch.setattr(router, "_route_content_plan", lambda *args: None)
+    monkeypatch.setattr(router, "_heal_layout_after_route", lambda: None)
+
+    router.route_selected("polly")
+
+    state = router._load_state()
+    assert state.get("selected") == "polly"
+    assert state.get("mounted_return_key") == "inbox"
 
 
 def test_right_pane_command_uses_exec_to_avoid_orphans(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1199

Records the static cockpit surface before mounting a live agent, so Esc from an Inbox-started architect chat routes back to Inbox instead of only focusing the rail. Static routes clear the return key after replacing the live pane.

Layer audit: UI/router only (`cockpit_ui`, `cockpit_rail`) plus cockpit regression tests. No store/domain boundary changes.