### PR TITLE
Fix #1446 suppress pytest work-db open audit

### DIFF
--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import sqlite3
 import subprocess
 from datetime import UTC, datetime
@@ -29,6 +30,13 @@ from pathlib import Path
 from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
+
+_DISABLE_WORK_DB_OPENED_AUDIT_ENV = "POLLYPM_DISABLE_WORK_DB_OPENED_AUDIT"
+
+
+def _work_db_opened_audit_disabled() -> bool:
+    value = os.environ.get(_DISABLE_WORK_DB_OPENED_AUDIT_ENV, "")
+    return value.strip().lower() not in {"", "0", "false", "no", "off"}
 
 
 # #894 — register the work_service module as an emitter that routes
@@ -742,31 +750,32 @@ class SQLiteWorkService:
         # broad try/except so audit infra failure cannot block work-
         # service init — matches the pattern used at the other audit
         # callsites in this module.
-        try:
-            from pollypm.audit import emit as _audit_emit
-            from pollypm.audit.log import EVENT_WORK_DB_OPENED
+        if not _work_db_opened_audit_disabled():
+            try:
+                from pollypm.audit import emit as _audit_emit
+                from pollypm.audit.log import EVENT_WORK_DB_OPENED
 
-            # ``emit()`` skips the central tail when ``project`` is
-            # empty (no project file to address), so use a synthetic
-            # workspace-level key. Keeps these rows out of any real
-            # project's central file while still landing them on disk
-            # for ``pm doctor`` / heartbeat to grep.
-            _audit_emit(
-                event=EVENT_WORK_DB_OPENED,
-                project="_workspace",
-                subject=str(db_path),
-                actor="system",
-                metadata={
-                    "had_messages_table_pre_open": _had_messages_table_pre_open,
-                    "tables_created": not _had_work_tables_pre_open,
-                    "project_path": (
-                        str(project_path) if project_path is not None else None
-                    ),
-                },
-                project_path=project_path,
-            )
-        except Exception:  # noqa: BLE001 — audit must never break init
-            pass
+                # ``emit()`` skips the central tail when ``project`` is
+                # empty (no project file to address), so use a synthetic
+                # workspace-level key. Keeps these rows out of any real
+                # project's central file while still landing them on disk
+                # for ``pm doctor`` / heartbeat to grep.
+                _audit_emit(
+                    event=EVENT_WORK_DB_OPENED,
+                    project="_workspace",
+                    subject=str(db_path),
+                    actor="system",
+                    metadata={
+                        "had_messages_table_pre_open": _had_messages_table_pre_open,
+                        "tables_created": not _had_work_tables_pre_open,
+                        "project_path": (
+                            str(project_path) if project_path is not None else None
+                        ),
+                    },
+                    project_path=project_path,
+                )
+            except Exception:  # noqa: BLE001 — audit must never break init
+                pass
         self._flush_task_delete_audit_outbox()
         self._gate_registry = GateRegistry(project_path=project_path)
         self._flow_cache: dict[tuple[str, int], FlowTemplate] = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ def pytest_configure(config):  # noqa: ARG001
     os.environ.setdefault("POLLYPM_SKIP_RAIL_DAEMON", "1")
     os.environ.setdefault("POLLYPM_DISABLE_ERROR_NOTIFICATIONS", "1")
     os.environ.setdefault("POLLYPM_DISABLE_AGENTIC_REVIEW_SUMMARIES", "1")
+    os.environ.setdefault("POLLYPM_DISABLE_WORK_DB_OPENED_AUDIT", "1")
     os.environ.setdefault(
         "POLLYPM_ERROR_LOG_PATH",
         str(

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -47,6 +47,7 @@ def _isolate_audit_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path
     """Redirect the central-tail root so tests never touch ~/.pollypm/."""
     audit_home = tmp_path / "audit-home"
     monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+    monkeypatch.delenv("POLLYPM_DISABLE_WORK_DB_OPENED_AUDIT", raising=False)
     return audit_home
 
 
@@ -610,5 +611,34 @@ def test_workservice_open_per_project_log_when_project_path_supplied(
         opens = [r for r in rows if r["event"] == EVENT_WORK_DB_OPENED]
         assert len(opens) == 1
         assert opens[0]["metadata"]["project_path"] == str(project_root)
+    finally:
+        svc.close()
+
+
+def test_workservice_open_audit_can_be_disabled_for_pytest_isolation(
+    tmp_path: Path,
+    _isolate_audit_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pytest's global guard suppresses the DB-open breadcrumb entirely.
+
+    The central tail is already redirected during tests, but the per-project
+    audit log intentionally ignores that redirect. Suppressing only this
+    high-frequency lifecycle event keeps broad test sweeps out of a real
+    workspace's ``.pollypm/audit.jsonl``.
+    """
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    monkeypatch.setenv("POLLYPM_DISABLE_WORK_DB_OPENED_AUDIT", "1")
+
+    project_root = tmp_path / "proj"
+    (project_root / ".pollypm").mkdir(parents=True)
+    db_path = tmp_path / "disabled.db"
+
+    svc = SQLiteWorkService(db_path=db_path, project_path=project_root)
+    try:
+        records = _read_central_records(_isolate_audit_home)
+        assert [r for r in records if r["event"] == EVENT_WORK_DB_OPENED] == []
+        assert not (project_root / ".pollypm" / "audit.jsonl").exists()
     finally:
         svc.close()


### PR DESCRIPTION
Closes #1446

Suppress the high-frequency work_db.opened audit breadcrumb when POLLYPM_DISABLE_WORK_DB_OPENED_AUDIT is set, and set that guard for pytest by default. Audit-log tests explicitly clear the guard so production emit behavior remains covered, including the per-project log path added by #1454.

Layer self-audit: touched domain work-service constructor plus test configuration/coverage only; no UI, facade, or store boundary reach.