### PR TITLE
Fix #1442 audit raw task deletes

### DIFF
--- a/src/pollypm/work/schema.py
+++ b/src/pollypm/work/schema.py
@@ -126,6 +126,43 @@ CREATE INDEX IF NOT EXISTS idx_work_tasks_priority
 -- column the (pre-migration) legacy work_tasks table doesn't have
 -- yet, so it must live in the ensure helper rather than WORK_SCHEMA.
 
+CREATE TABLE IF NOT EXISTS work_task_delete_audit_outbox (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project TEXT NOT NULL,
+    task_number INTEGER NOT NULL,
+    title TEXT NOT NULL DEFAULT '',
+    flow_template_id TEXT NOT NULL DEFAULT '',
+    previous_status TEXT NOT NULL DEFAULT '',
+    created_by TEXT NOT NULL DEFAULT '',
+    deleted_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_task_delete_audit_outbox_project
+    ON work_task_delete_audit_outbox(project, task_number);
+
+CREATE TRIGGER IF NOT EXISTS trg_work_tasks_delete_audit_outbox
+AFTER DELETE ON work_tasks
+BEGIN
+    INSERT INTO work_task_delete_audit_outbox (
+        project,
+        task_number,
+        title,
+        flow_template_id,
+        previous_status,
+        created_by,
+        deleted_at
+    )
+    VALUES (
+        OLD.project,
+        OLD.task_number,
+        OLD.title,
+        OLD.flow_template_id,
+        OLD.work_status,
+        OLD.created_by,
+        strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+    );
+END;
+
 -- -------------------------------------------------------------------
 -- Task dependencies / relationships
 -- -------------------------------------------------------------------
@@ -475,6 +512,16 @@ _WORK_MIGRATIONS: list[tuple[int, str, list[str]]] = [
             # ADD COLUMN. The migration entry records the v8 bump so
             # ``work_schema_version`` stays accurate for both fresh
             # and legacy DBs.
+        ],
+    ),
+    (
+        9,
+        "Add work_task_delete_audit_outbox trigger so raw work_tasks "
+        "deletes emit task.deleted audit events",
+        [
+            # The table, index, and trigger are created by WORK_SCHEMA before
+            # the migration walk. This row records that the DB has the delete
+            # audit guard installed.
         ],
     ),
 ]

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -767,6 +767,7 @@ class SQLiteWorkService:
             )
         except Exception:  # noqa: BLE001 — audit must never break init
             pass
+        self._flush_task_delete_audit_outbox()
         self._gate_registry = GateRegistry(project_path=project_path)
         self._flow_cache: dict[tuple[str, int], FlowTemplate] = {}
         self._work_output_cache: dict[str, dict[str, Any]] = {}
@@ -790,9 +791,56 @@ class SQLiteWorkService:
 
     def close(self) -> None:
         """Close the database connection."""
+        if not self._conn.in_transaction:
+            self._flush_task_delete_audit_outbox()
         self._flow_cache.clear()
         self._work_output_cache.clear()
         self._conn.close()
+
+    def _flush_task_delete_audit_outbox(self) -> int:
+        """Emit JSONL audit rows captured by the work_tasks delete trigger."""
+        try:
+            rows = self._conn.execute(
+                "SELECT id, project, task_number, title, flow_template_id, "
+                "previous_status, created_by, deleted_at "
+                "FROM work_task_delete_audit_outbox ORDER BY id"
+            ).fetchall()
+        except sqlite3.Error:
+            return 0
+        if not rows:
+            return 0
+
+        try:
+            from pollypm.audit import emit as _audit_emit
+            from pollypm.audit.log import EVENT_TASK_DELETED
+
+            for row in rows:
+                project = str(row["project"])
+                task_number = int(row["task_number"])
+                _audit_emit(
+                    event=EVENT_TASK_DELETED,
+                    project=project,
+                    subject=f"{project}/{task_number}",
+                    actor="system",
+                    metadata={
+                        "reason": "work_tasks_delete_trigger",
+                        "title": row["title"],
+                        "flow_template": row["flow_template_id"],
+                        "previous_status": row["previous_status"],
+                        "created_by": row["created_by"],
+                        "deleted_at": row["deleted_at"],
+                    },
+                    project_path=self._project_path,
+                )
+            self._conn.executemany(
+                "DELETE FROM work_task_delete_audit_outbox WHERE id = ?",
+                [(row["id"],) for row in rows],
+            )
+            self._conn.commit()
+            return len(rows)
+        except Exception:  # noqa: BLE001
+            self._conn.rollback()
+            return 0
 
     def __enter__(self):
         return self
