### PR TITLE
Fix #1282 keep Inbox A on approval gate

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -3916,7 +3916,9 @@ class PollyCockpitRail:
             self.router.send_key_to_right_pane("Tab")
             return True
         if key == b"A":
-            if self.selected_key == "workers":
+            if self.selected_key == "inbox" or self.selected_key.startswith("inbox:"):
+                self.router.send_key_to_right_pane("A")
+            elif self.selected_key == "workers":
                 self.router.send_key_to_right_pane("A")
             else:
                 self.router.route_selected("workers")

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4683,6 +4683,41 @@ def test_cockpit_rail_forwards_detail_hint_keys(monkeypatch, tmp_path: Path) -> 
     assert rail.router.sent == ["Tab", "A"]
 
 
+def test_cockpit_rail_capital_a_on_inbox_forwards_approval_key(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """#1282: Inbox owns A so plan-review approval can show its gate toast."""
+    class FakeRouter:
+        def __init__(self, _config_path: Path) -> None:
+            self.calls: list[str] = []
+            self.sent: list[str] = []
+            self.tmux = None
+
+        def selected_key(self) -> str:
+            return "inbox"
+
+        def route_selected(self, key: str) -> None:
+            self.calls.append(key)
+
+        def send_key_to_right_pane(self, key: str) -> None:
+            self.sent.append(key)
+
+    monkeypatch.setattr("pollypm.cockpit_rail.CockpitRouter", FakeRouter)
+    from pollypm.cockpit_rail import CockpitItem, PollyCockpitRail
+
+    rail = PollyCockpitRail(tmp_path / "pollypm.toml")
+    items = [
+        CockpitItem("inbox", "Inbox", "has"),
+        CockpitItem("workers", "Workers", "ready"),
+    ]
+
+    assert rail._handle_key(b"A", items) is True
+
+    assert rail.router.sent == ["A"]
+    assert rail.router.calls == []
+    assert rail.selected_key == "inbox"
+
+
 def test_cockpit_rail_capital_a_routes_workers_when_not_active(
     monkeypatch, tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Closes #1282

Capital A on the raw cockpit rail now stays scoped to the Inbox surface and forwards the key to the right pane, so plan-review approval can show its pre-discussion gate instead of routing to Workers. The existing Workers shortcut behavior remains unchanged outside Inbox and on the Workers view.

Layer audit: touched UI/CLI rail handling only (`src/pollypm/cockpit_rail.py`) plus focused cockpit tests (`tests/test_cockpit.py`); no service, domain, or store imports added.

Tests:
- `uv run pytest tests/test_cockpit.py::test_cockpit_rail_capital_a_on_inbox_forwards_approval_key tests/test_cockpit.py::test_cockpit_rail_capital_a_routes_workers_when_not_active tests/test_cockpit.py::test_cockpit_capital_a_opens_workers_then_forwards_auto_refresh tests/test_cockpit.py::test_cockpit_inbox_surface_forwards_non_nav_footer_keys_to_inbox_pane tests/test_cockpit_input_bridge.py::test_cockpit_send_key_inbox_action_prefers_inbox_bridge_over_live_pane`
- `uv run pytest tests/test_cockpit.py::test_cockpit_rail_forwards_detail_hint_keys tests/test_cockpit.py::test_cockpit_rail_capital_a_on_inbox_forwards_approval_key tests/test_cockpit.py::test_cockpit_rail_capital_a_routes_workers_when_not_active`