### PR TITLE
Fix #1444 detect stale in-progress tasks

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -39,6 +39,11 @@ Detection rules (each returns a list of :class:`Finding`):
    following ``cancel_grace_seconds`` window. Indicates a planning
    stall after a self-cancel (savethenovel/1's class — a worker
    self-cancels but Polly never queues a follow-up).
+5. ``task_progress_stale`` — a live task currently at ``in_progress``
+   whose worker has produced no transition / heartbeat / task-context
+   activity for longer than ``progress_stale_seconds``. Catches the
+   alive-but-unproductive worker class, including auth-blocked panes
+   that keep accepting nudges but cannot make API calls.
 
 Severity is ``"warn"`` for every rule today. The recovery hint is
 attached to each finding so the alert message can include a
@@ -81,6 +86,7 @@ __all__ = [
     "RULE_STUCK_DRAFT",
     "RULE_CANCEL_NO_PROMOTION",
     "RULE_TASK_REVIEW_STALE",
+    "RULE_TASK_PROGRESS_STALE",
     "RULE_ROLE_SESSION_MISSING",
     "RULE_WORKER_SESSION_DEAD_LOOP",
     "RULE_TASK_ON_HOLD_STALE",
@@ -116,6 +122,7 @@ RULE_CANCEL_NO_PROMOTION = "cancellation_no_promotion"
 # matching role tmux session, and a worker reaper firing in a loop on
 # the same task.
 RULE_TASK_REVIEW_STALE = "task_review_stale"
+RULE_TASK_PROGRESS_STALE = "task_progress_stale"
 RULE_ROLE_SESSION_MISSING = "role_session_missing"
 RULE_WORKER_SESSION_DEAD_LOOP = "worker_session_dead_loop"
 # #1424 — task_on_hold_stale catches the savethenovel/11 pattern where
@@ -176,7 +183,7 @@ _MARKER_NAME_RE = re.compile(
 
 @dataclass(slots=True, frozen=True)
 class WatchdogConfig:
-    """Tunable thresholds for the four detection rules.
+    """Tunable thresholds for watchdog detection rules.
 
     All durations are in seconds. Defaults match the spec in the
     task brief — 30 min lookback for orphan/leak rules, 5 min for
@@ -198,6 +205,12 @@ class WatchdogConfig:
     # most recent transition older than this before we fire. 30 min
     # mirrors the savethenovel/10 case (reviewer agent never spawned).
     review_stale_seconds: int = 1800
+    # #1444 — task_progress_stale: a task at status=in_progress with no
+    # transition / worker heartbeat / task-context activity for this
+    # long is treated as a silent worker stall. 20 min is intentionally
+    # shorter than review stale because an implementing worker should
+    # either advance the task, emit progress context, or heartbeat.
+    progress_stale_seconds: int = 1200
     # #1424 — task_on_hold_stale: a task at status=on_hold for longer
     # than this triggers the architect-first escalation. Defaults to
     # 15 min — shorter than ``review_stale_seconds`` because on_hold is
@@ -250,6 +263,17 @@ def _parse_iso(stamp: str) -> datetime | None:
     if dt.tzinfo is None:
         return dt.replace(tzinfo=timezone.utc)
     return dt
+
+
+def _coerce_datetime(value: Any) -> datetime | None:
+    """Coerce datetime-ish values from models / events to tz-aware UTC."""
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value
+    if isinstance(value, str):
+        return _parse_iso(value)
+    return None
 
 
 def _marker_task_key(subject: str) -> tuple[str, int] | None:
@@ -946,6 +970,204 @@ def _detect_task_on_hold_stale(
     return findings
 
 
+def _latest_worker_heartbeat_time(
+    events: Sequence[AuditEvent],
+    *,
+    subject: str,
+    since: datetime,
+) -> datetime | None:
+    """Return the latest ``worker.heartbeat`` timestamp for ``subject``."""
+    latest: datetime | None = None
+    for ev in events:
+        if ev.event != "worker.heartbeat":
+            continue
+        meta = ev.metadata or {}
+        event_subjects = {
+            ev.subject,
+            str(meta.get("task_id") or ""),
+            str(meta.get("subject") or ""),
+        }
+        if subject not in event_subjects:
+            continue
+        ts = _parse_iso(ev.ts)
+        if ts is None or ts < since:
+            continue
+        if latest is None or ts > latest:
+            latest = ts
+    return latest
+
+
+def _latest_task_context_time(
+    task: Any, *, since: datetime,
+) -> tuple[datetime | None, str]:
+    """Return latest task-context timestamp after ``since``, if loaded."""
+    latest: datetime | None = None
+    latest_kind = ""
+    for entry in getattr(task, "context", None) or []:
+        ts = _coerce_datetime(getattr(entry, "timestamp", None))
+        if ts is None or ts < since:
+            continue
+        if latest is None or ts > latest:
+            latest = ts
+            entry_type = getattr(entry, "entry_type", None) or "context"
+            latest_kind = f"context:{entry_type}"
+    return latest, latest_kind
+
+
+def _detect_task_progress_stale(
+    events: Sequence[AuditEvent],
+    *,
+    now: datetime,
+    config: WatchdogConfig,
+    open_tasks: Sequence[Any] | None = None,
+) -> list[Finding]:
+    """Rule 5c (#1444): ``in_progress`` tasks with no recent progress.
+
+    The production path uses ``open_tasks`` so the detector keys off the
+    authoritative current work state, then measures activity from the
+    latest of entry into ``in_progress``, a future ``worker.heartbeat``
+    audit row for the same task, or a loaded task-context entry.
+
+    Audit-event fallback keeps ``scan_events`` useful for synthetic
+    fixtures and future producers that emit ``worker.heartbeat``.
+    """
+    findings: list[Finding] = []
+    seen_subjects: set[str] = set()
+    cutoff = now - timedelta(seconds=config.progress_stale_seconds)
+
+    if open_tasks:
+        for task in open_tasks:
+            status = getattr(task, "work_status", None)
+            status_value = getattr(status, "value", status)
+            if status_value != "in_progress":
+                continue
+            project = getattr(task, "project", "") or ""
+            task_number = getattr(task, "task_number", None)
+            if not project or task_number is None:
+                continue
+            subject = f"{project}/{task_number}"
+            entry_ts, tr_meta = _state_entry_time(task, "in_progress")
+            if entry_ts is None:
+                continue
+
+            last_activity = entry_ts
+            last_activity_kind = "state_entry"
+            heartbeat_ts = _latest_worker_heartbeat_time(
+                events, subject=subject, since=entry_ts,
+            )
+            if heartbeat_ts is not None and heartbeat_ts > last_activity:
+                last_activity = heartbeat_ts
+                last_activity_kind = "worker.heartbeat"
+            context_ts, context_kind = _latest_task_context_time(
+                task, since=entry_ts,
+            )
+            if context_ts is not None and context_ts > last_activity:
+                last_activity = context_ts
+                last_activity_kind = context_kind
+
+            if last_activity > cutoff:
+                continue
+            stuck_minutes = max(
+                1, int((now - last_activity).total_seconds() // 60),
+            )
+            in_progress_minutes = max(
+                1, int((now - entry_ts).total_seconds() // 60),
+            )
+            seen_subjects.add(subject)
+            findings.append(Finding(
+                rule=RULE_TASK_PROGRESS_STALE,
+                project=project,
+                subject=subject,
+                message=(
+                    f"Task {subject} has been at status=in_progress for "
+                    f"~{in_progress_minutes} min with no worker heartbeat "
+                    f"or progress activity for ~{stuck_minutes} min."
+                ),
+                recommendation=(
+                    f"Architect: inspect the worker for {subject}; check "
+                    f"auth, sandbox, and worker logic, then reassign, "
+                    f"resume, or cancel the task."
+                ),
+                metadata={
+                    "in_progress_since": entry_ts.isoformat(),
+                    "in_progress_minutes": in_progress_minutes,
+                    "last_activity_at": last_activity.isoformat(),
+                    "last_activity_kind": last_activity_kind,
+                    "stuck_minutes": stuck_minutes,
+                    "from": tr_meta.get("from"),
+                    "actor": tr_meta.get("actor"),
+                    "assignee": getattr(task, "assignee", None),
+                    "current_node_id": getattr(task, "current_node_id", None),
+                    "detected_via": "state",
+                },
+            ))
+
+    latest_transition: dict[str, tuple[datetime, AuditEvent]] = {}
+    for ev in events:
+        if ev.event != EVENT_TASK_STATUS_CHANGED:
+            continue
+        ts = _parse_iso(ev.ts)
+        if ts is None:
+            continue
+        prior = latest_transition.get(ev.subject)
+        if prior is None or ts > prior[0]:
+            latest_transition[ev.subject] = (ts, ev)
+
+    for subject, (entry_ts, ev) in latest_transition.items():
+        if subject in seen_subjects:
+            continue
+        meta = ev.metadata or {}
+        if meta.get("to") != "in_progress":
+            continue
+        key = _task_subject_key(subject)
+        if key is None:
+            continue
+        project, _ = key
+        last_activity = entry_ts
+        last_activity_kind = "task.status_changed"
+        heartbeat_ts = _latest_worker_heartbeat_time(
+            events, subject=subject, since=entry_ts,
+        )
+        if heartbeat_ts is not None and heartbeat_ts > last_activity:
+            last_activity = heartbeat_ts
+            last_activity_kind = "worker.heartbeat"
+        if last_activity > cutoff:
+            continue
+        stuck_minutes = max(
+            1, int((now - last_activity).total_seconds() // 60),
+        )
+        in_progress_minutes = max(
+            1, int((now - entry_ts).total_seconds() // 60),
+        )
+        seen_subjects.add(subject)
+        findings.append(Finding(
+            rule=RULE_TASK_PROGRESS_STALE,
+            project=project,
+            subject=subject,
+            message=(
+                f"Task {subject} has been at status=in_progress for "
+                f"~{in_progress_minutes} min with no worker heartbeat "
+                f"or progress activity for ~{stuck_minutes} min."
+            ),
+            recommendation=(
+                f"Architect: inspect the worker for {subject}; check "
+                f"auth, sandbox, and worker logic, then reassign, "
+                f"resume, or cancel the task."
+            ),
+            metadata={
+                "in_progress_since": ev.ts,
+                "in_progress_minutes": in_progress_minutes,
+                "last_activity_at": last_activity.isoformat(),
+                "last_activity_kind": last_activity_kind,
+                "stuck_minutes": stuck_minutes,
+                "from": meta.get("from"),
+                "actor": ev.actor,
+                "detected_via": "event",
+            },
+        ))
+    return findings
+
+
 def _detect_role_session_missing(
     events: Sequence[AuditEvent],
     *,
@@ -1151,6 +1373,9 @@ def scan_events(
         materialised, now=now, config=config, open_tasks=open_tasks,
     ))
     findings.extend(_detect_task_on_hold_stale(
+        materialised, now=now, config=config, open_tasks=open_tasks,
+    ))
+    findings.extend(_detect_task_progress_stale(
         materialised, now=now, config=config, open_tasks=open_tasks,
     ))
     findings.extend(_detect_role_session_missing(
@@ -1443,6 +1668,46 @@ def format_unstick_brief(finding: Finding) -> str:
             f"(b) review the work yourself and call `pm task done {subject}` "
             "if it's correct, "
             "(c) escalate to user via `pm notify` with a clear summary."
+        )
+    elif finding.rule == RULE_TASK_PROGRESS_STALE:
+        stuck_minutes = meta.get("stuck_minutes")
+        in_progress_minutes = meta.get("in_progress_minutes")
+        in_progress_since = meta.get("in_progress_since")
+        last_activity_at = meta.get("last_activity_at")
+        last_activity_kind = meta.get("last_activity_kind") or "<unknown>"
+        assignee = meta.get("assignee") or "<unknown>"
+        node = meta.get("current_node_id") or "<unknown>"
+        lines.append(
+            f"Stuck for: {stuck_minutes} minutes without progress activity"
+            if stuck_minutes else "Stuck for: unknown duration"
+        )
+        if in_progress_minutes:
+            lines.append(f"In progress for: {in_progress_minutes} minutes")
+        lines.append("Observed evidence:")
+        if in_progress_since:
+            lines.append(
+                f"- Task transitioned to status=in_progress at {in_progress_since}"
+            )
+        if last_activity_at:
+            lines.append(
+                f"- Last progress signal: {last_activity_kind} at {last_activity_at}"
+            )
+        lines.append(f"- Assignee: {assignee}; node: {node}")
+        lines.append(
+            "- Worker pane may be alive but unproductive: common causes "
+            "include auth failure, sandbox denial, quota/capacity, or "
+            "worker logic stuck after a nudge."
+        )
+        lines.append("")
+        lines.append(
+            "Your job: investigate and unstick. Options: "
+            "(a) inspect the worker pane and account/auth state, then "
+            "restart or fail over the worker if auth/quota is broken, "
+            "(b) reassign or resume the task and verify progress, "
+            f"(c) cancel and re-plan (`pm task cancel {subject}`) if the "
+            "claim cannot be recovered, "
+            "(d) escalate to user via `pm notify` only if credentials, "
+            "org policy, or external access need human action."
         )
     elif finding.rule == RULE_ROLE_SESSION_MISSING:
         expected = meta.get("expected_window") or "<unknown>"

--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -1065,6 +1065,7 @@ def _detect_task_progress_stale(
                 last_activity = context_ts
                 last_activity_kind = context_kind
 
+            seen_subjects.add(subject)
             if last_activity > cutoff:
                 continue
             stuck_minutes = max(
@@ -1073,7 +1074,6 @@ def _detect_task_progress_stale(
             in_progress_minutes = max(
                 1, int((now - entry_ts).total_seconds() // 60),
             )
-            seen_subjects.add(subject)
             findings.append(Finding(
                 rule=RULE_TASK_PROGRESS_STALE,
                 project=project,

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -36,6 +36,7 @@ from pollypm.audit.watchdog import (
     RULE_ROLE_SESSION_MISSING,
     RULE_STUCK_DRAFT,
     RULE_TASK_ON_HOLD_STALE,
+    RULE_TASK_PROGRESS_STALE,
     RULE_TASK_REVIEW_STALE,
     RULE_WORKER_SESSION_DEAD_LOOP,
     WATCHDOG_ALERT_TYPE,
@@ -61,6 +62,7 @@ _DISPATCHABLE_RULES: frozenset[str] = frozenset({
     # cancel, or rewrite them.
     RULE_STUCK_DRAFT,
     RULE_TASK_REVIEW_STALE,
+    RULE_TASK_PROGRESS_STALE,
     RULE_ROLE_SESSION_MISSING,
     RULE_WORKER_SESSION_DEAD_LOOP,
     # #1424 — on_hold escalation lands in the architect's pane with the
@@ -136,6 +138,7 @@ def _config_from_payload(payload: dict[str, Any]) -> WatchdogConfig:
         "stuck_draft_seconds",
         "cancel_grace_seconds",
         "review_stale_seconds",
+        "progress_stale_seconds",
         "on_hold_stale_seconds",
     ):
         raw = payload.get(field_name)
@@ -160,10 +163,11 @@ def _gather_open_tasks(project_key: str, project_path: Path | None) -> list[Any]
     ``db_path`` here. ``project_key`` is forwarded for resolver warnings
     and ``project_path`` for project-aware audit metadata only.
 
-    Powers four rules: ``role_session_missing`` (since #1414), and the
-    state-based variants of ``task_review_stale``, ``task_on_hold_stale``,
-    and ``stuck_draft`` (#1433). For tasks at the watched states
-    (review / on_hold / draft) we re-fetch via :meth:`get` so
+    Powers five rules: ``role_session_missing`` (since #1414),
+    ``task_progress_stale`` (#1444), and the state-based variants of
+    ``task_review_stale``, ``task_on_hold_stale``, and ``stuck_draft``
+    (#1433). For tasks at the watched states
+    (in_progress / review / on_hold / draft) we re-fetch via :meth:`get` so
     ``transitions`` are hydrated — :meth:`list_nonterminal_tasks` skips
     transition loading for non-plan-review tasks (it only includes
     history for plan-review labelled rows). Without transitions the
@@ -174,7 +178,7 @@ def _gather_open_tasks(project_key: str, project_path: Path | None) -> list[Any]
     even when the work-service is unreachable; the affected rules
     simply no-op for that project.
     """
-    _STATE_RULE_STATES = frozenset({"review", "on_hold", "draft"})
+    _STATE_RULE_STATES = frozenset({"in_progress", "review", "on_hold", "draft"})
     try:
         from pollypm.work import create_work_service
 

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -2364,6 +2364,42 @@ def test_task_progress_stale_state_based_silent_when_recent_context(
     assert not any(f.rule == RULE_TASK_PROGRESS_STALE for f in findings)
 
 
+def test_task_progress_stale_state_path_dedupes_event_fallback_with_context(
+    now: datetime,
+) -> None:
+    """Recent task context suppresses stale event fallback for the same task."""
+    task = _StatefulTask(
+        project="demo",
+        task_number=7,
+        work_status="in_progress",
+        transitions=[
+            _FakeTransition(
+                from_state="queued",
+                to_state="in_progress",
+                timestamp=now - timedelta(minutes=45),
+            ),
+        ],
+        updated_at=now - timedelta(minutes=45),
+        context=[
+            _FakeContext(
+                timestamp=now - timedelta(minutes=5),
+                entry_type="note",
+            ),
+        ],
+    )
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/7",
+            metadata={"from": "queued", "to": "in_progress"},
+            ts=now - timedelta(minutes=45),
+        ),
+    ]
+    findings = scan_events(events, now=now, open_tasks=[task])
+    assert not any(f.rule == RULE_TASK_PROGRESS_STALE for f in findings)
+
+
 def test_task_progress_stale_event_path_silent_with_recent_worker_heartbeat(
     now: datetime,
 ) -> None:

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -30,6 +30,7 @@ from pollypm.audit.watchdog import (
     RULE_MARKER_LEAKED,
     RULE_ORPHAN_MARKER,
     RULE_STUCK_DRAFT,
+    RULE_TASK_PROGRESS_STALE,
     Finding,
     WatchdogConfig,
     emit_finding,
@@ -1978,6 +1979,19 @@ class _FakeTransition:
         self.reason = reason
 
 
+class _FakeContext:
+    """Minimal stand-in for ``work.models.ContextEntry``."""
+
+    def __init__(
+        self,
+        *,
+        timestamp: datetime,
+        entry_type: str = "note",
+    ) -> None:
+        self.timestamp = timestamp
+        self.entry_type = entry_type
+
+
 class _StatefulTask:
     """Stand-in for ``work.models.Task`` with state + transitions + timestamps."""
 
@@ -1996,6 +2010,9 @@ class _StatefulTask:
         updated_at: datetime | None = None,
         created_by: str = "polly",
         title: str = "",
+        context: list[_FakeContext] | None = None,
+        assignee: str | None = None,
+        current_node_id: str | None = None,
     ) -> None:
         self.project = project
         self.task_number = task_number
@@ -2005,9 +2022,11 @@ class _StatefulTask:
         self.updated_at = updated_at
         self.created_by = created_by
         self.title = title
+        self.context = list(context or [])
         # Keep the role-session detector happy when reused.
         self.roles: dict[str, str] = {}
-        self.assignee: str | None = None
+        self.assignee: str | None = assignee
+        self.current_node_id = current_node_id
 
 
 def test_task_review_stale_state_based_fires_for_old_entry(now: datetime) -> None:
@@ -2287,9 +2306,194 @@ def test_stuck_draft_state_dedupes_with_event_path(now: datetime) -> None:
     assert matched[0].metadata["detected_via"] == "state"
 
 
+def test_task_progress_stale_state_based_fires_for_old_in_progress(
+    now: datetime,
+) -> None:
+    """#1444 — an old in_progress claim with no activity escalates."""
+    task = _StatefulTask(
+        project="savethenovel",
+        task_number=15,
+        work_status="in_progress",
+        transitions=[
+            _FakeTransition(
+                from_state="queued",
+                to_state="in_progress",
+                timestamp=now - timedelta(minutes=25),
+                actor="worker",
+            ),
+        ],
+        updated_at=now - timedelta(minutes=25),
+        assignee="claude:worker",
+        current_node_id="implement",
+    )
+    findings = scan_events([], now=now, open_tasks=[task])
+    matched = [f for f in findings if f.rule == RULE_TASK_PROGRESS_STALE]
+    assert len(matched) == 1
+    f = matched[0]
+    assert f.subject == "savethenovel/15"
+    assert f.metadata["detected_via"] == "state"
+    assert f.metadata["last_activity_kind"] == "state_entry"
+    assert f.metadata["stuck_minutes"] >= 20
+    assert "auth" in f.recommendation
+
+
+def test_task_progress_stale_state_based_silent_when_recent_context(
+    now: datetime,
+) -> None:
+    """A recent task-context progress note keeps an old claim fresh."""
+    task = _StatefulTask(
+        project="demo",
+        task_number=7,
+        work_status="in_progress",
+        transitions=[
+            _FakeTransition(
+                from_state="queued",
+                to_state="in_progress",
+                timestamp=now - timedelta(minutes=45),
+            ),
+        ],
+        updated_at=now - timedelta(minutes=45),
+        context=[
+            _FakeContext(
+                timestamp=now - timedelta(minutes=5),
+                entry_type="note",
+            ),
+        ],
+    )
+    findings = scan_events([], now=now, open_tasks=[task])
+    assert not any(f.rule == RULE_TASK_PROGRESS_STALE for f in findings)
+
+
+def test_task_progress_stale_event_path_silent_with_recent_worker_heartbeat(
+    now: datetime,
+) -> None:
+    """A worker.heartbeat after the in_progress transition suppresses the finding."""
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/8",
+            metadata={"from": "queued", "to": "in_progress"},
+            ts=now - timedelta(minutes=45),
+        ),
+        _make_event(
+            event="worker.heartbeat",
+            project="demo",
+            subject="demo/8",
+            metadata={"task_id": "demo/8"},
+            ts=now - timedelta(minutes=5),
+        ),
+    ]
+    findings = scan_events(events, now=now)
+    assert not any(f.rule == RULE_TASK_PROGRESS_STALE for f in findings)
+
+
+def test_task_progress_stale_event_path_fires_without_heartbeat(
+    now: datetime,
+) -> None:
+    events = [
+        _make_event(
+            event=EVENT_TASK_STATUS_CHANGED,
+            project="demo",
+            subject="demo/8",
+            metadata={"from": "queued", "to": "in_progress"},
+            ts=now - timedelta(minutes=45),
+        ),
+    ]
+    findings = scan_events(events, now=now)
+    matched = [f for f in findings if f.rule == RULE_TASK_PROGRESS_STALE]
+    assert len(matched) == 1
+    assert matched[0].subject == "demo/8"
+    assert matched[0].metadata["detected_via"] == "event"
+
+
+def test_format_unstick_brief_progress_stale_mentions_auth() -> None:
+    from pollypm.audit.watchdog import format_unstick_brief
+
+    finding = Finding(
+        rule=RULE_TASK_PROGRESS_STALE,
+        project="savethenovel",
+        subject="savethenovel/15",
+        message="Task savethenovel/15 has been in_progress with no activity.",
+        metadata={
+            "stuck_minutes": 25,
+            "in_progress_minutes": 25,
+            "in_progress_since": "2026-05-07T20:03:09+00:00",
+            "last_activity_at": "2026-05-07T20:03:09+00:00",
+            "last_activity_kind": "state_entry",
+            "assignee": "claude:worker",
+            "current_node_id": "implement",
+        },
+    )
+    brief = format_unstick_brief(finding)
+    assert "task_progress_stale" in brief
+    assert "auth" in brief.lower()
+    assert "sandbox" in brief.lower()
+    assert "pm task cancel savethenovel/15" in brief
+
+
+def test_cadence_handler_dispatches_task_progress_stale(
+    now: datetime, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The new in_progress detector is part of the architect dispatch set."""
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _scan_one_project,
+    )
+
+    task = _StatefulTask(
+        project="savethenovel",
+        task_number=15,
+        work_status="in_progress",
+        transitions=[
+            _FakeTransition(
+                from_state="queued",
+                to_state="in_progress",
+                timestamp=now - timedelta(minutes=25),
+                actor="worker",
+            ),
+        ],
+        updated_at=now - timedelta(minutes=25),
+        assignee="claude:worker",
+        current_node_id="implement",
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_open_tasks",
+        lambda key, path: [task],
+    )
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._gather_storage_windows",
+        lambda name: ["worker-savethenovel", "architect-savethenovel"],
+    )
+    sent: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "pollypm.plugins_builtin.core_recurring.audit_watchdog._send_brief_to_architect",
+        lambda target, brief: sent.append((target, brief)) or True,
+    )
+
+    store = _RecordingStore()
+    counters = _scan_one_project(
+        project_key="savethenovel",
+        project_path=None,
+        msg_store=store,
+        state_store=None,
+        now=now,
+        config=WatchdogConfig(),
+        storage_closet_name="pollypm-storage-closet",
+    )
+
+    assert counters["findings"] >= 1
+    assert counters["dispatches_sent"] == 1
+    assert len(sent) == 1
+    target, brief = sent[0]
+    assert target == "pollypm-storage-closet:architect-savethenovel"
+    assert RULE_TASK_PROGRESS_STALE in brief
+    assert "savethenovel/15" in brief
+
+
 def test_state_based_detectors_silent_when_open_tasks_empty(now: datetime) -> None:
     """No open_tasks → state path no-ops, original event path still works."""
     from pollypm.audit.watchdog import (
+        RULE_TASK_PROGRESS_STALE,
         RULE_TASK_ON_HOLD_STALE,
         RULE_TASK_REVIEW_STALE,
     )
@@ -2297,6 +2501,11 @@ def test_state_based_detectors_silent_when_open_tasks_empty(now: datetime) -> No
     findings = scan_events([], now=now, open_tasks=[])
     # No events, no tasks → nothing should fire.
     assert not any(
-        f.rule in (RULE_TASK_REVIEW_STALE, RULE_TASK_ON_HOLD_STALE, RULE_STUCK_DRAFT)
+        f.rule in (
+            RULE_TASK_REVIEW_STALE,
+            RULE_TASK_ON_HOLD_STALE,
+            RULE_TASK_PROGRESS_STALE,
+            RULE_STUCK_DRAFT,
+        )
         for f in findings
     )


### PR DESCRIPTION
Closes #1444

Adds a watchdog `task_progress_stale` detector for tasks currently stuck in `in_progress` without recent state, task-context, or worker heartbeat activity, and dispatches the architect brief with auth/sandbox recovery guidance. The recurring watchdog now hydrates `in_progress` tasks so the state-based rule has transition history.

Self-audit: touched watchdog domain code in `src/pollypm/audit/watchdog.py`, the recurring watchdog adapter in `src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py`, and focused watchdog tests only. No UI/store boundary changes.