### PR TITLE
Auto-unstick: watchdog detects wedged state, dispatches architect

### DIFF
--- a/src/pollypm/audit/__init__.py
+++ b/src/pollypm/audit/__init__.py
@@ -77,24 +77,32 @@ from pollypm.audit.log import (
     read_events,
 )
 from pollypm.audit.watchdog import (
+    ESCALATION_THROTTLE_SECONDS,
     EVENT_AUDIT_FINDING,
     EVENT_HEARTBEAT_TICK,
     Finding,
     WatchdogConfig,
+    emit_escalation_dispatched,
+    format_unstick_brief,
     scan_events,
     scan_project,
+    was_recently_dispatched,
 )
 
 __all__ = [
     "AuditEvent",
+    "ESCALATION_THROTTLE_SECONDS",
     "EVENT_AUDIT_FINDING",
     "EVENT_HEARTBEAT_TICK",
     "Finding",
     "WatchdogConfig",
     "central_log_path",
     "emit",
+    "emit_escalation_dispatched",
+    "format_unstick_brief",
     "project_log_path",
     "read_events",
     "scan_events",
     "scan_project",
+    "was_recently_dispatched",
 ]

--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -70,6 +70,18 @@ EVENT_SOCKET_REAPED = "socket.reaped"
 # render plan-history breadcrumbs without scanning task content.
 EVENT_PLAN_VERSION_INCREMENTED = "plan.version_incremented"
 EVENT_PLAN_SUCCESSOR_CREATED = "plan.successor_created"
+# #1414 — auto-unstick infrastructure. ``worker.session_reaped`` fires
+# whenever the worker-marker reaper unlinks an orphan marker (one event
+# per reaped marker); the watchdog's dead-loop detector counts these
+# per-task to spot a reaper firing repeatedly on the same task without
+# the underlying problem being fixed. ``watchdog.escalation_dispatched``
+# fires from the watchdog cadence handler when a finding is routed to
+# the project's architect with an unstick brief — the throttle window
+# query treats the audit log itself as the source of truth, so this
+# event must be present (and queryable by ``finding_type`` + ``subject``)
+# for the dedup to work.
+EVENT_WORKER_SESSION_REAPED = "worker.session_reaped"
+EVENT_WATCHDOG_ESCALATION_DISPATCHED = "watchdog.escalation_dispatched"
 
 
 @dataclass(slots=True, frozen=True)
