### PR TITLE
Route account_usage_sampler tmux invocation through tmux module

### DIFF
--- a/src/pollypm/account_usage_sampler.py
+++ b/src/pollypm/account_usage_sampler.py
@@ -13,7 +13,6 @@ Contract:
 from __future__ import annotations
 
 import logging
-import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -186,21 +185,18 @@ def _kill_probe_session(name: str, *, tmux=None) -> None:
         except Exception:  # noqa: BLE001
             logger.debug(
                 "account_usage_sampler: wrapped tmux client failed to kill "
-                "probe session %r; falling back to direct subprocess",
+                "probe session %r; falling back to canonical TmuxClient",
                 name,
                 exc_info=True,
             )
+    # Fallback: route through the canonical tmux module seam so version /
+    # quoting / timeout quirks stay handled in one place (#1373). A fresh
+    # ``TmuxClient`` instance bypasses whatever wrapper failed above.
     try:
-        subprocess.run(
-            ["tmux", "kill-session", "-t", f"={name}"],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
+        create_tmux_client().kill_session(name)
     except Exception:  # noqa: BLE001
         logger.warning(
-            "account_usage_sampler: direct tmux kill-session failed for %r; "
+            "account_usage_sampler: tmux kill-session failed for %r; "
             "boot-time orphan sweep will catch this on next supervisor start",
             name,
             exc_info=True,
@@ -221,44 +217,31 @@ def sweep_orphan_usage_sessions() -> int:
     logging so a busted tmux server can't keep the supervisor from
     starting.
     """
+    # Route through the canonical tmux module seam (#1373). ``list_sessions``
+    # already swallows ``no server running``, timeouts, and missing-binary
+    # errors — returning ``[]`` in every "tmux unavailable" case.
+    tmux = create_tmux_client()
     try:
-        listing = subprocess.run(
-            ["tmux", "list-sessions", "-F", "#{session_name}"],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
+        names = tmux.list_sessions()
     except Exception:  # noqa: BLE001
         logger.debug(
             "account_usage_sampler.sweep: tmux list-sessions failed",
             exc_info=True,
         )
         return 0
-    if listing.returncode != 0:
-        # ``no server running`` exits non-zero; nothing to sweep.
-        return 0
     killed = 0
-    for raw in listing.stdout.splitlines():
-        name = raw.strip()
+    for name in names:
         if not name.startswith(USAGE_PROBE_SESSION_PREFIX):
             continue
         try:
-            result = subprocess.run(
-                ["tmux", "kill-session", "-t", f"={name}"],
-                check=False,
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
+            if tmux.kill_session(name):
+                killed += 1
         except Exception:  # noqa: BLE001
             logger.debug(
                 "account_usage_sampler.sweep: kill-session failed for %r",
                 name, exc_info=True,
             )
             continue
-        if result.returncode == 0:
-            killed += 1
     if killed:
         logger.info(
             "account_usage_sampler.sweep: reaped %d orphan pm-usage-* "

--- a/src/pollypm/tmux/client.py
+++ b/src/pollypm/tmux/client.py
@@ -390,14 +390,22 @@ class TmuxClient:
         if result.returncode != 0:
             logger.debug("kill-window %r returned %d (likely already gone)", target, result.returncode)
 
-    def kill_session(self, name: str) -> None:
-        """Kill a session. No-op if it doesn't exist."""
+    def kill_session(self, name: str) -> bool:
+        """Kill a session. No-op if it doesn't exist.
+
+        Returns ``True`` when a kill was issued and tmux acknowledged it,
+        ``False`` when the session was already gone or the kill failed.
+        Callers that only care about best-effort teardown can ignore the
+        return value.
+        """
         if not self.has_session(name):
             logger.debug("Session %r does not exist, skipping kill", name)
-            return
+            return False
         result = self.run("kill-session", "-t", self._exact_target(name), check=False)
         if result.returncode != 0:
             logger.debug("kill-session %r returned %d (likely already gone)", name, result.returncode)
+            return False
+        return True
 
     def kill_pane(self, target: str) -> None:
         self.run("kill-pane", "-t", self._exact_target(target))
@@ -434,6 +442,28 @@ class TmuxClient:
     def pipe_pane(self, target: str, log_path: Path) -> None:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         self.run("pipe-pane", "-o", "-t", self._exact_target(target), f"cat >> {shlex.quote(str(log_path))}")
+
+    def list_sessions(self) -> list[str]:
+        """Return the names of every tmux session, or ``[]`` when unavailable.
+
+        The "unavailable" cases are deliberately swallowed so callers like the
+        boot-time orphan sweeper (#1009) can stay best-effort:
+
+        * No tmux server running — ``tmux list-sessions`` exits non-zero.
+        * tmux server wedged — :meth:`run` returns a 124 timeout result.
+        * Subprocess raises (e.g. tmux binary missing) — caught and treated
+          as "no sessions".
+        """
+        try:
+            result = self.run(
+                "list-sessions", "-F", "#{session_name}", check=False,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("list_sessions: tmux list-sessions failed", exc_info=True)
+            return []
+        if result.returncode != 0:
+            return []
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
     def list_windows(self, name: str) -> list[TmuxWindow]:
         fmt = (

--- a/tests/test_account_usage_sampler.py
+++ b/tests/test_account_usage_sampler.py
@@ -259,7 +259,12 @@ def test_collect_account_usage_sample_kills_session_on_exception_path(
 def test_collect_account_usage_sample_falls_back_to_subprocess_when_kill_raises(
     monkeypatch, tmp_path: Path,
 ) -> None:
-    """If the wrapped tmux client errors during teardown, fall back to ``tmux kill-session``."""
+    """If the wrapped tmux client errors during teardown, fall back to the canonical ``TmuxClient``.
+
+    Per #1373, the fallback path now routes through ``pollypm.tmux.client``
+    rather than calling ``subprocess.run`` directly — but the on-the-wire
+    ``tmux kill-session -t =<probe-session>`` invocation is unchanged.
+    """
     from pollypm.provider_sdk import ProviderUsageSnapshot
 
     config_path, _ = _config(tmp_path)
@@ -285,10 +290,15 @@ def test_collect_account_usage_sample_falls_back_to_subprocess_when_kill_raises(
 
     def _fake_run(args, **kwargs):
         direct_calls.append(list(args))
+        # Pretend the session exists for the has-session probe so that
+        # the fallback proceeds to issue an actual kill-session call.
         return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
 
+    # The canonical ``TmuxClient.run`` shells out via
+    # ``pollypm.tmux.client.subprocess.run``; patch there so the fallback
+    # path is observable in this test without touching the live tmux binary.
     monkeypatch.setattr(
-        "pollypm.account_usage_sampler.subprocess.run", _fake_run,
+        "pollypm.tmux.client.subprocess.run", _fake_run,
     )
 
     collect_account_usage_sample(
@@ -296,10 +306,14 @@ def test_collect_account_usage_sample_falls_back_to_subprocess_when_kill_raises(
     )
 
     assert direct_calls, (
-        "wrapped client raised on kill — must fall through to direct "
-        "subprocess tmux kill-session"
+        "wrapped client raised on kill — must fall through to canonical "
+        "TmuxClient kill-session"
     )
-    cmd = direct_calls[0]
+    kill_calls = [
+        c for c in direct_calls if c[:2] == ["tmux", "kill-session"]
+    ]
+    assert kill_calls, "expected at least one tmux kill-session invocation"
+    cmd = kill_calls[0]
     assert cmd[:3] == ["tmux", "kill-session", "-t"]
     # Must use the ``=`` exact-target prefix so we don't accidentally kill
     # something whose name starts with our probe session name.
@@ -307,7 +321,11 @@ def test_collect_account_usage_sample_falls_back_to_subprocess_when_kill_raises(
 
 
 def test_sweep_orphan_usage_sessions_kills_only_pm_usage_prefix(monkeypatch) -> None:
-    """The boot-time sweep must target only ``pm-usage-*`` sessions."""
+    """The boot-time sweep must target only ``pm-usage-*`` sessions.
+
+    Patches the canonical tmux module seam (#1373) — sampler now routes
+    list-sessions / kill-session through ``pollypm.tmux.client``.
+    """
     listed = (
         "pm-usage-claude_primary-1\n"
         "pm-usage-codex_backup-2\n"
@@ -323,6 +341,10 @@ def test_sweep_orphan_usage_sessions_kills_only_pm_usage_prefix(monkeypatch) -> 
             return subprocess.CompletedProcess(
                 args=args, returncode=0, stdout=listed, stderr="",
             )
+        if args[:2] == ["tmux", "has-session"]:
+            return subprocess.CompletedProcess(
+                args=args, returncode=0, stdout="", stderr="",
+            )
         if args[:2] == ["tmux", "kill-session"]:
             return subprocess.CompletedProcess(
                 args=args, returncode=0, stdout="", stderr="",
@@ -330,7 +352,7 @@ def test_sweep_orphan_usage_sessions_kills_only_pm_usage_prefix(monkeypatch) -> 
         raise AssertionError(f"unexpected subprocess.run call: {args!r}")
 
     monkeypatch.setattr(
-        "pollypm.account_usage_sampler.subprocess.run", _fake_run,
+        "pollypm.tmux.client.subprocess.run", _fake_run,
     )
 
     killed = sweep_orphan_usage_sessions()
@@ -352,7 +374,7 @@ def test_sweep_orphan_usage_sessions_returns_zero_when_no_tmux_server(monkeypatc
         )
 
     monkeypatch.setattr(
-        "pollypm.account_usage_sampler.subprocess.run", _fake_run,
+        "pollypm.tmux.client.subprocess.run", _fake_run,
     )
 
     assert sweep_orphan_usage_sessions() == 0
@@ -364,7 +386,7 @@ def test_sweep_orphan_usage_sessions_swallows_subprocess_errors(monkeypatch) -> 
         raise OSError("tmux binary missing")
 
     monkeypatch.setattr(
-        "pollypm.account_usage_sampler.subprocess.run", _explode,
+        "pollypm.tmux.client.subprocess.run", _explode,
     )
 
     # Must not raise; sweep is best-effort.


### PR DESCRIPTION
## Summary

Closes #1373. `pollypm.account_usage_sampler` was calling `subprocess.run(["tmux", ...])` directly at three sites, bypassing `pollypm.tmux.client` — the seam meant to be the single place we handle tmux version skew, quoting, and server-wedge timeouts. Mechanical fix: route every tmux call through `TmuxClient`.

## Before

```python
# src/pollypm/account_usage_sampler.py
# (1) _kill_probe_session fallback
subprocess.run(["tmux", "kill-session", "-t", f"={name}"], ...)

# (2) sweep_orphan_usage_sessions — list
subprocess.run(["tmux", "list-sessions", "-F", "#{session_name}"], ...)

# (3) sweep_orphan_usage_sessions — kill
subprocess.run(["tmux", "kill-session", "-t", f"={name}"], ...)
```

## After

```python
# (1) fallback now uses a fresh canonical TmuxClient
create_tmux_client().kill_session(name)

# (2) + (3) sweep uses the wrapped client
tmux = create_tmux_client()
for name in tmux.list_sessions():
    if name.startswith(USAGE_PROBE_SESSION_PREFIX):
        if tmux.kill_session(name):
            killed += 1
```

## Module changes

- `TmuxClient.list_sessions()` — new method; returns session names, `[]` when no tmux server / wedged / missing binary. Swallows the same failure modes the sampler previously catch'd inline.
- `TmuxClient.kill_session()` — return type widened from `None` to `bool` so the orphan sweep can count successful reaps without re-shelling. Additive; existing callers ignore the return value.

## Test plan

- [x] `pytest tests/test_account_usage_sampler.py tests/test_tmux_client.py tests/test_tmux_hardening.py tests/test_onboarding_login_flow.py` — 51 passed
- [x] All three sampler tests that patched `pollypm.account_usage_sampler.subprocess.run` updated to patch `pollypm.tmux.client.subprocess.run`; on-the-wire `tmux …` invocations are unchanged
- [ ] Live cockpit smoke not exercised in this PR (constraint: do not touch live cockpit). Sampler external behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)