### PR TITLE
Fix #1322 keep recent worker commits green

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -873,9 +873,9 @@ def _worker_health_snapshot(
             and last_commit_seconds_ago < 24 * 3600
         )
         health = (
-            "idle_warn"
-            if (dt is None and not recent_commit) or idle_long
-            else "alive"
+            "alive"
+            if recent_commit or (dt is not None and not idle_long)
+            else "idle_warn"
         )
     else:
         health = "alive"
@@ -885,6 +885,10 @@ def _worker_health_snapshot(
         )
     elif last_heartbeat_iso:
         heartbeat_part = f"last heartbeat {_format_heartbeat_age(last_heartbeat_iso)}"
+        if last_commit_seconds_ago is not None and status == "idle":
+            heartbeat_part += (
+                f"; last commit {_format_commit_age(last_commit_seconds_ago)}"
+            )
     elif status in {"working", "idle"}:
         heartbeat_part = f"{status}; heartbeat not recorded"
         if last_commit_seconds_ago is not None and status == "idle":

--- a/tests/test_worker_roster_ui.py
+++ b/tests/test_worker_roster_ui.py
@@ -314,6 +314,26 @@ def test_idle_worker_without_heartbeat_uses_recent_commit_as_alive_signal() -> N
     assert stale_health == "idle_warn"
 
 
+def test_idle_worker_stale_heartbeat_uses_recent_commit_as_alive_signal() -> None:
+    """#1322: recent project activity wins over an old idle heartbeat."""
+    from datetime import UTC, datetime, timedelta
+
+    from pollypm.cockpit_inbox import _worker_health_snapshot
+
+    stale_heartbeat = (datetime.now(UTC) - timedelta(minutes=12)).isoformat()
+    health, tooltip = _worker_health_snapshot(
+        status="idle",
+        last_heartbeat_iso=stale_heartbeat,
+        token_total=0,
+        session_name="worker_demo",
+        last_commit_seconds_ago=36 * 60,
+    )
+
+    assert health == "alive"
+    assert "last heartbeat 12m ago" in tooltip
+    assert "last commit 36m ago" in tooltip
+
+
 def test_offline_at_review_node_classifies_as_handed_off() -> None:
     """Regression: when a worker exits cleanly after handing off to a
     reviewer (task at ``code_review`` / ``user_approval``), the


### PR DESCRIPTION
Closes #1322

Worker roster idle health now treats a recent project/branch commit as an alive signal even when an idle heartbeat is stale, so a row with a 36m commit does not collapse back to the yellow idle-warning glyph. The tooltip also includes the commit age alongside any heartbeat age for that case.

Self-audit: touched the cockpit worker-roster view-model helper in src/pollypm/cockpit_inbox.py and focused worker-roster tests only; no UI-to-store boundary changes.