### PR TITLE
Plan task metadata — plan_version + predecessor_task_id

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -63,6 +63,13 @@ EVENT_WORKER_THREAD_LEAKED = "worker.thread_leaked"
 # ``cockpit-<pid>.sock`` whose owning PID is no longer alive. Lets
 # operators forensically count leak rates without scraping logs.
 EVENT_SOCKET_REAPED = "socket.reaped"
+# #1398 — plan task evolution. ``plan.version_incremented`` fires when
+# a plan task is refined in place (same task_id, version bump);
+# ``plan.successor_created`` fires when a replan creates a new task
+# linked to a predecessor. Together they let the heartbeat / inbox
+# render plan-history breadcrumbs without scanning task content.
+EVENT_PLAN_VERSION_INCREMENTED = "plan.version_incremented"
+EVENT_PLAN_SUCCESSOR_CREATED = "plan.successor_created"
 
 
 @dataclass(slots=True, frozen=True)
@@ -413,6 +420,8 @@ __all__ = [
     "EVENT_WORK_DB_OPENED",
     "EVENT_WORKER_THREAD_LEAKED",
     "EVENT_SOCKET_REAPED",
+    "EVENT_PLAN_VERSION_INCREMENTED",
+    "EVENT_PLAN_SUCCESSOR_CREATED",
     "AuditEvent",
     "central_log_path",
     "emit",

--- a/src/pollypm/work/mock_service.py
+++ b/src/pollypm/work/mock_service.py
@@ -127,6 +127,7 @@ class MockWorkService:
         relevant_files: list[str] | None = None,
         labels: list[str] | None = None,
         requires_human_review: bool = False,
+        predecessor_task_id: str | None = None,
     ) -> Task:
         template = self._resolve_flow(flow_template)
 
@@ -154,6 +155,12 @@ class MockWorkService:
         num = self._counter.get(project, 0) + 1
         self._counter[project] = num
 
+        # #1398 — normalise predecessor_task_id; raises on bad shape.
+        predecessor_normalized: str | None = None
+        if predecessor_task_id is not None:
+            pred_project, pred_number = _parse_task_id(predecessor_task_id)
+            predecessor_normalized = f"{pred_project}/{pred_number}"
+
         now = _now()
         task = Task(
             project=project,
@@ -176,12 +183,39 @@ class MockWorkService:
             created_at=now,
             created_by=created_by,
             updated_at=now,
+            plan_version=1,
+            predecessor_task_id=predecessor_normalized,
         )
         self._tasks[task.task_id] = task
         self._context[task.task_id] = []
         self._executions[task.task_id] = []
         self._transitions[task.task_id] = []
         return deepcopy(task)
+
+    def increment_plan_version(
+        self,
+        task_id: str,
+        *,
+        actor: str = "system",
+        reason: str | None = None,
+    ) -> Task:
+        """Bump ``plan_version`` on the in-memory task (#1398)."""
+        task = self._tasks.get(task_id)
+        if task is None:
+            raise TaskNotFoundError(f"Task '{task_id}' not found.")
+        task.plan_version = int(task.plan_version) + 1
+        task.updated_at = _now()
+        return deepcopy(task)
+
+    def list_successors(self, predecessor_task_id: str) -> list[Task]:
+        """Return tasks whose ``predecessor_task_id`` matches (#1398)."""
+        result = [
+            deepcopy(t)
+            for t in self._tasks.values()
+            if t.predecessor_task_id == predecessor_task_id
+        ]
+        result.sort(key=lambda t: (t.project, t.task_number))
+        return result
 
     def get(self, task_id: str) -> Task:
         task = self._tasks.get(task_id)

--- a/src/pollypm/work/models.py
+++ b/src/pollypm/work/models.py
@@ -286,6 +286,15 @@ class Task:
     superseded_by_project: str | None = None
     superseded_by_task_number: int | None = None
 
+    # --- Plan task evolution (#1398) ---
+    # ``plan_version`` increments on every refinement of a plan task
+    # (same task_id, new revision). Defaults to 1.
+    # ``predecessor_task_id`` points to the prior attempt when a
+    # replan creates a NEW task instead of refining the existing one;
+    # canonical ``project/task_number`` form, ``None`` for originals.
+    plan_version: int = 1
+    predecessor_task_id: str | None = None
+
     # --- Roles ---
     roles: dict[str, str] = field(default_factory=dict)
 

