### PR TITLE
Fix #1205 route help to content pane

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -20,6 +20,7 @@ import typer
 from pollypm.config import DEFAULT_CONFIG_PATH
 
 _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS = frozenset({"<esc>", "esc", "escape"})
+_HELP_KEY_TOKENS = frozenset({"?", "question_mark"})
 _RIGHT_PANE_TMUX_KEY_TOKENS: dict[str, str] = {
     "<bs>": "BSpace",
     "backspace": "BSpace",
@@ -46,6 +47,41 @@ _RIGHT_PANE_TMUX_KEY_TOKENS: dict[str, str] = {
     "<end>": "End",
     "end": "End",
 }
+
+
+def _is_help_key(key: str) -> bool:
+    return key.strip().lower() in _HELP_KEY_TOKENS
+
+
+def _content_bridge_kind_for_selected_key(selected_key: str) -> str | None:
+    """Return the right-pane bridge kind for selected static cockpit views."""
+    if selected_key in {"dashboard", "polly"}:
+        return "dashboard"
+    if selected_key == "inbox" or selected_key.startswith("inbox:"):
+        return "pane-inbox"
+    if selected_key == "settings":
+        return "settings"
+    return None
+
+
+def _send_help_key_to_content_bridge(config_path: Path, key: str) -> Path | None:
+    """Deliver ``?`` to the selected content-pane app when it has a bridge."""
+    if not _is_help_key(key):
+        return None
+    try:
+        from pollypm.cockpit_input_bridge import send_key_to_first_live
+        from pollypm.cockpit_rail import CockpitRouter
+
+        selected = CockpitRouter(config_path).selected_key()
+    except Exception:  # noqa: BLE001
+        return None
+    kind = _content_bridge_kind_for_selected_key(selected)
+    if kind is None:
+        return None
+    try:
+        return send_key_to_first_live(config_path, key, kind=kind, timeout=0.2)
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def _tmux_event_for_cockpit_key(key: str) -> tuple[str, bool] | None:
@@ -361,6 +397,12 @@ def register_ui_commands(app: typer.Typer) -> None:
                 typer.echo(
                     f"Delivered {key!r} via cockpit right pane {delivered_to_right}"
                 )
+                return
+            delivered_to_content = _send_help_key_to_content_bridge(
+                config_path, key,
+            )
+            if delivered_to_content is not None:
+                typer.echo(f"Delivered {key!r} via {delivered_to_content}")
                 return
 
         delivered_to = send_key_to_first_live(config_path, key, kind=kind)

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -82,6 +82,20 @@ def fake_config() -> Iterator[Path]:
         shutil.rmtree(root, ignore_errors=True)
 
 
+@pytest.fixture()
+def valid_cockpit_config(tmp_path: Path) -> Path:
+    """Minimal config that ``CockpitRouter`` can use for state lookup."""
+    base_dir = tmp_path / ".pollypm"
+    config = tmp_path / "pollypm.toml"
+    config.write_text(
+        "[project]\n"
+        'name = "PollyPM"\n'
+        'tmux_session = "pollypm-test"\n'
+        f'base_dir = "{base_dir}"\n'
+    )
+    return config
+
+
 def test_start_input_bridge_creates_socket(fake_config: Path) -> None:
     app = _FakeApp()
     handle = start_input_bridge(app, kind="cockpit", config_path=fake_config)
@@ -223,6 +237,51 @@ def test_cockpit_send_key_defaults_to_cockpit_socket(fake_config: Path) -> None:
     finally:
         cockpit.stop()
         dashboard.stop()
+
+
+@pytest.mark.parametrize(
+    ("selected_key", "bridge_kind"),
+    [
+        ("dashboard", "dashboard"),
+        ("inbox", "pane-inbox"),
+    ],
+)
+def test_cockpit_send_key_question_mark_prefers_content_pane_bridge(
+    valid_cockpit_config: Path,
+    selected_key: str,
+    bridge_kind: str,
+) -> None:
+    import typer
+    from typer.testing import CliRunner
+
+    from pollypm.cli_features.ui import register_ui_commands
+    from pollypm.cockpit_rail import CockpitRouter
+
+    cockpit_app = _FakeApp()
+    content_app = _FakeApp()
+    cockpit = start_input_bridge(
+        cockpit_app, kind="cockpit", config_path=valid_cockpit_config,
+    )
+    assert cockpit is not None
+    content = start_input_bridge(
+        content_app, kind=bridge_kind, config_path=valid_cockpit_config,
+    )
+    assert content is not None
+    try:
+        CockpitRouter(valid_cockpit_config).set_selected_key(selected_key)
+
+        app = typer.Typer()
+        register_ui_commands(app)
+        result = CliRunner().invoke(
+            app, ["cockpit-send-key", "?", "--config", str(valid_cockpit_config)]
+        )
+        assert result.exit_code == 0, result.output
+        assert f"via {content.socket_path}" in result.output
+        assert _wait_for(lambda: content_app.keys == ["question_mark"])
+        assert cockpit_app.keys == []
+    finally:
+        cockpit.stop()
+        content.stop()
 
 
 def test_cockpit_send_key_forwards_to_focused_live_right_pane(


### PR DESCRIPTION
Closes #1205

Routes the default cockpit-send-key help keystroke to the selected content-pane bridge when one is live, so '?' opens keyboard help in the wide dashboard/inbox pane instead of the rail. Ordinary default keystrokes still target the rail, and live right-pane focus forwarding remains unchanged.

Self-audit: touched CLI/input-bridge routing plus focused bridge tests only; no store/domain imports or boundary debt.