### PR TITLE
Fix #1282 inbox A fires approve gate even after rail nav drift

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -310,6 +310,19 @@ def _send_selected_action_key_to_content_bridge(
     except Exception:  # noqa: BLE001
         return None
     kind = _content_bridge_kind_for_selected_key(selected)
+    # #1282: rail nav keys (`<home>`, `g`, `G`, j/k bursts) drift the
+    # rail's `selected_key` away from "inbox" even when the Inbox surface
+    # is still mounted in the right pane. Gate inbox action keys on the
+    # visible surface — i.e. presence of a live `pane-inbox` bridge —
+    # rather than on `selected_key`, so e.g. `<esc> → I → <home> → A`
+    # still fires the approve gate instead of hijacking to Workers.
+    if token in _INBOX_BRIDGE_FIRST_TOKENS and _has_live_inbox_bridge(config_path):
+        try:
+            return send_key_to_first_live(
+                config_path, key, kind="pane-inbox", timeout=0.2,
+            )
+        except Exception:  # noqa: BLE001
+            return None
     if kind == "pane-inbox" and token in _INBOX_BRIDGE_FIRST_TOKENS:
         pass
     elif (
@@ -326,6 +339,23 @@ def _send_selected_action_key_to_content_bridge(
         return send_key_to_first_live(config_path, key, kind=kind, timeout=0.2)
     except Exception:  # noqa: BLE001
         return None
+
+
+def _has_live_inbox_bridge(config_path: Path) -> bool:
+    """Return True when an Inbox right-pane bridge socket is live (#1282).
+
+    The Inbox app starts a `kind="pane-inbox"` bridge on mount and stops
+    it on unmount, so a live socket is the canonical signal that the
+    Inbox surface is the visible right-pane content — independent of the
+    rail's `selected_key`, which can drift to "dashboard" after `<home>`
+    or other rail nav.
+    """
+    try:
+        from pollypm.cockpit_input_bridge import list_bridge_sockets
+
+        return bool(list_bridge_sockets(config_path, kind="pane-inbox"))
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def _inbox_filter_token(token: str, lowered: str) -> bool:

--- a/tests/test_cockpit_input_bridge.py
+++ b/tests/test_cockpit_input_bridge.py
@@ -557,6 +557,72 @@ def test_cockpit_send_key_inbox_action_prefers_inbox_bridge_over_live_pane(
         inbox.stop()
 
 
+def test_cockpit_send_key_inbox_A_after_home_drift_still_routes_to_inbox(
+    valid_cockpit_config: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1282 regression: tester repro `<esc> → I → <home> → A`.
+
+    The rail handles `<home>` itself (jump to first selectable item),
+    which moves `selected_key` from "inbox" to "dashboard" even though
+    the Inbox surface is still mounted in the right pane. Capital A
+    must continue to fire the approve gate — i.e. land on the live
+    `pane-inbox` bridge — instead of falling through to the cockpit
+    bridge (which would route to Workers).
+
+    The bounced PR #1332 only handled the case where `selected_key`
+    was still "inbox"; this test pins the documented drift path that
+    PR could not catch.
+    """
+    import typer
+    from typer.testing import CliRunner
+
+    from pollypm.cli_features import ui as ui_commands
+    from pollypm.cockpit_rail import CockpitRouter
+
+    cockpit_app = _FakeApp()
+    inbox_app = _FakeApp()
+    cockpit = start_input_bridge(
+        cockpit_app, kind="cockpit", config_path=valid_cockpit_config,
+    )
+    assert cockpit is not None
+    inbox = start_input_bridge(
+        inbox_app, kind="pane-inbox", config_path=valid_cockpit_config,
+    )
+    assert inbox is not None
+
+    monkeypatch.setattr(
+        ui_commands,
+        "_send_key_to_active_live_right_pane",
+        lambda _config_path, _key: None,
+    )
+    try:
+        # Simulate the full repro: user pressed I (inbox selected),
+        # then <home>, which the rail intercepted and moved selection
+        # to the first selectable item ("dashboard"). The Inbox app is
+        # still mounted in the right pane (its bridge is still live).
+        router = CockpitRouter(valid_cockpit_config)
+        router.set_selected_key("inbox")
+        router.set_selected_key("dashboard")
+        assert router.selected_key() == "dashboard"
+
+        app = typer.Typer()
+        ui_commands.register_ui_commands(app)
+        result = CliRunner().invoke(
+            app, ["cockpit-send-key", "A", "--config", str(valid_cockpit_config)]
+        )
+        assert result.exit_code == 0, result.output
+        # The visible surface (Inbox) owns A — not the rail.
+        assert f"via {inbox.socket_path}" in result.output
+        assert _wait_for(lambda: inbox_app.keys == ["A"])
+        # The rail/cockpit bridge must NOT see this A; otherwise the
+        # rail's `_handle_key` would route to Workers (the bug).
+        assert "A" not in cockpit_app.keys
+    finally:
+        cockpit.stop()
+        inbox.stop()
+
+
 @pytest.mark.parametrize(
     ("key", "expected"),
     [


### PR DESCRIPTION
Closes #1282. Supersedes #1332.

## Root cause

The tester repro path is:

    <esc> → I → <home> → A

`<home>` is a rail navigation key — the rail's `_handle_key` runs `_select_first(items)`, which moves `selected_key` from `"inbox"` to the first selectable rail item (`"dashboard"`). The Inbox surface is still mounted in the right pane, but `pm cockpit-send-key A` no longer recognizes the inbox as the action target because `_send_selected_action_key_to_content_bridge` in `cli_features/ui.py` derives the bridge `kind` from `router.selected_key()`. Since `selected_key=="dashboard"`, `kind=="dashboard"`, the inbox-action branch is skipped, and `A` falls through to the cockpit/rail bridge. The rail's `_handle_key` then sees `A` with `selected_key=="dashboard"` and routes to Workers — the bug.

## Fix

Gate inbox action keys (`A`, `a`, `d`, `/`) on the **visible** right-pane surface, not on the rail's `selected_key`. The Inbox app calls `start_input_bridge(kind="pane-inbox")` on mount and `bridge.stop()` on unmount, so the presence of a live `pane-inbox` socket is the canonical signal that the Inbox is the visible content. When that socket exists and the key is an inbox action token, route to it directly — regardless of what the rail thinks is selected.

Surgical edit: one new helper (`_has_live_inbox_bridge`) and a four-line guard at the top of `_send_selected_action_key_to_content_bridge`. No changes to the rail itself, no behavior change for `selected_key`, no widening of any existing branch.

## How this differs from #1332

PR #1332 added a `selected_key == "inbox"` branch to the rail's `_handle_key`. That branch is unreachable on the documented repro because by the time `A` arrives, `selected_key` is already `"dashboard"` (rail just consumed `<home>`). The reviewer confirmed: when they manually kept `selected_key=="inbox"` the gate fired, but the live repro path drifts. This PR gates on the visible surface, which does not drift.

## Repro path pinned by test

`tests/test_cockpit_input_bridge.py::test_cockpit_send_key_inbox_A_after_home_drift_still_routes_to_inbox`

The test:
1. Starts both a `cockpit` bridge (the rail) and a `pane-inbox` bridge (the visible Inbox).
2. Sets `selected_key` to `"inbox"` and then to `"dashboard"` to simulate `I` then `<home>`.
3. Sends `A` via `cockpit-send-key`.
4. Asserts `A` lands on the inbox bridge socket and **NOT** on the cockpit/rail socket — proving the rail can't hijack to Workers.

The test fails on unfixed code (A goes to `cockpit-…sock`, which is the rail) and passes after the fix (A goes to `pane_inbox-…sock`).

## Test plan

- [x] New regression test fails on unfixed code, passes after fix
- [x] `tests/test_cockpit_input_bridge.py` — all 45 tests pass
- [x] `tests/test_cockpit.py` rail/inbox/capital_a subset — all 44 pass
- [x] `tests/test_cockpit_inbox_ui.py` — all 73 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)