### PR TITLE
Validate --role agent values against legal registry

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/proposals.py
+++ b/src/pollypm/plugins_builtin/project_planning/proposals.py
@@ -255,13 +255,19 @@ def accept_proposal(
     title = (spec.get("title") or "").strip() or "Proposal follow-up"
     description = (spec.get("description") or "").strip()
     acceptance_criteria = spec.get("acceptance_criteria") or None
+    # The user-review flow has reviewer as ``actor_type: human``, so no
+    # ``reviewer=`` role assignment is needed. Previously this used the
+    # ``standard`` flow with ``reviewer=user`` — that's the savethenovel
+    # bug shape (``user`` is not an autonomous agent that can claim a
+    # role-typed review node). The user-review flow is the structurally
+    # correct way to express "worker implements, human reviews".
     task = service.create(
         title=title,
         description=description,
         type="task",
         project=project_key,
-        flow_template="standard",
-        roles={"worker": "worker", "reviewer": "user", "requester": "user"},
+        flow_template="user-review",
+        roles={"worker": "worker", "requester": "user"},
         priority="normal",
         created_by=actor,
         acceptance_criteria=acceptance_criteria,

--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -74,6 +74,9 @@ _INVALID_TASK_ID_RE = re.compile(r"Invalid task_id '([^']+)'\.")
 _REQUIRED_ROLE_RE = re.compile(
     r"Required role '([^']+)' not provided\. Flow '([^']+)' requires: \[(.*)\]"
 )
+_INVALID_AGENT_VALUE_RE = re.compile(
+    r"Invalid agent value\(s\) for role\(s\): (.+?)\. '([^']+)' is not an autonomous agent"
+)
 
 
 def _nearest_task_id(service: object | None, task_id: str) -> str | None:
@@ -145,7 +148,30 @@ def _render_work_service_error(exc: Exception, fn) -> str:
                     f"flow '{flow_name}' requires "
                     f"{', '.join(required_roles)}."
                 ),
-                fix=f"rerun with `{role_flags}`.",
+                fix=(
+                    f"rerun with `{role_flags}` where `<agent>` is one of: "
+                    f"architect, reviewer, worker, polly, russell, triage "
+                    f"(NOT `user` — that's a human, not an autonomous agent)."
+                ),
+            )
+        match = _INVALID_AGENT_VALUE_RE.search(message)
+        if match:
+            offending_pairs = match.group(1)
+            sample_value = match.group(2)
+            return format_cli_error(
+                "Invalid agent value for an autonomous role.",
+                why=(
+                    f"{offending_pairs}: '{sample_value}' is not an "
+                    f"autonomous agent identity. Workers and reviewers "
+                    f"are agents that claim and execute the node; the "
+                    f"human ('user' / 'human' / 'sam') cannot."
+                ),
+                fix=(
+                    "rerun with one of: architect, reviewer, worker, "
+                    "polly, russell, triage — or, for project planning, "
+                    "use `pm project plan <project>` instead of `pm task "
+                    "create`."
+                ),
             )
 
     return render_cli_error(message)

