### PR TITLE
Fix #1238 route inbox keys to inbox pane

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -23,7 +23,18 @@ _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS = frozenset({"<esc>", "esc", "escape"})
 _LIVE_RIGHT_PANE_INPUT_STICKY = "live_right_pane_input_sticky"
 _HELP_KEY_TOKENS = frozenset({"?", "question_mark"})
 _HELP_CONTENT_BRIDGE_FALLBACK_KINDS = ("dashboard", "pane-inbox", "settings")
-_INBOX_BRIDGE_FIRST_TOKENS = frozenset({"/", "d"})
+_INBOX_BRIDGE_FIRST_TOKENS = frozenset({
+    "/",
+    "<down>",
+    "<up>",
+    "A",
+    "a",
+    "d",
+    "down",
+    "j",
+    "k",
+    "up",
+})
 _INBOX_FILTER_INPUT_TOKENS = frozenset({
     "<bs>",
     "<cr>",

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -1680,10 +1680,12 @@ class PollyCockpitApp(App[None]):
         value = state.get("mounted_return_key")
         return value if isinstance(value, str) and value else None
 
-    def _send_key_to_right_pane(self, key: str) -> None:
+    def _send_key_to_right_pane(self, key: str) -> bool:
         send_method = getattr(self.router, "send_key_to_right_pane", None)
         if callable(send_method):
             send_method(key)
+            return True
+        return False
 
     def _send_key_to_settings_pane(self, key: str) -> None:
         delivered = None
@@ -1725,8 +1727,7 @@ class PollyCockpitApp(App[None]):
         if self._right_pane_has_live_session():
             return False
         try:
-            self._send_key_to_right_pane(key)
-            return True
+            return self._send_key_to_right_pane(key)
         except Exception:  # noqa: BLE001
             return False
 
@@ -2499,6 +2500,8 @@ class PollyCockpitApp(App[None]):
         self._apply_active_view_to_rows()
 
     def action_cursor_down(self) -> None:
+        if self._on_inbox_surface() and self._send_key_to_inbox_pane("j"):
+            return
         if self.selected_key == "settings":
             return
         self._align_nav_cursor_to_selected_key()
@@ -2516,6 +2519,8 @@ class PollyCockpitApp(App[None]):
         self._sync_selected_from_nav()
 
     def action_cursor_up(self) -> None:
+        if self._on_inbox_surface() and self._send_key_to_inbox_pane("k"):
+            return
         if self.selected_key == "settings" and self._settings_visible():
             last_idx = self._last_nav_index()
             if last_idx is None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4082,8 +4082,8 @@ def test_cockpit_ui_arrow_and_enter_route_selected(tmp_path: Path) -> None:
     asyncio.run(exercise())
 
 
-def test_cockpit_send_key_inbox_shortcut_keeps_rail_nav_active(tmp_path: Path) -> None:
-    """#1206/#1236: after global ``I``, Down/Up still move the rail."""
+def test_cockpit_send_key_inbox_shortcut_keeps_inbox_nav_active(tmp_path: Path) -> None:
+    """#1238: after global ``I``, Down/Up stay owned by the Inbox."""
 
     class FakeRouter:
         def __init__(self) -> None:
@@ -4146,16 +4146,22 @@ def test_cockpit_send_key_inbox_shortcut_keeps_rail_nav_active(tmp_path: Path) -
             await pilot.pause(0.4)
             assert app.selected_key == "inbox"
             assert app._selected_row_key() == "inbox"
+            forwarded: list[str] = []
+            app._send_key_to_inbox_pane = (  # type: ignore[method-assign]
+                lambda key: forwarded.append(key) or True
+            )
 
             send_key(handle.socket_path, "<down>")
             await pilot.pause(0.4)
-            assert app.selected_key == "activity"
-            assert app._selected_row_key() == "activity"
+            assert app.selected_key == "inbox"
+            assert app._selected_row_key() == "inbox"
+            assert forwarded == ["j"]
 
             send_key(handle.socket_path, "<up>")
             await pilot.pause(0.4)
             assert app.selected_key == "inbox"
             assert app._selected_row_key() == "inbox"
+            assert forwarded == ["j", "k"]
 
     asyncio.run(exercise())
 
@@ -5343,8 +5349,8 @@ class _StubNav:
                 return
 
 
-def test_cockpit_jk_from_inbox_navigates_rail_round_trip() -> None:
-    """#1236: active Inbox must not capture rail navigation keys."""
+def test_cockpit_jk_from_inbox_forwards_to_inbox_pane() -> None:
+    """#1137/#1238: active Inbox owns row-navigation keys."""
     app = PollyCockpitApp.__new__(PollyCockpitApp)
     items = [
         _StubItem("inbox"),
@@ -5373,15 +5379,61 @@ def test_cockpit_jk_from_inbox_navigates_rail_round_trip() -> None:
 
     app.action_cursor_down()
 
-    assert nav.index == 2
-    assert app.selected_key == "project:booktalk"
-    assert captured == []
+    assert nav.index == 0
+    assert app.selected_key == "inbox"
+    assert captured == ["j"]
 
     app.action_cursor_up()
 
     assert nav.index == 0
     assert app.selected_key == "inbox"
-    assert captured == []
+    assert captured == ["j", "k"]
+
+
+def test_cockpit_jk_from_inbox_falls_back_when_pane_cannot_accept() -> None:
+    """If the Inbox pane bridge is unavailable, j/k still move the rail."""
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+    items = [
+        _StubItem("inbox"),
+        _StubItem(None, disabled=True),  # ── projects ── divider
+        _StubItem("project:booktalk"),
+        _StubItem("project:blackjack-trainer"),
+    ]
+    nav = _StubNav(items)
+    nav.index = 0
+    app.nav = nav  # type: ignore[assignment]
+    app.selected_key = "inbox"
+    app._tick_count = 0
+    app._last_nav_change = -10
+    app._apply_active_view_to_rows = lambda: None  # type: ignore[method-assign]
+
+    def _selected_row_key() -> str | None:
+        idx = nav.index
+        if idx is None:
+            return None
+        return items[idx].cockpit_key
+
+    app._selected_row_key = _selected_row_key  # type: ignore[method-assign]
+
+    captured: list[str] = []
+
+    def _decline_inbox_key(key: str) -> bool:
+        captured.append(key)
+        return False
+
+    app._send_key_to_inbox_pane = _decline_inbox_key  # type: ignore[method-assign]
+
+    app.action_cursor_down()
+
+    assert nav.index == 2
+    assert app.selected_key == "project:booktalk"
+    assert captured == ["j"]
+
+    app.action_cursor_up()
+
+    assert nav.index == 0
+    assert app.selected_key == "inbox"
+    assert captured == ["j"]
 
 
 def test_cockpit_j_at_last_item_is_silent_noop() -> None:

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -321,7 +321,19 @@ def test_cockpit_send_key_question_mark_falls_back_to_visible_dashboard_bridge(
         dashboard.stop()
 
 
-@pytest.mark.parametrize(("key", "expected"), [("d", "d"), ("/", "/")])
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("d", "d"),
+        ("/", "/"),
+        ("a", "a"),
+        ("A", "A"),
+        ("j", "j"),
+        ("k", "k"),
+        ("<down>", "down"),
+        ("<up>", "up"),
+    ],
+)
 def test_cockpit_send_key_inbox_action_prefers_inbox_bridge_over_live_pane(
     valid_cockpit_config: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #1238

Routes Inbox-owned navigation/action keys from both `pm cockpit-send-key` and rail-focused cockpit bindings to the live Inbox pane before rail navigation or Metrics fallback can consume them. This restores `j`/Down row movement and `a` archive behavior while preserving rail fallback when no Inbox pane can accept the key.

Layer self-audit: touched UI/CLI routing (`src/pollypm/cockpit_ui.py`, `src/pollypm/cli_features/ui.py`) and UI/CLI tests only; no store/domain boundary changes.