### PR TITLE
pm notify: default to caller's project context (not synthetic inbox)

### DIFF
--- a/src/pollypm/cli_features/session_runtime.py
+++ b/src/pollypm/cli_features/session_runtime.py
@@ -106,6 +106,23 @@ def _infer_notify_actor(config_path: Path, actor: str) -> tuple[str, str | None]
     """
     if (actor or "").strip() != "polly":
         return actor, None
+    matched = _match_notify_session_config(config_path)
+    if matched is None:
+        return actor, None
+    session_name, _session_cfg = matched
+    return session_name, session_name
+
+
+def _match_notify_session_config(
+    config_path: Path,
+) -> tuple[str, object] | None:
+    """Find the configured session matching the current tmux window.
+
+    Returns ``(session_name, session_cfg)`` when the caller is running
+    inside a managed role pane (reviewer, operator, architect, worker),
+    or ``None`` when no match can be made. Shared by the actor and
+    project inference paths so both surfaces agree on the session.
+    """
     try:
         from pollypm.config import load_config
         from pollypm.session_services import create_tmux_client
@@ -114,23 +131,48 @@ def _infer_notify_actor(config_path: Path, actor: str) -> tuple[str, str | None]
         tmux_session = tmux.current_session_name()
         window_index = tmux.current_window_index()
         if not tmux_session or window_index is None:
-            return actor, None
+            return None
         window_name = None
         for window in tmux.list_windows(tmux_session):
             if str(getattr(window, "index", "")) == str(window_index):
                 window_name = getattr(window, "name", None)
                 break
         if not window_name:
-            return actor, None
+            return None
         config = load_config(config_path)
         sessions = getattr(config, "sessions", {}) or {}
         for session_name, session_cfg in sessions.items():
             expected = getattr(session_cfg, "window_name", None) or session_name
             if expected == window_name:
-                return session_name, session_name
+                return session_name, session_cfg
     except Exception:  # noqa: BLE001
-        return actor, None
-    return actor, None
+        return None
+    return None
+
+
+def _infer_notify_project(config_path: Path) -> str | None:
+    """Resolve ``pm notify``'s default ``--project`` from the calling pane.
+
+    Issue #1425: when an agent that's running in a project context
+    (e.g. ``reviewer-savethenovel``) calls ``pm notify`` without an
+    explicit ``--project``, the message should land at that project's
+    namespace — not the synthetic ``inbox`` bucket. Otherwise project-
+    scoped views (``pm message list --project <key>``, the cockpit's
+    project-filtered inbox) silently drop substantive review feedback
+    because the operator has to know to look in the global inbox.
+
+    Returns the matching session's ``project`` key, or ``None`` when no
+    project context can be inferred (so the caller can fall back to
+    the legacy ``inbox`` default).
+    """
+    matched = _match_notify_session_config(config_path)
+    if matched is None:
+        return None
+    _session_name, session_cfg = matched
+    project_key = getattr(session_cfg, "project", None)
+    if not project_key:
+        return None
+    return str(project_key)
 
 
 def _hold_review_tasks_for_notify(
@@ -517,8 +559,17 @@ def register_session_runtime_commands(app: typer.Typer, *, helpers) -> None:
         body: str = typer.Argument(..., help="Message body. Pass '-' to read from stdin."),
         actor: str = typer.Option("polly", "--actor", help="Who is posting the notification."),
         project: str = typer.Option(
-            "inbox", "--project", "-p",
-            help="Project namespace for the notification task (default: 'inbox').",
+            "", "--project", "-p",
+            help=(
+                "Project namespace for the notification task. When omitted, "
+                "infer from the calling tmux pane's session config "
+                "(reviewer-<project>, worker-<project>, architect, …) — "
+                "agents running in a project context land their notify on "
+                "that project automatically (#1425). Falls back to 'inbox' "
+                "(global) when no project context is detectable. Pass "
+                "``--project inbox`` explicitly to force a global "
+                "notification from a project-scoped pane."
+            ),
         ),
         priority: str = typer.Option(
             "auto", "--priority",
@@ -639,6 +690,17 @@ def register_session_runtime_commands(app: typer.Typer, *, helpers) -> None:
         actor, current_session_name = _infer_notify_actor(
             resolved_config_path, actor,
         )
+
+        # #1425 — when the caller didn't pass ``--project``, infer it
+        # from the calling pane's session config so a reviewer running
+        # in ``reviewer-savethenovel`` lands its notify on
+        # ``project=savethenovel`` instead of the synthetic global
+        # ``inbox`` bucket. Explicit ``--project inbox`` (or any other
+        # value) still wins so global broadcasts and bootstrap scripts
+        # keep working from inside a project-scoped pane.
+        if not (project or "").strip():
+            inferred_project = _infer_notify_project(resolved_config_path)
+            project = inferred_project or "inbox"
 
         from pollypm.store.classifier import classify_priority, validate_priority
 

--- a/tests/test_cli_notify.py
+++ b/tests/test_cli_notify.py
@@ -569,3 +569,200 @@ class TestNotifyReviewerEscalations:
         assert held == []
         task = svc.get(task_id)
         assert task.work_status == WorkStatus.REVIEW
+
+
+def _patch_tmux_session(monkeypatch, *, window_name: str, sessions: dict[str, object]):
+    """Wire up a fake tmux client + ``load_config`` for project-inference tests.
+
+    The fake tmux always reports a single window with ``window_name`` so
+    the session match is deterministic; ``sessions`` mirrors the
+    ``SessionConfig`` shape (``window_name`` + ``project``) the inference
+    helpers consume. Returns nothing — the monkeypatch installs both
+    seams in-place.
+    """
+
+    class _Tmux:
+        def current_session_name(self):
+            return "pollypm-storage-closet"
+
+        def current_window_index(self):
+            return "2"
+
+        def list_windows(self, _session_name):
+            return [SimpleNamespace(index=2, name=window_name)]
+
+    config = SimpleNamespace(sessions=sessions)
+    monkeypatch.setattr(
+        "pollypm.session_services.create_tmux_client",
+        lambda: _Tmux(),
+    )
+    monkeypatch.setattr(
+        "pollypm.config.load_config",
+        lambda _path=None: config,
+    )
+
+
+class TestNotifyDefaultProjectInference:
+    """Issue #1425 — ``pm notify`` from a project-scoped pane should
+    default-route to that project, not the synthetic global ``inbox``
+    bucket. Regression caught when reviewer-savethenovel's substantive
+    review feedback landed at ``project=inbox`` and was invisible from
+    every project-filtered surface."""
+
+    def test_infer_notify_project_from_reviewer_window(
+        self, monkeypatch, tmp_path: Path,
+    ):
+        from pollypm.cli_features.session_runtime import _infer_notify_project
+
+        _patch_tmux_session(
+            monkeypatch,
+            window_name="reviewer-savethenovel",
+            sessions={
+                "reviewer_savethenovel": SimpleNamespace(
+                    window_name="reviewer-savethenovel",
+                    project="savethenovel",
+                ),
+            },
+        )
+
+        inferred = _infer_notify_project(tmp_path / "pollypm.toml")
+
+        assert inferred == "savethenovel"
+
+    def test_infer_notify_project_returns_none_without_match(
+        self, monkeypatch, tmp_path: Path,
+    ):
+        from pollypm.cli_features.session_runtime import _infer_notify_project
+
+        _patch_tmux_session(
+            monkeypatch,
+            window_name="some-unrelated-window",
+            sessions={
+                "reviewer_savethenovel": SimpleNamespace(
+                    window_name="reviewer-savethenovel",
+                    project="savethenovel",
+                ),
+            },
+        )
+
+        assert _infer_notify_project(tmp_path / "pollypm.toml") is None
+
+    def test_notify_without_project_uses_inferred_project(
+        self, monkeypatch, db_path,
+    ):
+        """Reviewer-savethenovel calls ``pm notify`` (no ``--project``).
+        The message + task should land at ``project=savethenovel``."""
+        monkeypatch.setattr(
+            "pollypm.cli_features.session_runtime._infer_notify_project",
+            lambda _config_path: "savethenovel",
+        )
+
+        result = _invoke_notify(
+            db_path,
+            "Rejecting savethenovel/11",
+            "Footer.astro:20-22 still has placeholder copy.",
+        )
+        assert result.exit_code == 0, result.output
+
+        rows = _fetch_messages(db_path)
+        assert len(rows) == 1
+        row = rows[0]
+        # Message scope + payload.project both reflect the inferred key.
+        assert row["scope"] == "savethenovel"
+        payload = json.loads(row["payload_json"])
+        assert payload["project"] == "savethenovel"
+
+        # The work-service inbox task created for immediate-priority
+        # notifies inherits the same project.
+        svc = SQLiteWorkService(db_path=db_path)
+        try:
+            task = svc.get(payload["task_id"])
+        finally:
+            svc.close()
+        assert task.project == "savethenovel"
+
+    def test_notify_explicit_project_wins_over_inference(
+        self, monkeypatch, db_path,
+    ):
+        """``--project inbox`` (or any explicit value) must override the
+        inferred project so global broadcasts still work from a
+        project-scoped pane."""
+        monkeypatch.setattr(
+            "pollypm.cli_features.session_runtime._infer_notify_project",
+            lambda _config_path: "savethenovel",
+        )
+
+        result = _invoke_notify(
+            db_path,
+            "Site-wide announcement",
+            "Cockpit reboot in 5m.",
+            "--project", "inbox",
+        )
+        assert result.exit_code == 0, result.output
+
+        rows = _fetch_messages(db_path)
+        assert rows[0]["scope"] == "inbox"
+        payload = json.loads(rows[0]["payload_json"])
+        assert payload["project"] == "inbox"
+
+    def test_notify_falls_back_to_inbox_without_inferred_project(
+        self, monkeypatch, db_path,
+    ):
+        """Outside a managed pane (no tmux match), ``pm notify`` keeps
+        its legacy ``project=inbox`` default so existing scripts and
+        ad-hoc operator invocations don't silently change semantics."""
+        monkeypatch.setattr(
+            "pollypm.cli_features.session_runtime._infer_notify_project",
+            lambda _config_path: None,
+        )
+
+        result = _invoke_notify(
+            db_path,
+            "Operator note",
+            "Posted from a bare shell.",
+        )
+        assert result.exit_code == 0, result.output
+
+        rows = _fetch_messages(db_path)
+        assert rows[0]["scope"] == "inbox"
+        payload = json.loads(rows[0]["payload_json"])
+        assert payload["project"] == "inbox"
+
+    def test_reviewer_savethenovel_integration(self, monkeypatch, db_path):
+        """Integration: simulate the exact reviewer-savethenovel pane
+        from issue #1425. The reviewer calls ``pm notify`` (no flags)
+        and the resulting message + inbox task carry
+        ``project=savethenovel`` — visible from
+        ``pm message list --project savethenovel`` and the cockpit's
+        project-filtered inbox."""
+        _patch_tmux_session(
+            monkeypatch,
+            window_name="reviewer-savethenovel",
+            sessions={
+                "reviewer_savethenovel": SimpleNamespace(
+                    window_name="reviewer-savethenovel",
+                    project="savethenovel",
+                ),
+            },
+        )
+
+        result = _invoke_notify(
+            db_path,
+            "Rejecting savethenovel/11",
+            "Footer.astro:20-22 still has placeholder copy. "
+            "Needs operator decision before re-queue.",
+        )
+        assert result.exit_code == 0, result.output
+
+        rows = _fetch_messages(db_path)
+        assert len(rows) == 1
+        row = rows[0]
+        # Sender flips from default ``polly`` to the matched session
+        # name (existing actor inference behavior).
+        assert row["sender"] == "reviewer_savethenovel"
+        # And the project routing — the regression — lands at
+        # ``savethenovel`` rather than the synthetic ``inbox`` bucket.
+        assert row["scope"] == "savethenovel"
+        payload = json.loads(row["payload_json"])
+        assert payload["project"] == "savethenovel"
+        assert payload["actor"] == "reviewer_savethenovel"


