### PR TITLE
Cockpit: prefer workspace canonical DB over per-project legacy DB

### DIFF
--- a/src/pollypm/cockpit_tasks.py
+++ b/src/pollypm/cockpit_tasks.py
@@ -1578,6 +1578,16 @@ class PollyTasksApp(App[None]):
         created via ``pm task ...`` with no project DB seeded) render
         with zero rows even though ``pm task counts`` reports them
         — issue #919/#920.
+
+        Order (#1004): the workspace-root canonical DB is preferred
+        first because the work-DB resolver collapsed to workspace-root
+        as the single source of truth. The per-project
+        ``<project>/.pollypm/state.db`` is retained as a legacy
+        fallback so unmigrated projects still render, but workspace
+        wins when both DBs hold rows for the project — otherwise the
+        Tasks pane (which picks the FIRST candidate with any matching
+        rows in :meth:`_get_svc`) latches onto a stale per-project DB
+        and shows split-brain results vs. the live worker session.
         """
         config = load_config(self.config_path)
         project = config.projects.get(self.project_key)
@@ -1596,11 +1606,11 @@ class PollyTasksApp(App[None]):
             seen.add(candidate)
             candidates.append((candidate, project.path))
 
-        _add(project.path / ".pollypm" / "state.db")
         project_settings = getattr(config, "project", None)
         workspace_root = getattr(project_settings, "workspace_root", None)
         if workspace_root is not None:
             _add(Path(workspace_root) / ".pollypm" / "state.db")
+        _add(project.path / ".pollypm" / "state.db")
         state_db = getattr(project_settings, "state_db", None)
         if state_db is not None:
             _add(state_db)

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -11948,7 +11948,15 @@ def _dashboard_task_blocker_body_with_kind(task: object) -> tuple[str, str]:
 
 
 def _dashboard_task_db_paths(config: object, project_path: Path) -> list[Path]:
-    """Return task DBs that can hold work for a registered project."""
+    """Return task DBs that can hold work for a registered project.
+
+    Order (#1004): workspace-root canonical DB first, per-project
+    ``<project>/.pollypm/state.db`` as a legacy fallback. Must mirror
+    :meth:`pollypm.cockpit_tasks.PollyTasksApp._candidate_dbs` —
+    a divergence here surfaces as split-brain rendering between the
+    dashboard (which unions across DBs) and the Tasks pane (which
+    picks the first DB with matching rows).
+    """
     candidates: list[Path] = []
 
     def _add(path: object) -> None:
@@ -11959,12 +11967,12 @@ def _dashboard_task_db_paths(config: object, project_path: Path) -> list[Path]:
         if candidate not in candidates and candidate.exists():
             candidates.append(candidate)
 
-    _add(project_path / ".pollypm" / "state.db")
-
     project_settings = getattr(config, "project", None)
     workspace_root = getattr(project_settings, "workspace_root", None)
     if workspace_root is not None:
         _add(Path(workspace_root) / ".pollypm" / "state.db")
+
+    _add(project_path / ".pollypm" / "state.db")
 
     state_db = getattr(project_settings, "state_db", None)
     if state_db is not None:

--- a/tests/test_cockpit_tasks_candidate_dbs.py
+++ b/tests/test_cockpit_tasks_candidate_dbs.py
@@ -1,0 +1,106 @@
+"""Regression tests for ``PollyTasksApp._candidate_dbs`` ordering (#1004).
+
+Background — the work-DB resolver collapsed onto the workspace-root
+``state.db`` as the single source of truth. The cockpit Tasks pane
+still tolerates a per-project ``<project>/.pollypm/state.db`` as a
+legacy fallback (some unmigrated projects only have rows there), but
+when both DBs exist with rows the workspace must win — otherwise
+``_get_svc`` latches onto the stale per-project DB and the live-task
+drilldown shows split-brain results vs. the running worker session
+("No active worker session is currently attached to this task." while
+the heartbeat is plainly attached to a tmux pane).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+def _write_config(project_path: Path, config_path: Path, *, workspace_root: Path) -> None:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "[project]\n"
+        f'tmux_session = "pollypm-test"\n'
+        f'workspace_root = "{workspace_root}"\n'
+        "\n"
+        "[projects.demo]\n"
+        'key = "demo"\n'
+        'name = "Demo"\n'
+        f'path = "{project_path}"\n'
+    )
+
+
+def _create_empty_state_db(db_path: Path) -> None:
+    """Touch a SQLite file at ``db_path`` so ``Path.exists()`` is True.
+
+    ``_candidate_dbs`` filters with ``candidate.exists()`` — we don't
+    need a real schema to exercise the ordering logic, just a real
+    file on disk.
+    """
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.close()
+
+
+def test_candidate_dbs_prefers_workspace_when_both_exist(tmp_path: Path) -> None:
+    """Workspace-root DB must come first when both DBs exist.
+
+    Pre-#1004 ordering returned the per-project DB first, so
+    ``_get_svc`` would short-circuit on the stale per-project rows
+    even when the live workspace DB had the in-progress task and its
+    work_sessions row.
+    """
+    from pollypm.cockpit_tasks import PollyTasksApp
+
+    workspace_root = tmp_path
+    project_path = workspace_root / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    config_path = workspace_root / "pollypm.toml"
+    _write_config(project_path, config_path, workspace_root=workspace_root)
+
+    workspace_db = workspace_root / ".pollypm" / "state.db"
+    per_project_db = project_path / ".pollypm" / "state.db"
+    _create_empty_state_db(workspace_db)
+    _create_empty_state_db(per_project_db)
+
+    app = PollyTasksApp(config_path, "demo")
+    candidates = app._candidate_dbs()
+    paths = [db for db, _ in candidates]
+
+    assert workspace_db in paths
+    assert per_project_db in paths
+    assert paths.index(workspace_db) < paths.index(per_project_db), (
+        f"workspace DB must precede per-project DB; got order: {paths}"
+    )
+
+
+def test_candidate_dbs_falls_back_to_per_project_when_workspace_missing(
+    tmp_path: Path,
+) -> None:
+    """Legacy fallback: if only the per-project DB exists, return it.
+
+    Some unmigrated projects still have rows only in
+    ``<project>/.pollypm/state.db``; we must not regress those.
+    """
+    from pollypm.cockpit_tasks import PollyTasksApp
+
+    workspace_root = tmp_path
+    project_path = workspace_root / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    config_path = workspace_root / "pollypm.toml"
+    _write_config(project_path, config_path, workspace_root=workspace_root)
+
+    per_project_db = project_path / ".pollypm" / "state.db"
+    _create_empty_state_db(per_project_db)
+    # Deliberately do NOT create the workspace_root state.db.
+
+    app = PollyTasksApp(config_path, "demo")
+    candidates = app._candidate_dbs()
+    paths = [db for db, _ in candidates]
+
+    assert per_project_db in paths, (
+        f"per-project DB must remain a legacy fallback; got: {paths}"
+    )


### PR DESCRIPTION
## Summary

Reorder `_candidate_dbs` (cockpit_tasks.py) and `_dashboard_task_db_paths` (cockpit_ui.py) so the workspace-root canonical `state.db` is checked before the project-local one. Per #1004 the per-project DB is deprecated; both helpers were still preferring it, which caused the task-drilldown Live tab to show "No active worker session" even when canonical had the in_progress row + work_sessions row.

## Context

Reproduced live during today's debugging session: clicked savethenovel → task /15 → Live and saw "No active worker session attached to this task" while the worker pane (`%11933`) was actively coding Module 6. Diagnosed as `_get_svc()` picking the per-project DB first because it had 68 stale advisor.tick rows; that DB had zero `work_sessions`, so `get_worker_session(active_only=True)` returned None.

## What changed

- `src/pollypm/cockpit_tasks.py:_candidate_dbs` — reorder so workspace root is added first, project-local second, config-state-db override last.
- `src/pollypm/cockpit_ui.py:_dashboard_task_db_paths` — same reorder for the dashboard mirror.
- `tests/test_cockpit_tasks_candidate_dbs.py` — new file with two regression tests:
  - `test_candidate_dbs_prefers_workspace_when_both_exist` — workspace wins when both DBs exist with rows.
  - `test_candidate_dbs_falls_back_to_per_project_when_workspace_missing` — legacy back-compat when only per-project exists.

## Test plan

- [x] `tests/test_cockpit_tasks_candidate_dbs.py` (2 new tests, pass)
- [x] Targeted suite: `test_audit_watchdog.py`, `test_legacy_per_project_db_migration.py`, `test_workspace_scope_resolution.py` (88 passed)
- [x] Broader cockpit_tasks-touching tests (118 passed)
- [x] Reinstall + manual verification: `pm cockpit-pane` task drilldown Live tab now resolves correctly through the workspace DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)