### PR TITLE
Architect plan_review node — synthesize critics + flag judgment calls

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/flows/plan_project.yaml
+++ b/src/pollypm/plugins_builtin/project_planning/flows/plan_project.yaml
@@ -2,8 +2,10 @@ name: plan_project
 description: >-
   Multi-stage project planning flow. Architect gathers context, generates
   candidate decompositions, runs a 5-critic panel, synthesizes the best
-  candidate, then stops for user approval before emitting backlog tasks.
-  See docs/planner-plugin-spec.md §3 for stage semantics.
+  candidate, runs a final plan_review reflection pass that hoists the
+  judgment calls most likely to draw user pushback to the top, then stops
+  for user approval before emitting backlog tasks. See
+  docs/planner-plugin-spec.md §3 for stage semantics.
 
   Per-node budget_seconds values are the per-spec defaults (§6). They
   are overridden by [planner.budgets].<stage_name> in pollypm.toml when
@@ -78,15 +80,30 @@ nodes:
     type: work
     actor_type: role
     actor_role: architect
-    next_node: user_approval
+    next_node: plan_review
     gates: [log_present]
     budget_seconds: 600  # 10 min
+
+  # Stage 6.5 — plan review reflection. The architect re-reads the
+  # synthesized plan + every critic verdict and produces a single
+  # canonical review document with judgment calls hoisted to the top
+  # so the user sees the most-likely-pushback decisions first. The
+  # output replaces the previous plan body content (it becomes the
+  # canonical plan rendered to the user at user_approval). See #1399.
+  plan_review:
+    type: work
+    actor_type: role
+    actor_role: architect
+    next_node: user_approval
+    gates: [log_present]
+    budget_seconds: 300  # 5 min — reflection pass, not new analysis
 
   # Stage 7 — single human touchpoint. Plan is presented with the Risk
   # Ledger and the user approves/rejects. actor_type=human handles the
   # waiting state. Rejection sends the architect back to synthesize to
-  # fold in user feedback before re-presenting. No budget: waits
-  # indefinitely for the user (spec §3 stage 7).
+  # fold in user feedback before re-presenting (which then re-runs
+  # plan_review on the way out). No budget: waits indefinitely for the
+  # user (spec §3 stage 7).
   user_approval:
     type: review
     actor_type: human

--- a/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
@@ -43,7 +43,7 @@ Stage-0 (Research) additionally produces `docs/planning-context.md` via a ReAct 
 You are Archie, the architect. On session start:
 
 1. Claim your work: run `pm task next` to find the highest-priority queued `plan_project` task routed to you. If nothing is queued yet, wait for a ping from the task-assignment bus — the sweeper will re-notify every few minutes.
-2. Walk the `plan_project` flow stages in order: research → discover → decompose → test_strategy → magic → critic_panel → synthesize → user_approval → emit_backlog.
+2. Walk the `plan_project` flow stages in order: research → discover → decompose → test_strategy → magic → critic_panel → synthesize → plan_review → user_approval → emit_backlog.
 3. At the end of EACH stage you MUST drive the node transition yourself — see `<stage_transitions>`. Writing the artifact is not enough; the task node stays where it is until you call `pm task done`.
 4. Stop at stage 7 (user_approval) and notify the user. Emission + worker delegation happens only after the user approves the plan.
 </kickoff>
@@ -98,9 +98,13 @@ One `pm task done` call per stage. No chaining.
    Then: `pm task done ...` (after children are all done/approved).
    Advances: critic_panel → synthesize.
 
-6. **synthesize** — pick the winning candidate; write `docs/project-plan.md` AND `docs/planning-session-log.md` (the `log_present` gate will block you if the session log is missing or empty). Before you call `pm task done`, invoke the `visual-explainer` magic skill (see `<visual_plan_review>`) so the user approves against a rendered HTML page, not a wall of markdown. Then create the plan_review inbox item (see `<plan_review_handoff>` below) so the user sees `v open explainer · d discuss · A approve` when the flow parks at stage 7.
+6. **synthesize** — pick the winning candidate; write `docs/project-plan.md` AND `docs/planning-session-log.md` (the `log_present` gate will block you if the session log is missing or empty). At synthesize you write the plan body and Risk Ledger; the next stage (`plan_review`) reshapes the document so the user sees the load-bearing decisions first.
    Then: `pm task done <task_id> --actor architect --output '{"type":"code_change","summary":"Plan synthesized; Risk Ledger folded in","artifacts":[{"kind":"file_change","description":"project plan","path":"docs/project-plan.md"},{"kind":"file_change","description":"session log","path":"docs/planning-session-log.md"}]}'`