--- a/src/pollypm/work/schema.py
+++ b/src/pollypm/work/schema.py
@@ -81,6 +81,19 @@ CREATE TABLE IF NOT EXISTS work_tasks (
     supersedes_project TEXT,
     supersedes_task_number INTEGER,
 
+    -- #1398 — plan task evolution metadata.
+    -- ``plan_version`` increments each time a plan task gets refined
+    -- in place (same task ID, new revision). Defaults to 1 so legacy
+    -- rows (created before this column existed) read as the first
+    -- revision without requiring a backfill pass.
+    plan_version INTEGER NOT NULL DEFAULT 1,
+    -- ``predecessor_task_id`` points to the prior attempt when a
+    -- replan creates a new task instead of refining the existing
+    -- one. Stored as canonical ``project/task_number`` text so the
+    -- foreign key shape matches the rest of the codebase's task-id
+    -- convention; NULL means "no predecessor — original attempt".
+    predecessor_task_id TEXT,
+
     roles TEXT NOT NULL DEFAULT '{}',
     external_refs TEXT NOT NULL DEFAULT '{}',
 
@@ -107,6 +120,11 @@ CREATE INDEX IF NOT EXISTS idx_work_tasks_active
 
 CREATE INDEX IF NOT EXISTS idx_work_tasks_priority
     ON work_tasks(priority, work_status);
+-- idx_work_tasks_predecessor is created by
+-- _ensure_work_task_plan_columns after the column is backfilled
+-- (migration 8). SQLite won't parse an index that references a
+-- column the (pre-migration) legacy work_tasks table doesn't have
+-- yet, so it must live in the ensure helper rather than WORK_SCHEMA.
 
 -- -------------------------------------------------------------------
 -- Task dependencies / relationships
@@ -238,6 +256,7 @@ def create_work_tables(conn: sqlite3.Connection) -> None:
     _ensure_flow_node_columns(conn)
     _ensure_context_entry_columns(conn)
     _ensure_node_execution_columns(conn)
+    _ensure_work_task_plan_columns(conn)
     _run_work_migrations(conn)
 
 
@@ -278,6 +297,36 @@ def _ensure_node_execution_columns(conn: sqlite3.Connection) -> None:
         conn.execute(
             "ALTER TABLE work_node_executions ADD COLUMN kickoff_sent_at TEXT"
         )
+
+
+def _ensure_work_task_plan_columns(conn: sqlite3.Connection) -> None:
+    """Backfill plan_version + predecessor_task_id on work_tasks (#1398).
+
+    Mirrors the pattern used for kickoff_sent_at / entry_type / agent_name:
+    SQLite lacks IF NOT EXISTS on ADD COLUMN and CREATE TABLE IF NOT
+    EXISTS is a no-op on already-present tables, so legacy DBs that
+    pre-date this migration need an explicit guarded ALTER TABLE.
+    Migration v8 records the version bump for both fresh and legacy
+    rows so the schema_version row stays accurate.
+    """
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(work_tasks)")}
+    if "plan_version" not in cols:
+        conn.execute(
+            "ALTER TABLE work_tasks "
+            "ADD COLUMN plan_version INTEGER NOT NULL DEFAULT 1"
+        )
+    if "predecessor_task_id" not in cols:
+        conn.execute(
+            "ALTER TABLE work_tasks ADD COLUMN predecessor_task_id TEXT"
+        )
+    # Successors lookup index. Created here (not just in WORK_SCHEMA)
+    # because legacy DBs that already have a work_tasks table must get
+    # the partial index after the column lands.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_work_tasks_predecessor "
+        "ON work_tasks(predecessor_task_id) "
+        "WHERE predecessor_task_id IS NOT NULL"
+    )
 
 
 def _ensure_context_entry_columns(conn: sqlite3.Connection) -> None:
