### PR TITLE
Fix #1372 #1374 close StateStore in load_runtime_services callers

### DIFF
--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -1165,12 +1165,20 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                     throttle_seconds=DEDUPE_WINDOW_SECONDS,
                 )
             finally:
-                closer = getattr(services.work_service, "close", None)
-                if callable(closer):
-                    try:
-                        closer()
-                    except Exception:  # noqa: BLE001
-                        pass
+                # #1372 — release every owned sqlite connection. The
+                # pre-fix version closed only ``services.work_service``
+                # and leaked the fresh ``StateStore`` opened by
+                # ``load_runtime_services`` on each resume_ping
+                # evaluation (regression of #1069 — the same pattern
+                # this plugin's handlers/notify.py and handlers/sweep.py
+                # already fixed via ``services.close()``).
+                try:
+                    services.close()
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "heartbeat resume_ping: services.close raised",
+                        exc_info=True,
+                    )
 
             # Raise a low-severity alert so the cockpit surfaces it.
             try:

--- a/src/pollypm/plugins_builtin/task_assignment_notify/resolver.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/resolver.py
@@ -414,15 +414,18 @@ def clear_alerts_for_cancelled_task(
         owns_work_service = True
         store = services.msg_store or services.state_store
     if store is None:
-        # Best-effort: nothing to do without a store. Still close any
-        # incidental work-service connection the resolver opened.
+        # Best-effort: nothing to do without a store. Still close every
+        # incidental connection the resolver opened. #1374 — pre-fix
+        # closed only services.work_service and leaked the fresh
+        # ``StateStore`` opened by ``load_runtime_services``.
         if owns_work_service and services is not None:
-            work_closer = getattr(services.work_service, "close", None)
-            if callable(work_closer):
-                try:
-                    work_closer()
-                except Exception:  # noqa: BLE001
-                    pass
+            try:
+                services.close()
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "task_assignment_notify clear_alerts: services.close raised",
+                    exc_info=True,
+                )
         return {
             "cleared_per_task": cleared_per_task,
             "cleared_project": cleared_project,
@@ -459,16 +462,19 @@ def clear_alerts_for_cancelled_task(
                     "task_assignment_notify: clear_alert(no_session) "
                     "failed for %s", candidate, exc_info=True,
                 )
-    # Close the work-service connection we incidentally opened via
+    # Close every connection we incidentally opened via
     # ``load_runtime_services`` — the cancel call site owns its own
-    # connection and we mustn't leak ours.
+    # connections and we mustn't leak ours. #1374 — pre-fix closed
+    # only services.work_service and leaked the fresh StateStore
+    # (regression of #1069's documented pattern).
     if owns_work_service and services is not None:
-        work_closer = getattr(services.work_service, "close", None)
-        if callable(work_closer):
-            try:
-                work_closer()
-            except Exception:  # noqa: BLE001
-                pass
+        try:
+            services.close()
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "task_assignment_notify clear_alerts: services.close raised",
+                exc_info=True,
+            )
     return {
         "cleared_per_task": cleared_per_task,
         "cleared_project": cleared_project,
@@ -521,13 +527,18 @@ def clear_no_session_alert_for_task(
                     "failed for %s", task_id, exc_info=True,
                 )
     finally:
+        # #1374 — close every owned sqlite connection. Pre-fix closed
+        # only services.work_service and leaked the fresh StateStore
+        # opened by load_runtime_services on every approve.
         if owns_work_service and services is not None:
-            work_closer = getattr(services.work_service, "close", None)
-            if callable(work_closer):
-                try:
-                    work_closer()
-                except Exception:  # noqa: BLE001
-                    pass
+            try:
+                services.close()
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "task_assignment_notify clear_no_session_alert: "
+                    "services.close raised",
+                    exc_info=True,
+                )
     return {"cleared_per_task": cleared_per_task}
 
 


### PR DESCRIPTION
## Summary
- Closes #1372: heartbeats/local.py:1145 (_apply_resume_ping) leaked StateStore.
- Closes #1374: task_assignment_notify/resolver.py:413, :508 leaked StateStore from clear_alerts_for_cancelled_task and clear_no_session_alert_for_task.
- Each site now calls services.close() instead of closing only services.work_service, mirroring the pattern PR #1069 already applied to handlers/notify.py and handlers/sweep.py inside the same plugin.

## Why this is safe
- Mechanical change, no new behavior — services.close() in runtime_services.py is idempotent and a strict superset of the prior work_service-only close.
- Same fix shape PR #1069 documented and shipped 4 days ago.

## Test plan
- [x] tests/test_task_assignment_notify.py + tests/test_task_assignment_notify_api_contract.py — 92 passed
- [x] tests/test_heartbeats_local_classify.py + tests/test_heartbeats_local_classify_snippet.py + tests/test_recovery_policy.py — 54 passed
- [ ] Live: watch lsof on rail_daemon process during a stuck-session resume_ping cycle and during approve/cancel — fd count should plateau instead of growing

🤖 Generated with [Claude Code](https://claude.com/claude-code)