### PR TITLE
Fix #1315 show network-dead chat failure

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -22,6 +22,7 @@ from pollypm.config import DEFAULT_CONFIG_PATH
 
 _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS = frozenset({"<esc>", "esc", "escape"})
 _LIVE_RIGHT_PANE_INPUT_STICKY = "live_right_pane_input_sticky"
+_LIVE_CHAT_NETWORK_DEAD_PROMPT_ACTIVE = "live_chat_network_dead_prompt_active"
 _HELP_MODAL_BRIDGE_KIND = "help_modal_bridge_kind"
 _HELP_MODAL_SELECTED_KEY = "help_modal_selected_key"
 _HELP_MODAL_OPENED_AT = "help_modal_opened_at"
@@ -117,7 +118,7 @@ _RIGHT_PANE_TMUX_KEY_TOKENS: dict[str, str] = {
 }
 _LIVE_CHAT_NETWORK_DEAD_MESSAGE = (
     "PollyPM chat failed: network unreachable. "
-    "Input cleared; check connection and try again."
+    "Type again to clear this and retry; check connection."
 )
 
 
@@ -375,17 +376,46 @@ def _live_chat_submit_blocked_by_network_dead(
             run = getattr(tmux, "run", None)
             if callable(run):
                 run("send-keys", "-t", right_pane, "C-u", check=False)
-                run(
-                    "display-message",
-                    "-d",
-                    "5000",
-                    "-t",
+            send_keys = getattr(tmux, "send_keys", None)
+            if callable(send_keys):
+                send_keys(
                     right_pane,
                     _LIVE_CHAT_NETWORK_DEAD_MESSAGE,
-                    check=False,
+                    press_enter=False,
                 )
+                _set_live_chat_network_dead_prompt_active(router, True)
         return True
     return False
+
+
+def _set_live_chat_network_dead_prompt_active(router: object, active: bool) -> None:
+    try:
+        load_state = getattr(router, "_load_state")
+        write_state = getattr(router, "_write_state")
+        state = load_state()
+        if not isinstance(state, dict):
+            return
+        if active:
+            if state.get(_LIVE_CHAT_NETWORK_DEAD_PROMPT_ACTIVE) is True:
+                return
+            state[_LIVE_CHAT_NETWORK_DEAD_PROMPT_ACTIVE] = True
+        else:
+            if _LIVE_CHAT_NETWORK_DEAD_PROMPT_ACTIVE not in state:
+                return
+            state.pop(_LIVE_CHAT_NETWORK_DEAD_PROMPT_ACTIVE, None)
+        write_state(state)
+    except Exception:  # noqa: BLE001
+        return
+
+
+def _live_chat_network_dead_prompt_active(router: object) -> bool:
+    try:
+        state = getattr(router, "_load_state")()
+    except Exception:  # noqa: BLE001
+        return False
+    if not isinstance(state, dict):
+        return False
+    return state.get(_LIVE_CHAT_NETWORK_DEAD_PROMPT_ACTIVE) is True
 
 
 def _set_live_right_pane_input_sticky(router: object, active: bool) -> None:
@@ -446,6 +476,22 @@ def _sticky_live_right_pane_id(router: object) -> str | None:
     return right_pane_id
 
 
+def _clear_live_chat_network_dead_prompt(
+    router: object,
+    right_pane: str,
+    event: tuple[str, bool],
+) -> bool:
+    if not _live_chat_network_dead_prompt_active(router):
+        return False
+    tmux = getattr(router, "tmux", None)
+    run = getattr(tmux, "run", None) if tmux is not None else None
+    if callable(run):
+        run("send-keys", "-t", right_pane, "C-u", check=False)
+    _set_live_chat_network_dead_prompt_active(router, False)
+    value, literal = event
+    return not literal and value in {"Enter", "BSpace"}
+
+
 def _send_key_to_active_live_right_pane(config_path: Path, key: str) -> str | None:
     """Deliver ``key`` to the focused live right pane, if one owns focus."""
     try:
@@ -456,6 +502,10 @@ def _send_key_to_active_live_right_pane(config_path: Path, key: str) -> str | No
     except Exception:  # noqa: BLE001
         return None
     if key.strip().lower() in _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS:
+        if right_pane is None:
+            right_pane = _sticky_live_right_pane_id(router)
+        if right_pane is not None:
+            _clear_live_chat_network_dead_prompt(router, right_pane, ("Escape", False))
         _set_live_right_pane_input_sticky(router, False)
         return None
     if right_pane is None:
@@ -470,6 +520,9 @@ def _send_key_to_active_live_right_pane(config_path: Path, key: str) -> str | No
     ):
         return right_pane
     value, literal = event
+    if _clear_live_chat_network_dead_prompt(router, right_pane, event):
+        _set_live_right_pane_input_sticky(router, True)
+        return right_pane
     if literal:
         router.tmux.send_keys(right_pane, value, press_enter=False)
     else:

--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -18,11 +18,15 @@ from pathlib import Path
 
 import typer
 
+from pollypm.cockpit_live_chat_notice import (
+    LIVE_CHAT_NETWORK_DEAD_TMUX_DISPLAY_MS,
+    LIVE_CHAT_NETWORK_DEAD_TMUX_MESSAGE,
+    install_live_chat_network_dead_notice,
+)
 from pollypm.config import DEFAULT_CONFIG_PATH
 
 _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS = frozenset({"<esc>", "esc", "escape"})
 _LIVE_RIGHT_PANE_INPUT_STICKY = "live_right_pane_input_sticky"
-_LIVE_CHAT_NETWORK_DEAD_PROMPT_ACTIVE = "live_chat_network_dead_prompt_active"
 _HELP_MODAL_BRIDGE_KIND = "help_modal_bridge_kind"
 _HELP_MODAL_SELECTED_KEY = "help_modal_selected_key"
 _HELP_MODAL_OPENED_AT = "help_modal_opened_at"
@@ -116,12 +120,6 @@ _RIGHT_PANE_TMUX_KEY_TOKENS: dict[str, str] = {
     "<end>": "End",
     "end": "End",
 }
-_LIVE_CHAT_NETWORK_DEAD_MESSAGE = (
-    "PollyPM chat failed: network unreachable. "
-    "Type again to clear this and retry; check connection."
-)
-
-
 def _is_help_key(key: str) -> bool:
     return key.strip().lower() in _HELP_KEY_TOKENS
 
@@ -376,46 +374,18 @@ def _live_chat_submit_blocked_by_network_dead(
             run = getattr(tmux, "run", None)
             if callable(run):
                 run("send-keys", "-t", right_pane, "C-u", check=False)
-            send_keys = getattr(tmux, "send_keys", None)
-            if callable(send_keys):
-                send_keys(
+                run(
+                    "display-message",
+                    "-d",
+                    LIVE_CHAT_NETWORK_DEAD_TMUX_DISPLAY_MS,
+                    "-t",
                     right_pane,
-                    _LIVE_CHAT_NETWORK_DEAD_MESSAGE,
-                    press_enter=False,
+                    LIVE_CHAT_NETWORK_DEAD_TMUX_MESSAGE,
+                    check=False,
                 )
-                _set_live_chat_network_dead_prompt_active(router, True)
+        install_live_chat_network_dead_notice(router)
         return True
     return False
-
-
-def _set_live_chat_network_dead_prompt_active(router: object, active: bool) -> None:
-    try:
-        load_state = getattr(router, "_load_state")
-        write_state = getattr(router, "_write_state")
-        state = load_state()
-        if not isinstance(state, dict):
-            return
-        if active:
-            if state.get(_LIVE_CHAT_NETWORK_DEAD_PROMPT_ACTIVE) is True:
-                return
-            state[_LIVE_CHAT_NETWORK_DEAD_PROMPT_ACTIVE] = True
-        else:
-            if _LIVE_CHAT_NETWORK_DEAD_PROMPT_ACTIVE not in state:
-                return
-            state.pop(_LIVE_CHAT_NETWORK_DEAD_PROMPT_ACTIVE, None)
-        write_state(state)
-    except Exception:  # noqa: BLE001
-        return
-
-
-def _live_chat_network_dead_prompt_active(router: object) -> bool:
-    try:
-        state = getattr(router, "_load_state")()
-    except Exception:  # noqa: BLE001
-        return False
-    if not isinstance(state, dict):
-        return False
-    return state.get(_LIVE_CHAT_NETWORK_DEAD_PROMPT_ACTIVE) is True
 
 
 def _set_live_right_pane_input_sticky(router: object, active: bool) -> None:
@@ -476,22 +446,6 @@ def _sticky_live_right_pane_id(router: object) -> str | None:
     return right_pane_id
 
 
-def _clear_live_chat_network_dead_prompt(
-    router: object,
-    right_pane: str,
-    event: tuple[str, bool],
-) -> bool:
-    if not _live_chat_network_dead_prompt_active(router):
-        return False
-    tmux = getattr(router, "tmux", None)
-    run = getattr(tmux, "run", None) if tmux is not None else None
-    if callable(run):
-        run("send-keys", "-t", right_pane, "C-u", check=False)
-    _set_live_chat_network_dead_prompt_active(router, False)
-    value, literal = event
-    return not literal and value in {"Enter", "BSpace"}
-
-
 def _send_key_to_active_live_right_pane(config_path: Path, key: str) -> str | None:
     """Deliver ``key`` to the focused live right pane, if one owns focus."""
     try:
@@ -504,8 +458,6 @@ def _send_key_to_active_live_right_pane(config_path: Path, key: str) -> str | No
     if key.strip().lower() in _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS:
         if right_pane is None:
             right_pane = _sticky_live_right_pane_id(router)
-        if right_pane is not None:
-            _clear_live_chat_network_dead_prompt(router, right_pane, ("Escape", False))
         _set_live_right_pane_input_sticky(router, False)
         return None
     if right_pane is None:
@@ -520,9 +472,6 @@ def _send_key_to_active_live_right_pane(config_path: Path, key: str) -> str | No
     ):
         return right_pane
     value, literal = event
-    if _clear_live_chat_network_dead_prompt(router, right_pane, event):
-        _set_live_right_pane_input_sticky(router, True)
-        return right_pane
     if literal:
         router.tmux.send_keys(right_pane, value, press_enter=False)
     else:

--- a/src/pollypm/cockpit_live_chat_notice.py
+++ b/src/pollypm/cockpit_live_chat_notice.py
@@ -1,0 +1,106 @@
+"""Transient cockpit notices for live chat failures.
+
+The cockpit-send-key bridge runs in a short-lived CLI process, while the
+visible rail is a separate Textual process. This module keeps the tiny shared
+state contract for non-input live-chat notices in one place.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+
+LIVE_CHAT_NETWORK_DEAD_PROMPT_ACTIVE_KEY = "live_chat_network_dead_prompt_active"
+LIVE_CHAT_NETWORK_DEAD_NOTICE_MESSAGE_KEY = "live_chat_network_dead_notice_message"
+LIVE_CHAT_NETWORK_DEAD_NOTICE_UNTIL_KEY = "live_chat_network_dead_notice_until"
+LIVE_CHAT_NETWORK_DEAD_NOTICE_TTL_SECONDS = 10.0
+LIVE_CHAT_NETWORK_DEAD_TMUX_DISPLAY_MS = "10000"
+LIVE_CHAT_NETWORK_DEAD_TMUX_MESSAGE = (
+    "PollyPM chat failed: network unreachable. "
+    "Retry after checking connection."
+)
+LIVE_CHAT_NETWORK_DEAD_RAIL_MESSAGE = "Chat failed: retry/check net"
+
+
+def install_live_chat_network_dead_notice(
+    router: object,
+    *,
+    now: float | None = None,
+) -> None:
+    """Persist a transient rail notice without touching the live chat input."""
+    try:
+        load_state = getattr(router, "_load_state")
+        write_state = getattr(router, "_write_state")
+        state = load_state()
+        if not isinstance(state, dict):
+            return
+        deadline = (time.time() if now is None else now) + (
+            LIVE_CHAT_NETWORK_DEAD_NOTICE_TTL_SECONDS
+        )
+        state[LIVE_CHAT_NETWORK_DEAD_NOTICE_MESSAGE_KEY] = (
+            LIVE_CHAT_NETWORK_DEAD_RAIL_MESSAGE
+        )
+        state[LIVE_CHAT_NETWORK_DEAD_NOTICE_UNTIL_KEY] = deadline
+        state.pop(LIVE_CHAT_NETWORK_DEAD_PROMPT_ACTIVE_KEY, None)
+        write_state(state)
+    except Exception:  # noqa: BLE001
+        return
+    _bump_state_epoch()
+
+
+def current_live_chat_network_dead_notice(
+    state: Mapping[str, object],
+    *,
+    now: float | None = None,
+) -> str | None:
+    message = state.get(LIVE_CHAT_NETWORK_DEAD_NOTICE_MESSAGE_KEY)
+    until = state.get(LIVE_CHAT_NETWORK_DEAD_NOTICE_UNTIL_KEY)
+    if not isinstance(message, str) or not message:
+        return None
+    try:
+        deadline = float(until)
+    except (TypeError, ValueError):
+        return None
+    if deadline <= (time.time() if now is None else now):
+        return None
+    return message
+
+
+def live_chat_network_dead_notice_present(state: Mapping[str, object]) -> bool:
+    return (
+        LIVE_CHAT_NETWORK_DEAD_NOTICE_MESSAGE_KEY in state
+        or LIVE_CHAT_NETWORK_DEAD_NOTICE_UNTIL_KEY in state
+    )
+
+
+def clear_live_chat_network_dead_notice(router: object) -> None:
+    try:
+        load_state = getattr(router, "_load_state")
+        write_state = getattr(router, "_write_state")
+        state = load_state()
+        if not isinstance(state, dict):
+            return
+        changed = False
+        for key in (
+            LIVE_CHAT_NETWORK_DEAD_NOTICE_MESSAGE_KEY,
+            LIVE_CHAT_NETWORK_DEAD_NOTICE_UNTIL_KEY,
+            LIVE_CHAT_NETWORK_DEAD_PROMPT_ACTIVE_KEY,
+        ):
+            if key in state:
+                state.pop(key, None)
+                changed = True
+        if not changed:
+            return
+        write_state(state)
+    except Exception:  # noqa: BLE001
+        return
+    _bump_state_epoch()
+
+
+def _bump_state_epoch() -> None:
+    try:
+        from pollypm.state_epoch import bump
+
+        bump()
+    except Exception:  # noqa: BLE001
+        return

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -78,6 +78,12 @@ from pollypm.cockpit_inbox_items import (
     message_row_to_inbox_entry,
     task_to_inbox_entry,
 )
+from pollypm.cockpit_live_chat_notice import (
+    LIVE_CHAT_NETWORK_DEAD_TMUX_MESSAGE,
+    clear_live_chat_network_dead_notice,
+    current_live_chat_network_dead_notice,
+    live_chat_network_dead_notice_present,
+)
 from pollypm.cockpit_metrics import (  # noqa: F401  (re-exported)
     PollyMetricsApp,
     _MetricsDrillDownModal,
@@ -1234,6 +1240,7 @@ class PollyCockpitApp(App[None]):
             window_manager=_CockpitRouteWindowApplier(self),
         )
         self._route_status_hint: str | None = None
+        self._transient_notice_active = False
 
     def compose(self) -> ComposeResult:
         with Vertical():
@@ -1251,6 +1258,7 @@ class PollyCockpitApp(App[None]):
         self._refresh_rows()
         self._update_ticker()
         self._update_pill_refresh()
+        self._update_transient_notice()
         self.set_interval(0.8, self._tick)
         self.set_interval(self.SCHEDULER_POLL_INTERVAL_SECONDS, self._tick_scheduler)
         self.nav.focus()
@@ -1891,6 +1899,7 @@ class PollyCockpitApp(App[None]):
         # feedback loop from "upgrade complete" → visible notice is
         # sub-second.
         self._check_post_upgrade_flag()
+        self._update_transient_notice()
         # Layout check much less frequently
         if self._tick_count % self._LAYOUT_CHECK_INTERVAL == 0:
             try:
@@ -2217,6 +2226,27 @@ class PollyCockpitApp(App[None]):
         ticker_text = self._event_ticker_text()
         self.ticker.update(ticker_text)
         self.ticker.display = bool(ticker_text)
+
+    def _update_transient_notice(self) -> bool:
+        try:
+            state = self.router._load_state()
+        except Exception:  # noqa: BLE001
+            return False
+        notice = current_live_chat_network_dead_notice(state)
+        if notice is None:
+            if live_chat_network_dead_notice_present(state):
+                clear_live_chat_network_dead_notice(self.router)
+            if self._transient_notice_active:
+                self._transient_notice_active = False
+                self.update_pill.tooltip = None
+                self.update_pill.display = False
+                self._update_pill_refresh()
+            return False
+        self._transient_notice_active = True
+        self.update_pill.tooltip = LIVE_CHAT_NETWORK_DEAD_TMUX_MESSAGE
+        self.update_pill.update(f"[#ff5f6d]{_escape(notice)}[/]")
+        self.update_pill.display = True
+        return True
 
     def _update_pill_refresh(self) -> None:
         """Refresh the update-available pill in the rail top area.

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -726,9 +726,16 @@ def test_cockpit_send_key_enter_consumes_network_dead_for_live_right_pane(
     class FakeRouter:
         def __init__(self) -> None:
             self.tmux = FakeTmux()
+            self.state: dict[str, object] = {}
 
         def active_live_right_pane_id(self) -> str:
             return "%2"
+
+        def _load_state(self) -> dict[str, object]:
+            return dict(self.state)
+
+        def _write_state(self, state: dict[str, object]) -> None:
+            self.state = dict(state)
 
     router = FakeRouter()
     monkeypatch.setattr(cockpit_rail, "CockpitRouter", lambda _path: router)
@@ -744,17 +751,66 @@ def test_cockpit_send_key_enter_consumes_network_dead_for_live_right_pane(
     assert router.tmux.calls == [
         ("run", "send-keys", "-t", "%2", "C-u", {"check": False}),
         (
-            "run",
-            "display-message",
-            "-d",
-            "5000",
-            "-t",
+            "send_keys",
             "%2",
             "PollyPM chat failed: network unreachable. "
-            "Input cleared; check connection and try again.",
-            {"check": False},
+            "Type again to clear this and retry; check connection.",
+            False,
         ),
     ]
+    assert router.state["live_chat_network_dead_prompt_active"] is True
+
+
+def test_cockpit_send_key_after_network_dead_prompt_clears_before_typing(
+    valid_cockpit_config: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import pollypm.cockpit_rail as cockpit_rail
+    from pollypm.cli_features import ui as ui_commands
+
+    class FakeTmux:
+        def __init__(self) -> None:
+            self.calls: list[tuple[object, ...]] = []
+
+        def run(self, *args: object, **kwargs: object) -> None:
+            self.calls.append(("run", *args, kwargs))
+
+        def send_keys(
+            self, target: str, text: str, *, press_enter: bool = True,
+        ) -> None:
+            self.calls.append(("send_keys", target, text, press_enter))
+
+    class FakeRouter:
+        def __init__(self) -> None:
+            self.tmux = FakeTmux()
+            self.state = {
+                "mounted_session": "operator",
+                "right_pane_id": "%2",
+                "live_right_pane_input_sticky": True,
+                "live_chat_network_dead_prompt_active": True,
+            }
+
+        def active_live_right_pane_id(self) -> str:
+            return "%2"
+
+        def _load_state(self) -> dict[str, object]:
+            return dict(self.state)
+
+        def _write_state(self, state: dict[str, object]) -> None:
+            self.state = dict(state)
+
+    router = FakeRouter()
+    monkeypatch.setattr(cockpit_rail, "CockpitRouter", lambda _path: router)
+
+    delivered = ui_commands._send_key_to_active_live_right_pane(
+        valid_cockpit_config, "h",
+    )
+
+    assert delivered == "%2"
+    assert router.tmux.calls == [
+        ("run", "send-keys", "-t", "%2", "C-u", {"check": False}),
+        ("send_keys", "%2", "h", False),
+    ]
+    assert "live_chat_network_dead_prompt_active" not in router.state
 
 
 def test_cockpit_send_key_keeps_live_right_pane_sticky_after_first_char(
@@ -843,6 +899,7 @@ def test_cockpit_send_key_escape_clears_live_right_pane_sticky(
                 "mounted_session": "architect_demo",
                 "right_pane_id": "%2",
                 "live_right_pane_input_sticky": True,
+                "live_chat_network_dead_prompt_active": True,
             }
 
         def active_live_right_pane_id(self) -> str | None:
@@ -861,6 +918,7 @@ def test_cockpit_send_key_escape_clears_live_right_pane_sticky(
         valid_cockpit_config, "<esc>",
     ) is None
     assert "live_right_pane_input_sticky" not in router.state
+    assert "live_chat_network_dead_prompt_active" not in router.state
 
 
 def test_send_key_to_first_live_skips_stale_sockets(fake_config: Path, tmp_path: Path) -> None:

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -708,6 +708,13 @@ def test_cockpit_send_key_enter_consumes_network_dead_for_live_right_pane(
     valid_cockpit_config: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import pollypm.cockpit_rail as cockpit_rail
+    from pollypm.cockpit_live_chat_notice import (
+        LIVE_CHAT_NETWORK_DEAD_NOTICE_MESSAGE_KEY,
+        LIVE_CHAT_NETWORK_DEAD_NOTICE_UNTIL_KEY,
+        LIVE_CHAT_NETWORK_DEAD_RAIL_MESSAGE,
+        LIVE_CHAT_NETWORK_DEAD_TMUX_MESSAGE,
+        LIVE_CHAT_NETWORK_DEAD_TMUX_DISPLAY_MS,
+    )
     from pollypm.cli_features import ui as ui_commands
     from pollypm.dev_network_simulation import arm_network_dead, network_dead_armed
 
@@ -751,20 +758,32 @@ def test_cockpit_send_key_enter_consumes_network_dead_for_live_right_pane(
     assert router.tmux.calls == [
         ("run", "send-keys", "-t", "%2", "C-u", {"check": False}),
         (
-            "send_keys",
+            "run",
+            "display-message",
+            "-d",
+            LIVE_CHAT_NETWORK_DEAD_TMUX_DISPLAY_MS,
+            "-t",
             "%2",
-            "PollyPM chat failed: network unreachable. "
-            "Type again to clear this and retry; check connection.",
-            False,
+            LIVE_CHAT_NETWORK_DEAD_TMUX_MESSAGE,
+            {"check": False},
         ),
     ]
-    assert router.state["live_chat_network_dead_prompt_active"] is True
+    assert router.state[LIVE_CHAT_NETWORK_DEAD_NOTICE_MESSAGE_KEY] == (
+        LIVE_CHAT_NETWORK_DEAD_RAIL_MESSAGE
+    )
+    assert router.state[LIVE_CHAT_NETWORK_DEAD_NOTICE_UNTIL_KEY] > time.time()
+    assert "live_chat_network_dead_prompt_active" not in router.state
 
 
-def test_cockpit_send_key_after_network_dead_prompt_clears_before_typing(
+def test_cockpit_send_key_after_network_dead_notice_forwards_typing(
     valid_cockpit_config: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import pollypm.cockpit_rail as cockpit_rail
+    from pollypm.cockpit_live_chat_notice import (
+        LIVE_CHAT_NETWORK_DEAD_NOTICE_MESSAGE_KEY,
+        LIVE_CHAT_NETWORK_DEAD_NOTICE_UNTIL_KEY,
+        LIVE_CHAT_NETWORK_DEAD_RAIL_MESSAGE,
+    )
     from pollypm.cli_features import ui as ui_commands
 
     class FakeTmux:
@@ -786,7 +805,10 @@ def test_cockpit_send_key_after_network_dead_prompt_clears_before_typing(
                 "mounted_session": "operator",
                 "right_pane_id": "%2",
                 "live_right_pane_input_sticky": True,
-                "live_chat_network_dead_prompt_active": True,
+                LIVE_CHAT_NETWORK_DEAD_NOTICE_MESSAGE_KEY: (
+                    LIVE_CHAT_NETWORK_DEAD_RAIL_MESSAGE
+                ),
+                LIVE_CHAT_NETWORK_DEAD_NOTICE_UNTIL_KEY: time.time() + 10,
             }
 
         def active_live_right_pane_id(self) -> str:
@@ -807,10 +829,11 @@ def test_cockpit_send_key_after_network_dead_prompt_clears_before_typing(
 
     assert delivered == "%2"
     assert router.tmux.calls == [
-        ("run", "send-keys", "-t", "%2", "C-u", {"check": False}),
         ("send_keys", "%2", "h", False),
     ]
-    assert "live_chat_network_dead_prompt_active" not in router.state
+    assert router.state[LIVE_CHAT_NETWORK_DEAD_NOTICE_MESSAGE_KEY] == (
+        LIVE_CHAT_NETWORK_DEAD_RAIL_MESSAGE
+    )
 
 
 def test_cockpit_send_key_keeps_live_right_pane_sticky_after_first_char(
@@ -899,7 +922,6 @@ def test_cockpit_send_key_escape_clears_live_right_pane_sticky(
                 "mounted_session": "architect_demo",
                 "right_pane_id": "%2",
                 "live_right_pane_input_sticky": True,
-                "live_chat_network_dead_prompt_active": True,
             }
 
         def active_live_right_pane_id(self) -> str | None:
@@ -918,7 +940,6 @@ def test_cockpit_send_key_escape_clears_live_right_pane_sticky(
         valid_cockpit_config, "<esc>",
     ) is None
     assert "live_right_pane_input_sticky" not in router.state
-    assert "live_chat_network_dead_prompt_active" not in router.state
 
 
 def test_send_key_to_first_live_skips_stale_sockets(fake_config: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1315

Restores a visible, actionable network-dead failure in the live Polly chat pane by writing a temporary failure prompt instead of relying on an ephemeral tmux display message. The next typed key, Enter, Backspace, or Escape clears that temporary prompt before continuing so the user can recover without appending to the error text.

Layer audit: UI/CLI only. Touched the cockpit send-key bridge in src/pollypm/cli_features/ui.py and focused regression coverage in tests/test_cockpit_input_bridge.py; no facade, domain, or store changes.