### PR TITLE
Fix inbox filter and static-pane key routing

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -21,7 +21,18 @@ from pollypm.config import DEFAULT_CONFIG_PATH
 
 _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS = frozenset({"<esc>", "esc", "escape"})
 _HELP_KEY_TOKENS = frozenset({"?", "question_mark"})
-_INBOX_BRIDGE_FIRST_TOKENS = frozenset({"d"})
+_INBOX_BRIDGE_FIRST_TOKENS = frozenset({"/", "d"})
+_INBOX_FILTER_INPUT_TOKENS = frozenset({
+    "<bs>",
+    "<cr>",
+    "<esc>",
+    "<space>",
+    "backspace",
+    "enter",
+    "esc",
+    "escape",
+    "space",
+})
 _SETTINGS_BRIDGE_FIRST_TOKENS = frozenset({
     "<down>",
     "<tab>",
@@ -105,11 +116,18 @@ def _send_selected_action_key_to_content_bridge(
         from pollypm.cockpit_input_bridge import send_key_to_first_live
         from pollypm.cockpit_rail import CockpitRouter
 
-        selected = CockpitRouter(config_path).selected_key()
+        router = CockpitRouter(config_path)
+        selected = router.selected_key()
     except Exception:  # noqa: BLE001
         return None
     kind = _content_bridge_kind_for_selected_key(selected)
     if kind == "pane-inbox" and token in _INBOX_BRIDGE_FIRST_TOKENS:
+        pass
+    elif (
+        kind == "pane-inbox"
+        and _inbox_filter_token(token, lowered)
+        and router.inbox_filter_input_active()
+    ):
         pass
     elif kind == "settings" and lowered in _SETTINGS_BRIDGE_FIRST_TOKENS:
         pass
@@ -119,6 +137,12 @@ def _send_selected_action_key_to_content_bridge(
         return send_key_to_first_live(config_path, key, kind=kind, timeout=0.2)
     except Exception:  # noqa: BLE001
         return None
+
+
+def _inbox_filter_token(token: str, lowered: str) -> bool:
+    if lowered in _INBOX_FILTER_INPUT_TOKENS:
+        return True
+    return len(token) == 1 and token.isprintable()
 
 
 def _tmux_event_for_cockpit_key(key: str) -> tuple[str, bool] | None:

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -2786,6 +2786,8 @@ class CockpitRouter:
             return None
         if getattr(active, "pane_id", None) != right_pane_id:
             return None
+        if not self._is_live_provider_pane(active):
+            return None
         return right_pane_id
 
     def reload_cockpit_shell(

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -863,6 +863,22 @@ class CockpitRouter:
         except Exception:  # noqa: BLE001
             pass
 
+    def inbox_filter_input_active(self) -> bool:
+        data = self._load_state()
+        return data.get("inbox_filter_input_active") is True
+
+    def set_inbox_filter_input_active(self, active: bool) -> None:
+        data = self._load_state()
+        if active:
+            if data.get("inbox_filter_input_active") is True:
+                return
+            data["inbox_filter_input_active"] = True
+        else:
+            if "inbox_filter_input_active" not in data:
+                return
+            data.pop("inbox_filter_input_active", None)
+        self._write_state(data)
+
     def _return_key_for_live_mount(self, previous_key: object) -> str | None:
         """Return the static cockpit route to restore after a live mount."""
         if not isinstance(previous_key, str) or not previous_key:

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -7344,6 +7344,7 @@ class PollyInboxApp(App[None]):
             self.filter_input.display = False
             self.filter_bar.display = False
             self.filter_chips.display = False
+        self._set_filter_bridge_active(False)
         self._refresh_list(select_first=True)
         self.set_interval(self.REFRESH_INTERVAL_SECONDS, self._background_refresh)
         self.list_view.focus()
@@ -7367,12 +7368,19 @@ class PollyInboxApp(App[None]):
             self._input_bridge_handle = None
 
     def on_unmount(self) -> None:
+        self._set_filter_bridge_active(False)
         bridge = getattr(self, "_input_bridge_handle", None)
         if bridge is not None:
             try:
                 bridge.stop()
             except Exception:  # noqa: BLE001
                 pass
+
+    def _set_filter_bridge_active(self, active: bool) -> None:
+        try:
+            CockpitRouter(self.config_path).set_inbox_filter_input_active(active)
+        except Exception:  # noqa: BLE001
+            pass
 
     # #1078 — switch to stacked (detail-below-list) layout when the
     # detail column would otherwise drop below this many cols of usable
@@ -7975,6 +7983,7 @@ class PollyInboxApp(App[None]):
         self.filter_input.value = self._filter_text
         self._update_filter_chips()
         self.filter_input.focus()
+        self._set_filter_bridge_active(True)
 
     def action_toggle_filter_unread(self) -> None:
         if self.reply_input.has_focus or self.filter_input.has_focus:
@@ -8069,6 +8078,7 @@ class PollyInboxApp(App[None]):
         # Enter inside the filter Input applies + returns focus to the
         # list so j/k works without an extra Esc.
         self.list_view.focus()
+        self._set_filter_bridge_active(False)
 
     # ------------------------------------------------------------------
     # Detail rendering
@@ -8662,6 +8672,7 @@ class PollyInboxApp(App[None]):
             self._filter_text = ""
             self.filter_input.value = ""
             self._filter_bar_visible = False
+            self._set_filter_bridge_active(False)
             self._render_list(select_first=False)
             self.list_view.focus()
             return

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -2932,14 +2932,21 @@ def test_cockpit_router_detects_active_live_right_pane(tmp_path: Path) -> None:
     )
 
     class FakeTmux:
-        def __init__(self, right_active: bool) -> None:
+        def __init__(self, right_active: bool, right_command: str = "codex") -> None:
             self.right_active = right_active
+            self.right_command = right_command
 
         def list_panes(self, target: str):
             assert target == "pollypm:PollyPM"
             return [
-                SimpleNamespace(pane_id="%1", active=not self.right_active, pane_dead=False),
-                SimpleNamespace(pane_id="%2", active=self.right_active, pane_dead=False),
+                SimpleNamespace(
+                    pane_id="%1", active=not self.right_active,
+                    pane_dead=False, pane_current_command="uv",
+                ),
+                SimpleNamespace(
+                    pane_id="%2", active=self.right_active,
+                    pane_dead=False, pane_current_command=self.right_command,
+                ),
             ]
 
     router = CockpitRouter(config_path)
@@ -2949,6 +2956,9 @@ def test_cockpit_router_detects_active_live_right_pane(tmp_path: Path) -> None:
     assert router.active_live_right_pane_id() == "%2"
 
     router.tmux = FakeTmux(right_active=False)  # type: ignore[assignment]
+    assert router.active_live_right_pane_id() is None
+
+    router.tmux = FakeTmux(right_active=True, right_command="python")  # type: ignore[assignment]
     assert router.active_live_right_pane_id() is None
 
 

--- a/tests/test_cockpit_inbox_ui.py
+++ b/tests/test_cockpit_inbox_ui.py
@@ -2341,6 +2341,67 @@ def test_inbox_filter_bridge_literal_slash_opens_input(inbox_env) -> None:
     _run(body())
 
 
+def test_cockpit_send_key_inbox_filter_sequence_routes_to_inbox_bridge(
+    inbox_env,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1214: default cockpit-send-key drives Inbox filter text via bridge."""
+    if not _load_config_compatible(inbox_env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    import typer
+    from typer.testing import CliRunner
+
+    from pollypm.cli_features import ui as ui_commands
+    from pollypm.cockpit_rail import CockpitRouter
+    from pollypm.cockpit_ui import PollyInboxApp
+
+    cli = typer.Typer()
+    ui_commands.register_ui_commands(cli)
+    live_pane_attempts: list[tuple[Path, str]] = []
+
+    def fake_live_pane(config_path: Path, key: str) -> str | None:
+        live_pane_attempts.append((config_path, key))
+        return "%2"
+
+    monkeypatch.setattr(
+        ui_commands,
+        "_send_key_to_active_live_right_pane",
+        fake_live_pane,
+    )
+
+    app = PollyInboxApp(inbox_env["config_path"])
+    CockpitRouter(inbox_env["config_path"]).set_selected_key("inbox")
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            initial_count = len(_visible_titles(app))
+            assert initial_count > 1
+            handle = getattr(app, "_input_bridge_handle", None)
+            assert handle is not None
+
+            for key in ("/", "V", "C", "L"):
+                result = CliRunner().invoke(
+                    cli,
+                    [
+                        "cockpit-send-key",
+                        key,
+                        "--config",
+                        str(inbox_env["config_path"]),
+                    ],
+                )
+                assert result.exit_code == 0, result.output
+                assert str(handle.socket_path) in result.output
+                await pilot.pause(0.1)
+
+            assert live_pane_attempts == []
+            assert app.filter_input.value == "VCL"
+            assert _visible_titles(app) == ["Deploy blocked"]
+            assert len(_visible_titles(app)) < initial_count
+
+    _run(body())
+
+
 def test_inbox_bridge_n_keypress_toggles_notifications_visible(
     inbox_env,
 ) -> None:

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -284,9 +284,12 @@ def test_cockpit_send_key_question_mark_prefers_content_pane_bridge(
         content.stop()
 
 
-def test_cockpit_send_key_inbox_discuss_prefers_inbox_bridge_over_live_pane(
+@pytest.mark.parametrize(("key", "expected"), [("d", "d"), ("/", "/")])
+def test_cockpit_send_key_inbox_action_prefers_inbox_bridge_over_live_pane(
     valid_cockpit_config: Path,
     monkeypatch: pytest.MonkeyPatch,
+    key: str,
+    expected: str,
 ) -> None:
     import typer
     from typer.testing import CliRunner
@@ -316,11 +319,11 @@ def test_cockpit_send_key_inbox_discuss_prefers_inbox_bridge_over_live_pane(
         app = typer.Typer()
         ui_commands.register_ui_commands(app)
         result = CliRunner().invoke(
-            app, ["cockpit-send-key", "d", "--config", str(valid_cockpit_config)]
+            app, ["cockpit-send-key", key, "--config", str(valid_cockpit_config)]
         )
         assert result.exit_code == 0, result.output
         assert f"via {inbox.socket_path}" in result.output
-        assert _wait_for(lambda: inbox_app.keys == ["d"])
+        assert _wait_for(lambda: inbox_app.keys == [expected])
         assert live_pane_attempts == []
     finally:
         inbox.stop()


### PR DESCRIPTION
Closes #1214
Closes #1217

Builds on merged PR #1216.

Fixes the Inbox filter bridge path by sending `/` and subsequent filter text/edit keys to the pane-inbox bridge while the filter input is active. This keeps `pm cockpit-send-key /` followed by typed text from falling back to the rail or stale live-pane routing.

Fixes dashboard Settings navigation by tightening `CockpitRouter.active_live_right_pane_id()` so only active panes running a live provider command (`codex`/`claude`/`node`/version-like Claude command) can steal bridge-delivered keys. Static dashboard/settings panes with stale mounted state now fall through to the cockpit rail bridge, where `s` opens Settings.

Self-audit: touched UI/CLI routing (`cli_features/ui.py`, `cockpit_ui.py`, `cockpit_rail.py`) and focused tests only; no facade/domain/store boundary crossing.

Tests:
- `uv run --extra dev python -m pytest tests/test_cockpit_input_bridge.py -q`
- `uv run --extra dev python -m pytest tests/test_cockpit_inbox_ui.py -k "filter or bridge" -q`
- `uv run --extra dev python -m pytest tests/test_cockpit.py::test_cockpit_router_detects_active_live_right_pane -q`
