### PR TITLE
Fix #1360 move routing tag helper

### DIFF
--- a/src/pollypm/cockpit_activity.py
+++ b/src/pollypm/cockpit_activity.py
@@ -582,8 +582,9 @@ class PollyActivityFeedApp(App[None]):
             # head of the message \u2014 they're notify/supervisor
             # routing labels, not natural-language content, and the
             # Event column already conveys the kind.
-            from pollypm.cockpit_ui import _strip_action_subject_prefix
-            summary_text = _strip_action_subject_prefix(summary_text)
+            from pollypm.notify_task import strip_routing_tag_prefix
+
+            summary_text = strip_routing_tag_prefix(summary_text)
             self.table.add_row(
                 time_text,
                 project_text,

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -123,7 +123,7 @@ from pollypm.cockpit_settings_history import (
 )
 from pollypm.cockpit_settings_projects import collect_settings_projects
 from pollypm.cockpit_workers import PollyWorkerRosterApp  # noqa: F401
-from pollypm.notify_task import is_notify_inbox_task
+from pollypm.notify_task import is_notify_inbox_task, strip_routing_tag_prefix
 from pollypm.rejection_feedback import (
     feedback_target_task_id,
     is_rejection_feedback_task,
@@ -6858,7 +6858,7 @@ def _archive_success_message(item, task_id: str) -> str:
         return f"Archived {task_id}"
     title = str(getattr(item, "title", "") or "").strip()
     if title:
-        return f"Archived {_strip_action_subject_prefix(title)}"
+        return f"Archived {strip_routing_tag_prefix(title)}"
     return "Archived notification"
 
 
@@ -7006,7 +7006,7 @@ def _format_inbox_row(
     # stamping every title with "[Action]" is redundant noise that
     # eats list-pane width and buries the actual subject.
     if getattr(task, "triage_bucket", "") == "action":
-        subject = _strip_action_subject_prefix(subject)
+        subject = strip_routing_tag_prefix(subject)
     reply_suffix = ""
     if reply_count:
         noun = "reply" if reply_count == 1 else "replies"
@@ -9396,7 +9396,7 @@ class PollyInboxApp(App[None]):
         # header should not lead with "[Action]" boilerplate.
         subject = item.title or "(no subject)"
         if _triage_bucket(item) == "action":
-            subject = _strip_action_subject_prefix(subject)
+            subject = strip_routing_tag_prefix(subject)
         sections.append(f"[b #eef2f4]{_escape(subject)}[/b #eef2f4]")
         meta_bits = [f"[#5b8aff]{_escape(sender)}[/#5b8aff]"]
         if when:
@@ -9583,7 +9583,7 @@ class PollyInboxApp(App[None]):
         # Same routing-tag strip as the list rail — the focused message
         # header should not lead with "[Action]" boilerplate.
         if getattr(task, "triage_bucket", "") == "action":
-            subject = _strip_action_subject_prefix(subject)
+            subject = strip_routing_tag_prefix(subject)
         sections.append(f"[b #eef2f4]{_escape(subject)}[/b #eef2f4]")
         meta_bits = [f"[#5b8aff]{_escape(sender)}[/#5b8aff]"]
         if when:
@@ -13821,29 +13821,6 @@ def _action_card_click_hint(action_items: list[dict]) -> str:
 def _dashboard_action_key(index: int, slot: str) -> str:
     offset = {"primary": 1, "secondary": 2, "other": 3}[slot]
     return str(index * 3 + offset)
-
-
-_ROUTING_TAG_PREFIXES = ("[action]", "[alert]")
-
-
-def _strip_action_subject_prefix(subject: str) -> str:
-    """Drop a leading routing tag (``[Action]``, ``[Alert]``) from a
-    user-facing subject.
-
-    These bracketed prefixes are tier/recipient routing labels added by
-    the notify CLI and the supervisor's alert path; they have no
-    natural-language value for the operator reading the subject. The
-    inbox list rail already strips ``[Action]`` for action-bucket rows;
-    the detail pane and the activity feed mirror the strip so a focused
-    message or feed row doesn't lead with the routing tag.
-    """
-    if not subject:
-        return subject
-    lowered = subject.lower()
-    for tag in _ROUTING_TAG_PREFIXES:
-        if lowered.startswith(tag):
-            return subject[len(tag):].lstrip(" :-—")
-    return subject
 
 
 def _clean_hold_reason(

--- a/src/pollypm/notify_task.py
+++ b/src/pollypm/notify_task.py
@@ -54,6 +54,19 @@ _NOTIFY_TITLE_PREFIXES: tuple[str, ...] = (
     "Repeated stale",
 )
 
+_ROUTING_TAG_PREFIXES = ("[action]", "[alert]")
+
+
+def strip_routing_tag_prefix(subject: str) -> str:
+    """Drop a leading notify/supervisor routing tag from a subject."""
+    if not subject:
+        return subject
+    lowered = subject.lower()
+    for tag in _ROUTING_TAG_PREFIXES:
+        if lowered.startswith(tag):
+            return subject[len(tag):].lstrip(" :-—")
+    return subject
+
 
 def _coerce_roles(value: object) -> dict[str, str]:
     """Best-effort coerce ``task.roles`` into a ``{str: str}`` mapping.
@@ -156,4 +169,5 @@ __all__ = [
     "NOTIFY_LABEL",
     "is_notify_inbox_task",
     "is_notify_only_inbox_entry",
+    "strip_routing_tag_prefix",
 ]

--- a/src/pollypm/work/inbox_cli.py
+++ b/src/pollypm/work/inbox_cli.py
@@ -418,11 +418,9 @@ def _render_message_display(row: dict[str, Any]) -> list[str]:
     # Strip notify/supervisor routing tags ("[Action]", "[Alert]") so
     # the user-facing CLI matches the cockpit-pane inbox detail
     # rendering. Raw tags are routing artefacts, not natural language.
-    try:
-        from pollypm.cockpit_ui import _strip_action_subject_prefix
-        subject = _strip_action_subject_prefix(subject)
-    except Exception:  # noqa: BLE001
-        pass
+    from pollypm.notify_task import strip_routing_tag_prefix
+
+    subject = strip_routing_tag_prefix(subject)
     sender = row.get("sender") or "(unknown)"
     recipient = row.get("recipient") or "user"
     scope = row.get("scope") or "-"

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -2166,62 +2166,62 @@ def test_clean_hold_reason_without_title_map_keeps_legacy_behavior() -> None:
     ) == "Waiting on operator: polly_remote/12 to land"
 
 
-def test_strip_action_subject_prefix_also_strips_alert_routing_tag() -> None:
+def test_strip_routing_tag_prefix_also_strips_alert_routing_tag() -> None:
     """Alerts emit subjects with an ``[Alert]`` tier prefix from the
     supervisor — same routing-tag pattern as ``[Action]``. The strip
     helper must drop both so the activity feed Message column doesn't
     render ``[Alert] Additional work remains —`` with the bracketed
     routing label leading the prose.
     """
-    from pollypm.cockpit_ui import _strip_action_subject_prefix
+    from pollypm.notify_task import strip_routing_tag_prefix
 
-    assert _strip_action_subject_prefix(
+    assert strip_routing_tag_prefix(
         "[Alert] Additional work remains — open inbox to triage"
     ) == "Additional work remains — open inbox to triage"
-    assert _strip_action_subject_prefix(
+    assert strip_routing_tag_prefix(
         "[ALERT] disk filling"
     ) == "disk filling"
     # No tag → unchanged.
-    assert _strip_action_subject_prefix(
+    assert strip_routing_tag_prefix(
         "Calculator CLI E2E complete"
     ) == "Calculator CLI E2E complete"
 
 
-def test_strip_action_subject_prefix_drops_routing_tag() -> None:
+def test_strip_routing_tag_prefix_drops_routing_tag() -> None:
     """The ``[Action]`` prefix is a tier/recipient routing label added
     by the notify CLI; it must not survive into user-facing subject
     rendering. The inbox list rail already strips it for action-bucket
     rows, and the detail pane mirrors the same strip — exercise the
     helper directly so both call sites stay in sync.
     """
-    from pollypm.cockpit_ui import _strip_action_subject_prefix
+    from pollypm.notify_task import strip_routing_tag_prefix
 
     # Standard form: "[Action] <subject>"
-    assert _strip_action_subject_prefix(
+    assert strip_routing_tag_prefix(
         "[Action] N-RC1 review (polly_remote/12): code solid"
     ) == "N-RC1 review (polly_remote/12): code solid"
 
     # Case-insensitive prefix match.
-    assert _strip_action_subject_prefix(
+    assert strip_routing_tag_prefix(
         "[ACTION] hold this thing"
     ) == "hold this thing"
 
     # Strips trailing punctuation/separators glued to the prefix so
     # the rendered subject doesn't lead with stray ":" or "-".
-    assert _strip_action_subject_prefix(
+    assert strip_routing_tag_prefix(
         "[Action]: do the thing"
     ) == "do the thing"
-    assert _strip_action_subject_prefix(
+    assert strip_routing_tag_prefix(
         "[Action] — escalation"
     ) == "escalation"
 
     # No prefix → unchanged.
-    assert _strip_action_subject_prefix(
+    assert strip_routing_tag_prefix(
         "Plan ready for review: booktalk"
     ) == "Plan ready for review: booktalk"
 
     # Empty / falsy → unchanged.
-    assert _strip_action_subject_prefix("") == ""
+    assert strip_routing_tag_prefix("") == ""
 
 
 def test_stuck_alert_covers_action_dedupes_user_waiting_alerts() -> None:


### PR DESCRIPTION
Closes #1360

Moves the routing-tag subject stripper from `cockpit_ui` into the neutral notification helper module and updates the cockpit, activity feed, work inbox CLI, and tests to call `strip_routing_tag_prefix`.

Layer audit: `pollypm.work.inbox_cli` no longer imports the UI module or a private helper. UI callers import the shared helper from `pollypm.notify_task`; no store/UI reach-through or circular import was added.

Verification:
- `uv run pytest tests/test_project_dashboard_ui.py -k "strip_routing_tag_prefix or clean_hold_reason_without_title_map"`
- `uv run pytest tests/test_inbox_show_msg.py -k "strips_routing_tag"`
- `uv run pytest tests/test_import_boundary.py`
- `uv run python -c 'import sys; import pollypm.work.inbox_cli; assert "pollypm.cockpit_ui" not in sys.modules'`\n- `uv run ruff check src/pollypm/notify_task.py src/pollypm/cockpit_ui.py src/pollypm/cockpit_activity.py src/pollypm/work/inbox_cli.py`\n- `git diff --check`\n\nNote: `uv run ruff check` including `tests/test_project_dashboard_ui.py` still reports pre-existing `F541` at line 5020 on `origin/main`.