### PR TITLE
Fix #1318 speed inbox action prepaint

### DIFF
--- a/src/pollypm/__main__.py
+++ b/src/pollypm/__main__.py
@@ -106,6 +106,27 @@ def _default_config_path() -> Path:
 def _paint_inbox_snapshot(config_path: Path, *, project: str | None) -> Exception | None:
     """Prepaint a real inbox list before importing the interactive TUI."""
     try:
+        from pollypm.storage.inbox_action_preview import (
+            load_fast_inbox_action_preview,
+        )
+
+        fast_preview = load_fast_inbox_action_preview(
+            config_path,
+            project=project,
+            limit=_INBOX_PREPAINT_LIMIT,
+        )
+        if fast_preview is not None:
+            preview, preview_unread, preview_total = fast_preview
+            frame = _render_inbox_snapshot(
+                preview,
+                total=preview_total,
+                unread_count=len(preview_unread),
+                project=project,
+            )
+            sys.stdout.write(f"{_CLEAR_SCREEN}{frame}")
+            sys.stdout.flush()
+            return None
+
         from pollypm.cockpit_inbox_items import (
             load_inbox_action_preview,
             load_inbox_entries,

--- a/src/pollypm/storage/inbox_action_preview.py
+++ b/src/pollypm/storage/inbox_action_preview.py
@@ -1,0 +1,356 @@
+"""Fast read-only inbox action preview for cockpit first paint.
+
+This helper exists for the ``python -m pollypm cockpit-pane inbox`` hot path.
+It reads only Store-backed ``messages`` rows with stdlib modules, avoiding the
+SQLAlchemy/Textual/work-service imports that the full interactive Inbox needs.
+If it cannot prove there are action rows, callers fall back to the full loader.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import sqlite3
+import tomllib
+from typing import Any
+
+
+WORKSPACE_DB_KEY = "__workspace__"
+
+_MARKDOWN_DECORATION_RE = re.compile(r"[*_`#>\[\]]+")
+_DIGEST_SUBJECT_RE = re.compile(
+    r"^\s*(?:[A-Za-z]+\s+)?digest\b\s*[:—–-]",
+    re.IGNORECASE,
+)
+_OPS_ANOMALY_SUBJECT_RE = re.compile(
+    r"^\s*(?:[A-Za-z]+\s+)?(?:"
+    r"misrouted\s+review\s+ping"
+    r"|repeated\s+stale\s+review\s+ping"
+    r"|second\s+bogus\s+review\s+ping"
+    r"|bogus\s+review\s+ping"
+    r"|stale\s+planner\s+tasks?"
+    r"|review\s+requested\s+for\s+missing\s+task"
+    r"|review-needed\s+notifications?\s+(?:contain|missing)"
+    r")\b",
+    re.IGNORECASE,
+)
+_COMPLETION_RE = re.compile(
+    r"\b(complete|completed|shipped|done|merged|deliverable)\b",
+    re.IGNORECASE,
+)
+_ACTION_RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "decision needed",
+        re.compile(
+            r"\b(decision|triage|your call|need Polly's call|need your call|scope escalation)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "needs unblock",
+        re.compile(
+            r"\b(blocked|blocking|waiting on|on hold|stale review ping)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "setup needed",
+        re.compile(
+            r"\b(set up|setup|sign in|login|account access|access expired|"
+            r"fly\.io|fly deploy|verification email|email click|click the link)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "review needed",
+        re.compile(r"\b(review|approve|approval)\b", re.IGNORECASE),
+    ),
+    (
+        "action required",
+        re.compile(
+            r"^(\[action\]|action)\b|"
+            r"\b(action required|needs? your|need your|need Polly|question)\b",
+            re.IGNORECASE,
+        ),
+    ),
+)
+
+
+@dataclass(slots=True)
+class FastInboxPreviewEntry:
+    task_id: str = ""
+    title: str = ""
+    project: str = ""
+    triage_label: str = "action required"
+    labels: tuple[str, ...] = ()
+    created_at: object | None = None
+    updated_at: object | None = None
+    needs_action: bool = True
+
+
+def load_fast_inbox_action_preview(
+    config_path: Path,
+    *,
+    project: str | None = None,
+    limit: int = 12,
+) -> tuple[list[FastInboxPreviewEntry], set[str], int] | None:
+    """Return Store-backed action rows without importing the full inbox stack.
+
+    ``None`` means "not enough information"; callers should use the normal
+    loader. A non-empty tuple means actual action rows were found and are safe
+    to prepaint.
+    """
+    preview_limit = max(int(limit), 1)
+    try:
+        raw = tomllib.loads(config_path.read_text())
+    except Exception:  # noqa: BLE001
+        return None
+    sources, known_projects = _message_sources(raw, config_path=config_path)
+    if not sources:
+        return None
+
+    items: list[FastInboxPreviewEntry] = []
+    rows_per_source = max(preview_limit * 4, 48)
+    for source_key, db_path in sources:
+        if not db_path.exists():
+            continue
+        for row in _query_message_rows(db_path, limit=rows_per_source):
+            item = _row_to_entry(
+                row,
+                source_key=source_key,
+                known_projects=known_projects,
+            )
+            if item is None:
+                continue
+            if project and item.project != project:
+                continue
+            items.append(item)
+
+    if not items:
+        return None
+
+    items = _dedupe_replayed_plan_reviews(items)
+    items.sort(key=_entry_sort_value, reverse=True)
+    preview = items[:preview_limit]
+    return preview, {item.task_id for item in preview}, len(items)
+
+
+def _message_sources(
+    raw: dict[str, Any], *, config_path: Path,
+) -> tuple[list[tuple[str, Path]], set[str]]:
+    base = config_path.parent
+    projects_raw = raw.get("projects")
+    projects = projects_raw if isinstance(projects_raw, dict) else {}
+    known_projects = {str(key) for key in projects}
+    sources: list[tuple[str, Path]] = []
+    seen: set[Path] = set()
+
+    def _add(source_key: str, db_path: Path) -> None:
+        resolved = db_path.resolve() if db_path.exists() else db_path
+        if resolved in seen:
+            return
+        seen.add(resolved)
+        sources.append((source_key, db_path))
+
+    for project_key, project_raw in projects.items():
+        if not isinstance(project_raw, dict):
+            continue
+        path_raw = project_raw.get("path")
+        if not isinstance(path_raw, str) or not path_raw.strip():
+            continue
+        project_path = Path(path_raw).expanduser()
+        if not project_path.is_absolute():
+            project_path = base / project_path
+        _add(str(project_key), project_path / ".pollypm" / "state.db")
+
+    project_settings = raw.get("project")
+    if isinstance(project_settings, dict):
+        workspace_raw = project_settings.get("workspace_root")
+        if isinstance(workspace_raw, str) and workspace_raw.strip():
+            workspace = Path(workspace_raw).expanduser()
+            if not workspace.is_absolute():
+                workspace = base / workspace
+            _add(WORKSPACE_DB_KEY, workspace / ".pollypm" / "state.db")
+    return sources, known_projects
+
+
+def _query_message_rows(db_path: Path, *, limit: int) -> list[dict[str, object]]:
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=0.2)
+    except Exception:  # noqa: BLE001
+        return []
+    conn.row_factory = sqlite3.Row
+    try:
+        try:
+            rows = conn.execute(
+                """
+                SELECT
+                    id, scope, type, tier, recipient, sender, state, parent_id,
+                    subject, body, payload_json, labels, created_at, updated_at,
+                    closed_at
+                FROM messages
+                WHERE recipient = ?
+                  AND state = ?
+                  AND type IN (?, ?, ?)
+                ORDER BY created_at DESC, id DESC
+                LIMIT ?
+                """,
+                ("user", "open", "notify", "inbox_task", "alert", int(limit)),
+            ).fetchall()
+        except sqlite3.Error:
+            return []
+        return [dict(row) for row in rows]
+    finally:
+        try:
+            conn.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _row_to_entry(
+    row: dict[str, object],
+    *,
+    source_key: str,
+    known_projects: set[str],
+) -> FastInboxPreviewEntry | None:
+    labels = _labels(row.get("labels"))
+    if "channel:dev" in labels:
+        return None
+    payload = _payload(row.get("payload_json"))
+    scope = str(row.get("scope") or "").strip()
+    project = str(
+        payload.get("project")
+        or scope
+        or ("inbox" if source_key == WORKSPACE_DB_KEY else source_key)
+    )
+    if _is_orphaned_project(project, known_projects=known_projects):
+        return None
+    title = str(row.get("subject") or "(no subject)")
+    body = str(row.get("body") or "").replace("\\n", "\n")
+    triage_label = _fast_action_label(title=title, body=body, labels=labels)
+    if triage_label is None:
+        return None
+    row_id = row.get("id")
+    return FastInboxPreviewEntry(
+        task_id=f"msg:{source_key}:{row_id}",
+        title=title,
+        project=project,
+        triage_label=triage_label,
+        labels=tuple(labels),
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at") or row.get("created_at"),
+    )
+
+
+def _fast_action_label(
+    *,
+    title: str,
+    body: str,
+    labels: list[str],
+) -> str | None:
+    if "plan_review" in labels:
+        return "plan review"
+    if "blocking_question" in labels:
+        return "worker blocked"
+    title_plain = _plain_text(title)
+    title_lower = title_plain.lower()
+    if _DIGEST_SUBJECT_RE.search(title_lower):
+        return None
+    if _OPS_ANOMALY_SUBJECT_RE.search(title_lower):
+        return None
+    if _COMPLETION_RE.search(title_plain):
+        return None
+    text = " ".join(
+        part for part in (title_plain, _plain_text(body)) if part
+    ).strip()
+    for label, pattern in _ACTION_RULES:
+        if pattern.search(text):
+            return label
+    return None
+
+
+def _plain_text(value: object | None) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    text = _MARKDOWN_DECORATION_RE.sub("", text)
+    return " ".join(part.strip() for part in text.splitlines() if part.strip())
+
+
+def _labels(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(label) for label in value if str(label).strip()]
+    if isinstance(value, str) and value:
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            parsed = []
+        if isinstance(parsed, list):
+            return [str(label) for label in parsed if str(label).strip()]
+    return []
+
+
+def _payload(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value:
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            parsed = {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def _is_orphaned_project(project: str, *, known_projects: set[str]) -> bool:
+    project = (project or "").strip()
+    if not project or project == "inbox":
+        return False
+    return project not in known_projects
+
+
+def _entry_sort_value(item: FastInboxPreviewEntry) -> str:
+    for value in (item.updated_at, item.created_at):
+        if value is None:
+            continue
+        if hasattr(value, "isoformat"):
+            try:
+                return value.isoformat()
+            except Exception:  # noqa: BLE001
+                continue
+        return str(value)
+    return ""
+
+
+def _dedupe_replayed_plan_reviews(
+    items: list[FastInboxPreviewEntry],
+) -> list[FastInboxPreviewEntry]:
+    keep: dict[tuple[str, str], FastInboxPreviewEntry] = {}
+    drop_ids: set[str] = set()
+    for item in items:
+        labels = set(item.labels)
+        if "plan_review" not in labels:
+            continue
+        plan_task = ""
+        for label in labels:
+            if label.startswith("plan_task:"):
+                plan_task = label.split(":", 1)[1].strip()
+                break
+        if not plan_task:
+            continue
+        key = (item.project, plan_task)
+        existing = keep.get(key)
+        if existing is None:
+            keep[key] = item
+            continue
+        if _entry_sort_value(item) > _entry_sort_value(existing):
+            drop_ids.add(existing.task_id)
+            keep[key] = item
+        else:
+            drop_ids.add(item.task_id)
+    if not drop_ids:
+        return items
+    return [item for item in items if item.task_id not in drop_ids]

--- a/tests/test_cockpit_right_pane_command.py
+++ b/tests/test_cockpit_right_pane_command.py
@@ -1,5 +1,6 @@
 import builtins
 import os
+import sqlite3
 import subprocess
 import sys
 from pathlib import Path
@@ -16,6 +17,63 @@ def _router(tmp_path: Path) -> CockpitRouter:
         f"base_dir = \"{tmp_path / '.pollypm'}\"\n"
     )
     return CockpitRouter(config_path)
+
+
+def _seed_fast_preview_message_db(root: Path) -> Path:
+    db = root / ".pollypm" / "state.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                scope TEXT NOT NULL,
+                type TEXT NOT NULL,
+                tier TEXT NOT NULL,
+                recipient TEXT NOT NULL,
+                sender TEXT NOT NULL,
+                state TEXT NOT NULL,
+                parent_id INTEGER,
+                subject TEXT NOT NULL,
+                body TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                labels TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                closed_at TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO messages (
+                scope, type, tier, recipient, sender, state, parent_id,
+                subject, body, payload_json, labels, created_at, updated_at,
+                closed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "inbox",
+                "notify",
+                "immediate",
+                "user",
+                "polly",
+                "open",
+                None,
+                "[Action] Need your call on launch scope",
+                "Please decide before I continue.",
+                "{}",
+                "[]",
+                "2026-05-06T05:00:00+00:00",
+                "2026-05-06T05:00:00+00:00",
+                None,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return db
 
 
 def test_right_pane_command_skips_uv_run_startup(tmp_path: Path) -> None:
@@ -274,7 +332,7 @@ def test_package_main_fast_dispatches_inbox_pane(
 
     assert handled is True
     assert first_package_import
-    assert first_package_import[0][0] == "pollypm.cockpit_inbox_items"
+    assert first_package_import[0][0] == "pollypm.storage.inbox_action_preview"
     pre_import_output = first_package_import[0][1]
     assert "Inbox" in pre_import_output
     assert "Loading messages..." in pre_import_output
@@ -330,3 +388,42 @@ def test_package_main_prepaints_action_preview_without_full_inbox_load(
     assert "action needed" in out
     assert "Plan ready for review" in out
     assert "1 needs action" in out
+
+
+def test_package_main_fast_message_prepaint_skips_full_inbox_import(
+    capsys,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """#1318: Store-backed action rows should paint before full inbox imports."""
+
+    from pollypm import __main__ as package_main
+
+    _seed_fast_preview_message_db(tmp_path)
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        "[project]\n"
+        f"workspace_root = \"{tmp_path}\"\n"
+    )
+    original_import = builtins.__import__
+
+    def fail_full_inbox_import(
+        name: str,
+        globals: dict[str, Any] | None = None,
+        locals: dict[str, Any] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
+        if level == 0 and name == "pollypm.cockpit_inbox_items":
+            raise AssertionError("fast Store preview should avoid full inbox import")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fail_full_inbox_import)
+
+    error = package_main._paint_inbox_snapshot(config_path, project=None)
+
+    out = capsys.readouterr().out
+    assert error is None
+    assert "Inbox" in out
+    assert "action needed" in out
+    assert "Need your call on launch scope" in out


### PR DESCRIPTION
Closes #1318

Adds a read-only Store-backed fast action preview for the Inbox pane so capital-I can print real action rows before importing the full Textual/work-service inbox stack. The existing full preview/load path remains the fallback when the fast path cannot prove Store-backed action rows exist.

Layer self-audit: touched the cockpit pane launcher in `src/pollypm/__main__.py`, added a Store/IO read-only helper in `src/pollypm/storage/inbox_action_preview.py`, and covered the hot path in `tests/test_cockpit_right_pane_command.py`; no UI-to-SQLite import was added.