### PR TITLE
Surface unpromoted drafts in cockpit project drilldown

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -11055,6 +11055,7 @@ def _dashboard_gather_tasks(
         return {}, {}
 
     buckets: dict[str, list[dict]] = {
+        "draft": [],
         "queued": [],
         "in_progress": [],
         "review": [],
@@ -13115,6 +13116,23 @@ class PollyProjectDashboardApp(App[None]):
     #proj-empty-state.-hidden {
         display: none;
     }
+    /* Drafts-pending affordance: fires when the project has draft tasks
+       but no live (queued/in_progress/review) work. Mirrors the empty-
+       state's "you need to take action" tone — a project full of
+       unpromoted drafts looks dead but actually has work waiting. The
+       108-drafts forensic (oldest 16d) showed drafts can sit invisibly
+       for weeks. */
+    #proj-drafts-pending {
+        height: auto;
+        margin-bottom: 1;
+        padding: 0 2;
+        background: #1a2330;
+        color: #d6dee5;
+        border: round #97a6b2;
+    }
+    #proj-drafts-pending.-hidden {
+        display: none;
+    }
     #proj-plan-scroll {
         height: auto;
         max-height: 30;
@@ -13212,6 +13230,14 @@ class PollyProjectDashboardApp(App[None]):
         # on ``data.task_counts`` totals.
         self.empty_state = Static(
             "", id="proj-empty-state", classes="-hidden", markup=True,
+        )
+        # Drafts-pending panel — surfaces unpromoted drafts when no
+        # live work exists. Without this, drafts pile up invisibly
+        # (forensic found 108 system-wide, oldest 16 days) because the
+        # empty-state only fires at total==0 and the pipeline strip
+        # historically omitted ``draft``.
+        self.drafts_pending = Static(
+            "", id="proj-drafts-pending", classes="-hidden", markup=True,
         )
         self.now_title = Static(
             "[b]Current activity[/b]",
@@ -13355,6 +13381,12 @@ class PollyProjectDashboardApp(App[None]):
                 # navigate into a fresh project. Hidden by default; the
                 # ``-hidden`` class is removed only when totals are zero.
                 yield self.empty_state
+                # Drafts-pending sits just below empty-state so the
+                # affordance reads top-down: zero-tasks > unpromoted
+                # drafts > everything else. Hidden by default; the
+                # render path toggles ``-hidden`` based on whether
+                # there's draft work with no live work to act on.
+                yield self.drafts_pending
                 with Vertical(classes="proj-section", id="proj-inbox-section"):
                     yield self.inbox_title
                     yield self.inbox_lead
@@ -13516,6 +13548,22 @@ class PollyProjectDashboardApp(App[None]):
         else:
             self.empty_state.update("")
             self.empty_state.add_class("-hidden")
+
+        # ── Drafts-pending affordance ──
+        # Drafts that never got promoted (``pm task queue``) accumulate
+        # invisibly: the empty-state only fires at total==0, and a
+        # project with 1 draft + 1 cancelled has total>0 but nothing
+        # live. The forensic audit found 108 such drafts system-wide
+        # (oldest 16d). Surface them prominently when no live work
+        # exists; the pipeline-strip ``draft`` bucket handles the
+        # mixed-state case.
+        drafts_text = self._render_drafts_pending(data)
+        if drafts_text:
+            self.drafts_pending.update(drafts_text)
+            self.drafts_pending.remove_class("-hidden")
+        else:
+            self.drafts_pending.update("")
+            self.drafts_pending.add_class("-hidden")
 
         # ── Current activity ──
         self.now_body.update(self._render_now_body(data))
@@ -13864,6 +13912,66 @@ class PollyProjectDashboardApp(App[None]):
             f"architect, or [b]pm task create[/b] to add one manually.[/]"
         )
 
