### PR TITLE
Fix #1439 route review handoffs to reviewer

### DIFF
--- a/src/pollypm/work/task_assignment.py
+++ b/src/pollypm/work/task_assignment.py
@@ -169,28 +169,20 @@ def role_candidate_names(
     project that still runs a long-lived worker (e.g. booktalk's pre-
     existing setup) keeps working.
 
-    #1057 — the per-task window also fulfills NON-worker roles for that
+    #1057 — the per-task window also fulfills ad-hoc task roles for that
     specific task. When the planner spawns critic subtasks the task is
     in_progress with assignee ``critic_simplicity`` (or similar planner-
     emitted role) and a ``task-<project>-<N>`` window is doing the work.
     The role-assignment resolver must accept that window as fulfillment
     so the ``no_session_for_assignment`` alert doesn't fire spuriously.
-    The shape: when ``task_number`` is supplied for *any* role, prepend
-    ``task-<project>-<N>`` ahead of the role-specific candidates. The
-    long-lived ``<role>-<project>`` / ``<role>_<project>`` candidates
-    stay so workspaces that still run dedicated role sessions keep
-    resolving via the legacy fallback.
+    Static control roles (reviewer / operator / triage / heartbeat)
+    deliberately skip that fallback; a still-open worker task pane must
+    not steal reviewer handoff pings from the reviewer session (#1439).
     """
     key = role.strip().lower()
-    # #1057 — per-task worker windows fulfill ANY role for their
-    # specific task. Compute the per-task candidate once and prepend
-    # below so it takes precedence over role-specific candidates.
-    # Note: the simpler "per-task worker fulfills any role" semantics
-    # is the shipped behavior (#1057 CLOSED). If we ever decide a
-    # per-task pane should only fulfill the role it was spawned to
-    # handle (e.g. because the window's persona was overwritten),
-    # narrow this check by reading the task's ``assignee`` and matching
-    # it against ``role``.
+    # #1057 — per-task worker windows fulfill task-local roles such as
+    # worker, critic_*, and planner-emitted ad-hoc roles. They do not
+    # fulfill static control lanes handled by long-lived sessions.
     per_task_candidate: str | None = None
     if task_number is not None and project:
         per_task_candidate = f"task-{project}-{int(task_number)}"
@@ -230,10 +222,6 @@ def role_candidate_names(
     if not project_key:
         return static
     project_scoped = [f"{key}_{project_key}", f"{key}-{project_key}"]
-    # #1057 — per-task window also fulfills singleton-named control
-    # roles (reviewer/operator/triage/heartbeat) for that task.
-    if per_task_candidate is not None:
-        return [per_task_candidate, *project_scoped, *static]
     return project_scoped + static
 
 

--- a/tests/test_task_assignment_notify.py
+++ b/tests/test_task_assignment_notify.py
@@ -123,6 +123,16 @@ class TestRoleCandidates:
             "reviewer_bikepath", "reviewer-bikepath", "reviewer", "pm-reviewer",
         ]
 
+    def test_reviewer_with_task_number_still_uses_reviewer_lane(self):
+        # #1439 — a still-open per-task worker pane must not steal
+        # review-node handoff pings from the long-lived reviewer lane.
+        assert role_candidate_names("reviewer", "savethenovel", task_number=12) == [
+            "reviewer_savethenovel",
+            "reviewer-savethenovel",
+            "reviewer",
+            "pm-reviewer",
+        ]
+
     def test_reviewer_without_project_pins_to_singleton(self):
         # Empty project key → singleton-only (legacy behaviour).
         assert role_candidate_names("reviewer", "") == ["reviewer", "pm-reviewer"]
@@ -185,6 +195,21 @@ class TestSessionRoleIndexResolve:
         assert handle is not None
         assert handle.name == "pm-reviewer"
 
+    def test_reviewer_ignores_matching_task_window(self):
+        svc = FakeSessionService(handles=[
+            FakeHandle("task-savethenovel-12"),
+            FakeHandle("reviewer_savethenovel"),
+        ])
+        index = SessionRoleIndex(svc)
+        handle = index.resolve(
+            ActorType.ROLE,
+            "reviewer",
+            "savethenovel",
+            task_number=12,
+        )
+        assert handle is not None
+        assert handle.name == "reviewer_savethenovel"
+
     def test_agent_exact_name(self):
         svc = FakeSessionService(handles=[
             FakeHandle("polly"), FakeHandle("pm-reviewer"),
@@ -224,6 +249,35 @@ class TestSessionRoleIndexResolve:
         handle = index.resolve(ActorType.ROLE, "worker", "demo")
         assert handle is not None
         assert handle.name == "worker_demo"
+
+
+class TestReviewerNotifyRouting:
+    def test_review_ping_targets_reviewer_not_task_worker(self, state_store):
+        svc = FakeSessionService(handles=[
+            FakeHandle("task-savethenovel-12"),
+            FakeHandle("reviewer_savethenovel"),
+        ])
+        services = _RuntimeServices(
+            session_service=svc,
+            state_store=state_store,
+            work_service=None,
+            project_root=Path("."),
+        )
+        event = _event(
+            task_id="savethenovel/12",
+            project="savethenovel",
+            actor_name="reviewer",
+            current_node="code_review",
+            current_node_kind="review",
+            work_status="review",
+        )
+
+        outcome = notify(event, services=services)
+
+        assert outcome["outcome"] == "sent"
+        assert outcome["session"] == "reviewer_savethenovel"
+        assert svc.sent[0][0] == "reviewer_savethenovel"
+        assert "Review needed" in svc.sent[0][1]
 
 
 def test_load_runtime_services_uses_workspace_root_work_db(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
Closes #1439

Review handoff events no longer let a still-open per-task worker pane satisfy the reviewer control role. Reviewer assignments now resolve to the per-project reviewer lane or singleton reviewer session, so the review ping wakes Russell instead of the task worker window.

Layer audit: domain-only change in work task-assignment role resolution plus focused task-assignment tests; no UI/store boundary changes.

Tests:
- PYTHONPATH=src /Users/sam/dev/pollypm/.venv/bin/python -m pytest tests/test_task_assignment_notify.py -q
- PYTHONPATH=src /Users/sam/dev/pollypm/.venv/bin/python -m pytest tests/test_no_session_auto_recovery.py -q
- PYTHONPATH=src /Users/sam/dev/pollypm/.venv/bin/python -m pytest tests/test_reviewer_provisioning.py -q
- PYTHONPATH=src /Users/sam/dev/pollypm/.venv/bin/python -m pytest tests/test_sessions_registration.py -q
- PYTHONPATH=src /Users/sam/dev/pollypm/.venv/bin/python -m pytest tests/test_work_queries.py -q
- PYTHONPATH=src /Users/sam/dev/pollypm/.venv/bin/python -m pytest tests/test_architect_bootstrap.py -q

Overlap check: no open PR touched src/pollypm/work/task_assignment.py or tests/test_task_assignment_notify.py.