### PR TITLE
Add pm doctor with dual-DB and worker-marker health checks

### DIFF
--- a/src/pollypm/cli_features/maintenance.py
+++ b/src/pollypm/cli_features/maintenance.py
@@ -336,6 +336,36 @@ def register_maintenance_commands(app: typer.Typer) -> None:
         if fix_summary:
             typer.echo("")
             typer.echo(fix_summary)
+
+        # #savethenovel-followup: emit a ``pm.doctor_run`` audit event
+        # so the heartbeat watchdog can correlate doctor runs with
+        # subsequent state mutations (e.g. "the user ran pm doctor and
+        # then the table got wiped" vs "the table wiped without
+        # operator intervention"). Best-effort; never blocks the CLI.
+        try:
+            from pollypm.audit import emit as _audit_emit
+
+            _audit_emit(
+                event="pm.doctor_run",
+                project="_workspace",
+                subject="pm doctor",
+                actor="user",
+                status="ok" if report.ok else "warn",
+                metadata={
+                    "findings_total": len(report.errors) + len(report.warnings),
+                    "errors": len(report.errors),
+                    "warnings": len(report.warnings),
+                    "checks_total": len(report.results),
+                    "passed": report.passed_count,
+                    "skipped": report.skipped_count,
+                    "duration_seconds": round(report.duration_seconds, 3),
+                    "json_output": bool(json_output),
+                    "fix_applied": bool(fix),
+                },
+            )
+        except Exception:  # noqa: BLE001 — audit must never break CLI
+            pass
+
         raise typer.Exit(code=0 if report.ok else 1)
 
     @app.command(

--- a/src/pollypm/doctor.py
+++ b/src/pollypm/doctor.py
@@ -1009,6 +1009,545 @@ def check_db_layout_canonical() -> CheckResult:
 
 
 # --------------------------------------------------------------------- #
+# Workspace-health checks added by #savethenovel-followup
+#
+# These probes surface the dual-DB schema-drift class of bugs that the
+# 2026-05-06 post-mortem pinned on "the wrong state.db got passed to
+# SQLiteWorkService". They are pure read-only file/sqlite probes — safe
+# to run while the cockpit is alive (no locks held, no writes to live
+# DBs). See :func:`check_dual_db_work_tasks_drift`,
+# :func:`check_orphan_worker_markers`, and
+# :func:`check_doubled_pollypm_path` below.
+# --------------------------------------------------------------------- #
+
+
+def _count_work_tasks_ro(db_path: Path) -> int | None:
+    """Return ``COUNT(*) FROM work_tasks`` on ``db_path``, or ``None``.
+
+    Returns ``None`` when the file is missing OR when the ``work_tasks``
+    table does not exist on it. Returns 0 when the table exists but is
+    empty. Read-only access (``mode=ro``) — never mutates the DB,
+    never holds a write lock; safe to run against a live cockpit DB.
+    """
+    if not db_path.is_file():
+        return None
+    uri = f"file:{db_path}?mode=ro"
+    try:
+        conn = sqlite3.connect(uri, uri=True, timeout=1.0)
+    except sqlite3.Error:
+        return None
+    try:
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='work_tasks'"
+            ).fetchone()
+        except sqlite3.Error:
+            return None
+        if row is None:
+            return None
+        try:
+            row = conn.execute("SELECT COUNT(*) FROM work_tasks").fetchone()
+        except sqlite3.Error:
+            return None
+        return int(row[0]) if row and row[0] is not None else 0
+    finally:
+        conn.close()
+
+
+def _has_messages_table_ro(db_path: Path) -> bool:
+    """Return True when ``db_path`` is a messages-side DB (has ``messages``).
+
+    Read-only probe; returns False on any open / read failure.
+    """
+    if not db_path.is_file():
+        return False
+    uri = f"file:{db_path}?mode=ro"
+    try:
+        conn = sqlite3.connect(uri, uri=True, timeout=1.0)
+    except sqlite3.Error:
+        return False
+    try:
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='messages'"
+            ).fetchone()
+        except sqlite3.Error:
+            return False
+        return row is not None
+    finally:
+        conn.close()
+
+
+def _messages_side_db_path(config: PollyPMConfig | None = None) -> Path | None:
+    """Return ``config.project.state_db`` — the messages-side DB.
+
+    This is the path the supervisor's :class:`StateStore` opens and
+    where ``messages``/``sessions``/``heartbeats`` live. When the user's
+    config keeps ``state_db = "state.db"`` and ``base_dir = "."`` this
+    resolves under ``~/.pollypm/state.db``, which is *not* the same as
+    the workspace work DB at ``<workspace_root>/.pollypm/state.db``.
+    Returns ``None`` when no config can be loaded.
+    """
+    if config is None:
+        from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+
+        if not DEFAULT_CONFIG_PATH.exists():
+            return None
+        try:
+            config = load_config(DEFAULT_CONFIG_PATH)
+        except Exception:  # noqa: BLE001
+            return None
+    try:
+        db_path = getattr(config.project, "state_db", None)
+    except Exception:  # noqa: BLE001
+        return None
+    if db_path is None:
+        return None
+    return Path(db_path)
+
+
+def _read_recent_work_db_opened_events(
+    *, limit: int = 5, project_path: Path | None = None,
+) -> list[dict[str, object]]:
+    """Tail the ``work_db.opened`` audit events with ``had_messages_table_pre_open=true``.
+
+    Reads the central tail at
+    ``~/.pollypm/audit/_workspace.jsonl`` (the synthetic project key
+    ``SQLiteWorkService.__init__`` emits under). Each returned dict
+    carries the parsed ``ts``, ``subject`` (the DB path stamped) and
+    metadata so the doctor output can name the offending callsite.
+
+    Read-only / best-effort — returns ``[]`` on any failure or when the
+    audit log does not yet exist (fresh install or pre-#1343 build).
+    """
+    try:
+        from pollypm.audit.log import (
+            EVENT_WORK_DB_OPENED,
+            read_events,
+        )
+    except Exception:  # noqa: BLE001
+        return []
+    try:
+        events = read_events(
+            "_workspace",
+            event=EVENT_WORK_DB_OPENED,
+            project_path=project_path,
+        )
+    except Exception:  # noqa: BLE001
+        return []
+    flagged: list[dict[str, object]] = []
+    for ev in events:
+        meta = ev.metadata or {}
+        if meta.get("had_messages_table_pre_open"):
+            flagged.append(
+                {
+                    "ts": ev.ts,
+                    "subject": ev.subject,
+                    "project_path": meta.get("project_path"),
+                    "tables_created": meta.get("tables_created"),
+                }
+            )
+    if limit is not None and limit >= 0:
+        return flagged[-limit:]
+    return flagged
+
+
+def check_dual_db_work_tasks_drift() -> CheckResult:
+    """Detect work-tables stamped on the messages-side DB (savethenovel class).
+
+    PollyPM keeps two state DBs that look similar but serve different
+    purposes:
+
+    * ``~/.pollypm/state.db`` (``config.project.state_db``) — messages,
+      sessions, heartbeats. The supervisor's :class:`StateStore` writes
+      here.
+    * ``<workspace_root>/.pollypm/state.db`` (resolved via
+      :func:`pollypm.work.db_resolver.resolve_work_db_path`) — work
+      tables (``work_tasks``, transitions, sessions). The work service
+      writes here.
+
+    ``SQLiteWorkService.__init__`` auto-creates the work tables on
+    *whatever* DB it is handed. When a callsite hands it the messages-
+    side DB by accident, an empty ``work_tasks`` table gets stamped on
+    the wrong file. A diagnostic agent that reads from that DB then
+    sees "0 rows" and misdiagnoses a wipe — exactly the savethenovel
+    failure mode.
+
+    This check warns when any of:
+
+    * Both DBs hold ``COUNT(*) FROM work_tasks > 0`` (schema drift —
+      writers are split across two files; the canonical workspace DB
+      should be the source of truth).
+    * The messages-side DB has a ``work_tasks`` table at all (even
+      empty) — that's a stamping bug, the table should never have
+      been created here. The check tails the central audit log for
+      recent ``work_db.opened`` events with
+      ``had_messages_table_pre_open=true`` so the report can name the
+      most recent callsites.
+
+    Severity is ``warning`` (not error): the dual-DB confusion is a
+    forensic / diagnostic hazard, not a correctness regression —
+    readers go through ``resolve_work_db_path``, so the canonical
+    workspace DB is still authoritative for the live system.
+    """
+    _path, config = _safe_load_config()
+    if config is None:
+        return _skip("dual-db check skipped (no config)")
+
+    messages_db = _messages_side_db_path(config)
+    workspace_db = _workspace_state_db_path(config)
+
+    if messages_db is None or workspace_db is None:
+        return _skip("dual-db check skipped (state_db / workspace_root unset)")
+
+    # Same path resolves to same file — collapsed layout, no drift
+    # possible.
+    try:
+        if messages_db.resolve() == workspace_db.resolve():
+            return _ok(
+                "dual-db drift impossible (single state.db)",
+                data={
+                    "messages_db": str(messages_db),
+                    "workspace_db": str(workspace_db),
+                },
+            )
+    except OSError:
+        # ``resolve()`` can fail on non-existent symlinks; fall through
+        # to the count-based comparison below.
+        pass
+
+    messages_count = _count_work_tasks_ro(messages_db)
+    workspace_count = _count_work_tasks_ro(workspace_db)
+
+    recent_stampings = _read_recent_work_db_opened_events(limit=5)
+
+    data = {
+        "messages_db": str(messages_db),
+        "messages_db_work_tasks": messages_count,
+        "workspace_db": str(workspace_db),
+        "workspace_db_work_tasks": workspace_count,
+        "recent_stampings": recent_stampings,
+    }
+
+    # Case 1: schema drift — both DBs hold rows.
+    if (
+        messages_count is not None
+        and workspace_count is not None
+        and messages_count > 0
+        and workspace_count > 0
+    ):
+        return _fail(
+            (
+                f"work_tasks rows on BOTH DBs "
+                f"(messages-side={messages_count}, workspace={workspace_count}) "
+                f"— readers see {workspace_db}"
+            ),
+            why=(
+                "PollyPM keeps two state DBs and the work-service has "
+                "stamped tables on both. The canonical reader is the "
+                "workspace DB; rows on the messages-side DB are stranded "
+                "writes from a callsite that passed the wrong path. A "
+                "diagnostic agent reading the messages-side DB will "
+                "misdiagnose the canonical (workspace) state."
+            ),
+            fix=(
+                f"Canonical work DB:  {workspace_db}\n"
+                f"Stamped (orphan):   {messages_db}\n"
+                "Confirm rows on the messages-side DB are stale, then "
+                "archive that file —\n"
+                f"  sqlite3 {messages_db} 'SELECT project, task_number, work_status FROM work_tasks;'\n"
+                f"  mv {messages_db} {messages_db}.stamped-bak\n"
+                "Recheck: pm doctor"
+            ),
+            severity="warning",
+            data=data,
+        )
+
+    # Case 2: stamping bug — work tables exist on the messages-side DB
+    # at all, even if empty. The presence of the table means at least
+    # one ``SQLiteWorkService.__init__`` ran against the wrong path.
+    if messages_count is not None:
+        suffix = ""
+        if recent_stampings:
+            tails = [
+                f"\n  - {ev.get('ts', '?')}: subject={ev.get('subject', '?')} "
+                f"project_path={ev.get('project_path', '?')}"
+                for ev in recent_stampings[-3:]
+            ]
+            suffix = (
+                f"\nRecent ``work_db.opened`` events with "
+                f"``had_messages_table_pre_open=true`` ("
+                f"{len(recent_stampings)} total):"
+                + "".join(tails)
+            )
+        return _fail(
+            (
+                f"work_tasks table stamped on messages-side DB "
+                f"(rows={messages_count}) at {messages_db}"
+            ),
+            why=(
+                "``SQLiteWorkService.__init__`` auto-creates work tables "
+                "on whatever DB it's handed. The presence of ``work_tasks`` "
+                "on the messages-side DB means at least one callsite "
+                "passed the wrong path. This is the savethenovel class "
+                "of bug — empty tables on the wrong file fool diagnostic "
+                "agents into reporting a 'wholesale wipe'."
+            ),
+            fix=(
+                f"Canonical work DB:  {workspace_db}\n"
+                f"Stamped (orphan):   {messages_db}\n"
+                "Drop the stamped tables (safe — readers go through "
+                "resolve_work_db_path) —\n"
+                f"  sqlite3 {messages_db} 'DROP TABLE work_tasks; "
+                "DROP TABLE IF EXISTS work_transitions; "
+                "DROP TABLE IF EXISTS work_sessions;'\n"
+                "Or archive the file:\n"
+                f"  mv {messages_db} {messages_db}.stamped-bak\n"
+                "Then grep the central audit log to find the offending "
+                "callsite —\n"
+                "  grep '\"had_messages_table_pre_open\": true' "
+                "~/.pollypm/audit/_workspace.jsonl"
+                + suffix +
+                "\nRecheck: pm doctor"
+            ),
+            severity="warning",
+            data=data,
+        )
+
+    return _ok(
+        "no dual-DB drift (messages-side has no work tables)",
+        data=data,
+    )
+
+
+def _iter_orphan_worker_markers_safe() -> tuple[list[Any], str | None]:
+    """Run :func:`reap_orphan_worker_markers`-style classification, no unlinks.
+
+    Returns ``(orphan_markers, skip_reason)``. ``skip_reason`` is None
+    when the probe ran end-to-end; otherwise it carries a short
+    explanation the doctor can surface as a clean skip. Never raises;
+    never mutates the filesystem.
+    """
+    _path, config = _safe_load_config()
+    if config is None:
+        return [], "no config"
+    projects = getattr(config, "projects", None) or {}
+    if not projects:
+        return [], "no projects"
+
+    # Reuse the reaper's pure helpers — same window-name parser, same
+    # classifier, same status probe — so the doctor output stays
+    # consistent with the bootstrap reaper landed in #1341.
+    try:
+        from pollypm.work.worker_marker_reaper import (
+            _classify_marker,
+            _iter_worker_markers,
+            _resolve_workspace_root,
+        )
+    except Exception:  # noqa: BLE001
+        return [], "reaper module unavailable"
+
+    workspace_root = _resolve_workspace_root(config)
+    # Doctor must not poke tmux from a check (fast & safe by spec) —
+    # pass an empty live-window set so a marker only counts as orphan
+    # when its task row is missing or terminal. The bootstrap / runtime
+    # reaper paths take care of the "tmux window dead" branch.
+    live_windows: set[str] = set()
+
+    orphans: list[Any] = []
+    for project_key, project in projects.items():
+        project_path = getattr(project, "path", None)
+        if project_path is None:
+            continue
+        project_path = Path(project_path)
+        try:
+            markers = _iter_worker_markers(project_path)
+        except Exception:  # noqa: BLE001
+            continue
+        for marker in markers:
+            try:
+                decision = _classify_marker(
+                    marker=marker,
+                    project_key=str(project_key),
+                    project_path=project_path,
+                    workspace_root=workspace_root,
+                    live_window_names=live_windows,
+                )
+            except Exception:  # noqa: BLE001
+                continue
+            if decision is not None:
+                orphans.append(decision)
+    return orphans, None
+
+
+def check_orphan_worker_markers() -> CheckResult:
+    """Surface ``worker-markers/*.fresh`` files whose backing task is gone.
+
+    The bootstrap reaper landed in #1341 clears orphan markers when the
+    cockpit boots. This check exists for the in-between case: the user
+    has not booted ``pm up`` recently but wants to verify the workspace
+    is clean. Reuses the reaper's pure helpers (``_classify_marker`` /
+    ``_iter_worker_markers``) so the verdict is byte-identical.
+
+    Doctor never touches tmux from a check; the "tmux window dead for
+    a non-terminal task" branch is intentionally skipped here. The
+    runtime sweep covers it once the supervisor is alive.
+    """
+    orphans, skip_reason = _iter_orphan_worker_markers_safe()
+    if skip_reason is not None:
+        return _skip(f"orphan-worker-markers check skipped ({skip_reason})")
+
+    if not orphans:
+        return _ok("no orphan worker markers", data={"count": 0})
+
+    samples = [
+        {
+            "project": getattr(o, "project_key", "?"),
+            "window": getattr(o, "window_name", "?"),
+            "marker": str(getattr(o, "marker_path", "")),
+            "reason": getattr(o, "reason", "?"),
+        }
+        for o in orphans[:5]
+    ]
+    word = "marker" if len(orphans) == 1 else "markers"
+    summary = ", ".join(
+        f"{s['project']}/{s['window']} ({s['reason']})" for s in samples[:3]
+    )
+    return _fail(
+        f"{len(orphans)} orphan worker {word}: {summary}",
+        why=(
+            "Worker markers at ``<project>/.pollypm/worker-markers/"
+            "*.fresh`` should be unlinked once their task either ships "
+            "or is cancelled. Leaked markers cause SessionManager to "
+            "skip the kickoff string for the next worker that lands on "
+            "that window — the worker boots silent."
+        ),
+        fix=(
+            "Boot the cockpit to run the bootstrap reaper —\n"
+            "  pm up   # auto-clears at supervisor start\n"
+            "Or remove the orphans by hand once you've confirmed they "
+            "really are dead —\n"
+            "  rm <listed-marker-paths>\n"
+            "Recheck: pm doctor"
+        ),
+        severity="warning",
+        data={"count": len(orphans), "samples": samples},
+    )
+
+
+def check_doubled_pollypm_path() -> CheckResult:
+    """Detect the legacy ``~/.pollypm/.pollypm/`` doubled-path artifact.
+
+    ``config._resolve_path`` documents the failure mode (config.py
+    around line 104): older renders wrote sibling paths as
+    ``.pollypm/...`` relative to ``~/.pollypm``, which reloads as a
+    bogus nested ``~/.pollypm/.pollypm`` directory. The resolver
+    now strips the duplicate prefix on read, but a previous bad
+    render may have already materialised files under that path.
+    Nothing reads them; they just waste disk and make grep noisy.
+
+    Surfaces the path with size + age when present; clean otherwise.
+    """
+    from pollypm.config import GLOBAL_CONFIG_DIR
+
+    doubled = GLOBAL_CONFIG_DIR / GLOBAL_CONFIG_DIR.name
+    data: dict[str, object] = {"path": str(doubled)}
+
+    if not doubled.exists():
+        return _ok("no doubled ~/.pollypm/.pollypm/ path", data=data)
+
+    # Walk the tree once, summing sizes and tracking newest mtime.
+    total_bytes = 0
+    file_count = 0
+    newest_mtime = 0.0
+    try:
+        for entry in doubled.rglob("*"):
+            try:
+                if entry.is_file():
+                    stat = entry.stat()
+                    total_bytes += stat.st_size
+                    file_count += 1
+                    if stat.st_mtime > newest_mtime:
+                        newest_mtime = stat.st_mtime
+            except OSError:
+                continue
+    except OSError as exc:
+        return _fail(
+            f"~/.pollypm/.pollypm/ exists but is unreadable: {exc}",
+            why=(
+                "The doubled-path artifact is unreadable. Even an empty "
+                "directory under this name is a leftover from a buggy "
+                "config render and should be removed."
+            ),
+            fix=(
+                f"Remove the directory once you've confirmed it isn't "
+                f"holding anything you need —\n"
+                f"  rm -rf {doubled}\n"
+                "Recheck: pm doctor"
+            ),
+            severity="warning",
+            data=data,
+        )
+
+    data.update(
+        {
+            "size_bytes": total_bytes,
+            "file_count": file_count,
+            "newest_mtime": newest_mtime,
+        }
+    )
+
+    # Empty-directory case — still flag (the path should not exist at
+    # all) but report it as a tiny, informational warn.
+    if file_count == 0:
+        return _fail(
+            f"empty ~/.pollypm/.pollypm/ directory (artifact)",
+            why=(
+                "An empty doubled-path directory is a leftover scaffold "
+                "from a pre-fix config render. Removing it keeps grep / "
+                "find output honest."
+            ),
+            fix=(
+                f"Remove the empty directory —\n"
+                f"  rmdir {doubled}\n"
+                "Recheck: pm doctor"
+            ),
+            severity="warning",
+            data=data,
+        )
+
+    age_seconds = max(0.0, time.time() - newest_mtime) if newest_mtime else 0.0
+    age_days = age_seconds / 86400.0
+    size_kib = total_bytes / 1024.0
+    word = "file" if file_count == 1 else "files"
+    return _fail(
+        (
+            f"~/.pollypm/.pollypm/ holds {file_count} {word} "
+            f"({size_kib:.1f} KiB, newest {age_days:.1f}d old)"
+        ),
+        why=(
+            "config.py:_resolve_path documents this artifact: an older "
+            "render wrote sibling paths relative to ``~/.pollypm`` and "
+            "reload now strips the duplicate prefix, but pre-fix files "
+            "stranded under ``~/.pollypm/.pollypm/`` are read by no "
+            "code path. They waste disk and confuse forensic grep."
+        ),
+        fix=(
+            f"Move the artifact to a backup location once you have "
+            f"confirmed nothing under it is needed —\n"
+            f"  mv {doubled} {doubled}.bak-$(date +%Y%m%d)\n"
+            "Or remove it outright:\n"
+            f"  rm -rf {doubled}\n"
+            "Recheck: pm doctor"
+        ),
+        severity="warning",
+        data=data,
+    )
+
+
+# --------------------------------------------------------------------- #
 # Tmux session state
 # --------------------------------------------------------------------- #
 