+    def _render_drafts_pending(self, data: ProjectDashboardData) -> str:
+        """Return the drafts-pending affordance, or "" when there's
+        live work or no drafts.
+
+        Surfaces unpromoted drafts when the project has zero live
+        (queued / in_progress / review) tasks. The savethenovel repro
+        had 1 cancelled + 1 draft = 2 tasks total, so the empty-state
+        affordance suppressed itself, and the pipeline strip
+        historically omitted ``draft`` — the only "live" work was
+        invisible. Forensic audit found 108 drafts stuck system-wide,
+        oldest 16d, exactly this pattern.
+
+        Hidden when there's any live work (drafts coexist with live
+        tasks via the pipeline-strip ``draft`` bucket instead) and
+        when there are no drafts at all.
+        """
+        if not data.exists_on_disk:
+            return ""
+        counts = data.task_counts or {}
+        buckets = data.task_buckets or {}
+        draft_count = int(counts.get("draft", 0))
+        if draft_count <= 0:
+            return ""
+        live_count = (
+            int(counts.get("queued", 0))
+            + int(counts.get("in_progress", 0))
+            + int(counts.get("review", 0))
+        )
+        if live_count > 0:
+            # Drafts coexist with live work — pipeline-strip draft
+            # bucket already shows them; don't duplicate.
+            return ""
+        # Build a short list of draft refs (project/N) for the lead
+        # line. Cap at three so narrow widths stay readable.
+        draft_rows = list(buckets.get("draft", []) or [])
+        refs: list[str] = []
+        for row in draft_rows[:3]:
+            num = row.get("task_number")
+            if num is None:
+                continue
+            refs.append(f"{data.project_key}/{num}")
+        more = max(draft_count - len(refs), 0)
+        head = ", ".join(_escape(r) for r in refs) if refs else ""
+        if more and head:
+            head = f"{head} (+{more} more)"
+        elif more and not head:
+            head = f"+{more} more"
+        noun = "draft" if draft_count == 1 else "drafts"
+        lead = (
+            f"[#f7d67a][b]{draft_count} {noun} pending[/b][/]"
+        )
+        if head:
+            lead = f"{lead} [#d6dee5]({head})[/]"
+        return (
+            f"{lead}\n"
+            f"[#d6dee5]No live work — run "
+            f"[b]pm task queue <id>[/b] to promote a draft to the "
+            f"architect.[/]"
+        )
+
     def _render_now_body(self, data: ProjectDashboardData) -> str:
         w = data.active_worker
         if w:
@@ -14035,7 +14143,15 @@ class PollyProjectDashboardApp(App[None]):
         # (squared inner square) for blocked so the "waiting on
         # dependencies" rows look distinct from the "in flight" rows
         # at a glance.
