### PR TITLE
Add stale socket reaper for ~/.pollypm/cockpit_inputs/

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -59,6 +59,10 @@ EVENT_WORK_DB_OPENED = "work_db.opened"
 # the fleet quantify whether the fix is holding without grepping
 # ``errors.log``.
 EVENT_WORKER_THREAD_LEAKED = "worker.thread_leaked"
+# #1368 — emitted by ``cockpit_socket_reaper`` when it unlinks a stale
+# ``cockpit-<pid>.sock`` whose owning PID is no longer alive. Lets
+# operators forensically count leak rates without scraping logs.
+EVENT_SOCKET_REAPED = "socket.reaped"
 
 
 @dataclass(slots=True, frozen=True)
@@ -408,6 +412,7 @@ __all__ = [
     "EVENT_WORK_TABLE_CLEARED",
     "EVENT_WORK_DB_OPENED",
     "EVENT_WORKER_THREAD_LEAKED",
+    "EVENT_SOCKET_REAPED",
     "AuditEvent",
     "central_log_path",
     "emit",

--- a/src/pollypm/cockpit_socket_reaper.py
+++ b/src/pollypm/cockpit_socket_reaper.py
@@ -1,0 +1,276 @@
+"""Reaper for stale ``~/.pollypm/cockpit_inputs/*.sock`` files (#1368).
+
+Background
+----------
+:mod:`pollypm.cockpit_input_bridge` binds an AF_UNIX socket per cockpit
+process at ``<base_dir>/cockpit_inputs/<kind>-<pid>.sock``. The
+``BridgeHandle.stop`` happy-path unlinks on clean shutdown, but:
+
+* ``SIGKILL`` / crash / tmux session teardown skip cleanup entirely.
+* The only opportunistic GC is inside
+  :func:`cockpit_input_bridge.send_key_to_first_live`, which only
+  unlinks a socket if a caller actually attempts a connection AND
+  receives ``ConnectionRefusedError`` AND the encoded PID is dead.
+
+In practice the directory accumulates one entry per crashed cockpit
+boot. On the reporting machine 318 stale entries had piled up; every
+``send_key`` walks all 318 (newest-first sorted) before reaching the
+live socket.
+
+This module mirrors :mod:`pollypm.work.worker_marker_reaper` for the
+session-marker / worker-marker case: a bootstrap-time sweep that runs
+once at ``Supervisor.bootstrap_tmux`` and unlinks any
+``cockpit-<pid>.sock`` whose PID is no longer alive.
+
+Staleness signal
+----------------
+The socket filename already encodes the cockpit PID (see
+``cockpit_input_bridge._socket_filename``). We re-use that PID for the
+liveness check rather than running ``lsof`` per socket — at 318+ files
+the ``lsof`` approach is N round-trips through the kernel, whereas
+``os.kill(pid, 0)`` is constant-time per file.
+
+A socket is reaped when ALL of the following hold:
+
+* Filename parses as ``<kind>-<pid>.sock`` with an integer PID.
+* ``os.kill(pid, 0)`` returns ``ProcessLookupError`` (or any
+  non-permission-error variant signalling the PID is gone).
+* The on-disk entry is actually a socket file (not a regular file
+  someone dropped here by mistake).
+
+A live cockpit's socket is preserved unconditionally — we err on the
+side of leaking one socket rather than nuking the live cockpit's only
+discoverable bridge.
+
+Why bootstrap-only
+------------------
+The cockpit can re-bind the same path while a runtime sweep races; the
+existing creation-side code already calls ``socket_path.unlink()``
+before ``bind`` to clear stale leftovers, so a runtime sweeper doesn't
+add much over the bootstrap reaper. Restricting the sweep to
+``bootstrap_tmux`` means: no per-task cockpit is alive yet, so any
+reapable socket is by definition dead.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class ReapedSocket:
+    """Record of a cockpit-input socket that was unlinked by the reaper.
+
+    Surfaces enough context for log lines / audit events: which
+    directory it lived in, what kind of pane it served, the PID encoded
+    in the filename, the on-disk path, and the staleness reason.
+    """
+
+    socket_path: Path
+    kind: str
+    pid: int | None
+    reason: str
+
+
+def _candidate_dirs(base_dir: Path) -> list[Path]:
+    """Return the directories the bridge can drop sockets into.
+
+    Mirrors ``cockpit_input_bridge._bridge_dir`` and the AF_UNIX
+    fallback in ``_resolve_bridge_path``. We sweep both so the reaper
+    has the same view as ``list_bridge_sockets``.
+    """
+    primary = base_dir / "cockpit_inputs"
+    fallback = Path(tempfile.gettempdir()) / "pollypm-cockpit_inputs"
+    out: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in (primary, fallback):
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            resolved = candidate
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        out.append(candidate)
+    return out
+
+
+def _iter_socket_entries(directory: Path) -> Iterable[Path]:
+    """Yield ``*.sock`` files inside ``directory``.
+
+    Returns an empty iterator (rather than raising) when the directory
+    is missing — fresh installs and machines that have never booted a
+    cockpit simply have nothing to reap.
+    """
+    try:
+        if not directory.is_dir():
+            return ()
+        return tuple(p for p in directory.iterdir() if p.name.endswith(".sock"))
+    except OSError as exc:
+        logger.debug(
+            "cockpit_socket_reaper: cannot list %s: %s", directory, exc,
+        )
+        return ()
+
+
+def _parse_socket_filename(name: str) -> tuple[str, int | None]:
+    """Parse ``<kind>-<pid>.sock`` into ``(kind, pid)``.
+
+    Returns ``(kind, None)`` when the filename does not match the
+    expected shape — caller should treat unparseable entries as
+    unknown and leave them alone.
+    """
+    stem = name.removesuffix(".sock")
+    kind, separator, pid_text = stem.rpartition("-")
+    if not separator:
+        return (stem, None)
+    try:
+        return (kind, int(pid_text))
+    except ValueError:
+        return (kind, None)
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Return True iff ``pid`` corresponds to a live process.
+
+    ``EPERM`` (PermissionError) means the PID exists but isn't ours —
+    treat as alive. Any other ``OSError`` is treated as "can't tell"
+    and surfaces as dead, matching the conservative behaviour of
+    :func:`cockpit_input_bridge._pid_is_alive`.
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _classify(socket_path: Path) -> ReapedSocket | None:
+    """Decide whether ``socket_path`` is reapable. ``None`` keeps it.
+
+    A live socket is preserved. A socket whose PID we cannot parse is
+    preserved (we don't recognise the format — better to leak one
+    than nuke a future format). A socket whose PID is gone is reaped.
+    A non-socket file that ended in ``.sock`` is left alone — we do
+    not own arbitrary files in this directory.
+    """
+    name = socket_path.name
+    kind, pid = _parse_socket_filename(name)
+    if pid is None:
+        # Unrecognised shape. Don't touch.
+        return None
+
+    try:
+        if not socket_path.is_socket():
+            return None
+    except OSError:
+        return None
+
+    if _pid_is_alive(pid):
+        return None
+
+    return ReapedSocket(
+        socket_path=socket_path,
+        kind=kind,
+        pid=pid,
+        reason=f"owning pid {pid} is not alive",
+    )
+
+
+def _emit_audit(reaped: ReapedSocket) -> None:
+    """Emit a ``socket.reaped`` event via :mod:`pollypm.audit`.
+
+    Best-effort: the audit module already swallows write failures, but
+    we additionally guard against the import itself failing on installs
+    where the audit package is unavailable (shouldn't happen post
+    PR #1342, but mirroring the defensive pattern in
+    ``session_services/tmux.py``).
+    """
+    try:
+        from pollypm.audit import emit as _audit_emit
+        from pollypm.audit.log import EVENT_SOCKET_REAPED
+    except Exception:  # noqa: BLE001
+        return
+    try:
+        # ``cockpit_inputs`` lives at the workspace level, not under any
+        # one project, but the audit log's central-tail writer only fires
+        # when ``project`` is truthy. Use a fixed ``_workspace`` key so
+        # operators can ``cat ~/.pollypm/audit/_workspace.jsonl`` to see
+        # every cockpit-socket reap across boot cycles.
+        _audit_emit(
+            event=EVENT_SOCKET_REAPED,
+            project="_workspace",
+            subject=reaped.socket_path.name,
+            actor="system",
+            status="ok",
+            metadata={
+                "path": str(reaped.socket_path),
+                "kind": reaped.kind,
+                "pid": reaped.pid,
+                "reason": reaped.reason,
+            },
+        )
+    except Exception:  # noqa: BLE001
+        # Audit is best-effort by design. Never fail the reap path.
+        pass
+
+
+def reap_stale_cockpit_sockets(base_dir: Path) -> list[ReapedSocket]:
+    """Bootstrap-time reaper. Walk known socket dirs, unlink dead entries.
+
+    Mirrors :func:`pollypm.work.worker_marker_reaper.reap_orphan_worker_markers`.
+    Designed to be called from ``Supervisor._bootstrap_clear_markers``
+    so the cockpit boots into a clean ``cockpit_inputs/`` directory.
+
+    Args:
+        base_dir: ``self.config.project.base_dir`` — typically
+            ``~/.pollypm``. The reaper inspects ``base_dir/cockpit_inputs``
+            and the AF_UNIX-fallback ``$TMPDIR/pollypm-cockpit_inputs``.
+
+    Returns:
+        The list of :class:`ReapedSocket` records that were unlinked,
+        so callers can log / count / surface to the audit log.
+    """
+    reaped: list[ReapedSocket] = []
+    for directory in _candidate_dirs(base_dir):
+        for entry in _iter_socket_entries(directory):
+            decision = _classify(entry)
+            if decision is None:
+                continue
+            try:
+                entry.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning(
+                    "cockpit_socket_reaper: failed to unlink %s: %s",
+                    entry, exc,
+                )
+                continue
+            logger.warning(
+                "cockpit_socket_reaper: reaped %s (kind=%s, pid=%s, reason=%s)",
+                decision.socket_path,
+                decision.kind,
+                decision.pid,
+                decision.reason,
+            )
+            _emit_audit(decision)
+            reaped.append(decision)
+    return reaped
+
+
+__all__ = [
+    "ReapedSocket",
+    "reap_stale_cockpit_sockets",
+]

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -831,6 +831,24 @@ class Supervisor:
                 "worker-marker reaper failed at bootstrap", exc_info=True,
             )
 
+        # #1368 — reap stale ``cockpit_inputs/*.sock`` whose owning PID
+        # is dead. The bridge unlinks on clean shutdown but ``SIGKILL``
+        # / crash paths leave one entry per crashed cockpit boot; in the
+        # field we observed 318 stale sockets accumulating. Bootstrap is
+        # the safe sweep time — no cockpit is alive yet, so any reapable
+        # socket is by definition dead and a runtime race can't unlink
+        # a live cockpit's only discoverable bridge.
+        try:
+            from pollypm.cockpit_socket_reaper import (
+                reap_stale_cockpit_sockets,
+            )
+
+            reap_stale_cockpit_sockets(self.config.project.base_dir)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "cockpit-socket reaper failed at bootstrap", exc_info=True,
+            )
+
     def repair_sessions_table(self) -> int:
         """Upsert a ``sessions`` row for every configured session whose
         tmux window is currently alive.

--- a/tests/test_cockpit_socket_reaper.py
+++ b/tests/test_cockpit_socket_reaper.py
@@ -1,0 +1,317 @@
+"""Tests for the cockpit-input-socket reaper (#1368).
+
+The reaper unlinks stale ``cockpit_inputs/<kind>-<pid>.sock`` entries
+whose owning PID is no longer alive. We use real Unix sockets bound at
+real on-disk paths (no kernel-state mocks) so the tests exercise the
+same ``Path.is_socket`` / ``os.kill`` codepaths the production reaper
+hits at supervisor boot.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from pollypm.cockpit_socket_reaper import (
+    ReapedSocket,
+    reap_stale_cockpit_sockets,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _bind_socket(path: Path) -> socket.socket:
+    """Bind a real AF_UNIX socket at ``path`` (caller is responsible for
+    closing + unlinking on cleanup)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.bind(str(path))
+    sock.listen(1)
+    return sock
+
+
+def _spawn_briefly() -> int:
+    """Spawn a short-lived subprocess and return its PID after it exits.
+
+    Used to obtain a PID that is guaranteed dead at the time of the
+    reap call, so we can name-encode it into a stale socket filename
+    and verify the reaper picks it up. We capture the PID via
+    ``Popen`` (``subprocess.run`` returns a ``CompletedProcess`` that
+    intentionally does not expose ``pid`` once the child has reaped).
+    """
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import sys; sys.exit(0)"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    pid = proc.pid
+    proc.wait()
+    return pid
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def base_dir() -> Iterator[Path]:
+    """Synthesize a ``self.config.project.base_dir`` under a short root.
+
+    The reaper inspects ``<base_dir>/cockpit_inputs``. We avoid
+    pytest's ``tmp_path`` here because its default location lives
+    deep enough that the resulting AF_UNIX paths exceed the 104-char
+    ``sun_path`` limit on macOS — the same constraint the production
+    bridge code worked around in ``_resolve_bridge_path``. Using
+    ``/tmp/pb-<rand>`` keeps every socket path short.
+    """
+    root = Path("/tmp") / f"pbrp-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    base = root / "p"
+    (base / "cockpit_inputs").mkdir(parents=True)
+    try:
+        yield base
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap reaper — staleness + preservation
+# ---------------------------------------------------------------------------
+
+
+def test_reaps_socket_whose_pid_is_dead(base_dir: Path) -> None:
+    """A real socket file whose encoded PID is dead is unlinked."""
+    dead_pid = _spawn_briefly()
+    stale = base_dir / "cockpit_inputs" / f"cockpit-{dead_pid}.sock"
+    sock = _bind_socket(stale)
+    sock.close()  # binding leaves the inode; no live process holds it now.
+    assert stale.exists()
+
+    reaped = reap_stale_cockpit_sockets(base_dir)
+
+    assert not stale.exists(), "stale socket should have been unlinked"
+    assert len(reaped) == 1
+    entry = reaped[0]
+    assert isinstance(entry, ReapedSocket)
+    assert entry.socket_path == stale
+    assert entry.kind == "cockpit"
+    assert entry.pid == dead_pid
+    assert "not alive" in entry.reason
+
+
+def test_preserves_socket_owned_by_live_process(base_dir: Path) -> None:
+    """A socket whose encoded PID is the live test process is preserved.
+
+    ``os.getpid()`` is by definition alive for the duration of the
+    test. The reaper must not touch it — that's the live cockpit on
+    a real system.
+    """
+    live_pid = os.getpid()
+    live_path = base_dir / "cockpit_inputs" / f"cockpit-{live_pid}.sock"
+    sock = _bind_socket(live_path)
+    try:
+        reaped = reap_stale_cockpit_sockets(base_dir)
+        assert reaped == []
+        assert live_path.exists()
+        assert live_path.is_socket()
+    finally:
+        sock.close()
+        live_path.unlink(missing_ok=True)
+
+
+def test_reaps_only_stale_when_mixed(base_dir: Path) -> None:
+    """Mixed dir of live + stale sockets: only the stale ones go."""
+    live_pid = os.getpid()
+    dead_pid = _spawn_briefly()
+
+    live_path = base_dir / "cockpit_inputs" / f"cockpit-{live_pid}.sock"
+    stale_path = base_dir / "cockpit_inputs" / f"dashboard-{dead_pid}.sock"
+    live_sock = _bind_socket(live_path)
+    stale_sock = _bind_socket(stale_path)
+    stale_sock.close()
+    try:
+        reaped = reap_stale_cockpit_sockets(base_dir)
+
+        assert {r.socket_path for r in reaped} == {stale_path}
+        assert live_path.exists() and live_path.is_socket()
+        assert not stale_path.exists()
+    finally:
+        live_sock.close()
+        live_path.unlink(missing_ok=True)
+
+
+def test_skips_files_with_unparseable_names(base_dir: Path) -> None:
+    """A ``.sock`` file that doesn't parse as ``<kind>-<pid>.sock`` is left."""
+    weird = base_dir / "cockpit_inputs" / "no-pid-here.sock"
+    weird.parent.mkdir(parents=True, exist_ok=True)
+    # Write a regular file rather than a socket; the reaper should
+    # leave it alone either way because the PID parse fails.
+    weird.write_text("not a real socket")
+
+    reaped = reap_stale_cockpit_sockets(base_dir)
+
+    # ``no-pid-here.sock`` parses as kind="no-pid", pid="here" → ValueError.
+    # Reaper falls into the ``pid is None`` branch and preserves the file.
+    assert reaped == []
+    assert weird.exists()
+
+
+def test_skips_non_socket_file_with_dead_pid_name(base_dir: Path) -> None:
+    """A regular file whose name encodes a dead PID is preserved.
+
+    The reaper only touches actual socket inodes — we don't own
+    arbitrary ``.sock``-named regular files in this directory.
+    """
+    dead_pid = _spawn_briefly()
+    impostor = base_dir / "cockpit_inputs" / f"cockpit-{dead_pid}.sock"
+    impostor.write_text("not a socket")
+
+    reaped = reap_stale_cockpit_sockets(base_dir)
+
+    assert reaped == []
+    assert impostor.exists()
+
+
+def test_handles_missing_directory() -> None:
+    """A base_dir without ``cockpit_inputs/`` is a no-op, not an error."""
+    root = Path("/tmp") / f"pbrp-fresh-{uuid.uuid4().hex[:8]}"
+    root.mkdir()
+    try:
+        # No ``cockpit_inputs`` subdir.
+        reaped = reap_stale_cockpit_sockets(root)
+        assert reaped == []
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_sweeps_tmpdir_fallback_directory() -> None:
+    """Stale sockets in the AF_UNIX-fallback ``$TMPDIR`` dir are also reaped.
+
+    ``cockpit_input_bridge._resolve_bridge_path`` falls back to
+    ``$TMPDIR/pollypm-cockpit_inputs`` when the primary path exceeds
+    the ``sun_path`` limit. The reaper must sweep both so a long
+    workspace path doesn't quietly leak sockets in /tmp.
+    """
+    root = Path("/tmp") / f"pbrp-fb-{uuid.uuid4().hex[:8]}"
+    base = root / ".pollypm"
+    base.mkdir(parents=True)
+
+    fallback_dir = Path(tempfile.gettempdir()) / "pollypm-cockpit_inputs"
+    fallback_dir.mkdir(parents=True, exist_ok=True)
+
+    dead_pid = _spawn_briefly()
+    stale_clean = fallback_dir / f"cockpit-{dead_pid}.sock"
+    sock = _bind_socket(stale_clean)
+    sock.close()
+    try:
+        reaped = reap_stale_cockpit_sockets(base)
+        assert any(r.socket_path == stale_clean for r in reaped), (
+            f"fallback dir not swept: {reaped}"
+        )
+        assert not stale_clean.exists()
+    finally:
+        try:
+            stale_clean.unlink()
+        except FileNotFoundError:
+            pass
+        shutil.rmtree(root, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Integration: bootstrap path emits a ``socket.reaped`` audit event
+# ---------------------------------------------------------------------------
+
+
+def test_emits_socket_reaped_audit_event(
+    base_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reaping a stale socket appends a ``socket.reaped`` line to the
+    central audit tail.
+
+    Audit emit is best-effort and project-empty; the central tail
+    lives at ``$POLLYPM_AUDIT_HOME/_unknown.jsonl`` for workspace-wide
+    events. Setting the env var redirects writes off the user's real
+    audit log so the test never touches live state.
+    """
+    audit_home = tmp_path / "audit-home"
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+    dead_pid = _spawn_briefly()
+    stale = base_dir / "cockpit_inputs" / f"cockpit-{dead_pid}.sock"
+    sock = _bind_socket(stale)
+    sock.close()
+
+    reaped = reap_stale_cockpit_sockets(base_dir)
+    assert reaped, "expected the stale socket to be reaped"
+
+    # ``cockpit_socket_reaper`` writes against the ``_workspace`` project
+    # key (workspace-wide, not project-scoped). Read via the public
+    # API so the test stays decoupled from the on-disk filename.
+    from pollypm.audit.log import central_log_path, read_events
+
+    central = central_log_path("_workspace")
+    assert central.exists(), f"audit central tail missing: {central}"
+
+    events = read_events("_workspace")
+    socket_events = [e for e in events if e.event == "socket.reaped"]
+    assert socket_events, f"expected socket.reaped event, got {[e.event for e in events]}"
+    last = socket_events[-1]
+    assert last.subject == stale.name
+    assert last.metadata.get("pid") == dead_pid
+    assert last.metadata.get("kind") == "cockpit"
+    assert last.actor == "system"
+
+
+# ---------------------------------------------------------------------------
+# Integration: full create-then-reap cycle
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_path_creates_then_reaps_only_stale(base_dir: Path) -> None:
+    """Bootstrap-style flow: bind sockets, kill some "owners" by closing
+    + naming them with dead PIDs, run reaper, assert only stale ones
+    are gone."""
+    live_pid = os.getpid()
+    dead_pid_a = _spawn_briefly()
+    dead_pid_b = _spawn_briefly()
+    while dead_pid_b == dead_pid_a:
+        dead_pid_b = _spawn_briefly()
+
+    paths = {
+        "live": base_dir / "cockpit_inputs" / f"cockpit-{live_pid}.sock",
+        "dead_a": base_dir / "cockpit_inputs" / f"cockpit-{dead_pid_a}.sock",
+        "dead_b": base_dir / "cockpit_inputs" / f"dashboard-{dead_pid_b}.sock",
+    }
+    socks: dict[str, socket.socket] = {}
+    for key, p in paths.items():
+        socks[key] = _bind_socket(p)
+
+    # Close + leave file for the dead ones (simulating crashed cockpits
+    # that didn't run BridgeHandle.stop). Live one stays bound.
+    socks["dead_a"].close()
+    socks["dead_b"].close()
+
+    try:
+        reaped = reap_stale_cockpit_sockets(base_dir)
+        reaped_paths = {r.socket_path for r in reaped}
+
+        assert paths["live"].exists()
+        assert not paths["dead_a"].exists()
+        assert not paths["dead_b"].exists()
+        assert reaped_paths == {paths["dead_a"], paths["dead_b"]}
+    finally:
+        socks["live"].close()
+        for p in paths.values():
+            p.unlink(missing_ok=True)


### PR DESCRIPTION
## Context

Closes #1368

Each cockpit boot binds an AF_UNIX socket at
``~/.pollypm/cockpit_inputs/cockpit-<pid>.sock`` (see
``cockpit_input_bridge.start_input_bridge``). ``BridgeHandle.stop`` unlinks
on clean shutdown, but the cockpit can be SIGKILLed / its tmux session torn
down / its host process panic — none of which run cleanup. The only
opportunistic GC lives inside ``send_key_to_first_live`` and only fires
when a *caller* hits ``ConnectionRefusedError`` AND the encoded PID is
dead. Sockets nobody tries to connect to stay forever.

In the field 318 stale entries had piled up. Every ``send_key`` walks
all 318 (newest-first sort + connect-and-fail) before reaching the live
socket.

## What this PR does

Mirrors the worker-marker reaper pattern from #1338:

- New module ``src/pollypm/cockpit_socket_reaper.py`` exposes
  ``reap_stale_cockpit_sockets(base_dir)``.
- Wired into ``Supervisor._bootstrap_clear_markers`` so it runs at
  supervisor boot, alongside the existing session-marker /
  worker-marker sweeps.
- Walks both the primary ``<base_dir>/cockpit_inputs/`` directory and
  the ``$TMPDIR/pollypm-cockpit_inputs/`` AF_UNIX-fallback that the
  bridge uses when the primary path exceeds ``sun_path``.
- Parses the encoded PID out of each ``<kind>-<pid>.sock`` filename,
  preserves any socket whose PID is alive (``os.kill(pid, 0)``), and
  unlinks the rest.
- Emits a ``socket.reaped`` audit event (new
  ``EVENT_SOCKET_REAPED`` constant in ``pollypm.audit.log``) under the
  ``_workspace`` project key per reap, so leak rates can be
  forensically counted from ``~/.pollypm/audit/_workspace.jsonl``.

## Why bootstrap-only

At supervisor boot no cockpit is alive yet, so every reapable socket
is by definition dead — no race with the live cockpit binding the
same path. A runtime sweeper would race with the bridge's pre-bind
unlink. The issue explicitly flagged this concern; we sidestep it by
restricting the sweep to bootstrap.

## Staleness criteria

A ``.sock`` entry is reaped when ALL of:
- Filename parses as ``<kind>-<pid>.sock`` with an integer PID.
- ``os.kill(pid, 0)`` returns ``ProcessLookupError`` (PID is gone).
- The on-disk entry is actually a socket inode (not a regular file).

We chose PID-from-filename over ``lsof`` per-socket because at 318+
files the ``lsof`` approach is N kernel round-trips, whereas
``os.kill`` is constant-time per file. The bridge already encodes the
PID into the filename for exactly this reason
(``_socket_filename`` / ``_socket_owner_pid``).

## Test plan

- [x] Unit: ``test_reaps_socket_whose_pid_is_dead`` — real Unix
      socket with a dead PID gets unlinked.
- [x] Unit: ``test_preserves_socket_owned_by_live_process`` — current
      test process's PID is preserved.
- [x] Unit: ``test_reaps_only_stale_when_mixed`` — mixed live/stale
      directory: only stale ones go.
- [x] Unit: ``test_skips_files_with_unparseable_names`` — random
      ``.sock`` files in the dir are left alone.
- [x] Unit: ``test_skips_non_socket_file_with_dead_pid_name`` —
      regular files (not socket inodes) are preserved even if they
      happen to be named ``cockpit-<dead-pid>.sock``.
- [x] Unit: ``test_handles_missing_directory`` — fresh install where
      ``cockpit_inputs/`` doesn't exist is a no-op.
- [x] Unit: ``test_sweeps_tmpdir_fallback_directory`` — the
      ``$TMPDIR/pollypm-cockpit_inputs`` fallback dir is also swept.
- [x] Integration: ``test_emits_socket_reaped_audit_event`` —
      reap path writes a ``socket.reaped`` line to the central
      audit tail.
- [x] Integration: ``test_bootstrap_path_creates_then_reaps_only_stale``
      — full create-then-reap cycle.
- [x] Existing ``tests/test_supervisor.py`` (73 tests) still pass.
- [x] Existing ``tests/test_audit_log.py`` + ``test_audit_watchdog.py`` (43 tests) still pass.
- [x] Existing ``tests/test_cockpit_input_bridge.py`` + ``test_worker_marker_reaper.py`` (66 tests) still pass.

All sockets in tests are real AF_UNIX inodes — no kernel-state mocks.