### PR TITLE
Web API spec — design doc + OpenAPI 3.1 for separate-repo frontend

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,1258 @@
+openapi: 3.1.0
+info:
+  title: PollyPM Web API
+  version: 0.1.0
+  summary: HTTP API that lets a separate frontend drive PollyPM.
+  description: |
+    The PollyPM Web API exposes the same surface the TUI cockpit drives:
+    project drilldown, plan review, task triage, inbox replies, and a
+    realtime activity feed.
+
+    See [`docs/web-api-spec.md`](../web-api-spec.md) for the design
+    rationale, auth model, SSE semantics, and out-of-scope decisions.
+
+    The API is single-user / personal-use. There is no multi-tenant
+    auth in v1.
+  contact:
+    name: PollyPM project
+    url: https://github.com/swhmm/pollypm/issues
+  license:
+    name: See repository LICENSE
+    url: https://github.com/swhmm/pollypm/blob/main/LICENSE
+
+servers:
+  - url: http://{host}:{port}/api/v1
+    description: Local pm serve instance (loopback by default)
+    variables:
+      host:
+        default: 127.0.0.1
+        description: Host pm serve is bound to.
+      port:
+        default: "8765"
+        description: Port pm serve is listening on.
+
+security:
+  - bearerAuth: []
+
+tags:
+  - name: Health
+    description: Liveness and diagnostic endpoints.
+  - name: Projects
+    description: Registered project state and project-level actions.
+  - name: Tasks
+    description: Task list and task-level actions.
+  - name: Plans
+    description: Structured plan body for review.
+  - name: Inbox
+    description: Inbox items and threads.
+  - name: Events
+    description: Realtime audit-log stream.
+
+paths:
+  /health:
+    get:
+      tags: [Health]
+      operationId: getHealth
+      summary: Liveness + version info
+      description: Public endpoint; does not require authentication.
+      security: []
+      responses:
+        "200":
+          description: Server is alive.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+              examples:
+                ok:
+                  value:
+                    status: ok
+                    version: 0.1.0
+                    schema_version: 1
+                    started_at: "2026-05-07T12:00:00Z"
+
+  /doctor:
+    get:
+      tags: [Health]
+      operationId: getDoctor
+      summary: Structured pm doctor output
+      description: |
+        Mirrors the structured JSON output of `pm doctor` (PR #1347).
+        Returns each check with status (ok / warn / fail), an actor
+        message, and an optional remediation hint.
+      responses:
+        "200":
+          description: Doctor results (200 even when checks fail; consult `overall`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DoctorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /projects:
+    get:
+      tags: [Projects]
+      operationId: listProjects
+      summary: List registered projects
+      parameters:
+        - in: query
+          name: tracked
+          schema: { type: boolean }
+          description: When true, returns only `tracked=true` projects.
+      responses:
+        "200":
+          description: All registered projects with derived state.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Project"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+    post:
+      tags: [Projects]
+      operationId: registerProject
+      summary: Register a new project
+      description: Mirrors `pm add-project`. Idempotent on `path`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterProjectRequest"
+            examples:
+              minimal:
+                value:
+                  path: /Users/me/dev/myrepo
+              full:
+                value:
+                  path: /Users/me/dev/myrepo
+                  name: My Project
+                  slug: myproj
+                  tracked: true
+      responses:
+        "201":
+          description: Project registered (or returned if already present at path).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "400":
+          $ref: "#/components/responses/InvalidRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+  /projects/{key}:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey"
+    get:
+      tags: [Projects]
+      operationId: getProject
+      summary: Project drilldown
+      description: |
+        Returns project state + recent activity + top tasks +
+        pending plan-review (if any). One round trip is enough to
+        render the cockpit's project drilldown.
+      responses:
+        "200":
+          description: Project drilldown payload.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectDrilldown"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /projects/{key}/plan:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey"
+    get:
+      tags: [Plans]
+      operationId: getProjectPlan
+      summary: Structured plan body for the active plan-review task
+      description: |
+        Returns the structured plan for the project's active
+        `plan_review` task — the one currently sitting at
+        `status=review` on the `user_approval` node. Mirrors PR #1408's
+        structured output (summary, judgment calls, body,
+        critic synthesis).
+      parameters:
+        - in: query
+          name: version
+          schema: { type: integer, minimum: 1 }
+          description: |
+            Optional plan version. Defaults to the latest. Older
+            versions are returned for diff / history rendering.
+      responses:
+        "200":
+          description: Structured plan body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Plan"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: No plan in review for this project.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+    post:
+      tags: [Projects]
+      operationId: kickoffPlan
+      summary: Kick off pm project plan (initial or replan)
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlanRequest"
+            examples:
+              initial:
+                value:
+                  kind: initial
+              replan:
+                value:
+                  kind: replan
+                  reason: "Approach pivoted; rescoping for the new target."
+      responses:
+        "202":
+          description: Plan kickoff accepted. Subscribe to SSE for progress.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlanKickoffAccepted"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /projects/{key}/chat:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey"
+    post:
+      tags: [Projects]
+      operationId: sendProjectChat
+      summary: Send a chat message to the project's PM persona
+      description: |
+        Replicates the cockpit chat surface. Returns immediately with a
+        thread ID; the PM persona's reply lands as audit events on the
+        SSE stream and as inbox messages on the thread.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChatRequest"
+      responses:
+        "202":
+          description: Message accepted; persona reply lands asynchronously.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChatAccepted"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+  /projects/{key}/tasks:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey"
+    get:
+      tags: [Tasks]
+      operationId: listProjectTasks
+      summary: List tasks for a project
+      parameters:
+        - in: query
+          name: status
+          schema:
+            $ref: "#/components/schemas/TaskStatus"
+          description: Filter by `work_status`.
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
+        - in: query
+          name: cursor
+          schema: { type: string }
+          description: Opaque cursor from a previous response's `next_cursor`.
+      responses:
+        "200":
+          description: Page of tasks.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /tasks/{project}/{n}:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey2"
+      - $ref: "#/components/parameters/TaskNumber"
+    get:
+      tags: [Tasks]
+      operationId: getTask
+      summary: Task detail
+      description: |
+        Full task record — status, current node, executions,
+        transitions, plan content (when this task is a plan task).
+      responses:
+        "200":
+          description: Task detail.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /tasks/{project}/{n}/approve:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey2"
+      - $ref: "#/components/parameters/TaskNumber"
+    post:
+      tags: [Tasks]
+      operationId: approveTask
+      summary: Approve plan or code review
+      description: |
+        Approves the current review-node execution. The `kind` field
+        on the request body discriminates plan-review vs
+        code-review approvals; absent it, the API approves whichever
+        review is active.
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ApproveRequest"
+      responses:
+        "200":
+          description: Approval recorded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActionResult"
+        "400":
+          $ref: "#/components/responses/InvalidRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /tasks/{project}/{n}/reject:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey2"
+      - $ref: "#/components/parameters/TaskNumber"
+    post:
+      tags: [Tasks]
+      operationId: rejectTask
+      summary: Reject plan or code review with a reason
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RejectRequest"
+            examples:
+              plan:
+                value:
+                  kind: plan
+                  reason: "Scope is too broad — split into 3 tasks first."
+      responses:
+        "200":
+          description: Rejection recorded; task transitions to `rework`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActionResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+  /tasks/{project}/{n}/queue:
+    parameters:
+      - $ref: "#/components/parameters/ProjectKey2"
+      - $ref: "#/components/parameters/TaskNumber"
+    post:
+      tags: [Tasks]
+      operationId: queueTask
+      summary: Queue a draft task for execution
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      responses:
+        "200":
+          description: Task transitioned `draft` → `queued`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActionResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /inbox:
+    get:
+      tags: [Inbox]
+      operationId: listInbox
+      summary: List inbox items
+      parameters:
+        - in: query
+          name: project
+          schema: { type: string }
+        - in: query
+          name: type
+          schema:
+            $ref: "#/components/schemas/InboxItemType"
+        - in: query
+          name: state
+          schema:
+            $ref: "#/components/schemas/InboxItemState"
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 200, default: 50 }
+        - in: query
+          name: cursor
+          schema: { type: string }
+      responses:
+        "200":
+          description: Page of inbox items.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InboxListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /inbox/{id}:
+    parameters:
+      - $ref: "#/components/parameters/InboxId"
+    get:
+      tags: [Inbox]
+      operationId: getInboxItem
+      summary: Inbox item detail with full thread messages
+      responses:
+        "200":
+          description: Inbox item detail.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InboxItemDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /inbox/{id}/reply:
+    parameters:
+      - $ref: "#/components/parameters/InboxId"
+    post:
+      tags: [Inbox]
+      operationId: replyInbox
+      summary: Reply to a thread
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InboxReplyRequest"
+      responses:
+        "201":
+          description: Reply appended to the thread.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InboxMessage"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+  /inbox/{id}/archive:
+    parameters:
+      - $ref: "#/components/parameters/InboxId"
+    post:
+      tags: [Inbox]
+      operationId: archiveInbox
+      summary: Archive (close) an inbox item
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      responses:
+        "200":
+          description: Item moved to `closed/`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActionResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+  /events:
+    get:
+      tags: [Events]
+      operationId: streamEvents
+      summary: Server-Sent Events stream of audit-log events
+      description: |
+        Returns a `text/event-stream`. Each SSE message has:
+        - `event: audit`
+        - `id: <ts>` (the audit event timestamp; clients use this as
+          `Last-Event-ID` on reconnect)
+        - `data: <json>` matching the `Event` schema below.
+
+        Server emits `: keep-alive` comment lines every 15 seconds.
+
+        ### Filtering
+        - `project=<key>` — only events for this project
+        - `event=<glob>` — wildcard match on event name (e.g.
+          `task.*`, `watchdog.*`).
+
+        ### Reconnect
+        - Browsers automatically send `Last-Event-ID` after a drop;
+          the server replays from that point and tails.
+        - For an explicit cold start, pass `?since=<ISO-8601>`.
+        - With neither, the server only tails (no replay).
+      parameters:
+        - in: query
+          name: since
+          schema:
+            type: string
+            format: date-time
+          description: ISO-8601 timestamp; replay events with `ts > since`.
+        - in: query
+          name: project
+          schema: { type: string }
+        - in: query
+          name: event
+          schema: { type: string }
+          description: Wildcard pattern matched against `event` field.
+        - in: header
+          name: Last-Event-ID
+          schema: { type: string }
+          description: Reconnect cursor; takes precedence over `since`.
+      responses:
+        "200":
+          description: SSE stream.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: |
+                  Stream of newline-delimited SSE messages. The `data:`
+                  field of each message is an `Event` JSON object.
+              examples:
+                stream:
+                  summary: Two audit events
+                  value: |
+                    event: audit
+                    id: 2026-05-07T12:01:33.022Z
+                    data: {"schema":1,"ts":"2026-05-07T12:01:33.022Z","project":"pollypm","event":"task.status_changed","subject":"pollypm/142","actor":"pm","status":"done","metadata":{}}
+
+                    event: audit
+                    id: 2026-05-07T12:01:34.110Z
+                    data: {"schema":1,"ts":"2026-05-07T12:01:34.110Z","project":"pollypm","event":"plan.version_incremented","subject":"pollypm/144","actor":"architect","status":"ok","metadata":{"version":2}}
+
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: opaque
+      description: |
+        Token from `~/.pollypm/api-token`. Generated on first
+        `pm serve` startup; rotated via `pm api regen-token`.
+
+  parameters:
+    ProjectKey:
+      in: path
+      name: key
+      required: true
+      schema: { type: string }
+      description: Project key (slug).
+    ProjectKey2:
+      in: path
+      name: project
+      required: true
+      schema: { type: string }
+      description: Project key (slug).
+    TaskNumber:
+      in: path
+      name: n
+      required: true
+      schema: { type: integer, minimum: 1 }
+      description: Task number within the project (per-project sequence).
+    InboxId:
+      in: path
+      name: id
+      required: true
+      schema: { type: string }
+      description: Inbox item identifier.
+    IdempotencyKey:
+      in: header
+      name: Idempotency-Key
+      required: false
+      schema: { type: string, maxLength: 128 }
+      description: |
+        Optional client-supplied key. Server caches the response for
+        24h and replays it on retry with the same key.
+
+  responses:
+    Unauthorized:
+      description: Missing or invalid bearer token.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          examples:
+            missing:
+              value:
+                error:
+                  code: unauthorized
+                  message: Bearer token required
+    InvalidRequest:
+      description: Malformed body or query parameters.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    ValidationError:
+      description: Body shape valid but values failed validation.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ValidationErrorResponse"
+    NotFound:
+      description: Resource does not exist.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    Conflict:
+      description: Concurrent write conflict; state changed between read and write.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+  schemas:
+    # ---- Common -----------------------------------------------------
+    ErrorBody:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+          description: Stable snake_case error code.
+        message: { type: string }
+        hint: { type: string }
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          $ref: "#/components/schemas/ErrorBody"
+    ValidationErrorDetail:
+      type: object
+      required: [field, message]
+      properties:
+        field: { type: string }
+        message: { type: string }
+    ValidationErrorResponse:
+      allOf:
+        - $ref: "#/components/schemas/ErrorResponse"
+        - type: object
+          properties:
+            details:
+              type: array
+              items:
+                $ref: "#/components/schemas/ValidationErrorDetail"
+
+    ActionResult:
+      type: object
+      required: [ok]
+      properties:
+        ok: { type: boolean }
+        message: { type: string }
+
+    # ---- Health -----------------------------------------------------
+    HealthResponse:
+      type: object
+      required: [status, version, schema_version, started_at]
+      properties:
+        status:
+          type: string
+          enum: [ok, degraded]
+        version:
+          type: string
+          description: PollyPM package version.
+        schema_version:
+          type: integer
+          description: Audit-log / DB schema version.
+        started_at:
+          type: string
+          format: date-time
+
+    DoctorCheck:
+      type: object
+      required: [name, status, message]
+      properties:
+        name: { type: string }
+        status:
+          type: string
+          enum: [ok, warn, fail]
+        message: { type: string }
+        hint: { type: string }
+    DoctorResponse:
+      type: object
+      required: [overall, checks]
+      properties:
+        overall:
+          type: string
+          enum: [ok, warn, fail]
+        checks:
+          type: array
+          items:
+            $ref: "#/components/schemas/DoctorCheck"
+
+    # ---- Projects ---------------------------------------------------
+    ProjectKind:
+      type: string
+      enum: [git, polyglot, monorepo, unknown]
+      description: Detected project kind. Extends with new values; clients should treat unknown values as `unknown`.
+
+    ProjectGlyph:
+      type: string
+      enum: [green, amber, red, paused, unknown]
+      description: Stop-light signal derived from the briefing.
+
+    TaskCounts:
+      type: object
+      additionalProperties:
+        type: integer
+      description: Map of TaskStatus value -> count.
+      example:
+        draft: 3
+        queued: 1
+        in_progress: 2
+        review: 1
+        done: 42
+
+    Project:
+      type: object
+      required: [key, name, path, tracked, kind, glyph, task_counts, open_inbox_count, pending_plan_review]
+      properties:
+        key: { type: string }
+        name: { type: string }
+        path: { type: string, description: Filesystem path (server-local). }
+        tracked: { type: boolean }
+        kind:
+          $ref: "#/components/schemas/ProjectKind"
+        persona_name: { type: string }
+        state:
+          type: string
+          description: Briefing-derived high-level state label.
+        glyph:
+          $ref: "#/components/schemas/ProjectGlyph"
+        task_counts:
+          $ref: "#/components/schemas/TaskCounts"
+        open_inbox_count: { type: integer }
+        pending_plan_review: { type: boolean }
+
+    ProjectActivityEntry:
+      type: object
+      required: [ts, event, subject, actor]
+      properties:
+        ts: { type: string, format: date-time }
+        event: { type: string }
+        subject: { type: string }
+        actor: { type: string }
+        status: { type: string }
+        summary: { type: string }
+
+    ProjectDrilldown:
+      allOf:
+        - $ref: "#/components/schemas/Project"
+        - type: object
+          required: [recent_activity, top_tasks]
+          properties:
+            recent_activity:
+              type: array
+              items:
+                $ref: "#/components/schemas/ProjectActivityEntry"
+            top_tasks:
+              type: array
+              items:
+                $ref: "#/components/schemas/TaskSummary"
+            plan_review:
+              $ref: "#/components/schemas/Plan"
+
+    RegisterProjectRequest:
+      type: object
+      required: [path]
+      properties:
+        path:
+          type: string
+          description: Absolute filesystem path to the project repository.
+        name:
+          type: string
+          description: Display name. Defaults to repo directory name.
+        slug:
+          type: string
+          description: |
+            Optional canonical slug. Must match
+            `slugify_project_key()` rules; rejected with
+            `validation_error` otherwise.
+        tracked:
+          type: boolean
+          default: true
+
+    PlanRequest:
+      type: object
+      properties:
+        kind:
+          type: string
+          enum: [initial, replan]
+          default: initial
+        reason:
+          type: string
+          description: Required when `kind=replan`.
+    PlanKickoffAccepted:
+      type: object
+      required: [task_id, status]
+      properties:
+        task_id: { type: string, description: "Plan task id (project/N)." }
+        status:
+          type: string
+          enum: [accepted]
+
+    ChatRequest:
+      type: object
+      required: [message]
+      properties:
+        message: { type: string }
+        thread_id:
+          type: string
+          description: Continue an existing thread when present.
+    ChatAccepted:
+      type: object
+      required: [thread_id, status]
+      properties:
+        thread_id: { type: string }
+        status:
+          type: string
+          enum: [accepted]
+
+    # ---- Tasks ------------------------------------------------------
+    TaskStatus:
+      type: string
+      enum:
+        - draft
+        - queued
+        - in_progress
+        - rework
+        - blocked
+        - on_hold
+        - review
+        - done
+        - cancelled
+
+    TaskType:
+      type: string
+      enum: [epic, task, subtask, bug, spike]
+
+    TaskPriority:
+      type: string
+      enum: [critical, high, normal, low]
+
+    TaskSummary:
+      type: object
+      required: [task_id, project, task_number, title, work_status, type, priority]
+      properties:
+        task_id: { type: string }
+        project: { type: string }
+        task_number: { type: integer }
+        title: { type: string }
+        work_status:
+          $ref: "#/components/schemas/TaskStatus"
+        type:
+          $ref: "#/components/schemas/TaskType"
+        priority:
+          $ref: "#/components/schemas/TaskPriority"
+        assignee: { type: string }
+        current_node_id: { type: string }
+        plan_version: { type: integer }
+        updated_at: { type: string, format: date-time }
+
+    Transition:
+      type: object
+      required: [from_state, to_state, actor, timestamp]
+      properties:
+        from_state: { type: string }
+        to_state: { type: string }
+        actor: { type: string }
+        timestamp: { type: string, format: date-time }
+        reason: { type: string }
+
+    Artifact:
+      type: object
+      required: [kind, description]
+      properties:
+        kind:
+          type: string
+          enum: [commit, file_change, action, note]
+        description: { type: string }
+        ref: { type: string }
+        path: { type: string }
+        external_ref: { type: string }
+
+    WorkOutput:
+      type: object
+      required: [type, summary]
+      properties:
+        type:
+          type: string
+          enum: [code_change, action, document, mixed]
+        summary: { type: string }
+        artifacts:
+          type: array
+          items:
+            $ref: "#/components/schemas/Artifact"
+
+    FlowNodeExecution:
+      type: object
+      required: [task_id, node_id, visit, status]
+      properties:
+        task_id: { type: string }
+        node_id: { type: string }
+        visit: { type: integer }
+        status:
+          type: string
+          enum: [pending, active, blocked, completed, abandoned]
+        decision:
+          type: string
+          enum: [approved, rejected]
+        decision_reason: { type: string }
+        started_at: { type: string, format: date-time }
+        completed_at: { type: string, format: date-time }
+        work_output:
+          $ref: "#/components/schemas/WorkOutput"
+
+    ContextEntry:
+      type: object
+      required: [actor, timestamp, text, entry_type]
+      properties:
+        actor: { type: string }
+        timestamp: { type: string, format: date-time }
+        text: { type: string }
+        entry_type:
+          type: string
+          enum: [note, reply, read]
+
+    TaskRelationships:
+      type: object
+      properties:
+        parent: { type: string, description: "Parent task id (project/N) or null." }
+        children:
+          type: array
+          items: { type: string }
+        blocks:
+          type: array
+          items: { type: string }
+        blocked_by:
+          type: array
+          items: { type: string }
+        relates_to:
+          type: array
+          items: { type: string }
+        supersedes: { type: string }
+        superseded_by: { type: string }
+
+    TaskDetail:
+      allOf:
+        - $ref: "#/components/schemas/TaskSummary"
+        - type: object
+          required: [description, transitions, executions, relationships]
+          properties:
+            description: { type: string }
+            acceptance_criteria: { type: string }
+            constraints: { type: string }
+            labels:
+              type: array
+              items: { type: string }
+            relevant_files:
+              type: array
+              items: { type: string }
+            relationships:
+              $ref: "#/components/schemas/TaskRelationships"
+            flow_template_id: { type: string }
+            flow_template_version: { type: integer }
+            requires_human_review: { type: boolean }
+            predecessor_task_id: { type: string }
+            transitions:
+              type: array
+              items:
+                $ref: "#/components/schemas/Transition"
+            executions:
+              type: array
+              items:
+                $ref: "#/components/schemas/FlowNodeExecution"
+            context:
+              type: array
+              items:
+                $ref: "#/components/schemas/ContextEntry"
+            external_refs:
+              type: object
+              additionalProperties: { type: string }
+            total_input_tokens: { type: integer }
+            total_output_tokens: { type: integer }
+            session_count: { type: integer }
+            created_at: { type: string, format: date-time }
+            created_by: { type: string }
+            plan:
+              $ref: "#/components/schemas/Plan"
+              description: Populated only when this task is a plan task at review.
+
+    TaskListResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/TaskSummary"
+        next_cursor:
+          type: string
+          description: Absent when no more pages.
+
+    ApproveRequest:
+      type: object
+      properties:
+        kind:
+          type: string
+          enum: [plan, code_review, auto]
+          default: auto
+          description: |
+            `auto` (default) approves whichever review is active.
+            `plan` and `code_review` are explicit and reject with
+            `invalid_state` if that review type is not active.
+        note:
+          type: string
+          description: Optional approval note recorded on the execution.
+
+    RejectRequest:
+      type: object
+      required: [reason]
+      properties:
+        kind:
+          type: string
+          enum: [plan, code_review, auto]
+          default: auto
+        reason:
+          type: string
+          minLength: 1
+
+    # ---- Plan -------------------------------------------------------
+    PlanJudgmentCall:
+      type: object
+      required: [point]
+      properties:
+        point:
+          type: string
+          description: One judgment-call bullet from the architect.
+
+    Plan:
+      type: object
+      required: [task_id, version, summary, judgment_calls, body, created_at]
+      properties:
+        task_id: { type: string }
+        version: { type: integer, minimum: 1 }
+        predecessor_task_id: { type: string }
+        summary: { type: string }
+        judgment_calls:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlanJudgmentCall"
+        body:
+          type: string
+          description: Full plan markdown.
+        critic_synthesis:
+          type: string
+          description: Architect critic notes; nullable.
+        created_at: { type: string, format: date-time }
+
+    # ---- Inbox ------------------------------------------------------
+    InboxItemType:
+      type: string
+      description: |
+        Open enumeration. Known values include `message`,
+        `plan_review`, `blocking_question`, `alert`. Clients should
+        treat unknown values as `message`.
+      enum:
+        - message
+        - plan_review
+        - blocking_question
+        - alert
+
+    InboxItemState:
+      type: string
+      enum:
+        - open
+        - threaded
+        - waiting-on-pa
+        - waiting-on-pm
+        - resolved
+        - closed
+
+    InboxOwner:
+      type: string
+      enum: [pm, pa, worker, operator]
+
+    InboxItem:
+      type: object
+      required: [id, project, type, state, subject, owner, created_at, updated_at]
+      properties:
+        id: { type: string }
+        project: { type: string }
+        type:
+          $ref: "#/components/schemas/InboxItemType"
+        state:
+          $ref: "#/components/schemas/InboxItemState"
+        subject: { type: string }
+        preview: { type: string, description: Short preview of the body. }
+        owner:
+          $ref: "#/components/schemas/InboxOwner"
+        thread_id: { type: string }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+        metadata:
+          type: object
+          additionalProperties: true
+          description: |
+            Sidecar fields. For `plan_review` items this includes
+            `task_id`, `judgment_calls` (string array), and a plan
+            preview.
+
+    InboxMessage:
+      type: object
+      required: [id, sender, timestamp, body]
+      properties:
+        id: { type: string }
+        sender:
+          type: string
+          description: "`operator`, `pm`, `pa`, or worker session name."
+        timestamp: { type: string, format: date-time }
+        body: { type: string }
+
+    InboxItemDetail:
+      allOf:
+        - $ref: "#/components/schemas/InboxItem"
+        - type: object
+          required: [messages]
+          properties:
+            messages:
+              type: array
+              items:
+                $ref: "#/components/schemas/InboxMessage"
+
+    InboxListResponse:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/InboxItem"
+        next_cursor: { type: string }
+
+    InboxReplyRequest:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+          minLength: 1
+
+    # ---- Events -----------------------------------------------------
+    Event:
+      type: object
+      required: [schema, ts, project, event, subject, actor, status]
+      properties:
+        schema:
+          type: integer
+          description: Audit-log schema version (currently 1).
+        ts:
+          type: string
+          format: date-time
+        project: { type: string }
+        event:
+          type: string
+          description: |
+            Stable `noun.verb` event name. Examples: `task.created`,
+            `task.status_changed`, `plan.version_incremented`,
+            `plan.successor_created`, `worker.session_reaped`,
+            `watchdog.escalation_dispatched`, `socket.reaped`,
+            `work_db.opened`.
+        subject:
+          type: string
+          description: Resource id the event is about (e.g. `pollypm/142`).
+        actor: { type: string }
+        status: { type: string }
+        metadata:
+          type: object
+          additionalProperties: true
+      example:
+        schema: 1
+        ts: "2026-05-07T12:01:33.022Z"
+        project: pollypm
+        event: task.status_changed
+        subject: pollypm/142
+        actor: pm
+        status: done
+        metadata: {}

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -1,0 +1,584 @@
+# PollyPM Web API — Design Spec
+
+Status: Draft (v0.1.0)
+Audience: PollyPM maintainers, separate-repo frontend developers, typed-client codegen consumers.
+Companion artifact: [`docs/api/openapi.yaml`](api/openapi.yaml)
+
+This document describes the HTTP API that allows a separate web frontend
+to drive PollyPM. The API surface mirrors what a user can do from the
+TUI cockpit today — list projects, drive plan reviews, queue and approve
+tasks, reply to inbox threads, and watch the activity stream live.
+
+The design is **spec-only**. No `pm serve` implementation lands with this
+PR; the OpenAPI document is the contract a frontend developer can target,
+and the milestones at the end of this doc lay out the implementation
+phases.
+
+---
+
+## 1. Goal
+
+PollyPM today is a TUI cockpit. A separate-repo frontend (the user's
+upcoming web app) needs to drive the same workflows: project drilldown,
+plan review, task triage, inbox replies, and a live activity feed.
+
+Hard requirements driving the design:
+
+- **Read everything the cockpit shows.** Projects, tasks, plans, inbox
+  items, doctor results, and the audit-log activity stream.
+- **Write everything the cockpit lets you write.** Approve / reject
+  plans and reviews, queue drafts, reply to inbox threads, kick off
+  replans, send chat messages to the project PM persona.
+- **Codegen-friendly.** Strict OpenAPI 3.1 so a TypeScript / Swift /
+  Kotlin client generator produces a typed SDK out of the box. No
+  custom JSON schemas embedded in prose — every response has a
+  schema reference.
+- **Realtime updates.** The cockpit's activity feed has to work in the
+  browser too; the audit log is the source of truth, so the API streams
+  it via Server-Sent Events.
+- **Minimal but real auth.** Single-user, personal-use scope. No
+  multi-tenant story in v1.
+
+Non-goals (see §9): cockpit-specific shortcuts, file-system browsing,
+worker-process control, multi-tenant authentication.
+
+---
+
+## 2. Architecture
+
+### Process model
+
+`pm serve --port N` is a **separate process** from the cockpit. It is a
+peer that reads and writes the same `state.db` and `audit.jsonl` via the
+existing `create_work_service` factory (see #1389) and the existing
+`pollypm.service_api.v1.PollyPMService` facade. The cockpit and the API
+server are independent — the frontend keeps working when the cockpit
+is down, and vice versa.
+
+```
+                ┌─────────────────┐
+                │  Frontend repo  │
+                │  (separate)     │
+                └────────┬────────┘
+                         │ HTTPS + SSE
+                         ▼
+                ┌─────────────────┐
+                │   pm serve      │  ← FastAPI (recommended)
+                └────────┬────────┘
+                         │ SDK (PollyPMService, create_work_service)
+                         ▼
+              ┌──────────────────────┐
+              │ state.db, audit.jsonl│  ← shared with cockpit
+              └──────────────────────┘
+```
+
+### Why a separate process?
+
+- **Crash isolation.** The cockpit is a Textual TUI with its own
+  rendering loop and tmux session. Hosting an HTTP server inside it
+  would bind two unrelated lifecycles (TUI process + HTTP process)
+  and force a frontend developer to keep `pm cockpit` running just to
+  serve requests.
+- **Restart independently.** API regressions won't kick the user out
+  of their cockpit window; cockpit hot-reload won't drop SSE
+  subscriptions.
+- **Same backing store.** Both processes go through
+  `create_work_service` and the audit log — there is no second source
+  of truth, no cache invalidation problem, and the audit log
+  guarantees ordering even with concurrent writers.
+
+### Why FastAPI?
+
+FastAPI is recommended because:
+
+- It generates an OpenAPI document directly from typed Python models,
+  so the `docs/api/openapi.yaml` artifact stays in sync with the
+  implementation when it lands.
+- SSE is one `EventSourceResponse` away.
+- The dependency-injection model maps naturally to "every endpoint
+  needs a `PollyPMService`."
+- Async support means a single worker can hold many SSE
+  subscriptions open without blocking.
+
+The spec does not depend on FastAPI; any HTTP framework that can
+emit the contract is acceptable. FastAPI is just the path of least
+resistance.
+
+### Concurrency model
+
+`pm serve` is a single-process, single-worker server in v1. SQLite
+WAL handles multi-reader / single-writer fine for personal-use
+volumes; the audit log is append-only JSONL. If we need to scale,
+the upgrade path is documented separately (process-per-request or
+SQLite → Postgres).
+
+---
+
+## 3. Authentication
+
+### Bearer token
+
+Every request (except `GET /api/v1/health`) must carry:
+
+```
+Authorization: Bearer <token>
+```
+
+### Token storage
+
+- Token lives at `~/.pollypm/api-token` (mode `0600`).
+- Generated on first `pm serve` startup if absent.
+- 256-bit random, base64url-encoded (≈43 chars).
+- Regenerated via `pm api regen-token` (rotates the token, prints the
+  new value once, invalidates all prior tokens).
+
+### Threat model
+
+- Single-user, personal-use. No multi-tenant separation.
+- The token is a simple shared secret; loss equals full access.
+- TLS is the operator's responsibility — `pm serve` defaults to
+  binding `127.0.0.1` and refuses non-loopback binds without
+  `--allow-remote`.
+- Out of scope: OAuth, JWT, role-based access, audit logging of API
+  callers (the frontend developer is the same human as the cockpit
+  user).
+
+### Failure modes
+
+- **Missing token:** `401 Unauthorized` with
+  `{"error":{"code":"unauthorized","message":"Bearer token required"}}`.
+- **Wrong token:** `401 Unauthorized` with
+  `{"error":{"code":"invalid_token","message":"Bearer token rejected"}}`.
+
+---
+
+## 4. Realtime
+
+### SSE design
+
+`GET /api/v1/events` returns a `text/event-stream` of audit-log
+events. Each SSE message is one audit-log line as JSON:
+
+```
+event: audit
+id: 2026-05-07T12:01:33.022Z
+data: {"schema":1,"ts":"2026-05-07T12:01:33.022Z","project":"pollypm","event":"task.status_changed","subject":"pollypm/142","actor":"pm","status":"done","metadata":{}}
+
+```
+
+### Reconnect semantics
+
+- Client sends `Last-Event-ID` on reconnect (the timestamp from the
+  last seen event).
+- Server replays from the audit log starting after `Last-Event-ID`,
+  then tails live.
+- For an explicit cold start, client sends `?since=<ISO-8601>` (no
+  `Last-Event-ID`). Server emits all events since `since`, then tails.
+- If `since` is empty / missing on initial connect, server only tails
+  (no replay).
+
+### Filtering
+
+Two query parameters, both optional:
+
+- `project=<key>` — only events for this project.
+- `event=<glob>` — wildcard match on event name; e.g.
+  `event=task.*`, `event=watchdog.*`, `event=plan.version_incremented`.
+
+Both filters AND together when both are supplied. Filtering is
+server-side, so a noisy fleet doesn't drown a single-project
+frontend.
+
+### Heartbeats
+
+Server emits a comment line (`: keep-alive\n\n`) every 15 seconds so
+intermediate proxies don't drop idle connections. The client SDK
+ignores comment lines.
+
+### Why SSE and not WebSocket?
+
+- The audit log is one-way (server → client). WebSocket buys a duplex
+  channel we don't need.
+- SSE is plain HTTP — easy to load through a CDN, transparent to
+  proxies, easy to auth with the same bearer token.
+- Browser `EventSource` handles auto-reconnect; we get the
+  `Last-Event-ID` machinery for free.
+- Codegen tooling for OpenAPI handles `text/event-stream` cleanly;
+  WebSocket lives outside the spec.
+
+WebSocket is **explicitly out of scope for v1.**
+
+---
+
+## 5. Versioning
+
+- All endpoints live under `/api/v1/...`.
+- Bump to `/api/v2/...` on **breaking** changes (response shape
+  removals, semantics changes, status-code changes for existing
+  flows).
+- Additive changes (new endpoints, new optional fields) ship in v1
+  forever.
+- The OpenAPI `info.version` field tracks the same major version
+  ("0.1.0", "0.2.0", ..., "1.0.0", then "2.0.0" on the v2 cutover).
+
+The `pm serve` process exposes its OpenAPI document at
+`/api/v1/openapi.json` so the frontend's typed-client generator can
+fetch the live contract during CI.
+
+---
+
+## 6. Errors
+
+### Format
+
+Every 4xx and 5xx response body is:
+
+```json
+{
+  "error": {
+    "code": "string_error_code",
+    "message": "Human-readable explanation",
+    "hint": "Optional remediation hint"
+  }
+}
+```
+
+- `code` is a stable string (snake_case) — clients should match on
+  this, not the message.
+- `message` is for display.
+- `hint` is optional remediation text ("Run `pm doctor` to diagnose
+  the database mismatch.").
+
+### Standard codes
+
+| HTTP | Code | When |
+|------|------|------|
+| 400 | `invalid_request` | Malformed body, bad query parameters |
+| 400 | `invalid_state` | Action not allowed in the current task / inbox state (e.g. approving a plan that has no review pending) |
+| 401 | `unauthorized` | Missing bearer token |
+| 401 | `invalid_token` | Bearer token did not match |
+| 403 | `forbidden` | Action requires capabilities the API doesn't expose (e.g. multi-tenant) |
+| 404 | `not_found` | Project / task / inbox item does not exist |
+| 409 | `conflict` | Concurrent write conflict (state changed between read and write) |
+| 422 | `validation_error` | Body shape valid, but values failed validation (e.g. empty `reason`) |
+| 429 | `rate_limited` | Burst protection (future) |
+| 500 | `internal_error` | Unhandled server exception |
+| 503 | `service_unavailable` | Backing store unreachable (`state.db` lock contention beyond retry) |
+
+Validation errors carry an extra `details` field shaped like
+`[{"field": "reason", "message": "must be non-empty"}]`.
+
+---
+
+## 7. Resource model
+
+These are the conceptual types; the OpenAPI document is the
+authoritative shape definition.
+
+### Project
+
+A registered repository PollyPM tracks. Mirrors `KnownProject` in
+`pollypm.config`.
+
+Fields: `key`, `name`, `path`, `kind`, `tracked`, `persona_name`,
+plus derived: `state` (briefing-derived signal), `glyph` (stop-light
+indicator), `task_counts` (by status), `pending_plan_review` (bool),
+`open_inbox_count`.
+
+### Task
+
+The atomic unit of work. Mirrors `pollypm.work.models.Task`.
+
+Fields: `project`, `task_number`, `task_id` (`{project}/{n}`),
+`title`, `type`, `priority`, `work_status` (`TaskStatus` enum),
+`current_node_id`, `assignee`, `description`, `labels`,
+`relationships`, `flow_template_id`, `flow_template_version`,
+`plan_version`, `predecessor_task_id`, `transitions`, `executions`
+(optional, only on detail), `total_input_tokens`,
+`total_output_tokens`, `session_count`, timestamps.
+
+### TaskStatus (enum)
+
+`draft`, `queued`, `in_progress`, `rework`, `blocked`, `on_hold`,
+`review`, `done`, `cancelled`.
+
+Mirrors `WorkStatus` in `pollypm.work.models`.
+
+### Plan
+
+The structured plan body for a task at `status=review` on the
+`user_approval` node. Mirrors PR #1408's structured output and the
+inbox `plan_review` payload (see `_extract_plan_judgment_calls` in
+`cockpit_ui.py`).
+
+Fields:
+- `task_id`
+- `version` (`plan_version`; integer, increments on refinement)
+- `predecessor_task_id` (nullable; populated when a replan creates a
+  new task)
+- `summary` (one-paragraph synthesis)
+- `judgment_calls` (`PlanJudgmentCall[]`; the bulleted list under
+  `## Judgment calls` in the plan body)
+- `body` (full plan markdown)
+- `critic_synthesis` (architect critic notes; nullable)
+- `created_at`
+
+### PlanJudgmentCall
+
+`{ "point": "string" }` — one decision the architect flagged for
+operator review. Currently a single string; modeled as an object so
+future fields (severity, suggested-resolution) ship without a
+breaking change.
+
+### InboxItem
+
+A triaged item in `<project>/.pollypm/inbox/`. Mirrors the inbox
+plugin's item shape (see `docs/v1/09-inbox-and-threads.md`).
+
+Fields: `id`, `project`, `type` (`message`, `plan_review`,
+`blocking_question`, `alert`, ...), `state` (`open`, `threaded`,
+`waiting-on-pa`, `waiting-on-pm`, `resolved`, `closed`), `subject`,
+`preview`, `owner` (`pm` / `pa` / `worker`), `created_at`,
+`updated_at`, `thread_id` (nullable), `metadata` (sidecar labels),
+`messages` (`InboxMessage[]`, only on detail).
+
+### Event
+
+A single audit-log line. Mirrors `pollypm.audit.log.AuditEvent`.
+
+Fields: `schema`, `ts`, `project`, `event`, `subject`, `actor`,
+`status`, `metadata`.
+
+### ErrorResponse
+
+`{ "error": { "code", "message", "hint?" } }` plus optional
+`details[]` for validation errors.
+
+---
+
+## 8. Endpoint table
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET    | `/api/v1/health` | Liveness + version info (no auth) |
+| GET    | `/api/v1/doctor` | Structured `pm doctor` output (#1347) |
+| GET    | `/api/v1/projects` | List registered projects with state, glyph, counts |
+| POST   | `/api/v1/projects` | Register a project (mirrors `pm add-project`) |
+| GET    | `/api/v1/projects/{key}` | Project drilldown — state, recent activity, top tasks, pending plan review |
+| POST   | `/api/v1/projects/{key}/plan` | Kick off `pm project plan` (initial or replan) |
+| POST   | `/api/v1/projects/{key}/chat` | Send a chat message to the project's PM persona |
+| GET    | `/api/v1/projects/{key}/tasks` | Task list (`?status=&limit=&cursor=`) |
+| GET    | `/api/v1/projects/{key}/plan` | Structured plan body (`?version=N`) |
+| GET    | `/api/v1/tasks/{project}/{n}` | Task detail — status, node, executions, transitions |
+| POST   | `/api/v1/tasks/{project}/{n}/approve` | Approve plan or code review |
+| POST   | `/api/v1/tasks/{project}/{n}/reject` | Reject + capture reason |
+| POST   | `/api/v1/tasks/{project}/{n}/queue` | Queue a draft task |
+| GET    | `/api/v1/inbox` | List inbox items (`?project=&type=&state=&limit=&cursor=`) |
+| GET    | `/api/v1/inbox/{id}` | Inbox item detail (with full thread messages) |
+| POST   | `/api/v1/inbox/{id}/reply` | Reply to a thread |
+| POST   | `/api/v1/inbox/{id}/archive` | Archive (close) the item |
+| GET    | `/api/v1/events` | SSE stream of audit-log events (`?since=&project=&event=`) |
+
+That's 17 endpoints in v1. The OpenAPI document is the authoritative
+list; if anything here drifts, the YAML wins.
+
+---
+
+## 9. Out of scope (v1)
+
+The following are intentionally not in v1 so the surface stays small
+and the frontend developer can ship something the day this lands:
+
+- **Multi-tenant auth.** No user accounts, no roles, no per-project
+  ACLs. Single shared bearer token.
+- **File-system browsing.** No "show me the files in this repo"
+  endpoint. Frontend uses GitHub URLs / external hosting if it needs
+  to render a repo tree.
+- **Worker process control.** No "kill this worker session,"
+  "restart this tmux pane," "spawn a new worker." That is cockpit /
+  CLI territory; the API is a project-management surface, not a
+  process supervisor.
+- **Cockpit-specific actions.** Keyboard shortcuts, palette
+  commands, focus management — none of that maps to HTTP. The API
+  exposes the underlying actions, not the cockpit's UI affordances.
+- **WebSocket transport.** SSE only. Reconsidered in v2 if the
+  frontend needs to push.
+- **Plugin discovery / configuration.** The cockpit's plugin
+  settings panel does not have an API counterpart. Plugins are
+  configured via `pollypm.toml`, period.
+- **Account / provider management.** No login flows for Claude /
+  Codex providers; that's the cockpit's account TUI.
+- **Bulk mutation endpoints.** No "approve all," "queue all
+  drafts." If the frontend wants bulk, it loops.
+
+---
+
+## 10. Frontend integration notes
+
+### Generating a typed client
+
+The OpenAPI document at `/api/v1/openapi.json` is consumable by any
+codegen tool. Recommended:
+
+- **TypeScript:** [`openapi-typescript`](https://github.com/drwpow/openapi-typescript) +
+  [`openapi-fetch`](https://github.com/drwpow/openapi-fetch) for a
+  zero-dependency typed client. No runtime overhead beyond fetch.
+- **Vite + React:** the generated types feed directly into TanStack
+  Query hooks. Pattern:
+
+  ```ts
+  import createClient from "openapi-fetch";
+  import type { paths } from "./generated/pollypm";
+
+  const client = createClient<paths>({
+    baseUrl: "http://127.0.0.1:8765/api/v1",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  const { data, error } = await client.GET("/projects");
+  ```
+
+CI step: `npx openapi-typescript http://localhost:8765/api/v1/openapi.json -o src/generated/pollypm.ts`
+when `pm serve` is reachable in CI; otherwise vendor the YAML and
+generate from it.
+
+### SSE reconnect
+
+The frontend should:
+
+1. On mount, hit `GET /api/v1/events?since=<bootstrap-ts>` where
+   `bootstrap-ts` is the `ts` of the most recent event already in
+   the local cache (or the page-load time on cold start).
+2. Use the browser `EventSource` API; it handles `Last-Event-ID`
+   automatically on reconnect.
+3. On `error` events, back off (1s, 2s, 5s, 30s), then re-open with
+   `since` set to the last seen `ts`.
+
+The audit log is append-only and event IDs are timestamps, so a
+duplicate replay is harmless — the frontend deduplicates by
+`(ts, event, subject)`.
+
+### Handling plan-review
+
+The plan-review surface is the most UI-heavy piece. Recommended
+pattern:
+
+1. List view: hit `GET /api/v1/inbox?type=plan_review&state=open` to
+   show the plan-review queue. Each item carries a preview and the
+   `judgment_calls` so the operator can scan without drilldown.
+2. Drilldown: hit `GET /api/v1/projects/{key}/plan` for the
+   structured plan body. Render `summary` prominently,
+   `judgment_calls` as a checklist, `body` as collapsed markdown,
+   `critic_synthesis` as a sidebar.
+3. Approve: `POST /api/v1/tasks/{project}/{n}/approve` with
+   `{ "kind": "plan" }` (the action body discriminates plan vs
+   code-review approvals; see OpenAPI for `ApproveRequest`).
+4. Reject: `POST /api/v1/tasks/{project}/{n}/reject` with
+   `{ "reason": "..." }` — the reason is required and non-empty
+   per `validation_error`.
+
+Cockpit semantics to mirror: PR #1421's approve flow displays a
+toast with a 10-second undo. The frontend gets the same affordance
+by deferring the API call until the toast expires; it's a UI
+concern, not an API concern.
+
+### Pagination
+
+List endpoints (`/projects/{key}/tasks`, `/inbox`) use cursor
+pagination with `?limit=` and `?cursor=`. Response body carries
+`{ items, next_cursor? }`. `next_cursor` absent ⇒ end of list.
+
+### Idempotency
+
+`POST` endpoints accept an optional `Idempotency-Key` header. When
+present, the server stores the response for 24h and replays it for
+duplicate keys. Recommended for approve / reject / queue / reply,
+where a network glitch + retry could otherwise double-submit.
+
+---
+
+## 11. Implementation milestones
+
+This PR ships only the spec. The implementation lands across three
+phases, each as a separate issue (issues to be opened by the user
+after this PR merges).
+
+### Phase 1 — Read + auth + SSE (issue: TBD)
+
+- `pm serve` skeleton with FastAPI, bearer-token auth, OpenAPI doc at
+  `/api/v1/openapi.json`, `pm api regen-token` CLI.
+- `GET /api/v1/health`
+- `GET /api/v1/projects`, `GET /api/v1/projects/{key}`
+- `GET /api/v1/projects/{key}/tasks`, `GET /api/v1/tasks/{project}/{n}`
+- `GET /api/v1/projects/{key}/plan`
+- `GET /api/v1/inbox`, `GET /api/v1/inbox/{id}`
+- `GET /api/v1/events` (SSE)
+
+Outcome: frontend can render the dashboard and stream live updates.
+
+### Phase 2 — Write endpoints (issue: TBD)
+
+- `POST /api/v1/projects` (register)
+- `POST /api/v1/projects/{key}/plan` (kick off / replan)
+- `POST /api/v1/projects/{key}/chat`
+- `POST /api/v1/tasks/{project}/{n}/approve`
+- `POST /api/v1/tasks/{project}/{n}/reject`
+- `POST /api/v1/tasks/{project}/{n}/queue`
+- `POST /api/v1/inbox/{id}/reply`
+- `POST /api/v1/inbox/{id}/archive`
+
+Outcome: frontend has feature parity with the cockpit for the
+documented surface.
+
+### Phase 3 — Doctor + admin (issue: TBD)
+
+- `GET /api/v1/doctor` (#1347)
+- Idempotency-Key persistence
+- Rate limiting (`429`)
+- `--allow-remote` non-loopback bind support with TLS guidance
+
+Outcome: production-grade for personal-use deployments.
+
+---
+
+## Open questions
+
+These are intentionally not blocking the spec but should be
+resolved during implementation:
+
+- **Chat backpressure.** `POST /projects/{key}/chat` enqueues a
+  message to the PM persona; the response can either (a) wait for
+  the persona to reply (high-latency, simple) or (b) return
+  immediately with a thread ID and let the frontend subscribe via
+  SSE. Recommendation: (b), to keep request handlers fast.
+- **Plan replan vs initial plan.** `POST /projects/{key}/plan` does
+  both today via `pm project plan`. The endpoint accepts an optional
+  `{ "kind": "replan", "reason": "..." }` body, defaulting to
+  initial. Document the precise semantics when the implementation
+  lands.
+- **Token rotation timing.** Should `pm api regen-token` invalidate
+  the old token immediately or grant a 60-second overlap? Short
+  overlap is friendlier for an in-progress frontend session;
+  immediate is simpler.
+
+---
+
+## References
+
+- `pollypm.service_api.v1.PollyPMService` — the facade `pm serve`
+  composes against.
+- `pollypm.work.factory.create_work_service` (#1389) — canonical
+  work-service constructor.
+- `pollypm.audit.log` — audit-log writer / reader (`AuditEvent`,
+  `SCHEMA_VERSION`).
+- `pollypm.work.models` — Task, WorkStatus, FlowNodeExecution,
+  Transition.
+- `pollypm.projects.register_project` — backing call for `POST
+  /api/v1/projects`.
+- PR #1408 — structured plan-review output.
+- PR #1347 — `pm doctor` structured JSON.
+- PR #1421 — approve flow with undo toast (UI mirror).
+- `docs/v1/09-inbox-and-threads.md` — inbox state machine the API
+  exposes.
+- `docs/work-service-spec.md` — the sealed work-service contract
+  the API operates through.


### PR DESCRIPTION
## Context

A separate-repo web frontend (the user is going to build it) needs to drive PollyPM. PollyPM today is a TUI cockpit. This PR adds the design spec + OpenAPI 3.1 contract so the frontend dev can generate a typed client and start coding the day this lands.

**Spec only — no `pm serve` implementation in this PR.** The implementation phases are listed in the design doc; each will land as its own issue.

## Files

- `docs/web-api-spec.md` — design rationale: process model, auth, realtime, versioning, errors, resource model, endpoint table, out-of-scope, frontend integration notes, three implementation milestones.
- `docs/api/openapi.yaml` — OpenAPI 3.1 contract.

## Key design decisions (encoded in the spec)

- **Separate process.** `pm serve --port N` is a peer to the cockpit. Both go through `create_work_service` (#1389) and the audit log; no second source of truth. Cockpit and API server are independent — frontend works even with the cockpit down.
- **FastAPI recommended** (typed → OpenAPI directly, easy SSE, async-friendly). Spec doesn't depend on it.
- **Bearer token auth.** Lives at `~/.pollypm/api-token`; rotated via `pm api regen-token`. Single-user / personal-use. No multi-tenant in v1.
- **SSE for realtime.** `GET /api/v1/events` streams audit-log events. Filtered subscriptions (`?project=`, `?event=` glob), `Last-Event-ID` reconnect, 15-second keep-alives. WebSocket explicitly out of scope.
- **Versioning.** `/api/v1/...`; bump on breaking changes. OpenAPI `info.version` tracks the same major.
- **Error format.** `{ "error": { "code", "message", "hint?" } }` + standard codes table.

## Endpoint coverage (18 operations, 16 path objects)

- Projects: list, register, drilldown, plan kickoff, chat
- Tasks: list, detail, approve, reject, queue
- Plans: structured plan body (mirrors PR #1408 — summary, judgment_calls, body, critic_synthesis)
- Inbox: list, detail, reply, archive
- Events: SSE stream
- Health: liveness + structured `pm doctor` (mirrors PR #1347)

44 component schemas covering Project, Task (with executions, transitions, relationships), Plan, PlanJudgmentCall, InboxItem, InboxMessage, Event, ErrorResponse, etc.

## Implementation milestones (separate issues)

1. **Phase 1** — `pm serve` skeleton + auth + read endpoints + SSE.
2. **Phase 2** — Write endpoints (approve, reject, queue, register, replan, chat, inbox reply/archive).
3. **Phase 3** — Doctor, idempotency-key, rate limit, `--allow-remote` + TLS guidance.

## Out of scope (v1)

Multi-tenant auth, file-system browsing, worker process control, cockpit-specific actions, WebSocket transport, plugin discovery, account/provider management, bulk mutations.

## How a frontend dev consumes this

1. `npx openapi-typescript docs/api/openapi.yaml -o src/generated/pollypm.ts`
2. Use `openapi-fetch` with the bearer token; types come from the generated file.
3. Subscribe to SSE via browser `EventSource` against `/api/v1/events`.
4. Plan-review UI: list via `GET /inbox?type=plan_review`, drill via `GET /projects/{key}/plan`, approve/reject via `POST /tasks/{project}/{n}/{approve,reject}`.

YAML parses cleanly with PyYAML; spec validates as OpenAPI 3.1.

## Test plan

- [ ] Maintainer reviews `docs/web-api-spec.md` for design correctness.
- [ ] Maintainer validates `docs/api/openapi.yaml` with an OpenAPI 3.1 linter (e.g. `redocly lint` or `spectral lint`).
- [ ] Frontend dev attempts `openapi-typescript` codegen against the YAML and reports any schema gaps.
- [ ] Phase 1 implementation issue gets opened.