### PR TITLE
Fix #1291 clean operator chat prelude

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -584,8 +584,14 @@ def _build_operator_primer(supervisor) -> str | None:
     projects = getattr(supervisor.config, "projects", {}) or {}
     for project_key, project in projects.items():
         project_count += 1
-        project_name = getattr(project, "name", None) or project_key
-        project_lines.append(f"  - {project_name} ({project_key})")
+        display_label = getattr(project, "display_label", None)
+        if callable(display_label):
+            project_name = display_label()
+        else:
+            project_name = getattr(project, "name", None) or project_key.replace(
+                "_", "-"
+            )
+        project_lines.append(f"  - {project_name}")
         if inbox_tasks is None or SQLiteWorkService is None:
             continue
         db_path = project.path / ".pollypm" / "state.db"
@@ -600,7 +606,7 @@ def _build_operator_primer(supervisor) -> str | None:
                 for task in items[:2]:
                     title = (task.title or "").strip()
                     if title:
-                        inbox_titles.append((project_key, f"{task.task_id}: {title}"))
+                        inbox_titles.append((project_name, title))
         except Exception:  # noqa: BLE001 — primer is best-effort
             continue
 
@@ -621,14 +627,13 @@ def _build_operator_primer(supervisor) -> str | None:
     if project_lines:
         lines.append("Projects:")
         lines.extend(project_lines[:10])
-    lines.append(f"Active inbox (workspace-wide): {inbox_total} item(s)")
+    lines.append(f"Active inbox: {inbox_total} item(s)")
     if inbox_titles:
         lines.append("Recent inbox:")
-        for project_key, title in inbox_titles[:5]:
-            lines.append(f"  - [{project_key}] {title}")
+        for project_name, title in inbox_titles[:5]:
+            lines.append(f"  - {project_name}: {title}")
     lines.append(
-        "Glance at the inbox/status (`pm inbox`, `pm status`) and "
-        "pick up wherever the user takes the conversation."
+        "Use the visible inbox and status context, then follow the user's lead."
     )
     return "\n".join(lines)
 

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -1901,7 +1901,7 @@ def test_cockpit_router_primes_workspace_operator_on_attach() -> None:
     class _FakeConfig:
         projects = {
             "alpha": _Project("alpha", "Alpha"),
-            "beta": _Project("beta", "Beta"),
+            "health_coach": _Project("health_coach", "health-coach"),
         }
 
     class _FakeSupervisor:
@@ -1959,7 +1959,13 @@ def test_cockpit_router_primes_workspace_operator_on_attach() -> None:
     assert "operator chat" in text
     # Workspace-scope (not project-scope) discriminators.
     assert "Workspace:" in text
-    assert "Active inbox (workspace-wide):" in text
+    assert "Active inbox:" in text
+    assert "workspace-wide" not in text
+    assert "pm inbox" not in text
+    assert "pm status" not in text
+    assert "Alpha (alpha)" not in text
+    assert "health-coach (health_coach)" not in text
+    assert "health-coach" in text
     # Distinct from the per-project primer's signature.
     assert "Project root:" not in text  # per-project primer marker
     assert "Plan: " not in text  # per-project primer marker


### PR DESCRIPTION
Closes #1291

Updates the Polly operator chat primer to show display project names only, remove workspace-wide wording, and avoid exposing pm inbox/pm status in the user-visible prelude.

Layer audit: UI-only change in cockpit_rail.py, plus a focused cockpit regression test. No facade/domain/store boundary changes.