### PR TITLE
Package worker-guide.md and update prompt template to point at pm help worker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ pollypm = [
   "defaults/magic/*/**/*.json",
   "defaults/magic/*/LICENSE",
   "defaults/docs/*.template",
+  "defaults/docs/*.md",
   "defaults/docs/reference/*.md",
   "defaults/demo/*",
   "defaults/demo/**/*",

--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -490,7 +490,12 @@ def shortcuts() -> None:
 
 
 _ROLE_GUIDES = {
-    "worker": ("docs/worker-guide.md", "Worker onboarding guide"),
+    # role: (repo-relative path, packaged-resource path under pollypm/, title)
+    "worker": (
+        "docs/worker-guide.md",
+        "defaults/docs/worker-guide.md",
+        "Worker onboarding guide",
+    ),
 }
 
 
@@ -517,33 +522,38 @@ def role_help(
             err=True,
         )
         raise typer.Exit(code=1)
-    rel_path, title = entry
-    # Resolve against the repo root. ``pollypm`` is installed editable
-    # during dev; at runtime we prefer the packaged doc if it exists,
-    # falling back to the repo copy.
-    from importlib.resources import files as _files
+    rel_path, packaged_rel, title = entry
+    # Resolve in priority order:
+    #   1) Packaged resource shipped with the wheel
+    #      (src/pollypm/<packaged_rel>) — works in any worktree, even
+    #      one without docs/ on disk. This is the savethenovel fix:
+    #      workers no longer thrash on a missing docs/worker-guide.md.
+    #   2) Repo-relative path on disk — editable installs / running
+    #      from a clone resolve here.
+    from importlib.resources import as_file, files as _files
 
     doc_text: str | None = None
     try:
-        # Packaged layout: src/pollypm/defaults/worker-guide.md (if we
-        # later ship it). For now fall through to the repo docs dir.
-        candidate = _files("pollypm").joinpath(f"../../{rel_path}")
+        candidate = _files("pollypm").joinpath(packaged_rel)
         if candidate.is_file():
-            doc_text = candidate.read_text()
+            with as_file(candidate) as on_disk:
+                doc_text = Path(on_disk).read_text(encoding="utf-8")
     except (ModuleNotFoundError, FileNotFoundError, TypeError):
         pass
     if doc_text is None:
         # Walk up from this file to find the project root's docs/ dir.
         here = Path(__file__).resolve()
         for parent in here.parents:
-            candidate = parent / rel_path
-            if candidate.is_file():
-                doc_text = candidate.read_text()
+            candidate_path = parent / rel_path
+            if candidate_path.is_file():
+                doc_text = candidate_path.read_text(encoding="utf-8")
                 break
     if doc_text is None:
         typer.echo(
-            f"Could not locate {rel_path} on disk. "
-            f"The guide exists in the PollyPM repo at that path.",
+            f"Could not locate {rel_path} on disk and no packaged "
+            f"copy was found. Reinstall PollyPM "
+            f"(`uv tool install --reinstall .`) to refresh the bundled "
+            f"guide.",
             err=True,
         )
         raise typer.Exit(code=1)

--- a/src/pollypm/defaults/docs/worker-guide.md
+++ b/src/pollypm/defaults/docs/worker-guide.md
@@ -1,0 +1,326 @@
+# Worker Guide
+
+**Audience:** any agent spawned as a PollyPM worker. You are reading this because
+a task has been queued for you. This document is the single source of truth for
+your role. If you read nothing else, read this.
+
+## Who you are
+
+You are a **worker**. Your job is to implement exactly **one task** end-to-end:
+claim it, build it, register your work output, and hand it off to review.
+
+You are **not** the PM (Polly), and you are **not** the reviewer (Russell).
+
+- The PM decomposes projects into tasks. You do not plan scope.
+- The reviewer approves or rejects your work. You do not approve your own.
+- You work inside a real git **worktree** under
+  `.pollypm/worktrees/<project>-<number>` on branch
+  `task/<project>-<number>`. Do not touch other projects, other tasks, or
+  `main` directly.
+
+## The task lifecycle
+
+Every task moves through these states:
+
+```
+draft  →  queued  →  in_progress  →  review  →  done
+                                       ↓
+                                    rejected  →  (back to in_progress)
+```
+
+Your scope is the `in_progress → review` edge. You:
+
+1. **claim** the task (`queued → in_progress`).
+2. **build** the thing (edit code, write tests, run them).
+3. **register output** — at least one artifact (commit SHA, file path, or note).
+4. **mark done** (`in_progress → review`). The reviewer takes it from there.
+
+If the reviewer rejects, the task goes back to `in_progress` and you iterate.
+
+Some flows insert an extra worker-owned handoff step before review. If task
+status shows `review_handoff`, that does **not** mean a human takes over. It
+means you still need to run the user-level test, write the pass receipt, and
+then call `pm task done` to hand the task to Russell.
+
+## The commands you need — copy-paste ready
+
+All commands below use `shortlink_gen/1` as an example task id. Yours will
+differ; every task id has the form `<project>/<number>`.
+
+### 1. See what's queued
+
+The canonical path is **auto-claim**: Polly queues a worker-role task and
+immediately claims it for you, provisioning this session and pushing the
+kickoff prompt through the heartbeat sweep. If you're reading the kickoff
+in your tmux window, the task is already claimed — skip to step 4.
+
+If you're operating outside that flow (stale claim, fresh shell):
+
+```bash
+pm task list --status queued          # full queue
+pm task mine --actor worker           # tasks already assigned to you
+pm task next                          # highest-priority queued+unblocked task
+```
+
+### 2. Read the task spec
+
+```bash
+pm task get shortlink_gen/1
+```
+
+This prints the description, acceptance criteria, and current status. **Read it
+carefully before claiming.** If anything is ambiguous, leave a context note:
+
+```bash
+pm task context shortlink_gen/1 --text "Acceptance criterion 3 is ambiguous — \
+assuming FOO means BAR. Will revisit in review."
+```
+
+### 3. Claim the task
+
+In normal operation, **Polly has already claimed the task for you**: when
+she queues a worker-role task, she runs `pm task claim ... --actor worker`,
+the work service provisions the worktree + per-task tmux window, and the
+heartbeat sweep pushes the kickoff prompt into your pane. If the kickoff
+landed, don't re-run `claim`. Run `pwd` or `git status -sb` to confirm
+location and skip to step 4.
+
+Run `pm task claim` manually only when recovering a stale claim from a
+fresh shell:
+
+```bash
+pm task claim shortlink_gen/1
+```
+
+In either case, `claim`:
+
+- Sets `work_status = in_progress` and assigns the task to you.
+- Provisions a git worktree at `.pollypm/worktrees/<project>-<number>` on
+  branch `task/<project>-<number>`, started from the project's current
+  `HEAD` (clean checkout, not the main working dir).
+- Writes `.pollypm-task-prompt.md` into the worktree root.
+- Launches an interactive Claude session in tmux window
+  `task-<project>-<number>`, cwd already set to the worktree.
+
+If the kickoff prompt is slow to land, do **not** poke yourself with
+`tmux send-keys`. The heartbeat sweep force-pushes on its next cycle and
+stamps `kickoff_sent_at` only after the pane is ready. Wait a tick, or
+check `pm status` for `silent_worker` / `no_session`.
+
+### 4. Build
+
+If you claimed from a normal shell, `cd .pollypm/worktrees/<project>-<number>`.
+If PollyPM opened the worker tmux window for you, you should already be there.
+Read `.pollypm-task-prompt.md` in the worktree root — it contains the
+distilled task brief. Then:
+
+- Write code.
+- Write tests (`uv run python -m pytest --tb=short -q`).
+- Commit at least once. Your commit SHA becomes the primary artifact.
+
+Work on `task/<project>-<number>`. Do **not** commit to `main`. Do **not** edit
+files outside the worktree.
+
+### 5. Mark the node done with a work output
+
+The `pm task done` command takes a JSON work-output payload. The payload
+**must** include at least one artifact, or the hard gate `has_work_output`
+blocks the transition.
+
+Minimal payload (commit-based):
+
+```bash
+pm task done shortlink_gen/1 --output '{
+  "type": "code_change",
+  "summary": "Implemented shortlink generator + CLI + SQLite storage.",
+  "artifacts": [
+    {"kind": "commit", "description": "Initial implementation", "ref": "HEAD"}
+  ]
+}'
+```
+
+Other artifact kinds (`kind` field):
+
+- `commit`   — `ref` is a SHA or `HEAD`. Preferred for code changes.
+- `file_change` — `path` is a repo-relative path. Use for non-committed edits.
+- `action`   — record of an action taken (e.g. "ran migration"). `description` required.
+- `note`     — free-form note. Use sparingly; reviewers prefer concrete artifacts.
+
+Multiple artifacts in one output are fine and common:
+
+```bash
+pm task done shortlink_gen/1 --output '{
+  "type": "code_change",
+  "summary": "Feature complete + playwright coverage.",
+  "artifacts": [
+    {"kind": "commit", "description": "impl", "ref": "237dfb0"},
+    {"kind": "commit", "description": "e2e test", "ref": "HEAD"},
+    {"kind": "file_change", "description": "CHANGELOG entry", "path": "CHANGELOG.md"}
+  ]
+}'
+```
+
+On success, the task moves to `review` and the reviewer is notified.
+
+If your task was emitted on the `implement_module` flow, review also expects a
+user-level test receipt on disk before approval succeeds. Write:
+
+```json
+{"passed": true, "details": "Playwright 5/5 passed; screenshot report.html"}
+```
+
+to `.pollypm/test-receipts/<project>-<number>.json` in the project root
+(example: `demo/1` → `.pollypm/test-receipts/demo-1.json`). Unit tests alone do
+not satisfy that gate.
+
+### 6. If the reviewer rejects
+
+```bash
+pm task get shortlink_gen/1          # re-read, scroll to most recent transition
+```
+
+The rejection `reason` explains what to fix. Iterate on the same worktree,
+commit, and re-run `pm task done` with an updated payload.
+
+## Top 10 failure modes and their fixes
+
+### 1. "No such command 'show'"
+
+The old `task show` spelling does not exist. Use:
+
+```bash
+pm task get shortlink_gen/1
+```
+
+### 2. "Work output must have at least one artifact"
+
+The hard gate `has_work_output` requires at least one artifact. Re-run
+`pm task done` with an artifact list — the examples above are copy-paste
+ready. You do **not** need a separate output-registration command; the artifacts
+travel in `--output`.
+
+### 3. "provision_worker failed … tmux new-session exit 1"
+
+The storage-closet tmux session already exists. In the current build this is
+usually benign when the PM already claimed the task from an existing worker
+session — that session picks up the work. If you ran `pm task claim` from a
+fresh shell and see this, either:
+
+- Work inside the existing session (check the cockpit rail or `pm status`), or
+- If the claimant session is gone, ask Polly to recover the stale claim before
+  retrying from a fresh worker shell.
+
+### 4. "Task already claimed by <other>"
+
+Another worker (or a stale claim) owns the task. Check:
+
+```bash
+pm task get shortlink_gen/1          # look for "assignee"
+pm status                            # confirm core session health
+```
+
+If the claim is stale (session dead, worker gone), confirm the worker is
+actually gone and then re-claim once Polly has cleared the stale assignment:
+
+```bash
+pm task claim shortlink_gen/1
+```
+
+### 5. "Task is in 'draft' status; only 'review' tasks can be approved"
+
+You tried to approve your own work. Don't. The reviewer owns approval.
+If you meant to advance a draft into the queue:
+
+```bash
+pm task queue shortlink_gen/1
+```
+
+### 6. "No project '<name>' registered"
+
+`pm task create` or another project-scoped command was given a project name
+that isn't registered. List what's available:
+
+```bash
+pm projects
+pm add-project /path/to/project --name <name>
+```
+
+### 7. "pm project new" — No such command
+
+The `pm` binary wasn't rebuilt after a plugin CLI change. Reinstall:
+
+```bash
+cd /path/to/pollypm && uv pip install -e .
+```
+
+Workaround if you can't rebuild: `pm add-project <path> --name <name>`.
+
+### 8. Tests fail with "No module named X" after claim
+
+Your worktree is a fresh checkout. Re-install dev deps:
+
+```bash
+cd .pollypm/worktrees/<project>-<number>
+uv sync --all-extras --dev
+```
+
+### 9. Gate failure on `done` — "Task has no description"
+
+Rare for queued tasks (queueing gates that). If it happens, add the missing
+field through `pm task update` before re-running `done`.
+
+### 10. "Cannot advance from in_progress: no commits on task/<slug>"
+
+You marked done before committing. Commit your work, then re-run
+`pm task done`. Use `git log --oneline task/<slug>` to verify the branch
+has your changes.
+
+## What NOT to do
+
+- **Do not edit other projects.** Stay in your worktree. If you need a change
+  to a sibling project, leave a context note and file a new task.
+- **Do not approve your own work.** `pm task approve` is for the reviewer.
+  Workers produce, reviewers judge.
+- **Do not run `pm task done` without artifacts.** The hard gate will block
+  it, and even if you bypass with `--skip-gates` (don't), the reviewer cannot
+  see what you built.
+- **Do not commit to `main`.** Your worktree is on `task/<slug>`. All commits
+  belong there. If you accidentally committed to `main`, `git reset` carefully
+  or ask for help.
+- **Do not skip tests.** If the project has a test suite, run it. Record
+  pass/fail in your work-output `summary`.
+- **Do not decompose the task further.** If it's too big, say so in a context
+  note and let the PM split it.
+- **Do not delete the worktree yourself.** Teardown happens automatically on
+  approval or cancel. Manual deletion will confuse the session manager.
+
+## How to ask for help
+
+- Leave a context note on the task:
+  `pm task context shortlink_gen/1 --text "Blocked on X because Y."`
+- The PM watches the queue and will respond.
+- If truly stuck and no PM is online, **mark done with a clear summary** of
+  what you got to and what's left. The reviewer can reject with guidance, or
+  the PM can re-scope.
+
+## Quick reference card
+
+```
+pm task next                             # find work
+pm task get <id>                         # read the spec
+pm task claim <id>                       # take it
+# ... code, test, commit ...
+pm task done <id> --output '{            # hand to review
+  "type": "code_change",
+  "summary": "...",
+  "artifacts": [{"kind":"commit","description":"impl","ref":"HEAD"}]
+}'
+
+pm task context <id> --text "..."        # leave a breadcrumb
+pm status                                # check cockpit/core health
+pm task list --status <status>           # browse
+pm help worker                           # re-read this guide
+```
+
+That's it. One task, one worktree, one branch, one set of artifacts, one
+handoff. Ship.

--- a/src/pollypm/memory_prompts.py
+++ b/src/pollypm/memory_prompts.py
@@ -313,15 +313,23 @@ def _locate_worker_guide() -> Path | None:
 
     We walk up from this file's directory looking for a sibling
     ``docs/worker-guide.md``. In an editable install this resolves to
-    the repo's real doc; in a packaged install where the doc isn't
-    shipped, the search returns ``None`` and the caller falls through
-    to an empty injection (so session startup isn't blocked).
+    the repo's real doc; in a packaged install we fall back to the
+    bundled copy under ``pollypm/defaults/docs/worker-guide.md`` so
+    workers running in a fresh worktree (no ``docs/`` checked out)
+    still get the playbook.
     """
     here = Path(__file__).resolve()
     for parent in here.parents:
         candidate = parent / _WORKER_GUIDE_RELATIVE
         if candidate.is_file():
             return candidate
+    # Packaged fallback: the doc is shipped under the pollypm package
+    # tree. This makes ``pm`` self-sufficient in any worktree (the
+    # savethenovel fix — workers no longer fail to read a missing
+    # docs/worker-guide.md).
+    packaged = Path(__file__).resolve().parent / "defaults" / "docs" / "worker-guide.md"
+    if packaged.is_file():
+        return packaged
     return None
 
 
@@ -362,10 +370,26 @@ def build_worker_protocol_injection(
         return ""
     guide_ref = guide_reference or "docs/worker-guide.md"
     # Keep the kickoff compact: the full playbook lives in docs/worker-guide.md.
+    #
+    # Workers spawn in a git worktree where ``docs/`` is rarely checked
+    # out. The previous kickoff told the worker to "Read
+    # docs/worker-guide.md" and the file wasn't there — savethenovel
+    # spent 37s thrashing on the missing path. The kickoff now tells the
+    # worker to run ``pm help worker`` (which prints the guide from a
+    # packaged resource) when the reference is the default repo path.
+    if guide_ref == "docs/worker-guide.md":
+        return (
+            f"{WORKER_PROTOCOL_HEADING}\n\n"
+            "Run `pm help worker` for the worker playbook, including "
+            "how to claim work, ship it, and recover. (`pm help worker` "
+            "prints the guide from PollyPM's packaged resources, so it "
+            "works in any worktree.)"
+        )
     return (
         f"{WORKER_PROTOCOL_HEADING}\n\n"
         f"Read `{guide_ref}` for the worker playbook, including how to "
-        "claim work, ship it, and recover."
+        "claim work, ship it, and recover. If that file is missing, "
+        "run `pm help worker` for the built-in guide."
     )
 
 

--- a/src/pollypm/project_guides.py
+++ b/src/pollypm/project_guides.py
@@ -206,7 +206,21 @@ def built_in_guide_source_path(role: str) -> Path | None:
     if normalized == "reviewer":
         return Path(__file__).resolve().parent / "plugins_builtin" / "core_agent_profiles" / "profiles.py"
     if normalized == "worker":
-        return _locate_repo_file("docs/worker-guide.md")
+        # Prefer the repo copy (editable install / in-tree dev) so
+        # forks of the doc surface during dev cycles. In a packaged
+        # install the repo copy isn't present — fall back to the
+        # bundled copy under ``pollypm/defaults/docs/worker-guide.md``
+        # so workers in any worktree get a real guide path.
+        repo_copy = _locate_repo_file("docs/worker-guide.md")
+        if repo_copy is not None:
+            return repo_copy
+        packaged = (
+            Path(__file__).resolve().parent
+            / "defaults"
+            / "docs"
+            / "worker-guide.md"
+        )
+        return packaged if packaged.is_file() else None
     raise ValueError(f"Unsupported role '{role}'.")
 
 

--- a/src/pollypm/work/session_manager.py
+++ b/src/pollypm/work/session_manager.py
@@ -1208,14 +1208,32 @@ class SessionManager:
 
         guide_reference = worker_guide_reference(self._project_path)
 
+        # When there's no project-local guide, point the worker at the
+        # `pm help worker` meta-command — it prints the playbook from a
+        # packaged resource and works in any worktree, even one without
+        # docs/ on disk (savethenovel fix). When a project has its own
+        # forked guide, name that file directly so the worker reads
+        # the local override.
+        if guide_reference == "docs/worker-guide.md":
+            guide_instruction = (
+                "Run `pm help worker` first for the worker playbook. "
+                "(`pm help worker` prints the guide from PollyPM's "
+                "packaged resources, so it works in any worktree.)"
+            )
+        else:
+            guide_instruction = (
+                f"Read `{guide_reference}` first for the worker playbook "
+                f"(project-local override). If that file is missing, run "
+                f"`pm help worker` for the built-in guide."
+            )
+
         return (
             f"You are a PollyPM task worker. You have one job: complete the task below.\n\n"
             f"You are working in a git worktree at: {worktree_path}\n"
             f"This is an isolated branch — your changes won't affect other workers.\n\n"
             f"{task_info}"
             f"## Worker Guide\n\n"
-            f"Read `{guide_reference}` first for the worker playbook. Use the "
-            f"project-local guide when present; otherwise use the built-in one.\n\n"
+            f"{guide_instruction}\n\n"
             f"## How to Work\n\n"
             f"1. Read the task description carefully\n"
             f"2. Implement the work: read code, write code, run tests, commit\n"

--- a/tests/test_packaged_worker_guide.py
+++ b/tests/test_packaged_worker_guide.py
@@ -1,0 +1,142 @@
+"""Tests for the packaged worker-guide resource (savethenovel fix).
+
+The worker-guide.md doc is the worker playbook. Workers spawn in a
+git worktree where ``docs/`` is rarely checked out, so the kickoff
+prompt cannot point at ``docs/worker-guide.md`` by path — the file
+isn't there and workers thrash on a missing path (savethenovel: 37s
+of recovery loop).
+
+Fix: ship a bundled copy under ``src/pollypm/defaults/docs/worker-
+guide.md`` and update the kickoff to call ``pm help worker``, which
+prints the bundled copy via ``importlib.resources``. This module
+pins the invariants:
+
+1. The bundled file exists in the source tree.
+2. The bundled file matches the canonical ``docs/worker-guide.md``
+   (no drift). If they ever diverge we've created two sources of
+   truth — one of them needs to win.
+3. The bundled file is declared in pyproject's ``package-data`` so
+   the wheel actually carries it.
+4. ``pm help worker`` reads from the bundled resource even when the
+   repo's ``docs/`` directory is hidden (simulates a worktree without
+   ``docs/`` checked out).
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm.cli import app
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CANONICAL_GUIDE = REPO_ROOT / "docs" / "worker-guide.md"
+PACKAGED_GUIDE = (
+    REPO_ROOT / "src" / "pollypm" / "defaults" / "docs" / "worker-guide.md"
+)
+
+
+def test_packaged_worker_guide_exists_in_source_tree() -> None:
+    assert PACKAGED_GUIDE.is_file(), (
+        f"Expected packaged worker guide at {PACKAGED_GUIDE} — this file "
+        "is what `pm help worker` falls back to in worktrees without "
+        "docs/ checked out. If you removed it, restore it (copy from "
+        "docs/worker-guide.md)."
+    )
+
+
+def test_packaged_worker_guide_matches_canonical() -> None:
+    """The packaged copy must be byte-identical to the repo doc.
+    Drift here means workers in worktrees see different content from
+    workers in the source tree — exactly the failure mode this fix
+    closes. If you updated docs/worker-guide.md, refresh the bundle:
+
+        cp docs/worker-guide.md src/pollypm/defaults/docs/worker-guide.md
+    """
+    if not CANONICAL_GUIDE.is_file():
+        pytest.skip("canonical docs/worker-guide.md not in this checkout")
+    canonical = CANONICAL_GUIDE.read_text(encoding="utf-8")
+    packaged = PACKAGED_GUIDE.read_text(encoding="utf-8")
+    assert canonical == packaged, (
+        "docs/worker-guide.md and src/pollypm/defaults/docs/worker-"
+        "guide.md have diverged. Refresh the packaged copy: "
+        "`cp docs/worker-guide.md src/pollypm/defaults/docs/worker-"
+        "guide.md` and commit."
+    )
+
+
+def test_pyproject_declares_packaged_worker_guide() -> None:
+    """The bundled copy must be in setuptools' package-data glob.
+    Without this, ``uv tool install --reinstall .`` produces a wheel
+    that doesn't ship the file and ``pm help worker`` falls back to
+    the on-disk path — which isn't there in a fresh worktree."""
+    pyproject = REPO_ROOT / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8")
+    # Either an explicit entry or a glob that covers it.
+    assert (
+        '"defaults/docs/*.md"' in text
+        or '"defaults/docs/worker-guide.md"' in text
+    ), (
+        "pyproject.toml must declare 'defaults/docs/*.md' (or the "
+        "explicit path) under [tool.setuptools.package-data] so the "
+        "bundled worker guide is shipped in the wheel."
+    )
+
+
+def test_pm_help_worker_reads_packaged_resource_when_repo_docs_hidden(
+    tmp_path: Path,
+) -> None:
+    """Simulate a worktree without ``docs/`` checked out: hide the repo
+    doc by chdir-ing into a temp dir and confirm ``pm help worker``
+    still prints the playbook. The CLI walks up from the package
+    location, so the test stages a real package install layout in
+    ``tmp_path`` with only the packaged copy present.
+
+    This is the savethenovel regression test: without the bundled
+    copy, this command would emit "Could not locate
+    docs/worker-guide.md on disk" and exit 1.
+    """
+    # Stage a fake install root under tmp_path containing ONLY the
+    # packaged resource — no docs/ at the top.
+    install_root = tmp_path / "fake-install"
+    pkg_root = install_root / "site-packages" / "pollypm"
+    (pkg_root / "defaults" / "docs").mkdir(parents=True)
+    shutil.copy2(
+        PACKAGED_GUIDE,
+        pkg_root / "defaults" / "docs" / "worker-guide.md",
+    )
+    # Sanity: no docs/ at the install root level.
+    assert not (install_root / "docs").exists()
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["help", "worker"])
+    assert result.exit_code == 0, result.output
+    # Signature strings from docs/worker-guide.md.
+    assert "Worker Guide" in result.output
+    assert "pm task done" in result.output
+
+
+def test_built_in_guide_source_path_falls_back_to_packaged_copy(
+    monkeypatch,
+) -> None:
+    """``built_in_guide_source_path('worker')`` must return a real
+    file even when the repo copy isn't on disk. The function feeds
+    other surfaces (``pm upgrade`` notice, project-guide drift, etc.)
+    so a ``None`` return there breaks downstream callers."""
+    from pollypm import project_guides
+
+    # Force the repo-walk to fail.
+    monkeypatch.setattr(
+        project_guides, "_locate_repo_file", lambda _rel: None
+    )
+
+    resolved = project_guides.built_in_guide_source_path("worker")
+    assert resolved is not None
+    assert resolved.is_file()
+    # Should be the packaged copy, not the repo copy.
+    assert resolved.name == "worker-guide.md"
+    assert "defaults/docs" in str(resolved).replace("\\", "/")

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -293,7 +293,13 @@ def test_build_task_prompt_points_at_builtin_worker_guide(manager, tmp_project) 
     )
 
     assert "## Worker Guide" in prompt
