### PR TITLE
Chat-to-refine flow — open PM chat with refinement primer, in-place revision

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -15159,7 +15159,28 @@ class PollyProjectDashboardApp(App[None]):
         cockpit_key, pm_label = _resolve_pm_target(
             self.config_path, self.project_key,
         )
-        if self._idle_project_needs_plan():
+        # #1404 — chat-to-refine. When the project drilldown is showing a
+        # pending plan-review surface, ``[c]`` opens the PM chat with a
+        # refinement primer (in-place revision, same task id, version
+        # bumps via the SDK once the architect ships the rewrite). The
+        # routing helper returns ``None`` for non-plan-review dashboards
+        # so the existing idle-plan / blocker-context / generic branches
+        # still fire for everything else.
+        refinement_primer: str | None = None
+        try:
+            from pollypm.plan_refinement import (
+                select_chat_primer_for_project_dashboard,
+            )
+            data = getattr(self, "data", None)
+            if data is not None:
+                refinement_primer = select_chat_primer_for_project_dashboard(
+                    data,
+                )
+        except Exception:  # noqa: BLE001
+            refinement_primer = None
+        if refinement_primer is not None:
+            context_line = refinement_primer
+        elif self._idle_project_needs_plan():
             context_line = (
                 f're: project/{self.project_key} '
                 f'"please draft an initial plan for this project"'

--- a/src/pollypm/plan_refinement.py
+++ b/src/pollypm/plan_refinement.py
@@ -1,0 +1,351 @@
+"""Chat-to-refine flow — primer + architect revision pass (#1404).
+
+The user lands on the project drilldown plan-review surface (#1401) with
+a plan parked at ``user_approval``. They press ``[c]`` to chat-to-refine:
+the cockpit opens the project's PM chat thread and seeds the input with
+a refinement primer that frames the conversation as in-place plan
+revision, not abandonment. After the user discusses tweaks, they emit
+the refinement signal (``go architect`` / ``revise the plan`` / etc.);
+the architect then runs a revision pass that rewrites the plan body in
+place under the SAME task id, with ``plan_version`` bumping via
+:meth:`WorkService.increment_plan_version` (#1407 SDK).
+
+Distinct from the deny flow (#1403) — deny CANCELS the current plan task
+and creates a successor with a ``predecessor_task_id`` link. Refine
+KEEPS the same task; the version counter records the revision history
+so plan-history consumers can walk it.
+
+The module is intentionally framework-agnostic: the cockpit UI calls
+:func:`build_plan_refinement_primer` to seed the chat, and a downstream
+process (the architect's revision turn, kicked off when the user signals
+"go architect") calls :func:`apply_plan_refinement` to write the new
+plan body and bump the version.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+# Phrases that, when present in the user's chat message, signal "we're
+# done discussing — go run the architect's revision pass on the new
+# plan". Match is case-insensitive and substring-based; we accept the
+# canonical "go architect" gesture plus a small set of natural-language
+# equivalents so the user doesn't have to memorise an exact incantation.
+#
+# Kept module-level so tests can introspect the list and the cockpit
+# input surface (when wired) can render a hint listing the recognised
+# phrases.
+REFINEMENT_SIGNAL_PHRASES: tuple[str, ...] = (
+    "go architect",
+    "ship the revision",
+    "revise the plan",
+    "rewrite the plan",
+    "apply the revision",
+    "run the revision",
+    "send to architect",
+)
+
+
+def is_refinement_signal(text: str | None) -> bool:
+    """Return ``True`` when ``text`` carries a "go architect" gesture.
+
+    Case-insensitive substring match against
+    :data:`REFINEMENT_SIGNAL_PHRASES`. Returns ``False`` for ``None`` /
+    empty input so the caller can pass raw user messages without
+    pre-validating.
+    """
+
+    if not text:
+        return False
+    haystack = str(text).lower()
+    return any(phrase in haystack for phrase in REFINEMENT_SIGNAL_PHRASES)
+
+
+def build_plan_refinement_primer(
+    *,
+    project_key: str,
+    plan_task_id: str,
+    plan_version: int,
+    plan_body: str,
+    plan_path: str | None = None,
+    reviewer_name: str = "Sam",
+) -> str:
+    """Build the PM chat primer for the chat-to-refine flow (#1404).
+
+    The primer frames the conversation as IN-PLACE plan revision (same
+    task id, version counter bumps), distinct from the deny-and-replan
+    flow which spawns a successor task. The architect that picks up the
+    refinement signal will rewrite the plan body in place via
+    :func:`apply_plan_refinement`.
+
+    The plan body is quoted directly so the PM has the canonical text
+    to refer to without re-reading the file from disk; ``plan_path`` is
+    appended as a pointer when supplied so the PM can deep-read sections
+    that don't fit in the primer (long plans).
+
+    Mirrors the shape of ``_build_plan_review_primer`` (the existing
+    inbox-row discuss primer, used by ``[d]``) so both surfaces feel
+    consistent: same architect-as-co-refiner framing, same approval
+    handoff. The refinement primer ADDS the explicit "this is in-place,
+    same task, version will bump" framing, the canonical refinement
+    signal phrases, and the quoted plan body.
+    """
+
+    person = reviewer_name.strip() or "Sam"
+    quoted_body = _quote_plan_body(plan_body)
+    plan_path_line = f"Plan file: {plan_path}\n" if plan_path else ""
+    signal_examples = ", ".join(f'"{phrase}"' for phrase in REFINEMENT_SIGNAL_PHRASES[:3])
+    return (
+        f"{person} is here to refine plan {plan_task_id} v{plan_version} "
+        f"for project {project_key}.\n"
+        f"This is an in-place revision: same task id, plan_version will "
+        f"bump to v{plan_version + 1} once the architect ships the rewrite. "
+        f"Do NOT create a successor task; the deny flow handles that.\n"
+        f"{plan_path_line}"
+        "\n"
+        "Current plan body (v"
+        f"{plan_version}):\n"
+        f"{quoted_body}\n"
+        "\n"
+        "Your job in this conversation:\n"
+        f"- Co-refine the plan with {person}; capture concrete tweaks, "
+        "not vibes\n"
+        "- Push hard on decomposition, magic, and risk decisions when "
+        f"{person} flags them\n"
+        f"- When {person} signals 'go architect' (or one of: "
+        f"{signal_examples}), hand off to the architect for the revision "
+        "pass — DO NOT rewrite the plan yourself in this chat\n"
+        f"- The architect will rewrite the plan body in place, bump "
+        f"plan_version to v{plan_version + 1}, and re-park the task at "
+        "user_approval; the cockpit picks up the new version inline\n"
+        f"- If {person} pings without a specific tweak, your default "
+        "opener is to walk through the riskiest decisions in the current "
+        "plan and ask which one to dig into first"
+    )
+
+
+def _quote_plan_body(body: str | None) -> str:
+    """Return ``body`` with each line prefixed by ``> `` for chat quoting.
+
+    The ``>`` form is the standard markdown blockquote and renders
+    distinctly in every chat surface we use (Codex, Claude). Lines that
+    are already blockquoted stay single-prefixed so we don't end up with
+    ``> > line``.
+    """
+
+    if not body:
+        return "> (plan body is empty)"
+    lines = []
+    for raw in str(body).splitlines() or [str(body)]:
+        if raw.startswith(">"):
+            lines.append(raw)
+        else:
+            lines.append(f"> {raw}" if raw else ">")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Architect revision pass — applies a refined plan body to disk + bumps the
+# plan_version on the task. Pure I/O at this layer; the architect's actual
+# rewrite turn (the LLM call) lives upstream in the planner plugin.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class PlanRefinementResult:
+    """Outcome of a chat-to-refine architect revision pass (#1404).
+
+    Carries enough state for the cockpit to show the new version inline
+    (the inline-render PR #1397 reads ``plan_version`` off the task
+    directly) and for tests to assert the SDK + filesystem side effects
+    landed.
+    """
+
+    task_id: str
+    old_version: int
+    new_version: int
+    plan_path: Path | None
+    bytes_written: int
+
+
+def apply_plan_refinement(
+    work_service,
+    *,
+    task_id: str,
+    new_plan_body: str,
+    project_path: Path | None = None,
+    actor: str = "architect",
+    reason: str | None = None,
+) -> PlanRefinementResult:
+    """Apply a refined plan body in place and bump ``plan_version``.
+
+    Steps (all best-effort except the version bump, which is the
+    canonical revision marker):
+
+    1. Resolve the canonical plan file path under ``project_path`` —
+       ``docs/plan/plan.md`` wins over ``docs/project-plan.md`` to match
+       the precedence in :data:`CANONICAL_PLAN_RELATIVE_PATHS`. When the
+       project has no plan file yet (synthesize hasn't landed), we write
+       ``docs/project-plan.md`` since that's where the synthesize stage
+       puts it.
+    2. Write ``new_plan_body`` to the resolved path. Failure here
+       degrades to a logged warning rather than aborting — the version
+       bump is the actual contract; the file write is a convenience for
+       the inline-render path.
+    3. Call :meth:`WorkService.increment_plan_version` to bump the
+       version and emit the ``plan.version_incremented`` audit event
+       (#1407). The reason defaults to ``"chat-to-refine"`` so audit
+       consumers can distinguish refinement bumps from architect
+       internal revisions.
+
+    Returns a :class:`PlanRefinementResult` with the old/new version and
+    the plan-file metadata so the caller can surface the bump in the UI
+    without re-reading the task.
+    """
+
+    bump_reason = reason or "chat-to-refine"
+    plan_path: Path | None = None
+    bytes_written = 0
+
+    if project_path is not None:
+        plan_path = _resolve_plan_path(project_path)
+        try:
+            plan_path.parent.mkdir(parents=True, exist_ok=True)
+            data = new_plan_body if new_plan_body.endswith("\n") else new_plan_body + "\n"
+            plan_path.write_text(data, encoding="utf-8")
+            bytes_written = len(data.encode("utf-8"))
+        except OSError:
+            # Filesystem failures shouldn't block the version bump — the
+            # bump is the canonical revision marker. The file write is a
+            # best-effort to keep the on-disk plan in sync with what the
+            # task records.
+            plan_path = None
+            bytes_written = 0
+
+    refreshed = work_service.increment_plan_version(
+        task_id, actor=actor, reason=bump_reason,
+    )
+    new_version = int(getattr(refreshed, "plan_version", 0) or 0)
+    old_version = max(new_version - 1, 0)
+    return PlanRefinementResult(
+        task_id=task_id,
+        old_version=old_version,
+        new_version=new_version,
+        plan_path=plan_path,
+        bytes_written=bytes_written,
+    )
+
+
+def select_chat_primer_for_project_dashboard(
+    dashboard_data,
+    *,
+    reviewer_name: str = "Sam",
+) -> str | None:
+    """Return a refinement primer when the project drilldown is showing a
+    pending plan-review surface, else ``None``.
+
+    Inputs: a ``ProjectDashboardData`` (or any duck-typed object exposing
+    ``project_key``, ``action_items``, ``task_buckets``, ``plan_text``,
+    ``plan_path``). When the dashboard's pending action items include a
+    ``plan_review`` row OR the task buckets include a ``review`` task
+    parked at ``user_approval``, we treat the surface as a plan-review
+    drilldown and return a refinement primer pre-filled with the plan
+    body.
+
+    Returns ``None`` when the surface isn't a plan-review (the caller
+    falls back to its existing context-line heuristics) so the routing
+    is opt-in and degrades gracefully on dashboards without the right
+    context.
+
+    Kept here (next to the primer + apply helpers) so the cockpit's
+    ``action_chat_pm`` can call into a single module to decide whether
+    to route to refine-mode without re-implementing the gating logic.
+    Coordinates with the deny flow (#1403): both want a single chat
+    primer infra; the deny path will surface its own primer-builder via
+    a sibling helper that this routing function NEVER masks (it returns
+    ``None`` when no plan_review is pending so deny-only surfaces are
+    untouched).
+    """
+
+    project_key = getattr(dashboard_data, "project_key", "")
+    plan_review_item = _find_plan_review_action_item(dashboard_data)
+    if plan_review_item is None:
+        return None
+    plan_task_id = str(
+        plan_review_item.get("plan_task_id")
+        or plan_review_item.get("primary_ref")
+        or plan_review_item.get("task_id")
+        or ""
+    )
+    if not plan_task_id:
+        return None
+    plan_version = int(plan_review_item.get("plan_version", 1) or 1)
+    plan_body = str(getattr(dashboard_data, "plan_text", "") or "")
+    plan_path = getattr(dashboard_data, "plan_path", None)
+    plan_path_str = str(plan_path) if plan_path else None
+    return build_plan_refinement_primer(
+        project_key=project_key,
+        plan_task_id=plan_task_id,
+        plan_version=plan_version,
+        plan_body=plan_body,
+        plan_path=plan_path_str,
+        reviewer_name=reviewer_name,
+    )
+
+
+def _find_plan_review_action_item(dashboard_data) -> dict | None:
+    """Return the dashboard's pending plan_review action item, if any.
+
+    Looks first at ``action_items`` (the action-card row items the
+    dashboard renders) for an entry flagged ``is_plan_review`` or with
+    ``plan_review`` in labels. Falls back to scanning ``task_buckets``
+    for a ``review`` task at the ``user_approval`` node — that's the
+    raw work-service signal even when no inbox row has been emitted
+    yet.
+    """
+
+    action_items = getattr(dashboard_data, "action_items", None) or []
+    for item in action_items:
+        if not isinstance(item, dict):
+            continue
+        if item.get("is_plan_review"):
+            return item
+        labels = item.get("labels") or []
+        if isinstance(labels, list) and "plan_review" in labels:
+            return item
+    buckets = getattr(dashboard_data, "task_buckets", None) or {}
+    review_bucket = buckets.get("review", []) if isinstance(buckets, dict) else []
+    for entry in review_bucket:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("current_node_id") == "user_approval":
+            return entry
+        labels = entry.get("labels") or []
+        if isinstance(labels, list) and "plan_review" in labels:
+            return entry
+    return None
+
+
+def _resolve_plan_path(project_path: Path) -> Path:
+    """Return the canonical plan file path for ``project_path``.
+
+    Precedence:
+
+    1. ``docs/plan/plan.md`` if it exists (planner-plugin convention).
+    2. ``docs/project-plan.md`` if it exists (synthesize-stage default).
+    3. ``docs/project-plan.md`` as the fallback for fresh projects so
+       the architect's revision lands somewhere the inline-render path
+       (#1397) will pick up.
+
+    Mirrors :data:`pollypm.plugins_builtin.project_planning.plan_presence.CANONICAL_PLAN_RELATIVE_PATHS`
+    so both reads + writes follow the same path resolution.
+    """
+
+    plan_dir_plan = project_path / "docs" / "plan" / "plan.md"
+    project_plan = project_path / "docs" / "project-plan.md"
+    if plan_dir_plan.is_file():
+        return plan_dir_plan
+    if project_plan.is_file():
+        return project_plan
+    return project_plan

--- a/tests/test_plan_refinement.py
+++ b/tests/test_plan_refinement.py
@@ -1,0 +1,502 @@
+"""Tests for the chat-to-refine flow (#1404).
+
+Coverage:
+- Primer text shape (refinement framing, version + task ids quoted, body
+  inlined as a markdown blockquote, signal-phrase examples surfaced).
+- ``is_refinement_signal`` detects the canonical phrases case-insensitively.
+- ``select_chat_primer_for_project_dashboard`` returns ``None`` when no
+  plan_review is pending and a fully-formed primer when one is.
+- ``apply_plan_refinement`` writes the new plan body to the canonical
+  path AND bumps ``plan_version`` via the SDK (audit event fires).
+- Integration: full chat-to-refine cycle with a mocked architect — primer
+  is built, signal triggers the apply path, version increments, audit
+  event fires, file content is replaced.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pollypm.plan_refinement import (
+    PlanRefinementResult,
+    REFINEMENT_SIGNAL_PHRASES,
+    apply_plan_refinement,
+    build_plan_refinement_primer,
+    is_refinement_signal,
+    select_chat_primer_for_project_dashboard,
+)
+from pollypm.work.sqlite_service import SQLiteWorkService
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_plan_task(svc, project="demo"):
+    return svc.create(
+        title="Plan demo",
+        description="Initial plan body",
+        type="task",
+        project=project,
+        flow_template="standard",
+        roles={"worker": "architect", "reviewer": "reviewer"},
+        priority="normal",
+        created_by="architect",
+    )
+
+
+@pytest.fixture
+def svc(tmp_path):
+    return SQLiteWorkService(db_path=tmp_path / "work.db")
+
+
+class _FakeDashboardData:
+    """Duck-typed stand-in for ``ProjectDashboardData`` used by the
+    routing helper. We only feed in the fields the helper reads so the
+    test stays decoupled from cockpit_ui's heavier ProjectDashboardData
+    constructor.
+    """
+
+    def __init__(
+        self,
+        *,
+        project_key="demo",
+        action_items=None,
+        task_buckets=None,
+        plan_text="The plan body, version one.",
+        plan_path=None,
+    ):
+        self.project_key = project_key
+        self.action_items = action_items or []
+        self.task_buckets = task_buckets or {}
+        self.plan_text = plan_text
+        self.plan_path = plan_path
+
+
+# ---------------------------------------------------------------------------
+# Primer text shape
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPlanRefinementPrimer:
+    """Primer text needs to (a) frame the conversation as in-place
+    revision, (b) quote the plan body so the PM can refer to it, (c)
+    name the canonical refinement-signal phrases so the user knows the
+    handoff gesture, and (d) NOT instruct the PM to rewrite the plan
+    itself — that's the architect's job.
+    """
+
+    def test_includes_project_task_and_version(self):
+        primer = build_plan_refinement_primer(
+            project_key="savethenovel",
+            plan_task_id="savethenovel/4",
+            plan_version=2,
+            plan_body="Build the world.",
+        )
+        assert "savethenovel" in primer
+        assert "savethenovel/4" in primer
+        assert "v2" in primer
+        # The next-version hint helps the user understand version bumping.
+        assert "v3" in primer
+
+    def test_quotes_plan_body_as_blockquote(self):
+        primer = build_plan_refinement_primer(
+            project_key="demo",
+            plan_task_id="demo/1",
+            plan_version=1,
+            plan_body="Line one\nLine two\n\nLine four",
+        )
+        assert "> Line one" in primer
+        assert "> Line two" in primer
+        # Blank lines stay as bare ``>`` markers (markdown convention).
+        assert "\n>\n" in primer or ">\n>" in primer
+        assert "> Line four" in primer
+
+    def test_handles_empty_plan_body(self):
+        primer = build_plan_refinement_primer(
+            project_key="demo",
+            plan_task_id="demo/1",
+            plan_version=1,
+            plan_body="",
+        )
+        assert "> (plan body is empty)" in primer
+
+    def test_includes_signal_phrase_examples(self):
+        primer = build_plan_refinement_primer(
+            project_key="demo",
+            plan_task_id="demo/1",
+            plan_version=1,
+            plan_body="x",
+        )
+        # At least the canonical "go architect" gesture must be quoted
+        # so the user knows the handoff phrase. Other examples come
+        # from REFINEMENT_SIGNAL_PHRASES.
+        assert "go architect" in primer
+
+    def test_includes_plan_path_when_supplied(self):
+        primer = build_plan_refinement_primer(
+            project_key="demo",
+            plan_task_id="demo/1",
+            plan_version=1,
+            plan_body="x",
+            plan_path="/repo/docs/project-plan.md",
+        )
+        assert "/repo/docs/project-plan.md" in primer
+
+    def test_omits_plan_path_line_when_missing(self):
+        primer = build_plan_refinement_primer(
+            project_key="demo",
+            plan_task_id="demo/1",
+            plan_version=1,
+            plan_body="x",
+            plan_path=None,
+        )
+        assert "Plan file:" not in primer
+
+    def test_uses_reviewer_name_for_pronouns(self):
+        primer = build_plan_refinement_primer(
+            project_key="demo",
+            plan_task_id="demo/1",
+            plan_version=1,
+            plan_body="x",
+            reviewer_name="Polly",
+        )
+        assert "Polly is here to refine" in primer
+
+    def test_frames_in_place_revision_explicitly(self):
+        primer = build_plan_refinement_primer(
+            project_key="demo",
+            plan_task_id="demo/1",
+            plan_version=1,
+            plan_body="x",
+        )
+        # Anti-deny framing: the primer must say "same task id" so the
+        # PM doesn't accidentally request a replan/successor.
+        assert "in-place" in primer.lower()
+        assert "same task id" in primer.lower()
+
+    def test_does_not_instruct_pm_to_rewrite_plan(self):
+        """The architect, not the PM, ships the rewrite; primer must
+        say so or the PM will burn tokens drafting plan markdown in
+        the chat instead of handing off."""
+        primer = build_plan_refinement_primer(
+            project_key="demo",
+            plan_task_id="demo/1",
+            plan_version=1,
+            plan_body="x",
+        )
+        assert "DO NOT rewrite the plan yourself" in primer
+
+
+# ---------------------------------------------------------------------------
+# Refinement-signal detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsRefinementSignal:
+    @pytest.mark.parametrize(
+        "phrase",
+        list(REFINEMENT_SIGNAL_PHRASES),
+    )
+    def test_canonical_phrases_match(self, phrase):
+        assert is_refinement_signal(phrase) is True
+
+    def test_match_is_case_insensitive(self):
+        assert is_refinement_signal("Go Architect") is True
+        assert is_refinement_signal("REVISE THE PLAN") is True
+
+    def test_match_is_substring_so_natural_text_works(self):
+        assert is_refinement_signal(
+            "ok let's go architect on it"
+        ) is True
+        assert is_refinement_signal(
+            "yeah revise the plan and ping me when it's done"
+        ) is True
+
+    def test_unrelated_text_does_not_match(self):
+        assert is_refinement_signal("looks good") is False
+        assert is_refinement_signal("hmm let me think") is False
+
+    def test_empty_input_does_not_match(self):
+        assert is_refinement_signal("") is False
+        assert is_refinement_signal(None) is False
+
+
+# ---------------------------------------------------------------------------
+# Routing helper for the project dashboard
+# ---------------------------------------------------------------------------
+
+
+class TestSelectChatPrimerForProjectDashboard:
+    def test_returns_none_when_no_plan_review_pending(self):
+        data = _FakeDashboardData(action_items=[], task_buckets={})
+        assert select_chat_primer_for_project_dashboard(data) is None
+
+    def test_returns_primer_when_action_item_flags_plan_review(self):
+        data = _FakeDashboardData(
+            action_items=[
+                {
+                    "is_plan_review": True,
+                    "primary_ref": "demo/4",
+                    "plan_version": 2,
+                }
+            ],
+            plan_text="Plan body for demo.",
+            plan_path="/repo/docs/project-plan.md",
+        )
+        primer = select_chat_primer_for_project_dashboard(data)
+        assert primer is not None
+        assert "demo/4" in primer
+        assert "v2" in primer
+        assert "> Plan body for demo." in primer
+        assert "/repo/docs/project-plan.md" in primer
+
+    def test_returns_primer_when_action_item_label_is_plan_review(self):
+        data = _FakeDashboardData(
+            action_items=[
+                {
+                    "labels": ["plan_review"],
+                    "primary_ref": "demo/9",
+                }
+            ],
+            plan_text="x",
+        )
+        primer = select_chat_primer_for_project_dashboard(data)
+        assert primer is not None
+        assert "demo/9" in primer
+
+    def test_falls_back_to_review_bucket_when_no_action_item(self):
+        """Even before an inbox row is emitted, a task parked at
+        ``user_approval`` should make ``[c]`` route to refine mode so
+        the UX doesn't depend on the inbox-emit timing."""
+        data = _FakeDashboardData(
+            action_items=[],
+            task_buckets={
+                "review": [
+                    {
+                        "task_id": "demo/7",
+                        "current_node_id": "user_approval",
+                    }
+                ]
+            },
+            plan_text="hello",
+        )
+        primer = select_chat_primer_for_project_dashboard(data)
+        assert primer is not None
+        assert "demo/7" in primer
+
+    def test_returns_none_for_dashboard_without_plan_task_id(self):
+        data = _FakeDashboardData(
+            action_items=[
+                {
+                    "is_plan_review": True,
+                    # Missing every id field — degrade to None instead
+                    # of a malformed primer.
+                }
+            ],
+        )
+        assert select_chat_primer_for_project_dashboard(data) is None
+
+
+# ---------------------------------------------------------------------------
+# Architect revision pass — apply_plan_refinement
+# ---------------------------------------------------------------------------
+
+
+class TestApplyPlanRefinement:
+    def test_bumps_plan_version_via_sdk(self, svc):
+        task = _create_plan_task(svc)
+        result = apply_plan_refinement(
+            svc,
+            task_id=task.task_id,
+            new_plan_body="Revised body",
+        )
+        assert isinstance(result, PlanRefinementResult)
+        assert result.task_id == task.task_id
+        assert result.old_version == 1
+        assert result.new_version == 2
+        # SDK side-effect: the task on disk has the new version.
+        refetched = svc.get(task.task_id)
+        assert refetched.plan_version == 2
+
+    def test_writes_plan_body_to_canonical_path(self, svc, tmp_path):
+        task = _create_plan_task(svc)
+        project_path = tmp_path / "proj"
+        project_path.mkdir()
+        result = apply_plan_refinement(
+            svc,
+            task_id=task.task_id,
+            new_plan_body="Brand new plan body",
+            project_path=project_path,
+        )
+        # Default fallback path for fresh projects.
+        expected_path = project_path / "docs" / "project-plan.md"
+        assert result.plan_path == expected_path
+        assert expected_path.read_text(encoding="utf-8").startswith(
+            "Brand new plan body"
+        )
+        assert result.bytes_written > 0
+
+    def test_writes_to_existing_plan_dir_path(self, svc, tmp_path):
+        task = _create_plan_task(svc)
+        project_path = tmp_path / "proj"
+        plan_dir = project_path / "docs" / "plan"
+        plan_dir.mkdir(parents=True)
+        # Pre-create plan.md so the resolver picks ``docs/plan/plan.md``.
+        (plan_dir / "plan.md").write_text("old", encoding="utf-8")
+        result = apply_plan_refinement(
+            svc,
+            task_id=task.task_id,
+            new_plan_body="updated",
+            project_path=project_path,
+        )
+        assert result.plan_path == plan_dir / "plan.md"
+        assert (plan_dir / "plan.md").read_text(encoding="utf-8").startswith(
+            "updated"
+        )
+
+    def test_emits_plan_version_incremented_audit(
+        self, svc, tmp_path, monkeypatch
+    ):
+        from pollypm.audit import read_events
+        from pollypm.audit.log import EVENT_PLAN_VERSION_INCREMENTED
+
+        audit_home = tmp_path / "audit-home"
+        monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+        task = _create_plan_task(svc, project="refproj")
+        apply_plan_refinement(
+            svc,
+            task_id=task.task_id,
+            new_plan_body="refined body",
+        )
+        events = read_events(
+            "refproj", event=EVENT_PLAN_VERSION_INCREMENTED
+        )
+        assert len(events) == 1
+        assert events[0].metadata.get("reason") == "chat-to-refine"
+        assert events[0].metadata["old_version"] == 1
+        assert events[0].metadata["new_version"] == 2
+
+    def test_skips_file_write_when_no_project_path(self, svc):
+        task = _create_plan_task(svc)
+        result = apply_plan_refinement(
+            svc,
+            task_id=task.task_id,
+            new_plan_body="x",
+        )
+        assert result.plan_path is None
+        assert result.bytes_written == 0
+        # Version still bumps even without a project_path — the SDK is
+        # the canonical revision marker.
+        assert result.new_version == 2
+
+    def test_appends_trailing_newline_when_missing(self, svc, tmp_path):
+        task = _create_plan_task(svc)
+        project_path = tmp_path / "proj"
+        project_path.mkdir()
+        apply_plan_refinement(
+            svc,
+            task_id=task.task_id,
+            new_plan_body="no trailing newline",
+            project_path=project_path,
+        )
+        body = (project_path / "docs" / "project-plan.md").read_text(
+            encoding="utf-8"
+        )
+        assert body.endswith("\n")
+
+
+# ---------------------------------------------------------------------------
+# Integration — full chat-to-refine cycle with a mocked architect.
+# ---------------------------------------------------------------------------
+
+
+class TestChatToRefineFullCycle:
+    """End-to-end: dashboard surfaces a plan_review → user opens chat
+    with refinement primer → user types tweaks → user emits the
+    refinement signal → architect (mocked) ships a rewritten plan body
+    → ``apply_plan_refinement`` bumps the version and rewrites the
+    file. The cockpit's inline-render path (#1397) reads ``plan_version``
+    off the task directly, so we assert the post-bump task carries the
+    new version.
+    """
+
+    def test_full_refinement_cycle(self, svc, tmp_path, monkeypatch):
+        from pollypm.audit import read_events
+        from pollypm.audit.log import EVENT_PLAN_VERSION_INCREMENTED
+
+        audit_home = tmp_path / "audit-home"
+        monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+        # 1. A real plan task exists (post-synthesize, parked at
+        # user_approval).
+        task = _create_plan_task(svc, project="ref")
+        project_path = tmp_path / "ref-proj"
+        (project_path / "docs").mkdir(parents=True)
+        (project_path / "docs" / "project-plan.md").write_text(
+            "v1 plan\n", encoding="utf-8"
+        )
+
+        # 2. Dashboard would surface a plan_review action item; the
+        # routing helper builds a refinement primer.
+        data = _FakeDashboardData(
+            project_key="ref",
+            action_items=[
+                {
+                    "is_plan_review": True,
+                    "primary_ref": task.task_id,
+                    "plan_version": 1,
+                }
+            ],
+            plan_text="v1 plan",
+            plan_path=str(project_path / "docs" / "project-plan.md"),
+        )
+        primer = select_chat_primer_for_project_dashboard(data)
+        assert primer is not None
+        assert task.task_id in primer
+
+        # 3. User chats refinements; eventually says "go architect".
+        last_user_message = (
+            "yeah we should split module B into B1 and B2 then go architect"
+        )
+        assert is_refinement_signal(last_user_message) is True
+
+        # 4. (Mocked architect) — produces a rewritten plan body. In the
+        # real flow this is the architect session running its revision
+        # turn; the test stands in with a fixed string.
+        revised_body = "v2 plan with B1/B2 split"
+
+        # 5. Apply the refinement: writes file + bumps version + emits
+        # the audit event.
+        result = apply_plan_refinement(
+            svc,
+            task_id=task.task_id,
+            new_plan_body=revised_body,
+            project_path=project_path,
+            actor="architect",
+            reason="chat-to-refine",
+        )
+
+        # 6. Assertions: task version, file body, audit event.
+        assert result.old_version == 1
+        assert result.new_version == 2
+        refetched = svc.get(task.task_id)
+        assert refetched.plan_version == 2
+        # Same task id — refinement is in-place; not a successor.
+        assert refetched.task_id == task.task_id
+        assert refetched.predecessor_task_id is None
+
+        plan_file = project_path / "docs" / "project-plan.md"
+        assert plan_file.read_text(encoding="utf-8").startswith(
+            "v2 plan with B1/B2 split"
+        )
+
+        events = read_events(
+            "ref", event=EVENT_PLAN_VERSION_INCREMENTED
+        )
+        assert len(events) == 1
+        assert events[0].metadata["task_id"] == task.task_id
+        assert events[0].metadata["new_version"] == 2
+        assert events[0].metadata.get("reason") == "chat-to-refine"


### PR DESCRIPTION
Closes #1404. Chat-to-refine half of the plan-review UX redesign.

## Summary

When the project drilldown surfaces a pending plan_review, `[c]` now opens the project's PM chat thread seeded with a refinement primer framed as IN-PLACE plan revision — same task id, `plan_version` bumps to v+1 once the architect ships the rewrite. Distinct from the deny flow (#1403) which cancels the current plan and creates a successor with a `predecessor_task_id` link.

## What changed

- **New module `pollypm.plan_refinement`** (framework-agnostic):
  - `build_plan_refinement_primer(...)` — primer text. Frames the conversation as in-place revision, quotes the plan body as a markdown blockquote, names the canonical "go architect" handoff phrases, and explicitly tells the PM "DO NOT rewrite the plan yourself — that's the architect's job".
  - `is_refinement_signal(text)` — case-insensitive substring match against `REFINEMENT_SIGNAL_PHRASES` (`"go architect"`, `"revise the plan"`, `"ship the revision"`, etc.). The user can emit the signal naturally mid-message — no special gesture needed.
  - `apply_plan_refinement(work_service, ...)` — architect's revision pass. Writes the rewritten plan body to the canonical file (`docs/plan/plan.md` if present, else `docs/project-plan.md`) and bumps `plan_version` via `WorkService.increment_plan_version` (#1407 SDK). The version bump is the canonical revision marker; file write is best-effort. Emits `plan.version_incremented` audit event with `reason="chat-to-refine"`.
  - `select_chat_primer_for_project_dashboard(data)` — routing helper. Returns the refinement primer when a plan_review is pending on the dashboard, else `None` so the cockpit's existing branches still fire.

- **Cockpit hook** (`src/pollypm/cockpit_ui.py`, `PollyProjectDashboardApp.action_chat_pm`): one branch added at the top — when the routing helper returns a primer, use it as the context line. Idle-plan / blocker-context / generic chat branches stay intact for non-plan-review dashboards.

## Refinement signal endpoint

The user signals "go architect" naturally in chat (full list of phrases: `go architect`, `ship the revision`, `revise the plan`, `rewrite the plan`, `apply the revision`, `run the revision`, `send to architect`). The PM hands off to the architect; the architect produces a revised body and calls `apply_plan_refinement` to land the rewrite atomically (file write + version bump + audit emit).

I picked the explicit-phrase gesture (vs. "natural endpoint detection") because it's debuggable, deterministic, and the user can browse the phrase list in the primer text. Future work: a `/go-architect` slash command if natural-language matching feels too coarse.

## Version-increment path

`apply_plan_refinement → WorkService.increment_plan_version → audit emit`. Same task id; `plan_version` increments by 1 each cycle. The cockpit's inline-render PR (#1397) reads `plan_version` off the task directly so the new version surfaces without an explicit refresh.

## Surface placement note

Issue #1401 (project drilldown plan-review surface) hasn't merged. This PR wires the primer routing to the existing `PollyProjectDashboardApp.action_chat_pm` (the project drilldown's `[c]` binding) so the chat-to-refine flow lands on whatever surface today shows the plan. When #1401 ships, the same hook fires from the new surface — no further changes needed. The routing helper's None-return default keeps deny-only and non-plan-review surfaces untouched.

## Coordination with #1403 (deny flow)

Both PRs touch the same chat-primer infra. The deny flow ships its own primer-builder; this PR's `select_chat_primer_for_project_dashboard` returns `None` when no plan_review is pending, so the deny path's hook fires unmolested. If both surfaces eventually want a shared chat-primer router, the natural extraction is `pollypm.chat_primer_routing` calling into both modules — left for a follow-up once #1403 lands so the seam is real, not speculative.

## Files changed

- `src/pollypm/plan_refinement.py` (new — primer, signal detector, revision applier, routing helper)
- `src/pollypm/cockpit_ui.py` (+22 lines — primer-routing hook in `action_chat_pm`)
- `tests/test_plan_refinement.py` (new — 32 tests)

## Test plan

- [x] `tests/test_plan_refinement.py` — 32 tests pass:
  - `TestBuildPlanRefinementPrimer` (9): primer shape — task id + version, blockquote body, empty body, signal phrases, plan path, reviewer name, in-place framing, no-rewrite-yourself instruction.
  - `TestIsRefinementSignal` (11): each canonical phrase matches, case-insensitive, substring matching for natural text, unrelated text doesn't match, empty input.
  - `TestSelectChatPrimerForProjectDashboard` (5): None when no plan_review, primer when action_item flagged, primer when label is `plan_review`, fallback to review bucket at `user_approval`, None when no resolvable task id.
  - `TestApplyPlanRefinement` (6): version bump, file write to canonical path, file write to existing `docs/plan/plan.md`, audit event with `reason="chat-to-refine"`, file-write skip when no project_path, trailing newline.
  - `TestChatToRefineFullCycle` (1): full integration — dashboard surfaces plan_review → primer built → user signals "go architect" → mocked architect ships revised body → version bumps in-place → audit fires → file rewritten.
- [x] `tests/test_work_service.py tests/test_project_dashboard_ui.py tests/test_project_dashboard_plan_viewer.py tests/test_project_dashboard_signature.py` (224 tests) — all pass with my changes; the routing hook is gated on dashboard data shape so the cockpit's existing flows are untouched.
- [ ] Manual: pending #1401 surface — visual confirmation of `[c]` opening PM chat with the refinement primer when a plan_review is on the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)