### PR TITLE
Fix #1268 surface Home quota header

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -3350,7 +3350,17 @@ class PollyDashboardApp(App[None]):
             parts.append(
                 f"[#f85149][b]{data.alert_count}[/b] needs action[/#f85149]"
             )
-        header_text = "  " + "  \u00b7  ".join(parts)
+        header_lines = ["  " + "  \u00b7  ".join(parts)]
+        account_usages = getattr(data, "account_usages", [])
+        if account_usages:
+            usage = account_usages[0]
+            label = usage.provider or usage.account_name
+            header_lines.append(
+                "  "
+                f"LLM quota: {_escape(label)} \u00b7 "
+                f"[b]{usage.used_pct}%[/b] used of {_escape(usage.limit_label)}"
+            )
+        header_text = "\n".join(header_lines)
         if data.briefing:
             header_text += f"\n\n  [#58a6ff]{data.briefing}[/#58a6ff]"
         self.header_w.update(header_text)
@@ -3472,7 +3482,6 @@ class PollyDashboardApp(App[None]):
 
         # ── Token chart + cached LLM account quota ──
         chart_lines: list[str] = []
-        account_usages = getattr(data, "account_usages", [])
         if account_usages:
             chart_lines.append("[b]LLM account quota usage[/b]")
             for usage in account_usages:

--- a/tests/test_polly_dashboard_ui.py
+++ b/tests/test_polly_dashboard_ui.py
@@ -194,6 +194,10 @@ def test_polly_dashboard_renders_llm_quota_usage(tmp_path: Path) -> None:
 
     app._render_dashboard(_fake_config(), data)
 
+    header = str(app.header_w.render())
+    assert "LLM quota:" in header
+    assert "84% used of weekly limit" in header
+
     rendered = str(app.chart_body.render())
     assert "LLM account quota usage" in rendered
     assert "84% used of weekly limit" in rendered


### PR DESCRIPTION
Closes #1268

Adds a compact LLM quota summary to the Home dashboard header so the weekly usage percentage is visible above the Now feed even in a short/narrow cockpit pane. Keeps the existing full Tokens quota panel intact and extends the focused dashboard UI test to cover the header signal.

Layer audit: UI-only change in cockpit_ui.py plus focused UI test coverage; no facade, domain, or store changes.