### PR TITLE
Fix #1240 ignore late job fail retries

### DIFF
--- a/src/pollypm/jobs/queue.py
+++ b/src/pollypm/jobs/queue.py
@@ -450,12 +450,14 @@ class JobQueue:
         def _do_fail() -> None:
             with self._lock:
                 row = self._conn.execute(
-                    "SELECT attempt, max_attempts FROM work_jobs WHERE id = ?",
+                    "SELECT status, attempt, max_attempts FROM work_jobs WHERE id = ?",
                     (int(job_id),),
                 ).fetchone()
                 if row is None:
                     return
-                attempt, max_attempts = int(row[0]), int(row[1])
+                status, attempt, max_attempts = str(row[0]), int(row[1]), int(row[2])
+                if status != JobStatus.CLAIMED.value:
+                    return
 
                 if not retry or attempt >= max_attempts:
                     self._conn.execute(

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -143,6 +143,26 @@ def test_dedupe_key_allows_reenqueue_after_failed(tmp_path: Path) -> None:
     assert jid2 != jid1
 
 
+def test_late_retry_fail_does_not_resurrect_terminal_dedupe_row(
+    tmp_path: Path,
+) -> None:
+    q = JobQueue(db_path=tmp_path / "q.db")
+    jid1 = q.enqueue("sweep", dedupe_key="sweep:a")
+    (job,) = q.claim("w")
+    q.fail(job.id, "terminal", retry=False)
+    jid2 = q.enqueue("sweep", dedupe_key="sweep:a")
+
+    q.fail(job.id, "late timeout", retry=True)
+
+    old = q.get(jid1)
+    new = q.get(jid2)
+    assert old is not None
+    assert old.status is JobStatus.FAILED
+    assert q.get_last_error(jid1) == "terminal"
+    assert new is not None
+    assert new.status is JobStatus.QUEUED
+
+
 def test_recover_orphaned_claims_resets_status_and_frees_dedupe(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Closes #1240

Prevents late `JobQueue.fail(retry=True)` bookkeeping from resurrecting a job that is no longer claimed, avoiding dedupe-key UNIQUE collisions when another queued/claimed job already owns that key. The terminal failure record remains intact and the active deduped retry row is left alone.

Layer self-audit: touched jobs queue persistence and regression tests only; no UI/domain boundary changes.

Tests: `uv run --extra dev pytest tests/test_job_queue.py tests/test_job_workers.py tests/test_sqlite_wal_and_lock_retry.py -x`.