### PR TITLE
Fix #1293 use process liveness instead of capture-token scan

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -671,7 +671,9 @@ def _build_launch_probe(supervisor) -> LaunchProbe:
         if panes:
             capture_pane = getattr(tmux, "capture_pane", None)
             console_pane_alive, rail_pane_alive, rail_pane_running_non_shell = (
-                _classify_cockpit_panes(panes, capture_pane=capture_pane)
+                _classify_cockpit_panes(
+                    panes, tmux=tmux, capture_pane=capture_pane
+                )
             )
 
     return LaunchProbe(
@@ -686,7 +688,9 @@ def _build_launch_probe(supervisor) -> LaunchProbe:
     )
 
 
-def _classify_cockpit_panes(panes, *, capture_pane=None) -> tuple[bool, bool, bool]:
+def _classify_cockpit_panes(
+    panes, *, tmux=None, capture_pane=None
+) -> tuple[bool, bool, bool]:
     """Classify the cockpit window's pane list into the three
     pane-liveness probe fields.
 
@@ -696,8 +700,14 @@ def _classify_cockpit_panes(panes, *, capture_pane=None) -> tuple[bool, bool, bo
     one pane is present, infer whether it is the rail from the command:
     shell means the rail has not started; non-shell means the right pane
     is missing. Some real rail panes report the shell wrapper as the
-    current command even while the cockpit rail is visibly running; when a
-    safe pane capture proves that UI is present, treat the rail as healthy.
+    current command even while the cockpit rail is visibly running (the
+    rail launcher wraps ``pm cockpit`` in a ``while true; do … done`` shell
+    loop, so during a brief moment between iterations or right at startup
+    the foreground process is the bash wrapper rather than Python). #1293:
+    when ``pane_current_command`` reports a shell, walk the pane's
+    process tree for a Python/``pm`` descendant before declaring the rail
+    dead — this is independent of redraw timing, unlike a capture-pane
+    token scan.
     """
     left = None
     right = None
