### PR TITLE
Heartbeat audit-log watchdog (orphan markers, stuck drafts, cancellation gaps)

### DIFF
--- a/src/pollypm/audit/__init__.py
+++ b/src/pollypm/audit/__init__.py
@@ -76,11 +76,25 @@ from pollypm.audit.log import (
     project_log_path,
     read_events,
 )
+from pollypm.audit.watchdog import (
+    EVENT_AUDIT_FINDING,
+    EVENT_HEARTBEAT_TICK,
+    Finding,
+    WatchdogConfig,
+    scan_events,
+    scan_project,
+)
 
 __all__ = [
     "AuditEvent",
+    "EVENT_AUDIT_FINDING",
+    "EVENT_HEARTBEAT_TICK",
+    "Finding",
+    "WatchdogConfig",
     "central_log_path",
     "emit",
     "project_log_path",
     "read_events",
+    "scan_events",
+    "scan_project",
 ]

--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -1,0 +1,646 @@
+"""Audit-log watchdog — pure detectors for orphan / stuck / leak patterns.
+
+Born from the savethenovel post-mortem (2026-05-06): task #1 was
+cancelled by Polly ~37s after start, leaving an orphan worker-marker
+and an unpromoted draft #2 with zero cockpit affordance. The reaper
+(#1341) cleans up stale markers on bootstrap, the audit log (#1342)
+records every task / marker mutation, and *this* module is the
+heartbeat consumer that scans those events to surface the same broken
+state classes *before* a user notices.
+
+The detectors are pure functions over a list of :class:`AuditEvent`
+objects so unit tests can exercise each rule against a synthetic
+fixture without spinning up the full heartbeat stack. The cadence
+wiring lives in :mod:`pollypm.plugins_builtin.core_recurring.audit_watchdog`
+which fans this detector out across every registered project, opens
+the appropriate alert sink, and emits findings via ``upsert_alert``
+(the existing surface used by ``blocked_chain.sweep`` and friends —
+no new alert channel is introduced).
+
+Detection rules (each returns a list of :class:`Finding`):
+
+1. ``orphan_marker`` — ``marker.created`` for ``task-<project>-<N>``
+   with no matching ``marker.released`` within the window AND no
+   ``task.status_changed`` to a terminal state (``done`` / ``cancelled``
+   / ``abandoned``) in that window. Catches the savethenovel pattern
+   where a worker is launched and the task is then cancelled but the
+   on-disk marker lingers.
+2. ``marker_leaked`` — any ``marker.leaked`` event in the window.
+   Each occurrence is a finding because the persona-swap-detected
+   branch firing at all means a worker was redirected — we want
+   visible signal on the leak rate, not silent log noise.
+3. ``stuck_draft`` — ``task.created`` event from > ``stuck_draft_seconds``
+   ago with no follow-up ``task.status_changed`` for the same subject
+   to ``queued`` / ``in_progress`` / ``review``. (savethenovel/2's
+   class — a planning draft that never got promoted and would only
+   surface to the user via the empty-state affordance from #1340.)
+4. ``cancellation_no_promotion`` — ``task.status_changed`` to
+   ``cancelled`` with no ``task.created`` for the same project in the
+   following ``cancel_grace_seconds`` window. Indicates a planning
+   stall after a self-cancel (savethenovel/1's class — a worker
+   self-cancels but Polly never queues a follow-up).
+
+Severity is ``"warn"`` for every rule today. The recovery hint is
+attached to each finding so the alert message can include a
+copy-pasteable next step (``"run pm task promote ..."``).
+
+The watchdog itself emits a synthetic ``heartbeat.tick`` audit event
+each time it runs so we can prove the heartbeat is alive (and
+notice when it stops) — the cadence handler calls
+:func:`emit_heartbeat_tick` after the scan.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from pollypm.audit.log import (
+    EVENT_MARKER_CREATED,
+    EVENT_MARKER_LEAKED,
+    EVENT_MARKER_RELEASED,
+    EVENT_TASK_CREATED,
+    EVENT_TASK_STATUS_CHANGED,
+    AuditEvent,
+)
+
+
+__all__ = [
+    "Finding",
+    "WatchdogConfig",
+    "EVENT_HEARTBEAT_TICK",
+    "EVENT_AUDIT_FINDING",
+    "RULE_ORPHAN_MARKER",
+    "RULE_MARKER_LEAKED",
+    "RULE_STUCK_DRAFT",
+    "RULE_CANCEL_NO_PROMOTION",
+    "scan_events",
+    "scan_project",
+    "emit_heartbeat_tick",
+    "emit_finding",
+    "watchdog_alert_session_name",
+    "WATCHDOG_ALERT_TYPE",
+    "format_finding_message",
+]
+
+
+logger = logging.getLogger(__name__)
+
+
+# Stable rule names — pinned because alert dedupe uses them as part of
+# the synthetic session_name key, and operators grep them in the audit
+# log. New rules should follow ``noun.verb_or_state`` form.
+RULE_ORPHAN_MARKER = "orphan_marker"
+RULE_MARKER_LEAKED = "marker_leaked"
+RULE_STUCK_DRAFT = "stuck_draft"
+RULE_CANCEL_NO_PROMOTION = "cancellation_no_promotion"
+
+# Audit events emitted *by* the watchdog itself.
+EVENT_HEARTBEAT_TICK = "heartbeat.tick"
+EVENT_AUDIT_FINDING = "audit.finding"
+
+# Alert type used for ``upsert_alert`` — single type for all watchdog
+# rules; the rule name lands in the message body and metadata so the
+# operator can still tell them apart without us inventing four new
+# alert types.
+WATCHDOG_ALERT_TYPE = "audit_watchdog"
+
+# Terminal task states — a transition into any of these means the
+# task is no longer running, which closes out an orphan-marker check.
+_TERMINAL_TASK_STATES: frozenset[str] = frozenset({
+    "done", "cancelled", "abandoned",
+})
+
+# Promotion-out-of-draft states — when a draft transitions to any of
+# these, we treat it as no longer "stuck".
+_DRAFT_PROMOTION_STATES: frozenset[str] = frozenset({
+    "queued", "in_progress", "review", "blocked", "rework",
+})
+
+# Marker filename pattern: ``task-<project>-<N>.<kind>`` (typically
+# ``.fresh``). Captures the project and task_number so the orphan
+# check can correlate the marker with task.status_changed events.
+_MARKER_NAME_RE = re.compile(
+    r"task-(?P<project>[^/\\]+?)-(?P<num>\d+)(?:\.\w+)?$"
+)
+
+
+@dataclass(slots=True, frozen=True)
+class WatchdogConfig:
+    """Tunable thresholds for the four detection rules.
+
+    All durations are in seconds. Defaults match the spec in the
+    task brief — 30 min lookback for orphan/leak rules, 5 min for
+    the cheaper draft / cancellation gates.
+    """
+
+    # Lookback for orphan-marker + leak detection.
+    window_seconds: int = 1800
+    # A draft must have existed this long with no promotion before
+    # it counts as stuck. Short enough to catch the savethenovel
+    # pattern (planning queue stalled mid-flight) without false
+    # positives during normal multi-step plan generation.
+    stuck_draft_seconds: int = 300
+    # After a cancel, this long is the grace window for Polly to
+    # queue the replacement. If no ``task.created`` for the same
+    # project lands in that window, fire the finding.
+    cancel_grace_seconds: int = 300
+
+
+@dataclass(slots=True, frozen=True)
+class Finding:
+    """One watchdog detection — what was wrong, where, and what to do.
+
+    ``rule`` is one of the ``RULE_*`` constants. ``project`` and
+    ``subject`` mirror the audit-event shape so a downstream alert
+    can scope itself the same way other PollyPM alerts do.
+    ``recommendation`` is a copy-pasteable hint (CLI command, file
+    pointer, etc.) — surfaced to the user verbatim.
+    """
+
+    rule: str
+    project: str
+    subject: str
+    severity: str = "warn"
+    message: str = ""
+    recommendation: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(stamp: str) -> datetime | None:
+    """Parse an ISO-8601 timestamp string into a tz-aware datetime."""
+    if not stamp:
+        return None
+    try:
+        # ``datetime.fromisoformat`` handles the ``+00:00`` suffix our
+        # writer emits. Earlier Pythons choked on ``Z`` but 3.11+ does
+        # not — and we target 3.11+ everywhere.
+        dt = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _marker_task_key(subject: str) -> tuple[str, int] | None:
+    """Extract ``(project, task_number)`` from a marker subject path.
+
+    Marker subjects are absolute paths like
+    ``/.../<root>/.pollypm/worker-markers/task-savethenovel-1.fresh``.
+    Returns ``None`` for marker filenames we don't recognise — those
+    are never task-bound markers (e.g. future ``advisor-*`` markers)
+    and we skip them rather than firing spurious findings.
+    """
+    if not subject:
+        return None
+    name = Path(subject).name
+    match = _MARKER_NAME_RE.match(name)
+    if match is None:
+        return None
+    project = match.group("project")
+    try:
+        num = int(match.group("num"))
+    except ValueError:
+        return None
+    return (project, num)
+
+
+def _task_subject_key(subject: str) -> tuple[str, int] | None:
+    """Parse ``project/N`` task subject into ``(project, N)``."""
+    if not subject or "/" not in subject:
+        return None
+    project, _, num_s = subject.rpartition("/")
+    try:
+        return (project, int(num_s))
+    except ValueError:
+        return None
+
+
+def watchdog_alert_session_name(rule: str, project: str, subject: str) -> str:
+    """Synthetic session name for ``upsert_alert`` dedupe.
+
+    Mirrors :func:`pollypm.plugins_builtin.core_recurring.blocked_chain
+    .blocked_dead_end_session_name` — one row per (rule, project,
+    subject) so repeated ticks refresh the same alert instead of
+    spawning duplicates.
+    """
+    safe_subject = subject.replace("/", "_").replace(" ", "_") or "_"
+    return f"audit-{rule}-{project}-{safe_subject}"
+
+
+def format_finding_message(finding: Finding) -> str:
+    """Render a Finding as the alert message body."""
+    parts = [finding.message or finding.rule]
+    if finding.recommendation:
+        parts.append(f"Recommendation: {finding.recommendation}")
+    return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Rule implementations — each returns ``list[Finding]``
+# ---------------------------------------------------------------------------
+
+
+def _detect_orphan_markers(
+    events: Sequence[AuditEvent],
+    *,
+    now: datetime,
+    config: WatchdogConfig,
+) -> list[Finding]:
+    """Rule 1: ``marker.created`` with no release + no terminal transition.
+
+    Walks the windowed event list once. For each ``marker.created``
+    we extract the (project, task_number) and check whether either
+    a ``marker.released`` for the same marker subject *or* a
+    ``task.status_changed`` to a terminal state for the same task
+    appears later in the window. If neither, it's an orphan.
+    """
+    findings: list[Finding] = []
+    cutoff = now - timedelta(seconds=config.window_seconds)
+
+    # Collect created markers within the window.
+    created: list[tuple[AuditEvent, tuple[str, int]]] = []
+    released_subjects: set[str] = set()
+    terminal_tasks: set[tuple[str, int]] = set()
+
+    for ev in events:
+        ts = _parse_iso(ev.ts)
+        if ts is None or ts < cutoff:
+            continue
+        if ev.event == EVENT_MARKER_CREATED and ev.status == "ok":
+            key = _marker_task_key(ev.subject)
+            if key is not None:
+                created.append((ev, key))
+        elif ev.event == EVENT_MARKER_RELEASED:
+            released_subjects.add(ev.subject)
+        elif ev.event == EVENT_TASK_STATUS_CHANGED:
+            to_state = (ev.metadata or {}).get("to")
+            if isinstance(to_state, str) and to_state in _TERMINAL_TASK_STATES:
+                key = _task_subject_key(ev.subject)
+                if key is not None:
+                    terminal_tasks.add(key)
+
+    for ev, key in created:
+        if ev.subject in released_subjects:
+            continue
+        if key in terminal_tasks:
+            # Task transitioned to a terminal state — the reaper /
+            # cleanup paths will handle the marker; don't double-warn.
+            continue
+        project, task_number = key
+        findings.append(Finding(
+            rule=RULE_ORPHAN_MARKER,
+            project=project,
+            subject=f"{project}/{task_number}",
+            message=(
+                f"Worker marker for task {project}/{task_number} has "
+                f"been alive for >{config.window_seconds // 60} min "
+                f"with no release and no terminal task transition."
+            ),
+            recommendation=(
+                f"Inspect the worker pane (window task-{project}-"
+                f"{task_number}) and either resume or run "
+                f"`pm task cancel {project}/{task_number}` to release "
+                f"the marker."
+            ),
+            metadata={
+                "marker_subject": ev.subject,
+                "created_at": ev.ts,
+                "actor": ev.actor,
+            },
+        ))
+    return findings
+
+
+def _detect_marker_leaks(
+    events: Sequence[AuditEvent],
+    *,
+    now: datetime,
+    config: WatchdogConfig,
+) -> list[Finding]:
+    """Rule 2: any ``marker.leaked`` event in the window.
+
+    The persona-swap-detected branch only emits this when a worker
+    was redirected mid-launch. Every occurrence is worth surfacing —
+    we want a visible leak counter, not silent log noise.
+    """
+    findings: list[Finding] = []
+    cutoff = now - timedelta(seconds=config.window_seconds)
+    for ev in events:
+        if ev.event != EVENT_MARKER_LEAKED:
+            continue
+        ts = _parse_iso(ev.ts)
+        if ts is None or ts < cutoff:
+            continue
+        key = _marker_task_key(ev.subject)
+        if key is not None:
+            project, task_number = key
+            subject = f"{project}/{task_number}"
+        else:
+            project = ev.project
+            subject = ev.subject or "<unknown>"
+        findings.append(Finding(
+            rule=RULE_MARKER_LEAKED,
+            project=project,
+            subject=subject,
+            message=(
+                f"Marker leak detected at {ev.ts} (persona-swap path). "
+                f"A worker pane was redirected before its marker could "
+                f"be released."
+            ),
+            recommendation=(
+                "Investigate session_services/tmux.py "
+                "persona_swap_detected branch — this should be rare; "
+                "repeat occurrences point at a tmux session-name "
+                "collision."
+            ),
+            metadata={
+                "marker_subject": ev.subject,
+                "leaked_at": ev.ts,
+                "actor": ev.actor,
+                **dict(ev.metadata or {}),
+            },
+        ))
+    return findings
+
+
+def _detect_stuck_drafts(
+    events: Sequence[AuditEvent],
+    *,
+    now: datetime,
+    config: WatchdogConfig,
+) -> list[Finding]:
+    """Rule 3: ``task.created`` older than ``stuck_draft_seconds`` with
+    no promotion.
+
+    Iterates ``task.created`` events older than the threshold. For
+    each, we check whether *any* ``task.status_changed`` for the
+    same subject exists at all (looking at the full event list, not
+    just inside the lookback window — a task that got promoted before
+    the window started is fine). If no promotion is recorded, the
+    draft is stuck.
+    """
+    findings: list[Finding] = []
+    cutoff = now - timedelta(seconds=config.stuck_draft_seconds)
+
+    promoted_subjects: set[str] = set()
+    created_events: list[AuditEvent] = []
+    for ev in events:
+        if ev.event == EVENT_TASK_STATUS_CHANGED:
+            to_state = (ev.metadata or {}).get("to")
+            if isinstance(to_state, str) and (
+                to_state in _DRAFT_PROMOTION_STATES
+                or to_state in _TERMINAL_TASK_STATES
+            ):
+                promoted_subjects.add(ev.subject)
+        elif ev.event == EVENT_TASK_CREATED:
+            ts = _parse_iso(ev.ts)
+            if ts is None or ts > cutoff:
+                # Too recent — give it grace.
+                continue
+            created_events.append(ev)
+
+    for ev in created_events:
+        if ev.subject in promoted_subjects:
+            continue
+        key = _task_subject_key(ev.subject)
+        if key is None:
+            continue
+        project, task_number = key
+        findings.append(Finding(
+            rule=RULE_STUCK_DRAFT,
+            project=project,
+            subject=ev.subject,
+            message=(
+                f"Draft task {ev.subject} has sat unpromoted for "
+                f">{config.stuck_draft_seconds // 60} min "
+                f"(created {ev.ts})."
+            ),
+            recommendation=(
+                f"Promote with `pm task promote {ev.subject}` or "
+                f"discard with `pm task cancel {ev.subject}`. "
+                f"Originating actor: {ev.actor or 'unknown'}."
+            ),
+            metadata={
+                "created_at": ev.ts,
+                "actor": ev.actor,
+                "title": (ev.metadata or {}).get("title"),
+            },
+        ))
+    return findings
+
+
+def _detect_cancellation_no_promotion(
+    events: Sequence[AuditEvent],
+    *,
+    now: datetime,
+    config: WatchdogConfig,
+) -> list[Finding]:
+    """Rule 4: cancel without follow-up create within the grace window.
+
+    The savethenovel/1 pattern: Polly cancels a task, then never
+    queues the replacement. Detection: for each ``task.status_changed``
+    to ``cancelled`` whose timestamp lies in
+    ``[now - window, now - cancel_grace_seconds]`` (i.e. the grace
+    window has fully elapsed), check whether any ``task.created`` for
+    the same project exists with a strictly later timestamp. If not,
+    fire.
+    """
+    findings: list[Finding] = []
+    grace = timedelta(seconds=config.cancel_grace_seconds)
+    window_start = now - timedelta(seconds=config.window_seconds)
+    grace_cutoff = now - grace
+
+    # Map project -> sorted list of task.created timestamps.
+    created_by_project: dict[str, list[datetime]] = {}
+    cancellations: list[tuple[AuditEvent, datetime]] = []
+    for ev in events:
+        ts = _parse_iso(ev.ts)
+        if ts is None:
+            continue
+        if ev.event == EVENT_TASK_CREATED and ev.project:
+            created_by_project.setdefault(ev.project, []).append(ts)
+        elif ev.event == EVENT_TASK_STATUS_CHANGED:
+            to_state = (ev.metadata or {}).get("to")
+            if to_state == "cancelled" and ts >= window_start and ts <= grace_cutoff:
+                cancellations.append((ev, ts))
+
+    for ev, ts in cancellations:
+        creates = created_by_project.get(ev.project, [])
+        # Was there *any* task.created for this project after the
+        # cancellation? Even one means Polly kept the queue moving.
+        followed = any(c > ts for c in creates)
+        if followed:
+            continue
+        findings.append(Finding(
+            rule=RULE_CANCEL_NO_PROMOTION,
+            project=ev.project,
+            subject=ev.subject,
+            message=(
+                f"Task {ev.subject} was cancelled at {ev.ts} but no "
+                f"replacement task.created landed in the next "
+                f"{config.cancel_grace_seconds // 60} min. The "
+                f"planning queue may have stalled."
+            ),
+            recommendation=(
+                f"Open the project drilldown and check Polly's "
+                f"planning state, or run `pm chat {ev.project}` and "
+                f"prompt 'what's next?' to nudge the queue."
+            ),
+            metadata={
+                "cancelled_at": ev.ts,
+                "actor": ev.actor,
+                "from": (ev.metadata or {}).get("from"),
+            },
+        ))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Public API — scan_events / scan_project
+# ---------------------------------------------------------------------------
+
+
+def scan_events(
+    events: Iterable[AuditEvent],
+    *,
+    now: datetime,
+    config: WatchdogConfig | None = None,
+) -> list[Finding]:
+    """Run every detection rule against ``events`` and return findings.
+
+    Pure function — no I/O. Tests pass a synthetic event list directly.
+    The events are iterated multiple times so an iterable is materialised
+    into a list up front.
+
+    Args:
+        events: audit events to scan. Order need not be sorted —
+            individual detectors compare timestamps.
+        now: tz-aware "current" wall clock — typically
+            ``datetime.now(timezone.utc)`` in production, a fixed
+            instant in tests.
+        config: tunable thresholds. ``None`` uses :class:`WatchdogConfig`
+            defaults.
+    """
+    if config is None:
+        config = WatchdogConfig()
+    if now.tzinfo is None:
+        raise ValueError("scan_events requires a timezone-aware ``now``")
+    materialised = list(events)
+    findings: list[Finding] = []
+    findings.extend(_detect_orphan_markers(
+        materialised, now=now, config=config,
+    ))
+    findings.extend(_detect_marker_leaks(
+        materialised, now=now, config=config,
+    ))
+    findings.extend(_detect_stuck_drafts(
+        materialised, now=now, config=config,
+    ))
+    findings.extend(_detect_cancellation_no_promotion(
+        materialised, now=now, config=config,
+    ))
+    return findings
+
+
+def scan_project(
+    project: str,
+    *,
+    project_path: Path | str | None = None,
+    now: datetime | None = None,
+    config: WatchdogConfig | None = None,
+) -> list[Finding]:
+    """Read audit events for ``project`` and scan them.
+
+    Convenience wrapper used by the cadence handler. Pulls events
+    from the per-project log when ``project_path`` exists, else
+    from the central tail (mirrors :func:`pollypm.audit.read_events`
+    source-preference rules).
+    """
+    from pollypm.audit.log import read_events
+
+    if config is None:
+        config = WatchdogConfig()
+    resolved_now = now or datetime.now(timezone.utc)
+    # Pull a window-sized lookback from the log. We pad by 2x the
+    # window so the cancel-no-promotion rule can still see the
+    # ``task.created`` that resolved a cancel just outside the
+    # window. The detectors filter further by timestamp.
+    since = (
+        resolved_now - timedelta(seconds=config.window_seconds * 2)
+    ).isoformat()
+    events = read_events(
+        project,
+        since=since,
+        project_path=project_path,
+    )
+    return scan_events(events, now=resolved_now, config=config)
+
+
+# ---------------------------------------------------------------------------
+# Emit helpers — one for the heartbeat self-check, one for findings
+# ---------------------------------------------------------------------------
+
+
+def emit_heartbeat_tick(
+    *,
+    project: str = "",
+    actor: str = "audit_watchdog",
+    metadata: dict[str, Any] | None = None,
+    project_path: Path | str | None = None,
+) -> None:
+    """Emit a ``heartbeat.tick`` audit event so we can prove liveness.
+
+    Called by the cadence handler at the start of every scan. An
+    operator (or a future ``pm doctor``) can grep the central tail
+    for ``heartbeat.tick`` and observe the cadence — if the gaps grow,
+    the heartbeat itself is wedged.
+    """
+    from pollypm.audit.log import emit as _audit_emit
+    try:
+        _audit_emit(
+            event=EVENT_HEARTBEAT_TICK,
+            project=project,
+            subject="audit_watchdog",
+            actor=actor,
+            metadata=dict(metadata or {}),
+            project_path=project_path,
+        )
+    except Exception:  # noqa: BLE001 — never fail the cadence on audit hiccups
+        logger.debug("emit_heartbeat_tick failed", exc_info=True)
+
+
+def emit_finding(finding: Finding) -> None:
+    """Emit an ``audit.finding`` event for posterity.
+
+    The cadence handler also routes findings to ``upsert_alert`` for
+    user-visible surfacing; this audit emit is the durable forensic
+    trail. Best-effort — never raises.
+    """
+    from pollypm.audit.log import emit as _audit_emit
+    try:
+        _audit_emit(
+            event=EVENT_AUDIT_FINDING,
+            project=finding.project,
+            subject=finding.subject,
+            actor="audit_watchdog",
+            status=finding.severity,
+            metadata={
+                "rule": finding.rule,
+                "message": finding.message,
+                "recommendation": finding.recommendation,
+                **dict(finding.metadata or {}),
+            },
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("emit_finding failed", exc_info=True)

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -1,0 +1,222 @@
+"""``audit.watchdog`` cadence handler — surface forensic findings.
+
+Born from the savethenovel post-mortem (2026-05-06): the audit log
+(#1342) records every task / marker mutation; this handler reads
+those events on a fixed cadence and surfaces "broken state" findings
+via the existing ``upsert_alert`` channel — the same surface used by
+``blocked_chain.sweep`` (#1073) and the supervisor's session-health
+sweep. No new alert channel is introduced.
+
+The handler is a thin wrapper around :mod:`pollypm.audit.watchdog`,
+which holds the pure detectors. The heartbeat scheduler invokes
+``audit_watchdog_handler`` every 5 minutes; per-tick behaviour:
+
+1. Emit a ``heartbeat.tick`` audit event so liveness is observable.
+2. For each known project, read the last ``window_seconds * 2`` of
+   audit events and run the four detectors.
+3. For every finding, emit an ``audit.finding`` audit event AND
+   upsert an alert keyed by ``(rule, project, subject)``.
+
+Idempotent across ticks because :meth:`upsert_alert` collapses
+repeats. The emitted ``audit.finding`` events are deliberately
+duplicated each tick — the audit log is append-only and operators
+want to see "this fired N ticks in a row" as a signal of severity.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pollypm.audit.watchdog import (
+    Finding,
+    WATCHDOG_ALERT_TYPE,
+    WatchdogConfig,
+    emit_finding,
+    emit_heartbeat_tick,
+    format_finding_message,
+    scan_project,
+    watchdog_alert_session_name,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "audit_watchdog_handler",
+    "AUDIT_WATCHDOG_HANDLER_NAME",
+    "AUDIT_WATCHDOG_SCHEDULE",
+]
+
+
+AUDIT_WATCHDOG_HANDLER_NAME = "audit.watchdog"
+# Every 5 minutes is the same cadence as ``stuck_claims.sweep`` /
+# ``alerts.gc`` — enough to catch the savethenovel-class symptom
+# within ~5 min of occurrence without spamming the queue.
+AUDIT_WATCHDOG_SCHEDULE = "@every 5m"
+
+
+def _route_to_alert_sink(
+    finding: Finding,
+    *,
+    msg_store: Any,
+    state_store: Any,
+) -> bool:
+    """Upsert a finding via the unified Store, falling back to StateStore.
+
+    Mirrors ``blocked_chain._emit_alert``: prefer the unified
+    ``msg_store`` (post-#349 path) and fall back to the legacy
+    ``StateStore`` so the cadence still works on installs that
+    haven't migrated yet.
+    """
+    target = msg_store or state_store
+    if target is None:
+        return False
+    upsert = getattr(target, "upsert_alert", None)
+    if not callable(upsert):
+        return False
+    session_name = watchdog_alert_session_name(
+        finding.rule, finding.project, finding.subject,
+    )
+    try:
+        upsert(
+            session_name,
+            WATCHDOG_ALERT_TYPE,
+            finding.severity,
+            format_finding_message(finding),
+        )
+        return True
+    except Exception:  # noqa: BLE001 — alert path failures must not crash the sweep
+        logger.debug(
+            "audit.watchdog: upsert_alert failed for %s/%s",
+            finding.rule, finding.project, exc_info=True,
+        )
+        return False
+
+
+def _config_from_payload(payload: dict[str, Any]) -> WatchdogConfig:
+    """Build a :class:`WatchdogConfig` from the handler payload."""
+    if not isinstance(payload, dict):
+        return WatchdogConfig()
+    kwargs: dict[str, int] = {}
+    for field_name in ("window_seconds", "stuck_draft_seconds", "cancel_grace_seconds"):
+        raw = payload.get(field_name)
+        if raw is None:
+            continue
+        try:
+            kwargs[field_name] = max(0, int(raw))
+        except (TypeError, ValueError):
+            continue
+    return WatchdogConfig(**kwargs) if kwargs else WatchdogConfig()
+
+
+def _scan_one_project(
+    *,
+    project_key: str,
+    project_path: Path | None,
+    msg_store: Any,
+    state_store: Any,
+    now: datetime,
+    config: WatchdogConfig,
+) -> dict[str, int]:
+    """Scan one project and route every finding. Returns counters."""
+    counters = {
+        "findings": 0,
+        "alerts_raised": 0,
+        "alert_failures": 0,
+    }
+    try:
+        findings = scan_project(
+            project_key,
+            project_path=project_path,
+            now=now,
+            config=config,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: scan_project(%s) failed",
+            project_key, exc_info=True,
+        )
+        return counters
+
+    for finding in findings:
+        counters["findings"] += 1
+        emit_finding(finding)
+        if _route_to_alert_sink(
+            finding, msg_store=msg_store, state_store=state_store,
+        ):
+            counters["alerts_raised"] += 1
+        else:
+            counters["alert_failures"] += 1
+            # Last-resort surface so a finding with no alert sink
+            # still lands somewhere visible to operators.
+            logger.warning(
+                "audit.watchdog finding [%s] %s/%s: %s | %s",
+                finding.rule, finding.project, finding.subject,
+                finding.message, finding.recommendation,
+            )
+    return counters
+
+
+def audit_watchdog_handler(payload: dict[str, Any]) -> dict[str, Any]:
+    """Cadence handler entry point.
+
+    Reads the audit log for every known project, runs the watchdog
+    detectors, and routes every finding to an alert + a forensic
+    audit event.
+
+    Returns a dict with per-project + total counters for observability.
+    """
+    from pollypm.runtime_services import load_runtime_services
+
+    config = _config_from_payload(payload or {})
+    config_path_hint = (
+        payload.get("config_path") if isinstance(payload, dict) else None
+    )
+    config_path = Path(config_path_hint) if config_path_hint else None
+
+    services = load_runtime_services(config_path=config_path)
+    now = datetime.now(UTC)
+
+    # Liveness ping — emitted before scanning so that even if
+    # scanning blows up the heartbeat-tick still lands in the log.
+    emit_heartbeat_tick(metadata={"cadence": AUDIT_WATCHDOG_SCHEDULE})
+
+    totals = {
+        "projects_scanned": 0,
+        "findings": 0,
+        "alerts_raised": 0,
+        "alert_failures": 0,
+    }
+
+    try:
+        seen_projects: set[str] = set()
+        for project in services.known_projects or ():
+            project_key = getattr(project, "key", None)
+            if not project_key or project_key in seen_projects:
+                continue
+            seen_projects.add(project_key)
+            project_path = getattr(project, "path", None)
+            partial = _scan_one_project(
+                project_key=project_key,
+                project_path=Path(project_path) if project_path else None,
+                msg_store=services.msg_store,
+                state_store=services.state_store,
+                now=now,
+                config=config,
+            )
+            totals["projects_scanned"] += 1
+            for k, v in partial.items():
+                totals[k] += v
+    finally:
+        try:
+            services.close()
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "audit.watchdog: services.close raised", exc_info=True,
+            )
+
+    return {"outcome": "swept", **totals}

--- a/src/pollypm/plugins_builtin/core_recurring/plugin.py
+++ b/src/pollypm/plugins_builtin/core_recurring/plugin.py
@@ -31,6 +31,11 @@ from pollypm.plugins_builtin.core_recurring.shared import (  # noqa: F401
     is_ephemeral_session_name,
     sweep_ephemeral_sessions,
 )
+from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+    AUDIT_WATCHDOG_HANDLER_NAME,
+    AUDIT_WATCHDOG_SCHEDULE,
+    audit_watchdog_handler,
+)
 from pollypm.plugins_builtin.core_recurring.blocked_chain import (
     blocked_chain_sweep_handler,
 )
