### PR TITLE
Fix #1256 upgrade rail toast

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -2276,14 +2276,9 @@ class PollyCockpitApp(App[None]):
             "[#e0af68]Upgrading… see window `pm-upgrade`[/]"
         )
         self.update_pill.display = True
-        try:
-            self.notify(
-                "Upgrade started in window `pm-upgrade`. Keep working; "
-                "the rail will tell you when it's done.",
-                timeout=5,
-            )
-        except Exception:  # noqa: BLE001
-            pass
+        # #1256: this app renders in the narrow rail pane. A long
+        # success toast wraps through rail rows, so keep success feedback
+        # in the existing one-line pill.
 
     def _post_upgrade_flag_path(self) -> Path:
         """Sentinel written by ``pm upgrade`` on success.

--- a/tests/test_rail_oneclick_upgrade.py
+++ b/tests/test_rail_oneclick_upgrade.py
@@ -99,6 +99,21 @@ def test_trigger_upgrade_updates_pill_to_upgrading_state(fake_config):
     assert app.update_pill.display is True
 
 
+def test_trigger_upgrade_success_does_not_emit_rail_toast(fake_config, monkeypatch):
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+    app = PollyCockpitApp(fake_config)
+    app.router.tmux = MagicMock()
+    notices: list[str] = []
+    monkeypatch.setattr(
+        app, "notify", lambda msg, *, timeout=None: notices.append(msg),
+    )
+
+    app.action_trigger_upgrade()
+
+    assert notices == []
+
+
 def test_trigger_upgrade_handles_tmux_failure(fake_config, monkeypatch):
     from pollypm.cockpit_ui import PollyCockpitApp
 


### PR DESCRIPTION
Closes #1256

Removed the redundant success toast from the rail one-click upgrade path; the existing one-line upgrade pill remains the success feedback. Added regression coverage that successful upgrade launch does not emit a rail toast.

Self-audit: touched only UI rail behavior in src/pollypm/cockpit_ui.py and the scoped rail upgrade test; no facade/domain/store changes and no boundary crossings.