--- a/src/pollypm/work/role_validation.py
+++ b/src/pollypm/work/role_validation.py
@@ -1,0 +1,167 @@
+"""Role-assignment validation for ``pm task create`` (savethenovel forensic).
+
+The ``--role <role>=<agent>`` flag historically accepted any string as
+``<agent>``. The savethenovel forensic exposed how badly this fails when
+an LLM (or human) types a non-agent value: Polly typed
+``--role worker=user --role reviewer=user`` while planning a project,
+and the work service happily stored ``roles={"worker":"user","reviewer":"user"}``.
+The resulting worker session then ran with ``Assignee: user`` for ~37
+seconds before Polly self-cancelled.
+
+The fix has two parts:
+
+1. **Reject non-agent values for autonomous-agent roles.** A role is
+   "autonomous-agent" when the flow declares a node with
+   ``actor_type=role`` referencing it — i.e., the role drives a node
+   that an autonomous agent must claim and execute. ``user`` (and
+   friends like ``human`` / ``sam`` / ``nobody``) cannot autonomously
+   claim work, so they are never legal values for those roles.
+
+2. **Allow ``user`` for metadata-only roles.** ``requester=user`` and
+   ``operator=user`` (when the flow doesn't actually drive an
+   ``actor_type=role`` node off ``operator``) remain legal — that's
+   the existing inbox-view convention for marking a task as
+   user-facing (see ``pollypm.work.inbox_view._roles_match_user``).
+
+Legal autonomous-agent identities are intentionally not enumerated as a
+closed set. The codebase already uses a wide range of conventions:
+agent-profile names (``polly``, ``russell``, ``worker``, ``triage``,
+``heartbeat``), role-contract canonical keys (``architect``,
+``reviewer``, ``operator_pm``), persona aliases (``archie``), opaque
+worker IDs in test fixtures (``agent-1``, ``agent-2``), and per-project
+worker handles (``worker-pollypm`` …). Whitelisting any one of these
+families would break every other family. Instead we **blacklist** the
+specific values that are demonstrably non-agent identities.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from pollypm.work.models import ActorType, FlowTemplate
+from pollypm.work.service_support import ValidationError
+
+
+# Values that are not autonomous-agent identities. The first two
+# (``user`` / ``human``) are how the work service refers to "the
+# human" everywhere else (see ``inbox_view._roles_match_user`` and
+# ``approve_human_review``'s ``_HUMAN_ACTOR_NAMES``); they can never
+# claim a work or review node. The placeholder values catch the
+# common LLM/typo failure shape ("oh, it wants a value, I'll fill
+# something in") that produced the savethenovel incident.
+#
+# Personal names like "sam" are intentionally NOT in this set:
+# existing test fixtures use them as opaque worker IDs, and no
+# project should bake the operator's name into validation. The
+# canonical human-marker is "user".
+NON_AGENT_VALUES: frozenset[str] = frozenset(
+    {
+        "user",
+        "human",
+        "nobody",
+        "none",
+        "tbd",
+        "todo",
+        "fixme",
+        "?",
+    }
+)
+
+
+def autonomous_agent_roles(template: FlowTemplate) -> set[str]:
+    """Return roles that drive a *required* autonomous-agent execution node.
+
+    A role is autonomous-agent when at least one node in ``template``
+    has ``actor_type=ActorType.ROLE`` and ``actor_role`` equal to the
+    role name. We further restrict to roles the template marks as
+    *required* (non-optional) — optional roles are by definition
+    metadata or fallback hints (e.g. ``chat``'s ``operator`` is
+    optional and "defaults to Polly when omitted"), and historic
+    fixtures use them as feedback markers like ``operator=user`` even
+    though the node never actually fires. Tightening only the
+    required-role lane catches the savethenovel shape (``worker=user``
+    on the standard/bug/spike/user-review flows, all of which mark
+    ``worker`` and ``reviewer`` as required) without breaking those
+    fixtures.
+    """
+    roles: set[str] = set()
+    for node in template.nodes.values():
+        if node.actor_type != ActorType.ROLE:
+            continue
+        if not node.actor_role:
+            continue
+        role_def = template.roles.get(node.actor_role)
+        is_optional = isinstance(role_def, dict) and role_def.get(
+            "optional", False
+        )
+        if is_optional:
+            continue
+        roles.add(node.actor_role)
+    return roles
+
+
+def _legal_examples() -> str:
+    """Render a short, stable hint of legal agent values."""
+    # Pulled from ROLE_REGISTRY canonical keys + agent-profile names.
+    # Kept inline rather than imported so this module can validate
+    # before the heavier supervisor / plugin host imports run.
+    return "architect, reviewer, worker, polly, russell, triage"
+
+
+def validate_role_assignments(
+    template: FlowTemplate, roles: dict[str, str]
+) -> None:
+    """Reject obviously-wrong agent values on autonomous-agent roles.
+
+    Raises :class:`ValidationError` (a :class:`WorkServiceError` so the
+    CLI renderer in :mod:`pollypm.work.cli` can surface it without a
+    traceback). The error message lists the offending role/value, names
+    legal-value examples, and points at ``pm project plan`` for the
+    common case where the caller meant to draft a project plan rather
+    than to assign autonomous workers.
+
+    Idempotent and safe to call before any DB mutation: it does not
+    consult the connection or the audit log.
+    """
+    auto_roles = autonomous_agent_roles(template)
+    if not auto_roles:
+        return
+    bad: list[tuple[str, str]] = []
+    for role_name, value in roles.items():
+        if role_name not in auto_roles:
+            continue  # metadata-only role (e.g. ``requester=user``).
+        if value is None:
+            continue
+        normalized = str(value).strip().lower()
+        if normalized in NON_AGENT_VALUES:
+            bad.append((role_name, value))
+    if not bad:
+        return
+
+    # Build a single ValidationError that describes every offence.
+    # The CLI renderer matches on the message prefix to render with
+    # the standard ✗/Why/Fix layout.
+    pairs = ", ".join(f"{r}={v!r}" for r, v in bad)
+    legal = _legal_examples()
+    raise ValidationError(
+        f"Invalid agent value(s) for role(s): {pairs}. "
+        f"'{bad[0][1]}' is not an autonomous agent — workers and reviewers "
+        f"must be agent identities (examples: {legal}). "
+        f"Hint: for project planning, use `pm project plan <project>` "
+        f"instead of creating a worker task."
+    )
+
+
+def is_non_agent_value(value: str | None) -> bool:
+    """Convenience check used by tests and the CLI gate."""
+    if value is None:
+        return False
+    return str(value).strip().lower() in NON_AGENT_VALUES
+
+
+__all__: Iterable[str] = (
+    "NON_AGENT_VALUES",
+    "autonomous_agent_roles",
+    "validate_role_assignments",
+    "is_non_agent_value",
+)

--- a/src/pollypm/work/service_queries.py
+++ b/src/pollypm/work/service_queries.py
@@ -14,6 +14,7 @@ import json
 from typing import TYPE_CHECKING
 
 from pollypm.work.models import Priority, Task, TaskType, WorkStatus
+from pollypm.work.role_validation import validate_role_assignments
 from pollypm.work.service_support import TaskNotFoundError, ValidationError, _now, _parse_task_id
 
 if TYPE_CHECKING:
@@ -47,6 +48,14 @@ def create_task(
                 f"Flow '{template.name}' requires: "
                 f"{[r for r, d in template.roles.items() if not (isinstance(d, dict) and d.get('optional', False))]}"
             )
+
+    # savethenovel-forensic guard: reject ``user`` / ``human`` and similar
+    # non-agent values for roles that drive autonomous-agent nodes (e.g.
+    # ``worker=user`` or ``reviewer=user`` would otherwise produce a task
+    # whose worker session runs with ``Assignee: user``). Metadata-only
+    # roles like ``requester=user`` remain legal — that's the inbox-view
+    # convention for marking a task as user-facing.
+    validate_role_assignments(template, roles)
 
     try:
         task_type = TaskType(type)

--- a/tests/test_role_validation.py
+++ b/tests/test_role_validation.py
@@ -1,0 +1,173 @@
+"""Tests for ``pollypm.work.role_validation``.
+
+savethenovel forensic — Polly typed ``--role worker=user --role
+reviewer=user``. The validation module must reject those values
+without a closed whitelist, so opaque worker IDs (``agent-1``,
+``worker-pollypm``, …) keep working in existing fixtures.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pollypm.work.models import ActorType, FlowNode, FlowTemplate, NodeType
+from pollypm.work.role_validation import (
+    NON_AGENT_VALUES,
+    autonomous_agent_roles,
+    is_non_agent_value,
+    validate_role_assignments,
+)
+from pollypm.work.service_support import ValidationError
+
+
+def _standard_template() -> FlowTemplate:
+    """Mirror ``src/pollypm/work/flows/standard.yaml`` in code."""
+    return FlowTemplate(
+        name="standard",
+        description="test fixture",
+        roles={
+            "worker": {"description": "implements"},
+            "reviewer": {"description": "reviews"},
+            "requester": {"description": "asker", "optional": True},
+        },
+        nodes={
+            "implement": FlowNode(
+                name="implement",
+                type=NodeType.WORK,
+                actor_type=ActorType.ROLE,
+                actor_role="worker",
+                next_node_id="code_review",
+            ),
+            "code_review": FlowNode(
+                name="code_review",
+                type=NodeType.REVIEW,
+                actor_type=ActorType.ROLE,
+                actor_role="reviewer",
+                next_node_id="done",
+            ),
+            "done": FlowNode(name="done", type=NodeType.TERMINAL),
+        },
+        start_node="implement",
+    )
+
+
+class TestAutonomousAgentRoles:
+    def test_extracts_role_actor_roles_only(self):
+        roles = autonomous_agent_roles(_standard_template())
+        assert roles == {"worker", "reviewer"}
+
+    def test_ignores_metadata_roles(self):
+        # ``requester`` is declared in template.roles but no node uses it,
+        # so it isn't autonomous.
+        assert "requester" not in autonomous_agent_roles(_standard_template())
+
+    def test_ignores_optional_roles(self):
+        # The chat flow marks ``operator`` as optional ("defaults to
+        # Polly"). Existing fixtures use ``operator=user`` as a
+        # feedback-task marker even though that node never fires;
+        # validation must let those through.
+        chat = FlowTemplate(
+            name="chat",
+            description="",
+            roles={
+                "operator": {"optional": True},
+                "requester": {"optional": True},
+            },
+            nodes={
+                "user_message": FlowNode(
+                    name="user_message",
+                    type=NodeType.WORK,
+                    actor_type=ActorType.HUMAN,
+                ),
+                "agent_response": FlowNode(
+                    name="agent_response",
+                    type=NodeType.WORK,
+                    actor_type=ActorType.ROLE,
+                    actor_role="operator",
+                ),
+            },
+            start_node="user_message",
+        )
+        assert autonomous_agent_roles(chat) == set()
+
+
+class TestValidateRoleAssignments:
+    def test_user_on_worker_raises(self):
+        template = _standard_template()
+        with pytest.raises(ValidationError) as exc:
+            validate_role_assignments(
+                template, {"worker": "user", "reviewer": "russell"}
+            )
+        assert "worker='user'" in str(exc.value)
+        assert "not an autonomous agent" in str(exc.value)
+
+    def test_user_on_reviewer_raises(self):
+        with pytest.raises(ValidationError):
+            validate_role_assignments(
+                _standard_template(),
+                {"worker": "worker", "reviewer": "user"},
+            )
+
+    def test_user_on_requester_is_allowed(self):
+        # Metadata-only role — inbox-view relies on ``requester=user``
+        # for the user-facing membership signal.
+        validate_role_assignments(
+            _standard_template(),
+            {"worker": "worker", "reviewer": "russell", "requester": "user"},
+        )
+
+    def test_human_and_placeholder_values_are_rejected(self):
+        # Personal names like "sam" are NOT in the blocklist — existing
+        # fixtures use them as opaque worker IDs. Only canonical
+        # human-markers and obvious placeholders are rejected.
+        for bad in ("human", "nobody", "  USER  ", "tbd", "TODO", "?"):
+            with pytest.raises(ValidationError):
+                validate_role_assignments(
+                    _standard_template(),
+                    {"worker": bad, "reviewer": "russell"},
+                )
+
+    def test_opaque_agent_ids_pass(self):
+        # The existing fixture pattern across the test suite — must
+        # remain valid (this fix is a blacklist, not a whitelist).
+        for ok in ("agent-1", "worker-pollypm", "pa/worker_xyz", "polly"):
+            validate_role_assignments(
+                _standard_template(),
+                {"worker": ok, "reviewer": "russell"},
+            )
+
+    def test_collects_all_offences_in_one_error(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_role_assignments(
+                _standard_template(),
+                {"worker": "user", "reviewer": "user"},
+            )
+        msg = str(exc.value)
+        assert "worker='user'" in msg
+        assert "reviewer='user'" in msg
+
+    def test_empty_template_is_no_op(self):
+        empty = FlowTemplate(
+            name="empty", description="", roles={}, nodes={}, start_node=""
+        )
+        validate_role_assignments(empty, {"anything": "user"})
+
+
+class TestIsNonAgentValue:
+    def test_user_is_non_agent(self):
+        assert is_non_agent_value("user")
+        assert is_non_agent_value("USER")
+        assert is_non_agent_value("  user  ")
+
+    def test_known_agents_are_not_non_agent(self):
+        for name in ("polly", "russell", "architect", "agent-1"):
+            assert not is_non_agent_value(name), name
+
+    def test_none_is_not_non_agent(self):
+        assert not is_non_agent_value(None)
+
+
+def test_non_agent_values_constant_includes_savethenovel_culprit():
+    """Defensive: make sure ``user`` doesn't get accidentally removed."""
+    assert "user" in NON_AGENT_VALUES
+    assert "human" in NON_AGENT_VALUES

--- a/tests/test_work_cli.py
+++ b/tests/test_work_cli.py
@@ -651,7 +651,11 @@ class TestCliErrors:
         assert "Traceback" not in result.output
         assert "✗ Required task roles are missing." in result.output
         assert "Why: flow 'standard' requires worker, reviewer." in result.output
-        assert "Fix: rerun with `--role worker=<agent> --role reviewer=<agent>`." in result.output
+        # Tightened post-savethenovel: the fix-suggestion now spells out
+        # legal agent values and explicitly warns against ``user``.
+        assert "--role worker=<agent> --role reviewer=<agent>" in result.output
+        assert "architect, reviewer, worker, polly, russell, triage" in result.output
+        assert "NOT `user`" in result.output
 
     def test_cli_get_missing_task_includes_why_fix_and_suggestion(self, db_path):
         _create_task(db_path, title="Only task")
@@ -682,6 +686,89 @@ class TestCliErrors:
         assert "Why: `pm task update` only changes fields you pass as flags." in result.output
         assert "--title" in result.output
         assert "--relevant-files" in result.output
+
+
+class TestCliCreateRoleAgentValidation:
+    """savethenovel forensic — Polly typed ``--role worker=user --role
+    reviewer=user`` while planning a project, and the work service
+    happily stored ``roles={"worker":"user","reviewer":"user"}``. The
+    resulting worker session ran with ``Assignee: user`` for ~37
+    seconds before she self-cancelled. The validation gate must
+    reject ``user`` (and similar non-agent values) on roles that
+    drive autonomous-agent execution nodes.
+    """
+
+    def _create(self, db_path, roles, flow="standard"):
+        args = [
+            "create",
+            "Plan task",
+            "--project",
+            "proj",
+            "--flow",
+            flow,
+            "--db",
+            db_path,
+        ]
+        for r in roles:
+            args.extend(["--role", r])
+        return runner.invoke(task_app, args)
+
+    def test_worker_user_is_rejected_with_clear_error(self, db_path):
+        result = self._create(db_path, ["worker=user", "reviewer=user"])
+        assert result.exit_code == 1
+        assert "Traceback" not in result.output
+        assert "✗ Invalid agent value for an autonomous role." in result.output
+        assert "worker='user'" in result.output
+        assert "reviewer='user'" in result.output
+        # The error must list legal options so the next try works.
+        assert "architect" in result.output
+        assert "polly" in result.output
+        # And it must point at the project-plan escape hatch.
+        assert "pm project plan" in result.output
+
+    def test_human_and_placeholder_values_are_also_rejected(self, db_path):
+        # Personal names ("sam") are NOT rejected — existing fixtures use
+        # them as opaque worker IDs. Only canonical human-markers and
+        # obvious placeholders trip the gate.
+        for bad in ("human", "  USER  ", "nobody", "tbd", "?"):
+            result = self._create(db_path, [f"worker={bad}", "reviewer=russell"])
+            assert result.exit_code == 1, f"{bad!r} should be rejected: {result.output}"
+            assert "✗ Invalid agent value for an autonomous role." in result.output
+
+    def test_legitimate_agent_values_succeed(self, db_path):
+        # Canonical role-contract names.
+        result = self._create(
+            db_path, ["worker=architect", "reviewer=russell"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "Created proj/" in result.output
+
+    def test_agent_dash_id_pattern_still_succeeds(self, db_path):
+        # The existing test convention uses ``agent-1`` / ``agent-2`` — those
+        # opaque worker IDs must remain valid (the fix is a blacklist, not a
+        # whitelist).
+        result = self._create(
+            db_path, ["worker=agent-1", "reviewer=agent-2"]
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_requester_user_remains_legal(self, db_path):
+        # Metadata-only roles like ``requester`` are NOT autonomous — the
+        # inbox view explicitly relies on ``requester=user`` to mark a
+        # task as user-facing (pollypm.work.inbox_view._roles_match_user).
+        result = self._create(
+            db_path,
+            ["worker=worker", "reviewer=russell", "requester=user"],
+        )
+        assert result.exit_code == 0, result.output
+
+    def test_required_role_gate_still_fires_for_missing_role(self, db_path):
+        # When ``--role`` is omitted entirely we should still hit the
+        # "Required task roles are missing" gate, not the new
+        # invalid-agent gate.
+        result = self._create(db_path, [])
+        assert result.exit_code == 1
+        assert "✗ Required task roles are missing." in result.output
 
 
 class TestCliContext:


### PR DESCRIPTION
## Context: savethenovel forensic

A forensic agent traced Polly's mistake on the savethenovel project: she ran

```
pm task create "Plan savethenovel.org website build" --project savethenovel \
  --role worker=user --role reviewer=user
```

The required-role gate at `src/pollypm/work/cli.py:143-148` had rejected her first attempt with `"rerun with --role worker=<agent> --role reviewer=<agent>"` — and Polly literally typed `user` as both values. The gate accepted `user` as a valid agent string, so the resulting task had `roles={"worker":"user","reviewer":"user"}` and the worker session ran with `Assignee: user` for ~37 seconds before Polly self-cancelled.

The bug had two surfaces:

1. The required-role fix-suggestion was too permissive — it suggested `<agent>` as a placeholder without constraining what's legal.
2. There was no downstream validation that the value passed for `<agent>` could actually autonomously claim a node.

## What this PR does

### New module: `pollypm.work.role_validation`

- `NON_AGENT_VALUES` — the canonical "this is a human, not an agent" set: `{user, human, nobody, none, tbd, todo, fixme, ?}`. Personal names like `sam` are intentionally NOT in the set; existing fixtures use them as opaque worker IDs.
- `autonomous_agent_roles(template)` — returns roles that drive a *required* node with `actor_type=role`. Optional roles (e.g. `chat.operator`, which "defaults to Polly") are skipped because historic fixtures use them as feedback-task markers.
- `validate_role_assignments(template, roles)` — raises `ValidationError` when any autonomous role gets a value in `NON_AGENT_VALUES`. Aggregates all offences into one error.

Wired into `pollypm.work.service_queries.create_task` immediately after the existing required-role gate, so every `service.create()` caller (CLI, plugins, future programmatic users) is protected.

### CLI surface (`pollypm.work.cli`)

- Required-role fix-suggestion now spells out legal `<agent>` values (`architect, reviewer, worker, polly, russell, triage`) and explicitly warns `NOT user`.
- New `_INVALID_AGENT_VALUE_RE` renders the new `ValidationError` with the standard ✗/Why/Fix layout, naming the offending `role=value` pair, pointing at `pm project plan <project>` for the project-planning case Polly was actually trying to do.

### Fix one pre-existing instance of the same bug shape

`plugins_builtin/project_planning/proposals.accept_proposal` was creating a `standard`-flow task with `reviewer=user`. That's structurally the same broken state as the savethenovel bug. Switched it to the `user-review` flow (which has reviewer as `actor_type: human` and doesn't need a `reviewer=` role assignment at all). This avoids the new validation gate without weakening it, and is more honest about the workflow ("worker implements, human reviews").

## Hard constraints respected

- No flow YAMLs modified
- No assignee resolver modified
- No cockpit/tmux interactions, no `pm up` / `pm reset` / `uv tool install`

## Test plan

- [x] `tests/test_role_validation.py` — 13 unit tests for the validation module: `NON_AGENT_VALUES` coverage, autonomous-role extraction, optional-role skip, opaque agent-id passthrough, multi-offence aggregation.
- [x] `tests/test_work_cli.py::TestCliCreateRoleAgentValidation` — 6 CLI integration tests:
  - `worker=user` reproduces the savethenovel shape and is rejected with a clear error
  - `human`/`USER`/`nobody`/`tbd`/`?` are all rejected
  - `worker=architect, reviewer=russell` succeeds (canonical role-contract names)
  - `worker=agent-1, reviewer=agent-2` succeeds (existing opaque-ID fixture pattern)
  - `requester=user` remains legal (inbox-view convention for user-facing tasks)
  - The required-role gate still fires when `--role` is omitted entirely
- [x] Existing `test_cli_create_missing_roles_shows_fix_without_traceback` updated to assert the tightened fix-suggestion text
- [x] Broader sweep: 663+ adjacent tests passing across `test_work_*`, `test_inbox_*`, `test_chat_flow`, `test_human_review_queue`, `test_auto_claim_sweep`, `test_cockpit_inbox_ui`, `test_state_drift_reconciliation`, `test_task_assignment_*`, `test_blocked_chain_sweep`, `test_review_pending_alerts`, `test_audit_log`, `test_work_progress_sweep`, `test_work_task_tokens`, `test_missing_task_worker`, `test_work_service`, `test_work_approval`, `test_flow_progression`, `test_gates`, `test_plan_review_flow`, `test_project_planning_plugin`, `test_inbox_actions`, `test_error_messages`, `test_task_invariants`, `test_next_task_corrupt_roles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)