### PR TITLE
Default tracked=true for pm add-project

### DIFF
--- a/src/pollypm/cli_features/projects.py
+++ b/src/pollypm/cli_features/projects.py
@@ -188,12 +188,12 @@ def register_project_commands(app: typer.Typer) -> None:
             [
                 ("pm add-project ~/dev/my-app", "register a repo and import its history"),
                 (
-                    'pm add-project ~/dev/my-app --name "My App"',
-                    "override the display name",
-                ),
-                (
                     "pm add-project ~/dev/my-app --skip-plan",
                     "register the repo without planner auto-fire",
+                ),
+                (
+                    "pm add-project ~/dev/my-app --no-track",
+                    "register without marking the project as tracked",
                 ),
             ],
         )
@@ -211,6 +211,16 @@ def register_project_commands(app: typer.Typer) -> None:
                 "the global switch."
             ),
         ),
+        track: bool = typer.Option(
+            True,
+            "--track/--no-track",
+            help=(
+                "Mark the project as tracked so cockpit surfaces (rail "
+                "badges, morning briefings, recovery prompts) include it. "
+                "Defaults to tracked=true; pass --no-track to opt out for "
+                "experimental or archival registrations."
+            ),
+        ),
         config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
     ) -> None:
         from pollypm.projects import normalize_project_path
@@ -226,7 +236,9 @@ def register_project_commands(app: typer.Typer) -> None:
         except Exception:  # noqa: BLE001
             was_preexisting = False
 
-        project = register_project(config_path, repo_path, name=name)
+        project = register_project(
+            config_path, repo_path, name=name, tracked=bool(track),
+        )
         typer.echo(f"Registered project {project.name or project.key} at {project.path}")
 
         if not was_preexisting:

--- a/src/pollypm/projects.py
+++ b/src/pollypm/projects.py
@@ -493,6 +493,7 @@ def register_project(
     *,
     name: str | None = None,
     slug: str | None = None,
+    tracked: bool = True,
 ) -> KnownProject:
     """Register a project under ``config_path``.
 
@@ -501,6 +502,13 @@ def register_project(
     :func:`slugify_project_key`) and checked for uniqueness against
     existing projects. When not provided, the key is computed from the
     repo path's last segment — the legacy behavior. See #766.
+
+    ``tracked`` defaults to ``True`` so freshly registered projects are
+    visible to cockpit surfaces (rail badges, morning briefings,
+    recovery prompts) immediately. Pass ``tracked=False`` to opt a
+    project out at registration time — downgrading happens later if the
+    project goes cold. See savethenovel "silently invisible fresh
+    project" failure mode.
     """
     config = load_config(config_path)
     normalized_path = normalize_project_path(repo_path)
@@ -536,6 +544,7 @@ def register_project(
         name=name or normalized_path.name,
         persona_name=default_persona_name(name or normalized_path.name),
         kind=detect_project_kind(normalized_path),
+        tracked=bool(tracked),
     )
     config.projects[key] = project
     write_config(config, config_path, force=True)

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -112,6 +112,66 @@ def test_register_project_accepts_plain_folder_and_can_enable_tracker(tmp_path: 
     assert (project_path / "issues" / ".latest_issue_number").exists()
 
 
+def test_register_project_defaults_tracked_true(tmp_path: Path) -> None:
+    """Fresh registrations default to ``tracked=True`` so cockpit
+    surfaces (rail badges, morning briefings, recovery prompts) include
+    the project immediately. Previously projects landed as ``tracked
+    =False`` and disappeared from those surfaces — the savethenovel
+    "silently invisible fresh project" failure mode."""
+    project_path = tmp_path / "fresh-default"
+    project_path.mkdir()
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path, base_dir=tmp_path / ".pollypm",
+            logs_dir=tmp_path / ".pollypm/logs",
+            snapshots_dir=tmp_path / ".pollypm/snapshots",
+            state_db=tmp_path / ".pollypm/state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account=""),
+        accounts={},
+        sessions={},
+        projects={},
+    )
+    config_path = tmp_path / "pollypm.toml"
+    write_config(config, config_path, force=True)
+
+    project = register_project(config_path, project_path, name="Fresh")
+    assert project.tracked is True
+    # The persisted toml entry must also reflect tracked=true so the
+    # next config-load picks it up correctly.
+    assert "tracked = true" in config_path.read_text()
+
+
+def test_register_project_honors_explicit_no_track_opt_out(tmp_path: Path) -> None:
+    """``register_project(..., tracked=False)`` is the documented
+    opt-out for experimental/archival registrations. The flag must be
+    threaded through and persisted; the toml entry should omit the
+    ``tracked = true`` line (the writer only emits the line for
+    truthy values)."""
+    project_path = tmp_path / "opt-out"
+    project_path.mkdir()
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path, base_dir=tmp_path / ".pollypm",
+            logs_dir=tmp_path / ".pollypm/logs",
+            snapshots_dir=tmp_path / ".pollypm/snapshots",
+            state_db=tmp_path / ".pollypm/state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account=""),
+        accounts={},
+        sessions={},
+        projects={},
+    )
+    config_path = tmp_path / "pollypm.toml"
+    write_config(config, config_path, force=True)
+
+    project = register_project(
+        config_path, project_path, name="OptOut", tracked=False,
+    )
+    assert project.tracked is False
+    assert "tracked = true" not in config_path.read_text()
+
+
 def test_register_project_accepts_explicit_slug_override(tmp_path: Path) -> None:
     """#766: callers (CLI --slug, cockpit slug picker) can pin the
     project key instead of relying on auto-derivation."""
