### PR TITLE
Fix #1210 route inbox discuss key via bridge

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -21,6 +21,7 @@ from pollypm.config import DEFAULT_CONFIG_PATH
 
 _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS = frozenset({"<esc>", "esc", "escape"})
 _HELP_KEY_TOKENS = frozenset({"?", "question_mark"})
+_INBOX_BRIDGE_FIRST_TOKENS = frozenset({"d"})
 _RIGHT_PANE_TMUX_KEY_TOKENS: dict[str, str] = {
     "<bs>": "BSpace",
     "backspace": "BSpace",
@@ -80,6 +81,30 @@ def _send_help_key_to_content_bridge(config_path: Path, key: str) -> Path | None
         return None
     try:
         return send_key_to_first_live(config_path, key, kind=kind, timeout=0.2)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _send_selected_action_key_to_content_bridge(
+    config_path: Path, key: str,
+) -> Path | None:
+    """Deliver selected-pane action keys before live-pane PTY fallback."""
+    token = key.strip()
+    if token not in _INBOX_BRIDGE_FIRST_TOKENS:
+        return None
+    try:
+        from pollypm.cockpit_input_bridge import send_key_to_first_live
+        from pollypm.cockpit_rail import CockpitRouter
+
+        selected = CockpitRouter(config_path).selected_key()
+    except Exception:  # noqa: BLE001
+        return None
+    if _content_bridge_kind_for_selected_key(selected) != "pane-inbox":
+        return None
+    try:
+        return send_key_to_first_live(
+            config_path, key, kind="pane-inbox", timeout=0.2,
+        )
     except Exception:  # noqa: BLE001
         return None
 
@@ -390,6 +415,12 @@ def register_ui_commands(app: typer.Typer) -> None:
         from pollypm.cockpit_input_bridge import send_key_to_first_live
 
         if kind == "cockpit":
+            delivered_to_content = _send_selected_action_key_to_content_bridge(
+                config_path, key,
+            )
+            if delivered_to_content is not None:
+                typer.echo(f"Delivered {key!r} via {delivered_to_content}")
+                return
             delivered_to_right = _send_key_to_active_live_right_pane(
                 config_path, key,
             )

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -284,6 +284,48 @@ def test_cockpit_send_key_question_mark_prefers_content_pane_bridge(
         content.stop()
 
 
+def test_cockpit_send_key_inbox_discuss_prefers_inbox_bridge_over_live_pane(
+    valid_cockpit_config: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import typer
+    from typer.testing import CliRunner
+
+    from pollypm.cli_features import ui as ui_commands
+    from pollypm.cockpit_rail import CockpitRouter
+
+    inbox_app = _FakeApp()
+    inbox = start_input_bridge(
+        inbox_app, kind="pane-inbox", config_path=valid_cockpit_config,
+    )
+    assert inbox is not None
+    live_pane_attempts: list[tuple[Path, str]] = []
+
+    def fake_live_pane(config_path: Path, key: str) -> str | None:
+        live_pane_attempts.append((config_path, key))
+        return "%2"
+
+    monkeypatch.setattr(
+        ui_commands,
+        "_send_key_to_active_live_right_pane",
+        fake_live_pane,
+    )
+    try:
+        CockpitRouter(valid_cockpit_config).set_selected_key("inbox")
+
+        app = typer.Typer()
+        ui_commands.register_ui_commands(app)
+        result = CliRunner().invoke(
+            app, ["cockpit-send-key", "d", "--config", str(valid_cockpit_config)]
+        )
+        assert result.exit_code == 0, result.output
+        assert f"via {inbox.socket_path}" in result.output
+        assert _wait_for(lambda: inbox_app.keys == ["d"])
+        assert live_pane_attempts == []
+    finally:
+        inbox.stop()
+
+
 def test_cockpit_send_key_forwards_to_focused_live_right_pane(
     fake_config: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Closes #1210

Routes bare `pm cockpit-send-key d` to the selected Inbox pane bridge before falling back to active live right-pane PTY dispatch, so stale mounted-pane state cannot swallow the plan-review discuss action. Added a regression covering selected Inbox plus an available live-pane fallback.

Self-audit: touched CLI/UI input routing (`src/pollypm/cli_features/ui.py`) and CLI bridge tests only; no service, domain, or store layers changed.