### PR TITLE
Fix #1443 watchdog cadence dedupe

### DIFF
--- a/src/pollypm/heartbeat/tick.py
+++ b/src/pollypm/heartbeat/tick.py
@@ -139,6 +139,9 @@ class Heartbeat:
                 entry.first_seen_at = now
 
             if self._is_due(entry, now, prev):
+                if self._dedupe_recent_or_active(entry, now):
+                    result.skipped_not_due += 1
+                    continue
                 payload_snapshot = _snapshot_payload(entry.payload)
                 job_id = self.queue.enqueue(
                     entry.handler_name,
@@ -186,6 +189,30 @@ class Heartbeat:
 
         # Unknown schedule type — be strict, don't fire.
         return False
+
+    def _dedupe_recent_or_active(
+        self,
+        entry: RosterEntry,
+        now: datetime,
+    ) -> bool:
+        """Coalesce same-window ``@every`` dedupe keys across live rails.
+
+        ``JobQueue.enqueue(dedupe_key=...)`` suppresses only queued/claimed
+        rows. If a cadence job finishes quickly, a second HeartbeatRail with a
+        slightly different in-memory anchor can otherwise enqueue the same
+        handler again seconds later. Conversely, if the previous row is still
+        active, treating that deduped enqueue as a fire consumes the next beat.
+        """
+        if not entry.dedupe_key or not isinstance(entry.schedule, EverySchedule):
+            return False
+        checker = getattr(self.queue, "has_recent_or_active_dedupe", None)
+        if not callable(checker):
+            return False
+        since = now - entry.schedule.interval
+        try:
+            return bool(checker(entry.dedupe_key, since=since))
+        except Exception:  # noqa: BLE001
+            return False
 
     def _every_is_due(
         self,

--- a/src/pollypm/jobs/queue.py
+++ b/src/pollypm/jobs/queue.py
@@ -363,6 +363,45 @@ class JobQueue:
             label="JobQueue.enqueue",
         )
 
+    def has_recent_or_active_dedupe(
+        self,
+        dedupe_key: str,
+        *,
+        since: datetime,
+    ) -> bool:
+        """Return True if ``dedupe_key`` is active or already fired since ``since``.
+
+        ``enqueue(dedupe_key=...)`` only dedupes queued/claimed rows. A
+        second HeartbeatRail can therefore enqueue the same cadence handler
+        seconds after the first one completes. Recurring ticks use this
+        read-side guard to coalesce same-window pulses across rails without
+        permanently reserving the dedupe key.
+        """
+        if not dedupe_key:
+            return False
+        since_iso = since.astimezone(UTC).isoformat()
+
+        def _do_check() -> bool:
+            with self._lock:
+                row = self._conn.execute(
+                    """
+                    SELECT id FROM work_jobs
+                    WHERE dedupe_key = ?
+                      AND (
+                        status IN ('queued', 'claimed')
+                        OR enqueued_at > ?
+                      )
+                    LIMIT 1
+                    """,
+                    (dedupe_key, since_iso),
+                ).fetchone()
+                return row is not None
+
+        return self._retry_reopening_closed_connection(
+            _do_check,
+            label="JobQueue.has_recent_or_active_dedupe",
+        )
+
     # ------------------------------------------------------------------
     # Claim / complete / fail
     # ------------------------------------------------------------------

--- a/tests/test_heartbeat_tick.py
+++ b/tests/test_heartbeat_tick.py
@@ -55,6 +55,29 @@ class FakeQueue:
         return self.next_id
 
 
+@dataclass
+class DedupeAwareQueue(FakeQueue):
+    """Fake queue exposing the durable dedupe recency hook."""
+
+    active_keys: set[str] = field(default_factory=set)
+    recent_enqueued_at: dict[str, list[datetime]] = field(default_factory=dict)
+    dedupe_checks: list[tuple[str, datetime]] = field(default_factory=list)
+
+    def has_recent_or_active_dedupe(
+        self,
+        dedupe_key: str,
+        *,
+        since: datetime,
+    ) -> bool:
+        self.dedupe_checks.append((dedupe_key, since))
+        if dedupe_key in self.active_keys:
+            return True
+        return any(
+            enqueued_at > since
+            for enqueued_at in self.recent_enqueued_at.get(dedupe_key, [])
+        )
+
+
 def _utc(year=2026, month=1, day=1, hour=0, minute=0, second=0) -> datetime:
     return datetime(year, month, day, hour, minute, second, tzinfo=UTC)
 
@@ -247,6 +270,62 @@ class TestHeartbeatTick:
         # t=120s: fires again.
         hb.tick(_utc(minute=2))
         assert len(queue.enqueued) == 2
+
+    def test_every_dedupe_active_job_does_not_consume_next_beat(self) -> None:
+        roster = Roster()
+        roster.register(
+            schedule="@every 5m",
+            handler_name="audit.watchdog",
+            payload={},
+            dedupe_key="audit.watchdog",
+        )
+        queue = DedupeAwareQueue(active_keys={"audit.watchdog"})
+        hb = Heartbeat(roster, queue)
+
+        hb.tick(_utc(hour=12, minute=0))
+        result = hb.tick(_utc(hour=12, minute=5))
+
+        assert result.enqueued_count == 0
+        assert queue.enqueued == []
+        entry = roster.entries[0]
+        assert entry.last_fired_at is None
+        assert queue.dedupe_checks == [
+            ("audit.watchdog", _utc(hour=12, minute=0))
+        ]
+
+        queue.active_keys.clear()
+        result = hb.tick(_utc(hour=12, minute=5, second=15))
+
+        assert result.enqueued_count == 1
+        assert queue.enqueued[0]["handler_name"] == "audit.watchdog"
+        assert entry.last_fired_at == _utc(hour=12, minute=5, second=15)
+
+    def test_every_dedupe_recent_job_blocks_second_rail_double_pulse(self) -> None:
+        roster = Roster()
+        roster.register(
+            schedule="@every 5m",
+            handler_name="audit.watchdog",
+            payload={},
+            dedupe_key="audit.watchdog",
+        )
+        queue = DedupeAwareQueue(
+            recent_enqueued_at={"audit.watchdog": [_utc(hour=12, minute=5)]}
+        )
+        hb = Heartbeat(roster, queue)
+
+        hb.tick(_utc(hour=12, minute=0, second=26))
+        result = hb.tick(_utc(hour=12, minute=5, second=26))
+
+        assert result.enqueued_count == 0
+        assert queue.enqueued == []
+        entry = roster.entries[0]
+        assert entry.last_fired_at is None
+
+        result = hb.tick(_utc(hour=12, minute=10, second=1))
+
+        assert result.enqueued_count == 1
+        assert queue.enqueued[0]["handler_name"] == "audit.watchdog"
+        assert entry.last_fired_at == _utc(hour=12, minute=10, second=1)
 
     def test_single_due_cron_entry(self) -> None:
         roster = Roster()

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -166,6 +166,29 @@ def test_dedupe_key_allows_reenqueue_after_failed(tmp_path: Path) -> None:
     assert jid2 != jid1
 
 
+def test_has_recent_or_active_dedupe_tracks_active_and_recent_rows(
+    tmp_path: Path,
+) -> None:
+    q = JobQueue(db_path=tmp_path / "q.db")
+    before_enqueue = datetime.now(UTC) - timedelta(seconds=1)
+    jid = q.enqueue("sweep", dedupe_key="sweep:a")
+
+    assert q.has_recent_or_active_dedupe(
+        "sweep:a",
+        since=datetime.now(UTC) + timedelta(days=1),
+    )
+
+    (job,) = q.claim("w")
+    q.complete(job.id)
+
+    assert q.has_recent_or_active_dedupe("sweep:a", since=before_enqueue)
+    assert not q.has_recent_or_active_dedupe(
+        "sweep:a",
+        since=datetime.now(UTC) + timedelta(days=1),
+    )
+    assert q.get(jid) is not None
+
+
 def test_late_retry_fail_does_not_resurrect_terminal_dedupe_row(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Closes #1443

Adds a durable queue-side recency check for deduped recurring jobs and has the heartbeat skip same-window @every pulses without advancing local cadence. This prevents an active watchdog job from consuming the next beat and prevents a second HeartbeatRail from double-firing the same dedupe key seconds later.

Self-audit: touched heartbeat scheduling/domain code and the durable job queue API only; no UI or service facade changes.