### PR TITLE
Fix #1288 settings narrow nav marker

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -4831,7 +4831,11 @@ class PollySettingsPaneApp(App[None]):
                 widget.add_class("-section-active")
 
     def _nav_label(self, key: str, label: str, *, count: int | None) -> str:
-        marker = "\u25b8" if key == self._active_section else " "
+        try:
+            cursor_key = _SETTINGS_SECTIONS[self._nav_cursor][0]
+        except (AttributeError, IndexError):
+            cursor_key = self._active_section
+        marker = "\u25b8" if key == cursor_key else " "
         cnt = f"  [dim]{count}[/dim]" if count is not None else ""
         return f"{marker} {_escape(label)}{cnt}"
 

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4780,6 +4780,15 @@ def test_settings_pane_renders_accounts_and_toggles_permissions(monkeypatch, tmp
     asyncio.run(exercise())
 
 
+def test_settings_nav_marker_follows_visible_cursor_not_active_section() -> None:
+    app = PollySettingsPaneApp.__new__(PollySettingsPaneApp)
+    app._active_section = "accounts"
+    app._nav_cursor = 1
+
+    assert app._nav_label("accounts", "Accounts", count=2).startswith("  ")
+    assert app._nav_label("projects", "Projects", count=10).startswith("\u25b8 ")
+
+
 def test_cockpit_app_tick_scheduler_is_noop(tmp_path: Path) -> None:
     """The scheduler tick is a no-op — heartbeat runs via cron, not the cockpit."""
     app = PollyCockpitApp(tmp_path / "pollypm.toml")


### PR DESCRIPTION
Closes #1288

Updates the Settings left-nav marker to follow the visible nav cursor, so j/k movement at narrow widths shows Projects, Roles, and later sections without relying on the right-pane header.

Self-audit: touched only the cockpit UI layer (src/pollypm/cockpit_ui.py) and a focused cockpit regression test (tests/test_cockpit.py); no service, domain, or store changes.