### PR TITLE
Audit-log SQLiteWorkService DB-open events for dual-DB observability

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -39,6 +39,16 @@ EVENT_MARKER_RELEASED = "marker.released"
 EVENT_MARKER_CREATE_FAILED = "marker.create_failed"
 EVENT_MARKER_LEAKED = "marker.leaked"
 EVENT_WORK_TABLE_CLEARED = "work_table.cleared"
+# #savethenovel-followup: emitted from ``SQLiteWorkService.__init__``
+# every time the service stamps work tables onto a SQLite file. The
+# dual-DB layout (``~/.pollypm/state.db`` vs
+# ``<workspace>/.pollypm/state.db``) made it easy for callsites to
+# pass the wrong path and silently create empty work tables on the
+# messages-side DB. Pairing this with the ``had_messages_table_pre_open``
+# flag in metadata gives operators an immediate "wrong DB"
+# breadcrumb — see comment in ``SQLiteWorkService.__init__`` for the
+# reasoning.
+EVENT_WORK_DB_OPENED = "work_db.opened"
 
 
 @dataclass(slots=True, frozen=True)
@@ -386,6 +396,7 @@ __all__ = [
     "EVENT_MARKER_CREATE_FAILED",
     "EVENT_MARKER_LEAKED",
     "EVENT_WORK_TABLE_CLEARED",
+    "EVENT_WORK_DB_OPENED",
     "AuditEvent",
     "central_log_path",
     "emit",

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -689,7 +689,58 @@ class SQLiteWorkService:
 
         apply_workspace_pragmas(self._conn, busy_timeout_ms=30000)
         self._conn.execute("PRAGMA foreign_keys=ON")
+        # #savethenovel-followup: forensic breadcrumb for the dual-DB
+        # layout. The workspace has TWO state DBs by accident — the
+        # CLI-side ``~/.pollypm/state.db`` (messages/sessions) and the
+        # workspace-local ``<root>/.pollypm/state.db`` (work tables) —
+        # and several callsites historically passed the wrong path,
+        # silently stamping empty work tables on the messages-side DB
+        # and looking like a wipe. Snapshot the pre-existing tables so
+        # the audit row distinguishes "first-time workspace open" from
+        # "stamped onto the wrong DB".
+        _had_messages_table_pre_open = False
+        _had_work_tables_pre_open = False
+        try:
+            _row = self._conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name IN ('messages', 'work_tasks')",
+            ).fetchall()
+            _names = {r[0] for r in _row}
+            _had_messages_table_pre_open = "messages" in _names
+            _had_work_tables_pre_open = "work_tasks" in _names
+        except Exception:  # noqa: BLE001 — diagnostic only
+            pass
         create_work_tables(self._conn)
