### PR TITLE
Fix #1233 keep live chat bridge input sticky

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -20,6 +20,7 @@ import typer
 from pollypm.config import DEFAULT_CONFIG_PATH
 
 _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS = frozenset({"<esc>", "esc", "escape"})
+_LIVE_RIGHT_PANE_INPUT_STICKY = "live_right_pane_input_sticky"
 _HELP_KEY_TOKENS = frozenset({"?", "question_mark"})
 _HELP_CONTENT_BRIDGE_FALLBACK_KINDS = ("dashboard", "pane-inbox", "settings")
 _INBOX_BRIDGE_FIRST_TOKENS = frozenset({"/", "d"})
@@ -210,10 +211,66 @@ def _live_chat_submit_blocked_by_network_dead(
     return False
 
 
+def _set_live_right_pane_input_sticky(router: object, active: bool) -> None:
+    try:
+        load_state = getattr(router, "_load_state")
+        write_state = getattr(router, "_write_state")
+        state = load_state()
+        if not isinstance(state, dict):
+            return
+        if active:
+            if state.get(_LIVE_RIGHT_PANE_INPUT_STICKY) is True:
+                return
+            state[_LIVE_RIGHT_PANE_INPUT_STICKY] = True
+        else:
+            if _LIVE_RIGHT_PANE_INPUT_STICKY not in state:
+                return
+            state.pop(_LIVE_RIGHT_PANE_INPUT_STICKY, None)
+        write_state(state)
+    except Exception:  # noqa: BLE001
+        return
+
+
+def _sticky_live_right_pane_id(router: object) -> str | None:
+    try:
+        state = getattr(router, "_load_state")()
+    except Exception:  # noqa: BLE001
+        return None
+    if not isinstance(state, dict):
+        return None
+    if state.get(_LIVE_RIGHT_PANE_INPUT_STICKY) is not True:
+        return None
+    mounted = state.get("mounted_session")
+    right_pane_id = state.get("right_pane_id")
+    if not isinstance(mounted, str) or not mounted:
+        _set_live_right_pane_input_sticky(router, False)
+        return None
+    if not isinstance(right_pane_id, str) or not right_pane_id:
+        _set_live_right_pane_input_sticky(router, False)
+        return None
+    try:
+        config = getattr(router, "_load_config")()
+        cockpit_window = getattr(router, "_COCKPIT_WINDOW", "PollyPM")
+        window_target = f"{config.project.tmux_session}:{cockpit_window}"
+        panes = router.tmux.list_panes(window_target)
+    except Exception:  # noqa: BLE001
+        return None
+    right_pane = next(
+        (pane for pane in panes if getattr(pane, "pane_id", None) == right_pane_id),
+        None,
+    )
+    if right_pane is None or getattr(right_pane, "pane_dead", False):
+        _set_live_right_pane_input_sticky(router, False)
+        return None
+    is_live_provider_pane = getattr(router, "_is_live_provider_pane", None)
+    if callable(is_live_provider_pane) and not is_live_provider_pane(right_pane):
+        _set_live_right_pane_input_sticky(router, False)
+        return None
+    return right_pane_id
+
+
 def _send_key_to_active_live_right_pane(config_path: Path, key: str) -> str | None:
     """Deliver ``key`` to the focused live right pane, if one owns focus."""
-    if key.strip().lower() in _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS:
-        return None
     try:
         from pollypm.cockpit_rail import CockpitRouter
 
@@ -221,8 +278,13 @@ def _send_key_to_active_live_right_pane(config_path: Path, key: str) -> str | No
         right_pane = router.active_live_right_pane_id()
     except Exception:  # noqa: BLE001
         return None
-    if right_pane is None:
+    if key.strip().lower() in _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS:
+        _set_live_right_pane_input_sticky(router, False)
         return None
+    if right_pane is None:
+        right_pane = _sticky_live_right_pane_id(router)
+        if right_pane is None:
+            return None
     event = _tmux_event_for_cockpit_key(key)
     if event is None:
         return None
@@ -235,6 +297,7 @@ def _send_key_to_active_live_right_pane(config_path: Path, key: str) -> str | No
         router.tmux.send_keys(right_pane, value, press_enter=False)
     else:
         router.tmux.run("send-keys", "-t", right_pane, value, check=False)
+    _set_live_right_pane_input_sticky(router, True)
     return right_pane
 
 

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -17,6 +17,7 @@ import time
 import uuid
 from collections.abc import Iterator
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Callable
 
 import pytest
@@ -504,6 +505,112 @@ def test_cockpit_send_key_enter_consumes_network_dead_for_live_right_pane(
             False,
         ),
     ]