@@ -422,6 +434,8 @@ __all__ = [
     "EVENT_SOCKET_REAPED",
     "EVENT_PLAN_VERSION_INCREMENTED",
     "EVENT_PLAN_SUCCESSOR_CREATED",
+    "EVENT_WORKER_SESSION_REAPED",
+    "EVENT_WATCHDOG_ESCALATION_DISPATCHED",
     "AuditEvent",
     "central_log_path",
     "emit",

--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -65,6 +65,8 @@ from pollypm.audit.log import (
     EVENT_MARKER_RELEASED,
     EVENT_TASK_CREATED,
     EVENT_TASK_STATUS_CHANGED,
+    EVENT_WATCHDOG_ESCALATION_DISPATCHED,
+    EVENT_WORKER_SESSION_REAPED,
     AuditEvent,
 )
 
@@ -78,13 +80,19 @@ __all__ = [
     "RULE_MARKER_LEAKED",
     "RULE_STUCK_DRAFT",
     "RULE_CANCEL_NO_PROMOTION",
+    "RULE_TASK_REVIEW_STALE",
+    "RULE_ROLE_SESSION_MISSING",
+    "RULE_WORKER_SESSION_DEAD_LOOP",
     "scan_events",
     "scan_project",
     "emit_heartbeat_tick",
     "emit_finding",
+    "emit_escalation_dispatched",
+    "format_unstick_brief",
     "watchdog_alert_session_name",
     "WATCHDOG_ALERT_TYPE",
     "format_finding_message",
+    "ESCALATION_THROTTLE_SECONDS",
 ]
 
 
@@ -98,6 +106,23 @@ RULE_ORPHAN_MARKER = "orphan_marker"
 RULE_MARKER_LEAKED = "marker_leaked"
 RULE_STUCK_DRAFT = "stuck_draft"
 RULE_CANCEL_NO_PROMOTION = "cancellation_no_promotion"
+# #1414 — auto-unstick rules. ``task_review_stale`` catches a task
+# parked at status=review with no transitions for a while; that's the
+# savethenovel/10 pattern (reviewer agent never spawned). The other
+# two cover the architectural pattern: an in-flight task with no
+# matching role tmux session, and a worker reaper firing in a loop on
+# the same task.
+RULE_TASK_REVIEW_STALE = "task_review_stale"
+RULE_ROLE_SESSION_MISSING = "role_session_missing"
+RULE_WORKER_SESSION_DEAD_LOOP = "worker_session_dead_loop"
+
+# Throttle window for the dispatch path. We re-fire findings on every
+# tick (the audit log is forensic and operators want repeat counts),
+# but we deliberately do NOT re-dispatch the architect for the same
+# (project, finding_type, subject) within 30 min. The dispatch event
+# itself is the source of truth — querying the audit log avoids any
+# in-memory state that wouldn't survive a heartbeat process restart.
+ESCALATION_THROTTLE_SECONDS = 1800
 
 # Audit events emitted *by* the watchdog itself.
 EVENT_HEARTBEAT_TICK = "heartbeat.tick"
@@ -149,6 +174,14 @@ class WatchdogConfig:
     # queue the replacement. If no ``task.created`` for the same
     # project lands in that window, fire the finding.
     cancel_grace_seconds: int = 300
+    # #1414 — task_review_stale: a task at status=review must have its
+    # most recent transition older than this before we fire. 30 min
+    # mirrors the savethenovel/10 case (reviewer agent never spawned).
+    review_stale_seconds: int = 1800
+    # #1414 — worker_session_dead_loop: how many reaper events for the
+    # same task within ``dead_loop_window_seconds`` count as a loop.
+    dead_loop_threshold: int = 3
+    dead_loop_window_seconds: int = 600
 
 
 @dataclass(slots=True, frozen=True)
@@ -507,6 +540,217 @@ def _detect_cancellation_no_promotion(
 
 
 # ---------------------------------------------------------------------------
+# Auto-unstick rules (#1414)
+# ---------------------------------------------------------------------------
+
+
+def _detect_task_review_stale(
+    events: Sequence[AuditEvent],
+    *,
+    now: datetime,
+    config: WatchdogConfig,
+) -> list[Finding]:
+    """Rule 5: task at ``status=review`` with no transition for > threshold.
+
+    Walks ``task.status_changed`` events and finds the latest transition
+    per task subject. If the latest transition lands the task in
+    ``review`` and is older than ``review_stale_seconds`` ago, fire.
+    """
+    findings: list[Finding] = []
+    cutoff = now - timedelta(seconds=config.review_stale_seconds)
+
+    # subject -> (latest_ts, ev) — pick the latest transition per task.
+    latest: dict[str, tuple[datetime, AuditEvent]] = {}
+    for ev in events:
+        if ev.event != EVENT_TASK_STATUS_CHANGED:
+            continue
+        ts = _parse_iso(ev.ts)
+        if ts is None:
+            continue
+        prior = latest.get(ev.subject)
+        if prior is None or ts > prior[0]:
+            latest[ev.subject] = (ts, ev)
+
+    for subject, (ts, ev) in latest.items():
+        to_state = (ev.metadata or {}).get("to")
+        if to_state != "review":
+            continue
+        if ts > cutoff:
+            # Not stale enough yet — give the reviewer time to act.
+            continue
+        key = _task_subject_key(subject)
+        if key is None:
+            continue
+        project, _ = key
+        stuck_minutes = max(1, int((now - ts).total_seconds() // 60))
+        findings.append(Finding(
+            rule=RULE_TASK_REVIEW_STALE,
+            project=project,
+            subject=subject,
+            message=(
+                f"Task {subject} has been at status=review for "
+                f"~{stuck_minutes} min with no further transitions."
+            ),
+            recommendation=(
+                f"Either spawn a reviewer or run `pm task done "
+                f"{subject}` if the work is correct as-is."
+            ),
+            metadata={
+                "review_since": ev.ts,
+                "stuck_minutes": stuck_minutes,
+                "from": (ev.metadata or {}).get("from"),
+                "actor": ev.actor,
+            },
+        ))
+    return findings
+
+
+def _detect_role_session_missing(
+    events: Sequence[AuditEvent],
+    *,
+    now: datetime,
+    config: WatchdogConfig,
+    open_tasks: Sequence[Any] | None = None,
+    storage_window_names: Sequence[str] | None = None,
+    project: str = "",
+) -> list[Finding]:
+    """Rule 6: in-flight task whose assigned role has no tmux session.
+
+    Iterates ``open_tasks`` (in_progress / review with an assignee or
+    role mapping). For each task whose role can be resolved, check
+    whether ``<role>-<project>`` exists in the storage-closet window
+    list. If not, fire.
+
+    The window-name list is passed in (not queried here) so the pure
+    detector can be unit-tested without spinning up tmux.
+    """
+    findings: list[Finding] = []
+    if not open_tasks or storage_window_names is None:
+        return findings
+    window_set = {str(name).strip() for name in storage_window_names if name}
+
+    for task in open_tasks:
+        status = getattr(task, "work_status", None)
+        # Accept either a WorkStatus enum or a raw string.
+        status_value = getattr(status, "value", status)
+        if status_value not in ("in_progress", "review"):
+            continue
+        task_project = getattr(task, "project", "") or project
+        task_number = getattr(task, "task_number", None)
+        if not task_project or task_number is None:
+            continue
+        # Role resolution preference: explicit roles dict (architect /
+        # reviewer / worker) → assignee fallback. We pick the most
+        # specific role for the current state — review tasks need a
+        # reviewer; in_progress tasks need a worker.
+        roles = getattr(task, "roles", {}) or {}
+        candidate_roles: list[str] = []
+        if status_value == "review":
+            candidate_roles = ["reviewer", "architect", "worker"]
+        else:
+            candidate_roles = ["worker", "architect", "reviewer"]
+        role_used: str | None = None
+        for role in candidate_roles:
+            if role in roles and roles[role]:
+                role_used = role
+                break
+        if role_used is None:
+            assignee = getattr(task, "assignee", None)
+            if assignee:
+                # Best-effort: use assignee as the role token. Most of
+                # PollyPM's per-task workers run as ``worker-<project>``,
+                # so this is the right default when no roles are set.
+                role_used = "worker"
+        if role_used is None:
+            continue
+        expected_window = f"{role_used}-{task_project}"
+        if expected_window in window_set:
+            continue
+        findings.append(Finding(
+            rule=RULE_ROLE_SESSION_MISSING,
+            project=task_project,
+            subject=f"{task_project}/{task_number}",
+            message=(
+                f"Task {task_project}/{task_number} is at "
+                f"status={status_value} but no '{expected_window}' "
+                f"window exists in the storage-closet — the role agent "
+                f"is not running."
+            ),
+            recommendation=(
+                f"Spawn a `{role_used}` for {task_project} (e.g. "
+                f"`pm chat {task_project} --role {role_used}`) or "
+                f"reassign the task."
+            ),
+            metadata={
+                "expected_window": expected_window,
+                "role": role_used,
+                "status": status_value,
+            },
+        ))
+    return findings
+
+
+def _detect_worker_session_dead_loop(
+    events: Sequence[AuditEvent],
+    *,
+    now: datetime,
+    config: WatchdogConfig,
+) -> list[Finding]:
+    """Rule 7: 3+ ``worker.session_reaped`` for the same task in a 10-min window.
+
+    Each reaping is itself a sign the worker session crashed; three in
+    a row means the underlying problem isn't the session, it's the
+    task — and the architect needs to look at it instead of the reaper
+    burning energy in a loop.
+    """
+    findings: list[Finding] = []
+    cutoff = now - timedelta(seconds=config.dead_loop_window_seconds)
+
+    # subject -> [(ts, ev), ...]
+    by_subject: dict[str, list[tuple[datetime, AuditEvent]]] = {}
+    for ev in events:
+        if ev.event != EVENT_WORKER_SESSION_REAPED:
+            continue
+        ts = _parse_iso(ev.ts)
+        if ts is None or ts < cutoff:
+            continue
+        if not ev.subject:
+            continue
+        by_subject.setdefault(ev.subject, []).append((ts, ev))
+
+    for subject, hits in by_subject.items():
+        if len(hits) < config.dead_loop_threshold:
+            continue
+        key = _task_subject_key(subject)
+        if key is None:
+            continue
+        project, _ = key
+        latest_ts, latest_ev = max(hits, key=lambda x: x[0])
+        findings.append(Finding(
+            rule=RULE_WORKER_SESSION_DEAD_LOOP,
+            project=project,
+            subject=subject,
+            message=(
+                f"Worker session for {subject} was reaped "
+                f"{len(hits)} times in the last "
+                f"{config.dead_loop_window_seconds // 60} min — the "
+                f"reaper is firing in a loop."
+            ),
+            recommendation=(
+                f"Inspect the task and decide whether to cancel "
+                f"(`pm task cancel {subject}`), reassign, or fix the "
+                f"underlying spawn failure."
+            ),
+            metadata={
+                "reap_count": len(hits),
+                "latest_at": latest_ev.ts,
+                "latest_reason": (latest_ev.metadata or {}).get("reason"),
+            },
+        ))
+    return findings
+
+
+# ---------------------------------------------------------------------------
 # Public API — scan_events / scan_project
 # ---------------------------------------------------------------------------
 
@@ -516,6 +760,9 @@ def scan_events(
     *,
     now: datetime,
     config: WatchdogConfig | None = None,
+    open_tasks: Sequence[Any] | None = None,
+    storage_window_names: Sequence[str] | None = None,
+    project: str = "",
 ) -> list[Finding]:
     """Run every detection rule against ``events`` and return findings.
 
@@ -531,6 +778,15 @@ def scan_events(
             instant in tests.
         config: tunable thresholds. ``None`` uses :class:`WatchdogConfig`
             defaults.
+        open_tasks: live in-flight tasks for the ``role_session_missing``
+            rule — typically the result of
+            ``WorkService.list_nonterminal_tasks(project=...)``. ``None``
+            disables the rule (e.g. unit tests that only feed events).
+        storage_window_names: window names visible in the storage-closet
+            tmux session. Passed in so ``role_session_missing`` stays a
+            pure function.
+        project: project key — only used by ``role_session_missing``
+            when the open_task rows don't carry it.
     """
     if config is None:
         config = WatchdogConfig()
@@ -550,6 +806,20 @@ def scan_events(
     findings.extend(_detect_cancellation_no_promotion(
         materialised, now=now, config=config,
     ))
+    findings.extend(_detect_task_review_stale(
+        materialised, now=now, config=config,
+    ))
+    findings.extend(_detect_role_session_missing(
+        materialised,
+        now=now,
+        config=config,
+        open_tasks=open_tasks,
+        storage_window_names=storage_window_names,
+        project=project,
+    ))
+    findings.extend(_detect_worker_session_dead_loop(
+        materialised, now=now, config=config,
+    ))
     return findings
 
 
@@ -559,6 +829,8 @@ def scan_project(
     project_path: Path | str | None = None,
     now: datetime | None = None,
     config: WatchdogConfig | None = None,
+    open_tasks: Sequence[Any] | None = None,
+    storage_window_names: Sequence[str] | None = None,
 ) -> list[Finding]:
     """Read audit events for ``project`` and scan them.
 
@@ -566,6 +838,11 @@ def scan_project(
     from the per-project log when ``project_path`` exists, else
     from the central tail (mirrors :func:`pollypm.audit.read_events`
     source-preference rules).
+
+    ``open_tasks`` and ``storage_window_names`` are pass-through inputs
+    for the auto-unstick rules (#1414); when omitted those rules become
+    no-ops, which is the right default for callers that only have audit
+    events on hand.
     """
     from pollypm.audit.log import read_events
 
@@ -584,7 +861,14 @@ def scan_project(
         since=since,
         project_path=project_path,
     )
-    return scan_events(events, now=resolved_now, config=config)
+    return scan_events(
+        events,
+        now=resolved_now,
+        config=config,
+        open_tasks=open_tasks,
+        storage_window_names=storage_window_names,
+        project=project,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -644,3 +928,190 @@ def emit_finding(finding: Finding) -> None:
         )
     except Exception:  # noqa: BLE001
         logger.debug("emit_finding failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Auto-unstick dispatch (#1414)
+# ---------------------------------------------------------------------------
+
+
+def was_recently_dispatched(
+    *,
+    project: str,
+    finding_type: str,
+    subject: str,
+    now: datetime,
+    project_path: Path | str | None = None,
+    throttle_seconds: int = ESCALATION_THROTTLE_SECONDS,
+) -> bool:
+    """Return True iff the audit log shows a matching dispatch in-window.
+
+    The throttle uses the audit log itself as the source of truth so a
+    heartbeat-process restart doesn't reset the dedup window. We scan
+    ``EVENT_WATCHDOG_ESCALATION_DISPATCHED`` for the project in the last
+    ``throttle_seconds`` and look for a row whose metadata.finding_type
+    and subject both match.
+    """
+    from pollypm.audit.log import read_events
+
+    cutoff = (now - timedelta(seconds=throttle_seconds)).isoformat()
+    try:
+        recent = read_events(
+            project,
+            since=cutoff,
+            event=EVENT_WATCHDOG_ESCALATION_DISPATCHED,
+            project_path=project_path,
+        )
+    except Exception:  # noqa: BLE001 — never block dispatch on read failure
+        logger.debug(
+            "was_recently_dispatched: read_events failed", exc_info=True,
+        )
+        return False
+    for ev in recent:
+        meta = ev.metadata or {}
+        if (
+            meta.get("finding_type") == finding_type
+            and (ev.subject == subject or meta.get("subject") == subject)
+        ):
+            return True
+    return False
+
+
+def emit_escalation_dispatched(
+    *,
+    project: str,
+    finding_type: str,
+    subject: str,
+    brief: str,
+    project_path: Path | str | None = None,
+) -> None:
+    """Emit a ``watchdog.escalation_dispatched`` event.
+
+    The metadata carries enough to reconstruct the dispatch decision:
+    finding_type, subject, and the brief that was sent. Best-effort —
+    never raises.
+    """
+    from pollypm.audit.log import emit as _audit_emit
+    try:
+        _audit_emit(
+            event=EVENT_WATCHDOG_ESCALATION_DISPATCHED,
+            project=project,
+            subject=subject,
+            actor="audit_watchdog",
+            status="warn",
+            metadata={
+                "finding_type": finding_type,
+                "subject": subject,
+                "brief": brief,
+            },
+            project_path=project_path,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("emit_escalation_dispatched failed", exc_info=True)
+
+
+def format_unstick_brief(finding: Finding) -> str:
+    """Render a finding as a structured brief for the architect.
+
+    Each rule produces a tailored brief — the framing is the same
+    (``WATCHDOG ESCALATION`` header + structured fields + decision
+    options) but the ``Observed evidence`` and ``Your job`` lines vary
+    so the architect knows which lever to pull first.
+    """
+    project = finding.project or "<unknown>"
+    subject = finding.subject or "<unknown>"
+    meta = finding.metadata or {}
+
+    lines: list[str] = ["WATCHDOG ESCALATION", ""]
+    lines.append(f"Project: {project}")
+    lines.append(f"Finding: {finding.rule}")
+    lines.append(f"Subject: {subject}")
+
+    if finding.rule == RULE_TASK_REVIEW_STALE:
+        stuck_minutes = meta.get("stuck_minutes")
+        review_since = meta.get("review_since")
+        lines.append(
+            f"Stuck for: {stuck_minutes} minutes" if stuck_minutes
+            else "Stuck for: unknown duration"
+        )
+        lines.append("Observed evidence:")
+        if review_since:
+            lines.append(f"- Task transitioned to status=review at {review_since}")
+        lines.append(
+            "- No subsequent task.status_changed for this subject"
+        )
+        lines.append(
+            "- Reviewer agent appears to be absent or stuck"
+        )
+        lines.append("")
+        lines.append(
+            "Your job: investigate and unstick. Options: "
+            "(a) spawn a reviewer for this project so the queue resumes, "
+            f"(b) review the work yourself and call `pm task done {subject}` "
+            "if it's correct, "
+            "(c) escalate to user via `pm notify` with a clear summary."
+        )
+    elif finding.rule == RULE_ROLE_SESSION_MISSING:
+        expected = meta.get("expected_window") or "<unknown>"
+        role = meta.get("role") or "<unknown>"
+        status = meta.get("status") or "<unknown>"
+        lines.append("Stuck for: a watchdog cycle (>= 5 minutes)")
+        lines.append("Observed evidence:")
+        lines.append(f"- Task at status={status} with role={role}")
+        lines.append(
+            f"- No '{expected}' window in the storage-closet "
+            f"tmux session"
+        )
+        lines.append(
+            "- Without the role session, the task cannot make progress"
+        )
+        lines.append("")
+        lines.append(
+            "Your job: investigate and unstick. Options: "
+            f"(a) spawn the missing `{role}` (e.g. "
+            f"`pm chat {project} --role {role}`) and let it pick up the work, "
+            "(b) reassign the task to a role that IS present, "
+            "(c) escalate to user via `pm notify` if the spawn failure is "
+            "persistent (config / auth / quota)."
+        )
+    elif finding.rule == RULE_WORKER_SESSION_DEAD_LOOP:
+        reap_count = meta.get("reap_count") or "?"
+        latest_reason = meta.get("latest_reason") or "<unknown>"
+        lines.append(
+            f"Stuck for: {reap_count} reaps in the last 10 minutes"
+        )
+        lines.append("Observed evidence:")
+        lines.append(
+            f"- Worker session for {subject} reaped {reap_count} times"
+        )
+        lines.append(f"- Most recent reaper reason: {latest_reason}")
+        lines.append(
+            "- The reaper is firing in a loop — the session keeps "
+            "dying after spawn"
+        )
+        lines.append("")
+        lines.append(
+            "Your job: investigate and unstick. Options: "
+            f"(a) cancel the task (`pm task cancel {subject}`) if it's "
+            "fundamentally broken, "
+            "(b) reassign or rewrite the task to bypass the spawn failure, "
+            "(c) escalate to user via `pm notify` if the failure is in the "
+            "spawn infra itself, not the task content."
+        )
+    else:
+        # Fallback: orphan_marker / marker_leaked / stuck_draft / cancel_no_promotion
+        # all have human-readable messages already; we re-use those.
+        lines.append("Stuck for: see message")
+        lines.append("Observed evidence:")
+        if finding.message:
+            lines.append(f"- {finding.message}")
+        if finding.recommendation:
+            lines.append(f"- Recommendation: {finding.recommendation}")
+        lines.append("")
+        lines.append(
+            "Your job: investigate and unstick. Options: "
+            "(a) act on the recommendation above, "
+            "(b) take a different action you judge appropriate, "
+            "(c) escalate to user via `pm notify`."
+        )
+    return "\n".join(lines)

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -31,15 +31,33 @@ from pathlib import Path
 from typing import Any
 
 from pollypm.audit.watchdog import (
+    ESCALATION_THROTTLE_SECONDS,
     Finding,
+    RULE_ROLE_SESSION_MISSING,
+    RULE_TASK_REVIEW_STALE,
+    RULE_WORKER_SESSION_DEAD_LOOP,
     WATCHDOG_ALERT_TYPE,
     WatchdogConfig,
+    emit_escalation_dispatched,
     emit_finding,
     emit_heartbeat_tick,
     format_finding_message,
+    format_unstick_brief,
     scan_project,
+    was_recently_dispatched,
     watchdog_alert_session_name,
 )
+
+
+# #1414 — only the auto-unstick rules are eligible for architect dispatch.
+# Existing rules (orphan_marker, stuck_draft, etc.) already have
+# operator-actionable alerts and predate this dispatch path; we leave
+# them additive-only to keep the blast radius small.
+_DISPATCHABLE_RULES: frozenset[str] = frozenset({
+    RULE_TASK_REVIEW_STALE,
+    RULE_ROLE_SESSION_MISSING,
+    RULE_WORKER_SESSION_DEAD_LOOP,
+})
 
 
 logger = logging.getLogger(__name__)
@@ -113,6 +131,147 @@ def _config_from_payload(payload: dict[str, Any]) -> WatchdogConfig:
     return WatchdogConfig(**kwargs) if kwargs else WatchdogConfig()
 
 
+def _gather_open_tasks(project_key: str, project_path: Path | None) -> list[Any]:
+    """Best-effort load of in-flight tasks for ``role_session_missing``.
+
+    Returns an empty list on any failure — the watchdog keeps working
+    even when the work-service is unreachable; the new rule simply
+    no-ops for that project.
+    """
+    if project_path is None:
+        return []
+    try:
+        from pollypm.work import create_work_service
+
+        db_path = project_path / ".pollypm" / "state.db"
+        if not db_path.exists():
+            return []
+        with create_work_service(
+            db_path=db_path, project_path=project_path,
+        ) as svc:
+            list_fn = getattr(svc, "list_nonterminal_tasks", None)
+            if not callable(list_fn):
+                return []
+            return list(list_fn(project=project_key))
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: open-task load failed for %s",
+            project_key, exc_info=True,
+        )
+        return []
+
+
+def _gather_storage_windows(storage_closet_name: str | None) -> list[str]:
+    """Best-effort list of window names in the storage-closet session.
+
+    Returns an empty list when tmux is unreachable — the
+    ``role_session_missing`` rule then conservatively no-ops rather
+    than firing false-positives during a tmux outage.
+    """
+    if not storage_closet_name:
+        return []
+    try:
+        from pollypm.tmux.client import TmuxClient
+
+        tmux = TmuxClient()
+        if not tmux.has_session(storage_closet_name):
+            return []
+        windows = tmux.list_windows(storage_closet_name)
+        return [getattr(w, "name", "") or "" for w in windows]
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: list_windows failed for %s",
+            storage_closet_name, exc_info=True,
+        )
+        return []
+
+
+def _architect_window_target(
+    storage_closet_name: str | None, project_key: str,
+) -> str | None:
+    """Return ``<closet>:architect-<project>`` if the closet exists.
+
+    The dispatch path send-keys's the brief to that window. Returning
+    ``None`` means we can't dispatch right now (no closet, no architect
+    window) — the cadence handler treats that as a soft-fail so the
+    audit emit + alert still fire.
+    """
+    if not storage_closet_name or not project_key:
+        return None
+    return f"{storage_closet_name}:architect-{project_key}"
+
+
+def _send_brief_to_architect(
+    target: str, brief: str,
+) -> bool:
+    """Best-effort tmux send-keys of the brief to the architect window.
+
+    Returns True on success. The brief is sent as multiple lines —
+    each line followed by a literal Enter — so the architect's chat
+    surface treats it as a single user turn ending with Enter.
+    """
+    try:
+        from pollypm.tmux.client import TmuxClient
+
+        tmux = TmuxClient()
+        # Send the brief as a single literal text blob; no Enter so the
+        # architect can review before submitting. Mirrors the cockpit's
+        # ``_perform_pm_dispatch`` semantics where the user finishes
+        # the send themselves — except here the "user" is the architect.
+        tmux.send_keys(target, brief, press_enter=False)
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: send_keys(%s) failed", target, exc_info=True,
+        )
+        return False
+
+
+def _maybe_dispatch_to_architect(
+    finding: Finding,
+    *,
+    project_path: Path | None,
+    storage_closet_name: str | None,
+    now: datetime,
+) -> str:
+    """Apply throttle + emit + send brief. Returns a status code.
+
+    Status codes (used by the per-project counters):
+    * ``"skipped"`` — rule isn't dispatchable.
+    * ``"throttled"`` — already dispatched within the throttle window.
+    * ``"dispatched"`` — brief sent successfully.
+    * ``"send_failed"`` — emit ran, send-keys failed.
+    """
+    if finding.rule not in _DISPATCHABLE_RULES:
+        return "skipped"
+    if was_recently_dispatched(
+        project=finding.project,
+        finding_type=finding.rule,
+        subject=finding.subject,
+        now=now,
+        project_path=project_path,
+        throttle_seconds=ESCALATION_THROTTLE_SECONDS,
+    ):
+        return "throttled"
+    brief = format_unstick_brief(finding)
+    # Emit the dispatch event BEFORE the send so the throttle window
+    # is engaged even if the send fails — otherwise a tmux outage would
+    # cause every cadence tick to re-emit and re-attempt.
+    emit_escalation_dispatched(
+        project=finding.project,
+        finding_type=finding.rule,
+        subject=finding.subject,
+        brief=brief,
+        project_path=project_path,
+    )
+    target = _architect_window_target(storage_closet_name, finding.project)
+    if target is None:
+        return "send_failed"
+    if not _send_brief_to_architect(target, brief):
+        return "send_failed"
+    return "dispatched"
+
+
 def _scan_one_project(
     *,
     project_key: str,
@@ -121,19 +280,27 @@ def _scan_one_project(
     state_store: Any,
     now: datetime,
     config: WatchdogConfig,
+    storage_closet_name: str | None = None,
 ) -> dict[str, int]:
     """Scan one project and route every finding. Returns counters."""
     counters = {
         "findings": 0,
         "alerts_raised": 0,
         "alert_failures": 0,
+        "dispatches_sent": 0,
+        "dispatches_throttled": 0,
+        "dispatches_failed": 0,
     }
+    open_tasks = _gather_open_tasks(project_key, project_path)
+    storage_window_names = _gather_storage_windows(storage_closet_name)
     try:
         findings = scan_project(
             project_key,
             project_path=project_path,
             now=now,
             config=config,
+            open_tasks=open_tasks,
+            storage_window_names=storage_window_names,
         )
     except Exception:  # noqa: BLE001
         logger.debug(
@@ -158,6 +325,21 @@ def _scan_one_project(
                 finding.rule, finding.project, finding.subject,
                 finding.message, finding.recommendation,
             )
+        # #1414 — eligible findings get an architect dispatch on top
+        # of the alert. Throttle window is owned by the audit log so
+        # repeat dispatches are deduped across cadence-process restarts.
+        outcome = _maybe_dispatch_to_architect(
+            finding,
+            project_path=project_path,
+            storage_closet_name=storage_closet_name,
+            now=now,
+        )
+        if outcome == "dispatched":
+            counters["dispatches_sent"] += 1
+        elif outcome == "throttled":
+            counters["dispatches_throttled"] += 1
+        elif outcome == "send_failed":
+            counters["dispatches_failed"] += 1
     return counters
 
 
@@ -190,10 +372,16 @@ def audit_watchdog_handler(payload: dict[str, Any]) -> dict[str, Any]:
         "findings": 0,
         "alerts_raised": 0,
         "alert_failures": 0,
+        "dispatches_sent": 0,
+        "dispatches_throttled": 0,
+        "dispatches_failed": 0,
     }
 
     try:
         seen_projects: set[str] = set()
+        storage_closet_name = getattr(
+            services, "storage_closet_name", None,
+        )
         for project in services.known_projects or ():
             project_key = getattr(project, "key", None)
             if not project_key or project_key in seen_projects:
@@ -207,6 +395,7 @@ def audit_watchdog_handler(payload: dict[str, Any]) -> dict[str, Any]:
                 state_store=services.state_store,
                 now=now,
                 config=config,
+                storage_closet_name=storage_closet_name,
             )
             totals["projects_scanned"] += 1
             for k, v in partial.items():

--- a/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
@@ -213,6 +213,43 @@ feedback). DO NOT also send a separate `pm notify` plan-ready message
 — the plan_review inbox item IS the notification.
 </plan_review_handoff>
 
+<watchdog_unstick_mode>
+If a system message that begins with `WATCHDOG ESCALATION` lands in your
+session, the audit watchdog (#1414) has detected that a task on this
+project is wedged and is asking you — not the user — to unstick it.
+
+The brief carries: project, finding type (`task_review_stale`,
+`role_session_missing`, or `worker_session_dead_loop`), the canonical
+`<project>/<task_number>` subject, how long it has been stuck, and the
+observed evidence the watchdog used to fire.
+
+Decide quickly. The default options listed in every brief are:
+
+- (a) **Spawn the missing role.** For `role_session_missing` this is
+  usually the right move: run `pm chat <project> --role <role>` (or the
+  equivalent spawn command) so the absent agent can pick up the work.
+- (b) **Review and act yourself.** For `task_review_stale` you can read
+  the work output and call `pm task done <subject>` if it is correct,
+  or `pm task reject <subject>` with feedback if it is not.
+- (c) **Cancel and re-plan.** For `worker_session_dead_loop` the task
+  itself is usually the problem; cancel and replace it rather than
+  spinning the reaper.
+- (d) **Escalate to user.** When the failure is in the spawn infra
+  (auth, quota, config) or the right answer requires a product
+  judgement, send a `pm notify --priority immediate` with a clear
+  summary instead of acting unilaterally.
+
+Defer to the user when: the underlying cause is environmental,
+the same finding has fired three or more times despite your previous
+intervention, or the right answer changes the project's direction.
+Act unilaterally when: the fix is mechanical (spawn a missing role,
+approve a clearly-correct review, cancel an obviously-broken task).
+
+Watchdog escalations are throttled at 30 minutes per
+`(project, finding, subject)` triple, so you have a full cycle to act
+before the next one will land.
+</watchdog_unstick_mode>
+
 <waiting_on_user_handoff>
 Whenever a task or project is waiting on Sam/user input, do not emit a
 raw internal status dump. Before you stop, create exactly one user-facing

--- a/src/pollypm/work/worker_marker_reaper.py
+++ b/src/pollypm/work/worker_marker_reaper.py
@@ -75,6 +75,53 @@ WORKER_MARKER_REAPABLE_STATUSES: frozenset[str] = (
 )
 
 
+def _emit_worker_session_reaped(decision: "ReapedMarker") -> None:
+    """Best-effort audit emit for one reaped marker.
+
+    The watchdog's ``worker_session_dead_loop`` rule (#1414) counts
+    these per task to detect a reaper firing repeatedly without the
+    underlying problem being fixed. We carry the window name (so the
+    rule can parse out ``<project>/<task_number>``) and the reaper's
+    classification reason as metadata. Best-effort — never raises.
+    """
+    try:
+        from pollypm.audit.log import (
+            EVENT_WORKER_SESSION_REAPED,
+            emit as _audit_emit,
+        )
+
+        # Parse the window name to a canonical ``<project>/<N>`` subject.
+        subject = ""
+        try:
+            parsed = parse_task_window_name(decision.window_name)
+            if parsed is not None:
+                # ``parse_task_window_name`` returns (project, num) per
+                # the existing helper; use it for the subject when
+                # present, else fall back to the raw window name.
+                proj, num = parsed
+                subject = f"{proj}/{num}"
+        except Exception:  # noqa: BLE001
+            subject = ""
+        if not subject:
+            subject = f"{decision.project_key}/{decision.window_name}"
+        _audit_emit(
+            event=EVENT_WORKER_SESSION_REAPED,
+            project=decision.project_key,
+            subject=subject,
+            actor="worker_marker_reaper",
+            status="warn",
+            metadata={
+                "window_name": decision.window_name,
+                "marker_path": str(decision.marker_path),
+                "reason": decision.reason,
+            },
+        )
+    except Exception:  # noqa: BLE001 — audit failures must never block reaping
+        logger.debug(
+            "worker_marker_reaper: audit emit failed", exc_info=True,
+        )
+
+
 @dataclass(frozen=True, slots=True)
 class ReapedMarker:
     """Record of a worker marker that was unlinked by the reaper.
@@ -298,8 +345,13 @@ def reap_orphan_worker_markers(
                 decision.window_name,
                 decision.reason,
             )
-            # Placeholder for the parallel audit-log infra. When that
-            # ships, replace this print with an audit event.
+            # #1414 — audit-log emit so the watchdog's
+            # ``worker_session_dead_loop`` rule can count repeat reaps
+            # per task. Subject is the canonical ``<project>/<task_number>``
+            # parsed from the window name (``task-<project>-<N>``); we
+            # fall back to the marker path when the window name isn't
+            # task-bound (e.g. future advisor markers).
+            _emit_worker_session_reaped(decision)
             print(
                 f"[worker_marker_reaper] reaped {decision.window_name} "
                 f"in {decision.project_key}: {decision.reason}",

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -496,3 +496,585 @@ def test_cadence_handler_routes_finding_to_alert_sink(now: datetime) -> None:
     assert counters["alert_failures"] == 0
     rules_alerted = {a[1] for a in store.alerts}
     assert WATCHDOG_ALERT_TYPE in rules_alerted
+
+
+# ---------------------------------------------------------------------------
+# #1414 — auto-unstick rules
+# ---------------------------------------------------------------------------
+
+
+def test_task_review_stale_fires_after_threshold(now: datetime) -> None:
+    """A task at status=review whose latest transition is >30min old fires."""
+    from pollypm.audit.watchdog import RULE_TASK_REVIEW_STALE
+
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="savethenovel",
+            subject="savethenovel/10",
+            metadata={"from": "in_progress", "to": "review"},
+            ts=now - timedelta(minutes=45),
+        ),
+    ]
+    findings = scan_events(events, now=now)
+    review_findings = [f for f in findings if f.rule == RULE_TASK_REVIEW_STALE]
+    assert len(review_findings) == 1
+    f = review_findings[0]
+    assert f.subject == "savethenovel/10"
+    assert f.project == "savethenovel"
+    assert "review" in f.message
+    assert "savethenovel/10" in f.message
+
+
+def test_task_review_stale_silent_when_within_grace(now: datetime) -> None:
+    """A review that just transitioned doesn't fire."""
+    from pollypm.audit.watchdog import RULE_TASK_REVIEW_STALE
+
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/3",
+            metadata={"from": "in_progress", "to": "review"},
+            ts=now - timedelta(minutes=5),
+        ),
+    ]
+    findings = scan_events(events, now=now)
+    assert not any(f.rule == RULE_TASK_REVIEW_STALE for f in findings)
+
+
+def test_task_review_stale_silent_when_later_transition_exists(now: datetime) -> None:
+    """Latest transition isn't to review → no fire even if older one was."""
+    from pollypm.audit.watchdog import RULE_TASK_REVIEW_STALE
+
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/3",
+            metadata={"from": "in_progress", "to": "review"},
+            ts=now - timedelta(minutes=45),
+        ),
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/3",
+            metadata={"from": "review", "to": "done"},
+            ts=now - timedelta(minutes=10),
+        ),
+    ]
+    findings = scan_events(events, now=now)
+    assert not any(f.rule == RULE_TASK_REVIEW_STALE for f in findings)
+
+
+class _FakeTask:
+    """Minimal stand-in for ``work.models.Task`` for the role-session rule."""
+
+    class _Status:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+    def __init__(
+        self,
+        *,
+        project: str,
+        task_number: int,
+        work_status: str,
+        roles: dict[str, str] | None = None,
+        assignee: str | None = None,
+    ) -> None:
+        self.project = project
+        self.task_number = task_number
+        self.work_status = self._Status(work_status)
+        self.roles = roles or {}
+        self.assignee = assignee
+
+
+def test_role_session_missing_fires_when_window_absent(now: datetime) -> None:
+    """A review-state task with no reviewer-<project> window fires."""
+    from pollypm.audit.watchdog import RULE_ROLE_SESSION_MISSING
+
+    task = _FakeTask(
+        project="savethenovel",
+        task_number=10,
+        work_status="review",
+        roles={"reviewer": "claude:reviewer"},
+    )
+    findings = scan_events(
+        [],
+        now=now,
+        open_tasks=[task],
+        storage_window_names=["worker-savethenovel", "architect-savethenovel"],
+        project="savethenovel",
+    )
+    matched = [f for f in findings if f.rule == RULE_ROLE_SESSION_MISSING]
+    assert len(matched) == 1
+    f = matched[0]
+    assert f.subject == "savethenovel/10"
+    assert f.metadata["expected_window"] == "reviewer-savethenovel"
+    assert f.metadata["role"] == "reviewer"
+
+
+def test_role_session_missing_silent_when_window_present(now: datetime) -> None:
+    """When the storage closet has the role window, no finding fires."""
+    from pollypm.audit.watchdog import RULE_ROLE_SESSION_MISSING
+
+    task = _FakeTask(
+        project="demo",
+        task_number=1,
+        work_status="in_progress",
+        assignee="alice",
+    )
+    findings = scan_events(
+        [],
+        now=now,
+        open_tasks=[task],
+        storage_window_names=["worker-demo"],
+        project="demo",
+    )
+    assert not any(f.rule == RULE_ROLE_SESSION_MISSING for f in findings)
+
+
+def test_role_session_missing_noop_without_inputs(now: datetime) -> None:
+    """Without open_tasks / storage_window_names the rule is a no-op."""
+    from pollypm.audit.watchdog import RULE_ROLE_SESSION_MISSING
+
+    findings = scan_events([], now=now)
+    assert not any(f.rule == RULE_ROLE_SESSION_MISSING for f in findings)
+
+
+def test_worker_session_dead_loop_fires_at_threshold(now: datetime) -> None:
+    """3+ worker.session_reaped for the same task in 10min fires."""
+    from pollypm.audit.log import EVENT_WORKER_SESSION_REAPED
+    from pollypm.audit.watchdog import RULE_WORKER_SESSION_DEAD_LOOP
+
+    events = [
+        _make_event(
+            event=EVENT_WORKER_SESSION_REAPED,
+            project="demo",
+            subject="demo/4",
+            metadata={"reason": "spawn_failed"},
+            ts=now - timedelta(minutes=delta),
+        )
+        for delta in (8, 5, 2)
+    ]
+    findings = scan_events(events, now=now)
+    matched = [f for f in findings if f.rule == RULE_WORKER_SESSION_DEAD_LOOP]
+    assert len(matched) == 1
+    assert matched[0].subject == "demo/4"
+    assert matched[0].metadata["reap_count"] == 3
+
+
+def test_worker_session_dead_loop_below_threshold_silent(now: datetime) -> None:
+    """Two reaps don't fire."""
+    from pollypm.audit.log import EVENT_WORKER_SESSION_REAPED
+    from pollypm.audit.watchdog import RULE_WORKER_SESSION_DEAD_LOOP
+
+    events = [
+        _make_event(
+            event=EVENT_WORKER_SESSION_REAPED,
+            project="demo",
+            subject="demo/4",
+            ts=now - timedelta(minutes=delta),
+        )
+        for delta in (8, 5)
+    ]
+    findings = scan_events(events, now=now)
+    assert not any(f.rule == RULE_WORKER_SESSION_DEAD_LOOP for f in findings)
+
+
+def test_worker_session_dead_loop_outside_window_silent(now: datetime) -> None:
+    """3 reaps but spread across > 10min don't fire — only ones in-window count."""
+    from pollypm.audit.log import EVENT_WORKER_SESSION_REAPED
+    from pollypm.audit.watchdog import RULE_WORKER_SESSION_DEAD_LOOP
+
+    events = [
+        _make_event(
+            event=EVENT_WORKER_SESSION_REAPED,
+            project="demo",
+            subject="demo/4",
+            ts=now - timedelta(minutes=delta),
+        )
+        # 30, 25, 20 are all > 10 min ago
+        for delta in (30, 25, 20)
+    ]
+    findings = scan_events(events, now=now)
+    assert not any(f.rule == RULE_WORKER_SESSION_DEAD_LOOP for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# Brief formatting per rule
+# ---------------------------------------------------------------------------
+
+
+def test_format_unstick_brief_review_stale_includes_options() -> None:
+    from pollypm.audit.watchdog import (
+        RULE_TASK_REVIEW_STALE,
+        format_unstick_brief,
+    )
+
+    finding = Finding(
+        rule=RULE_TASK_REVIEW_STALE,
+        project="savethenovel",
+        subject="savethenovel/10",
+        message="Task savethenovel/10 has been at status=review for ~45 min...",
+        recommendation="Spawn a reviewer.",
+        metadata={"stuck_minutes": 45, "review_since": "2026-05-07T08:37:00+00:00"},
+    )
+    brief = format_unstick_brief(finding)
+    assert brief.startswith("WATCHDOG ESCALATION")
+    assert "Project: savethenovel" in brief
+    assert "Finding: task_review_stale" in brief
+    assert "Subject: savethenovel/10" in brief
+    assert "45 minutes" in brief
+    assert "2026-05-07T08:37:00+00:00" in brief
+    assert "pm task done savethenovel/10" in brief
+    assert "pm notify" in brief
+
+
+def test_format_unstick_brief_role_session_missing_names_window() -> None:
+    from pollypm.audit.watchdog import (
+        RULE_ROLE_SESSION_MISSING,
+        format_unstick_brief,
+    )
+
+    finding = Finding(
+        rule=RULE_ROLE_SESSION_MISSING,
+        project="savethenovel",
+        subject="savethenovel/10",
+        message="...",
+        metadata={
+            "expected_window": "reviewer-savethenovel",
+            "role": "reviewer",
+            "status": "review",
+        },
+    )
+    brief = format_unstick_brief(finding)
+    assert "reviewer-savethenovel" in brief
+    assert "pm chat savethenovel --role reviewer" in brief
+    assert "pm notify" in brief
+
+
+def test_format_unstick_brief_dead_loop_quotes_count() -> None:
+    from pollypm.audit.watchdog import (
+        RULE_WORKER_SESSION_DEAD_LOOP,
+        format_unstick_brief,
+    )
+
+    finding = Finding(
+        rule=RULE_WORKER_SESSION_DEAD_LOOP,
+        project="demo",
+        subject="demo/4",
+        message="reaped 5 times",
+        metadata={"reap_count": 5, "latest_reason": "spawn_failed"},
+    )
+    brief = format_unstick_brief(finding)
+    assert "5 reaps" in brief
+    assert "spawn_failed" in brief
+    assert "pm task cancel demo/4" in brief
+
+
+# ---------------------------------------------------------------------------
+# Throttle — was_recently_dispatched
+# ---------------------------------------------------------------------------
+
+
+def test_was_recently_dispatched_false_on_empty_log(now: datetime) -> None:
+    from pollypm.audit.watchdog import was_recently_dispatched
+
+    assert not was_recently_dispatched(
+        project="demo",
+        finding_type="task_review_stale",
+        subject="demo/1",
+        now=now,
+    )
+
+
+def test_was_recently_dispatched_true_after_emit(now: datetime) -> None:
+    from pollypm.audit.watchdog import (
+        emit_escalation_dispatched,
+        was_recently_dispatched,
+    )
+
+    emit_escalation_dispatched(
+        project="demo",
+        finding_type="task_review_stale",
+        subject="demo/1",
+        brief="WATCHDOG ESCALATION ...",
+    )
+    assert was_recently_dispatched(
+        project="demo",
+        finding_type="task_review_stale",
+        subject="demo/1",
+        now=now + timedelta(minutes=10),
+    )
+
+
+def test_was_recently_dispatched_expires_after_window(now: datetime) -> None:
+    """A dispatch older than the throttle window doesn't dedupe."""
+    from pollypm.audit.watchdog import (
+        ESCALATION_THROTTLE_SECONDS,
+        was_recently_dispatched,
+    )
+
+    # Manually seed a dispatch event >throttle ago via the central log.
+    from pollypm.audit.log import (
+        EVENT_WATCHDOG_ESCALATION_DISPATCHED,
+        central_log_path,
+    )
+    central = central_log_path("demo")
+    central.parent.mkdir(parents=True, exist_ok=True)
+    old_ts = now - timedelta(seconds=ESCALATION_THROTTLE_SECONDS + 60)
+    payload = {
+        "schema": 1,
+        "ts": old_ts.isoformat(),
+        "project": "demo",
+        "event": EVENT_WATCHDOG_ESCALATION_DISPATCHED,
+        "subject": "demo/1",
+        "actor": "audit_watchdog",
+        "status": "warn",
+        "metadata": {
+            "finding_type": "task_review_stale",
+            "subject": "demo/1",
+            "brief": "...",
+        },
+    }
+    central.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    assert not was_recently_dispatched(
+        project="demo",
+        finding_type="task_review_stale",
+        subject="demo/1",
+        now=now,
+    )
+
+
+def test_was_recently_dispatched_distinguishes_finding_types(now: datetime) -> None:
+    """A dispatch for finding A doesn't suppress a different finding type."""
+    from pollypm.audit.watchdog import (
+        emit_escalation_dispatched,
+        was_recently_dispatched,
+    )
+
+    emit_escalation_dispatched(
+        project="demo",
+        finding_type="task_review_stale",
+        subject="demo/1",
+        brief="...",
+    )
+    assert not was_recently_dispatched(
+        project="demo",
+        finding_type="role_session_missing",
+        subject="demo/1",
+        now=now + timedelta(minutes=5),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cadence handler — dispatch path (mocked architect)
+# ---------------------------------------------------------------------------
+
+
+def test_cadence_handler_dispatches_eligible_finding(
+    now: datetime, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A task_review_stale finding triggers an architect dispatch."""
+    from pollypm.audit.log import central_log_path
+    from pollypm.audit.watchdog import RULE_TASK_REVIEW_STALE
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _scan_one_project,
+    )
+
+    # Seed a stale review transition into the central tail.
+    central = central_log_path("savethenovel")
+    central.parent.mkdir(parents=True, exist_ok=True)
+    stale_ts = (now - timedelta(minutes=45)).isoformat()
+    payload = {
+        "schema": 1,
+        "ts": stale_ts,
+        "project": "savethenovel",
+        "event": EVENT_TASK_STATUS_CHANGED,
+        "subject": "savethenovel/10",
+        "actor": "polly",
+        "status": "ok",
+        "metadata": {"from": "in_progress", "to": "review"},
+    }
+    central.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    # Capture send-keys calls instead of touching tmux.
+    sent: list[tuple[str, str]] = []
+
+    def _fake_send(target: str, brief: str) -> bool:
+        sent.append((target, brief))
+        return True
+
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._send_brief_to_architect",
+        _fake_send,
+    )
+    # Stub list-windows / open-task gathering so the dispatch path doesn't
+    # require a live tmux server or work-service db.
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_storage_windows",
+        lambda name: [],
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_open_tasks",
+        lambda key, path: [],
+    )
+
+    store = _RecordingStore()
+    counters = _scan_one_project(
+        project_key="savethenovel",
+        project_path=None,
+        msg_store=store,
+        state_store=None,
+        now=now,
+        config=WatchdogConfig(),
+        storage_closet_name="pollypm-storage-closet",
+    )
+
+    assert counters["findings"] >= 1
+    assert counters["dispatches_sent"] == 1
+    assert counters["dispatches_throttled"] == 0
+    assert len(sent) == 1
+    target, brief = sent[0]
+    assert target == "pollypm-storage-closet:architect-savethenovel"
+    assert RULE_TASK_REVIEW_STALE in brief
+    assert "savethenovel/10" in brief
+
+    # Dispatch event should have landed in the audit log.
+    rows = [
+        json.loads(line)
+        for line in central.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    dispatch_rows = [
+        r for r in rows if r["event"] == "watchdog.escalation_dispatched"
+    ]
+    assert len(dispatch_rows) == 1
+    assert dispatch_rows[0]["metadata"]["finding_type"] == RULE_TASK_REVIEW_STALE
+
+
+def test_cadence_handler_throttles_repeat_dispatch(
+    now: datetime, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two ticks within 30 min → only one architect send."""
+    from pollypm.audit.log import central_log_path
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _scan_one_project,
+    )
+
+    # Seed a stale review transition.
+    central = central_log_path("savethenovel")
+    central.parent.mkdir(parents=True, exist_ok=True)
+    stale_ts = (now - timedelta(minutes=45)).isoformat()
+    payload = {
+        "schema": 1,
+        "ts": stale_ts,
+        "project": "savethenovel",
+        "event": EVENT_TASK_STATUS_CHANGED,
+        "subject": "savethenovel/10",
+        "actor": "polly",
+        "status": "ok",
+        "metadata": {"from": "in_progress", "to": "review"},
+    }
+    central.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    sent: list[tuple[str, str]] = []
+
+    def _fake_send(target: str, brief: str) -> bool:
+        sent.append((target, brief))
+        return True
+
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._send_brief_to_architect",
+        _fake_send,
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_storage_windows",
+        lambda name: [],
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_open_tasks",
+        lambda key, path: [],
+    )
+
+    store = _RecordingStore()
+    first = _scan_one_project(
+        project_key="savethenovel",
+        project_path=None,
+        msg_store=store,
+        state_store=None,
+        now=now,
+        config=WatchdogConfig(),
+        storage_closet_name="pollypm-storage-closet",
+    )
+    second = _scan_one_project(
+        project_key="savethenovel",
+        project_path=None,
+        msg_store=store,
+        state_store=None,
+        now=now + timedelta(minutes=5),
+        config=WatchdogConfig(),
+        storage_closet_name="pollypm-storage-closet",
+    )
+
+    assert first["dispatches_sent"] == 1
+    assert second["dispatches_sent"] == 0
+    assert second["dispatches_throttled"] == 1
+    # Architect should only have received one brief.
+    assert len(sent) == 1
+
+
+def test_cadence_handler_skips_dispatch_for_legacy_rules(
+    now: datetime, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """orphan_marker is NOT in the dispatchable set — no architect call."""
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _scan_one_project,
+    )
+
+    central = central_log_path("demo")
+    central.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": 1,
+        "ts": (now - timedelta(minutes=20)).isoformat(),
+        "project": "demo",
+        "event": EVENT_MARKER_CREATED,
+        "subject": "/x/demo/.pollypm/worker-markers/task-demo-1.fresh",
+        "actor": "polly",
+        "status": "ok",
+        "metadata": {},
+    }
+    central.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    sent: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._send_brief_to_architect",
+        lambda target, brief: sent.append((target, brief)) or True,
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_storage_windows",
+        lambda name: [],
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_open_tasks",
+        lambda key, path: [],
+    )
+
+    store = _RecordingStore()
+    counters = _scan_one_project(
+        project_key="demo",
+        project_path=None,
+        msg_store=store,
+        state_store=None,
+        now=now,
+        config=WatchdogConfig(),
+        storage_closet_name="pollypm-storage-closet",
+    )
+
+    assert counters["findings"] >= 1
+    assert counters["dispatches_sent"] == 0
+    assert counters["dispatches_throttled"] == 0
+    assert sent == []


