### PR TITLE
Fix #1220 route help to visible content bridge

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -21,6 +21,7 @@ from pollypm.config import DEFAULT_CONFIG_PATH
 
 _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS = frozenset({"<esc>", "esc", "escape"})
 _HELP_KEY_TOKENS = frozenset({"?", "question_mark"})
+_HELP_CONTENT_BRIDGE_FALLBACK_KINDS = ("dashboard", "pane-inbox", "settings")
 _INBOX_BRIDGE_FIRST_TOKENS = frozenset({"/", "d"})
 _INBOX_FILTER_INPUT_TOKENS = frozenset({
     "<bs>",
@@ -98,12 +99,24 @@ def _send_help_key_to_content_bridge(config_path: Path, key: str) -> Path | None
     except Exception:  # noqa: BLE001
         return None
     kind = _content_bridge_kind_for_selected_key(selected)
-    if kind is None:
-        return None
-    try:
-        return send_key_to_first_live(config_path, key, kind=kind, timeout=0.2)
-    except Exception:  # noqa: BLE001
-        return None
+    candidates = []
+    if kind is not None:
+        candidates.append(kind)
+    candidates.extend(
+        fallback
+        for fallback in _HELP_CONTENT_BRIDGE_FALLBACK_KINDS
+        if fallback not in candidates
+    )
+    for candidate in candidates:
+        try:
+            delivered = send_key_to_first_live(
+                config_path, key, kind=candidate, timeout=0.2,
+            )
+        except Exception:  # noqa: BLE001
+            delivered = None
+        if delivered is not None:
+            return delivered
+    return None
 
 
 def _send_selected_action_key_to_content_bridge(

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -284,6 +284,42 @@ def test_cockpit_send_key_question_mark_prefers_content_pane_bridge(
         content.stop()
 
 
+def test_cockpit_send_key_question_mark_falls_back_to_visible_dashboard_bridge(
+    valid_cockpit_config: Path,
+) -> None:
+    import typer
+    from typer.testing import CliRunner
+
+    from pollypm.cli_features.ui import register_ui_commands
+    from pollypm.cockpit_rail import CockpitRouter
+
+    cockpit_app = _FakeApp()
+    dashboard_app = _FakeApp()
+    cockpit = start_input_bridge(
+        cockpit_app, kind="cockpit", config_path=valid_cockpit_config,
+    )
+    assert cockpit is not None
+    dashboard = start_input_bridge(
+        dashboard_app, kind="dashboard", config_path=valid_cockpit_config,
+    )
+    assert dashboard is not None
+    try:
+        CockpitRouter(valid_cockpit_config).set_selected_key("inbox")
+
+        app = typer.Typer()
+        register_ui_commands(app)
+        result = CliRunner().invoke(
+            app, ["cockpit-send-key", "?", "--config", str(valid_cockpit_config)]
+        )
+        assert result.exit_code == 0, result.output
+        assert f"via {dashboard.socket_path}" in result.output
+        assert _wait_for(lambda: dashboard_app.keys == ["question_mark"])
+        assert cockpit_app.keys == []
+    finally:
+        cockpit.stop()
+        dashboard.stop()
+
+
 @pytest.mark.parametrize(("key", "expected"), [("d", "d"), ("/", "/")])
 def test_cockpit_send_key_inbox_action_prefers_inbox_bridge_over_live_pane(
     valid_cockpit_config: Path,

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -314,7 +314,7 @@ def test_cockpit_send_key_question_mark_falls_back_to_visible_dashboard_bridge(
         assert result.exit_code == 0, result.output
         assert f"via {dashboard.socket_path}" in result.output
         assert _wait_for(lambda: dashboard_app.keys == ["question_mark"])
-        assert cockpit_app.keys == []
+        assert "question_mark" not in cockpit_app.keys
     finally:
         cockpit.stop()
         dashboard.stop()


### PR DESCRIPTION
Closes #1220

When `pm cockpit-send-key '?'` targets the cockpit, try the bridge for the selected content pane first and then fall back across live static content bridges before delivering to the rail. This covers the rail/content mismatch where the persisted selection points at Inbox but the visible right pane is still Home, so help opens in the visible dashboard pane instead of being swallowed by the raw rail.

Layer audit: touched UI/CLI keystroke routing in `src/pollypm/cli_features/ui.py` and focused bridge tests in `tests/test_cockpit_input_bridge.py`; no domain/store boundary changes.

Tests: `uv run --extra dev pytest tests/test_cockpit_input_bridge.py tests/test_keyboard_help.py -x`; `uv run --extra dev ruff check src/pollypm/cli_features/ui.py tests/test_cockpit_input_bridge.py`.