@@ -413,6 +462,19 @@ _WORK_MIGRATIONS: list[tuple[int, str, list[str]]] = [
             # column on freshly-created tables. This migration entry
             # exists so the schema-version row records the v7 bump for
             # both fresh and pre-v7 databases.
+        ],
+    ),
+    (
+        8,
+        "Add plan_version + predecessor_task_id to work_tasks for "
+        "plan-task evolution (refinement vs replan) — #1398",
+        [
+            # Same pattern as v7 — the columns are actually added by
+            # ``_ensure_work_task_plan_columns`` (runs BEFORE the
+            # migration walk) because SQLite lacks IF NOT EXISTS on
+            # ADD COLUMN. The migration entry records the v8 bump so
+            # ``work_schema_version`` stays accurate for both fresh
+            # and legacy DBs.
         ],
     ),
 ]

--- a/src/pollypm/work/service.py
+++ b/src/pollypm/work/service.py
@@ -46,6 +46,7 @@ class WorkService(Protocol):
         relevant_files: list[str] | None = None,
         labels: list[str] | None = None,
         requires_human_review: bool = False,
+        predecessor_task_id: str | None = None,
     ) -> Task:
         """Create a task in ``draft`` state.
 
@@ -54,7 +55,32 @@ class WorkService(Protocol):
         ``created_by`` records the author of the task. Defaults to
         ``"system"`` for orchestrator-spawned work; CLI / API callers
         should pass a real actor (#796).
+
+        ``predecessor_task_id`` (#1398) wires the new task as the
+        successor of an earlier attempt (replan flow). Defaults to
+        ``None`` (no predecessor — original task). Setting the value
+        emits a ``plan.successor_created`` audit event.
         """
+        ...
+
+    def increment_plan_version(
+        self,
+        task_id: str,
+        *,
+        actor: str = "system",
+        reason: str | None = None,
+    ) -> Task:
+        """Bump ``plan_version`` on a plan task and emit an audit event (#1398).
+
+        Used by the plan-refinement flow when an architect updates a
+        plan in place. Emits ``plan.version_incremented`` with the
+        old/new version pair so plan-history consumers can reconstruct
+        the revision timeline.
+        """
+        ...
+
+    def list_successors(self, predecessor_task_id: str) -> list[Task]:
+        """Return tasks that descend from ``predecessor_task_id`` (#1398)."""
         ...
 
     def get(self, task_id: str) -> Task:

--- a/src/pollypm/work/service_queries.py
+++ b/src/pollypm/work/service_queries.py
@@ -37,6 +37,7 @@ def create_task(
     relevant_files: list[str] | None = None,
     labels: list[str] | None = None,
     requires_human_review: bool = False,
+    predecessor_task_id: str | None = None,
 ) -> Task:
     template = service._ensure_flow_in_db(flow_template)
 
@@ -75,14 +76,25 @@ def create_task(
     ).fetchone()
     task_number = row["max_num"] + 1
 
+    # #1398 — normalise predecessor_task_id and let validation surface
+    # malformed forms early. ``_parse_task_id`` raises ValidationError
+    # on bad input; we deliberately don't verify the predecessor exists
+    # in work_tasks here so a caller can re-thread a replan even after
+    # the prior attempt has been pruned (e.g. cancelled/cleaned).
+    predecessor_normalized: str | None = None
+    if predecessor_task_id is not None:
+        pred_project, pred_number = _parse_task_id(predecessor_task_id)
+        predecessor_normalized = f"{pred_project}/{pred_number}"
+
     service._conn.execute(
         "INSERT INTO work_tasks "
         "(project, task_number, title, type, labels, work_status, "
         "flow_template_id, flow_template_version, current_node_id, "
         "assignee, priority, requires_human_review, description, "
         "acceptance_criteria, constraints, relevant_files, "
-        "roles, external_refs, created_at, created_by, updated_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "roles, external_refs, created_at, created_by, updated_at, "
+        "plan_version, predecessor_task_id) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             project,
             task_number,
@@ -105,6 +117,8 @@ def create_task(
             now,
             created_by,
             now,
+            1,
+            predecessor_normalized,
         ),
     )
     service._conn.commit()
@@ -130,6 +144,23 @@ def create_task(
             },
             project_path=service._project_path,
         )
