### PR TITLE
Fix #1323 readable task summary statuses

### DIFF
--- a/src/pollypm/cockpit_tasks.py
+++ b/src/pollypm/cockpit_tasks.py
@@ -1820,7 +1820,7 @@ class PollyTasksApp(App[None]):
             count = counts.get(status, 0)
             if count:
                 icon = self._STATUS_ICONS.get(status, "·")
-                parts.append(f"{icon} {count} {status.replace('_', ' ')}")
+                parts.append(f"{icon} {count} {_status_display_label(status)}")
         total = len(self._tasks)
         shown = len(visible)
         if shown != total:

--- a/tests/test_tasks_ui.py
+++ b/tests/test_tasks_ui.py
@@ -1615,10 +1615,21 @@ def test_task_app_all_filter_uses_human_readable_status_labels(
             await pilot.pause()
 
             rows = _table_rows(app.query_one("#tasks-table", DataTable))
+            summary = str(app.query_one("#tasks-summary", Static).render())
+            header = str(app.query_one("#task-header", Static).render())
+            overview = str(app.query_one("#task-detail", Static).render())
             assert [row[1] for row in rows] == ["On hold", "Draft", "Done"]
+            assert "On hold" in summary
+            assert "Done" in summary
+            assert "on_hold" not in summary
+            assert "done" not in summary
+            assert "On hold" in header
+            assert "Status     On hold" in overview
             assert "on_hold" not in rows[0]
             assert "draft" not in rows[1]
             assert "done" not in rows[2]
+            assert "on_hold" not in header
+            assert "on_hold" not in overview
 
     _run(body())
 


### PR DESCRIPTION
Closes #1323

Tasks view summary counts now use the same human-readable status formatter as the table, selected-task header, and detail Status field, so the visible Tasks surface does not leak raw status keys like on_hold/done in the count line.

Self-audit: touched UI layer only (src/pollypm/cockpit_tasks.py) plus the focused Tasks UI test (tests/test_tasks_ui.py); no facade, domain, store, or boundary changes.