### PR TITLE
Fix #1330 surface network-dead rail pill

### DIFF
--- a/src/pollypm/plugins_builtin/core_rail_items/plugin.py
+++ b/src/pollypm/plugins_builtin/core_rail_items/plugin.py
@@ -159,11 +159,26 @@ def _active_task_numbers(project: Any, *, config: Any = None) -> list[int]:
 
 
 def _polly_state(ctx: RailContext) -> str:
+    notice_state = _live_chat_network_dead_state(ctx)
+    if notice_state is not None:
+        return notice_state
     return _session_state(ctx, "operator")
 
 
 def _russell_state(ctx: RailContext) -> str:
     return _session_state(ctx, "reviewer")
+
+
+def _live_chat_network_dead_state(ctx: RailContext) -> str | None:
+    try:
+        from pollypm.cockpit_live_chat_notice import (
+            current_live_chat_network_dead_notice,
+        )
+
+        notice = current_live_chat_network_dead_notice(ctx.cockpit_state)
+    except Exception:  # noqa: BLE001
+        return None
+    return f"! {notice}" if notice else None
 
 
 def _session_configured(ctx: RailContext, session_name: str) -> bool:

--- a/tests/test_core_rail_items.py
+++ b/tests/test_core_rail_items.py
@@ -5,10 +5,16 @@ See docs/extensible-rail-spec.md §5 and issue #222.
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
 
+from pollypm.cockpit_live_chat_notice import (
+    LIVE_CHAT_NETWORK_DEAD_NOTICE_MESSAGE_KEY,
+    LIVE_CHAT_NETWORK_DEAD_NOTICE_UNTIL_KEY,
+    LIVE_CHAT_NETWORK_DEAD_RAIL_MESSAGE,
+)
 from pollypm.cockpit_rail import CockpitRouter
 from pollypm.models import KnownProject, ProjectKind
 from pollypm.plugin_api.v1 import (
@@ -86,6 +92,48 @@ class _FakeWindow:
         self.name = name
         self.pane_dead = pane_dead
         self.pane_id = f"%{name}"
+
+
+def test_polly_state_surfaces_live_chat_network_dead_notice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        core_rail_items_plugin,
+        "_session_state",
+        lambda *_args, **_kwargs: "ready",
+    )
+    ctx = RailContext(
+        cockpit_state={
+            LIVE_CHAT_NETWORK_DEAD_NOTICE_MESSAGE_KEY: (
+                LIVE_CHAT_NETWORK_DEAD_RAIL_MESSAGE
+            ),
+            LIVE_CHAT_NETWORK_DEAD_NOTICE_UNTIL_KEY: time.time() + 30,
+        },
+    )
+
+    assert core_rail_items_plugin._polly_state(ctx) == (
+        f"! {LIVE_CHAT_NETWORK_DEAD_RAIL_MESSAGE}"
+    )
+
+
+def test_polly_state_ignores_expired_live_chat_network_dead_notice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        core_rail_items_plugin,
+        "_session_state",
+        lambda *_args, **_kwargs: "ready",
+    )
+    ctx = RailContext(
+        cockpit_state={
+            LIVE_CHAT_NETWORK_DEAD_NOTICE_MESSAGE_KEY: (
+                LIVE_CHAT_NETWORK_DEAD_RAIL_MESSAGE
+            ),
+            LIVE_CHAT_NETWORK_DEAD_NOTICE_UNTIL_KEY: time.time() - 1,
+        },
+    )
+
+    assert core_rail_items_plugin._polly_state(ctx) == "ready"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1330

When the cockpit send-key bridge records an active network-dead live chat notice, the core rail now reports the Polly chat row as an actionable red state instead of only relying on the separate transient pill. Expired notices fall back to the normal operator session state.

Layer audit: UI/CLI rail rendering only. Touched src/pollypm/plugins_builtin/core_rail_items/plugin.py and focused tests in tests/test_core_rail_items.py; no facade, domain, store, or IO changes.

Tests: uv run --extra dev pytest tests/test_core_rail_items.py tests/test_cockpit_input_bridge.py -q