### PR TITLE
Fix #1203 route live cockpit keys

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -19,6 +19,74 @@ import typer
 
 from pollypm.config import DEFAULT_CONFIG_PATH
 
+_RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS = frozenset({"<esc>", "esc", "escape"})
+_RIGHT_PANE_TMUX_KEY_TOKENS: dict[str, str] = {
+    "<bs>": "BSpace",
+    "backspace": "BSpace",
+    "<cr>": "Enter",
+    "enter": "Enter",
+    "<tab>": "Tab",
+    "tab": "Tab",
+    "<space>": "Space",
+    "space": "Space",
+    "<up>": "Up",
+    "up": "Up",
+    "<down>": "Down",
+    "down": "Down",
+    "<left>": "Left",
+    "left": "Left",
+    "<right>": "Right",
+    "right": "Right",
+    "<pgup>": "PageUp",
+    "pageup": "PageUp",
+    "<pgdn>": "PageDown",
+    "pagedown": "PageDown",
+    "<home>": "Home",
+    "home": "Home",
+    "<end>": "End",
+    "end": "End",
+}
+
+
+def _tmux_event_for_cockpit_key(key: str) -> tuple[str, bool] | None:
+    """Return ``(value, literal)`` for forwarding a bridge token to tmux."""
+    token = key.strip()
+    if not token:
+        return None
+    lowered = token.lower()
+    mapped = _RIGHT_PANE_TMUX_KEY_TOKENS.get(lowered)
+    if mapped is not None:
+        return mapped, False
+    if lowered.startswith("ctrl+") and len(token) > len("ctrl+"):
+        return f"C-{token[len('ctrl+'):].lower()}", False
+    if lowered.startswith("c-") and len(token) > 2:
+        return f"C-{token[2:].lower()}", False
+    return key, True
+
+
+def _send_key_to_active_live_right_pane(config_path: Path, key: str) -> str | None:
+    """Deliver ``key`` to the focused live right pane, if one owns focus."""
+    if key.strip().lower() in _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS:
+        return None
+    try:
+        from pollypm.cockpit_rail import CockpitRouter
+
+        router = CockpitRouter(config_path)
+        right_pane = router.active_live_right_pane_id()
+    except Exception:  # noqa: BLE001
+        return None
+    if right_pane is None:
+        return None
+    event = _tmux_event_for_cockpit_key(key)
+    if event is None:
+        return None
+    value, literal = event
+    if literal:
+        router.tmux.send_keys(right_pane, value, press_enter=False)
+    else:
+        router.tmux.run("send-keys", "-t", right_pane, value, check=False)
+    return right_pane
+
 
 def _install_cockpit_debug_log_handler(config_path: Path) -> None:
     """Attach a ``FileHandler`` so cockpit-side ``logger.info``/``warning``
@@ -284,6 +352,16 @@ def register_ui_commands(app: typer.Typer) -> None:
         ),
     ) -> None:
         from pollypm.cockpit_input_bridge import send_key_to_first_live
+
+        if kind == "cockpit":
+            delivered_to_right = _send_key_to_active_live_right_pane(
+                config_path, key,
+            )
+            if delivered_to_right is not None:
+                typer.echo(
+                    f"Delivered {key!r} via cockpit right pane {delivered_to_right}"
+                )
+                return
 
         delivered_to = send_key_to_first_live(config_path, key, kind=kind)
         if delivered_to is None:

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -2741,6 +2741,37 @@ class CockpitRouter:
         if right_pane is not None:
             self.tmux.run("send-keys", "-t", right_pane, key, check=False)
 
+    def active_live_right_pane_id(self) -> str | None:
+        """Return the right pane id when tmux focus is in a mounted live agent.
+
+        ``pm cockpit-send-key`` normally enters through the rail's Textual
+        input bridge. After a live chat mount, though, the cockpit
+        intentionally moves tmux focus to the right pane so typing should
+        reach Codex/Claude instead of rail hotkeys.
+        """
+        state = self._load_state()
+        mounted = state.get("mounted_session")
+        right_pane_id = state.get("right_pane_id")
+        if not isinstance(mounted, str) or not mounted:
+            return None
+        if not isinstance(right_pane_id, str) or not right_pane_id:
+            return None
+        try:
+            config = self._load_config()
+            window_target = f"{config.project.tmux_session}:{self._COCKPIT_WINDOW}"
+            panes = self.tmux.list_panes(window_target)
+        except Exception:  # noqa: BLE001
+            return None
+        active = next(
+            (pane for pane in panes if getattr(pane, "active", False)),
+            None,
+        )
+        if active is None or getattr(active, "pane_dead", False):
+            return None
+        if getattr(active, "pane_id", None) != right_pane_id:
+            return None
+        return right_pane_id
+
     def reload_cockpit_shell(
         self,
         *,

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -2924,6 +2924,34 @@ def test_cockpit_router_focus_right_shows_return_affordance(monkeypatch, tmp_pat
     assert calls[1] == ("select", ("%2",))
 
 
+def test_cockpit_router_detects_active_live_right_pane(tmp_path: Path) -> None:
+    """#1203: bridge-delivered typing should follow live right-pane focus."""
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+
+    class FakeTmux:
+        def __init__(self, right_active: bool) -> None:
+            self.right_active = right_active
+
+        def list_panes(self, target: str):
+            assert target == "pollypm:PollyPM"
+            return [
+                SimpleNamespace(pane_id="%1", active=not self.right_active, pane_dead=False),
+                SimpleNamespace(pane_id="%2", active=self.right_active, pane_dead=False),
+            ]
+
+    router = CockpitRouter(config_path)
+    router._write_state({"right_pane_id": "%2", "mounted_session": "architect_demo"})
+    router.tmux = FakeTmux(right_active=True)  # type: ignore[assignment]
+
+    assert router.active_live_right_pane_id() == "%2"
+
+    router.tmux = FakeTmux(right_active=False)  # type: ignore[assignment]
+    assert router.active_live_right_pane_id() is None
+
+
 def test_cockpit_router_focus_rail_selects_leftmost_pane(
     monkeypatch, tmp_path: Path,
 ) -> None:

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -225,6 +225,44 @@ def test_cockpit_send_key_defaults_to_cockpit_socket(fake_config: Path) -> None:
         dashboard.stop()
 
 
