### PR TITLE
Fix #1245 keep Home help on cockpit bridge

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -111,6 +111,8 @@ def _send_help_key_to_content_bridge(config_path: Path, key: str) -> Path | None
         selected = CockpitRouter(config_path).selected_key()
     except Exception:  # noqa: BLE001
         return None
+    if selected in {"dashboard", "polly"}:
+        return None
     kind = _content_bridge_kind_for_selected_key(selected)
     candidates = []
     if kind is not None:

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -243,7 +243,6 @@ def test_cockpit_send_key_defaults_to_cockpit_socket(fake_config: Path) -> None:
 @pytest.mark.parametrize(
     ("selected_key", "bridge_kind"),
     [
-        ("dashboard", "dashboard"),
         ("inbox", "pane-inbox"),
     ],
 )
@@ -283,6 +282,44 @@ def test_cockpit_send_key_question_mark_prefers_content_pane_bridge(
     finally:
         cockpit.stop()
         content.stop()
+
+
+@pytest.mark.parametrize("selected_key", ["dashboard", "polly"])
+def test_cockpit_send_key_question_mark_on_home_stays_on_cockpit_bridge(
+    valid_cockpit_config: Path,
+    selected_key: str,
+) -> None:
+    import typer
+    from typer.testing import CliRunner
+
+    from pollypm.cli_features.ui import register_ui_commands
+    from pollypm.cockpit_rail import CockpitRouter
+
+    cockpit_app = _FakeApp()
+    dashboard_app = _FakeApp()
+    cockpit = start_input_bridge(
+        cockpit_app, kind="cockpit", config_path=valid_cockpit_config,
+    )
+    assert cockpit is not None
+    dashboard = start_input_bridge(
+        dashboard_app, kind="dashboard", config_path=valid_cockpit_config,
+    )
+    assert dashboard is not None
+    try:
+        CockpitRouter(valid_cockpit_config).set_selected_key(selected_key)
+
+        app = typer.Typer()
+        register_ui_commands(app)
+        result = CliRunner().invoke(
+            app, ["cockpit-send-key", "?", "--config", str(valid_cockpit_config)]
+        )
+        assert result.exit_code == 0, result.output
+        assert f"via {cockpit.socket_path}" in result.output
+        assert _wait_for(lambda: cockpit_app.keys == ["question_mark"])
+        assert dashboard_app.keys == []
+    finally:
+        cockpit.stop()
+        dashboard.stop()
 
 
 def test_cockpit_send_key_question_mark_falls_back_to_visible_dashboard_bridge(


### PR DESCRIPTION
Closes #1245

Summary:
- Keep bare `pm cockpit-send-key ?` on the cockpit bridge when the rail is on Home (`dashboard` / `polly`), so the rail help opens instead of handing Home help to the right-pane dashboard bridge.
- Preserve contextual content-pane help routing for non-Home surfaces and add a regression test for the Home route.

Self-audit:
- Layer touched: UI / CLI input routing plus directly related regression tests.
- No store/domain/service imports added; no boundary changes.
