### PR TITLE
Cockpit empty-state affordance for projects with zero tasks

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -13098,6 +13098,23 @@ class PollyProjectDashboardApp(App[None]):
     .proj-empty {
         color: #6b7a88;
     }
+    /* #1290 follow-up — empty-state affordance for projects with zero
+       work_tasks rows. Without this panel the drilldown was completely
+       silent (bare ◯ glyph, no copy) for hours after a fresh
+       ``pm add-project`` if no task ever landed. The panel sits above
+       every other section so it's the first thing the operator sees
+       when they navigate into the project. */
+    #proj-empty-state {
+        height: auto;
+        margin-bottom: 1;
+        padding: 0 2;
+        background: #1a2330;
+        color: #f7d67a;
+        border: round #5b8aff;
+    }
+    #proj-empty-state.-hidden {
+        display: none;
+    }
     #proj-plan-scroll {
         height: auto;
         max-height: 30;
@@ -13189,6 +13206,13 @@ class PollyProjectDashboardApp(App[None]):
         self.topbar = Static("", id="proj-topbar", markup=True)
         self.status_line = Static("", id="proj-status", markup=True)
         self.action_bar = Static("", id="proj-action-bar", markup=True)
+        # #1290 follow-up — empty-state panel surfaces a clear
+        # affordance when a project has zero ``work_tasks`` rows.
+        # Hidden by default; ``_render`` toggles ``-hidden`` based
+        # on ``data.task_counts`` totals.
+        self.empty_state = Static(
+            "", id="proj-empty-state", classes="-hidden", markup=True,
+        )
         self.now_title = Static(
             "[b]Current activity[/b]",
             classes="proj-section-title",
@@ -13325,6 +13349,12 @@ class PollyProjectDashboardApp(App[None]):
             yield self.status_line
             yield self.action_bar
             with VerticalScroll(id="proj-body"):
+                # #1290 follow-up — empty-state for "registered project
+                # with zero work_tasks rows" sits at the top of the body
+                # so the operator sees the affordance the instant they
+                # navigate into a fresh project. Hidden by default; the
+                # ``-hidden`` class is removed only when totals are zero.
+                yield self.empty_state
                 with Vertical(classes="proj-section", id="proj-inbox-section"):
                     yield self.inbox_title
                     yield self.inbox_lead
@@ -13468,6 +13498,24 @@ class PollyProjectDashboardApp(App[None]):
         )
         self.status_line.update(status_markup)
         self._update_action_bar(data)
+
+        # ── Empty-state affordance ──
+        # #1290 follow-up — savethenovel landed in a state with zero
+        # ``work_tasks`` rows (registered project, never planned, never
+        # had a task). The drilldown showed a bare ``○`` glyph and no
+        # affordances; the operator watched it for hours with nothing
+        # to act on. Surface a one-line panel pointing at the two
+        # commands that move the project forward (planner architect or
+        # manual task create). Renders for ``tracked=False`` projects
+        # too — the renderer doesn't filter on tracked, so an untracked
+        # fresh project still gets the affordance.
+        empty_text = self._render_empty_state(data)
+        if empty_text:
+            self.empty_state.update(empty_text)
+            self.empty_state.remove_class("-hidden")
+        else:
+            self.empty_state.update("")
+            self.empty_state.add_class("-hidden")
 
         # ── Current activity ──
         self.now_body.update(self._render_now_body(data))
@@ -13786,6 +13834,35 @@ class PollyProjectDashboardApp(App[None]):
     # Section renderers — all return Rich-markup strings, all handle
     # missing-data gracefully with friendly empty-state copy.
     # ------------------------------------------------------------------
+
+    def _render_empty_state(self, data: ProjectDashboardData) -> str:
+        """Return the prominent zero-tasks affordance, or "" when there
+        is at least one ``work_tasks`` row.
+
+        Triggered when the project has zero rows in *any* status bucket
+        (queued / in_progress / review / blocked / on_hold / done). The
+        savethenovel repro showed the dashboard going completely silent
+        in this state — the operator watched a bare ``○`` glyph for
+        2.5+ hours with no copy and no affordances. The panel names the
+        two commands that move a fresh project forward so the user can
+        act without having to leave the cockpit and grep the docs.
+        """
+        # Don't surface an affordance when the project path is missing —
+        # that's a separate (and louder) failure mode the topbar
+        # already calls out.
+        if not data.exists_on_disk:
+            return ""
+        counts = data.task_counts or {}
+        buckets = data.task_buckets or {}
+        total = sum(int(v or 0) for v in counts.values())
+        if total or any(buckets.values()):
+            return ""
+        project = _escape(data.project_key)
+        return (
+            f"[#f7d67a][b]No tasks for {project}.[/b][/] "
+            f"[#d6dee5]Run [b]pm project plan {project}[/b] to start the "
+            f"architect, or [b]pm task create[/b] to add one manually.[/]"
+        )
 
     def _render_now_body(self, data: ProjectDashboardData) -> str:
         w = data.active_worker

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -4640,3 +4640,194 @@ def test_gather_project_dashboard_completes_under_budget(
         f"sessions configured — exceeds 500ms budget. Likely regression "
         f"of #1290 (worker enumeration re-running the launch pipeline)."
     )
