### PR TITLE
Rail affordance: also surface on_hold tasks (not just review+human)

### DIFF
--- a/src/pollypm/cockpit_project_state.py
+++ b/src/pollypm/cockpit_project_state.py
@@ -72,11 +72,17 @@ class ProjectStateRollup:
     sort_rank: int
     actionable_key: str | None = None
     reason: str = ""
-    # #1390 — Count of tasks where status=review AND a human is the
-    # assignee/actor (e.g. user_approval node). The rail uses this to
-    # render a prominent "needs your decision" affordance — savethenovel
-    # had a plan parked at user_approval for hours without any
-    # rail-level signal because the GREEN dot reads as "fine, moving".
+    # #1390 / #1426 — Count of tasks on this project that are parked
+    # in a "needs a decision before progress" state. The rail uses
+    # this to render a prominent "needs your decision" affordance.
+    #
+    # Originally (#1390) only ``status=review`` + assignee=human
+    # counted; #1426 widened to also fire on:
+    #   * any ``status=review`` task (reviewer-actor decisions stall
+    #     the project until acted on; not just human-actor).
+    #   * any ``status=on_hold`` task (parked, regardless of
+    #     assignee — savethenovel/11 sat in on_hold for 1+ hour
+    #     with no rail signal even though a real wedge existed).
     approvals_pending: int = 0
 
 
@@ -131,7 +137,7 @@ def rollup_project_state(
         if not _is_terminal(task) and _status(task) not in _INACTIVE_STATUSES
     ]
     approvals_pending = sum(
-        1 for task in active_tasks if _is_human_review(task)
+        1 for task in active_tasks if _is_decision_pending(task)
     )
     if not active_tasks:
         return _rollup(ProjectRailState.NONE, project_key=project_key)
@@ -255,27 +261,29 @@ def _is_waiting_on_user(task: object) -> bool:
     return _status(task) in _WAITING_STATUSES
 
 
-def _is_human_review(task: object) -> bool:
-    """Return True for tasks parked at a human-decision review node.
+def _is_decision_pending(task: object) -> bool:
+    """Return True for tasks parked in a "needs a decision" state.
 
