### PR TITLE
Fix #1283 align project PM persona labels

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -6778,6 +6778,41 @@ class _InboxProjectPickerModal(ModalScreen[str | None]):
         self.action_select()
 
 
+def _project_pm_persona(config: object, project_key: str, project: object) -> str | None:
+    sessions = getattr(config, "sessions", {}) or {}
+    session_role: object | None = None
+    if isinstance(sessions, dict):
+        from pollypm.models import CONTROL_ROLES
+
+        for session in sessions.values():
+            if getattr(session, "project", None) != project_key:
+                continue
+            if getattr(session, "enabled", True) is False:
+                continue
+            role = getattr(session, "role", "")
+            if role in CONTROL_ROLES:
+                continue
+            session_role = role
+            break
+
+    if isinstance(session_role, str) and session_role.strip():
+        try:
+            from pollypm.role_contract import canonical_role, persona_for
+
+            if canonical_role(session_role) == "architect":
+                return persona_for("architect")
+        except ValueError:
+            pass
+
+    persona = getattr(project, "persona_name", None)
+    return persona.strip() if isinstance(persona, str) and persona.strip() else None
+
+
+def _project_pm_label(config: object, project_key: str, project: object) -> str:
+    persona = _project_pm_persona(config, project_key, project)
+    return f"PM: {persona}" if persona else "PM: Project PM"
+
+
 def _resolve_pm_target(config_path: Path, project_key: str | None) -> tuple[str, str]:
     """Resolve the cockpit-router key + display name for a project's PM.
 
@@ -6800,10 +6835,8 @@ def _resolve_pm_target(config_path: Path, project_key: str | None) -> tuple[str,
     project = projects.get(project_key)
     if project is None:
         return fallback_key, fallback_name
-    persona = getattr(project, "persona_name", None)
-    if isinstance(persona, str) and persona.strip():
-        return f"project:{project_key}:session", persona.strip()
-    return f"project:{project_key}:session", "Project PM"
+    persona = _project_pm_persona(config, project_key, project)
+    return f"project:{project_key}:session", persona or "Project PM"
 
 
 def _build_pm_context_line(
@@ -12650,11 +12683,7 @@ def _gather_project_dashboard(
         else (getattr(project, "name", None) or project_key)
     )
     persona = getattr(project, "persona_name", None)
-    pm_label = (
-        f"PM: {persona.strip()}"
-        if isinstance(persona, str) and persona.strip()
-        else "PM: Project PM"
-    )
+    pm_label = _project_pm_label(config, project_key, project)
 
     exists_on_disk = bool(
         project_path is not None
@@ -12781,6 +12810,7 @@ def _project_dashboard_signature(
     worker = data.active_worker or {}
     return (
         data.project_key,
+        data.pm_label,
         data.exists_on_disk,
         data.status_dot,
         data.status_label,

--- a/tests/test_project_dashboard_signature.py
+++ b/tests/test_project_dashboard_signature.py
@@ -73,6 +73,12 @@ def test_signature_changes_on_status_label_change() -> None:
     assert _project_dashboard_signature(a) != _project_dashboard_signature(b)
 
 
+def test_signature_changes_on_pm_label_change() -> None:
+    a = _make(pm_label="PM: Bea")
+    b = _make(pm_label="PM: Archie")
+    assert _project_dashboard_signature(a) != _project_dashboard_signature(b)
+
+
 def test_signature_changes_on_worker_heartbeat() -> None:
     """Heartbeat updates intentionally invalidate so the worker
     section stays current."""

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -674,6 +674,52 @@ def test_topbar_uses_configured_persona(tmp_path: Path) -> None:
     _run(body())
 
 
+def test_project_pm_labels_match_architect_session_persona(tmp_path: Path) -> None:
+    """When PM Chat routes to an architect session, adjacent content
+    surfaces should name Archie instead of the project's worker persona.
+    """
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        "[project]\n"
+        'tmux_session = "pollypm-test"\n'
+        f'workspace_root = "{tmp_path}"\n'
+        "\n"
+        "[accounts.controller]\n"
+        'provider = "claude"\n'
+        "\n"
+        "[sessions.architect_demo]\n"
+        'role = "architect"\n'
+        'provider = "claude"\n'
+        'account = "controller"\n'
+        f'cwd = "{project_path}"\n'
+        'project = "demo"\n'
+        'window_name = "architect-demo"\n'
+        "\n"
+        "[projects.demo]\n"
+        'key = "demo"\n'
+        'name = "Demo"\n'
+        f'path = "{project_path}"\n'
+        'persona_name = "Bea"\n',
+        encoding="utf-8",
+    )
+    _seed_tasks(project_path)
+    if not _load_config_compatible(config_path):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+
+    from pollypm.cockpit_ui import _gather_project_dashboard, _resolve_pm_target
+
+    dashboard = _gather_project_dashboard(config_path, "demo")
+    assert dashboard is not None
+    assert dashboard.pm_label == "PM: Archie"
+    assert _resolve_pm_target(config_path, "demo") == (
+        "project:demo:session",
+        "Archie",
+    )
+
+
 # ---------------------------------------------------------------------------
 # 2. Status indicator — reflects active-worker / attention / idle
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1283

Summary:
- Derive project PM labels from the active project session role persona when PM Chat routes to that session.
- Include the PM label in the project dashboard signature so persona changes repaint.

Tests:
- PYTHONPATH=src /private/tmp/review-pollypm-13-env-dev2/bin/python -m pytest tests/test_project_dashboard_ui.py::test_project_pm_labels_match_architect_session_persona tests/test_project_dashboard_signature.py::test_signature_changes_on_pm_label_change tests/test_cockpit_inbox_ui.py::test_d_key_with_persona_routes_to_project_session tests/test_core_rail_items.py::test_pm_chat_label_matches_project_session_persona -q
- /private/tmp/wt-codex-issue-1280/.venv/bin/python -m ruff check src/pollypm/cockpit_ui.py tests/test_project_dashboard_signature.py tests/test_project_dashboard_ui.py