### PR TITLE
Fix #1436 orphan marker age threshold

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -20,11 +20,11 @@ no new alert channel is introduced).
 Detection rules (each returns a list of :class:`Finding`):
 
 1. ``orphan_marker`` — ``marker.created`` for ``task-<project>-<N>``
-   with no matching ``marker.released`` within the window AND no
-   ``task.status_changed`` to a terminal state (``done`` / ``cancelled``
-   / ``abandoned``) in that window. Catches the savethenovel pattern
-   where a worker is launched and the task is then cancelled but the
-   on-disk marker lingers.
+   older than the configured threshold with no matching
+   ``marker.released`` AND no ``task.status_changed`` to a terminal
+   state (``done`` / ``cancelled`` / ``abandoned``). Catches the
+   savethenovel pattern where a worker is launched and the task is
+   then cancelled but the on-disk marker lingers.
 2. ``marker_leaked`` — any ``marker.leaked`` event in the window.
    Each occurrence is a finding because the persona-swap-detected
    branch firing at all means a worker was redirected — we want
@@ -186,11 +186,12 @@ class WatchdogConfig:
     """Tunable thresholds for watchdog detection rules.
 
     All durations are in seconds. Defaults match the spec in the
-    task brief — 30 min lookback for orphan/leak rules, 5 min for
-    the cheaper draft / cancellation gates.
+    task brief — 30 min orphan age threshold / leak lookback, 5 min
+    for the cheaper draft / cancellation gates.
     """
 
-    # Lookback for orphan-marker + leak detection.
+    # Age threshold for orphan-marker detection, and lookback for
+    # marker-leak detection.
     window_seconds: int = 1800
     # A draft must have existed this long with no promotion before
     # it counts as stuck. Short enough to catch the savethenovel