@@ -2628,29 +2676,7 @@ class SQLiteWorkService:
         except Exception:
             self._conn.rollback()
             raise
-        # Audit hook (#savethenovel) — record the row delete.
-        # work_tasks is the spine; once a row leaves it the only
-        # forensic trail of "this task ever existed" is the audit
-        # log. Emit AFTER commit so we don't record phantom
-        # deletes for rolled-back transactions.
-        try:
-            from pollypm.audit import emit as _audit_emit
-            from pollypm.audit.log import EVENT_TASK_DELETED
-
-            _audit_emit(
-                event=EVENT_TASK_DELETED,
-                project=task.project,
-                subject=task.task_id,
-                actor="system",
-                metadata={
-                    "reason": "prune_cancelled_critique_child",
-                    "flow_template": task.flow_template_id,
-                    "title": task.title,
-                },
-                project_path=self._project_path,
-            )
-        except Exception:  # noqa: BLE001
-            pass
+        self._flush_task_delete_audit_outbox()
 
     def _on_task_done(self, task_id: str, actor: str) -> None:
         """Post-commit hook — fire milestone/digest flush on done transitions.

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -21,6 +21,7 @@ locations.
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -34,6 +35,7 @@ from pollypm.audit import (
 )
 from pollypm.audit.log import (
     EVENT_TASK_CREATED,
+    EVENT_TASK_DELETED,
     EVENT_TASK_STATUS_CHANGED,
     EVENT_WORK_DB_OPENED,
     SCHEMA_VERSION,
@@ -409,6 +411,62 @@ def test_workservice_transition_emits_status_changed(tmp_path: Path) -> None:
     assert "from" in last.metadata
     assert "to" in last.metadata
     assert last.metadata["to"] == "queued"
+
+
+def test_workservice_flushes_raw_work_task_delete_to_audit(
+    tmp_path: Path,
+) -> None:
+    """A raw SQL sweeper cannot make a work_tasks row vanish silently.
+
+    The delete trigger records the old task id in an outbox inside the
+    work DB. The next work-service open flushes that outbox to the JSONL
+    audit stream as ``task.deleted``.
+    """
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    project_root = tmp_path / "savethenovel"
+    (project_root / ".pollypm").mkdir(parents=True)
+    db_path = tmp_path / "work.db"
+
+    svc = SQLiteWorkService(db_path=db_path, project_path=project_root)
+    try:
+        task = svc.create(
+            title="Advisor review for savethenovel",
+            description="Review recent project trajectory.",
+            type="task",
+            project="savethenovel",
+            flow_template="advisor_review",
+            roles={"advisor": "advisor"},
+            priority="normal",
+            created_by="advisor.tick",
+            labels=["advisor"],
+        )
+        svc.queue(task.task_id, "advisor.tick")
+    finally:
+        svc.close()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "DELETE FROM work_transitions "
+            "WHERE task_project = ? AND task_number = ?",
+            (task.project, task.task_number),
+        )
+        conn.execute(
+            "DELETE FROM work_tasks WHERE project = ? AND task_number = ?",
+            (task.project, task.task_number),
+        )
+        conn.commit()
+
+    svc2 = SQLiteWorkService(db_path=db_path, project_path=project_root)
+    svc2.close()
+
+    deleted = read_events(
+        "savethenovel", project_path=project_root, event=EVENT_TASK_DELETED,
+    )
+    assert len(deleted) == 1
+    assert deleted[0].subject == task.task_id
+    assert deleted[0].metadata["flow_template"] == "advisor_review"
+    assert deleted[0].metadata["previous_status"] == "queued"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_work_schema.py
+++ b/tests/test_work_schema.py
@@ -29,6 +29,7 @@ EXPECTED_TABLES = [
     "work_node_executions",
     "work_context_entries",
     "work_transitions",
+    "work_task_delete_audit_outbox",
 ]
 
 
@@ -270,10 +271,8 @@ def test_legacy_db_gets_hot_query_indexes_and_schema_bump(conn):
     version = conn.execute(
         "SELECT COALESCE(MAX(version), 0) FROM work_schema_version"
     ).fetchone()[0]
-    # Migration 8 (#1398) records the plan_version + predecessor_task_id
-    # column bumps on work_tasks so plan-task evolution metadata
-    # surfaces on legacy DBs without a backfill pass.
-    assert version == 8
+    # Migration 9 records the task-delete audit outbox/trigger.
+    assert version == 9
 
 
 def test_migration_6_adds_provider_columns_to_work_sessions(conn):
@@ -309,10 +308,10 @@ def test_migration_7_adds_kickoff_sent_at_to_work_node_executions(conn):
         "SELECT COALESCE(MAX(version), 0) FROM work_schema_version"
     ).fetchone()[0]
     # The migration walk applies every pending step in order, so a v6
-    # legacy DB ends up at the latest version (v8 after #1398) — not
+    # legacy DB ends up at the latest version (v9 after #1442) — not
     # at v7. Asserting the whole walk completed protects future
     # migrations from a stale floor here.
-    assert version == 8
+    assert version == 9
 
 
 def test_migration_8_adds_plan_metadata_columns_to_work_tasks(conn):
@@ -324,7 +323,7 @@ def test_migration_8_adds_plan_metadata_columns_to_work_tasks(conn):
       * existing rows default to ``plan_version=1`` and
         ``predecessor_task_id=NULL`` (additive migration — no data
         loss / shape change),
-      * the schema_version row bumps to v8.
+      * the schema_version row bumps to the latest migration.
     """
     # Create a v7-shaped work_tasks table (no plan_version /
     # predecessor_task_id columns) plus the schema_version row that
