### PR TITLE
Fix #1300 keep metrics pane visible during gather

### DIFF
--- a/src/pollypm/cockpit_metrics.py
+++ b/src/pollypm/cockpit_metrics.py
@@ -117,6 +117,8 @@ class PollyMetricsApp(App[None]):
         self.snapshot = None
         self._auto_refresh: bool = False
         self._auto_refresh_timer = None
+        self._refresh_in_flight: bool = False
+        self._refresh_seq: int = 0
         self._selected_index: int = 0
         self._section_order = [
             "fleet",
@@ -146,6 +148,7 @@ class PollyMetricsApp(App[None]):
         yield self.hint
 
     def on_mount(self) -> None:
+        self._render()
         self._refresh()
         # Alert toast surface removed in #956 — the alert list still
         # renders inside this metrics pane via the drill-down modal.
@@ -170,8 +173,37 @@ class PollyMetricsApp(App[None]):
             return None
 
     def _refresh(self) -> None:
-        self.snapshot = self._gather()
-        self._render()
+        if self._refresh_in_flight:
+            return
+        self._refresh_seq += 1
+        seq = self._refresh_seq
+        self._refresh_in_flight = True
+        try:
+            self.run_worker(
+                lambda: self._refresh_worker(seq),
+                thread=True,
+                exclusive=True,
+                group="metrics_refresh",
+            )
+        except Exception:  # noqa: BLE001
+            self._refresh_in_flight = False
+            self.snapshot = self._gather()
+            self._render()
+
+    def _refresh_worker(self, seq: int) -> None:
+        snap = self._gather()
+
+        def _apply() -> None:
+            self._refresh_in_flight = False
+            if seq != self._refresh_seq:
+                return
+            self.snapshot = snap
+            self._render()
+
+        try:
+            self.call_from_thread(_apply)
+        except Exception:  # noqa: BLE001
+            _apply()
 
     @staticmethod
     def _tone_colour(tone: str) -> str:

--- a/tests/test_metrics_ui.py
+++ b/tests/test_metrics_ui.py
@@ -177,6 +177,41 @@ def test_compact_viewport_renders_section_labels(metrics_env, metrics_app) -> No
     _run(body())
 
 
+def test_mount_paints_shell_before_slow_metrics_gather(metrics_env) -> None:
+    """The Metrics pane should not stay blank while live gather is slow."""
+    async def body() -> None:
+        from threading import Event
+
+        from pollypm.cockpit_smoke import SmokeHarness
+        from pollypm.cockpit_ui import PollyMetricsApp
+
+        release_gather = Event()
+        metrics_app = PollyMetricsApp(metrics_env["config_path"])
+
+        def _slow_gather():
+            release_gather.wait(timeout=2.0)
+            return _make_snapshot()
+
+        metrics_app._gather = _slow_gather  # type: ignore[method-assign]
+        async with SmokeHarness.mount(metrics_app, size=(189, 80)) as smoke:
+            capture = smoke.snapshot()
+            text = capture.rendered_text
+            assert sum(1 for line in capture.visible_lines if line.strip()) > 0
+            assert "Metrics" in text
+            assert "Fleet" in text
+            assert "no snapshot" in text
+
+            release_gather.set()
+            for _ in range(20):
+                await asyncio.sleep(0.05)
+                if "Workers:" in smoke.snapshot().rendered_text:
+                    break
+            else:
+                pytest.fail("metrics gather did not repaint populated rows")
+
+    _run(body())
+
+
 # ---------------------------------------------------------------------------
 # 2. Fleet counts line up with synthetic task/worker data
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1300

Metrics now paints its shell immediately on mount and gathers the live snapshot in a background worker, so a slow or locked live metrics read cannot leave the cockpit right pane blank. Added a regression test that blocks metrics gather and asserts the 189x80 pane still shows Metrics, section headings, and then repaints populated rows.

Layer self-audit: touched UI-only metrics pane rendering and its UI smoke test; no facade, domain, store, or boundary-crossing changes.