### PR DESCRIPTION
Closes #1414.

## Summary

Active recovery for wedged projects. The watchdog already detects orphan markers, leaks, stuck drafts, and stalled cancellations (PR #1344); this PR extends it with three new rules tuned to the savethenovel-class failure modes (task at `code_review` with no reviewer agent, role session missing entirely, worker reaper firing in a loop) and adds a dispatch path that hands the finding to the project's architect with a tailored brief — instead of waiting for the user to notice the alert and intervene.

## New detection rules

Additive — none of the existing 5 rules are modified.

1. **`task_review_stale`** — for any task whose latest `task.status_changed` lands in `review` and is older than `review_stale_seconds` (default 30 min) ago. Catches savethenovel/10's class.
2. **`role_session_missing`** — for any non-terminal task at `in_progress`/`review` whose resolved role (`reviewer` for review tasks, `worker` for in-progress, falling back through `roles` then `assignee`) has no `<role>-<project>` window in the storage-closet tmux session.
3. **`worker_session_dead_loop`** — when 3+ `worker.session_reaped` audit events fire for the same task within 10 min.

## New audit events

- **`worker.session_reaped`** — emitted from `worker_marker_reaper` for every reaped marker. Subject is the canonical `<project>/<task_number>` (parsed from the window name) so the dead-loop rule can group cleanly. Replaces the inline placeholder print.
- **`watchdog.escalation_dispatched`** — emitted from the cadence handler when a finding is routed to the architect. Metadata carries `{finding_type, subject, brief}`. Doubles as the throttle source of truth (see below) so dedupe survives heartbeat-process restarts.

## Dispatch path

For each finding whose rule is in `_DISPATCHABLE_RULES` (only the three new rules):

1. Check `was_recently_dispatched(project, finding_type, subject, now)` — scans the audit log for a matching `watchdog.escalation_dispatched` in the last 30 min. If found, increment `dispatches_throttled` and skip.
2. Build the brief via `format_unstick_brief(finding)` — per-rule formatter that emits a structured `WATCHDOG ESCALATION` block with project/finding/subject/duration/observed evidence plus tailored decision options (spawn missing role / review work / cancel task / escalate to user).
3. Emit `watchdog.escalation_dispatched` *before* the send so the throttle window engages even if the send fails (otherwise a tmux outage would re-emit on every tick).
4. `tmux send-keys` the brief to `<storage-closet>:architect-<project>` with `press_enter=False` — the architect reviews before submitting (mirrors `_perform_pm_dispatch` semantics).

Counters surface as `dispatches_sent`, `dispatches_throttled`, `dispatches_failed` in the handler return value for observability.

## Throttle

`ESCALATION_THROTTLE_SECONDS = 1800` (30 min). The throttle uses the audit log itself as the source of truth — no in-memory state — so a heartbeat-process restart doesn't reset the dedup window. The query filters on `event=watchdog.escalation_dispatched` plus `metadata.finding_type` plus subject match.

## Architect prompt

New `<watchdog_unstick_mode>` section in `architect.md` (~25 lines). Explains the brief format, lists the four standard options (spawn role / review-and-act / cancel-and-replan / escalate via `pm notify`), and gives explicit defer-to-user vs act-unilaterally guidance — keeps it prose, not a script.

## Files changed

- `src/pollypm/audit/log.py` — `EVENT_WORKER_SESSION_REAPED`, `EVENT_WATCHDOG_ESCALATION_DISPATCHED` constants + exports.
- `src/pollypm/audit/watchdog.py` — 3 new detector functions, extended `WatchdogConfig` (3 new thresholds), `was_recently_dispatched`, `emit_escalation_dispatched`, `format_unstick_brief`, `ESCALATION_THROTTLE_SECONDS`, plus new params on `scan_events`/`scan_project` for `open_tasks` + `storage_window_names`.
- `src/pollypm/audit/__init__.py` — export the new public surface.
- `src/pollypm/work/worker_marker_reaper.py` — emit `worker.session_reaped` per reaping (subject parsed via `parse_task_window_name`).
- `src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py` — `_DISPATCHABLE_RULES`, `_gather_open_tasks`, `_gather_storage_windows`, `_architect_window_target`, `_send_brief_to_architect`, `_maybe_dispatch_to_architect`, plus extended `_scan_one_project`/`audit_watchdog_handler` counters.
- `src/pollypm/plugins_builtin/project_planning/profiles/architect.md` — new `<watchdog_unstick_mode>` block.
- `tests/test_audit_watchdog.py` — 19 new tests (per-rule fire/silent/boundary, brief format per rule, throttle: empty/post-emit/expiration/type-isolation, integration: dispatch + throttle + skip-legacy).

## Test plan

- [x] `uv run --extra dev pytest tests/test_audit_watchdog.py` — 42/42 pass (23 existing + 19 new).
- [x] `uv run --extra dev pytest tests/test_worker_marker_reaper.py` — 12/12 pass (reaper unaffected by new audit emit).
- [x] `uv run --extra dev pytest tests/test_audit_log.py tests/test_contract_audit.py tests/test_worktree_state_audit.py` — 66/66 pass.
- [ ] Manual end-to-end on a wedged project (out of scope for this PR; behavioural test covered by integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)