@@ -141,6 +146,7 @@ _DEDUPED_CADENCE_HANDLERS: frozenset[str] = frozenset({
     "task_assignment.sweep",
     "itsalive.deploy_sweep",
     "blocked_chain.sweep",
+    "audit.watchdog",
 })
 _STALE_QUEUED_CUTOFF_SECONDS: float = 3600.0
 
@@ -443,6 +449,14 @@ def _register_handlers(api: JobHandlerAPI) -> None:
         "blocked_chain.sweep", blocked_chain_sweep_handler,
         max_attempts=1, timeout_seconds=120.0,
     )
+    # #savethenovel followup — audit-log watchdog. Reads the per-project
+    # / central audit-log tail and surfaces orphan markers, marker
+    # leaks, stuck drafts, and post-cancel planning stalls via the
+    # existing ``upsert_alert`` channel. Idempotent across ticks.
+    api.register_handler(
+        AUDIT_WATCHDOG_HANDLER_NAME, audit_watchdog_handler,
+        max_attempts=1, timeout_seconds=60.0,
+    )
 
 
 def _register_roster(api: RosterAPI) -> None:
@@ -514,6 +528,14 @@ def _register_roster(api: RosterAPI) -> None:
         "@every 10m", "blocked_chain.sweep", {},
         dedupe_key="blocked_chain.sweep",
     )
