### PR TITLE
Fix #1205 dashboard help binding

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -2999,6 +2999,7 @@ class PollyDashboardApp(App[None]):
     BINDINGS = [
         Binding("i", "jump_inbox", "Inbox"),
         Binding("r", "refresh", "Refresh"),
+        Binding("question_mark", "show_keyboard_help", "Help", priority=True),
         # The screen overflows on a 65-row laptop terminal — Tokens
         # sits below the fold (#874). The Screen already declares
         # ``overflow-y: auto`` but Textual does not bind navigation
@@ -3032,6 +3033,9 @@ class PollyDashboardApp(App[None]):
     .chart-section { padding: 0 0 0 2; }
     .footer { color: #484f58; padding: 1 0 0 0; }
     """
+
+    def action_show_keyboard_help(self) -> None:
+        _open_keyboard_help(self)
 
     def __init__(self, config_path: Path) -> None:
         super().__init__()

--- a/tests/test_keyboard_help.py
+++ b/tests/test_keyboard_help.py
@@ -132,6 +132,7 @@ async def _wait_for_help_modal(app, pilot, *, attempts: int = 5):
 @pytest.mark.parametrize(
     "app_factory_name",
     [
+        "PollyDashboardApp",
         "PollyInboxApp",
         "PollyCockpitApp",
         "PollyWorkerRosterApp",
@@ -162,11 +163,14 @@ def test_question_mark_opens_help_modal(
     _run(body())
 
 
-@pytest.mark.parametrize("app_factory_name", ["PollyCockpitApp", "PollyInboxApp"])
+@pytest.mark.parametrize(
+    "app_factory_name",
+    ["PollyCockpitApp", "PollyDashboardApp", "PollyInboxApp"],
+)
 def test_bridge_literal_question_mark_opens_help_modal(
     single_project_env, app_factory_name,
 ) -> None:
-    """``pm cockpit-send-key '?'`` opens help from rail and inbox surfaces."""
+    """``pm cockpit-send-key '?'`` opens help from bridged cockpit surfaces."""
     if not _load_config_compatible(single_project_env["config_path"]):
         pytest.skip("minimal pollypm.toml fixture not supported by loader")
     from pollypm import cockpit_ui
@@ -539,6 +543,7 @@ def test_question_mark_binding_registered_on_every_cockpit_app() -> None:
     from pollypm.cockpit_ui import (
         PollyActivityFeedApp,
         PollyCockpitApp,
+        PollyDashboardApp,
         PollyInboxApp,
         PollyProjectDashboardApp,
         PollySettingsPaneApp,
@@ -554,6 +559,7 @@ def test_question_mark_binding_registered_on_every_cockpit_app() -> None:
 
     for cls in (
         PollyCockpitApp,
+        PollyDashboardApp,
         PollyInboxApp,
         PollyProjectDashboardApp,
         PollyWorkerRosterApp,


### PR DESCRIPTION
Closes #1205

Adds the missing `?` / `show_keyboard_help` binding to `PollyDashboardApp`, so the content-pane dashboard bridge opened by `pm cockpit-send-key ?` can display the shared keyboard help modal.

Self-audit: touched cockpit UI binding/action wiring and focused keyboard-help tests only; no store/domain imports or boundary debt.