-    assert "docs/worker-guide.md" in prompt
+    # The default kickoff routes through `pm help worker` (which prints
+    # the playbook from a packaged resource) instead of pointing at
+    # docs/worker-guide.md by path. Workers spawn in worktrees where
+    # docs/ is rarely checked out — the savethenovel forensic showed
+    # this contributed to a 37s thrash on the missing path.
+    assert "pm help worker" in prompt
+    assert "docs/worker-guide.md" not in prompt
 
 
 def test_build_task_prompt_prefers_project_local_worker_guide(manager, tmp_project) -> None:
@@ -308,6 +314,9 @@ def test_build_task_prompt_prefers_project_local_worker_guide(manager, tmp_proje
 
     assert str(guide_path.resolve()) in prompt
     assert "docs/worker-guide.md" not in prompt
+    # Project-local override path still names `pm help worker` as the
+    # built-in fallback in case the local file is missing.
+    assert "pm help worker" in prompt
 
 
 def _decode_local_runtime_payload(command: str) -> dict[str, object]:

--- a/tests/test_worker_protocol_injection.py
+++ b/tests/test_worker_protocol_injection.py
@@ -60,7 +60,10 @@ def test_injection_empty_for_non_worker_roles():
 def test_injection_non_empty_for_worker_role():
     out = build_worker_protocol_injection(session_role="worker")
     assert out.startswith(WORKER_PROTOCOL_HEADING)
-    assert "docs/worker-guide.md" in out
+    # Default kickoff routes through `pm help worker` — savethenovel
+    # showed that pointing workers at docs/worker-guide.md by path
+    # fails in any worktree where docs/ isn't checked out.
+    assert "pm help worker" in out
     assert "claim work" in out
     assert "ship it" in out
     assert "recover" in out
@@ -75,7 +78,9 @@ def test_injection_accepts_explicit_guide_text_for_isolation():
         guide_text=payload,
     )
     assert out.startswith(WORKER_PROTOCOL_HEADING + "\n")
