### PR TITLE
Fix #1290 speed project drilldown render

### DIFF
--- a/src/pollypm/__main__.py
+++ b/src/pollypm/__main__.py
@@ -46,17 +46,18 @@ def _run_cockpit_pane_fast(argv: list[str]) -> bool:
 
     ``CockpitRouter`` spawns panes with ``python -m pollypm cockpit-pane ...``.
     Importing :mod:`pollypm.cli` first loads every top-level command family
-    before the pane-specific command can import its Textual app. The Inbox
-    cold path is budgeted from keystroke to first paint, so avoid that root CLI
-    import for the pane launches the cockpit itself generates. Help and any
-    unfamiliar shape fall back to the Typer command below.
+    before the pane-specific command can import its Textual app. The Inbox and
+    project-dashboard cold paths are budgeted from keystroke to first paint, so
+    avoid that root CLI import for the pane launches the cockpit itself
+    generates. Help and any unfamiliar shape fall back to the Typer command
+    below.
     """
     if len(argv) < 2 or argv[0] != "cockpit-pane":
         return False
     if any(token in _COCKPIT_PANE_HELP_FLAGS for token in argv[1:]):
         return False
     kind = argv[1]
-    if kind != "inbox":
+    if kind not in {"inbox", "project"}:
         return False
 
     parsed = _parse_cockpit_pane_options(argv)
@@ -64,6 +65,23 @@ def _run_cockpit_pane_fast(argv: list[str]) -> bool:
         return False
     config_path, project = parsed
     resolved_config_path = config_path or _default_config_path()
+    if kind == "project":
+        if not project:
+            return False
+        _paint_project_dashboard_snapshot(resolved_config_path, project)
+        from pollypm.cli_features.ui import (
+            _enforce_migration_gate,
+            _install_cockpit_debug_log_handler,
+        )
+
+        _enforce_migration_gate(resolved_config_path)
+        _install_cockpit_debug_log_handler(resolved_config_path)
+
+        from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+        PollyProjectDashboardApp(resolved_config_path, project).run(mouse=True)
+        return True
+
     _paint_inbox_loading_placeholder()
     snapshot_error = _paint_inbox_snapshot(resolved_config_path, project=project)
 
@@ -80,6 +98,61 @@ def _run_cockpit_pane_fast(argv: list[str]) -> bool:
 
     PollyInboxApp(resolved_config_path, initial_project=project).run(mouse=True)
     return True
+
+
+def _paint_project_dashboard_snapshot(config_path: Path, project: str) -> None:
+    """Prepaint a cheap project-dashboard frame before Textual imports."""
+    try:
+        frame = _render_project_dashboard_snapshot(config_path, project)
+        sys.stdout.write(f"{_CLEAR_SCREEN}{frame}")
+        sys.stdout.flush()
+    except Exception:  # noqa: BLE001 - prepaint must never block launch
+        pass
+
+
+def _render_project_dashboard_snapshot(config_path: Path, project: str) -> str:
+    try:
+        from pollypm.config import load_config
+
+        config = load_config(config_path)
+        project_obj = (getattr(config, "projects", {}) or {}).get(project)
+        if project_obj is None:
+            return (
+                f"{project}   PM: Project PM\n\n"
+                "Loading project dashboard..."
+            )
+        name = (
+            project_obj.display_label()
+            if hasattr(project_obj, "display_label")
+            else (getattr(project_obj, "name", None) or project)
+        )
+        persona = getattr(project_obj, "persona_name", None)
+        pm = (
+            f"PM: {persona.strip()}"
+            if isinstance(persona, str) and persona.strip()
+            else "PM: Project PM"
+        )
+        return "\n".join(
+            [
+                f"{_plain_inbox_text(name)}   {_plain_inbox_text(pm)}",
+                "",
+                "Loading project dashboard...",
+                "",
+                "Inbox",
+                "  Loading project inbox...",
+                "",
+                "Current activity",
+                "  Loading worker state...",
+                "",
+                "Task pipeline",
+                "  Loading task pipeline...",
+                "",
+                "Recent activity",
+                "  Loading recent activity...",
+            ]
+        )
+    except Exception:  # noqa: BLE001
+        return f"{project}   PM: Project PM\n\nLoading project dashboard..."
 
 
 def _paint_inbox_loading_placeholder() -> None:

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import gc
 import asyncio
 import json
+import logging
 import os
 import resource
 from pathlib import Path
@@ -152,6 +153,8 @@ from pollypm.cockpit_rail import CockpitItem, CockpitPresence, CockpitRouter
 
 import re as _re
 
+
+logger = logging.getLogger(__name__)
 
 _INLINE_BOLD_RE = _re.compile(r"\*\*(.+?)\*\*")
 _INLINE_ITALIC_RE = _re.compile(r"\*(.+?)\*")
@@ -10386,10 +10389,6 @@ _PLAN_EXPLAINER_CANDIDATES_FMT: tuple[str, ...] = (
 _PLAN_INLINE_PREVIEW_MAX_LINES = 120
 
 
-def _unexpected_keyword_type_error(exc: TypeError) -> bool:
-    return "unexpected keyword argument" in str(exc)
-
-
 def _dashboard_plan_path(project_path: Path) -> Path | None:
     for rel in _PLAN_FILE_CANDIDATES:
         p = project_path / rel
@@ -10647,6 +10646,7 @@ class ProjectDashboardData:
         "action_items",
         "alert_count",
         "enforce_plan",
+        "is_loading",
     )
 
     def __init__(
@@ -10678,6 +10678,7 @@ class ProjectDashboardData:
         action_items: list[dict],
         alert_count: int,
         enforce_plan: bool = True,
+        is_loading: bool = False,
     ) -> None:
         self.project_key = project_key
         self.project_name = project_name
@@ -10705,6 +10706,7 @@ class ProjectDashboardData:
         self.action_items = action_items
         self.alert_count = alert_count
         self.enforce_plan = enforce_plan
+        self.is_loading = is_loading
 
 
 # Module-level cache keyed by project plus the task DB paths/mtimes so a
@@ -12784,10 +12786,32 @@ def _dashboard_activity(
     return result
 
 
-def _gather_project_dashboard(
+def _project_dashboard_gather_profile(
+    project_key: str,
+    total_ms: float,
+    timings: list[tuple[str, float]],
+) -> None:
+    """Log slow project-dashboard gathers with per-section timings."""
+    if total_ms < 1000.0:
+        return
+    parts = " ".join(f"{label}={ms:.1f}ms" for label, ms in timings)
+    logger.info(
+        "project_dashboard_gather project=%s total=%.1fms %s",
+        project_key,
+        total_ms,
+        parts,
+    )
+
+
+def _gather_project_dashboard_shell(
     config_path: Path, project_key: str,
 ) -> ProjectDashboardData | None:
-    """Build the full ``ProjectDashboardData`` snapshot for one project."""
+    """Build the cheap first-paint shell for a project dashboard.
+
+    This intentionally avoids Store/Supervisor/activity-feed reads so a
+    project drilldown can show the project name and ``PM:`` header while the
+    full gather fills in the heavy sections on the worker thread.
+    """
     try:
         config = load_config(config_path)
     except Exception:  # noqa: BLE001
@@ -12810,25 +12834,117 @@ def _gather_project_dashboard(
         and isinstance(project_path, Path)
         and project_path.exists()
     )
+    planner_settings = getattr(config, "planner", None)
+    global_enforce = bool(getattr(planner_settings, "enforce_plan", True))
+    project_enforce = getattr(project, "enforce_plan", None)
+    enforce_plan = (
+        project_enforce if project_enforce is not None else global_enforce
+    )
+    empty_buckets = {
+        "queued": [],
+        "in_progress": [],
+        "review": [],
+        "blocked": [],
+        "on_hold": [],
+        "done": [],
+    }
+    plan_path = (
+        _dashboard_plan_path(project_path)
+        if exists_on_disk and isinstance(project_path, Path)
+        else None
+    )
+    return ProjectDashboardData(
+        project_key=project_key,
+        project_name=name,
+        project_path=project_path if exists_on_disk else None,
+        persona_name=persona if isinstance(persona, str) else None,
+        pm_label=pm_label,
+        exists_on_disk=exists_on_disk,
+        status_dot="○",
+        status_color="#6b7a88",
+        status_label="loading",
+        active_worker=None,
+        architect=None,
+        task_counts={},
+        task_buckets=empty_buckets,
+        plan_path=plan_path,
+        plan_sections=[],
+        plan_explainer=None,
+        plan_text=None,
+        plan_aux_files=[],
+        plan_mtime=None,
+        plan_stale_reason=None,
+        activity_entries=[],
+        inbox_count=0,
+        inbox_top=[],
+        action_items=[],
+        alert_count=0,
+        enforce_plan=enforce_plan,
+        is_loading=True,
+    )
+
+
+def _gather_project_dashboard(
+    config_path: Path, project_key: str,
+) -> ProjectDashboardData | None:
+    """Build the full ``ProjectDashboardData`` snapshot for one project."""
+    gather_start = time.perf_counter()
+    timings: list[tuple[str, float]] = []
+
+    def _timed(label: str, func: Callable[[], object]) -> object:
+        start = time.perf_counter()
+        try:
+            return func()
+        finally:
+            timings.append((label, (time.perf_counter() - start) * 1000.0))
+
+    try:
+        config = _timed("load_config", lambda: load_config(config_path))
+    except Exception:  # noqa: BLE001
+        return None
+    projects = getattr(config, "projects", {}) or {}
+    project = projects.get(project_key)
+    if project is None:
+        return None
+
+    project_path = getattr(project, "path", None)
+    name = (
+        project.display_label() if hasattr(project, "display_label")
+        else (getattr(project, "name", None) or project_key)
+    )
+    persona = getattr(project, "persona_name", None)
+    pm_label = _project_pm_label(config, project_key, project)
+
+    exists_on_disk = bool(
+        project_path is not None
+        and isinstance(project_path, Path)
+        and project_path.exists()
+    )
 
     if exists_on_disk:
-        counts, buckets = _dashboard_gather_tasks(config, project_key, project_path)
-        try:
-            inbox_count, inbox_top, action_items = _dashboard_inbox(
-                config_path, project_key, project_path, config=config,
-            )
-        except TypeError as exc:
-            if not _unexpected_keyword_type_error(exc):
-                raise
-            inbox_count, inbox_top, action_items = _dashboard_inbox(
-                config_path, project_key, project_path,
-            )
-        plan_path = _dashboard_plan_path(project_path)
+        counts, buckets = _timed(
+            "tasks",
+            lambda: _dashboard_gather_tasks(config, project_key, project_path),
+        )
+        inbox_count, inbox_top, action_items = _timed(
+            "inbox",
+            lambda: _dashboard_inbox(
+                config_path,
+                project_key,
+                project_path,
+                config=config,
+            ),
+        )
+        plan_path = _timed(
+            "plan_path", lambda: _dashboard_plan_path(project_path),
+        )
         plan_text: str | None = None
         plan_mtime: float | None = None
         if plan_path is not None:
             try:
-                plan_text = plan_path.read_text(encoding="utf-8")
+                plan_text = _timed(
+                    "plan_read", lambda: plan_path.read_text(encoding="utf-8"),
+                )
                 plan_sections = _extract_h2_sections(plan_text)
             except OSError:
                 plan_sections = []
@@ -12839,19 +12955,23 @@ def _gather_project_dashboard(
                 plan_mtime = None
         else:
             plan_sections = []
-        plan_explainer = _dashboard_plan_explainer(project_path, project_key)
-        plan_aux_files = _dashboard_plan_aux_files(project_path)
-        plan_stale_reason = _dashboard_plan_staleness(
-            plan_path, plan_mtime, project_path, project_key,
+        plan_explainer = _timed(
+            "plan_explainer",
+            lambda: _dashboard_plan_explainer(project_path, project_key),
         )
-        try:
-            activity_entries = _dashboard_activity(
-                config_path, project_key, config=config,
-            )
-        except TypeError as exc:
-            if not _unexpected_keyword_type_error(exc):
-                raise
-            activity_entries = _dashboard_activity(config_path, project_key)
+        plan_aux_files = _timed(
+            "plan_aux", lambda: _dashboard_plan_aux_files(project_path),
+        )
+        plan_stale_reason = _timed(
+            "plan_stale",
+            lambda: _dashboard_plan_staleness(
+                plan_path, plan_mtime, project_path, project_key,
+            ),
+        )
+        activity_entries = _timed(
+            "activity",
+            lambda: _dashboard_activity(config_path, project_key, config=config),
+        )
     else:
         counts = {}
         buckets = {}
@@ -12867,20 +12987,16 @@ def _gather_project_dashboard(
         plan_stale_reason = None
         activity_entries = []
 
-    try:
-        active_worker, alert_count = _dashboard_active_worker(
+    active_worker, alert_count = _timed(
+        "active_worker",
+        lambda: _dashboard_active_worker(
             config_path,
             project_key,
             action_items=action_items,
             config=config,
             task_buckets=buckets,
-        )
-    except TypeError as exc:
-        if not _unexpected_keyword_type_error(exc):
-            raise
-        active_worker, alert_count = _dashboard_active_worker(
-            config_path, project_key, action_items=action_items,
-        )
+        ),
+    )
     blocker_count = int(counts.get("blocked", 0))
     on_hold_count = int(counts.get("on_hold", 0))
     in_progress_count = int(counts.get("in_progress", 0))
@@ -12909,7 +13025,7 @@ def _gather_project_dashboard(
         project_enforce if project_enforce is not None else global_enforce
     )
 
-    return ProjectDashboardData(
+    data = ProjectDashboardData(
         project_key=project_key,
         project_name=name,
         project_path=project_path if exists_on_disk else None,
@@ -12937,6 +13053,12 @@ def _gather_project_dashboard(
         alert_count=alert_count,
         enforce_plan=enforce_plan,
     )
+    _project_dashboard_gather_profile(
+        project_key,
+        (time.perf_counter() - gather_start) * 1000.0,
+        timings,
+    )
+    return data
 
 
 def _project_dashboard_signature(
@@ -12955,6 +13077,7 @@ def _project_dashboard_signature(
     worker = data.active_worker or {}
     return (
         data.project_key,
+        bool(getattr(data, "is_loading", False)),
         data.pm_label,
         data.exists_on_disk,
         data.status_dot,
@@ -13366,18 +13489,22 @@ class PollyProjectDashboardApp(App[None]):
         yield self.hint
 
     def on_mount(self) -> None:
-        # Paint a "Loading…" placeholder immediately so the click-to-
-        # visible-pane delay is just the Python + Textual cold-boot
-        # cost, not an additional 1–2s of synchronous DB walks. The
-        # actual gather runs on a worker thread (mirrors the workspace
-        # dashboard's ``_refresh_dashboard_sync`` pattern) and the
-        # first ``_render`` fires when it completes.
-        self.topbar.update(
-            f"[b]{_escape(self.project_key)}[/b]   "
-            f"[dim]loading project dashboard…[/dim]"
-        )
         self._first_refresh_running = False
-        self._refresh()
+        self._full_refresh_loaded = False
+        # Paint a cheap shell immediately: config/project labels only,
+        # no Store/Supervisor/activity reads. The full gather still runs
+        # off-thread and replaces the section placeholders when complete.
+        shell = _gather_project_dashboard_shell(self.config_path, self.project_key)
+        if shell is not None:
+            self.data = shell
+            self._last_render_signature = _project_dashboard_signature(shell)
+            self._render()
+        else:
+            self.topbar.update(
+                f"[b]{_escape(self.project_key)}[/b]   "
+                f"[dim]loading project dashboard…[/dim]"
+            )
+        self._start_first_refresh()
         self.set_interval(self.REFRESH_INTERVAL_SECONDS, self._refresh)
         # Alert toast surface removed in #956 — ``a`` still opens the
         # alert list (Metrics drill-down).
@@ -13390,23 +13517,17 @@ class PollyProjectDashboardApp(App[None]):
     # ------------------------------------------------------------------
 
     def _refresh(self) -> None:
-        # First refresh runs off the UI thread so the placeholder topbar
-        # stays visible until data lands. Subsequent timer-driven
-        # refreshes are cheap (cycle 138/139 caches collapse them to
-        # stat()s when nothing has changed), so we keep them on the
-        # UI thread to avoid worker-thread overhead.
         if getattr(self, "_first_refresh_running", False):
             # Worker is still gathering — avoid a parallel sync gather
             # that would race the worker's call_from_thread completion.
             return
-        if self.data is None:
-            self._first_refresh_running = True
-            self.run_worker(
-                self._first_refresh_sync,
-                thread=True,
-                exclusive=True,
-                group="proj_dashboard_first_refresh",
-            )
+        # The first full refresh runs off the UI thread so the cheap
+        # shell remains responsive while cold Store/Supervisor/activity
+        # reads finish. Subsequent timer-driven refreshes are cheap
+        # enough to keep synchronous because the caches collapse them to
+        # stat()s when nothing changed.
+        if not getattr(self, "_full_refresh_loaded", False):
+            self._start_first_refresh()
             return
         try:
             self.data = _gather_project_dashboard(
@@ -13431,6 +13552,17 @@ class PollyProjectDashboardApp(App[None]):
         self._last_render_signature = signature
         self._render()
 
+    def _start_first_refresh(self) -> None:
+        if getattr(self, "_first_refresh_running", False):
+            return
+        self._first_refresh_running = True
+        self.run_worker(
+            self._first_refresh_sync,
+            thread=True,
+            exclusive=True,
+            group="proj_dashboard_first_refresh",
+        )
+
     def _first_refresh_sync(self) -> None:
         """Off-thread first-refresh: gather then hand back to the UI
         thread for render. Keeps the placeholder topbar visible