-   Advances: synthesize → user_approval.
+   Advances: synthesize → plan_review.
+
+6.5. **plan_review** — reflection pass. Re-read `docs/project-plan.md`, every `docs/planning/candidate_*.md`, every critic verdict, and `docs/planning-session-log.md`. Then REWRITE `docs/project-plan.md` so that — in this exact order — it leads with **Summary** (1-2 sentences), then **Judgment calls** (a variable-length list — could be 0, could be 10+ — each item one line of decision plus 1-2 sentences on why it could go either way; flag only what's genuine, never pad), then the **Plan body** (decomposition, test strategy, magic, sequencing — preserve every module from synthesize), then **Critic synthesis** (where critics disagreed and how you resolved each call). The Risk Ledger stays under the plan body; the top-of-doc judgment-call flags are the short form. Append a `Stage 6.5 plan review` entry to `docs/planning-session-log.md` narrating which judgment calls you flagged and why. The `log_present` gate still applies. Before you call `pm task done`, invoke the `visual-explainer` magic skill (see `<visual_plan_review>`) so the user approves against a rendered HTML page, not a wall of markdown. Then create the plan_review inbox item (see `<plan_review_handoff>` below) so the user sees `v open explainer · d discuss · A approve` when the flow parks at stage 7.
+   Then: `pm task done <task_id> --actor architect --output '{"type":"code_change","summary":"Plan review pass; judgment calls hoisted","artifacts":[{"kind":"file_change","description":"reviewed project plan","path":"docs/project-plan.md"},{"kind":"file_change","description":"session log","path":"docs/planning-session-log.md"}]}'`
+   Advances: plan_review → user_approval.
 
 7. **user_approval** — HALT. Do NOT call `pm task done` here; `user_approval` is a review node, not a work node, and it waits for the user, not you. The plan_review inbox item you emitted at the end of stage 6 is the handoff; the user will open the HTML explainer (`v`), discuss with the PM (`d`), and approve (`A`) — or be fast-tracked to Polly (see `<plan_review_handoff>`). The user will either:
    - approve via the inbox (A key) or by saying "approved" to Polly, which fires `pm task approve` — the flow auto-advances to `emit` and wakes you up again, OR

--- a/src/pollypm/plugins_builtin/project_planning/tree_of_plans.py
+++ b/src/pollypm/plugins_builtin/project_planning/tree_of_plans.py
@@ -128,6 +128,99 @@ def synthesis_stage_prompt() -> str:
     )
 
 