-    assert "docs/worker-guide.md" in out
+    # Default reference now routes through the packaged-resource
+    # printer (`pm help worker`), not the docs/ path.
+    assert "pm help worker" in out
     assert "Body goes here." not in out
 
 
@@ -89,14 +94,15 @@ def test_injection_uses_explicit_guide_reference_when_provided():
 
 
 def test_injection_uses_pointer_when_guide_missing():
-    """Blank guide text no longer inlines the guide; it still points
-    workers at docs/worker-guide.md."""
+    """Blank guide text no longer inlines the guide; it points workers
+    at ``pm help worker`` (which prints the packaged guide) so a worker
+    in a worktree without docs/ on disk can still recover."""
     out = build_worker_protocol_injection(
         session_role="worker",
         guide_text="",
     )
     assert out.startswith(WORKER_PROTOCOL_HEADING)
-    assert "docs/worker-guide.md" in out
+    assert "pm help worker" in out
     assert "Body goes here." not in out
 
 
@@ -219,7 +225,9 @@ def test_tmux_service_injects_worker_protocol_for_worker(tmux_service):
         user_id="operator",
     )
     assert WORKER_PROTOCOL_HEADING in out
-    assert "docs/worker-guide.md" in out
+    # Default kickoff points at `pm help worker` so it works in any
+    # worktree (savethenovel fix).
+    assert "pm help worker" in out
     assert persona in out
     # Protocol appears above the persona.
     assert out.index(WORKER_PROTOCOL_HEADING) < out.index(persona)
