### PR TITLE
Fix #1293 target cockpit panes by id

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -669,8 +669,9 @@ def _build_launch_probe(supervisor) -> LaunchProbe:
         # is the source of truth.
         panes = _safe("list_panes", target, default=None)
         if panes:
+            capture_pane = getattr(tmux, "capture_pane", None)
             console_pane_alive, rail_pane_alive, rail_pane_running_non_shell = (
-                _classify_cockpit_panes(panes)
+                _classify_cockpit_panes(panes, capture_pane=capture_pane)
             )
 
     return LaunchProbe(
@@ -685,7 +686,7 @@ def _build_launch_probe(supervisor) -> LaunchProbe:
     )
 
 
-def _classify_cockpit_panes(panes) -> tuple[bool, bool, bool]:
+def _classify_cockpit_panes(panes, *, capture_pane=None) -> tuple[bool, bool, bool]:
     """Classify the cockpit window's pane list into the three
     pane-liveness probe fields.
 
@@ -694,7 +695,9 @@ def _classify_cockpit_panes(panes) -> tuple[bool, bool, bool]:
     Returns ``(console_alive, rail_alive, rail_non_shell)``. When only
     one pane is present, infer whether it is the rail from the command:
     shell means the rail has not started; non-shell means the right pane
-    is missing.
+    is missing. Some real rail panes report the shell wrapper as the
+    current command even while the cockpit rail is visibly running; when a
+    safe pane capture proves that UI is present, treat the rail as healthy.
     """
     left = None
     right = None
@@ -714,7 +717,10 @@ def _classify_cockpit_panes(panes) -> tuple[bool, bool, bool]:
         pane = left[1]
         pane_alive = not bool(getattr(pane, "pane_dead", False))
         pane_cmd = (getattr(pane, "pane_current_command", "") or "").lower()
-        pane_non_shell = pane_alive and pane_cmd not in _SHELL_COMMANDS
+        pane_non_shell = pane_alive and (
+            pane_cmd not in _SHELL_COMMANDS
+            or _pane_capture_looks_like_cockpit_rail(pane, capture_pane)
+        )
         if pane_non_shell:
             return (False, True, True)
         return (pane_alive, False, False)
@@ -727,8 +733,30 @@ def _classify_cockpit_panes(panes) -> tuple[bool, bool, bool]:
     console_alive = not bool(getattr(console_pane, "pane_dead", False))
     rail_alive = not bool(getattr(rail_pane, "pane_dead", False))
     rail_cmd = (getattr(rail_pane, "pane_current_command", "") or "").lower()
-    rail_non_shell = rail_alive and rail_cmd not in _SHELL_COMMANDS
+    rail_non_shell = rail_alive and (
+        rail_cmd not in _SHELL_COMMANDS
+        or _pane_capture_looks_like_cockpit_rail(rail_pane, capture_pane)
+    )
     return (console_alive, rail_alive, rail_non_shell)
+
+
+def _pane_capture_looks_like_cockpit_rail(pane, capture_pane) -> bool:
+    if not callable(capture_pane):
+        return False
+    pane_id = getattr(pane, "pane_id", None)
+    if not isinstance(pane_id, str) or not pane_id:
+        return False
+    try:
+        text = str(capture_pane(pane_id, lines=40) or "")
+    except Exception:  # noqa: BLE001
+        return False
+    normalized = " ".join(text.lower().split())
+    return (
+        "polly" in normalized
+        and "home" in normalized
+        and "workers" in normalized
+        and "inbox" in normalized
+    )
 
 
 @app.command(help=_UP_HELP)

--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -661,7 +661,7 @@ def _build_launch_probe(supervisor) -> LaunchProbe:
     rail_pane_alive = True
     rail_pane_running_non_shell = True
     if main_alive and main_name:
-        target = f"{main_name}:{_COCKPIT_WINDOW_NAME}"
+        target = _cockpit_window_pane_target(tmux, main_name)
         # ``list_panes`` returns ``[]`` for both "window absent" and
         # "tmux unavailable"; the state machine treats both as
         # console+rail healthy via the default-True values above.
