### PR TITLE
Fix #1221 make rail cursor navigation incremental

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -2307,6 +2307,7 @@ class PollyCockpitApp(App[None]):
         if key is not None:
             self._cancel_pending_route_selection()
             self.selected_key = key
+            self._persist_router_selected_key(key)
             self._last_nav_change = self._tick_count
             self._apply_active_view_to_rows()
 
@@ -2379,6 +2380,16 @@ class PollyCockpitApp(App[None]):
         finally:
             self._suspend_selection_events = False
 
+    def _persist_router_selected_key(self, key: str) -> None:
+        set_selected = getattr(getattr(self, "router", None), "set_selected_key", None)
+        if not callable(set_selected):
+            return
+        try:
+            set_selected(key)
+        except Exception:  # noqa: BLE001
+            return
+        self._last_router_selected_key = key
+
     def _set_nav_index(self, index: int) -> None:
         self._suspend_selection_events = True
         try:
@@ -2409,6 +2420,7 @@ class PollyCockpitApp(App[None]):
     def _select_settings_row(self) -> None:
         self._cancel_pending_route_selection()
         self.selected_key = "settings"
+        self._persist_router_selected_key("settings")
         self._last_nav_change = self._tick_count
         self._apply_active_view_to_rows()
 

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -2002,6 +2002,9 @@ class PollyCockpitApp(App[None]):
         child = children[index]
         if isinstance(child, RailItem):
             return child.cockpit_key
+        child_key = getattr(child, "cockpit_key", None)
+        if isinstance(child_key, str):
+            return child_key
         return None
 
     def _apply_active_view_to_rows(self) -> None:
@@ -2327,21 +2330,25 @@ class PollyCockpitApp(App[None]):
 
     def _last_nav_index(self) -> int | None:
         """Highest selectable index in the nav ListView, or None."""
+        indices = self._selectable_nav_indices()
+        return indices[-1] if indices else None
+
+    def _selectable_nav_indices(self) -> list[int]:
         try:
             children = list(self.nav.children)
         except AttributeError:
-            return None
-        for i in range(len(children) - 1, -1, -1):
-            child = children[i]
+            return []
+        indices: list[int] = []
+        for i, child in enumerate(children):
             if getattr(child, "disabled", False):
                 continue
             # Allow RailItem in production, or anything with a non-None
             # ``cockpit_key`` for test stubs (#1080).
             if isinstance(child, RailItem):
-                return i
-            if getattr(child, "cockpit_key", None) is not None:
-                return i
-        return None
+                indices.append(i)
+            elif getattr(child, "cockpit_key", None) is not None:
+                indices.append(i)
+        return indices
 
     def _nav_index_for_key(self, key: str) -> int | None:
         try:
@@ -2372,6 +2379,33 @@ class PollyCockpitApp(App[None]):
         finally:
             self._suspend_selection_events = False
 
+    def _set_nav_index(self, index: int) -> None:
+        self._suspend_selection_events = True
+        try:
+            self.nav.index = index
+        finally:
+            self._suspend_selection_events = False
+
+    def _move_nav_cursor(self, delta: int) -> bool:
+        indices = self._selectable_nav_indices()
+        if not indices:
+            return False
+        current = self.nav.index
+        if current is None:
+            target = indices[0]
+        elif current in indices:
+            pos = indices.index(current) + delta
+            pos = max(0, min(pos, len(indices) - 1))
+            target = indices[pos]
+        elif delta > 0:
+            target = next((index for index in indices if index > current), indices[-1])
+        else:
+            target = next((index for index in reversed(indices) if index < current), indices[0])
+        if current == target:
+            return False
+        self._set_nav_index(target)
+        return True
+
     def _select_settings_row(self) -> None:
         self._cancel_pending_route_selection()
         self.selected_key = "settings"
@@ -2380,7 +2414,6 @@ class PollyCockpitApp(App[None]):
 
     def action_cursor_down(self) -> None:
         if self.selected_key == "settings":
-            self._send_key_to_settings_pane("j")
             return
         self._align_nav_cursor_to_selected_key()
         last_idx = self._last_nav_index()
@@ -2393,27 +2426,27 @@ class PollyCockpitApp(App[None]):
         ):
             self._select_settings_row()
             return