+    # #savethenovel followup — audit-log watchdog. Cadence matches
+    # ``alerts.gc`` / ``stuck_claims.sweep`` (5 min) so a savethenovel-
+    # class symptom (orphan marker, stuck draft, cancel-stall) lands
+    # in ``pm alerts`` within ~5 min of occurrence.
+    api.register_recurring(
+        AUDIT_WATCHDOG_SCHEDULE, AUDIT_WATCHDOG_HANDLER_NAME, {},
+        dedupe_key=AUDIT_WATCHDOG_HANDLER_NAME,
+    )
 
 
 plugin = PollyPMPlugin(
@@ -543,6 +565,7 @@ plugin = PollyPMPlugin(
         Capability(kind="job_handler", name="worktree.state_audit"),
         Capability(kind="job_handler", name="stuck_claims.sweep"),
         Capability(kind="job_handler", name="blocked_chain.sweep"),
+        Capability(kind="job_handler", name="audit.watchdog"),
         Capability(kind="roster_entry", name="core_recurring"),
     ),
     register_handlers=_register_handlers,

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -1,0 +1,498 @@
+"""Tests for the audit-log watchdog (savethenovel follow-up).
+
+Exercises the four pure detectors against synthetic event lists and
+confirms the integration path (read events from ``central_log_path``,
+detect findings, emit forensic ``audit.finding`` events) works
+end-to-end against an isolated audit home.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from pollypm.audit import emit
+from pollypm.audit.log import (
+    EVENT_MARKER_CREATED,
+    EVENT_MARKER_LEAKED,
+    EVENT_MARKER_RELEASED,
+    EVENT_TASK_CREATED,
+    EVENT_TASK_STATUS_CHANGED,
+    AuditEvent,
+    central_log_path,
+)
+from pollypm.audit.watchdog import (
+    EVENT_AUDIT_FINDING,
+    EVENT_HEARTBEAT_TICK,
+    RULE_CANCEL_NO_PROMOTION,
+    RULE_MARKER_LEAKED,
+    RULE_ORPHAN_MARKER,
+    RULE_STUCK_DRAFT,
+    Finding,
+    WatchdogConfig,
+    emit_finding,
+    emit_heartbeat_tick,
+    format_finding_message,
+    scan_events,
+    scan_project,
+    watchdog_alert_session_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_audit_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the central-tail root so tests never touch ~/.pollypm/."""
+    audit_home = tmp_path / "audit-home"
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+    return audit_home
+
+
+@pytest.fixture
+def now() -> datetime:
+    """Fixed wall-clock — gives every detector deterministic windowing."""
+    return datetime(2026, 5, 6, 17, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_event(
+    *,
+    event: str,
+    project: str = "demo",
+    subject: str = "",
+    actor: str = "polly",
+    status: str = "ok",
+    metadata: dict | None = None,
+    ts: datetime,
+) -> AuditEvent:
+    return AuditEvent(
+        ts=ts.isoformat(),
+        project=project,
+        event=event,
+        subject=subject,
+        actor=actor,
+        status=status,
+        metadata=metadata or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule 1: orphan marker
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_marker_detected_when_no_release_or_terminal(now: datetime) -> None:
+    """A marker.created with neither release nor terminal transition fires."""
+    events = [
+        _make_event(
+            event=EVENT_MARKER_CREATED,
+            project="demo",
+            subject="/proj/demo/.pollypm/worker-markers/task-demo-1.fresh",
+            ts=now - timedelta(minutes=20),
+        ),
+    ]
+    findings = scan_events(events, now=now)
+    orphans = [f for f in findings if f.rule == RULE_ORPHAN_MARKER]
+    assert len(orphans) == 1
+    assert orphans[0].project == "demo"
+    assert orphans[0].subject == "demo/1"
+    assert "demo/1" in orphans[0].message
+    assert "pm task cancel demo/1" in orphans[0].recommendation
+
+
+def test_orphan_marker_silenced_by_release(now: datetime) -> None:
+    marker = "/proj/demo/.pollypm/worker-markers/task-demo-1.fresh"
+    events = [
+        _make_event(
+            event=EVENT_MARKER_CREATED, subject=marker,
+            ts=now - timedelta(minutes=20),
+        ),
+        _make_event(
+            event=EVENT_MARKER_RELEASED, subject=marker,
+            ts=now - timedelta(minutes=10),
+        ),
+    ]
+    findings = [f for f in scan_events(events, now=now) if f.rule == RULE_ORPHAN_MARKER]
+    assert findings == []
+
+
+def test_orphan_marker_silenced_by_terminal_transition(now: datetime) -> None:
+    """Cancellation transition closes out the orphan check (savethenovel/1)."""
+    marker = "/proj/demo/.pollypm/worker-markers/task-demo-1.fresh"
+    events = [
+        _make_event(
+            event=EVENT_MARKER_CREATED, subject=marker,
+            ts=now - timedelta(minutes=25),
+        ),
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            subject="demo/1",
+            metadata={"from": "in_progress", "to": "cancelled"},
+            ts=now - timedelta(minutes=24),
+        ),
+    ]
+    findings = [f for f in scan_events(events, now=now) if f.rule == RULE_ORPHAN_MARKER]
+    assert findings == []
+
+
+def test_orphan_marker_outside_window_ignored(now: datetime) -> None:
+    config = WatchdogConfig(window_seconds=600)
+    marker = "/proj/demo/.pollypm/worker-markers/task-demo-1.fresh"
+    events = [
+        _make_event(
+            event=EVENT_MARKER_CREATED, subject=marker,
+            ts=now - timedelta(hours=2),
+        ),
+    ]
+    findings = scan_events(events, now=now, config=config)
+    assert [f for f in findings if f.rule == RULE_ORPHAN_MARKER] == []
+
+
+def test_orphan_marker_skips_unrecognised_subject(now: datetime) -> None:
+    """Marker subjects we can't parse don't fire the rule."""
+    events = [
+        _make_event(
+            event=EVENT_MARKER_CREATED,
+            subject="/proj/demo/.pollypm/worker-markers/advisor-something.fresh",
+            ts=now - timedelta(minutes=10),
+        ),
+    ]
+    findings = [f for f in scan_events(events, now=now) if f.rule == RULE_ORPHAN_MARKER]
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: marker leaked
+# ---------------------------------------------------------------------------
+
+
+def test_marker_leaked_event_surfaces_finding(now: datetime) -> None:
+    events = [
+        _make_event(
+            event=EVENT_MARKER_LEAKED,
+            subject="/proj/demo/.pollypm/worker-markers/task-demo-2.fresh",
+            metadata={"reason": "persona_swap_detected"},
+            ts=now - timedelta(minutes=5),
+        ),
+    ]
+    findings = [f for f in scan_events(events, now=now) if f.rule == RULE_MARKER_LEAKED]
+    assert len(findings) == 1
+    assert findings[0].subject == "demo/2"
+    assert "persona-swap" in findings[0].message.lower()
+
+
+def test_marker_leaked_outside_window_ignored(now: datetime) -> None:
+    events = [
+        _make_event(
+            event=EVENT_MARKER_LEAKED,
+            subject="/proj/demo/.pollypm/worker-markers/task-demo-2.fresh",
+            ts=now - timedelta(hours=2),
+        ),
+    ]
+    assert [f for f in scan_events(events, now=now) if f.rule == RULE_MARKER_LEAKED] == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 3: stuck draft
+# ---------------------------------------------------------------------------
+
+
+def test_stuck_draft_detected_when_never_promoted(now: datetime) -> None:
+    """A draft older than ``stuck_draft_seconds`` with no promotion fires."""
+    events = [
+        _make_event(
+            event=EVENT_TASK_CREATED,
+            subject="demo/2",
+            metadata={"title": "Plan the next chapter"},
+            ts=now - timedelta(minutes=15),
+        ),
+    ]
+    findings = [f for f in scan_events(events, now=now) if f.rule == RULE_STUCK_DRAFT]
+    assert len(findings) == 1
+    assert findings[0].subject == "demo/2"
+    assert "pm task promote demo/2" in findings[0].recommendation
+
+
+def test_stuck_draft_silenced_by_promotion(now: datetime) -> None:
+    events = [
+        _make_event(
+            event=EVENT_TASK_CREATED, subject="demo/2",
+            ts=now - timedelta(minutes=15),
+        ),
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            subject="demo/2",
+            metadata={"from": "draft", "to": "queued"},
+            ts=now - timedelta(minutes=10),
+        ),
+    ]
+    findings = [f for f in scan_events(events, now=now) if f.rule == RULE_STUCK_DRAFT]
+    assert findings == []
+
+
+def test_stuck_draft_recent_create_within_grace(now: datetime) -> None:
+    """A freshly-created draft (<stuck_draft_seconds) does not yet fire."""
+    events = [
+        _make_event(
+            event=EVENT_TASK_CREATED, subject="demo/2",
+            ts=now - timedelta(seconds=60),
+        ),
+    ]
+    findings = [f for f in scan_events(events, now=now) if f.rule == RULE_STUCK_DRAFT]
+    assert findings == []
+
+
+def test_stuck_draft_silenced_by_cancellation(now: datetime) -> None:
+    """Cancelling a draft also clears the stuck-draft check."""
+    events = [
+        _make_event(
+            event=EVENT_TASK_CREATED, subject="demo/2",
+            ts=now - timedelta(minutes=15),
+        ),
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            subject="demo/2",
+            metadata={"from": "draft", "to": "cancelled"},
+            ts=now - timedelta(minutes=10),
+        ),
+    ]
+    findings = [f for f in scan_events(events, now=now) if f.rule == RULE_STUCK_DRAFT]
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 4: cancellation without promotion
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_without_replacement_fires(now: datetime) -> None:
+    """savethenovel/1 — cancel with no follow-up create."""
+    events = [
+        _make_event(
+            event=EVENT_TASK_CREATED, subject="demo/1",
+            ts=now - timedelta(minutes=30),
+        ),
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            subject="demo/1",
+            metadata={"from": "in_progress", "to": "cancelled"},
+            ts=now - timedelta(minutes=15),
+        ),
+    ]
+    findings = [
+        f for f in scan_events(events, now=now)
+        if f.rule == RULE_CANCEL_NO_PROMOTION
+    ]
+    assert len(findings) == 1
+    assert findings[0].subject == "demo/1"
+
+
+def test_cancel_with_followup_create_silenced(now: datetime) -> None:
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            subject="demo/1",
+            metadata={"to": "cancelled"},
+            ts=now - timedelta(minutes=15),
+        ),
+        _make_event(
+            event=EVENT_TASK_CREATED, subject="demo/2",
+            ts=now - timedelta(minutes=12),
+        ),
+    ]
+    findings = [
+        f for f in scan_events(events, now=now)
+        if f.rule == RULE_CANCEL_NO_PROMOTION
+    ]
+    assert findings == []
+
+
+def test_cancel_within_grace_window_silenced(now: datetime) -> None:
+    """A cancel that's still inside the grace window does not yet fire."""
+    config = WatchdogConfig(cancel_grace_seconds=300)
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            subject="demo/1",
+            metadata={"to": "cancelled"},
+            ts=now - timedelta(seconds=120),  # within 5min grace
+        ),
+    ]
+    findings = [
+        f for f in scan_events(events, now=now, config=config)
+        if f.rule == RULE_CANCEL_NO_PROMOTION
+    ]
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Empty-state + sanity
+# ---------------------------------------------------------------------------
+
+
+def test_empty_event_list_no_findings(now: datetime) -> None:
+    assert scan_events([], now=now) == []
+
+
+def test_scan_requires_tz_aware_now() -> None:
+    naive = datetime(2026, 5, 6, 17, 0, 0)
+    with pytest.raises(ValueError):
+        scan_events([], now=naive)
+
+
+def test_format_finding_message_includes_recommendation() -> None:
+    finding = Finding(
+        rule=RULE_STUCK_DRAFT,
+        project="demo",
+        subject="demo/2",
+        message="Draft demo/2 is stuck.",
+        recommendation="Run pm task promote demo/2.",
+    )
+    rendered = format_finding_message(finding)
+    assert "Draft demo/2 is stuck." in rendered
+    assert "Recommendation: Run pm task promote demo/2." in rendered
+
+
+def test_alert_session_name_is_stable() -> None:
+    name = watchdog_alert_session_name(RULE_STUCK_DRAFT, "demo", "demo/2")
+    assert name.startswith("audit-stuck_draft-demo-")
+    # Must not contain raw '/' so the session-name space stays clean.
+    assert "/" not in name
+
+
+# ---------------------------------------------------------------------------
+# Integration — round-trip through the on-disk audit log
+# ---------------------------------------------------------------------------
+
+
+def test_scan_project_against_empty_log_returns_no_findings(now: datetime) -> None:
+    """Fresh, empty audit home produces no findings."""
+    findings = scan_project("demo", now=now)
+    assert findings == []
+
+
+def test_scan_project_against_synthetic_log(now: datetime, tmp_path: Path) -> None:
+    """Write events through ``emit`` then read via ``scan_project``.
+
+    Exercises the central-tail read path the cadence handler will use
+    in production.
+    """
+    # Older orphan marker event (within 30 min window).
+    old_ts = now - timedelta(minutes=20)
+    # Use the writer with a manual ts bypass — emit() stamps "now",
+    # so we shape the event by writing JSON directly to the central
+    # tail. This mirrors what an in-process producer would have
+    # written 20 minutes ago.
+    central = central_log_path("savethenovel")
+    central.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": 1,
+        "ts": old_ts.isoformat(),
+        "project": "savethenovel",
+        "event": EVENT_MARKER_CREATED,
+        "subject": "/x/savethenovel/.pollypm/worker-markers/task-savethenovel-1.fresh",
+        "actor": "polly",
+        "status": "ok",
+        "metadata": {"window_name": "task-savethenovel-1"},
+    }
+    central.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    findings = scan_project("savethenovel", now=now)
+    assert any(f.rule == RULE_ORPHAN_MARKER for f in findings)
+
+
+def test_emit_heartbeat_tick_lands_in_audit_log() -> None:
+    emit_heartbeat_tick(project="demo", metadata={"cadence": "@every 5m"})
+    central = central_log_path("demo")
+    assert central.exists()
+    rows = [
+        json.loads(line)
+        for line in central.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    tick_rows = [r for r in rows if r["event"] == EVENT_HEARTBEAT_TICK]
+    assert len(tick_rows) == 1
+    assert tick_rows[0]["actor"] == "audit_watchdog"
+
+
+def test_emit_finding_writes_audit_finding_event() -> None:
+    finding = Finding(
+        rule=RULE_STUCK_DRAFT,
+        project="demo",
+        subject="demo/2",
+        message="msg",
+        recommendation="rec",
+    )
+    emit_finding(finding)
+    central = central_log_path("demo")
+    rows = [
+        json.loads(line)
+        for line in central.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    finding_rows = [r for r in rows if r["event"] == EVENT_AUDIT_FINDING]
+    assert len(finding_rows) == 1
+    assert finding_rows[0]["metadata"]["rule"] == RULE_STUCK_DRAFT
+    assert finding_rows[0]["metadata"]["recommendation"] == "rec"
+
+
+# ---------------------------------------------------------------------------
+# Cadence handler — alert routing
+# ---------------------------------------------------------------------------
+
+
+class _RecordingStore:
+    """Captures ``upsert_alert`` calls — mirrors blocked_chain test pattern."""
+
+    def __init__(self) -> None:
+        self.alerts: list[tuple[str, str, str, str]] = []
+
+    def upsert_alert(
+        self, scope: str, alert_type: str, severity: str, message: str,
+    ) -> None:
+        self.alerts.append((scope, alert_type, severity, message))
+
+
+def test_cadence_handler_routes_finding_to_alert_sink(now: datetime) -> None:
+    """The handler's per-project scan loop upserts one alert per finding."""
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        WATCHDOG_ALERT_TYPE,
+        _scan_one_project,
+    )
+
+    # Seed an orphan-marker event into the central tail.
+    central = central_log_path("demo")
+    central.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": 1,
+        "ts": (now - timedelta(minutes=20)).isoformat(),
+        "project": "demo",
+        "event": EVENT_MARKER_CREATED,
+        "subject": "/x/demo/.pollypm/worker-markers/task-demo-1.fresh",
+        "actor": "polly",
+        "status": "ok",
+        "metadata": {},
+    }
+    central.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    store = _RecordingStore()
+    counters = _scan_one_project(
+        project_key="demo",
+        project_path=None,
+        msg_store=store,
+        state_store=None,
+        now=now,
+        config=WatchdogConfig(),
+    )
+
+    assert counters["findings"] >= 1
+    assert counters["alerts_raised"] >= 1
+    assert counters["alert_failures"] == 0
+    rules_alerted = {a[1] for a in store.alerts}
+    assert WATCHDOG_ALERT_TYPE in rules_alerted

