### PR TITLE
Fix #1284 warn on missing worker heartbeat

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -849,7 +849,7 @@ def _worker_health_snapshot(
         if dt is not None and dt.tzinfo is None:
             dt = dt.replace(tzinfo=UTC)
         idle_long = dt is not None and dt <= datetime.now(UTC) - timedelta(minutes=5)
-        health = "idle_warn" if idle_long else "alive"
+        health = "idle_warn" if dt is None or idle_long else "alive"
     else:
         health = "alive"
     if health == "handed_off":

--- a/tests/test_worker_roster_ui.py
+++ b/tests/test_worker_roster_ui.py
@@ -273,6 +273,22 @@ def test_working_worker_without_heartbeat_explains_tmux_activity() -> None:
     assert "session: worker_demo" in tooltip
 
 
+def test_idle_worker_without_heartbeat_warns_instead_of_green() -> None:
+    """#1284: idle rows with no heartbeat must not render as healthy."""
+    from pollypm.cockpit_inbox import _worker_health_snapshot
+
+    health, tooltip = _worker_health_snapshot(
+        status="idle",
+        last_heartbeat_iso=None,
+        token_total=0,
+        session_name="worker_demo",
+    )
+
+    assert health == "idle_warn"
+    assert "idle; heartbeat not recorded" in tooltip
+    assert "session: worker_demo" in tooltip
+
+
 def test_offline_at_review_node_classifies_as_handed_off() -> None:
     """Regression: when a worker exits cleanly after handing off to a
     reviewer (task at ``code_review`` / ``user_approval``), the


### PR DESCRIPTION
Closes #1284

Idle worker rows with no recorded heartbeat now use the existing warning health bucket instead of the green healthy bucket, so the Workers Health column no longer contradicts the footer text.

Layer self-audit: touched worker roster UI data/render test surface only (cockpit_inbox health classification and worker roster tests). No store imports or boundary crossings.