### PR TITLE
Kill broken `v` keybinding (visual explainer)

### DIFF
--- a/src/pollypm/cockpit_palette.py
+++ b/src/pollypm/cockpit_palette.py
@@ -561,7 +561,6 @@ _GLOBAL_HELP_BINDINGS: list[tuple[str, str]] = [
 
 _INBOX_LABEL_HELP: dict[str, list[tuple[str, str]]] = {
     "plan_review": [
-        ("v", "open visual explainer"),
         ("A", "approve plan"),
     ],
     "proposal": [

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -7520,12 +7520,11 @@ class PollyInboxApp(App[None]):
         # archiving, but with a decision trail.
         Binding("A", "accept_proposal", "Accept", show=False),
         Binding("X", "reject_proposal", "Reject", show=False),
-        # Plan review (#297). ``v`` opens the rendered HTML explainer in
-        # the user's browser — reviewing against the visual page is the
-        # whole point of the plan-review flow. Accept (capital A) routes
-        # through ``action_accept_proposal`` which branches on label,
-        # so no separate keybinding is needed here for approve.
-        Binding("v", "open_plan_explainer", "Explainer", show=False),
+        # Plan review (#297). Accept (capital A) routes through
+        # ``action_accept_proposal`` which branches on label, so no
+        # separate keybinding is needed here for approve. The ``v``
+        # explainer keybinding was removed in #1405 (broken — never
+        # opened anything reliably; deferred to v1+ for redesign).
         Binding("e", "expand_all_rollup", "Expand all", show=False),
         # Filter / search bar (#NEW).
         Binding("slash", "start_filter", "Filter", show=False),
@@ -9830,14 +9829,16 @@ class PollyInboxApp(App[None]):
     )
     # Plan-review hint bars (#297). The gated variant hides ``A`` until
     # the thread has a round-trip; the ungated variant surfaces it.
+    # ``v open explainer`` was dropped in #1405 along with the broken
+    # keybinding \u2014 pending redesign post-v1.
     _PLAN_REVIEW_HINT_GATED = (
-        "v open explainer \u00b7 d discuss with PM \u00b7 q close"
+        "d discuss with PM \u00b7 q close"
     )
     _PLAN_REVIEW_HINT_OPEN = (
-        "v open explainer \u00b7 d discuss \u00b7 A approve \u00b7 q close"
+        "d discuss \u00b7 A approve \u00b7 q close"
     )
     _PLAN_REVIEW_HINT_FAST_TRACK = (
-        "v open explainer \u00b7 d discuss \u00b7 A approve \u00b7 q close"
+        "d discuss \u00b7 A approve \u00b7 q close"
     )
     # Blocking-question hint (#302). ``r`` replies to the worker via
     # ``pm send --force`` so the blocker clears without the PM needing
@@ -9874,7 +9875,12 @@ class PollyInboxApp(App[None]):
         Fast-tracked items (Polly's inbox) never gate — Accept is live
         from the first render. User-inbox items are gated until the
         thread has at least one exchange with the PM.
+
+        ``has_explainer`` is retained for call-site compatibility but
+        is no longer consulted — the ``v`` keybinding was removed in
+        #1405 and the hint bars never mention an explainer now.
         """
+        del has_explainer  # kwarg kept for API stability post-#1405
         if fast_track or round_trip:
             text = (
                 self._PLAN_REVIEW_HINT_FAST_TRACK
@@ -9882,8 +9888,6 @@ class PollyInboxApp(App[None]):
             )
         else:
             text = self._PLAN_REVIEW_HINT_GATED
-        if not has_explainer:
-            text = text.replace("v open explainer · ", "")
         try:
             self.hint.update(text)
         except Exception:  # noqa: BLE001
@@ -13219,7 +13223,9 @@ class PollyProjectDashboardApp(App[None]):
         Binding("4", "action_card_4", "Second card primary action"),
         Binding("5", "action_card_5", "Second card secondary action"),
         Binding("6", "action_card_6", "Second card reply"),
-        Binding("v", "open_explainer", "Explainer", show=False),
+        # ``v`` (open_explainer) was removed in #1405 — it was broken in
+        # practice and is deferred until the visual explainer is
+        # redesigned post-v1.
         Binding("o", "open_editor", "Editor", show=False),
         Binding("j", "plan_scroll_down", "Scroll down", show=False),
         Binding("k", "plan_scroll_up", "Scroll up", show=False),
@@ -14419,9 +14425,9 @@ class PollyProjectDashboardApp(App[None]):
                 except (ValueError, TypeError):
                     aux_rel = aux.name
                 lines.append(f"  \u00b7 {_escape(aux_rel)}")
-        if data.plan_explainer is not None:
-            lines.append("")
-            lines.append("[dim]Press [b]v[/b] to open the visual explainer[/dim]")
+        # Visual-explainer prompt removed in #1405 (keybinding broken,
+        # deferred for v1+). ``data.plan_explainer`` may still surface
+        # via other paths but we no longer advertise the ``v`` shortcut.
         return "\n".join(lines)
 
     def _render_plan_stale(self, data: ProjectDashboardData) -> str:

--- a/tests/test_plan_review_flow.py
+++ b/tests/test_plan_review_flow.py
@@ -397,8 +397,9 @@ def test_plan_review_label_swaps_hint_bar_to_gated(
             assert meta["plan_task_id"] == plan_review_env["plan_task_id"]
             assert meta["fast_track"] is False
             # Hint bar is gated — ``A`` is hidden until round-trip.
+            # ``v open explainer`` was removed in #1405 (broken keybinding).
             hint_text = str(inbox_app.hint.render())
-            assert "v open explainer" in hint_text
+            assert "v open explainer" not in hint_text
             assert "d discuss" in hint_text
             assert "A approve" not in hint_text
     _run(body())
@@ -624,10 +625,10 @@ def test_plan_review_message_approve_archives_notification(
     _run(body())
 
 
-def test_v_key_opens_explainer_with_path(
+def test_v_key_is_unbound_after_1405(
     plan_review_env, inbox_app,
 ) -> None:
-    """``v`` shells out via the ``_open_explainer`` hook; path is passed."""
+    """``v`` no longer triggers the explainer hook (binding removed in #1405)."""
     async def body() -> None:
         calls: list[str] = []
 
@@ -645,7 +646,10 @@ def test_v_key_opens_explainer_with_path(
                 await pilot.pause()
                 await pilot.press("v")
                 await pilot.pause()
-                assert calls == [plan_review_env["explainer_path"]]
+                assert calls == [], (
+                    "v keybinding was removed in #1405 "
+                    "(broken visual explainer, deferred to v1+)"
+                )
         finally:
             PollyInboxApp._open_explainer = original  # type: ignore[assignment]
     _run(body())

--- a/tests/test_project_dashboard_plan_viewer.py
+++ b/tests/test_project_dashboard_plan_viewer.py
@@ -299,12 +299,14 @@ def test_no_staleness_when_fresh(env, app) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 6a. `v` opens explainer when present
+# 6. ``v`` keybinding was removed in #1405 (broken visual explainer).
+# Pressing ``v`` is now a no-op at the dashboard layer regardless of
+# whether the explainer artifact exists on disk.
 # ---------------------------------------------------------------------------
 
 
-def test_v_opens_explainer_when_present(env, app, monkeypatch) -> None:
-    """Pressing ``v`` invokes ``_open_external`` on the explainer path."""
+def test_v_is_unbound_after_1405(env, app, monkeypatch) -> None:
+    """``v`` no longer triggers ``_open_external`` (binding removed)."""
     async def body() -> None:
         _write_plan(env["project_path"], "# Plan\n\n## One\n")
         reports = env["project_path"] / "reports"
@@ -328,41 +330,9 @@ def test_v_opens_explainer_when_present(env, app, monkeypatch) -> None:
         async with app.run_test(size=(140, 50)) as pilot:
             await pilot.pause()
             assert app.data is not None
-            assert app.data.plan_explainer == explainer
             await pilot.press("v")
             await pilot.pause()
-            assert opened, "expected _open_external to be called"
-            assert opened[-1] == explainer
-    _run(body())
-
-
-# ---------------------------------------------------------------------------
-# 6b. `v` is a no-op (warning notify, no crash) when absent
-# ---------------------------------------------------------------------------
-
-
-def test_v_noop_when_explainer_absent(env, app, monkeypatch) -> None:
-    """``v`` does not call ``_open_external`` when no explainer exists."""
-    async def body() -> None:
-        _write_plan(env["project_path"], "# Plan\n\n## One\n")
-
-        opened: list[Path] = []
-
-        def fake_open(self, path: Path) -> None:
-            opened.append(path)
-
-        from pollypm.cockpit_ui import PollyProjectDashboardApp
-        monkeypatch.setattr(
-            PollyProjectDashboardApp, "_open_external", fake_open,
-        )
-
-        async with app.run_test(size=(140, 50)) as pilot:
-            await pilot.pause()
-            assert app.data is not None
-            assert app.data.plan_explainer is None
-            await pilot.press("v")
-            await pilot.pause()
-            assert opened == [], "open_external must not fire without explainer"
+            assert opened == [], "v must be unbound after #1405"
     _run(body())
 
 


### PR DESCRIPTION
Closes #1405. `v` was supposed to open a visual explainer but did nothing; killed for v1.

## Files changed
- `src/pollypm/cockpit_ui.py` — remove the two `Binding("v", "open_*explainer", ...)` entries (inbox + project dashboard), drop "v open explainer" from `_PLAN_REVIEW_HINT_*` strings, strip the "Press v to open the visual explainer" line from the dashboard plan section, and stop consulting `has_explainer` in the hint-bar updater (kwarg kept for API stability).
- `src/pollypm/cockpit_palette.py` — drop the `("v", "open visual explainer")` entry from `_INBOX_LABEL_HELP` so the help palette no longer advertises a dead shortcut.
- `tests/test_project_dashboard_plan_viewer.py` — collapse the two pre-existing `v opens / v noop` tests into a single `test_v_is_unbound_after_1405` assertion.
- `tests/test_plan_review_flow.py` — flip `test_v_key_opens_explainer_with_path` to assert the binding is unbound, and update the gated-hint-bar assertion accordingly.

Action handlers `action_open_plan_explainer` / `action_open_explainer` and the `_open_explainer` helper are left in place for now (~65 LOC of dead code, over the 30-LOC budget the task brief allowed; deferred to a follow-up).

## Test plan
- [x] `uv run --extra dev pytest tests/test_cockpit.py -k "keybind or shortcut or v_key" -x` — passes
- [x] `uv run --extra dev pytest tests/test_cockpit_rail_routes.py tests/test_cockpit_rail_alert_metadata.py -x` — passes (no `test_cockpit_rail.py` exists)
- [x] `uv run --extra dev pytest tests/test_plan_review_flow.py tests/test_project_dashboard_plan_viewer.py -x` — passes
- [x] `uv run --extra dev pytest tests/test_cockpit_inbox_ui.py tests/test_cockpit_inbox_threads.py tests/test_tasks_ui.py -x` — passes (118 tests)
- [x] `uv run --extra dev pytest tests/test_command_palette.py tests/test_palette_recent_history.py -x` — passes

Generated with [Claude Code](https://claude.com/claude-code)