-        if self.nav.index is None:
-            self.nav.index = 0
-        else:
-            self.nav.action_cursor_down()
+        self._move_nav_cursor(1)
         self._sync_selected_from_nav()
 
     def action_cursor_up(self) -> None:
-        if self.selected_key == "settings":
-            self._send_key_to_settings_pane("k")
+        if self.selected_key == "settings" and self._settings_visible():
+            last_idx = self._last_nav_index()
+            if last_idx is None:
+                return
+            self._set_nav_index(last_idx)
+            self._sync_selected_from_nav()
             return
         self._align_nav_cursor_to_selected_key()
         # Step up off the virtual Settings row onto the last
         # selectable nav row (#1080).
-        if self.nav.index is None:
-            self.nav.index = 0
-        else:
-            self.nav.action_cursor_up()
+        self._move_nav_cursor(-1)
         self._sync_selected_from_nav()
 
     def action_cursor_first(self) -> None:
-        self.nav.index = 0
+        indices = self._selectable_nav_indices()
+        if indices:
+            self._set_nav_index(indices[0])
         self._sync_selected_from_nav()
 
     def action_cursor_last(self) -> None:
@@ -2423,9 +2456,9 @@ class PollyCockpitApp(App[None]):
         if self._settings_visible():
             self._select_settings_row()
             return
-        children = list(self.nav.children)
-        if children:
-            self.nav.index = len(children) - 1
+        last_idx = self._last_nav_index()
+        if last_idx is not None:
+            self._set_nav_index(last_idx)
         self._sync_selected_from_nav()
 
     def _selected_open_key(self) -> str | None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4100,6 +4100,9 @@ def test_cockpit_send_key_inbox_shortcut_keeps_rail_nav_active(tmp_path: Path) -
         def selected_key(self) -> str:
             return self._selected
 
+        def set_selected_key(self, key: str) -> None:
+            self._selected = key
+
         def _load_state(self) -> dict:
             return {}
 
@@ -5505,6 +5508,13 @@ def test_cockpit_jk_walks_visible_rail_rows_incrementally() -> None:
         selected_key="dashboard",
     )
     nav.index = 0