--- a/tests/test_core_recurring_migration.py
+++ b/tests/test_core_recurring_migration.py
@@ -56,6 +56,9 @@ class TestCoreRecurringPlugin:
             "stuck_claims.sweep",
             # #1073 — auto-escalate blocked-chain dead ends.
             "blocked_chain.sweep",
+            # #savethenovel followup — audit-log watchdog (orphan
+            # markers, stuck drafts, cancellation gaps).
+            "audit.watchdog",
         }
         assert expected.issubset(set(registry.names()))
         # inbox.sweep was retired with the legacy inbox subsystem (iv04).
@@ -96,6 +99,8 @@ class TestCoreRecurringPlugin:
             "stuck_claims.sweep",
             # #1073 — blocked-chain dead-end escalation, @every 10m.
             "blocked_chain.sweep",
+            # #savethenovel followup — audit-log watchdog, @every 5m.
+            "audit.watchdog",
         }
 
         # Cadences per issue #164 / #249.
@@ -138,6 +143,8 @@ class TestCoreRecurringPlugin:
         assert _interval_seconds(entries["stuck_claims.sweep"]) == 300
         # #1073 — blocked-chain escalation sweep, @every 10m.
         assert _interval_seconds(entries["blocked_chain.sweep"]) == 600
+        # #savethenovel followup — audit-log watchdog, @every 5m.
+        assert _interval_seconds(entries["audit.watchdog"]) == 300
 
     def test_plugin_declares_expected_capabilities(self) -> None:
         kinds = {cap.kind for cap in core_plugin.capabilities}


