### PR TITLE
Fix #1254 route Home help to dashboard bridge

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -109,15 +109,20 @@ def _send_help_key_to_content_bridge(config_path: Path, key: str) -> Path | None
         selected = CockpitRouter(config_path).selected_key()
     except Exception:  # noqa: BLE001
         return None
-    if selected in {"dashboard", "polly"}:
-        return None
     kind = _content_bridge_kind_for_selected_key(selected)
     candidates = []
     if kind is not None:
         candidates.append(kind)
+    if selected in {"dashboard", "polly"}:
+        # Home help belongs on the visible dashboard pane when its
+        # bridge is live, but it should not fall through to stale
+        # non-Home content bridges if that pane is not ready (#1254).
+        fallbacks: tuple[str, ...] = ()
+    else:
+        fallbacks = _HELP_CONTENT_BRIDGE_FALLBACK_KINDS
     candidates.extend(
         fallback
-        for fallback in _HELP_CONTENT_BRIDGE_FALLBACK_KINDS
+        for fallback in fallbacks
         if fallback not in candidates
     )
     for candidate in candidates:

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -243,6 +243,8 @@ def test_cockpit_send_key_defaults_to_cockpit_socket(fake_config: Path) -> None:
 @pytest.mark.parametrize(
     ("selected_key", "bridge_kind"),
     [
+        ("dashboard", "dashboard"),
+        ("polly", "dashboard"),
         ("inbox", "pane-inbox"),
     ],
 )
@@ -285,7 +287,7 @@ def test_cockpit_send_key_question_mark_prefers_content_pane_bridge(
 
 
 @pytest.mark.parametrize("selected_key", ["dashboard", "polly"])
-def test_cockpit_send_key_question_mark_on_home_stays_on_cockpit_bridge(
+def test_cockpit_send_key_question_mark_on_home_without_dashboard_bridge_stays_on_cockpit_bridge(
     valid_cockpit_config: Path,
     selected_key: str,
 ) -> None:
@@ -296,15 +298,10 @@ def test_cockpit_send_key_question_mark_on_home_stays_on_cockpit_bridge(
     from pollypm.cockpit_rail import CockpitRouter
 
     cockpit_app = _FakeApp()
-    dashboard_app = _FakeApp()
     cockpit = start_input_bridge(
         cockpit_app, kind="cockpit", config_path=valid_cockpit_config,
     )
     assert cockpit is not None
-    dashboard = start_input_bridge(
-        dashboard_app, kind="dashboard", config_path=valid_cockpit_config,
-    )
-    assert dashboard is not None
     try:
         CockpitRouter(valid_cockpit_config).set_selected_key(selected_key)
 
@@ -316,10 +313,8 @@ def test_cockpit_send_key_question_mark_on_home_stays_on_cockpit_bridge(
         assert result.exit_code == 0, result.output
         assert f"via {cockpit.socket_path}" in result.output
         assert _wait_for(lambda: cockpit_app.keys == ["question_mark"])
-        assert dashboard_app.keys == []
     finally:
         cockpit.stop()
-        dashboard.stop()
 
 
 def test_cockpit_send_key_question_mark_falls_back_to_visible_dashboard_bridge(


### PR DESCRIPTION
Closes #1254

Summary:
- Route bare `pm cockpit-send-key '?'` on Home/Polly to the live dashboard content bridge so the visible content pane shows the keyboard help overlay.
- Keep the cockpit bridge fallback when no dashboard bridge is live, and avoid falling through to unrelated content bridges from Home.

Self-audit:
- Layer touched: UI/CLI keystroke routing plus focused bridge regression tests.
- No store/domain/service imports added; no boundary changes.