### PR DESCRIPTION
Closes #1425.

<details>
<summary>Why</summary>

Reviewer-savethenovel reviewed savethenovel/11, decided to reject (placeholder copy in `Footer.astro:20-22`), and called `pm notify` to inform the operator. The message landed with `project=inbox` (synthetic project), so:
- `pm message list --project savethenovel` didn't surface it
- The cockpit's project-filtered inbox didn't show it under savethenovel
- The operator had to know to look in the global inbox to find substantive review feedback

This is a regression — it breaks "see what's happening on this project" for non-trivial review feedback.
</details>

## Summary

- `pm notify` now infers `--project` from the calling tmux pane's `SessionConfig.project` when no explicit value is passed.
- Detection mirrors the existing `_infer_notify_actor` path (window-name → session match in the loaded config). Factored out the shared lookup as `_match_notify_session_config` so actor + project inference stay consistent.
- Explicit `--project <key>` (including `--project inbox`) still wins so global broadcasts and bootstrap scripts keep working from a project-scoped pane.
- No session match → falls back to `inbox`, preserving legacy behavior for ad-hoc operator shells, scripts, and out-of-pane invocations.
- Reviewer / worker role guides already don't pass `--project inbox` — the default-inference fix means they auto-route to their project with zero prompt edits.

## Detection strategy

`tmux current_window_index → window_name → match against config.sessions[*].window_name → return session_cfg.project`

## Fallback behavior

No tmux session, no window match, no project on the matched session, or any exception during inference → `inbox` (legacy default).

## Test plan

- [x] Unit: `_infer_notify_project` returns matched session's project.
- [x] Unit: `_infer_notify_project` returns `None` without a window-name match.
- [x] Unit: `pm notify` (no `--project`) with mocked inference lands at `project=savethenovel` on both the message scope and the work-service inbox task.
- [x] Unit: `pm notify --project inbox` from a project-scoped pane still routes to inbox (explicit wins).
- [x] Unit: `pm notify` with no inferable session falls back to `project=inbox`.
- [x] Integration: simulate the exact reviewer-savethenovel pane — message scope + payload + sender all reflect `savethenovel`/`reviewer_savethenovel`.
- [x] Existing 25 `tests/test_cli_notify.py` tests still pass.
- [x] `tests/test_notify_task.py`, `tests/test_inbox_actions.py`, `tests/test_inbox_dedup.py`, `tests/test_notification_tiering.py`, `tests/test_cli_help_examples.py` — all green.