### PR TITLE
Fix #1437 allow Codex workers to write project state

### DIFF
--- a/src/pollypm/work/session_manager.py
+++ b/src/pollypm/work/session_manager.py
@@ -501,7 +501,7 @@ class SessionManager:
             # archival reads ambient env (legacy behaviour).
             return legacy_cmd, "claude", agent_name, None, None
 
-        from pollypm.models import SessionConfig
+        from pollypm.models import ProviderKind, SessionConfig
         from pollypm.onboarding import default_session_args
         from pollypm.providers import get_provider
         from pollypm.runtimes import get_runtime
@@ -564,6 +564,20 @@ class SessionManager:
                 routed_assignment.source,
             )
 
+        session_args = default_session_args(
+            session_provider,
+            open_permissions=config.pollypm.open_permissions_by_default,
+            role="worker",
+            model=session_model,
+        )
+        if session_provider is ProviderKind.CODEX:
+            # Per-task workers run from ``.pollypm/worktrees/<task>``.
+            # Codex's workspace-write sandbox otherwise allows that
+            # worktree but rejects the parent project state directory
+            # that ``pm task done`` must update (#1437).
+            project_state_dir = (self._project_path / ".pollypm").resolve()
+            session_args = [*session_args, "--add-dir", str(project_state_dir)]
+
         session = SessionConfig(
             name=window_name,
             role="worker",
@@ -572,12 +586,7 @@ class SessionManager:
             cwd=worktree_path,
             project=project,
             window_name=window_name,
-            args=default_session_args(
-                session_provider,
-                open_permissions=config.pollypm.open_permissions_by_default,
-                role="worker",
-                model=session_model,
-            ),
+            args=session_args,
         )
         provider = get_provider(session_provider, root_dir=config.project.root_dir)
         runtime = get_runtime(account.runtime, root_dir=config.project.root_dir)

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -836,6 +836,8 @@ class TestProvisionWorker:
             "never",
             "--model",
             "gpt-5.4",
+            "--add-dir",
+            str((tmp_project / ".pollypm").resolve()),
         ]
 
     def test_provision_worker_aborts_when_prompt_write_fails(


### PR DESCRIPTION
Closes #1437

Per-task Codex workers now launch with the project `.pollypm` directory added as an explicit writable directory, so `pm task done` can update project state from a task worktree while keeping the normal `workspace-write` sandbox. The regression test asserts the extra `--add-dir` is present only on the per-task Codex worker launch path.

Layer audit: touched domain launch orchestration in `work/session_manager.py` plus focused unit coverage in `tests/test_session_manager.py`; no UI, facade, or store imports added.