### PR TITLE
Fix #1288 settings narrow nav cursor

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -4880,10 +4880,28 @@ class PollySettingsPaneApp(App[None]):
             "inbox": len(data.inbox) if data else 0,
             "about": len(data.about) if data else 0,
         }
+        # #1288 — re-resolve nav widgets from the live DOM each render.
+        # The cached ``_nav_widgets`` references can go stale if Textual
+        # re-mounts a child (e.g. on a layout pass triggered by toggling
+        # the ``-narrow`` class), and a stale ``Static.update`` is a
+        # silent no-op — leaving the ▸ marker pinned to its first
+        # painted row at narrow widths even though ``_nav_cursor`` is
+        # advancing on every j/k.
+        try:
+            live_nav_items = list(self.nav.query(".nav-item"))
+        except Exception:  # noqa: BLE001
+            live_nav_items = []
+        live_by_index: dict[int, Static] = {}
+        for index, widget in enumerate(live_nav_items):
+            if isinstance(widget, Static):
+                live_by_index[index] = widget
         for i, (key, label) in enumerate(_SETTINGS_SECTIONS):
-            widget = self._nav_widgets.get(key)
+            widget = live_by_index.get(i) or self._nav_widgets.get(key)
             if widget is None:
                 continue
+            # Keep the cache in sync so callers that introspect
+            # ``_nav_widgets`` still see the live widget.
+            self._nav_widgets[key] = widget
             widget.update(self._nav_label(key, label, count=counts.get(key)))
             widget.remove_class("-selected")
             widget.remove_class("-section-active")
@@ -4891,6 +4909,14 @@ class PollySettingsPaneApp(App[None]):
                 widget.add_class("-selected")
             if key == self._active_section:
                 widget.add_class("-section-active")
+            # Force a repaint even when the renderable text is the
+            # same length as before — Static.update can short-circuit
+            # in that case, which is what was anchoring the ▸ glyph
+            # at narrow widths (#1288).
+            try:
+                widget.refresh()
+            except Exception:  # noqa: BLE001
+                pass
 
     def _nav_label(self, key: str, label: str, *, count: int | None) -> str:
         try:

--- a/tests/test_settings_ui.py
+++ b/tests/test_settings_ui.py
@@ -928,3 +928,58 @@ def test_mount_perf_budget_for_20_projects_5_accounts(tmp_path: Path, monkeypatc
         assert elapsed < 1.5, f"mount too slow: {elapsed:.3f}s"
 
     _run(body())
+
+
+def test_narrow_settings_nav_cursor_advances_visibly_on_j(settings_env) -> None:
+    """#1288 — at narrow widths the ▸ glyph in the left nav must follow
+    j/k, not just the right-pane overlay header. Previously the cached
+    ``_nav_widgets`` references could go stale across the layout pass
+    that toggles the ``-narrow`` class, so ``Static.update`` was a
+    silent no-op and the cursor stayed pinned to row 0 (Accounts) on
+    every j press even though ``_nav_cursor`` had advanced.
+    """
+    app = settings_env["app"]
+
+    async def body() -> None:
+        # Width <110 → narrow mode (see ``_NARROW_THRESHOLD``).
+        async with app.run_test(size=(80, 40)) as pilot:
+            await pilot.pause()
+            from textual.containers import Vertical
+            from textual.widgets import Static
+
+            outer = app.query_one("#settings-outer", Vertical)
+            assert outer.has_class("-narrow"), (
+                "size=(80, 40) should put the settings pane in narrow mode"
+            )
+
+            # Use ``simulate_key`` because that's the path
+            # ``pm cockpit-send-key 'j'`` takes via the input bridge.
+            app.simulate_key("j")
+            await pilot.pause()
+
+            assert app._nav_cursor == 1
+            nav_items = list(app.query("#settings-nav .nav-item"))
+            # 8 sections (accounts, projects, roles, heartbeat, plugins,
+            # planner, inbox, about) → 8 ``Static`` rows.
+            assert len(nav_items) >= 2
+            row_renders = [
+                str(item.render())
+                for item in nav_items
+                if isinstance(item, Static)
+            ]
+            assert row_renders[0].startswith("  Accounts"), row_renders[0]
+            assert row_renders[1].startswith("▸ Projects"), row_renders[1]
+
+            app.simulate_key("j")
+            await pilot.pause()
+
+            assert app._nav_cursor == 2
+            row_renders = [
+                str(item.render())
+                for item in app.query("#settings-nav .nav-item")
+                if isinstance(item, Static)
+            ]
+            assert row_renders[1].startswith("  Projects"), row_renders[1]
+            assert row_renders[2].startswith("▸ Roles"), row_renders[2]
+
+    _run(body())


### PR DESCRIPTION
## Summary
- The previous fix (#1302) updated `_nav_label` to read `_nav_cursor` instead of `_active_section`, but the ▸ glyph kept staying on Accounts at narrow widths in round 4 testing.
- Root cause: `_render_nav` calls `Static.update` on widgets cached in `_nav_widgets` at mount time, and those references can drift from the live DOM after the layout pass that toggles the `-narrow` class — making the update a silent no-op even though `_nav_cursor` advanced. The narrow overlay tracked the cursor because it queries its widget fresh every render; the nav rows did not.
- Fix: re-resolve nav-item `Static`s from the live DOM each render (mirroring the overlay), keep `_nav_widgets` in sync for any callers that introspect it, and call `widget.refresh()` after each update so `Static` can't short-circuit the repaint when the new label is the same length as the old one.

## What the regression test pins
`tests/test_settings_ui.py::test_narrow_settings_nav_cursor_advances_visibly_on_j`:
- Mounts `PollySettingsPaneApp` at 80×40 (below `_NARROW_THRESHOLD=110`).
- Asserts `#settings-outer` actually went into `-narrow`.
- Drives `j` via `app.simulate_key`, which is the path `pm cockpit-send-key 'j'` takes through the input bridge.
- After the first j: asserts `_nav_cursor == 1` and the rendered second nav row starts with `▸ Projects` while row 0 starts with two leading spaces (no marker).
- After the second j: asserts `_nav_cursor == 2` and the marker is on `▸ Roles`.

## Limitations
- I could not reproduce the exact "▸ stuck on Accounts" symptom in a `run_test` harness on the pre-fix code — the test harness redraws synchronously while the production layout pass is what appears to leave the cached widget references stale. The fix is defensive (always pull live nodes + force refresh) and pins the cursor-follows-cursor invariant; it does not change wide-mode behavior.
- The Enter desync the issue mentions in round 4 ("Enter snaps right pane back to Accounts") becomes a non-issue once the cursor and rendered marker stay in sync, but no separate Enter test is added — `action_activate_row` already reads `_nav_cursor` and is exercised by existing settings tests.

## Test plan
- [x] `uv run --with pytest pytest tests/test_settings_ui.py` (18 passed)
- [x] `uv run --with pytest pytest tests/test_cockpit.py -k settings` (13 passed, includes the prior #1302 marker test)
- [x] `uv run --with pytest pytest tests/test_keyboard_help.py` (27 passed)
- [ ] Live: at 80×40, open Settings, press j/k — ▸ should advance with each press.

🤖 Generated with [Claude Code](https://claude.com/claude-code)