### PR TITLE
Rail affordance for projects with human-review-pending tasks

### DIFF
--- a/src/pollypm/cockpit_project_state.py
+++ b/src/pollypm/cockpit_project_state.py
@@ -72,6 +72,12 @@ class ProjectStateRollup:
     sort_rank: int
     actionable_key: str | None = None
     reason: str = ""
+    # #1390 — Count of tasks where status=review AND a human is the
+    # assignee/actor (e.g. user_approval node). The rail uses this to
+    # render a prominent "needs your decision" affordance — savethenovel
+    # had a plan parked at user_approval for hours without any
+    # rail-level signal because the GREEN dot reads as "fine, moving".
+    approvals_pending: int = 0
 
 
 def task_id_for(task: object) -> str | None:
@@ -124,6 +130,9 @@ def rollup_project_state(
         task for task in task_list
         if not _is_terminal(task) and _status(task) not in _INACTIVE_STATUSES
     ]
+    approvals_pending = sum(
+        1 for task in active_tasks if _is_human_review(task)
+    )
     if not active_tasks:
         return _rollup(ProjectRailState.NONE, project_key=project_key)
 
@@ -164,6 +173,7 @@ def rollup_project_state(
             project_key=project_key,
             task=_first_actionable_task(alerted),
             reason="operational alert needs review",
+            approvals_pending=approvals_pending,
         )
     if user_waiting:
         return _rollup(
@@ -175,6 +185,7 @@ def rollup_project_state(
                 if len(user_waiting) == len(active_tasks)
                 else "some tasks waiting on user"
             ),
+            approvals_pending=approvals_pending,
         )
     if all(_is_user_review(task) for task in active_tasks):
         return _rollup(
@@ -182,6 +193,7 @@ def rollup_project_state(
             project_key=project_key,
             task=active_tasks[0],
             reason="user review remaining",
+            approvals_pending=approvals_pending,
         )
     if any(_is_automated_progress(task) for task in active_tasks):
         return _rollup(
@@ -192,11 +204,13 @@ def rollup_project_state(
                 if plan_blocked and not advanceable
                 else "automated work active"
             ),
+            approvals_pending=approvals_pending,
         )
     return _rollup(
         ProjectRailState.WORKING,
         project_key=project_key,
         reason="non-terminal work remains",
+        approvals_pending=approvals_pending,
     )
 
 
@@ -206,6 +220,7 @@ def _rollup(
     project_key: str,
     task: object | None = None,
     reason: str = "",
+    approvals_pending: int = 0,
 ) -> ProjectStateRollup:
     return ProjectStateRollup(
         state=state,
@@ -213,6 +228,7 @@ def _rollup(
         sort_rank=_SORT_RANKS[state],
         actionable_key=_actionable_key(project_key, task),
         reason=reason,
+        approvals_pending=approvals_pending,
     )
 
 
@@ -237,6 +253,29 @@ def _is_terminal(task: object) -> bool:
 
 def _is_waiting_on_user(task: object) -> bool:
     return _status(task) in _WAITING_STATUSES
+
+
+def _is_human_review(task: object) -> bool:
+    """Return True for tasks parked at a human-decision review node.
+
+    Scoped narrower than ``_is_user_review``: only counts tasks where
+    ``status=='review'`` AND a human is named as the actor/assignee
+    (or the node id explicitly marks a user/approval touchpoint).
+    Drives the rail's ``(N approvals)`` affordance — see #1390.
+    """
+    if _status(task) != "review":
+        return False
+    owner = str(getattr(task, "owner", "") or "").lower()
+    actor = str(getattr(task, "actor_type", "") or "").lower()
+    assignee = str(getattr(task, "assignee", "") or "").lower()
+    if owner in {"human", "user", "operator", "operator-pm"}:
+        return True
+    if actor == "human":
+        return True
+    if assignee == "human":
+        return True
+    node_id = _node_id(task)
+    return any(marker in node_id for marker in _USER_NODE_MARKERS)
 
 
 def _is_user_review(task: object) -> bool:

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -328,6 +328,10 @@ class CockpitItem:
     # ``alert_id`` is the supervisor's row id, used by recovery
     # handlers that need to clear/lookup the specific alert.
     alert_id: int | None = None
+    # #1390 — Number of tasks on this project that are parked at a
+    # human-decision review node (status=review + assignee=human).
+    # Drives the rail's ▶ "needs your decision" affordance + suffix.
+    approvals_pending: int = 0
 
 
 def _stuck_alert_already_user_waiting(
@@ -1688,12 +1692,20 @@ class CockpitRouter:
         label = item.label
         if self.is_project_pinned(item.key.split(":", 1)[1]):
             label = f"📌 {label}"
+        # #1390 — Append the "(N⚠)" approvals suffix BEFORE the activity
+        # sparkline so ``_strip_trailing_spark`` (used by the textual
+        # rail to render in the 30-col pane) can still peel the spark
+        # off the tail and the suffix survives into the visible label.
+        approvals = rollup.approvals_pending if rollup is not None else 0
+        if approvals > 0:
+            label = f"{label} ({approvals}⚠)"
         if sparkline:
             label = f"{label} {sparkline}"
         return replace(
             item,
             label=label,
             state=self._project_row_state(item.state, rollup),
+            approvals_pending=approvals,
         )
 
     def _project_row_state(
@@ -4216,6 +4228,15 @@ class PollyCockpitRail:
 
     def _indicator(self, item: CockpitItem) -> tuple[str, _C | None]:
         if item.key.startswith("project:"):
+            # #1390 — Approval-pending takes precedence over the rollup
+            # color so a project parked at user_approval reads as "act
+            # on me" even if it was otherwise GREEN/YELLOW. Skip RED so
+            # operational fault states keep their dedicated glyph.
+            if (
+                item.approvals_pending > 0
+                and item.state != "project-red"
+            ):
+                return "▶", PALETTE["alert_indicator"]
             if item.state == "project-red":
                 # #989 \u2014 The project rollup paints ``project-red`` for
                 # both warn and error alerts; pick the amber indicator

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -752,6 +752,15 @@ class RailItem(ListItem):
             "#f0c45a" if self.item.alert_severity == "warn" else "#ff5f6d"
         )
         if self.item.key.startswith("project:"):
+            # #1390 — Approval-pending takes precedence over the rollup
+            # color so a project parked at user_approval reads as "act
+            # on me" even if it was otherwise GREEN/YELLOW. Skip RED so
+            # the operational-fault triangle keeps its dedicated slot.
+            if (
+                getattr(self.item, "approvals_pending", 0) > 0
+                and self.item.state != "project-red"
+            ):
+                return "▶", "#ff5f6d"
             if self.item.state == "project-red":
                 return "▲", alert_color
             if self.item.state == "project-yellow":

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -863,6 +863,133 @@ def test_cockpit_ui_project_rollup_status_uses_indicator_not_label() -> None:
     asyncio.run(exercise())
 
 
+def test_cockpit_router_decorate_project_row_carries_approval_count() -> None:
+    """The router's row decoration step copies ``approvals_pending``
+    from the rollup onto the CockpitItem and appends the ``(N⚠)``
+    suffix — the renderer reads only the item, so without this the
+    affordance never reaches the rail."""
+    router = CockpitRouter.__new__(CockpitRouter)
+    router.is_project_pinned = lambda key: False  # type: ignore[method-assign]
+
+    rollup = ProjectStateRollup(
+        state=ProjectRailState.GREEN,
+        badge="🟢",
+        sort_rank=2,
+        actionable_key="project:savethenovel:issues",
+        reason="user review remaining",
+        approvals_pending=2,
+    )
+    decorated = router._decorate_project_row(
+        CockpitItem("project:savethenovel", "savethenovel", "idle"),
+        sparkline=None,
+        rollup=rollup,
+    )
+
+    assert decorated.approvals_pending == 2
+    assert decorated.label.endswith("(2⚠)")
+    assert decorated.state == "project-green"
+
+
+def test_cockpit_raw_rail_project_row_renders_approval_affordance() -> None:
+    """#1390 — savethenovel-class scenario: a project with at least one
+    task in status=review + assignee=human must render the prominent
+    ▶ glyph + ``(N⚠)`` suffix on the rail line, not the quiet GREEN
+    dot, so the user can tell at a glance that a decision is waiting.
+    """
+    rail = PollyCockpitRail.__new__(PollyCockpitRail)
+    rail.selected_key = "polly"
+    rail.spinner_index = 0
+
+    row = rail._item_row(
+        CockpitItem(
+            "project:savethenovel",
+            "savethenovel (1⚠)",
+            "project-green",
+            approvals_pending=1,
+        ),
+        width=40,
+        active_view="polly",
+    )
+
+    assert "savethenovel" in row.text
+    assert "▶" in row.text
+    assert "(1⚠)" in row.text
+    # The quiet GREEN ``•`` indicator must be replaced — the whole
+    # point is to *not* read as an idle/moving project.
+    assert "• savethenovel" not in row.text
+
+
+def test_cockpit_raw_rail_project_row_no_affordance_without_pending() -> None:
+    """A normal moving project (no approvals_pending) keeps its
+    existing quiet glyph and bare label — the affordance is gated on
+    the explicit pending count, not on rollup color."""
+    rail = PollyCockpitRail.__new__(PollyCockpitRail)
+    rail.selected_key = "polly"
+    rail.spinner_index = 0
+
+    row = rail._item_row(
+        CockpitItem(
+            "project:savethenovel",
+            "savethenovel",
+            "project-working",
+        ),
+        width=40,
+        active_view="polly",
+    )
+
+    assert "savethenovel" in row.text
+    assert "▶" not in row.text
+    assert "⚠" not in row.text
+
+
+def test_cockpit_raw_rail_project_row_approval_count_pluralizes() -> None:
+    """When more than one task is parked at user_approval, the count
+    embedded in the label must reflect the actual number — single ▶
+    glyph stays the same, only the suffix changes."""
+    rail = PollyCockpitRail.__new__(PollyCockpitRail)
+    rail.selected_key = "polly"
+    rail.spinner_index = 0
+
+    row = rail._item_row(
+        CockpitItem(
+            "project:savethenovel",
+            "savethenovel (3⚠)",
+            "project-green",
+            approvals_pending=3,
+        ),
+        width=40,
+        active_view="polly",
+    )
+
+    assert "▶" in row.text
+    assert "(3⚠)" in row.text
+
+
+def test_cockpit_raw_rail_approval_affordance_fits_narrow_30col_pane() -> None:
+    """The rail's textual mode caps at 30 columns. The ▶ glyph + (N⚠)
+    suffix must not push the project name off-screen for typical
+    project keys (≤16 chars)."""
+    rail = PollyCockpitRail.__new__(PollyCockpitRail)
+    rail.selected_key = "polly"
+    rail.spinner_index = 0
+
+    row = rail._item_row(
+        CockpitItem(
+            "project:savethenovel",
+            "savethenovel (1⚠)",
+            "project-green",
+            approvals_pending=1,
+        ),
+        width=30,
+        active_view="polly",
+    )
+
+    # The full glyph + suffix combo fits in the 30-col pane without
+    # truncating the project key.
+    assert "▶" in row.text
+    assert "savethenovel" in row.text
+
+
 def test_cockpit_rail_session_indicator_combines_pulse_and_work_glyph(monkeypatch, tmp_path: Path) -> None:
     config_path = tmp_path / "pollypm.toml"
     config_path.write_text(

--- a/tests/test_cockpit_project_state.py
+++ b/tests/test_cockpit_project_state.py
@@ -17,6 +17,9 @@ def _task(
     node: str = "",
     flow: str = "implementation",
     project: str = "demo",
+    assignee: str = "",
+    actor_type: str = "",
+    owner: str = "",
 ):
     return SimpleNamespace(
         project=project,
@@ -26,6 +29,9 @@ def _task(
         current_node_id=node,
         flow_template_id=flow,
         labels=[],
+        assignee=assignee,
+        actor_type=actor_type,
+        owner=owner,
     )
 
 
@@ -239,6 +245,73 @@ def test_actionable_alert_prefixes_drive_red_state() -> None:
 
     assert rollup.state is ProjectRailState.RED
     assert rollup.badge == "🔴"
+
+
+def test_rollup_counts_human_review_tasks_for_rail_affordance() -> None:
+    """#1390 — savethenovel parked at user_approval for hours with no
+    rail-level signal. The rollup must count tasks where status=review
+    and a human is the assignee/actor so the rail can surface a
+    prominent "needs your decision" affordance."""
+    rollup = rollup_project_state(
+        "savethenovel",
+        [
+            _task(1, "review", node="user_approval", assignee="human"),
+            _task(2, "in_progress"),
+        ],
+    )
+
+    assert rollup.approvals_pending == 1
+
+
+def test_rollup_approvals_pending_counts_multiple() -> None:
+    """When more than one task is parked at a human-decision node the
+    rail's ``(N⚠)`` suffix must reflect the actual count."""
+    rollup = rollup_project_state(
+        "savethenovel",
+        [
+            _task(1, "review", node="user_approval", assignee="human"),
+            _task(2, "review", node="awaiting_approval", actor_type="human"),
+            _task(3, "review", node="user_approval", owner="user"),
+            _task(4, "in_progress"),
+        ],
+    )
+
+    assert rollup.approvals_pending == 3
+
+
+def test_rollup_approvals_pending_zero_without_human_review() -> None:
+    """Autoreview / automated review tasks must not inflate the count
+    — only human-decision review nodes drive the affordance."""
+    rollup = rollup_project_state(
+        "demo",
+        [
+            _task(1, "in_progress"),
+            _task(2, "review", node="autoreview"),
+            _task(3, "queued"),
+        ],
+    )
+
+    assert rollup.approvals_pending == 0
+
+
+def test_rollup_approvals_pending_survives_red_alert() -> None:
+    """Even when the project rolls up to RED for an operational alert,
+    the count of pending approvals must be preserved so a user-visible
+    decision isn't masked by an unrelated fault on a sibling task."""
+    alerts = [SimpleNamespace(alert_type="stuck_on_task:demo/2")]
+    rollup = rollup_project_state(
+        "demo",
+        [
+            _task(1, "review", node="user_approval", assignee="human"),
+            _task(2, "in_progress"),
+        ],
+        actionable_task_alert_ids=actionable_alert_task_ids(
+            alerts, project_key="demo",
+        ),
+    )
+
+    assert rollup.state is ProjectRailState.RED
+    assert rollup.approvals_pending == 1
 
 
 def test_surfaceable_operational_alert_taxonomy_keeps_user_action_signals_visible() -> None:


### PR DESCRIPTION
Closes #1390.

## Context

`savethenovel/2` sat in `status=review` / `node=user_approval` /
`assignee=human` for hours. The rail painted it as a perfectly normal
project entry (quiet GREEN dot) so the user couldn't tell from the
rail that a plan was waiting on their decision. PR #1351's "Drafts
pending" panel only shows up after you drill into the project — the
rail itself was silent.

## Change

When the project-state rollup runs, count tasks where
`status=='review'` AND a human is the assignee/actor (or the node id
explicitly marks a user/approval touchpoint). Thread that count
(`approvals_pending`) through `ProjectStateRollup` → `CockpitItem`
into both rail renderers (Textual `cockpit_ui.py` and raw `cockpit_rail.py`).

Both renderers replace the quiet `•` / `◆` indicator with a red `▶`
(U+25B6) when `approvals_pending > 0`, and `_decorate_project_row`
appends a `(N⚠)` suffix before the activity sparkline so
`_strip_trailing_spark` keeps cleaning the tail in the 30-col pane.

The override is gated to skip `project-red` so genuine operational
fault states keep their dedicated `▲` triangle slot — they're a
different signal class and need to stay visually distinct.

## Glyph / copy choice

- Glyph: `▶` (U+25B6 BLACK RIGHT-POINTING TRIANGLE) in
  `alert_indicator` red (`#ff5f6d`). Distinct from the existing
  alert `▲` (U+25B2), needs-attention `◆` (U+25C6), and idle
  `·` / `•` / `○` dots; reads as "act on me".
- Suffix: `(N⚠)` — terse so it survives in the 22-char label
  budget for typical 12-16-char project keys.

## Test plan

- [x] `tests/test_cockpit_project_state.py` — rollup counts human-review
  tasks (savethenovel-class), pluralizes correctly, ignores autoreview,
  preserves count under RED operational alerts.
- [x] `tests/test_cockpit.py` — raw rail renders `▶` + `(N⚠)`,
  no affordance without pending, count pluralizes, fits 30-col pane,
  router decoration carries the count from rollup → item.
- [x] Pre-existing `test_cockpit_project_state.py` (14 tests) and
  `test_cockpit.py` (~190 tests) still pass.
- [ ] Manual: pop savethenovel into the rail at a user_approval
  parking node; confirm `▶ savethenovel (1⚠)` shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)