@@ -259,8 +267,10 @@ def test_tmux_service_skips_worker_protocol_for_other_roles(tmux_service, role):
 
 
 def test_tmux_service_injects_worker_protocol_even_without_guide_text(tmux_service, monkeypatch):
-    """The kickoff now points to docs/worker-guide.md directly, so a
-    missing on-disk guide_text hook must not suppress the pointer."""
+    """A missing on-disk guide must not suppress the kickoff pointer.
+    The pointer now routes through `pm help worker` (packaged
+    resource), so workers in a fresh worktree without docs/ on disk
+    still get the playbook."""
     import pollypm.memory_prompts as mp
 
     monkeypatch.setattr(mp, "load_worker_guide_text", lambda: "")
@@ -274,5 +284,5 @@ def test_tmux_service_injects_worker_protocol_even_without_guide_text(tmux_servi
         user_id="operator",
     )
     assert WORKER_PROTOCOL_HEADING in out
-    assert "docs/worker-guide.md" in out
+    assert "pm help worker" in out
     assert persona in out


### PR DESCRIPTION
## Context (savethenovel forensic)

The forensic agent for the savethenovel worker thrashing incident found:

> The task-prompt template at `.pollypm-task-prompt.md` told the worker to "Read `docs/worker-guide.md` for the worker playbook" — but that file **does not exist in the worktree** (only in the PollyPM source repo). `pm help worker` even says: "Could not locate docs/worker-guide.md on disk."

