### PR TITLE
Fix #1272 keep Inbox rail nav active

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -58,10 +58,10 @@ _HELP_MODAL_CONTROL_TOKENS = frozenset({
     "<end>",
 })
 _HELP_CONTENT_BRIDGE_FALLBACK_KINDS = ("dashboard", "pane-inbox", "settings")
-# Keep row-navigation keys on the cockpit bridge. PollyCockpitApp still
-# forwards them to the Inbox pane when the Inbox surface is active (#1238),
-# but the CLI must not bypass the rail just because the rail cursor is on
-# the Inbox row (#1246).
+# Keep row-navigation keys on the cockpit bridge. The Inbox pane has its
+# own bridge for explicit Inbox actions/filter input, but rail j/k/arrows
+# must continue moving the rail cursor when the selected row is Inbox
+# (#1246/#1272).
 _INBOX_BRIDGE_FIRST_TOKENS = frozenset({
     "/",
     "A",

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -2611,7 +2611,10 @@ class PollyCockpitApp(App[None]):
         self._schedule_route_selected("settings", label="Settings")
 
     def action_open_inbox(self) -> None:
-        self._set_inbox_pane_nav_active(True)
+        # #1272: capital-I opens the Inbox content while keeping the rail
+        # cursor in charge of j/k/arrows. If the user later focuses the
+        # right pane directly, the Inbox app still owns its own keys.
+        self._set_inbox_pane_nav_active(False)
         self._schedule_route_selected("inbox", label="Inbox")
 
     def action_open_activity(self) -> None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4082,8 +4082,8 @@ def test_cockpit_ui_arrow_and_enter_route_selected(tmp_path: Path) -> None:
     asyncio.run(exercise())
 
 
-def test_cockpit_send_key_inbox_shortcut_keeps_inbox_nav_active(tmp_path: Path) -> None:
-    """#1238: after global ``I``, Down/Up stay owned by the Inbox."""
+def test_cockpit_send_key_inbox_shortcut_keeps_rail_nav_active(tmp_path: Path) -> None:
+    """#1272: after global ``I``, Down/Up/j/k keep moving the rail cursor."""
 
     class FakeRouter:
         def __init__(self) -> None:
@@ -4153,7 +4153,7 @@ def test_cockpit_send_key_inbox_shortcut_keeps_inbox_nav_active(tmp_path: Path) 
             await pilot.pause(0.4)
             assert app.selected_key == "inbox"
             assert app._selected_row_key() == "inbox"
-            assert app.router.inbox_pane_nav_active() is True
+            assert app.router.inbox_pane_nav_active() is False
             forwarded: list[str] = []
             app._send_key_to_inbox_pane = (  # type: ignore[method-assign]
                 lambda key: forwarded.append(key) or True
@@ -4161,15 +4161,27 @@ def test_cockpit_send_key_inbox_shortcut_keeps_inbox_nav_active(tmp_path: Path) 
 
             send_key(handle.socket_path, "<down>")
             await pilot.pause(0.4)
-            assert app.selected_key == "inbox"
-            assert app._selected_row_key() == "inbox"
-            assert forwarded == ["j"]
+            assert app.selected_key == "activity"
+            assert app._selected_row_key() == "activity"
+            assert forwarded == []
+
+            send_key(handle.socket_path, "j")
+            await pilot.pause(0.4)
+            assert app.selected_key == "project:demo"
+            assert app._selected_row_key() == "project:demo"
+            assert forwarded == []
 
             send_key(handle.socket_path, "<up>")
             await pilot.pause(0.4)
+            assert app.selected_key == "activity"
+            assert app._selected_row_key() == "activity"
+            assert forwarded == []
+
+            send_key(handle.socket_path, "k")
+            await pilot.pause(0.4)
             assert app.selected_key == "inbox"
             assert app._selected_row_key() == "inbox"
-            assert forwarded == ["j", "k"]
+            assert forwarded == []
 
     asyncio.run(exercise())
 


### PR DESCRIPTION
Closes #1272

Capital-I now opens the Inbox content pane while explicitly leaving rail j/k/arrows under rail control, so the cursor moves off Inbox instead of forwarding row navigation into the right pane. The regression test now covers the exact Down/j/Up/k round trip from Inbox.

Layer self-audit: touched UI/CLI only (PollyCockpitApp key handling, cockpit-send-key comment, cockpit UI test). No store/domain imports or boundary crossings.