### PR TITLE
Hoist SQLiteWorkService construction to work module factory

### DIFF
--- a/src/pollypm/cli_features/projects.py
+++ b/src/pollypm/cli_features/projects.py
@@ -92,9 +92,9 @@ def _emit_auto_plan_status(
     status: str | None = None
     if db_path.exists():
         try:
-            from pollypm.work.sqlite_service import SQLiteWorkService
+            from pollypm.work import create_work_service
 
-            with SQLiteWorkService(
+            with create_work_service(
                 db_path=db_path, project_path=project_path,
             ) as svc:
                 tasks = svc.list_tasks(project=project_key)

--- a/src/pollypm/cli_features/session_runtime.py
+++ b/src/pollypm/cli_features/session_runtime.py
@@ -877,9 +877,9 @@ def register_session_runtime_commands(app: typer.Typer, *, helpers) -> None:
 
         inbox_task_id: str | None = None
         if resolved_priority == "immediate":
-            from pollypm.work.sqlite_service import SQLiteWorkService
+            from pollypm.work import create_work_service
 
-            svc = SQLiteWorkService(
+            svc = create_work_service(
                 db_path=db_path,
                 project_path=db_path.parent.parent,
             )

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -54,13 +54,13 @@ def _timestamp_sort_value(value) -> float:
 
 def _render_work_service_issues(project: object) -> str:
     """Render tasks from the work service for a project."""
-    from pollypm.work.sqlite_service import SQLiteWorkService
+    from pollypm.work import create_work_service
 
     db_path = project.path / ".pollypm" / "state.db"
     if not db_path.exists():
         raise FileNotFoundError(db_path)
 
-    with SQLiteWorkService(db_path=db_path, project_path=project.path) as svc:
+    with create_work_service(db_path=db_path, project_path=project.path) as svc:
         counts = svc.state_counts(project=getattr(project, "key", None))
         tasks = svc.list_tasks(project=getattr(project, "key", None))
 
@@ -201,8 +201,8 @@ def _count_inbox_tasks_for_label(config) -> int:
     count.
     """
     try:
+        from pollypm.work import create_work_service
         from pollypm.work.inbox_view import inbox_tasks
-        from pollypm.work.sqlite_service import SQLiteWorkService
         from pollypm.cockpit_inbox_items import (
             _WORKSPACE_DB_KEY,
             _filter_approved_plan_reviews,
@@ -236,7 +236,7 @@ def _count_inbox_tasks_for_label(config) -> int:
         else:
             project_db_paths[_WORKSPACE_DB_KEY] = (db_path, project_path)
         try:
-            with SQLiteWorkService(
+            with create_work_service(
                 db_path=db_path, project_path=project_path,
             ) as svc:
                 for task in inbox_tasks(svc, project=project_key):
@@ -527,6 +527,7 @@ def _render_inbox_panel(config) -> str:
     each, and renders the combined view. Projects with no DB are silently
     skipped so a fresh install stays usable.
     """
+    from pollypm.work import create_work_service
     from pollypm.work.sqlite_service import SQLiteWorkService
 
     # Aggregate inbox tasks across all tracked projects. Each project has its
@@ -565,7 +566,7 @@ def _render_inbox_panel(config) -> str:
             if not db_path.exists():
                 continue
             try:
-                svc = SQLiteWorkService(
+                svc = create_work_service(
                     db_path=db_path, project_path=project_path,
                 )
             except Exception:  # noqa: BLE001
@@ -912,7 +913,7 @@ def _gather_worker_roster(config) -> list[WorkerRosterRow]:
     Always best-effort: a bad DB or missing tmux session degrades one
     project's worth of rows, never the whole roster.
     """
-    from pollypm.work.sqlite_service import SQLiteWorkService
+    from pollypm.work import create_work_service
 
     projects = getattr(config, "projects", {}) or {}
     if not projects:
@@ -952,7 +953,7 @@ def _gather_worker_roster(config) -> list[WorkerRosterRow]:
         if not db_path.exists():
             continue
         try:
-            svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+            svc = create_work_service(db_path=db_path, project_path=project_path)
         except Exception:  # noqa: BLE001
             continue
         try:

--- a/src/pollypm/cockpit_inbox_items.py
+++ b/src/pollypm/cockpit_inbox_items.py
@@ -30,6 +30,7 @@ from pollypm.work.inbox_plan_reviews import (
     is_plan_task_approved,
     task_user_approval_is_approved,
 )
+from pollypm.work import create_work_service
 from pollypm.work.sqlite_service import SQLiteWorkService
 
 logger = logging.getLogger(__name__)
@@ -706,7 +707,7 @@ def load_inbox_entries(
                 except Exception:  # noqa: BLE001
                     pass
         try:
-            svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+            svc = create_work_service(db_path=db_path, project_path=project_path)
         except Exception:  # noqa: BLE001
             continue
         try:

--- a/src/pollypm/cockpit_project_settings.py
+++ b/src/pollypm/cockpit_project_settings.py
@@ -38,7 +38,7 @@ from pollypm.model_registry import advisories_for, load_registry, resolve_alias
 from pollypm.models import ModelAssignment, ProviderKind
 from pollypm.role_routing import resolve_role_assignment
 from pollypm.service_api import PollyPMService
-from pollypm.work.sqlite_service import SQLiteWorkService
+from pollypm.work import create_work_service
 
 _PROJECT_ROLE_KEYS = ("architect", "worker", "reviewer")
 _ROLE_LABELS = {
@@ -583,7 +583,7 @@ class PollyProjectSettingsApp(App[None]):
         if not db_path.exists():
             return "[dim]No project database yet.[/dim]"
         try:
-            with SQLiteWorkService(db_path=db_path, project_path=project_path) as svc:
+            with create_work_service(db_path=db_path, project_path=project_path) as svc:
                 tasks = svc.list_tasks(assignee=worker.name, limit=5)
         except Exception as exc:  # noqa: BLE001
             return f"[dim]Recent tasks unavailable: {exc}[/dim]"

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -495,13 +495,13 @@ def _build_project_pm_primer(
     inbox_titles: list[str] = []
     inbox_total = 0
     try:
+        from pollypm.work import create_work_service
         from pollypm.work.inbox_view import inbox_tasks
         from pollypm.work.models import WorkStatus
-        from pollypm.work.sqlite_service import SQLiteWorkService
 
         db_path = project.path / ".pollypm" / "state.db"
         if db_path.exists():
-            with SQLiteWorkService(
+            with create_work_service(
                 db_path=db_path, project_path=project.path,
             ) as svc:
                 tasks = list(svc.list_tasks(project=project_key))
@@ -610,11 +610,11 @@ def _build_operator_primer(supervisor) -> str | None:
     inbox_titles: list[tuple[str, str]] = []
     project_count = 0
     try:
+        from pollypm.work import create_work_service
         from pollypm.work.inbox_view import inbox_tasks
-        from pollypm.work.sqlite_service import SQLiteWorkService
     except Exception:  # noqa: BLE001
         inbox_tasks = None  # type: ignore[assignment]
-        SQLiteWorkService = None  # type: ignore[assignment]
+        create_work_service = None  # type: ignore[assignment]
 
     projects = getattr(supervisor.config, "projects", {}) or {}
     for project_key, project in projects.items():
@@ -627,13 +627,13 @@ def _build_operator_primer(supervisor) -> str | None:
                 "_", "-"
             )
         project_lines.append(f"  - {project_name}")
-        if inbox_tasks is None or SQLiteWorkService is None:
+        if inbox_tasks is None or create_work_service is None:
             continue
         db_path = project.path / ".pollypm" / "state.db"
         if not db_path.exists():
             continue
         try:
-            with SQLiteWorkService(
+            with create_work_service(
                 db_path=db_path, project_path=project.path,
             ) as svc:
                 items = list(inbox_tasks(svc, project=project_key))
@@ -1752,10 +1752,10 @@ class CockpitRouter:
         if not db_path.exists():
             return [], False
         from pollypm.plugins_builtin.project_planning.plan_presence import has_acceptable_plan
+        from pollypm.work import create_work_service
         from pollypm.work.project_aliases import project_storage_aliases
-        from pollypm.work.sqlite_service import SQLiteWorkService
 
-        work = SQLiteWorkService(db_path, project_path=project_path)
+        work = create_work_service(db_path=db_path, project_path=project_path)
         try:
             # #1092 — match the dashboard's alias-aware lookup. The work
             # DB stores tasks under the display name (``booktalk``) while

--- a/src/pollypm/cockpit_sections/project_dashboard.py
+++ b/src/pollypm/cockpit_sections/project_dashboard.py
@@ -58,13 +58,13 @@ def _dashboard_project_tasks(
     if cached is not None and cached[0] == db_mtime:
         return cached[1], cached[2]
 
-    from pollypm.work.sqlite_service import SQLiteWorkService
+    from pollypm.work import create_work_service
     partitioned: dict[str, list] = {
         "in_progress": [], "review": [], "queued": [], "blocked": [], "done": [],
     }
     counts: dict[str, int] = {}
     try:
-        with SQLiteWorkService(db_path=db_path, project_path=project_path) as svc:
+        with create_work_service(db_path=db_path, project_path=project_path) as svc:
             tasks = svc.list_tasks(project=project_key)
             counts = svc.state_counts(project=project_key)
             for t in tasks:
@@ -95,7 +95,7 @@ def _render_project_dashboard(
     degrades gracefully on missing data so a fresh project with empty
     state still produces a readable surface.
     """
-    from pollypm.work.sqlite_service import SQLiteWorkService
+    from pollypm.work import create_work_service
 
     db_path = project.path / ".pollypm" / "state.db"
     if not db_path.exists():
@@ -104,7 +104,7 @@ def _render_project_dashboard(
     # Single SQLite open per render \u2014 every downstream section reuses
     # this hydrated task list and the counts map.
     inbox_count = 0
-    with SQLiteWorkService(db_path=db_path, project_path=project.path) as svc:
+    with create_work_service(db_path=db_path, project_path=project.path) as svc:
         try:
             from pollypm.work.inbox_view import inbox_tasks
         except Exception:  # noqa: BLE001

--- a/src/pollypm/cockpit_tasks.py
+++ b/src/pollypm/cockpit_tasks.py
@@ -1528,7 +1528,7 @@ class PollyTasksApp(App[None]):
         from. Fall back to the project-local DB so the legacy contract
         still holds when neither DB has a row yet.
         """
-        from pollypm.work.sqlite_service import SQLiteWorkService
+        from pollypm.work import create_work_service
 
         try:
             config = load_config(self.config_path)
@@ -1540,7 +1540,7 @@ class PollyTasksApp(App[None]):
             return None
         for db_path, project_path in candidates:
             try:
-                svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+                svc = create_work_service(db_path=db_path, project_path=project_path)
             except Exception:  # noqa: BLE001
                 continue
             try:
@@ -1561,7 +1561,7 @@ class PollyTasksApp(App[None]):
         # the rest of the pane still has a working service handle.
         first_db, first_project_path = candidates[0]
         try:
-            return SQLiteWorkService(
+            return create_work_service(
                 db_path=first_db, project_path=first_project_path,
             )
         except Exception:  # noqa: BLE001

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -4048,9 +4048,9 @@ def _collect_recent_tasks_by_account(
         if not db_path.exists():
             continue
         try:
-            from pollypm.work.sqlite_service import SQLiteWorkService
+            from pollypm.work import create_work_service
 
-            with SQLiteWorkService(db_path=db_path, project_path=project_path) as svc:
+            with create_work_service(db_path=db_path, project_path=project_path) as svc:
                 for status in account_statuses:
                     key = str(getattr(status, "key", ""))
                     if not key:
@@ -10566,12 +10566,12 @@ def _dashboard_plan_staleness(
             _find_approved_plan_task,
             _plan_approved_at,
         )
-        from pollypm.work.sqlite_service import SQLiteWorkService
+        from pollypm.work import create_work_service
     except Exception:  # noqa: BLE001
         return None
     result: str | None = None
     try:
-        with SQLiteWorkService(
+        with create_work_service(
             db_path=db_path, project_path=project_path,
         ) as svc:
             plan_task = _find_approved_plan_task(svc, project_key)
@@ -11081,7 +11081,7 @@ def _dashboard_gather_tasks(
         return cached
 
     try:
-        from pollypm.work.sqlite_service import SQLiteWorkService
+        from pollypm.work import create_work_service
     except Exception:  # noqa: BLE001
         return {}, {}
 
@@ -11111,7 +11111,7 @@ def _dashboard_gather_tasks(
             if discovered not in db_aliases:
                 db_aliases.append(discovered)
         try:
-            with SQLiteWorkService(db_path=db_path, project_path=project_path) as svc:
+            with create_work_service(db_path=db_path, project_path=project_path) as svc:
                 tasks: list = []
                 seen_ids: set[str] = set()
                 for alias in db_aliases:
@@ -11272,11 +11272,11 @@ def _classify_worker_activity(
     has_owned_task = False
     if project_path is not None:
         try:
-            from pollypm.work.sqlite_service import SQLiteWorkService
+            from pollypm.work import create_work_service
 
             db_path = project_path / ".pollypm" / "state.db"
             if db_path.exists():
-                with SQLiteWorkService(
+                with create_work_service(
                     db_path=db_path, project_path=project_path,
                 ) as svc:
                     for alias in project_aliases:
@@ -11569,8 +11569,8 @@ def _dashboard_inbox(
         return cached
     try:
         from pollypm.store import SQLAlchemyStore
+        from pollypm.work import create_work_service
         from pollypm.work.inbox_view import inbox_tasks
-        from pollypm.work.sqlite_service import SQLiteWorkService
         from pollypm.cockpit_inbox import _row_is_dev_channel
     except Exception:  # noqa: BLE001
         return 0, [], []
@@ -12034,7 +12034,7 @@ def _dashboard_inbox(
     known_projects = set(getattr(config, "projects", {}).keys())
     items: list[dict] = []
     try:
-        with SQLiteWorkService(
+        with create_work_service(
             db_path=db_path, project_path=project_path,
         ) as svc:
             # #920 — query each project alias and dedupe so projects
@@ -14906,7 +14906,7 @@ class PollyProjectDashboardApp(App[None]):
             self.notify("Could not open project database.", severity="error")
             return
         try:
-            from pollypm.work.sqlite_service import SQLiteWorkService
+            from pollypm.work import create_work_service
         except Exception as exc:  # noqa: BLE001
             self.notify(f"Could not load task service: {exc}", severity="error")
             return
@@ -14923,7 +14923,7 @@ class PollyProjectDashboardApp(App[None]):
         initial_status = ""
         final_status = ""
         try:
-            with SQLiteWorkService(
+            with create_work_service(
                 db_path=db_path, project_path=data.project_path,
             ) as svc:
                 initial_status = svc.get(task_id).work_status.value

--- a/src/pollypm/control_tui.py
+++ b/src/pollypm/control_tui.py
@@ -46,8 +46,8 @@ def _inbox_tasks_for_tui(config):
     any error so the TUI still renders instead of blowing up mid-refresh.
     """
     try:
+        from pollypm.work import create_work_service
         from pollypm.work.inbox_view import inbox_tasks
-        from pollypm.work.sqlite_service import SQLiteWorkService
     except Exception:  # noqa: BLE001
         return []
     out: list = []
@@ -56,7 +56,7 @@ def _inbox_tasks_for_tui(config):
         if not db_path.exists():
             continue
         try:
-            with SQLiteWorkService(
+            with create_work_service(
                 db_path=db_path, project_path=project.path,
             ) as svc:
                 out.extend(inbox_tasks(svc, project=project_key))

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -543,8 +543,8 @@ def _session_description(status: str, role: str, snapshot_path: str | None) -> s
 def _count_inbox_tasks(config: PollyPMConfig) -> int:
     """Total inbox tasks across all tracked projects (work-service backed)."""
     try:
+        from pollypm.work import create_work_service
         from pollypm.work.inbox_view import inbox_tasks
-        from pollypm.work.sqlite_service import SQLiteWorkService
     except Exception:  # noqa: BLE001
         return 0
     total = 0
@@ -562,7 +562,7 @@ def _count_inbox_tasks(config: PollyPMConfig) -> int:
         if not db_path.exists():
             continue
         try:
-            with SQLiteWorkService(
+            with create_work_service(
                 db_path=db_path, project_path=project.path,
             ) as svc:
                 total += len(inbox_tasks(svc, project=project_key))
@@ -653,8 +653,8 @@ def _inbox_sender(task) -> str:
 
 def _recent_inbox_messages(config: PollyPMConfig, *, limit: int = 3) -> list[InboxPreview]:
     try:
+        from pollypm.work import create_work_service
         from pollypm.work.inbox_view import inbox_tasks
-        from pollypm.work.sqlite_service import SQLiteWorkService
     except Exception:  # noqa: BLE001
         return []
 
@@ -678,7 +678,7 @@ def _recent_inbox_messages(config: PollyPMConfig, *, limit: int = 3) -> list[Inb
         if not db_path.exists():
             continue
         try:
-            with SQLiteWorkService(db_path=db_path, project_path=project_path) as svc:
+            with create_work_service(db_path=db_path, project_path=project_path) as svc:
                 for task in inbox_tasks(svc, project=project_key):
                     if task.task_id in seen_task_ids:
                         continue

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -186,13 +186,13 @@ def _collect_work_service_signals(
         if not work_db.exists():
             return out
 
-        from pollypm.work.sqlite_service import SQLiteWorkService
+        from pollypm.work import create_work_service
 
         worktree_path: str | None = None
         claim_started_at: str | None = None
         claim_task_id: str | None = None
         try:
-            with SQLiteWorkService(
+            with create_work_service(
                 db_path=work_db, project_path=project_path,
             ) as svc:
                 sessions = svc.list_worker_sessions(
@@ -1123,7 +1123,7 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                 load_runtime_services,
                 notify as _notify,
             )
-            from pollypm.work.sqlite_service import SQLiteWorkService
+            from pollypm.work import create_work_service
 
             task_id = signals.active_claim_task_id
             if not task_id or "/" not in task_id:
@@ -1144,7 +1144,7 @@ class LocalHeartbeatBackend(HeartbeatBackend):
 
             services = load_runtime_services()
             try:
-                with SQLiteWorkService(
+                with create_work_service(
                     db_path=work_db, project_path=project_cfg.path,
                 ) as svc:
                     tasks = svc.list_tasks(project=project)

--- a/src/pollypm/heartbeats/stall_classifier.py
+++ b/src/pollypm/heartbeats/stall_classifier.py
@@ -213,11 +213,11 @@ def has_pending_work_for_session(config, session_name: str) -> bool:
             pass
 
         try:
-            from pollypm.work.sqlite_service import SQLiteWorkService
+            from pollypm.work import create_work_service
 
             db_path = project_path / ".pollypm" / "state.db"
             if db_path.exists():
-                with SQLiteWorkService(
+                with create_work_service(
                     db_path=db_path, project_path=project_path,
                 ) as svc:
                     for task in svc.list_tasks(project=project_key):

--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -576,11 +576,11 @@ def _remove_demo_repo_files(target: Path, relative_names: set[str]) -> None:
 def seed_demo_project_task(project_path: Path, *, project_key: str) -> str:
     """Seed one small PollyPM task into the demo project's work DB."""
     from pollypm.projects import ensure_project_scaffold
-    from pollypm.work.sqlite_service import SQLiteWorkService
+    from pollypm.work import create_work_service
 
     ensure_project_scaffold(project_path)
     db_path = project_path / ".pollypm" / "state.db"
-    with SQLiteWorkService(db_path=db_path, project_path=project_path) as svc:
+    with create_work_service(db_path=db_path, project_path=project_path) as svc:
         existing = svc.list_tasks(project=project_key)
         for task in existing:
             if task.title == DEMO_PROJECT_TASK_TITLE:

--- a/src/pollypm/plugins_builtin/advisor/handlers/advisor_tick.py
+++ b/src/pollypm/plugins_builtin/advisor/handlers/advisor_tick.py
@@ -116,7 +116,7 @@ def enqueue_advisor_review(
     """
     close_service = False
     if work_service is None:
-        from pollypm.work.sqlite_service import SQLiteWorkService
+        from pollypm.work import create_work_service
 
         # Prefer an existing state.db (per-project or workspace-root,
         # #1037). Only synthesize the per-project path when neither
@@ -126,7 +126,7 @@ def enqueue_advisor_review(
         if db_path is None:
             db_path = project_path / ".pollypm" / "state.db"
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        work_service = SQLiteWorkService(db_path=db_path, project_path=project_path)
+        work_service = create_work_service(db_path=db_path, project_path=project_path)
         close_service = True
 
     try:
@@ -219,8 +219,8 @@ def has_project_stagnation_candidate(
         if db_path is None:
             return False
         try:
-            from pollypm.work.sqlite_service import SQLiteWorkService
-            work_service = SQLiteWorkService(db_path=db_path, project_path=project_path)
+            from pollypm.work import create_work_service
+            work_service = create_work_service(db_path=db_path, project_path=project_path)
             close_service = True
         except Exception:  # noqa: BLE001
             return False

--- a/src/pollypm/plugins_builtin/core_agent_profiles/profiles.py
+++ b/src/pollypm/plugins_builtin/core_agent_profiles/profiles.py
@@ -502,8 +502,8 @@ def _render_operator_state_brief(context: AgentProfileContext) -> str:
 
 def _project_inbox_snapshot(project_key: str, project_root: Path) -> list[dict[str, str]]:
     try:
+        from pollypm.work import create_work_service
         from pollypm.work.inbox_view import inbox_tasks
-        from pollypm.work.sqlite_service import SQLiteWorkService
     except Exception:  # noqa: BLE001
         return []
 
@@ -511,7 +511,7 @@ def _project_inbox_snapshot(project_key: str, project_root: Path) -> list[dict[s
     if not db_path.exists():
         return []
     try:
-        with SQLiteWorkService(db_path=db_path, project_path=project_root) as svc:
+        with create_work_service(db_path=db_path, project_path=project_root) as svc:
             return [
                 {
                     "status": task.work_status.value,

--- a/src/pollypm/plugins_builtin/core_recurring/maintenance.py
+++ b/src/pollypm/plugins_builtin/core_recurring/maintenance.py
@@ -653,12 +653,24 @@ def log_rotate_handler(payload: dict[str, Any]) -> dict[str, Any]:
 
 def notification_staging_prune_handler(payload: dict[str, Any]) -> dict[str, Any]:
     """Drop flushed + silent notification_staging rows older than 30d."""
-    from pollypm.work.sqlite_service import SQLiteWorkService
+    from pollypm.work import create_work_service
 
     with _load_config_and_store(payload) as (_config, store):
         retain_days = int(payload.get("retain_days") or 30)
-        db_path = getattr(store, "path", None) or _config.project.state_db
-        with SQLiteWorkService(db_path=db_path) as svc:
+        # #1369 / #savethenovel-followup: the legacy fallback here was
+        # ``_config.project.state_db`` — the *messages-side* DB. The
+        # ``notification_staging`` table lives on the work-side DB, so
+        # falling through to ``state_db`` would silently stamp the
+        # work schema onto the messages DB on a fresh install. Route
+        # through the work factory so the canonical resolver picks
+        # the workspace-root work DB regardless of which fallback the
+        # store ended up at.
+        store_path = getattr(store, "path", None)
+        if store_path is not None:
+            svc_ctx = create_work_service(db_path=store_path)
+        else:
+            svc_ctx = create_work_service(config=_config)
+        with svc_ctx as svc:
             summary = svc.prune_staged_notifications(retain_days=retain_days)
 
         msg_store = _open_msg_store(_config)

--- a/src/pollypm/plugins_builtin/core_recurring/sweeps.py
+++ b/src/pollypm/plugins_builtin/core_recurring/sweeps.py
@@ -762,11 +762,11 @@ def worktree_state_audit_handler(payload: dict[str, Any]) -> dict[str, Any]:
             return bool(rows)
 
         try:
-            from pollypm.work.sqlite_service import SQLiteWorkService
+            from pollypm.work import create_work_service
 
             project_root = config.project.root_dir
             db_path = project_root / ".pollypm" / "state.db"
-            work = SQLiteWorkService(db_path=db_path, project_path=project_root)
+            work = create_work_service(db_path=db_path, project_path=project_root)
         except Exception:  # noqa: BLE001
             logger.debug(
                 "worktree.state_audit: work service unavailable", exc_info=True,

--- a/src/pollypm/plugins_builtin/downtime/handlers/downtime_tick.py
+++ b/src/pollypm/plugins_builtin/downtime/handlers/downtime_tick.py
@@ -93,14 +93,14 @@ def schedule_downtime_task(
     matching handlers without reparsing the description.
     """
     try:
-        from pollypm.work.sqlite_service import SQLiteWorkService
+        from pollypm.work import create_work_service
     except Exception:  # noqa: BLE001 - work service optional in some tests
         logger.warning("downtime: work service unavailable, cannot schedule task")
         return None
 
     try:
         project_root = Path(getattr(config.project, "root_dir", Path.cwd()))
-        svc = SQLiteWorkService(
+        svc = create_work_service(
             db_path=str(db_path) if db_path else ":memory:",
             project_path=project_root,
         )
@@ -204,13 +204,13 @@ def has_active_downtime_task(
 ) -> bool:
     """Return True if any downtime-labelled task is ``in_progress`` or ``review``."""
     try:
-        from pollypm.work.sqlite_service import SQLiteWorkService
+        from pollypm.work import create_work_service
     except Exception:  # noqa: BLE001
         return False
     if db_path is None:
         return False
     try:
-        svc = SQLiteWorkService(
+        svc = create_work_service(
             db_path=str(db_path),
             project_path=project_root or Path.cwd(),
         )

--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -335,7 +335,7 @@ def _plan_project_task(
     # wired a full SQLite environment yet.
     import logging
 
-    from pollypm.work.sqlite_service import SQLiteWorkService
+    from pollypm.work import create_work_service
 
     log = logging.getLogger(__name__)
 
@@ -345,7 +345,7 @@ def _plan_project_task(
         create_parent=True,
     )
 
-    with SQLiteWorkService(db_path=db_path, project_path=project_path) as svc:
+    with create_work_service(db_path=db_path, project_path=project_path) as svc:
         task = svc.create(
             title=f"{title_prefix} {project_key}",
             description=description or (
@@ -483,11 +483,11 @@ def blocker_summary_cmd(
     )
 
     from pollypm.store import SQLAlchemyStore
-    from pollypm.work.sqlite_service import SQLiteWorkService
+    from pollypm.work import create_work_service
 
     store = SQLAlchemyStore(f"sqlite:///{db_path}")
     try:
-        with SQLiteWorkService(
+        with create_work_service(
             db_path=db_path, project_path=project_path,
         ) as svc:
             result = record_project_blocker_summary(
@@ -1136,9 +1136,9 @@ def _plan_task_exists(
     if not db_path.exists():
         return False
     try:
-        from pollypm.work.sqlite_service import SQLiteWorkService
+        from pollypm.work import create_work_service
 
-        with SQLiteWorkService(
+        with create_work_service(
             db_path=db_path, project_path=project_path,
         ) as svc:
             for task in svc.list_tasks(project=project_key):

--- a/src/pollypm/plugins_builtin/project_planning/plugin.py
+++ b/src/pollypm/plugins_builtin/project_planning/plugin.py
@@ -206,7 +206,7 @@ def _on_project_created(context) -> None:
         # service. Local import to avoid pulling SQLite deps into code
         # paths that don't need them.
         from pathlib import Path as _Path
-        from pollypm.work.sqlite_service import SQLiteWorkService
+        from pollypm.work import create_work_service
 
         project_path = _Path(project_path_raw)
         db_path = workspace_db_path or (project_path / ".pollypm" / "state.db")
@@ -225,7 +225,7 @@ def _on_project_created(context) -> None:
                 f"Auto-created on project.created. Run the architect "
                 f"+ 5-critic planning pipeline on {project_key}."
             )
-        with SQLiteWorkService(
+        with create_work_service(
             db_path=db_path, project_path=project_path,
         ) as svc:
             task = svc.create(

--- a/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
@@ -1987,10 +1987,10 @@ def _open_workspace_project_work_service(project: Any, services: Any) -> Any | N
     if not db_path.exists():
         return None
     try:
-        from pollypm.work.sqlite_service import SQLiteWorkService
+        from pollypm.work import create_work_service
 
         project_root = Path(project_path)
-        svc = SQLiteWorkService(db_path=db_path, project_path=project_root)
+        svc = create_work_service(db_path=db_path, project_path=project_root)
     except Exception:  # noqa: BLE001
         logger.debug(
             "task_assignment sweep: failed to open workspace DB at %s",
@@ -2016,9 +2016,9 @@ def _open_project_work_service(project: Any, services: Any) -> Any | None:
     if not db_path.exists():
         return None
     try:
-        from pollypm.work.sqlite_service import SQLiteWorkService
+        from pollypm.work import create_work_service
 
-        svc = SQLiteWorkService(db_path=db_path, project_path=Path(project_path))
+        svc = create_work_service(db_path=db_path, project_path=Path(project_path))
     except Exception:  # noqa: BLE001
         logger.debug(
             "task_assignment sweep: failed to open per-project DB at %s",

--- a/src/pollypm/recovery_prompt.py
+++ b/src/pollypm/recovery_prompt.py
@@ -222,8 +222,8 @@ def _pending_inbox_section(config: PollyPMConfig) -> RecoveryPromptSection | Non
     and summarises them. No legacy inbox.
     """
     try:
+        from pollypm.work import create_work_service
         from pollypm.work.inbox_view import inbox_tasks
-        from pollypm.work.sqlite_service import SQLiteWorkService
 
         summaries: list[str] = []
         total = 0
@@ -239,7 +239,7 @@ def _pending_inbox_section(config: PollyPMConfig) -> RecoveryPromptSection | Non
             if not db_path.exists():
                 continue
             try:
-                with SQLiteWorkService(
+                with create_work_service(
                     db_path=db_path, project_path=project.path,
                 ) as svc:
                     tasks = inbox_tasks(svc, project=project_key)

--- a/src/pollypm/runtime_services.py
+++ b/src/pollypm/runtime_services.py
@@ -96,11 +96,11 @@ def load_runtime_services(
     )
     work_service: Any | None
     try:
-        from pollypm.work.sqlite_service import SQLiteWorkService
+        from pollypm.work import create_work_service
 
         db_path = project_root / ".pollypm" / "state.db"
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        work_service = SQLiteWorkService(db_path=db_path, project_path=project_root)
+        work_service = create_work_service(db_path=db_path, project_path=project_root)
     except Exception:  # noqa: BLE001
         logger.debug("runtime_services: work service unavailable", exc_info=True)
         work_service = None

--- a/src/pollypm/store/migrations.py
+++ b/src/pollypm/store/migrations.py
@@ -310,12 +310,12 @@ def _apply_all(db_path: Path) -> None:
     a single pane of glass.
     """
     from pollypm.storage.state import StateStore
-    from pollypm.work.sqlite_service import SQLiteWorkService
+    from pollypm.work import create_work_service
 
     with StateStore(db_path) as _store:
         pass
 
-    with SQLiteWorkService(db_path) as _svc:
+    with create_work_service(db_path=db_path) as _svc:
         pass
 
     _record_schema_migrations(db_path)

--- a/src/pollypm/supervisor_alerts.py
+++ b/src/pollypm/supervisor_alerts.py
@@ -171,12 +171,12 @@ def _review_tasks_for_project(
     if cached is not None and cached[0] == db_mtime:
         return cached[1], cached[2]
 
-    from pollypm.work.sqlite_service import SQLiteWorkService
+    from pollypm.work import create_work_service
 
     entries: list[str] = []
     re_review_count = 0
     try:
-        with SQLiteWorkService(db_path=db_path) as svc:
+        with create_work_service(db_path=db_path) as svc:
             tasks = svc.list_tasks(work_status="review", project=project_key)
             for task in tasks:
                 if task.current_node_id and "human" in task.current_node_id:
@@ -520,8 +520,8 @@ def _build_task_nudge(supervisor: SupervisorAlertBoundary, launch: SessionLaunch
     # #804: same boundary fix as _build_review_nudge — public resolver,
     # logged failures instead of swallowing every exception.
     try:
+        from pollypm.work import create_work_service
         from pollypm.work.db_resolver import resolve_work_db_path
-        from pollypm.work.sqlite_service import SQLiteWorkService
 
         project = launch.session.project
         # #928: same boundary fix as _build_review_nudge — route the
@@ -532,7 +532,7 @@ def _build_task_nudge(supervisor: SupervisorAlertBoundary, launch: SessionLaunch
         db_path = resolve_work_db_path(project=project, config=supervisor.config)
         if not db_path.exists():
             return None
-        with SQLiteWorkService(db_path=db_path) as svc:
+        with create_work_service(db_path=db_path) as svc:
             task = svc.next(project=project)
             if task is None:
                 return None

--- a/src/pollypm/update.py
+++ b/src/pollypm/update.py
@@ -205,8 +205,8 @@ def count_in_progress_tasks() -> int:
     """
     try:
         from pollypm.config import DEFAULT_CONFIG_PATH
+        from pollypm.work import create_work_service
         from pollypm.work.db_resolver import resolve_work_db_path
-        from pollypm.work.sqlite_service import SQLiteWorkService
     except Exception:  # noqa: BLE001
         return 0
     try:
@@ -226,7 +226,7 @@ def count_in_progress_tasks() -> int:
     # CLI today, but the leaky pattern would bite any future caller
     # that loops. Mirrors the close-on-exit pattern from #1069 / #1381.
     try:
-        with SQLiteWorkService(db_path=db_path) as svc:
+        with create_work_service(db_path=db_path) as svc:
             tasks = svc.list_tasks(work_status="in_progress")
     except Exception:  # noqa: BLE001
         return 0

--- a/src/pollypm/work/__init__.py
+++ b/src/pollypm/work/__init__.py
@@ -1,1 +1,27 @@
 # Work service: sealed work management for PollyPM.
+"""Public construction surface for the SQLite-backed work service.
+
+Canonical usage outside ``pollypm.work.*``::
+
+    from pollypm.work import create_work_service
+
+    with create_work_service(project_path=project.path) as svc:
+        ...
+
+The factory resolves the canonical DB path via
+:func:`pollypm.work.db_resolver.resolve_work_db_path` and constructs the
+:class:`pollypm.work.sqlite_service.SQLiteWorkService`.
+
+Direct construction of ``SQLiteWorkService`` from outside the work
+package is discouraged: it forces every callsite to know the on-disk
+layout (workspace-vs-per-project, dual-DB confusion, etc.) and bypasses
+future resolver enhancements (env overrides, fallbacks, telemetry).
+
+Escape valve: callers that genuinely need a non-canonical path (legacy
+migration, tests, explicit ``--db`` overrides) may pass ``db_path=...``
+explicitly. That makes the deviation visible at the callsite.
+"""
+
+from pollypm.work.factory import create_work_service
+
+__all__ = ["create_work_service"]

--- a/src/pollypm/work/factory.py
+++ b/src/pollypm/work/factory.py
@@ -1,0 +1,110 @@
+"""Canonical factory for :class:`SQLiteWorkService`.
+
+This module exists so callers outside ``pollypm.work.*`` do not have to
+know how the work-service DB path is resolved. Every direct
+``SQLiteWorkService(...)`` callsite that lives in presentation, plugin,
+or heartbeat code is suspect — see issue #1369. Migrating those callers
+through this factory means the resolver is the single point of truth
+for "where does work data live".
+
+The factory is intentionally tiny: it composes
+:func:`pollypm.work.db_resolver.resolve_work_db_path` with the
+``SQLiteWorkService`` constructor. The audit emit added in #1343 lives
+in the constructor itself, so every path through this factory still
+records ``work_db.opened``.
+
+Escape valve
+------------
+A caller that genuinely needs a non-canonical path (legacy migration,
+explicit override, test fixture) may pass ``db_path=...`` directly.
+That keeps the callsite visibly different from the canonical pattern,
+which is the point: "this one is not using the resolver" should never
+be invisible.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pollypm.config import PollyPMConfig
+    from pollypm.work.service_dependencies import SyncManager
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+
+def create_work_service(
+    *,
+    db_path: str | Path | None = None,
+    project_path: str | Path | None = None,
+    config: "PollyPMConfig | None" = None,
+    project_key: str | None = None,
+    sync_manager: "SyncManager | None" = None,
+    session_manager: object | None = None,
+) -> "SQLiteWorkService":
+    """Construct a :class:`SQLiteWorkService` for the canonical work DB.
+
+    Parameters
+    ----------
+    db_path:
+        Explicit DB path override. When ``None`` (the canonical case),
+        the path is resolved via
+        :func:`pollypm.work.db_resolver.resolve_work_db_path`. Pass a
+        value here only when you genuinely need a non-canonical path
+        (legacy migration, tests, explicit ``--db`` overrides).
+    project_path:
+        Filesystem path of the project, when known. Forwarded to the
+        service constructor for project-aware operations (gates,
+        activity logs, audit metadata).
+    config:
+        Optional pre-loaded :class:`PollyPMConfig`. Forwarded to the
+        resolver to avoid a hidden ``load_config()`` call.
+    project_key:
+        Optional project key. Forwarded to the resolver so it can warn
+        about stale per-project DB files (#1004).
+    sync_manager / session_manager:
+        Forwarded to the constructor for callers that need to inject a
+        bespoke sync or session manager (the heartbeat does this).
+
+    Returns
+    -------
+    SQLiteWorkService
+        The constructed service. Use as a context manager to ensure
+        the underlying connection is closed.
+    """
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    resolved_path: Path
+    if db_path is None:
+        from pollypm.work.db_resolver import resolve_work_db_path
+
+        resolved_path = resolve_work_db_path(project=project_key, config=config)
+    else:
+        resolved_path = Path(db_path)
+
+    project_path_obj: Path | None = None
+    if project_path is not None:
+        project_path_obj = (
+            project_path if isinstance(project_path, Path) else Path(project_path)
+        )
+
+    # Forward only the args that callers explicitly opted into. The
+    # underlying ``SQLiteWorkService.__init__`` accepts ``sync_manager``
+    # and ``session_manager`` as keyword args, but several test doubles
+    # in the tree implement a narrower constructor signature
+    # (``db_path``, ``project_path`` only). Passing ``None`` for the
+    # optional managers in the factory's default path would TypeError
+    # against those doubles, so we only forward when the caller asked.
+    extra: dict[str, object] = {}
+    if sync_manager is not None:
+        extra["sync_manager"] = sync_manager
+    if session_manager is not None:
+        extra["session_manager"] = session_manager
+    return SQLiteWorkService(
+        db_path=resolved_path,
+        project_path=project_path_obj,
+        **extra,
+    )
+
+
+__all__ = ["create_work_service"]

--- a/tests/test_work_service_factory.py
+++ b/tests/test_work_service_factory.py
@@ -1,0 +1,188 @@
+"""Contract tests for ``pollypm.work.create_work_service`` (#1369).
+
+The factory is the canonical construction surface for the work service
+outside ``pollypm.work.*``. These tests pin down the public contract:
+
+1. ``create_work_service`` is exported from ``pollypm.work``.
+2. With no ``db_path``, it routes through
+   :func:`pollypm.work.db_resolver.resolve_work_db_path` to find the
+   canonical DB.
+3. With an explicit ``db_path``, the resolver is *not* consulted (the
+   escape valve for legacy / migration / test paths).
+4. The constructed service is a real ``SQLiteWorkService`` with an
+   open connection — basic CRUD round-trips work.
+5. ``project_path`` and ``config`` are forwarded as documented.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def test_factory_is_exported_from_work_package() -> None:
+    """``from pollypm.work import create_work_service`` must work."""
+    from pollypm.work import create_work_service
+
+    assert callable(create_work_service)
+
+
+def test_factory_with_explicit_db_path_skips_resolver(tmp_path: Path) -> None:
+    """An explicit ``db_path`` is the documented escape valve."""
+    from pollypm.work import create_work_service
+
+    db_path = tmp_path / "work.db"
+    with patch("pollypm.work.db_resolver.resolve_work_db_path") as mock_resolve:
+        svc = create_work_service(db_path=db_path)
+        try:
+            # Resolver MUST NOT be consulted when caller passes db_path.
+            mock_resolve.assert_not_called()
+        finally:
+            svc.close()
+    assert db_path.exists()
+
+
+def test_factory_without_db_path_calls_resolver(tmp_path: Path) -> None:
+    """When ``db_path`` is omitted, the canonical resolver runs."""
+    from pollypm.work import create_work_service
+
+    canonical = tmp_path / "canonical.db"
+    with patch(
+        "pollypm.work.db_resolver.resolve_work_db_path", return_value=canonical,
+    ) as mock_resolve:
+        svc = create_work_service()
+        try:
+            mock_resolve.assert_called_once()
+        finally:
+            svc.close()
+    assert canonical.exists()
+
+
+def test_factory_passes_config_and_project_key_to_resolver(tmp_path: Path) -> None:
+    """``config`` and ``project_key`` must reach the resolver verbatim."""
+    from pollypm.work import create_work_service
+
+    canonical = tmp_path / "canonical.db"
+    sentinel_config = object()
+    with patch(
+        "pollypm.work.db_resolver.resolve_work_db_path", return_value=canonical,
+    ) as mock_resolve:
+        svc = create_work_service(
+            config=sentinel_config, project_key="my-proj",  # type: ignore[arg-type]
+        )
+        svc.close()
+    kwargs = mock_resolve.call_args.kwargs
+    assert kwargs["config"] is sentinel_config
+    assert kwargs["project"] == "my-proj"
+
+
+def test_factory_returns_real_sqlite_work_service(tmp_path: Path) -> None:
+    """Constructed service must round-trip a basic create/get cycle."""
+    from pollypm.work import create_work_service
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    db_path = tmp_path / "work.db"
+    svc = create_work_service(db_path=db_path, project_path=tmp_path)
+    try:
+        assert isinstance(svc, SQLiteWorkService)
+        task = svc.create(
+            title="hello",
+            description="from factory",
+            type="task",
+            project="proj",
+            flow_template="standard",
+            roles={"worker": "agent-1", "reviewer": "agent-2"},
+            priority="normal",
+            created_by="tester",
+        )
+        got = svc.get(task.task_id)
+        assert got.title == "hello"
+    finally:
+        svc.close()
+
+
+def test_factory_accepts_str_or_path_for_db_path(tmp_path: Path) -> None:
+    """Both ``str`` and ``Path`` are accepted for ``db_path``."""
+    from pollypm.work import create_work_service
+
+    db_path = tmp_path / "work.db"
+    svc = create_work_service(db_path=str(db_path))
+    try:
+        # Reaching into the private attribute is fine for a contract
+        # test — we want to confirm the path was normalised to ``Path``.
+        assert isinstance(svc._db_path, Path)
+    finally:
+        svc.close()
+
+
+def test_factory_supports_context_manager(tmp_path: Path) -> None:
+    """``with create_work_service(...) as svc:`` is the canonical pattern."""
+    from pollypm.work import create_work_service
+
+    db_path = tmp_path / "work.db"
+    with create_work_service(db_path=db_path) as svc:
+        # Service is usable inside the ``with`` block.
+        tasks = svc.list_tasks()
+        assert tasks == []
+
+
+def test_no_callsites_outside_work_construct_sqlite_work_service_directly() -> None:
+    """Boundary check: no module outside ``pollypm.work.*`` should call
+    ``SQLiteWorkService(...)`` directly. Test files and the work package
+    itself are exempt; ``service_factory=SQLiteWorkService`` (class-as-
+    callable injection) is also exempt because no construction happens
+    at the callsite.
+
+    This is the regression guard for #1369. Future direct-construction
+    callsites added outside the work package will fail this test, which
+    is the point: "go through ``create_work_service``" should be the
+    only easy path.
+    """
+    import re
+
+    src_root = Path(__file__).parent.parent / "src" / "pollypm"
+    pattern = re.compile(r"\bSQLiteWorkService\s*\(")
+
+    offenders: list[tuple[Path, int, str]] = []
+    for py_file in src_root.rglob("*.py"):
+        # Skip the work package itself — direct construction is fine
+        # there, that's the implementation.
+        if "pollypm/work/" in str(py_file).replace("\\", "/"):
+            continue
+        try:
+            text = py_file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if pattern.search(line):
+                # Class-as-callable injection (passing the class
+                # reference itself) is allowed: it doesn't construct
+                # anything at the callsite.
+                if "service_factory=SQLiteWorkService" in line:
+                    continue
+                offenders.append((py_file, lineno, line.strip()))
+
+    assert not offenders, (
+        "Direct SQLiteWorkService(...) construction outside pollypm.work/ — "
+        "use pollypm.work.create_work_service instead. Offenders:\n"
+        + "\n".join(f"  {p}:{ln}: {src}" for p, ln, src in offenders)
+    )
+
+
+@pytest.mark.parametrize("project_path_input", ["string-path", Path("/tmp/foo")])
+def test_factory_normalises_project_path_to_path(
+    tmp_path: Path, project_path_input,
+) -> None:
+    """``project_path`` accepts ``str`` or ``Path`` and normalises to ``Path``."""
+    from pollypm.work import create_work_service
+
+    if isinstance(project_path_input, str):
+        project_path_input = str(tmp_path / project_path_input)
+    db_path = tmp_path / "work.db"
+    svc = create_work_service(db_path=db_path, project_path=project_path_input)
+    try:
+        assert svc._project_path is None or isinstance(svc._project_path, Path)
+    finally:
+        svc.close()


### PR DESCRIPTION
## Summary

Closes #1369.

- Adds `pollypm.work.create_work_service` as the canonical public construction surface, composing `resolve_work_db_path` with the `SQLiteWorkService` constructor.
- Migrates **every** direct `SQLiteWorkService(...)` callsite outside `pollypm.work/` — 38 sites across 27 files — onto the factory. After this PR a grep for `SQLiteWorkService(` outside `pollypm.work/` returns zero hits (excluding the existing class-as-callable injection in `cockpit_inbox_items.py`).
- Documents the canonical pattern in `pollypm.work.__init__` and the new `pollypm.work.factory` module.
- Bonus fix: the `notification_staging` prune handler in `plugins_builtin/core_recurring/maintenance.py` used to fall back to `_config.project.state_db` — the *messages-side* DB — when the store path was unavailable. `notification_staging` is a work-DB table, so that fallback would silently stamp the work schema onto the messages DB on fresh installs. The handler now routes through the factory so the canonical work DB is selected regardless.

## Factory API

```python
from pollypm.work import create_work_service

# Canonical: resolver picks the workspace-root DB.
with create_work_service(project_path=project.path) as svc: ...

# Escape valve (legacy migration, per-project scans, explicit overrides).
with create_work_service(db_path=db_path, project_path=project.path) as svc: ...
```

Signature:
```
create_work_service(
    *,
    db_path: str | Path | None = None,
    project_path: str | Path | None = None,
    config: PollyPMConfig | None = None,
    project_key: str | None = None,
    sync_manager: SyncManager | None = None,
    session_manager: object | None = None,
) -> SQLiteWorkService
```

## Test plan

- [x] Added `tests/test_work_service_factory.py` with 10 tests covering the public contract: factory is exported, resolver is called only when `db_path` is omitted, `config`/`project_key` are forwarded, the constructed service round-trips, both `str` and `Path` are accepted, the context-manager pattern works.
- [x] Added a regression guard test that scans `src/pollypm/` for any future direct `SQLiteWorkService(...)` construction outside the work package and fails CI if found.
- [x] All work-service / supervisor / heartbeat tests pass (394 tests in `pytest -k "factory or work_service or supervisor or heartbeat"`).
- [x] Targeted modules tested: advisor, dashboard_data, downtime, heartbeat, supervisor_alerts, recovery_prompt, control_tui, cockpit_inbox/_ui/_rail, onboarding, core_recurring (242 tests pass).
- [ ] Manual smoke: cockpit boot, `pm task list`, `pm doctor`, heartbeat tick, advisor tick.
- [ ] Watch for `work_db.opened` audit events on the workspace path (not the messages-side DB) after `notification_staging.prune` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)