### PR TITLE
Fix watchdog stuck_draft typo: pm task promote → pm task queue

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -42,7 +42,7 @@ Detection rules (each returns a list of :class:`Finding`):
 
 Severity is ``"warn"`` for every rule today. The recovery hint is
 attached to each finding so the alert message can include a
-copy-pasteable next step (``"run pm task promote ..."``).
+copy-pasteable next step (``"run pm task queue ..."``).
 
 The watchdog itself emits a synthetic ``heartbeat.tick`` audit event
 each time it runs so we can prove the heartbeat is alive (and
@@ -427,7 +427,7 @@ def _detect_stuck_drafts(
                 f"(created {ev.ts})."
             ),
             recommendation=(
-                f"Promote with `pm task promote {ev.subject}` or "
+                f"Promote with `pm task queue {ev.subject}` or "
                 f"discard with `pm task cancel {ev.subject}`. "
                 f"Originating actor: {ev.actor or 'unknown'}."
             ),

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -216,7 +216,7 @@ def test_stuck_draft_detected_when_never_promoted(now: datetime) -> None:
     findings = [f for f in scan_events(events, now=now) if f.rule == RULE_STUCK_DRAFT]
     assert len(findings) == 1
     assert findings[0].subject == "demo/2"
-    assert "pm task promote demo/2" in findings[0].recommendation
+    assert "pm task queue demo/2" in findings[0].recommendation
 
 
 def test_stuck_draft_silenced_by_promotion(now: datetime) -> None:
@@ -352,11 +352,11 @@ def test_format_finding_message_includes_recommendation() -> None:
         project="demo",
         subject="demo/2",
         message="Draft demo/2 is stuck.",
-        recommendation="Run pm task promote demo/2.",
+        recommendation="Run pm task queue demo/2.",
     )
     rendered = format_finding_message(finding)
     assert "Draft demo/2 is stuck." in rendered
-    assert "Recommendation: Run pm task promote demo/2." in rendered
+    assert "Recommendation: Run pm task queue demo/2." in rendered
 
 
 def test_alert_session_name_is_stable() -> None:


### PR DESCRIPTION
## Summary

PR #1344 added the heartbeat audit-log watchdog at `src/pollypm/audit/watchdog.py`. The `stuck_draft` rule's recommendation told users to:

> Promote with `pm task promote <id>`

but `pm task promote` is not a registered command. The actual draft → queued transition is **`pm task queue <id>`**, registered at `src/pollypm/work/cli.py:800` (`@task_app.command("queue")`). If the watchdog ever fires for a stuck draft, the user would have copy-pasted a command that doesn't exist.

## Changes

- `src/pollypm/audit/watchdog.py:430` — recommendation string: `pm task promote` → `pm task queue`
- `src/pollypm/audit/watchdog.py:45` — module docstring's example next-step hint
- `tests/test_audit_watchdog.py:219` — rule-output assertion
- `tests/test_audit_watchdog.py:355,359` — `format_finding_message` fixture + assertion

No watchdog behavior change — only the user-facing recommendation string.

## Test plan

- [x] `uv run --with pytest pytest tests/test_audit_watchdog.py -x -q` → 23 passed
- [ ] Reviewer confirms `pm task queue <id>` is the correct affordance for promoting a draft to queued

🤖 Generated with [Claude Code](https://claude.com/claude-code)