### PR TITLE
Auto-queue planning task in _plan_project_task (parity with project.created path)

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -320,11 +320,24 @@ def _plan_project_task(
 ) -> Any:
     """Create a ``flow=plan_project`` task on the project's work service.
 
-    Returns the created ``Task``. Caller owns output formatting.
+    Mirrors the ``project.created`` observer (``plugin.py``): create the
+    task and immediately auto-queue it so the architect's assignment
+    sweep finds real work instead of leaving the task ``draft`` forever
+    (issue #993 / savethenovel forensic). Best-effort: a failure in the
+    queue gate keeps the draft so the user can fix it manually.
+
+    Returns the created ``Task`` (post-queue when auto-queue succeeds).
+    The ``work_status`` on the returned task tells the caller whether
+    auto-queue fired (``queued``) or fell back to ``draft``. Caller owns
+    output formatting.
     """
-    # Local import to keep the CLI importable in tests that haven't wired
-    # a full SQLite environment yet.
+    # Local imports to keep the CLI importable in tests that haven't
+    # wired a full SQLite environment yet.
+    import logging
+
     from pollypm.work.sqlite_service import SQLiteWorkService
+
+    log = logging.getLogger(__name__)
 
     db_path = _planner_db_path(
         project_path,
@@ -345,6 +358,21 @@ def _plan_project_task(
             roles={"architect": actor},
             priority="high",
         )
+        # Parity with ``_on_project_created`` (plugin.py:249-258): the
+        # architect spawn relies on the assignment sweep finding a
+        # ``queued`` task. Leaving the explicitly-requested task in
+        # ``draft`` recreates the "ready, sit idle forever" pattern
+        # from #993 — a regression seen in the savethenovel forensic.
+        # Best-effort: keep the draft on gate failure so the user can
+        # recover via ``pm task queue`` rather than crashing the CLI.
+        try:
+            task = svc.queue(task.task_id, actor="planner")
+        except Exception as queue_exc:  # noqa: BLE001
+            log.warning(
+                "project_planning: auto-queue of %s failed (%s); "
+                "task left in draft. Run `pm task queue %s` manually.",
+                task.task_id, queue_exc, task.task_id,
+            )
     return task
 
 
@@ -689,10 +717,13 @@ def plan_cmd(
         f"Created planning task {task.task_id} on project '{key}' "
         f"(flow={task.flow_template_id})."
     )
-    typer.echo(
-        "Next: `pm task queue " + task.task_id + "` to hand it off to the "
-        "architect worker."
-    )
+    if task.work_status.value == "queued":
+        typer.echo("Auto-queued for the architect.")
+    else:
+        typer.echo(
+            "Auto-queue failed — run `pm task queue " + task.task_id
+            + "` to hand it off to the architect worker."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -750,10 +781,13 @@ def replan_cmd(
         f"Created replan task {task.task_id} on project '{key}' "
         f"(flow={task.flow_template_id}, mode=replan)."
     )
-    typer.echo(
-        "Next: `pm task queue " + task.task_id + "` to hand it off to the "
-        "architect worker."
-    )
+    if task.work_status.value == "queued":
+        typer.echo("Auto-queued for the architect.")
+    else:
+        typer.echo(
+            "Auto-queue failed — run `pm task queue " + task.task_id
+            + "` to hand it off to the architect worker."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -998,10 +1032,13 @@ def new_cmd(
         f"Created planning task {task.task_id} on project "
         f"'{project.key}' (flow={task.flow_template_id})."
     )
-    typer.echo(
-        "Next: `pm task queue " + task.task_id + "` to hand it off to the "
-        "architect worker."
-    )
+    if task.work_status.value == "queued":
+        typer.echo("Auto-queued for the architect.")
+    else:
+        typer.echo(
+            "Auto-queue failed — run `pm task queue " + task.task_id
+            + "` to hand it off to the architect worker."
+        )
     _auto_spawn_architect(path, project.key)
 
 

--- a/tests/test_project_planning_cli.py
+++ b/tests/test_project_planning_cli.py
@@ -364,6 +364,50 @@ class TestPlan:
         payload = json.loads(result.stdout)
         assert payload["project"] == "demo"
 
+    def test_plan_auto_queues_task(self, tmp_path: Path) -> None:
+        """Parity with ``project.created`` observer (#993).
+
+        ``pm project plan`` must leave the planning task in ``queued``,
+        not ``draft``: the architect's assignment sweep only finds queued
+        work, so a draft task sits idle forever (savethenovel forensic).
+        """
+        repo = _make_project_repo(tmp_path)
+        config_path = _write_minimal_config(tmp_path, projects={"demo": repo})
+
+        result = runner.invoke(
+            project_app,
+            ["plan", "demo", "--config", str(config_path), "--json"],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["work_status"] == "queued"
+
+    def test_plan_auto_queue_failure_keeps_draft(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """If ``svc.queue`` raises, the create still succeeds.
+
+        We don't crash the user's command — log a warning and leave the
+        task in ``draft`` so the user can recover via ``pm task queue``.
+        """
+        repo = _make_project_repo(tmp_path)
+        config_path = _write_minimal_config(tmp_path, projects={"demo": repo})
+
+        from pollypm.work.sqlite_service import SQLiteWorkService
+
+        def _boom(self, task_id, actor, skip_gates=False):  # noqa: ARG001
+            raise RuntimeError("synthetic gate failure")
+
+        monkeypatch.setattr(SQLiteWorkService, "queue", _boom)
+
+        result = runner.invoke(
+            project_app,
+            ["plan", "demo", "--config", str(config_path), "--json"],
+        )
+        assert result.exit_code == 0, result.stdout + result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["work_status"] == "draft"
+
 
 # ---------------------------------------------------------------------------
 # replan


### PR DESCRIPTION
## Context

Forensic on the savethenovel session traced "architect bootstraps, says ready, sits idle forever" to an asymmetry between PollyPM's two auto-fire paths for `flow=plan_project` tasks.

The `project.created` observer at `plugins_builtin/project_planning/plugin.py:228-258` already does the right thing: `svc.create(...)` then `svc.queue(task.task_id, actor="planner")`, with explicit best-effort isolation and a comment citing #993 (the original "ready, sit idle forever" fix).

The CLI helper `_plan_project_task` at `plugins_builtin/project_planning/cli/project.py:312-348` did *not* mirror that pattern. It created the task in `draft`, then printed a `Next: pm task queue ...` line to stdout. If Polly's session has closed, the user never sees the line — and the architect's assignment sweep, which only matches `queued` / `in_progress`, can't pick up the draft. Task sits forever.

`_plan_project_task` is the helper behind `pm project plan`, `pm project replan`, and the legacy `pm project new` (decline-auto-fire / non-observer) fallback path, so all three were affected.

## Fix

Mirror the working observer in `_plan_project_task`:

- Call `svc.queue(task.task_id, actor="planner")` immediately after `svc.create(...)`.
- Wrap in the same `try/except` shield used at `plugin.py:249-258` — log a warning and return the draft on gate failure rather than crashing the user's command.
- Update post-create messaging in `plan_cmd`, `replan_cmd`, and the legacy `pm project new` branch: `"Auto-queued for the architect."` on success, manual `pm task queue` hint only when auto-queue actually failed.

`plugin.py` is intentionally untouched.

## Tests

- `test_plan_auto_queues_task` — `pm project plan demo --json` reports `work_status=queued`.
- `test_plan_auto_queue_failure_keeps_draft` — `monkeypatch` `SQLiteWorkService.queue` to raise; CLI still exits 0 and reports `work_status=draft`.

`tests/test_project_planning_cli.py` (41 tests) and `tests/test_project_planning_plugin.py` (102 tests) both pass locally.

## Refs

- Issue #993 (original "ready, sit idle forever" fix on the observer side)
- savethenovel forensic, May 2026