### PR TITLE
Refs #1376 route work-task sqlite reads

### DIFF
--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -592,38 +592,12 @@ def _user_waiting_task_ids_across_projects(
     """Return ``project/N`` ids for every task in a user-waiting state
     across every tracked project.
 
-    Reads each project's ``state.db`` directly (read-only sqlite) so
-    we don't pay the work-service hydration cost just to filter
-    alerts. Used to suppress ``stuck_on_task:<id>`` alerts that are
-    already covered by the project's user-waiting status.
+    Used to suppress ``stuck_on_task:<id>`` alerts that are already
+    covered by the project's user-waiting status.
     """
-    import sqlite3 as _sqlite3
+    from pollypm.work.task_state import user_waiting_task_ids
 
-    out: set[str] = set()
-    for project_key, project in getattr(config, "projects", {}).items():
-        # Same tracked-only invariant as _count_inbox_tasks (cycle 86)
-        # and _pending_inbox_section (cycle 85).
-        if not getattr(project, "tracked", False):
-            continue
-        db_path = project.path / ".pollypm" / "state.db"
-        if not db_path.exists():
-            continue
-        try:
-            conn = _sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-            try:
-                rows = conn.execute(
-                    "SELECT task_number FROM work_tasks "
-                    "WHERE project = ? "
-                    "AND work_status IN ('blocked','on_hold','waiting_on_user')",
-                    (project_key,),
-                ).fetchall()
-            finally:
-                conn.close()
-        except (_sqlite3.Error, OSError):
-            continue
-        for (number,) in rows:
-            out.add(f"{project_key}/{number}")
-    return frozenset(out)
+    return user_waiting_task_ids(config)
 
 
 def _stuck_alert_already_user_waiting(

--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -227,11 +227,10 @@ def _has_work_tasks(
 ) -> bool:
     """Return True iff *this* project's DB has ≥1 work_tasks row.
 
-    Reads the sqlite table directly — ``SQLiteWorkService`` is a heavier
-    entrypoint and this path runs on the happy path for every
-    ``pm project new`` invocation, so we keep it lean. Fails closed:
-    any DB / IO error returns False so we don't accidentally flag a
-    greenfield project as existing on a transient error.
+    The storage-layer probe keeps this lightweight without exposing raw
+    SQLite handles or work-task schema details to the plugin CLI. Fails
+    closed: any DB / IO error returns False so we don't accidentally
+    flag a greenfield project as existing on a transient error.
 
     Post-#339 the workspace-scope DB holds tasks for *every* registered
     project — so counting "any row in the workspace DB" for an unkeyed
@@ -248,28 +247,9 @@ def _has_work_tasks(
     if not db_path.exists():
         return False
     try:
-        import sqlite3
+        from pollypm.work.task_state import has_work_tasks_in_db
 
-        from pollypm.storage.sqlite_pragmas import apply_workspace_pragmas
-
-        with sqlite3.connect(str(db_path)) as conn:
-            # #1018 — short busy_timeout so a planner probe doesn't
-            # race the heartbeat writer holding the same workspace DB.
-            apply_workspace_pragmas(conn)
-            cur = conn.execute(
-                "SELECT 1 FROM sqlite_master WHERE type='table' "
-                "AND name='work_tasks' LIMIT 1"
-            )
-            if cur.fetchone() is None:
-                return False
-            if project_key:
-                cur = conn.execute(
-                    "SELECT 1 FROM work_tasks WHERE project = ? LIMIT 1",
-                    (project_key,),
-                )
-            else:
-                cur = conn.execute("SELECT 1 FROM work_tasks LIMIT 1")
-            return cur.fetchone() is not None
+        return has_work_tasks_in_db(db_path, project_key=project_key)
     except Exception:  # noqa: BLE001
         return False
 

--- a/src/pollypm/storage/work_task_state.py
+++ b/src/pollypm/storage/work_task_state.py
@@ -135,6 +135,37 @@ def task_numbers_with_statuses(
     return []
 
 
+def has_work_task_rows(
+    db_path: Path,
+    *,
+    project_key: str | None = None,
+) -> bool:
+    """Return whether ``work_tasks`` has rows, optionally scoped by project."""
+    conn = _connect_readonly(db_path)
+    if conn is None:
+        return False
+    try:
+        try:
+            has_table = conn.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='work_tasks' LIMIT 1"
+            ).fetchone()
+            if has_table is None:
+                return False
+            if project_key:
+                row = conn.execute(
+                    "SELECT 1 FROM work_tasks WHERE project = ? LIMIT 1",
+                    (project_key,),
+                ).fetchone()
+            else:
+                row = conn.execute("SELECT 1 FROM work_tasks LIMIT 1").fetchone()
+            return row is not None
+        except sqlite3.Error:
+            return False
+    finally:
+        conn.close()
+
+
 def project_activity_probe(
     *,
     project_key: str,

--- a/src/pollypm/work/task_state.py
+++ b/src/pollypm/work/task_state.py
@@ -8,6 +8,7 @@ from typing import Any
 from pollypm.storage.work_task_state import (
     blocked_since_stamp,
     blocker_chain_statuses,
+    has_work_task_rows,
     project_activity_probe,
     task_numbers_with_statuses,
     task_status_probe,
@@ -63,6 +64,15 @@ def user_waiting_task_ids(config: Any) -> frozenset[str]:
         )
         out.update(f"{project_key}/{number}" for number in numbers)
     return frozenset(out)
+
+
+def has_work_tasks_in_db(
+    db_path: Path,
+    *,
+    project_key: str | None = None,
+) -> bool:
+    """Return whether a work DB has task rows without exposing SQLite to callers."""
+    return has_work_task_rows(Path(db_path), project_key=project_key)
 
 
 def project_activity(
@@ -166,6 +176,7 @@ __all__ = [
     "active_task_numbers",
     "blocked_since_stamp_for_service",
     "blocker_chain_for_service",
+    "has_work_tasks_in_db",
     "parse_task_window_name",
     "project_activity",
     "task_window_terminal_or_missing",

--- a/tests/test_plugin_boundary_conformance.py
+++ b/tests/test_plugin_boundary_conformance.py
@@ -92,6 +92,20 @@ def test_transition_query_plugin_handlers_do_not_open_sqlite_directly() -> None:
     assert offenders == []
 
 
+def test_work_task_query_callers_do_not_open_sqlite_directly() -> None:
+    """Issue #1376: UI/plugin callers route work-task reads via facades."""
+    rels = (
+        "src/pollypm/dashboard_data.py",
+        "src/pollypm/plugins_builtin/project_planning/cli/project.py",
+    )
+    offenders: list[str] = []
+    for rel in rels:
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        if "sqlite3.connect" in text or "import sqlite3" in text:
+            offenders.append(rel)
+    assert offenders == []
+
+
 def test_scanner_recognizes_private_symbol() -> None:
     """Scanner detects ``from X import _foo`` correctly."""
     # Synthetic test using the public `_split_imports` indirectly.


### PR DESCRIPTION
Refs #1376

This partial #1376 slice removes direct sqlite opens from two work-task read callers:
- `dashboard_data` now uses the existing `pollypm.work.task_state.user_waiting_task_ids` facade.
- the project-planning CLI work-task existence probe now goes through `pollypm.work.task_state.has_work_tasks_in_db`, backed by storage-owned read-only SQLite access.

Layer self-audit: UI/plugin callers no longer import/call sqlite for these reads; SQL/table ownership lives in `pollypm.storage.work_task_state`, exposed through `pollypm.work.task_state`. This avoids `cockpit_ui.py` while PR #1489 is open.

Tests:
- `uv run --extra dev pytest tests/test_dashboard_data_alert_dedup.py tests/test_project_new_replan_routing.py tests/test_plugin_boundary_conformance.py`
- `uv run --extra dev pytest tests/test_plugin_boundary_conformance.py::test_work_task_query_callers_do_not_open_sqlite_directly tests/test_dashboard_data_alert_dedup.py::test_user_waiting_task_ids_skips_non_tracked_projects tests/test_project_new_replan_routing.py::TestProjectNewReplanRouting::test_existing_workspace_tasks_classify_existing_replan`
- `uv run --extra dev ruff check --ignore E402,F401,F841 src/pollypm/dashboard_data.py src/pollypm/plugins_builtin/project_planning/cli/project.py src/pollypm/storage/work_task_state.py src/pollypm/work/task_state.py tests/test_plugin_boundary_conformance.py`
- `git diff --check`

Note: a raw `ruff check` on the same touched files still reports pre-existing `dashboard_data.py` `E402`, `F401`, and `F841` findings outside this patch.

Remaining #1376 scope after this PR includes `backup.py`, `cockpit.py`, `cockpit_sections/base.py`, `cockpit_settings_projects.py`, `cockpit_ui.py`, and `doctor.py`.
