### PR TITLE
Fix #1196 retry first-party heartbeat imports

### DIFF
--- a/src/pollypm/core/rail.py
+++ b/src/pollypm/core/rail.py
@@ -12,7 +12,9 @@ shutdown.
 
 from __future__ import annotations
 
+import importlib
 import logging
+import time
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -22,6 +24,38 @@ if TYPE_CHECKING:
     from pollypm.storage.state import StateStore
 
 logger = logging.getLogger(__name__)
+
+
+_HEARTBEAT_IMPORT_RETRY_DELAYS = (0.05, 0.2, 0.5)
+
+
+def _is_first_party_module_missing(exc: ModuleNotFoundError) -> bool:
+    missing_name = exc.name or ""
+    return missing_name == "pollypm" or missing_name.startswith("pollypm.")
+
+
+def _load_heartbeat_rail_class():
+    from pollypm.heartbeat.boot import HeartbeatRail
+
+    return HeartbeatRail
+
+
+def _load_heartbeat_rail_class_with_retry():
+    for delay in (*_HEARTBEAT_IMPORT_RETRY_DELAYS, None):
+        try:
+            return _load_heartbeat_rail_class()
+        except ModuleNotFoundError as exc:
+            if delay is None or not _is_first_party_module_missing(exc):
+                raise
+            logger.warning(
+                "CoreRail.start(): HeartbeatRail import missing first-party "
+                "module %r; retrying in %.2fs",
+                exc.name,
+                delay,
+            )
+            importlib.invalidate_caches()
+            time.sleep(delay)
+    raise RuntimeError("unreachable heartbeat import retry state")
 
 
 @runtime_checkable
@@ -160,7 +194,7 @@ class CoreRail:
         if self._heartbeat_rail is not None:
             return
         try:
