### PR TITLE
Fix #1298 activate Inbox pane navigation

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -1041,6 +1041,7 @@ class PollyCockpitApp(App[None]):
         # or a modal that just dismissed) intercepts the keystroke and
         # the rail's cursor stops moving — the user has to Tab back
         # to the nav before navigation responds again.
+        Binding("right", "focus_inbox_pane_nav", "Inbox pane", show=False, priority=True),
         Binding("j,down", "cursor_down", "Down", show=False, priority=True),
         Binding("k,up", "cursor_up", "Up", show=False, priority=True),
         Binding("g,home", "cursor_first", "First", show=False, priority=True),
@@ -1087,6 +1088,7 @@ class PollyCockpitApp(App[None]):
         "cursor_up",             # k, up
         "cursor_first",          # g, home
         "cursor_last",           # G, end
+        "focus_inbox_pane_nav",  # right
         "forward_tab_to_right",  # tab
         "forward_action_button_1",
         "forward_action_button_2",
@@ -1120,6 +1122,7 @@ class PollyCockpitApp(App[None]):
         "cursor_up",             # k, up
         "cursor_first",          # g, home
         "cursor_last",           # G, end
+        "focus_inbox_pane_nav",  # right
         "forward_tab_to_right",  # tab
         "forward_action_button_1",
         "forward_action_button_2",
@@ -1771,6 +1774,15 @@ class PollyCockpitApp(App[None]):
             return self._send_key_to_right_pane(key)
         except Exception:  # noqa: BLE001
             return False
+
+    def _activate_inbox_pane_nav(self, *, focus_pane: bool = False) -> bool:
+        """Let the mounted Inbox pane own row-navigation keys."""
+        if not self._on_inbox_surface():
+            return False
+        self._set_inbox_pane_nav_active(True)
+        if focus_pane:
+            self._focus_right_pane()
+        return True
 
     def _cancel_pending_route_selection(self) -> None:
         controller = getattr(self, "_navigation_controller", None)
@@ -2605,6 +2617,9 @@ class PollyCockpitApp(App[None]):
         key = self._selected_open_key()
         if key is None:
             return
+        inbox_nav_requested = key == "inbox" or key.startswith("inbox:")
+        if inbox_nav_requested:
+            self._set_inbox_pane_nav_active(True)
         self._schedule_route_selected(key, label=key)
 
     def action_open_settings(self) -> None:
@@ -2854,6 +2869,8 @@ class PollyCockpitApp(App[None]):
                 self._refresh_rows()
             except Exception:  # noqa: BLE001
                 pass
+            if self._on_inbox_surface() and self._inbox_pane_owns_nav():
+                self._focus_right_pane()
 
         try:
             self.call_from_thread(_apply)
@@ -2890,10 +2907,15 @@ class PollyCockpitApp(App[None]):
             _apply()
 
     def action_forward_tab_to_right(self) -> None:
+        if self._activate_inbox_pane_nav(focus_pane=True):
+            return
         if self._right_pane_has_live_session():
             self._focus_right_pane()
             return
         self._send_key_to_right_pane("Tab")
+
+    def action_focus_inbox_pane_nav(self) -> None:
+        self._activate_inbox_pane_nav(focus_pane=True)
 
     def action_forward_workers_auto_refresh(self) -> None:
         if self._on_inbox_surface():
@@ -2971,6 +2993,11 @@ class PollyCockpitApp(App[None]):
         via capital ``Q`` / ``Ctrl-Q``. Off a project surface this is
         a no-op (Esc still routes to Home everywhere).
         """
+        if self._inbox_pane_owns_nav():
+            if self._send_key_to_inbox_pane("q"):
+                return
+            self._set_inbox_pane_nav_active(False)
+            return
         if self._on_project_surface():
             self._send_key_to_right_pane("q")
 
@@ -3083,6 +3110,11 @@ class PollyCockpitApp(App[None]):
     def action_back_to_home(self) -> None:
         if self._inbox_filter_input_active():
             self._send_key_to_inbox_pane("escape")
+            return
+        if self._inbox_pane_owns_nav():
+            if self._send_key_to_inbox_pane("escape"):
+                return
+            self._set_inbox_pane_nav_active(False)
             return
         if self._right_pane_has_live_session():
             return_key = self._mounted_return_key()

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -5454,6 +5454,63 @@ class _InboxNavRouter:
         self.persisted.append(key)
 
 
+def test_cockpit_inbox_tab_right_and_enter_activate_pane_nav() -> None:
+    """#1298: explicit Inbox focus keys make j/k drive the Inbox list."""
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+    router = _InboxNavRouter(active=False)
+    app.router = router  # type: ignore[assignment]
+    app.selected_key = "inbox"
+    app._items = [SimpleNamespace(key="inbox", selectable=True)]
+    app._selected_row_key = lambda: "inbox"  # type: ignore[method-assign]
+    app._right_pane_has_live_session = lambda: False  # type: ignore[method-assign]
+
+    focused: list[str] = []
+    sent_right: list[str] = []
+    routes: list[str] = []
+    app._focus_right_pane = lambda: focused.append("focus")  # type: ignore[method-assign]
+    app._send_key_to_right_pane = lambda key: sent_right.append(key)  # type: ignore[method-assign]
+    app._schedule_route_selected = (  # type: ignore[method-assign]
+        lambda key, *, label=None: routes.append(key)
+    )
+
+    app.action_forward_tab_to_right()
+    assert router.active is True
+    assert focused == ["focus"]
+    assert sent_right == []
+
+    router.active = False
+    app.action_focus_inbox_pane_nav()
+    assert router.active is True
+    assert focused == ["focus", "focus"]
+
+    router.active = False
+    app.action_open_selected()
+    assert router.active is True
+    assert routes == ["inbox"]
+
+
+def test_cockpit_escape_and_q_from_active_inbox_nav_return_to_inbox_pane() -> None:
+    """Bridge-delivered Esc/q should release Inbox nav through the Inbox app."""
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+    router = _InboxNavRouter(active=True)
+    app.router = router  # type: ignore[assignment]
+    app.selected_key = "inbox"
+
+    forwarded: list[str] = []
+    navigated: list[str] = []
+    app._send_key_to_inbox_pane = (  # type: ignore[method-assign]
+        lambda key: forwarded.append(key) or True
+    )
+    app._right_pane_has_live_session = lambda: False  # type: ignore[method-assign]
+    app._navigate_home = lambda: navigated.append("home") or True  # type: ignore[method-assign]
+
+    app.action_back_to_home()
+    app.action_forward_project_home()
+
+    assert forwarded == ["escape", "q"]
+    assert navigated == []
+
+
 def test_cockpit_jk_from_inbox_forwards_to_inbox_pane() -> None:
     """#1137/#1238: active Inbox owns row-navigation keys."""
     app = PollyCockpitApp.__new__(PollyCockpitApp)


### PR DESCRIPTION
Closes #1298

Adds an explicit activation path for the mounted Inbox pane: Tab/right/Enter on Inbox mark the pane as owning row navigation, so subsequent j/k/arrows and bridge-delivered Esc/q can drive or release the Inbox instead of being trapped on the rail. Capital-I still opens Inbox with rail navigation active, preserving the #1272 behavior.

Layer self-audit: touched UI/CLI surface only (PollyCockpitApp focus/key ownership and cockpit UI tests). No store/domain imports or boundary crossings.