### PR TITLE
Fix #1481 ignore terminal backlog tasks

### DIFF
--- a/src/pollypm/plan_presence.py
+++ b/src/pollypm/plan_presence.py
@@ -324,6 +324,10 @@ def _latest_backlog_created_at(work_service: Any, project_key: str) -> float | N
     excluded so the planner's own task doesn't count as "backlog" for
     the purpose of the staleness check.
 
+    Terminal implementation tasks are also excluded. Done and cancelled
+    rows no longer represent active backlog, so their timestamps must
+    not make an approved plan look stale.
+
     Tasks that are **children of an approved plan_project task** are
     also excluded. These are the architect's own emit output — they
     exist *because of* the plan, so the fact that they're newer than
@@ -360,6 +364,11 @@ def _latest_backlog_created_at(work_service: Any, project_key: str) -> float | N
         if flow_id in _PLANNING_FLOWS:
             continue
         if flow_id in _NON_BACKLOG_FLOWS:
+            continue
+        status = getattr(getattr(task, "work_status", None), "value", None) or str(
+            getattr(task, "work_status", "") or ""
+        )
+        if status in {WorkStatus.DONE.value, WorkStatus.CANCELLED.value}:
             continue
         labels = set(getattr(task, "labels", None) or [])
         if labels & _NON_BACKLOG_LABELS:

--- a/tests/test_plan_presence_gate.py
+++ b/tests/test_plan_presence_gate.py
@@ -648,6 +648,42 @@ class TestPlanApprovedAtTimestamp:
         finally:
             work.close()
 
+    def test_gate_ignores_terminal_tasks_newer_than_plan_approval(self, tmp_path):
+        """Done/cancelled rows do not represent active backlog drift."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        _write_plan(proj)
+
+        stale = datetime.now(timezone.utc) - timedelta(hours=1)
+        _create_done_approved_plan_task(
+            proj, project_key="proj", approved_at=stale,
+        )
+        done_task_id = _create_queued_impl_task(
+            proj, project_key="proj", title="Already done",
+        )
+        cancelled_task_id = _create_queued_impl_task(
+            proj, project_key="proj", title="Cancelled spam",
+        )
+
+        db_path = proj / ".pollypm" / "state.db"
+        work = SQLiteWorkService(db_path=db_path, project_path=proj)
+        try:
+            for task_id, status in (
+                (done_task_id, WorkStatus.DONE.value),
+                (cancelled_task_id, WorkStatus.CANCELLED.value),
+            ):
+                project, number = task_id.rsplit("/", 1)
+                work._conn.execute(
+                    "UPDATE work_tasks SET work_status = ? "
+                    "WHERE project = ? AND task_number = ?",
+                    (status, project, int(number)),
+                )
+            work._conn.commit()
+
+            assert has_acceptable_plan("proj", proj, work) is True
+        finally:
+            work.close()
+
     def test_gate_falls_back_to_execution_completed_at_for_prefix_projects(
         self, tmp_path,
     ):


### PR DESCRIPTION
Closes #1481

Summary:
- Excludes done and cancelled tasks from the plan gate's latest-backlog staleness scan.
- Adds regression coverage for terminal tasks created after plan approval so they do not close the gate.

Layer audit:
- Domain-only change in the shared plan-presence predicate plus domain-level regression test.
- No UI, facade, store, or cross-layer imports added.