@@ -3247,6 +3786,13 @@ def _registered_checks() -> list[Check]:
         Check("pollypm-plugins-dir", check_pollypm_plugins_dir, "filesystem", severity="warning"),
         Check("tracked-project-paths", check_tracked_project_state_parents, "filesystem"),
         Check("db-layout-canonical", check_db_layout_canonical, "filesystem", severity="warning"),
+        # #savethenovel-followup: dual-DB drift, orphan worker markers,
+        # and the ~/.pollypm/.pollypm/ doubled-path artifact. All three
+        # are filesystem-scope health probes so they sit next to the
+        # existing layout / tracked-project-path checks.
+        Check("dual-db-work-tasks-drift", check_dual_db_work_tasks_drift, "filesystem", severity="warning"),
+        Check("orphan-worker-markers", check_orphan_worker_markers, "filesystem", severity="warning"),
+        Check("doubled-pollypm-path", check_doubled_pollypm_path, "filesystem", severity="warning"),
         Check("disk-space", check_disk_space, "filesystem"),
         # Tmux session state
         Check("tmux-daemon", check_tmux_daemon, "tmux"),

--- a/tests/test_doctor_dual_db_health.py
+++ b/tests/test_doctor_dual_db_health.py
@@ -1,0 +1,455 @@
+"""Coverage for the savethenovel-followup ``pm doctor`` workspace-health checks.
+
+Three new probes were added to :mod:`pollypm.doctor` after the
+2026-05-06 dual-DB post-mortem:
+
+* :func:`pollypm.doctor.check_dual_db_work_tasks_drift` — detects
+  ``work_tasks`` tables stamped on the messages-side DB.
+* :func:`pollypm.doctor.check_orphan_worker_markers` — surfaces stale
+  ``worker-markers/*.fresh`` files when the cockpit has not booted
+  recently.
+* :func:`pollypm.doctor.check_doubled_pollypm_path` — flags the
+  legacy ``~/.pollypm/.pollypm/`` artifact.
+
+Tests follow the existing pattern in ``test_doctor_enhancements.py``:
+each check gets at least one PASS and one WARN/FAIL case, and we
+monkeypatch helper internals so the real filesystem / config is never
+touched outside ``tmp_path``.
+
+Run targeted (full pytest is forbidden by the task spec)::
+
+    HOME=/tmp/pytest-agent-doctor uv run pytest \
+        tests/test_doctor_dual_db_health.py -q
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm import doctor
+
+
+# --------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------- #
+
+
+def _make_messages_db(path: Path) -> Path:
+    """Create a messages-side DB with the ``messages`` table only."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS messages (
+                id INTEGER PRIMARY KEY,
+                body TEXT
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+def _make_work_db(path: Path, *, rows: int = 0) -> Path:
+    """Create a workspace-side DB with the ``work_tasks`` table."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS work_tasks (
+                project TEXT,
+                task_number INTEGER,
+                work_status TEXT
+            );
+            """
+        )
+        for i in range(rows):
+            conn.execute(
+                "INSERT INTO work_tasks (project, task_number, work_status) "
+                "VALUES (?, ?, ?)",
+                ("demo", i + 1, "queued"),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+def _stamp_work_tables_onto(path: Path) -> Path:
+    """Add ``work_tasks`` to an existing messages-side DB.
+
+    Reproduces the savethenovel stamping bug: the work-service was
+    pointed at the messages-side DB and ``CREATE TABLE IF NOT EXISTS
+    work_tasks`` ran against the wrong file.
+    """
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS work_tasks (
+                project TEXT,
+                task_number INTEGER,
+                work_status TEXT
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+def _patch_dual_db_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    messages_db: Path | None,
+    workspace_db: Path | None,
+) -> None:
+    """Pin the messages-side / workspace DB path resolvers for one test.
+
+    A fake config is also installed so ``check_dual_db_work_tasks_drift``
+    does not short-circuit on the "no config" skip branch.
+    """
+    fake_config = type("FakeConfig", (), {"project": object(), "projects": {}})()
+    monkeypatch.setattr(
+        doctor, "_safe_load_config",
+        lambda: (Path("/tmp/fake-config.toml"), fake_config),
+    )
+    monkeypatch.setattr(
+        doctor, "_messages_side_db_path", lambda config=None: messages_db,
+    )
+    monkeypatch.setattr(
+        doctor, "_workspace_state_db_path", lambda config=None: workspace_db,
+    )
+    # Don't let the real audit log leak in.
+    monkeypatch.setattr(
+        doctor,
+        "_read_recent_work_db_opened_events",
+        lambda *, limit=5, project_path=None: [],
+    )
+
+
+# --------------------------------------------------------------------- #
+# check_dual_db_work_tasks_drift
+# --------------------------------------------------------------------- #
+
+
+def test_dual_db_skip_without_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(doctor, "_safe_load_config", lambda: (None, None))
+    result = doctor.check_dual_db_work_tasks_drift()
+    assert result.skipped
+    assert result.passed  # skipped checks pass
+
+
+def test_dual_db_pass_when_messages_side_clean(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    messages_db = _make_messages_db(tmp_path / "user" / "state.db")
+    workspace_db = _make_work_db(tmp_path / "ws" / "state.db", rows=3)
+    _patch_dual_db_paths(
+        monkeypatch, messages_db=messages_db, workspace_db=workspace_db,
+    )
+    result = doctor.check_dual_db_work_tasks_drift()
+    assert result.passed
+    assert "no dual-DB drift" in result.status
+    assert result.data["messages_db_work_tasks"] is None
+    assert result.data["workspace_db_work_tasks"] == 3
+
+
+def test_dual_db_warns_on_stamping_bug_empty_table(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Empty ``work_tasks`` on the messages-side DB → stamping bug warn."""
+    messages_db = _make_messages_db(tmp_path / "user" / "state.db")
+    _stamp_work_tables_onto(messages_db)  # zero rows, table present
+    workspace_db = _make_work_db(tmp_path / "ws" / "state.db", rows=2)
+    _patch_dual_db_paths(
+        monkeypatch, messages_db=messages_db, workspace_db=workspace_db,
+    )
+    result = doctor.check_dual_db_work_tasks_drift()
+    assert not result.passed
+    assert result.severity == "warning"
+    assert "stamped on messages-side DB" in result.status
+    assert "rows=0" in result.status
+    assert result.data["messages_db_work_tasks"] == 0
+    assert result.data["workspace_db_work_tasks"] == 2
+
+
+def test_dual_db_fails_on_real_drift_both_have_rows(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Both DBs hold ``work_tasks`` rows → schema-drift warn."""
+    messages_db = _make_messages_db(tmp_path / "user" / "state.db")
+    _stamp_work_tables_onto(messages_db)
+    # Add rows to the messages-side DB to simulate stranded writes.
+    conn = sqlite3.connect(messages_db)
+    try:
+        conn.execute(
+            "INSERT INTO work_tasks (project, task_number, work_status) "
+            "VALUES (?, ?, ?)",
+            ("demo", 99, "queued"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    workspace_db = _make_work_db(tmp_path / "ws" / "state.db", rows=4)
+    _patch_dual_db_paths(
+        monkeypatch, messages_db=messages_db, workspace_db=workspace_db,
+    )
+    result = doctor.check_dual_db_work_tasks_drift()
+    assert not result.passed
+    assert result.severity == "warning"
+    assert "BOTH DBs" in result.status
+    assert "messages-side=1" in result.status
+    assert "workspace=4" in result.status
+    # Fix block names the canonical workspace path.
+    assert str(workspace_db) in result.fix
+
+
+def test_dual_db_pass_when_paths_collapse_to_same_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Messages-side and workspace resolve to the same file → no drift possible."""
+    db = _make_messages_db(tmp_path / "state.db")
+    _stamp_work_tables_onto(db)
+    _patch_dual_db_paths(
+        monkeypatch, messages_db=db, workspace_db=db,
+    )
+    result = doctor.check_dual_db_work_tasks_drift()
+    assert result.passed
+    assert "single state.db" in result.status
+
+
+def test_dual_db_surfaces_recent_audit_events(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """When ``had_messages_table_pre_open=true`` events exist, fix block
+    names them so operators can find the offending callsite."""
+    messages_db = _make_messages_db(tmp_path / "user" / "state.db")
+    _stamp_work_tables_onto(messages_db)
+    workspace_db = _make_work_db(tmp_path / "ws" / "state.db", rows=1)
+    _patch_dual_db_paths(
+        monkeypatch, messages_db=messages_db, workspace_db=workspace_db,
+    )
+    fake_events = [
+        {
+            "ts": "2026-05-06T10:00:00+00:00",
+            "subject": str(messages_db),
+            "project_path": "/path/to/project",
+            "tables_created": True,
+        },
+    ]
+    monkeypatch.setattr(
+        doctor,
+        "_read_recent_work_db_opened_events",
+        lambda *, limit=5, project_path=None: fake_events,
+    )
+    result = doctor.check_dual_db_work_tasks_drift()
+    assert not result.passed
+    assert "2026-05-06T10:00:00+00:00" in result.fix
+    assert "/path/to/project" in result.fix
+
+
+# --------------------------------------------------------------------- #
+# check_orphan_worker_markers
+# --------------------------------------------------------------------- #
+
+
+def test_orphan_worker_markers_skip_without_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(doctor, "_safe_load_config", lambda: (None, None))
+    result = doctor.check_orphan_worker_markers()
+    assert result.skipped
+    assert result.passed
+
+
+def test_orphan_worker_markers_skip_without_projects(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    cfg = type("C", (), {"projects": {}})()
+    monkeypatch.setattr(
+        doctor, "_safe_load_config",
+        lambda: (Path("/tmp/x"), cfg),
+    )
+    result = doctor.check_orphan_worker_markers()
+    assert result.skipped
+
+
+def test_orphan_worker_markers_pass_when_dir_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """No ``worker-markers/`` directory → no orphans, clean pass."""
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    fake_project = type("P", (), {"path": project_path, "tracked": True})
+    fake_config = type("C", (), {"projects": {"demo": fake_project}, "project": object()})
+    monkeypatch.setattr(
+        doctor, "_safe_load_config",
+        lambda: (Path("/tmp/x"), fake_config),
+    )
+    result = doctor.check_orphan_worker_markers()
+    assert result.passed
+    assert "no orphan worker markers" in result.status
+
+
+def test_orphan_worker_markers_warns_when_marker_has_no_task(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """A marker file whose backing task row is missing → orphan warn."""
+    project_path = tmp_path / "demo"
+    marker_dir = project_path / ".pollypm" / "worker-markers"
+    marker_dir.mkdir(parents=True)
+    marker = marker_dir / "task-demo-7.fresh"
+    marker.write_text("")
+
+    # Stub the reaper helpers so we do not need the real status_probe
+    # / parse_task_window_name infrastructure spun up here. We are
+    # specifically testing the doctor wrapper's plumbing — the reaper's
+    # own classification is covered by ``test_worker_marker_reaper``.
+    from pollypm.work import worker_marker_reaper as wm_reaper
+
+    def _fake_classify(*, marker, project_key, project_path, workspace_root, live_window_names):
+        return wm_reaper.ReapedMarker(
+            project_key=project_key,
+            window_name=marker.stem,
+            marker_path=marker,
+            reason="orphan: no work_tasks row",
+        )
+
+    monkeypatch.setattr(wm_reaper, "_classify_marker", _fake_classify)
+
+    fake_project = type("P", (), {"path": project_path, "tracked": True})
+    fake_config = type(
+        "C",
+        (),
+        {"projects": {"demo": fake_project}, "project": object()},
+    )
+    monkeypatch.setattr(
+        doctor, "_safe_load_config",
+        lambda: (Path("/tmp/x"), fake_config),
+    )
+    result = doctor.check_orphan_worker_markers()
+    assert not result.passed
+    assert result.severity == "warning"
+    assert "1 orphan worker marker" in result.status
+    assert result.data["count"] == 1
+    samples = result.data["samples"]
+    assert samples[0]["window"] == "task-demo-7"
+    assert samples[0]["project"] == "demo"
+
+
+# --------------------------------------------------------------------- #
+# check_doubled_pollypm_path
+# --------------------------------------------------------------------- #
+
+
+def test_doubled_pollypm_path_pass_when_absent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """No ``~/.pollypm/.pollypm/`` directory → clean pass."""
+    fake_home = tmp_path / "home" / ".pollypm"
+    fake_home.mkdir(parents=True)
+    monkeypatch.setattr("pollypm.config.GLOBAL_CONFIG_DIR", fake_home)
+    result = doctor.check_doubled_pollypm_path()
+    assert result.passed
+    assert "no doubled" in result.status
+
+
+def test_doubled_pollypm_path_warns_with_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Doubled directory with content → warn carrying size + age."""
+    fake_home = tmp_path / "home" / ".pollypm"
+    doubled = fake_home / ".pollypm"
+    doubled.mkdir(parents=True)
+    (doubled / "stray.toml").write_text("legacy = true\n" * 50)
+    (doubled / "logs").mkdir()
+    (doubled / "logs" / "old.log").write_text("noise\n" * 100)
+    monkeypatch.setattr("pollypm.config.GLOBAL_CONFIG_DIR", fake_home)
+    result = doctor.check_doubled_pollypm_path()
+    assert not result.passed
+    assert result.severity == "warning"
+    assert "files" in result.status
+    assert "KiB" in result.status
+    assert result.data["file_count"] == 2
+    assert result.data["size_bytes"] > 0
+    # Fix block tells the user to move/remove and gives a backup
+    # naming pattern (the ``mv ... .bak-$(date ...)`` line).
+    assert ".bak-" in result.fix
+
+
+def test_doubled_pollypm_path_warns_when_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Empty doubled directory still gets flagged (just smaller fix block)."""
+    fake_home = tmp_path / "home" / ".pollypm"
+    doubled = fake_home / ".pollypm"
+    doubled.mkdir(parents=True)
+    monkeypatch.setattr("pollypm.config.GLOBAL_CONFIG_DIR", fake_home)
+    result = doctor.check_doubled_pollypm_path()
+    assert not result.passed
+    assert result.severity == "warning"
+    assert "empty" in result.status.lower()
+    assert "rmdir" in result.fix
+
+
+# --------------------------------------------------------------------- #
+# Registration + audit emit
+# --------------------------------------------------------------------- #
+
+
+def test_new_checks_registered_under_filesystem_category() -> None:
+    """All three new checks must appear in ``_registered_checks`` under
+    the filesystem category at warning severity."""
+    registered = {check.name: check for check in doctor._registered_checks()}
+    for name in (
+        "dual-db-work-tasks-drift",
+        "orphan-worker-markers",
+        "doubled-pollypm-path",
+    ):
+        assert name in registered, f"{name!r} not registered"
+        assert registered[name].category == "filesystem"
+        assert registered[name].severity == "warning"
+
+
+def test_cli_doctor_emits_pm_doctor_run_audit_event(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """The ``pm doctor`` command must emit a ``pm.doctor_run`` audit row.
+
+    Stub the registered checks to a single passing probe so the output
+    is deterministic, redirect the audit central root with
+    ``$POLLYPM_AUDIT_HOME`` to a temp dir, then assert the event landed.
+    """
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit"))
+
+    def _pass() -> doctor.CheckResult:
+        return doctor._ok("ok")
+
+    monkeypatch.setattr(
+        doctor, "_registered_checks",
+        lambda: [doctor.Check("demo", _pass, "test")],
+    )
+
+    import pollypm.cli as cli_mod
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.app, ["doctor"])
+    assert result.exit_code == 0
+
+    central = tmp_path / "audit" / "_workspace.jsonl"
+    assert central.exists(), f"audit log not written at {central}"
+    body = central.read_text()
+    assert "pm.doctor_run" in body
+    assert '"actor":"user"' in body
+    assert '"checks_total":1' in body
+    assert '"findings_total":0' in body


### PR DESCRIPTION
## Context

The 2026-05-06 savethenovel post-mortem traced a "wholesale work_tasks wipe" misdiagnosis to dual-DB schema-drift confusion. PollyPM keeps two state DBs that look similar but serve different purposes:

- ``~/.pollypm/state.db`` — messages / sessions / heartbeats (``config.project.state_db``)
- ``<workspace_root>/.pollypm/state.db`` — work tables (``resolve_work_db_path()``)

``SQLiteWorkService.__init__`` auto-creates work tables on whatever DB it is handed; several callsites historically passed the wrong path and silently stamped empty work tables on the messages-side DB. A diagnostic agent reading from that DB then reports "0 rows" and misdiagnoses a wipe.

PR #1343 landed the ``work_db.opened`` audit event for forensic visibility. This PR adds active ``pm doctor`` checks that read those events and report the situation to the operator at command-invocation time.

## Summary

Three new ``pm doctor`` checks under the ``filesystem`` category, all warning-severity and read-only:

- **``dual-db-work-tasks-drift``** — counts ``work_tasks`` rows on both DBs. Warns when both hold rows (real drift) or when the messages-side DB has the ``work_tasks`` table at all (stamping bug). Tails the ``~/.pollypm/audit/_workspace.jsonl`` central log for recent ``work_db.opened`` events with ``had_messages_table_pre_open=true`` so the fix block names the offending callsite.
- **``orphan-worker-markers``** — reuses the bootstrap reaper's pure helpers (``_classify_marker`` / ``_iter_worker_markers``) to surface stale ``worker-markers/*.fresh`` files when the cockpit has not booted recently. Doctor never pokes tmux from a check.
- **``doubled-pollypm-path``** — flags the ``~/.pollypm/.pollypm/`` artifact documented in ``config.py:_resolve_path`` with size + age and the safe ``mv ... .bak-$(date)`` remediation.

The ``pm doctor`` command now also emits a ``pm.doctor_run`` audit event (findings count, errors, warnings, duration) so the heartbeat watchdog can correlate operator runs with subsequent state mutations.

## Sample output (against the current workspace)

```
-- Filesystem --
! dual-db-work-tasks-drift: work_tasks table stamped on messages-side DB (rows=0) at /Users/sam/.pollypm/state.db
✓ orphan-worker-markers: no orphan worker markers
! doubled-pollypm-path: ~/.pollypm/.pollypm/ holds 249 files (1193.8 KiB, newest 0.0d old)

Failures:

! dual-db-work-tasks-drift: work_tasks table stamped on messages-side DB (rows=0) at /Users/sam/.pollypm/state.db

  Why: ``SQLiteWorkService.__init__`` auto-creates work tables on whatever DB it's handed.
       The presence of ``work_tasks`` on the messages-side DB means at least one callsite
       passed the wrong path. This is the savethenovel class of bug — empty tables on the
       wrong file fool diagnostic agents into reporting a 'wholesale wipe'.

  Canonical work DB:  /Users/sam/dev/.pollypm/state.db
  Stamped (orphan):   /Users/sam/.pollypm/state.db
  Drop the stamped tables (safe — readers go through resolve_work_db_path) —
    sqlite3 /Users/sam/.pollypm/state.db 'DROP TABLE work_tasks; DROP TABLE IF EXISTS work_transitions; DROP TABLE IF EXISTS work_sessions;'
  Or archive the file:
    mv /Users/sam/.pollypm/state.db /Users/sam/.pollypm/state.db.stamped-bak
  Then grep the central audit log to find the offending callsite —
    grep '"had_messages_table_pre_open": true' ~/.pollypm/audit/_workspace.jsonl
  Recent ``work_db.opened`` events with ``had_messages_table_pre_open=true`` (5 total):
    - 2026-05-07T03:14:57.025655+00:00: subject=/Users/sam/dev/camptown/.pollypm/state.db project_path=/Users/sam/dev/camptown
    - 2026-05-07T03:14:57.086853+00:00: subject=/Users/sam/dev/health-coach/.pollypm/state.db project_path=/Users/sam/dev/health-coach
    - 2026-05-07T03:14:57.147294+00:00: subject=/Users/sam/dev/itsalive/.pollypm/state.db project_path=/Users/sam/dev/itsalive
  Recheck: pm doctor

! doubled-pollypm-path: ~/.pollypm/.pollypm/ holds 249 files (1193.8 KiB, newest 0.0d old)

  Why: config.py:_resolve_path documents this artifact: an older render wrote sibling paths
       relative to ``~/.pollypm`` and reload now strips the duplicate prefix, but pre-fix
       files stranded under ``~/.pollypm/.pollypm/`` are read by no code path.

  Move the artifact to a backup location once you have confirmed nothing under it is needed —
    mv /Users/sam/.pollypm/.pollypm /Users/sam/.pollypm/.pollypm.bak-$(date +%Y%m%d)
  Or remove it outright:
    rm -rf /Users/sam/.pollypm/.pollypm
  Recheck: pm doctor
```

## Hard constraints respected

- Read-only probes (``sqlite3 mode=ro``, ``Path.stat``). Safe to run while the cockpit is alive.
- No tmux pokes from doctor; runtime sweep already handles "window dead" cases.
- No live-DB writes; ``--fix`` was intentionally not wired (the remediation is destructive enough to deserve manual operator review).
- No changes to existing checks.

## Test plan

- [x] ``HOME=/tmp/... uv run --with pytest pytest tests/test_doctor_dual_db_health.py -q`` — 15 tests pass (unit + CLI integration).
- [x] ``pytest tests/test_doctor.py -q`` — existing 75 tests still pass.
- [x] ``pytest tests/test_doctor_enhancements.py -q`` — existing 104 tests still pass.
- [x] Live invocation via ``uv run python -c "...run_checks()..."`` against the current workspace — checks correctly fire warnings on the live drift / doubled-path artifacts.
- [ ] Operator verification: run ``pm doctor`` (without ``--fix``) on a cockpit-alive workspace and confirm the new checks render without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)