### PR TITLE
Fix #1291 clean remaining operator prelude jargon

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -618,16 +618,20 @@ def _build_operator_primer(supervisor) -> str | None:
     # New wording is conversational: the user just mounted Polly chat,
     # so frame the primer as a workspace briefing she'd want before
     # the user starts talking, rather than a role-imposition.
+    project_word = "project" if project_count == 1 else "projects"
     lines = [
         "Hey Polly — the user just opened the operator chat. Quick "
         "workspace briefing so you have the context they're seeing "
         "before they say anything.",
-        f"Workspace: {project_count} project(s) under management.",
+        f"The user can see {project_count} {project_word} in PollyPM.",
     ]
     if project_lines:
-        lines.append("Projects:")
+        lines.append("Visible projects:")
         lines.extend(project_lines[:10])
-    lines.append(f"Active inbox: {inbox_total} item(s)")
+    if inbox_total == 1:
+        lines.append("1 inbox item is waiting.")
+    else:
+        lines.append(f"{inbox_total} inbox items are waiting.")
     if inbox_titles:
         lines.append("Recent inbox:")
         for project_name, title in inbox_titles[:5]:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -1957,9 +1957,15 @@ def test_cockpit_router_primes_workspace_operator_on_attach() -> None:
     # the workspace-scope discriminators below still uniquely identify
     # the workspace primer.
     assert "operator chat" in text
-    # Workspace-scope (not project-scope) discriminators.
-    assert "Workspace:" in text
-    assert "Active inbox:" in text
+    # Workspace-scope (not project-scope) context, phrased without
+    # implementation-y counters or CLI command names.
+    assert "The user can see 2 projects in PollyPM." in text
+    assert "Visible projects:" in text
+    assert "0 inbox items are waiting." in text
+    assert "Workspace:" not in text
+    assert "under management" not in text
+    assert "project(s)" not in text
+    assert "item(s)" not in text
     assert "workspace-wide" not in text
     assert "pm inbox" not in text
     assert "pm status" not in text


### PR DESCRIPTION
Closes #1291

Updates the workspace operator primer to use conversational project and inbox wording instead of templated "project(s) under management" / "item(s)" counters.

Layer audit: UI/cockpit rail only; test coverage updated in tests/test_cockpit.py. No domain/store boundary changes.