### PR TITLE
Heartbeat: auth_broken → recovery + filter unhealthy accounts on respawn

### DIFF
--- a/src/pollypm/accounts.py
+++ b/src/pollypm/accounts.py
@@ -154,6 +154,41 @@ def _cached_account_usage_summary(account: AccountConfig) -> tuple[str, str, str
     return ("unknown", "unknown", "status unavailable")
 
 
+_AUTH_BROKEN_STATUSES = frozenset({"auth_broken", "auth-broken", "signed-out"})
+
+
+def is_account_status_unhealthy(value: str | None) -> bool:
+    """Return True when ``value`` denotes an unhealthy account status.
+
+    Accepts both ``"auth_broken"`` (canonical underscore form written by
+    runtime writers in ``heartbeats/api.py`` and ``supervisor.py``) and
+    ``"auth-broken"`` (hyphen form used by ``CapacityState`` /
+    ``account_usage.health``). Centralising the check makes readers
+    tolerant of either form so account-runtime writes always reach the
+    "skip this account" branches in worker selection (#1437).
+    """
+    return value in _AUTH_BROKEN_STATUSES
+
+
+def is_account_runtime_unavailable(value: str | None) -> bool:
+    """Return True when an ``account_runtime.status`` should block use.
+
+    Mirrors the canonical list used by ``Supervisor._account_is_viable``
+    (auth_broken / exhausted / provider_outage / blocked) but also
+    tolerates the hyphenated ``"auth-broken"`` form so legacy rows or
+    UI-driven writes still match.
+    """
+    if value is None:
+        return False
+    return value in {
+        "auth_broken",
+        "auth-broken",
+        "exhausted",
+        "provider_outage",
+        "blocked",
+    }
+
+
 def _effective_logged_in(
     account: AccountConfig,
     *,
@@ -161,9 +196,9 @@ def _effective_logged_in(
     runtime_status: str | None = None,
     probe_live: bool = True,
 ) -> bool:
-    if runtime_status in {"auth-broken", "signed-out"}:
+    if is_account_status_unhealthy(runtime_status):
         return False
-    if cached_health in {"auth-broken", "signed-out"}:
+    if is_account_status_unhealthy(cached_health):
         return False
     if not probe_live:
         if cached_health:

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -510,6 +510,8 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         "please login",
         "please log in",
         "invalid api key",
+        "disabled claude subscription",
+        "use an anthropic api key",
     )
     _WAITING_PATTERNS = (
         "let me know",
@@ -1006,6 +1008,20 @@ class LocalHeartbeatBackend(HeartbeatBackend):
             )
             alerts.append("auth_broken")
             status_locked = True
+            # #1437 — without this call the recovery ladder never fires
+            # for per-task workers that hit an auth-block on their
+            # provider account. The heartbeat would mark the account
+            # ``auth_broken`` and pin the session status, but the wedged
+            # tmux window kept running until manual ``pm reset``.
+            # ``recover_session`` routes through Supervisor.maybe_recover
+            # which (combined with #1437 Fix #3 in session_manager.py)
+            # picks a healthy failover account on the relaunch.
+            self._recover_session(
+                api,
+                context,
+                failure_type="auth_broken",
+                message="Authentication failure reported",
+            )
         else:
             api.clear_alert(context.session_name, "auth_broken")
 

--- a/src/pollypm/work/session_manager.py
+++ b/src/pollypm/work/session_manager.py
@@ -101,7 +101,9 @@ def _first_matching_account(
     *,
     provider: object,
     preferred_names: list[str],
+    excluded_names: frozenset[str] | set[str] | None = None,
 ) -> tuple[str, object] | tuple[None, None]:
+    excluded = excluded_names or frozenset()
     ordered: list[str] = []
     for name in preferred_names:
         if name and name not in ordered:
@@ -110,10 +112,47 @@ def _first_matching_account(
         if name not in ordered:
             ordered.append(name)
     for name in ordered:
+        if name in excluded:
+            continue
         account = accounts.get(name)
         if account is not None and getattr(account, "provider", None) is provider:
             return name, account
     return None, None
+
+
+def _unavailable_account_names(config: object) -> frozenset[str]:
+    """Return account names whose runtime status marks them unavailable.
+
+    Mirrors ``Supervisor._candidate_accounts`` / ``_account_is_viable``
+    so per-task worker spawn skips the same accounts the control-plane
+    failover skips. Reads ``account_runtime`` from the project state DB
+    and consults ``is_account_runtime_unavailable`` (auth_broken,
+    auth-broken, exhausted, provider_outage, blocked).
+
+    Returns an empty frozenset when the state DB is unreachable so a
+    transient store error does not block all worker launches — the
+    supervisor still owns the authoritative gating, this filter just
+    prevents the obviously-wedged account from being picked first.
+    """
+    project = getattr(config, "project", None)
+    state_db = getattr(project, "state_db", None) if project is not None else None
+    if state_db is None:
+        return frozenset()
+    try:
+        from pollypm.accounts import is_account_runtime_unavailable
+        from pollypm.storage.state import StateStore
+
+        unavailable: set[str] = set()
+        accounts = getattr(config, "accounts", {}) or {}
+        with StateStore(state_db) as store:
+            for name in accounts:
+                runtime = store.get_account_runtime(name)
+                if runtime is not None and is_account_runtime_unavailable(runtime.status):
+                    unavailable.add(name)
+        return frozenset(unavailable)
+    except Exception:  # noqa: BLE001
+        logger.exception("worker launch: account-runtime filter failed; allowing all")
+        return frozenset()
 
 
 # ---------------------------------------------------------------------------
@@ -501,7 +540,7 @@ class SessionManager:
             # archival reads ambient env (legacy behaviour).
             return legacy_cmd, "claude", agent_name, None, None
 
-        from pollypm.models import SessionConfig
+        from pollypm.models import ProviderKind, SessionConfig
         from pollypm.onboarding import default_session_args
         from pollypm.providers import get_provider
         from pollypm.runtimes import get_runtime
@@ -517,22 +556,64 @@ class SessionManager:
                 f"Worker routing for project {project} resolved an unknown provider "
                 f"{routed_assignment.provider!r}: {exc}"
             ) from exc
+        # Per #1437: filter out accounts whose runtime status marks them
+        # unavailable (auth_broken / exhausted / provider_outage / blocked)
+        # before account selection. Without this, a heartbeat that just
+        # marked claude_main as ``auth_broken`` would still see the next
+        # per-task worker spawn pick claude_main, leaving the user wedged
+        # until manual ``pm reset``. Mirrors Supervisor._candidate_accounts.
+        unavailable_accounts = _unavailable_account_names(config)
+        # Thread configured failover accounts into the preference list so
+        # a healthy fallback wins selection once the primary is filtered.
+        pollypm_settings = getattr(config, "pollypm", None)
+        failover_accounts: list[str] = list(
+            getattr(pollypm_settings, "failover_accounts", []) or []
+        )
         preferred_names = [
             agent_name if agent_name in accounts else "",
-            getattr(getattr(config, "pollypm", None), "controller_account", ""),
+            getattr(pollypm_settings, "controller_account", ""),
+            *failover_accounts,
         ]
         if routed_assignment.source == "fallback":
             legacy_name = preferred_names[0] or preferred_names[1]
-            account_name = legacy_name
-            account = accounts.get(account_name)
+            account_name = (
+                legacy_name if legacy_name not in unavailable_accounts else ""
+            )
+            account = accounts.get(account_name) if account_name else None
+            if account is None:
+                # Walk failover accounts before resorting to first-available.
+                for candidate in failover_accounts:
+                    if candidate in accounts and candidate not in unavailable_accounts:
+                        account_name, account = candidate, accounts[candidate]
+                        break
             if account is None and accounts:
+                for candidate_name, candidate_account in accounts.items():
+                    if candidate_name in unavailable_accounts:
+                        continue
+                    account_name, account = candidate_name, candidate_account
+                    break
+            if account is None and accounts:
+                # All accounts are flagged unavailable — fall back to the
+                # first one rather than failing outright. The supervisor
+                # owns the authoritative recovery ladder; this stay-alive
+                # behaviour matches the pre-#1437 fallback semantics.
                 account_name, account = next(iter(accounts.items()))
         else:
             account_name, account = _first_matching_account(
                 accounts,
                 provider=routed_provider,
                 preferred_names=preferred_names,
+                excluded_names=unavailable_accounts,
             )
+            if account is None and accounts:
+                # Final fallback: ignore the unavailable filter so we
+                # still produce a launch bundle. The supervisor will
+                # observe the failure and run its own recovery ladder.
+                account_name, account = _first_matching_account(
+                    accounts,
+                    provider=routed_provider,
+                    preferred_names=preferred_names,
+                )
         if account is None:
             if accounts:
                 raise ProvisionError(
@@ -564,6 +645,20 @@ class SessionManager:
                 routed_assignment.source,
             )
 
+        session_args = default_session_args(
+            session_provider,
+            open_permissions=config.pollypm.open_permissions_by_default,
+            role="worker",
+            model=session_model,
+        )
+        if session_provider is ProviderKind.CODEX:
+            # Per-task workers run from ``.pollypm/worktrees/<task>``.
+            # Codex's workspace-write sandbox otherwise allows that
+            # worktree but rejects the parent project state directory
+            # that ``pm task done`` must update (#1437).
+            project_state_dir = (self._project_path / ".pollypm").resolve()
+            session_args = [*session_args, "--add-dir", str(project_state_dir)]
+
         session = SessionConfig(
             name=window_name,
             role="worker",
@@ -572,12 +667,7 @@ class SessionManager:
             cwd=worktree_path,
             project=project,
             window_name=window_name,
-            args=default_session_args(
-                session_provider,
-                open_permissions=config.pollypm.open_permissions_by_default,
-                role="worker",
-                model=session_model,
-            ),
+            args=session_args,
         )
         provider = get_provider(session_provider, root_dir=config.project.root_dir)
         runtime = get_runtime(account.runtime, root_dir=config.project.root_dir)

--- a/src/pollypm/workers.py
+++ b/src/pollypm/workers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import typer
 
+from pollypm.accounts import is_account_runtime_unavailable
 from pollypm.acct import detect_logged_in
 from pollypm.config import load_config, write_config
 from pollypm.onboarding import default_session_args
@@ -37,7 +38,11 @@ def _account_is_available(config_path: Path, account_name: str) -> bool:
         return False
     with StateStore(config.project.state_db) as store:
         runtime = store.get_account_runtime(account_name)
-    if runtime is not None and runtime.status in {"auth-broken", "exhausted", "provider_outage", "blocked"}:
+    # Accept both ``auth_broken`` (canonical, written by heartbeats/api.py
+    # and supervisor.py) and the legacy hyphenated ``auth-broken`` form
+    # so a runtime row written by either side correctly excludes the
+    # account from worker selection (#1437).
+    if runtime is not None and is_account_runtime_unavailable(runtime.status):
         return False
     return True
 

--- a/tests/test_heartbeat_plugin_api.py
+++ b/tests/test_heartbeat_plugin_api.py
@@ -946,6 +946,69 @@ def test_local_heartbeat_backend_marks_auth_broken() -> None:
     assert ("worker_pollypm", "auth_broken") in api.alerts
 
 
+def test_local_heartbeat_backend_marks_auth_broken_on_org_disabled() -> None:
+    # Regression: Claude Code prints "Your organization has disabled Claude
+    # subscription access for Claude Code · Use an Anthropic API key instead"
+    # when the account's org disables Claude Code. Heartbeat must classify
+    # this as auth_broken so the recovery ladder can fail over.
+    pane_text = (
+        "Your organization has disabled Claude subscription access for "
+        "Claude Code · Use an Anthropic API key instead, or ask your admin "
+        "to enable access"
+    )
+    api = FakeHeartbeatAPI([_context(transcript_delta=pane_text)])
+
+    LocalHeartbeatBackend().run(api)
+
+    assert api.statuses["worker_pollypm"][0] == "auth_broken"
+    assert ("worker_pollypm", "auth_broken") in api.alerts
+    assert api.account_marks == [
+        ("claude_controller", "claude", "live session reported authentication failure")
+    ]
+
+
+def test_local_heartbeat_backend_triggers_recovery_on_auth_broken() -> None:
+    """Regression for #1437 (Bug B): when a per-task worker hits an
+    auth-block, the heartbeat must call ``recover_session`` so the
+    recovery ladder relaunches the session on a healthy failover
+    account. Before the fix, the heartbeat marked the account
+    auth_broken and pinned the session status but never invoked
+    recovery — the wedged tmux window stayed up for hours until manual
+    ``pm reset``."""
+    api = FakeHeartbeatAPI(
+        [_context(transcript_delta="Authentication failure: please login again.")]
+    )
+
+    LocalHeartbeatBackend().run(api)
+
+    # Existing assertions (unchanged behaviour).
+    assert api.statuses["worker_pollypm"][0] == "auth_broken"
+    assert ("worker_pollypm", "auth_broken") in api.alerts
+    # New assertion: recovery_session must fire so the supervisor's
+    # ladder can pick a healthy failover account on relaunch.
+    assert any(
+        session == "worker_pollypm" and failure_type == "auth_broken"
+        for session, failure_type, _ in api.recoveries
+    ), f"expected auth_broken recovery in {api.recoveries!r}"
+
+
+def test_local_heartbeat_backend_triggers_recovery_on_org_disabled() -> None:
+    """Companion to the org-disabled marking test: the org-disabled
+    pane text must also drive ``recover_session`` end-to-end (#1437)."""
+    pane_text = (
+        "Your organization has disabled Claude subscription access for "
+        "Claude Code · Use an Anthropic API key instead"
+    )
+    api = FakeHeartbeatAPI([_context(transcript_delta=pane_text)])
+
+    LocalHeartbeatBackend().run(api)
+
+    assert any(
+        session == "worker_pollypm" and failure_type == "auth_broken"
+        for session, failure_type, _ in api.recoveries
+    ), f"expected auth_broken recovery in {api.recoveries!r}"
+
+
 def test_local_heartbeat_backend_raises_alert_for_unfinished_turn() -> None:
     """Heartbeat raises an alert for needs_followup but does NOT inject messages into operator chat."""
     api = FakeHeartbeatAPI([_context(transcript_delta="Implemented the parser. Next step: add coverage.")])

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -836,6 +836,8 @@ class TestProvisionWorker:
             "never",
             "--model",
             "gpt-5.4",
+            "--add-dir",
+            str((tmp_project / ".pollypm").resolve()),
         ]
 
     def test_provision_worker_aborts_when_prompt_write_fails(

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -897,6 +897,174 @@ class TestProvisionWorker:
         assert argv[1:] == []
 
 
+class TestWorkerLaunchBundleAccountFilter:
+    """Regression tests for #1437 (Bug B): per-task worker spawn must
+    skip accounts whose ``account_runtime.status`` marks them
+    auth_broken/exhausted/etc., or the relaunch after an auth-block
+    just lands back on the same wedged account."""
+
+    def _multi_account_config(
+        self, tmp_project: Path, *, primary_home: Path, fallback_home: Path
+    ) -> PollyPMConfig:
+        base_dir = tmp_project / ".pollypm"
+        base_dir.mkdir(parents=True, exist_ok=True)
+        return PollyPMConfig(
+            project=ProjectSettings(
+                name="Fixture",
+                root_dir=tmp_project,
+                tmux_session="pollypm",
+                base_dir=base_dir,
+                logs_dir=base_dir / "logs",
+                snapshots_dir=base_dir / "snapshots",
+                state_db=base_dir / "state.db",
+            ),
+            pollypm=PollyPMSettings(
+                controller_account="claude_main",
+                failover_accounts=["claude_backup"],
+                failover_enabled=True,
+            ),
+            accounts={
+                "claude_main": AccountConfig(
+                    name="claude_main",
+                    provider=ProviderKind.CLAUDE,
+                    runtime=RuntimeKind.LOCAL,
+                    home=primary_home,
+                ),
+                "claude_backup": AccountConfig(
+                    name="claude_backup",
+                    provider=ProviderKind.CLAUDE,
+                    runtime=RuntimeKind.LOCAL,
+                    home=fallback_home,
+                ),
+            },
+            sessions={},
+        )
+
+    def test_worker_launch_bundle_skips_auth_broken_primary(
+        self, mock_tmux, mock_svc, tmp_project, tmp_path,
+    ):
+        """When the primary account has runtime status ``auth_broken``
+        (the canonical underscore form supervisor + heartbeat writers
+        emit), ``_worker_launch_bundle`` must pick the configured
+        failover account instead. Pre-#1437 the primary was selected
+        unconditionally, so a heartbeat-marked auth break could not
+        clear without manual ``pm reset``."""
+        from pollypm.storage.state import StateStore
+
+        primary_home = tmp_path / "claude-main-home"
+        fallback_home = tmp_path / "claude-backup-home"
+        config = self._multi_account_config(
+            tmp_project, primary_home=primary_home, fallback_home=fallback_home,
+        )
+
+        # Mark the primary account auth_broken in the project state DB.
+        with StateStore(config.project.state_db) as store:
+            store.upsert_account_runtime(
+                account_name="claude_main",
+                provider=ProviderKind.CLAUDE.value,
+                status="auth_broken",
+                reason="live session reported authentication failure",
+            )
+
+        manager = SessionManager(
+            mock_tmux,
+            mock_svc,
+            tmp_project,
+            config=config,
+            session_service=MagicMock(),
+        )
+
+        worktree_path = tmp_project / ".pollypm" / "worktrees" / "proj-1"
+        worktree_path.mkdir(parents=True, exist_ok=True)
+        (
+            _command,
+            _provider_name,
+            account_name,
+            _fresh_marker,
+            _provider_home,
+        ) = manager._worker_launch_bundle(
+            worktree_path=worktree_path,
+            agent_name="claude_main",
+            window_name="task-proj-1",
+            project="proj",
+        )
+
+        assert account_name == "claude_backup", (
+            "Worker spawn must avoid the auth_broken primary and pick the "
+            f"failover; got {account_name!r}"
+        )
+
+    def test_worker_launch_bundle_accepts_legacy_hyphen_form(
+        self, mock_tmux, mock_svc, tmp_project, tmp_path,
+    ):
+        """Legacy rows (or UI writes) may still use ``"auth-broken"``
+        with a hyphen — the filter must skip them too."""
+        from pollypm.storage.state import StateStore
+
+        primary_home = tmp_path / "claude-main-home"
+        fallback_home = tmp_path / "claude-backup-home"
+        config = self._multi_account_config(
+            tmp_project, primary_home=primary_home, fallback_home=fallback_home,
+        )
+
+        with StateStore(config.project.state_db) as store:
+            store.upsert_account_runtime(
+                account_name="claude_main",
+                provider=ProviderKind.CLAUDE.value,
+                status="auth-broken",
+                reason="legacy hyphen form",
+            )
+
+        manager = SessionManager(
+            mock_tmux,
+            mock_svc,
+            tmp_project,
+            config=config,
+            session_service=MagicMock(),
+        )
+
+        worktree_path = tmp_project / ".pollypm" / "worktrees" / "proj-1"
+        worktree_path.mkdir(parents=True, exist_ok=True)
+        (_cmd, _prov, account_name, _fresh, _home) = manager._worker_launch_bundle(
+            worktree_path=worktree_path,
+            agent_name="claude_main",
+            window_name="task-proj-1",
+            project="proj",
+        )
+
+        assert account_name == "claude_backup"
+
+    def test_worker_launch_bundle_keeps_healthy_primary(
+        self, mock_tmux, mock_svc, tmp_project, tmp_path,
+    ):
+        """Sanity check: when no account is marked auth_broken, the
+        existing preference order still wins (primary keeps the slot)."""
+        primary_home = tmp_path / "claude-main-home"
+        fallback_home = tmp_path / "claude-backup-home"
+        config = self._multi_account_config(
+            tmp_project, primary_home=primary_home, fallback_home=fallback_home,
+        )
+
+        manager = SessionManager(
+            mock_tmux,
+            mock_svc,
+            tmp_project,
+            config=config,
+            session_service=MagicMock(),
+        )
+
+        worktree_path = tmp_project / ".pollypm" / "worktrees" / "proj-1"
+        worktree_path.mkdir(parents=True, exist_ok=True)
+        (_cmd, _prov, account_name, _fresh, _home) = manager._worker_launch_bundle(
+            worktree_path=worktree_path,
+            agent_name="claude_main",
+            window_name="task-proj-1",
+            project="proj",
+        )
+
+        assert account_name == "claude_main"
+
+
 # ---------------------------------------------------------------------------
 # Teardown tests
 # ---------------------------------------------------------------------------

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -136,6 +136,31 @@ def test_auto_select_worker_skips_runtime_unhealthy_account(tmp_path: Path, monk
     assert selected == "claude_worker"
 
 
+def test_auto_select_worker_skips_runtime_unhealthy_account_underscore_form(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Regression for #1437: writers in heartbeats/api.py and supervisor.py
+    persist ``status="auth_broken"`` (underscore). The account-runtime
+    reader must accept the canonical underscore form so per-task workers
+    skip the wedged account during selection. Before the fix, the reader
+    only matched the hyphenated form and silently let the wedged account
+    through, producing the savethenovel/15 wedge."""
+    config, config_path = _config(tmp_path)
+    store = StateStore(config.project.state_db)
+    store.upsert_account_runtime(
+        account_name="codex_backup",
+        provider=ProviderKind.CODEX.value,
+        status="auth_broken",
+        reason="live session reported authentication failure",
+    )
+
+    monkeypatch.setattr("pollypm.workers.detect_logged_in", lambda account: True)
+
+    selected = auto_select_worker_account(config_path)
+
+    assert selected == "claude_worker"
+
+
 def test_auto_select_worker_uses_control_plane_account_before_controller_last_resort(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

Closes the `auth_broken → failover` loop for per-task workers — the chain was broken in four places. /15 sat wedged for 4 hours today on a Claude org-disabled error before manual `pm reset` cleared it.

## What was broken (live diagnosis from today)

1. **Pattern detection gap.** `_AUTH_FAILURE_PATTERNS` in `heartbeats/local.py` didn't match Claude Code's "Your organization has disabled Claude subscription access" / "Use an Anthropic API key instead" — only caught `authentication failure` / `login required` / etc. Heartbeat saw the wedged pane and classified as idle, never as auth_broken.
2. **Heartbeat detected but never recovered.** `heartbeats/local.py:983-1012` emitted the alert, marked the account, set session status — but never called `self._recover_session(failure_type="auth_broken")`. Compare to `pane_dead` (line 769) and `missing_window` (line 735) which DO. Recovery ladder never fired.
3. **`_worker_launch_bundle` re-picked the dead account.** Even on respawn, `_first_matching_account` didn't consult `account_runtime.status` or `failover_accounts` from `pollypm.toml`. So a fresh worker would pick the same auth-broken Claude account.
4. **String mismatch smoking gun.** Writers store `"auth_broken"` (underscore — `heartbeats/api.py:203`, `supervisor.py:3088`); readers in `workers.py:40`, `accounts.py:164`, `capacity.py:29` checked `"auth-broken"` (hyphen). They never matched, so existing dead-account-skip code was silently dead.

## What this PR does

- **Fix #4 — Canonicalize tolerantly.** Adds `is_account_status_unhealthy` / `is_account_runtime_unavailable` helpers in `accounts.py` that handle both underscore and hyphen forms. `workers.py` uses them. Left `CapacityState.AUTH_BROKEN` enum as hyphen because `account_usage.health` is canonically hyphen and changing the enum would ValueError-fall-through `_health_to_state` and break `test_capacity` assertions.
- **Fix #3 — Filter at spawn.** `_first_matching_account` accepts `excluded_names`; new `_unavailable_account_names()` reads `account_runtime` from the project state DB (mirrors `Supervisor._account_is_viable`). `_worker_launch_bundle` threads `failover_accounts` from config and excludes auth_broken / exhausted / provider_outage / blocked accounts in both routed-provider and legacy-fallback paths.
- **Fix #1 — Trigger recovery.** Heartbeat now calls `self._recover_session(failure_type="auth_broken")` after the existing alert/mark/status block (mirrors `pane_dead` / `missing_window` paths).
- **Pattern additions.** `_AUTH_FAILURE_PATTERNS` gains `"disabled claude subscription"` and `"use an anthropic api key"`.

## Closes

#1444 (worker alive-but-auth-blocked detector + recovery).

## Conflict notes

This PR's changes to `session_manager.py` were merged with PR #1450's `--add-dir` change via `git apply --3way`. Both edits are in `_worker_launch_bundle` but on different lines and clean to coexist.

## Test plan

- [x] `test_local_heartbeat_backend_marks_auth_broken_on_org_disabled` — pattern regression
- [x] `test_local_heartbeat_backend_triggers_recovery_on_auth_broken` — end-to-end chain
- [x] `TestWorkerLaunchBundleAccountFilter` — 3 cases (skip auth-broken primary, accept legacy hyphen, keep healthy)
- [x] `test_auto_select_worker_skips_runtime_unhealthy_account_underscore_form` — string-mismatch regression
- [x] Targeted suite: 36+3+206 tests pass; broad sweep 442 pass; one cockpit_enter test fails order-dependent only (pre-existing flake unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)