### PR TITLE
Fix #1110 refuse update from agent worktrees

### DIFF
--- a/src/pollypm/update.py
+++ b/src/pollypm/update.py
@@ -50,6 +50,19 @@ def is_git_checkout(repo_root: Path) -> bool:
     return (repo_root / ".git").exists()
 
 
+def _is_claude_agent_worktree(repo_root: Path) -> bool:
+    """True iff ``repo_root`` points at or inside a Claude agent worktree."""
+    parts = repo_root.parts
+    for index in range(len(parts) - 2):
+        if (
+            parts[index] == ".claude"
+            and parts[index + 1] == "worktrees"
+            and parts[index + 2].startswith("agent-")
+        ):
+            return True
+    return False
+
+
 @dataclass(slots=True)
 class CommitInfo:
     sha: str
@@ -267,6 +280,23 @@ def update(
     do_reset = reset_runner or (
         lambda r, target: _do_reset_hard(r, target)
     )
+
+    if _is_claude_agent_worktree(repo):
+        msg = (
+            f"refusing to update: repo_root {repo} looks like a Claude "
+            "agent worktree, not the canonical install path. Run "
+            "`pm update` from the canonical install directory."
+        )
+        step(msg)
+        return UpdateResult(
+            ok=False,
+            check_only=check_only,
+            refused=True,
+            old_sha="",
+            new_sha="",
+            commits=[],
+            message=msg,
+        )
 
     # Refuse on in_progress work — yanking source out from under a live
     # worker corrupts logs and confuses the supervisor. The user can

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -72,6 +72,44 @@ def test_update_refuses_when_repo_not_a_git_checkout(tmp_path: Path) -> None:
     assert "not a git checkout" in result.message
 
 
+def test_update_refuses_claude_agent_worktree_before_side_effects(tmp_path: Path) -> None:
+    repo = tmp_path / "pollypm" / ".claude" / "worktrees" / "agent-abc123"
+    repo.mkdir(parents=True)
+    (repo / ".git").write_text("gitdir: /tmp/gitdir\n")
+    calls: list[str] = []
+
+    def _fetcher(repo_root: Path) -> tuple[bool, str]:
+        calls.append("fetch")
+        return (True, "")
+
+    def _resolver(repo_root: Path) -> update_mod.PendingCommits:
+        calls.append("resolve")
+        return update_mod.PendingCommits(head_sha="aaaa", target_sha="bbbb")
+
+    def _runner(argv: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append("install")
+        return _ok_run()
+
+    def _reset(repo_root: Path, target: str) -> tuple[bool, str]:
+        calls.append("reset")
+        return (True, "")
+
+    result = update_mod.update(
+        repo_root=repo,
+        in_progress_count=0,
+        fetcher=_fetcher,
+        resolver=_resolver,
+        runner=_runner,
+        reset_runner=_reset,
+    )
+
+    assert result.ok is False
+    assert result.refused is True
+    assert "agent worktree" in result.message
+    assert "canonical install" in result.message
+    assert calls == []
+
+
 # --------------------------------------------------------------------------- #
 # update() — fetch + check-only
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes #1110

Refuses `pm update` when the resolved repo root is at or inside `.claude/worktrees/agent-*`, before fetch/reset/reinstall can run. Adds a regression test that all side-effect seams remain untouched for an agent worktree path.

Layer audit: touched `src/pollypm/update.py` in the UI/CLI update orchestration layer and `tests/test_update.py`; no boundary crossings.