### PR TITLE
Fix #1246 preserve rail nav after inbox focus

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -23,17 +23,15 @@ _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS = frozenset({"<esc>", "esc", "escape"})
 _LIVE_RIGHT_PANE_INPUT_STICKY = "live_right_pane_input_sticky"
 _HELP_KEY_TOKENS = frozenset({"?", "question_mark"})
 _HELP_CONTENT_BRIDGE_FALLBACK_KINDS = ("dashboard", "pane-inbox", "settings")
+# Keep row-navigation keys on the cockpit bridge. PollyCockpitApp still
+# forwards them to the Inbox pane when the Inbox surface is active (#1238),
+# but the CLI must not bypass the rail just because the rail cursor is on
+# the Inbox row (#1246).
 _INBOX_BRIDGE_FIRST_TOKENS = frozenset({
     "/",
-    "<down>",
-    "<up>",
     "A",
     "a",
     "d",
-    "down",
-    "j",
-    "k",
-    "up",
 })
 _INBOX_FILTER_INPUT_TOKENS = frozenset({
     "<bs>",

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -862,6 +862,8 @@ class CockpitRouter:
         if data.get("selected") == key:
             return
         data["selected"] = key
+        if not (key == "inbox" or key.startswith("inbox:")):
+            data.pop("inbox_pane_nav_active", None)
         self._write_state(data)
         try:
             from pollypm.state_epoch import bump
@@ -883,6 +885,22 @@ class CockpitRouter:
             if "inbox_filter_input_active" not in data:
                 return
             data.pop("inbox_filter_input_active", None)
+        self._write_state(data)
+
+    def inbox_pane_nav_active(self) -> bool:
+        data = self._load_state()
+        return data.get("inbox_pane_nav_active") is True
+
+    def set_inbox_pane_nav_active(self, active: bool) -> None:
+        data = self._load_state()
+        if active:
+            if data.get("inbox_pane_nav_active") is True:
+                return
+            data["inbox_pane_nav_active"] = True
+        else:
+            if "inbox_pane_nav_active" not in data:
+                return
+            data.pop("inbox_pane_nav_active", None)
         self._write_state(data)
 
     def _return_key_for_live_mount(self, previous_key: object) -> str | None:
@@ -2814,6 +2832,7 @@ class CockpitRouter:
         config = self._load_config()
         window_target = f"{config.project.tmux_session}:{self._COCKPIT_WINDOW}"
         self.ensure_cockpit_layout()
+        self.set_inbox_pane_nav_active(False)
         rail_pane = self._left_pane_id(window_target)
         if rail_pane is not None:
             self.tmux.select_pane(rail_pane)

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -1707,6 +1707,26 @@ class PollyCockpitApp(App[None]):
         key = getattr(self, "selected_key", None)
         return isinstance(key, str) and (key == "inbox" or key.startswith("inbox:"))
 
+    def _set_inbox_pane_nav_active(self, active: bool) -> None:
+        set_active = getattr(self.router, "set_inbox_pane_nav_active", None)
+        if not callable(set_active):
+            return
+        try:
+            set_active(active)
+        except Exception:  # noqa: BLE001
+            return
+
+    def _inbox_pane_owns_nav(self) -> bool:
+        if not self._on_inbox_surface():
+            return False
+        is_active = getattr(self.router, "inbox_pane_nav_active", None)
+        if not callable(is_active):
+            return False
+        try:
+            return bool(is_active())
+        except Exception:  # noqa: BLE001
+            return False
+
     def _send_key_to_inbox_pane(self, key: str) -> bool:
         """Forward an Inbox-owned key to the right-pane Inbox app.
 
@@ -2383,6 +2403,7 @@ class PollyCockpitApp(App[None]):
             self._cancel_pending_route_selection()
             self.selected_key = key
             self._persist_router_selected_key(key)
+            self._set_inbox_pane_nav_active(False)
             self._last_nav_change = self._tick_count
             self._apply_active_view_to_rows()
 
@@ -2500,7 +2521,7 @@ class PollyCockpitApp(App[None]):
         self._apply_active_view_to_rows()
 
     def action_cursor_down(self) -> None:
-        if self._on_inbox_surface() and self._send_key_to_inbox_pane("j"):
+        if self._inbox_pane_owns_nav() and self._send_key_to_inbox_pane("j"):
             return
         if self.selected_key == "settings":
             return
@@ -2519,7 +2540,7 @@ class PollyCockpitApp(App[None]):
         self._sync_selected_from_nav()
 
     def action_cursor_up(self) -> None:
-        if self._on_inbox_surface() and self._send_key_to_inbox_pane("k"):
+        if self._inbox_pane_owns_nav() and self._send_key_to_inbox_pane("k"):
             return
         if self.selected_key == "settings" and self._settings_visible():
             last_idx = self._last_nav_index()
@@ -2574,6 +2595,7 @@ class PollyCockpitApp(App[None]):
         self._schedule_route_selected("settings", label="Settings")
 
     def action_open_inbox(self) -> None:
+        self._set_inbox_pane_nav_active(True)
         self._schedule_route_selected("inbox", label="Inbox")
 
     def action_open_activity(self) -> None:
@@ -2668,6 +2690,8 @@ class PollyCockpitApp(App[None]):
         # canonical selection (e.g. ``project:x`` → ``project:x:dashboard``).
         optimistic_key = self._optimistic_selected_key_for_route(key)
         self.selected_key = optimistic_key
+        if not (optimistic_key == "inbox" or optimistic_key.startswith("inbox:")):
+            self._set_inbox_pane_nav_active(False)
         if optimistic_key != key:
             try:
                 self.router.set_selected_key(optimistic_key)
@@ -8917,7 +8941,11 @@ class PollyInboxApp(App[None]):
         environment that hosts it (including ``run_test`` harnesses
         without a live tmux server).
         """
-        from pollypm.cockpit_rail import focus_cockpit_rail_pane
+        from pollypm.cockpit_rail import CockpitRouter, focus_cockpit_rail_pane
+        try:
+            CockpitRouter(self.config_path).set_inbox_pane_nav_active(False)
+        except Exception:  # noqa: BLE001
+            pass
         try:
             focus_cockpit_rail_pane(self.config_path)
         except Exception:  # noqa: BLE001

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -1708,7 +1708,10 @@ class PollyCockpitApp(App[None]):
         return isinstance(key, str) and (key == "inbox" or key.startswith("inbox:"))
 
     def _set_inbox_pane_nav_active(self, active: bool) -> None:
-        set_active = getattr(self.router, "set_inbox_pane_nav_active", None)
+        router = getattr(self, "router", None)
+        if router is None:
+            return
+        set_active = getattr(router, "set_inbox_pane_nav_active", None)
         if not callable(set_active):
             return
         try:
@@ -1719,7 +1722,10 @@ class PollyCockpitApp(App[None]):
     def _inbox_pane_owns_nav(self) -> bool:
         if not self._on_inbox_surface():
             return False
-        is_active = getattr(self.router, "inbox_pane_nav_active", None)
+        router = getattr(self, "router", None)
+        if router is None:
+            return False
+        is_active = getattr(router, "inbox_pane_nav_active", None)
         if not callable(is_active):
             return False
         try:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4089,6 +4089,7 @@ def test_cockpit_send_key_inbox_shortcut_keeps_inbox_nav_active(tmp_path: Path) 
         def __init__(self) -> None:
             self.calls: list[str] = []
             self._selected = "polly"
+            self._inbox_pane_nav_active = False
 
         @property
         def tmux(self):
@@ -4102,6 +4103,12 @@ def test_cockpit_send_key_inbox_shortcut_keeps_inbox_nav_active(tmp_path: Path) 
 
         def set_selected_key(self, key: str) -> None:
             self._selected = key
+
+        def inbox_pane_nav_active(self) -> bool:
+            return self._inbox_pane_nav_active
+
+        def set_inbox_pane_nav_active(self, active: bool) -> None:
+            self._inbox_pane_nav_active = active
 
         def _load_state(self) -> dict:
             return {}
@@ -4146,6 +4153,7 @@ def test_cockpit_send_key_inbox_shortcut_keeps_inbox_nav_active(tmp_path: Path) 
             await pilot.pause(0.4)
             assert app.selected_key == "inbox"
             assert app._selected_row_key() == "inbox"
+            assert app.router.inbox_pane_nav_active() is True
             forwarded: list[str] = []
             app._send_key_to_inbox_pane = (  # type: ignore[method-assign]
                 lambda key: forwarded.append(key) or True
@@ -5300,6 +5308,32 @@ def test_cockpit_inbox_forward_does_not_tmux_forward_into_live_session(
     assert sent == []
 
 
+def test_inbox_focus_rail_releases_inbox_nav_ownership(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Esc/q in the Inbox pane hands j/k ownership back to the rail."""
+    from pollypm.cockpit_ui import PollyInboxApp
+
+    app = PollyInboxApp.__new__(PollyInboxApp)
+    app.config_path = tmp_path / "pollypm.toml"
+    focus_calls: list[Path] = []
+    router = _InboxNavRouter(active=True)
+
+    monkeypatch.setattr(
+        "pollypm.cockpit_rail.CockpitRouter",
+        lambda config_path: router,
+    )
+    monkeypatch.setattr(
+        "pollypm.cockpit_rail.focus_cockpit_rail_pane",
+        lambda config_path: focus_calls.append(config_path),
+    )
+
+    app._focus_cockpit_rail()
+
+    assert router.active is False
+    assert focus_calls == [app.config_path]
+
+
 class _StubItem:
     """Minimal stand-in for a ListItem with a ``disabled`` flag and a
     cockpit key — used to drive the rail's ``action_cursor_down`` over a
@@ -5349,6 +5383,21 @@ class _StubNav:
                 return
 
 
+class _InboxNavRouter:
+    def __init__(self, *, active: bool) -> None:
+        self.active = active
+        self.persisted: list[str] = []
+
+    def inbox_pane_nav_active(self) -> bool:
+        return self.active
+
+    def set_inbox_pane_nav_active(self, active: bool) -> None:
+        self.active = active
+
+    def set_selected_key(self, key: str) -> None:
+        self.persisted.append(key)
+
+
 def test_cockpit_jk_from_inbox_forwards_to_inbox_pane() -> None:
     """#1137/#1238: active Inbox owns row-navigation keys."""
     app = PollyCockpitApp.__new__(PollyCockpitApp)
@@ -5362,6 +5411,7 @@ def test_cockpit_jk_from_inbox_forwards_to_inbox_pane() -> None:
     nav.index = 0  # cursor on Inbox
     app.nav = nav  # type: ignore[assignment]
     app.selected_key = "inbox"
+    app.router = _InboxNavRouter(active=True)  # type: ignore[assignment]
     app._tick_count = 0
     app._last_nav_change = -10
     app._apply_active_view_to_rows = lambda: None  # type: ignore[method-assign]
@@ -5390,6 +5440,48 @@ def test_cockpit_jk_from_inbox_forwards_to_inbox_pane() -> None:
     assert captured == ["j", "k"]
 
 
+def test_cockpit_jk_from_inbox_after_rail_focus_moves_rail() -> None:
+    """#1246: once Inbox yields focus, Inbox row selection is rail-only."""
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+    items = [
+        _StubItem("inbox"),
+        _StubItem("activity"),
+        _StubItem(None, disabled=True),  # ── projects ── divider
+        _StubItem("project:booktalk"),
+    ]
+    nav = _StubNav(items)
+    nav.index = 0  # rail cursor visibly on Inbox
+    app.nav = nav  # type: ignore[assignment]
+    app.selected_key = "inbox"
+    app.router = _InboxNavRouter(active=False)  # type: ignore[assignment]
+    app._tick_count = 0
+    app._last_nav_change = -10
+    app._apply_active_view_to_rows = lambda: None  # type: ignore[method-assign]
+
+    def _selected_row_key() -> str | None:
+        idx = nav.index
+        if idx is None:
+            return None
+        return items[idx].cockpit_key
+
+    app._selected_row_key = _selected_row_key  # type: ignore[method-assign]
+
+    captured: list[str] = []
+    app._send_key_to_inbox_pane = lambda key: captured.append(key) or True  # type: ignore[method-assign]
+
+    app.action_cursor_down()
+
+    assert nav.index == 1
+    assert app.selected_key == "activity"
+    assert captured == []
+
+    app.action_cursor_down()
+
+    assert nav.index == 3
+    assert app.selected_key == "project:booktalk"
+    assert captured == []
+
+
 def test_cockpit_jk_from_inbox_falls_back_when_pane_cannot_accept() -> None:
     """If the Inbox pane bridge is unavailable, j/k still move the rail."""
     app = PollyCockpitApp.__new__(PollyCockpitApp)
@@ -5403,6 +5495,7 @@ def test_cockpit_jk_from_inbox_falls_back_when_pane_cannot_accept() -> None:
     nav.index = 0
     app.nav = nav  # type: ignore[assignment]
     app.selected_key = "inbox"
+    app.router = _InboxNavRouter(active=True)  # type: ignore[assignment]
     app._tick_count = 0
     app._last_nav_change = -10
     app._apply_active_view_to_rows = lambda: None  # type: ignore[method-assign]

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -365,10 +365,6 @@ def test_cockpit_send_key_question_mark_falls_back_to_visible_dashboard_bridge(
         ("/", "/"),
         ("a", "a"),
         ("A", "A"),
-        ("j", "j"),
-        ("k", "k"),
-        ("<down>", "down"),
-        ("<up>", "up"),
     ],
 )
 def test_cockpit_send_key_inbox_action_prefers_inbox_bridge_over_live_pane(
@@ -412,6 +408,61 @@ def test_cockpit_send_key_inbox_action_prefers_inbox_bridge_over_live_pane(
         assert _wait_for(lambda: inbox_app.keys == [expected])
         assert live_pane_attempts == []
     finally:
+        inbox.stop()
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("j", "j"),
+        ("k", "k"),
+        ("<down>", "down"),
+        ("<up>", "up"),
+    ],
+)
+def test_cockpit_send_key_inbox_nav_keeps_default_cockpit_bridge(
+    valid_cockpit_config: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    key: str,
+    expected: str,
+) -> None:
+    """#1246: rail navigation reaches the cockpit before Inbox fallback."""
+    import typer
+    from typer.testing import CliRunner
+
+    from pollypm.cli_features import ui as ui_commands
+    from pollypm.cockpit_rail import CockpitRouter
+
+    cockpit_app = _FakeApp()
+    inbox_app = _FakeApp()
+    cockpit = start_input_bridge(
+        cockpit_app, kind="cockpit", config_path=valid_cockpit_config,
+    )
+    assert cockpit is not None
+    inbox = start_input_bridge(
+        inbox_app, kind="pane-inbox", config_path=valid_cockpit_config,
+    )
+    assert inbox is not None
+
+    monkeypatch.setattr(
+        ui_commands,
+        "_send_key_to_active_live_right_pane",
+        lambda _config_path, _key: None,
+    )
+    try:
+        CockpitRouter(valid_cockpit_config).set_selected_key("inbox")
+
+        app = typer.Typer()
+        ui_commands.register_ui_commands(app)
+        result = CliRunner().invoke(
+            app, ["cockpit-send-key", key, "--config", str(valid_cockpit_config)]
+        )
+        assert result.exit_code == 0, result.output
+        assert f"via {cockpit.socket_path}" in result.output
+        assert _wait_for(lambda: cockpit_app.keys == [expected])
+        assert inbox_app.keys == []
+    finally:
+        cockpit.stop()
         inbox.stop()
 
 


### PR DESCRIPTION
Closes #1246

Summary:
- Keep j/k/up/down on the cockpit bridge first, then let the cockpit decide whether Inbox owns row navigation.
- Add explicit Inbox pane navigation ownership state: global `I` enables Inbox row nav for #1238, while rail cursor movement and Inbox Esc/Ctrl-h release that ownership so rail j/k works again for #1246.
- Add regressions for CLI bridge routing, the #1238 global-I path, rail-focus j/k movement from Inbox, and Inbox rail-focus release.

#1238 reconciliation:
- This does not revert #1238. After explicit global `I`, `inbox_pane_nav_active` is set and `j`/`k` are still forwarded to the Inbox pane. #1246 only changes the rail-focus path: when Inbox has yielded focus or the rail cursor simply lands on Inbox, j/k remain rail navigation.

Self-audit:
- Layers touched: UI/CLI input routing plus CockpitRouter state used by the UI. No store imports or cross-layer reach added.

Tests:
- `.venv/bin/pytest tests/test_cockpit_input_bridge.py tests/test_cockpit.py -k "cockpit_send_key or jk_from_inbox or inbox_shortcut or inbox_focus_rail"`
- `.venv/bin/pytest tests/test_cockpit_input_bridge.py`
- `.venv/bin/ruff check src/pollypm/cli_features/ui.py src/pollypm/cockpit_rail.py src/pollypm/cockpit_ui.py tests/test_cockpit_input_bridge.py tests/test_cockpit.py`