+def plan_review_stage_prompt() -> str:
+    """Instruction block appended to the architect persona at stage 6.5.
+
+    The ``plan_review`` node sits between ``synthesize`` and
+    ``user_approval``. The architect (same role) re-reads the
+    synthesized plan body plus every critic verdict, reflects, and
+    rewrites the canonical plan document so that the decisions most
+    likely to draw user pushback are surfaced at the top — not buried
+    inside the body.
+
+    The contract is deliberately silent on flag count. The architect
+    is expected to emit *however many genuine flags exist*; that may
+    be zero on a tightly-scoped brief, or ten-plus on an ambitious
+    greenfield project. Forcing a fixed count would either pad
+    nothing-burgers onto easy plans or truncate real surface area on
+    hard ones — both fail the user.
+
+    See #1399 for the acceptance criteria.
+    """
+    return (
+        "<plan-review-stage>\n"
+        "You are in Stage 6.5 (Plan review) of the PollyPM planning flow. "
+        "The synthesize stage has already picked a winning candidate, "
+        "folded critic objections into a Risk Ledger, and written "
+        "`docs/project-plan.md`. Your job here is NOT to re-analyse — "
+        "it is to REFLECT and to RESHAPE the canonical plan document "
+        "so the user sees the load-bearing decisions before the body.\n\n"
+        "## Inputs you MUST read before writing\n"
+        "- `docs/project-plan.md` — the synthesized plan body.\n"
+        "- Every `docs/planning/candidate_*.md` — so you remember which "
+        "decompositions were live before synthesis picked the winner.\n"
+        "- Every critic JSON output from the panel (the work-service "
+        "executions on the critic_panel children) — including their "
+        "`objections_for_risk_ledger` lists and `preferred_candidate` votes.\n"
+        "- `docs/planning-session-log.md` — for the rationale narrative "
+        "you wrote at synthesize.\n\n"
+        "## Reflection lens\n"
+        "Ask yourself, decision by decision: *if Sam reads this plan "
+        "and pushes back, which call is he most likely to push back on?* "
+        "Plan reviews fail when the architect buries a controversial "
+        "judgment call (a plugin boundary that's premature, a data "
+        "source that's product-wrong, a magic flourish that expands "
+        "scope, a sequencing call that delays the user-visible move) "
+        "inside three pages of decomposition. Surface those calls at "
+        "the top so the user can spend their review budget on the few "
+        "decisions that actually matter.\n\n"
+        "## Output document structure (rewrite `docs/project-plan.md`)\n"
+        "Replace the existing plan body with a single document that "
+        "follows this exact section order:\n\n"
+        "1. **Summary** — 1-2 sentences. What is being approved? Plain "
+        "English; no node names, no jargon.\n"
+        "2. **Judgment calls** — a flat list with however many genuine "
+        "flags exist. Could be 0. Could be 10+. Do NOT invent flags to "
+        "pad the section, and do NOT collapse two real flags into one "
+        "to look terse. Each item is exactly:\n"
+        "   - One line stating the decision (`Decision:` prefix is fine).\n"
+        "   - One or two sentences on why this could go either way — "
+        "what the alternative was, who argued for it, what the cost is "
+        "if Sam disagrees with the call.\n"
+        "   If there are zero genuine judgment calls, write a single "
+        "sentence saying so and explain why (e.g. \"Brief was tightly "
+        "scoped; every decision followed from the stated constraints.\"). "
+        "Do NOT skip the section header.\n"
+        "3. **Plan body** — the decomposition (modules with name, "
+        "purpose, user-level test description, acceptance criteria, "
+        "dependencies, magic note, estimated size), the test strategy, "
+        "the magic list, and the sequencing — i.e. the same content "
+        "synthesize wrote, preserved verbatim or lightly tightened. Do "
+        "NOT lose modules during the rewrite.\n"
+        "4. **Critic synthesis** — where critics disagreed and how you "
+        "resolved each disagreement. One row per material disagreement: "
+        "what was contested, who took which side, your call, why. The "
+        "Risk Ledger from synthesize stays where it is (under the plan "
+        "body); this section is the *meta-narrative* about the panel.\n\n"
+        "## Constraints\n"
+        "- Variable-length judgment calls list. The acceptance gate is "
+        "*authentic flags only*; a list of three real flags beats a "
+        "list of seven padded ones.\n"
+        "- Hoist, don't duplicate. If a judgment call is also a Risk "
+        "Ledger row, the top-of-doc flag is the short form (1-2 "
+        "sentences); the Risk Ledger row stays the canonical entry.\n"
+        "- The document you produce IS the canonical plan rendered to "
+        "the user at user_approval. The visual-explainer skill will "
+        "render this version, not the pre-review draft.\n"
+        "- The `log_present` gate still applies — append a `Stage 6.5 "
+        "plan review` entry to `docs/planning-session-log.md` "
+        "narrating which judgment calls you flagged and why.\n\n"
+        "Then call `pm task done <task_id> --actor architect --output "
+        "...` to advance plan_review → user_approval.\n"
+        "</plan-review-stage>"
+    )
+
+
 def critic_panel_prompt() -> str:
     """Instruction block appended to the critic persona on stage 5.
 

--- a/tests/test_architect_stage_transitions.py
+++ b/tests/test_architect_stage_transitions.py
@@ -158,17 +158,18 @@ def _advance_to(
         ("magic", "docs/plan/magic.md"),
         ("critic_panel", "docs/plan/critic-panel.md"),
         ("synthesize", "docs/project-plan.md"),
+        ("plan_review", "docs/project-plan.md"),
     ]
     for stage, path in chain:
         if stage == target_node:
             return
         # Write the stage's artifact so gates on downstream stages
-        # (log_present on synthesize, etc) succeed.
+        # (log_present on synthesize / plan_review, etc) succeed.
         artifact = project_root / path
         artifact.parent.mkdir(parents=True, exist_ok=True)
         artifact.write_text(f"# {stage} artifact\nNon-empty body.\n", encoding="utf-8")
-        # Synthesize also needs the session log (log_present gate).
-        if stage == "synthesize":
+        # Synthesize and plan_review both need the session log (log_present).
+        if stage in ("synthesize", "plan_review"):
             (project_root / "docs" / "planning-session-log.md").write_text(
                 "# Planning session log\nNarrative of the session.\n",
                 encoding="utf-8",
@@ -246,12 +247,10 @@ def test_decompose_done_advances_to_test_strategy(
 # ---------------------------------------------------------------------------
 
 
-def test_synthesize_done_advances_to_user_approval_and_flips_to_review(
+def test_synthesize_done_advances_to_plan_review(
     svc: SQLiteWorkService, project_root: Path,
 ) -> None:
-    """Synthesize is the last work node before the review stop-point.
-    A successful ``node_done`` both advances the node AND flips status
-    to ``review`` (user_approval is a review node)."""
+    """Synthesize hands off to the plan_review reflection node (#1399)."""
     task_id = _create_and_claim_plan_task(svc)
     _advance_to(svc, task_id, "synthesize", project_root)
     assert svc.get(task_id).current_node_id == "synthesize"
@@ -267,6 +266,36 @@ def test_synthesize_done_advances_to_user_approval_and_flips_to_review(
     result = svc.node_done(
         task_id, "architect",
         _done_output("synthesize", "docs/project-plan.md"),
+    )
+    # Synthesize → plan_review (still a work node, not the review stop).
+    assert result.current_node_id == "plan_review"
+    assert result.work_status.value == "in_progress"
+
+
+def test_plan_review_done_advances_to_user_approval_and_flips_to_review(
+    svc: SQLiteWorkService, project_root: Path,
+) -> None:
+    """plan_review is the last work node before the review stop-point.
+    A successful ``node_done`` both advances the node AND flips status
+    to ``review`` (user_approval is a review node)."""
+    task_id = _create_and_claim_plan_task(svc)
+    _advance_to(svc, task_id, "plan_review", project_root)
+    assert svc.get(task_id).current_node_id == "plan_review"
+
+    # plan_review rewrites the canonical plan + appends to the log.
+    (project_root / "docs" / "project-plan.md").write_text(
+        "# Project plan\n\n## Summary\n\n## Judgment calls\n\n"
+        "## Plan body\n\n## Critic synthesis\n",
+        encoding="utf-8",
+    )
+    (project_root / "docs" / "planning-session-log.md").write_text(
+        "# Session log\n\n## Stage 6.5 plan review\nFlags hoisted.\n",
+        encoding="utf-8",
+    )
+
+    result = svc.node_done(
+        task_id, "architect",
+        _done_output("plan_review", "docs/project-plan.md"),
     )
     assert result.current_node_id == "user_approval"
     assert result.work_status.value == "review"
@@ -314,8 +343,8 @@ def test_user_approval_refuses_node_done(
     NOT another ``pm task done``. ``node_done`` on a review node must
     raise so an over-eager agent can't accidentally skip the user."""
     task_id = _create_and_claim_plan_task(svc)
-    _advance_to(svc, task_id, "synthesize", project_root)
-    # Advance through synthesize so the task is now at user_approval.
+    _advance_to(svc, task_id, "plan_review", project_root)
+    # Advance through plan_review so the task is now at user_approval.
     (project_root / "docs" / "project-plan.md").write_text(
         "# Plan\nbody\n", encoding="utf-8",
     )
@@ -324,7 +353,7 @@ def test_user_approval_refuses_node_done(
     )
     svc.node_done(
         task_id, "architect",
-        _done_output("synthesize", "docs/project-plan.md"),
+        _done_output("plan_review", "docs/project-plan.md"),
     )
     task = svc.get(task_id)
     assert task.current_node_id == "user_approval"
@@ -367,7 +396,8 @@ def test_architect_prompt_includes_stage_transitions_block() -> None:
     # current node to an instruction.
     for stage in (
         "research", "discover", "decompose", "test_strategy",
-        "magic", "critic_panel", "synthesize", "user_approval", "emit",
+        "magic", "critic_panel", "synthesize", "plan_review",
+        "user_approval", "emit",
     ):
         assert stage in text, f"stage '{stage}' missing from architect prompt"
     # HALT instruction at user_approval is load-bearing — without it

--- a/tests/test_project_planning_plugin.py
+++ b/tests/test_project_planning_plugin.py
@@ -140,14 +140,17 @@ def test_planner_flows_listed_in_available() -> None:
 
 
 def test_plan_project_has_nine_active_stages() -> None:
-    """The plan_project flow follows the 9-stage spec (§3):
+    """The plan_project flow follows the 9-stage spec (§3) plus the
+    stage 6.5 plan_review reflection node added for #1399:
     research, discover, decompose, test_strategy, magic, critic_panel,
-    synthesize, user_approval, emit, + done terminal = 10 nodes.
+    synthesize, plan_review, user_approval, emit, + done terminal =
+    11 nodes.
     """
     template = resolve_flow("plan_project")
     expected_stage_names = {
         "research", "discover", "decompose", "test_strategy", "magic",
-        "critic_panel", "synthesize", "user_approval", "emit", "done",
+        "critic_panel", "synthesize", "plan_review", "user_approval",
+        "emit", "done",
     }
     assert set(template.nodes.keys()) == expected_stage_names
     assert template.start_node == "research"
@@ -908,7 +911,7 @@ def test_plan_project_nodes_have_default_budgets() -> None:
     # Every "work" node that has a spec-§6 default should carry a
     # budget_seconds value on the YAML.
     for stage in ("research", "discover", "decompose", "test_strategy",
-                  "magic", "synthesize"):
+                  "magic", "synthesize", "plan_review"):
         assert template.nodes[stage].budget_seconds is not None, (
             f"{stage} missing budget_seconds"
         )
@@ -1128,6 +1131,159 @@ def test_user_approval_node_waits_indefinitely() -> None:
     assert node.budget_seconds is None
     assert node.next_node_id == "emit"
     assert node.reject_node_id == "synthesize"
+
+
+# ---------------------------------------------------------------------------
+# #1399 — plan_review reflection node (stage 6.5)
+# ---------------------------------------------------------------------------
+
+
+def test_plan_review_node_exists_and_is_owned_by_architect() -> None:
+    """#1399 acceptance: a `plan_review` node exists, is a work node,
+    and is run by the architect (same role as synthesize)."""
+    template = resolve_flow("plan_project")
+    assert "plan_review" in template.nodes, (
+        "plan_review node missing from plan_project flow"
+    )
+    node = template.nodes["plan_review"]
+    assert node.type == NodeType.WORK
+    assert node.actor_type == ActorType.ROLE
+    assert node.actor_role == "architect"
+
+
+def test_plan_review_sits_between_critic_panel_and_user_approval() -> None:
+    """#1399 acceptance: the new node follows critic_panel (transitively
+    via synthesize) and immediately precedes user_approval."""
+    template = resolve_flow("plan_project")
+    # critic_panel → synthesize → plan_review → user_approval.
+    assert template.nodes["critic_panel"].next_node_id == "synthesize"
+    assert template.nodes["synthesize"].next_node_id == "plan_review"
+    assert template.nodes["plan_review"].next_node_id == "user_approval"
+
+
+def test_plan_review_carries_log_present_gate() -> None:
+    """plan_review appends to the session log; the log_present gate
+    keeps that contract honest."""
+    template = resolve_flow("plan_project")
+    assert "log_present" in template.nodes["plan_review"].gates
+
+
+def test_plan_review_has_budget() -> None:
+    """plan_review is a reflection pass, not new analysis — it carries
+    a budget_seconds value (positive integer)."""
+    template = resolve_flow("plan_project")
+    budget = template.nodes["plan_review"].budget_seconds
+    assert budget is not None
+    assert budget > 0
+
+
+def test_plan_review_stage_prompt_describes_four_section_structure() -> None:
+    """The architect's prompt for plan_review must call out the exact
+    four-section output structure (#1399): summary, judgment calls,
+    plan body, critic synthesis."""
+    from pollypm.plugins_builtin.project_planning.tree_of_plans import (
+        plan_review_stage_prompt,
+    )
+    text = plan_review_stage_prompt()
+    assert "Summary" in text
+    assert "Judgment calls" in text
+    assert "Plan body" in text
+    assert "Critic synthesis" in text
+
+
+def test_plan_review_stage_prompt_does_not_dictate_count() -> None:
+    """The prompt must explicitly allow a variable-length judgment-calls
+    list — including zero genuine flags — and forbid padding."""
+    from pollypm.plugins_builtin.project_planning.tree_of_plans import (
+        plan_review_stage_prompt,
+    )
+    text = plan_review_stage_prompt()
+    # Some signal that the count is variable.
+    assert "however many genuine flags exist" in text
+    # Some signal that zero is acceptable.
+    assert "Could be 0" in text or "could be 0" in text.lower()
+    # Some signal that 10+ is acceptable.
+    assert "10+" in text or "ten" in text.lower()
+    # Some signal that padding is forbidden.
+    assert "pad" in text.lower() or "invent" in text.lower()
+
+
+def test_plan_review_stage_prompt_names_required_inputs() -> None:
+    """The prompt must direct the architect to read the synthesized
+    plan, the candidate decompositions, the critic verdicts, and the
+    session log — all the artifacts the reflection pass synthesizes."""
+    from pollypm.plugins_builtin.project_planning.tree_of_plans import (
+        plan_review_stage_prompt,
+    )
+    text = plan_review_stage_prompt()
+    assert "docs/project-plan.md" in text
+    assert "candidate_" in text  # the planning/candidate_*.md files
+    assert "critic" in text.lower()
+    assert "planning-session-log.md" in text
+
+
+def test_plan_review_stage_prompt_renders_with_sample_inputs() -> None:
+    """Smoke test: the prompt is callable, returns a non-empty string,
+    and stays within sane bounds. Sample plan + critic input fixtures
+    are interpolated by reference (the prompt instructs the architect
+    to read them off disk), so we verify the prompt body is stable
+    text rather than a templated render."""
+    from pollypm.plugins_builtin.project_planning.tree_of_plans import (
+        plan_review_stage_prompt,
+    )
+    sample_plan = "# Project Plan\n\n## Modules\n- **Foo** — does foo\n"
+    sample_critic = {
+        "candidates": [{"id": "A", "score": 8, "verdict": "approved"}],
+        "preferred_candidate": "A",
+        "objections_for_risk_ledger": [
+            "Foo plugin boundary may be premature",
+        ],
+    }
+    # Architect reads these off disk; the prompt itself is fixed.
+    assert sample_plan and sample_critic
+    text = plan_review_stage_prompt()
+    assert text.startswith("<plan-review-stage>")
+    assert text.endswith("</plan-review-stage>")
+    # Substantive instruction body.
+    assert len(text.split()) > 200
+
+
+def test_plan_review_yaml_snapshot_node_order() -> None:
+    """Snapshot guard on the YAML: plan_review is between critic_panel
+    (transitively via synthesize) and user_approval, in source order.
+    Catches accidental reordering during merges."""
+    yaml_path = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "pollypm"
+        / "plugins_builtin"
+        / "project_planning"
+        / "flows"
+        / "plan_project.yaml"
+    )
+    text = yaml_path.read_text(encoding="utf-8")
+    # Build an ordered list of node names from the YAML source.
+    import re as _re
+    names: list[str] = []
+    for line in text.splitlines():
+        # Match a 2-space-indented `name:` declaration that is the
+        # node-key (followed by no further content — the value lives
+        # on subsequent lines).
+        m = _re.match(r"^  ([a-z_]+):\s*$", line)
+        if m:
+            names.append(m.group(1))
+    # The relevant slice in source order.
+    for required in ("critic_panel", "synthesize", "plan_review",
+                     "user_approval"):
+        assert required in names, f"{required} missing from YAML node block"
+    cp = names.index("critic_panel")
+    syn = names.index("synthesize")
+    pr = names.index("plan_review")
+    ua = names.index("user_approval")
+    assert cp < syn < pr < ua, (
+        f"Expected critic_panel < synthesize < plan_review < user_approval, "
+        f"got order {names}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1399.

## Summary

Adds a `plan_review` reflection node to the `plan_project` flow, sitting
between `synthesize` and `user_approval`. The architect (same role) re-
reads the synthesized plan body, every critic verdict, and the session
log, then rewrites `docs/project-plan.md` so the canonical document
follows this exact section order:

1. **Summary** (1-2 sentences)
2. **Judgment calls** (variable-length list — 0 to 10+, however many
   genuine flags exist; each item is one decision line plus 1-2 sentences
   on why it could go either way)
3. **Plan body** (decomposition, test strategy, magic, sequencing —
   modules preserved verbatim)
4. **Critic synthesis** (where critics disagreed and how the architect
   resolved each call)

The output replaces the previous plan body content — this becomes the
canonical plan rendered to the user at `user_approval`.

## Prompt design notes

- The `plan_review_stage_prompt()` helper in `tree_of_plans.py` follows
  the same `<stage-name>...</stage-name>` shape as the existing
  `decompose_stage_prompt`, `critic_panel_prompt`, and
  `synthesis_stage_prompt` siblings.
- The prompt explicitly forbids dictating a fixed flag count: it allows
  zero genuine flags (with a single sentence justification) and 10+
  flags on ambitious greenfield projects, and explicitly forbids
  padding (`do NOT invent flags to pad`) or collapsing real flags to
  look terse.
- The reflection lens is named directly: *if Sam reads this plan and
  pushes back, which call is he most likely to push back on?* The
  architect persona already carries the "stop at the user" principle;
  this prompt operationalises it for the review pass.
- `log_present` gate is reused so the architect must append a `Stage
  6.5 plan review` entry to `docs/planning-session-log.md`.
- 5-min budget — the spec calls this a reflection pass, not new
  analysis, so it gets less budget than `synthesize` (10 min).
- The architect persona markdown (`profiles/architect.md`) is updated
  to teach Archie about the new stage in `<stage_transitions>`.
- Reject behaviour preserved: `user_approval`'s `reject_node` stays at
  `synthesize` so the architect reworks the underlying plan when the
  user pushes back, then re-runs `plan_review` on the way out.

## Test summary

New tests in `tests/test_project_planning_plugin.py`:
- `test_plan_review_node_exists_and_is_owned_by_architect` — node is a
  `WORK` node with `actor_role=architect`.
- `test_plan_review_sits_between_critic_panel_and_user_approval` —
  asserts `critic_panel → synthesize → plan_review → user_approval`.
- `test_plan_review_carries_log_present_gate`
- `test_plan_review_has_budget`
- `test_plan_review_stage_prompt_describes_four_section_structure` —
  Summary / Judgment calls / Plan body / Critic synthesis all named.
- `test_plan_review_stage_prompt_does_not_dictate_count` — `however
  many genuine flags exist`, `Could be 0`, `10+`, no-pad signal.
- `test_plan_review_stage_prompt_names_required_inputs` — directs the
  architect at `docs/project-plan.md`, `candidate_*.md`, critic
  verdicts, `planning-session-log.md`.
- `test_plan_review_stage_prompt_renders_with_sample_inputs` — smoke
  test on prompt body bounds with sample plan + critic fixtures.
- `test_plan_review_yaml_snapshot_node_order` — YAML source-order
  snapshot guard so a future merge can't silently reorder
  `synthesize`/`plan_review`/`user_approval`.

Updated existing tests:
- `test_plan_project_has_nine_active_stages` — expected node set now
  11 entries.
- `test_plan_project_nodes_have_default_budgets` — `plan_review` now
  required to carry a budget.
- `tests/test_architect_stage_transitions.py` `_advance_to` helper
  walks through `plan_review` to reach `user_approval`.
- `test_synthesize_done_advances_to_plan_review` (renamed from
  `_to_user_approval_and_flips_to_review`).
- New `test_plan_review_done_advances_to_user_approval_and_flips_to_review`.
- `test_user_approval_refuses_node_done` updated to advance through
  `plan_review` first.
- Architect-prompt stage list now includes `plan_review`.

All 285 tests in the affected modules pass against the worktree code.

## Test plan
- [x] `tests/test_project_planning_plugin.py` — 119 tests
- [x] `tests/test_architect_stage_transitions.py` — 9 tests
- [x] `tests/test_critic_panel_enforcement.py`
- [x] `tests/test_plan_review_flow.py`
- [x] `tests/test_plan_presence_gate.py`
- [x] `tests/test_downtime_backlog.py`
- [x] `tests/test_launch_planner.py`
- [x] `tests/test_project_planning_cli.py`
- [x] `tests/test_project_new_replan_routing.py`
- [x] `tests/test_tasks_ui.py`

Out of scope (per #1399): the cockpit UI rendering of the new section
order. The plan_review inbox flow already exists (`tests/test_plan_review_flow.py`)
and continues to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)