### PR TITLE
Fix #1306 consistent PM Chat rail label

### DIFF
--- a/src/pollypm/plugins_builtin/core_rail_items/plugin.py
+++ b/src/pollypm/plugins_builtin/core_rail_items/plugin.py
@@ -337,7 +337,7 @@ def _selected_key(ctx: RailContext) -> str:
     return str(value) if isinstance(value, str) and value else "polly"
 
 
-def _project_chat_persona(project: Any, session_role: Any) -> str | None:
+def _project_chat_persona(project: Any, session_role: Any) -> str:
     if isinstance(session_role, str) and session_role.strip():
         try:
             from pollypm.role_contract import canonical_role, persona_for
@@ -351,7 +351,7 @@ def _project_chat_persona(project: Any, session_role: Any) -> str | None:
     return (
         persona_raw.strip()
         if isinstance(persona_raw, str) and persona_raw.strip()
-        else None
+        else "Project PM"
     )
 
 
@@ -407,7 +407,7 @@ def _project_rows(ctx: RailContext) -> list[RailRow]:
                 state="sub",
             ))
             persona = _project_chat_persona(project, session_role)
-            label = f"  PM Chat ({persona})" if persona else "  PM Chat"
+            label = f"  PM Chat ({persona})"
             rows.append(RailRow(
                 key=f"project:{project_key}:session",
                 label=label,

--- a/tests/test_core_rail_items.py
+++ b/tests/test_core_rail_items.py
@@ -141,6 +141,43 @@ def test_pm_chat_label_matches_project_session_persona(
     assert session_row.label == expected_label
 
 
+def test_pm_chat_label_uses_project_pm_fallback(monkeypatch, tmp_path: Path) -> None:
+    project = KnownProject(
+        key="booktalk",
+        path=tmp_path,
+        name="Booktalk",
+        persona_name=None,
+        kind=ProjectKind.GIT,
+    )
+    config = type("Config", (), {"projects": {"booktalk": project}})()
+
+    class _Router:
+        def _session_state(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            return "idle"
+
+    monkeypatch.setattr(
+        core_rail_items_plugin,
+        "_classify_projects",
+        lambda ctx: ([("booktalk", project)], [], {"booktalk": False}),
+    )
+    monkeypatch.setattr(
+        core_rail_items_plugin,
+        "_active_task_numbers",
+        lambda project, *, config=None: [],
+    )
+    ctx = RailContext(
+        router=_Router(),
+        config=config,
+        launches=[],
+        cockpit_state={"selected": "project:booktalk"},
+    )
+
+    rows = core_rail_items_plugin._project_rows(ctx)
+
+    session_row = next(row for row in rows if row.key == "project:booktalk:session")
+    assert session_row.label == "  PM Chat (Project PM)"
+
+
 def _fake_supervisor(
     tmp_path: Path,
     *,


### PR DESCRIPTION
Closes #1306

Expanded project rail rows now always render the PM Chat label with a parenthesized PM name: architect sessions still show Archie, configured project personas still show their names, and projects without a configured persona fall back to Project PM.

Self-audit: touched the UI/plugin rail layer only (src/pollypm/plugins_builtin/core_rail_items/plugin.py) plus focused rail tests; no store, service facade, or domain imports added.