### PR TITLE
Refs #1367 Break plugin validation import cycle

### DIFF
--- a/src/pollypm/plugin_host.py
+++ b/src/pollypm/plugin_host.py
@@ -46,6 +46,7 @@ from pollypm.plugin_api.v1 import (
     check_requires_api,
 )
 from pollypm.plugin_trust import warn_third_party_extension_trust_once
+from pollypm.plugin_validate import validate_plugin
 
 logger = logging.getLogger(__name__)
 
@@ -653,7 +654,6 @@ class ExtensionHost:
                 return
             # Validate the plugin implements its declared interfaces
             try:
-                from pollypm.plugin_validate import validate_plugin
                 result = validate_plugin(plugin)
                 if not result.passed:
                     failures = ", ".join(c.message for c in result.checks if not c.passed)

--- a/src/pollypm/plugin_validate.py
+++ b/src/pollypm/plugin_validate.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from pollypm.plugin_api.v1 import PollyPMPlugin
-from pollypm.plugin_host import ExtensionHost
+
+if TYPE_CHECKING:
+    from pollypm.plugin_host import ExtensionHost
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Refs #1367

This fixes one low-risk circular-import slice: `plugin_validate` now imports `ExtensionHost` only under `TYPE_CHECKING`, so `plugin_host` can import `validate_plugin` normally instead of inside `_install`.

Self-audit: touched only the plugin service/facade validation path (`src/pollypm/plugin_host.py`, `src/pollypm/plugin_validate.py`). No UI, domain, store, or cross-layer imports added.

Remaining scope for #1367: current import scan still reports 13 pairs, including CLI feature pairs, cockpit pairs, onboarding, activity_feed, advisor inbox, and work service query/notification pairs. This PR intentionally leaves those for follow-up slices.