### PR TITLE
Fix #1427 preserve reviewer finding evidence

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -1388,12 +1388,11 @@ def format_unstick_brief(finding: Finding) -> str:
             lines.append(
                 f"- Task transitioned {from_state} -> on_hold at {on_hold_since}"
             )
-        if reason:
-            lines.append(f"- Reviewer rationale: {reason}")
-        else:
-            lines.append("- No transition reason was recorded.")
         if reviewer_evidence:
-            lines.append("- Recent reviewer evidence:")
+            lines.append(
+                "- Recent reviewer/inbox rationale evidence "
+                "(authoritative if it differs from the transition reason):"
+            )
             for entry in reviewer_evidence:
                 # Each entry is a one-line string already shaped by
                 # the cadence handler (exec row OR inbox message).
@@ -1403,6 +1402,10 @@ def format_unstick_brief(finding: Finding) -> str:
                 "- No additional reviewer execution rows or inbox "
                 "messages were available."
             )
+        if reason:
+            lines.append(f"- On-hold transition reason: {reason}")
+        else:
+            lines.append("- No transition reason was recorded.")
         lines.append("")
         lines.append(
             "Your job (DEFAULT: fix and re-submit). Options: "

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -309,7 +309,7 @@ def _gather_reviewer_evidence(
     subject: str,
     msg_store: Any,
     limit_executions: int = 2,
-    limit_messages: int = 2,
+    limit_messages: int = 5,
 ) -> list[str]:
     """Collect reviewer execution rows + recent inbox messages for ``subject``.
 
@@ -386,7 +386,24 @@ def _gather_reviewer_evidence(
     # canonical ``project/N`` string is considered relevant.
     try:
         if msg_store is not None and hasattr(msg_store, "query_messages"):
-            rows = msg_store.query_messages(project=project_key) or []
+            scopes = [project_key] if project_key else []
+            if "inbox" not in scopes:
+                # Pre-#1425 reviewer notifies could land in the global
+                # inbox scope even when the subject was project-specific.
+                # Include that legacy scope so forensic briefs see the
+                # actual reviewer finding instead of only the transition
+                # reason that parked the task.
+                scopes.append("inbox")
+            rows: list[dict[str, Any]] = []
+            seen_message_ids: set[Any] = set()
+            for scope in scopes:
+                for row in msg_store.query_messages(scope=scope) or []:
+                    message_id = row.get("id")
+                    if message_id is not None:
+                        if message_id in seen_message_ids:
+                            continue
+                        seen_message_ids.add(message_id)
+                    rows.append(row)
             matched: list[dict[str, Any]] = []
             for row in rows:
                 body = (

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -1526,11 +1526,12 @@ def test_format_unstick_brief_on_hold_includes_evidence_and_default() -> None:
     assert "Project: savethenovel" in brief
     assert "Finding: task_on_hold_stale" in brief
     assert "20 minutes" in brief
-    # The on_hold reason / reviewer rationale must be visible verbatim.
+    # The on_hold transition reason and reviewer evidence must both be visible.
     assert "Footer.astro:20" in brief
+    assert "On-hold transition reason:" in brief
     assert "Routing: architect-actionable" in brief
     # Reviewer evidence section must list both lines.
-    assert "Recent reviewer evidence" in brief
+    assert "Recent reviewer/inbox rationale evidence" in brief
     assert "code_review" in brief
     assert "russell" in brief
     # Default action must steer the architect to fix and re-queue.
@@ -1539,6 +1540,47 @@ def test_format_unstick_brief_on_hold_includes_evidence_and_default() -> None:
     assert "pm task approve savethenovel/11" in brief
     # Escalation path is mentioned but framed as last-resort.
     assert "pm notify" in brief
+
+
+def test_format_unstick_brief_on_hold_distinguishes_transition_reason() -> None:
+    """A policy/merge hold reason must not be mislabeled as reviewer rationale."""
+    from pollypm.audit.watchdog import (
+        RULE_TASK_ON_HOLD_STALE,
+        format_unstick_brief,
+    )
+
+    finding = Finding(
+        rule=RULE_TASK_ON_HOLD_STALE,
+        project="savethenovel",
+        subject="savethenovel/11",
+        metadata={
+            "stuck_minutes": 126,
+            "on_hold_since": "2026-05-07T15:46:17.005979+00:00",
+            "from": "review",
+            "reason": (
+                "Waiting on operator: review passed, but approve auto-merge "
+                "is blocked because the project root has untracked planning docs."
+            ),
+            "routing": "architect-actionable",
+            "reviewer_evidence": [
+                "inbox msg from reviewer_savethenovel: review decision blocked "
+                "savethenovel/11 — Decision would be reject: Criterion 3 "
+                "(No placeholders) fails. Live evidence: "
+                "src/components/Footer.astro:20-22 renders placeholder copy.",
+            ],
+        },
+    )
+
+    brief = format_unstick_brief(finding)
+
+    assert "Reviewer rationale: Waiting on operator" not in brief
+    assert "On-hold transition reason: Waiting on operator" in brief
+    assert "Recent reviewer/inbox rationale evidence" in brief
+    assert "Decision would be reject" in brief
+    assert "Footer.astro:20-22" in brief
+    assert brief.index("Decision would be reject") < brief.index(
+        "On-hold transition reason"
+    )
 
 
 def test_format_unstick_brief_on_hold_handles_missing_evidence() -> None:
@@ -1562,8 +1604,92 @@ def test_format_unstick_brief_on_hold_handles_missing_evidence() -> None:
     )
     brief = format_unstick_brief(finding)
     assert "no transition reason" in brief.lower()
-    # Don't include a stale "Recent reviewer evidence" header.
+    # Don't include a stale reviewer-evidence header.
     assert "No additional reviewer execution rows" in brief
+
+
+def test_gather_reviewer_evidence_checks_project_and_global_inbox_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy reviewer notifies may be global inbox rows, not project-scoped rows."""
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _gather_reviewer_evidence,
+    )
+
+    def _boom_create_work_service(*_args, **_kwargs):
+        raise RuntimeError("skip execution lookup")
+
+    monkeypatch.setattr(
+        "pollypm.work.create_work_service",
+        _boom_create_work_service,
+    )
+
+    class _MsgStore:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def query_messages(self, **filters):  # noqa: ANN001
+            self.calls.append(filters)
+            if filters.get("scope") == "savethenovel":
+                return [
+                    {
+                        "id": 1,
+                        "subject": "savethenovel/11 approval blocked",
+                        "body": "Reviewed savethenovel/11 as approve-blocked.",
+                        "sender": "heartbeat",
+                        "created_at": "2026-05-07T15:46:31+00:00",
+                    },
+                ]
+            if filters.get("scope") == "inbox":
+                return [
+                    {
+                        "id": 4,
+                        "subject": "savethenovel/11 review completed but task is on_hold",
+                        "body": (
+                            "Russell completed code review for savethenovel/11. "
+                            "Verdict would be APPROVE after the hold is cleared."
+                        ),
+                        "sender": "heartbeat",
+                        "created_at": "2026-05-07T15:49:50+00:00",
+                    },
+                    {
+                        "id": 3,
+                        "subject": "savethenovel/11 review complete but task is on_hold",
+                        "body": (
+                            "Russell completed code review for savethenovel/11 "
+                            "and would approve it, but pm task approve is blocked."
+                        ),
+                        "sender": "heartbeat",
+                        "created_at": "2026-05-07T15:48:08+00:00",
+                    },
+                    {
+                        "id": 2,
+                        "subject": "review decision blocked: savethenovel/11 on_hold",
+                        "body": (
+                            "Decision would be reject: Criterion 3 "
+                            "(No placeholders) fails. Live evidence: "
+                            "src/components/Footer.astro:20-22 renders "
+                            "placeholder copy."
+                        ),
+                        "sender": "reviewer_savethenovel",
+                        "created_at": "2026-05-07T15:47:13+00:00",
+                    },
+                ]
+            return []
+
+    store = _MsgStore()
+
+    evidence = _gather_reviewer_evidence(
+        project_key="savethenovel",
+        project_path=None,
+        subject="savethenovel/11",
+        msg_store=store,
+    )
+
+    assert {"scope": "savethenovel"} in store.calls
+    assert {"scope": "inbox"} in store.calls
+    assert any("Decision would be reject" in line for line in evidence)
+    assert any("Footer.astro:20-22" in line for line in evidence)
 
 
 def test_cadence_handler_dispatches_on_hold_with_reviewer_evidence(


### PR DESCRIPTION
Closes #1427

When a stale on_hold escalation is built, the watchdog now queries message scope correctly and includes legacy global inbox rows so reviewer notifications that mention the task are folded into the architect brief. The brief now distinguishes the operational on-hold transition reason from reviewer/inbox rationale evidence, so a dirty-root hold cannot masquerade as the actual review finding.

Self-audit: touched audit watchdog domain code only: pure brief formatting in src/pollypm/audit/watchdog.py, recurring watchdog enrichment in src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py, and focused watchdog tests. No UI/store boundary changes.