+
+
+# ---------------------------------------------------------------------------
+# #1290 follow-up — zero-tasks empty-state affordance
+# ---------------------------------------------------------------------------
+#
+# The savethenovel project landed in a state with zero ``work_tasks`` rows
+# (registered, briefly had a task, then deleted). The drilldown showed a
+# bare ``○`` glyph and no affordances — the operator watched it for 2.5+
+# hours with nothing to act on. The empty-state panel must surface the
+# moment the user navigates into a project with zero tasks, regardless of
+# tracked-state, and must NOT appear when there are real tasks.
+
+
+def _empty_project_env(tmp_path: Path):
+    """Fresh project with the config wired up but zero ``work_tasks`` rows."""
+    project_path = tmp_path / "savethenovel"
+    project_path.mkdir()
+    _init_git_repo(project_path)
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(project_path, config_path)
+    return {
+        "config_path": config_path,
+        "project_path": project_path,
+    }
+
+
+def test_empty_state_appears_when_zero_tasks(tmp_path: Path) -> None:
+    """Zero ``work_tasks`` rows → drilldown surfaces the affordance copy
+    naming both the planner and manual-create commands."""
+    env = _empty_project_env(tmp_path)
+    if not _load_config_compatible(env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+    from pollypm import cockpit_ui as _cockpit_ui
+    _cockpit_ui._PROJECT_DASHBOARD_TASK_CACHE.clear()
+    app = PollyProjectDashboardApp(env["config_path"], "demo")
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 50)) as pilot:
+            await pilot.pause()
+            assert app.data is not None
+            # Sanity: the fixture really has zero tasks.
+            total = sum(int(v or 0) for v in (app.data.task_counts or {}).values())
+            assert total == 0
+            # Empty-state panel must be visible (not -hidden) and contain
+            # the affordance copy.
+            assert "-hidden" not in app.empty_state.classes
+            rendered = str(app.empty_state.render())
+            assert "No tasks for" in rendered
+            assert "pm project plan" in rendered
+            assert "pm task create" in rendered
+    _run(body())
+
+
+def test_empty_state_hidden_when_tasks_exist(dashboard_env, dashboard_app) -> None:
+    """Real tasks present → the empty-state panel must NOT render. The
+    fixture's seeded queued/in_progress/done tasks should suppress it."""
+    async def body() -> None:
+        async with dashboard_app.run_test(size=(140, 50)) as pilot:
+            await pilot.pause()
+            assert dashboard_app.data is not None
+            total = sum(
+                int(v or 0)
+                for v in (dashboard_app.data.task_counts or {}).values()
+            )
+            assert total > 0
+            assert "-hidden" in dashboard_app.empty_state.classes
+            assert str(dashboard_app.empty_state.render()).strip() == ""
+    _run(body())
+
+
+def test_empty_state_renders_at_narrow_width(tmp_path: Path) -> None:
+    """Narrow cockpit (80 cols) must still render the affordance — copy
+    is short enough to fit on one wrapped line."""
+    env = _empty_project_env(tmp_path)
+    if not _load_config_compatible(env["config_path"]):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+    from pollypm import cockpit_ui as _cockpit_ui
+    _cockpit_ui._PROJECT_DASHBOARD_TASK_CACHE.clear()
+    app = PollyProjectDashboardApp(env["config_path"], "demo")
+
+    async def body() -> None:
+        async with app.run_test(size=(80, 50)) as pilot:
+            await pilot.pause()
+            assert "-hidden" not in app.empty_state.classes
+            rendered = str(app.empty_state.render())
+            assert "No tasks for" in rendered
+            # The pipeline section must still render (no layout break)
+            assert app.pipeline_body is not None
+    _run(body())
+
+
+def test_empty_state_pure_renderer_returns_affordance(tmp_path: Path) -> None:
+    """Unit-level: ``_render_empty_state`` returns the affordance string
+    when ``data.task_counts`` and ``data.task_buckets`` are both empty,
+    and returns ``""`` when any task is present."""
+    from pollypm.cockpit_ui import (
+        PollyProjectDashboardApp,
+        ProjectDashboardData,
+    )
+
+    base_kwargs = dict(
+        project_key="savethenovel",
+        project_name="Save The Novel",
+        project_path=tmp_path,
+        persona_name=None,
+        pm_label="PM: polly",
+        exists_on_disk=True,
+        status_dot="○",
+        status_color="#4a5568",
+        status_label="idle",
+        active_worker=None,
+        architect=None,
+        plan_path=None,
+        plan_sections=[],
+        plan_explainer=None,
+        plan_text=None,
+        plan_aux_files=[],
+        plan_mtime=None,
+        plan_stale_reason=None,
+        activity_entries=[],
+        inbox_count=0,
+        inbox_top=[],
+        action_items=[],
+        alert_count=0,
+    )
+
+    empty = ProjectDashboardData(
+        task_counts={},
+        task_buckets={},
+        **base_kwargs,
+    )
+    rendered_empty = PollyProjectDashboardApp._render_empty_state(
+        None, empty,  # type: ignore[arg-type]
+    )
+    assert "No tasks for savethenovel" in rendered_empty
+    assert "pm project plan savethenovel" in rendered_empty
+    assert "pm task create" in rendered_empty
+
+    populated = ProjectDashboardData(
+        task_counts={"queued": 1},
+        task_buckets={
+            "queued": [{"task_id": "t1", "title": "Real task"}],
+        },
+        **base_kwargs,
+    )
+    assert PollyProjectDashboardApp._render_empty_state(
+        None, populated,  # type: ignore[arg-type]
+    ) == ""
+
+
+def test_empty_state_suppressed_when_path_missing(tmp_path: Path) -> None:
+    """When the project path does not exist on disk, the topbar already
+    surfaces a louder warning — the empty-state panel should defer."""
+    from pollypm.cockpit_ui import (
+        PollyProjectDashboardApp,
+        ProjectDashboardData,
+    )
+
+    data = ProjectDashboardData(
+        project_key="missing",
+        project_name="missing",
+        project_path=None,
+        persona_name=None,
+        pm_label="PM: polly",
+        exists_on_disk=False,
+        status_dot="○",
+        status_color="#4a5568",
+        status_label="idle",
+        active_worker=None,
+        architect=None,
+        task_counts={},
+        task_buckets={},
+        plan_path=None,
+        plan_sections=[],
+        plan_explainer=None,
+        plan_text=None,
+        plan_aux_files=[],
+        plan_mtime=None,
+        plan_stale_reason=None,
+        activity_entries=[],
+        inbox_count=0,
+        inbox_top=[],
+        action_items=[],
+        alert_count=0,
+    )
+    assert PollyProjectDashboardApp._render_empty_state(
+        None, data,  # type: ignore[arg-type]
+    ) == ""


