### PR TITLE
Fix #1364 decouple assignment alert cleanup

### DIFF
--- a/src/pollypm/plugins_builtin/task_assignment_notify/api.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/api.py
@@ -15,11 +15,6 @@ here keep their published shape.
 
 Core runtime callers route through the same surface (#939):
 
-* ``pollypm.work.service_transition_manager`` — uses
-  :func:`clear_alerts_for_cancelled_task` from the cancel path so
-  the alert hygiene fix from #927 doesn't pin core to a private
-  resolver symbol; and :func:`clear_no_session_alert_for_task`
-  from the approve path for the same reason (#953).
 * ``pollypm.heartbeats.local`` — uses :func:`build_event_for_task`,
   :func:`load_runtime_services`, :func:`notify`, and
   :data:`DEDUPE_WINDOW_SECONDS` to fire resume pings without

--- a/src/pollypm/plugins_builtin/task_assignment_notify/plugin.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/plugin.py
@@ -38,10 +38,13 @@ from pollypm.plugins_builtin.task_assignment_notify.handlers.sweep import (
 )
 from pollypm.plugins_builtin.task_assignment_notify.resolver import (
     DEDUPE_WINDOW_SECONDS,
+    clear_alerts_for_cancelled_task,
+    clear_no_session_alert_for_task,
     load_runtime_services,
     notify,
 )
 from pollypm.session_services import base as _session_bus
+from pollypm.work import task_assignment_alerts as _assignment_alert_bus
 from pollypm.work import task_assignment as _task_assignment_bus
 
 logger = logging.getLogger(__name__)
@@ -156,6 +159,26 @@ def _session_created_listener(event) -> None:
                     pass
 
 
+def _assignment_alert_cleanup_listener(
+    event: _assignment_alert_bus.TaskAssignmentAlertEvent,
+) -> None:
+    """Clear assignment alerts made stale by work-service transitions."""
+    if isinstance(event, _assignment_alert_bus.CancelledTaskAssignmentAlertsEvent):
+        clear_alerts_for_cancelled_task(
+            task_id=event.task_id,
+            project=event.project,
+            role_names=tuple(event.role_names),
+            has_other_active_for_role=dict(event.has_other_active_for_role),
+            store=event.store,
+        )
+        return
+    if isinstance(event, _assignment_alert_bus.ClearNoSessionAlertForTaskEvent):
+        clear_no_session_alert_for_task(
+            task_id=event.task_id,
+            store=event.store,
+        )
+
+
 def _register_handlers(api: JobHandlerAPI) -> None:
     # Notify is idempotent (dedupe table throttles duplicate pings), so
     # we give it a generous retry count. The sweeper is a @every job so
@@ -191,6 +214,7 @@ def _initialize(api: PluginAPI) -> None:
     subscribers.
     """
     _task_assignment_bus.register_listener(_in_process_listener)
+    _assignment_alert_bus.register_listener(_assignment_alert_cleanup_listener)
     # #246: subscribe to session births so a restarted worker gets its
     # resume ping inside ~1s instead of on the next sweeper cycle.
     _session_bus.register_session_listener(_session_created_listener)

--- a/src/pollypm/work/service_transition_manager.py
+++ b/src/pollypm/work/service_transition_manager.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Callable
 
 from pollypm.review_notify import notify_requires_review_hold
 from pollypm.task_review_summary import store_review_plain_summary
+from pollypm.work import task_assignment_alerts
 from pollypm.work.gates import evaluate_gates, has_hard_failure
 from pollypm.work.models import (
     ActorType,
@@ -693,32 +694,23 @@ class WorkTransitionManager:
         )
 
     def _clear_assignment_alerts_after_cancel(self, task: Task) -> None:
-        """Clear no_session alerts referencing a just-cancelled task.
+        """Publish cleanup for no_session alerts on a just-cancelled task.
 
-        Defers to ``task_assignment_notify.resolver.clear_alerts_for_cancelled_task``
-        — kept as a deferred import so the work module stays importable
-        without the plugin runtime (tests, contrib doubles). Any error
-        is swallowed.
+        The task_assignment_notify plugin owns these alert families. The
+        work service publishes a neutral cleanup event and the plugin
+        handles it when loaded; without that subscriber this is a no-op.
 
         Per-project ``(worker-<project>, no_session)`` is only cleared
         when no other active task on the project still routes to that
         role. We compute the "other active" map here against the work
-        service so the resolver helper stays generic.
+        service so the subscriber doesn't need to reach back into the
+        transition manager.
 
         We resolve the alert store from the unified Store registry and
-        pass it in, so the helper doesn't need to spin up a second
+        pass it in, so the subscriber doesn't need to spin up a second
         work-service connection against the same SQLite file while our
         caller's cancel transaction is still in flight.
         """
-        try:
-            # #939: route through the plugin's public API rather than
-            # importing from ``resolver`` directly. Keeps core decoupled
-            # from the plugin's internal module layout.
-            from pollypm.plugins_builtin.task_assignment_notify.api import (
-                clear_alerts_for_cancelled_task,
-            )
-        except Exception:  # noqa: BLE001
-            return
         try:
             roles = tuple((task.roles or {}).keys()) or ("worker",)
         except Exception:  # noqa: BLE001
@@ -760,18 +752,19 @@ class WorkTransitionManager:
                         break
                 if active_map[role]:
                     break
-        store = self._resolve_alert_store()
         try:
-            clear_alerts_for_cancelled_task(
-                task_id=task.task_id,
-                project=task.project,
-                role_names=roles,
-                has_other_active_for_role=active_map,
-                store=store,
+            task_assignment_alerts.dispatch(
+                task_assignment_alerts.CancelledTaskAssignmentAlertsEvent(
+                    task_id=task.task_id,
+                    project=task.project,
+                    role_names=roles,
+                    has_other_active_for_role=active_map,
+                    store=self._resolve_alert_store(),
+                )
             )
         except Exception:  # noqa: BLE001
             logger.debug(
-                "clear_alerts_for_cancelled_task failed for %s",
+                "assignment alert cleanup dispatch failed for %s",
                 task.task_id,
                 exc_info=True,
             )
@@ -848,35 +841,25 @@ class WorkTransitionManager:
             )
 
     def _clear_no_session_alert_after_approve(self, task: Task) -> None:
-        """Clear the per-task no_session alert after an approve transition.
+        """Publish cleanup for a per-task no_session alert after approve.
 
-        Defers to ``task_assignment_notify.api.clear_no_session_alert_for_task``
-        — narrower than the cancel cleanup (#927): only the per-task
-        ``no_session_for_assignment:<task_id>`` alert is cleared. The
-        project-level ``worker-<project>/no_session`` alert is left
-        alone, because the just-approved task may now route to a new
-        role on the same project, or other active siblings may still
-        need the role.
-
-        Routed through the plugin's public API surface so core stays
-        decoupled from the plugin's internal module layout (#939).
-        Any error is swallowed.
+        This is narrower than the cancel cleanup (#927): only the
+        per-task ``no_session_for_assignment:<task_id>`` alert is stale.
+        The project-level ``worker-<project>/no_session`` alert is left
+        alone, because the just-approved task may now route to a new role
+        on the same project, or other active siblings may still need the
+        role.
         """
         try:
-            from pollypm.plugins_builtin.task_assignment_notify.api import (
-                clear_no_session_alert_for_task,
-            )
-        except Exception:  # noqa: BLE001
-            return
-        store = self._resolve_alert_store()
-        try:
-            clear_no_session_alert_for_task(
-                task_id=task.task_id,
-                store=store,
+            task_assignment_alerts.dispatch(
+                task_assignment_alerts.ClearNoSessionAlertForTaskEvent(
+                    task_id=task.task_id,
+                    store=self._resolve_alert_store(),
+                )
             )
         except Exception:  # noqa: BLE001
             logger.debug(
-                "clear_no_session_alert_for_task failed for %s",
+                "no_session alert cleanup dispatch failed for %s",
                 task.task_id,
                 exc_info=True,
             )

--- a/src/pollypm/work/task_assignment_alerts.py
+++ b/src/pollypm/work/task_assignment_alerts.py
@@ -1,0 +1,78 @@
+"""Task-assignment alert cleanup events.
+
+Work-service transitions publish cleanup intent here when an assignment
+alert becomes stale. The task_assignment_notify plugin subscribes when it
+is loaded; without a subscriber these events are a no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import TypeAlias
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class CancelledTaskAssignmentAlertsEvent:
+    """A cancelled task's assignment alerts can be cleared."""
+
+    task_id: str
+    project: str
+    role_names: tuple[str, ...]
+    has_other_active_for_role: Mapping[str, bool]
+    store: object | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class ClearNoSessionAlertForTaskEvent:
+    """A task-level no-session assignment alert can be cleared."""
+
+    task_id: str
+    store: object | None = None
+
+
+TaskAssignmentAlertEvent: TypeAlias = (
+    CancelledTaskAssignmentAlertsEvent | ClearNoSessionAlertForTaskEvent
+)
+TaskAssignmentAlertListener = Callable[[TaskAssignmentAlertEvent], None]
+
+_listeners: list[TaskAssignmentAlertListener] = []
+
+
+def register_listener(listener: TaskAssignmentAlertListener) -> None:
+    """Register ``listener`` for assignment-alert cleanup events."""
+    if listener not in _listeners:
+        _listeners.append(listener)
+
+
+def unregister_listener(listener: TaskAssignmentAlertListener) -> None:
+    """Remove a previously-registered cleanup listener."""
+    try:
+        _listeners.remove(listener)
+    except ValueError:
+        pass
+
+
+def clear_listeners() -> None:
+    """Drop every registered listener. Intended for tests."""
+    _listeners.clear()
+
+
+def dispatch(event: TaskAssignmentAlertEvent) -> None:
+    """Deliver ``event`` to registered subscribers.
+
+    Listener errors are logged and swallowed so alert hygiene can never
+    block the work transition that made the alert stale.
+    """
+    for listener in list(_listeners):
+        try:
+            listener(event)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "task_assignment_alert listener %r raised on %s",
+                getattr(listener, "__name__", listener),
+                getattr(event, "task_id", "?"),
+            )

--- a/tests/test_cancel_clears_no_session_alerts.py
+++ b/tests/test_cancel_clears_no_session_alerts.py
@@ -41,6 +41,7 @@ from pollypm.work.models import (
 )
 from pollypm.storage.state import StateStore
 from pollypm.work import task_assignment as bus
+from pollypm.work import task_assignment_alerts as alert_bus
 from pollypm.work.sqlite_service import SQLiteWorkService
 
 
@@ -77,6 +78,7 @@ class _FakeSessionService:
 
 def _make_environment(tmp_path: Path) -> tuple[SQLiteWorkService, StateStore]:
     bus.clear_listeners()
+    alert_bus.clear_listeners()
     work = SQLiteWorkService(db_path=tmp_path / "work.db")
     store = StateStore(tmp_path / "state.db")
     return work, store
@@ -156,6 +158,11 @@ def _install_resolver_loader(monkeypatch, services: _RuntimeServices) -> None:
         "pollypm.work.service_transition_manager.WorkTransitionManager._resolve_alert_store",
         staticmethod(lambda: None),
     )
+    from pollypm.plugins_builtin.task_assignment_notify.plugin import (
+        _assignment_alert_cleanup_listener,
+    )
+
+    alert_bus.register_listener(_assignment_alert_cleanup_listener)
 
 
 def _install_sweep_loader(monkeypatch, services: _RuntimeServices) -> None:
@@ -364,6 +371,7 @@ class TestClearHelperRespectsHasOtherActive:
         self, tmp_path, monkeypatch,
     ):
         bus.clear_listeners()
+        alert_bus.clear_listeners()
         store = StateStore(tmp_path / "state.db")
         store.upsert_alert(
             "task_assignment",
@@ -393,6 +401,7 @@ class TestClearHelperRespectsHasOtherActive:
         self, tmp_path, monkeypatch,
     ):
         bus.clear_listeners()
+        alert_bus.clear_listeners()
         store = StateStore(tmp_path / "state.db")
         store.upsert_alert(
             "task_assignment",
@@ -707,6 +716,7 @@ class TestClearNoSessionAlertHelper:
 
     def test_clears_per_task_alert_only(self, tmp_path, monkeypatch):
         bus.clear_listeners()
+        alert_bus.clear_listeners()
         store = StateStore(tmp_path / "state.db")
         store.upsert_alert(
             "task_assignment",
@@ -735,3 +745,54 @@ class TestClearNoSessionAlertHelper:
             "project-level alert must NOT be cleared by the approve-side "
             "helper; only the per-task alert is unambiguously stale"
         )
+
+
+class TestPluginAlertCleanupSubscription:
+    def test_initialize_subscribes_to_alert_cleanup_bus(
+        self, tmp_path, monkeypatch,
+    ):
+        bus.clear_listeners()
+        alert_bus.clear_listeners()
+        from pollypm.session_services import base as session_bus
+
+        session_bus.clear_session_listeners()
+        store = StateStore(tmp_path / "state.db")
+        store.upsert_alert(
+            "task_assignment",
+            "no_session_for_assignment:demo/1",
+            "warning",
+            "msg",
+        )
+        services = _RuntimeServices(
+            session_service=None,
+            state_store=store,
+            work_service=None,
+            project_root=tmp_path,
+            msg_store=store,
+        )
+        monkeypatch.setattr(
+            "pollypm.plugins_builtin.task_assignment_notify.resolver.load_runtime_services",
+            lambda *, config_path=None: services,
+        )
+
+        from pollypm.plugin_api.v1 import PluginAPI
+        from pollypm.plugins_builtin.task_assignment_notify.plugin import _initialize
+
+        _initialize(
+            PluginAPI(
+                plugin_name="task_assignment_notify",
+                roster_api=None,
+                jobs_api=None,
+            )
+        )
+        alert_bus.dispatch(
+            alert_bus.ClearNoSessionAlertForTaskEvent(task_id="demo/1")
+        )
+
+        assert (
+            "task_assignment",
+            "no_session_for_assignment:demo/1",
+        ) not in _open_alerts(store)
+        bus.clear_listeners()
+        alert_bus.clear_listeners()
+        session_bus.clear_session_listeners()

--- a/tests/test_task_assignment_notify_api_contract.py
+++ b/tests/test_task_assignment_notify_api_contract.py
@@ -20,7 +20,8 @@ Two shapes are pinned here:
    ``task_assignment_notify.resolver``. The companion
    :mod:`tests.test_plugin_boundary_conformance` only catches
    plugin-to-plugin private imports; this test extends that contract
-   to the core-to-plugin direction the issue (#939) flagged.
+   to the core-to-plugin direction the issue (#939) flagged. The work
+   layer is stricter after #1364: it must not import this plugin at all.
 """
 
 from __future__ import annotations
@@ -196,15 +197,41 @@ def test_no_core_or_peer_imports_from_plugin_internals() -> None:
     )
 
 
-def test_known_core_callers_use_public_api() -> None:
-    """Spot-check that the three core callers cited in #939 import
+_FORBIDDEN_WORK_PLUGIN_IMPORT_PATTERN = re.compile(
+    r"^\s*(?:"
+    r"from\s+pollypm\.plugins_builtin\.task_assignment_notify(?:\.|\s)"
+    r"|import\s+pollypm\.plugins_builtin\.task_assignment_notify(?:\.|\s|$)"
+    r")",
+    re.MULTILINE,
+)
+
+
+def test_work_layer_does_not_import_task_assignment_notify_plugin() -> None:
+    """``pollypm.work`` publishes neutral events instead of calling this
+    plugin directly (#1364)."""
+    offenders: list[str] = []
+    for source_file in (SRC_ROOT / "work").rglob("*.py"):
+        text = source_file.read_text(encoding="utf-8")
+        for match in _FORBIDDEN_WORK_PLUGIN_IMPORT_PATTERN.finditer(text):
+            line_no = text[: match.start()].count("\n") + 1
+            rel = source_file.relative_to(REPO_ROOT).as_posix()
+            offenders.append(f"{rel}:{line_no}: {match.group(0)}")
+    assert offenders == [], (
+        "pollypm.work must not import task_assignment_notify directly. "
+        "Publish a work-layer event and let the plugin subscribe instead. "
+        "Offenders:\n  - " + "\n  - ".join(offenders)
+    )
+
+
+def test_known_non_work_callers_use_public_api() -> None:
+    """Spot-check that the non-work runtime callers cited in #939 import
     from ``api`` specifically — guards against a future refactor
     that leaves the boundary technically clean (no private import)
     but routes through some other ad-hoc shim."""
     targets = (
-        SRC_ROOT / "work" / "service_transition_manager.py",
         SRC_ROOT / "cockpit_tasks.py",
         SRC_ROOT / "heartbeats" / "local.py",
+        SRC_ROOT / "plugins_builtin" / "core_recurring" / "sweeps.py",
     )
     for target in targets:
         text = target.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #1364

Introduces a neutral work-layer task-assignment alert cleanup bus and has `service_transition_manager` publish cleanup events instead of importing `task_assignment_notify`. The built-in `task_assignment_notify` plugin now subscribes during initialization and performs the existing resolver cleanup when present; with no subscriber the work-layer event is a no-op.

Self-audit: touched work-domain transition orchestration/new event bus, the task_assignment_notify plugin subscriber, and focused boundary/alert tests. This removes the work -> plugins_builtin dependency and does not add UI/store reach-through.

Tests:
- PYTHONPATH=src /Users/sam/dev/pollypm/.venv/bin/python -m pytest tests/test_cancel_clears_no_session_alerts.py tests/test_task_assignment_notify_api_contract.py tests/test_import_boundary.py tests/test_plugin_boundary_conformance.py tests/test_task_assignment_notify.py -q
- /Users/sam/dev/pollypm/.venv/bin/ruff check src/pollypm/work/task_assignment_alerts.py src/pollypm/work/service_transition_manager.py src/pollypm/plugins_builtin/task_assignment_notify/plugin.py src/pollypm/plugins_builtin/task_assignment_notify/api.py tests/test_cancel_clears_no_session_alerts.py tests/test_task_assignment_notify_api_contract.py

Overlap check: no open PR touched the files changed by this branch.