-    Scoped narrower than ``_is_user_review``: only counts tasks where
-    ``status=='review'`` AND a human is named as the actor/assignee
-    (or the node id explicitly marks a user/approval touchpoint).
-    Drives the rail's ``(N approvals)`` affordance — see #1390.
+    Drives the rail's ``▶ <project> (N⚠)`` affordance.
+
+    Originally (#1390) only ``status=='review'`` + a human actor
+    counted, but the savethenovel/11 wedge (#1426) showed two real
+    holes in that scope:
+
+    * A reviewer (russell, architect) parking a task at ``review``
+      with a non-human actor still stalls the project until the
+      reviewer acts. The rail must surface those, not just human
+      decisions.
+    * A task in ``on_hold`` is by definition awaiting a decision
+      before it can move — savethenovel/11 sat there for 1+ hour
+      with no rail signal even though a real wedge existed.
+
+    Both cases are "needs a decision before progress" and roll up
+    into a single count so the 22-char rail row stays within the
+    label budget from #1396.
     """
-    if _status(task) != "review":
-        return False
-    owner = str(getattr(task, "owner", "") or "").lower()
-    actor = str(getattr(task, "actor_type", "") or "").lower()
-    assignee = str(getattr(task, "assignee", "") or "").lower()
-    if owner in {"human", "user", "operator", "operator-pm"}:
-        return True
-    if actor == "human":
-        return True
-    if assignee == "human":
-        return True
-    node_id = _node_id(task)
-    return any(marker in node_id for marker in _USER_NODE_MARKERS)
+    status = _status(task)
+    return status in {"review", "on_hold"}
 
 
 def _is_user_review(task: object) -> bool:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -990,6 +990,58 @@ def test_cockpit_raw_rail_approval_affordance_fits_narrow_30col_pane() -> None:
     assert "savethenovel" in row.text
 
 
+def test_cockpit_raw_rail_on_hold_renders_decision_affordance() -> None:
+    """#1426 — when a project carries an on_hold task the rollup now
+    sets approvals_pending>0; the rail must render the same ▶ + (N⚠)
+    affordance it uses for review tasks so the user gets a single
+    consistent "needs your decision" signal in the rail line."""
+    rail = PollyCockpitRail.__new__(PollyCockpitRail)
+    rail.selected_key = "polly"
+    rail.spinner_index = 0
+
+    # The rollup produces YELLOW for an on_hold task (it falls in
+    # _WAITING_STATUSES) — the affordance must still win over the
+    # quiet ◆ glyph, matching the behavior for review.
+    row = rail._item_row(
+        CockpitItem(
+            "project:savethenovel",
+            "savethenovel (1⚠)",
+            "project-yellow",
+            approvals_pending=1,
+        ),
+        width=40,
+        active_view="polly",
+    )
+
+    assert "savethenovel" in row.text
+    assert "▶" in row.text
+    assert "(1⚠)" in row.text
+
+
+def test_cockpit_raw_rail_on_hold_affordance_fits_narrow_pane() -> None:
+    """80x40 / 30-col-rail narrow-mode rendering for the on_hold
+    affordance. The ▶ + (N⚠) suffix must fit without truncating
+    typical project keys, matching the #1396 narrow-mode budget."""
+    rail = PollyCockpitRail.__new__(PollyCockpitRail)
+    rail.selected_key = "polly"
+    rail.spinner_index = 0
+
+    row = rail._item_row(
+        CockpitItem(
+            "project:savethenovel",
+            "savethenovel (2⚠)",
+            "project-yellow",
+            approvals_pending=2,
+        ),
+        width=30,
+        active_view="polly",
+    )
+
+    assert "▶" in row.text
+    assert "savethenovel" in row.text
+    assert "(2⚠)" in row.text
+
+
 def test_cockpit_rail_session_indicator_combines_pulse_and_work_glyph(monkeypatch, tmp_path: Path) -> None:
     config_path = tmp_path / "pollypm.toml"
     config_path.write_text(

--- a/tests/test_cockpit_project_state.py
+++ b/tests/test_cockpit_project_state.py
@@ -279,15 +279,66 @@ def test_rollup_approvals_pending_counts_multiple() -> None:
     assert rollup.approvals_pending == 3
 
 
-def test_rollup_approvals_pending_zero_without_human_review() -> None:
-    """Autoreview / automated review tasks must not inflate the count
-    — only human-decision review nodes drive the affordance."""
+def test_rollup_approvals_pending_includes_autoreview_after_widening() -> None:
+    """#1426 widened the rail affordance from "human-review only" to
+    "any task in review or on_hold" — a reviewer parking a task at
+    autoreview still stalls the project until the reviewer acts, so
+    the rail must surface it, not pretend the project is moving."""
     rollup = rollup_project_state(
         "demo",
         [
             _task(1, "in_progress"),
             _task(2, "review", node="autoreview"),
             _task(3, "queued"),
+        ],
+    )
+
+    assert rollup.approvals_pending == 1
+
+
+def test_rollup_approvals_pending_fires_on_on_hold_only_project() -> None:
+    """#1426 — savethenovel/11 sat in on_hold for 1+ hour with no rail
+    signal because #1390 only counted ``status=review``. A task parked
+    at on_hold is by definition awaiting a decision before it can
+    move — the rail must surface it just like a review."""
+    rollup = rollup_project_state(
+        "savethenovel",
+        [
+            _task(1, "on_hold"),
+            _task(2, "in_progress"),
+        ],
+    )
+
+    assert rollup.approvals_pending == 1
+
+
+def test_rollup_approvals_pending_combines_review_and_on_hold() -> None:
+    """When a project has both a task in review AND a task in on_hold,
+    the count rolls them up into a single (N⚠) suffix — per #1426 we
+    keep one count so the 22-char label budget from #1396 is safe."""
+    rollup = rollup_project_state(
+        "savethenovel",
+        [
+            _task(1, "review", node="user_approval", assignee="human"),
+            _task(2, "on_hold"),
+            _task(3, "in_progress"),
+        ],
+    )
+
+    assert rollup.approvals_pending == 2
+
+
+def test_rollup_approvals_pending_zero_for_done_and_blocked_only() -> None:
+    """Tasks that are terminal (done/cancelled) or blocked-on-deps
+    must NOT inflate the count. ``blocked`` is a wait-on-system state,
+    not a wait-on-decision state — surfacing every blocked task as
+    "needs your decision" would flood the rail."""
+    rollup = rollup_project_state(
+        "demo",
+        [
+            _task(1, "done"),
+            _task(2, "blocked"),
+            _task(3, "cancelled"),
         ],
     )
 


### PR DESCRIPTION
Closes #1426. Extends #1396.

<details>
<summary>What changed</summary>

The rail glyph (`▶ <project> (N⚠)`) added in #1396 fired only on tasks where `status=review` AND `assignee=human`. The savethenovel/11 wedge showed two real holes in that scope:

- **`on_hold` was silent.** A task parked in `on_hold` is by definition awaiting a decision before it can move; savethenovel/11 sat there for 1+ hour with no rail signal.
- **Reviewer-actor `review` tasks were silent.** Russell/architect parking a task at `review` with a non-human actor still stalls the project until the reviewer acts.

This PR widens `_is_decision_pending` (formerly `_is_human_review`) to count any task in `status in {review, on_hold}`. Both states roll up into a single `approvals_pending` count so the 22-char rail row from #1396 stays in budget; the glyph (`▶`) is unchanged.

Out of scope: watchdog escalation visibility (#1424), `blocked` tasks (those are wait-on-system, not wait-on-decision).

</details>

## Summary

- Widen the rail "needs your decision" count to include `status=on_hold` (was `review`+`assignee=human` only).
- Drop the human-only filter on `review` so reviewer-actor decisions surface too.
- Single rolled-up count keeps the 22-char label budget from #1396 — glyph stays `▶`.

## Test plan

- [x] Unit: project with `on_hold` task → `approvals_pending == 1`.
- [x] Unit: project with `review`+`human` task → still counts (existing behavior preserved).
- [x] Unit: project with both `review` and `on_hold` → count is 2.
- [x] Unit: project with only `done`/`blocked`/`cancelled` → count is 0.
- [x] Unit: project with `review`+autoreview node now counts (widened intentionally).
- [x] Rail render (40-col): `on_hold` project shows `▶ savethenovel (1⚠)`.
- [x] Rail render (30-col narrow / 80x40): glyph + suffix fit without truncating typical project keys.
- [x] Full `tests/test_cockpit*.py` + `tests/test_*rail*.py` suites green (262 + 84 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)