+
+
+def test_cockpit_send_key_keeps_live_right_pane_sticky_after_first_char(
+    valid_cockpit_config: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import pollypm.cockpit_rail as cockpit_rail
+    from pollypm.cli_features import ui as ui_commands
+
+    class FakeTmux:
+        def __init__(self) -> None:
+            self.calls: list[tuple[object, ...]] = []
+
+        def list_panes(self, target: str):
+            assert target == "pollypm-test:PollyPM"
+            return [
+                SimpleNamespace(
+                    pane_id="%1", active=True, pane_dead=False,
+                    pane_current_command="uv",
+                ),
+                SimpleNamespace(
+                    pane_id="%2", active=False, pane_dead=False,
+                    pane_current_command="codex",
+                ),
+            ]
+
+        def send_keys(
+            self, target: str, text: str, *, press_enter: bool = True,
+        ) -> None:
+            self.calls.append(("send_keys", target, text, press_enter))
+
+    class FakeRouter:
+        _COCKPIT_WINDOW = "PollyPM"
+
+        def __init__(self) -> None:
+            self.tmux = FakeTmux()
+            self.state = {
+                "mounted_session": "architect_demo",
+                "right_pane_id": "%2",
+            }
+            self.active_calls = 0
+
+        def active_live_right_pane_id(self) -> str | None:
+            self.active_calls += 1
+            return "%2" if self.active_calls == 1 else None
+
+        def _load_state(self) -> dict[str, object]:
+            return dict(self.state)
+
+        def _write_state(self, state: dict[str, object]) -> None:
+            self.state = dict(state)
+
+        def _load_config(self):
+            return SimpleNamespace(
+                project=SimpleNamespace(tmux_session="pollypm-test")
+            )
+
+        def _is_live_provider_pane(self, pane: object) -> bool:
+            return getattr(pane, "pane_current_command", None) == "codex"
+
+    router = FakeRouter()
+    monkeypatch.setattr(cockpit_rail, "CockpitRouter", lambda _path: router)
+
+    assert ui_commands._send_key_to_active_live_right_pane(
+        valid_cockpit_config, "R",
+    ) == "%2"
+    assert router.state["live_right_pane_input_sticky"] is True
+
+    assert ui_commands._send_key_to_active_live_right_pane(
+        valid_cockpit_config, "e",
+    ) == "%2"
+    assert router.tmux.calls == [
+        ("send_keys", "%2", "R", False),
+        ("send_keys", "%2", "e", False),
+    ]
+
+
+def test_cockpit_send_key_escape_clears_live_right_pane_sticky(
+    valid_cockpit_config: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import pollypm.cockpit_rail as cockpit_rail
+    from pollypm.cli_features import ui as ui_commands
+
+    class FakeRouter:
+        def __init__(self) -> None:
+            self.state = {
+                "mounted_session": "architect_demo",
+                "right_pane_id": "%2",
+                "live_right_pane_input_sticky": True,
+            }
+
+        def active_live_right_pane_id(self) -> str | None:
+            return "%2"
+
+        def _load_state(self) -> dict[str, object]:
+            return dict(self.state)
+
+        def _write_state(self, state: dict[str, object]) -> None:
+            self.state = dict(state)
+
+    router = FakeRouter()
+    monkeypatch.setattr(cockpit_rail, "CockpitRouter", lambda _path: router)
+
+    assert ui_commands._send_key_to_active_live_right_pane(
+        valid_cockpit_config, "<esc>",
+    ) is None
+    assert "live_right_pane_input_sticky" not in router.state
 
 
 def test_send_key_to_first_live_skips_stale_sockets(fake_config: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1233

Keeps `pm cockpit-send-key` routed to a mounted live chat after the first successful right-pane delivery, even if a later CLI invocation observes stale tmux active-pane state. Escape clears the sticky bridge ownership so the cockpit rail/back path still receives the key.

Layer audit: touched CLI/UI bridge routing (`src/pollypm/cli_features/ui.py`) and input bridge tests only. Bug layer is UI/CLI. No boundary violation; no `cockpit_ui.py`, `cockpit_rail.py`, or inbox test overlap with active PRs.