So workers spawn, try to read the playbook, fail, and have no graceful recovery. 37 seconds of thrashing.

## Fix (Option C+: package the guide, route through `pm help worker`)

1. **Bundle the guide as package data.** Copy `docs/worker-guide.md` to `src/pollypm/defaults/docs/worker-guide.md` and add `defaults/docs/*.md` to `[tool.setuptools.package-data]`. The wheel now ships the playbook so any worktree (with or without `docs/` checked out) can find it via `importlib.resources`.
2. **Sync test.** `tests/test_packaged_worker_guide.py` asserts the bundled copy is byte-identical to the canonical doc, the file is shipped in `package-data`, and `pm help worker` reads it without `docs/` on disk. Future updates to `docs/worker-guide.md` must be mirrored to the bundled copy or this test fails (no silent drift).
3. **Loaders fall back to the bundled copy.**
   - `pollypm.cli.role_help` (`pm help worker`) prefers the bundled resource via `importlib.resources.files("pollypm")`, then walks up to the repo doc, then errors with a "reinstall" hint.
   - `pollypm.memory_prompts._locate_worker_guide` falls back to the bundled copy when the repo walk misses.
   - `pollypm.project_guides.built_in_guide_source_path("worker")` falls back too — feeds upgrade-notice and project-guide-drift surfaces.
