### PR TITLE
Watchdog: state-based detection for review/on_hold/role_session_missing rules

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -439,20 +439,71 @@ def _detect_stuck_drafts(
     *,
     now: datetime,
     config: WatchdogConfig,
+    open_tasks: Sequence[Any] | None = None,
 ) -> list[Finding]:
-    """Rule 3: ``task.created`` older than ``stuck_draft_seconds`` with
-    no promotion.
+    """Rule 3 (state-based, #1433): tasks currently at ``status=draft``
+    older than ``stuck_draft_seconds``.
 
-    Iterates ``task.created`` events older than the threshold. For
-    each, we check whether *any* ``task.status_changed`` for the
-    same subject exists at all (looking at the full event list, not
-    just inside the lookback window — a task that got promoted before
-    the window started is fine). If no promotion is recorded, the
-    draft is stuck.
+    Primary detection path queries the live ``work_tasks`` view via
+    ``open_tasks`` — any task currently at ``status=draft`` whose
+    ``created_at`` is older than the threshold is stuck. The audit-event
+    path still fires for synthetic-fixture tests (and as a safety net
+    when ``open_tasks`` isn't supplied), so old behavior is preserved.
+
+    Findings produced by the state path take precedence — we dedupe
+    on ``(project, subject)`` so a task that is both visible in
+    ``open_tasks`` AND has a matching audit event only fires once.
     """
     findings: list[Finding] = []
+    seen_subjects: set[str] = set()
     cutoff = now - timedelta(seconds=config.stuck_draft_seconds)
 
+    # State-based path (#1433): walks current ``work_tasks`` rows.
+    if open_tasks:
+        for task in open_tasks:
+            status = getattr(task, "work_status", None)
+            status_value = getattr(status, "value", status)
+            if status_value != "draft":
+                continue
+            created_at = getattr(task, "created_at", None)
+            if created_at is None:
+                continue
+            if getattr(created_at, "tzinfo", None) is None:
+                created_at = created_at.replace(tzinfo=timezone.utc)
+            if created_at > cutoff:
+                continue
+            project = getattr(task, "project", "") or ""
+            task_number = getattr(task, "task_number", None)
+            if not project or task_number is None:
+                continue
+            subject = f"{project}/{task_number}"
+            if subject in seen_subjects:
+                continue
+            seen_subjects.add(subject)
+            actor = getattr(task, "created_by", "") or "unknown"
+            findings.append(Finding(
+                rule=RULE_STUCK_DRAFT,
+                project=project,
+                subject=subject,
+                message=(
+                    f"Draft task {subject} has sat unpromoted for "
+                    f">{config.stuck_draft_seconds // 60} min "
+                    f"(created {created_at.isoformat()})."
+                ),
+                recommendation=(
+                    f"Promote with `pm task queue {subject}` or "
+                    f"discard with `pm task cancel {subject}`. "
+                    f"Originating actor: {actor}."
+                ),
+                metadata={
+                    "created_at": created_at.isoformat(),
+                    "actor": actor,
+                    "title": getattr(task, "title", None),
+                    "detected_via": "state",
+                },
+            ))
+
+    # Event-based fallback (backward-compat with old fixtures).
     promoted_subjects: set[str] = set()
     created_events: list[AuditEvent] = []
     for ev in events:
@@ -473,10 +524,13 @@ def _detect_stuck_drafts(
     for ev in created_events:
         if ev.subject in promoted_subjects:
             continue
+        if ev.subject in seen_subjects:
+            continue
         key = _task_subject_key(ev.subject)
         if key is None:
             continue
         project, task_number = key
+        seen_subjects.add(ev.subject)
         findings.append(Finding(
             rule=RULE_STUCK_DRAFT,
             project=project,
@@ -495,6 +549,7 @@ def _detect_stuck_drafts(
                 "created_at": ev.ts,
                 "actor": ev.actor,
                 "title": (ev.metadata or {}).get("title"),
+                "detected_via": "event",
             },
         ))
     return findings
@@ -571,22 +626,123 @@ def _detect_cancellation_no_promotion(
 # ---------------------------------------------------------------------------
 
 
+def _state_entry_time(
+    task: Any, target_state: str,
+) -> tuple[datetime | None, dict[str, Any]]:
+    """Return ``(entry_ts, transition_meta)`` for ``task`` entering ``target_state``.
+
+    Walks ``task.transitions`` (newest first by timestamp) and returns
+    the timestamp of the most recent transition whose ``to_state``
+    matches. ``transition_meta`` carries ``from``, ``actor``, and
+    ``reason`` so callers can fold them into the Finding metadata
+    without re-walking.
+
+    When the task carries no transition history (e.g. the
+    ``include_history=False`` path of :class:`SQLiteWorkService`),
+    falls back to ``task.updated_at`` and finally ``task.created_at``.
+    Either fallback is best-effort but yields a still-useful "stuck
+    since" signal — the threshold check still gates the finding.
+    """
+    transitions = list(getattr(task, "transitions", None) or [])
+    matching: list[Any] = []
+    for tr in transitions:
+        to_state = getattr(tr, "to_state", None)
+        if to_state == target_state:
+            matching.append(tr)
+    if matching:
+        matching.sort(
+            key=lambda tr: getattr(tr, "timestamp", None) or datetime.min,
+            reverse=True,
+        )
+        latest = matching[0]
+        ts = getattr(latest, "timestamp", None)
+        if isinstance(ts, datetime):
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            return ts, {
+                "from": getattr(latest, "from_state", None),
+                "actor": getattr(latest, "actor", None),
+                "reason": getattr(latest, "reason", None),
+            }
+    # Fallback: ``updated_at`` is touched on every status change, so
+    # for a task currently *at* ``target_state`` it's a reasonable
+    # proxy for state-entry time. ``created_at`` is the last-resort.
+    fallback = getattr(task, "updated_at", None) or getattr(
+        task, "created_at", None,
+    )
+    if isinstance(fallback, datetime):
+        if fallback.tzinfo is None:
+            fallback = fallback.replace(tzinfo=timezone.utc)
+        return fallback, {"from": None, "actor": None, "reason": None}
+    return None, {"from": None, "actor": None, "reason": None}
+
+
 def _detect_task_review_stale(
     events: Sequence[AuditEvent],
     *,
     now: datetime,
     config: WatchdogConfig,
+    open_tasks: Sequence[Any] | None = None,
 ) -> list[Finding]:
-    """Rule 5: task at ``status=review`` with no transition for > threshold.
+    """Rule 5 (state-based, #1433): tasks currently at ``status=review``
+    whose entry-into-review is older than ``review_stale_seconds``.
 
-    Walks ``task.status_changed`` events and finds the latest transition
-    per task subject. If the latest transition lands the task in
-    ``review`` and is older than ``review_stale_seconds`` ago, fire.
+    Primary path queries the live ``work_tasks`` view (any task at
+    ``status=review``) and computes "how long in this state" from the
+    most recent ``review`` transition (``task.transitions``) or
+    falls back to ``updated_at`` / ``created_at``. This catches tasks
+    that entered ``review`` *before* the audit-log scan window and
+    would otherwise be invisible to the watchdog.
+
+    Audit-event scan is preserved as a fallback so synthetic-fixture
+    tests (and event-only callers) keep firing. Findings dedupe on
+    ``subject`` so we never report the same task twice in one tick.
     """
     findings: list[Finding] = []
+    seen_subjects: set[str] = set()
     cutoff = now - timedelta(seconds=config.review_stale_seconds)
 
-    # subject -> (latest_ts, ev) — pick the latest transition per task.
+    # State-based path (#1433): walks current ``work_tasks`` rows.
+    if open_tasks:
+        for task in open_tasks:
+            status = getattr(task, "work_status", None)
+            status_value = getattr(status, "value", status)
+            if status_value != "review":
+                continue
+            project = getattr(task, "project", "") or ""
+            task_number = getattr(task, "task_number", None)
+            if not project or task_number is None:
+                continue
+            subject = f"{project}/{task_number}"
+            entry_ts, tr_meta = _state_entry_time(task, "review")
+            if entry_ts is None:
+                continue
+            if entry_ts > cutoff:
+                continue
+            stuck_minutes = max(1, int((now - entry_ts).total_seconds() // 60))
+            seen_subjects.add(subject)
+            findings.append(Finding(
+                rule=RULE_TASK_REVIEW_STALE,
+                project=project,
+                subject=subject,
+                message=(
+                    f"Task {subject} has been at status=review for "
+                    f"~{stuck_minutes} min with no further transitions."
+                ),
+                recommendation=(
+                    f"Either spawn a reviewer or run `pm task done "
+                    f"{subject}` if the work is correct as-is."
+                ),
+                metadata={
+                    "review_since": entry_ts.isoformat(),
+                    "stuck_minutes": stuck_minutes,
+                    "from": tr_meta.get("from"),
+                    "actor": tr_meta.get("actor"),
+                    "detected_via": "state",
+                },
+            ))
+
+    # Event-based fallback path (backward-compat with old fixtures).
     latest: dict[str, tuple[datetime, AuditEvent]] = {}
     for ev in events:
         if ev.event != EVENT_TASK_STATUS_CHANGED:
@@ -599,17 +755,19 @@ def _detect_task_review_stale(
             latest[ev.subject] = (ts, ev)
 
     for subject, (ts, ev) in latest.items():
+        if subject in seen_subjects:
+            continue
         to_state = (ev.metadata or {}).get("to")
         if to_state != "review":
             continue
         if ts > cutoff:
-            # Not stale enough yet — give the reviewer time to act.
             continue
         key = _task_subject_key(subject)
         if key is None:
             continue
         project, _ = key
         stuck_minutes = max(1, int((now - ts).total_seconds() // 60))
+        seen_subjects.add(subject)
         findings.append(Finding(
             rule=RULE_TASK_REVIEW_STALE,
             project=project,
@@ -627,6 +785,7 @@ def _detect_task_review_stale(
                 "stuck_minutes": stuck_minutes,
                 "from": (ev.metadata or {}).get("from"),
                 "actor": ev.actor,
+                "detected_via": "event",
             },
         ))
     return findings
@@ -661,24 +820,74 @@ def _detect_task_on_hold_stale(
     *,
     now: datetime,
     config: WatchdogConfig,
+    open_tasks: Sequence[Any] | None = None,
 ) -> list[Finding]:
-    """Rule 5b (#1424): task at ``status=on_hold`` for > threshold.
+    """Rule 5b (state-based, #1424 + #1433): tasks currently at
+    ``status=on_hold`` longer than ``on_hold_stale_seconds``.
 
-    Mirrors :func:`_detect_task_review_stale` — pick the latest
-    transition per task subject. If the latest transition lands the
-    task in ``on_hold`` and is older than ``on_hold_stale_seconds``,
-    fire. The reviewer's transition reason is included in the finding
-    metadata so the brief generator can surface it to the architect.
+    Primary path queries the live ``work_tasks`` view; fires for any
+    task currently at ``on_hold`` whose entry-into-on_hold (from
+    ``task.transitions`` or ``updated_at`` fallback) is older than the
+    threshold. This catches tasks that entered ``on_hold`` *before*
+    the audit-log scan window — savethenovel/11's class.
 
-    The two rules are intentionally separate (different windows,
-    different routing). The architect-vs-human routing hint is computed
-    here from the reason tag and stored under ``routing`` in metadata
-    so the cadence handler can read it without re-parsing the reason.
+    Audit-event scan is preserved for synthetic-fixture tests and as
+    a safety net. Findings dedupe on ``subject``.
     """
     findings: list[Finding] = []
+    seen_subjects: set[str] = set()
     cutoff = now - timedelta(seconds=config.on_hold_stale_seconds)
 
-    # subject -> (latest_ts, ev) — pick the latest transition per task.
+    # State-based path (#1433): walks current ``work_tasks`` rows.
+    if open_tasks:
+        for task in open_tasks:
+            status = getattr(task, "work_status", None)
+            status_value = getattr(status, "value", status)
+            if status_value != "on_hold":
+                continue
+            project = getattr(task, "project", "") or ""
+            task_number = getattr(task, "task_number", None)
+            if not project or task_number is None:
+                continue
+            subject = f"{project}/{task_number}"
+            entry_ts, tr_meta = _state_entry_time(task, "on_hold")
+            if entry_ts is None:
+                continue
+            if entry_ts > cutoff:
+                continue
+            stuck_minutes = max(1, int((now - entry_ts).total_seconds() // 60))
+            reason = tr_meta.get("reason")
+            routing = _classify_on_hold_reason(
+                reason if isinstance(reason, str) else None,
+            )
+            seen_subjects.add(subject)
+            findings.append(Finding(
+                rule=RULE_TASK_ON_HOLD_STALE,
+                project=project,
+                subject=subject,
+                message=(
+                    f"Task {subject} has been at status=on_hold for "
+                    f"~{stuck_minutes} min — escalating to architect for "
+                    f"first-responder unstick."
+                ),
+                recommendation=(
+                    f"Architect: re-read the reviewer's rationale, fix the "
+                    f"issue, then `pm task queue {subject}`. Only escalate "
+                    f"to user via `pm notify` if the issue genuinely needs "
+                    f"human judgement."
+                ),
+                metadata={
+                    "on_hold_since": entry_ts.isoformat(),
+                    "stuck_minutes": stuck_minutes,
+                    "from": tr_meta.get("from"),
+                    "reason": reason if isinstance(reason, str) else None,
+                    "routing": routing,
+                    "actor": tr_meta.get("actor"),
+                    "detected_via": "state",
+                },
+            ))
+
+    # Event-based fallback path (backward-compat with old fixtures).
     latest: dict[str, tuple[datetime, AuditEvent]] = {}
     for ev in events:
         if ev.event != EVENT_TASK_STATUS_CHANGED:
@@ -691,12 +900,13 @@ def _detect_task_on_hold_stale(
             latest[ev.subject] = (ts, ev)
 
     for subject, (ts, ev) in latest.items():
+        if subject in seen_subjects:
+            continue
         meta = ev.metadata or {}
         to_state = meta.get("to")
         if to_state != "on_hold":
             continue
         if ts > cutoff:
-            # Fresh on_hold — give the reviewer / architect a beat.
             continue
         key = _task_subject_key(subject)
         if key is None:
@@ -707,6 +917,7 @@ def _detect_task_on_hold_stale(
         routing = _classify_on_hold_reason(
             reason if isinstance(reason, str) else None,
         )
+        seen_subjects.add(subject)
         findings.append(Finding(
             rule=RULE_TASK_ON_HOLD_STALE,
             project=project,
@@ -729,6 +940,7 @@ def _detect_task_on_hold_stale(
                 "reason": reason if isinstance(reason, str) else None,
                 "routing": routing,
                 "actor": ev.actor,
+                "detected_via": "event",
             },
         ))
     return findings
@@ -930,16 +1142,16 @@ def scan_events(
         materialised, now=now, config=config,
     ))
     findings.extend(_detect_stuck_drafts(
-        materialised, now=now, config=config,
+        materialised, now=now, config=config, open_tasks=open_tasks,
     ))
     findings.extend(_detect_cancellation_no_promotion(
         materialised, now=now, config=config,
     ))
     findings.extend(_detect_task_review_stale(
-        materialised, now=now, config=config,
+        materialised, now=now, config=config, open_tasks=open_tasks,
     ))
     findings.extend(_detect_task_on_hold_stale(
-        materialised, now=now, config=config,
+        materialised, now=now, config=config, open_tasks=open_tasks,
     ))
     findings.extend(_detect_role_session_missing(
         materialised,

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -144,7 +144,7 @@ def _config_from_payload(payload: dict[str, Any]) -> WatchdogConfig:
 
 
 def _gather_open_tasks(project_key: str, project_path: Path | None) -> list[Any]:
-    """Best-effort load of in-flight tasks for ``role_session_missing``.
+    """Best-effort load of in-flight tasks for state-based rules.
 
     Routes through :func:`pollypm.work.create_work_service` (the factory
     landed in #1389), which delegates path resolution to
@@ -155,10 +155,21 @@ def _gather_open_tasks(project_key: str, project_path: Path | None) -> list[Any]
     ``db_path`` here. ``project_key`` is forwarded for resolver warnings
     and ``project_path`` for project-aware audit metadata only.
 
+    Powers four rules: ``role_session_missing`` (since #1414), and the
+    state-based variants of ``task_review_stale``, ``task_on_hold_stale``,
+    and ``stuck_draft`` (#1433). For tasks at the watched states
+    (review / on_hold / draft) we re-fetch via :meth:`get` so
+    ``transitions`` are hydrated — :meth:`list_nonterminal_tasks` skips
+    transition loading for non-plan-review tasks (it only includes
+    history for plan-review labelled rows). Without transitions the
+    state-based detectors fall back to ``updated_at``, which is touched
+    on every status change and is therefore a noisy proxy.
+
     Returns an empty list on any failure — the watchdog keeps working
-    even when the work-service is unreachable; the new rule simply
-    no-ops for that project.
+    even when the work-service is unreachable; the affected rules
+    simply no-op for that project.
     """
+    _STATE_RULE_STATES = frozenset({"review", "on_hold", "draft"})
     try:
         from pollypm.work import create_work_service
 
@@ -169,7 +180,37 @@ def _gather_open_tasks(project_key: str, project_path: Path | None) -> list[Any]
             list_fn = getattr(svc, "list_nonterminal_tasks", None)
             if not callable(list_fn):
                 return []
-            return list(list_fn(project=project_key))
+            tasks = list(list_fn(project=project_key))
+            # Hydrate transitions for tasks at the watched states so the
+            # state-based detectors can compute "time in this state"
+            # accurately. Best-effort; if ``svc.get`` blows up we fall
+            # through to the un-hydrated row (the detector then falls
+            # back to ``updated_at``, which is still better than nothing).
+            get_fn = getattr(svc, "get", None)
+            if callable(get_fn):
+                hydrated: list[Any] = []
+                for task in tasks:
+                    status = getattr(task, "work_status", None)
+                    status_value = getattr(status, "value", status)
+                    if status_value in _STATE_RULE_STATES:
+                        try:
+                            project = getattr(task, "project", "")
+                            task_number = getattr(task, "task_number", None)
+                            if project and task_number is not None:
+                                full = get_fn(f"{project}/{task_number}")
+                                if full is not None:
+                                    hydrated.append(full)
+                                    continue
+                        except Exception:  # noqa: BLE001
+                            logger.debug(
+                                "audit.watchdog: hydrate-transitions failed for %s/%s",
+                                getattr(task, "project", "?"),
+                                getattr(task, "task_number", "?"),
+                                exc_info=True,
+                            )
+                    hydrated.append(task)
+                return hydrated
+            return tasks
     except Exception:  # noqa: BLE001
         logger.debug(
             "audit.watchdog: open-task load failed for %s",

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -1754,3 +1754,358 @@ def test_classify_on_hold_reason_defaults_to_architect() -> None:
     assert _classify_on_hold_reason("human-needed: y") == ON_HOLD_HUMAN_NEEDED_TAG
     # Case-insensitive
     assert _classify_on_hold_reason("[HUMAN-NEEDED] z") == ON_HOLD_HUMAN_NEEDED_TAG
+
+
+# ---------------------------------------------------------------------------
+# #1433 — state-based detection for review / on_hold / stuck_draft
+#
+# Issue #1433: previously these rules only fired when a matching
+# transition event landed inside the audit-log scan window (~1h). Tasks
+# that entered the watched state earlier were invisible — savethenovel/11
+# sat at on_hold for ~110 min and never got escalated. The state-based
+# path queries the live ``work_tasks`` view via ``open_tasks`` so the
+# detection horizon no longer depends on the audit log's retention.
+# ---------------------------------------------------------------------------
+
+
+class _FakeTransition:
+    """Minimal stand-in for ``work.models.Transition`` (frozen-ish)."""
+
+    def __init__(
+        self,
+        *,
+        from_state: str,
+        to_state: str,
+        timestamp: datetime,
+        actor: str = "polly",
+        reason: str | None = None,
+    ) -> None:
+        self.from_state = from_state
+        self.to_state = to_state
+        self.timestamp = timestamp
+        self.actor = actor
+        self.reason = reason
+
+
+class _StatefulTask:
+    """Stand-in for ``work.models.Task`` with state + transitions + timestamps."""
+
+    class _Status:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+    def __init__(
+        self,
+        *,
+        project: str,
+        task_number: int,
+        work_status: str,
+        transitions: list[_FakeTransition] | None = None,
+        created_at: datetime | None = None,
+        updated_at: datetime | None = None,
+        created_by: str = "polly",
+        title: str = "",
+    ) -> None:
+        self.project = project
+        self.task_number = task_number
+        self.work_status = self._Status(work_status)
+        self.transitions = list(transitions or [])
+        self.created_at = created_at
+        self.updated_at = updated_at
+        self.created_by = created_by
+        self.title = title
+        # Keep the role-session detector happy when reused.
+        self.roles: dict[str, str] = {}
+        self.assignee: str | None = None
+
+
+def test_task_review_stale_state_based_fires_for_old_entry(now: datetime) -> None:
+    """A task at status=review whose review transition predates the
+    audit-event scan window still fires via the state-based path."""
+    from pollypm.audit.watchdog import RULE_TASK_REVIEW_STALE
+
+    # Transition is 4h old — well outside the default scan window.
+    task = _StatefulTask(
+        project="savethenovel",
+        task_number=10,
+        work_status="review",
+        transitions=[
+            _FakeTransition(
+                from_state="in_progress",
+                to_state="review",
+                timestamp=now - timedelta(hours=4),
+                actor="russell",
+            ),
+        ],
+        created_at=now - timedelta(hours=5),
+        updated_at=now - timedelta(hours=4),
+    )
+    findings = scan_events([], now=now, open_tasks=[task])
+    matched = [f for f in findings if f.rule == RULE_TASK_REVIEW_STALE]
+    assert len(matched) == 1
+    f = matched[0]
+    assert f.subject == "savethenovel/10"
+    assert f.metadata["detected_via"] == "state"
+    assert f.metadata["stuck_minutes"] >= 30
+
+
+def test_task_review_stale_state_based_silent_when_briefly_in_state(
+    now: datetime,
+) -> None:
+    """A task that just entered review (within grace) does not fire."""
+    from pollypm.audit.watchdog import RULE_TASK_REVIEW_STALE
+
+    task = _StatefulTask(
+        project="demo",
+        task_number=3,
+        work_status="review",
+        transitions=[
+            _FakeTransition(
+                from_state="in_progress",
+                to_state="review",
+                timestamp=now - timedelta(minutes=2),
+                actor="polly",
+            ),
+        ],
+        updated_at=now - timedelta(minutes=2),
+    )
+    findings = scan_events([], now=now, open_tasks=[task])
+    assert not any(f.rule == RULE_TASK_REVIEW_STALE for f in findings)
+
+
+def test_task_review_stale_state_based_silent_when_no_longer_in_state(
+    now: datetime,
+) -> None:
+    """A task that has moved out of review is not reported."""
+    from pollypm.audit.watchdog import RULE_TASK_REVIEW_STALE
+
+    task = _StatefulTask(
+        project="demo",
+        task_number=3,
+        work_status="done",  # No longer in review
+        transitions=[
+            _FakeTransition(
+                from_state="in_progress",
+                to_state="review",
+                timestamp=now - timedelta(hours=4),
+            ),
+            _FakeTransition(
+                from_state="review",
+                to_state="done",
+                timestamp=now - timedelta(minutes=10),
+            ),
+        ],
+        updated_at=now - timedelta(minutes=10),
+    )
+    findings = scan_events([], now=now, open_tasks=[task])
+    assert not any(f.rule == RULE_TASK_REVIEW_STALE for f in findings)
+
+
+def test_task_review_stale_state_dedupes_with_event_path(now: datetime) -> None:
+    """A task visible to BOTH paths fires exactly once (state path wins)."""
+    from pollypm.audit.watchdog import RULE_TASK_REVIEW_STALE
+
+    task = _StatefulTask(
+        project="demo",
+        task_number=4,
+        work_status="review",
+        transitions=[
+            _FakeTransition(
+                from_state="in_progress",
+                to_state="review",
+                timestamp=now - timedelta(minutes=45),
+            ),
+        ],
+        updated_at=now - timedelta(minutes=45),
+    )
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/4",
+            metadata={"from": "in_progress", "to": "review"},
+            ts=now - timedelta(minutes=45),
+        ),
+    ]
+    findings = scan_events(events, now=now, open_tasks=[task])
+    matched = [f for f in findings if f.rule == RULE_TASK_REVIEW_STALE]
+    assert len(matched) == 1
+    assert matched[0].metadata["detected_via"] == "state"
+
+
+def test_task_review_stale_state_falls_back_to_updated_at(now: datetime) -> None:
+    """A task with no hydrated transitions still fires using updated_at."""
+    from pollypm.audit.watchdog import RULE_TASK_REVIEW_STALE
+
+    task = _StatefulTask(
+        project="demo",
+        task_number=5,
+        work_status="review",
+        transitions=[],  # no history loaded
+        updated_at=now - timedelta(hours=2),
+        created_at=now - timedelta(hours=3),
+    )
+    findings = scan_events([], now=now, open_tasks=[task])
+    matched = [f for f in findings if f.rule == RULE_TASK_REVIEW_STALE]
+    assert len(matched) == 1
+    assert matched[0].metadata["detected_via"] == "state"
+
+
+def test_task_on_hold_stale_state_based_fires_for_old_entry(
+    now: datetime,
+) -> None:
+    """savethenovel/11 class — on_hold > 1h, no recent transition events."""
+    from pollypm.audit.watchdog import RULE_TASK_ON_HOLD_STALE
+
+    task = _StatefulTask(
+        project="savethenovel",
+        task_number=11,
+        work_status="on_hold",
+        transitions=[
+            _FakeTransition(
+                from_state="review",
+                to_state="on_hold",
+                timestamp=now - timedelta(minutes=110),
+                actor="russell",
+                reason="[architect-actionable] Footer.astro:20 placeholder copy",
+            ),
+        ],
+        updated_at=now - timedelta(minutes=110),
+    )
+    findings = scan_events([], now=now, open_tasks=[task])
+    matched = [f for f in findings if f.rule == RULE_TASK_ON_HOLD_STALE]
+    assert len(matched) == 1
+    f = matched[0]
+    assert f.subject == "savethenovel/11"
+    assert f.metadata["detected_via"] == "state"
+    assert f.metadata["routing"] == "architect-actionable"
+    assert "Footer.astro" in (f.metadata.get("reason") or "")
+    assert f.metadata["stuck_minutes"] >= 90
+
+
+def test_task_on_hold_stale_state_based_silent_when_briefly_in_state(
+    now: datetime,
+) -> None:
+    """An on_hold task entered <threshold ago does not fire."""
+    from pollypm.audit.watchdog import RULE_TASK_ON_HOLD_STALE
+
+    task = _StatefulTask(
+        project="demo",
+        task_number=3,
+        work_status="on_hold",
+        transitions=[
+            _FakeTransition(
+                from_state="review",
+                to_state="on_hold",
+                timestamp=now - timedelta(minutes=5),
+            ),
+        ],
+        updated_at=now - timedelta(minutes=5),
+    )
+    findings = scan_events([], now=now, open_tasks=[task])
+    assert not any(f.rule == RULE_TASK_ON_HOLD_STALE for f in findings)
+
+
+def test_task_on_hold_stale_state_dedupes_with_event_path(now: datetime) -> None:
+    """A task visible to BOTH paths fires once; state path wins."""
+    from pollypm.audit.watchdog import RULE_TASK_ON_HOLD_STALE
+
+    task = _StatefulTask(
+        project="demo",
+        task_number=6,
+        work_status="on_hold",
+        transitions=[
+            _FakeTransition(
+                from_state="review",
+                to_state="on_hold",
+                timestamp=now - timedelta(minutes=20),
+                reason="[architect-actionable] x",
+            ),
+        ],
+        updated_at=now - timedelta(minutes=20),
+    )
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/6",
+            metadata={"from": "review", "to": "on_hold", "reason": "[architect-actionable] x"},
+            ts=now - timedelta(minutes=20),
+        ),
+    ]
+    findings = scan_events(events, now=now, open_tasks=[task])
+    matched = [f for f in findings if f.rule == RULE_TASK_ON_HOLD_STALE]
+    assert len(matched) == 1
+    assert matched[0].metadata["detected_via"] == "state"
+
+
+def test_stuck_draft_state_based_fires_for_old_draft(now: datetime) -> None:
+    """A task currently at status=draft older than threshold fires."""
+    task = _StatefulTask(
+        project="demo",
+        task_number=2,
+        work_status="draft",
+        transitions=[],
+        created_at=now - timedelta(hours=2),
+        updated_at=now - timedelta(hours=2),
+        created_by="polly",
+        title="Plan the next chapter",
+    )
+    findings = scan_events([], now=now, open_tasks=[task])
+    matched = [f for f in findings if f.rule == RULE_STUCK_DRAFT]
+    assert len(matched) == 1
+    f = matched[0]
+    assert f.subject == "demo/2"
+    assert f.metadata["detected_via"] == "state"
+    assert f.metadata["title"] == "Plan the next chapter"
+
+
+def test_stuck_draft_state_based_silent_when_promoted(now: datetime) -> None:
+    """A task that has moved out of draft is not reported."""
+    task = _StatefulTask(
+        project="demo",
+        task_number=2,
+        work_status="queued",  # promoted
+        created_at=now - timedelta(hours=2),
+        updated_at=now - timedelta(minutes=10),
+    )
+    findings = scan_events([], now=now, open_tasks=[task])
+    assert not any(f.rule == RULE_STUCK_DRAFT for f in findings)
+
+
+def test_stuck_draft_state_dedupes_with_event_path(now: datetime) -> None:
+    """A draft visible to BOTH paths fires once; state path wins."""
+    task = _StatefulTask(
+        project="demo",
+        task_number=2,
+        work_status="draft",
+        created_at=now - timedelta(minutes=15),
+        updated_at=now - timedelta(minutes=15),
+    )
+    events = [
+        _make_event(
+            event=EVENT_TASK_CREATED,
+            subject="demo/2",
+            metadata={"title": "Plan the next chapter"},
+            ts=now - timedelta(minutes=15),
+        ),
+    ]
+    findings = scan_events(events, now=now, open_tasks=[task])
+    matched = [f for f in findings if f.rule == RULE_STUCK_DRAFT]
+    assert len(matched) == 1
+    assert matched[0].metadata["detected_via"] == "state"
+
+
+def test_state_based_detectors_silent_when_open_tasks_empty(now: datetime) -> None:
+    """No open_tasks → state path no-ops, original event path still works."""
+    from pollypm.audit.watchdog import (
+        RULE_TASK_ON_HOLD_STALE,
+        RULE_TASK_REVIEW_STALE,
+    )
+
+    findings = scan_events([], now=now, open_tasks=[])
+    # No events, no tasks → nothing should fire.
+    assert not any(
+        f.rule in (RULE_TASK_REVIEW_STALE, RULE_TASK_ON_HOLD_STALE, RULE_STUCK_DRAFT)
+        for f in findings
+    )


### PR DESCRIPTION
Closes #1433.

## Summary

The watchdog's ``task_review_stale``, ``task_on_hold_stale`` and ``stuck_draft`` rules previously detected via an audit-event window scan (~1h lookback). Tasks that entered the watched state *before* the lookback boundary were invisible — savethenovel/11 sat at ``on_hold`` for ~110 min and never got escalated even with a healthy daemon.

Each of these rules now queries the live ``work_tasks`` view via ``open_tasks`` and computes "time in current state" from ``task.transitions`` (falling back to ``updated_at`` / ``created_at``). Detection horizon is no longer bounded by the audit-log retention window.

<details>
<summary>Implementation notes</summary>

- ``_detect_task_review_stale``, ``_detect_task_on_hold_stale``, ``_detect_stuck_drafts`` each gain an ``open_tasks`` parameter and a state-based path that runs first; the existing event-window scan is preserved as a backward-compat fallback.
- New helper ``_state_entry_time(task, target_state)`` returns ``(entry_ts, transition_meta)`` from the most recent matching transition, with sensible fallbacks when transitions weren't hydrated.
- Findings dedupe on ``subject`` so a task visible to both detection paths fires exactly once. The state-path-derived finding wins (carries ``metadata.detected_via='state'``); the event-path equivalent carries ``detected_via='event'``.
- Cadence handler's ``_gather_open_tasks`` re-fetches via ``svc.get`` for any task at ``review`` / ``on_hold`` / ``draft`` so ``transitions`` are hydrated. ``list_nonterminal_tasks`` only loads history for plan_review labels by default, which would force the ``updated_at`` fallback (noisy because it's touched on plan / external_refs edits too).
- ``worker_session_dead_loop`` (rate-based), ``marker_leaked`` (per-event), ``orphan_marker`` and ``cancellation_no_promotion`` (event-window-y) are unchanged.
- The 30-min audit-log-as-source-of-truth throttle path (``was_recently_dispatched`` / ``ESCALATION_THROTTLE_SECONDS``) is untouched; it doesn't care how a finding was detected.

</details>

## Test plan

- [x] All 55 pre-existing watchdog tests still pass (backward compat).
- [x] 12 new state-based tests covering: state path fires for old-entry tasks, silent within grace, silent when no longer in state, dedupe with event path, ``updated_at`` fallback, empty ``open_tasks`` no-op.
- [x] Broader ``-k 'watchdog or audit'`` suite (165 tests) green.
- [ ] After merge + cockpit cycle: savethenovel/11 should escalate within ~5 min (acceptance criterion in #1433).

🤖 Generated with [Claude Code](https://claude.com/claude-code)