@@ -13447,6 +13579,7 @@ class PollyProjectDashboardApp(App[None]):
 
     def _first_refresh_completed(self, data) -> None:
         self._first_refresh_running = False
+        self._full_refresh_loaded = True
         self.data = data
         self._last_render_signature = _project_dashboard_signature(data)
         self._render()
@@ -13554,6 +13687,11 @@ class PollyProjectDashboardApp(App[None]):
         self.hint.update(hint)
 
     def _update_action_bar(self, data: ProjectDashboardData) -> None:
+        if getattr(data, "is_loading", False):
+            self.action_bar.remove_class("-attention")
+            self.action_bar.remove_class("-critical")
+            self.action_bar.update("[b]Loading project dashboard...[/b]")
+            return
         # #1025 — only count review tasks that genuinely need a user
         # decision. ``review`` rows that are auto-handled (Russell
         # mid-review) are not actionable for the operator; counting
@@ -13801,6 +13939,8 @@ class PollyProjectDashboardApp(App[None]):
     # ------------------------------------------------------------------
 
     def _render_now_body(self, data: ProjectDashboardData) -> str:
+        if getattr(data, "is_loading", False):
+            return "[dim]Loading worker state...[/dim]"
         w = data.active_worker
         if w:
             sess_raw = w.get("session_name") or ""
