### PR TITLE
Fix #1280 keep inbox archive toast clear

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -6403,6 +6403,15 @@ def _triage_label(task) -> str:
     return "update"
 
 
+def _archive_success_message(item, task_id: str) -> str:
+    if is_task_inbox_entry(item):
+        return f"Archived {task_id}"
+    title = str(getattr(item, "title", "") or "").strip()
+    if title:
+        return f"Archived {_strip_action_subject_prefix(title)}"
+    return "Archived notification"
+
+
 def _render_user_prompt_block(payload: object) -> str | None:
     """Build the plain-English action block for a message detail pane.
 
@@ -7208,6 +7217,11 @@ class PollyInboxApp(App[None]):
         background: #0f1317;
         color: #eef2f4;
         padding: 0;
+    }
+    ToastRack {
+        /* #1280: keep bottom-right toasts above the reply input and
+           pane borders instead of painting through their box lines. */
+        margin-bottom: 6;
     }
     #inbox-layout {
         height: 1fr;
@@ -9225,7 +9239,12 @@ class PollyInboxApp(App[None]):
             except Exception as exc:  # noqa: BLE001
                 self.notify(f"Archive failed: {exc}", severity="error")
                 return
-            self.notify(f"Archived {task_id}", severity="information", timeout=2.0)
+            self.notify(
+                _archive_success_message(item, task_id),
+                severity="information",
+                timeout=2.0,
+                markup=False,
+            )
             self._tasks = [task for task in self._tasks if task.task_id != task_id]
             self._unread_ids.discard(task_id)
             self._session_read_ids.discard(task_id)
@@ -9272,7 +9291,12 @@ class PollyInboxApp(App[None]):
         self._emit_event(
             task_id, "inbox.message.archived", f"user archived {task_id}",
         )
-        self.notify(f"Archived {task_id}", severity="information", timeout=2.0)
+        self.notify(
+            _archive_success_message(item, task_id),
+            severity="information",
+            timeout=2.0,
+            markup=False,
+        )
         # Remove from local state + list so the row disappears immediately
         # (the 8s background refresh would do it anyway, but snappy UX).
         self._tasks = [t for t in self._tasks if t.task_id != task_id]

--- a/tests/test_cockpit_inbox_ui.py
+++ b/tests/test_cockpit_inbox_ui.py
@@ -1722,6 +1722,54 @@ def test_archive_closes_store_notification_and_removes_row(inbox_env, inbox_app)
     _run(body())
 
 
+def test_archive_store_notification_toast_stays_clear_of_reply_border(
+    inbox_env,
+) -> None:
+    """#1280: archive toast must not paint through inbox pane borders."""
+    message_id = _seed_workspace_message(
+        inbox_env["project_path"].parent,
+        subject="Workspace notify",
+        body="Fresh notification from Store.",
+        scope="__workspace__",
+    )
+
+    async def body() -> None:
+        from pollypm.cockpit_ui import PollyInboxApp, _InboxListItem
+
+        app = PollyInboxApp(inbox_env["config_path"])
+        async with app.run_test(size=(220, 80), notifications=True) as pilot:
+            await pilot.pause()
+            await pilot.press("m")
+            await pilot.press("O")
+            await pilot.pause()
+
+            visible_items = [
+                child for child in app.list_view.children
+                if isinstance(child, _InboxListItem)
+            ]
+            app.list_view.index = next(
+                idx for idx, child in enumerate(visible_items)
+                if child.task_ref.message_id == message_id
+            )
+            await pilot.press("enter")
+            await pilot.pause()
+            await pilot.press("a")
+            await pilot.pause()
+
+            lines = [strip.text for strip in app.screen._compositor.render_strips()]
+            toast_lines = [line for line in lines if "\u258c" in line]
+            toast_text = "\n".join(toast_lines)
+            assert "Archived Workspace notify" in toast_text
+            assert "msg:" not in toast_text
+            assert "__workspace__" not in toast_text
+            assert not any(
+                any(ch in line for ch in "\u256d\u256e\u2570\u256f\u2500")
+                for line in toast_lines
+            ), toast_lines
+
+    _run(body())
+
+
 def test_empty_state_message_when_no_inbox(tmp_path: Path) -> None:
     """An inbox with zero messages shows the friendly empty-state copy."""
     async def body() -> None:


### PR DESCRIPTION
Closes #1280

Moves inbox toasts above the reply input/bottom pane borders and uses the message subject for archived store-notification toast copy instead of the internal msg id.

Layer audit: UI-only change in `cockpit_ui.py`, with a focused Textual inbox regression test in `tests/test_cockpit_inbox_ui.py`; no store/domain boundary reach added.