### PR TITLE
Fix #1371 expose rail task number helper

### DIFF
--- a/src/pollypm/plugins_builtin/core_rail_items/plugin.py
+++ b/src/pollypm/plugins_builtin/core_rail_items/plugin.py
@@ -125,7 +125,7 @@ def _user_waiting_task_ids(ctx: RailContext) -> frozenset[str]:
     return user_waiting_task_ids(config)
 
 
-def _active_task_numbers(project: Any, *, config: Any = None) -> list[int]:
+def active_task_numbers(project: Any, *, config: Any = None) -> list[int]:
     """Return per-task task numbers that the DB considers actively worked.
 
     DB-truth source for the rail's per-project ``Task #N`` rows (#1002).
@@ -153,9 +153,9 @@ def _active_task_numbers(project: Any, *, config: Any = None) -> list[int]:
     project_key = getattr(project, "key", None)
     if not project_key:
         return []
-    from pollypm.work.task_state import active_task_numbers
+    from pollypm.work.task_state import active_task_numbers as work_active_task_numbers
 
-    return active_task_numbers(project, config=config)
+    return work_active_task_numbers(project, config=config)
 
 
 def _polly_state(ctx: RailContext) -> str:
@@ -433,7 +433,7 @@ def _project_rows(ctx: RailContext) -> list[RailRow]:
                 label="  Tasks",
                 state="sub",
             ))
-            for task_num in _active_task_numbers(project, config=config):
+            for task_num in active_task_numbers(project, config=config):
                 rows.append(RailRow(
                     key=f"project:{project_key}:task:{task_num}",
                     label=f"  \u27f3 Task #{task_num}",
@@ -574,3 +574,6 @@ plugin = PollyPMPlugin(
     ),
     initialize=_initialize,
 )
+
+
+__all__ = ["active_task_numbers", "plugin"]

--- a/tests/test_core_rail_items.py
+++ b/tests/test_core_rail_items.py
@@ -166,7 +166,7 @@ def test_pm_chat_label_matches_project_session_persona(
     )
     monkeypatch.setattr(
         core_rail_items_plugin,
-        "_active_task_numbers",
+        "active_task_numbers",
         lambda project, *, config=None: [],
     )
     ctx = RailContext(
@@ -210,7 +210,7 @@ def test_pm_chat_label_uses_project_pm_fallback(monkeypatch, tmp_path: Path) -> 
     )
     monkeypatch.setattr(
         core_rail_items_plugin,
-        "_active_task_numbers",
+        "active_task_numbers",
         lambda project, *, config=None: [],
     )
     ctx = RailContext(
@@ -790,7 +790,7 @@ def test_active_task_numbers_excludes_terminal_and_review_tasks(
     active claim and are doing work) surface as worker rows.
     """
     import sqlite3
-    from pollypm.plugins_builtin.core_rail_items.plugin import _active_task_numbers
+    from pollypm.plugins_builtin.core_rail_items.plugin import active_task_numbers
     from pollypm.models import KnownProject, ProjectKind
 
     project_root = tmp_path / "demo"
@@ -835,7 +835,7 @@ def test_active_task_numbers_excludes_terminal_and_review_tasks(
         kind=ProjectKind.GIT, tracked=True,
     )
 
-    assert _active_task_numbers(project) == [3, 4]
+    assert active_task_numbers(project) == [3, 4]
 
 
 def test_active_task_numbers_handles_missing_db_gracefully(
@@ -843,11 +843,11 @@ def test_active_task_numbers_handles_missing_db_gracefully(
 ) -> None:
     """A project without a ``state.db`` (e.g. fresh / never-touched)
     must not raise; the rail just shows no per-task rows."""
-    from pollypm.plugins_builtin.core_rail_items.plugin import _active_task_numbers
+    from pollypm.plugins_builtin.core_rail_items.plugin import active_task_numbers
     from pollypm.models import KnownProject, ProjectKind
 
     project = KnownProject(
         key="empty", path=tmp_path / "empty", name="Empty",
         kind=ProjectKind.GIT, tracked=True,
     )
-    assert _active_task_numbers(project) == []
+    assert active_task_numbers(project) == []


### PR DESCRIPTION
Refs #1371

Promotes the core rail task-number helper from _active_task_numbers to active_task_numbers, exports it in the plugin module contract, and updates the focused core rail tests to use the public helper/monkeypatch seam.

This is a targeted slice of the umbrella boundary cleanup; the broader test suite still has other underscore-prefixed imports to retire in follow-up module sweeps.

Self-audit: touched the core rail built-in plugin and its focused tests only. This stays within the UI/plugin rail layer and does not add store or service-facade imports.

Tests:
- PYTHONPATH=src /Users/sam/dev/pollypm/.venv/bin/python -m pytest tests/test_core_rail_items.py -q
- PYTHONPATH=src /Users/sam/dev/pollypm/.venv/bin/python -m pytest tests/test_plugin_boundary_conformance.py -q
- PYTHONPATH=src /Users/sam/dev/pollypm/.venv/bin/python -m pytest tests/test_import_boundary.py -q

Overlap check: no open PR touched src/pollypm/plugins_builtin/core_rail_items/plugin.py or tests/test_core_rail_items.py.