@@ -13957,6 +14097,8 @@ class PollyProjectDashboardApp(App[None]):
         return "[dim]Idle. No tasks in flight and no user action needed.[/dim]"
 
     def _render_pipeline_body(self, data: ProjectDashboardData) -> str:
+        if getattr(data, "is_loading", False):
+            return "[dim]Loading task pipeline...[/dim]"
         if not data.exists_on_disk:
             return "[dim]No project path on disk.[/dim]"
         counts = data.task_counts
@@ -14152,6 +14294,8 @@ class PollyProjectDashboardApp(App[None]):
         return "\n".join(out)
 
     def _render_plan_body(self, data: ProjectDashboardData) -> str:
+        if getattr(data, "is_loading", False):
+            return "[dim]Loading plan summary...[/dim]"
         if not data.exists_on_disk:
             return "[dim]Virtual project — no plan on disk.[/dim]"
         if data.plan_path is None:
@@ -14232,6 +14376,8 @@ class PollyProjectDashboardApp(App[None]):
             return _escape_body(text)
 
     def _render_activity_body(self, data: ProjectDashboardData) -> str:
+        if getattr(data, "is_loading", False):
+            return "[dim]Loading recent activity...[/dim]"
         if not data.activity_entries:
             return "[dim]No recent activity for this project.[/dim]"
         lines: list[str] = []