+    persisted: list[str] = []
+
+    class _Router:
+        def set_selected_key(self, key: str) -> None:
+            persisted.append(key)
+
+    app.router = _Router()  # type: ignore[assignment]
 
     expected_down = [
         ("polly", 1),
@@ -5520,6 +5530,7 @@ def test_cockpit_jk_walks_visible_rail_rows_incrementally() -> None:
         app.action_cursor_down()
         assert app.selected_key == key
         assert nav.index == index
+        assert persisted[-1] == key
 
     expected_up = [
         ("activity", 8),
@@ -5535,6 +5546,7 @@ def test_cockpit_jk_walks_visible_rail_rows_incrementally() -> None:
         app.action_cursor_up()
         assert app.selected_key == key
         assert nav.index == index
+        assert persisted[-1] == key
 
 
 def test_cockpit_j_at_last_nav_row_steps_onto_settings() -> None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -5174,8 +5174,15 @@ def test_cockpit_jk_navigates_rail_outside_inbox_surface() -> None:
     app._send_key_to_right_pane = lambda key: sent.append(key)  # type: ignore[method-assign]
     app._sync_selected_from_nav = lambda: moves.append("sync")  # type: ignore[method-assign]
 
+    class _Child:
+        disabled = False
+
+        def __init__(self, cockpit_key: str) -> None:
+            self.cockpit_key = cockpit_key
+
     class _Nav:
         index: int | None = 0
+        children = [_Child("polly"), _Child("activity"), _Child("metrics")]
 
         def action_cursor_down(self) -> None:
             moves.append("nav_down")
@@ -5191,7 +5198,7 @@ def test_cockpit_jk_navigates_rail_outside_inbox_surface() -> None:
         sent.clear()
 
         app.action_cursor_down()
-        assert moves == ["nav_down", "sync"], (
+        assert moves == ["sync"], (
             f"j on {surface!r} should navigate the rail, got moves={moves}"
         )
         assert sent == [], (
@@ -5200,7 +5207,7 @@ def test_cockpit_jk_navigates_rail_outside_inbox_surface() -> None:
 
         moves.clear()
         app.action_cursor_up()
-        assert moves == ["nav_up", "sync"]
+        assert moves == ["sync"]
         assert sent == []
 
 
@@ -5469,6 +5476,67 @@ def test_cockpit_down_starts_from_visible_project_subtab_after_pane_swap() -> No
     assert app.selected_key == "project:demo:issues"
 
 
+def test_cockpit_jk_walks_visible_rail_rows_incrementally() -> None:
+    """#1221: j/k/arrows must move one visible rail row at a time."""
+    items = [
+        _StubItem("dashboard"),
+        _StubItem("polly"),
+        _StubItem("workers"),
+        _StubItem("metrics"),
+        _StubItem("inbox"),
+        _StubItem(None, disabled=True),  # ── projects ── divider
+        _StubItem("project:bikepath"),
+        _StubItem("project:booktalk"),
+        _StubItem("activity"),
+    ]
+    app, nav = _make_rail_app_with_settings(
+        items,
+        items_keys=[
+            "dashboard",
+            "polly",
+            "workers",
+            "metrics",
+            "inbox",
+            "project:bikepath",
+            "project:booktalk",
+            "activity",
+            "settings",
+        ],
+        selected_key="dashboard",
+    )
+    nav.index = 0
+
+    expected_down = [
+        ("polly", 1),
+        ("workers", 2),
+        ("metrics", 3),
+        ("inbox", 4),
+        ("project:bikepath", 6),
+        ("project:booktalk", 7),
+        ("activity", 8),
+        ("settings", 8),
+    ]
+    for key, index in expected_down:
+        app.action_cursor_down()
+        assert app.selected_key == key
+        assert nav.index == index
+
+    expected_up = [
+        ("activity", 8),
+        ("project:booktalk", 7),
+        ("project:bikepath", 6),
+        ("inbox", 4),
+        ("metrics", 3),
+        ("workers", 2),
+        ("polly", 1),
+        ("dashboard", 0),
+    ]
+    for key, index in expected_up:
+        app.action_cursor_up()
+        assert app.selected_key == key
+        assert nav.index == index
+
+
 def test_cockpit_j_at_last_nav_row_steps_onto_settings() -> None:
     """j on the last nav row (Activity) lands on Settings when the gear
     row is visible — the blank gap between Activity and Settings must
@@ -5486,16 +5554,16 @@ def test_cockpit_j_at_last_nav_row_steps_onto_settings() -> None:
         f"j from Activity should land on Settings; got {app.selected_key!r}"
     )
 
-    # Repeat j on Settings belongs to the Settings pane's own nav.
+    # Repeat j on Settings stays at the bottom of the rail.
     sent: list[str] = []
     app._send_key_to_settings_pane = lambda key: sent.append(key)  # type: ignore[method-assign]
     app.action_cursor_down()
     assert app.selected_key == "settings"
-    assert sent == ["j"]
+    assert sent == []
 
 
-def test_cockpit_k_on_settings_forwards_to_settings_pane() -> None:
-    """k from Settings belongs to the Settings pane's own nav (#1130)."""
+def test_cockpit_k_on_settings_steps_back_to_last_nav_row() -> None:
+    """k/up from Settings returns to the previous rail row (#1221)."""
     items = [_StubItem("polly"), _StubItem("activity")]
     app, nav = _make_rail_app_with_settings(
         items,
@@ -5507,9 +5575,9 @@ def test_cockpit_k_on_settings_forwards_to_settings_pane() -> None:
     app._send_key_to_settings_pane = lambda key: sent.append(key)  # type: ignore[method-assign]
 
     app.action_cursor_up()
-    assert app.selected_key == "settings"
-    assert nav.index == 0
-    assert sent == ["k"]
+    assert app.selected_key == "activity"
+    assert nav.index == 1
+    assert sent == []
 
 
 def test_cockpit_G_lands_on_settings_when_visible() -> None:


### PR DESCRIPTION
## Summary
- Make cockpit rail cursor movement deterministic by walking selectable row indices directly instead of delegating to Textual ListView cursor actions.
- Treat Settings as the virtual bottom rail row while allowing k/up to step back to Activity.
- Persist cursor-only selection changes into the cockpit router state so repeated `pm cockpit-send-key` calls keep using the current rail selection.

## Tests
- `uv run --extra dev pytest tests/test_cockpit.py -x`
- `uv run --extra dev ruff check src/pollypm/cockpit_ui.py tests/test_cockpit.py`

Fixes #1221
