### PR TITLE
Polly operator guide: prefer pm project plan over pm task create for planning

### DIFF
--- a/src/pollypm/plugins_builtin/core_agent_profiles/profiles/polly-operator-guide.md
+++ b/src/pollypm/plugins_builtin/core_agent_profiles/profiles/polly-operator-guide.md
@@ -83,6 +83,14 @@ Do NOT:
 
 If Sam later wants to change the slug: run `pm project rename <old> <new>` (dry-run first), then restart affected sessions.
 
+## Project Planning
+
+When a project needs a plan (initial planning or re-planning after cancellation):
+
+- **Use `pm project plan <project>`** to spawn the architect with the planning flow.
+- Do NOT craft a "Plan X" task manually with `pm task create` — that uses the standard flow with `worker=worker`, lacks the architect's planning structure, and routes through code review instead of plan review.
+- This applies to BOTH the first plan after `pm project new` AND any re-plan after a cancelled or stale plan.
+
 ## Plan Review
 
 A `plan_review` item means the architect produced a plan.
@@ -107,6 +115,8 @@ pm task create "Title" -p <project> -d "desc + acceptance criteria" \
   -f standard --priority normal -r worker=worker -r reviewer=russell
 pm task queue <id>
 ```
+
+For "Plan <project>" work, use `pm project plan <project>` instead — see the Project Planning section above.
 
 ### Monitor
 


### PR DESCRIPTION
## Summary

Adds a single rule to Polly's operator guide so she reaches for `pm project plan <project>` instead of crafting a "Plan X" task by hand with `pm task create`.

## Why

Forensic on `savethenovel/1` found the initial plan task was created with:

```
pm task create "Plan savethenovel.org website build" --project savethenovel ...
```

instead of `pm project plan savethenovel`. That single misroute kicked off the savethenovel chain of failures:

- wrong flow (standard, not planning)
- role gate accepting `user` because the planning role contract was bypassed
- worker thrashing as the plan task tried to run through the standard worker path
- cancellation cascade
- draft accumulation in the inbox

The guide already covers `pm project new` for project registration but never says "if you're about to create a 'Plan X' task, use `pm project plan X` instead." Polly read the guide, saw `pm task create` modeled in the Dispatch block, and pattern-matched.

## Change

- New short **Project Planning** section between Creating Projects and Plan Review (5 lines). States: use `pm project plan <project>`, do NOT craft a Plan task with `pm task create`, applies to both initial planning and re-plans.
- One-line callout in the Worker Management → Dispatch block pointing back at the new section, since that's where the wrong pattern gets imitated.

Total: +10 lines in one markdown file. No code changes.

## Test plan

- [x] `pytest` over the seven test files that reference the guide path (`test_core_agent_profiles.py`, `test_role_contract.py`, `test_persona_drift.py`, `test_workers.py`, `test_upgrade_notice.py`, `test_project_paths.py`, `test_prompt_assembly_integration.py`) — 122 passed
- [ ] Spot-check a fresh `pm project new` flow: confirm Polly now opens a Project Planning rule when next asked to plan a project