### PR DESCRIPTION
## Summary

The savethenovel project (and any other project that ends up with zero `work_tasks` rows) currently renders a completely silent cockpit drilldown — bare `○` glyph, no copy, no affordances. The operator watched it for 2.5+ hours during manual testing with nothing to act on.

This PR surfaces a prominent one-line affordance at the top of the project drilldown body whenever the project has zero rows in any task-status bucket:

> **No tasks for `<key>`.** Run **pm project plan `<key>`** to start the architect, or **pm task create** to add one manually.

## What changed

- **`src/pollypm/cockpit_ui.py`** — `PollyProjectDashboardApp`:
  - New `self.empty_state` `Static` widget mounted at the top of `proj-body` (above the inbox section). Hidden by default via the `-hidden` CSS class.
  - New `_render_empty_state(data)` helper. Returns the affordance string when `data.task_counts` totals zero and every bucket is empty; returns `""` otherwise. Suppresses itself when `exists_on_disk` is False (the topbar already shouts about that case).
  - `_render` toggles `-hidden` based on the helper's output.
  - New CSS rules for `#proj-empty-state` (yellow text on a dark blue-bordered panel — visually loud without being alarming red).

- **`tests/test_project_dashboard_ui.py`** — five new tests:
  - `test_empty_state_appears_when_zero_tasks` — full Pilot run, fixture has zero tasks, panel must be visible with all three required strings (`No tasks for`, `pm project plan`, `pm task create`).
  - `test_empty_state_hidden_when_tasks_exist` — uses the existing `dashboard_env` fixture (queued + in_progress + done seeded) → panel must carry `-hidden` and render to `""`.
  - `test_empty_state_renders_at_narrow_width` — same but at `(80, 50)` cols. Asserts the panel still surfaces and the pipeline section still renders (no layout break).
  - `test_empty_state_pure_renderer_returns_affordance` — unit-level: empty `task_counts`/`task_buckets` → affordance string; populated → `""`.
  - `test_empty_state_suppressed_when_path_missing` — `exists_on_disk=False` → renderer returns `""`.

## Behaviour notes

- **Tracked vs untracked.** The drilldown renderer itself doesn't filter on `tracked`, so an untracked fresh project (the default for `pm add-project`) gets the affordance too. Per scope, this PR does NOT change the `tracked` default.
- **Not surfaced.** `history-import` state stays hidden (per the diagnostic — locked == success). No watchdog logic added (separate PR).
- **Not a popup.** It's an inline panel, visible immediately when the user navigates into the project.

## Affordance text (exact)

```
No tasks for <key>. Run pm project plan <key> to start the architect, or pm task create to add one manually.
```

## Test plan

- [x] `tests/test_project_dashboard_ui.py -k empty_state` — 6 passed (5 new + 1 transitive)
- [x] Full dashboard suite (200 tests across `test_project_dashboard_ui.py`, `test_cockpit_project_dashboard.py`, `test_project_dashboard_signature.py`, `test_project_dashboard_plan_viewer.py`) — all pass.
- [ ] Manual smoke against savethenovel: navigate the cockpit into the project drilldown, confirm the affordance copy is the first visible content under the action bar.