@@ -684,6 +684,23 @@ def _build_launch_probe(supervisor) -> LaunchProbe:
         rail_pane_running_non_shell=rail_pane_running_non_shell,
         current_tmux_session=current_tmux,
     )
+
+
+def _cockpit_window_pane_target(tmux, main_name: str) -> str:
+    """Return an unambiguous tmux target for the cockpit window's panes."""
+    list_windows = getattr(tmux, "list_windows", None)
+    if callable(list_windows):
+        try:
+            windows = list_windows(main_name) or []
+        except Exception:  # noqa: BLE001
+            windows = []
+        for window in windows:
+            if getattr(window, "name", "") != _COCKPIT_WINDOW_NAME:
+                continue
+            pane_id = getattr(window, "pane_id", None)
+            if isinstance(pane_id, str) and pane_id:
+                return pane_id
+    return f"{main_name}:{_COCKPIT_WINDOW_NAME}"
 
 
 def _classify_cockpit_panes(panes, *, capture_pane=None) -> tuple[bool, bool, bool]:

--- a/tests/test_cli_up_state_machine.py
+++ b/tests/test_cli_up_state_machine.py
@@ -570,6 +570,84 @@ def test_probe_treats_rail_running_shell_as_recoverable() -> None:
     assert plan.state.value in {"recover_dead_rail"}
 
 
