### PR TITLE
Refs #1363 stop core importing plan presence plugin

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -1763,7 +1763,7 @@ class CockpitRouter:
         db_path = project_path / ".pollypm" / "state.db"
         if not db_path.exists():
             return [], False
-        from pollypm.plugins_builtin.project_planning.plan_presence import has_acceptable_plan
+        from pollypm.plan_presence import has_acceptable_plan
         from pollypm.work import create_work_service
         from pollypm.work.project_aliases import project_storage_aliases
 

--- a/src/pollypm/cockpit_tasks.py
+++ b/src/pollypm/cockpit_tasks.py
@@ -43,7 +43,7 @@ from pollypm.cockpit_task_review import (
 from pollypm.cockpit_formatting import format_event_time
 from pollypm.cockpit_formatting import format_relative_age as _format_relative_age
 from pollypm.config import load_config, project_config_path
-from pollypm.plugins_builtin.project_planning.plan_presence import (
+from pollypm.plan_presence import (
     plan_approval_task,
     plan_blocked_task_ids,
 )

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -106,7 +106,7 @@ from pollypm.cockpit_palette import (  # noqa: F401  (re-exported)
 from pollypm.cockpit_project_settings import PollyProjectSettingsApp  # noqa: F401
 from pollypm.cockpit_sections.action_bar import render_project_action_bar
 from pollypm.cockpit_settings_accounts import SETTINGS_ACCOUNT_ACTIONS
-from pollypm.plugins_builtin.project_planning.plan_presence import (
+from pollypm.plan_presence import (
     CANONICAL_PLAN_RELATIVE_PATHS as _PLAN_FILE_CANDIDATES,
 )
 from pollypm.cockpit_settings_history import (
@@ -11957,7 +11957,7 @@ def _dashboard_plan_staleness(
         _PLAN_STALENESS_CACHE.move_to_end(cache_key)
         return _PLAN_STALENESS_CACHE[cache_key]
     try:
-        from pollypm.plugins_builtin.project_planning.plan_presence import (
+        from pollypm.plan_presence import (
             _find_approved_plan_task,
             _plan_approved_at,
         )

--- a/src/pollypm/plan_refinement.py
+++ b/src/pollypm/plan_refinement.py
@@ -338,7 +338,7 @@ def _resolve_plan_path(project_path: Path) -> Path:
        the architect's revision lands somewhere the inline-render path
        (#1397) will pick up.
 
-    Mirrors :data:`pollypm.plugins_builtin.project_planning.plan_presence.CANONICAL_PLAN_RELATIVE_PATHS`
+    Mirrors :data:`pollypm.plan_presence.CANONICAL_PLAN_RELATIVE_PATHS`
     so both reads + writes follow the same path resolution.
     """
 

--- a/src/pollypm/recovery/state_reconciliation.py
+++ b/src/pollypm/recovery/state_reconciliation.py
@@ -59,6 +59,10 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from pollypm.plan_presence import (
+    CANONICAL_PLAN_RELATIVE_PATHS as _PLAN_FILE_CANDIDATES,
+)
+
 
 # Minimum non-whitespace byte count before a plan file counts as a
 # real plan. Mirrors ``plan_presence.MIN_PLAN_SIZE_BYTES`` so the two
@@ -68,11 +72,8 @@ MIN_PLAN_SIZE_BYTES = 500
 # Candidate plan-file locations scanned in order. The first match wins.
 # Shared with the plan-presence gate, the advisor context pack, and
 # the cockpit plan-review widget — see
-# :data:`pollypm.plugins_builtin.project_planning.plan_presence.CANONICAL_PLAN_RELATIVE_PATHS`
+# :data:`pollypm.plan_presence.CANONICAL_PLAN_RELATIVE_PATHS`
 # for the authoritative tuple.
-from pollypm.plugins_builtin.project_planning.plan_presence import (
-    CANONICAL_PLAN_RELATIVE_PATHS as _PLAN_FILE_CANDIDATES,
-)
 
 # Window for matching a "plan ready" notify against the current sweep.
 # 1h is generous — the architect's turn might have ended anywhere from

--- a/tests/test_dashboard_plan_staleness_cache.py
+++ b/tests/test_dashboard_plan_staleness_cache.py
@@ -67,10 +67,10 @@ def test_cache_avoids_reopening_workservice_on_repeat_call(tmp_path: Path) -> No
     with patch(
         "pollypm.work.sqlite_service.SQLiteWorkService", _FakeSvc,
     ), patch(
-        "pollypm.plugins_builtin.project_planning.plan_presence._find_approved_plan_task",
+        "pollypm.plan_presence._find_approved_plan_task",
         lambda _svc, _key: fake_plan_task,
     ), patch(
-        "pollypm.plugins_builtin.project_planning.plan_presence._plan_approved_at",
+        "pollypm.plan_presence._plan_approved_at",
         lambda _svc, _task: 1_700_000_000.0,
     ):
         first = _dashboard_plan_staleness(plan, plan_mtime, project, "demo")
@@ -106,10 +106,10 @@ def test_cache_invalidates_when_db_mtime_changes(tmp_path: Path) -> None:
     with patch(
         "pollypm.work.sqlite_service.SQLiteWorkService", _FakeSvc,
     ), patch(
-        "pollypm.plugins_builtin.project_planning.plan_presence._find_approved_plan_task",
+        "pollypm.plan_presence._find_approved_plan_task",
         lambda _svc, _key: fake_plan_task,
     ), patch(
-        "pollypm.plugins_builtin.project_planning.plan_presence._plan_approved_at",
+        "pollypm.plan_presence._plan_approved_at",
         lambda _svc, _task: 1_700_000_000.0,
     ):
         _dashboard_plan_staleness(plan, plan_mtime, project, "demo")

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -39,6 +39,7 @@ this unavoidable?" before merging.
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -157,6 +158,40 @@ def _is_private_conn_owner(rel: str) -> bool:
     if rel in _PRIVATE_CONN_ALLOWLIST:
         return True
     return any(rel.startswith(prefix) for prefix in _PRIVATE_CONN_OWNING_PREFIXES)
+
+
+# ---------------------------------------------------------------------------
+# Core -> built-in plugin import slices
+# ---------------------------------------------------------------------------
+
+_PLAN_PRESENCE_PLUGIN_MODULE = (
+    "pollypm.plugins_builtin.project_planning.plan_presence"
+)
+
+
+def _imports_module(source_file: Path, module: str) -> bool:
+    tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == module:
+            return True
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == module or alias.name.startswith(f"{module}."):
+                    return True
+    return False
+
+
+def test_non_plugin_sources_do_not_import_project_planning_plan_presence() -> None:
+    """The shared plan gate lives in core, not in the optional plugin tree."""
+    root = _project_root()
+    offenders: list[str] = []
+    for source_file in _iter_source_files(root):
+        rel = _relative_posix(source_file, root)
+        if "/plugins_builtin/" in rel:
+            continue
+        if _imports_module(source_file, _PLAN_PRESENCE_PLUGIN_MODULE):
+            offenders.append(rel)
+    assert offenders == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #1363

Moves the remaining non-plugin/core callers of the plan-presence gate to the shared pollypm.plan_presence module that is now on main. The project_planning plugin shim remains only for compatibility, while cockpit/recovery callers and dashboard tests now patch the core module directly.

Layer self-audit: touched cockpit UI/rail surfaces, recovery reconciliation, and tests only to remove imports from the optional plugin tree. No store access was added and no plugin-private API imports were introduced.

Checks:
- uv run pytest tests/test_import_boundary.py tests/test_plan_presence_gate.py tests/test_dashboard_plan_staleness_cache.py
- uv run ruff check src/pollypm/cockpit_rail.py src/pollypm/cockpit_tasks.py src/pollypm/cockpit_ui.py src/pollypm/plan_refinement.py src/pollypm/recovery/state_reconciliation.py tests/test_dashboard_plan_staleness_cache.py tests/test_import_boundary.py
- git diff --check
- Mandatory open-PR overlap check returned []

Note: full uv run ruff check still fails on pre-existing repo-wide lint debt unrelated to this slice.