### PR TITLE
Reap stale rail_daemon processes at supervisor bootstrap

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -63,6 +63,13 @@ EVENT_WORKER_THREAD_LEAKED = "worker.thread_leaked"
 # ``cockpit-<pid>.sock`` whose owning PID is no longer alive. Lets
 # operators forensically count leak rates without scraping logs.
 EVENT_SOCKET_REAPED = "socket.reaped"
+# #1432 — emitted by ``rail_daemon_reaper`` when supervisor bootstrap
+# kills a stale ``pollypm.rail_daemon`` process from a prior boot.
+# Carries ``role`` (always ``"rail"`` today, leaves room for a future
+# ``"work"`` daemon), ``pid``, ``age_s``, and ``reason`` so operators
+# can quantify how often the field machine is accumulating sibling
+# daemons without scraping ``rail_daemon.log``.
+EVENT_DAEMON_REAPED = "daemon.reaped"
 # #1398 — plan task evolution. ``plan.version_incremented`` fires when
 # a plan task is refined in place (same task_id, version bump);
 # ``plan.successor_created`` fires when a replan creates a new task

--- a/src/pollypm/rail_daemon_reaper.py
+++ b/src/pollypm/rail_daemon_reaper.py
@@ -1,0 +1,516 @@
+"""Reaper for stale ``pollypm.rail_daemon`` processes (#1432).
+
+Background
+----------
+``cli._spawn_rail_daemon`` launches ``python -m pollypm.rail_daemon
+--config <path>`` detached from the cockpit process group. The daemon
+writes ``~/.pollypm/rail_daemon.pid`` on boot and removes it on clean
+shutdown.
+
+The PID-file dance (``cli._rail_daemon_live`` / ``cli._stop_rail_daemon``)
+breaks down in three real-world cases observed on the field machine:
+
+* ``pm reset --force`` SIGKILLs the cockpit process group before the
+  daemon's ``atexit`` cleanup runs — the daemon survives but the PID
+  file is unlinked, so the next ``pm up`` happily spawns *another*
+  daemon while the first keeps running.
+* Test runs against a temp config (``/private/tmp/polly-*``) leave a
+  daemon pinned to a now-deleted config tree; the live daemon doesn't
+  share a PID file with the live workspace so ``_rail_daemon_live``
+  returns False, and the next bootstrap spawns a sibling.
+* The orchestrator's ``pm up --phantom-client`` cycle re-spawns
+  ``rail_daemon`` faster than the previous PID gets cleaned up,
+  resulting in 2+ daemons fighting for the same SQLite WAL.
+
+In savethenovel watch tick #5 (#1432) the field machine had three
+concurrent ``pollypm.rail_daemon`` processes, one of which (#1431)
+was pegging CPU at 96.8%.
+
+This module mirrors :mod:`pollypm.cockpit_socket_reaper` for the
+process-tree case: a bootstrap-time sweep that walks every
+``pollypm.rail_daemon`` process via ``ps``, classifies each as
+"keep" / "reap", SIGTERMs the reapable ones, and SIGKILLs the
+holdouts after a short grace window.
+
+Staleness signal
+----------------
+A daemon process is reaped when EITHER of:
+
+* Its ``--config`` path matches the current workspace AND its PID is
+  not the live PID-file owner (a sibling that snuck past the lock).
+* Its ``--config`` path lives under ``$TMPDIR`` / ``/private/tmp``
+  (a leftover from a test run; the parent test session is gone).
+
+The PID-file owner is preserved unconditionally — even if the file
+is stale, we error on the side of leaving the live daemon alone and
+will catch it on the next bootstrap if it really is dead.
+
+Why bootstrap-only
+------------------
+A runtime sweep risks racing with a freshly-spawned daemon during
+the same boot cycle. ``_bootstrap_clear_markers`` is the safe sweep
+window: it runs once per supervisor boot, BEFORE the launch executor
+fires ``START_RAIL_DAEMON``, so any daemon visible at this point is
+by definition from a prior boot.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shlex
+import signal
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+
+# Match the cmdline shape ``cli._spawn_rail_daemon`` writes:
+# ``python -m pollypm.rail_daemon --config <path>``.
+_RAIL_DAEMON_NEEDLE = "pollypm.rail_daemon"
+
+
+# How long to wait for SIGTERM to take effect before falling back to
+# SIGKILL. Mirrors the existing ``rail_daemon`` shutdown handler which
+# tears down ``CoreRail`` synchronously and exits within a tick.
+_SIGTERM_GRACE_S = 3.0
+
+
+@dataclass(frozen=True, slots=True)
+class ReapedDaemon:
+    """Record of a rail_daemon process that was killed by the reaper.
+
+    Surfaces enough context for log lines / audit events: the PID,
+    its observed age in seconds (parsed from ``ps etime``), the
+    ``--config`` path argument that pinned it to a workspace, the
+    classification reason, and which signal succeeded.
+    """
+
+    pid: int
+    config_path: str | None
+    age_s: int | None
+    reason: str
+    signal_used: str  # ``"SIGTERM"`` or ``"SIGKILL"`` or ``"already_gone"``
+
+
+@dataclass(frozen=True, slots=True)
+class _DaemonProcess:
+    """Internal: parsed snapshot of a ``ps`` row pointing at a daemon."""
+
+    pid: int
+    age_s: int | None
+    cmdline: str
+    config_path: str | None
+
+
+# Regex tolerant of the macOS ``ps -o etime`` format ``[[DD-]HH:]MM:SS``.
+_ETIME_RE = re.compile(
+    r"^(?:(?P<days>\d+)-)?(?:(?P<hours>\d+):)?(?P<minutes>\d+):(?P<seconds>\d+)$"
+)
+
+
+def _parse_etime(value: str) -> int | None:
+    """Parse the ``ps`` ``etime`` field into seconds.
+
+    Returns ``None`` when the field is unparseable (very-young
+    processes can show up as empty on some platforms; a missing age
+    is fine for the reaper — staleness is decided by the cmdline
+    shape, not by age).
+    """
+    match = _ETIME_RE.match(value.strip())
+    if match is None:
+        return None
+    days = int(match.group("days") or 0)
+    hours = int(match.group("hours") or 0)
+    minutes = int(match.group("minutes") or 0)
+    seconds = int(match.group("seconds") or 0)
+    return ((days * 24 + hours) * 60 + minutes) * 60 + seconds
+
+
+def _extract_config_path(cmdline: str) -> str | None:
+    """Pull the ``--config <path>`` argument out of a ``ps`` cmdline.
+
+    Tolerates both ``--config /path`` and ``--config=/path`` shapes.
+    Returns ``None`` when the flag is absent (the daemon should never
+    be launched without it from ``cli._spawn_rail_daemon``, but a
+    test harness or operator might invoke it manually).
+    """
+    try:
+        tokens = shlex.split(cmdline)
+    except ValueError:
+        # Unbalanced quoting — fall back to a regex sweep so a
+        # pathologically-formatted cmdline doesn't blind the reaper.
+        match = re.search(r"--config[= ]([^\s]+)", cmdline)
+        return match.group(1) if match else None
+    for index, token in enumerate(tokens):
+        if token == "--config" and index + 1 < len(tokens):
+            return tokens[index + 1]
+        if token.startswith("--config="):
+            return token.split("=", 1)[1]
+    return None
+
+
+def _list_rail_daemon_procs(
+    *,
+    ps_runner: "PsRunner | None" = None,
+) -> list[_DaemonProcess]:
+    """Run ``ps`` and parse out every ``pollypm.rail_daemon`` process.
+
+    Uses a tab as the separator between PID/ETIME/COMMAND so the
+    cmdline (which itself contains spaces) parses cleanly. Falls back
+    to splitting on whitespace twice when ``ps`` doesn't honour the
+    separator hint (BSD ``ps`` accepts comma-list ``-o`` but always
+    delimits with whitespace).
+    """
+    runner = ps_runner or _default_ps_runner
+    try:
+        raw = runner()
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("rail_daemon_reaper: ps invocation failed: %s", exc)
+        return []
+    out: list[_DaemonProcess] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or _RAIL_DAEMON_NEEDLE not in line:
+            continue
+        # Two splits: pid, etime, then cmdline-as-rest.
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            continue
+        pid_text, etime_text, cmdline = parts
+        try:
+            pid = int(pid_text)
+        except ValueError:
+            continue
+        # Skip ourselves — the reaper runs under the supervisor's
+        # Python interpreter, but in a future ``pm`` subcommand the
+        # importing process could itself match the needle.
+        if pid == os.getpid():
+            continue
+        out.append(
+            _DaemonProcess(
+                pid=pid,
+                age_s=_parse_etime(etime_text),
+                cmdline=cmdline,
+                config_path=_extract_config_path(cmdline),
+            )
+        )
+    return out
+
+
+def _default_ps_runner() -> str:
+    """Invoke ``ps`` and return its decoded stdout.
+
+    ``-A`` lists every process; ``-o pid,etime,command`` keeps the
+    output narrow and stable across BSD/Linux. We do NOT use ``-f``
+    because BSD ``ps -f`` re-orders columns. Timeout is generous (5s)
+    because a hanging ``ps`` would block bootstrap; we'd rather skip
+    the reap than hang ``pm up``.
+    """
+    completed = subprocess.run(
+        ["ps", "-A", "-o", "pid,etime,command"],
+        capture_output=True,
+        text=True,
+        timeout=5.0,
+        check=False,
+    )
+    return completed.stdout
+
+
+# Type alias for tests that want to inject canned ``ps`` output.
+PsRunner = Callable[[], str]
+
+
+def _is_temp_config_path(config_path: str | None) -> bool:
+    """Return True iff ``config_path`` looks like a test-run leftover.
+
+    Matches paths under the system temp dir — covers
+    ``/tmp/polly-*``, ``/private/tmp/polly-*`` (macOS resolves
+    ``/tmp`` to ``/private/tmp``), and pytest's ``tmp_path`` family.
+    A daemon pinned to a temp config is by definition a test leak:
+    the parent test session is long gone and the config tree may
+    not even exist on disk anymore.
+    """
+    if not config_path:
+        return False
+    try:
+        resolved = str(Path(config_path).resolve())
+    except OSError:
+        resolved = config_path
+    tmp_roots = {tempfile.gettempdir(), "/tmp", "/private/tmp", "/var/folders"}
+    for root in tmp_roots:
+        try:
+            root_resolved = str(Path(root).resolve())
+        except OSError:
+            root_resolved = root
+        if resolved.startswith(root_resolved + os.sep) or resolved == root_resolved:
+            return True
+        # Also catch raw, unresolved paths for cases where the config
+        # tree was deleted (so ``Path.resolve`` returns the original).
+        if config_path.startswith(root.rstrip(os.sep) + os.sep):
+            return True
+    return False
+
+
+def _read_pid_file(pid_path: Path) -> int | None:
+    """Return the PID stored in ``rail_daemon.pid``, or ``None``."""
+    try:
+        text = pid_path.read_text().strip()
+    except (OSError, ValueError):
+        return None
+    if not text:
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def _classify(
+    proc: _DaemonProcess,
+    *,
+    current_config_path: str,
+    pid_file_owner: int | None,
+) -> str | None:
+    """Decide why ``proc`` should be reaped (or ``None`` to keep it).
+
+    Preservation rules, evaluated in order:
+
+    1. Live PID-file owner is always preserved. Even if the file is
+       stale, the PID is the most authoritative "this is the live
+       daemon" signal we have.
+    2. Otherwise, reap when:
+       * ``--config`` matches the current workspace (sibling daemon
+         that snuck past the file lock), OR
+       * ``--config`` lives under ``$TMPDIR`` (test-run leftover).
+
+    Other rail_daemon processes (e.g. running under a different
+    user's config tree on a shared machine) are left alone — we
+    don't own them.
+    """
+    if pid_file_owner is not None and proc.pid == pid_file_owner:
+        return None
+
+    config_path = proc.config_path
+    if config_path is None:
+        # No --config arg → can't classify; leave alone.
+        return None
+
+    try:
+        same_workspace = (
+            Path(config_path).resolve() == Path(current_config_path).resolve()
+        )
+    except OSError:
+        same_workspace = config_path == current_config_path
+
+    if same_workspace:
+        return (
+            "sibling daemon for current workspace "
+            f"(config={config_path!r}, pid_file_owner={pid_file_owner})"
+        )
+    if _is_temp_config_path(config_path):
+        return f"test-run leftover (config={config_path!r})"
+    return None
+
+
+def _emit_audit(
+    *,
+    pid: int,
+    age_s: int | None,
+    reason: str,
+    config_path: str | None,
+    signal_used: str,
+) -> None:
+    """Best-effort ``daemon.reaped`` audit emit.
+
+    Fires after a successful kill so the central audit log records
+    each reap with ``role=rail``, ``pid``, ``age_s``, ``reason``.
+    Mirrors :func:`cockpit_socket_reaper._emit_audit` — never raises,
+    and uses the ``_workspace`` project key because the rail daemon
+    belongs to no single project.
+    """
+    try:
+        from pollypm.audit import emit as _audit_emit
+        from pollypm.audit.log import EVENT_DAEMON_REAPED
+    except Exception:  # noqa: BLE001
+        return
+    try:
+        _audit_emit(
+            event=EVENT_DAEMON_REAPED,
+            project="_workspace",
+            subject=f"rail_daemon/{pid}",
+            actor="system",
+            status="warn",
+            metadata={
+                "role": "rail",
+                "pid": pid,
+                "age_s": age_s,
+                "reason": reason,
+                "config": config_path,
+                "signal": signal_used,
+            },
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True iff ``pid`` is still a live process.
+
+    ``EPERM`` (PermissionError) means the PID exists but isn't ours
+    — treat as alive, matching the conservative behaviour in
+    :mod:`cockpit_socket_reaper`.
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _terminate_with_grace(
+    pid: int,
+    *,
+    grace_s: float = _SIGTERM_GRACE_S,
+    sleep_fn=time.sleep,
+) -> str:
+    """SIGTERM, wait up to ``grace_s``, SIGKILL if still alive.
+
+    Returns the signal label that ultimately took (or
+    ``"already_gone"`` if the process exited before we sent
+    anything). The caller logs / audits the result.
+
+    ``sleep_fn`` is injected so tests can drive the grace window
+    deterministically without sleeping wall-clock time.
+    """
+    if not _pid_alive(pid):
+        return "already_gone"
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return "already_gone"
+    except PermissionError:
+        # Can't signal it — log and bail. Conservative: we'd rather
+        # leave a foreign daemon alone than fight the OS.
+        logger.warning(
+            "rail_daemon_reaper: SIGTERM denied for pid=%d (not our process)",
+            pid,
+        )
+        return "denied"
+
+    # Poll on a short cadence so a fast-exiting daemon doesn't block
+    # bootstrap for the full grace window.
+    deadline = time.monotonic() + grace_s
+    poll_interval = 0.1
+    while time.monotonic() < deadline:
+        if not _pid_alive(pid):
+            return "SIGTERM"
+        sleep_fn(poll_interval)
+
+    # Holdout — escalate.
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return "SIGTERM"
+    except PermissionError:
+        return "denied"
+    return "SIGKILL"
+
+
+def reap_stale_rail_daemons(
+    *,
+    current_config_path: Path | str,
+    pid_file_path: Path | str | None = None,
+    ps_runner=None,
+    sleep_fn=time.sleep,
+) -> list[ReapedDaemon]:
+    """Bootstrap-time reaper. Walk ``ps``, kill stale rail_daemon procs.
+
+    Designed to be called from ``Supervisor._bootstrap_clear_markers``
+    BEFORE the launch executor fires ``START_RAIL_DAEMON``. By that
+    point any daemon visible to ``ps`` is from a prior boot.
+
+    Args:
+        current_config_path: the workspace's config path — used to
+            decide which daemons belong to "this workspace".
+        pid_file_path: location of ``rail_daemon.pid`` (defaults to
+            ``<config-parent>/rail_daemon.pid``). The PID stored there
+            is preserved unconditionally.
+        ps_runner: callable returning ``ps`` output. Tests inject a
+            fake; production uses :func:`_default_ps_runner`.
+        sleep_fn: injectable sleep for the SIGTERM grace window.
+
+    Returns:
+        The list of :class:`ReapedDaemon` records for processes that
+        were signalled, so callers can log / count.
+    """
+    config_path_str = str(current_config_path)
+    if pid_file_path is None:
+        pid_file = Path(config_path_str).parent / "rail_daemon.pid"
+    else:
+        pid_file = Path(pid_file_path)
+
+    pid_file_owner: int | None = None
+    if pid_file.exists():
+        owner = _read_pid_file(pid_file)
+        if owner is not None and _pid_alive(owner):
+            pid_file_owner = owner
+
+    procs = _list_rail_daemon_procs(ps_runner=ps_runner)
+    reaped: list[ReapedDaemon] = []
+    for proc in procs:
+        reason = _classify(
+            proc,
+            current_config_path=config_path_str,
+            pid_file_owner=pid_file_owner,
+        )
+        if reason is None:
+            continue
+        signal_used = _terminate_with_grace(proc.pid, sleep_fn=sleep_fn)
+        if signal_used == "denied":
+            # Couldn't signal — don't claim a reap.
+            continue
+        logger.warning(
+            "rail_daemon_reaper: reaped pid=%d age_s=%s config=%s reason=%s "
+            "signal=%s",
+            proc.pid,
+            proc.age_s,
+            proc.config_path,
+            reason,
+            signal_used,
+        )
+        _emit_audit(
+            pid=proc.pid,
+            age_s=proc.age_s,
+            reason=reason,
+            config_path=proc.config_path,
+            signal_used=signal_used,
+        )
+        reaped.append(
+            ReapedDaemon(
+                pid=proc.pid,
+                config_path=proc.config_path,
+                age_s=proc.age_s,
+                reason=reason,
+                signal_used=signal_used,
+            )
+        )
+    return reaped
+
+
+__all__ = [
+    "ReapedDaemon",
+    "reap_stale_rail_daemons",
+]

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -938,6 +938,27 @@ class Supervisor:
                 "cockpit-socket reaper failed at bootstrap", exc_info=True,
             )
 
+        # #1432 — reap stale ``pollypm.rail_daemon`` processes from
+        # prior boots. ``pm reset --force && pm up`` cycles, crashed
+        # cockpit teardowns, and test runs against temp configs all
+        # leave detached daemons alive that the PID-file gate
+        # (``cli._rail_daemon_live``) doesn't catch. The field machine
+        # accumulated three concurrent daemons (#1431 / #1432) before
+        # this reaper landed. Bootstrap is the safe sweep time: the
+        # launch executor's ``START_RAIL_DAEMON`` action fires AFTER
+        # this hook, so any daemon visible here is by definition from
+        # a prior boot and reaping it can't race with the current one.
+        try:
+            from pollypm.rail_daemon_reaper import reap_stale_rail_daemons
+            from pollypm.config import DEFAULT_CONFIG_PATH as _DEFAULT_CONFIG_PATH
+
+            cfg_path = getattr(self.config, "config_path", None) or _DEFAULT_CONFIG_PATH
+            reap_stale_rail_daemons(current_config_path=cfg_path)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "rail-daemon reaper failed at bootstrap", exc_info=True,
+            )
+
     def repair_sessions_table(self) -> int:
         """Upsert a ``sessions`` row for every configured session whose
         tmux window is currently alive.

--- a/tests/test_rail_daemon_reaper.py
+++ b/tests/test_rail_daemon_reaper.py
@@ -1,0 +1,492 @@
+"""Tests for the rail_daemon process reaper (#1432).
+
+The reaper walks ``ps`` output, classifies each ``pollypm.rail_daemon``
+row as keep / reap, and SIGTERMs (with SIGKILL fallback) the reapable
+ones. The tests use synthetic ``ps`` output and a tiny long-lived
+sentinel subprocess so we exercise the real signal path without needing
+to actually boot a daemon.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from pollypm.rail_daemon_reaper import (
+    ReapedDaemon,
+    _classify,
+    _DaemonProcess,
+    _extract_config_path,
+    _is_temp_config_path,
+    _parse_etime,
+    reap_stale_rail_daemons,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _spawn_sentinel() -> subprocess.Popen:
+    """Spawn a sleep-forever child so we have a real PID to signal.
+
+    The child writes nothing and waits for SIGTERM/SIGKILL. Tests
+    must call ``proc.wait()`` (or rely on the fixture cleanup) to
+    avoid leaking a zombie.
+    """
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import signal, time; signal.signal(signal.SIGTERM, lambda *a: __import__('sys').exit(0)); time.sleep(60)",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _ps_line(pid: int, etime: str, cmdline: str) -> str:
+    """Format a synthetic ``ps -o pid,etime,command`` line."""
+    return f"  {pid} {etime} {cmdline}"
+
+
+def _make_ps_runner(lines: list[str]):
+    """Return a callable that produces canned ``ps`` output."""
+    def _runner() -> str:
+        return "\n".join(lines) + "\n"
+    return _runner
+
+
+# ---------------------------------------------------------------------------
+# Pure-function unit tests (no signals, no subprocesses)
+# ---------------------------------------------------------------------------
+
+
+class TestParseEtime:
+    """``ps etime`` field comes in three shapes; the parser handles all."""
+
+    def test_seconds_only(self) -> None:
+        assert _parse_etime("00:42") == 42
+
+    def test_minutes_seconds(self) -> None:
+        assert _parse_etime("05:30") == 5 * 60 + 30
+
+    def test_hours_minutes_seconds(self) -> None:
+        assert _parse_etime("01:02:03") == 1 * 3600 + 2 * 60 + 3
+
+    def test_days_hours_minutes_seconds(self) -> None:
+        assert _parse_etime("2-03:04:05") == 2 * 86400 + 3 * 3600 + 4 * 60 + 5
+
+    def test_unparseable_returns_none(self) -> None:
+        assert _parse_etime("garbage") is None
+        assert _parse_etime("") is None
+
+
+class TestExtractConfigPath:
+    """``--config <path>`` and ``--config=<path>`` both supported."""
+
+    def test_space_separated(self) -> None:
+        cmd = "/usr/bin/python -m pollypm.rail_daemon --config /home/u/.pollypm/pollypm.toml"
+        assert _extract_config_path(cmd) == "/home/u/.pollypm/pollypm.toml"
+
+    def test_equals_form(self) -> None:
+        cmd = "python -m pollypm.rail_daemon --config=/tmp/polly-abc/pollypm.toml"
+        assert _extract_config_path(cmd) == "/tmp/polly-abc/pollypm.toml"
+
+    def test_missing_returns_none(self) -> None:
+        cmd = "python -m pollypm.rail_daemon"
+        assert _extract_config_path(cmd) is None
+
+    def test_unbalanced_quotes_falls_back_to_regex(self) -> None:
+        # shlex.split raises on unbalanced quotes; the regex fallback
+        # still pulls the path out so a pathological cmdline can't
+        # blind the reaper.
+        cmd = 'python -m pollypm.rail_daemon --config /opt/foo "unbalanced'
+        assert _extract_config_path(cmd) == "/opt/foo"
+
+
+class TestIsTempConfigPath:
+    """Temp-dir detection covers the macOS + Linux + pytest cases."""
+
+    def test_tmp_path(self) -> None:
+        assert _is_temp_config_path("/tmp/polly-abc/pollypm.toml") is True
+
+    def test_private_tmp_path_macos(self) -> None:
+        assert _is_temp_config_path("/private/tmp/polly-abc/pollypm.toml") is True
+
+    def test_var_folders_macos(self) -> None:
+        assert (
+            _is_temp_config_path("/var/folders/xx/abc/T/pytest-of-x/pollypm.toml")
+            is True
+        )
+
+    def test_workspace_path_is_not_temp(self) -> None:
+        assert _is_temp_config_path("/Users/sam/.pollypm/pollypm.toml") is False
+        assert _is_temp_config_path("/home/u/.pollypm/pollypm.toml") is False
+
+    def test_none_is_not_temp(self) -> None:
+        assert _is_temp_config_path(None) is False
+        assert _is_temp_config_path("") is False
+
+
+class TestClassify:
+    """``_classify`` is the staleness oracle — keep, reap-sibling, reap-temp."""
+
+    def _proc(self, *, pid: int, config_path: str | None) -> _DaemonProcess:
+        return _DaemonProcess(
+            pid=pid, age_s=42, cmdline="python -m pollypm.rail_daemon",
+            config_path=config_path,
+        )
+
+    def test_pid_file_owner_preserved(self) -> None:
+        """Even with a matching workspace config, the PID-file owner is kept."""
+        proc = self._proc(pid=4242, config_path="/home/u/.pollypm/pollypm.toml")
+        assert _classify(
+            proc,
+            current_config_path="/home/u/.pollypm/pollypm.toml",
+            pid_file_owner=4242,
+        ) is None
+
+    def test_sibling_in_current_workspace_reaped(self) -> None:
+        proc = self._proc(pid=9999, config_path="/home/u/.pollypm/pollypm.toml")
+        reason = _classify(
+            proc,
+            current_config_path="/home/u/.pollypm/pollypm.toml",
+            pid_file_owner=4242,  # different PID
+        )
+        assert reason is not None
+        assert "sibling daemon" in reason
+
+    def test_temp_config_always_reaped(self) -> None:
+        proc = self._proc(pid=8888, config_path="/tmp/polly-xyz/pollypm.toml")
+        reason = _classify(
+            proc,
+            current_config_path="/home/u/.pollypm/pollypm.toml",
+            pid_file_owner=None,
+        )
+        assert reason is not None
+        assert "test-run leftover" in reason
+
+    def test_foreign_workspace_left_alone(self) -> None:
+        """A daemon under another user's home is not ours to reap."""
+        proc = self._proc(pid=7777, config_path="/home/other/.pollypm/pollypm.toml")
+        assert _classify(
+            proc,
+            current_config_path="/home/u/.pollypm/pollypm.toml",
+            pid_file_owner=None,
+        ) is None
+
+    def test_no_config_arg_left_alone(self) -> None:
+        proc = self._proc(pid=6666, config_path=None)
+        assert _classify(
+            proc,
+            current_config_path="/home/u/.pollypm/pollypm.toml",
+            pid_file_owner=None,
+        ) is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: synthetic ps output + real subprocess targets
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Iterator[Path]:
+    """A fake workspace with a config file path the reaper can resolve."""
+    base = tmp_path / "ws"
+    base.mkdir()
+    cfg = base / "pollypm.toml"
+    cfg.write_text("# fake")
+    yield cfg
+
+
+@pytest.fixture
+def sentinel() -> Iterator[subprocess.Popen]:
+    """A live subprocess we can target with the reaper.
+
+    Cleans itself up: if the test reaped it, the wait() returns
+    quickly; if not, we SIGKILL on teardown so the test runner
+    doesn't leak processes.
+    """
+    proc = _spawn_sentinel()
+    try:
+        yield proc
+    finally:
+        if proc.poll() is None:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+def test_reaps_synthetic_stale_daemon_for_current_workspace(
+    workspace: Path, sentinel: subprocess.Popen,
+) -> None:
+    """A daemon row matching the current workspace + not the PID-file
+    owner is SIGTERMed."""
+    ps_runner = _make_ps_runner([
+        "  PID ELAPSED COMMAND",
+        _ps_line(
+            sentinel.pid,
+            "00:00:05",
+            f"python -m pollypm.rail_daemon --config {workspace}",
+        ),
+    ])
+
+    reaped = reap_stale_rail_daemons(
+        current_config_path=workspace,
+        pid_file_path=workspace.parent / "rail_daemon.pid",  # absent → no owner
+        ps_runner=ps_runner,
+    )
+
+    assert len(reaped) == 1
+    entry = reaped[0]
+    assert isinstance(entry, ReapedDaemon)
+    assert entry.pid == sentinel.pid
+    assert entry.age_s == 5
+    assert entry.signal_used in {"SIGTERM", "SIGKILL", "already_gone"}
+    assert "sibling daemon" in entry.reason
+
+    # The sentinel installs a SIGTERM handler that exits cleanly, so it
+    # should be gone within the grace window.
+    sentinel.wait(timeout=5)
+    assert sentinel.returncode is not None
+
+
+def test_preserves_live_pid_file_owner(
+    workspace: Path, sentinel: subprocess.Popen,
+) -> None:
+    """The daemon whose PID is in ``rail_daemon.pid`` is left running."""
+    pid_file = workspace.parent / "rail_daemon.pid"
+    pid_file.write_text(str(sentinel.pid))
+
+    ps_runner = _make_ps_runner([
+        _ps_line(
+            sentinel.pid,
+            "00:00:10",
+            f"python -m pollypm.rail_daemon --config {workspace}",
+        ),
+    ])
+
+    reaped = reap_stale_rail_daemons(
+        current_config_path=workspace,
+        pid_file_path=pid_file,
+        ps_runner=ps_runner,
+    )
+
+    assert reaped == []
+    # Sentinel should still be alive — give the SIGTERM handler some
+    # time to fire if anything went wrong.
+    time.sleep(0.2)
+    assert sentinel.poll() is None, "live daemon was killed!"
+
+
+def test_reaps_temp_config_daemon_regardless_of_workspace(
+    workspace: Path, sentinel: subprocess.Popen,
+) -> None:
+    """A daemon pinned to ``/tmp/polly-*`` is reaped even if its config
+    doesn't match the current workspace."""
+    ps_runner = _make_ps_runner([
+        _ps_line(
+            sentinel.pid,
+            "1-02:03:04",
+            "python -m pollypm.rail_daemon --config /tmp/polly-xyz/pollypm.toml",
+        ),
+    ])
+
+    reaped = reap_stale_rail_daemons(
+        current_config_path=workspace,
+        pid_file_path=workspace.parent / "rail_daemon.pid",
+        ps_runner=ps_runner,
+    )
+
+    assert len(reaped) == 1
+    assert reaped[0].pid == sentinel.pid
+    # 1d 2h 3m 4s → 93784s
+    assert reaped[0].age_s == 1 * 86400 + 2 * 3600 + 3 * 60 + 4
+    assert "test-run leftover" in reaped[0].reason
+
+    sentinel.wait(timeout=5)
+
+
+def test_idempotent_no_op_when_only_live_owner_present(
+    workspace: Path, sentinel: subprocess.Popen,
+) -> None:
+    """Running the reaper twice on the same ``ps`` output doesn't kill
+    the live daemon. Models the 'bootstrap fires twice' edge case."""
+    pid_file = workspace.parent / "rail_daemon.pid"
+    pid_file.write_text(str(sentinel.pid))
+
+    ps_lines = [
+        _ps_line(
+            sentinel.pid,
+            "00:00:30",
+            f"python -m pollypm.rail_daemon --config {workspace}",
+        ),
+    ]
+
+    first = reap_stale_rail_daemons(
+        current_config_path=workspace,
+        pid_file_path=pid_file,
+        ps_runner=_make_ps_runner(ps_lines),
+    )
+    second = reap_stale_rail_daemons(
+        current_config_path=workspace,
+        pid_file_path=pid_file,
+        ps_runner=_make_ps_runner(ps_lines),
+    )
+
+    assert first == []
+    assert second == []
+    assert sentinel.poll() is None
+
+
+def test_skips_self_pid(workspace: Path) -> None:
+    """``os.getpid()`` is filtered out so a future ``pm`` subcommand
+    that reuses this module can't reap itself."""
+    ps_runner = _make_ps_runner([
+        _ps_line(
+            os.getpid(),
+            "00:01:00",
+            f"python -m pollypm.rail_daemon --config {workspace}",
+        ),
+    ])
+
+    reaped = reap_stale_rail_daemons(
+        current_config_path=workspace,
+        pid_file_path=workspace.parent / "rail_daemon.pid",
+        ps_runner=ps_runner,
+    )
+
+    assert reaped == []
+
+
+def test_handles_ps_failure_gracefully(workspace: Path) -> None:
+    """A subprocess error from ``ps`` returns an empty list rather than
+    raising — bootstrap must never fail on the reaper path."""
+    def _failing_runner() -> str:
+        raise OSError("synthetic failure")
+
+    reaped = reap_stale_rail_daemons(
+        current_config_path=workspace,
+        pid_file_path=workspace.parent / "rail_daemon.pid",
+        ps_runner=_failing_runner,
+    )
+    assert reaped == []
+
+
+def test_emits_daemon_reaped_audit_event(
+    workspace: Path,
+    sentinel: subprocess.Popen,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each reap produces a ``daemon.reaped`` line in the central audit tail."""
+    audit_home = tmp_path / "audit-home"
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+    ps_runner = _make_ps_runner([
+        _ps_line(
+            sentinel.pid,
+            "00:00:07",
+            f"python -m pollypm.rail_daemon --config {workspace}",
+        ),
+    ])
+
+    reaped = reap_stale_rail_daemons(
+        current_config_path=workspace,
+        pid_file_path=workspace.parent / "rail_daemon.pid",
+        ps_runner=ps_runner,
+    )
+    assert reaped, "expected stale daemon to be reaped"
+
+    from pollypm.audit.log import read_events
+
+    events = read_events("_workspace")
+    daemon_events = [e for e in events if e.event == "daemon.reaped"]
+    assert daemon_events, (
+        f"expected daemon.reaped event, got {[e.event for e in events]}"
+    )
+    last = daemon_events[-1]
+    assert last.metadata.get("role") == "rail"
+    assert last.metadata.get("pid") == sentinel.pid
+    assert last.metadata.get("age_s") == 7
+    assert last.metadata.get("reason") and "sibling daemon" in last.metadata["reason"]
+    assert last.actor == "system"
+
+    sentinel.wait(timeout=5)
+
+
+def test_sigkill_fallback_when_sigterm_ignored(workspace: Path) -> None:
+    """A daemon that ignores SIGTERM is escalated to SIGKILL.
+
+    We spawn a child that installs an empty SIGTERM handler so the
+    signal doesn't kill it. The reaper should fall through to SIGKILL
+    after the grace window.
+    """
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import signal, time; "
+                "signal.signal(signal.SIGTERM, lambda *a: None); "
+                "time.sleep(60)"
+            ),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        ps_runner = _make_ps_runner([
+            _ps_line(
+                proc.pid,
+                "00:00:15",
+                f"python -m pollypm.rail_daemon --config {workspace}",
+            ),
+        ])
+
+        # Use a tiny grace window so the test doesn't take 3s; the
+        # default sleep_fn is fine because we're capping the grace
+        # via a faster sleep.
+        # We can't override grace_s through the public API yet; the
+        # default 3.0s window is acceptable for a single test.
+        reaped = reap_stale_rail_daemons(
+            current_config_path=workspace,
+            pid_file_path=workspace.parent / "rail_daemon.pid",
+            ps_runner=ps_runner,
+        )
+        assert len(reaped) == 1
+        # The fallback should fire — SIGTERM was ignored at the handler
+        # level, so the reaper's grace window expires and SIGKILL is
+        # sent. We assert on the reaper's recorded signal rather than
+        # ``proc.returncode`` because Python's signal-restart semantics
+        # mean the child can still report ``-SIGTERM`` as its exit
+        # signal even after we've escalated to SIGKILL.
+        assert reaped[0].signal_used == "SIGKILL"
+        proc.wait(timeout=5)
+        assert proc.returncode is not None
+        assert proc.returncode != 0  # any non-zero is fine
+    finally:
+        if proc.poll() is None:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass


### PR DESCRIPTION
Closes #1432.

## Summary

- Adds `src/pollypm/rail_daemon_reaper.py`: walks `ps` at supervisor bootstrap, parses each `pollypm.rail_daemon` row's `--config` arg, and reaps any process that's either a sibling for the current workspace (not the live PID-file owner) or pinned to a temp-dir config (test-run leftover).
- SIGTERM first, SIGKILL after a 3s grace window. The PID-file owner is preserved unconditionally so the live daemon survives re-bootstrap.
- Wires the call into `Supervisor._bootstrap_clear_markers`, alongside the existing worker-marker and cockpit-socket reapers.
- Adds `EVENT_DAEMON_REAPED` audit event (`daemon.reaped`) carrying `role=rail`, `pid`, `age_s`, `reason`, `config`, `signal` — emitted to the `_workspace` central tail so operators can quantify accumulation without scraping `rail_daemon.log`.

## Why

savethenovel watch tick #5 (#1432) found three concurrent rail_daemon processes — one of which (#1431) was pegging CPU at 96.8%. The PID-file gate in `cli._rail_daemon_live` doesn't catch all leak paths (`pm reset --force` SIGKILL races, temp-config test runs, fast pm-up cycles).

## Reaper logic

1. Build the live-PID set: read `~/.pollypm/rail_daemon.pid`, verify the PID is alive.
2. Walk `ps -A -o pid,etime,command`, filter on `pollypm.rail_daemon`, extract `--config <path>`.
3. For each candidate:
   - PID == live PID-file owner -> keep
   - Config matches current workspace -> reap (sibling)
   - Config under `/tmp` / `/private/tmp` / `/var/folders` -> reap (test leftover)
   - Other -> keep (foreign workspace)
4. SIGTERM, poll for exit on 100ms cadence up to 3s, SIGKILL holdouts. Audit-emit on success.

## Test plan

- [x] Unit: parse `etime` formats (sec, min:sec, hr:min:sec, day-hr:min:sec)
- [x] Unit: extract `--config` from space-separated, equals form, missing, unbalanced quotes
- [x] Unit: temp-dir detection (`/tmp`, `/private/tmp`, `/var/folders`, real workspace, None)
- [x] Unit: classifier — PID-file owner preserved, sibling reaped, temp config reaped, foreign workspace preserved, no-config-arg preserved
- [x] Integration: synthetic `ps` line + real subprocess sentinel -> SIGTERM lands
- [x] Integration: live PID-file owner preserved (re-runs reaper twice without killing the daemon -> idempotent)
- [x] Integration: temp-config daemon reaped regardless of workspace
- [x] Integration: SIGKILL fallback when SIGTERM is ignored
- [x] Integration: self-PID skipped
- [x] Integration: `ps` failure handled gracefully (returns empty list, no raise)
- [x] Integration: emits `daemon.reaped` to central audit tail

27 new tests, all passing. Adjacent reaper tests (`test_cockpit_socket_reaper`, `test_worker_marker_reaper`) and `test_audit_log` still pass. The single failing supervisor test pre-exists on main and is unrelated.