+def test_probe_treats_shell_wrapped_visible_cockpit_rail_as_healthy() -> None:
+    """#1293 — tmux may report the rail pane's shell wrapper as
+    ``pane_current_command`` while the cockpit rail UI is visibly
+    running. The probe should trust that capture before emitting a
+    recover_dead_rail diagnostic."""
+    from pollypm.launch_state import LaunchAction, LaunchState, plan_launch
+    from pollypm.tmux.client import TmuxPane
+
+    class _FakeTmux:
+        def has_session(self, name: str) -> bool:
+            return name in {"pollypm", "pollypm-storage-closet"}
+
+        def current_session_name(self) -> None:
+            return None
+
+        def list_panes(self, _target: str) -> list[TmuxPane]:
+            return [
+                TmuxPane(
+                    session="pollypm",
+                    window_index="0",
+                    window_name="PollyPM",
+                    pane_index="0",
+                    pane_id="%1",
+                    active=True,
+                    pane_current_command="zsh",
+                    pane_current_path="/",
+                    pane_dead=False,
+                    pane_left=0,
+                    pane_width=30,
+                ),
+                TmuxPane(
+                    session="pollypm",
+                    window_index="0",
+                    window_name="PollyPM",
+                    pane_index="1",
+                    pane_id="%2",
+                    active=False,
+                    pane_current_command="Python",
+                    pane_current_path="/",
+                    pane_dead=False,
+                    pane_left=31,
+                    pane_width=120,
+                ),
+            ]
+
+        def capture_pane(self, target: str, lines: int = 200) -> str:
+            assert target == "%1"
+            assert lines == 40
+            return """
+     █▀█ █▀█ █   █   █▄█     │
+     █▀▀ █▄█ █▄▄ █▄▄  █      │
+        Plans first.         │
+        Chaos later.         │
+   ○ Home                    │
+   ♡· Polly · chat           │
+   ○ Workers (11)            │
+   ◆ Inbox (42)              │
+   ── projects ────────      │
+"""
+
+    class _FakeSupervisor:
+        def __init__(self) -> None:
+            self.tmux = _FakeTmux()
+            self.config = type(
+                "Config",
+                (),
+                {"project": type("Project", (), {"tmux_session": "pollypm"})()},
+            )()
+
+    probe = cli._build_launch_probe(_FakeSupervisor())
+    assert probe.rail_pane_alive is True
+    assert probe.rail_pane_running_non_shell is True
+
+    plan = plan_launch(probe)
+    assert plan.state is LaunchState.ATTACH_EXISTING
+    assert LaunchAction.RESPAWN_RAIL not in plan.actions
+
+
 def test_probe_falls_back_when_list_panes_unavailable() -> None:
     """#906 — when ``list_panes`` cannot enumerate (returns an
     empty list / raises), pane-liveness defaults to True. The

--- a/tests/test_cli_up_state_machine.py
+++ b/tests/test_cli_up_state_machine.py
@@ -648,6 +648,108 @@ def test_probe_treats_shell_wrapped_visible_cockpit_rail_as_healthy() -> None:
     assert LaunchAction.RESPAWN_RAIL not in plan.actions
 
 
+def test_probe_lists_cockpit_panes_from_window_pane_id() -> None:
+    """#1293 — resolve the cockpit window through the exact session before
+    listing panes so tmux cannot classify a similarly named session."""
+    from pollypm.launch_state import LaunchState, plan_launch
+    from pollypm.tmux.client import TmuxPane, TmuxWindow
+
+    class _FakeTmux:
+        def __init__(self) -> None:
+            self.pane_targets: list[str] = []
+
+        def has_session(self, name: str) -> bool:
+            return name in {"pollypm", "pollypm-storage-closet"}
+
+        def current_session_name(self) -> None:
+            return None
+
+        def list_windows(self, name: str) -> list[TmuxWindow]:
+            assert name == "pollypm"
+            return [
+                TmuxWindow(
+                    session="pollypm",
+                    index=0,
+                    name="PollyPM",
+                    active=True,
+                    pane_id="%rail",
+                    pane_current_command="zsh",
+                    pane_current_path="/",
+                    pane_dead=False,
+                )
+            ]
+
+        def list_panes(self, target: str) -> list[TmuxPane]:
+            self.pane_targets.append(target)
+            if target == "%rail":
+                return [
+                    TmuxPane(
+                        session="pollypm",
+                        window_index=0,
+                        window_name="PollyPM",
+                        pane_index=0,
+                        pane_id="%rail",
+                        active=True,
+                        pane_current_command="zsh",
+                        pane_current_path="/",
+                        pane_dead=False,
+                        pane_left=0,
+                        pane_width=30,
+                    ),
+                    TmuxPane(
+                        session="pollypm",
+                        window_index=0,
+                        window_name="PollyPM",
+                        pane_index=1,
+                        pane_id="%right",
+                        active=False,
+                        pane_current_command="python",
+                        pane_current_path="/",
+                        pane_dead=False,
+                        pane_left=31,
+                        pane_width=120,
+                    ),
+                ]
+            return [
+                TmuxPane(
+                    session="pollypm-extra",
+                    window_index=0,
+                    window_name="PollyPM",
+                    pane_index=0,
+                    pane_id="%wrong",
+                    active=True,
+                    pane_current_command="zsh",
+                    pane_current_path="/",
+                    pane_dead=False,
+                    pane_left=0,
+                    pane_width=30,
+                )
+            ]
+
+        def capture_pane(self, target: str, lines: int = 200) -> str:
+            assert lines == 40
+            if target != "%rail":
+                return ""
+            return "Polly Home Workers Inbox"
+
+    class _FakeSupervisor:
+        def __init__(self) -> None:
+            self.tmux = _FakeTmux()
+            self.config = type(
+                "Config",
+                (),
+                {"project": type("Project", (), {"tmux_session": "pollypm"})()},
+            )()
+
+    supervisor = _FakeSupervisor()
+    probe = cli._build_launch_probe(supervisor)
+    plan = plan_launch(probe)
+
+    assert supervisor.tmux.pane_targets == ["%rail"]
+    assert probe.rail_pane_running_non_shell is True
+    assert plan.state is LaunchState.ATTACH_EXISTING
+
+
 def test_probe_falls_back_when_list_panes_unavailable() -> None:
     """#906 — when ``list_panes`` cannot enumerate (returns an
     empty list / raises), pane-liveness defaults to True. The


### PR DESCRIPTION
Closes #1293

Resolves the launcher pane probe through the exact cockpit window first, then lists panes by pane id so similarly named tmux sessions cannot feed the dead-rail classifier. Keeps the prior visible-rail capture fallback and adds coverage for the ambiguous-target path.

Layer audit: CLI launch probe only; test coverage in the CLI launch-state test module.