### PR TITLE
Fix #1441 quiet notify fallback note

### DIFF
--- a/src/pollypm/cli_features/session_runtime.py
+++ b/src/pollypm/cli_features/session_runtime.py
@@ -58,6 +58,13 @@ def _fake_recovery_inbox_override_enabled() -> bool:
     raw = os.environ.get("POLLYPM_DEV_FAKE_RECOVERY_INBOX", "").strip().lower()
     return raw in {"1", "true", "yes", "on"}
 
+
+def _notify_user_prompt_fallback_note_enabled() -> bool:
+    """Return True when missing-user-prompt fallback notes should be printed."""
+    raw = os.environ.get("POLLYPM_NOTIFY_USER_PROMPT_FALLBACK_NOTE", "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
 # ``<project>/<N>`` matches the canonical task id form. When ``pm send``
 # receives an argument matching this shape we translate it to the
 # per-task worker window name (#924) so the user does not have to know
@@ -830,25 +837,22 @@ def register_session_runtime_commands(app: typer.Typer, *, helpers) -> None:
                         raise typer.Exit(code=1)
             user_prompt_payload = parsed_prompt
 
-        # Surface the contract gap at producer time — without this,
-        # operators discover hours later (in the dashboard or via
-        # release_invariants) that the Action Needed card fell back to
-        # heuristic body parsing because no ``--user-prompt-json`` was
-        # passed. The release invariant ``user_action_message_missing_
-        # user_prompt`` is the scan-side companion; this is the
-        # emit-side reminder. We warn (don't reject) so existing
-        # callers in scripts / older role prompts keep working —
-        # tightening to a hard error is a separate decision.
+        # The dashboard has a heuristic fallback when producers omit
+        # ``--user-prompt-json``. Keep that fallback quiet by default:
+        # role panes often stream stderr into user-facing logs, where a
+        # "Warning:" prefix reads like a broken escalation. Developers
+        # debugging producer payloads can opt into this diagnostic note.
         if (
             user_prompt_payload is None
             and resolved_priority == "immediate"
             and requester_role == "user"
             and channel_name == "inbox"
+            and _notify_user_prompt_fallback_note_enabled()
         ):
             typer.echo(
-                "Warning: posting an immediate-priority user-facing "
+                "note: posting an immediate-priority user-facing "
                 "notify without --user-prompt-json. The dashboard's "
-                "Action Needed card will fall back to body heuristics "
+                "Action Needed card is using body-heuristic fallback "
                 "and lose structured steps + decision question + "
                 "contextual buttons. Pass --user-prompt-json '{...}' "
                 "with at least one of summary/steps/question for a "

--- a/tests/test_cli_notify.py
+++ b/tests/test_cli_notify.py
@@ -26,7 +26,6 @@ from pollypm.work.sqlite_service import SQLiteWorkService
 from pollypm.cli import app as root_app
 from pollypm.store import SQLAlchemyStore
 from pollypm.work.models import WorkStatus
-from pollypm.work.sqlite_service import SQLiteWorkService
 
 
 runner = CliRunner()
@@ -37,11 +36,17 @@ def db_path(tmp_path: Path) -> str:
     return str(tmp_path / "state.db")
 
 
-def _invoke_notify(db_path: str, *args: str, input_text: str | None = None):
+def _invoke_notify(
+    db_path: str,
+    *args: str,
+    input_text: str | None = None,
+    env: dict[str, str] | None = None,
+):
     return runner.invoke(
         root_app,
         ["notify", *args, "--db", db_path],
         input=input_text,
+        env=env,
     )
 
 
@@ -308,13 +313,14 @@ class TestNotifyWritesToMessages:
         # tripped the validator without re-counting array indices.
         assert "Approve" in combined
 
-    def test_immediate_user_notify_without_user_prompt_warns(self, db_path):
+    def test_immediate_user_notify_without_user_prompt_is_quiet_by_default(
+        self, db_path
+    ):
         """An immediate-priority user-facing notify without ``--user-
         prompt-json`` is accepted (back-compat for legacy callers) but
-        produces a stderr warning so the operator knows the dashboard
-        will degrade to body heuristics. Pairs with the scan-side
-        ``user_action_message_missing_user_prompt`` invariant — this
-        is the emit-side reminder.
+        does not print a fallback warning. Role panes stream stderr
+        into user-visible logs, so the dashboard's heuristic fallback
+        must not look like a broken escalation.
         """
         result = _invoke_notify(
             db_path,
@@ -322,16 +328,32 @@ class TestNotifyWritesToMessages:
             "Review this plan.",
             "--priority", "immediate",
         )
-        # Exit 0 — warning, not rejection. Existing scripts keep working.
         assert result.exit_code == 0, result.output
         combined = result.output + (result.stderr or "")
-        assert "Warning" in combined
-        assert "--user-prompt-json" in combined
-        assert "Action Needed" in combined or "heuristic" in combined.lower()
+        assert "Warning" not in combined
+        assert "--user-prompt-json" not in combined
+        assert "Action Needed" not in combined
         # Message still landed.
         rows = _fetch_messages(db_path)
         assert len(rows) == 1
         assert rows[0]["tier"] == "immediate"
+
+    def test_immediate_user_notify_without_user_prompt_debug_note(self, db_path):
+        """Developers can opt into the missing-user-prompt diagnostic
+        without restoring the user-facing ``Warning:`` prefix."""
+        result = _invoke_notify(
+            db_path,
+            "Plan ready",
+            "Review this plan.",
+            "--priority", "immediate",
+            env={"POLLYPM_NOTIFY_USER_PROMPT_FALLBACK_NOTE": "1"},
+        )
+        assert result.exit_code == 0, result.output
+        combined = result.output + (result.stderr or "")
+        assert "Warning" not in combined
+        assert "note:" in combined
+        assert "--user-prompt-json" in combined
+        assert "fallback" in combined.lower()
 
     def test_immediate_user_notify_with_user_prompt_does_not_warn(self, db_path):
         """When the producer DOES pass ``--user-prompt-json``, no


### PR DESCRIPTION
Closes #1441

Suppresses the missing --user-prompt-json fallback diagnostic by default for immediate user-facing notify messages, so role panes no longer stream a Warning-looking line into user-facing logs. Developers can opt back in with POLLYPM_NOTIFY_USER_PROMPT_FALLBACK_NOTE=1, which prints a lowercase note instead of Warning:.

Layer audit: touched CLI command handling and CLI notify tests only; no service/domain/store imports or boundary changes.