4. **Prompt-template change.** The kickoff for default workers now reads:

   _Before_:
   > Read `docs/worker-guide.md` first for the worker playbook.

   _After_:
   > Run `pm help worker` first for the worker playbook. (`pm help worker` prints the guide from PollyPM's packaged resources, so it works in any worktree.)

   Project-local forks (`.pollypm/project-guides/worker.md`) still win when present and now mention `pm help worker` as the built-in fallback.

## Verification

- Built a fresh wheel (`uv build --wheel`); confirmed `pollypm/defaults/docs/worker-guide.md` is in the zip listing.
- Installed the wheel into a clean tmp env (no `docs/` on disk) and ran `pm help worker` — it prints the full playbook (exit 0).
- 5 new tests + 4 updated tests in the existing worker-protocol/session-manager suites all pass.
- Broader sweep: `pytest -k "worker or help or prompt or guide"` → 599 passed, 1 unrelated flake (`test_job_workers.py::test_pool_drains_when_db_connection_closed_under_workers` — passes in isolation, doesn't touch any of the changed modules).

## Reproducibility

`uv tool install --reinstall .` from `main` will pick up the bundled resource: setuptools' `package-data` glob captures `defaults/docs/*.md`, and `pm help worker` reads it via `importlib.resources` (no filesystem-relative-path coupling).

## Files changed

- `pyproject.toml` (one-line glob addition)
- `src/pollypm/defaults/docs/worker-guide.md` (new — bundled copy)
- `src/pollypm/cli.py` (`pm help worker` falls back to packaged resource)
- `src/pollypm/memory_prompts.py` (`_locate_worker_guide` fallback + kickoff text)
- `src/pollypm/project_guides.py` (`built_in_guide_source_path` fallback)
- `src/pollypm/work/session_manager.py` (`_build_task_prompt` text)
- `tests/test_packaged_worker_guide.py` (new — 5 invariants)
- `tests/test_worker_protocol_injection.py` (4 assertion updates)
- `tests/test_session_manager.py` (2 assertion updates)

Hard constraint: `docs/worker-guide.md` content is unchanged.

## Test plan

- [x] `pm help worker` prints the guide in a fresh worktree without `docs/`
- [x] Existing prompt-template references updated (no remaining `docs/worker-guide.md` literal in default kickoff)
- [x] Wheel zip contains `pollypm/defaults/docs/worker-guide.md`
- [x] Sync test enforces byte-identical packaged + canonical copies

Generated with [Claude Code](https://claude.com/claude-code)