+        # #1398 — separate event for replan successor links so the
+        # heartbeat can render plan-history breadcrumbs without
+        # re-parsing every task.created metadata blob.
+        if predecessor_normalized is not None:
+            from pollypm.audit.log import EVENT_PLAN_SUCCESSOR_CREATED
+
+            _audit_emit(
+                event=EVENT_PLAN_SUCCESSOR_CREATED,
+                project=project,
+                subject=task.task_id,
+                actor=created_by or "system",
+                metadata={
+                    "predecessor": predecessor_normalized,
+                    "successor": task.task_id,
+                },
+                project_path=service._project_path,
+            )
     except Exception:  # noqa: BLE001 — audit must never break creates
         pass
     if service._sync:

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -157,6 +157,32 @@ def first_shipped_at(path: Path | None = None) -> str | None:
     return str(value) if isinstance(value, str) and value else None
 
 
+def _row_get(row: object, column: str, default: object = None) -> object:
+    """Read ``column`` from a sqlite3.Row, returning ``default`` if absent.
+
+    ``sqlite3.Row.keys()`` reports the columns available on the
+    underlying SELECT result. We need this defensive accessor for
+    columns added by recent migrations (e.g. ``plan_version`` /
+    ``predecessor_task_id`` from #1398) so a row produced by a
+    SELECT * against a partially-migrated DB — or by test code that
+    inserts via legacy column lists — doesn't ``IndexError`` here.
+    Production DBs always carry the column post-``create_work_tables``,
+    but the helper preserves the corrupt-payload-defense pattern used
+    by ``_safe_json_dict`` / ``_safe_json_list`` below.
+    """
+    try:
+        keys = row.keys()
+    except (AttributeError, TypeError):
+        return default
+    if column in keys:
+        try:
+            value = row[column]
+        except (KeyError, IndexError):
+            return default
+        return default if value is None else value
+    return default
+
+
 def _safe_json_dict(raw: object) -> dict:
     """Decode a JSON column expected to be a dict, defensively.
 
@@ -1142,6 +1168,11 @@ class SQLiteWorkService:
             supersedes_task_number=row["supersedes_task_number"],
             superseded_by_project=rels.get("superseded_by_project"),
             superseded_by_task_number=rels.get("superseded_by_task_number"),
+            # #1398 — plan-task evolution metadata. Legacy rows that
+            # pre-date the column read NULL/None which we coerce to
+            # the documented defaults.
+            plan_version=int(_row_get(row, "plan_version", 1) or 1),
+            predecessor_task_id=_row_get(row, "predecessor_task_id", None),
             roles=_safe_json_dict(row["roles"]),
             external_refs=_safe_json_dict(row["external_refs"]),
             created_at=datetime.fromisoformat(row["created_at"]),
@@ -1598,8 +1629,17 @@ class SQLiteWorkService:
         relevant_files: list[str] | None = None,
         labels: list[str] | None = None,
         requires_human_review: bool = False,
+        predecessor_task_id: str | None = None,
     ) -> Task:
-        """Create a task in draft state."""
+        """Create a task in draft state.
+
+        ``predecessor_task_id`` (#1398) wires this new task as the
+        successor of an earlier attempt — used by the plan-replan flow
+        when a fresh task supersedes a prior one. ``None`` is the
+        default and produces a regular standalone task. Setting the
+        value emits a ``plan.successor_created`` audit event so the
+        heartbeat can render plan-history breadcrumbs.
+        """
         return create_task(
             self,
             title=title,
@@ -1615,7 +1655,84 @@ class SQLiteWorkService:
             relevant_files=relevant_files,
             labels=labels,
             requires_human_review=requires_human_review,
+            predecessor_task_id=predecessor_task_id,
         )
+
+    def increment_plan_version(
+        self,
+        task_id: str,
+        *,
+        actor: str = "system",
+        reason: str | None = None,
+    ) -> Task:
+        """Bump ``plan_version`` on a plan task and emit an audit event (#1398).
+
+        Used by the plan-refinement flow: the architect updates the
+        plan in place (same task_id) and the version increments to
+        record the revision history. Emits
+        ``plan.version_incremented`` with the old/new version pair so
+        downstream consumers (heartbeat, inbox, plan-history UI) can
+        reconstruct the revision timeline without scanning task
+        content. Audit emission is best-effort — a failed audit write
+        never blocks the version bump.
+
+        Returns the refreshed Task with the new version applied.
+        """
+        project, task_number = _parse_task_id(task_id)
+        row = self._conn.execute(
+            "SELECT plan_version FROM work_tasks "
+            "WHERE project = ? AND task_number = ?",
+            (project, task_number),
+        ).fetchone()
+        if row is None:
+            raise TaskNotFoundError(f"Task '{task_id}' not found.")
+        old_version = int(_row_get(row, "plan_version", 1) or 1)
+        new_version = old_version + 1
+        self._conn.execute(
+            "UPDATE work_tasks "
+            "SET plan_version = ?, updated_at = ? "
+            "WHERE project = ? AND task_number = ?",
+            (new_version, _now(), project, task_number),
+        )
+        self._conn.commit()
+
+        try:
+            from pollypm.audit import emit as _audit_emit
+            from pollypm.audit.log import EVENT_PLAN_VERSION_INCREMENTED
+
+            metadata: dict[str, object] = {
+                "task_id": task_id,
+                "old_version": old_version,
+                "new_version": new_version,
+            }
+            if reason:
+                metadata["reason"] = reason
+            _audit_emit(
+                event=EVENT_PLAN_VERSION_INCREMENTED,
+                project=project,
+                subject=task_id,
+                actor=actor or "system",
+                metadata=metadata,
+                project_path=self._project_path,
+            )
+        except Exception:  # noqa: BLE001 — audit must never break the bump
+            pass
+
+        return self.get(task_id)
+
+    def list_successors(self, predecessor_task_id: str) -> list[Task]:
+        """Return tasks whose ``predecessor_task_id`` is ``predecessor_task_id`` (#1398).
+
+        Forward-walks the replan chain. Empty list when no replans
+        exist. Stable ordering by ``project, task_number`` matches
+        ``list_tasks`` so callers can present chronological succession.
+        """
+        rows = self._conn.execute(
+            "SELECT * FROM work_tasks WHERE predecessor_task_id = ? "
+            "ORDER BY project, task_number",
+            (predecessor_task_id,),
+        ).fetchall()
+        return [self._row_to_task(row) for row in rows]
 
     def has_human_review_approval(self, task_id: str) -> bool:
         """Return True when a pre-queue human review approval is recorded."""

--- a/tests/test_work_schema.py
+++ b/tests/test_work_schema.py
@@ -97,6 +97,13 @@ class TestWorkTasksColumns:
         for col in ("parent_project", "parent_task_number", "supersedes_project", "supersedes_task_number"):
             assert col in cols, f"Missing column: {col}"
 
+    def test_plan_metadata_columns(self, conn):
+        """#1398 — plan_version + predecessor_task_id present on fresh DB."""
+        create_work_tables(conn)
+        cols = _columns(conn, "work_tasks")
+        assert "plan_version" in cols
+        assert "predecessor_task_id" in cols
+
     def test_audit_columns(self, conn):
         create_work_tables(conn)
         cols = _columns(conn, "work_tasks")
@@ -263,10 +270,10 @@ def test_legacy_db_gets_hot_query_indexes_and_schema_bump(conn):
     version = conn.execute(
         "SELECT COALESCE(MAX(version), 0) FROM work_schema_version"
     ).fetchone()[0]
-    # Migration 7 (#922) records the kickoff_sent_at column bump on
-    # work_node_executions so the heartbeat sweep can force the first
-    # 'Resume work' ping past the bootstrap race.
-    assert version == 7
+    # Migration 8 (#1398) records the plan_version + predecessor_task_id
+    # column bumps on work_tasks so plan-task evolution metadata
+    # surfaces on legacy DBs without a backfill pass.
+    assert version == 8
 
 
 def test_migration_6_adds_provider_columns_to_work_sessions(conn):
@@ -301,4 +308,99 @@ def test_migration_7_adds_kickoff_sent_at_to_work_node_executions(conn):
     version = conn.execute(
         "SELECT COALESCE(MAX(version), 0) FROM work_schema_version"
     ).fetchone()[0]
-    assert version == 7
+    # The migration walk applies every pending step in order, so a v6
+    # legacy DB ends up at the latest version (v8 after #1398) — not
+    # at v7. Asserting the whole walk completed protects future
+    # migrations from a stale floor here.
+    assert version == 8
+
+
+def test_migration_8_adds_plan_metadata_columns_to_work_tasks(conn):
+    """#1398: legacy work_tasks rows get plan_version + predecessor_task_id.
+
+    Builds a v7-shaped DB with a populated row that pre-dates the
+    columns, runs the migration, and asserts:
+      * the new columns exist after migration,
+      * existing rows default to ``plan_version=1`` and
+        ``predecessor_task_id=NULL`` (additive migration — no data
+        loss / shape change),
+      * the schema_version row bumps to v8.
+    """
+    # Create a v7-shaped work_tasks table (no plan_version /
+    # predecessor_task_id columns) plus the schema_version row that
+    # pins us to v7 so the migration walk has to apply v8.
+    conn.executescript(
+        """
+        CREATE TABLE work_schema_version (
+            version INTEGER NOT NULL,
+            description TEXT NOT NULL,
+            applied_at TEXT NOT NULL
+        );
+        INSERT INTO work_schema_version (version, description, applied_at)
+        VALUES (7, 'pre-#1398', '2026-04-01T00:00:00+00:00');
+
+        CREATE TABLE work_tasks (
+            project TEXT NOT NULL,
+            task_number INTEGER NOT NULL,
+            title TEXT NOT NULL,
+            type TEXT NOT NULL,
+            labels TEXT NOT NULL DEFAULT '[]',
+            work_status TEXT NOT NULL DEFAULT 'draft',
+            flow_template_id TEXT NOT NULL,
+            flow_template_version INTEGER NOT NULL DEFAULT 1,
+            current_node_id TEXT,
+            assignee TEXT,
+            priority TEXT NOT NULL DEFAULT 'normal',
+            requires_human_review INTEGER NOT NULL DEFAULT 0,
+            description TEXT NOT NULL DEFAULT '',
+            acceptance_criteria TEXT,
+            constraints TEXT,
+            relevant_files TEXT NOT NULL DEFAULT '[]',
+            parent_project TEXT,
+            parent_task_number INTEGER,
+            supersedes_project TEXT,
+            supersedes_task_number INTEGER,
+            roles TEXT NOT NULL DEFAULT '{}',
+            external_refs TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL,
+            created_by TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (project, task_number)
+        );
+        INSERT INTO work_tasks
+            (project, task_number, title, type, flow_template_id,
+             created_at, created_by, updated_at)
+        VALUES
+            ('demo', 1, 'pre-existing', 'task', 'standard',
+             '2026-01-01T00:00:00+00:00', 'tester',
+             '2026-01-01T00:00:00+00:00');
+        """
+    )
+
+    create_work_tables(conn)
+
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(work_tasks)")}
+    assert "plan_version" in cols, "plan_version column should exist post-migration"
+    assert "predecessor_task_id" in cols, (
+        "predecessor_task_id column should exist post-migration"
+    )
+
+    row = conn.execute(
+        "SELECT title, plan_version, predecessor_task_id FROM work_tasks "
+        "WHERE project = ? AND task_number = ?",
+        ("demo", 1),
+    ).fetchone()
+    assert row is not None, "existing row must survive additive migration"
+    assert row[0] == "pre-existing", "title must be untouched"
+    assert row[1] == 1, "plan_version defaults to 1 for pre-#1398 rows"
+    assert row[2] is None, "predecessor_task_id defaults to NULL"
+
+    version = conn.execute(
+        "SELECT COALESCE(MAX(version), 0) FROM work_schema_version"
+    ).fetchone()[0]
+    assert version == 8
+
+    idxs = _indexes(conn)
+    assert "idx_work_tasks_predecessor" in idxs, (
+        "successors lookup index should be created on legacy DB"
+    )

--- a/tests/test_work_service.py
+++ b/tests/test_work_service.py
@@ -1078,3 +1078,141 @@ class TestActorTypeAgent:
         """)
         with pytest.raises(FlowValidationError, match="agent_name"):
             parse_flow_yaml(yaml_text)
+
+
+# ---------------------------------------------------------------------------
+# Plan task evolution metadata (#1398)
+# ---------------------------------------------------------------------------
+
+
+class TestPlanTaskMetadata:
+    """Coverage for plan_version + predecessor_task_id (#1398)."""
+
+    def test_create_defaults_plan_version_to_1(self, svc):
+        task = _create_standard_task(svc)
+        assert task.plan_version == 1
+        assert task.predecessor_task_id is None
+
+    def test_create_with_predecessor_records_link(self, svc):
+        first = _create_standard_task(svc, title="original")
+        successor = _create_standard_task(
+            svc,
+            title="replan",
+            predecessor_task_id=first.task_id,
+        )
+        # Predecessor link should be queryable on the successor
+        assert successor.predecessor_task_id == first.task_id
+        # Re-read from the DB to confirm persistence (not just the
+        # post-INSERT in-memory shape).
+        refetched = svc.get(successor.task_id)
+        assert refetched.predecessor_task_id == first.task_id
+
+    def test_list_successors_returns_replan_chain(self, svc):
+        first = _create_standard_task(svc, title="original")
+        s1 = _create_standard_task(
+            svc, title="replan-1", predecessor_task_id=first.task_id
+        )
+        s2 = _create_standard_task(
+            svc, title="replan-2", predecessor_task_id=first.task_id
+        )
+        # Unrelated task shouldn't appear in the result.
+        _create_standard_task(svc, title="unrelated")
+
+        successors = svc.list_successors(first.task_id)
+        ids = {s.task_id for s in successors}
+        assert ids == {s1.task_id, s2.task_id}
+
+    def test_increment_plan_version_bumps_value(self, svc):
+        task = _create_standard_task(svc)
+        assert task.plan_version == 1
+        bumped = svc.increment_plan_version(task.task_id, actor="architect")
+        assert bumped.plan_version == 2
+        # Re-fetch to confirm the bump persisted.
+        refetched = svc.get(task.task_id)
+        assert refetched.plan_version == 2
+
+    def test_increment_plan_version_emits_audit_event(
+        self, svc, tmp_path, monkeypatch
+    ):
+        """``plan.version_incremented`` should fire with old/new versions."""
+        from pollypm.audit import central_log_path, read_events
+        from pollypm.audit.log import EVENT_PLAN_VERSION_INCREMENTED
+
+        # Redirect the central audit tail to a temp dir so the test
+        # never touches the user's real ~/.pollypm/audit/ tree.
+        audit_home = tmp_path / "audit-home"
+        monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+        task = _create_standard_task(svc, project="auditproj")
+        svc.increment_plan_version(
+            task.task_id, actor="architect", reason="refined plan"
+        )
+
+        events = read_events(
+            "auditproj", event=EVENT_PLAN_VERSION_INCREMENTED
+        )
+        assert len(events) == 1, (
+            f"expected one plan.version_incremented event, "
+            f"got: {[e.event for e in events]}"
+        )
+        evt = events[0]
+        assert evt.subject == task.task_id
+        assert evt.actor == "architect"
+        assert evt.metadata["old_version"] == 1
+        assert evt.metadata["new_version"] == 2
+        assert evt.metadata["task_id"] == task.task_id
+        assert evt.metadata.get("reason") == "refined plan"
+        # Sanity: the central tail file exists where we expect.
+        assert central_log_path("auditproj").exists()
+
+    def test_create_successor_emits_plan_successor_audit_event(
+        self, svc, tmp_path, monkeypatch
+    ):
+        from pollypm.audit import read_events
+        from pollypm.audit.log import EVENT_PLAN_SUCCESSOR_CREATED
+
+        audit_home = tmp_path / "audit-home"
+        monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+        first = _create_standard_task(svc, project="replanproj")
+        successor = _create_standard_task(
+            svc,
+            project="replanproj",
+            title="replan",
+            predecessor_task_id=first.task_id,
+        )
+
+        events = read_events(
+            "replanproj", event=EVENT_PLAN_SUCCESSOR_CREATED
+        )
+        assert len(events) == 1
+        evt = events[0]
+        assert evt.subject == successor.task_id
+        assert evt.metadata["predecessor"] == first.task_id
+        assert evt.metadata["successor"] == successor.task_id
+
+    def test_create_no_predecessor_does_not_emit_successor_event(
+        self, svc, tmp_path, monkeypatch
+    ):
+        """A regular task create must NOT emit plan.successor_created."""
+        from pollypm.audit import read_events
+        from pollypm.audit.log import EVENT_PLAN_SUCCESSOR_CREATED
+
+        audit_home = tmp_path / "audit-home"
+        monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+        _create_standard_task(svc, project="noreplan")
+        events = read_events("noreplan", event=EVENT_PLAN_SUCCESSOR_CREATED)
+        assert events == []
+
+    def test_increment_plan_version_unknown_task_raises(self, svc):
+        with pytest.raises(TaskNotFoundError):
+            svc.increment_plan_version("ghost/999")
+
+    def test_create_with_malformed_predecessor_raises(self, svc):
+        with pytest.raises(ValidationError):
+            _create_standard_task(
+                svc,
+                title="bad replan",
+                predecessor_task_id="not-a-task-id",
+            )


### PR DESCRIPTION
Closes #1398. Schema + SDK + audit emit. UI consumers come in sibling PRs.

## Summary

- **Schema**: `work_tasks` gains `plan_version INTEGER NOT NULL DEFAULT 1` and `predecessor_task_id TEXT NULL` plus a partial index `idx_work_tasks_predecessor` for successor lookups. Migration v8 is additive — legacy rows default `plan_version=1` and `predecessor_task_id=NULL`, no backfill required. The columns are added by `_ensure_work_task_plan_columns` (matching the existing `kickoff_sent_at` / `entry_type` / `agent_name` pattern) so legacy DBs get the columns via `ALTER TABLE` before the migration registry walks.
- **SDK**: `WorkService.create(predecessor_task_id=...)` now accepts an optional predecessor link. New `WorkService.increment_plan_version(task_id, actor=, reason=)` bumps the version and emits an audit event. New `WorkService.list_successors(predecessor_task_id)` walks the replan chain forward. Mock service mirrors the new methods so protocol conformance holds.
- **Audit**: Two new events with stable names — `plan.version_incremented` (`{task_id, old_version, new_version, reason?}`) on refinement bumps; `plan.successor_created` (`{predecessor, successor}`) when a task is created with a predecessor link.

## Test summary

`tests/test_work_schema.py` (3 new + 2 updated):
- Fresh-DB column existence (`plan_version`, `predecessor_task_id`).
- `test_migration_8_adds_plan_metadata_columns_to_work_tasks` — builds a v7-shaped DB with a populated row, runs the migration, asserts the columns exist, the row's title/data is untouched, defaults apply, schema_version bumps to 8, and the predecessor index lands.
- Bumped expected `schema_version == 8` in the existing legacy-bump test + kickoff_sent_at test.

`tests/test_work_service.py::TestPlanTaskMetadata` (9 new):
- Default `plan_version=1`, `predecessor_task_id=None` on create.
- Successor link round-trip (create with predecessor, re-fetch, assert).
- `list_successors` returns the replan chain, ignores unrelated tasks.
- `increment_plan_version` bumps and persists.
- `plan.version_incremented` audit event fires with old/new versions, actor, reason — central tail asserted.
- `plan.successor_created` fires when a successor is created.
- A regular create (no predecessor) does NOT emit `plan.successor_created`.
- `increment_plan_version` on missing task raises `TaskNotFoundError`.
- Malformed `predecessor_task_id` raises `ValidationError`.

## Tests run

- `pytest tests/test_work_schema.py` — 21 passed
- `pytest tests/test_work_service.py` — 70 passed (61 existing + 9 new)
- `pytest tests/test_audit_log.py tests/test_work_service_protocol_conformance.py tests/test_work_service_factory.py tests/test_work_service_spec_docs.py` — 73 passed
- `pytest tests/test_legacy_per_project_db_migration.py` — 7 passed
- Broader filtered run (`-k "work or audit or task or schema or migration"`): 431 passed, 1 unrelated flaky failure (`test_pool_drains_when_db_connection_closed_under_workers` — passes in isolation, thread-timing flake unrelated to this change).

## Test plan
- [x] Migration test: schema has new columns after migration; existing data unaffected
- [x] SDK test: create a task, increment version, assert audit event fires
- [x] SDK test: create a successor task linking to predecessor, assert link is queryable
- [x] No UI changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)