@@ -398,9 +397,52 @@ def test_migration_8_adds_plan_metadata_columns_to_work_tasks(conn):
     version = conn.execute(
         "SELECT COALESCE(MAX(version), 0) FROM work_schema_version"
     ).fetchone()[0]
-    assert version == 8
+    assert version == 9
 
     idxs = _indexes(conn)
     assert "idx_work_tasks_predecessor" in idxs, (
         "successors lookup index should be created on legacy DB"
     )
+
+
+def test_migration_9_adds_task_delete_audit_outbox_and_trigger(conn):
+    """#1442: raw work_tasks deletes leave a durable audit outbox row."""
+    create_work_tables(conn)
+
+    tables = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    assert "work_task_delete_audit_outbox" in tables
+
+    trigger = conn.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE type='trigger' AND name='trg_work_tasks_delete_audit_outbox'"
+    ).fetchone()
+    assert trigger is not None
+
+    conn.execute(
+        "INSERT INTO work_tasks "
+        "(project, task_number, title, type, flow_template_id, "
+        "created_at, created_by, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "demo",
+            1,
+            "to be swept",
+            "task",
+            "standard",
+            "2026-01-01T00:00:00+00:00",
+            "tester",
+            "2026-01-01T00:00:00+00:00",
+        ),
+    )
+    conn.execute("DELETE FROM work_tasks WHERE project = ? AND task_number = ?", ("demo", 1))
+
+    row = conn.execute(
+        "SELECT project, task_number, title, flow_template_id, previous_status, "
+        "created_by FROM work_task_delete_audit_outbox"
+    ).fetchone()
+    assert row == ("demo", 1, "to be swept", "standard", "draft", "tester")


### PR DESCRIPTION
Closes #1442

Adds a SQLite delete-trigger outbox for work_tasks and flushes it through SQLiteWorkService so raw row deletes become task.deleted audit events. Covers the advisor_review-shaped repro where a queued task is removed by direct SQL outside the work-service transition machinery.

Layer audit: touched store/IO-owned work schema and work-service persistence only, plus focused schema/audit regression tests; no UI or service-facade imports added.