### PR TITLE
Auto-unstick dispatch: submit brief to architect (press_enter=True)

### DIFF
--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -206,19 +206,31 @@ def _send_brief_to_architect(
 ) -> bool:
     """Best-effort tmux send-keys of the brief to the architect window.
 
-    Returns True on success. The brief is sent as multiple lines —
-    each line followed by a literal Enter — so the architect's chat
-    surface treats it as a single user turn ending with Enter.
+    Returns True on success. The brief is sent as a single text blob
+    followed by Enter so the architect agent (Codex/Claude) actually
+    processes the turn — agents don't act on their input buffer until
+    Enter lands.
+
+    #1420: previously called ``send_keys(..., press_enter=False)`` on
+    the rationale that the architect should "review before submitting"
+    (mirroring ``_perform_pm_dispatch``'s human-gated semantics). But
+    ``_perform_pm_dispatch`` is for *user-initiated* cockpit dispatches
+    where a human finalizes the send; here the receiver is an agent,
+    so the brief sat in the prompt indefinitely until a human pressed
+    Enter — undermining auto-unstick's "no user intervention" framing.
+
+    The Enter is delivered by ``TmuxClient.send_keys`` after a 500ms
+    settle delay on the paste-buffer path, mirroring the supervisor
+    primer (``cockpit_rail.py`` ``_maybe_prime_*``) and chat dispatch
+    convention (#1403, #1404, #1411).
     """
     try:
         from pollypm.tmux.client import TmuxClient
 
         tmux = TmuxClient()
-        # Send the brief as a single literal text blob; no Enter so the
-        # architect can review before submitting. Mirrors the cockpit's
-        # ``_perform_pm_dispatch`` semantics where the user finishes
-        # the send themselves — except here the "user" is the architect.
-        tmux.send_keys(target, brief, press_enter=False)
+        # press_enter=True so the agent submits the turn autonomously.
+        # See module-level docstring + #1420 for the rationale.
+        tmux.send_keys(target, brief, press_enter=True)
         return True
     except Exception:  # noqa: BLE001
         logger.debug(

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -1078,3 +1078,54 @@ def test_cadence_handler_skips_dispatch_for_legacy_rules(
     assert counters["dispatches_sent"] == 0
     assert counters["dispatches_throttled"] == 0
     assert sent == []
+
+
+# ---------------------------------------------------------------------------
+# #1420 — auto-unstick brief must be SUBMITTED, not just typed
+# ---------------------------------------------------------------------------
+
+
+def test_send_brief_to_architect_presses_enter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #1420.
+
+    PR #1415 originally called ``tmux.send_keys(..., press_enter=False)``,
+    so the brief sat in the architect pane's input buffer until a human
+    pressed Enter — undermining the "no user intervention" goal.
+
+    The dispatch helper must call ``send_keys`` with ``press_enter=True``
+    (or pass a positional True) so the architect agent actually processes
+    the turn.
+    """
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _send_brief_to_architect,
+    )
+
+    captured: list[dict] = []
+
+    class _FakeTmux:
+        def send_keys(
+            self, target: str, text: str, press_enter: bool = True,
+        ) -> None:
+            captured.append(
+                {"target": target, "text": text, "press_enter": press_enter},
+            )
+
+    # Patch the import inside the helper so it picks up our fake.
+    import pollypm.tmux.client as tmux_mod
+
+    monkeypatch.setattr(tmux_mod, "TmuxClient", _FakeTmux)
+
+    ok = _send_brief_to_architect(
+        "pollypm-storage-closet:architect-savethenovel",
+        "WATCHDOG ESCALATION ...",
+    )
+    assert ok is True
+    assert len(captured) == 1
+    call = captured[0]
+    assert call["target"] == "pollypm-storage-closet:architect-savethenovel"
+    assert call["press_enter"] is True, (
+        "Auto-unstick must submit the brief (press_enter=True); otherwise "
+        "the architect agent never processes it. See issue #1420."
+    )


### PR DESCRIPTION
Closes #1420.

## Problem

PR #1415 (auto-unstick architect dispatch) sent the watchdog brief with `tmux.send_keys(target, brief, press_enter=False)`, on the rationale that it mirrored `_perform_pm_dispatch`. But `_perform_pm_dispatch` is for **user-initiated** cockpit dispatches where a human finalizes the send. Here the receiver is the architect **agent** (Codex/Claude) — agents don't act on their input buffer until Enter lands.

Reviewer of #1415 had to press Enter manually during the demo for the brief to be processed. That contradicts auto-unstick's "no user intervention" framing.

## Fix

`src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py:_send_brief_to_architect` now calls `send_keys(..., press_enter=True)`, matching the supervisor primer convention (`cockpit_rail.py:3128, 3172`). The existing `TmuxClient.send_keys` helper already includes a 500ms settle delay between paste-buffer load and Enter, so no extra safeguard is needed at the call site.

Updated the docstring to call out the #1420 rationale so a future reader doesn't revert this for the same "review before submit" reason.

## Regression test

`tests/test_audit_watchdog.py::test_send_brief_to_architect_presses_enter` patches `TmuxClient` and asserts `press_enter is True`. Will fail loudly if anyone flips it back.

## Test plan

- [x] `pytest tests/test_audit_watchdog.py` — 43 passed
- [x] Grep for other `press_enter=False` callsites — all are human-typing context (cockpit UI prefill, supervisor "2" key send), not agent dispatch. Convention preserved.

<details>
<summary>Files changed</summary>

- `src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py` (callsite at line ~221 → `press_enter=True`; expanded docstring)
- `tests/test_audit_watchdog.py` (new `test_send_brief_to_architect_presses_enter`)

</details>

Generated with [Claude Code](https://claude.com/claude-code)