### PR TITLE
Fix #1440 dispatch stuck draft watchdog

### DIFF
--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -34,6 +34,7 @@ from pollypm.audit.watchdog import (
     ESCALATION_THROTTLE_SECONDS,
     Finding,
     RULE_ROLE_SESSION_MISSING,
+    RULE_STUCK_DRAFT,
     RULE_TASK_ON_HOLD_STALE,
     RULE_TASK_REVIEW_STALE,
     RULE_WORKER_SESSION_DEAD_LOOP,
@@ -51,10 +52,14 @@ from pollypm.audit.watchdog import (
 
 
 # #1414 — only the auto-unstick rules are eligible for architect dispatch.
-# Existing rules (orphan_marker, stuck_draft, etc.) already have
+# Legacy forensic rules (orphan_marker, marker_leaked, etc.) already have
 # operator-actionable alerts and predate this dispatch path; we leave
 # them additive-only to keep the blast radius small.
 _DISPATCHABLE_RULES: frozenset[str] = frozenset({
+    # #1440 — stale drafts are architect-originated planning stalls. Alerting
+    # alone leaves them parked forever; dispatch the architect to queue,
+    # cancel, or rewrite them.
+    RULE_STUCK_DRAFT,
     RULE_TASK_REVIEW_STALE,
     RULE_ROLE_SESSION_MISSING,
     RULE_WORKER_SESSION_DEAD_LOOP,

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -14,7 +14,6 @@ from pathlib import Path
 
 import pytest
 
-from pollypm.audit import emit
 from pollypm.audit.log import (
     EVENT_MARKER_CREATED,
     EVENT_MARKER_LEAKED,
@@ -954,6 +953,72 @@ def test_cadence_handler_dispatches_eligible_finding(
     ]
     assert len(dispatch_rows) == 1
     assert dispatch_rows[0]["metadata"]["finding_type"] == RULE_TASK_REVIEW_STALE
+
+
+def test_cadence_handler_dispatches_stuck_draft(
+    now: datetime, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale draft finding triggers an architect dispatch (#1440)."""
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _scan_one_project,
+    )
+
+    task = _StatefulTask(
+        project="savethenovel",
+        task_number=8,
+        work_status="draft",
+        created_at=now - timedelta(hours=12),
+        updated_at=now - timedelta(hours=12),
+        created_by="architect",
+        title="Decide next chapter plan",
+    )
+
+    sent: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._send_brief_to_architect",
+        lambda target, brief: sent.append((target, brief)) or True,
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_storage_windows",
+        lambda name: [],
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_open_tasks",
+        lambda key, path: [task],
+    )
+
+    store = _RecordingStore()
+    counters = _scan_one_project(
+        project_key="savethenovel",
+        project_path=None,
+        msg_store=store,
+        state_store=None,
+        now=now,
+        config=WatchdogConfig(),
+        storage_closet_name="pollypm-storage-closet",
+    )
+
+    assert counters["findings"] == 1
+    assert counters["dispatches_sent"] == 1
+    assert counters["dispatches_throttled"] == 0
+    assert len(sent) == 1
+    target, brief = sent[0]
+    assert target == "pollypm-storage-closet:architect-savethenovel"
+    assert RULE_STUCK_DRAFT in brief
+    assert "savethenovel/8" in brief
+
+    rows = [
+        json.loads(line)
+        for line in central_log_path("savethenovel")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line.strip()
+    ]
+    dispatch_rows = [
+        r for r in rows if r["event"] == "watchdog.escalation_dispatched"
+    ]
+    assert len(dispatch_rows) == 1
+    assert dispatch_rows[0]["metadata"]["finding_type"] == RULE_STUCK_DRAFT
 
 
 def test_cadence_handler_throttles_repeat_dispatch(


### PR DESCRIPTION
Closes #1440

Adds `stuck_draft` to the watchdog architect-dispatch allowlist so stale draft findings trigger the same escalation/throttle path as other auto-unstick rules. Adds a cadence-handler regression test covering the state-based stale-draft path.

Self-audit: touched the plugins_builtin watchdog dispatch wiring and watchdog tests only; no UI/store boundary changes.