### PR TITLE
Fix #1255 guard task reject modal dismiss

### DIFF
--- a/src/pollypm/cockpit_tasks.py
+++ b/src/pollypm/cockpit_tasks.py
@@ -1033,32 +1033,40 @@ class _TaskRejectReasonModal(ModalScreen[str | None]):
     def on_mount(self) -> None:
         self.reason_input.focus()
 
+    def _dismiss_if_current(self, result: str | None) -> None:
+        screen_stack = self.app.screen_stack
+        if len(screen_stack) <= 1 or screen_stack[-1] is not self:
+            return
+        self.dismiss(result)
+
     def action_cancel(self) -> None:
-        self.dismiss(None)
+        self._dismiss_if_current(None)
 
     def action_pick_tests(self) -> None:
-        self.dismiss("Tests missing or broken")
+        self._dismiss_if_current("Tests missing or broken")
 
     def action_pick_scope(self) -> None:
-        self.dismiss("Scope drift")
+        self._dismiss_if_current("Scope drift")
 
     def action_pick_fix(self) -> None:
         def _after(reason: str | None) -> None:
-            self.dismiss(reason or None)
+            self.app.call_after_refresh(
+                lambda: self._dismiss_if_current(reason or None)
+            )
 
         self.app.push_screen(_TaskRejectFixModal(), _after)
 
     def action_pick_other(self) -> None:
         reason = (self.reason_input.value or "").strip()
         if reason:
-            self.dismiss(reason)
+            self._dismiss_if_current(reason)
             return
         self.reason_input.focus()
 
     @on(Input.Submitted, "#task-reject-reason")
     def _on_submit(self, event: Input.Submitted) -> None:
         reason = (event.value or "").strip()
-        self.dismiss(reason or None)
+        self._dismiss_if_current(reason or None)
 
     @on(Button.Pressed, "#task-reject-tests")
     def _on_press_tests(self) -> None:

--- a/tests/test_tasks_ui.py
+++ b/tests/test_tasks_ui.py
@@ -2226,6 +2226,40 @@ def test_task_reject_modal_quick_pick_and_follow_up_reason(env, monkeypatch) -> 
     _run(body())
 
 
+def test_task_reject_modal_ignores_stale_submit_after_dismiss(env, monkeypatch) -> None:
+    if not _load_config_compatible(env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_tasks import PollyTasksApp
+
+    task = _task(node_id="critic_panel", status=WorkStatus.REVIEW)
+    fake_svc = _FakeSvc(tasks_factory=lambda: [task], flow=_flow())
+
+    monkeypatch.setattr("pollypm.cockpit_tasks.create_tmux_client", lambda: _FakeTmux([]))
+    monkeypatch.setattr("pollypm.cockpit_tasks._PENDING_UNDO_SECONDS", 60.0)
+
+    app = PollyTasksApp(env["config_path"], "demo")
+    app._get_svc = lambda: fake_svc  # type: ignore[method-assign]
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 50)) as pilot:
+            await pilot.pause()
+            app.reject_button.press()
+            await pilot.pause()
+            modal = app._active_reject_modal
+            assert modal is not None
+            modal._on_submit(Input.Submitted(modal.reason_input, "needs tests"))
+            await pilot.pause()
+            assert app._active_reject_modal is None
+            assert app._pending_review_action is not None
+            assert app._pending_review_action.reason == "needs tests"
+
+            modal._on_submit(Input.Submitted(modal.reason_input, "late duplicate"))
+            await pilot.pause()
+            assert app._pending_review_action.reason == "needs tests"
+
+    _run(body())
+
+
 def test_task_live_scroll_pauses_on_scroll_up_and_resumes(env, monkeypatch) -> None:
     if not _load_config_compatible(env["config_path"]):
         pytest.skip("minimal pollypm.toml fixture not supported by loader")


### PR DESCRIPTION
Closes #1255

Adds a top-of-stack guard around the Tasks reject modal dismiss path so stale or duplicate submit events cannot pop the base Textual screen and surface a ScreenStackError. Adds focused UI coverage for a stale submit after the reject modal has already dismissed.

Layer self-audit: touched UI-only task pane code in src/pollypm/cockpit_tasks.py and its focused UI tests; no service, domain, store, or IO boundary changes.