### PR TITLE
Fix #1293 retry rail capture before declaring dead

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -740,23 +740,76 @@ def _classify_cockpit_panes(panes, *, capture_pane=None) -> tuple[bool, bool, bo
     return (console_alive, rail_alive, rail_non_shell)
 
 
+_RAIL_CAPTURE_RETRY_DELAYS_S: tuple[float, ...] = (0.05, 0.1, 0.2)
+"""Backoff delays for retrying a transient-empty rail pane capture.
+
+#1293 — ``tmux capture-pane`` against the cockpit rail can return an
+empty / mid-redraw buffer when ``pm`` polls during a state transition
+(right after a resize / refresh, between Textual draw cycles, while the
+cockpit is repainting). A single empty capture used to flip
+``rail_pane_running_non_shell`` to ``False`` and route a healthy rail
+through ``RECOVER_DEAD_RAIL``, surfacing a false-positive diagnostic to
+the user. Quick retries with short backoffs absorb the redraw window
+without measurably slowing the launch path; the cumulative worst-case
+budget is ~350ms across three retries, only paid when the *first*
+capture is empty/short.
+"""
+
+
+_RAIL_CAPTURE_MIN_CHARS: int = 4
+"""Minimum non-whitespace characters that count as a "real" capture.
+
+A capture below this threshold is treated as transient-empty and
+retried. The cockpit rail prints multi-line ASCII art plus the four
+required tokens; a real capture is hundreds of characters. The bar is
+deliberately low — anything above noise but below "actual UI" still
+triggers a retry rather than declaring the rail dead.
+"""
+
+
 def _pane_capture_looks_like_cockpit_rail(pane, capture_pane) -> bool:
     if not callable(capture_pane):
         return False
     pane_id = getattr(pane, "pane_id", None)
     if not isinstance(pane_id, str) or not pane_id:
         return False
-    try:
-        text = str(capture_pane(pane_id, lines=40) or "")
-    except Exception:  # noqa: BLE001
-        return False
-    normalized = " ".join(text.lower().split())
-    return (
-        "polly" in normalized
-        and "home" in normalized
-        and "workers" in normalized
-        and "inbox" in normalized
-    )
+
+    # #1293 — retry on transient-empty / mid-redraw captures before
+    # declaring the rail dead. The rail is a Textual TUI; tmux can
+    # capture a blank buffer if we hit it between draw cycles. A
+    # single empty capture used to surface a false-positive
+    # ``recover_dead_rail`` diagnostic. Quick backoff retries absorb
+    # the redraw window. Real dead-rail detection still works: every
+    # retry returns empty, the loop exits, and the function returns
+    # False as before.
+    import time
+
+    delays = (0.0,) + _RAIL_CAPTURE_RETRY_DELAYS_S
+    for delay in delays:
+        if delay:
+            try:
+                time.sleep(delay)
+            except Exception:  # noqa: BLE001 — never block the probe
+                pass
+        try:
+            text = str(capture_pane(pane_id, lines=40) or "")
+        except Exception:  # noqa: BLE001
+            return False
+        # Only retry on transient-empty / very short captures. A real
+        # capture that simply lacks the four tokens (rail genuinely
+        # showing some other content) should fall through immediately —
+        # retrying that case wastes time and changes nothing.
+        stripped = text.strip()
+        if len(stripped) < _RAIL_CAPTURE_MIN_CHARS:
+            continue
+        normalized = " ".join(text.lower().split())
+        return (
+            "polly" in normalized
+            and "home" in normalized
+            and "workers" in normalized
+            and "inbox" in normalized
+        )
+    return False
 
 
 @app.command(help=_UP_HELP)

--- a/tests/test_cli_up_state_machine.py
+++ b/tests/test_cli_up_state_machine.py
@@ -648,6 +648,140 @@ def test_probe_treats_shell_wrapped_visible_cockpit_rail_as_healthy() -> None:
     assert LaunchAction.RESPAWN_RAIL not in plan.actions
 
 
+def test_probe_retries_transient_empty_rail_capture(monkeypatch) -> None:
+    """#1293 — ``tmux capture-pane`` against the cockpit rail can
+    return an empty / mid-redraw buffer when ``pm`` polls during a
+    state transition. A single empty capture used to flip the rail
+    classification to ``running_non_shell=False`` and route a healthy
+    rail through ``RECOVER_DEAD_RAIL``, surfacing a false-positive
+    diagnostic. The probe must retry on transient-empty captures
+    before declaring the rail dead.
+
+    Pins: first capture returns ``""`` (mid-redraw), second returns
+    real cockpit content. Probe must trust the retry and emit
+    ``ATTACH_EXISTING`` — not ``RECOVER_DEAD_RAIL``."""
+    from pollypm.launch_state import LaunchAction, LaunchState, plan_launch
+    from pollypm.tmux.client import TmuxPane
+
+    # Capture call counter — first call returns empty, subsequent
+    # calls return a real rail capture. This is the actual failure
+    # mode the bug report describes (transient-empty / mid-redraw).
+    capture_calls: list[str] = []
+
+    class _FakeTmux:
+        def has_session(self, name: str) -> bool:
+            return name in {"pollypm", "pollypm-storage-closet"}
+
+        def current_session_name(self) -> None:
+            return None
+
+        def list_panes(self, _target: str) -> list[TmuxPane]:
+            return [
+                TmuxPane(
+                    session="pollypm",
+                    window_index="0",
+                    window_name="PollyPM",
+                    pane_index="0",
+                    pane_id="%1",
+                    active=True,
+                    pane_current_command="zsh",
+                    pane_current_path="/",
+                    pane_dead=False,
+                    pane_left=0,
+                    pane_width=30,
+                ),
+                TmuxPane(
+                    session="pollypm",
+                    window_index="0",
+                    window_name="PollyPM",
+                    pane_index="1",
+                    pane_id="%2",
+                    active=False,
+                    pane_current_command="Python",
+                    pane_current_path="/",
+                    pane_dead=False,
+                    pane_left=31,
+                    pane_width=120,
+                ),
+            ]
+
+        def capture_pane(self, target: str, lines: int = 200) -> str:
+            capture_calls.append(target)
+            # First call: empty (mid-redraw). Subsequent calls:
+            # real cockpit content with all four required tokens.
+            if len(capture_calls) == 1:
+                return ""
+            return """
+     █▀█ █▀█ █   █   █▄█     │
+     █▀▀ █▄█ █▄▄ █▄▄  █      │
+        Plans first.         │
+        Chaos later.         │
+   ○ Home                    │
+   ♡· Polly · chat           │
+   ○ Workers (11)            │
+   ◆ Inbox (42)              │
+   ── projects ────────      │
+"""
+
+    class _FakeSupervisor:
+        def __init__(self) -> None:
+            self.tmux = _FakeTmux()
+            self.config = type(
+                "Config",
+                (),
+                {"project": type("Project", (), {"tmux_session": "pollypm"})()},
+            )()
+
+    # Don't actually sleep during the test — the retry backoff is
+    # an internal implementation detail. Patching ``time.sleep`` on
+    # the cli module would shadow other call sites; the function
+    # imports ``time`` locally so we patch the module reference.
+    import time as _time
+
+    monkeypatch.setattr(_time, "sleep", lambda _s: None)
+
+    probe = cli._build_launch_probe(_FakeSupervisor())
+    # Probe must trust the retry — rail is healthy, not dead.
+    assert probe.rail_pane_alive is True
+    assert probe.rail_pane_running_non_shell is True
+    # And we must have actually retried — at least two captures.
+    assert len(capture_calls) >= 2
+
+    plan = plan_launch(probe)
+    assert plan.state is LaunchState.ATTACH_EXISTING
+    assert LaunchAction.RESPAWN_RAIL not in plan.actions
+
+
+def test_pane_capture_retry_gives_up_on_persistent_empty() -> None:
+    """The retry loop must terminate when captures are persistently
+    empty. A genuinely dead rail (every retry empty) should still
+    return False so the legit ``RECOVER_DEAD_RAIL`` path keeps
+    working — the fix for #1293 must not hide real dead rails."""
+    capture_calls: list[str] = []
+
+    def _always_empty_capture(_pane_id: str, lines: int = 40) -> str:
+        capture_calls.append(_pane_id)
+        return ""
+
+    class _Pane:
+        pane_id = "%9"
+
+    import time as _time
+
+    # Don't burn wall clock on retry delays; we only assert the
+    # function gave up and returned False.
+    original_sleep = _time.sleep
+    _time.sleep = lambda _s: None  # type: ignore[assignment]
+    try:
+        result = cli._pane_capture_looks_like_cockpit_rail(_Pane(), _always_empty_capture)
+    finally:
+        _time.sleep = original_sleep  # type: ignore[assignment]
+
+    assert result is False
+    # Retry loop must have actually retried, then given up.
+    assert len(capture_calls) >= 2
+
+
 def test_probe_falls_back_when_list_panes_unavailable() -> None:
     """#906 — when ``list_panes`` cannot enumerate (returns an
     empty list / raises), pane-liveness defaults to True. The


### PR DESCRIPTION
Closes #1293

## Root cause

`_pane_capture_looks_like_cockpit_rail` (src/pollypm/cli.py) calls `tmux capture-pane` once and returns `False` if the buffer is empty / lacks any of `polly`/`home`/`workers`/`inbox`. The cockpit rail is a Textual TUI; `capture-pane` can return an empty / mid-redraw buffer when `pm` polls during a state transition (right after a resize or refresh, between draw cycles, while the cockpit is repainting). One empty capture flipped `rail_pane_running_non_shell` to `False` and routed a healthy rail through `RECOVER_DEAD_RAIL`, surfacing the false-positive diagnostic the user reported (3/10 runs after #1333 activated).

## Failure mode pinned

The new test `test_probe_retries_transient_empty_rail_capture` fakes the exact race:

- First `capture_pane` call returns `""` (mid-redraw)
- Second call returns the real cockpit ASCII art with all four required tokens

Without the fix, the probe sees one empty capture and emits `rail_pane_running_non_shell=False` -> `RECOVER_DEAD_RAIL`. Confirmed the test fails on unfixed `cli.py` (stash + run + restore) and passes after the fix.

## Approach

Option (a) from the issue triage: retry on empty/short capture with short backoffs `(50ms, 100ms, 200ms)` before declaring the rail dead. Cumulative worst-case ~350ms, only paid when the *first* capture is empty. A genuinely dead rail (every retry empty) still falls through and returns `False`, preserving the legitimate `RECOVER_DEAD_RAIL` path (covered by `test_pane_capture_retry_gives_up_on_persistent_empty`).

## How this differs from #1333

#1333 refactored pane targeting to use pane IDs (so similarly-named tmux sessions couldn't feed the wrong panes into the dead-rail classifier). That handled a *different* failure mode. The reviewer's pinpoint diagnosis was that `_pane_capture_looks_like_cockpit_rail` itself returns `False` on transient-empty captures regardless of pane targeting, which #1333 did not address. This PR fixes that by absorbing the redraw window with quick retries.

## Test plan

- [x] `pytest tests/test_cli_up_state_machine.py` -> 16 passed (14 existing + 2 new)
- [x] Confirmed new regression test fails on unfixed code
- [ ] Reviewer attaches to a healthy cockpit and runs bare `pm` repeatedly to confirm the false-positive `recover_dead_rail` is gone
- [ ] Reviewer kills the rail manually and confirms `RECOVER_DEAD_RAIL` still recovers (legit path unchanged)