### PR TITLE
Auto-provision reviewer session for tracked projects (mirrors worker pattern)

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -82,6 +82,14 @@ EVENT_PLAN_SUCCESSOR_CREATED = "plan.successor_created"
 # for the dedup to work.
 EVENT_WORKER_SESSION_REAPED = "worker.session_reaped"
 EVENT_WATCHDOG_ESCALATION_DISPATCHED = "watchdog.escalation_dispatched"
+# #1413 — emitted whenever the supervisor / on-demand path provisions a
+# project-scoped role session (e.g. reviewer-<project>) that did not
+# previously exist. The watchdog (#1414) reads this stream to surface
+# "tracked project shipped without a reviewer for N hours" without
+# scraping logs. ``metadata`` carries ``role`` (``"reviewer"`` /
+# ``"architect"``), ``project``, and ``reason`` (``"bootstrap"`` /
+# ``"on_demand_review"``).
+EVENT_SESSION_PROVISIONED = "session.provisioned"
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/pollypm/recovery/reviewer_provisioning.py
+++ b/src/pollypm/recovery/reviewer_provisioning.py
@@ -1,0 +1,284 @@
+"""Auto-provision reviewer sessions for tracked projects (#1413).
+
+Background
+----------
+Per-project worker sessions get auto-provisioned via
+``SessionManager.provision_worker`` when a task transitions to a worker
+node and no live session exists. Architect sessions get auto-spawned at
+``pm project new`` via ``project_planning.cli.project._auto_spawn_architect``.
+
+Reviewers had no equivalent path. ``savethenovel`` registered with
+``tracked=true``, got a worker provisioned on demand, but its
+``reviewer-savethenovel`` session was never created — so the first task
+to land at ``code_review`` sat there forever (and dependency-blocked
+every successor task).
+
+This module fixes that with two complementary entry points:
+
+* :func:`ensure_reviewer_sessions_for_tracked_projects` — bootstrap-time
+  sweep called from :meth:`Supervisor.bootstrap_tmux` BEFORE
+  ``plan_launches`` reads the session table. Iterates every tracked
+  project and ensures a ``reviewer_<project>`` session exists in the
+  config.
+* :func:`ensure_reviewer_session_for_project` — on-demand entry point
+  called from the work-service transition path when a task lands at a
+  review node. Mirrors the worker provisioning hook in
+  ``service_transition_manager.complete_node``.
+
+Both paths are idempotent: a reviewer session that already exists in
+config is left alone. Both emit ``session.provisioned`` audit events
+when they actually create a new session, so the watchdog (#1414) can
+quantify provisioning activity.
+
+Constraints
+-----------
+* Best-effort: failures are logged and swallowed. The bootstrap path
+  must not block cockpit startup if (e.g.) one project's reviewer
+  account routing is broken — the other tracked projects still get
+  their sessions and the heartbeat's existing ``no_session`` recovery
+  catches the stragglers.
+* Does NOT touch architect or worker provisioning — that's #1413's
+  hard constraint. Pure additive scope.
+* Workers continue to be provisioned per-task; this module only owns
+  the long-lived reviewer-per-project lane.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ``reason`` values accepted by the audit emit. Other callers can extend
+# this list as needed; the watchdog treats unknown reasons as "other".
+REASON_BOOTSTRAP = "bootstrap"
+REASON_ON_DEMAND_REVIEW = "on_demand_review"
+
+
+def _emit_provisioned(
+    *,
+    project: str,
+    role: str,
+    reason: str,
+    session_name: str,
+    project_path: Path | None,
+    status: str = "ok",
+    detail: str = "",
+) -> None:
+    """Best-effort emit of the ``session.provisioned`` audit event.
+
+    The watchdog (#1414) reads this stream to detect tracked projects
+    that shipped without a reviewer session. Audit failures must never
+    block the provisioning path — a missed event is strictly better
+    than a failed bootstrap.
+    """
+    try:
+        from pollypm.audit import emit as _audit_emit
+        from pollypm.audit.log import EVENT_SESSION_PROVISIONED
+
+        _audit_emit(
+            event=EVENT_SESSION_PROVISIONED,
+            project=project,
+            subject=session_name,
+            actor="system",
+            status=status,
+            metadata={
+                "role": role,
+                "project": project,
+                "reason": reason,
+                "detail": detail,
+            },
+            project_path=project_path,
+        )
+    except Exception:  # noqa: BLE001 — audit must never block provisioning
+        logger.debug(
+            "reviewer_provisioning: audit emit failed for %s/%s",
+            project, role, exc_info=True,
+        )
+
+
+def _existing_reviewer_session(config: Any, project_key: str) -> Any | None:
+    """Return the enabled reviewer session for ``project_key``, or None."""
+    for session in getattr(config, "sessions", {}).values():
+        if (
+            getattr(session, "role", None) == "reviewer"
+            and getattr(session, "project", None) == project_key
+            and getattr(session, "enabled", True)
+        ):
+            return session
+    return None
+
+
+def ensure_reviewer_session_for_project(
+    config_path: Path,
+    project_key: str,
+    *,
+    reason: str = REASON_ON_DEMAND_REVIEW,
+    launch: bool = True,
+) -> tuple[bool, str]:
+    """Ensure a reviewer session exists for ``project_key``.
+
+    Returns ``(created, detail)``. ``created`` is True when this call
+    actually registered a new session in config (or launched a stale
+    one); False when the session already existed and we left it alone.
+    The ``detail`` string carries either the session name (success) or
+    the failure reason.
+
+    Idempotent. Safe to call multiple times for the same project — the
+    second call sees the session and returns ``(False, "already_exists")``.
+
+    The ``reason`` is recorded on the audit event so the watchdog can
+    distinguish bootstrap-time provisioning from on-demand catch-up.
+    Set ``launch=False`` from contexts where the supervisor will launch
+    the new session itself (e.g. bootstrap, where ``plan_launches``
+    will pick up the session config and ``_bootstrap_launches`` will
+    create the window).
+    """
+    try:
+        from pollypm.config import load_config
+    except Exception as exc:  # noqa: BLE001
+        return False, f"import failed: {exc}"
+
+    try:
+        config = load_config(config_path)
+    except Exception as exc:  # noqa: BLE001
+        return False, f"load_config failed: {exc}"
+
+    project = getattr(config, "projects", {}).get(project_key)
+    if project is None:
+        return False, f"unknown project: {project_key}"
+
+    project_path = getattr(project, "path", None)
+
+    existing = _existing_reviewer_session(config, project_key)
+    if existing is not None:
+        return False, f"already_exists:{existing.name}"
+
+    # Mirror the no_session_spawn path: route through ``create_worker_session``
+    # with role="reviewer" so account routing, worktree provisioning, and
+    # window-name conventions all match the existing reviewer/architect
+    # creation paths.
+    try:
+        from pollypm.workers import create_worker_session, launch_worker_session
+    except Exception as exc:  # noqa: BLE001
+        return False, f"import workers failed: {exc}"
+
+    try:
+        session = create_worker_session(
+            config_path,
+            project_key=project_key,
+            prompt=None,
+            role="reviewer",
+        )
+    except Exception as exc:  # noqa: BLE001
+        _emit_provisioned(
+            project=project_key,
+            role="reviewer",
+            reason=reason,
+            session_name=f"reviewer_{project_key}",
+            project_path=project_path,
+            status="error",
+            detail=f"create_worker_session failed: {exc}",
+        )
+        return False, f"create_worker_session failed: {exc}"
+
+    launched_ok = True
+    launch_error: str | None = None
+    if launch:
+        try:
+            launch_worker_session(config_path, session.name)
+        except Exception as exc:  # noqa: BLE001
+            launched_ok = False
+            launch_error = str(exc)
+            logger.info(
+                "reviewer_provisioning: %s registered but not launched (%s). "
+                "Heartbeat / no_session recovery will pick it up.",
+                session.name, exc,
+            )
+
+    _emit_provisioned(
+        project=project_key,
+        role="reviewer",
+        reason=reason,
+        session_name=session.name,
+        project_path=project_path,
+        status="ok" if launched_ok else "warn",
+        detail=(
+            f"session={session.name}"
+            if launched_ok
+            else f"session={session.name} launch_error={launch_error}"
+        ),
+    )
+    return True, f"session={session.name}"
+
+
+def ensure_reviewer_sessions_for_tracked_projects(
+    config_path: Path,
+    *,
+    launch: bool = False,
+) -> list[tuple[str, bool, str]]:
+    """Sweep every tracked project and ensure a reviewer session exists.
+
+    Called from :meth:`Supervisor.bootstrap_tmux` BEFORE ``plan_launches``
+    so any newly-registered reviewer session is included in the bootstrap
+    launch plan. ``launch`` defaults to False at bootstrap because
+    ``_bootstrap_launches`` will create the window from ``plan_launches``.
+
+    Returns ``[(project_key, created, detail), ...]`` for the caller to
+    log / aggregate. Per-project failures are recorded as
+    ``(project_key, False, "<error>")`` and don't abort the sweep —
+    one broken project must not block reviewer provisioning for the
+    rest of the workspace.
+    """
+    try:
+        from pollypm.config import load_config
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "reviewer_provisioning: load_config import failed: %s", exc,
+        )
+        return []
+
+    try:
+        config = load_config(config_path)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "reviewer_provisioning: load_config failed: %s", exc,
+        )
+        return []
+
+    results: list[tuple[str, bool, str]] = []
+    projects = getattr(config, "projects", {})
+    for project_key, project in projects.items():
+        if not getattr(project, "tracked", True):
+            # Untracked projects opt out of the auto-provision sweep
+            # (matches the cockpit visibility model — see
+            # project_v1_tag and tracked_filter_asymmetry notes).
+            results.append((project_key, False, "not_tracked"))
+            continue
+        try:
+            created, detail = ensure_reviewer_session_for_project(
+                config_path,
+                project_key,
+                reason=REASON_BOOTSTRAP,
+                launch=launch,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "reviewer_provisioning: ensure failed for %s: %s",
+                project_key, exc,
+            )
+            results.append((project_key, False, f"error:{exc}"))
+            continue
+        results.append((project_key, created, detail))
+    return results
+
+
+__all__ = [
+    "REASON_BOOTSTRAP",
+    "REASON_ON_DEMAND_REVIEW",
+    "ensure_reviewer_session_for_project",
+    "ensure_reviewer_sessions_for_tracked_projects",
+]

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -760,12 +760,26 @@ class Supervisor:
         session_name = self.config.project.tmux_session
         existing = [name for name in self._all_tmux_session_names() if self.session_service.tmux.has_session(name)]
         if existing:
-            # Sessions already running — reconcile instead of failing
+            # Sessions already running — reconcile instead of failing.
+            # Auto-provision reviewer rows BEFORE reconcile so any
+            # tracked project missing a reviewer session gets one in
+            # this pass (#1413). The reconcile path's ``plan_launches``
+            # call below picks up the new session config.
+            self._ensure_tracked_reviewer_sessions()
             return self._reconcile_existing(session_name, on_status=on_status)
 
         # Clear stale markers BEFORE plan_launches so launch commands don't
         # use --continue from a previous run's resume markers.
         self._bootstrap_clear_markers()
+
+        # #1413 — auto-provision reviewer sessions for every tracked
+        # project before plan_launches reads the session table.
+        # ``savethenovel`` shipped without a reviewer because nothing in
+        # the bootstrap path mirrored the architect auto-spawn (#257) for
+        # the reviewer role; the first task to land at code_review sat
+        # there forever. Workers stay per-task (not bootstrap-time);
+        # reviewers are long-lived per-project, like architects.
+        self._ensure_tracked_reviewer_sessions()
 
         failures: list[str] = []
         for controller_account in self._controller_candidates():
@@ -797,6 +811,81 @@ class Supervisor:
                         self.session_service.tmux.kill_session(tmux_session)
 
         raise RuntimeError("PollyPM could not launch any controller account: " + "; ".join(failures))
+
+    def _ensure_tracked_reviewer_sessions(self) -> None:
+        """Auto-provision a reviewer session for every tracked project (#1413).
+
+        Mirrors the architect auto-spawn (#257) but at supervisor
+        bootstrap rather than ``pm project new``. Every project with
+        ``tracked=True`` and no enabled reviewer session in config gets
+        a fresh ``reviewer_<project>`` SessionConfig added so the
+        downstream ``plan_launches`` call sees it. Idempotent — projects
+        whose reviewer already exists are left alone.
+
+        The actual launch is handled by ``_bootstrap_launches`` /
+        ``_reconcile_existing`` which iterate ``plan_launches()`` after
+        this hook runs. We don't launch here to avoid duplicating
+        launch wiring for the bootstrap path; the on-demand path
+        (``ensure_reviewer_session_for_project``) launches inline
+        because it runs after bootstrap and the supervisor is already
+        live.
+
+        Best-effort: a per-project failure logs and continues to the
+        next project so a single misconfigured account can't block the
+        whole workspace boot.
+        """
+        try:
+            from pollypm.recovery.reviewer_provisioning import (
+                ensure_reviewer_sessions_for_tracked_projects,
+            )
+            from pollypm.config import DEFAULT_CONFIG_PATH
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "reviewer auto-provision: import failed", exc_info=True,
+            )
+            return
+        # The supervisor doesn't carry the config path it was loaded
+        # from (config object is detached after construction). Mirror
+        # the no_session_spawn fallback: prefer ``self.config.config_path``
+        # if a future refactor adds it, otherwise resolve via the
+        # workspace default.
+        cfg_path = getattr(self.config, "config_path", None)
+        if cfg_path is None:
+            cfg_path = DEFAULT_CONFIG_PATH
+        try:
+            results = ensure_reviewer_sessions_for_tracked_projects(
+                cfg_path, launch=False,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "reviewer auto-provision: bootstrap sweep failed",
+                exc_info=True,
+            )
+            return
+        # Refresh the in-memory config so plan_launches sees the new
+        # sessions registered in the on-disk config. ``write_config``
+        # invalidates ``_config_cache`` via mtime, but our ``self.config``
+        # was loaded before this sweep ran.
+        created_count = sum(1 for _, created, _ in results if created)
+        if created_count:
+            try:
+                from pollypm.config import load_config
+
+                refreshed = load_config(cfg_path)
+                self.config = refreshed
+                # Drop the cached launch plan so the new reviewer
+                # sessions appear in the next plan_launches() call.
+                self.invalidate_launch_cache()
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "reviewer auto-provision: config refresh failed",
+                    exc_info=True,
+                )
+            logger.info(
+                "reviewer auto-provision: provisioned %d reviewer "
+                "session(s) at bootstrap (results=%s)",
+                created_count, results,
+            )
 
     def _bootstrap_clear_markers(self) -> None:
         """Clear stale session markers so all sessions start fresh."""

--- a/src/pollypm/work/service_transition_manager.py
+++ b/src/pollypm/work/service_transition_manager.py
@@ -1137,12 +1137,66 @@ class WorkTransitionManager:
                             exc,
                         )
                 self.service._on_task_done(task_id, actor)
+            elif result.work_status == WorkStatus.REVIEW:
+                # #1413 — when a worker finishes a node and the task
+                # advances to a review node, make sure the project has
+                # a reviewer session ready to consume the queue. The
+                # bootstrap sweep handles fresh-boot tracked projects;
+                # this hook catches projects registered AFTER bootstrap
+                # (or whose reviewer session was manually torn down)
+                # without waiting for the heartbeat's 60s threshold.
+                self._ensure_reviewer_for_review_handoff(result)
 
         return self._finish(
             task_id,
             task.work_status.value,
             after_reload=_before_sync,
         )
+
+    def _ensure_reviewer_for_review_handoff(self, task: Task) -> None:
+        """Fire-and-forget provision of a reviewer session for ``task.project``.
+
+        Called from ``complete_node`` when the task transitions to
+        ``review``. Mirrors the worker provision hook in :meth:`claim`
+        (which calls ``self.service._session_mgr.provision_worker``).
+        Reviewer provisioning lives in
+        :mod:`pollypm.recovery.reviewer_provisioning` because it operates
+        on the long-lived per-project reviewer lane (config-level), not
+        per-task tmux windows like worker provisioning.
+
+        Best-effort: any failure is logged and swallowed — the task is
+        already in REVIEW state and the heartbeat's no_session recovery
+        catches stragglers within ~60s. We log so the audit trail
+        records the attempt, and we never block the transition path.
+        """
+        try:
+            from pollypm.config import DEFAULT_CONFIG_PATH
+            from pollypm.recovery.reviewer_provisioning import (
+                ensure_reviewer_session_for_project,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "complete_node: reviewer provisioning import failed",
+                exc_info=True,
+            )
+            return
+        try:
+            created, detail = ensure_reviewer_session_for_project(
+                DEFAULT_CONFIG_PATH,
+                task.project,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "complete_node: ensure_reviewer_session failed for %s: %s",
+                task.project, exc,
+            )
+            return
+        if created:
+            logger.info(
+                "complete_node: provisioned reviewer session for %s "
+                "on review handoff (%s)",
+                task.project, detail,
+            )
 
     def approve(
         self,

--- a/tests/test_reviewer_provisioning.py
+++ b/tests/test_reviewer_provisioning.py
@@ -1,0 +1,322 @@
+"""Tests for reviewer auto-provisioning (#1413).
+
+Three load-bearing behaviours covered:
+
+1. **Bootstrap sweep** — ``ensure_reviewer_sessions_for_tracked_projects``
+   provisions a ``reviewer_<project>`` SessionConfig for every tracked
+   project that doesn't already have one. Untracked projects are left
+   alone (matches the cockpit visibility model — tracked projects are
+   the ones the watchdog cares about).
+
+2. **On-demand provision** — ``ensure_reviewer_session_for_project``
+   creates a reviewer session when called for a project that lacks one,
+   and emits a ``session.provisioned`` audit event so the watchdog
+   (#1414) can quantify provisioning activity.
+
+3. **Idempotency** — running the bootstrap sweep twice does NOT create
+   two reviewer sessions for the same project. The second pass is a
+   no-op.
+
+The bootstrap-time test deliberately uses the real ``register_project``
++ ``create_worker_session`` helpers so we exercise the full config-write
+path instead of a happy-path stub. Mock seams (``_spawn``-style
+parameters) live in ``test_no_session_auto_recovery.py``; this file
+proves the integration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pollypm.recovery.reviewer_provisioning as rp
+from pollypm.audit.log import EVENT_SESSION_PROVISIONED
+from pollypm.config import write_config
+from pollypm.models import (
+    AccountConfig,
+    KnownProject,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectKind,
+    ProjectSettings,
+    ProviderKind,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_repo(tmp_path: Path, name: str) -> Path:
+    repo = tmp_path / name
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    # ``ensure_project_scaffold`` will create ``.pollypm/`` under each
+    # registered repo; pre-create it so the audit emit's per-project
+    # log path exists for our assertions.
+    (repo / ".pollypm").mkdir(parents=True, exist_ok=True)
+    return repo
+
+
+def _write_config_with_projects(
+    tmp_path: Path,
+    *,
+    projects: dict[str, tuple[Path, bool]],
+) -> Path:
+    """Build a PollyPMConfig with one account and the given projects.
+
+    ``projects`` maps project_key -> (path, tracked).
+    """
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            workspace_root=tmp_path,
+            base_dir=tmp_path / ".pollypm",
+            logs_dir=tmp_path / ".pollypm/logs",
+            snapshots_dir=tmp_path / ".pollypm/snapshots",
+            state_db=tmp_path / ".pollypm/state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account="claude_1"),
+        accounts={
+            "claude_1": AccountConfig(
+                name="claude_1",
+                provider=ProviderKind.CLAUDE,
+                email="c@example.com",
+                home=tmp_path / ".pollypm/homes/claude_1",
+            ),
+        },
+        sessions={},
+        projects={
+            key: KnownProject(
+                key=key,
+                path=path,
+                name=key,
+                persona_name="",
+                kind=ProjectKind.FOLDER,
+                tracked=tracked,
+            )
+            for key, (path, tracked) in projects.items()
+        },
+    )
+    config_path = tmp_path / "pollypm.toml"
+    write_config(config, config_path, force=True)
+    return config_path
+
+
+# ---------------------------------------------------------------------------
+# 1. Bootstrap sweep provisions a reviewer per tracked project
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_sweep_provisions_reviewer_for_tracked_project(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A tracked project with no reviewer session at boot gets one.
+
+    Uses the real ``ensure_reviewer_session_for_project`` path (which
+    routes through ``create_worker_session``) so we exercise the full
+    config-write contract, not a stub. The launch step is suppressed
+    via ``launch=False`` (the real bootstrap path delegates launch to
+    ``_bootstrap_launches`` via ``plan_launches``)."""
+    repo = _make_repo(tmp_path, "savethenovel")
+    config_path = _write_config_with_projects(
+        tmp_path, projects={"savethenovel": (repo, True)},
+    )
+
+    # Suppress the real worktree creation — this test exercises the
+    # config-write idempotency contract, not git-worktree plumbing.
+    # ``ensure_worktree`` is the only collaborator we don't want to run
+    # for real (it shells out to git and writes under the repo).
+    import pollypm.workers as workers_mod
+
+    monkeypatch.setattr(workers_mod, "ensure_worktree", lambda *a, **kw: None)
+    monkeypatch.setattr(workers_mod, "detect_logged_in", lambda account: True)
+
+    results = rp.ensure_reviewer_sessions_for_tracked_projects(
+        config_path, launch=False,
+    )
+
+    # One project, one created session, detail names the session.
+    assert len(results) == 1
+    project_key, created, detail = results[0]
+    assert project_key == "savethenovel"
+    assert created is True
+    assert detail.startswith("session=reviewer_savethenovel"), detail
+
+    # The on-disk config now carries the reviewer session.
+    from pollypm.config import load_config
+    config = load_config(config_path)
+    reviewer_sessions = [
+        s for s in config.sessions.values()
+        if s.role == "reviewer" and s.project == "savethenovel"
+    ]
+    assert len(reviewer_sessions) == 1
+    assert reviewer_sessions[0].name == "reviewer_savethenovel"
+    assert reviewer_sessions[0].window_name == "reviewer-savethenovel"
+
+
+def test_bootstrap_sweep_skips_untracked_projects(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Untracked projects are left alone — they opt out of the cockpit
+    visibility model and shouldn't burn account routing on a session
+    nobody monitors."""
+    repo_tracked = _make_repo(tmp_path, "tracked_proj")
+    repo_untracked = _make_repo(tmp_path, "untracked_proj")
+    config_path = _write_config_with_projects(
+        tmp_path,
+        projects={
+            "tracked_proj": (repo_tracked, True),
+            "untracked_proj": (repo_untracked, False),
+        },
+    )
+
+    import pollypm.workers as workers_mod
+    monkeypatch.setattr(workers_mod, "ensure_worktree", lambda *a, **kw: None)
+    monkeypatch.setattr(workers_mod, "detect_logged_in", lambda account: True)
+
+    results = rp.ensure_reviewer_sessions_for_tracked_projects(
+        config_path, launch=False,
+    )
+
+    by_project = {key: (created, detail) for key, created, detail in results}
+    assert by_project["tracked_proj"][0] is True
+    assert by_project["untracked_proj"] == (False, "not_tracked")
+
+    from pollypm.config import load_config
+    config = load_config(config_path)
+    reviewer_for_untracked = [
+        s for s in config.sessions.values()
+        if s.role == "reviewer" and s.project == "untracked_proj"
+    ]
+    assert reviewer_for_untracked == [], (
+        "Untracked projects must not get a reviewer session"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. On-demand provisioning fires when a task hits code_review
+# ---------------------------------------------------------------------------
+
+
+def test_on_demand_provision_creates_session_and_emits_audit_event(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A task hitting ``code_review`` with no reviewer session triggers
+    a fresh provision and emits a ``session.provisioned`` audit event
+    with role/project/reason metadata so the watchdog (#1414) can
+    surface provisioning activity."""
+    repo = _make_repo(tmp_path, "demo")
+    config_path = _write_config_with_projects(
+        tmp_path, projects={"demo": (repo, True)},
+    )
+
+    import pollypm.workers as workers_mod
+    monkeypatch.setattr(workers_mod, "ensure_worktree", lambda *a, **kw: None)
+    monkeypatch.setattr(workers_mod, "detect_logged_in", lambda account: True)
+
+    # Capture emitted audit events so we can assert on shape.
+    captured: list[dict[str, Any]] = []
+
+    def fake_emit(**kwargs: Any) -> None:
+        captured.append(kwargs)
+
+    monkeypatch.setattr("pollypm.audit.emit", fake_emit)
+
+    created, detail = rp.ensure_reviewer_session_for_project(
+        config_path, "demo", launch=False,
+    )
+    assert created is True
+    assert detail == "session=reviewer_demo"
+
+    # Audit event was emitted with the right shape.
+    provisioned_events = [
+        e for e in captured if e.get("event") == EVENT_SESSION_PROVISIONED
+    ]
+    assert len(provisioned_events) == 1
+    event = provisioned_events[0]
+    assert event["project"] == "demo"
+    assert event["status"] == "ok"
+    assert event["subject"] == "reviewer_demo"
+    assert event["metadata"]["role"] == "reviewer"
+    assert event["metadata"]["project"] == "demo"
+    # On-demand reason — the default for ensure_reviewer_session_for_project.
+    assert event["metadata"]["reason"] == rp.REASON_ON_DEMAND_REVIEW
+
+
+def test_on_demand_provision_idempotent_when_session_exists(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A second call for the same project is a no-op."""
+    repo = _make_repo(tmp_path, "demo")
+    config_path = _write_config_with_projects(
+        tmp_path, projects={"demo": (repo, True)},
+    )
+
+    import pollypm.workers as workers_mod
+    monkeypatch.setattr(workers_mod, "ensure_worktree", lambda *a, **kw: None)
+    monkeypatch.setattr(workers_mod, "detect_logged_in", lambda account: True)
+
+    first_created, _ = rp.ensure_reviewer_session_for_project(
+        config_path, "demo", launch=False,
+    )
+    assert first_created is True
+
+    second_created, second_detail = rp.ensure_reviewer_session_for_project(
+        config_path, "demo", launch=False,
+    )
+    assert second_created is False
+    assert second_detail.startswith("already_exists:")
+
+    # Still exactly one reviewer session in config.
+    from pollypm.config import load_config
+    config = load_config(config_path)
+    reviewer_sessions = [
+        s for s in config.sessions.values()
+        if s.role == "reviewer" and s.project == "demo"
+    ]
+    assert len(reviewer_sessions) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Idempotent bootstrap — running twice doesn't create duplicates
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_sweep_is_idempotent(tmp_path: Path, monkeypatch) -> None:
+    """Running the bootstrap sweep twice doesn't double-provision.
+
+    This is the load-bearing guard against the failure mode where a
+    cockpit restart re-runs ``bootstrap_tmux`` and accidentally adds a
+    second ``reviewer_<project>_2`` session to the config. The second
+    pass must be a pure no-op."""
+    repo = _make_repo(tmp_path, "savethenovel")
+    config_path = _write_config_with_projects(
+        tmp_path, projects={"savethenovel": (repo, True)},
+    )
+
+    import pollypm.workers as workers_mod
+    monkeypatch.setattr(workers_mod, "ensure_worktree", lambda *a, **kw: None)
+    monkeypatch.setattr(workers_mod, "detect_logged_in", lambda account: True)
+
+    first = rp.ensure_reviewer_sessions_for_tracked_projects(
+        config_path, launch=False,
+    )
+    second = rp.ensure_reviewer_sessions_for_tracked_projects(
+        config_path, launch=False,
+    )
+
+    # First pass created the session, second pass is a no-op.
+    assert first[0][1] is True, first
+    assert second[0][1] is False, second
+    assert second[0][2].startswith("already_exists:"), second
+
+    # Exactly one reviewer session in config after both passes.
+    from pollypm.config import load_config
+    config = load_config(config_path)
+    reviewer_sessions = [
+        s for s in config.sessions.values()
+        if s.role == "reviewer" and s.project == "savethenovel"
+    ]
+    assert len(reviewer_sessions) == 1


### PR DESCRIPTION
Closes #1413.

<details>
<summary>Why</summary>

`savethenovel` was registered with `tracked=true`, got an architect session (auto-spawned at `pm project new` via `_auto_spawn_architect`, #257) and a worker (auto-provisioned per-task on claim via `SessionManager.provision_worker`). But its `reviewer-savethenovel` session was never created — so the first task to land at `code_review` (savethenovel/10) sat there forever, dependency-blocking every successor task (/11–/17).

Reviewer was the missing leg of the auto-provision triangle. This PR adds it without touching the architect or worker paths.
</details>

<details>
<summary>Changes</summary>

**New module: `src/pollypm/recovery/reviewer_provisioning.py`**
- `ensure_reviewer_session_for_project(config_path, project_key, *, reason, launch)` — idempotent provision; routes through `create_worker_session(role="reviewer")` so account routing / worktree provisioning / window-name conventions all match existing reviewer creation paths.
- `ensure_reviewer_sessions_for_tracked_projects(config_path, *, launch=False)` — bootstrap-time sweep over tracked projects; per-project failures don't abort the sweep.
- Emits `session.provisioned` audit event with `{role, project, reason}` metadata (consumed by watchdog #1414).

**Bootstrap hook: `Supervisor._ensure_tracked_reviewer_sessions`**
- Called from `bootstrap_tmux` BEFORE `plan_launches` reads the session table — so newly registered reviewer sessions appear in the bootstrap launch plan.
- Refreshes `self.config` and invalidates `launch_planner` cache when sessions were added.
- Also wired into the `_reconcile_existing` path so a cockpit reconcile catches newly tracked projects.

**On-demand hook: `service_transition_manager._ensure_reviewer_for_review_handoff`**
- Fires from `complete_node`'s `_before_sync` when the transition lands the task in `REVIEW` status.
- Best-effort, fire-and-forget: any failure is logged and swallowed; the heartbeat's existing `no_session` recovery (#1005) catches stragglers within ~60s.

**Audit event: `EVENT_SESSION_PROVISIONED = "session.provisioned"`**
- New stable event name in `pollypm/audit/log.py`. Metadata carries `{role, project, reason, detail}` where `reason ∈ {"bootstrap", "on_demand_review"}`.

**Tests: `tests/test_reviewer_provisioning.py`** (5 tests, all passing)
- Bootstrap sweep provisions a reviewer for a tracked project at boot.
- Bootstrap sweep skips untracked projects.
- On-demand provision creates the session and emits the audit event with the correct metadata.
- On-demand is idempotent when a session already exists.
- Bootstrap sweep is idempotent — running it twice doesn't double-provision.
</details>

<details>
<summary>Hard-constraint compliance</summary>

- Did NOT touch live cockpit. No `pm up`, `pm reset`, `tmux switch-client`, etc.
- Did NOT modify existing worker provisioning (`SessionManager.provision_worker` and friends are untouched).
- Did NOT run wide filesystem scans.
- All tool calls under 120s aliveness window.
- Tests run via `uv run --with pytest python -m pytest …`; no global package state mutated.
</details>

## Test plan

- [x] `pytest tests/test_reviewer_provisioning.py` (5/5 passing)
- [x] `pytest tests/test_architect_bootstrap.py tests/test_no_session_auto_recovery.py` (22/22 passing — regression guard for the architect path the new bootstrap hook sits next to, and the existing reviewer auto-recovery from #1005)
- [x] `pytest -k "supervisor or bootstrap or complete_node or transition_manager or session_manager"` (246/246 passing)
- [x] `pytest -k "work_service or transition or task_done or complete_node or work_status"` (181/181 passing)
- [ ] Manual verification on next `pm up` cycle — savethenovel should grow a `reviewer-savethenovel` window in the storage closet, and savethenovel/10 should leave `code_review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)