### PR TITLE
Watchdog: escalate on_hold tasks to architect (default first-responder)

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -83,6 +83,9 @@ __all__ = [
     "RULE_TASK_REVIEW_STALE",
     "RULE_ROLE_SESSION_MISSING",
     "RULE_WORKER_SESSION_DEAD_LOOP",
+    "RULE_TASK_ON_HOLD_STALE",
+    "ON_HOLD_HUMAN_NEEDED_TAG",
+    "ON_HOLD_ARCHITECT_TAG",
     "scan_events",
     "scan_project",
     "emit_heartbeat_tick",
@@ -115,6 +118,23 @@ RULE_CANCEL_NO_PROMOTION = "cancellation_no_promotion"
 RULE_TASK_REVIEW_STALE = "task_review_stale"
 RULE_ROLE_SESSION_MISSING = "role_session_missing"
 RULE_WORKER_SESSION_DEAD_LOOP = "worker_session_dead_loop"
+# #1424 — task_on_hold_stale catches the savethenovel/11 pattern where
+# the reviewer transitions a task to status=on_hold (instead of reject),
+# parking it for a human. The watchdog used to go silent on on_hold
+# because ``task_review_stale`` only matches status=review. The new rule
+# escalates to the architect by default — the architect re-assesses the
+# reviewer's findings and either fixes them or, if the issue genuinely
+# requires human judgement, calls ``pm notify`` itself.
+RULE_TASK_ON_HOLD_STALE = "task_on_hold_stale"
+
+# Reason-string tags reviewers use to hint the watchdog routing. The
+# default (no tag) is architect-actionable. ``ON_HOLD_HUMAN_NEEDED_TAG``
+# is reserved for cases that genuinely need a product/taste call from
+# the user; the dispatch path can escalate to user directly when it
+# spots this prefix. The strings are matched case-insensitively against
+# the leading characters of the on_hold transition reason.
+ON_HOLD_ARCHITECT_TAG = "architect-actionable"
+ON_HOLD_HUMAN_NEEDED_TAG = "human-needed"
 
 # Throttle window for the dispatch path. We re-fire findings on every
 # tick (the audit log is forensic and operators want repeat counts),
@@ -178,6 +198,13 @@ class WatchdogConfig:
     # most recent transition older than this before we fire. 30 min
     # mirrors the savethenovel/10 case (reviewer agent never spawned).
     review_stale_seconds: int = 1800
+    # #1424 — task_on_hold_stale: a task at status=on_hold for longer
+    # than this triggers the architect-first escalation. Defaults to
+    # 15 min — shorter than ``review_stale_seconds`` because on_hold is
+    # supposed to be a brief routing detour (reviewer can't decide,
+    # parks task), not a sustained state. Anything longer than the
+    # cadence-tick stride means a human is now load-bearing.
+    on_hold_stale_seconds: int = 900
     # #1414 — worker_session_dead_loop: how many reaper events for the
     # same task within ``dead_loop_window_seconds`` count as a loop.
     dead_loop_threshold: int = 3
@@ -605,6 +632,108 @@ def _detect_task_review_stale(
     return findings
 
 
+def _classify_on_hold_reason(reason: str | None) -> str:
+    """Return ``architect-actionable`` or ``human-needed`` based on the reason.
+
+    Reviewers tag on_hold transitions with a leading routing hint so the
+    watchdog can decide whether the architect or the user should be the
+    first responder. The match is case-insensitive and tolerant of
+    surrounding punctuation (``"[human-needed] copy approval"`` works).
+    Default routing is architect-actionable because that's what #1424
+    sets as the post-mortem default — the architect can always escalate
+    upward, but parking on the human is the failure mode.
+    """
+    if not reason:
+        return ON_HOLD_ARCHITECT_TAG
+    head = reason.strip().lower()
+    if head.startswith(ON_HOLD_HUMAN_NEEDED_TAG.lower()):
+        return ON_HOLD_HUMAN_NEEDED_TAG
+    # ``[architect-actionable] ...`` and bare ``architect-actionable: ...``
+    # both collapse to the architect default. Anything else also defaults
+    # to architect — the reviewer just didn't tag it.
+    if head.startswith("[" + ON_HOLD_HUMAN_NEEDED_TAG.lower()):
+        return ON_HOLD_HUMAN_NEEDED_TAG
+    return ON_HOLD_ARCHITECT_TAG
+
+
+def _detect_task_on_hold_stale(
+    events: Sequence[AuditEvent],
+    *,
+    now: datetime,
+    config: WatchdogConfig,
+) -> list[Finding]:
+    """Rule 5b (#1424): task at ``status=on_hold`` for > threshold.
+
+    Mirrors :func:`_detect_task_review_stale` — pick the latest
+    transition per task subject. If the latest transition lands the
+    task in ``on_hold`` and is older than ``on_hold_stale_seconds``,
+    fire. The reviewer's transition reason is included in the finding
+    metadata so the brief generator can surface it to the architect.
+
+    The two rules are intentionally separate (different windows,
+    different routing). The architect-vs-human routing hint is computed
+    here from the reason tag and stored under ``routing`` in metadata
+    so the cadence handler can read it without re-parsing the reason.
+    """
+    findings: list[Finding] = []
+    cutoff = now - timedelta(seconds=config.on_hold_stale_seconds)
+
+    # subject -> (latest_ts, ev) — pick the latest transition per task.
+    latest: dict[str, tuple[datetime, AuditEvent]] = {}
+    for ev in events:
+        if ev.event != EVENT_TASK_STATUS_CHANGED:
+            continue
+        ts = _parse_iso(ev.ts)
+        if ts is None:
+            continue
+        prior = latest.get(ev.subject)
+        if prior is None or ts > prior[0]:
+            latest[ev.subject] = (ts, ev)
+
+    for subject, (ts, ev) in latest.items():
+        meta = ev.metadata or {}
+        to_state = meta.get("to")
+        if to_state != "on_hold":
+            continue
+        if ts > cutoff:
+            # Fresh on_hold — give the reviewer / architect a beat.
+            continue
+        key = _task_subject_key(subject)
+        if key is None:
+            continue
+        project, _ = key
+        stuck_minutes = max(1, int((now - ts).total_seconds() // 60))
+        reason = meta.get("reason")
+        routing = _classify_on_hold_reason(
+            reason if isinstance(reason, str) else None,
+        )
+        findings.append(Finding(
+            rule=RULE_TASK_ON_HOLD_STALE,
+            project=project,
+            subject=subject,
+            message=(
+                f"Task {subject} has been at status=on_hold for "
+                f"~{stuck_minutes} min — escalating to architect for "
+                f"first-responder unstick."
+            ),
+            recommendation=(
+                f"Architect: re-read the reviewer's rationale, fix the "
+                f"issue, then `pm task queue {subject}`. Only escalate "
+                f"to user via `pm notify` if the issue genuinely needs "
+                f"human judgement."
+            ),
+            metadata={
+                "on_hold_since": ev.ts,
+                "stuck_minutes": stuck_minutes,
+                "from": meta.get("from"),
+                "reason": reason if isinstance(reason, str) else None,
+                "routing": routing,
+                "actor": ev.actor,
+            },
+        ))
+    return findings
+
+
 def _detect_role_session_missing(
     events: Sequence[AuditEvent],
     *,
@@ -807,6 +936,9 @@ def scan_events(
         materialised, now=now, config=config,
     ))
     findings.extend(_detect_task_review_stale(
+        materialised, now=now, config=config,
+    ))
+    findings.extend(_detect_task_on_hold_stale(
         materialised, now=now, config=config,
     ))
     findings.extend(_detect_role_session_missing(
@@ -1027,7 +1159,53 @@ def format_unstick_brief(finding: Finding) -> str:
     lines.append(f"Finding: {finding.rule}")
     lines.append(f"Subject: {subject}")
 
-    if finding.rule == RULE_TASK_REVIEW_STALE:
+    if finding.rule == RULE_TASK_ON_HOLD_STALE:
+        stuck_minutes = meta.get("stuck_minutes")
+        on_hold_since = meta.get("on_hold_since")
+        from_state = meta.get("from") or "<unknown>"
+        reason = meta.get("reason")
+        routing = meta.get("routing") or ON_HOLD_ARCHITECT_TAG
+        reviewer_evidence = meta.get("reviewer_evidence") or []
+        lines.append(
+            f"Stuck for: {stuck_minutes} minutes" if stuck_minutes
+            else "Stuck for: unknown duration"
+        )
+        lines.append(f"Routing: {routing}")
+        lines.append("Observed evidence:")
+        if on_hold_since:
+            lines.append(
+                f"- Task transitioned {from_state} -> on_hold at {on_hold_since}"
+            )
+        if reason:
+            lines.append(f"- Reviewer rationale: {reason}")
+        else:
+            lines.append("- No transition reason was recorded.")
+        if reviewer_evidence:
+            lines.append("- Recent reviewer evidence:")
+            for entry in reviewer_evidence:
+                # Each entry is a one-line string already shaped by
+                # the cadence handler (exec row OR inbox message).
+                lines.append(f"  * {entry}")
+        else:
+            lines.append(
+                "- No additional reviewer execution rows or inbox "
+                "messages were available."
+            )
+        lines.append("")
+        lines.append(
+            "Your job (DEFAULT: fix and re-submit). Options: "
+            "(a) address the reviewer's findings yourself (fix code / "
+            f"docs / commit untracked artifacts) and run `pm task queue "
+            f"{subject}` to put the task back in the worker pool, "
+            "(b) create a sibling tracking task for a non-blocking "
+            f"finding and `pm task approve {subject}` the original, "
+            "(c) ONLY escalate to user via `pm notify --priority "
+            "immediate` if the issue genuinely needs human judgement "
+            "(product direction, taste, external info you can't "
+            "access). Parking on the user is the failure mode this "
+            "rule exists to prevent."
+        )
+    elif finding.rule == RULE_TASK_REVIEW_STALE:
         stuck_minutes = meta.get("stuck_minutes")
         review_since = meta.get("review_since")
         lines.append(

--- a/src/pollypm/plugins_builtin/core_agent_profiles/profiles.py
+++ b/src/pollypm/plugins_builtin/core_agent_profiles/profiles.py
@@ -415,19 +415,32 @@ def reviewer_prompt() -> str:
         "that should have gone back to planning — DO NOT approve and DO "
         "NOT try to reject your way around it. Escalate to Polly and park "
         "the task explicitly:\n\n"
-        '  pm task hold <id> --actor russell --reason "Waiting on operator: '
+        '  pm task hold <id> --actor russell --reason "[architect-actionable] '
         '<brief issue>"\n'
         '  pm notify --priority immediate --requester polly \\\n'
         '    "<subject>" "<body describing the concern in reviewer terms>"\n\n'
-        "``--requester polly`` routes the escalation into Polly's inbox "
-        "instead of the user's — Polly is the operator who decides "
+        "**Tag the `--reason` so the watchdog can route correctly (#1424):**\n"
+        '  - `[architect-actionable] ...` — DEFAULT. The architect can fix '
+        "this without human input (placeholder copy, untracked artifacts, "
+        "missing test, broken style, dependency to install, etc.). Use "
+        "this tag for ~90% of holds.\n"
+        '  - `[human-needed] ...` — only when the issue genuinely needs '
+        "human judgement (product direction, copy approval, taste call, "
+        "external info you can't access). Don't reach for this when "
+        "you're uncertain — the architect is a competent first responder; "
+        "let them decide whether to forward to the user.\n\n"
+        "``--requester polly`` routes the inbox notification into Polly's "
+        "queue instead of the user's — Polly is the operator who decides "
         "whether Sam needs to be pulled in, and she rewrites the body "
         "into plain-English ``--user-prompt-json`` copy before any "
         "user-facing surface sees it. Sending reviewer-jargon "
         "directly to the user inbox bypasses that translation step.\n\n"
         "Then stop. Do not leave the task at `code_review`; it should sit "
-        "in `on_hold` until Polly or Sam decides whether to resume it, "
-        "re-scope it, or spin a follow-up.\n"
+        "in `on_hold` until the watchdog dispatches the architect (default) "
+        "or, if you tagged `[human-needed]`, until Polly or Sam decides. "
+        "The auto-unstick watchdog (#1414/#1424) will pick it up within "
+        "~15 min and route to the architect's pane with your rationale "
+        "folded into the brief.\n"
         "</escalation>\n\n"
         "<plan_reviews_not_yours>\n"
         "`plan_review` items are a separate surface. They go to Sam (the "

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -34,6 +34,7 @@ from pollypm.audit.watchdog import (
     ESCALATION_THROTTLE_SECONDS,
     Finding,
     RULE_ROLE_SESSION_MISSING,
+    RULE_TASK_ON_HOLD_STALE,
     RULE_TASK_REVIEW_STALE,
     RULE_WORKER_SESSION_DEAD_LOOP,
     WATCHDOG_ALERT_TYPE,
@@ -57,6 +58,11 @@ _DISPATCHABLE_RULES: frozenset[str] = frozenset({
     RULE_TASK_REVIEW_STALE,
     RULE_ROLE_SESSION_MISSING,
     RULE_WORKER_SESSION_DEAD_LOOP,
+    # #1424 — on_hold escalation lands in the architect's pane with the
+    # reviewer's rationale folded into the brief. Default first responder
+    # is the architect; only the architect calls ``pm notify`` if the
+    # issue genuinely needs human judgement.
+    RULE_TASK_ON_HOLD_STALE,
 })
 
 
@@ -120,7 +126,13 @@ def _config_from_payload(payload: dict[str, Any]) -> WatchdogConfig:
     if not isinstance(payload, dict):
         return WatchdogConfig()
     kwargs: dict[str, int] = {}
-    for field_name in ("window_seconds", "stuck_draft_seconds", "cancel_grace_seconds"):
+    for field_name in (
+        "window_seconds",
+        "stuck_draft_seconds",
+        "cancel_grace_seconds",
+        "review_stale_seconds",
+        "on_hold_stale_seconds",
+    ):
         raw = payload.get(field_name)
         if raw is None:
             continue
@@ -244,6 +256,166 @@ def _send_brief_to_architect(
         return False
 
 
+def _gather_reviewer_evidence(
+    *,
+    project_key: str,
+    project_path: Path | None,
+    subject: str,
+    msg_store: Any,
+    limit_executions: int = 2,
+    limit_messages: int = 2,
+) -> list[str]:
+    """Collect reviewer execution rows + recent inbox messages for ``subject``.
+
+    Returns a list of one-line strings safe to embed verbatim in the
+    architect brief. Best-effort — any failure (DB unreachable, message
+    store missing) returns an empty list and the brief just says "no
+    additional reviewer evidence available". The caller treats the
+    evidence as advisory only.
+
+    The execution rows are filtered to the reviewer node (``code_review``
+    or any node whose name contains ``review``) so the architect sees
+    the rejecting verdict, not the worker's commits. Inbox messages are
+    filtered to those that mention the subject so we don't dump the
+    whole project queue into the brief.
+    """
+    evidence: list[str] = []
+
+    # 1. Recent reviewer execution rows from the work-service DB.
+    try:
+        from pollypm.work import create_work_service
+
+        with create_work_service(
+            project_path=project_path,
+            project_key=project_key,
+        ) as svc:
+            try:
+                task = svc.get(subject)
+            except Exception:  # noqa: BLE001
+                task = None
+            if task is not None:
+                # ``task.executions`` is the in-memory join the work
+                # service hydrates on read (see SQLiteWorkService._load_executions).
+                executions = list(getattr(task, "executions", None) or [])
+                # Filter to reviewer-side rows; sort newest first; cap.
+                review_rows = [
+                    ex for ex in executions
+                    if "review" in (getattr(ex, "node_id", "") or "").lower()
+                ]
+                review_rows.sort(
+                    key=lambda ex: getattr(ex, "completed_at", None)
+                    or getattr(ex, "started_at", None)
+                    or "",
+                    reverse=True,
+                )
+                for ex in review_rows[:limit_executions]:
+                    decision = getattr(ex, "decision", None)
+                    decision_value = getattr(decision, "value", decision) or "?"
+                    reason = getattr(ex, "decision_reason", None) or ""
+                    node = getattr(ex, "node_id", "") or "?"
+                    completed = getattr(ex, "completed_at", None)
+                    completed_s = (
+                        completed.isoformat() if completed is not None else "?"
+                    )
+                    line = (
+                        f"reviewer exec [{node} @ {completed_s}] "
+                        f"decision={decision_value}"
+                    )
+                    if reason:
+                        # Truncate aggressively — the brief is
+                        # already structured.
+                        clipped = reason.strip().splitlines()[0][:240]
+                        line = f"{line} reason: {clipped}"
+                    evidence.append(line)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: reviewer-execution fetch failed for %s",
+            subject, exc_info=True,
+        )
+
+    # 2. Inbox messages that reference the task subject. We use the
+    # generic ``query_messages`` surface (post-#349) and filter
+    # client-side because every persona persists messages here. The
+    # filter is deliberately permissive — anything mentioning the
+    # canonical ``project/N`` string is considered relevant.
+    try:
+        if msg_store is not None and hasattr(msg_store, "query_messages"):
+            rows = msg_store.query_messages(project=project_key) or []
+            matched: list[dict[str, Any]] = []
+            for row in rows:
+                body = (
+                    str(row.get("body") or "")
+                    + " "
+                    + str(row.get("title") or "")
+                    + " "
+                    + str(row.get("subject") or "")
+                )
+                if subject in body or row.get("subject") == subject:
+                    matched.append(row)
+            # Sort by created_at desc when available, then cap.
+            matched.sort(
+                key=lambda r: r.get("created_at") or r.get("ts") or "",
+                reverse=True,
+            )
+            for row in matched[:limit_messages]:
+                role = (
+                    row.get("requester")
+                    or row.get("actor")
+                    or row.get("from")
+                    or "?"
+                )
+                title = row.get("title") or row.get("subject") or "(no title)"
+                body = (row.get("body") or "").strip().splitlines()
+                first_line = body[0][:240] if body else ""
+                line = f"inbox msg from {role}: {title}"
+                if first_line:
+                    line = f"{line} — {first_line}"
+                evidence.append(line)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: reviewer-message fetch failed for %s",
+            subject, exc_info=True,
+        )
+
+    return evidence
+
+
+def _enrich_finding_metadata(
+    finding: Finding,
+    *,
+    project_key: str,
+    project_path: Path | None,
+    msg_store: Any,
+) -> Finding:
+    """Return a copy of ``finding`` with reviewer evidence folded in.
+
+    Only :data:`RULE_TASK_ON_HOLD_STALE` is enriched today — the brief
+    generator surfaces ``metadata['reviewer_evidence']`` for that rule.
+    Other rules are returned unchanged. We rebuild a Finding rather than
+    mutating because :class:`Finding` is frozen.
+    """
+    if finding.rule != RULE_TASK_ON_HOLD_STALE:
+        return finding
+    evidence = _gather_reviewer_evidence(
+        project_key=project_key,
+        project_path=project_path,
+        subject=finding.subject,
+        msg_store=msg_store,
+    )
+    if not evidence:
+        return finding
+    enriched_meta = {**(finding.metadata or {}), "reviewer_evidence": evidence}
+    return Finding(
+        rule=finding.rule,
+        project=finding.project,
+        subject=finding.subject,
+        severity=finding.severity,
+        message=finding.message,
+        recommendation=finding.recommendation,
+        metadata=enriched_meta,
+    )
+
+
 def _maybe_dispatch_to_architect(
     finding: Finding,
     *,
@@ -345,8 +517,18 @@ def _scan_one_project(
         # #1414 — eligible findings get an architect dispatch on top
         # of the alert. Throttle window is owned by the audit log so
         # repeat dispatches are deduped across cadence-process restarts.
-        outcome = _maybe_dispatch_to_architect(
+        # #1424 — for ``task_on_hold_stale`` we enrich the finding with
+        # the reviewer's recent execution rows + inbox messages so the
+        # architect's brief carries the rejection rationale, not just
+        # the bare on_hold timestamp.
+        dispatch_finding = _enrich_finding_metadata(
             finding,
+            project_key=project_key,
+            project_path=project_path,
+            msg_store=msg_store,
+        )
+        outcome = _maybe_dispatch_to_architect(
+            dispatch_finding,
             project_path=project_path,
             storage_closet_name=storage_closet_name,
             now=now,

--- a/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
@@ -219,9 +219,10 @@ session, the audit watchdog (#1414) has detected that a task on this
 project is wedged and is asking you — not the user — to unstick it.
 
 The brief carries: project, finding type (`task_review_stale`,
-`role_session_missing`, or `worker_session_dead_loop`), the canonical
-`<project>/<task_number>` subject, how long it has been stuck, and the
-observed evidence the watchdog used to fire.
+`task_on_hold_stale`, `role_session_missing`, or
+`worker_session_dead_loop`), the canonical `<project>/<task_number>`
+subject, how long it has been stuck, and the observed evidence the
+watchdog used to fire.
 
 Decide quickly. The default options listed in every brief are:
 
@@ -244,6 +245,45 @@ the same finding has fired three or more times despite your previous
 intervention, or the right answer changes the project's direction.
 Act unilaterally when: the fix is mechanical (spawn a missing role,
 approve a clearly-correct review, cancel an obviously-broken task).
+
+## On-hold escalation (`task_on_hold_stale`, #1424)
+
+When a brief carries finding type `task_on_hold_stale`, a reviewer
+parked the task in `status=on_hold` instead of rejecting it. **Your
+DEFAULT is to fix the issue and re-submit, NOT to forward to the
+user.** Parking on the human is the failure mode this rule exists to
+prevent.
+
+The brief's `Observed evidence` section will include:
+- The on_hold transition reason (the reviewer's verbatim rationale).
+- Recent reviewer execution rows (last 1-2 rejection / hold verdicts
+  with their `decision_reason`).
+- Inbox messages the reviewer sent that mention the task subject.
+
+Resolution menu, in order of preference:
+
+1. **Fix and re-queue.** Address the reviewer's findings yourself
+   (commit the untracked docs, replace placeholder copy, fix the
+   broken test, etc.) and run `pm task queue <subject>` so the worker
+   pool picks the task back up. This is the right move ~90% of the
+   time.
+2. **Sibling-task split.** If the reviewer's finding is real but
+   non-blocking, create a sibling tracking task (`pm task new
+   <project> --title "<follow-up>"`) AND auto-approve the original
+   with `pm task approve <subject>`. The user gets the follow-up in
+   their "things to look at later" list; the project keeps moving.
+3. **Escalate to user.** ONLY when the issue genuinely needs human
+   judgement: product direction, taste calls, copy approval, external
+   info you cannot access, credentials/auth. Use
+   `pm notify --priority immediate --user-prompt-json '{...}'` with
+   the framing from `<waiting_on_user_handoff>` so the user lands on
+   a real action card, not a raw message dump.
+
+When the brief carries `Routing: human-needed`, the reviewer
+explicitly tagged the on_hold reason as needing human input. Treat
+that as a strong hint toward option 3 — but still confirm the issue
+genuinely needs human judgement before forwarding; reviewers can be
+wrong about routing.
 
 Watchdog escalations are throttled at 30 minutes per
 `(project, finding, subject)` triple, so you have a full cycle to act

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -1283,3 +1283,474 @@ def test_gather_open_tasks_returns_empty_on_factory_failure(
     )
 
     assert _gather_open_tasks("demo", None) == []
+
+
+# ---------------------------------------------------------------------------
+# #1424 — task_on_hold_stale rule + on_hold escalation dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_task_on_hold_stale_fires_after_threshold(now: datetime) -> None:
+    """A task at status=on_hold for >threshold fires the new rule."""
+    from pollypm.audit.watchdog import RULE_TASK_ON_HOLD_STALE
+
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="savethenovel",
+            subject="savethenovel/11",
+            metadata={
+                "from": "review",
+                "to": "on_hold",
+                "reason": (
+                    "[architect-actionable] Footer.astro placeholder "
+                    "copy fails 'No placeholders'"
+                ),
+            },
+            ts=now - timedelta(minutes=20),
+        ),
+    ]
+    findings = scan_events(events, now=now)
+    matched = [f for f in findings if f.rule == RULE_TASK_ON_HOLD_STALE]
+    assert len(matched) == 1
+    f = matched[0]
+    assert f.subject == "savethenovel/11"
+    assert f.project == "savethenovel"
+    assert f.metadata["routing"] == "architect-actionable"
+    assert "Footer.astro" in (f.metadata.get("reason") or "")
+    assert "review" == f.metadata["from"]
+
+
+def test_task_on_hold_stale_silent_within_grace(now: datetime) -> None:
+    """An on_hold transition within the grace window doesn't fire."""
+    from pollypm.audit.watchdog import RULE_TASK_ON_HOLD_STALE
+
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/3",
+            metadata={"from": "review", "to": "on_hold", "reason": "..."},
+            # Default threshold is 900s = 15 min; 5 min ago is fresh.
+            ts=now - timedelta(minutes=5),
+        ),
+    ]
+    findings = scan_events(events, now=now)
+    assert not any(f.rule == RULE_TASK_ON_HOLD_STALE for f in findings)
+
+
+def test_task_on_hold_stale_silent_when_resumed(now: datetime) -> None:
+    """A later transition out of on_hold suppresses the finding."""
+    from pollypm.audit.watchdog import RULE_TASK_ON_HOLD_STALE
+
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/3",
+            metadata={"from": "review", "to": "on_hold"},
+            ts=now - timedelta(minutes=45),
+        ),
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/3",
+            metadata={"from": "on_hold", "to": "queued"},
+            ts=now - timedelta(minutes=5),
+        ),
+    ]
+    findings = scan_events(events, now=now)
+    assert not any(f.rule == RULE_TASK_ON_HOLD_STALE for f in findings)
+
+
+def test_task_on_hold_stale_does_not_disturb_review_stale(now: datetime) -> None:
+    """Existing review_stale rule still fires only on status=review.
+
+    Regression guard for #1424's hard constraint: the new rule MUST be
+    additive. A status=review task should never trigger the on_hold rule
+    and vice-versa.
+    """
+    from pollypm.audit.watchdog import (
+        RULE_TASK_ON_HOLD_STALE,
+        RULE_TASK_REVIEW_STALE,
+    )
+
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/4",
+            metadata={"from": "in_progress", "to": "review"},
+            ts=now - timedelta(minutes=45),
+        ),
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/5",
+            metadata={"from": "review", "to": "on_hold", "reason": "x"},
+            ts=now - timedelta(minutes=20),
+        ),
+    ]
+    findings = scan_events(events, now=now)
+    review = [f for f in findings if f.rule == RULE_TASK_REVIEW_STALE]
+    on_hold = [f for f in findings if f.rule == RULE_TASK_ON_HOLD_STALE]
+    assert len(review) == 1
+    assert len(on_hold) == 1
+    assert review[0].subject == "demo/4"
+    assert on_hold[0].subject == "demo/5"
+
+
+def test_task_on_hold_stale_human_needed_routing(now: datetime) -> None:
+    """A reviewer-tagged ``[human-needed]`` reason routes to human."""
+    from pollypm.audit.watchdog import (
+        ON_HOLD_HUMAN_NEEDED_TAG,
+        RULE_TASK_ON_HOLD_STALE,
+    )
+
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/9",
+            metadata={
+                "from": "review",
+                "to": "on_hold",
+                "reason": "[human-needed] Need product call on copy direction",
+            },
+            ts=now - timedelta(minutes=20),
+        ),
+    ]
+    findings = scan_events(events, now=now)
+    matched = [f for f in findings if f.rule == RULE_TASK_ON_HOLD_STALE]
+    assert len(matched) == 1
+    assert matched[0].metadata["routing"] == ON_HOLD_HUMAN_NEEDED_TAG
+
+
+def test_format_unstick_brief_on_hold_includes_evidence_and_default() -> None:
+    """The brief lists the reviewer's reason, evidence, and 'fix and re-submit' default."""
+    from pollypm.audit.watchdog import (
+        RULE_TASK_ON_HOLD_STALE,
+        format_unstick_brief,
+    )
+
+    finding = Finding(
+        rule=RULE_TASK_ON_HOLD_STALE,
+        project="savethenovel",
+        subject="savethenovel/11",
+        message="Task savethenovel/11 has been at on_hold for ~20 min",
+        recommendation="Architect: re-read the rationale.",
+        metadata={
+            "stuck_minutes": 20,
+            "on_hold_since": "2026-05-07T08:30:00+00:00",
+            "from": "review",
+            "reason": (
+                "[architect-actionable] Footer.astro:20 placeholder "
+                "copy + untracked planning docs"
+            ),
+            "routing": "architect-actionable",
+            "reviewer_evidence": [
+                "reviewer exec [code_review @ 2026-05-07T08:25:00+00:00] "
+                "decision=rejected reason: placeholder copy fails 'No placeholders'",
+                "inbox msg from russell: review of savethenovel/11 — "
+                "Footer.astro:20 has TODO copy, untracked docs",
+            ],
+        },
+    )
+    brief = format_unstick_brief(finding)
+    assert brief.startswith("WATCHDOG ESCALATION")
+    assert "Project: savethenovel" in brief
+    assert "Finding: task_on_hold_stale" in brief
+    assert "20 minutes" in brief
+    # The on_hold reason / reviewer rationale must be visible verbatim.
+    assert "Footer.astro:20" in brief
+    assert "Routing: architect-actionable" in brief
+    # Reviewer evidence section must list both lines.
+    assert "Recent reviewer evidence" in brief
+    assert "code_review" in brief
+    assert "russell" in brief
+    # Default action must steer the architect to fix and re-queue.
+    assert "DEFAULT" in brief or "default" in brief.lower()
+    assert "pm task queue savethenovel/11" in brief
+    assert "pm task approve savethenovel/11" in brief
+    # Escalation path is mentioned but framed as last-resort.
+    assert "pm notify" in brief
+
+
+def test_format_unstick_brief_on_hold_handles_missing_evidence() -> None:
+    """When no reviewer evidence is available, the brief still renders cleanly."""
+    from pollypm.audit.watchdog import (
+        RULE_TASK_ON_HOLD_STALE,
+        format_unstick_brief,
+    )
+
+    finding = Finding(
+        rule=RULE_TASK_ON_HOLD_STALE,
+        project="demo",
+        subject="demo/1",
+        metadata={
+            "stuck_minutes": 25,
+            "on_hold_since": "2026-05-07T08:00:00+00:00",
+            "from": "in_progress",
+            "reason": None,
+            "routing": "architect-actionable",
+        },
+    )
+    brief = format_unstick_brief(finding)
+    assert "no transition reason" in brief.lower()
+    # Don't include a stale "Recent reviewer evidence" header.
+    assert "No additional reviewer execution rows" in brief
+
+
+def test_cadence_handler_dispatches_on_hold_with_reviewer_evidence(
+    now: datetime, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """End-to-end: an on_hold transition triggers a brief carrying evidence.
+
+    Seeds an on_hold transition into the central audit log and a real
+    reviewer rejection into a workspace-layout DB. The cadence handler
+    should fire ``task_on_hold_stale``, fold the reviewer's exec row +
+    inbox message into the brief, and send the result to the architect's
+    pane via the (stubbed) tmux send_keys.
+    """
+    from pollypm.audit.log import central_log_path
+    from pollypm.audit.watchdog import RULE_TASK_ON_HOLD_STALE
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _scan_one_project,
+    )
+    from pollypm.work import create_work_service
+
+    workspace_root = tmp_path / "workspace"
+    canonical_db = workspace_root / ".pollypm" / "state.db"
+    canonical_db.parent.mkdir(parents=True, exist_ok=True)
+    project_path = workspace_root / "savethenovel"
+    project_path.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        "pollypm.work.db_resolver.resolve_work_db_path",
+        lambda *a, **kw: canonical_db,
+    )
+
+    # Seed the task and a reviewer rejection row into the work-service DB.
+    with create_work_service(
+        db_path=canonical_db, project_path=project_path,
+    ) as svc:
+        task = svc.create(
+            title="hero copy",
+            description="hero copy work",
+            type="task",
+            project="savethenovel",
+            flow_template="standard",
+            roles={"worker": "claude:worker", "reviewer": "claude:reviewer"},
+            priority="normal",
+            created_by="tester",
+        )
+        # Insert a reviewer execution row directly so the test stays
+        # decoupled from the flow engine's transition wiring.
+        svc._conn.execute(
+            "INSERT INTO work_node_executions "
+            "(task_project, task_number, node_id, visit, status, "
+            " decision, decision_reason, started_at, completed_at, "
+            " work_output) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                task.project,
+                task.task_number,
+                "code_review",
+                1,
+                "completed",
+                "rejected",
+                "Footer.astro:20 placeholder copy fails No placeholders",
+                "2026-05-07T08:20:00+00:00",
+                "2026-05-07T08:25:00+00:00",
+                None,
+            ),
+        )
+        svc._conn.execute(
+            "UPDATE work_tasks SET work_status = ? "
+            "WHERE project = ? AND task_number = ?",
+            ("on_hold", task.project, task.task_number),
+        )
+        svc._conn.commit()
+        task_number = task.task_number
+
+    subject = f"savethenovel/{task_number}"
+
+    # Seed a stale on_hold transition into the central audit tail.
+    central = central_log_path("savethenovel")
+    central.parent.mkdir(parents=True, exist_ok=True)
+    stale_ts = (now - timedelta(minutes=20)).isoformat()
+    payload = {
+        "schema": 1,
+        "ts": stale_ts,
+        "project": "savethenovel",
+        "event": EVENT_TASK_STATUS_CHANGED,
+        "subject": subject,
+        "actor": "russell",
+        "status": "ok",
+        "metadata": {
+            "from": "review",
+            "to": "on_hold",
+            "reason": (
+                "[architect-actionable] Footer.astro:20 placeholder "
+                "copy + untracked planning docs"
+            ),
+        },
+    }
+    central.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    # Capture tmux send-keys instead of touching tmux.
+    sent: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._send_brief_to_architect",
+        lambda target, brief: sent.append((target, brief)) or True,
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_storage_windows",
+        lambda name: [],
+    )
+
+    class _MsgStore:
+        """Minimal stand-in that captures upserts AND surfaces a reviewer message."""
+
+        def __init__(self) -> None:
+            self.alerts: list = []
+
+        def upsert_alert(
+            self, scope: str, alert_type: str, severity: str, message: str,
+        ) -> None:
+            self.alerts.append((scope, alert_type, severity, message))
+
+        def query_messages(self, **filters):  # noqa: ANN001
+            return [
+                {
+                    "title": f"Russell: review of {subject}",
+                    "subject": subject,
+                    "body": (
+                        f"Rejecting {subject}: untracked planning docs at "
+                        "project root + Footer.astro:20 placeholder copy."
+                    ),
+                    "requester": "russell",
+                    "actor": "russell",
+                    "created_at": "2026-05-07T08:30:00+00:00",
+                    "project": "savethenovel",
+                },
+            ]
+
+    store = _MsgStore()
+    counters = _scan_one_project(
+        project_key="savethenovel",
+        project_path=project_path,
+        msg_store=store,
+        state_store=None,
+        now=now,
+        config=WatchdogConfig(),
+        storage_closet_name="pollypm-storage-closet",
+    )
+
+    assert counters["findings"] >= 1
+    assert counters["dispatches_sent"] == 1
+    assert len(sent) == 1
+    target, brief = sent[0]
+    assert target == "pollypm-storage-closet:architect-savethenovel"
+    assert RULE_TASK_ON_HOLD_STALE in brief
+    assert subject in brief
+    # Reviewer rationale (from the on_hold reason) must be in the brief.
+    assert "Footer.astro:20" in brief
+    # Reviewer execution row must be folded in via the enrichment path.
+    assert "code_review" in brief
+    assert "rejected" in brief
+    # Inbox-message lookup must surface russell's review message.
+    assert "russell" in brief.lower()
+    # Default-fix framing.
+    assert "pm task queue " + subject in brief
+
+
+def test_cadence_handler_throttles_on_hold_repeat_dispatch(
+    now: datetime, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 30-min throttle applies to on_hold escalations too."""
+    from pollypm.audit.log import central_log_path
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _scan_one_project,
+    )
+
+    central = central_log_path("savethenovel")
+    central.parent.mkdir(parents=True, exist_ok=True)
+    stale_ts = (now - timedelta(minutes=20)).isoformat()
+    payload = {
+        "schema": 1,
+        "ts": stale_ts,
+        "project": "savethenovel",
+        "event": EVENT_TASK_STATUS_CHANGED,
+        "subject": "savethenovel/11",
+        "actor": "russell",
+        "status": "ok",
+        "metadata": {
+            "from": "review",
+            "to": "on_hold",
+            "reason": "[architect-actionable] x",
+        },
+    }
+    central.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    sent: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._send_brief_to_architect",
+        lambda target, brief: sent.append((target, brief)) or True,
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_storage_windows",
+        lambda name: [],
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_open_tasks",
+        lambda key, path: [],
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_reviewer_evidence",
+        lambda **kw: [],
+    )
+
+    store = _RecordingStore()
+    first = _scan_one_project(
+        project_key="savethenovel",
+        project_path=None,
+        msg_store=store,
+        state_store=None,
+        now=now,
+        config=WatchdogConfig(),
+        storage_closet_name="pollypm-storage-closet",
+    )
+    second = _scan_one_project(
+        project_key="savethenovel",
+        project_path=None,
+        msg_store=store,
+        state_store=None,
+        now=now + timedelta(minutes=5),
+        config=WatchdogConfig(),
+        storage_closet_name="pollypm-storage-closet",
+    )
+
+    assert first["dispatches_sent"] == 1
+    assert second["dispatches_sent"] == 0
+    assert second["dispatches_throttled"] == 1
+    assert len(sent) == 1
+
+
+def test_classify_on_hold_reason_defaults_to_architect() -> None:
+    """Untagged or unknown-tag reason routes to architect-actionable."""
+    from pollypm.audit.watchdog import (
+        ON_HOLD_ARCHITECT_TAG,
+        ON_HOLD_HUMAN_NEEDED_TAG,
+        _classify_on_hold_reason,
+    )
+
+    assert _classify_on_hold_reason(None) == ON_HOLD_ARCHITECT_TAG
+    assert _classify_on_hold_reason("") == ON_HOLD_ARCHITECT_TAG
+    assert _classify_on_hold_reason("just stuck") == ON_HOLD_ARCHITECT_TAG
+    assert _classify_on_hold_reason("[architect-actionable] x") == ON_HOLD_ARCHITECT_TAG
+    assert _classify_on_hold_reason("architect-actionable: x") == ON_HOLD_ARCHITECT_TAG
+    assert _classify_on_hold_reason("[human-needed] copy") == ON_HOLD_HUMAN_NEEDED_TAG
+    assert _classify_on_hold_reason("human-needed: y") == ON_HOLD_HUMAN_NEEDED_TAG
+    # Case-insensitive
+    assert _classify_on_hold_reason("[HUMAN-NEEDED] z") == ON_HOLD_HUMAN_NEEDED_TAG


### PR DESCRIPTION
Closes #1424.

## Summary

The auto-unstick watchdog (#1414) only fires on ``status=review`` tasks
via ``task_review_stale``. When a reviewer parks a task in
``status=on_hold`` instead — which Russell is allowed to do for
"escalation" cases — the watchdog goes silent and the rejection
rationale ends up in ``inbox/N`` with no surface to the user. That is
the savethenovel/11 pattern documented in #1424.

This PR adds a parallel ``task_on_hold_stale`` rule and routes the
escalation to the architect with the reviewer's rationale folded into
the brief, so the architect can resolve issues directly instead of
the work parking on a human.

<details>
<summary>Implementation</summary>

### New rule ``task_on_hold_stale``
- Mirrors ``task_review_stale``: walks ``task.status_changed`` events,
  finds the latest transition per subject, fires when the latest is to
  ``on_hold`` and older than ``on_hold_stale_seconds`` (default 900s /
  15 min — shorter than ``review_stale_seconds`` since on_hold is meant
  to be a brief routing detour).
- Threshold tunable via the same ``WatchdogConfig`` pattern as the
  other rules; ``audit.watchdog`` cadence payload now accepts
  ``on_hold_stale_seconds`` and ``review_stale_seconds`` overrides.
- The transition reason is parsed for ``[human-needed]`` /
  ``[architect-actionable]`` routing tags. Default is
  architect-actionable.

### Brief enrichment with reviewer evidence
``_gather_reviewer_evidence`` (in the cadence handler) collects:
- Last 1-2 reviewer execution rows for the subject (decision +
  decision_reason from ``work_node_executions`` rows whose ``node_id``
  contains ``review``).
- Recent inbox messages mentioning the subject (via
  ``msg_store.query_messages``).

The on_hold finding is enriched in-place before dispatch so
``format_unstick_brief`` can fold the evidence into the
``Observed evidence`` section. Other rules are unaffected.

### Architect prompt
``<watchdog_unstick_mode>`` in
``profiles/architect.md`` extended with an "On-hold escalation" section
that names the new finding type, the resolution menu (1: fix and
re-queue, 2: sibling-task split + auto-approve, 3: escalate to user),
and the explicit DEFAULT framing — fix and re-submit, escalate only
when human judgement is genuinely required.

### Reviewer prompt
``reviewer_prompt()`` in ``core_agent_profiles.profiles`` now teaches
Russell to tag ``--reason "[architect-actionable] ..."`` (default) or
``[human-needed]`` (rare) on ``pm task hold`` calls so the watchdog can
route appropriately.

### Hard-constraint guard
The new rule is strictly additive. ``task_review_stale`` still fires
only on ``status=review``; a regression test
(``test_task_on_hold_stale_does_not_disturb_review_stale``) seeds both
states in one event list and asserts each subject lands in exactly one
finding bucket. Throttle (30-min audit-log lookup) is reused — no new
state.
</details>

## Test plan

- [x] ``tests/test_audit_watchdog.py`` — 10 new tests:
  - ``test_task_on_hold_stale_fires_after_threshold``
  - ``test_task_on_hold_stale_silent_within_grace``
  - ``test_task_on_hold_stale_silent_when_resumed``
  - ``test_task_on_hold_stale_does_not_disturb_review_stale``
  - ``test_task_on_hold_stale_human_needed_routing``
  - ``test_format_unstick_brief_on_hold_includes_evidence_and_default``
  - ``test_format_unstick_brief_on_hold_handles_missing_evidence``
  - ``test_cadence_handler_dispatches_on_hold_with_reviewer_evidence``
  - ``test_cadence_handler_throttles_on_hold_repeat_dispatch``
  - ``test_classify_on_hold_reason_defaults_to_architect``
- [x] All 55 watchdog tests pass; broader suites
  (``test_audit_log``, ``test_contract_audit``,
  ``test_core_agent_profiles``, ``test_workers``,
  ``test_work_service``) still pass.
- [ ] Live demo: savethenovel/11 should auto-unstick on next cadence
  tick once #1424 is merged into the running cockpit (deferred —
  caller is watching the live cockpit; do NOT bring this PR live yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)