### PR TITLE
Fix #1321 PM chat primer persona

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -426,7 +426,38 @@ def _visibility_passes(reg, ctx) -> bool:
     return True
 
 
-def _build_project_pm_primer(supervisor, project_key: str) -> str | None:
+def _project_pm_persona_for_role(session_role: object) -> str | None:
+    if isinstance(session_role, str) and session_role.strip():
+        try:
+            from pollypm.role_contract import canonical_role, persona_for
+
+            if canonical_role(session_role) == "architect":
+                return persona_for("architect")
+        except ValueError:
+            pass
+    return None
+
+
+def _session_role_for_name(supervisor, session_name: str | None) -> object | None:
+    if not session_name:
+        return None
+    try:
+        launches = supervisor.plan_launches()
+    except Exception:  # noqa: BLE001
+        return None
+    for launch in launches:
+        session = getattr(launch, "session", None)
+        if getattr(session, "name", None) == session_name:
+            return getattr(session, "role", None)
+    return None
+
+
+def _build_project_pm_primer(
+    supervisor,
+    project_key: str,
+    *,
+    session_name: str | None = None,
+) -> str | None:
     """Return a project-context priming message for a per-project PM session.
 
     The cockpit attaches a project's PM Chat to the project's worker
@@ -446,12 +477,16 @@ def _build_project_pm_primer(supervisor, project_key: str) -> str | None:
     project = supervisor.config.projects.get(project_key)
     if project is None:
         return None
-    persona_raw = getattr(project, "persona_name", None)
-    persona = (
-        persona_raw.strip()
-        if isinstance(persona_raw, str) and persona_raw.strip()
-        else None
+    persona = _project_pm_persona_for_role(
+        _session_role_for_name(supervisor, session_name),
     )
+    if persona is None:
+        persona_raw = getattr(project, "persona_name", None)
+        persona = (
+            persona_raw.strip()
+            if isinstance(persona_raw, str) and persona_raw.strip()
+            else None
+        )
     project_name = project.name or project_key
     project_path = str(project.path)
 
@@ -3112,7 +3147,11 @@ class CockpitRouter:
                 primed = set()
             if session_name in primed:
                 return
-            primer = _build_project_pm_primer(supervisor, project_key)
+            primer = _build_project_pm_primer(
+                supervisor,
+                project_key,
+                session_name=session_name,
+            )
             if not primer:
                 return
             right_pane_id = self._right_pane_id(window_target)

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -1471,6 +1471,67 @@ def test_cockpit_router_primes_per_project_pm_session_distinctly() -> None:
     assert len(sent) == 2  # unchanged
 
 
+def test_project_pm_primer_matches_architect_session_persona() -> None:
+    """An architect-backed PM Chat should greet Archie, not the project's
+    worker persona (#1321).
+    """
+    sent: list[tuple[str, str]] = []
+    primed_state: dict[str, object] = {}
+
+    class _FakeTmux:
+        def send_keys(self, target, text, press_enter=True):  # noqa: ARG002
+            sent.append((target, text))
+
+    class _Project:
+        key = "bikepath"
+        name = "bikepath"
+        path = Path("/tmp/bikepath-no-db")
+        persona_name = "Bea"
+
+    class _FakeConfig:
+        projects = {"bikepath": _Project()}
+
+    class _FakeSupervisor:
+        config = _FakeConfig()
+
+        def plan_launches(self):
+            class _Sess:
+                name = "architect_bikepath"
+                role = "architect"
+                project = "bikepath"
+
+            class _L:
+                session = _Sess()
+
+            return [_L()]
+
+    router = CockpitRouter.__new__(CockpitRouter)
+    router.config_path = Path("/tmp/pollypm.toml")
+    router.tmux = _FakeTmux()
+    router._right_pane_id = lambda window_target: "%right"  # type: ignore[assignment]
+    router._load_state = lambda: dict(primed_state)  # type: ignore[assignment]
+
+    def _write(data):
+        primed_state.clear()
+        primed_state.update(data)
+
+    router._write_state = _write  # type: ignore[assignment]
+    router._session_available_for_mount = lambda *a, **k: True  # type: ignore[assignment]
+    router._show_live_session = lambda *a, **k: None  # type: ignore[assignment]
+
+    supervisor = _FakeSupervisor()
+
+    router._route_project_selection(
+        supervisor,
+        "pollypm:PollyPM",
+        ProjectRoute(project_key="bikepath", sub_view="session"),
+    )
+
+    assert len(sent) == 1
+    assert "Hey Archie" in sent[0][1]
+    assert "Hey Bea" not in sent[0][1]
+
+
 def test_create_worker_and_route_targets_pm_chat_session_when_worker_exists() -> None:
     """#964 regression: after :meth:`create_worker_and_route` spawns
     the per-project worker (or finds a pre-existing one), it MUST route


### PR DESCRIPTION
Closes #1321

Project PM primers now resolve the mounted PM Chat session role before falling back to the configured project persona, so architect-backed PM Chat content greets Archie to match the rail label.

Self-audit: touched UI/CLI rail routing in src/pollypm/cockpit_rail.py plus focused cockpit tests only; no store/IO access added and no new cross-layer dependency beyond the existing role_contract persona lookup pattern.