@@ -14364,6 +14510,8 @@ class PollyProjectDashboardApp(App[None]):
         view stays around for tests + the click-hint computation in
         ``_action_card_click_hint`` callers.
         """
+        if getattr(data, "is_loading", False):
+            return "[dim]Loading project inbox...[/dim]"
         count = data.inbox_count
         blocked_total = int(data.task_counts.get("blocked", 0))
         on_hold_total = int(data.task_counts.get("on_hold", 0))

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -10383,6 +10383,11 @@ _PLAN_EXPLAINER_CANDIDATES_FMT: tuple[str, ...] = (
     "reports/plan-review.html",
     "reports/{key}-plan-review.html",
 )
+_PLAN_INLINE_PREVIEW_MAX_LINES = 120
+
+
+def _unexpected_keyword_type_error(exc: TypeError) -> bool:
+    return "unexpected keyword argument" in str(exc)
 
 
 def _dashboard_plan_path(project_path: Path) -> Path | None:
@@ -11161,6 +11166,7 @@ def _classify_worker_activity(
     project_aliases: set[str],
     project_path: Path | None,
     has_pane_permission_alert: bool,
+    task_buckets: dict[str, list[dict]] | None = None,
 ) -> str:
     """Return ``"working" | "idle" | "awaiting_user"`` for a live session.
 
