### PR TITLE
Fix #1292 keep chat failure out of prompt

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -115,7 +115,10 @@ _RIGHT_PANE_TMUX_KEY_TOKENS: dict[str, str] = {
     "<end>": "End",
     "end": "End",
 }
-_LIVE_CHAT_NETWORK_DEAD_MESSAGE_PREFIX = "PollyPM chat failed"
+_LIVE_CHAT_NETWORK_DEAD_MESSAGE = (
+    "PollyPM chat failed: network unreachable. "
+    "Input cleared; check connection and try again."
+)
 
 
 def _is_help_key(key: str) -> bool:
@@ -366,18 +369,20 @@ def _live_chat_submit_blocked_by_network_dead(
         )
 
         raise_if_network_dead(config_path, surface="cockpit live chat submit")
-    except SimulatedNetworkDead as exc:
+    except SimulatedNetworkDead:
         tmux = getattr(router, "tmux", None)
         if tmux is not None:
             run = getattr(tmux, "run", None)
             if callable(run):
                 run("send-keys", "-t", right_pane, "C-u", check=False)
-            send_keys = getattr(tmux, "send_keys", None)
-            if callable(send_keys):
-                send_keys(
+                run(
+                    "display-message",
+                    "-d",
+                    "5000",
+                    "-t",
                     right_pane,
-                    f"{_LIVE_CHAT_NETWORK_DEAD_MESSAGE_PREFIX}: {exc}",
-                    press_enter=False,
+                    _LIVE_CHAT_NETWORK_DEAD_MESSAGE,
+                    check=False,
                 )
         return True
     return False

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -744,11 +744,15 @@ def test_cockpit_send_key_enter_consumes_network_dead_for_live_right_pane(
     assert router.tmux.calls == [
         ("run", "send-keys", "-t", "%2", "C-u", {"check": False}),
         (
-            "send_keys",
+            "run",
+            "display-message",
+            "-d",
+            "5000",
+            "-t",
             "%2",
-            "PollyPM chat failed: network unreachable (simulated): "
-            "connection refused for cockpit live chat submit",
-            False,
+            "PollyPM chat failed: network unreachable. "
+            "Input cleared; check connection and try again.",
+            {"check": False},
         ),
     ]
 


### PR DESCRIPTION
Closes #1292

Clears the live chat prompt on simulated network-dead submit and surfaces the failure via a tmux display message with a recovery hint instead of typing the error into the provider input. The user can type the next recovery attempt into a fresh prompt, and the dev-only simulated marker text is no longer rendered to the chat prompt.

Layer audit: UI/CLI only. Touched the cockpit send-key bridge in src/pollypm/cli_features/ui.py and focused regression coverage in tests/test_cockpit_input_bridge.py; no facade, domain, or store changes.