### PR DESCRIPTION
## Context

Closes the savethenovel-class detection loop. The audit log scaffold landed in #1342, the worker-marker reaper landed in #1341. This PR adds the **steady-state** heartbeat consumer that scans the audit log every 5 min and surfaces broken state classes via the existing `upsert_alert` channel, so future occurrences of the savethenovel pattern (cancel at ~37s, orphan worker-marker, unpromoted draft #2) land in `pm alerts` within ~5 min instead of waiting for a user to notice.

## Rules implemented

All four headline rules from the brief, plus the heartbeat self-check:

1. **`orphan_marker`** — `marker.created` for `task-<project>-<N>` with no matching `marker.released` in the 30 min window AND no `task.status_changed` to `done`/`cancelled`/`abandoned` for that task. Catches the savethenovel "worker launched, task cancelled, marker lingers" pattern.
2. **`marker_leaked`** — any `marker.leaked` event in the window. Each occurrence is a finding so the persona-swap leak rate is visible (today these only emit a debug log).
3. **`stuck_draft`** — `task.created` from > 5 min ago with no `task.status_changed` to a non-draft state. (savethenovel/2's class: planning queue stalled with an unpromoted draft.)
4. **`cancellation_no_promotion`** — `task.status_changed` to `cancelled` with no follow-up `task.created` for the same project in the next 5 min. (savethenovel/1's class: Polly cancels but the queue stalls.)

Plus: every tick emits a `heartbeat.tick` audit event so liveness is observable post-hoc.

## How findings surface

Findings are routed through the **existing** `upsert_alert` channel — the same sink used by `blocked_chain.sweep` (#1073) and the supervisor's session-health sweep. No new alert channel is introduced. The synthetic alert session name is `audit-<rule>-<project>-<subject>` which idempotently dedupes across ticks. Each finding additionally emits an `audit.finding` event back to the audit log for forensic posterity, and a `logging.warning` lands as a last-resort surface when no alert sink is configured.

Findings carry a copy-pasteable recommendation (`"run pm task promote demo/2"` etc.) so the alert message is actionable.

## Wiring

- `pollypm.audit.watchdog` — pure detectors + `Finding` dataclass + `scan_events` / `scan_project`. Zero I/O in the detector path; tests pass synthetic event lists directly.
- `pollypm.plugins_builtin.core_recurring.audit_watchdog` — cadence handler that loads runtime services, fans out across `services.known_projects`, and routes findings through `upsert_alert`.
- Registered as `audit.watchdog` on `@every 5m` via the existing `register_recurring` API. `dedupe_key="audit.watchdog"` matches the convention used by other deduped cadence handlers.

## Tests

`tests/test_audit_watchdog.py` (23 tests):

- Pure-detector unit coverage: positive + silenced cases for all four rules (release silences orphan, terminal transition silences orphan, promotion silences stuck-draft, follow-up create silences cancel-stall, etc.).
- Window boundary checks (events outside the 30 min lookback ignored, freshly-cancelled tasks within grace window ignored).
- Empty-state: `scan_events([])` and `scan_project` against a fresh audit home both return `[]`.
- `scan_project` integration against a synthetic central-tail JSONL on disk.
- Cadence-handler routing via `_scan_one_project` + a recording StateStore double (mirrors the blocked_chain test pattern).
- Heartbeat-tick + audit.finding emit round-trip through `central_log_path`.

`tests/test_core_recurring_migration.py` extended to assert the new handler + `@every 5m` cadence are registered alongside the existing recurring suite.

## Test plan

- [x] `uv run pytest tests/test_audit_watchdog.py` — 23/23 pass.
- [x] `uv run pytest tests/test_audit_log.py tests/test_blocked_chain_sweep.py tests/test_core_recurring_migration.py tests/test_contract_audit.py` — 91/91 pass.
- [x] `uv run pytest -k "audit or watchdog or recurring or roster or heartbeat"` — 327/327 pass.
- [ ] Manual: after merge, confirm a `heartbeat.tick` event lands in `~/.pollypm/audit/<project>.jsonl` within 5 min of cockpit start.
- [ ] Manual: trigger a synthetic orphan marker (write `marker.created` with no release) and confirm the alert lands in `pm alerts` after the next tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)