### PR TITLE
Fix cockpit-send-key bridge routing regressions

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -21,7 +21,7 @@ from pollypm.config import DEFAULT_CONFIG_PATH
 
 _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS = frozenset({"<esc>", "esc", "escape"})
 _HELP_KEY_TOKENS = frozenset({"?", "question_mark"})
-_INBOX_BRIDGE_FIRST_TOKENS = frozenset({"d"})
+_INBOX_BRIDGE_FIRST_TOKENS = frozenset({"A", "d"})
 _RIGHT_PANE_TMUX_KEY_TOKENS: dict[str, str] = {
     "<bs>": "BSpace",
     "backspace": "BSpace",

--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -21,7 +21,7 @@ from pollypm.config import DEFAULT_CONFIG_PATH
 
 _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS = frozenset({"<esc>", "esc", "escape"})
 _HELP_KEY_TOKENS = frozenset({"?", "question_mark"})
-_INBOX_BRIDGE_FIRST_TOKENS = frozenset({"d"})
+_INBOX_BRIDGE_FIRST_TOKENS = frozenset({"/", "d"})
 _SETTINGS_BRIDGE_FIRST_TOKENS = frozenset({
     "<down>",
     "<tab>",

--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -21,6 +21,7 @@ from pollypm.config import DEFAULT_CONFIG_PATH
 
 _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS = frozenset({"<esc>", "esc", "escape"})
 _HELP_KEY_TOKENS = frozenset({"?", "question_mark"})
+_COCKPIT_BRIDGE_FIRST_TOKENS = frozenset({"s", "S"})
 _INBOX_BRIDGE_FIRST_TOKENS = frozenset({"/", "d"})
 _SETTINGS_BRIDGE_FIRST_TOKENS = frozenset({
     "<down>",
@@ -117,6 +118,21 @@ def _send_selected_action_key_to_content_bridge(
         return None
     try:
         return send_key_to_first_live(config_path, key, kind=kind, timeout=0.2)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _send_global_nav_key_to_cockpit_bridge(
+    config_path: Path, key: str,
+) -> Path | None:
+    """Deliver global rail navigation keys before live-pane PTY fallback."""
+    token = key.strip()
+    if token not in _COCKPIT_BRIDGE_FIRST_TOKENS:
+        return None
+    try:
+        from pollypm.cockpit_input_bridge import send_key_to_first_live
+
+        return send_key_to_first_live(config_path, key, kind="cockpit", timeout=0.2)
     except Exception:  # noqa: BLE001
         return None
 
@@ -432,6 +448,12 @@ def register_ui_commands(app: typer.Typer) -> None:
             )
             if delivered_to_content is not None:
                 typer.echo(f"Delivered {key!r} via {delivered_to_content}")
+                return
+            delivered_to_cockpit = _send_global_nav_key_to_cockpit_bridge(
+                config_path, key,
+            )
+            if delivered_to_cockpit is not None:
+                typer.echo(f"Delivered {key!r} via {delivered_to_cockpit}")
                 return
             delivered_to_right = _send_key_to_active_live_right_pane(
                 config_path, key,

--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -21,7 +21,17 @@ from pollypm.config import DEFAULT_CONFIG_PATH
 
 _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS = frozenset({"<esc>", "esc", "escape"})
 _HELP_KEY_TOKENS = frozenset({"?", "question_mark"})
-_INBOX_BRIDGE_FIRST_TOKENS = frozenset({"A", "d"})
+_INBOX_BRIDGE_FIRST_TOKENS = frozenset({"d"})
+_SETTINGS_BRIDGE_FIRST_TOKENS = frozenset({
+    "<down>",
+    "<tab>",
+    "<up>",
+    "down",
+    "j",
+    "k",
+    "tab",
+    "up",
+})
 _RIGHT_PANE_TMUX_KEY_TOKENS: dict[str, str] = {
     "<bs>": "BSpace",
     "backspace": "BSpace",
@@ -90,8 +100,7 @@ def _send_selected_action_key_to_content_bridge(
 ) -> Path | None:
     """Deliver selected-pane action keys before live-pane PTY fallback."""
     token = key.strip()
-    if token not in _INBOX_BRIDGE_FIRST_TOKENS:
-        return None
+    lowered = token.lower()
     try:
         from pollypm.cockpit_input_bridge import send_key_to_first_live
         from pollypm.cockpit_rail import CockpitRouter
@@ -99,12 +108,15 @@ def _send_selected_action_key_to_content_bridge(
         selected = CockpitRouter(config_path).selected_key()
     except Exception:  # noqa: BLE001
         return None
-    if _content_bridge_kind_for_selected_key(selected) != "pane-inbox":
+    kind = _content_bridge_kind_for_selected_key(selected)
+    if kind == "pane-inbox" and token in _INBOX_BRIDGE_FIRST_TOKENS:
+        pass
+    elif kind == "settings" and lowered in _SETTINGS_BRIDGE_FIRST_TOKENS:
+        pass
+    else:
         return None
     try:
-        return send_key_to_first_live(
-            config_path, key, kind="pane-inbox", timeout=0.2,
-        )
+        return send_key_to_first_live(config_path, key, kind=kind, timeout=0.2)
     except Exception:  # noqa: BLE001
         return None
 

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -383,7 +383,7 @@ def test_cockpit_send_key_settings_nav_prefers_settings_bridge_over_live_pane(
         settings.stop()
 
 
-def test_cockpit_send_key_forwards_to_focused_live_right_pane(
+def test_cockpit_send_key_global_settings_prefers_cockpit_bridge_over_live_pane(
     fake_config: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import typer
@@ -413,8 +413,45 @@ def test_cockpit_send_key_forwards_to_focused_live_right_pane(
             app, ["cockpit-send-key", "s", "--config", str(fake_config)]
         )
         assert result.exit_code == 0, result.output
+        assert f"via {cockpit.socket_path}" in result.output
+        assert forwarded == []
+        assert _wait_for(lambda: cockpit_app.keys == ["s"])
+    finally:
+        cockpit.stop()
+
+
+def test_cockpit_send_key_forwards_to_focused_live_right_pane(
+    fake_config: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import typer
+    from typer.testing import CliRunner
+
+    from pollypm.cli_features import ui as ui_commands
+
+    cockpit_app = _FakeApp()
+    cockpit = start_input_bridge(cockpit_app, kind="cockpit", config_path=fake_config)
+    assert cockpit is not None
+    forwarded: list[tuple[Path, str]] = []
+
+    def fake_forward(config_path: Path, key: str) -> str | None:
+        forwarded.append((config_path, key))
+        return "%2"
+
+    monkeypatch.setattr(
+        ui_commands,
+        "_send_key_to_active_live_right_pane",
+        fake_forward,
+    )
+
+    try:
+        app = typer.Typer()
+        ui_commands.register_ui_commands(app)
+        result = CliRunner().invoke(
+            app, ["cockpit-send-key", "x", "--config", str(fake_config)]
+        )
+        assert result.exit_code == 0, result.output
         assert "via cockpit right pane %2" in result.output
-        assert forwarded == [(fake_config, "s")]
+        assert forwarded == [(fake_config, "x")]
         time.sleep(0.1)
         assert cockpit_app.keys == []
     finally:

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -284,11 +284,9 @@ def test_cockpit_send_key_question_mark_prefers_content_pane_bridge(
         content.stop()
 
 
-@pytest.mark.parametrize("key", ["d", "A"])
-def test_cockpit_send_key_inbox_action_prefers_inbox_bridge_over_live_pane(
+def test_cockpit_send_key_inbox_discuss_prefers_inbox_bridge_over_live_pane(
     valid_cockpit_config: Path,
     monkeypatch: pytest.MonkeyPatch,
-    key: str,
 ) -> None:
     import typer
     from typer.testing import CliRunner
@@ -318,14 +316,68 @@ def test_cockpit_send_key_inbox_action_prefers_inbox_bridge_over_live_pane(
         app = typer.Typer()
         ui_commands.register_ui_commands(app)
         result = CliRunner().invoke(
-            app, ["cockpit-send-key", key, "--config", str(valid_cockpit_config)]
+            app, ["cockpit-send-key", "d", "--config", str(valid_cockpit_config)]
         )
         assert result.exit_code == 0, result.output
         assert f"via {inbox.socket_path}" in result.output
-        assert _wait_for(lambda: inbox_app.keys == [key])
+        assert _wait_for(lambda: inbox_app.keys == ["d"])
         assert live_pane_attempts == []
     finally:
         inbox.stop()
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("j", "j"),
+        ("k", "k"),
+        ("<down>", "down"),
+        ("<up>", "up"),
+        ("<tab>", "tab"),
+    ],
+)
+def test_cockpit_send_key_settings_nav_prefers_settings_bridge_over_live_pane(
+    valid_cockpit_config: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    key: str,
+    expected: str,
+) -> None:
+    import typer
+    from typer.testing import CliRunner
+
+    from pollypm.cli_features import ui as ui_commands
+    from pollypm.cockpit_rail import CockpitRouter
+
+    settings_app = _FakeApp()
+    settings = start_input_bridge(
+        settings_app, kind="settings", config_path=valid_cockpit_config,
+    )
+    assert settings is not None
+    live_pane_attempts: list[tuple[Path, str]] = []
+
+    def fake_live_pane(config_path: Path, key: str) -> str | None:
+        live_pane_attempts.append((config_path, key))
+        return "%2"
+
+    monkeypatch.setattr(
+        ui_commands,
+        "_send_key_to_active_live_right_pane",
+        fake_live_pane,
+    )
+    try:
+        CockpitRouter(valid_cockpit_config).set_selected_key("settings")
+
+        app = typer.Typer()
+        ui_commands.register_ui_commands(app)
+        result = CliRunner().invoke(
+            app, ["cockpit-send-key", key, "--config", str(valid_cockpit_config)]
+        )
+        assert result.exit_code == 0, result.output
+        assert f"via {settings.socket_path}" in result.output
+        assert _wait_for(lambda: settings_app.keys == [expected])
+        assert live_pane_attempts == []
+    finally:
+        settings.stop()
 
 
 def test_cockpit_send_key_forwards_to_focused_live_right_pane(

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -284,9 +284,11 @@ def test_cockpit_send_key_question_mark_prefers_content_pane_bridge(
         content.stop()
 
 
-def test_cockpit_send_key_inbox_discuss_prefers_inbox_bridge_over_live_pane(
+@pytest.mark.parametrize("key", ["d", "A"])
+def test_cockpit_send_key_inbox_action_prefers_inbox_bridge_over_live_pane(
     valid_cockpit_config: Path,
     monkeypatch: pytest.MonkeyPatch,
+    key: str,
 ) -> None:
     import typer
     from typer.testing import CliRunner
@@ -316,11 +318,11 @@ def test_cockpit_send_key_inbox_discuss_prefers_inbox_bridge_over_live_pane(
         app = typer.Typer()
         ui_commands.register_ui_commands(app)
         result = CliRunner().invoke(
-            app, ["cockpit-send-key", "d", "--config", str(valid_cockpit_config)]
+            app, ["cockpit-send-key", key, "--config", str(valid_cockpit_config)]
         )
         assert result.exit_code == 0, result.output
         assert f"via {inbox.socket_path}" in result.output
-        assert _wait_for(lambda: inbox_app.keys == ["d"])
+        assert _wait_for(lambda: inbox_app.keys == [key])
         assert live_pane_attempts == []
     finally:
         inbox.stop()

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -284,9 +284,12 @@ def test_cockpit_send_key_question_mark_prefers_content_pane_bridge(
         content.stop()
 
 
-def test_cockpit_send_key_inbox_discuss_prefers_inbox_bridge_over_live_pane(
+@pytest.mark.parametrize(("key", "expected"), [("d", "d"), ("/", "/")])
+def test_cockpit_send_key_inbox_action_prefers_inbox_bridge_over_live_pane(
     valid_cockpit_config: Path,
     monkeypatch: pytest.MonkeyPatch,
+    key: str,
+    expected: str,
 ) -> None:
     import typer
     from typer.testing import CliRunner
@@ -316,11 +319,11 @@ def test_cockpit_send_key_inbox_discuss_prefers_inbox_bridge_over_live_pane(
         app = typer.Typer()
         ui_commands.register_ui_commands(app)
         result = CliRunner().invoke(
-            app, ["cockpit-send-key", "d", "--config", str(valid_cockpit_config)]
+            app, ["cockpit-send-key", key, "--config", str(valid_cockpit_config)]
         )
         assert result.exit_code == 0, result.output
         assert f"via {inbox.socket_path}" in result.output
-        assert _wait_for(lambda: inbox_app.keys == ["d"])
+        assert _wait_for(lambda: inbox_app.keys == [expected])
         assert live_pane_attempts == []
     finally:
         inbox.stop()


### PR DESCRIPTION
Closes #1215
Closes #1214
Closes #1217

Supersedes #1216. This branch includes the existing Settings bridge-routing work plus two additional bridge regressions from the current `needs-fix` queue.

Routes Settings-owned cockpit-send-key navigation tokens (`j`, `k`, `<up>`, `<down>`, `<tab>`) directly to the Settings pane input bridge before live right-pane tmux fallback can intercept them.

Also routes Inbox `/` to the pane-inbox bridge so the filter input opens from `pm cockpit-send-key /`, and routes global `s` to the cockpit rail bridge before live right-pane fallback so dashboard Settings navigation works.

Self-audit: touched CLI routing and input-bridge tests only; UI/CLI layer plus tests; no facade/domain/store boundary crossing.

Tests:
- `uv run --extra dev python -m pytest tests/test_cockpit_input_bridge.py -q`
- `uv run --extra dev python -m pytest tests/test_cockpit_inbox_ui.py -k "text_filter or filter" -q`
