### PR TITLE
Fix #1262 resolve inbox source db fallback

### DIFF
--- a/src/pollypm/work/inbox_actions.py
+++ b/src/pollypm/work/inbox_actions.py
@@ -30,13 +30,40 @@ def resolve_inbox_work_service(config: Any, item: Any, task_id: str) -> Any | No
     """Resolve a work service for a cockpit inbox row.
 
     The task-id project key is tried first. If that does not map to a
-    registered project DB, the inbox entry's source ``db_path`` is used
-    as a best-effort fallback.
+    registered project DB, or if that DB exists but does not contain the
+    task that produced the inbox row, the inbox entry's source
+    ``db_path`` is used as a best-effort fallback.
     """
+    db_path = getattr(item, "db_path", None) if item is not None else None
     svc = open_work_service_for_task(config, task_id)
     if svc is not None:
-        return svc
-    db_path = getattr(item, "db_path", None) if item is not None else None
+        item_db_path = Path(db_path) if db_path is not None else None
+        svc_db_path = getattr(svc, "_db_path", None)
+        try:
+            same_db = (
+                item_db_path is not None
+                and svc_db_path is not None
+                and item_db_path.resolve() == Path(svc_db_path).resolve()
+            )
+        except Exception:  # noqa: BLE001
+            same_db = False
+        if item_db_path is None or same_db:
+            return svc
+        try:
+            svc.get(task_id)
+            return svc
+        except Exception:  # noqa: BLE001
+            try:
+                svc.close()
+            except Exception:  # noqa: BLE001
+                pass
+            logger.debug(
+                "cockpit inbox: registered project db did not contain %s; "
+                "falling back to source db_path=%r",
+                task_id,
+                db_path,
+                exc_info=True,
+            )
     if db_path is not None:
         try:
             from pollypm.work.sqlite_service import SQLiteWorkService

--- a/tests/test_inbox_actions.py
+++ b/tests/test_inbox_actions.py
@@ -8,6 +8,7 @@ threads, read-markers, and archival from the TUI.
 from __future__ import annotations
 
 import time
+from types import SimpleNamespace
 
 import pytest
 
@@ -186,3 +187,66 @@ class TestArchiveTask:
     def test_archive_on_missing_task_raises(self, svc):
         with pytest.raises(TaskNotFoundError):
             svc.archive_task("demo/777", actor="user")
+
+
+# ---------------------------------------------------------------------------
+# resolve_inbox_work_service
+# ---------------------------------------------------------------------------
+
+
+class TestResolveInboxWorkService:
+    def test_falls_back_to_source_db_when_registered_project_db_lacks_task(
+        self, tmp_path,
+    ):
+        """Workspace-root task rows must render even if a project DB exists."""
+        project_path = tmp_path / "pollypm"
+        project_path.mkdir()
+        project_db = project_path / ".pollypm" / "state.db"
+        project_db.parent.mkdir(parents=True, exist_ok=True)
+        project_svc = SQLiteWorkService(
+            db_path=project_db, project_path=project_path,
+        )
+        project_svc.close()
+
+        workspace_db = tmp_path / ".pollypm" / "state.db"
+        workspace_db.parent.mkdir(parents=True, exist_ok=True)
+        workspace_svc = SQLiteWorkService(
+            db_path=workspace_db, project_path=tmp_path,
+        )
+        try:
+            task = workspace_svc.create(
+                title="Plan ready for review: pollypm",
+                description="Plan: docs/project-plan.md",
+                type="task",
+                project="pollypm",
+                flow_template="chat",
+                roles={"requester": "user", "operator": "architect"},
+                priority="normal",
+                created_by="architect",
+                labels=[
+                    "plan_review",
+                    "project:pollypm",
+                    "plan_task:pollypm/1",
+                ],
+            )
+            task_id = task.task_id
+        finally:
+            workspace_svc.close()
+
+        from pollypm.work.inbox_actions import resolve_inbox_work_service
+
+        config = SimpleNamespace(
+            projects={"pollypm": SimpleNamespace(path=project_path)},
+        )
+        item = SimpleNamespace(
+            db_path=workspace_db,
+            project="pollypm",
+            scope="pollypm",
+        )
+        resolved = resolve_inbox_work_service(config, item, task_id)
+        assert resolved is not None
+        try:
+            assert getattr(resolved, "_db_path") == workspace_db
+            assert resolved.get(task_id).title == "Plan ready for review: pollypm"
+        finally:
+            resolved.close()


### PR DESCRIPTION
Closes #1262

Fixes cockpit inbox service resolution so task-backed plan-review rows loaded from the workspace-root state DB fall back to their source DB when the registered project DB exists but does not contain the task. This keeps the detail pane rendering the cached/source task instead of surfacing a single-line task-not-found error.

Layer audit: touched the work-service action resolver and its unit coverage; no UI-to-store boundary changes.