### PR TITLE
Fix #1287 keep help modal route across Home alias

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -204,7 +204,16 @@ def _recorded_help_modal_bridge(config_path: Path) -> str | None:
         return None
     if not isinstance(kind, str) or not kind:
         return None
-    if not isinstance(selected, str) or selected != current_selected:
+    if not isinstance(selected, str):
+        _clear_help_modal_bridge(config_path)
+        return None
+    if selected != current_selected:
+        selected_kind = _content_bridge_kind_for_selected_key(selected)
+        current_kind = _content_bridge_kind_for_selected_key(current_selected)
+        if selected_kind != kind or current_kind != kind:
+            _clear_help_modal_bridge(config_path)
+            return None
+    if not current_selected:
         _clear_help_modal_bridge(config_path)
         return None
     if not isinstance(opened_at, int | float):

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -392,6 +392,51 @@ def test_cockpit_send_key_help_modal_dismiss_clears_content_bridge(
         dashboard.stop()
 
 
+def test_help_modal_control_key_survives_home_alias_change(
+    valid_cockpit_config: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pollypm.cli_features import ui as ui_commands
+    import pollypm.cockpit_input_bridge as input_bridge
+    from pollypm.cockpit_rail import CockpitRouter
+
+    calls: list[tuple[str, str | None]] = []
+
+    def fake_send_key_to_first_live(
+        _config_path: Path,
+        key: str,
+        *,
+        kind: str | None = None,
+        timeout: float = 2.0,
+    ) -> Path:
+        calls.append((key, kind))
+        return Path("/tmp/dashboard.sock")
+
+    monkeypatch.setattr(
+        input_bridge,
+        "send_key_to_first_live",
+        fake_send_key_to_first_live,
+    )
+    router = CockpitRouter(valid_cockpit_config)
+    router.set_selected_key("polly")
+    ui_commands._remember_help_modal_bridge(
+        valid_cockpit_config,
+        kind="dashboard",
+        selected_key="polly",
+    )
+
+    router.set_selected_key("dashboard")
+
+    assert (
+        ui_commands._send_help_modal_key_to_recorded_bridge(
+            valid_cockpit_config,
+            "<pgdn>",
+        )
+        == Path("/tmp/dashboard.sock")
+    )
+    assert calls == [("<pgdn>", "dashboard")]
+
+
 @pytest.mark.parametrize("selected_key", ["dashboard", "polly"])
 def test_cockpit_send_key_question_mark_on_home_without_dashboard_bridge_stays_on_cockpit_bridge(
     valid_cockpit_config: Path,


### PR DESCRIPTION
Closes #1287

Summary:
- Keep recorded help-modal bridge routing valid across the Home surface alias from polly to dashboard.
- Add a regression test for forwarding help-modal controls after that selected-key transition.

Tests:
- PYTHONPATH=src /private/tmp/review-pollypm-13-env-dev2/bin/python -m pytest tests/test_cockpit_input_bridge.py::test_help_modal_control_key_survives_home_alias_change -q
- /private/tmp/wt-codex-issue-1280/.venv/bin/python -m ruff check src/pollypm/cli_features/ui.py tests/test_cockpit_input_bridge.py