+        # Emit AFTER stamping so ``tables_created`` reflects whether
+        # ``create_work_tables`` actually had work to do. Wrapped in a
+        # broad try/except so audit infra failure cannot block work-
+        # service init — matches the pattern used at the other audit
+        # callsites in this module.
+        try:
+            from pollypm.audit import emit as _audit_emit
+            from pollypm.audit.log import EVENT_WORK_DB_OPENED
+
+            # ``emit()`` skips the central tail when ``project`` is
+            # empty (no project file to address), so use a synthetic
+            # workspace-level key. Keeps these rows out of any real
+            # project's central file while still landing them on disk
+            # for ``pm doctor`` / heartbeat to grep.
+            _audit_emit(
+                event=EVENT_WORK_DB_OPENED,
+                project="_workspace",
+                subject=str(db_path),
+                actor="system",
+                metadata={
+                    "had_messages_table_pre_open": _had_messages_table_pre_open,
+                    "tables_created": not _had_work_tables_pre_open,
+                    "project_path": (
+                        str(project_path) if project_path is not None else None
+                    ),
+                },
+                project_path=project_path,
+            )
+        except Exception:  # noqa: BLE001 — audit must never break init
+            pass
         self._gate_registry = GateRegistry(project_path=project_path)
         self._flow_cache: dict[tuple[str, int], FlowTemplate] = {}
         self._work_output_cache: dict[str, dict[str, Any]] = {}

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -35,6 +35,7 @@ from pollypm.audit import (
 from pollypm.audit.log import (
     EVENT_TASK_CREATED,
     EVENT_TASK_STATUS_CHANGED,
+    EVENT_WORK_DB_OPENED,
     SCHEMA_VERSION,
 )
 
@@ -408,3 +409,148 @@ def test_workservice_transition_emits_status_changed(tmp_path: Path) -> None:
     assert "from" in last.metadata
     assert "to" in last.metadata
     assert last.metadata["to"] == "queued"
+
+
+# ---------------------------------------------------------------------------
+# Integration: SQLiteWorkService DB-open breadcrumb
+# ---------------------------------------------------------------------------
+
+
+def _read_central_records(audit_home: Path) -> list[dict]:
+    """Read every JSONL row across the central tail.
+
+    The ``work_db.opened`` event uses ``project=""`` (workspace-level,
+    not project-scoped), so it lands only in the central tail under
+    the sanitized ``"_unknown"`` filename. We scan every file in the
+    audit home so the test stays robust if the sanitizer changes.
+    """
+    records: list[dict] = []
+    if not audit_home.exists():
+        return records
+    for f in audit_home.iterdir():
+        if f.is_file() and f.suffix == ".jsonl":
+            for line in f.read_text(encoding="utf-8").splitlines():
+                if line.strip():
+                    records.append(json.loads(line))
+    return records
+
+
+def test_workservice_open_emits_work_db_opened_on_fresh_db(
+    tmp_path: Path, _isolate_audit_home: Path,
+) -> None:
+    """Opening a brand-new SQLite file emits ``work_db.opened`` with
+    ``had_messages_table_pre_open=False`` and ``tables_created=True`` —
+    the canonical "first-time workspace open" signal."""
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    db_path = tmp_path / "fresh.db"
+    svc = SQLiteWorkService(db_path=db_path)
+    try:
+        records = _read_central_records(_isolate_audit_home)
+        opens = [r for r in records if r["event"] == EVENT_WORK_DB_OPENED]
+        assert len(opens) == 1, f"expected one work_db.opened row, got {len(opens)}"
+        row = opens[0]
+        assert row["subject"] == str(db_path)
+        assert row["actor"] == "system"
+        assert row["metadata"]["had_messages_table_pre_open"] is False
+        assert row["metadata"]["tables_created"] is True
+    finally:
+        svc.close()
+
+
+def test_workservice_open_flags_messages_side_db(
+    tmp_path: Path, _isolate_audit_home: Path,
+) -> None:
+    """The dual-DB confusion case: a messages-side DB has a
+    ``messages`` table. When ``SQLiteWorkService`` is pointed at one,
+    the audit row carries ``had_messages_table_pre_open=True`` so a
+    grep over the audit log surfaces the misroute immediately."""
+    import sqlite3
+
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    db_path = tmp_path / "messages-side.db"
+    # Pre-create a messages-side DB by stamping the marker table.
+    pre = sqlite3.connect(db_path)
+    try:
+        pre.execute(
+            "CREATE TABLE messages ("
+            "id INTEGER PRIMARY KEY, body TEXT, created_at TEXT"
+            ")"
+        )
+        pre.commit()
+    finally:
+        pre.close()
+
+    svc = SQLiteWorkService(db_path=db_path)
+    try:
+        records = _read_central_records(_isolate_audit_home)
+        opens = [r for r in records if r["event"] == EVENT_WORK_DB_OPENED]
+        assert len(opens) == 1
+        row = opens[0]
+        # The warning signal — work_tasks didn't exist yet (so we
+        # stamped them on), but the DB ALREADY had a messages table.
+        # That combination = wrong DB.
+        assert row["metadata"]["had_messages_table_pre_open"] is True
+        assert row["metadata"]["tables_created"] is True
+    finally:
+        svc.close()
+
+
+def test_workservice_open_reports_tables_created_false_on_existing_work_db(
+    tmp_path: Path, _isolate_audit_home: Path,
+) -> None:
+    """Re-opening a workspace DB that already has work tables emits
+    ``tables_created=False`` — the steady-state signal that
+    distinguishes a normal restart from a first-time stamp."""
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    db_path = tmp_path / "existing.db"
+    # First open materializes work_tasks et al.
+    svc1 = SQLiteWorkService(db_path=db_path)
+    svc1.close()
+
+    # Wipe the audit log so we only see the second open's row.
+    for f in _isolate_audit_home.iterdir() if _isolate_audit_home.exists() else []:
+        if f.is_file():
+            f.unlink()
+
+    svc2 = SQLiteWorkService(db_path=db_path)
+    try:
+        records = _read_central_records(_isolate_audit_home)
+        opens = [r for r in records if r["event"] == EVENT_WORK_DB_OPENED]
+        assert len(opens) == 1
+        row = opens[0]
+        assert row["metadata"]["had_messages_table_pre_open"] is False
+        assert row["metadata"]["tables_created"] is False
+    finally:
+        svc2.close()
+
+
+def test_workservice_open_per_project_log_when_project_path_supplied(
+    tmp_path: Path, _isolate_audit_home: Path,
+) -> None:
+    """When the caller passes a ``project_path``, the breadcrumb also
+    lands in ``<project>/.pollypm/audit.jsonl`` so the row travels
+    with the project tree (matches the per-project + central
+    pattern used by every other audit hook in this module)."""
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    project_root = tmp_path / "proj"
+    (project_root / ".pollypm").mkdir(parents=True)
+    db_path = tmp_path / "p.db"
+
+    svc = SQLiteWorkService(db_path=db_path, project_path=project_root)
+    try:
+        per_project = project_log_path(project_root)
+        assert per_project is not None and per_project.exists()
+        rows = [
+            json.loads(l)
+            for l in per_project.read_text(encoding="utf-8").splitlines()
+            if l.strip()
+        ]
+        opens = [r for r in rows if r["event"] == EVENT_WORK_DB_OPENED]
+        assert len(opens) == 1
+        assert opens[0]["metadata"]["project_path"] == str(project_root)
+    finally:
+        svc.close()


### PR DESCRIPTION
## Summary

The workspace has two SQLite files that look identical:

- ``~/.pollypm/state.db`` — CLI-side, messages/sessions
- ``<workspace>/.pollypm/state.db`` — workspace-local, work tables

Several historical callsites passed the wrong path to ``SQLiteWorkService``, which silently stamped empty work tables on the messages-side DB. The result looked like a wholesale wipe but was actually a misroute — and there was no forensic trail.

This adds a breadcrumb at every ``SQLiteWorkService.__init__`` so the state surfaces immediately on the next ``pm doctor`` / heartbeat / audit-log grep.

## What changed

- **New ``EVENT_WORK_DB_OPENED``** constant (``work_db.opened``) in ``src/pollypm/audit/log.py``, exported from the package.
- **Emit in ``SQLiteWorkService.__init__``** (``src/pollypm/work/sqlite_service.py``):
  - Snapshots the ``messages`` and ``work_tasks`` tables BEFORE ``create_work_tables`` runs (so we can compute ``had_messages_table_pre_open`` and ``tables_created`` reliably).
  - Emits AFTER ``create_work_tables`` so ``tables_created`` reflects whether the call had work to do.
  - Wrapped in the same broad ``try/except`` the existing audit hooks (``EVENT_TASK_STATUS_CHANGED``, ``EVENT_TASK_DELETED``) use — audit infra failure cannot block work-service init.
  - Uses the synthetic ``_workspace`` project key so rows land in the central tail without polluting any real project file. Per-project log mirror is preserved when ``project_path`` is supplied.
- **Metadata**: ``had_messages_table_pre_open`` (bool), ``tables_created`` (bool), ``project_path`` (str or null). The ``had_messages_table_pre_open=True`` row is the warning signal — that means we just stamped work tables onto a messages-side DB.

## Why

Continues the post-mortem trail from PR #1342 (audit-log scaffold). The original PR deferred this hook; it's a 5-line addition that closes the dual-DB observability gap.

## Test plan

- [x] ``test_workservice_open_emits_work_db_opened_on_fresh_db`` — fresh DB → ``had_messages=False, tables_created=True``
- [x] ``test_workservice_open_flags_messages_side_db`` — pre-existing ``messages`` table → ``had_messages=True``, the warning signal
- [x] ``test_workservice_open_reports_tables_created_false_on_existing_work_db`` — re-open a workspace DB → ``tables_created=False``
- [x] ``test_workservice_open_per_project_log_when_project_path_supplied`` — pins the per-project log mirror
- [x] Existing audit + work-service suites still green (54 audit tests, 102 work-service tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)