### PR TITLE
Fix #1275 keep inbox filter escape local

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -1734,6 +1734,20 @@ class PollyCockpitApp(App[None]):
         except Exception:  # noqa: BLE001
             return False
 
+    def _inbox_filter_input_active(self) -> bool:
+        if not self._on_inbox_surface():
+            return False
+        router = getattr(self, "router", None)
+        if router is None:
+            return False
+        is_active = getattr(router, "inbox_filter_input_active", None)
+        if not callable(is_active):
+            return False
+        try:
+            return bool(is_active())
+        except Exception:  # noqa: BLE001
+            return False
+
     def _send_key_to_inbox_pane(self, key: str) -> bool:
         """Forward an Inbox-owned key to the right-pane Inbox app.
 
@@ -3064,6 +3078,9 @@ class PollyCockpitApp(App[None]):
         return True
 
     def action_back_to_home(self) -> None:
+        if self._inbox_filter_input_active():
+            self._send_key_to_inbox_pane("escape")
+            return
         if self._right_pane_has_live_session():
             return_key = self._mounted_return_key()
             if return_key:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4902,6 +4902,35 @@ def test_cockpit_escape_routes_back_to_home_from_settings() -> None:
     assert app.selected_key == "dashboard"
 
 
+def test_cockpit_escape_with_active_inbox_filter_stays_in_inbox() -> None:
+    """#1275: Esc in the active Inbox filter clears the filter only."""
+    app, calls = _build_back_to_home_app()
+    app.selected_key = "inbox"
+    app._last_router_selected_key = "inbox"
+    forwarded: list[str] = []
+
+    class _Router:
+        def _load_state(self) -> dict[str, object]:
+            return {}
+
+        def inbox_filter_input_active(self) -> bool:
+            return True
+
+    app.router = _Router()  # type: ignore[assignment]
+    app._send_key_to_inbox_pane = (  # type: ignore[method-assign]
+        lambda key: forwarded.append(key) or True
+    )
+    app._schedule_route_selected = (  # type: ignore[method-assign]
+        lambda key, *, label=None: calls.append(("route", key))
+    )
+
+    app.action_back_to_home()
+
+    assert forwarded == ["escape"]
+    assert calls == []
+    assert app.selected_key == "inbox"
+
+
 def test_cockpit_capital_h_routes_back_to_home() -> None:
     """#1163: capital H is an explicit global Home jump."""
     app, calls = _build_back_to_home_app()


### PR DESCRIPTION
Closes #1275

Esc from the cockpit rail now checks whether the Inbox filter input is active before routing Home. In that state, the rail forwards the Escape key to the Inbox pane so the filter clears and the Inbox remains selected.

Self-audit: touched UI/CLI layer only (`src/pollypm/cockpit_ui.py`) plus a focused cockpit regression test. No service, domain, or store changes.

Tests:
- `uv run --extra dev pytest -q tests/test_cockpit.py::test_cockpit_escape_routes_back_to_home_from_settings tests/test_cockpit.py::test_cockpit_escape_with_active_inbox_filter_stays_in_inbox tests/test_cockpit.py::test_cockpit_escape_at_home_is_noop tests/test_cockpit.py::test_cockpit_jk_from_inbox_forwards_to_inbox_pane tests/test_cockpit.py::test_inbox_focus_rail_releases_inbox_nav_ownership tests/test_cockpit_inbox_ui.py::test_inbox_back_or_cancel_skips_rail_focus_in_filter_input tests/test_cockpit_inbox_ui.py::test_cockpit_send_key_inbox_filter_sequence_routes_to_inbox_bridge tests/test_cockpit_input_bridge.py::test_cockpit_send_key_inbox_action_prefers_inbox_bridge_over_live_pane`
- `uv run --extra dev pytest tests/test_cockpit.py -q`