### PR TITLE
Bound dashboard mtime cache + close SQLiteWorkService in update.py

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -24,6 +24,7 @@ import asyncio
 import json
 import os
 import resource
+from collections import OrderedDict
 from pathlib import Path
 import subprocess
 import time
@@ -10477,6 +10478,31 @@ def _dashboard_plan_aux_files(project_path: Path) -> list[Path]:
     return out[:12]
 
 
+# Default eviction cap for the mtime-keyed dashboard caches below.
+# Each ``state.db`` write bumps the mtime and so produces a fresh
+# cache key; without bounds the cache grows monotonically over the
+# cockpit's lifetime (#1375). 256 is generous: 9 projects * the last
+# ~28 distinct mtimes still fits, which is far past anything the
+# 10s refresh tick can churn through within a useful window.
+_DASHBOARD_CACHE_MAXSIZE = 256
+
+
+def _dashboard_cache_set(
+    cache: "OrderedDict", key, value, *, maxsize: int = _DASHBOARD_CACHE_MAXSIZE,
+) -> None:
+    """Insert ``key`` into ``cache`` with LRU eviction past ``maxsize``.
+
+    Uses ``OrderedDict.move_to_end`` so a re-insert refreshes the
+    recency order. When the cache exceeds ``maxsize``, the least
+    recently used entry is popped from the front.
+    """
+    if key in cache:
+        cache.move_to_end(key)
+    cache[key] = value
+    while len(cache) > maxsize:
+        cache.popitem(last=False)
+
+
 # Per-project plan-staleness cache. Key includes plan_mtime AND
 # state.db mtime so the cache invalidates whenever the inputs that
 # could change the answer change — no TTL needed. Cycle 133 perf fix:
@@ -10484,7 +10510,11 @@ def _dashboard_plan_aux_files(project_path: Path) -> list[Path]:
 # the whole task list on every per-project dashboard refresh tick
 # (every 10s). With this cache, a project with no plan or task
 # changes pays zero work past the first refresh.
