### PR TITLE
Add worker-marker reaper at supervisor bootstrap + runtime sweep

### DIFF
--- a/src/pollypm/session_services/tmux.py
+++ b/src/pollypm/session_services/tmux.py
@@ -325,6 +325,15 @@ class TmuxSessionService:
                             # Fresh marker stays so the next correct
                             # send-tuple still bootstraps. The error
                             # log line above carries the diagnostic.
+                            # #1338 — flag the leak-prone branch so
+                            # marker-reap rates can be correlated with
+                            # persona-swap aborts in the heartbeat log.
+                            logger.warning(
+                                "fresh_launch_marker leak risk: persona_swap_detected for %s "
+                                "(window=%s); marker %s left in place — relies on a future "
+                                "correct send-tuple OR the worker_marker_reaper sweep.",
+                                name, wname, fresh_launch_marker,
+                            )
                             kickoff = None
                         else:
                             raise
@@ -333,6 +342,17 @@ class TmuxSessionService:
                         self.tmux.send_keys(target, kickoff)
                         self._verify_input_submitted(target, kickoff, provider)
                         fresh_launch_marker.unlink(missing_ok=True)
+                else:
+                    # #1338 — identity-stacking guards refused the
+                    # send. Marker is left in place (matches the
+                    # legacy contract) but flagged so leak rates are
+                    # visible without instrumenting the reaper.
+                    logger.warning(
+                        "fresh_launch_marker leak risk: identity guard refused kickoff "
+                        "for %s (window=%s); marker %s left in place — worker_marker_reaper "
+                        "will reap it once the task is terminal or the window dies.",
+                        name, wname, fresh_launch_marker,
+                    )
 
         # Write resume marker
         if resume_marker:

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -812,6 +812,25 @@ class Supervisor:
                     for marker in markers_dir.iterdir():
                         marker.unlink(missing_ok=True)
 
