### PR TITLE
[security] Escape backslashes in macOS notification AppleScript

### DIFF
--- a/src/pollypm/notifications.py
+++ b/src/pollypm/notifications.py
@@ -22,11 +22,23 @@ def send_notification(title: str, body: str, *, method: str = "macos") -> bool:
     return False
 
 
+def _escape_applescript(raw: str) -> str:
+    """Escape a Python string for embedding in an AppleScript string literal.
+
+    Order matters: replace backslashes *before* double quotes, otherwise the
+    backslashes we introduce while escaping ``"`` would be doubled again.
+    Skipping the backslash escape (the pre-#1378 behaviour) lets a caller
+    smuggle in ``\\"``, which AppleScript parses as ``\\`` followed by a
+    string-terminating ``"`` — opening a path to arbitrary AppleScript /
+    ``do shell script`` execution.
+    """
+    return raw.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def _macos_notification(title: str, body: str) -> bool:
     """Send a macOS notification via osascript."""
-    # Escape for AppleScript
-    title_escaped = title.replace('"', '\\"')
-    body_escaped = body.replace('"', '\\"')
+    title_escaped = _escape_applescript(title)
+    body_escaped = _escape_applescript(body)
     script = f'display notification "{body_escaped}" with title "{title_escaped}"'
     try:
         subprocess.run(


### PR DESCRIPTION
## Summary
- Adds `_escape_applescript` to `pollypm.notifications` that escapes backslashes before double quotes (matching the helper already used in `error_notifications`).
- Routes `_macos_notification`'s `title` / `body` through it so attacker-controlled strings can no longer break out of the AppleScript string literal and run arbitrary osascript / shell.

Fixes #1378.

## Test plan
- [ ] Manual: `python -c "from pollypm.notifications import send_notification; send_notification('Test', '\"; do shell script \"echo PWNED > /tmp/pwn\"; \"\\\\\\\"')"` produces a notification with the literal payload visible (not a `/tmp/pwn` file).
- [ ] `pytest tests/ -k notification` (no existing test asserts the escape; consider adding one).