-_PLAN_STALENESS_CACHE: dict[tuple[str, float | None, float | None], str | None] = {}
+#
+# #1375 — bounded with LRU eviction; each state.db write produces a
+# fresh cache key, so without a cap this grows for the cockpit's
+# lifetime.
+_PLAN_STALENESS_CACHE: "OrderedDict[tuple[str, float | None, float | None], str | None]" = OrderedDict()
 
 
 def _dashboard_plan_staleness(
@@ -10529,6 +10559,7 @@ def _dashboard_plan_staleness(
         db_mtime = None
     cache_key = (project_key, plan_mtime, db_mtime)
     if cache_key in _PLAN_STALENESS_CACHE:
+        _PLAN_STALENESS_CACHE.move_to_end(cache_key)
         return _PLAN_STALENESS_CACHE[cache_key]
     try:
         from pollypm.plugins_builtin.project_planning.plan_presence import (
@@ -10545,11 +10576,11 @@ def _dashboard_plan_staleness(
         ) as svc:
             plan_task = _find_approved_plan_task(svc, project_key)
             if plan_task is None:
-                _PLAN_STALENESS_CACHE[cache_key] = None
+                _dashboard_cache_set(_PLAN_STALENESS_CACHE, cache_key, None)
                 return None
             approved_at = _plan_approved_at(svc, plan_task)
             if approved_at is None:
-                _PLAN_STALENESS_CACHE[cache_key] = None
+                _dashboard_cache_set(_PLAN_STALENESS_CACHE, cache_key, None)
                 return None
             # Find latest non-planning task's created_at.
             tasks = svc.list_tasks(project=project_key)
@@ -10575,7 +10606,7 @@ def _dashboard_plan_staleness(
     except Exception:  # noqa: BLE001
         # Don't cache failures — let the next refresh retry.
         return None
-    _PLAN_STALENESS_CACHE[cache_key] = result
+    _dashboard_cache_set(_PLAN_STALENESS_CACHE, cache_key, result)
     return result
 
 
@@ -10732,10 +10763,9 @@ class ProjectDashboardData:
 # rapidly-rerendering dashboard doesn't hammer SQLite for the same data. The
 # dashboard refreshes every 10s by default; stale-cache hits are a net win
 # there too.
-_PROJECT_DASHBOARD_TASK_CACHE: dict[
-    tuple[str, tuple[tuple[str, float], ...]],
-    tuple[dict[str, int], dict[str, list[dict]]],
-] = {}
+#
+# #1375 — bounded with LRU eviction (see ``_dashboard_cache_set``).
+_PROJECT_DASHBOARD_TASK_CACHE: "OrderedDict[tuple[str, tuple[tuple[str, float], ...]], tuple[dict[str, int], dict[str, list[dict]]]]" = OrderedDict()
 
 
 def _dashboard_plain_text(value: object | None) -> str:
@@ -11047,6 +11077,7 @@ def _dashboard_gather_tasks(
     cache_token = tuple(cache_parts)
     cached = _PROJECT_DASHBOARD_TASK_CACHE.get((project_key, cache_token))
     if cached is not None:
+        _PROJECT_DASHBOARD_TASK_CACHE.move_to_end((project_key, cache_token))
         return cached
 
     try:
@@ -11177,7 +11208,11 @@ def _dashboard_gather_tasks(
     for status, items in buckets.items():
         items.sort(key=lambda d: d["updated_at"] or "", reverse=True)
 
-    _PROJECT_DASHBOARD_TASK_CACHE[(project_key, cache_token)] = (counts, buckets)
+    _dashboard_cache_set(
+        _PROJECT_DASHBOARD_TASK_CACHE,
+        (project_key, cache_token),
+        (counts, buckets),
+    )
     return counts, buckets
 
 
@@ -11505,10 +11540,9 @@ def _dashboard_active_worker(
 # task, or context entry bumps the mtime and the cache misses; an
 # idle project pays one stat() per tick instead of two DB opens.
 # Sister to ``_PLAN_STALENESS_CACHE`` (cycle 133).
-_DASHBOARD_INBOX_CACHE: dict[
-    tuple[str, float | None],
-    tuple[int, list[dict], list[dict]],
-] = {}
+#
+# #1375 — bounded with LRU eviction (see ``_dashboard_cache_set``).
+_DASHBOARD_INBOX_CACHE: "OrderedDict[tuple[str, float | None], tuple[int, list[dict], list[dict]]]" = OrderedDict()
 
 
 def _dashboard_inbox(
@@ -11531,6 +11565,7 @@ def _dashboard_inbox(
     cache_key = (project_key, db_mtime)
     cached = _DASHBOARD_INBOX_CACHE.get(cache_key)
     if cached is not None:
+        _DASHBOARD_INBOX_CACHE.move_to_end(cache_key)
         return cached
     try:
         from pollypm.store import SQLAlchemyStore
@@ -12254,7 +12289,7 @@ def _dashboard_inbox(
         if len(action_items) >= 2:
             break
     result = (_action_count(items, action_items), top, action_items)
-    _DASHBOARD_INBOX_CACHE[cache_key] = result
+    _dashboard_cache_set(_DASHBOARD_INBOX_CACHE, cache_key, result)
     return result
 
 
@@ -12736,9 +12771,9 @@ def _action_count(items: list[dict], action_items: list[dict]) -> int:
 # repeated work when no event has landed since the last call.
 # Sister to ``_DASHBOARD_INBOX_CACHE`` (cycle 138) and
 # ``_PLAN_STALENESS_CACHE`` (cycle 133).
-_DASHBOARD_ACTIVITY_CACHE: dict[
-    tuple[str, float | None, int], list[dict]
-] = {}
+#
+# #1375 — bounded with LRU eviction (see ``_dashboard_cache_set``).
+_DASHBOARD_ACTIVITY_CACHE: "OrderedDict[tuple[str, float | None, int], list[dict]]" = OrderedDict()
 
 
 def _dashboard_activity(
@@ -12771,6 +12806,7 @@ def _dashboard_activity(
     cache_key = (project_key, db_mtime, limit)
     cached = _DASHBOARD_ACTIVITY_CACHE.get(cache_key)
     if cached is not None:
+        _DASHBOARD_ACTIVITY_CACHE.move_to_end(cache_key)
         return cached
     projector = build_projector(config)
     if projector is None:
@@ -12793,7 +12829,7 @@ def _dashboard_activity(
         }
         for e in entries
     ]
-    _DASHBOARD_ACTIVITY_CACHE[cache_key] = result
+    _dashboard_cache_set(_DASHBOARD_ACTIVITY_CACHE, cache_key, result)
     return result
 
 

--- a/src/pollypm/update.py
+++ b/src/pollypm/update.py
@@ -221,9 +221,13 @@ def count_in_progress_tasks() -> int:
     # ``DEFAULT_CONFIG_PATH`` makes the dependency obvious for
     # readers and keeps the import-graph audit happy.
     _ = DEFAULT_CONFIG_PATH
+    # #1377 — wrap in a context manager so the SQLite connection is
+    # always closed. Process exit reaps it for ``pm update``'s one-shot
+    # CLI today, but the leaky pattern would bite any future caller
+    # that loops. Mirrors the close-on-exit pattern from #1069 / #1381.
     try:
-        svc = SQLiteWorkService(db_path=db_path)
-        tasks = svc.list_tasks(work_status="in_progress")
+        with SQLiteWorkService(db_path=db_path) as svc:
+            tasks = svc.list_tasks(work_status="in_progress")
     except Exception:  # noqa: BLE001
         return 0
     return len(tasks)

--- a/tests/test_dashboard_cache_eviction.py
+++ b/tests/test_dashboard_cache_eviction.py
@@ -1,0 +1,111 @@
+"""Tests for #1375 — bound the mtime-keyed dashboard caches.
+
+Each ``state.db`` write bumps the mtime, which produces a fresh
+cache key for each of:
+
+* ``_PLAN_STALENESS_CACHE``
+* ``_PROJECT_DASHBOARD_TASK_CACHE``
+* ``_DASHBOARD_INBOX_CACHE``
+* ``_DASHBOARD_ACTIVITY_CACHE``
+
+Without bounds the caches grow monotonically over the cockpit's
+lifetime. The fix wraps inserts through ``_dashboard_cache_set``
+which evicts the least recently used entry past
+``_DASHBOARD_CACHE_MAXSIZE`` (default 256).
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+import pytest
+
+from pollypm.cockpit_ui import (
+    _DASHBOARD_ACTIVITY_CACHE,
+    _DASHBOARD_CACHE_MAXSIZE,
+    _DASHBOARD_INBOX_CACHE,
+    _PLAN_STALENESS_CACHE,
+    _PROJECT_DASHBOARD_TASK_CACHE,
+    _dashboard_cache_set,
+)
+
+
+def setup_function(_func) -> None:
+    _PLAN_STALENESS_CACHE.clear()
+    _PROJECT_DASHBOARD_TASK_CACHE.clear()
+    _DASHBOARD_INBOX_CACHE.clear()
+    _DASHBOARD_ACTIVITY_CACHE.clear()
+
+
+def test_dashboard_cache_set_evicts_past_maxsize() -> None:
+    """Pumping past ``maxsize`` keeps the cache size capped."""
+    cache: OrderedDict[int, str] = OrderedDict()
+    for i in range(10):
+        _dashboard_cache_set(cache, i, f"v{i}", maxsize=4)
+    assert len(cache) == 4
+    # The four most-recent inserts should remain.
+    assert list(cache.keys()) == [6, 7, 8, 9]
+
+
+def test_dashboard_cache_set_refreshes_recency_on_reinsert() -> None:
+    """Re-inserting an existing key moves it to the MRU end so it
+    survives subsequent eviction passes."""
+    cache: OrderedDict[int, str] = OrderedDict()
+    for i in range(4):
+        _dashboard_cache_set(cache, i, f"v{i}", maxsize=4)
+    # Touch key 0 — should move to MRU end.
+    _dashboard_cache_set(cache, 0, "v0-updated", maxsize=4)
+    # Now insert 4 — should evict key 1 (LRU), not key 0.
+    _dashboard_cache_set(cache, 4, "v4", maxsize=4)
+    assert 0 in cache
+    assert 1 not in cache
+    assert cache[0] == "v0-updated"
+    assert len(cache) == 4
+
+
+def test_dashboard_cache_maxsize_is_generous() -> None:
+    """Sanity: the cap is set generously so normal use never churns.
+
+    9 projects * ~28 distinct mtimes is what we want to fit comfortably.
+    """
+    assert _DASHBOARD_CACHE_MAXSIZE >= 128
+
+
+@pytest.mark.parametrize(
+    "cache",
+    [
+        _PLAN_STALENESS_CACHE,
+        _PROJECT_DASHBOARD_TASK_CACHE,
+        _DASHBOARD_INBOX_CACHE,
+        _DASHBOARD_ACTIVITY_CACHE,
+    ],
+)
+def test_dashboard_caches_are_ordered_dicts(cache) -> None:
+    """All four module-level caches are ``OrderedDict`` instances so
+    LRU recency is preserved."""
+    assert isinstance(cache, OrderedDict)
+
+
+@pytest.mark.parametrize(
+    "cache",
+    [
+        _PLAN_STALENESS_CACHE,
+        _PROJECT_DASHBOARD_TASK_CACHE,
+        _DASHBOARD_INBOX_CACHE,
+        _DASHBOARD_ACTIVITY_CACHE,
+    ],
+)
+def test_dashboard_caches_evict_past_maxsize(cache) -> None:
+    """Each module-level cache stays bounded when pumped past the cap.
+
+    Simulates the per-project refresh tick churning fresh ``db_mtime``
+    keys (#1375). Without eviction this grows for the cockpit's
+    lifetime; with it, size stays at ``_DASHBOARD_CACHE_MAXSIZE``.
+    """
+    overshoot = _DASHBOARD_CACHE_MAXSIZE + 50
+    for i in range(overshoot):
+        # Use distinct keys per cache shape — only the LRU bound is
+        # under test, so any unique tuple works.
+        key = ("demo", float(i), float(i))
+        _dashboard_cache_set(cache, key, None)
+    assert len(cache) == _DASHBOARD_CACHE_MAXSIZE

--- a/tests/test_update_count_in_progress_close.py
+++ b/tests/test_update_count_in_progress_close.py
@@ -1,0 +1,116 @@
+"""Regression test for #1377 — ``count_in_progress_tasks`` must close
+the SQLiteWorkService it opens.
+
+The previous implementation opened the service but never closed it,
+relying on process exit to reap the SQLite connection. Process exit
+does that for ``pm update``'s one-shot CLI, but the leaky pattern
+would bite any future caller that loops.
+
+Mirrors the ``with`` / ``.close()`` pattern from PR #1069 / PR #1381.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from pollypm import update as update_mod
+
+
+def _install_fake_modules(
+    monkeypatch: pytest.MonkeyPatch, db_path: Path, fake_svc_cls: type,
+) -> None:
+    """Stub the three imports inside ``count_in_progress_tasks`` so the
+    test never touches a real SQLite file or config."""
+    fake_resolver = types.ModuleType("pollypm.work.db_resolver")
+    fake_resolver.resolve_work_db_path = lambda: db_path  # type: ignore[attr-defined]
+
+    fake_service = types.ModuleType("pollypm.work.sqlite_service")
+    fake_service.SQLiteWorkService = fake_svc_cls  # type: ignore[attr-defined]
+
+    fake_config = types.ModuleType("pollypm.config")
+    fake_config.DEFAULT_CONFIG_PATH = Path("/tmp/ignored")  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "pollypm.work.db_resolver", fake_resolver)
+    monkeypatch.setitem(sys.modules, "pollypm.work.sqlite_service", fake_service)
+    monkeypatch.setitem(sys.modules, "pollypm.config", fake_config)
+
+
+def test_count_in_progress_tasks_closes_workservice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The work-service connection is closed via the context manager.
+
+    Before #1377 the service was instantiated but never closed; this
+    asserts both ``__enter__`` and ``__exit__`` fire.
+    """
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"")
+
+    events: list[str] = []
+
+    class _FakeSvc:
+        def __init__(self, *, db_path: Path) -> None:
+            events.append("init")
+
+        def __enter__(self) -> "_FakeSvc":
+            events.append("enter")
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            events.append("exit")
+
+        def list_tasks(self, *, work_status: str = "") -> list:
+            events.append(f"list:{work_status}")
+            return [object(), object(), object()]
+
+        def close(self) -> None:  # pragma: no cover — unused by the fix
+            events.append("close")
+
+    _install_fake_modules(monkeypatch, db_path, _FakeSvc)
+
+    count = update_mod.count_in_progress_tasks()
+
+    assert count == 3
+    # Order matters: init -> enter -> list -> exit. The exit event is
+    # the load-bearing assertion — the previous implementation skipped
+    # it entirely.
+    assert events == ["init", "enter", "list:in_progress", "exit"]
+
+
+def test_count_in_progress_tasks_closes_workservice_on_query_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even when ``list_tasks`` raises, the context manager fires
+    ``__exit__`` so the connection is released."""
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"")
+
+    events: list[str] = []
+
+    class _FakeSvc:
+        def __init__(self, *, db_path: Path) -> None:
+            events.append("init")
+
+        def __enter__(self) -> "_FakeSvc":
+            events.append("enter")
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            events.append("exit")
+
+        def list_tasks(self, *, work_status: str = "") -> list:
+            raise RuntimeError("simulated DB failure")
+
+    _install_fake_modules(monkeypatch, db_path, _FakeSvc)
+
+    # The function is best-effort; a query failure returns 0 rather
+    # than raising.
+    assert update_mod.count_in_progress_tasks() == 0
+    # exit must still fire — the leak this test guards against is
+    # exactly the missing cleanup-on-error path.
+    assert "enter" in events
+    assert "exit" in events


### PR DESCRIPTION
## Summary

Two unrelated low-severity memory fixes bundled into one PR.

### Closes #1375 — bound the mtime-keyed dashboard caches

Four module-level dicts in `cockpit_ui.py` are keyed on `(project_key, db_mtime, ...)`. Every `state.db` write bumps the mtime so each per-project refresh tick (every 10s) adds a fresh entry — old entries are never removed. Worst case: thousands of entries per project after a long uptime.

Fix: convert all four to `collections.OrderedDict` and route inserts through a new `_dashboard_cache_set` helper that evicts the LRU entry past `_DASHBOARD_CACHE_MAXSIZE = 256`. Read paths now `move_to_end` on hit so recency reflects actual usage. The cap is generous (9 projects * ~28 distinct mtimes still fits) so normal use never churns.

Caches updated:
- `_PLAN_STALENESS_CACHE`
- `_PROJECT_DASHBOARD_TASK_CACHE`
- `_DASHBOARD_INBOX_CACHE`
- `_DASHBOARD_ACTIVITY_CACHE`

### Closes #1377 — close `SQLiteWorkService` in `count_in_progress_tasks`

`update.py:225` instantiated `SQLiteWorkService` but never closed it. Process exit reaped the connection for `pm update`'s one-shot CLI, but the leaky pattern would bite any future caller that loops. Wrapped in `with` to mirror the close-on-exit pattern from #1069 / #1381.

## Test plan

- [x] `tests/test_dashboard_cache_eviction.py` — pumps each of the four caches past `maxsize`, asserts size stays capped; verifies `_dashboard_cache_set` refreshes recency on re-insert.
- [x] `tests/test_update_count_in_progress_close.py` — asserts `__enter__` and `__exit__` both fire on the work-service stub, including the query-error path.
- [x] Existing `test_dashboard_inbox_cache.py`, `test_dashboard_activity_cache.py`, `test_dashboard_plan_staleness_cache.py` still pass (no behavior change for normal usage).

(2 pre-existing failures in `test_update.py` re: worktree-path detection are unrelated — they fail on baseline because the test suite is being run from `.claude/worktrees/agent-*`.)