@@ -719,6 +729,7 @@ def _classify_cockpit_panes(panes, *, capture_pane=None) -> tuple[bool, bool, bo
         pane_cmd = (getattr(pane, "pane_current_command", "") or "").lower()
         pane_non_shell = pane_alive and (
             pane_cmd not in _SHELL_COMMANDS
+            or _pane_runs_cockpit_python_descendant(pane, tmux)
             or _pane_capture_looks_like_cockpit_rail(pane, capture_pane)
         )
         if pane_non_shell:
@@ -735,9 +746,94 @@ def _classify_cockpit_panes(panes, *, capture_pane=None) -> tuple[bool, bool, bo
     rail_cmd = (getattr(rail_pane, "pane_current_command", "") or "").lower()
     rail_non_shell = rail_alive and (
         rail_cmd not in _SHELL_COMMANDS
+        or _pane_runs_cockpit_python_descendant(rail_pane, tmux)
         or _pane_capture_looks_like_cockpit_rail(rail_pane, capture_pane)
     )
     return (console_alive, rail_alive, rail_non_shell)
+
+
+# Process-name tokens that count as "the cockpit Python is running" when
+# found anywhere in the pane's process tree. ``pm`` is the installed
+# console_scripts entrypoint; ``python``/``python3`` are the interpreter
+# names users see on macOS and Linux when ``pm cockpit`` is exec'd via
+# ``uv run``; ``cockpit`` is a defensive match against the argv tail.
+_COCKPIT_PROCESS_NAMES: frozenset[str] = frozenset(
+    {"pm", "pollypm", "python", "python3", "cockpit"}
+)
+
+
+def _pane_runs_cockpit_python_descendant(pane, tmux) -> bool:
+    """Return True iff the pane's process tree contains a cockpit Python.
+
+    #1293 root cause: ``pane_current_command`` only reports the foreground
+    process name for the pane, which on the rail is the bash ``while true``
+    wrapper around ``pm cockpit``. During tmux's redraw windows (occasionally
+    20+ seconds on cold boot) capturing the rendered output is unreliable,
+    causing false-positive ``recover_dead_rail`` diagnostics on bare ``pm``.
+
+    Process liveness sidesteps redraw timing entirely: we ask tmux for the
+    pane's PID, then walk the process tree once with ``ps`` and look for
+    any descendant whose short name matches ``pm``/``python``/``pollypm``.
+    Returns False on any tmux/ps failure so the legitimate dead-rail
+    recovery path still fires when the rail truly dropped to a bare shell.
+    """
+    if tmux is None:
+        return False
+    pane_id = getattr(pane, "pane_id", None)
+    if not isinstance(pane_id, str) or not pane_id:
+        return False
+    get_pid = getattr(tmux, "get_pane_pid", None)
+    if not callable(get_pid):
+        return False
+    try:
+        root_pid = get_pid(pane_id)
+    except Exception:  # noqa: BLE001
+        return False
+    if not isinstance(root_pid, int) or root_pid <= 0:
+        return False
+
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pid=,ppid=,comm="],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=2,
+        )
+    except Exception:  # noqa: BLE001
+        return False
+    if result.returncode != 0:
+        return False
+
+    children: dict[int, list[int]] = {}
+    comms: dict[int, str] = {}
+    for line in result.stdout.splitlines():
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        comms[pid] = parts[2].strip()
+        children.setdefault(ppid, []).append(pid)
+
+    stack = [root_pid]
+    seen: set[int] = set()
+    while stack:
+        pid = stack.pop()
+        if pid in seen:
+            continue
+        seen.add(pid)
+        comm = comms.get(pid, "")
+        # Match on the basename of the comm (some kernels prefix paths,
+        # and some processes report e.g. ``Python`` with capitalization).
+        short = comm.rsplit("/", 1)[-1].lower()
+        if short in _COCKPIT_PROCESS_NAMES:
+            return True
+        stack.extend(children.get(pid, []))
+    return False
 
 
 def _pane_capture_looks_like_cockpit_rail(pane, capture_pane) -> bool:

--- a/tests/test_cli_up_state_machine.py
+++ b/tests/test_cli_up_state_machine.py
@@ -682,6 +682,244 @@ def test_probe_falls_back_when_list_panes_unavailable() -> None:
     assert plan_launch(probe).state is LaunchState.ATTACH_EXISTING
 
 
+def test_probe_treats_shell_with_python_descendant_as_healthy(monkeypatch) -> None:
+    """#1293 — when tmux reports the rail pane's foreground command as
+    a shell (the rail launcher's ``while true; do pm cockpit; done``
+    wrapper), the probe must walk the pane's process tree before
+    declaring the rail dead. If a ``pm`` / ``python`` descendant is
+    found, the cockpit is live regardless of redraw timing.
+
+    This is the regression fix: previous attempts (#1336, #1338) used a
+    capture-pane token scan with retry, but Textual redraw windows can
+    exceed 20 seconds on cold boot, far outside any reasonable retry
+    budget. Process liveness is independent of rendering."""
+    from pollypm.launch_state import LaunchAction, LaunchState, plan_launch
+    from pollypm.tmux.client import TmuxPane
+
+    class _FakeTmux:
+        def has_session(self, name: str) -> bool:
+            return name in {"pollypm", "pollypm-storage-closet"}
+
+        def current_session_name(self) -> None:
+            return None
+
+        def list_panes(self, _target: str) -> list[TmuxPane]:
+            return [
+                TmuxPane(
+                    session="pollypm",
+                    window_index="0",
+                    window_name="PollyPM",
+                    pane_index="0",
+                    pane_id="%1",
+                    active=True,
+                    pane_current_command="bash",  # shell wrapper foregrounded
+                    pane_current_path="/",
+                    pane_dead=False,
+                    pane_left=0,
+                    pane_width=30,
+                ),
+                TmuxPane(
+                    session="pollypm",
+                    window_index="0",
+                    window_name="PollyPM",
+                    pane_index="1",
+                    pane_id="%2",
+                    active=False,
+                    pane_current_command="bash",
+                    pane_current_path="/",
+                    pane_dead=False,
+                    pane_left=31,
+                    pane_width=120,
+                ),
+            ]
+
+        def get_pane_pid(self, pane_id: str) -> int | None:
+            # Rail pane's pid -> 4242, console pane's pid -> 5151.
+            if pane_id == "%1":
+                return 4242
+            if pane_id == "%2":
+                return 5151
+            return None
+
+    class _FakeSupervisor:
+        def __init__(self) -> None:
+            self.tmux = _FakeTmux()
+            self.config = type(
+                "Config",
+                (),
+                {"project": type("Project", (), {"tmux_session": "pollypm"})()},
+            )()
+
+    # ps output: pid 4242 (bash) -> child 4243 (pm = the cockpit Python)
+    # Console pane (5151) has no child.
+    fake_ps_stdout = (
+        "4242 1 bash\n"
+        "4243 4242 pm\n"
+        "5151 1 bash\n"
+    )
+
+    def _fake_run(cmd, **kwargs):
+        assert cmd[0] == "ps"
+        return type(
+            "Result",
+            (),
+            {"returncode": 0, "stdout": fake_ps_stdout, "stderr": ""},
+        )()
+
+    monkeypatch.setattr(cli.subprocess, "run", _fake_run)
+
+    probe = cli._build_launch_probe(_FakeSupervisor())
+    assert probe.rail_pane_alive is True
+    # Rail pane's bash wrapper has a `pm` child — cockpit is live.
+    assert probe.rail_pane_running_non_shell is True
+
+    plan = plan_launch(probe)
+    assert plan.state is LaunchState.ATTACH_EXISTING
+    assert LaunchAction.RESPAWN_RAIL not in plan.actions
+
+
+def test_probe_treats_bare_bash_pane_as_dead_rail(monkeypatch) -> None:
+    """#1293 — the legitimate dead-rail recovery path must still fire
+    when the pane is genuinely a bare shell with no cockpit Python in
+    its process tree. The new process-tree check returns False here so
+    the planner routes to RECOVER_DEAD_RAIL as it always has."""
+    from pollypm.launch_state import LaunchState, plan_launch
+    from pollypm.tmux.client import TmuxPane
+
+    class _FakeTmux:
+        def has_session(self, name: str) -> bool:
+            return name in {"pollypm", "pollypm-storage-closet"}
+
+        def current_session_name(self) -> None:
+            return None
+
+        def list_panes(self, _target: str) -> list[TmuxPane]:
+            return [
+                TmuxPane(
+                    session="pollypm",
+                    window_index="0",
+                    window_name="PollyPM",
+                    pane_index="0",
+                    pane_id="%1",
+                    active=True,
+                    pane_current_command="bash",
+                    pane_current_path="/",
+                    pane_dead=False,
+                    pane_left=0,
+                    pane_width=30,
+                ),
+                TmuxPane(
+                    session="pollypm",
+                    window_index="0",
+                    window_name="PollyPM",
+                    pane_index="1",
+                    pane_id="%2",
+                    active=False,
+                    pane_current_command="zsh",
+                    pane_current_path="/",
+                    pane_dead=False,
+                    pane_left=31,
+                    pane_width=120,
+                ),
+            ]
+
+        def get_pane_pid(self, pane_id: str) -> int | None:
+            return {"%1": 4242, "%2": 5151}.get(pane_id)
+
+        def capture_pane(self, target: str, lines: int = 200) -> str:
+            return "$ "  # bare shell prompt
+
+    class _FakeSupervisor:
+        def __init__(self) -> None:
+            self.tmux = _FakeTmux()
+            self.config = type(
+                "Config",
+                (),
+                {"project": type("Project", (), {"tmux_session": "pollypm"})()},
+            )()
+
+    # ps: only bash, no Python descendants anywhere.
+    fake_ps_stdout = (
+        "4242 1 bash\n"
+        "5151 1 zsh\n"
+    )
+
+    def _fake_run(cmd, **kwargs):
+        return type(
+            "Result",
+            (),
+            {"returncode": 0, "stdout": fake_ps_stdout, "stderr": ""},
+        )()
+
+    monkeypatch.setattr(cli.subprocess, "run", _fake_run)
+
+    probe = cli._build_launch_probe(_FakeSupervisor())
+    assert probe.rail_pane_alive is True
+    assert probe.rail_pane_running_non_shell is False
+
+    plan = plan_launch(probe)
+    assert plan.state is LaunchState.RECOVER_DEAD_RAIL
+
+
+def test_pane_runs_cockpit_python_descendant_unit(monkeypatch) -> None:
+    """Direct unit coverage for the process-tree liveness helper.
+
+    Pins:
+    - ``python`` descendant counts as cockpit-live.
+    - Capitalized ``Python`` counts (macOS).
+    - Path-prefixed comm (e.g. ``/usr/bin/python3``) counts.
+    - Tree without any cockpit process name returns False.
+    - Missing ``get_pane_pid`` (tmux too old / mock) returns False
+      so the legitimate dead-rail path keeps firing.
+    """
+
+    class _Pane:
+        pane_id = "%1"
+
+    class _Tmux:
+        def __init__(self, pid):
+            self._pid = pid
+
+        def get_pane_pid(self, pane_id: str) -> int | None:
+            return self._pid
+
+    def _stub_ps(stdout: str):
+        def _run(cmd, **kwargs):
+            return type(
+                "Result",
+                (),
+                {"returncode": 0, "stdout": stdout, "stderr": ""},
+            )()
+
+        monkeypatch.setattr(cli.subprocess, "run", _run)
+
+    # 1. python descendant.
+    _stub_ps("100 1 bash\n200 100 python\n")
+    assert cli._pane_runs_cockpit_python_descendant(_Pane(), _Tmux(100)) is True
+
+    # 2. capitalized Python.
+    _stub_ps("100 1 bash\n200 100 Python\n")
+    assert cli._pane_runs_cockpit_python_descendant(_Pane(), _Tmux(100)) is True
+
+    # 3. path-prefixed comm.
+    _stub_ps("100 1 bash\n200 100 /usr/bin/python3\n")
+    assert cli._pane_runs_cockpit_python_descendant(_Pane(), _Tmux(100)) is True
+
+    # 4. only bash, no cockpit process — process tree says dead.
+    _stub_ps("100 1 bash\n200 100 sleep\n")
+    assert cli._pane_runs_cockpit_python_descendant(_Pane(), _Tmux(100)) is False
+
+    # 5. tmux without ``get_pane_pid`` -> defensive False.
+    class _OldTmux:
+        pass
+
+    assert cli._pane_runs_cockpit_python_descendant(_Pane(), _OldTmux()) is False
+
+    # 6. ``pm`` entrypoint as the descendant.
+    _stub_ps("100 1 bash\n200 100 pm\n")
+    assert cli._pane_runs_cockpit_python_descendant(_Pane(), _Tmux(100)) is True
+
+
 def test_probe_plus_planner_attach_existing_no_typer() -> None:
     """End-to-end probe → planner check that bypasses Typer +
     monkeypatch + ``runner.invoke``.


### PR DESCRIPTION
## Summary

Fifth attempt at #1293. Three prior attempts (#1305, #1336, #1338) all reused some flavor of ``capture-pane`` + token scan with retry. PR #1338 even extended the retry budget to 1850ms, but real-world testing showed Textual redraw windows of **20+ seconds** on cold boot — well outside any retry budget — and worse, each false positive respawns the rail and creates another partial-render window, cascading from 2/20 false positives to 16/20.

This PR switches the slow path from rendered-output scanning to **process-tree liveness**, which is independent of redraw timing entirely.

## Root cause recap

The cockpit rail pane runs ``while true; do pm cockpit; sleep 2; done`` in bash. tmux's ``#{pane_current_command}`` reports the **foreground** process for the pane, which is the bash wrapper between iterations of the loop and very briefly at startup before ``pm`` is exec'd. The previous fix tried to disambiguate by capturing the rendered pane content and checking for cockpit tokens (``polly``, ``home``, ``workers``, ``inbox``). On cold boot, Textual hasn't painted yet — the capture is empty or shows partially-rendered content for many seconds — so the token check fails and the planner emits ``recover_dead_rail``.

## Why the retry approach can't work

- Redraw windows are unbounded (observed 20+ seconds).
- Making bare ``pm`` block 20+ seconds is itself a UX regression.
- Each false-positive respawn produces another partial-render window, so false positives cascade.

## How this fix sidesteps the redraw problem

When ``pane_current_command`` reports a shell, we now:

1. Ask tmux for the pane's PID via ``get_pane_pid`` (already exists on ``TmuxClient`` for the heartbeat's stopped-descendant probe).
2. Walk the process tree once with ``ps -axo pid=,ppid=,comm=``.
3. Return ``True`` iff any descendant's ``comm`` is in ``{pm, pollypm, python, python3, cockpit}``.

This is a one-shot syscall + a few hundred bytes of ``ps`` parsing. No retries, no waiting, no rendering dependency. The ``pm`` cockpit Python process exists in the tree the entire time the cockpit is alive, so the check is correct independent of whether Textual has finished its first paint.

The legitimate dead-rail recovery path still fires: when the pane is genuinely a bare bash with no Python descendant, ``_pane_runs_cockpit_python_descendant`` returns ``False`` and the planner routes to ``RECOVER_DEAD_RAIL`` exactly as before.

The capture-pane token scan stays as a deeper fallback for tmux versions / mocks without ``get_pane_pid``, so existing tests (and onboarding mocks) keep working.

## What tests pin

- ``test_probe_treats_shell_with_python_descendant_as_healthy`` — bash foreground + ``pm`` child → rail healthy, ``ATTACH_EXISTING`` (the #1293 regression).
- ``test_probe_treats_bare_bash_pane_as_dead_rail`` — bash foreground + no Python descendants → ``RECOVER_DEAD_RAIL`` still fires.
- ``test_pane_runs_cockpit_python_descendant_unit`` — direct unit coverage: ``python``, capitalized ``Python``, path-prefixed ``/usr/bin/python3``, ``pm``, missing ``get_pane_pid`` (defensive False), no Python in tree (False).
- All 14 existing ``test_cli_up_state_machine.py`` tests continue to pass, including ``test_probe_treats_shell_wrapped_visible_cockpit_rail_as_healthy`` (the capture-pane fallback still works).

Confirmed the new tests **fail on the unfixed code** (stash + run + restore).

## Test plan

- [x] ``pytest tests/test_cli_up_state_machine.py`` — 17 passed
- [x] ``pytest tests/test_launch_planner.py tests/test_launch_executor.py tests/test_launch_state.py`` — 54 passed
- [x] Confirmed regression tests fail without the fix
- [ ] Manual: run bare ``pm`` on a freshly booted cockpit — no spurious ``recover_dead_rail`` diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)