@@ -344,24 +345,26 @@ def _detect_orphan_markers(
     """Rule 1: ``marker.created`` with no release + no terminal transition.
 
     Walks the windowed event list once. For each ``marker.created``
-    we extract the (project, task_number) and check whether either
-    a ``marker.released`` for the same marker subject *or* a
-    ``task.status_changed`` to a terminal state for the same task
-    appears later in the window. If neither, it's an orphan.
+    older than ``window_seconds`` we extract the (project, task_number)
+    and check whether either a ``marker.released`` for the same marker
+    subject *or* a ``task.status_changed`` to a terminal state for the
+    same task appears in the scanned range. If neither, it's an orphan.
     """
     findings: list[Finding] = []
     cutoff = now - timedelta(seconds=config.window_seconds)
 
-    # Collect created markers within the window.
+    # Collect created markers that have crossed the orphan threshold.
     created: list[tuple[AuditEvent, tuple[str, int]]] = []
     released_subjects: set[str] = set()
     terminal_tasks: set[tuple[str, int]] = set()
 
     for ev in events:
         ts = _parse_iso(ev.ts)
-        if ts is None or ts < cutoff:
+        if ts is None:
             continue
         if ev.event == EVENT_MARKER_CREATED and ev.status == "ok":
+            if ts > cutoff:
+                continue
             key = _marker_task_key(ev.subject)
             if key is not None:
                 created.append((ev, key))

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -88,13 +88,13 @@ def _make_event(
 
 
 def test_orphan_marker_detected_when_no_release_or_terminal(now: datetime) -> None:
-    """A marker.created with neither release nor terminal transition fires."""
+    """An old marker.created with neither release nor terminal transition fires."""
     events = [
         _make_event(
             event=EVENT_MARKER_CREATED,
             project="demo",
             subject="/proj/demo/.pollypm/worker-markers/task-demo-1.fresh",
-            ts=now - timedelta(minutes=20),
+            ts=now - timedelta(minutes=40),
         ),
     ]
     findings = scan_events(events, now=now)
@@ -106,12 +106,36 @@ def test_orphan_marker_detected_when_no_release_or_terminal(now: datetime) -> No
     assert "pm task cancel demo/1" in orphans[0].recommendation
 
 
+def test_orphan_marker_recent_marker_ignored_even_when_task_is_old(
+    now: datetime,
+) -> None:
+    """Regression #1436: threshold age is marker age, not task age."""
+    marker = "/proj/demo/.pollypm/worker-markers/task-demo-1.fresh"
+    events = [
+        _make_event(
+            event=EVENT_TASK_CREATED,
+            subject="demo/1",
+            ts=now - timedelta(hours=6),
+        ),
+        _make_event(
+            event=EVENT_MARKER_CREATED,
+            subject=marker,
+            ts=now - timedelta(minutes=4),
+        ),
+    ]
+    findings = [
+        f for f in scan_events(events, now=now)
+        if f.rule == RULE_ORPHAN_MARKER
+    ]
+    assert findings == []
+
+
 def test_orphan_marker_silenced_by_release(now: datetime) -> None:
     marker = "/proj/demo/.pollypm/worker-markers/task-demo-1.fresh"
     events = [
         _make_event(
             event=EVENT_MARKER_CREATED, subject=marker,
-            ts=now - timedelta(minutes=20),
+            ts=now - timedelta(minutes=40),
         ),
         _make_event(
             event=EVENT_MARKER_RELEASED, subject=marker,
@@ -128,7 +152,7 @@ def test_orphan_marker_silenced_by_terminal_transition(now: datetime) -> None:
     events = [
         _make_event(
             event=EVENT_MARKER_CREATED, subject=marker,
-            ts=now - timedelta(minutes=25),
+            ts=now - timedelta(minutes=40),
         ),
         _make_event(
             event=EVENT_TASK_STATUS_CHANGED,
@@ -141,13 +165,13 @@ def test_orphan_marker_silenced_by_terminal_transition(now: datetime) -> None:
     assert findings == []
 
 
-def test_orphan_marker_outside_window_ignored(now: datetime) -> None:
+def test_orphan_marker_within_threshold_ignored(now: datetime) -> None:
     config = WatchdogConfig(window_seconds=600)
     marker = "/proj/demo/.pollypm/worker-markers/task-demo-1.fresh"
     events = [
         _make_event(
             event=EVENT_MARKER_CREATED, subject=marker,
-            ts=now - timedelta(hours=2),
+            ts=now - timedelta(minutes=9),
         ),
     ]
     findings = scan_events(events, now=now, config=config)
@@ -383,12 +407,12 @@ def test_scan_project_against_synthetic_log(now: datetime, tmp_path: Path) -> No
     Exercises the central-tail read path the cadence handler will use
     in production.
     """
-    # Older orphan marker event (within 30 min window).
-    old_ts = now - timedelta(minutes=20)
+    # Older orphan marker event (past the 30 min threshold).
+    old_ts = now - timedelta(minutes=40)
     # Use the writer with a manual ts bypass — emit() stamps "now",
     # so we shape the event by writing JSON directly to the central
     # tail. This mirrors what an in-process producer would have
-    # written 20 minutes ago.
+    # written 40 minutes ago.
     central = central_log_path("savethenovel")
     central.parent.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -471,7 +495,7 @@ def test_cadence_handler_routes_finding_to_alert_sink(now: datetime) -> None:
     central.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "schema": 1,
-        "ts": (now - timedelta(minutes=20)).isoformat(),
+        "ts": (now - timedelta(minutes=40)).isoformat(),
         "project": "demo",
         "event": EVENT_MARKER_CREATED,
         "subject": "/x/demo/.pollypm/worker-markers/task-demo-1.fresh",
@@ -1105,7 +1129,7 @@ def test_cadence_handler_skips_dispatch_for_legacy_rules(
     central.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "schema": 1,
-        "ts": (now - timedelta(minutes=20)).isoformat(),
+        "ts": (now - timedelta(minutes=40)).isoformat(),
         "project": "demo",
         "event": EVENT_MARKER_CREATED,
         "subject": "/x/demo/.pollypm/worker-markers/task-demo-1.fresh",


### PR DESCRIPTION
Closes #1436

Updates orphan_marker so the 30 minute threshold is evaluated against marker.created age instead of treating fresh marker.created events inside the scan window as already orphaned. The regression test covers an old task with a fresh marker to prevent false positives on active work.

Self-audit: touched only the audit watchdog detector and its focused tests; no layer-boundary changes.