### PR TITLE
Reword stale TODOs that reference closed issues (fixes #1359)

### DIFF
--- a/src/pollypm/service_api/v1.py
+++ b/src/pollypm/service_api/v1.py
@@ -842,9 +842,10 @@ class PollyPMService:
             verification=verification,
         )
         store = StateStore(config.project.state_db)
-        # TODO(#342-followup): ``record_checkpoint`` still writes the
-        # ``checkpoints`` domain table through StateStore; port to a Core
-        # Table def when the checkpoint surface moves.
+        # Note: ``record_checkpoint`` still writes the ``checkpoints``
+        # domain table through StateStore. The original #342 cleanup
+        # (CLOSED) didn't migrate this surface; revisit if the
+        # checkpoint surface ever moves to a Core Table def.
         record_checkpoint(
             store,
             launch,

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -650,15 +650,15 @@ def maybe_record_first_shipped(
 class SQLiteWorkService:
     """SQLite-backed work service implementing the WorkService protocol."""
 
-    # TODO(savethenovel-followup): emit ``work_table.cleared`` from
-    # the codepath that recreates ``work_tasks`` from scratch (DB
-    # rebuild on first open against a missing/empty file, or any
+    # Note: the audit-log surface should emit ``work_table.cleared``
+    # from any codepath that recreates ``work_tasks`` from scratch
+    # (DB rebuild on first open against a missing/empty file, or any
     # admin reset path). Today the only ``DELETE FROM work_tasks``
     # is the per-row prune in :meth:`_prune_cancelled_critique_child`
     # which is already audited as ``task.deleted``. The wholesale
-    # wipe vector that prompted this audit log is suspected to be
-    # an external ``pm reset``-class operation; instrument that
-    # caller (and any future bulk-clear path) here.
+    # wipe vector is suspected to be an external ``pm reset``-class
+    # operation; instrument that caller (and any future bulk-clear
+    # path) when it surfaces. Tracked in #1359.
     def __init__(
         self,
         db_path: Path,

--- a/src/pollypm/work/task_assignment.py
+++ b/src/pollypm/work/task_assignment.py
@@ -185,11 +185,12 @@ def role_candidate_names(
     # #1057 — per-task worker windows fulfill ANY role for their
     # specific task. Compute the per-task candidate once and prepend
     # below so it takes precedence over role-specific candidates.
-    # TODO(#1057): the simpler "per-task worker fulfills any role"
-    # semantics ships now. If we later decide a per-task pane should
-    # only fulfill the role it was spawned to handle (e.g. because the
-    # window's persona was overwritten), narrow this check by reading
-    # the task's ``assignee`` and matching it against ``role``.
+    # Note: the simpler "per-task worker fulfills any role" semantics
+    # is the shipped behavior (#1057 CLOSED). If we ever decide a
+    # per-task pane should only fulfill the role it was spawned to
+    # handle (e.g. because the window's persona was overwritten),
+    # narrow this check by reading the task's ``assignee`` and matching
+    # it against ``role``.
     per_task_candidate: str | None = None
     if task_number is not None and project:
         per_task_candidate = f"task-{project}-{int(task_number)}"


### PR DESCRIPTION
## Summary
- Fixes #1359
- Three TODO comments reference issues that are already closed (#342, #1057) or use a working name with no anchor (savethenovel-followup). Each TODO is documenting a *deliberately-deferred design decision*, not actionable work.
- Rewrite each as a Note: comment so future readers don't chase phantom followups. Re-anchor the savethenovel comment to #1359 so the audit-log surface work stays discoverable.

## Test plan
- [ ] \`python -m py_compile\` on the three touched files (verified by AST parse during authoring).
- [ ] No behavioral change; comments only.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)