+        # ``draft`` was previously omitted from the pipeline strip even
+        # though ``_dashboard_gather_tasks`` collects drafts \u2014 so a
+        # project with only unpromoted drafts looked empty on the
+        # drilldown. Forensic audit found 108 stuck drafts system-wide
+        # (oldest 16d) accumulating invisibly. Surface drafts here as a
+        # bucket so they coexist visibly with live work; the separate
+        # "Drafts pending" panel above handles the no-live-work case.
         strip_order = [
+            ("draft", "#97a6b2", "\u270e"),
             ("queued", "#6b7a88", "\u25cb"),
             ("in_progress", "#f0c45a", "\u25c6"),
             ("review", "#5b8aff", "\u25c9"),

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -4831,3 +4831,409 @@ def test_empty_state_suppressed_when_path_missing(tmp_path: Path) -> None:
     assert PollyProjectDashboardApp._render_empty_state(
         None, data,  # type: ignore[arg-type]
     ) == ""
+
+
+# ---------------------------------------------------------------------------
+# Drafts-pending affordance — surface unpromoted drafts in the drilldown
+# ---------------------------------------------------------------------------
+#
+# Forensic audit found 108 drafts stuck system-wide (oldest 16 days). The
+# pipeline-bucket renderer historically showed queued / in_progress /
+# review / blocked / on_hold / done — but NOT draft, so drafts piled up
+# invisibly. PR #1340's empty-state only fires when total tasks == 0; a
+# project with 1 cancelled + 1 draft (the savethenovel repro) has
+# total>0 but no live work, so neither affordance fired and the only
+# live task — the unpromoted draft — was hidden.
+
+
+def _draft_data(
+    tmp_path: Path,
+    *,
+    draft_count: int = 1,
+    extra_counts: dict[str, int] | None = None,
+    extra_buckets: dict[str, list[dict]] | None = None,
+):
+    """Build a ``ProjectDashboardData`` with N drafts and optional
+    other-status mix. Keeps the unit tests away from the work-service
+    bootstrap."""
+    from pollypm.cockpit_ui import ProjectDashboardData
+
+    counts: dict[str, int] = {"draft": draft_count}
+    counts.update(extra_counts or {})
+    buckets: dict[str, list[dict]] = {
+        "draft": [
+            {
+                "task_id": f"savethenovel/{i}",
+                "task_number": i,
+                "title": f"Draft {i}",
+                "updated_at": "",
+            }
+            for i in range(1, draft_count + 1)
+        ]
+    }
+    buckets.update(extra_buckets or {})
+    return ProjectDashboardData(
+        project_key="savethenovel",
+        project_name="Save The Novel",
+        project_path=tmp_path,
+        persona_name=None,
+        pm_label="PM: polly",
+        exists_on_disk=True,
+        status_dot="○",
+        status_color="#4a5568",
+        status_label="idle",
+        active_worker=None,
+        architect=None,
+        task_counts=counts,
+        task_buckets=buckets,
+        plan_path=None,
+        plan_sections=[],
+        plan_explainer=None,
+        plan_text=None,
+        plan_aux_files=[],
+        plan_mtime=None,
+        plan_stale_reason=None,
+        activity_entries=[],
+        inbox_count=0,
+        inbox_top=[],
+        action_items=[],
+        alert_count=0,
+    )
+
+
+def test_drafts_pending_renderer_fires_when_only_drafts(tmp_path: Path) -> None:
+    """Drafts present, no live work → ``_render_drafts_pending`` returns
+    the affordance copy with the count, the queue command, and the
+    project-qualified draft refs."""
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    data = _draft_data(tmp_path, draft_count=3)
+    rendered = PollyProjectDashboardApp._render_drafts_pending(
+        None, data,  # type: ignore[arg-type]
+    )
+    assert "3 drafts pending" in rendered
+    assert "pm task queue" in rendered
+    # Refs use project/N form so the operator can copy-paste
+    # ``pm task queue savethenovel/1``.
+    assert "savethenovel/1" in rendered
+    assert "savethenovel/2" in rendered
+    assert "savethenovel/3" in rendered
+
+
+def test_drafts_pending_renderer_singular_copy(tmp_path: Path) -> None:
+    """Single draft → ``1 draft pending`` (singular noun)."""
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    data = _draft_data(tmp_path, draft_count=1)
+    rendered = PollyProjectDashboardApp._render_drafts_pending(
+        None, data,  # type: ignore[arg-type]
+    )
+    assert "1 draft pending" in rendered
+    assert "drafts pending" not in rendered
+
+
+def test_drafts_pending_renderer_truncates_long_lists(tmp_path: Path) -> None:
+    """More than three drafts → first three refs + ``(+N more)`` so the
+    line stays readable on narrow terminals."""
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    data = _draft_data(tmp_path, draft_count=7)
+    rendered = PollyProjectDashboardApp._render_drafts_pending(
+        None, data,  # type: ignore[arg-type]
+    )
+    assert "7 drafts pending" in rendered
+    assert "savethenovel/1" in rendered
+    assert "savethenovel/3" in rendered
+    # Refs 4..7 collapse into "+N more"
+    assert "+4 more" in rendered
+    assert "savethenovel/7" not in rendered
+
+
+def test_drafts_pending_renderer_silent_when_live_work_exists(
+    tmp_path: Path,
+) -> None:
+    """Drafts coexist with live work (queued / in_progress / review) →
+    the panel stays hidden so it doesn't shout. The pipeline-strip
+    ``draft`` bucket carries the surface in that case."""
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    for live_status in ("queued", "in_progress", "review"):
+        data = _draft_data(
+            tmp_path,
+            draft_count=2,
+            extra_counts={live_status: 1},
+            extra_buckets={
+                live_status: [
+                    {
+                        "task_id": f"savethenovel/9",
+                        "task_number": 9,
+                        "title": "Live work",
+                        "updated_at": "",
+                    }
+                ],
+            },
+        )
+        rendered = PollyProjectDashboardApp._render_drafts_pending(
+            None, data,  # type: ignore[arg-type]
+        )
+        assert rendered == "", (
+            f"drafts panel must hide when {live_status!r} task exists "
+            f"(got {rendered!r})"
+        )
+
+
+def test_drafts_pending_renderer_silent_when_no_drafts(tmp_path: Path) -> None:
+    """Zero drafts → no false affordance, even with terminal-state
+    tasks (cancelled / done) on the project."""
+    from pollypm.cockpit_ui import (
+        PollyProjectDashboardApp,
+        ProjectDashboardData,
+    )
+
+    data = ProjectDashboardData(
+        project_key="savethenovel",
+        project_name="Save The Novel",
+        project_path=tmp_path,
+        persona_name=None,
+        pm_label="PM: polly",
+        exists_on_disk=True,
+        status_dot="○",
+        status_color="#4a5568",
+        status_label="idle",
+        active_worker=None,
+        architect=None,
+        task_counts={"done": 1},
+        task_buckets={
+            "done": [
+                {
+                    "task_id": "savethenovel/1",
+                    "task_number": 1,
+                    "title": "Shipped",
+                    "updated_at": "",
+                }
+            ]
+        },
+        plan_path=None,
+        plan_sections=[],
+        plan_explainer=None,
+        plan_text=None,
+        plan_aux_files=[],
+        plan_mtime=None,
+        plan_stale_reason=None,
+        activity_entries=[],
+        inbox_count=0,
+        inbox_top=[],
+        action_items=[],
+        alert_count=0,
+    )
+    assert PollyProjectDashboardApp._render_drafts_pending(
+        None, data,  # type: ignore[arg-type]
+    ) == ""
+
+
+def test_drafts_pending_renderer_silent_when_path_missing(
+    tmp_path: Path,
+) -> None:
+    """Project path missing on disk → topbar surfaces a louder warning
+    already; the drafts panel defers (matches empty-state behavior)."""
+    from pollypm.cockpit_ui import (
+        PollyProjectDashboardApp,
+        ProjectDashboardData,
+    )
+
+    data = ProjectDashboardData(
+        project_key="savethenovel",
+        project_name="Save The Novel",
+        project_path=None,
+        persona_name=None,
+        pm_label="PM: polly",
+        exists_on_disk=False,
+        status_dot="○",
+        status_color="#4a5568",
+        status_label="idle",
+        active_worker=None,
+        architect=None,
+        task_counts={"draft": 5},
+        task_buckets={
+            "draft": [
+                {
+                    "task_id": "savethenovel/1",
+                    "task_number": 1,
+                    "title": "Draft 1",
+                    "updated_at": "",
+                }
+            ]
+        },
+        plan_path=None,
+        plan_sections=[],
+        plan_explainer=None,
+        plan_text=None,
+        plan_aux_files=[],
+        plan_mtime=None,
+        plan_stale_reason=None,
+        activity_entries=[],
+        inbox_count=0,
+        inbox_top=[],
+        action_items=[],
+        alert_count=0,
+    )
+    assert PollyProjectDashboardApp._render_drafts_pending(
+        None, data,  # type: ignore[arg-type]
+    ) == ""
+
+
+def test_drafts_pending_does_not_block_empty_state_at_zero_total(
+    tmp_path: Path,
+) -> None:
+    """Trigger conditions are disjoint: empty-state fires at total==0,
+    drafts-pending fires at total>0 with draft>0 and live==0. Don't
+    regress the empty-state's own trigger when drafts==0 too."""
+    from pollypm.cockpit_ui import (
+        PollyProjectDashboardApp,
+        ProjectDashboardData,
+    )
+
+    zero = ProjectDashboardData(
+        project_key="savethenovel",
+        project_name="Save The Novel",
+        project_path=tmp_path,
+        persona_name=None,
+        pm_label="PM: polly",
+        exists_on_disk=True,
+        status_dot="○",
+        status_color="#4a5568",
+        status_label="idle",
+        active_worker=None,
+        architect=None,
+        task_counts={},
+        task_buckets={},
+        plan_path=None,
+        plan_sections=[],
+        plan_explainer=None,
+        plan_text=None,
+        plan_aux_files=[],
+        plan_mtime=None,
+        plan_stale_reason=None,
+        activity_entries=[],
+        inbox_count=0,
+        inbox_top=[],
+        action_items=[],
+        alert_count=0,
+    )
+    assert PollyProjectDashboardApp._render_drafts_pending(
+        None, zero,  # type: ignore[arg-type]
+    ) == ""
+    # Empty-state still fires at total==0 — guard the disjoint trigger.
+    assert "No tasks for savethenovel" in (
+        PollyProjectDashboardApp._render_empty_state(
+            None, zero,  # type: ignore[arg-type]
+        )
+    )
+
+
+def test_pipeline_strip_includes_draft_bucket(tmp_path: Path) -> None:
+    """A project with only drafts must still render the pipeline strip
+    with a ``draft`` glyph — the historical strip omitted it, which is
+    why drafts piled up invisibly."""
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    data = _draft_data(tmp_path, draft_count=2)
+    rendered = PollyProjectDashboardApp._render_pipeline_body(
+        None, data,  # type: ignore[arg-type]
+    )
+    assert "No tasks yet" not in rendered
+    assert "draft" in rendered.lower()
+    # Bucket header + at least one draft row by number
+    assert "Draft" in rendered  # status header (.title())
+    assert "#1" in rendered or "Draft 1" in rendered
+
+
+def test_drafts_pending_real_db_only_drafts_no_live_work(tmp_path: Path) -> None:
+    """Integration: a real work-DB with only a draft row → the
+    gathered ``ProjectDashboardData`` carries the draft count and the
+    drafts-pending renderer fires while the empty-state stays hidden.
+
+    Bypasses the App pilot so this doesn't race the first-refresh
+    worker thread; the renderer is still the one the App calls."""
+    # ``_write_config`` writes ``[projects.demo]`` with the project
+    # path pointing at the directory we create — keep the project
+    # dir name aligned so the work-service stores tasks under the
+    # canonical project alias the dashboard looks up.
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    _init_git_repo(project_path)
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(project_path, config_path)
+
+    if not _load_config_compatible(config_path):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+
+    project_db = project_path / ".pollypm" / "state.db"
+    project_db.parent.mkdir(parents=True, exist_ok=True)
+    with SQLiteWorkService(db_path=project_db, project_path=project_path) as svc:
+        svc.create(
+            title="Unpromoted draft",
+            description="seed",
+            type="task",
+            project="demo",
+            flow_template="standard",
+            roles={"worker": "worker", "reviewer": "reviewer"},
+            priority="normal",
+            created_by="polly",
+        )
+        # Note: do NOT call svc.queue() — the draft must stay in DRAFT.
+
+    from pollypm import cockpit_ui as _cockpit_ui
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    _cockpit_ui._PROJECT_DASHBOARD_TASK_CACHE.clear()
+    data = _cockpit_ui._gather_project_dashboard(config_path, "demo")
+    assert data is not None
+    # Sanity: exactly one draft, no live work, total > 0 (empty-state
+    # would have fired at total==0 instead).
+    assert data.task_counts.get("draft") == 1
+    assert not any(
+        int(data.task_counts.get(s, 0))
+        for s in ("queued", "in_progress", "review")
+    )
+    total = sum(int(v or 0) for v in (data.task_counts or {}).values())
+    assert total > 0
+
+    drafts_rendered = PollyProjectDashboardApp._render_drafts_pending(
+        None, data,  # type: ignore[arg-type]
+    )
+    assert "1 draft pending" in drafts_rendered
+    assert "pm task queue" in drafts_rendered
+
+    # Empty-state defers because total > 0.
+    empty_rendered = PollyProjectDashboardApp._render_empty_state(
+        None, data,  # type: ignore[arg-type]
+    )
+    assert empty_rendered == ""
+
+    # Pipeline body now contains the draft bucket too — verifying the
+    # historical "draft omitted" gap is closed.
+    pipeline_rendered = PollyProjectDashboardApp._render_pipeline_body(
+        None, data,  # type: ignore[arg-type]
+    )
+    assert "No tasks yet" not in pipeline_rendered
+    assert "draft" in pipeline_rendered.lower()
+
+
+def test_drafts_pending_panel_mounts_in_compose(tmp_path: Path) -> None:
+    """Confirm the drafts-pending widget participates in ``compose``
+    (mounted under ``proj-body`` between empty-state and inbox-section)
+    and starts hidden when the App is constructed."""
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    _init_git_repo(project_path)
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(project_path, config_path)
+
+    app = PollyProjectDashboardApp(config_path, "demo")
+    assert app.drafts_pending is not None
+    assert app.drafts_pending.id == "proj-drafts-pending"
+    # Hidden by default (CSS class). The render path toggles it.
+    assert "-hidden" in app.drafts_pending.classes


### PR DESCRIPTION
## Context

A forensic audit found **108 stuck drafts system-wide** (oldest 16 days) accumulating invisibly. Two gaps in the cockpit project drilldown made them disappear:

1. **Pipeline-bucket renderer omitted ``draft``.** The strip showed queued / in_progress / review / blocked / on_hold / done. Drafts were collected by ``_dashboard_gather_tasks`` but never displayed.
2. **PR #1340's empty-state only fires at ``total tasks == 0``.** The savethenovel repro had 1 cancelled + 1 draft = 2 tasks, so the empty-state suppressed itself even though the only "live" task (the draft) was unpromoted.

Net effect: a project full of unpromoted drafts looked dead, with no affordance pointing at ``pm task queue``.

## Changes

Hybrid surface — both bucket and standalone panel:

**Option A (pipeline bucket):** Add a ``draft`` bucket to ``_dashboard_gather_tasks`` and the strip in ``_render_pipeline_body``. Drafts now coexist visibly with live work in the standard pipeline rows.

**Option B (drafts-pending panel):** New ``#proj-drafts-pending`` Static, mounted between ``empty_state`` and the inbox section. Fires when ``draft > 0`` AND ``(queued + in_progress + review) == 0`` — exactly the savethenovel-style "looks dead but actually has work" case. Hidden when drafts coexist with live work (bucket carries the surface) or when there are no drafts.

**Affordance copy:**
```
N drafts pending (foo/3, foo/7, foo/12)
No live work — run `pm task queue <id>` to promote a draft to the architect.
```

Singular noun for one draft. Refs cap at three with ``(+N more)`` so narrow widths stay readable.

**Empty-state interaction:** ``_render_empty_state``'s trigger condition (``total == 0``) is unchanged. Drafts panel fills the disjoint ``total > 0 / live == 0`` gap.

## Test plan

- [x] Unit: drafts-pending renderer fires when only drafts present
- [x] Unit: drafts-pending stays hidden when ``queued`` / ``in_progress`` / ``review`` task exists
- [x] Unit: drafts-pending hidden when ``draft == 0``
- [x] Unit: drafts-pending hidden when ``exists_on_disk`` is false
- [x] Unit: singular vs plural copy ("1 draft pending" vs "N drafts pending")
- [x] Unit: ref-list truncation with ``+N more`` past three
- [x] Unit: empty-state's own ``total == 0`` trigger not regressed
- [x] Integration (real work-DB, no pilot): draft-only project → ``data.task_counts.draft == 1``, drafts-renderer fires, empty-state defers, pipeline includes ``draft`` bucket
- [x] Compose: ``proj-drafts-pending`` widget mounts and starts ``-hidden``
- [x] Pipeline strip includes draft glyph + per-bucket header
- [x] All existing project-dashboard / cockpit-dashboard tests still pass for non-pilot tests; the few asyncio-pilot tests that fail in this run are pre-existing flakes on main (verified by ``git stash``)