### PR TITLE
Fix #1327 Home Now feed tone

### DIFF
--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -72,6 +72,32 @@ def _truncate_for_now_panel(text: str, *, limit: int = 70) -> str:
     return text[:cut].rstrip() + "…"
 
 
+_NO_TASKS_FOUND_RE = re.compile(
+    r"(?:\bpm\s+task\s+list\b.*)?\b(?:result:\s*)?no tasks found\b",
+    re.IGNORECASE,
+)
+_ZERO_DURATION_RE = re.compile(r"0[sm](?:\s*0s)?")
+
+
+def _is_zero_duration(text: str) -> bool:
+    return _ZERO_DURATION_RE.fullmatch(text.strip()) is not None
+
+
+def _now_feed_friendly_fallback(line: str) -> str | None:
+    """Return cleaner Home Now copy for raw or fragmentary pane lines."""
+    text = line.strip()
+    if not text:
+        return None
+    lower = text.lower()
+    if _NO_TASKS_FOUND_RE.search(text):
+        return "Nothing on the burner"
+    if "implementing worker tasks" in lower:
+        return "On the line"
+    if text[0].islower():
+        return "On the line"
+    return None
+
+
 # Codex idle-input placeholder detection lives in
 # :mod:`pollypm.idle_placeholders` (#1010 extraction) so the dashboard
 # renderer here and the heartbeat session-health classifier share one
@@ -425,7 +451,10 @@ def _session_description(status: str, role: str, snapshot_path: str | None) -> s
                 # Working indicator with time
                 m = re.search(r"Working \((\d+[ms]\s?\d*s?)\s*", stripped)
                 if m:
-                    return f"working ({m.group(1).strip()})"
+                    duration = m.group(1).strip()
+                    if _is_zero_duration(duration):
+                        return "Warming up"
+                    return f"working ({duration})"
             # #1025 (Home dashboard "Now" feed) — when the visible
             # last-line of pane is mid-sentence noise, prefer a
             # recognized event signature picked from the most-recent
@@ -435,6 +464,9 @@ def _session_description(status: str, role: str, snapshot_path: str | None) -> s
             # whatever the cursor happens to be sitting on right now.
             event_match = _scan_for_event_signature(clean_lines)
             if event_match:
+                friendly = _now_feed_friendly_fallback(event_match)
+                if friendly is not None:
+                    return friendly
                 return _truncate_for_now_panel(event_match)
             # Look for meaningful lines in the snapshot — restrict to
             # escape-free lines so a fused render (#792) doesn't end
@@ -485,6 +517,9 @@ def _session_description(status: str, role: str, snapshot_path: str | None) -> s
                 # box (#994).
                 if _is_codex_idle_placeholder(line):
                     continue
+                friendly = _now_feed_friendly_fallback(line)
+                if friendly is not None:
+                    return friendly
                 return _truncate_for_now_panel(line)
         except (FileNotFoundError, OSError):
             pass

--- a/tests/test_dashboard_data_alert_dedup.py
+++ b/tests/test_dashboard_data_alert_dedup.py
@@ -269,8 +269,8 @@ def test_session_description_keeps_real_codex_working_status(tmp_path) -> None:
     assert "3m" in desc
 
 
-def test_session_description_trims_working_duration_spacing(tmp_path) -> None:
-    """#1299: ``Working (0s ...)`` should not render as ``working (0s )``."""
+def test_session_description_rewrites_zero_second_working_copy(tmp_path) -> None:
+    """#1327: zero-second Codex working chrome is filler, not useful status."""
     from pollypm.dashboard_data import _session_description
 
     snapshot = tmp_path / "snap.txt"
@@ -278,7 +278,44 @@ def test_session_description_trims_working_duration_spacing(tmp_path) -> None:
 
     desc = _session_description("healthy", "worker", str(snapshot))
 
-    assert desc == "working (0s)"
+    assert desc == "Warming up"
+
+
+def test_session_description_rewrites_raw_no_tasks_copy(tmp_path) -> None:
+    """#1327: task-list command output should not leak into the Now feed."""
+    from pollypm.dashboard_data import _session_description
+
+    raw_lines = (
+        "Result: No tasks found.",
+        "- pm task list --status review → No tasks found.",
+    )
+    for raw in raw_lines:
+        snapshot = tmp_path / "snap.txt"
+        snapshot.write_text(raw + "\n")
+
+        desc = _session_description("healthy", "worker", str(snapshot))
+
+        assert desc == "Nothing on the burner"
+        assert "No tasks found" not in desc
+        assert "pm task list" not in desc
+
+
+def test_session_description_rewrites_fragmentary_worker_copy(tmp_path) -> None:
+    """#1327: lower-case mid-sentence fragments get a stable worker idiom."""
+    from pollypm.dashboard_data import _session_description
+
+    fragments = (
+        "implementing worker tasks.",
+        "treat the worktree as potentially dirty and avoid clobbering unrelated",
+        "operating norms, the architect role guide, and the project rules…",
+    )
+    for fragment in fragments:
+        snapshot = tmp_path / "snap.txt"
+        snapshot.write_text(fragment + "\n")
+
+        desc = _session_description("healthy", "worker", str(snapshot))
+
+        assert desc == "On the line"
 
 
 def test_session_description_truncates_at_word_boundary(tmp_path) -> None:


### PR DESCRIPTION
Closes #1327

Normalizes Home Now feed snapshot copy so peer agents stop surfacing zero-second working chrome, raw task-list/no-tasks output, and lower-case fragments. Those cases now render as stable playful status lines that match Polly's voice.

Layer self-audit: touched dashboard data/UI copy only (`src/pollypm/dashboard_data.py`) plus focused tests; no store/domain imports or boundary changes.

Tests:
- `uv run --extra dev pytest tests/test_dashboard_data_alert_dedup.py -q`
- `uv run --extra dev pytest tests/test_cockpit.py::test_dashboard_now_panel_renders_each_session_health_state -q`

Note: `uv run --extra dev ruff check src/pollypm/dashboard_data.py tests/test_dashboard_data_alert_dedup.py` still reports pre-existing lint issues in these files (E402/F401/F841), so I left lint cleanup out of this cosmetic fix.