### PR TITLE
Add log rotation for ~/.pollypm/*.log files

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -1021,6 +1021,15 @@ def _spawn_rail_daemon(config_path: Path) -> None:
     pollypm_home = Path(DEFAULT_CONFIG_PATH).parent
     pollypm_home.mkdir(parents=True, exist_ok=True)
     log_path = pollypm_home / "rail_daemon.log"
+    # #1366: shell-piped logs can't use Python RotatingFileHandler
+    # (the FD lives in the spawned process), so cap the previous
+    # tail at restart instead. Best-effort — never blocks the spawn.
+    try:
+        from pollypm.log_rotation import bootstrap_truncate_if_too_big
+
+        bootstrap_truncate_if_too_big(log_path)
+    except Exception:  # noqa: BLE001
+        pass
     try:
         log_fh = open(log_path, "a", buffering=1)  # line-buffered
     except OSError as exc:
@@ -1081,6 +1090,16 @@ def _spawn_phantom_client(session_name: str) -> bool:
     pollypm_home = Path(DEFAULT_CONFIG_PATH).parent
     pollypm_home.mkdir(parents=True, exist_ok=True)
     log_path = pollypm_home / "phantom_client.log"
+    # #1366: phantom_client.log was the worst offender — observed at
+    # 275 MB on the reporter's machine. Cap the previous tail before
+    # the next spawn appends, so this file's worst-case is one
+    # phantom-client lifetime of growth instead of forever.
+    try:
+        from pollypm.log_rotation import bootstrap_truncate_if_too_big
+
+        bootstrap_truncate_if_too_big(log_path)
+    except Exception:  # noqa: BLE001
+        pass
     try:
         log_fh = open(log_path, "a", buffering=1)
     except OSError:

--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -528,20 +528,21 @@ def _install_cockpit_debug_log_handler(config_path: Path) -> None:
     launches in the same process won't stack handlers.
     """
     debug_log = config_path.parent / "cockpit_debug.log"
-    try:
-        debug_log.parent.mkdir(parents=True, exist_ok=True)
-    except OSError:
-        # If we can't create the dir, the open() below would fail too;
-        # logging is best-effort, never block cockpit boot on it.
-        return
     sentinel = "_pollypm_cockpit_debug_log"
     root = logging.getLogger()
     for existing in root.handlers:
         if getattr(existing, sentinel, False):
             return  # already installed in this process
+    # #1366: use a RotatingFileHandler so cockpit_debug.log doesn't
+    # balloon unbounded — previously it grew to 34 MB+ between
+    # rotations because nothing rotated ``~/.pollypm/`` files.
     try:
-        handler = logging.FileHandler(debug_log, mode="a", encoding="utf-8")
+        from pollypm.log_rotation import make_rotating_file_handler
+
+        handler = make_rotating_file_handler(debug_log)
     except OSError:
+        return
+    except Exception:  # noqa: BLE001
         return
     handler.setLevel(logging.INFO)
     handler.setFormatter(

--- a/src/pollypm/error_log.py
+++ b/src/pollypm/error_log.py
@@ -18,10 +18,12 @@ Design goals:
 - **Tracebacks included.** ``logger.exception(...)`` lands with
   the full traceback; plain ``logger.error("msg")`` lands with
   just the message. Both are useful; both are captured.
-- **No dependency on the scheduler/rail.** The handler is a plain
-  stdlib ``logging.FileHandler`` — safe to install before the
-  plugin host / rail / event bus exist. A boot-time crash still
-  gets logged.
+- **No dependency on the scheduler/rail.** The handler is a stdlib
+  :class:`~logging.handlers.RotatingFileHandler` (#1366) — safe to
+  install before the plugin host / rail / event bus exist. A
+  boot-time crash still gets logged, and the handler caps its own
+  growth at the configured ``[logging] rotate_size_mb`` so this
+  file no longer balloons to hundreds of MB.
 - **Idempotent.** Calling ``install`` twice (e.g. the cockpit
   initializing after ``pm up``) doesn't duplicate lines.
 
@@ -37,6 +39,7 @@ import os
 from pathlib import Path
 
 from pollypm.error_notifications import CriticalErrorNotificationHandler
+from pollypm.log_rotation import make_rotating_file_handler
 
 DEFAULT_LOG_FILENAME = "errors.log"
 DEFAULT_LEVEL = logging.WARNING
@@ -94,8 +97,7 @@ def install(
     if not any(getattr(h, "_pollypm_error_handler", False) for h in root.handlers):
         target = path or _log_path()
         try:
-            target.parent.mkdir(parents=True, exist_ok=True)
-            handler = logging.FileHandler(target, encoding="utf-8")
+            handler = make_rotating_file_handler(target)
         except Exception:  # noqa: BLE001
             # Can't write the log file — don't take the whole process
             # down over it. Callers still get stderr logging from their

--- a/src/pollypm/log_rotation.py
+++ b/src/pollypm/log_rotation.py
@@ -1,0 +1,255 @@
+"""Log rotation helpers for ``~/.pollypm/*.log`` files.
+
+Closes #1366. The hourly ``log.rotate`` recurring handler under
+``plugins_builtin/core_recurring/maintenance.py`` only walks the
+workspace ``logs_dir`` (i.e. ``.tmp-pm/logs``), which means every log
+file written under ``~/.pollypm/`` grows unbounded. On the reporter's
+machine ``phantom_client.log`` had reached 275 MB.
+
+This module covers the two writer styles that target ``~/.pollypm/``:
+
+* **Python logging-based writers** (``error_log.errors.log`` and
+  ``cli_features.ui.cockpit_debug.log``) get a Python
+  :class:`~logging.handlers.RotatingFileHandler` with a configurable
+  byte cap and backup count. Use :func:`make_rotating_file_handler` —
+  it mirrors the stdlib API but pulls defaults from
+  :class:`~pollypm.models.LoggingSettings` so the rotation thresholds
+  stay in sync with the existing ``log.rotate`` plugin.
+
+* **Shell-piped writers** (``rail_daemon.log``, ``phantom_client.log``
+  written via ``open(path, "a")`` then handed to ``Popen`` as
+  stdout/stderr) cannot pick up Python ``RotatingFileHandler`` rollover
+  — the file descriptor is held by the spawned process. For those we
+  call :func:`bootstrap_truncate_if_too_big` from the spawn path: if
+  the existing log already exceeds the cap, archive it once into a
+  ``.log.<ts>.gz`` sibling (best-effort) and start fresh. The newly
+  spawned process appends to a freshly empty file, so further growth
+  is bounded by however long the process lives between restarts. Daily
+  ``pm up`` cycles are enough to keep these from running away — the
+  phantom client gets respawned every cockpit boot, the rail daemon
+  every ``pm up``.
+
+Tests exercise both paths in ``tests/test_log_rotation.py``.
+"""
+
+from __future__ import annotations
+
+import gzip
+import logging
+import os
+import shutil
+import time
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Default cap per individual log file before rotation kicks in. 50 MB
+# keeps enough scrollback for incident debugging while staying well
+# below the runaway sizes from #1366. Operators who want tighter or
+# looser bounds set ``[logging] rotate_size_mb`` in the config (the
+# plugin handler reads the same field).
+DEFAULT_MAX_BYTES = 50 * 1024 * 1024
+
+# Default number of rolled backups to keep alongside the live file.
+# Five backups at 50 MB each = 300 MB ceiling per rotated log, which is
+# acceptable for a workstation tool. Operators who need less tune via
+# ``[logging] rotate_keep``.
+DEFAULT_BACKUP_COUNT = 5
+
+
+def _resolve_caps(
+    max_bytes: int | None,
+    backup_count: int | None,
+) -> tuple[int, int]:
+    """Resolve rotation caps from explicit args, config, or defaults.
+
+    Caller-supplied values win. Otherwise we lazy-import
+    :mod:`pollypm.config` and try to read the live ``[logging]``
+    section so the rotation thresholds stay aligned with the existing
+    ``log.rotate`` plugin handler. If config loading fails for any
+    reason we fall back to module defaults — log rotation is a hygiene
+    feature, not something to crash boot over.
+    """
+    if max_bytes is not None and backup_count is not None:
+        return max(1, int(max_bytes)), max(0, int(backup_count))
+    cfg_size_mb: int | None = None
+    cfg_keep: int | None = None
+    try:
+        from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+
+        config = load_config(Path(DEFAULT_CONFIG_PATH))
+    except Exception:  # noqa: BLE001
+        config = None
+    if config is not None:
+        try:
+            cfg_size_mb = int(config.logging.rotate_size_mb)
+            cfg_keep = int(config.logging.rotate_keep)
+        except Exception:  # noqa: BLE001
+            cfg_size_mb = None
+            cfg_keep = None
+    resolved_max = (
+        int(max_bytes) if max_bytes is not None
+        else (cfg_size_mb * 1024 * 1024 if cfg_size_mb else DEFAULT_MAX_BYTES)
+    )
+    resolved_keep = (
+        int(backup_count) if backup_count is not None
+        else (cfg_keep if cfg_keep is not None else DEFAULT_BACKUP_COUNT)
+    )
+    return max(1, resolved_max), max(0, resolved_keep)
+
+
+def make_rotating_file_handler(
+    path: Path,
+    *,
+    max_bytes: int | None = None,
+    backup_count: int | None = None,
+    encoding: str = "utf-8",
+    mode: str = "a",
+) -> RotatingFileHandler:
+    """Build a stdlib :class:`RotatingFileHandler` with PollyPM defaults.
+
+    ``max_bytes`` and ``backup_count`` default to the values from the
+    user's ``[logging]`` section (or the module constants if the
+    config can't be loaded). Pass explicit values to override per
+    call site (e.g. tests pinning a smaller threshold).
+
+    The handler's parent directory is created on demand so callers
+    don't have to mkdir. Returns the handler ready to attach with
+    ``logger.addHandler(...)``.
+    """
+    resolved_max, resolved_keep = _resolve_caps(max_bytes, backup_count)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handler = RotatingFileHandler(
+        path,
+        mode=mode,
+        maxBytes=resolved_max,
+        backupCount=resolved_keep,
+        encoding=encoding,
+    )
+    return handler
+
+
+def bootstrap_truncate_if_too_big(
+    path: Path,
+    *,
+    max_bytes: int | None = None,
+    backup_count: int | None = None,
+) -> bool:
+    """Archive + truncate ``path`` if it already exceeds the size cap.
+
+    Designed for shell-piped writers (``rail_daemon.log``,
+    ``phantom_client.log``) where the file descriptor lives in a
+    detached subprocess and Python's :class:`RotatingFileHandler`
+    can't see writes. Call this *before* the next spawn so the new
+    process starts at offset 0 in a fresh file.
+
+    Behaviour:
+
+    * If ``path`` doesn't exist or is under the cap, no-op (returns
+      ``False``).
+    * Otherwise rename to ``<path>.<ts>.gz`` (archived in place),
+      gzip the contents, drop the uncompressed rename, and prune
+      older ``<path>.<ts>.gz`` siblings beyond ``backup_count``.
+    * Returns ``True`` when a rotation actually happened. Errors are
+      swallowed and logged at DEBUG — log hygiene must never block
+      ``pm up``.
+
+    Note this is *not* per-write rotation; it caps the *previous*
+    process's tail at the next restart. Combined with the fact that
+    ``pm up`` / cockpit reboots happen frequently in normal use, that
+    bounds shell-piped logs to roughly one process-lifetime of
+    growth — far better than unbounded.
+    """
+    resolved_max, resolved_keep = _resolve_caps(max_bytes, backup_count)
+    try:
+        if not path.exists() or not path.is_file():
+            return False
+        size = path.stat().st_size
+    except OSError:
+        return False
+    if size <= resolved_max:
+        return False
+    ts = int(time.time())
+    archived = path.with_suffix(path.suffix + f".{ts}")
+    bump = 0
+    while archived.exists():
+        bump += 1
+        archived = path.with_suffix(path.suffix + f".{ts}.{bump}")
+    try:
+        os.rename(path, archived)
+    except OSError:
+        logger.debug(
+            "log_rotation: rename failed for %s", path, exc_info=True,
+        )
+        return False
+    gz_path = archived.with_suffix(archived.suffix + ".gz")
+    rotated = False
+    try:
+        with open(archived, "rb") as src, gzip.open(gz_path, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+        archived.unlink()
+        rotated = True
+    except OSError:
+        logger.debug(
+            "log_rotation: gzip failed for %s", archived, exc_info=True,
+        )
+        # Best-effort: leave the uncompressed rename in place rather
+        # than losing the data. Future runs will still keep logs
+        # bounded because the live file is now empty.
+    finally:
+        # Recreate an empty live file so the spawned process's append
+        # opens cleanly without depending on creation semantics.
+        try:
+            path.touch()
+        except OSError:
+            logger.debug(
+                "log_rotation: touch failed for %s", path, exc_info=True,
+            )
+    _prune_old_archives(path, resolved_keep)
+    return rotated
+
+
+def _prune_old_archives(path: Path, backup_count: int) -> None:
+    """Delete archived rotations beyond the retention count.
+
+    Matches files of the shape ``<path>.<ts>[.bump].gz``. Sorting is
+    by mtime (descending) so newest survives even if timestamp
+    parsing trips on a malformed name.
+    """
+    if backup_count < 0:
+        return
+    parent = path.parent
+    prefix = path.name + "."
+    candidates: list[tuple[float, Path]] = []
+    try:
+        for sibling in parent.iterdir():
+            if not sibling.is_file():
+                continue
+            if not sibling.name.startswith(prefix):
+                continue
+            if not sibling.name.endswith(".gz"):
+                continue
+            try:
+                mtime = sibling.stat().st_mtime
+            except OSError:
+                continue
+            candidates.append((mtime, sibling))
+    except OSError:
+        return
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    for _mtime, stale in candidates[backup_count:]:
+        try:
+            stale.unlink()
+        except OSError:
+            logger.debug(
+                "log_rotation: prune failed for %s", stale, exc_info=True,
+            )
+
+
+__all__ = [
+    "DEFAULT_MAX_BYTES",
+    "DEFAULT_BACKUP_COUNT",
+    "make_rotating_file_handler",
+    "bootstrap_truncate_if_too_big",
+]

--- a/tests/test_log_rotation.py
+++ b/tests/test_log_rotation.py
@@ -1,0 +1,257 @@
+"""Tests for ``pollypm.log_rotation`` — the ``~/.pollypm/`` log helpers.
+
+#1366: ``~/.pollypm/*.log`` files had no rotation, so phantom_client.log
+hit 275 MB. The helpers in :mod:`pollypm.log_rotation` cover both
+writer styles:
+
+* :func:`make_rotating_file_handler` — Python ``RotatingFileHandler``
+  for ``errors.log`` and ``cockpit_debug.log``.
+* :func:`bootstrap_truncate_if_too_big` — startup-time cleanup for
+  shell-piped writers (``rail_daemon.log``, ``phantom_client.log``)
+  whose FDs live in detached subprocesses.
+
+Both paths are exercised end-to-end below: handler-driven rollover
+producing ``.1`` / ``.2`` siblings, and bootstrap truncate archiving an
+oversized file into a ``.gz`` while leaving an empty live file.
+"""
+
+from __future__ import annotations
+
+import gzip
+import logging
+import time
+from pathlib import Path
+
+import pytest
+
+from pollypm.log_rotation import (
+    DEFAULT_BACKUP_COUNT,
+    DEFAULT_MAX_BYTES,
+    bootstrap_truncate_if_too_big,
+    make_rotating_file_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# make_rotating_file_handler — Python logging path
+# ---------------------------------------------------------------------------
+
+
+def test_handler_rotates_at_threshold(tmp_path: Path) -> None:
+    """RotatingFileHandler rolls over once the live file crosses ``maxBytes``."""
+    log_path = tmp_path / "errors.log"
+    handler = make_rotating_file_handler(
+        log_path,
+        max_bytes=200,
+        backup_count=3,
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger = logging.Logger("test_log_rotation_handler_rotates")
+    logger.addHandler(handler)
+    try:
+        # 50 lines of ~20 bytes each = ~1000 bytes total; with a
+        # 200-byte cap that's at least 4 rollovers.
+        for i in range(50):
+            logger.warning("entry-%03d-padding-bytes" % i)
+    finally:
+        handler.close()
+        logger.removeHandler(handler)
+
+    # The live file exists and is under the cap (rollover always
+    # truncates it back to empty before the next write).
+    assert log_path.exists()
+    assert log_path.stat().st_size <= 400  # most recent line(s) only
+    # Backups appear with .1, .2, .3 suffixes — never more than
+    # backup_count of them.
+    backups = sorted(tmp_path.glob("errors.log.*"))
+    assert backups, "expected at least one rolled backup"
+    assert len(backups) <= 3
+    backup_names = {b.name for b in backups}
+    assert "errors.log.1" in backup_names
+
+
+def test_handler_caps_backup_count(tmp_path: Path) -> None:
+    """Old backups beyond ``backup_count`` get deleted automatically."""
+    log_path = tmp_path / "noisy.log"
+    handler = make_rotating_file_handler(
+        log_path,
+        max_bytes=100,
+        backup_count=2,
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger = logging.Logger("test_log_rotation_caps_backups")
+    logger.addHandler(handler)
+    try:
+        for i in range(80):
+            logger.warning("line-%03d-padding" % i)
+    finally:
+        handler.close()
+        logger.removeHandler(handler)
+
+    backups = sorted(tmp_path.glob("noisy.log.*"))
+    # backup_count=2 means at most .1 and .2 are kept; .3 would have
+    # been rolled off.
+    assert len(backups) <= 2
+    for b in backups:
+        suffix = b.name.split(".")[-1]
+        assert suffix in {"1", "2"}, b.name
+
+
+def test_handler_creates_parent_dir(tmp_path: Path) -> None:
+    """Handler factory mkdirs the parent so callers don't have to."""
+    log_path = tmp_path / "nested" / "subdir" / "out.log"
+    handler = make_rotating_file_handler(log_path, max_bytes=1024, backup_count=1)
+    try:
+        handler.emit(
+            logging.LogRecord(
+                name="t", level=logging.INFO, pathname=__file__,
+                lineno=1, msg="hi", args=None, exc_info=None,
+            )
+        )
+        handler.flush()
+    finally:
+        handler.close()
+    assert log_path.exists()
+    assert "hi" in log_path.read_text()
+
+
+def test_handler_respects_explicit_caps(tmp_path: Path) -> None:
+    """Explicit args override config / module defaults."""
+    log_path = tmp_path / "explicit.log"
+    handler = make_rotating_file_handler(
+        log_path,
+        max_bytes=12345,
+        backup_count=7,
+    )
+    try:
+        assert handler.maxBytes == 12345
+        assert handler.backupCount == 7
+    finally:
+        handler.close()
+
+
+def test_handler_falls_back_to_module_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When config can't be loaded the module defaults apply."""
+    # Force the config import inside _resolve_caps to fail by pointing
+    # DEFAULT_CONFIG_PATH at a nonexistent location and stubbing
+    # load_config to raise.
+    import pollypm.log_rotation as mod
+
+    def _boom(_path: object) -> None:  # noqa: D401
+        raise RuntimeError("simulated config failure")
+
+    # Patch the lazy import inside _resolve_caps by intercepting
+    # pollypm.config.load_config.
+    import pollypm.config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "load_config", _boom)
+
+    log_path = tmp_path / "defaults.log"
+    handler = mod.make_rotating_file_handler(log_path)
+    try:
+        assert handler.maxBytes == DEFAULT_MAX_BYTES
+        assert handler.backupCount == DEFAULT_BACKUP_COUNT
+    finally:
+        handler.close()
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_truncate_if_too_big — shell-piped log path
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_truncate_skips_small_file(tmp_path: Path) -> None:
+    """A file under the cap is left alone."""
+    log_path = tmp_path / "rail_daemon.log"
+    log_path.write_bytes(b"small\n" * 10)
+    original_size = log_path.stat().st_size
+
+    rotated = bootstrap_truncate_if_too_big(
+        log_path, max_bytes=10_000, backup_count=3,
+    )
+    assert rotated is False
+    assert log_path.stat().st_size == original_size
+    assert not list(tmp_path.glob("rail_daemon.log.*"))
+
+
+def test_bootstrap_truncate_archives_oversized_file(tmp_path: Path) -> None:
+    """A file over the cap is gzipped aside and replaced with empty file."""
+    log_path = tmp_path / "phantom_client.log"
+    payload = b"X" * 4096
+    log_path.write_bytes(payload)
+
+    rotated = bootstrap_truncate_if_too_big(
+        log_path, max_bytes=1024, backup_count=3,
+    )
+    assert rotated is True
+    # Live file exists and is empty — the next ``open(path, "a")`` in
+    # the spawn path will land at offset 0.
+    assert log_path.exists()
+    assert log_path.stat().st_size == 0
+    # Exactly one .gz archive present, and it round-trips to the
+    # original bytes.
+    archives = sorted(tmp_path.glob("phantom_client.log.*.gz"))
+    assert len(archives) == 1
+    with gzip.open(archives[0], "rb") as fh:
+        assert fh.read() == payload
+    # No stray uncompressed rename was left behind.
+    leftovers = [
+        p for p in tmp_path.glob("phantom_client.log.*")
+        if not p.name.endswith(".gz")
+    ]
+    assert leftovers == []
+
+
+def test_bootstrap_truncate_prunes_old_archives(tmp_path: Path) -> None:
+    """Older ``.gz`` archives beyond ``backup_count`` are deleted."""
+    log_path = tmp_path / "rail_daemon.log"
+    # Seed three pre-existing archives at distinct mtimes (oldest first).
+    base_ts = int(time.time()) - 1000
+    seeded = []
+    for i in range(3):
+        archive = tmp_path / f"rail_daemon.log.{base_ts + i}.gz"
+        with gzip.open(archive, "wb") as fh:
+            fh.write(f"archived-{i}".encode())
+        # Force mtime to match the encoded ts so retention sees a
+        # stable order even on fast filesystems.
+        import os as _os
+
+        _os.utime(archive, (base_ts + i, base_ts + i))
+        seeded.append(archive)
+
+    # Now write an oversized live file and rotate with backup_count=2.
+    log_path.write_bytes(b"Y" * 4096)
+    rotated = bootstrap_truncate_if_too_big(
+        log_path, max_bytes=1024, backup_count=2,
+    )
+    assert rotated is True
+
+    surviving = sorted(tmp_path.glob("rail_daemon.log.*.gz"))
+    # New rotation + at most one of the previous three (backup_count=2
+    # total). The very oldest seeded file must have been pruned.
+    assert len(surviving) <= 2
+    assert seeded[0] not in surviving
+
+
+def test_bootstrap_truncate_missing_file(tmp_path: Path) -> None:
+    """No-op when the target file doesn't exist yet."""
+    log_path = tmp_path / "never_written.log"
+    rotated = bootstrap_truncate_if_too_big(
+        log_path, max_bytes=1024, backup_count=3,
+    )
+    assert rotated is False
+    assert not log_path.exists()
+
+
+def test_bootstrap_truncate_handles_directory_gracefully(tmp_path: Path) -> None:
+    """A directory at the path is rejected, not crashed on."""
+    not_a_file = tmp_path / "some_dir.log"
+    not_a_file.mkdir()
+    rotated = bootstrap_truncate_if_too_big(
+        not_a_file, max_bytes=1, backup_count=1,
+    )
+    assert rotated is False
+    # Directory is still there.
+    assert not_a_file.is_dir()


### PR DESCRIPTION
## Summary

Closes #1366. `phantom_client.log` was observed at 275 MB on the reporter's machine because every long-lived process opens its log under `~/.pollypm/` with plain `FileHandler` / `open(..., "a")`, and the existing `log.rotate` recurring handler only walks the workspace `logs_dir` (`.tmp-pm/logs/`). Files under `~/.pollypm/` were growing forever.

## What changed

New helper module `pollypm.log_rotation` with two entry points covering both writer styles in the codebase:

- **Python logging writers** (`errors.log`, `cockpit_debug.log`) now use `make_rotating_file_handler()` which builds a stdlib `RotatingFileHandler`. Caps come from `[logging] rotate_size_mb` / `rotate_keep` (the same fields the existing plugin handler reads). Defaults: 50 MB max, 5 backups.

- **Shell-piped writers** (`rail_daemon.log`, `phantom_client.log`) can't use `RotatingFileHandler` because the file descriptor lives in a detached subprocess. Instead, `bootstrap_truncate_if_too_big()` runs *before* each spawn — if the previous file is over the cap, archive + gzip it once, then leave an empty live file for the new process to append into. Worst-case growth becomes one process-lifetime instead of forever; combined with the cockpit's `pm up` cycle that bounds these in practice.

Call sites updated:
- `src/pollypm/error_log.py` — `errors.log` handler
- `src/pollypm/cli_features/ui.py` — `cockpit_debug.log` handler
- `src/pollypm/cli.py` — `_spawn_rail_daemon` and `_spawn_phantom_client`

## Test plan

- [x] New `tests/test_log_rotation.py` (10 tests): handler rotates at threshold, backup count enforced, parent dir auto-created, explicit caps win, fallback to module defaults when config unloadable; bootstrap archives oversized file + leaves empty live file, prunes old `.gz` archives, no-ops on small/missing/non-file targets.
- [x] Existing `tests/test_log_rotate.py` still passes (9 tests).
- [x] Existing `tests/test_pm_errors_summary.py`, `tests/test_error_notifications.py` pass — confirms `error_log.install` still wires up correctly.
- [x] Broader `-k "log or error"` suite: 306 passed.
- [x] Spawn-related tests (`-k "phantom or rail_daemon or cockpit_debug or spawn"`): 42 passed.
- [x] `ruff check` clean on new files.