### PR TITLE
Fix #1431 avoid duplicate foreground rail workers

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -914,7 +914,9 @@ def up(
     # to ensure_layout for layout scaffolding only; the executor below
     # owns ensure_heartbeat_schedule via the SCHEDULE_HEARTBEAT action.
     if hasattr(supervisor, "core_rail"):
-        supervisor.core_rail.start()
+        supervisor.core_rail.start(
+            start_workers=_start_foreground_core_rail_workers(plan),
+        )
     else:  # pragma: no cover - back-compat for mocked Supervisors in tests
         supervisor.ensure_layout()
     if all(hasattr(supervisor.config, field) for field in ("project", "accounts", "projects")) and hasattr(
@@ -969,6 +971,32 @@ def up(
 
     if result.exit_code is not None:
         raise typer.Exit(code=result.exit_code)
+
+
+def _start_foreground_core_rail_workers(plan) -> bool:
+    """Return True when ``pm up`` should run job workers in-process.
+
+    #1431: ``pm up`` attaches the user to tmux and may stay alive for
+    hours. If it starts a full HeartbeatRail while a headless daemon is
+    also running (or about to be spawned by the launch plan), the two
+    worker pools race on the same ``work_jobs`` table. During rolling
+    upgrades that lets an older foreground process claim jobs enqueued
+    by a newer roster and fail them as "No handler registered" before
+    the daemon can run them.
+    """
+    try:
+        from pollypm.launch_state import LaunchAction
+
+        if LaunchAction.START_RAIL_DAEMON in getattr(plan, "actions", ()):
+            return False
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        if _rail_daemon_live():
+            return False
+    except Exception:  # noqa: BLE001
+        pass
+    return True
 
 
 def _rail_daemon_pid_path() -> Path:

--- a/tests/test_cli_up_state_machine.py
+++ b/tests/test_cli_up_state_machine.py
@@ -10,10 +10,12 @@ existing supervisor calls without disturbing legacy behavior.
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 from typer.testing import CliRunner
 
 from pollypm import cli
+from pollypm.launch_state import LaunchAction
 
 
 # ---------------------------------------------------------------------------
@@ -79,6 +81,44 @@ def test_probe_builder_swallows_tmux_errors() -> None:
     probe = cli._build_launch_probe(_FakeSupervisor())
     assert probe.main_session_alive is False
     assert probe.closet_session_alive is False
+
+
+# ---------------------------------------------------------------------------
+# Foreground rail ownership
+# ---------------------------------------------------------------------------
+
+
+def test_pm_up_does_not_start_foreground_workers_when_daemon_planned(
+    monkeypatch,
+) -> None:
+    """#1431: ``pm up`` must not run a second cadence worker pool in
+    the foreground when the launch plan is about to spawn the daemon.
+    """
+    monkeypatch.setattr(cli, "_rail_daemon_live", lambda: False)
+    plan = SimpleNamespace(actions=(LaunchAction.START_RAIL_DAEMON,))
+
+    assert cli._start_foreground_core_rail_workers(plan) is False
+
+
+def test_pm_up_does_not_start_foreground_workers_when_daemon_live(
+    monkeypatch,
+) -> None:
+    """#1431: attaching to an existing cockpit with a live daemon must
+    leave job draining to that daemon, not the foreground ``pm up``.
+    """
+    monkeypatch.setattr(cli, "_rail_daemon_live", lambda: True)
+    plan = SimpleNamespace(actions=(LaunchAction.SCHEDULE_HEARTBEAT,))
+
+    assert cli._start_foreground_core_rail_workers(plan) is False
+
+
+def test_pm_up_starts_foreground_workers_only_without_daemon(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(cli, "_rail_daemon_live", lambda: False)
+    plan = SimpleNamespace(actions=(LaunchAction.SCHEDULE_HEARTBEAT,))
+
+    assert cli._start_foreground_core_rail_workers(plan) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1431

Stops `pm up` from starting a foreground HeartbeatRail worker pool when the launch plan will start a headless rail daemon, or when one is already alive. This keeps one process responsible for draining recurring cadence jobs so old foreground processes do not claim newer watchdog jobs and fail them as unregistered.

Layer audit: CLI launch orchestration only; no store or plugin boundary changes.

Tests:
- `PYTHONPATH=src /Users/sam/dev/pollypm/.venv/bin/python -m pytest tests/test_cli_up_state_machine.py -q`
- `PYTHONPATH=src /Users/sam/dev/pollypm/.venv/bin/python -m pytest tests/test_rail_ticker.py -q`
- `PYTHONPATH=src /Users/sam/dev/pollypm/.venv/bin/python -m pytest tests/test_core_rail.py -q`