### PR TITLE
Fix #1309 isolate pytest error log

### DIFF
--- a/src/pollypm/error_log.py
+++ b/src/pollypm/error_log.py
@@ -65,6 +65,10 @@ class _ProcessTagFilter(logging.Filter):
 
 def _log_path() -> Path:
     """~/.pollypm/errors.log — mirrors the DEFAULT_CONFIG_PATH convention."""
+    override = os.environ.get("POLLYPM_ERROR_LOG_PATH")
+    if override:
+        return Path(override).expanduser()
+
     from pollypm.config import DEFAULT_CONFIG_PATH
 
     return Path(DEFAULT_CONFIG_PATH).parent / DEFAULT_LOG_FILENAME

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ Module-specific fixtures live beside their tests.
 from __future__ import annotations
 
 import os
+import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -25,6 +27,14 @@ def pytest_configure(config):  # noqa: ARG001
     os.environ.setdefault("POLLYPM_SKIP_RAIL_DAEMON", "1")
     os.environ.setdefault("POLLYPM_DISABLE_ERROR_NOTIFICATIONS", "1")
     os.environ.setdefault("POLLYPM_DISABLE_AGENTIC_REVIEW_SUMMARIES", "1")
+    os.environ.setdefault(
+        "POLLYPM_ERROR_LOG_PATH",
+        str(
+            Path(tempfile.gettempdir())
+            / f"pollypm-pytest-{os.getpid()}"
+            / "errors.log"
+        ),
+    )
     # Tests build their config in pytest tmp dirs but ``state_db``
     # defaults to ``~/.pollypm/state.db`` on the dev machine — which
     # may legitimately have pending migrations. Skip the refuse-start

--- a/tests/test_error_notifications.py
+++ b/tests/test_error_notifications.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from pollypm.error_log import install
+from pollypm.error_log import install, path
 from pollypm.error_notifications import (
     CriticalErrorNotificationHandler,
     build_critical_error_notification,
@@ -145,6 +145,16 @@ def test_install_adds_notification_handler_once(tmp_path: Path, monkeypatch) -> 
                 pass
         root.handlers = old_handlers
         root.setLevel(old_level)
+
+
+def test_error_log_path_honors_env_override(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    target = tmp_path / "pytest-errors.log"
+    monkeypatch.setenv("POLLYPM_ERROR_LOG_PATH", str(target))
+
+    assert path() == target
 
 
 def test_install_can_disable_durable_error_notifications(


### PR DESCRIPTION
Closes #1309

Adds a POLLYPM_ERROR_LOG_PATH override for the centralized error log and points pytest at a process-local temp errors.log before test collection, so negative-path tests no longer write tracebacks into ~/.pollypm/errors.log.

Self-audit: touched logging infrastructure and pytest configuration only; no UI, facade, domain, store, or cross-layer imports changed.

Tests:
- uv run --extra dev pytest tests/test_launch_executor.py tests/test_error_notifications.py
- uv run --extra dev ruff check src/pollypm/error_log.py tests/conftest.py tests/test_error_notifications.py