-            from pollypm.heartbeat.boot import HeartbeatRail
+            HeartbeatRail = _load_heartbeat_rail_class_with_retry()
 
             rail = HeartbeatRail.from_plugin_host(
                 state_db=self._config.project.state_db,

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -48,6 +48,7 @@ Supervisor-direct imports are confined to the allow-list.
 from __future__ import annotations
 
 import json
+import importlib
 import logging
 import os
 import re
@@ -95,6 +96,37 @@ if TYPE_CHECKING:
     from pollypm.core import CoreRail
     from pollypm.providers.base import LaunchCommand
     from pollypm.store.protocol import Store
+
+
+_FIRST_PARTY_IMPORT_RETRY_DELAYS = (0.05, 0.2, 0.5)
+
+
+def _is_first_party_module_missing(exc: ModuleNotFoundError) -> bool:
+    missing_name = exc.name or ""
+    return missing_name == "pollypm" or missing_name.startswith("pollypm.")
+
+
+def _load_sweep_stale_notifies():
+    from pollypm.inbox_sweep import sweep_stale_notifies
+
+    return sweep_stale_notifies
+
+
+def _load_sweep_stale_notifies_with_retry():
+    for delay in (*_FIRST_PARTY_IMPORT_RETRY_DELAYS, None):
+        try:
+            return _load_sweep_stale_notifies()
+        except ModuleNotFoundError as exc:
+            if delay is None or not _is_first_party_module_missing(exc):
+                raise
+            logger.warning(
+                "notify-sweep import missing first-party module %r; retrying in %.2fs",
+                exc.name,
+                delay,
+            )
+            importlib.invalidate_caches()
+            time.sleep(delay)
+    raise RuntimeError("unreachable notify-sweep import retry state")
 
 
 def _count_open_fds() -> int | None:
@@ -1382,7 +1414,7 @@ class Supervisor:
         # a 59-item inbox, signal-to-noise <5%). Default retention is
         # 14 days; tunable via POLLYPM_NOTIFY_RETENTION_DAYS.
         try:
-            from pollypm.inbox_sweep import sweep_stale_notifies
+            sweep_stale_notifies = _load_sweep_stale_notifies_with_retry()
             sweep_stale_notifies(self._msg_store)
         except Exception:  # noqa: BLE001
             logger.warning("notify-sweep skipped", exc_info=True)

--- a/tests/test_core_rail.py
+++ b/tests/test_core_rail.py
@@ -299,6 +299,102 @@ def test_corerail_drives_plugin_host_load(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_corerail_start_retries_transient_first_party_heartbeat_import(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    import pollypm.core.rail as rail_mod
+
+    attempts = 0
+    sleeps: list[float] = []
+    started: list[bool] = []
+    stopped: list[bool] = []
+
+    class _FakeHost:
+        def plugins(self):
+            return {}
+
+    class _FakeHeartbeatRail:
+        def __init__(self) -> None:
+            self.roster = type("_Roster", (), {"entries": []})()
+
+        @classmethod
+        def from_plugin_host(cls, *, state_db, plugin_host):
+            return cls()
+
+        def start(self, *, start_workers: bool = True) -> None:
+            started.append(start_workers)
+
+        def stop(self) -> None:
+            stopped.append(True)
+
+    def _flaky_load_heartbeat_rail_class():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ModuleNotFoundError(
+                "No module named 'pollypm.heartbeat'",
+                name="pollypm.heartbeat",
+            )
+        return _FakeHeartbeatRail
+
+    monkeypatch.setattr(
+        rail_mod, "_load_heartbeat_rail_class", _flaky_load_heartbeat_rail_class,
+    )
+    monkeypatch.setattr(rail_mod.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    config = _config(tmp_path)
+    store = StateStore(config.project.state_db)
+    rail = CoreRail(config, store, _FakeHost())
+
+    rail.start()
+    try:
+        assert attempts == 2
+        assert sleeps == [rail_mod._HEARTBEAT_IMPORT_RETRY_DELAYS[0]]
+        assert started == [True]
+        assert isinstance(rail.get_heartbeat_rail(), _FakeHeartbeatRail)
+    finally:
+        rail.stop()
+    assert stopped == [True]
+
+
+def test_corerail_start_does_not_retry_non_first_party_missing_dependency(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    import pollypm.core.rail as rail_mod
+
+    attempts = 0
+    sleeps: list[float] = []
+
+    class _FakeHost:
+        def plugins(self):
+            return {}
+
+    def _load_heartbeat_rail_class():
+        nonlocal attempts
+        attempts += 1
+        raise ModuleNotFoundError(
+            "No module named 'third_party_dependency'",
+            name="third_party_dependency",
+        )
+
+    monkeypatch.setattr(
+        rail_mod, "_load_heartbeat_rail_class", _load_heartbeat_rail_class,
+    )
+    monkeypatch.setattr(rail_mod.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    config = _config(tmp_path)
+    store = StateStore(config.project.state_db)
+    rail = CoreRail(config, store, _FakeHost())
+
+    rail.start()
+    try:
+        assert attempts == 1
+        assert sleeps == []
+        assert rail.get_heartbeat_rail() is None
+    finally:
+        rail.stop()
+
+
 def test_corerail_start_boots_heartbeat_rail(tmp_path: Path) -> None:
     """CoreRail.start() constructs + boots a HeartbeatRail so roster-
     registered recurring handlers get drained by a running worker pool.

--- a/tests/test_package_imports.py
+++ b/tests/test_package_imports.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_first_party_heartbeat_and_inbox_sweep_imports_resolve() -> None:
+    heartbeat = importlib.import_module("pollypm.heartbeat")
+    heartbeat_boot = importlib.import_module("pollypm.heartbeat.boot")
+    inbox_sweep = importlib.import_module("pollypm.inbox_sweep")
+
+    assert hasattr(heartbeat, "Roster")
+    assert hasattr(heartbeat_boot, "HeartbeatRail")
+    assert hasattr(inbox_sweep, "sweep_stale_notifies")

--- a/tests/test_supervisor_alerts.py
+++ b/tests/test_supervisor_alerts.py
@@ -1083,6 +1083,58 @@ def test_run_heartbeat_invokes_recovery_alert_auto_clear_sweep(
     )
 
 
+def test_run_heartbeat_retries_transient_first_party_notify_sweep_import(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    import pollypm.supervisor as supervisor_mod
+
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    supervisor.ensure_layout()
+
+    attempts = 0
+    sleeps: list[float] = []
+    swept: list[object] = []
+
+    def _flaky_load_sweep_stale_notifies():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ModuleNotFoundError(
+                "No module named 'pollypm.inbox_sweep'",
+                name="pollypm.inbox_sweep",
+            )
+        return lambda store: swept.append(store)
+
+    monkeypatch.setattr(
+        supervisor_mod,
+        "_load_sweep_stale_notifies",
+        _flaky_load_sweep_stale_notifies,
+    )
+    monkeypatch.setattr(
+        supervisor_mod.time,
+        "sleep",
+        lambda seconds: sleeps.append(seconds),
+    )
+    monkeypatch.setattr(
+        "pollypm.supervisor.get_heartbeat_backend",
+        lambda name, root_dir=None: type(
+            "_Backend", (), {"run": staticmethod(lambda api, snapshot_lines=200: [])},
+        )(),
+    )
+    monkeypatch.setattr(supervisor, "ensure_heartbeat_schedule", lambda: None)
+    monkeypatch.setattr(
+        "pollypm.supervisor.sync_token_ledger_for_config",
+        lambda config: [],
+    )
+
+    supervisor.run_heartbeat()
+
+    assert attempts == 2
+    assert sleeps == [supervisor_mod._FIRST_PARTY_IMPORT_RETRY_DELAYS[0]]
+    assert swept == [supervisor._msg_store]
+
+
 # ---------------------------------------------------------------------------
 # #1019 — fd-exhaustion early-warning sweep
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1196

Adds short cache-invalidating retries for transient first-party `pollypm.*` import misses in CoreRail HeartbeatRail boot and the heartbeat notify-sweep import path. Also pins direct import resolution for `pollypm.heartbeat`, `pollypm.heartbeat.boot`, and `pollypm.inbox_sweep`.

Layer audit: touched CoreRail startup/domain orchestration in `src/pollypm/core/rail.py`, Supervisor heartbeat orchestration in `src/pollypm/supervisor.py`, and focused tests. No UI/store boundary crossings.