### PR TITLE
Refs #1354 Extract cockpit pane app

### DIFF
--- a/src/pollypm/cockpit_apps/__init__.py
+++ b/src/pollypm/cockpit_apps/__init__.py
@@ -1,0 +1,5 @@
+"""Focused Textual app modules extracted from ``cockpit_ui``."""
+
+from pollypm.cockpit_apps.pane import PollyCockpitPaneApp
+
+__all__ = ["PollyCockpitPaneApp"]

--- a/src/pollypm/cockpit_apps/pane.py
+++ b/src/pollypm/cockpit_apps/pane.py
@@ -1,0 +1,64 @@
+"""Fallback cockpit pane Textual app."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from pollypm.cockpit import build_cockpit_detail
+
+
+class PollyCockpitPaneApp(App[None]):
+    TITLE = "PollyPM"
+    SUB_TITLE = "Pane"
+    CSS = """
+    Screen {
+        background: #10161b;
+        color: #eef2f4;
+        padding: 1;
+    }
+    #body {
+        border: round #253140;
+        background: #111820;
+        padding: 1 2;
+    }
+    """
+
+    def __init__(self, config_path: Path, kind: str, target: str | None = None) -> None:
+        super().__init__()
+        self.config_path = config_path
+        self.kind = kind
+        self.target = target
+        self.body = Static("", id="body")
+
+    def compose(self) -> ComposeResult:
+        yield self.body
+
+    def on_mount(self) -> None:
+        self._refresh()
+        self.set_interval(5, self._refresh)
+        # #1109 follow-up: TTY-less keystroke bridge.
+        try:
+            from pollypm.cockpit_input_bridge import start_input_bridge
+
+            bridge_kind = f"pane-{self.kind}"
+            self._input_bridge_handle = start_input_bridge(
+                self,
+                kind=bridge_kind,
+                config_path=self.config_path,
+            )
+        except Exception:  # noqa: BLE001
+            self._input_bridge_handle = None
+
+    def on_unmount(self) -> None:
+        bridge = getattr(self, "_input_bridge_handle", None)
+        if bridge is not None:
+            try:
+                bridge.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def _refresh(self) -> None:
+        self.body.update(build_cockpit_detail(self.config_path, self.kind, self.target))

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -66,6 +66,7 @@ from pollypm.cockpit_activity import (  # noqa: F401  (re-exported)
     _activity_type_colour,
 )
 from pollypm.cockpit_alerts import _action_view_alerts
+from pollypm.cockpit_apps.pane import PollyCockpitPaneApp  # noqa: F401
 from pollypm.cockpit_inbox import (
     InboxThreadRow,
     build_inbox_thread_rows,
@@ -136,7 +137,6 @@ from pollypm.rejection_feedback import (
 # parameter annotations below (``service: PollyPMService | None``).
 if TYPE_CHECKING:
     from pollypm.service_api import PollyPMService  # noqa: F401
-from pollypm.cockpit import build_cockpit_detail
 from pollypm.cockpit_navigation import (
     InMemoryNavigationStateStore,
     NavigationCommand,
@@ -3709,57 +3709,6 @@ class PollyDashboardApp(App[None]):
             self.config_path,
             client_id="polly-dashboard",
         ).jump_to_inbox()
-
-
-class PollyCockpitPaneApp(App[None]):
-    TITLE = "PollyPM"
-    SUB_TITLE = "Pane"
-    CSS = """
-    Screen {
-        background: #10161b;
-        color: #eef2f4;
-        padding: 1;
-    }
-    #body {
-        border: round #253140;
-        background: #111820;
-        padding: 1 2;
-    }
-    """
-
-    def __init__(self, config_path: Path, kind: str, target: str | None = None) -> None:
-        super().__init__()
-        self.config_path = config_path
-        self.kind = kind
-        self.target = target
-        self.body = Static("", id="body")
-
-    def compose(self) -> ComposeResult:
-        yield self.body
-
-    def on_mount(self) -> None:
-        self._refresh()
-        self.set_interval(5, self._refresh)
-        # #1109 follow-up — TTY-less keystroke bridge.
-        try:
-            from pollypm.cockpit_input_bridge import start_input_bridge
-            bridge_kind = f"pane-{self.kind}"
-            self._input_bridge_handle = start_input_bridge(
-                self, kind=bridge_kind, config_path=self.config_path,
-            )
-        except Exception:  # noqa: BLE001
-            self._input_bridge_handle = None
-
-    def on_unmount(self) -> None:
-        bridge = getattr(self, "_input_bridge_handle", None)
-        if bridge is not None:
-            try:
-                bridge.stop()
-            except Exception:  # noqa: BLE001
-                pass
-
-    def _refresh(self) -> None:
-        self.body.update(build_cockpit_detail(self.config_path, self.kind, self.target))
 
 
 # Re-export the extracted task screen so existing import paths keep working.

--- a/tests/test_cockpit_pane_app.py
+++ b/tests/test_cockpit_pane_app.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+
+def test_cockpit_ui_reexports_pane_app() -> None:
+    from pollypm.cockpit_apps.pane import PollyCockpitPaneApp as DirectPaneApp
+    from pollypm.cockpit_ui import PollyCockpitPaneApp as CompatPaneApp
+
+    assert CompatPaneApp is DirectPaneApp
+
+
+def test_pane_app_refresh_uses_cockpit_detail(monkeypatch, tmp_path: Path) -> None:
+    from pollypm.cockpit_apps import pane
+
+    config_path = tmp_path / "pollypm.toml"
+    calls: list[tuple[Path, str, str | None]] = []
+
+    def fake_build_cockpit_detail(
+        actual_config_path: Path,
+        kind: str,
+        target: str | None,
+    ) -> str:
+        calls.append((actual_config_path, kind, target))
+        return "pane content"
+
+    monkeypatch.setattr(pane, "build_cockpit_detail", fake_build_cockpit_detail)
+
+    app = pane.PollyCockpitPaneApp(config_path, "dashboard", "demo")
+    app._refresh()
+
+    assert calls == [(config_path, "dashboard", "demo")]
+    assert app.body.content == "pane content"


### PR DESCRIPTION
Refs #1354

Extracts the fallback cockpit pane Textual app into `pollypm.cockpit_apps.pane` and keeps `pollypm.cockpit_ui.PollyCockpitPaneApp` as a compatibility re-export. This is one low-risk slice of the cockpit_ui god-module breakup; the remaining app classes and shared helpers still need follow-up extraction.

Layer self-audit: UI-only change. The new app module depends on Textual and the existing public `build_cockpit_detail` helper; it does not add store/sqlite/sqlalchemy imports or new cross-layer reach-through.

Checks run:
- `uv run --extra dev pytest tests/test_cockpit_pane_app.py tests/test_import_boundary.py`
- `uv run --extra dev ruff check src/pollypm/cockpit_ui.py src/pollypm/cockpit_apps tests/test_cockpit_pane_app.py`

Note: the broader cockpit contract check currently fails on existing `origin/main` tmux allowlist drift in `src/pollypm/cli_features/ui.py`, `src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py`, and `src/pollypm/work/worker_marker_reaper.py`; this PR does not touch those files.