### PR TITLE
Render plan content inline in cockpit

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -7010,6 +7010,131 @@ def _extract_plan_review_meta(labels: list[str] | None) -> dict:
     return meta
 
 
+def _plan_content_for_review(
+    plan_review_meta: dict,
+    config_path: object | None,
+) -> str | None:
+    """Load the plan markdown content referenced by a plan_review item.
+
+    Resolves the project from the meta, walks ``CANONICAL_PLAN_RELATIVE_PATHS``
+    for the project's on-disk path, and returns the file's text. Returns
+    ``None`` when the plan can't be located or read — callers fall back
+    to whatever they had before this lookup. Issue #1397: the cockpit
+    surfaces the plan inline instead of pointing at a file path the
+    user can't reach from a TUI.
+    """
+    if not isinstance(plan_review_meta, dict):
+        return None
+    project_key = str(plan_review_meta.get("project") or "").strip()
+    if not project_key:
+        plan_task_id = str(plan_review_meta.get("plan_task_id") or "")
+        if "/" in plan_task_id:
+            project_key = plan_task_id.split("/", 1)[0].strip()
+    if not project_key or config_path is None:
+        return None
+    try:
+        cfg = load_config(Path(config_path) if not isinstance(config_path, Path) else config_path)
+    except Exception:  # noqa: BLE001
+        return None
+    project = getattr(cfg, "projects", {}).get(project_key)
+    if project is None:
+        return None
+    project_path = getattr(project, "path", None)
+    if not isinstance(project_path, Path):
+        try:
+            project_path = Path(str(project_path))
+        except Exception:  # noqa: BLE001
+            return None
+    if not project_path.exists():
+        return None
+    plan_path = _dashboard_plan_path(project_path)
+    if plan_path is None:
+        return None
+    try:
+        return plan_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _extract_plan_summary_block(plan_text: str) -> str:
+    """Pull the leading summary paragraph from a plan markdown body.
+
+    Heuristic: the architect's ``plan_review`` synthesis (PR #1408)
+    leads with a ``## Summary`` section; pre-#1408 plans lead with the
+    first paragraph after the H1. Both shapes resolve here. Returns an
+    empty string when nothing summary-shaped is present.
+    """
+    text = (plan_text or "").strip()
+    if not text:
+        return ""
+    lines = text.splitlines()
+    # Look for a ``## Summary`` (or ``# Summary``) header and grab the
+    # paragraph that follows it.
+    for idx, line in enumerate(lines):
+        stripped = line.strip().lower()
+        if stripped in {"## summary", "# summary", "### summary"}:
+            collected: list[str] = []
+            for follow in lines[idx + 1:]:
+                if follow.strip().startswith("#"):
+                    break
+                if not follow.strip():
+                    if collected:
+                        break
+                    continue
+                collected.append(follow.strip())
+            if collected:
+                return " ".join(collected)
+    # Fall back to the first non-header paragraph.
+    collected = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            if collected:
+                break
+            continue
+        if stripped.startswith("#"):
+            if collected:
+                break
+            continue
+        collected.append(stripped)
+    return " ".join(collected)
+
+
+def _extract_plan_judgment_calls(plan_text: str, *, limit: int = 5) -> list[str]:
+    """Extract the bullet list under a ``## Judgment calls`` header.
+
+    The PR #1408 ``plan_review`` synthesis encodes the architect's
+    flagged points as a bulleted list under ``## Judgment calls``
+    (case-insensitive). When that section is absent, returns an empty
+    list — callers should treat that as "no flagged points" rather
+    than synthesising a fake one.
+    """
+    text = plan_text or ""
+    if not text.strip():
+        return []
+    lines = text.splitlines()
+    target_headers = {"## judgment calls", "## judgement calls", "### judgment calls"}
+    out: list[str] = []
+    capturing = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.lower() in target_headers:
+            capturing = True
+            continue
+        if not capturing:
+            continue
+        if stripped.startswith("#"):
+            break
+        match = _ACTION_STEP_RE.match(line)
+        if match is not None:
+            point = _re.sub(r"\s+", " ", match.group("step")).strip()
+            if point:
+                out.append(point)
+                if len(out) >= limit:
+                    break
+    return out
+
+
 def _extract_blocking_question_meta(labels: list[str] | None) -> dict:
     """Parse ``blocking_question`` sidecar labels into a structured dict.
 
@@ -8613,6 +8738,13 @@ class PollyInboxApp(App[None]):
             # data, and the inbox detail surface should match. The
             # raw body still renders below for technical context.
             prompt_block = _render_heuristic_action_block(item.description)
+        # #1397: for plan_review items, the heuristic prompt block can
+        # echo the architect's "Plan: <abs path>" line as if it were a
+        # decision prompt. Suppress it — the inline plan render below
+        # is the canonical surface and the file path leaks an
+        # implementation detail.
+        if is_plan_review:
+            prompt_block = None
         if prompt_block:
             sections.append("")
             sections.append(prompt_block)
@@ -8622,7 +8754,22 @@ class PollyInboxApp(App[None]):
         if is_plan_review:
             body = _plan_review_message_body_for_display(body, plan_review_meta)
         sections.append("")
-        sections.append(_md_to_rich(_escape_body(body)))
+        if is_plan_review:
+            # #1397: surface the plan body inline instead of the
+            # file-pointer text the architect emitted. Users on remote
+            # TUIs cannot click through to a local markdown path.
+            plan_text = _plan_content_for_review(
+                plan_review_meta, getattr(self, "config_path", None),
+            )
+            if plan_text:
+                sections.append(_md_to_rich(_escape_body(plan_text)))
+            else:
+                sections.append(
+                    "[#f0c45a]Plan content is not available on disk yet — "
+                    "discuss with the PM (press d) to learn more.[/#f0c45a]"
+                )
+        else:
+            sections.append(_md_to_rich(_escape_body(body)))
         self.detail.update("\n".join(sections))
         self._proposal_specs.pop(item.task_id, None)
         if is_plan_review:
@@ -8760,7 +8907,26 @@ class PollyInboxApp(App[None]):
             sections.append(triage_banner)
         sections.append("")  # blank line before body
         body = task.description or "(no body)"
-        sections.append(_md_to_rich(_escape_body(body)))
+        # #1397: when this task IS a plan_review, surface the plan body
+        # inline rather than the architect's "Plan: <abs path>..." text.
+        # Users on a remote TUI cannot click through to a local file.
+        _task_labels_for_body = list(getattr(task, "labels", []) or [])
+        if "plan_review" in _task_labels_for_body:
+            _plan_review_meta_for_body = _extract_plan_review_meta(
+                _task_labels_for_body,
+            )
+            _plan_text_for_body = _plan_content_for_review(
+                _plan_review_meta_for_body,
+                getattr(self, "config_path", None),
+            )
+            if _plan_text_for_body:
+                sections.append(
+                    _md_to_rich(_escape_body(_plan_text_for_body))
+                )
+            else:
+                sections.append(_md_to_rich(_escape_body(body)))
+        else:
+            sections.append(_md_to_rich(_escape_body(body)))
 
         if replies:
             sections.append("")
@@ -11887,8 +12053,30 @@ def _dashboard_inbox(
             "Read the plan and any open decisions.",
             "Approve the plan when it is ready, or discuss changes with the PM.",
         ]
+        # #1397: load the plan markdown so the dashboard's action card +
+        # the cockpit drilldown can render the summary + judgment-call
+        # points inline. Falls back gracefully when the file isn't on
+        # disk yet (rare race window, or pre-#1408 plans without a
+        # ``## Summary`` block).
+        plan_text: str | None = None
+        plan_path_obj = _dashboard_plan_path(project_path)
+        if plan_path_obj is not None:
+            try:
+                plan_text = plan_path_obj.read_text(encoding="utf-8")
+            except OSError:
+                plan_text = None
+        plan_summary = (
+            _extract_plan_summary_block(plan_text or "") if plan_text else ""
+        )
+        judgment_calls = (
+            _extract_plan_judgment_calls(plan_text or "") if plan_text else []
+        )
+        plain_prompt = (
+            plan_summary if plan_summary
+            else "A full project plan is ready for your review."
+        )
         return {
-            "plain_prompt": "A full project plan is ready for your review.",
+            "plain_prompt": plain_prompt,
             "unblock_steps": steps[:5],
             "steps_heading": "What to do",
             "decision_question": (
@@ -11909,6 +12097,9 @@ def _dashboard_inbox(
                 "task_id": plan_task_id or fallback_task_id,
             },
             "other_placeholder": "Reply with plan feedback...",
+            "plan_summary": plan_summary,
+            "judgment_calls": list(judgment_calls),
+            "plan_text": plan_text or "",
         }
 
     def _deployment_decision(body: str, steps: list[str]) -> dict[str, object]:
@@ -12243,6 +12434,41 @@ def _dashboard_inbox(
                     )
                     or _plain_decision_from_body(subject, body, steps)
                 )
+                # #1397: when this is a plan_review item but
+                # ``_user_prompt_decision`` won the dispatch (the
+                # architect's payload provides a structured user_prompt),
+                # the plan summary / judgment-call points still need to
+                # ride along on the action card so the drilldown surface
+                # renders inline plan content. Always merge those fields
+                # in for plan_review items, regardless of which decision
+                # producer fired.
+                if "plan_review" in labels:
+                    plan_review_extras = _plan_review_decision(
+                        labels,
+                        body,
+                        fallback_task_id=(
+                            str(payload.get("task_id") or "")
+                            if payload.get("task_id")
+                            else None
+                        ),
+                    ) or {}
+                    for plan_key in (
+                        "plan_summary", "judgment_calls", "plan_text",
+                    ):
+                        if plan_key in plan_review_extras:
+                            decision.setdefault(plan_key, plan_review_extras[plan_key])
+                    # Override the prompt with the plan summary when the
+                    # user_prompt's summary is the generic boilerplate
+                    # (so the card actually surfaces the plan's leading
+                    # paragraph instead of "A full project plan is ready
+                    # for your review.").
+                    plan_summary = plan_review_extras.get("plan_summary") or ""
+                    current_prompt = str(decision.get("plain_prompt") or "")
+                    if (
+                        plan_summary
+                        and "ready for your review" in current_prompt.lower()
+                    ):
+                        decision["plain_prompt"] = plan_summary
                 items.append(
                     {
                         "task_id": entry.task_id,
@@ -14404,27 +14630,18 @@ class PollyProjectDashboardApp(App[None]):
                 "Press [b]c[/b] in this pane to chat with the PM and "
                 "ask for a plan now.[/dim]"
             )
+        # #1397: drop the leading file-path line and the
+        # ``Also in docs/plan/`` enumeration \u2014 file paths are an
+        # implementation detail, and users on a remote TUI cannot
+        # navigate to them anyway. The H2 outline below is the
+        # navigational hint; the full plan body renders inline via
+        # ``_render_plan_content``.
         lines: list[str] = []
-        rel_path = ""
-        try:
-            rel_path = str(data.plan_path.relative_to(data.project_path))
-        except (ValueError, TypeError):
-            rel_path = str(data.plan_path.name)
-        lines.append(f"[dim]{_escape(rel_path)}[/dim]")
         if data.plan_sections:
             for title in data.plan_sections:
                 lines.append(f"  \u25aa {_escape(title)}")
         else:
             lines.append("  [dim](no H2 sections found)[/dim]")
-        if data.plan_aux_files:
-            lines.append("")
-            lines.append("[dim]Also in docs/plan/:[/dim]")
-            for aux in data.plan_aux_files:
-                try:
-                    aux_rel = str(aux.relative_to(data.project_path))
-                except (ValueError, TypeError):
-                    aux_rel = aux.name
-                lines.append(f"  \u00b7 {_escape(aux_rel)}")
         # Visual-explainer prompt removed in #1405 (keybinding broken,
         # deferred for v1+). ``data.plan_explainer`` may still surface
         # via other paths but we no longer advertise the ``v`` shortcut.
@@ -14546,12 +14763,39 @@ class PollyProjectDashboardApp(App[None]):
         and polly_remote routinely renders two cards with 5 steps
         each, blowing past a single screen.
         """
