### PR TITLE
Fix #1230 surface cockpit network-dead simulation

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -70,6 +70,7 @@ _RIGHT_PANE_TMUX_KEY_TOKENS: dict[str, str] = {
     "<end>": "End",
     "end": "End",
 }
+_LIVE_CHAT_NETWORK_DEAD_MESSAGE_PREFIX = "PollyPM chat failed"
 
 
 def _is_help_key(key: str) -> bool:
@@ -174,6 +175,41 @@ def _tmux_event_for_cockpit_key(key: str) -> tuple[str, bool] | None:
     return key, True
 
 
+def _live_chat_submit_blocked_by_network_dead(
+    config_path: Path,
+    key: str,
+    *,
+    router: object,
+    right_pane: str,
+) -> bool:
+    """Consume the dev network-dead marker on live-chat submit."""
+    event = _tmux_event_for_cockpit_key(key)
+    if event != ("Enter", False):
+        return False
+    try:
+        from pollypm.dev_network_simulation import (
+            SimulatedNetworkDead,
+            raise_if_network_dead,
+        )
+
+        raise_if_network_dead(config_path, surface="cockpit live chat submit")
+    except SimulatedNetworkDead as exc:
+        tmux = getattr(router, "tmux", None)
+        if tmux is not None:
+            run = getattr(tmux, "run", None)
+            if callable(run):
+                run("send-keys", "-t", right_pane, "C-u", check=False)
+            send_keys = getattr(tmux, "send_keys", None)
+            if callable(send_keys):
+                send_keys(
+                    right_pane,
+                    f"{_LIVE_CHAT_NETWORK_DEAD_MESSAGE_PREFIX}: {exc}",
+                    press_enter=False,
+                )
+        return True
+    return False
+
+
 def _send_key_to_active_live_right_pane(config_path: Path, key: str) -> str | None:
     """Deliver ``key`` to the focused live right pane, if one owns focus."""
     if key.strip().lower() in _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS:
@@ -190,6 +226,10 @@ def _send_key_to_active_live_right_pane(config_path: Path, key: str) -> str | No
     event = _tmux_event_for_cockpit_key(key)
     if event is None:
         return None
+    if _live_chat_submit_blocked_by_network_dead(
+        config_path, key, router=router, right_pane=right_pane,
+    ):
+        return right_pane
     value, literal = event
     if literal:
         router.tmux.send_keys(right_pane, value, press_enter=False)

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -9209,6 +9209,9 @@ class PollyInboxApp(App[None]):
         a real tmux server. See ``test_cockpit_inbox_ui.py`` for the
         monkeypatch target.
         """
+        from pollypm.dev_network_simulation import raise_if_network_dead
+
+        raise_if_network_dead(self.config_path, surface="Inbox discuss with PM")
         router = CockpitRouter(self.config_path)
         router.route_selected(cockpit_key)
         supervisor = router._load_supervisor()
@@ -14566,6 +14569,11 @@ class PollyProjectDashboardApp(App[None]):
         Split out exactly like the inbox path so the same
         ``monkeypatch`` strategy works for the dashboard's chat keybind.
         """
+        from pollypm.dev_network_simulation import raise_if_network_dead
+
+        raise_if_network_dead(
+            self.config_path, surface="Project dashboard discuss with PM",
+        )
         router = CockpitRouter(self.config_path)
         router.route_selected(cockpit_key)
         supervisor = router._load_supervisor()

--- a/tests/test_cockpit_inbox_ui.py
+++ b/tests/test_cockpit_inbox_ui.py
@@ -1774,6 +1774,26 @@ def test_status_bar_pluralises_message_and_action_count(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_pm_dispatch_consumes_network_dead_marker(inbox_env) -> None:
+    from pollypm.cockpit_ui import PollyInboxApp
+    from pollypm.dev_network_simulation import (
+        SimulatedNetworkDead,
+        arm_network_dead,
+        network_dead_armed,
+    )
+
+    config_path = inbox_env["config_path"]
+    app = PollyInboxApp.__new__(PollyInboxApp)
+    app.config_path = config_path
+
+    arm_network_dead(config_path)
+
+    with pytest.raises(SimulatedNetworkDead, match="network unreachable"):
+        app._perform_pm_dispatch("project:demo:session", 're: inbox/1 "stub"')
+
+    assert not network_dead_armed(config_path)
+
+
 def _write_persona_config(
     project_path: Path, config_path: Path, persona_name: str,
 ) -> None:

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -457,6 +457,55 @@ def test_cockpit_send_key_forwards_to_focused_live_right_pane(
         cockpit.stop()
 
 
+def test_cockpit_send_key_enter_consumes_network_dead_for_live_right_pane(
+    valid_cockpit_config: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import pollypm.cockpit_rail as cockpit_rail
+    from pollypm.cli_features import ui as ui_commands
+    from pollypm.dev_network_simulation import arm_network_dead, network_dead_armed
+
+    class FakeTmux:
+        def __init__(self) -> None:
+            self.calls: list[tuple[object, ...]] = []
+
+        def run(self, *args: object, **kwargs: object) -> None:
+            self.calls.append(("run", *args, kwargs))
+
+        def send_keys(
+            self, target: str, text: str, *, press_enter: bool = True,
+        ) -> None:
+            self.calls.append(("send_keys", target, text, press_enter))
+
+    class FakeRouter:
+        def __init__(self) -> None:
+            self.tmux = FakeTmux()
+
+        def active_live_right_pane_id(self) -> str:
+            return "%2"
+
+    router = FakeRouter()
+    monkeypatch.setattr(cockpit_rail, "CockpitRouter", lambda _path: router)
+
+    arm_network_dead(valid_cockpit_config)
+
+    delivered = ui_commands._send_key_to_active_live_right_pane(
+        valid_cockpit_config, "<cr>",
+    )
+
+    assert delivered == "%2"
+    assert not network_dead_armed(valid_cockpit_config)
+    assert router.tmux.calls == [
+        ("run", "send-keys", "-t", "%2", "C-u", {"check": False}),
+        (
+            "send_keys",
+            "%2",
+            "PollyPM chat failed: network unreachable (simulated): "
+            "connection refused for cockpit live chat submit",
+            False,
+        ),
+    ]
+
+
 def test_send_key_to_first_live_skips_stale_sockets(fake_config: Path, tmp_path: Path) -> None:
     bridge_dir = fake_config.parent / "cockpit_inputs"
     bridge_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- consume the dev network-dead marker when cockpit-send-key submits a mounted live right-pane chat, and show a visible failed/network message in that pane instead of forwarding Enter
- consume the same marker before Inbox/PM discuss dispatch routes into a live PM session, using the existing Jump to PM failed notification path
- add focused regressions for the live right-pane submit and Inbox discuss paths

## Tests
- uv run --extra dev pytest tests/test_cockpit_input_bridge.py tests/test_cockpit_inbox_ui.py::test_pm_dispatch_consumes_network_dead_marker tests/test_dev_network_simulation.py -q
- uv run --extra dev pytest tests/test_cockpit_inbox_ui.py -k "d_key or pm_dispatch" -q
- uv run --extra dev ruff check src/pollypm/cli_features/ui.py src/pollypm/cockpit_ui.py tests/test_cockpit_input_bridge.py tests/test_cockpit_inbox_ui.py

Fixes #1230