@@ -11208,7 +11214,13 @@ def _classify_worker_activity(
         pane_changed = False
 
     has_owned_task = False
-    if project_path is not None:
+    if task_buckets is not None:
+        for row in task_buckets.get("in_progress", []) or []:
+            assignee = str(row.get("assignee") or "")
+            if assignee == session_name or assignee == role:
+                has_owned_task = True
+                break
+    elif project_path is not None:
         try:
             from pollypm.work.sqlite_service import SQLiteWorkService
 
@@ -11257,6 +11269,8 @@ def _dashboard_active_worker(
     project_key: str,
     *,
     action_items: list[dict] | None = None,
+    config: object | None = None,
+    task_buckets: dict[str, list[dict]] | None = None,
 ) -> tuple[dict | None, int]:
     """Inspect supervisor state for a live worker on this project.
 
@@ -11286,7 +11300,9 @@ def _dashboard_active_worker(
     alert_count = 0
     try:
         from pollypm.service_api import PollyPMService
-        supervisor = PollyPMService(config_path).load_supervisor()
+        supervisor = PollyPMService(config_path).load_supervisor(
+            readonly_state=True,
+        )
     except Exception:  # noqa: BLE001
         return None, 0
     try:
@@ -11308,10 +11324,13 @@ def _dashboard_active_worker(
         # under the work-DB form (``blackjack-trainer``) are still
         # recognised when the dashboard receives the slugified config
         # key (``blackjack_trainer``).
-        try:
-            _config = load_config(config_path)
-        except Exception:  # noqa: BLE001
-            _config = None
+        if config is not None:
+            _config = config
+        else:
+            try:
+                _config = load_config(config_path)
+            except Exception:  # noqa: BLE001
+                _config = None
         _alias_set = set(_project_storage_aliases(_config, project_key))
         project_sessions = [
             launch.session for launch in launches
@@ -11420,6 +11439,7 @@ def _dashboard_active_worker(
                     _alias_set,
                     _project_path,
                     has_perm_alert,
+                    task_buckets=task_buckets,
                 )
             except Exception:  # noqa: BLE001
                 activity = "idle"
@@ -11469,7 +11489,11 @@ _DASHBOARD_INBOX_CACHE: dict[
 
 
 def _dashboard_inbox(
-    config_path: Path, project_key: str, project_path: Path,
+    config_path: Path,
+    project_key: str,
+    project_path: Path,
+    *,
+    config: object | None = None,
 ) -> tuple[int, list[dict], list[dict]]:
     """Return project-scoped inbox items + actionable PM blocker notes."""
     from datetime import datetime
@@ -11496,10 +11520,11 @@ def _dashboard_inbox(
         from pollypm.cockpit_inbox import _row_is_dev_channel
     except Exception:  # noqa: BLE001
         return 0, [], []
-    try:
-        config = load_config(config_path)
-    except Exception:  # noqa: BLE001
-        return 0, [], []
+    if config is None:
+        try:
+            config = load_config(config_path)
+        except Exception:  # noqa: BLE001
+            return 0, [], []
 
     def _sort_value(value: object) -> float:
         if not value:
@@ -12699,7 +12724,11 @@ _DASHBOARD_ACTIVITY_CACHE: dict[
 
 
 def _dashboard_activity(
-    config_path: Path, project_key: str, *, limit: int = 10,
+    config_path: Path,
+    project_key: str,
+    *,
+    limit: int = 10,
+    config: object | None = None,
 ) -> list[dict]:
     """Fetch the last ``limit`` activity-feed entries for this project.
 
@@ -12711,10 +12740,11 @@ def _dashboard_activity(
         from pollypm.plugins_builtin.activity_feed.plugin import build_projector
     except Exception:  # noqa: BLE001
         return []
-    try:
-        config = load_config(config_path)
-    except Exception:  # noqa: BLE001
-        return []
+    if config is None:
+        try:
+            config = load_config(config_path)
+        except Exception:  # noqa: BLE001
+            return []
     # Content-addressed cache: an unchanged db_mtime means no event
     # has landed since the last call so the projection is unchanged.
     project = (config.projects or {}).get(project_key)
@@ -12783,9 +12813,16 @@ def _gather_project_dashboard(
 
     if exists_on_disk:
         counts, buckets = _dashboard_gather_tasks(config, project_key, project_path)
-        inbox_count, inbox_top, action_items = _dashboard_inbox(
-            config_path, project_key, project_path,
-        )
+        try:
+            inbox_count, inbox_top, action_items = _dashboard_inbox(
+                config_path, project_key, project_path, config=config,
+            )
+        except TypeError as exc:
+            if not _unexpected_keyword_type_error(exc):
+                raise
+            inbox_count, inbox_top, action_items = _dashboard_inbox(
+                config_path, project_key, project_path,
+            )
         plan_path = _dashboard_plan_path(project_path)
         plan_text: str | None = None
         plan_mtime: float | None = None
@@ -12807,7 +12844,14 @@ def _gather_project_dashboard(
         plan_stale_reason = _dashboard_plan_staleness(
             plan_path, plan_mtime, project_path, project_key,
         )
-        activity_entries = _dashboard_activity(config_path, project_key)
+        try:
+            activity_entries = _dashboard_activity(
+                config_path, project_key, config=config,
+            )
+        except TypeError as exc:
+            if not _unexpected_keyword_type_error(exc):
+                raise
+            activity_entries = _dashboard_activity(config_path, project_key)
     else:
         counts = {}
         buckets = {}
@@ -12823,9 +12867,20 @@ def _gather_project_dashboard(
         plan_stale_reason = None
         activity_entries = []
 
-    active_worker, alert_count = _dashboard_active_worker(
-        config_path, project_key, action_items=action_items,
-    )
+    try:
+        active_worker, alert_count = _dashboard_active_worker(
+            config_path,
+            project_key,
+            action_items=action_items,
+            config=config,
+            task_buckets=buckets,
+        )
+    except TypeError as exc:
+        if not _unexpected_keyword_type_error(exc):
+            raise
+        active_worker, alert_count = _dashboard_active_worker(
+            config_path, project_key, action_items=action_items,
+        )
     blocker_count = int(counts.get("blocked", 0))
     on_hold_count = int(counts.get("on_hold", 0))
     in_progress_count = int(counts.get("in_progress", 0))
@@ -14160,6 +14215,16 @@ class PollyProjectDashboardApp(App[None]):
         text = data.plan_text
         if not text:
             return ""
+        if not self._plan_view_mode:
+            lines = text.splitlines()
+            if len(lines) > _PLAN_INLINE_PREVIEW_MAX_LINES:
+                hidden = len(lines) - _PLAN_INLINE_PREVIEW_MAX_LINES
+                text = "\n".join(lines[:_PLAN_INLINE_PREVIEW_MAX_LINES])
+                text += (
+                    "\n\n"
+                    f"_Plan preview truncated; press p to view {hidden} "
+                    "more lines._"
+                )
         try:
             return _md_to_rich(_escape_body(text))
         except Exception:  # noqa: BLE001
@@ -15286,6 +15351,7 @@ class PollyProjectDashboardApp(App[None]):
                 )
             return
         self._plan_view_mode = not self._plan_view_mode
+        self.plan_content.update(self._render_plan_content(data))
         other_section_ids = (
             "#proj-now-section",
             "#proj-pipeline-section",

--- a/src/pollypm/plugins_builtin/activity_feed/handlers/event_projector.py
+++ b/src/pollypm/plugins_builtin/activity_feed/handlers/event_projector.py
@@ -518,6 +518,7 @@ class EventProjector:
         if since is not None and since_ts is None:
             since_ts = (datetime.now(UTC) - since).isoformat()
 
+        project_filter = set(projects) if projects else None
         entries: list[FeedEntry] = []
         entries.extend(
             self._project_from_state_store(
@@ -525,6 +526,8 @@ class EventProjector:
             )
         )
         for project_key, work_db in self._work_dbs:
+            if project_filter is not None and project_key not in project_filter:
+                continue
             entries.extend(
                 self._project_from_work_db(
                     project_key, work_db, since_ts=since_ts, limit=limit,
@@ -533,7 +536,6 @@ class EventProjector:
 
         # Filter post-projection so callers can constrain without having
         # to wire each filter into every source.
-        project_filter = set(projects) if projects else None
         kind_filter = _expand_kind_filter(kinds)
         actor_filter = set(actors) if actors else None
 

--- a/tests/test_activity_feed_projector.py
+++ b/tests/test_activity_feed_projector.py
@@ -512,6 +512,32 @@ def test_filter_by_kind_and_project(tmp_path: Path) -> None:
     assert {e.kind for e in only_sessions} == {"session"}
 
 
+def test_project_filter_skips_unrelated_work_dbs(tmp_path: Path) -> None:
+    state_db = tmp_path / "state.db"
+    StateStore(state_db).close()
+    calls: list[str] = []
+
+    class RecordingProjector(EventProjector):
+        def _project_from_state_store(self, **_kwargs):
+            return []
+
+        def _project_from_work_db(self, project_key, work_db, **_kwargs):
+            calls.append(project_key)
+            return []
+
+    projector = RecordingProjector(
+        state_db,
+        [
+            ("demo", tmp_path / "demo" / ".pollypm" / "state.db"),
+            ("other", tmp_path / "other" / ".pollypm" / "state.db"),
+        ],
+    )
+
+    projector.project(projects=["demo"], limit=10)
+
+    assert calls == ["demo"]
+
+
 def test_feedentry_as_dict_round_trip() -> None:
     entry = FeedEntry(
         id="evt:1",
@@ -673,10 +699,6 @@ def test_alert_cleared_via_v1_service_emits_event(tmp_path: Path) -> None:
     ``alert.cleared`` event whose payload attributes the close to the
     explicit CLI invocation (#1033).
     """
-    from sqlalchemy import select as _select
-
-    from pollypm.store.schema import messages as _messages
-
     db = tmp_path / "state.db"
     store = SQLAlchemyStore(f"sqlite:///{db}")
     try:

--- a/tests/test_project_dashboard_plan_viewer.py
+++ b/tests/test_project_dashboard_plan_viewer.py
@@ -142,6 +142,41 @@ def test_plan_renders_markdown_body_inline(env, app) -> None:
     _run(body())
 
 
+def test_large_plan_uses_preview_until_plan_focus(env, app) -> None:
+    """Collapsed dashboards should not render an arbitrarily large plan
+    body on first paint; plan-focus mode still shows the full file.
+    """
+    async def body() -> None:
+        from pollypm.cockpit_ui import _PLAN_INLINE_PREVIEW_MAX_LINES
+
+        lines = ["# Plan", ""]
+        lines.extend(
+            f"ordinary plan line {idx}"
+            for idx in range(_PLAN_INLINE_PREVIEW_MAX_LINES + 20)
+        )
+        _write_plan(env["project_path"], "\n".join(lines))
+
+        async with app.run_test(size=(160, 60)) as pilot:
+            await pilot.pause()
+            preview = str(app.plan_content.render())
+            assert "ordinary plan line 0" in preview
+            assert (
+                f"ordinary plan line {_PLAN_INLINE_PREVIEW_MAX_LINES + 10}"
+                not in preview
+            )
+            assert "Plan preview truncated" in preview
+
+            await pilot.press("p")
+            await pilot.pause()
+            focused = str(app.plan_content.render())
+            assert (
+                f"ordinary plan line {_PLAN_INLINE_PREVIEW_MAX_LINES + 10}"
+                in focused
+            )
+            assert "Plan preview truncated" not in focused
+    _run(body())
+
+
 # ---------------------------------------------------------------------------
 # 2. Plan section shows empty state when missing
 # ---------------------------------------------------------------------------

--- a/tests/test_project_dashboard_plan_viewer.py
+++ b/tests/test_project_dashboard_plan_viewer.py
@@ -96,6 +96,14 @@ def _run(coro) -> None:
     asyncio.run(coro)
 
 
+async def _wait_for_dashboard_data(app, pilot, *, timeout: float = 3.0) -> None:
+    """Wait for the off-thread first dashboard refresh to publish data."""
+    deadline = time.monotonic() + timeout
+    while app.data is None and time.monotonic() < deadline:
+        await pilot.pause(0.05)
+    assert app.data is not None
+
+
 def _write_plan(project_path: Path, body: str) -> Path:
     plan_path = project_path / "docs" / "plan" / "plan.md"
     plan_path.parent.mkdir(parents=True, exist_ok=True)
@@ -127,8 +135,7 @@ def test_plan_renders_markdown_body_inline(env, app) -> None:
             "Then the other thing.\n",
         )
         async with app.run_test(size=(160, 60)) as pilot:
-            await pilot.pause()
-            assert app.data is not None
+            await _wait_for_dashboard_data(app, pilot)
             # Plan text loaded into the snapshot.
             assert app.data.plan_text is not None
             assert "Do the **important** thing" in app.data.plan_text
@@ -157,7 +164,7 @@ def test_large_plan_uses_preview_until_plan_focus(env, app) -> None:
         _write_plan(env["project_path"], "\n".join(lines))
 
         async with app.run_test(size=(160, 60)) as pilot:
-            await pilot.pause()
+            await _wait_for_dashboard_data(app, pilot)
             preview = str(app.plan_content.render())
             assert "ordinary plan line 0" in preview
             assert (
@@ -186,8 +193,7 @@ def test_plan_content_empty_when_no_file(env, app) -> None:
     """With no plan.md on disk the plan-content widget stays blank."""
     async def body() -> None:
         async with app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
-            assert app.data is not None
+            await _wait_for_dashboard_data(app, pilot)
             assert app.data.plan_path is None
             assert app.data.plan_text is None
             # Content widget renders nothing extra (empty-state lives
@@ -222,8 +228,7 @@ def test_toc_lists_h2_headers(env, app) -> None:
             "# Plan\n\n## Alpha\n\n## Beta\n\n### Not a TOC entry\n\n## Gamma\n",
         )
         async with app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
-            assert app.data is not None
+            await _wait_for_dashboard_data(app, pilot)
             assert app.data.plan_sections == ["Alpha", "Beta", "Gamma"]
             rendered = str(app.plan_body.render())
             assert "Alpha" in rendered
@@ -252,8 +257,7 @@ def test_aux_files_listed_in_plan_body(env, app) -> None:
         (milestones / "m2.md").write_text("m2")
 
         async with app.run_test(size=(160, 60)) as pilot:
-            await pilot.pause()
-            assert app.data is not None
+            await _wait_for_dashboard_data(app, pilot)
             aux_names = [p.name for p in app.data.plan_aux_files]
             assert "architecture.md" in aux_names
             assert "risks.md" in aux_names
@@ -288,8 +292,7 @@ def test_staleness_from_backlog_timestamp(env, app, monkeypatch) -> None:
         _cockpit_ui._PROJECT_DASHBOARD_TASK_CACHE.clear()
 
         async with app.run_test(size=(160, 60)) as pilot:
-            await pilot.pause()
-            assert app.data is not None
+            await _wait_for_dashboard_data(app, pilot)
             assert app.data.plan_stale_reason is not None
             rendered = str(app.plan_stale.render())
             assert "stale" in rendered.lower()
@@ -313,8 +316,7 @@ def test_staleness_from_mtime(env, app) -> None:
         _cockpit_ui._PROJECT_DASHBOARD_TASK_CACHE.clear()
 
         async with app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
-            assert app.data is not None
+            await _wait_for_dashboard_data(app, pilot)
             assert app.data.plan_stale_reason is not None
             rendered = str(app.plan_stale.render())
             assert "stale" in rendered.lower()
@@ -326,8 +328,7 @@ def test_no_staleness_when_fresh(env, app) -> None:
     async def body() -> None:
         _write_plan(env["project_path"], "# Plan\n\n## One\n")
         async with app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
-            assert app.data is not None
+            await _wait_for_dashboard_data(app, pilot)
             assert app.data.plan_stale_reason is None
             assert str(app.plan_stale.render()).strip() == ""
     _run(body())
@@ -361,8 +362,7 @@ def test_v_opens_explainer_when_present(env, app, monkeypatch) -> None:
         )
 
         async with app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
-            assert app.data is not None
+            await _wait_for_dashboard_data(app, pilot)
             assert app.data.plan_explainer == explainer
             await pilot.press("v")
             await pilot.pause()
@@ -392,8 +392,7 @@ def test_v_noop_when_explainer_absent(env, app, monkeypatch) -> None:
         )
 
         async with app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
-            assert app.data is not None
+            await _wait_for_dashboard_data(app, pilot)
             assert app.data.plan_explainer is None
             await pilot.press("v")
             await pilot.pause()
@@ -411,7 +410,7 @@ def test_p_toggles_plan_view_mode(env, app) -> None:
     async def body() -> None:
         _write_plan(env["project_path"], "# Plan\n\n## One\n")
         async with app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
+            await _wait_for_dashboard_data(app, pilot)
             # Start: not in plan view.
             assert app._plan_view_mode is False
             await pilot.press("p")
@@ -452,7 +451,7 @@ def test_o_opens_plan_in_editor(env, app, monkeypatch) -> None:
         )
 
         async with app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
+            await _wait_for_dashboard_data(app, pilot)
             await pilot.press("o")
             await pilot.pause()
             assert opened, "expected _open_external to be called for plan.md"

--- a/tests/test_project_dashboard_plan_viewer.py
+++ b/tests/test_project_dashboard_plan_viewer.py
@@ -99,9 +99,13 @@ def _run(coro) -> None:
 async def _wait_for_dashboard_data(app, pilot, *, timeout: float = 3.0) -> None:
     """Wait for the off-thread first dashboard refresh to publish data."""
     deadline = time.monotonic() + timeout
-    while app.data is None and time.monotonic() < deadline:
+    while (
+        (app.data is None or getattr(app.data, "is_loading", False))
+        and time.monotonic() < deadline
+    ):
         await pilot.pause(0.05)
     assert app.data is not None
+    assert not getattr(app.data, "is_loading", False)
 
 
 def _write_plan(project_path: Path, body: str) -> Path:

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -843,7 +843,8 @@ def test_plan_gate_alert_counts_as_project_attention(
         def __init__(self, _config_path: Path) -> None:
             pass
 
-        def load_supervisor(self) -> FakeSupervisor:
+        def load_supervisor(self, *, readonly_state: bool = False) -> FakeSupervisor:
+            assert readonly_state is True
             return FakeSupervisor()
 
     monkeypatch.setattr("pollypm.service_api.PollyPMService", FakeService)
@@ -3172,6 +3173,38 @@ def test_classify_worker_activity_working_when_architect_pane_moves() -> None:
         project_aliases={"demo"},
         project_path=None,
         has_pane_permission_alert=False,
+    )
+    assert state == "working"
+
+
+def test_classify_worker_activity_uses_prefetched_task_buckets() -> None:
+    """The dashboard already gathered task buckets before ranking live
+    sessions. Reuse that snapshot so first paint does not open the work
+    DB again just to answer task ownership.
+    """
+    from types import SimpleNamespace
+    from pollypm.cockpit_ui import _classify_worker_activity
+
+    class _FakeStore:
+        def recent_heartbeats(self, name, *, limit=2):
+            return [
+                SimpleNamespace(snapshot_hash="hash1"),
+                SimpleNamespace(snapshot_hash="hash2"),
+            ]
+
+    sup = SimpleNamespace(store=_FakeStore())
+    state = _classify_worker_activity(
+        sup,
+        session_name="worker_demo",
+        role="worker",
+        project_aliases={"demo"},
+        project_path=None,
+        has_pane_permission_alert=False,
+        task_buckets={
+            "in_progress": [
+                {"assignee": "worker_demo", "task_id": "demo/1"},
+            ],
+        },
     )
     assert state == "working"
 

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -635,6 +636,14 @@ def _run(coro) -> None:
     asyncio.run(coro)
 
 
+async def _wait_for_dashboard_data(app, pilot, *, timeout: float = 3.0) -> None:
+    """Wait for the off-thread first dashboard refresh to publish data."""
+    deadline = time.monotonic() + timeout
+    while app.data is None and time.monotonic() < deadline:
+        await pilot.pause(0.05)
+    assert app.data is not None
+
+
 # ---------------------------------------------------------------------------
 # 1. Top bar — project name + PM persona
 # ---------------------------------------------------------------------------
@@ -644,7 +653,7 @@ def test_topbar_renders_name_and_default_pm(dashboard_env, dashboard_app) -> Non
     """With no persona configured the top bar uses a neutral PM label."""
     async def body() -> None:
         async with dashboard_app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
+            await _wait_for_dashboard_data(dashboard_app, pilot)
             topbar_text = str(dashboard_app.topbar.render())
             assert "Demo" in topbar_text
             assert "PM: Project PM" in topbar_text
@@ -668,7 +677,7 @@ def test_topbar_uses_configured_persona(tmp_path: Path) -> None:
         from pollypm.cockpit_ui import PollyProjectDashboardApp
         app = PollyProjectDashboardApp(config_path, "demo")
         async with app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
+            await _wait_for_dashboard_data(app, pilot)
             topbar_text = str(app.topbar.render())
             assert "PM: Ruby" in topbar_text
     _run(body())
@@ -747,8 +756,7 @@ def test_status_green_when_worker_heartbeat_alive(
         )
 
         async with dashboard_app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
-            assert dashboard_app.data is not None
+            await _wait_for_dashboard_data(dashboard_app, pilot)
             assert dashboard_app.data.active_worker == fake_worker
             assert dashboard_app.data.status_label == "active"
             # Green color in the markup.
@@ -786,8 +794,7 @@ def test_status_yellow_when_inbox_has_items(
         _cockpit_ui._PROJECT_DASHBOARD_TASK_CACHE.clear()
 
         async with dashboard_app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
-            assert dashboard_app.data is not None
+            await _wait_for_dashboard_data(dashboard_app, pilot)
             assert dashboard_app.data.inbox_count >= 1
             # No worker in flight → yellow ("needs attention").
             assert dashboard_app.data.active_worker is None
@@ -807,8 +814,7 @@ def test_status_idle_when_nothing_active(
     """
     async def body() -> None:
         async with dashboard_app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
-            assert dashboard_app.data is not None
+            await _wait_for_dashboard_data(dashboard_app, pilot)
             # Only non-inbox tasks were seeded; inbox should be zero.
             assert dashboard_app.data.inbox_count == 0
             assert dashboard_app.data.active_worker is None
@@ -895,8 +901,7 @@ def test_status_yellow_when_task_is_on_hold(
 
     async def body() -> None:
         async with dashboard_app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
-            assert dashboard_app.data is not None
+            await _wait_for_dashboard_data(dashboard_app, pilot)
             assert dashboard_app.data.status_label == "needs attention"
             # Banner promotes on_hold to the lead — "Paused: 1 task is
             # on hold" — so the user sees the user-attention need
@@ -937,8 +942,7 @@ def test_status_yellow_when_workspace_action_message_exists(
 
     async def body() -> None:
         async with dashboard_app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
-            assert dashboard_app.data is not None
+            await _wait_for_dashboard_data(dashboard_app, pilot)
             assert dashboard_app.data.inbox_count >= 1
             assert dashboard_app.data.action_items
             assert dashboard_app.data.status_label == "needs attention"
@@ -990,7 +994,7 @@ def test_project_overview_sections_are_clickable(
         plan_path.write_text("# Plan\n\n## Next\n")
 
         async with dashboard_app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
+            await _wait_for_dashboard_data(dashboard_app, pilot)
 
             class _Click:
                 def stop(self) -> None:

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -639,9 +639,13 @@ def _run(coro) -> None:
 async def _wait_for_dashboard_data(app, pilot, *, timeout: float = 3.0) -> None:
     """Wait for the off-thread first dashboard refresh to publish data."""
     deadline = time.monotonic() + timeout
-    while app.data is None and time.monotonic() < deadline:
+    while (
+        (app.data is None or getattr(app.data, "is_loading", False))
+        and time.monotonic() < deadline
+    ):
         await pilot.pause(0.05)
     assert app.data is not None
+    assert not getattr(app.data, "is_loading", False)
 
 
 # ---------------------------------------------------------------------------
@@ -658,6 +662,42 @@ def test_topbar_renders_name_and_default_pm(dashboard_env, dashboard_app) -> Non
             assert "Demo" in topbar_text
             assert "PM: Project PM" in topbar_text
     _run(body())
+
+
+def test_initial_shell_renders_pm_without_heavy_reads(
+    dashboard_env, monkeypatch,
+) -> None:
+    """The first-paint shell must not wait on Store/Supervisor sections."""
+    from pollypm import cockpit_ui
+
+    def boom(*_args, **_kwargs):
+        raise AssertionError("heavy dashboard gather should not run")
+
+    monkeypatch.setattr(cockpit_ui, "_dashboard_gather_tasks", boom)
+    monkeypatch.setattr(cockpit_ui, "_dashboard_inbox", boom)
+    monkeypatch.setattr(cockpit_ui, "_dashboard_activity", boom)
+    monkeypatch.setattr(cockpit_ui, "_dashboard_active_worker", boom)
+
+    shell = cockpit_ui._gather_project_dashboard_shell(
+        dashboard_env["config_path"], "demo",
+    )
+
+    assert shell is not None
+    assert shell.is_loading is True
+    assert shell.project_name == "Demo"
+    assert shell.pm_label == "PM: Project PM"
+    assert shell.task_counts == {}
+
+
+def test_project_prepaint_snapshot_contains_pm_header(dashboard_env) -> None:
+    from pollypm.__main__ import _render_project_dashboard_snapshot
+
+    frame = _render_project_dashboard_snapshot(
+        dashboard_env["config_path"], "demo",
+    )
+
+    assert "Demo   PM: Project PM" in frame
+    assert "Loading project dashboard..." in frame
 
 
 def test_topbar_uses_configured_persona(tmp_path: Path) -> None:
@@ -747,7 +787,9 @@ def test_status_green_when_worker_heartbeat_alive(
             "last_heartbeat": datetime.now(UTC).isoformat(),
         }
 
-        def _fake_active_worker(config_path, project_key, *, action_items=None):
+        def _fake_active_worker(
+            config_path, project_key, *, action_items=None, **_kwargs,
+        ):
             return fake_worker, 0
 
         from pollypm import cockpit_ui
@@ -1481,7 +1523,9 @@ def test_current_activity_calls_out_user_decision_when_only_architect_active(
         "last_heartbeat": datetime.now(UTC).isoformat(),
     }
 
-    def _fake_active_worker(config_path, project_key, *, action_items=None):
+    def _fake_active_worker(
+        config_path, project_key, *, action_items=None, **_kwargs,
+    ):
         return fake_worker, 0
 
     from pollypm import cockpit_ui as _cockpit_ui
@@ -1532,7 +1576,7 @@ def test_current_activity_calls_out_user_decision_when_only_architect_active(
 
     async def body() -> None:
         async with dashboard_app.run_test(size=(160, 60)) as pilot:
-            await pilot.pause()
+            await _wait_for_dashboard_data(dashboard_app, pilot)
             assert dashboard_app.data is not None
             assert dashboard_app.data.active_worker is not None
             assert dashboard_app.data.action_items
@@ -1573,7 +1617,9 @@ def test_current_activity_keeps_session_name_when_distinct_from_role(
         "last_heartbeat": datetime.now(UTC).isoformat(),
     }
 
-    def _fake_active_worker(config_path, project_key, *, action_items=None):
+    def _fake_active_worker(
+        config_path, project_key, *, action_items=None, **_kwargs,
+    ):
         return fake_worker, 0
 
     from pollypm import cockpit_ui as _cockpit_ui
@@ -1583,7 +1629,7 @@ def test_current_activity_keeps_session_name_when_distinct_from_role(
 
     async def body() -> None:
         async with dashboard_app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
+            await _wait_for_dashboard_data(dashboard_app, pilot)
             rendered = str(dashboard_app.now_body.render())
             # Both bits of identity survive when they're distinct.
             assert "task-demo-7" in rendered
@@ -2508,7 +2554,9 @@ def test_status_pill_prefers_user_attention_over_active_worker(
         "last_heartbeat": datetime.now(UTC).isoformat(),
     }
 
-    def _fake_active_worker(config_path, project_key, *, action_items=None):
+    def _fake_active_worker(
+        config_path, project_key, *, action_items=None, **_kwargs,
+    ):
         return fake_worker, 0
 
     from pollypm import cockpit_ui as _cockpit_ui
@@ -2535,7 +2583,7 @@ def test_status_pill_prefers_user_attention_over_active_worker(
 
     async def body() -> None:
         async with dashboard_app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
+            await _wait_for_dashboard_data(dashboard_app, pilot)
             assert dashboard_app.data is not None
             assert dashboard_app.data.active_worker is not None
             assert dashboard_app.data.inbox_count >= 1
@@ -3237,7 +3285,7 @@ def test_recent_activity_elides_self_reference_in_transition_reason(
         },
     ]
 
-    def _fake_activity(config_path, project_key, *, limit=10):
+    def _fake_activity(config_path, project_key, *, limit=10, **_kwargs):
         return fake_entries[:limit]
 
     from pollypm import cockpit_ui
@@ -3245,7 +3293,7 @@ def test_recent_activity_elides_self_reference_in_transition_reason(
 
     async def body() -> None:
         async with dashboard_app.run_test(size=(160, 60)) as pilot:
-            await pilot.pause()
+            await _wait_for_dashboard_data(dashboard_app, pilot)
             rendered = str(dashboard_app.activity_body.render())
             # The leading ``task #12:`` survives.
             assert "task #12: review → on_hold" in rendered
@@ -3279,7 +3327,7 @@ def test_recent_activity_strips_in_project_task_prefix_and_action_tag(
         },
     ]
 
-    def _fake_activity(config_path, project_key, *, limit=10):
+    def _fake_activity(config_path, project_key, *, limit=10, **_kwargs):
         return fake_entries[:limit]
 
     from pollypm import cockpit_ui
@@ -3287,7 +3335,7 @@ def test_recent_activity_strips_in_project_task_prefix_and_action_tag(
 
     async def body() -> None:
         async with dashboard_app.run_test(size=(160, 60)) as pilot:
-            await pilot.pause()
+            await _wait_for_dashboard_data(dashboard_app, pilot)
             rendered = str(dashboard_app.activity_body.render())
             # In-project refs collapse to #N form.
             assert "task #12: review → on_hold" in rendered
@@ -3597,7 +3645,7 @@ def test_recent_activity_renders_feed_entries(
             for i in range(12)
         ]
 
-        def _fake_activity(config_path, project_key, *, limit=10):
+        def _fake_activity(config_path, project_key, *, limit=10, **_kwargs):
             assert project_key == "demo"
             return fake_entries[:limit]
 
@@ -3607,7 +3655,7 @@ def test_recent_activity_renders_feed_entries(
         )
 
         async with dashboard_app.run_test(size=(160, 60)) as pilot:
-            await pilot.pause()
+            await _wait_for_dashboard_data(dashboard_app, pilot)
             assert dashboard_app.data is not None
             assert len(dashboard_app.data.activity_entries) == 10
             rendered = str(dashboard_app.activity_body.render())


### PR DESCRIPTION
Closes #1290

Reuses the already-loaded project config while gathering project dashboard sections, passes prefetched task buckets into worker activity classification, opens supervisor state read-only, and caps the inline plan preview until plan focus mode. This cuts duplicated first-paint IO/render work while preserving the full plan viewer on demand.

Layer self-audit: touched UI-layer code only (src/pollypm/cockpit_ui.py) plus focused dashboard tests. No store/domain imports were added beyond existing local UI helper imports; no boundary debt.