@@ -711,3 +771,88 @@ def test_pm_add_project_leaves_git_status_clean_on_fresh_repo(tmp_path: Path) ->
         check=True, capture_output=True, text=True,
     ).stdout
     assert ".gitignore" in tree
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git not available")
+def test_pm_add_project_default_writes_tracked_true_to_toml(tmp_path: Path) -> None:
+    """Default ``pm add-project`` must persist ``tracked = true`` in
+    ``pollypm.toml`` so cockpit surfaces (rail badges, morning
+    briefings, recovery prompts) include the project on the next
+    config-load. Regression guard for the savethenovel "silently
+    invisible fresh project" failure mode."""
+    from typer.testing import CliRunner
+    from pollypm.cli import app as root_app
+
+    repo = tmp_path / "fresh-repo"
+    repo.mkdir()
+    _git_init_repo(repo)
+
+    config_path = tmp_path / "pollypm.toml"
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            workspace_root=tmp_path,
+            base_dir=tmp_path / ".pollypm",
+            logs_dir=tmp_path / ".pollypm/logs",
+            snapshots_dir=tmp_path / ".pollypm/snapshots",
+            state_db=tmp_path / ".pollypm/state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account=""),
+        accounts={},
+        sessions={},
+        projects={},
+    )
+    write_config(config, config_path, force=True)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        root_app,
+        [
+            "add-project", str(repo), "--skip-import", "--skip-plan",
+            "--config", str(config_path), "--name", "fresh-repo",
+        ],
+    )
+    assert result.exit_code == 0, (result.stdout or "") + (result.stderr or "")
+    assert "tracked = true" in config_path.read_text()
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git not available")
+def test_pm_add_project_no_track_flag_omits_tracked_in_toml(tmp_path: Path) -> None:
+    """``pm add-project --no-track`` opts the project out of tracked
+    mode so it stays out of cockpit surfaces. The toml writer omits the
+    ``tracked = true`` line entirely when the value is falsy."""
+    from typer.testing import CliRunner
+    from pollypm.cli import app as root_app
+
+    repo = tmp_path / "opt-out-repo"
+    repo.mkdir()
+    _git_init_repo(repo)
+
+    config_path = tmp_path / "pollypm.toml"
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            workspace_root=tmp_path,
+            base_dir=tmp_path / ".pollypm",
+            logs_dir=tmp_path / ".pollypm/logs",
+            snapshots_dir=tmp_path / ".pollypm/snapshots",
+            state_db=tmp_path / ".pollypm/state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account=""),
+        accounts={},
+        sessions={},
+        projects={},
+    )
+    write_config(config, config_path, force=True)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        root_app,
+        [
+            "add-project", str(repo), "--skip-import", "--skip-plan",
+            "--no-track",
+            "--config", str(config_path), "--name", "opt-out-repo",
+        ],
+    )
+    assert result.exit_code == 0, (result.stdout or "") + (result.stderr or "")
+    assert "tracked = true" not in config_path.read_text()


### PR DESCRIPTION
## Context

Currently `pm add-project` registers projects with `tracked=False` by default. Several cockpit surfaces (rail badges, morning briefings, recovery prompts) filter out untracked projects, which produced the savethenovel **"silently invisible fresh project"** failure mode: the user added a project, but the cockpit never picked it up because the toml entry omitted `tracked = true`.

The user has decided fresh projects should default to tracked=true; downgrading happens later if the project goes cold.

## What changed

- `register_project()` gains a keyword arg `tracked: bool = True` and threads it into the `KnownProject(...)` constructor. Default flipped from False to True.
- `pm add-project` gains a `--track/--no-track` flag (defaults to `--track`). `--no-track` is the documented opt-out for experimental or archival registrations.
- Help-text examples updated to surface the new flag.

## Backwards compatibility

- **Existing pollypm.toml entries are unaffected.** `config.py:627` still loads `bool(item_raw.get("tracked", False))`, so projects whose toml block omits `tracked = ...` keep their current False value at load. Only **newly registered** projects pick up the new default.
- No migration needed.

## Tests

Added under `tests/test_projects.py`:

- `test_register_project_defaults_tracked_true` — unit-level: `register_project(...)` with no flag returns `tracked=True` and persists `tracked = true` to the toml.
- `test_register_project_honors_explicit_no_track_opt_out` — unit-level: `register_project(..., tracked=False)` is honored end-to-end.
- `test_pm_add_project_default_writes_tracked_true_to_toml` — CLI-level: invoking `pm add-project` via Typer writes `tracked = true` into pollypm.toml.
- `test_pm_add_project_no_track_flag_omits_tracked_in_toml` — CLI-level: `pm add-project --no-track` opts the project out at the toml level.

Existing assertion in `test_register_project_accepts_plain_folder_and_can_enable_tracker` (`enable_tracked_project` returns `tracked is True`) still holds.

## Test plan

- [x] `uv run pytest tests/test_projects.py` — 32 passed
- [x] `uv run pytest tests/test_cli_help_examples.py tests/test_project_planning_cli.py tests/integration/test_persona_integration.py` — 76 passed (CLI help-block constraint of 2-3 examples respected)
- [x] `uv run pytest tests/test_polly_dashboard_ui.py tests/test_morning_briefing_gather.py tests/test_recovery_prompt.py tests/test_settings_ui.py tests/test_dashboard_data_alert_dedup.py tests/test_core_rail_items.py tests/test_cockpit_settings_projects.py tests/test_project_rename.py` — 132 passed (cockpit surfaces that filter on `.tracked` still pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)