### PR TITLE
Fix #1269 metrics section content height

### DIFF
--- a/src/pollypm/cockpit_metrics.py
+++ b/src/pollypm/cockpit_metrics.py
@@ -67,6 +67,7 @@ class PollyMetricsApp(App[None]):
         scrollbar-color: #2a3340;
     }
     .me-section {
+        height: auto;
         margin-bottom: 1;
         padding: 1 2;
         background: #111820;

--- a/tests/test_metrics_ui.py
+++ b/tests/test_metrics_ui.py
@@ -161,6 +161,22 @@ def test_mount_renders_all_five_sections(metrics_env, metrics_app) -> None:
     _run(body())
 
 
+def test_compact_viewport_renders_section_labels(metrics_env, metrics_app) -> None:
+    """At the issue's 80x24 size, section boxes must not render blank."""
+    async def body() -> None:
+        from pollypm.cockpit_smoke import SmokeHarness
+
+        metrics_app._gather = lambda: _make_snapshot()  # type: ignore[method-assign]
+        async with SmokeHarness.mount(metrics_app, size=(80, 24)) as smoke:
+            capture = smoke.snapshot()
+            text = capture.rendered_text
+            assert "Fleet" in text
+            assert "Workers:" in text
+            assert "Resources" in text
+            assert "state.db:" in text
+    _run(body())
+
+
 # ---------------------------------------------------------------------------
 # 2. Fleet counts line up with synthetic task/worker data
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1269

Metrics sections now explicitly auto-size to their rendered title/body so the compact 80x24 Textual pane shows labels and data instead of blank bordered boxes. Added a regression test that captures the issue viewport and asserts section labels are visible.

Layer self-audit: touched UI-only metrics pane CSS and UI test; no facade, domain, or store changes and no boundary crossings.