### PR TITLE
Refs #1376 route plugin transition reads through storage

### DIFF
--- a/src/pollypm/plugins_builtin/activity_feed/handlers/event_projector.py
+++ b/src/pollypm/plugins_builtin/activity_feed/handlers/event_projector.py
@@ -40,11 +40,12 @@ from __future__ import annotations
 import json
 import logging
 import re
-import sqlite3
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Iterable
+
+from pollypm.storage.work_transition_queries import activity_feed_transition_rows
 
 # Best-effort project inference for events whose alert/notify payload
 # omits an explicit ``project`` key but whose body names a task by
@@ -431,38 +432,11 @@ class EventProjector:
         since_ts: str | None,
         limit: int,
     ) -> list[FeedEntry]:
-        if not work_db.exists():
-            return []
-        conn = sqlite3.connect(
-            f"file:{work_db}?mode=ro", uri=True, check_same_thread=False,
+        rows = activity_feed_transition_rows(
+            work_db,
+            since_ts=since_ts,
+            limit=limit,
         )
-        try:
-            conn.row_factory = sqlite3.Row
-            has_work_transitions = conn.execute(
-                "SELECT 1 FROM sqlite_master "
-                "WHERE type = 'table' AND name = 'work_transitions'"
-            ).fetchone()
-            if has_work_transitions is None:
-                return []
-            params: list[Any] = []
-            where = ""
-            if since_ts is not None:
-                where = "WHERE created_at >= ?"
-                params.append(since_ts)
-            rows = conn.execute(
-                f"SELECT id, task_project, task_number, from_state, to_state, "
-                f"actor, reason, created_at FROM work_transitions {where} "
-                f"ORDER BY id DESC LIMIT ?",
-                (*params, int(limit)),
-            ).fetchall()
-        except sqlite3.DatabaseError:
-            logger.exception(
-                "activity_feed: work-db projection failed for %s (%s)",
-                project_key, work_db,
-            )
-            rows = []
-        finally:
-            conn.close()
 
         entries: list[FeedEntry] = []
         for row in rows:

--- a/src/pollypm/plugins_builtin/advisor/handlers/detect_changes.py
+++ b/src/pollypm/plugins_builtin/advisor/handlers/detect_changes.py
@@ -29,7 +29,6 @@ the cached report instead of re-shelling out to git.
 from __future__ import annotations
 
 import logging
-import sqlite3
 import subprocess
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -224,21 +223,8 @@ def _parse_unique_paths(raw: str) -> list[Path]:
 
 
 # ---------------------------------------------------------------------------
-# Work-service transitions — direct read-only SQL, same pattern as briefing.
+# Work-service transitions.
 # ---------------------------------------------------------------------------
-
-
-_TRANSITION_SQL = (
-    "SELECT t.task_project AS project, t.task_number AS task_number, "
-    "       COALESCE(w.title, '') AS title, "
-    "       t.from_state AS from_state, t.to_state AS to_state, "
-    "       t.actor AS actor, t.created_at AS created_at "
-    "FROM work_transitions t "
-    "LEFT JOIN work_tasks w "
-    "  ON w.project = t.task_project AND w.task_number = t.task_number "
-    "WHERE t.task_project = ? AND t.created_at >= ? "
-    "ORDER BY t.created_at ASC"
-)
 
 
 def _transitions_db_path(project_path: Path) -> Path | None:
@@ -274,8 +260,8 @@ def _gather_task_transitions(
 
     Prefers a caller-supplied work-service handle (tests inject an
     in-memory fake). Falls back to a read-only sqlite open of the
-    project's ``.pollypm/state.db`` so the advisor doesn't have to
-    round-trip through the single-writer daemon.
+    project's ``.pollypm/state.db`` through the storage query facade so
+    the advisor doesn't own raw SQLite connection details.
     """
     since_iso = since.isoformat() if since else _default_since_iso()
 
@@ -294,25 +280,13 @@ def _gather_task_transitions(
     if db_path is None or not db_path.exists():
         return []
 
-    try:
-        uri = f"file:{db_path}?mode=ro"
-        conn = sqlite3.connect(uri, uri=True)
-    except sqlite3.Error as exc:
-        logger.debug("advisor: cannot open work DB %s: %s", db_path, exc)
-        return []
-    try:
-        conn.row_factory = sqlite3.Row
-        try:
-            rows = conn.execute(
-                _TRANSITION_SQL, (project_key, since_iso),
-            ).fetchall()
-        except sqlite3.Error as exc:
-            logger.debug(
-                "advisor: transitions SQL failed for %s: %s", project_key, exc,
-            )
-            return []
-    finally:
-        conn.close()
+    from pollypm.storage.work_transition_queries import advisor_transition_rows
+
+    rows = advisor_transition_rows(
+        db_path,
+        project_key=project_key,
+        since_iso=since_iso,
+    )
 
     out: list[TaskTransitionRecord] = []
     for r in rows:

--- a/src/pollypm/storage/work_transition_queries.py
+++ b/src/pollypm/storage/work_transition_queries.py
@@ -1,0 +1,135 @@
+"""Read-only work-transition query helpers.
+
+Plugin and presentation layers should not open workspace SQLite files
+directly. This module owns the raw connection and schema details for
+small projection-style reads that are not yet on a richer work-service
+API.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from pollypm.storage.sqlite_pragmas import apply_workspace_pragmas
+
+logger = logging.getLogger(__name__)
+
+
+_ADVISOR_TRANSITION_SQL = (
+    "SELECT t.task_project AS project, t.task_number AS task_number, "
+    "       COALESCE(w.title, '') AS title, "
+    "       t.from_state AS from_state, t.to_state AS to_state, "
+    "       t.actor AS actor, t.created_at AS created_at "
+    "FROM work_transitions t "
+    "LEFT JOIN work_tasks w "
+    "  ON w.project = t.task_project AND w.task_number = t.task_number "
+    "WHERE t.task_project = ? AND t.created_at >= ? "
+    "ORDER BY t.created_at ASC"
+)
+
+
+def _open_readonly(db_path: Path) -> sqlite3.Connection | None:
+    try:
+        if not db_path.exists():
+            return None
+    except OSError:
+        return None
+    try:
+        conn = sqlite3.connect(
+            f"file:{db_path}?mode=ro",
+            uri=True,
+            check_same_thread=False,
+        )
+    except sqlite3.Error as exc:
+        logger.debug(
+            "work_transition_queries: read-only connect failed for %s: %s",
+            db_path,
+            exc,
+        )
+        return None
+    apply_workspace_pragmas(conn, readonly=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _row_dict(row: sqlite3.Row) -> dict[str, Any]:
+    return {key: row[key] for key in row.keys()}
+
+
+def advisor_transition_rows(
+    db_path: Path,
+    *,
+    project_key: str,
+    since_iso: str,
+) -> list[dict[str, Any]]:
+    """Return transition rows for advisor change detection."""
+    conn = _open_readonly(db_path)
+    if conn is None:
+        return []
+    try:
+        try:
+            rows = conn.execute(
+                _ADVISOR_TRANSITION_SQL,
+                (project_key, since_iso),
+            ).fetchall()
+        except sqlite3.Error as exc:
+            logger.debug(
+                "work_transition_queries: advisor transition query failed for %s: %s",
+                project_key,
+                exc,
+            )
+            return []
+    finally:
+        conn.close()
+    return [_row_dict(row) for row in rows]
+
+
+def activity_feed_transition_rows(
+    db_path: Path,
+    *,
+    since_ts: str | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Return recent work-transition rows for activity-feed projection."""
+    conn = _open_readonly(db_path)
+    if conn is None:
+        return []
+    try:
+        try:
+            has_work_transitions = conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type = 'table' AND name = 'work_transitions'"
+            ).fetchone()
+            if has_work_transitions is None:
+                return []
+
+            params: list[Any] = []
+            where = ""
+            if since_ts is not None:
+                where = "WHERE created_at >= ?"
+                params.append(since_ts)
+            rows = conn.execute(
+                "SELECT id, task_project, task_number, from_state, to_state, "
+                f"actor, reason, created_at FROM work_transitions {where} "
+                f"ORDER BY id DESC LIMIT ?",
+                (*params, int(limit)),
+            ).fetchall()
+        except sqlite3.DatabaseError as exc:
+            logger.debug(
+                "work_transition_queries: activity-feed transition query failed for %s: %s",
+                db_path,
+                exc,
+            )
+            return []
+    finally:
+        conn.close()
+    return [_row_dict(row) for row in rows]
+
+
+__all__ = [
+    "activity_feed_transition_rows",
+    "advisor_transition_rows",
+]

--- a/tests/test_advisor_detect_changes.py
+++ b/tests/test_advisor_detect_changes.py
@@ -14,6 +14,7 @@ Covers:
 from __future__ import annotations
 
 import subprocess
+import sqlite3
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -21,11 +22,11 @@ import pytest
 
 from pollypm.plugins_builtin.advisor.handlers import detect_changes as dc_module
 from pollypm.plugins_builtin.advisor.handlers.detect_changes import (
-    ChangeReport,
     TaskTransitionRecord,
     clear_cache,
     detect_changes,
 )
+from pollypm.work.schema import create_work_tables
 
 
 # ---------------------------------------------------------------------------
@@ -144,6 +145,69 @@ class TestDetectChangesUnit:
         assert report.has_changes is True
         assert len(report.task_transitions) == 1
         assert report.task_transitions[0].task_id == "proj/42"
+
+    def test_task_transitions_sqlite_fallback_uses_storage_query(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        workspace = tmp_path / "workspace"
+        project = workspace / "proj"
+        project.mkdir(parents=True)
+        state_dir = workspace / ".pollypm"
+        state_dir.mkdir()
+        db_path = state_dir / "state.db"
+
+        created_at = "2026-04-16T12:01:00+00:00"
+        conn = sqlite3.connect(str(db_path))
+        try:
+            create_work_tables(conn)
+            conn.execute(
+                "INSERT INTO work_tasks (project, task_number, title, type, "
+                "flow_template_id, created_at, created_by, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "proj",
+                    7,
+                    "storage boundary",
+                    "task",
+                    "chat",
+                    created_at,
+                    "test",
+                    created_at,
+                ),
+            )
+            conn.execute(
+                "INSERT INTO work_transitions "
+                "(task_project, task_number, from_state, to_state, actor, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("proj", 7, "queued", "in_progress", "worker", created_at),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Post-#1471 the advisor resolves the workspace DB through the
+        # canonical resolver (no project_path arg). Pin it to the test's
+        # tmp workspace so the SQLite fallback exercises the storage facade.
+        monkeypatch.setattr(
+            dc_module, "_transitions_db_path", lambda _project_path: db_path,
+        )
+
+        rows = dc_module._gather_task_transitions(
+            project,
+            "proj",
+            datetime(2026, 4, 16, 12, 0, tzinfo=UTC),
+        )
+
+        assert len(rows) == 1
+        assert rows[0] == TaskTransitionRecord(
+            project="proj",
+            task_number=7,
+            task_title="storage boundary",
+            from_state="queued",
+            to_state="in_progress",
+            actor="worker",
+            timestamp=created_at,
+        )
 
     def test_no_signals_returns_has_changes_false(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_plugin_boundary_conformance.py
+++ b/tests/test_plugin_boundary_conformance.py
@@ -78,6 +78,20 @@ def test_no_cross_plugin_private_imports() -> None:
     assert violations == [], "\n".join(v.summary for v in violations)
 
 
+def test_transition_query_plugin_handlers_do_not_open_sqlite_directly() -> None:
+    """Issue #1376: plugin handlers route work-transition reads via storage."""
+    rels = (
+        "src/pollypm/plugins_builtin/activity_feed/handlers/event_projector.py",
+        "src/pollypm/plugins_builtin/advisor/handlers/detect_changes.py",
+    )
+    offenders: list[str] = []
+    for rel in rels:
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        if "sqlite3.connect" in text or "import sqlite3" in text:
+            offenders.append(rel)
+    assert offenders == []
+
+
 def test_scanner_recognizes_private_symbol() -> None:
     """Scanner detects ``from X import _foo`` correctly."""
     # Synthetic test using the public `_split_imports` indirectly.


### PR DESCRIPTION
Refs #1376

Summary:
- Added a storage-owned read-only work-transition query helper.
- Routed the activity-feed and advisor plugin transition projections through that helper so those plugin handlers no longer import or call sqlite3 directly.
- Added focused behavior and boundary tests for the migrated plugin handlers.

Layer self-audit:
- Storage/IO: new pollypm.storage.work_transition_queries owns sqlite3.connect, table checks, and read-only pragmas.
- Plugin/domain: activity_feed and advisor handlers now consume plain row dictionaries and keep projection logic only.
- No UI-to-storage imports or private connection reach-through added.

Remaining #1376 scope:
- Direct sqlite3.connect sites remain in backup.py, cockpit.py, cockpit_sections/base.py, cockpit_settings_projects.py, cockpit_ui.py, dashboard_data.py, doctor.py, and plugins_builtin/project_planning/cli/project.py.
- I avoided project_planning/cockpit/dashboard files in this patch because another local worker branch is already broad-touching that area.