-        prompt = _escape(
+        raw_prompt = (
             item.get("plain_prompt")
             or item.get("next_action")
             or "Polly needs your decision before this project can continue."
         )
+        # #1397: in the inbox-row preview the plan summary can be a
+        # full paragraph; cap it at ~80 chars so the rail row stays
+        # readable. The full text still renders in the drilldown +
+        # detail surfaces.
+        if item.get("is_plan_review") and len(raw_prompt) > 80:
+            raw_prompt = raw_prompt[:77].rstrip() + "..."
+        prompt = _escape(raw_prompt)
         lines: list[str] = [f"  [#f0c45a]◆[/#f0c45a] {prompt}"]
+        # #1397: when this is a plan_review item, show the architect's
+        # flagged judgment calls right under the summary. They're the
+        # single most decision-relevant thing to surface; everything
+        # else is inert "open the plan" boilerplate.
+        judgment_calls = [
+            str(point).strip()
+            for point in (item.get("judgment_calls") or [])
+            if str(point).strip()
+        ]
+        if judgment_calls:
+            lines.append("    [b]Flagged judgment calls[/b]")
+            point_cap = 2 if compact else 5
+            visible_points = judgment_calls[:point_cap]
+            for point in visible_points:
+                lines.append(f"    [#f0c45a]·[/#f0c45a] {_escape(point)}")
+            hidden_points = len(judgment_calls) - len(visible_points)
+            if hidden_points > 0:
+                lines.append(
+                    f"    [dim](+{hidden_points} more — open the plan to see all)[/dim]"
+                )
         unblock_steps = [
             str(step)
             for step in (item.get("unblock_steps") or item.get("steps") or [])

--- a/tests/test_plan_review_flow.py
+++ b/tests/test_plan_review_flow.py
@@ -566,8 +566,15 @@ def test_plan_review_message_uses_plan_review_controls(
             detail_text = str(plan_review_message_app.detail.render())
             hint_text = str(plan_review_message_app.hint.render())
 
-            assert "Press v to open the explainer (unavailable)" not in detail_text
-            assert "No visual explainer is available for this plan" in detail_text
+            # #1397: the file-pointer body has been replaced. When no
+            # plan markdown is on disk, we surface a fallback rather
+            # than the legacy "Press v" / explainer-unavailable copy.
+            assert "Press v to open the explainer" not in detail_text
+            assert "No visual explainer is available for this plan" not in detail_text
+            assert (
+                "Plan content is not available on disk yet" in detail_text
+                or "## " in detail_text
+            )
             assert "v open explainer" not in hint_text
             assert "d discuss" in hint_text
             assert "A approve" in hint_text
@@ -863,4 +870,320 @@ def test_no_x_binding_on_plan_review_items(
                 t.task_id == plan_review_env["plan_review_id"]
                 for t in inbox_app._tasks
             )
+    _run(body())
+
+
+# ---------------------------------------------------------------------------
+# #1397 — render plan content inline in the cockpit
+# ---------------------------------------------------------------------------
+
+
+class TestPlanInlineRendering:
+    """Helpers that turn a plan body into structured preview blocks."""
+
+    def test_summary_block_extracts_paragraph_under_summary_header(self) -> None:
+        from pollypm.cockpit_ui import _extract_plan_summary_block
+        text = (
+            "# Project plan\n\n"
+            "## Summary\n"
+            "Ship the rendering pipeline in three steps; each step lands\n"
+            "as its own task so we can pause between phases.\n\n"
+            "## Judgment calls\n- foo\n"
+        )
+        summary = _extract_plan_summary_block(text)
+        assert summary.startswith("Ship the rendering pipeline")
+        assert "three steps" in summary
+        assert "foo" not in summary  # stops at the next header
+
+    def test_summary_block_falls_back_to_first_paragraph(self) -> None:
+        from pollypm.cockpit_ui import _extract_plan_summary_block
+        text = (
+            "# Old-style plan\n\n"
+            "This is the leading paragraph that doubles as a summary.\n\n"
+            "## Some other header\nThe rest.\n"
+        )
+        summary = _extract_plan_summary_block(text)
+        assert summary.startswith("This is the leading paragraph")
+
+    def test_judgment_calls_extracts_bullet_list(self) -> None:
+        from pollypm.cockpit_ui import _extract_plan_judgment_calls
+        text = (
+            "## Summary\nA paragraph.\n\n"
+            "## Judgment calls\n"
+            "- Whether to ship the rename in a single PR or split it\n"
+            "- The cache eviction strategy\n"
+            "- Stamping plan_version on every transition or only on user_approval\n\n"
+            "## Plan body\nActual plan...\n"
+        )
+        points = _extract_plan_judgment_calls(text)
+        assert len(points) == 3
+        assert points[0].startswith("Whether to ship the rename")
+        assert "cache eviction" in points[1]
+
+    def test_judgment_calls_returns_empty_when_section_missing(self) -> None:
+        from pollypm.cockpit_ui import _extract_plan_judgment_calls
+        assert _extract_plan_judgment_calls("# A plan\n\nNo judgment section.") == []
+
+    def test_action_card_renders_judgment_calls_for_plan_review(self) -> None:
+        """The Action Needed card on the project drilldown surfaces
+        the architect's flagged judgment-call points right under the
+        summary so the user knows what to weigh in on."""
+        from pollypm.cockpit_ui import PollyProjectDashboardApp
+        # Just exercise the pure render helper — no Pilot needed.
+        app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+        item = {
+            "is_plan_review": True,
+            "plain_prompt": "A short plan summary appears here.",
+            "judgment_calls": [
+                "Whether to ship in one PR or split it.",
+                "The cache eviction strategy.",
+            ],
+            "unblock_steps": ["Open the plan review surface."],
+            "decision_question": "Is this ready to become tasks?",
+        }
+        body = app._render_action_card_body(item, compact=False)
+        assert "Flagged judgment calls" in body
+        assert "Whether to ship in one PR" in body
+        assert "cache eviction" in body
+        assert "A short plan summary appears here" in body
+
+    def test_action_card_caps_long_summary_at_80_chars(self) -> None:
+        from pollypm.cockpit_ui import PollyProjectDashboardApp
+        app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+        long_summary = "x" * 200
+        item = {
+            "is_plan_review": True,
+            "plain_prompt": long_summary,
+            "judgment_calls": [],
+            "unblock_steps": [],
+            "decision_question": "Ready?",
+        }
+        body = app._render_action_card_body(item, compact=False)
+        # Summary is truncated with an ellipsis, so the rendered ``x``
+        # run is well under 200 chars.
+        assert "x" * 100 not in body
+        assert "..." in body
+
+    def test_action_card_omits_judgment_calls_when_not_plan_review(self) -> None:
+        from pollypm.cockpit_ui import PollyProjectDashboardApp
+        app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+        item = {
+            "plain_prompt": "Generic message.",
+            "unblock_steps": ["Step 1.", "Step 2."],
+            "decision_question": "Choose.",
+        }
+        body = app._render_action_card_body(item, compact=False)
+        assert "Flagged judgment calls" not in body
+
+
+def test_plan_review_message_detail_renders_plan_inline_when_available(
+    tmp_path: Path,
+) -> None:
+    """Issue #1397: when a plan_review message renders, the detail pane
+    shows the plan markdown body inline instead of the file-pointer
+    text the architect emits."""
+    from pollypm.cockpit_ui import PollyInboxApp
+
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    (project_path / "docs").mkdir()
+    plan_md = (
+        "# Demo plan\n\n"
+        "## Summary\n"
+        "We will ship the rendering pipeline as three small tasks.\n\n"
+        "## Judgment calls\n"
+        "- Whether to keep the legacy code path during migration.\n"
+        "- Cache eviction strategy in the renderer.\n\n"
+        "## Plan body\n"
+        "1. Wire the renderer.\n2. Migrate callers.\n3. Drop the legacy path.\n"
+    )
+    (project_path / "docs" / "project-plan.md").write_text(plan_md, encoding="utf-8")
+    config_path = tmp_path / "pollypm.toml"
+    _write_minimal_config(project_path, config_path)
+    plan_task_id = _seed_plan_task(project_path)
+    message_id = _seed_plan_review_message(
+        project_path,
+        plan_task_id=plan_task_id,
+        body=(
+            f"Plan: {project_path}/docs/project-plan.md\n"
+            "Press v to open the explainer (unavailable), "
+            "d to discuss with the PM, A to approve."
+        ),
+    )
+    if not _load_config_compatible(config_path):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    app = PollyInboxApp(config_path)
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            app._selected_task_id = message_id
+            app._render_detail(message_id)
+            await pilot.pause()
+            detail = str(app.detail.render())
+            assert "Demo plan" in detail
+            assert "rendering pipeline as three small tasks" in detail
+            # File path NOT surfaced in the body — implementation detail.
+            assert "/docs/project-plan.md" not in detail
+            assert "Press v to open the explainer" not in detail
+
+    _run(body())
+
+
+def test_plan_review_message_detail_falls_back_when_plan_missing(
+    plan_review_message_env, plan_review_message_app,
+) -> None:
+    """When no plan markdown is on disk, the detail pane shows a
+    discoverability hint rather than the file-pointer body."""
+    async def body() -> None:
+        async with plan_review_message_app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            task_id = plan_review_message_env["message_id"]
+            plan_review_message_app._selected_task_id = task_id
+            plan_review_message_app._render_detail(task_id)
+            await pilot.pause()
+            detail = str(plan_review_message_app.detail.render())
+            # Fallback hint replaces the file-pointer body.
+            assert "Plan content is not available on disk yet" in detail
+            assert "Plan: docs/project-plan.md" not in detail
+
+    _run(body())
+
+
+def test_long_plan_renders_in_scrollable_detail_pane(tmp_path: Path) -> None:
+    """A long plan should not break the inbox detail layout; the host
+    pane is a VerticalScroll so the long render scrolls inside it."""
+    from pollypm.cockpit_ui import PollyInboxApp
+    from textual.containers import VerticalScroll
+
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    (project_path / "docs").mkdir()
+    big_body = ["# Demo plan", "", "## Summary", "Tiny summary.", ""]
+    for idx in range(120):
+        big_body.append(f"## Section {idx}")
+        big_body.append(f"Body for section {idx}.")
+        big_body.append("")
+    (project_path / "docs" / "project-plan.md").write_text(
+        "\n".join(big_body), encoding="utf-8",
+    )
+    config_path = tmp_path / "pollypm.toml"
+    _write_minimal_config(project_path, config_path)
+    plan_task_id = _seed_plan_task(project_path)
+    message_id = _seed_plan_review_message(
+        project_path,
+        plan_task_id=plan_task_id,
+    )
+    if not _load_config_compatible(config_path):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    app = PollyInboxApp(config_path)
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause()
+            app._selected_task_id = message_id
+            app._render_detail(message_id)
+            await pilot.pause()
+            # The host scroll exists and contains the detail Static.
+            scroll = app.query_one("#inbox-detail-scroll", VerticalScroll)
+            assert scroll is not None
+            detail = str(app.detail.render())
+            # Many sections rendered without crashing layout.
+            assert "Section 0" in detail
+            assert "Section 119" in detail
+
+    _run(body())
+
+
+def test_project_drilldown_plan_review_card_surfaces_plan_summary(
+    tmp_path: Path,
+) -> None:
+    """Drilling into a project with a pending plan_review action card
+    surfaces the plan summary + judgment-call points inline (the rich
+    project drilldown surface that #1397 calls out)."""
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    (project_path / "docs").mkdir()
+    plan_md = (
+        "# Demo plan\n\n"
+        "## Summary\n"
+        "Three-phase rollout: scaffolding, migration, cleanup.\n\n"
+        "## Judgment calls\n"
+        "- Whether to keep the legacy path during migration.\n"
+        "- Where to cut the cache invalidation.\n\n"
+        "## Plan body\nDetails...\n"
+    )
+    (project_path / "docs" / "project-plan.md").write_text(plan_md, encoding="utf-8")
+    config_path = tmp_path / "pollypm.toml"
+    _write_minimal_config(project_path, config_path)
+    plan_task_id = _seed_plan_task(project_path)
+    # Use the work service so the row carries the right needs_action /
+    # triage_bucket flags the dashboard's action_items extractor uses.
+    db_path = project_path / ".pollypm" / "state.db"
+    svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+    try:
+        from pollypm.store import SQLAlchemyStore
+        store = SQLAlchemyStore(f"sqlite:///{db_path}")
+        try:
+            store.enqueue_message(
+                type="notify",
+                tier="immediate",
+                recipient="user",
+                sender="architect",
+                subject="Plan ready for review: demo",
+                body=(
+                    f"Plan: {project_path}/docs/project-plan.md\n\n"
+                    "Press v to open the explainer (unavailable), "
+                    "d to discuss with the PM, A to approve."
+                ),
+                scope="demo",
+                labels=[
+                    "plan_review",
+                    "project:demo",
+                    f"plan_task:{plan_task_id}",
+                ],
+                payload={
+                    "actor": "architect",
+                    "project": "demo",
+                    "user_prompt": {
+                        "summary": "A full project plan is ready for your review.",
+                        "actions": [
+                            {"label": "Review plan", "kind": "review_plan"},
+                            {"label": "Open task", "kind": "open_task",
+                             "task_id": plan_task_id},
+                        ],
+                    },
+                },
+                state="open",
+            )
+        finally:
+            store.close()
+    finally:
+        svc.close()
+    if not _load_config_compatible(config_path):
+        pytest.skip("minimal pollypm.toml fixture not supported by loader")
+    from pollypm import cockpit_ui as _cockpit_ui
+    _cockpit_ui._PROJECT_DASHBOARD_TASK_CACHE.clear()
+    _cockpit_ui._DASHBOARD_INBOX_CACHE.clear()
+    app = PollyProjectDashboardApp(config_path, "demo")
+
+    async def body() -> None:
+        async with app.run_test(size=(140, 60)) as pilot:
+            await pilot.pause()
+            rendered = app._inbox_section_text()
+            # Plan summary surfaced (at minimum, the leading clause).
+            assert "Three-phase rollout" in rendered
+            # Judgment calls surfaced as the flagged-points block.
+            assert "Flagged judgment calls" in rendered
+            assert "legacy path during migration" in rendered
+            assert "cache invalidation" in rendered
+            # File path NOT surfaced in the action card.
+            assert "docs/project-plan.md" not in rendered
+
     _run(body())


### PR DESCRIPTION
Closes #1397.

## Summary

Today the cockpit shows a file path when a plan is pending review and tells the user to open it locally. That's broken for users on a remote TUI. This PR renders the plan body inline.

## What changes

### Inbox detail surface (`PollyInboxApp`)
- For `plan_review` messages and tasks, the detail pane now renders the plan markdown content (loaded from `docs/project-plan.md` / `docs/plan/plan.md`) inline through `_md_to_rich`. Long plans scroll in the existing `#inbox-detail-scroll` `VerticalScroll`.
- Suppresses the heuristic action prompt block for `plan_review` items so the architect's "`Plan: <abs path>`" line never leaks back into the rendered detail.
- Falls back to a discoverability hint ("Plan content is not available on disk yet — discuss with the PM") when the file is missing.

### Project drilldown action card (`PollyProjectDashboardApp`)
- `_plan_review_decision` now reads the plan markdown and exposes `plan_summary`, `judgment_calls`, and `plan_text`. These ride along on the action item even when `_user_prompt_decision` wins the dispatch.
- The action-card body renders the plan summary as the prompt (capped at ~80 chars in the rail preview) and surfaces the architect's `## Judgment calls` bullet list as a "Flagged judgment calls" block right under the summary.
- `_render_plan_body` no longer leads with the relative file path or enumerates `docs/plan/` aux files — file paths are an implementation detail.

### Helpers (pure functions, easy to test)
- `_plan_content_for_review(meta, config_path)` — resolves the project from plan_review meta and returns the plan markdown.
- `_extract_plan_summary_block(text)` — pulls the paragraph under `## Summary`, falling back to the first non-header paragraph for pre-#1408 plans.
- `_extract_plan_judgment_calls(text)` — extracts the bullet list under `## Judgment calls`.

## Storage

Plan content lives at `<project>/docs/project-plan.md` (or `docs/plan/plan.md`) — already enumerated by `CANONICAL_PLAN_RELATIVE_PATHS` from `pollypm.plugins_builtin.project_planning.plan_presence`.

## Test plan

- [x] `tests/test_plan_review_flow.py` — new `TestPlanInlineRendering` class covers the summary/judgment-call extractors and the action-card render helper.
- [x] `test_plan_review_message_detail_renders_plan_inline_when_available` — drives `_render_detail` against a fixture with a real plan.md, asserts the plan body is inline and the file path isn't.
- [x] `test_plan_review_message_detail_falls_back_when_plan_missing` — asserts the discoverability hint replaces the file-pointer body.
- [x] `test_long_plan_renders_in_scrollable_detail_pane` — 120-section plan renders without breaking layout, lives inside the `VerticalScroll` host.
- [x] `test_project_drilldown_plan_review_card_surfaces_plan_summary` — drilldown action card renders the plan summary + judgment calls and never shows the file path.
- [x] All 28 tests in `tests/test_plan_review_flow.py` pass.
- [x] All 134 tests in `tests/test_project_dashboard_ui.py` pass.
- [x] All 72 non-flake tests in `tests/test_cockpit_inbox_ui.py` pass (the two pre-existing failures — `test_cockpit_send_key_inbox_filter_sequence_routes_to_inbox_bridge` and `test_modal_surfaces_plan_review_keys_when_selected` — also fail on `main` and are unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)