### PR TITLE
Fix JobWorkerPool thread leak (cooperative cancellation)

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -49,6 +49,16 @@ EVENT_WORK_TABLE_CLEARED = "work_table.cleared"
 # breadcrumb — see comment in ``SQLiteWorkService.__init__`` for the
 # reasoning.
 EVENT_WORK_DB_OPENED = "work_db.opened"
+# #1370 — emitted from ``JobWorkerPool.stop()`` whenever a worker
+# thread does not exit within the join deadline. Pre-fix this fired
+# 8841 times in errors.log because ``_run_one`` spawned a fresh
+# ``threading.Thread`` per job attempt and abandoned it on handler
+# timeout. The fix routes invocations through a per-worker
+# ``ThreadPoolExecutor(max_workers=1)`` so the worker reuses one
+# executor thread instead of leaking one per attempt; this event lets
+# the fleet quantify whether the fix is holding without grepping
+# ``errors.log``.
+EVENT_WORKER_THREAD_LEAKED = "worker.thread_leaked"
 
 
 @dataclass(slots=True, frozen=True)
@@ -397,6 +407,7 @@ __all__ = [
     "EVENT_MARKER_LEAKED",
     "EVENT_WORK_TABLE_CLEARED",
     "EVENT_WORK_DB_OPENED",
+    "EVENT_WORKER_THREAD_LEAKED",
     "AuditEvent",
     "central_log_path",
     "emit",

--- a/src/pollypm/jobs/workers.py
+++ b/src/pollypm/jobs/workers.py
@@ -20,6 +20,7 @@ dict ``{handler_name: HandlerSpec}`` is fine.
 
 from __future__ import annotations
 
+import concurrent.futures
 import logging
 import threading
 import time
@@ -232,6 +233,11 @@ class JobWorkerPool:
         Workers finish their current job before exiting. Any thread still
         alive after ``timeout`` is left as a daemon — callers should treat
         this as best-effort.
+
+        When a worker thread fails to stop within the deadline we also
+        emit a ``worker.thread_leaked`` audit event (#1370) so the fleet
+        can quantify how often this is firing without grepping
+        ``errors.log``.
         """
         with self._lock:
             if not self._started:
@@ -246,6 +252,29 @@ class JobWorkerPool:
             t.join(timeout=remaining)
             if t.is_alive():
                 logger.warning("JobWorkerPool: thread %s did not stop within timeout", t.name)
+                self._emit_thread_leaked(t.name, timeout)
+
+    @staticmethod
+    def _emit_thread_leaked(thread_name: str, timeout: float) -> None:
+        """Best-effort audit hook for #1370.
+
+        Audit emit is intentionally lazy-imported and exception-swallowed:
+        the shutdown path must never raise from a telemetry hook.
+        """
+        try:
+            from pollypm.audit.log import EVENT_WORKER_THREAD_LEAKED
+            from pollypm.audit.log import emit as _audit_emit
+
+            _audit_emit(
+                event=EVENT_WORKER_THREAD_LEAKED,
+                project="",
+                subject=thread_name,
+                actor="system",
+                status="warn",
+                metadata={"timeout_seconds": float(timeout)},
+            )
+        except Exception:  # noqa: BLE001 — audit must not break stop()
+            pass
 
     @property
     def is_running(self) -> bool:
@@ -261,41 +290,73 @@ class JobWorkerPool:
 
     def _run(self, worker_id: str) -> None:
         logger.debug("JobWorkerPool: worker %s starting", worker_id)
-        while not self._stop_event.is_set():
-            try:
-                batch = self.queue.claim(worker_id, limit=1)
-            except Exception as exc:  # noqa: BLE001
-                if _is_closed_db_error(exc):
-                    self._handle_closed_db(worker_id, "claim")
-                    break
-                if _is_database_locked_error(exc):
-                    # #1018 — transient WAL contention on claim; back
-                    # off briefly and retry on the next poll. Don't log
-                    # a full traceback (would spam ``errors.log`` and,
-                    # via the heartbeat alert pipeline, raise a
-                    # ``critical_error`` for a recoverable condition).
-                    logger.debug(
-                        "JobWorkerPool: claim hit transient lock for %s; "
-                        "backing off",
-                        worker_id,
-                    )
+        # #1370 — per-worker single-threaded executor reused across
+        # job invocations. Pre-fix, ``_run_one`` spawned a fresh
+        # ``threading.Thread(daemon=True)`` per attempt and abandoned
+        # the reference on timeout, leaking one thread per timed-out
+        # handler attempt (and up to four per job once the lock-retry
+        # loop kicked in). With a single-slot executor the worker has
+        # at most one in-flight handler thread at a time; on timeout
+        # the executor's worker keeps running the dead handler in the
+        # background but no *new* thread is created — the next attempt
+        # reuses the next executor slot once the old future drops the
+        # reservation. The executor is shut down with
+        # ``cancel_futures=True`` and ``wait=False`` when the worker
+        # exits so a wedged handler can't block ``pool.stop()``.
+        executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix=f"{self.worker_name_prefix}-handler",
+        )
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    batch = self.queue.claim(worker_id, limit=1)
+                except Exception as exc:  # noqa: BLE001
+                    if _is_closed_db_error(exc):
+                        self._handle_closed_db(worker_id, "claim")
+                        break
+                    if _is_database_locked_error(exc):
+                        # #1018 — transient WAL contention on claim; back
+                        # off briefly and retry on the next poll. Don't log
+                        # a full traceback (would spam ``errors.log`` and,
+                        # via the heartbeat alert pipeline, raise a
+                        # ``critical_error`` for a recoverable condition).
+                        logger.debug(
+                            "JobWorkerPool: claim hit transient lock for %s; "
+                            "backing off",
+                            worker_id,
+                        )
+                        if self._stop_event.wait(self.poll_interval):
+                            break
+                        continue
+                    logger.exception("JobWorkerPool: claim failed for %s: %s", worker_id, exc)
                     if self._stop_event.wait(self.poll_interval):
                         break
                     continue
-                logger.exception("JobWorkerPool: claim failed for %s: %s", worker_id, exc)
-                if self._stop_event.wait(self.poll_interval):
-                    break
-                continue
 
-            if not batch:
-                if self._stop_event.wait(self.poll_interval):
-                    break
-                continue
+                if not batch:
+                    if self._stop_event.wait(self.poll_interval):
+                        break
+                    continue
 
-            for job in batch:
-                self._run_one(job)
-                if self._stop_event.is_set():
-                    break
+                for job in batch:
+                    self._run_one(job, executor)
+                    if self._stop_event.is_set():
+                        break
+        finally:
+            # ``cancel_futures=True`` drops anything still queued behind
+            # an in-flight handler; ``wait=False`` lets a wedged handler
+            # die at process exit instead of pinning the worker thread
+            # in ``executor.__exit__``. Both are deliberate — the
+            # alternative is exactly the leak this PR is fixing.
+            try:
+                executor.shutdown(wait=False, cancel_futures=True)
+            except Exception:  # noqa: BLE001 — never block worker exit
+                logger.debug(
+                    "JobWorkerPool: worker %s executor shutdown raised",
+                    worker_id,
+                    exc_info=True,
+                )
 
         logger.debug("JobWorkerPool: worker %s stopping", worker_id)
 
@@ -329,7 +390,7 @@ class JobWorkerPool:
             return self._registry.get(name)
         return self._registry.get(name)
 
-    def _run_one(self, job) -> None:
+    def _run_one(self, job, executor: concurrent.futures.ThreadPoolExecutor) -> None:
         spec = self._lookup_handler(job.handler_name)
         if spec is None:
             # No handler — fail permanently with a clear message.
@@ -358,33 +419,49 @@ class JobWorkerPool:
             # falling through to the regular ``fail()`` path. Without
             # this, every transient lock during ``session.health_sweep``
             # bubbled up as a ``critical_error`` alert (#67108).
+            #
+            # #1370 — invocations route through a single-slot
+            # ``ThreadPoolExecutor`` owned by the worker thread, not a
+            # fresh ``threading.Thread`` per attempt. ``future.result()``
+            # gives the same per-attempt timeout semantics as
+            # ``Thread.join(timeout=)`` without spawning a new OS thread
+            # each retry. On timeout we abandon the future (the
+            # underlying handler keeps running in the executor's worker
+            # thread) and bail out of the retry loop — re-submitting
+            # while the previous attempt is still alive would either
+            # block on the executor's single slot or, pre-fix, double
+            # up handler threads against the same job.
             attempts = 1 + len(_DB_LOCK_RETRY_BACKOFF)
-            result_holder: dict[str, Any] = {}
-            exc_holder: dict[str, BaseException] = {}
             timed_out = False
+            last_err: BaseException | None = None
             for attempt_index in range(attempts):
-                result_holder = {}
-                exc_holder = {}
+                payload_copy = dict(job.payload)
+                try:
+                    future = executor.submit(spec.handler, payload_copy)
+                except RuntimeError:
+                    # Executor was shut down underneath us (pool stopping).
+                    # Treat as a stop signal and exit without bookkeeping —
+                    # ``stop()`` already accounts for in-flight work.
+                    return
 
-                def _invoke() -> None:
-                    try:
-                        result_holder["value"] = spec.handler(dict(job.payload))
-                    except BaseException as e:  # noqa: BLE001
-                        exc_holder["err"] = e
-
-                t = threading.Thread(
-                    target=_invoke,
-                    name=f"{self.worker_name_prefix}-handler-{job.id}",
-                    daemon=True,
-                )
-                t.start()
-                t.join(timeout=spec.timeout_seconds)
-                if t.is_alive():
+                try:
+                    future.result(timeout=spec.timeout_seconds)
+                    last_err = None
+                except concurrent.futures.TimeoutError:
+                    # Handler is still running on the executor's worker
+                    # thread. Abandon the future — the executor will
+                    # not accept a new submit() until this one finishes
+                    # (single-slot), and re-trying while it's stuck
+                    # would just block here on the next submit(). Mark
+                    # timed_out and break so the regular timeout-fail
+                    # path runs.
+                    future.cancel()  # no-op once running, but cheap.
                     timed_out = True
                     break
+                except BaseException as e:  # noqa: BLE001
+                    last_err = e
 
-                err = exc_holder.get("err")
-                if err is None or not _is_database_locked_error(err):
+                if last_err is None or not _is_database_locked_error(last_err):
                     break
 
                 # Lock-retry path. Last attempt falls through with the
@@ -417,8 +494,8 @@ class JobWorkerPool:
                     )
                 return
 
-            if "err" in exc_holder:
-                err = exc_holder["err"]
+            if last_err is not None:
+                err = last_err
                 tb = "".join(traceback.format_exception(type(err), err, err.__traceback__))
                 elapsed_ms = (time.monotonic() - start) * 1000
                 # #1018 — log lock-exhaustion at WARNING (not ERROR /

--- a/tests/test_job_workers.py
+++ b/tests/test_job_workers.py
@@ -413,3 +413,178 @@ def test_metrics_track_per_handler_counts_and_duration(tmp_path: Path) -> None:
     assert snapshot["a"]["avg_duration_ms"] > 0
     assert snapshot["b"]["jobs_completed"] == 0
     assert snapshot["b"]["jobs_failed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# #1370 — JobWorkerPool thread leak regression coverage
+# ---------------------------------------------------------------------------
+
+
+def _handler_thread_count(prefix: str) -> int:
+    """Count live threads whose name starts with ``<prefix>-handler``.
+
+    Pre-fix, ``_run_one`` spawned one such thread per job *attempt*
+    and abandoned it on timeout, so the count grew monotonically.
+    Post-fix the executor reuses a single handler thread per worker.
+    """
+    return sum(
+        1 for t in threading.enumerate()
+        if t.name.startswith(f"{prefix}-handler") and t.is_alive()
+    )
+
+
+def test_handler_thread_does_not_leak_per_attempt(tmp_path: Path) -> None:
+    """#1370: handler invocations must reuse one thread per worker.
+
+    Pre-fix, ``_run_one`` spawned a fresh ``threading.Thread`` for
+    every retry attempt and abandoned the reference on the timeout
+    path. With the lock-retry loop active that meant up to 4 threads
+    per job, all daemon, all leaked for the lifetime of the process.
+    The fix routes invocations through a single-slot
+    ``ThreadPoolExecutor`` per worker, so the live handler-thread
+    count stays bounded by ``concurrency`` no matter how many jobs
+    run.
+    """
+    q = _make_queue(tmp_path)
+
+    def quick(payload: dict) -> None:
+        return None
+
+    prefix = "leak-test-pool"
+    registry = {"q": HandlerSpec("q", quick, timeout_seconds=5)}
+    pool = JobWorkerPool(
+        q, registry=registry, poll_interval=0.01,
+        worker_name_prefix=prefix,
+    )
+    pool.start(concurrency=2)
+    try:
+        for _ in range(50):
+            q.enqueue("q")
+        assert _wait_until(lambda: q.stats().done == 50, timeout=10.0)
+        # With concurrency=2 and the executor-based fix, at most two
+        # handler threads should ever be alive concurrently. Pre-fix
+        # this would be ~50 (one per completed job, since daemon
+        # threads outlive their invocation by epsilon under load).
+        live = _handler_thread_count(prefix)
+        assert live <= 2, f"handler threads leaked: {live} alive"
+    finally:
+        pool.stop(timeout=2)
+
+
+def test_timed_out_handler_does_not_spawn_new_thread_each_retry(
+    tmp_path: Path,
+) -> None:
+    """#1370: a hung handler must not multiply handler threads.
+
+    Pre-fix, every lock-retry attempt that timed out left a daemon
+    thread running the original handler. The post-fix executor
+    serializes attempts on a single slot — once a handler hangs past
+    its timeout we stop submitting new attempts (the executor would
+    block on the same slot anyway). Verifies the count stays at most
+    ``concurrency`` even when every handler hangs.
+    """
+    q = _make_queue(tmp_path)
+    release = threading.Event()
+
+    def hang(payload: dict) -> None:
+        # Block until the test releases us — must not be killed.
+        release.wait(timeout=10)
+
+    prefix = "hang-test-pool"
+    registry = {"hang": HandlerSpec(
+        "hang", hang, timeout_seconds=0.05, max_attempts=1,
+    )}
+    pool = JobWorkerPool(
+        q, registry=registry, poll_interval=0.01,
+        worker_name_prefix=prefix,
+    )
+    pool.start(concurrency=1)
+    try:
+        for _ in range(5):
+            q.enqueue("hang", max_attempts=1)
+        # Each job times out at 50ms; with 5 jobs the worker will
+        # cycle through them in <2s. We only care about leak count,
+        # not job outcomes.
+        assert _wait_until(lambda: q.stats().failed >= 1, timeout=5.0)
+        live = _handler_thread_count(prefix)
+        # With concurrency=1, one executor handler thread is expected.
+        # Pre-fix this was 1-per-attempt-per-job, easily 5+.
+        assert live <= 1, f"handler threads leaked under hang: {live} alive"
+    finally:
+        # Release the hung handlers so the executor's worker thread
+        # can exit cleanly when the pool tears down.
+        release.set()
+        pool.stop(timeout=2)
+
+
+def test_stop_emits_thread_leaked_audit_when_worker_blocked(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """#1370: ``pool.stop()`` emits ``worker.thread_leaked`` on join timeout.
+
+    Without this hook the only signal of a leaked worker thread was a
+    log line — and the heartbeat / pm doctor surfaces don't ingest
+    arbitrary log text. Emitting an audit event lets the fleet count
+    these without grepping ``errors.log``.
+    """
+    q = _make_queue(tmp_path)
+    release = threading.Event()
+
+    def hang(payload: dict) -> None:
+        release.wait(timeout=30)
+
+    registry = {"h": HandlerSpec("h", hang, timeout_seconds=30, max_attempts=1)}
+    pool = JobWorkerPool(q, registry=registry, poll_interval=0.01)
+
+    captured: list[dict] = []
+
+    def fake_emit(**kwargs):
+        captured.append(kwargs)
+
+    # Patch the lazy import target.
+    import pollypm.audit.log as audit_log
+    monkeypatch.setattr(audit_log, "emit", fake_emit)
+
+    pool.start(concurrency=1)
+    try:
+        q.enqueue("h", max_attempts=1)
+        # Wait for the worker to be inside the handler.
+        time.sleep(0.2)
+        # Fast stop — worker is wedged inside future.result(timeout=30s)
+        # so the join will time out.
+        pool.stop(timeout=0.2)
+    finally:
+        release.set()
+        # Defensive — give the wedged worker a chance to drop its lock.
+        time.sleep(0.05)
+
+    leaked_events = [e for e in captured if e.get("event") == "worker.thread_leaked"]
+    assert leaked_events, (
+        f"expected at least one worker.thread_leaked audit event, got {captured!r}"
+    )
+    assert leaked_events[0]["status"] == "warn"
+    assert "timeout_seconds" in leaked_events[0]["metadata"]
+
+
+def test_stop_does_not_emit_thread_leaked_for_clean_shutdown(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """#1370 happy-path: idle pool shuts down without emitting leak events."""
+    q = _make_queue(tmp_path)
+    pool = JobWorkerPool(q, registry={}, poll_interval=0.01)
+
+    captured: list[dict] = []
+
+    def fake_emit(**kwargs):
+        captured.append(kwargs)
+
+    import pollypm.audit.log as audit_log
+    monkeypatch.setattr(audit_log, "emit", fake_emit)
+
+    pool.start(concurrency=2)
+    pool.stop(timeout=2)
+
+    leaked_events = [e for e in captured if e.get("event") == "worker.thread_leaked"]
+    assert not leaked_events, (
+        f"clean shutdown should not emit leak events, got {leaked_events!r}"
+    )


### PR DESCRIPTION
Closes #1370.

## Context

`~/.pollypm/errors.log` contains **8841 hits** of `JobWorkerPool: thread pollypm-jobworker-N did not stop within timeout`. The leak is in `src/pollypm/jobs/workers.py:_run_one`:

```python
t = threading.Thread(target=_invoke, daemon=True)
t.start()
t.join(timeout=spec.timeout_seconds)
if t.is_alive():
    timed_out = True
    break
```

Every job attempt spawns a fresh daemon `Thread`. On timeout the worker abandons the reference and moves on — the thread keeps running until process exit, holding whatever the handler had open (DB cursors, file handles). The lock-retry loop (`_DB_LOCK_RETRY_BACKOFF`, 3 retries) means up to **four** abandoned threads per job in the worst case, all running concurrently against the same handler.

The 8841 warnings then come from `pool.stop()` — worker threads themselves don't drain because they're stuck in `Thread.join(timeout=spec.timeout_seconds)` waiting on a hung handler.

## Fix

Route handler invocations through a per-worker `concurrent.futures.ThreadPoolExecutor(max_workers=1)` reused across jobs. `submit()` + `result(timeout=)` gives the same per-attempt timeout semantics without spawning a fresh OS thread each retry. The executor's worker thread is reused; on timeout we abandon the future and break out of the retry loop (the next submit would block on the executor's single slot anyway, since the wedged handler still owns it).

On worker exit the executor is shut down with `wait=False, cancel_futures=True` so a wedged handler can't block `pool.stop()` — the wedged thread becomes a daemon and dies at process exit just like before, but we no longer multiply them per attempt.

Also adds a `worker.thread_leaked` audit event emitted from `pool.stop()` whenever a worker thread misses its join deadline. This is the issue's "audit emit" requirement and lets the fleet quantify residual leaks without grepping `errors.log`.

## Files changed

- `src/pollypm/jobs/workers.py` — replace per-attempt `threading.Thread` with per-worker `ThreadPoolExecutor`; emit `worker.thread_leaked` on join timeout.
- `src/pollypm/audit/log.py` — new `EVENT_WORKER_THREAD_LEAKED = "worker.thread_leaked"` constant.
- `tests/test_job_workers.py` — 4 new regression tests.

## Tests

Existing 13 `test_job_workers.py` tests still pass (covers timeout, retry, closed-DB, concurrency, idempotent stop, in-flight job). 4 new tests:

- `test_handler_thread_does_not_leak_per_attempt` — runs 50 quick jobs against concurrency=2, asserts `_handler_thread_count <= 2`. Pre-fix would be ~50.
- `test_timed_out_handler_does_not_spawn_new_thread_each_retry` — 5 hung jobs at concurrency=1, asserts `_handler_thread_count <= 1` even with attempts piling up.
- `test_stop_emits_thread_leaked_audit_when_worker_blocked` — wedge a worker, fast-stop, assert a `worker.thread_leaked` audit event was emitted with `status=warn` and `metadata.timeout_seconds`.
- `test_stop_does_not_emit_thread_leaked_for_clean_shutdown` — happy-path negative assertion.

Broader job-related test sweep (job_workers / job_handler_registry / jobs_cli / inline_scheduler_corrupt_jobs / job_runner_prune_summary / stuck_claims_sweep / audit_log / audit_watchdog): **110 passed.**

## Risk

Shared infrastructure — the worker pool is on the cockpit hot path. Lean conservative.

- **Behavioural compat:** `submit()` + `result(timeout=)` is semantically equivalent to `Thread.start()` + `Thread.join(timeout=)` for the existing handler contract (callable taking a payload dict). Same exception flow, same timeout semantics. The retry-on-locked branch still fires, the per-handler-spec timeout still fires, the `_handle_closed_db` shortcut still fires.
- **Subtle change:** when a handler hangs past its timeout, the *next* attempt of the same job no longer happens — pre-fix it would run concurrently against the wedged thread, which is itself a bug (issue calls this out as a compounding factor). Post-fix the retry loop bails on `TimeoutError` and the regular `queue.fail(retry=True)` path runs, so the job gets re-attempted via the queue's normal retry policy on a future poll. This is strictly safer.
- **Executor shutdown:** `executor.shutdown(wait=False, cancel_futures=True)` does not interrupt running handlers (Python provides no portable thread-kill). A wedged handler keeps running as a daemon and dies at process exit — same end-state as the pre-fix leaked thread, but bounded by 1 per worker instead of N per worker.
- **No state-on-disk changes.** Audit emit is best-effort and exception-swallowed.

## Test plan

- [x] Run existing `tests/test_job_workers.py` suite
- [x] Run new regression tests for thread accounting
- [x] Run new audit-emit tests
- [x] Run broader job + audit test sweep