### PR TITLE
Fix #1301 human-readable task labels

### DIFF
--- a/src/pollypm/cockpit_tasks.py
+++ b/src/pollypm/cockpit_tasks.py
@@ -347,6 +347,34 @@ def _task_status_value(task) -> str:
     )
 
 
+_STATUS_DISPLAY_LABELS = {
+    "autoreview": "Auto review",
+    "blocked": "Blocked",
+    "cancelled": "Cancelled",
+    "done": "Done",
+    "draft": "Draft",
+    "in_progress": "In progress",
+    "on_hold": "On hold",
+    "queued": "Queued",
+    "review": "In review",
+    "rework": "Rework needed",
+    "user-review": "Needs review",
+    "waiting_on_plan": "Waiting on plan",
+}
+
+
+def _display_label(value: object, *, fallback: str = "—") -> str:
+    text = str(value or "").strip()
+    if not text:
+        return fallback
+    label = text.replace("_", " ").replace("-", " ")
+    return label[:1].upper() + label[1:]
+
+
+def _status_display_label(status: str) -> str:
+    return _STATUS_DISPLAY_LABELS.get(status, _display_label(status))
+
+
 def _task_sort_key(
     task,
     *,
@@ -371,16 +399,16 @@ def _format_stage_label(task, flow) -> str:
     if not node_id:
         return "—"
     if flow is None:
-        return str(node_id)
+        return _display_label(node_id)
     node = getattr(flow, "nodes", {}).get(node_id)
     if node is None:
-        return str(node_id)
-    parts = [str(node_id)]
+        return _display_label(node_id)
+    parts = [_display_label(getattr(node, "name", None) or node_id)]
     node_type = getattr(getattr(node, "type", None), "value", None) or getattr(
         node, "type", None
     )
     if node_type:
-        parts.append(str(node_type))
+        parts.append(_display_label(node_type))
     actor = (
         getattr(node, "actor_role", None)
         or getattr(node, "agent_name", None)
@@ -388,7 +416,7 @@ def _format_stage_label(task, flow) -> str:
         or getattr(node, "actor_type", None)
     )
     if actor:
-        parts.append(str(actor))
+        parts.append(_display_label(actor))
     return " · ".join(parts)
 
 
@@ -727,7 +755,7 @@ def _render_overview(
         ])
     lines.extend([
         "",
-        f"Status     {status_label}",
+        f"Status     {_status_display_label(status_label)}",
         f"Priority   {priority_label(task)}",
         f"Flow       {task.flow_template_id}",
         f"Stage      {_format_stage_label(task, flow)}",
@@ -1956,9 +1984,10 @@ class PollyTasksApp(App[None]):
             feedback = self._rejection_feedback_by_task_id.get(task.task_id)
             plan_blocked = task.task_id in self._plan_blocked_task_ids
             recently_pinged = task.task_id in self._recent_sweeper_ping_task_ids
-            status = _status_label(task, owner, plan_blocked=plan_blocked)
+            status_label = _status_label(task, owner, plan_blocked=plan_blocked)
+            status = _status_display_label(status_label)
             title = f"{priority_glyph(task)} {task.title}"
-            stage = task.current_node_id or "—"
+            stage = _display_label(task.current_node_id)
             task_number = f"#{task.task_number}"
             if task.task_id in self._selected_task_ids:
                 task_number = f"◉ {task_number}"
@@ -2090,7 +2119,10 @@ class PollyTasksApp(App[None]):
         icon = self._STATUS_ICONS.get(status_label, "·")
         header_bits = [
             f"{'🔄 ' if feedback is not None else ''}{icon} #{task.task_number} {priority_glyph(task)} {task.title}",
-            f"{status_label} · {_format_relative_age(task.updated_at or task.created_at)}",
+            (
+                f"{_status_display_label(status_label)} · "
+                f"{_format_relative_age(task.updated_at or task.created_at)}"
+            ),
         ]
         if recently_pinged:
             header_bits.append("Sweeper pinged in the last minute")

--- a/tests/test_tasks_ui.py
+++ b/tests/test_tasks_ui.py
@@ -463,7 +463,7 @@ def test_task_app_surfaces_stage_timestamps_and_live_session_tabs(env, monkeypat
             live = str(app.query_one("#task-live", Static).render())
             timeline_rows = _table_rows(app.query_one("#task-timeline", DataTable))
 
-            assert "Stage      synthesize · work · architect" in overview
+            assert "Stage      Synthesize · Work · Architect" in overview
             assert "Session    architect_polly_remote" in overview
             assert "Branch     demo-architect" in live
             assert "Peek" in live
@@ -680,7 +680,7 @@ def test_task_app_refresh_preserves_selected_task_and_updates_tabs(env, monkeypa
             await pilot.pause()
             first = str(app.query_one("#task-detail", Static).render())
             first_live = str(app.query_one("#task-live", Static).render())
-            assert "synthesize · work · architect" in first
+            assert "Synthesize · Work · Architect" in first
             assert "Still synthesizing" in first_live
 
             state["task"] = _task(
@@ -716,7 +716,7 @@ def test_task_app_refresh_preserves_selected_task_and_updates_tabs(env, monkeypa
             second_live = str(app.query_one("#task-live", Static).render())
             timeline_rows = _table_rows(app.query_one("#task-timeline", DataTable))
 
-            assert "critic_panel · review · reviewer" in second
+            assert "Critic Panel · Review · Reviewer" in second
             assert "Waiting on critic feedback" in second_live
             assert timeline_rows[-1][0] == "⟳ critic_panel"
             assert timeline_rows[-1][2] == "TS[17:20]"
@@ -1358,10 +1358,10 @@ def test_task_app_surfaces_unread_rejection_feedback(env, monkeypatch) -> None:
             overview = str(app.query_one("#task-detail", Static).render())
 
             assert len(rows) == 1
-            assert rows[0][1] == "in_progress"
+            assert rows[0][1] == "In progress"
             assert rows[0][2] == "🔄 🟠 Ship Notesy visibility"
-            assert rows[0][4] == "synthesize"
-            assert "in_progress" in header
+            assert rows[0][4] == "Synthesize"
+            assert "In progress" in header
             assert "Unread rejection feedback in inbox" in header
             assert overview.index("In plain English") < overview.index("Status")
             assert "This task has unread reviewer feedback in the inbox." in overview
@@ -1463,7 +1463,7 @@ def test_task_app_leads_user_review_with_plain_language_summary(
             header = str(app.query_one("#task-header", Static).render())
             overview = str(app.query_one("#task-detail", Static).render())
 
-            assert "user-review" in header
+            assert "Needs review" in header
             assert overview.index("In plain English") < overview.index("Status")
             assert "Review needed: the project plan is waiting" in overview
             assert "approve it or reject with the changes you need" in overview
@@ -1527,9 +1527,16 @@ def test_task_app_leads_on_hold_feedback_with_paused_review_summary(
             "Confidence: 6/10 — core is correct, but two gaps block approval."
         ),
     )
+    flow = _flow()
+    flow.nodes["code_review"] = FlowNode(
+        name="Code review",
+        type=NodeType.REVIEW,
+        actor_type=ActorType.ROLE,
+        actor_role="reviewer",
+    )
     fake_svc = _FakeSvc(
         tasks_factory=lambda: [work_task, feedback_task],
-        flow=_flow(),
+        flow=flow,
         context_by_id={("demo/1", None): work_task.context},
     )
 
@@ -1541,8 +1548,14 @@ def test_task_app_leads_on_hold_feedback_with_paused_review_summary(
     async def body() -> None:
         async with app.run_test(size=(140, 50)) as pilot:
             await pilot.pause()
+            rows = _table_rows(app.query_one("#tasks-table", DataTable))
+            header = str(app.query_one("#task-header", Static).render())
             overview = str(app.query_one("#task-detail", Static).render())
 
+            assert rows[0][1] == "On hold"
+            assert rows[0][4] == "Code review"
+            assert "On hold" in header
+            assert "on_hold" not in header
             assert overview.index("In plain English") < overview.index("Status")
             assert (
                 "You're being asked to approve two deviations from the original plan."
@@ -1550,6 +1563,62 @@ def test_task_app_leads_on_hold_feedback_with_paused_review_summary(
             assert "Browser requirement: strike browser use from v1" in overview
             assert "Eventbrite: move it to v2 so v1 can get to testing" in overview
             assert "Confidence: 6/10" in overview
+            assert "Status     On hold" in overview
+            assert "Stage      Code review · Review · Reviewer" in overview
+            assert "on_hold" not in overview
+            assert "code_review" not in overview
+
+    _run(body())
+
+
+def test_task_app_all_filter_uses_human_readable_status_labels(
+    env, monkeypatch,
+) -> None:
+    """#1301 — the Tasks table must not leak raw WorkStatus enum values."""
+    if not _load_config_compatible(env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_tasks import PollyTasksApp
+
+    on_hold = _task(
+        node_id="code_review",
+        title="Paused scraper work",
+        status=WorkStatus.ON_HOLD,
+    )
+    draft = _task(
+        task_number=2,
+        node_id="research",
+        title="Plan next milestone",
+        status=WorkStatus.DRAFT,
+    )
+    complete = _task(
+        task_number=3,
+        node_id="research",
+        title="Completed migration",
+        status=WorkStatus.DONE,
+    )
+    fake_svc = _FakeSvc(
+        tasks_factory=lambda: [draft, complete, on_hold],
+        flow=_flow(),
+    )
+
+    monkeypatch.setattr("pollypm.cockpit_tasks.create_tmux_client", lambda: _FakeTmux([]))
+
+    app = PollyTasksApp(env["config_path"], "demo")
+    app._get_svc = lambda: fake_svc  # type: ignore[method-assign]
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 50)) as pilot:
+            await pilot.pause()
+            app._status_filter = "all"
+            app._sync_filter_buttons()
+            app._render_table(select_first=True)
+            await pilot.pause()
+
+            rows = _table_rows(app.query_one("#tasks-table", DataTable))
+            assert [row[1] for row in rows] == ["On hold", "Draft", "Done"]
+            assert "on_hold" not in rows[0]
+            assert "draft" not in rows[1]
+            assert "done" not in rows[2]
 
     _run(body())
 
@@ -1593,12 +1662,12 @@ def test_task_app_keeps_autoreview_state_distinct_from_feedback_inbox(
             overview = str(app.query_one("#task-detail", Static).render())
 
             assert len(rows) == 1
-            assert rows[0][1] == "autoreview"
+            assert rows[0][1] == "Auto review"
             assert rows[0][2] == "🔄 🟠 Review Notesy visibility"
-            assert rows[0][4] == "critic_panel"
-            assert "autoreview" in header
+            assert rows[0][4] == "Critic panel"
+            assert "Auto review" in header
             assert "Unread rejection feedback in inbox" in header
-            assert "Status     autoreview" in overview
+            assert "Status     Auto review" in overview
             assert "Artifact   Unread rejection feedback (demo/99)" in overview
             assert "Need stronger rollout coverage before approval." in overview
 
@@ -1657,9 +1726,9 @@ def test_task_app_sorts_user_review_before_autoreview(
             rows = _table_rows(app.query_one("#tasks-table", DataTable))
 
             assert [row[1] for row in rows] == [
-                "user-review",
-                "user-review",
-                "autoreview",
+                "Needs review",
+                "Needs review",
+                "Auto review",
             ]
             assert [row[2] for row in rows] == [
                 "🟠 Human high-priority review",
@@ -1705,9 +1774,9 @@ def test_task_app_surfaces_plan_blocked_queued_tasks(env, monkeypatch) -> None:
             header = str(app.query_one("#task-header", Static).render())
             overview = str(app.query_one("#task-detail", Static).render())
 
-            assert rows[0][1] == "waiting_on_plan"
+            assert rows[0][1] == "Waiting on plan"
             assert rows[0][2] == "🟠 Implement planned child"
-            assert "waiting_on_plan" in header
+            assert "Waiting on plan" in header
             assert "Plan Gate" in overview
             assert "Approve    demo/2 · plan_project/user_approval" in overview
 
@@ -1753,10 +1822,10 @@ def test_task_app_honours_per_project_enforce_plan_false(env, monkeypatch) -> No
         async with app.run_test(size=(140, 50)) as pilot:
             await pilot.pause()
             rows = _table_rows(app.query_one("#tasks-table", DataTable))
-            # Without bypass this would render "waiting_on_plan" because
+            # Without bypass this would render "Waiting on plan" because
             # the project has no plan.md / approved plan_project task.
-            assert rows[0][1] == "queued", (
-                f"expected 'queued' with per-project bypass, got {rows[0][1]!r}"
+            assert rows[0][1] == "Queued", (
+                f"expected 'Queued' with per-project bypass, got {rows[0][1]!r}"
             )
 
     _run(body())
@@ -1838,7 +1907,7 @@ def test_task_app_clears_rejection_feedback_after_inbox_open(env, monkeypatch) -
             overview = str(app.query_one("#task-detail", Static).render())
 
             assert len(rows) == 1
-            assert rows[0][1] == "in_progress"
+            assert rows[0][1] == "In progress"
             assert rows[0][2] == "🟠 Ship Notesy visibility"
             assert "Inbox Feedback" not in overview
 


### PR DESCRIPTION
Closes #1301

Tasks view now keeps raw work-state values for logic but formats status and stage labels at the UI boundary, so table cells, detail headers, and detail Status/Stage rows render human-readable labels.

Self-audit: touched UI layer only (src/pollypm/cockpit_tasks.py) and focused UI tests (tests/test_tasks_ui.py); no facade, domain, store, or boundary changes.