### PR TITLE
Fix #1273 speed inbox action prepaint

### DIFF
--- a/src/pollypm/__main__.py
+++ b/src/pollypm/__main__.py
@@ -106,10 +106,33 @@ def _default_config_path() -> Path:
 def _paint_inbox_snapshot(config_path: Path, *, project: str | None) -> Exception | None:
     """Prepaint a real inbox list before importing the interactive TUI."""
     try:
-        from pollypm.cockpit_inbox_items import load_inbox_entries
+        from pollypm.cockpit_inbox_items import (
+            load_inbox_action_preview,
+            load_inbox_entries,
+        )
         from pollypm.config import load_config
 
         config = load_config(config_path)
+        try:
+            preview, preview_unread, preview_total = load_inbox_action_preview(
+                config,
+                project=project,
+                limit=_INBOX_PREPAINT_LIMIT,
+            )
+        except Exception:  # noqa: BLE001 - exact loader below is the fallback
+            preview = []
+            preview_unread = set()
+            preview_total = 0
+        if preview:
+            frame = _render_inbox_snapshot(
+                preview,
+                total=preview_total,
+                unread_count=len(preview_unread),
+                project=project,
+            )
+            sys.stdout.write(f"{_CLEAR_SCREEN}{frame}")
+            sys.stdout.flush()
+            return None
         items, unread, _replies = load_inbox_entries(config)
         visible = _initial_inbox_visible_items(items, project=project)
         frame = _render_inbox_snapshot(

--- a/src/pollypm/cockpit_inbox_items.py
+++ b/src/pollypm/cockpit_inbox_items.py
@@ -772,3 +772,72 @@ def load_inbox_entries(
         items, project_db_paths=project_db_paths,
     )
     return items, unread, replies_by_task
+
+
+def load_inbox_action_preview(
+    config,
+    *,
+    project: str | None = None,
+    limit: int = 12,
+) -> tuple[list[InboxEntry], set[str], int]:
+    """Load a small Store-backed action preview for first Inbox paint.
+
+    The interactive Inbox still does the full ``load_inbox_entries`` pass.
+    This helper is only for the cockpit-pane prepaint path, where showing the
+    first action rows quickly matters more than reply counts or task-backed
+    rows that will arrive with the Textual app's normal refresh.
+    """
+    preview_limit = max(int(limit), 1)
+    rows_per_source = max(preview_limit * 4, 48)
+    known_projects = set(getattr(config, "projects", {}).keys())
+    items: list[InboxEntry] = []
+
+    for project_key, db_path, _project_path in _inbox_db_sources(config):
+        if not db_path.exists():
+            continue
+        try:
+            store = SQLAlchemyStore(f"sqlite:///{db_path}")
+        except Exception:  # noqa: BLE001
+            continue
+        try:
+            try:
+                rows = store.query_messages(
+                    recipient="user",
+                    state="open",
+                    type=["notify", "inbox_task", "alert"],
+                    limit=rows_per_source,
+                )
+            except Exception:  # noqa: BLE001
+                rows = []
+            for row in rows:
+                if _row_is_dev_channel(row.get("labels")):
+                    continue
+                item = annotate_inbox_entry(
+                    message_row_to_inbox_entry(
+                        row,
+                        source_key=project_key or _WORKSPACE_DB_KEY,
+                        db_path=db_path,
+                    ),
+                    known_projects=known_projects,
+                )
+                if project and (getattr(item, "project", "") or "") != project:
+                    continue
+                if getattr(item, "is_orphaned", False):
+                    continue
+                if not getattr(item, "needs_action", False):
+                    continue
+                items.append(item)
+        finally:
+            try:
+                store.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    if not items:
+        return [], set(), 0
+
+    items = _dedupe_replayed_plan_reviews(items)
+    items.sort(key=_entry_sort_value, reverse=True)
+    preview = items[:preview_limit]
+    unread = {item.task_id for item in preview}
+    return preview, unread, len(items)

--- a/tests/test_cockpit_right_pane_command.py
+++ b/tests/test_cockpit_right_pane_command.py
@@ -284,3 +284,49 @@ def test_package_main_fast_dispatches_inbox_pane(
     assert ("log", config_path) in calls
     assert ("app", (config_path, "demo")) in calls
     assert ("run", True) in calls
+
+
+def test_package_main_prepaints_action_preview_without_full_inbox_load(
+    capsys,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """#1273: first Inbox frame should not wait for the full inbox load."""
+
+    import pollypm.config as config_mod
+    import pollypm.cockpit_inbox_items as inbox_items
+    from pollypm import __main__ as package_main
+
+    config_path = tmp_path / "pollypm.toml"
+    config = SimpleNamespace(projects={"demo": object()})
+    preview = SimpleNamespace(
+        task_id="msg:demo:1",
+        title="[Action] Plan ready for review",
+        project="demo",
+        triage_label="plan review",
+        needs_action=True,
+        is_orphaned=False,
+    )
+
+    monkeypatch.setattr(config_mod, "load_config", lambda path: config)
+    monkeypatch.setattr(
+        inbox_items,
+        "load_inbox_action_preview",
+        lambda loaded, *, project, limit: ([preview], {"msg:demo:1"}, 1),
+    )
+    monkeypatch.setattr(
+        inbox_items,
+        "load_inbox_entries",
+        lambda loaded: (_ for _ in ()).throw(
+            AssertionError("full inbox load should not run for action preview")
+        ),
+    )
+
+    error = package_main._paint_inbox_snapshot(config_path, project="demo")
+
+    out = capsys.readouterr().out
+    assert error is None
+    assert "Inbox" in out
+    assert "action needed" in out
+    assert "Plan ready for review" in out
+    assert "1 needs action" in out


### PR DESCRIPTION
Closes #1273

Adds a Store-backed action preview for the Inbox cockpit-pane prepaint so capital-I can show the first action-needed frame before the full inbox loader and Textual app startup finish. If the preview cannot produce action rows, the existing full load remains the fallback.

Layer audit: touched the cockpit package entrypoint and shared cockpit inbox item adapter only; no direct sqlite/sqlalchemy imports from UI and no cross-layer reach beyond existing Store/WorkService adapters.