### PR TITLE
Fix #1227 fresh init session collisions

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -48,7 +48,6 @@ from pollypm.cli_help import help_with_examples
 from pollypm.cli_features.alerts import alert_app, heartbeat_app, session_app
 from pollypm.launch_executor import LaunchPlanExecutor
 from pollypm.launch_state import (
-    LaunchAction,
     LaunchProbe,
     LaunchState,
     plan_launch,
@@ -101,6 +100,7 @@ _UP_HELP = help_with_examples(
         "working when you detach."
     ),
 )
+_UP_INVOCATION_COMMAND = "pm up"
 
 _STATUS_HELP = help_with_examples(
     "Show configured session state, runtime status, and open-alert counts.",
@@ -324,6 +324,7 @@ def _refuse_foreign_tmux_sessions(
     supervisor,
     probe: LaunchProbe,
     config_path: Path,
+    command_display: str = "pm up",
 ) -> None:
     """Fail closed before mutating a same-named session from another HOME."""
     sessions = (
@@ -343,7 +344,7 @@ def _refuse_foreign_tmux_sessions(
             f"tmux session '{session_name}' is in use by another HOME "
             f"({owner_home}); current HOME is {current_home}. Set "
             f"`project.tmux_session` in {config_path} to a unique name "
-            "before running `pm up`."
+            f"before running `{command_display}`."
         )
 
 
@@ -459,7 +460,13 @@ def main(
         # didn't reliably apply the Typer Option default in production
         # (the OptionInfo sentinel survived and tripped the phantom-client
         # launch path on bare `pm`).
-        ctx.invoke(up, config_path=config_path, phantom_client=False)
+        global _UP_INVOCATION_COMMAND
+        previous_command = _UP_INVOCATION_COMMAND
+        _UP_INVOCATION_COMMAND = "pm"
+        try:
+            ctx.invoke(up, config_path=config_path, phantom_client=False)
+        finally:
+            _UP_INVOCATION_COMMAND = previous_command
 
 
 @app.command(help="Write the example PollyPM config to disk to bootstrap a new install.")
@@ -755,7 +762,12 @@ def up(
     # ambient state. The probe only reads tmux + config; building it
     # is side-effect-free.
     probe = _build_launch_probe(supervisor)
-    _refuse_foreign_tmux_sessions(supervisor, probe, config_path)
+    _refuse_foreign_tmux_sessions(
+        supervisor,
+        probe,
+        config_path,
+        command_display=_UP_INVOCATION_COMMAND,
+    )
     plan = plan_launch(probe)
     typer.echo(f"[launch] {plan.state.value}: {plan.reason}")
     if plan.state is LaunchState.UNSUPPORTED:

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import logging
 import tomllib
 from pathlib import Path
@@ -1033,13 +1034,22 @@ def render_example_config() -> str:
     return render_config(_build_example_config(root))
 
 
-def _build_example_config(root: Path) -> PollyPMConfig:
+def _default_init_tmux_session(root: Path) -> str:
+    try:
+        identity = str(root.resolve())
+    except OSError:
+        identity = str(root.absolute())
+    digest = hashlib.sha1(identity.encode("utf-8")).hexdigest()[:8]
+    return f"pollypm-{digest}"
+
+
+def _build_example_config(root: Path, *, tmux_session: str = "pollypm") -> PollyPMConfig:
     base_dir = root / ".pollypm"
     return PollyPMConfig(
         project=ProjectSettings(
             name="PollyPM",
             root_dir=root,
-            tmux_session="pollypm",
+            tmux_session=tmux_session,
             workspace_root=Path.home() / "dev",
             base_dir=base_dir,
             logs_dir=base_dir / "logs",
@@ -1121,7 +1131,11 @@ def write_example_config(path: Path = DEFAULT_CONFIG_PATH, force: bool = False) 
     if path.exists() and not force:
         raise FileExistsError(f"Config already exists: {path}")
     root = path.resolve().parent
-    return write_config(_build_example_config(root), path, force=True)
+    return write_config(
+        _build_example_config(root, tmux_session=_default_init_tmux_session(root)),
+        path,
+        force=True,
+    )
 
 
 def write_config(config: PollyPMConfig, path: Path = DEFAULT_CONFIG_PATH, force: bool = False) -> Path:

--- a/tests/test_cli_up_state_machine.py
+++ b/tests/test_cli_up_state_machine.py
@@ -321,7 +321,62 @@ def test_up_refuses_foreign_home_tmux_session_before_side_effects(
     assert result.exit_code != 0
     assert "tmux session 'pollypm' is in use by another HOME" in result.output
     assert "project.tmux_session" in result.output
+    assert "before running `pm up`" in result.output
     assert side_effects == []
+
+
+def test_root_pm_foreign_home_tmux_session_error_names_pm(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """#1227: bare ``pm`` should not report that the user ran ``pm up``."""
+    fresh_home = tmp_path / "fresh-home"
+    fresh_home.mkdir()
+    monkeypatch.setenv("HOME", str(fresh_home))
+    config_path = fresh_home / ".pollypm" / "pollypm.toml"
+    config_path.parent.mkdir()
+    config_path.write_text("[project]\nname = \"pollypm\"\n")
+
+    class _FakeTmux:
+        def has_session(self, name: str) -> bool:
+            return name == "pollypm"
+
+        def current_session_name(self) -> None:
+            return None
+
+        def show_environment(self, session_name: str, variable: str) -> str | None:
+            assert session_name == "pollypm"
+            assert variable == "HOME"
+            return "/Users/sam"
+
+    class _FakeSupervisor:
+        def __init__(self) -> None:
+            self.tmux = _FakeTmux()
+            self.config = type(
+                "Config",
+                (),
+                {
+                    "project": type(
+                        "Project",
+                        (),
+                        {
+                            "tmux_session": "pollypm",
+                            "base_dir": config_path.parent,
+                        },
+                    )(),
+                    "accounts": {},
+                    "projects": {},
+                },
+            )()
+
+    monkeypatch.setattr(cli, "_load_supervisor", lambda _path: _FakeSupervisor())
+
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["--config", str(config_path)])
+
+    assert result.exit_code != 0
+    assert "tmux session 'pollypm' is in use by another HOME" in result.output
+    assert "before running `pm`" in result.output
+    assert "before running `pm up`" not in result.output
 
 
 def test_probe_detects_dead_console_pane() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,14 @@
 from pathlib import Path
 
 from pollypm.plugins_builtin.core_agent_profiles.profiles import heartbeat_prompt, polly_prompt
-from pollypm.config import load_config, project_config_path, render_example_config, resolve_config_path, write_config
+from pollypm.config import (
+    load_config,
+    project_config_path,
+    render_example_config,
+    resolve_config_path,
+    write_config,
+    write_example_config,
+)
 from pollypm.models import (
     AccountConfig,
     KnownProject,
@@ -34,6 +41,16 @@ def test_load_example_config(tmp_path: Path) -> None:
     assert set(config.projects) == {"pollypm"}
     assert config.sessions["operator"].provider.value == "codex"
     assert config.sessions["heartbeat"].provider.value == "codex"
+
+
+def test_write_example_config_uses_fresh_install_session_name(tmp_path: Path) -> None:
+    config_path = tmp_path / ".pollypm" / "pollypm.toml"
+
+    write_example_config(config_path)
+    config = load_config(config_path)
+
+    assert config.project.tmux_session.startswith("pollypm-")
+    assert config.project.tmux_session != "pollypm"
 
 
 def test_resolve_config_path_returns_global_config(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make pm init write a fresh-install pollypm-<hash> tmux session name instead of the canonical pollypm
- keep the printed example config canonical while making the written init config collision-resistant
- report "before running pm" when bare pm dispatches into up, while direct pm up keeps the pm up wording

## Tests
- uv run --extra dev pytest tests/test_config.py tests/test_cli_up_state_machine.py -x
- uv run --extra dev ruff check --ignore E402 src/pollypm/config.py src/pollypm/cli.py tests/test_config.py tests/test_cli_up_state_machine.py

Fixes #1227