### PR TITLE
Fix #1239 tolerate pipe-pane bootstrap failures

### DIFF
--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -894,7 +894,7 @@ class Supervisor:
             target = f"{storage_session}:{launch.window_name}"
             self._set_window_option_best_effort(target, "allow-passthrough", "on")
             self._set_window_option_best_effort(target, "focus-events", "on")
-            self.session_service.tmux.pipe_pane(target, launch.log_path)
+            self._pipe_pane_best_effort(target, launch.log_path)
             self._record_launch(launch)
             created += 1
 
@@ -933,7 +933,7 @@ class Supervisor:
             window_target = f"{storage_session}:{first.window_name}"
             self._set_window_option_best_effort(window_target, "allow-passthrough", "on")
             self._set_window_option_best_effort(window_target, "focus-events", "on")
-            self.session_service.tmux.pipe_pane(window_target, first.log_path)
+            self._pipe_pane_best_effort(window_target, first.log_path)
             self._record_launch(first)
             # Use pane ID from create_session for unambiguous targeting
             pane_target = first_pane_id or window_target
@@ -945,7 +945,7 @@ class Supervisor:
                 window_target = f"{storage_session}:{launch.window_name}"
                 self._set_window_option_best_effort(window_target, "allow-passthrough", "on")
                 self._set_window_option_best_effort(window_target, "focus-events", "on")
-                self.session_service.tmux.pipe_pane(window_target, launch.log_path)
+                self._pipe_pane_best_effort(window_target, launch.log_path)
                 self._record_launch(launch)
                 # Use pane ID returned by create_window for unambiguous targeting
                 pane_target = pane_id or self._resolve_pane_id(storage_session, launch.window_name) or window_target
@@ -981,6 +981,16 @@ class Supervisor:
                 target,
                 option,
                 value,
+                exc,
+            )
+
+    def _pipe_pane_best_effort(self, target: str, log_path: Path) -> None:
+        try:
+            self.session_service.tmux.pipe_pane(target, log_path)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            logger.warning(
+                "tmux pipe-pane failed for %s during bootstrap; continuing without live log piping: %s",
+                target,
                 exc,
             )
 
@@ -3226,7 +3236,7 @@ class Supervisor:
         target = new_pane_id or window_target
         # Cap scrollback to prevent slow pane-switching in the cockpit
         self.session_service.tmux.set_pane_history_limit(target, 200)
-        self.session_service.tmux.pipe_pane(target, launch.log_path)
+        self._pipe_pane_best_effort(target, launch.log_path)
         self._record_launch(launch)
         # #935 — defer the resume-UUID capture until after the bootstrap
         # text lands in the transcript. Stash the pre-launch snapshot

--- a/tests/test_sessions_registration.py
+++ b/tests/test_sessions_registration.py
@@ -155,6 +155,31 @@ def test_bootstrap_registers_every_session_row(monkeypatch, tmp_path: Path) -> N
     assert rows["pm-reviewer"].role == "reviewer"
 
 
+def test_bootstrap_continues_when_pipe_pane_fails(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    config = _config(tmp_path)
+    supervisor = Supervisor(config)
+    _neutralize_tmux(supervisor, monkeypatch)
+    piped_targets: list[str] = []
+
+    def _pipe_pane(target: str, _path: Path) -> None:
+        piped_targets.append(target)
+        raise subprocess.CalledProcessError(
+            1,
+            ["tmux", "pipe-pane", "-t", target],
+        )
+
+    monkeypatch.setattr(supervisor.tmux, "pipe_pane", _pipe_pane)
+
+    controller = supervisor.bootstrap_tmux()
+
+    assert controller == "claude_controller"
+    assert piped_targets
+    rows = sorted(s.name for s in supervisor.store.list_sessions())
+    assert rows == ["heartbeat", "operator", "pm-reviewer"]
+
+
 def test_rebootstrap_is_idempotent(monkeypatch, tmp_path: Path) -> None:
     """A second bootstrap over already-live sessions must upsert (not duplicate)
     and must register any sessions that were already running — the scenario


### PR DESCRIPTION
Closes #1239

Makes tmux `pipe-pane` setup best-effort during bootstrap/session launch setup so transient tmux target races do not bubble out of `bootstrap_launches` as launch-executor tracebacks. Session creation and session table recording continue; failures are logged as warnings.

Layer self-audit: touched supervisor/session orchestration and regression tests only; no UI/store boundary changes.

Tests: `uv run --extra dev pytest tests/test_sessions_registration.py tests/test_supervisor.py tests/test_launch_executor.py -x`.