+def test_cockpit_send_key_forwards_to_focused_live_right_pane(
+    fake_config: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import typer
+    from typer.testing import CliRunner
+
+    from pollypm.cli_features import ui as ui_commands
+
+    cockpit_app = _FakeApp()
+    cockpit = start_input_bridge(cockpit_app, kind="cockpit", config_path=fake_config)
+    assert cockpit is not None
+    forwarded: list[tuple[Path, str]] = []
+
+    def fake_forward(config_path: Path, key: str) -> str | None:
+        forwarded.append((config_path, key))
+        return "%2"
+
+    monkeypatch.setattr(
+        ui_commands,
+        "_send_key_to_active_live_right_pane",
+        fake_forward,
+    )
+
+    try:
+        app = typer.Typer()
+        ui_commands.register_ui_commands(app)
+        result = CliRunner().invoke(
+            app, ["cockpit-send-key", "s", "--config", str(fake_config)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "via cockpit right pane %2" in result.output
+        assert forwarded == [(fake_config, "s")]
+        time.sleep(0.1)
+        assert cockpit_app.keys == []
+    finally:
+        cockpit.stop()
+
+
 def test_send_key_to_first_live_skips_stale_sockets(fake_config: Path, tmp_path: Path) -> None:
     bridge_dir = fake_config.parent / "cockpit_inputs"
     bridge_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Closes #1203

Routes default `pm cockpit-send-key` input to the active live right pane when tmux focus is already inside a mounted Codex/Claude chat, so typed rejection text reaches the agent instead of rail hotkeys. Escape still goes through the rail bridge to preserve the existing return-to-inbox path.

Layer self-audit: touched UI/CLI routing only (`cli_features/ui.py`, `cockpit_rail.py`) plus focused tests. No store/domain imports or boundary crossings added.