### PR TITLE
Fix #1252 empty init project state

### DIFF
--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -1115,14 +1115,7 @@ def _build_example_config(root: Path, *, tmux_session: str = "pollypm") -> Polly
                 prompt="Inspect the repository and propose the next high-leverage implementation step.",
             ),
         },
-        projects={
-            "pollypm": KnownProject(
-                key="pollypm",
-                path=root,
-                name="PollyPM",
-                kind=ProjectKind.GIT if (root / ".git").exists() else ProjectKind.FOLDER,
-            ),
-        },
+        projects={},
         memory=MemorySettings(backend="file"),
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,9 +38,10 @@ def test_load_example_config(tmp_path: Path) -> None:
     assert config.memory.backend == "file"
     assert set(config.accounts) == {"codex_primary", "claude_primary"}
     assert set(config.sessions) == {"heartbeat", "operator"}
-    assert set(config.projects) == {"pollypm"}
+    assert config.projects == {}
     assert config.sessions["operator"].provider.value == "codex"
     assert config.sessions["heartbeat"].provider.value == "codex"
+    assert "[projects." not in config_path.read_text()
 
 
 def test_write_example_config_uses_fresh_install_session_name(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1252

Stops `pm init` from registering the control-plane PollyPM root as a user project, so a fresh install has zero project rows and the existing Home empty-state hint is shown.

Self-audit: touched config generation plus its config regression test only; no UI, facade, domain, store, or boundary-crossing changes.