+        # #1338 — reap orphan worker-marker .fresh files left behind by
+        # the asymmetric cleanup paths in
+        # ``session_services/tmux.py``. Bootstrap is a safe time to run
+        # this because no per-task workers are alive yet — every
+        # remaining ``*.fresh`` file is by definition stale. Failures
+        # are logged inside the reaper, never raised, so a stat failure
+        # on one project doesn't block cockpit startup.
+        try:
+            from pollypm.work.worker_marker_reaper import (
+                reap_orphan_worker_markers,
+            )
+
+            tmux = getattr(self.session_service, "tmux", None)
+            reap_orphan_worker_markers(self.config, tmux=tmux)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "worker-marker reaper failed at bootstrap", exc_info=True,
+            )
+
     def repair_sessions_table(self) -> int:
         """Upsert a ``sessions`` row for every configured session whose
         tmux window is currently alive.
@@ -1428,6 +1447,21 @@ class Supervisor:
             sweep_stale_notifies(self._msg_store)
         except Exception:  # noqa: BLE001
             logger.warning("notify-sweep skipped", exc_info=True)
+
+        # #1338 — runtime reconciliation for ``worker-markers/*.fresh``
+        # files. Complements the bootstrap reaper above: handles
+        # orphans created *after* startup (cancelled tasks, worker
+        # crashes whose tmux window also vanished) without requiring
+        # a supervisor restart. The sweep additionally kills any dead
+        # tmux window matching a reaped marker so a re-claim can
+        # cleanly bootstrap a fresh worker.
+        try:
+            from pollypm.work.worker_marker_reaper import sweep_worker_markers
+
+            tmux = getattr(self.session_service, "tmux", None)
+            sweep_worker_markers(self.config, tmux=tmux)
+        except Exception:  # noqa: BLE001
+            logger.warning("worker-marker sweep skipped", exc_info=True)
 
         # Re-arm the heartbeat schedule so the next sweep is always queued.
         # Without this, the scheduler permanently stops if the heartbeat

--- a/src/pollypm/work/worker_marker_reaper.py
+++ b/src/pollypm/work/worker_marker_reaper.py
@@ -1,0 +1,359 @@
+"""Reaper for stale ``.pollypm/worker-markers/*.fresh`` files.
+
+Background
+----------
+``SessionManager._launch_worker_window`` writes a per-task fresh-launch
+marker at ``<project>/.pollypm/worker-markers/<window_name>.fresh`` so
+``TmuxSessionService.create`` knows to send the kickoff string as
+initial input on first boot. The marker is removed on the *happy
+path* — only after the kickoff has been sent and verified
+(``session_services/tmux.py`` around the ``fresh_launch_marker.unlink``
+call).
+
+The legacy implementation never removed the marker on any of the
+sad-path branches:
+
+* Identity-stacking guards rejected the kickoff before the unlink.
+* ``_prepare_initial_input`` raised ``persona_swap_detected`` and the
+  send was skipped (the comment promised "next correct send-tuple
+  cleans up", which never happens once the task is deleted/abandoned).
+* ``SessionService.create`` raised before the unlink.
+* The ``work_tasks`` row was deleted/cancelled out from under the
+  marker (the savethenovel orphan that prompted #1338).
+
+Compare ``_bootstrap_clear_markers`` in ``supervisor.py`` for the
+asymmetric ``session-markers/`` reaper that already runs at supervisor
+boot.
+
+This module owns:
+
+* :func:`reap_orphan_worker_markers` — pure, side-effect-light helper
+  that walks every project's ``.pollypm/worker-markers/`` directory
+  and unlinks ``*.fresh`` files whose backing tmux window is dead OR
+  whose ``work_tasks`` row is missing / terminal. Returns the list of
+  markers it reaped so callers can log / emit events.
+
+* :func:`sweep_worker_markers` — runtime variant that also kills the
+  (probably-dead) tmux window when a marker has no matching
+  ``work_tasks`` row. Mirrors the bootstrap reaper but is safe to call
+  from the heartbeat sweep without restarting the supervisor.
+
+Both helpers are intentionally defensive: if the projects table or
+work_tasks table is missing (fresh install, mid-migration), they
+no-op for that project rather than raising.
+
+The structured logging / print events at reap callsites are placeholder
+hooks for the audit-log infrastructure shipping in parallel; converting
+them to audit-log events is a one-line change once that lands.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from pollypm.work.task_state import (
+    TERMINAL_TASK_STATUSES,
+    parse_task_window_name,
+)
+from pollypm.storage.work_task_state import task_status_probe
+
+logger = logging.getLogger(__name__)
+
+
+# Statuses that mean "this worker marker should be reaped".
+#
+# The work-service only stores ``done``/``cancelled`` as terminal in
+# ``work_status``, but the reaper accepts ``abandoned`` too — defensive
+# in case a future migration promotes the execution-status value to a
+# task-level field, and harmless today (the comparison is a frozenset
+# membership test).
+WORKER_MARKER_REAPABLE_STATUSES: frozenset[str] = (
+    TERMINAL_TASK_STATUSES | frozenset({"abandoned"})
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ReapedMarker:
+    """Record of a worker marker that was unlinked by the reaper.
+
+    Surfaces enough context for log lines / future audit-log events:
+    the project the marker lived under, the tmux window name encoded
+    in the file stem, the on-disk path, and the reason the reaper
+    decided to remove it.
+    """
+
+    project_key: str
+    window_name: str
+    marker_path: Path
+    reason: str
+
+
+def _iter_worker_markers(project_path: Path) -> Iterable[Path]:
+    """Yield ``*.fresh`` files inside ``project_path/.pollypm/worker-markers``.
+
+    Returns an empty iterator (rather than raising) when the directory
+    is missing — fresh installs and projects that have never claimed a
+    task simply have nothing to reap.
+    """
+    marker_dir = project_path / ".pollypm" / "worker-markers"
+    try:
+        if not marker_dir.is_dir():
+            return ()
+        return tuple(marker_dir.glob("*.fresh"))
+    except OSError as exc:
+        logger.debug(
+            "worker_marker_reaper: cannot list %s: %s", marker_dir, exc,
+        )
+        return ()
+
+
+def _live_worker_window_names(
+    tmux: Any | None, storage_session: str | None,
+) -> set[str]:
+    """Return the set of live ``task-*`` window names in the storage closet.
+
+    Returns an empty set on any tmux error — the reaper then errs on
+    the side of treating windows as dead and reaping their markers.
+    Callers that want a softer "tmux unreachable, skip everything"
+    behaviour should check ``tmux.has_session`` themselves first.
+    """
+    if tmux is None or not storage_session:
+        return set()
+    try:
+        if not tmux.has_session(storage_session):
+            return set()
+    except Exception:  # noqa: BLE001
+        return set()
+    try:
+        windows = tmux.list_windows(storage_session)
+    except Exception:  # noqa: BLE001
+        return set()
+    out: set[str] = set()
+    for window in windows:
+        name = getattr(window, "name", None)
+        if isinstance(name, str):
+            out.add(name)
+    return out
+
+
+def _classify_marker(
+    *,
+    marker: Path,
+    project_key: str,
+    project_path: Path,
+    workspace_root: Path | None,
+    live_window_names: set[str],
+) -> ReapedMarker | None:
+    """Return a :class:`ReapedMarker` when ``marker`` should be reaped, else None.
+
+    A marker is reapable when EITHER:
+
+    * The task row is missing from ``work_tasks`` (orphan — task was
+      cancelled/deleted out from under the marker), OR
+    * The task row's ``work_status`` is in
+      :data:`WORKER_MARKER_REAPABLE_STATUSES`, OR
+    * The task row exists in a non-terminal state but the corresponding
+      tmux window is dead (the savethenovel case — the worker session
+      crashed and the marker never got its happy-path unlink).
+
+    The window-name → ``(project, task_number)`` parse is shared with
+    the inbox / cockpit so the reaper stays in sync with the launch
+    side of the contract.
+    """
+    window_name = marker.stem  # ``task-<project>-<N>.fresh`` → ``task-<project>-<N>``
+    parsed = parse_task_window_name(window_name)
+    if parsed is None:
+        # Marker file with an unrecognised name. Don't touch — better
+        # to leak one marker than nuke a future format we don't
+        # understand yet.
+        return None
+    parsed_project, task_number = parsed
+
+    found_db, status = task_status_probe(
+        project_key=parsed_project,
+        task_number=task_number,
+        project_path=project_path,
+        workspace_root=workspace_root,
+    )
+
+    if not found_db:
+        # No DB at all (fresh install or mid-migration). Be defensive
+        # and skip — we don't have evidence the marker is actually
+        # orphaned, only that we can't tell.
+        return None
+
+    if status is None:
+        return ReapedMarker(
+            project_key=project_key,
+            window_name=window_name,
+            marker_path=marker,
+            reason="orphan: no work_tasks row",
+        )
+
+    if status in WORKER_MARKER_REAPABLE_STATUSES:
+        return ReapedMarker(
+            project_key=project_key,
+            window_name=window_name,
+            marker_path=marker,
+            reason=f"task in terminal status '{status}'",
+        )
+
+    if window_name not in live_window_names:
+        return ReapedMarker(
+            project_key=project_key,
+            window_name=window_name,
+            marker_path=marker,
+            reason=(
+                f"tmux window missing for non-terminal task "
+                f"(status='{status}')"
+            ),
+        )
+
+    return None
+
+
+def _resolve_workspace_root(config: Any) -> Path | None:
+    """Pull ``project.workspace_root`` off the config, defensively."""
+    project_settings = getattr(config, "project", None)
+    workspace_root = getattr(project_settings, "workspace_root", None)
+    if workspace_root is None:
+        return None
+    return Path(workspace_root)
+
+
+_STORAGE_CLOSET_SESSION_SUFFIX = "-storage-closet"
+
+
+def _resolve_storage_session(config: Any) -> str | None:
+    """Mirror ``Supervisor.storage_closet_session_name`` without the import.
+
+    The supervisor builds the storage-closet session name as
+    ``<tmux_session>-storage-closet``. We duplicate the suffix here so
+    the reaper can run in the heartbeat path without circular imports
+    against ``Supervisor`` — covered by a regression test in
+    ``tests/test_worker_marker_reaper.py``.
+    """
+    project_settings = getattr(config, "project", None)
+    base = getattr(project_settings, "tmux_session", None)
+    if not base:
+        return None
+    return f"{base}{_STORAGE_CLOSET_SESSION_SUFFIX}"
+
+
+def reap_orphan_worker_markers(
+    config: Any,
+    *,
+    tmux: Any | None = None,
+) -> list[ReapedMarker]:
+    """Bootstrap-time reaper. Walk every known project and unlink orphan markers.
+
+    Mirrors :meth:`Supervisor._bootstrap_clear_markers` for the
+    ``session-markers/`` directory. Designed to be called once at
+    supervisor startup to clear the legacy backlog of leaked markers
+    accumulated by builds prior to #1338.
+
+    The function is logging-only on the destructive path: each
+    reap emits a ``logging.warning`` so leak rates can be spotted in
+    the cockpit log without a separate audit-log dependency.
+    """
+    projects = getattr(config, "projects", None) or {}
+    if not projects:
+        return []
+
+    workspace_root = _resolve_workspace_root(config)
+    storage_session = _resolve_storage_session(config)
+    live_windows = _live_worker_window_names(tmux, storage_session)
+
+    reaped: list[ReapedMarker] = []
+    for project_key, project in projects.items():
+        project_path = getattr(project, "path", None)
+        if project_path is None:
+            continue
+        project_path = Path(project_path)
+        for marker in _iter_worker_markers(project_path):
+            decision = _classify_marker(
+                marker=marker,
+                project_key=str(project_key),
+                project_path=project_path,
+                workspace_root=workspace_root,
+                live_window_names=live_windows,
+            )
+            if decision is None:
+                continue
+            try:
+                marker.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning(
+                    "worker_marker_reaper: failed to unlink %s: %s",
+                    marker, exc,
+                )
+                continue
+            logger.warning(
+                "worker_marker_reaper: reaped %s (project=%s, window=%s, reason=%s)",
+                decision.marker_path,
+                decision.project_key,
+                decision.window_name,
+                decision.reason,
+            )
+            # Placeholder for the parallel audit-log infra. When that
+            # ships, replace this print with an audit event.
+            print(
+                f"[worker_marker_reaper] reaped {decision.window_name} "
+                f"in {decision.project_key}: {decision.reason}",
+                flush=True,
+            )
+            reaped.append(decision)
+    return reaped
+
+
+def sweep_worker_markers(
+    config: Any,
+    *,
+    tmux: Any | None = None,
+) -> list[ReapedMarker]:
+    """Runtime sweep — reap orphan markers AND kill any matching dead windows.
+
+    Same orphan classification as :func:`reap_orphan_worker_markers`,
+    but additionally calls ``tmux.kill_window`` on the dead pane (if
+    any) for each reaped marker. Safe to call from the heartbeat
+    sweep without restarting the supervisor — the per-task workers
+    already tolerate their session being killed via
+    ``release_stale_claim``.
+
+    Returns the list of markers reaped so callers can log / emit
+    events. ``tmux.kill_window`` failures are swallowed (best-effort);
+    the marker is unlinked regardless so the next claim can re-issue
+    a fresh kickoff.
+    """
+    reaped = reap_orphan_worker_markers(config, tmux=tmux)
+    if not reaped or tmux is None:
+        return reaped
+    storage_session = _resolve_storage_session(config)
+    if not storage_session:
+        return reaped
+    for entry in reaped:
+        target = f"{storage_session}:{entry.window_name}"
+        try:
+            tmux.kill_window(target)
+            logger.info(
+                "worker_marker_reaper: killed stale tmux window %s", target,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Best-effort; the window was probably already dead, which
+            # is exactly why we're reaping the marker in the first place.
+            logger.debug(
+                "worker_marker_reaper: kill_window(%s) failed: %s",
+                target, exc,
+            )
+    return reaped
+
+
+__all__ = [
+    "ReapedMarker",
+    "WORKER_MARKER_REAPABLE_STATUSES",
+    "reap_orphan_worker_markers",
+    "sweep_worker_markers",
+]

--- a/tests/test_worker_marker_reaper.py
+++ b/tests/test_worker_marker_reaper.py
@@ -1,0 +1,376 @@
+"""Tests for the worker-marker reaper (#1338).
+
+Covers both the bootstrap-time reaper
+(:func:`reap_orphan_worker_markers`) and the runtime sweep
+(:func:`sweep_worker_markers`). Each test wires up a minimal
+``PollyPMConfig`` with a single project and a fake tmux client so the
+classification + tmux-kill paths can be exercised without a live tmux
+or live cockpit.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pollypm.models import (
+    AccountConfig,
+    KnownProject,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectKind,
+    ProjectSettings,
+    ProviderKind,
+)
+from pollypm.work.worker_marker_reaper import (
+    WORKER_MARKER_REAPABLE_STATUSES,
+    reap_orphan_worker_markers,
+    sweep_worker_markers,
+    _resolve_storage_session,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap_work_db(db_path: Path) -> None:
+    """Create a minimal ``work_tasks`` table at ``db_path``."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE work_tasks (
+                project TEXT NOT NULL,
+                task_number INTEGER NOT NULL,
+                title TEXT NOT NULL DEFAULT '',
+                type TEXT NOT NULL DEFAULT 'task',
+                labels TEXT NOT NULL DEFAULT '[]',
+                work_status TEXT NOT NULL DEFAULT 'draft',
+                flow_template_id TEXT NOT NULL DEFAULT 'default',
+                flow_template_version INTEGER NOT NULL DEFAULT 1,
+                current_node_id TEXT,
+                assignee TEXT,
+                priority TEXT NOT NULL DEFAULT 'normal',
+                requires_human_review INTEGER NOT NULL DEFAULT 0,
+                description TEXT NOT NULL DEFAULT '',
+                acceptance_criteria TEXT,
+                constraints TEXT,
+                relevant_files TEXT NOT NULL DEFAULT '[]',
+                parent_project TEXT,
+                parent_task_number INTEGER,
+                supersedes_project TEXT,
+                supersedes_task_number INTEGER,
+                roles TEXT NOT NULL DEFAULT '{}',
+                external_refs TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL DEFAULT '',
+                created_by TEXT NOT NULL DEFAULT '',
+                updated_at TEXT NOT NULL DEFAULT '',
+                PRIMARY KEY (project, task_number)
+            )
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _insert_task(db_path: Path, project: str, number: int, status: str) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO work_tasks (project, task_number, title, "
+            "flow_template_id, work_status) VALUES (?, ?, ?, ?, ?)",
+            (project, number, f"task-{number}", "default", status),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _make_config(
+    *,
+    workspace_root: Path,
+    project_path: Path,
+    project_key: str = "demo",
+) -> PollyPMConfig:
+    project = KnownProject(
+        key=project_key,
+        path=project_path,
+        name="Demo",
+        kind=ProjectKind.FOLDER,
+        tracked=True,
+    )
+    return PollyPMConfig(
+        project=ProjectSettings(
+            name="Workspace",
+            root_dir=workspace_root,
+            tmux_session="test-pm",
+            workspace_root=workspace_root,
+            base_dir=workspace_root / ".pollypm",
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="claude_test",
+            failover_accounts=[],
+        ),
+        accounts={
+            "claude_test": AccountConfig(
+                name="claude_test",
+                provider=ProviderKind.CLAUDE,
+                email="t@example.com",
+                home=workspace_root / ".pollypm" / "homes" / "claude_test",
+            ),
+        },
+        sessions={},
+        projects={project_key: project},
+    )
+
+
+def _write_marker(project_path: Path, window_name: str) -> Path:
+    marker_dir = project_path / ".pollypm" / "worker-markers"
+    marker_dir.mkdir(parents=True, exist_ok=True)
+    marker = marker_dir / f"{window_name}.fresh"
+    marker.write_text("ts")
+    return marker
+
+
+class FakeTmux:
+    """Minimal tmux double — enough to satisfy the reaper's call surface."""
+
+    def __init__(
+        self,
+        *,
+        session_name: str | None = None,
+        window_names: list[str] | None = None,
+    ) -> None:
+        self._session_name = session_name
+        self._window_names = list(window_names or [])
+        self.killed: list[str] = []
+
+    def has_session(self, name: str) -> bool:
+        return name == self._session_name
+
+    def list_windows(self, name: str) -> list[Any]:
+        if name != self._session_name:
+            return []
+
+        class _W:
+            def __init__(self, n: str) -> None:
+                self.name = n
+
+        return [_W(n) for n in self._window_names]
+
+    def kill_window(self, target: str) -> None:
+        self.killed.append(target)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_storage_session_uses_supervisor_suffix(tmp_path: Path) -> None:
+    """``_resolve_storage_session`` must mirror Supervisor's actual suffix."""
+    from pollypm.supervisor import Supervisor
+
+    config = _make_config(
+        workspace_root=tmp_path,
+        project_path=tmp_path / "project",
+    )
+    suffix = Supervisor._STORAGE_CLOSET_SESSION_SUFFIX
+    expected = f"{config.project.tmux_session}{suffix}"
+
+    assert _resolve_storage_session(config) == expected
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap reaper
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_reaps_marker_with_missing_task_row(tmp_path: Path) -> None:
+    """Marker present, no work_tasks row → orphan, reap."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    db_path = project_path / ".pollypm" / "state.db"
+    _bootstrap_work_db(db_path)
+
+    marker = _write_marker(project_path, "task-demo-7")
+    config = _make_config(
+        workspace_root=tmp_path, project_path=project_path,
+    )
+
+    reaped = reap_orphan_worker_markers(config, tmux=FakeTmux())
+
+    assert not marker.exists()
+    assert len(reaped) == 1
+    assert reaped[0].window_name == "task-demo-7"
+    assert "no work_tasks row" in reaped[0].reason
+
+
+@pytest.mark.parametrize("status", sorted(WORKER_MARKER_REAPABLE_STATUSES))
+def test_bootstrap_reaps_marker_for_terminal_task(
+    tmp_path: Path, status: str,
+) -> None:
+    """Marker present, work_tasks row in done/cancelled/abandoned → reap."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    db_path = project_path / ".pollypm" / "state.db"
+    _bootstrap_work_db(db_path)
+    _insert_task(db_path, "demo", 12, status)
+
+    marker = _write_marker(project_path, "task-demo-12")
+    config = _make_config(workspace_root=tmp_path, project_path=project_path)
+
+    reaped = reap_orphan_worker_markers(config, tmux=FakeTmux())
+
+    assert not marker.exists()
+    assert len(reaped) == 1
+    assert status in reaped[0].reason
+
+
+def test_bootstrap_keeps_live_marker(tmp_path: Path) -> None:
+    """Marker present, work_tasks row in_progress, tmux window live → keep."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    db_path = project_path / ".pollypm" / "state.db"
+    _bootstrap_work_db(db_path)
+    _insert_task(db_path, "demo", 4, "in_progress")
+
+    marker = _write_marker(project_path, "task-demo-4")
+    config = _make_config(workspace_root=tmp_path, project_path=project_path)
+    storage = _resolve_storage_session(config)
+    assert storage is not None
+    tmux = FakeTmux(session_name=storage, window_names=["task-demo-4"])
+
+    reaped = reap_orphan_worker_markers(config, tmux=tmux)
+
+    assert marker.exists(), "live marker must not be reaped"
+    assert reaped == []
+
+
+def test_bootstrap_reaps_savethenovel_case(tmp_path: Path) -> None:
+    """Marker present, work_tasks in_progress, tmux window MISSING → reap.
+
+    The savethenovel orphan that prompted #1338: the work_tasks row
+    looks alive, but the tmux window crashed without firing the
+    happy-path unlink. The reaper should still pick it up.
+    """
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    db_path = project_path / ".pollypm" / "state.db"
+    _bootstrap_work_db(db_path)
+    _insert_task(db_path, "demo", 99, "in_progress")
+
+    marker = _write_marker(project_path, "task-demo-99")
+    config = _make_config(workspace_root=tmp_path, project_path=project_path)
+    # Storage session exists but does not include the task window.
+    storage = _resolve_storage_session(config)
+    assert storage is not None
+    tmux = FakeTmux(session_name=storage, window_names=[])
+
+    reaped = reap_orphan_worker_markers(config, tmux=tmux)
+
+    assert not marker.exists()
+    assert len(reaped) == 1
+    assert "tmux window missing" in reaped[0].reason
+
+
+def test_bootstrap_no_op_when_db_missing(tmp_path: Path) -> None:
+    """Fresh install: no DB at all → reaper must be a no-op (defensive)."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    # No DB; just a marker.
+    marker = _write_marker(project_path, "task-demo-1")
+    config = _make_config(workspace_root=tmp_path, project_path=project_path)
+
+    reaped = reap_orphan_worker_markers(config, tmux=FakeTmux())
+
+    assert marker.exists(), "must not reap without evidence of orphan"
+    assert reaped == []
+
+
+def test_bootstrap_skips_unrecognised_marker_names(tmp_path: Path) -> None:
+    """Markers not matching ``task-<project>-<N>`` must be left untouched."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    db_path = project_path / ".pollypm" / "state.db"
+    _bootstrap_work_db(db_path)
+
+    marker = _write_marker(project_path, "weird-name-without-task-prefix")
+    config = _make_config(workspace_root=tmp_path, project_path=project_path)
+
+    reaped = reap_orphan_worker_markers(config, tmux=FakeTmux())
+
+    assert marker.exists()
+    assert reaped == []
+
+
+def test_bootstrap_handles_no_projects(tmp_path: Path) -> None:
+    """Empty ``config.projects`` → no-op."""
+    config = _make_config(workspace_root=tmp_path, project_path=tmp_path / "p")
+    config.projects.clear()
+
+    assert reap_orphan_worker_markers(config, tmux=FakeTmux()) == []
+
+
+# ---------------------------------------------------------------------------
+# Runtime sweep
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_sweep_kills_dead_window_and_unlinks_marker(
+    tmp_path: Path,
+) -> None:
+    """Runtime sweep finds orphan, kills its (mocked-dead) window, unlinks marker.
+
+    The sweep should call ``kill_window`` with the canonical
+    ``<storage>:<window>`` target so a stale ``remain-on-exit`` pane
+    can't trip the next ``_kill_stale_task_window`` re-claim path.
+    """
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    db_path = project_path / ".pollypm" / "state.db"
+    _bootstrap_work_db(db_path)
+    # Task row is gone (cancelled/deleted), but marker is still on disk.
+    marker = _write_marker(project_path, "task-demo-42")
+
+    config = _make_config(workspace_root=tmp_path, project_path=project_path)
+    storage = _resolve_storage_session(config)
+    assert storage is not None
+    tmux = FakeTmux(session_name=storage, window_names=[])
+
+    reaped = sweep_worker_markers(config, tmux=tmux)
+
+    assert not marker.exists()
+    assert len(reaped) == 1
+    assert tmux.killed == [f"{storage}:task-demo-42"]
+
+
+def test_runtime_sweep_handles_kill_failure_silently(tmp_path: Path) -> None:
+    """``kill_window`` failure must not stop the marker unlink."""
+    project_path = tmp_path / "project"
+    project_path.mkdir()
+    db_path = project_path / ".pollypm" / "state.db"
+    _bootstrap_work_db(db_path)
+    marker = _write_marker(project_path, "task-demo-8")
+
+    config = _make_config(workspace_root=tmp_path, project_path=project_path)
+    storage = _resolve_storage_session(config)
+    assert storage is not None
+
+    class _FlakyTmux(FakeTmux):
+        def kill_window(self, target: str) -> None:  # noqa: D401
+            raise RuntimeError("tmux unhappy")
+
+    tmux = _FlakyTmux(session_name=storage, window_names=[])
+
+    reaped = sweep_worker_markers(config, tmux=tmux)
+
+    assert not marker.exists(), "marker must be unlinked even if kill fails"
+    assert len(reaped) == 1


### PR DESCRIPTION
## Bug

`.pollypm/worker-markers/<window>.fresh` files are written by the
per-task launcher at `src/pollypm/work/session_manager.py:641-648`,
but only unlinked on the happy path at
`src/pollypm/session_services/tmux.py:335`.

Markers are leaked permanently when:
- The `_target_window_matches_expected` / `_pane_already_bootstrapped_as_other_role` identity guards refuse the kickoff (`tmux.py:304-309`).
- `_prepare_initial_input` raises `persona_swap_detected` (`tmux.py:325-328`) — the comment relies on a "future correct send-tuple" to clean up; if the task is cancelled/deleted first, the marker leaks.
- `SessionService.create` raises before line 335.
- The `work_tasks` row is deleted/abandoned out from under the marker (the savethenovel orphan that triggered #1338 — observed leaked at ~165 minutes).

`session-markers/` is reaped at supervisor bootstrap (`supervisor.py:801-813`); `worker-markers/` had no reaper at all.

## Fix (A + B together)

New module `pollypm.work.worker_marker_reaper` with two entry points:

**A. Bootstrap reaper** — `reap_orphan_worker_markers()`. Mirrors `_bootstrap_clear_markers` for `worker-markers/`. Walks every `config.projects` entry, classifies each `*.fresh` against the `work_tasks` row (orphan / terminal status / non-terminal-but-dead-window) using the existing `task_status_probe` accessor, and unlinks orphans. Wired into `Supervisor._bootstrap_clear_markers` so the legacy backlog clears at the next cockpit boot.

**B. Runtime sweep** — `sweep_worker_markers()`. Same classification, plus calls `tmux.kill_window` on each reaped marker's (probably-dead) pane so a re-claim doesn't trip on a `remain-on-exit` corpse. Wired into `Supervisor.run_heartbeat` after the notify-sweep block — handles new orphans without requiring a supervisor restart.

Reapable when the work_tasks row is missing OR `work_status` is in `{done, cancelled, abandoned}` OR the row is non-terminal but the storage-closet has no live window for it.

## Leak instrumentation

Added `logger.warning` at the two leak-prone branches in `session_services/tmux.py` (persona_swap aborts and identity-guard refusal). Behaviour is unchanged on those paths — just logs so reap rates can be correlated. Reap callsites also `print` so the parallel audit-log work can convert them with a single regex once it lands.

## Test plan

- [x] `tests/test_worker_marker_reaper.py` — 12 tests covering:
  - Bootstrap reaps marker with missing work_tasks row
  - Bootstrap reaps marker for done/cancelled/abandoned row (parametrized)
  - Bootstrap keeps marker when row is in_progress AND tmux window is live
  - Bootstrap reaps savethenovel case: row in_progress, tmux window MISSING
  - Bootstrap is a defensive no-op when no DB exists (fresh install)
  - Bootstrap skips unrecognised marker filenames
  - Bootstrap handles empty `config.projects`
  - Runtime sweep kills dead window AND unlinks marker
  - Runtime sweep continues unlinking even when `kill_window` raises
  - `_resolve_storage_session` regression test against `Supervisor._STORAGE_CLOSET_SESSION_SUFFIX`
- [x] Re-ran existing `test_auth_integration`, `test_supervisor`, `test_session_manager`, `test_tmux_client`, `test_tmux_hardening`, `test_persona_swap_detection`, `test_runtime_launcher`, `test_launch_planner`, `test_heartbeat_tick`, `test_heartbeat_plugin_api`, `test_import_boundary` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)