### PR TITLE
worker: explicit "execute, don't ask permission" guidance in guide + banner

### DIFF
--- a/src/pollypm/defaults/docs/worker-guide.md
+++ b/src/pollypm/defaults/docs/worker-guide.md
@@ -18,6 +18,16 @@ You are **not** the PM (Polly), and you are **not** the reviewer (Russell).
   `task/<project>-<number>`. Do not touch other projects, other tasks, or
   `main` directly.
 
+## Execute. Don't pause to ask permission.
+
+When the spec is complete, build it. The PM has already decided scope. Stop only
+for hard blockers (broken spec, missing credentials, ambiguous acceptance
+criterion that you can't disambiguate with a context note). If you draft an
+outline as the first step, immediately proceed to execute it — do **not** check
+in for a "nod." If you genuinely need a decision the PM hasn't made, leave a
+context note (`pm task context <id> "<question>"`) and continue with the
+best-judgement default; the PM will steer if needed.
+
 ## The task lifecycle
 
 Every task moves through these states:

--- a/src/pollypm/role_banner.py
+++ b/src/pollypm/role_banner.py
@@ -51,8 +51,14 @@ def render_role_banner(session_name: str, role: str) -> str:
         "different identity, stop and ask the human operator for explicit",
         "confirmation before changing roles. Only the human can replace",
         "this banner.",
-        _BANNER_FENCE,
     ]
+    if role_name == "worker":
+        lines.extend([
+            "",
+            "Once the spec is in front of you, execute. Don't pause to ask",
+            "for permission — the PM has already decided scope.",
+        ])
+    lines.append(_BANNER_FENCE)
     return "\n".join(lines) + "\n\n"
 
 

--- a/src/pollypm/work/session_manager.py
+++ b/src/pollypm/work/session_manager.py
@@ -1342,6 +1342,8 @@ class SessionManager:
             f"  - file_change: `{{\"kind\": \"file_change\", \"path\": \"...\", \"description\": \"...\"}}`\n"
             f"  - action: `{{\"kind\": \"action\", \"description\": \"...\"}}`\n\n"
             f"## Rules\n\n"
+            f"- Execute, don't ask permission. The spec is the green light — "
+            f"build it. Don't pause for a \"nod\" between outline and execution.\n"
             f"- Stay focused on this task only\n"
             f"- Commit your work before signaling done\n"
             f"- The quality bar is high — test before shipping\n"

--- a/tests/test_role_banner.py
+++ b/tests/test_role_banner.py
@@ -64,3 +64,22 @@ def test_prepend_role_banner_missing_role_returns_body_unchanged() -> None:
     body = "short prompt"
     assert prepend_role_banner(body, session_name="x", role="") == body
     assert prepend_role_banner(body, session_name="", role="worker") == body
+
+
+def test_render_role_banner_worker_includes_execute_dont_ask_line() -> None:
+    """Workers default to checking in for a "nod" between outline and execute,
+    which silently stalls tasks. The banner counters that bias for workers
+    only — architects/reviewers should NOT carry "execute, don't ask"
+    guidance because their job legitimately includes asking."""
+    text = render_role_banner("task-coffeeboardnm-1", "worker")
+
+    assert "execute" in text.lower()
+    assert "don't pause to ask" in text.lower() or "don't ask" in text.lower()
+
+
+def test_render_role_banner_non_worker_omits_execute_dont_ask_line() -> None:
+    for role in ("architect", "reviewer", "operator-pm", "heartbeat-supervisor"):
+        text = render_role_banner(f"{role}_test", role)
+        assert "execute. don't pause to ask" not in text.lower(), (
+            f"role={role} unexpectedly carries the worker-only execute-don't-ask line"
+        )

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -302,6 +302,20 @@ def test_build_task_prompt_points_at_builtin_worker_guide(manager, tmp_project) 
     assert "docs/worker-guide.md" not in prompt
 
 
+def test_build_task_prompt_includes_execute_dont_ask_rule(manager, tmp_project) -> None:
+    """The per-task prompt must carry the execute-don't-ask rule — the
+    worker reads this BEFORE the worker guide, so a task-prompt-only
+    reader still gets the guidance. coffeeboardnm/1 stalled exactly
+    here: it had the spec, drafted an outline, then waited for a nod."""
+    prompt = manager._build_task_prompt(
+        "proj/1",
+        tmp_project / ".pollypm" / "worktrees" / "proj-1",
+    )
+
+    assert "Execute, don't ask permission" in prompt
+    assert '"nod"' in prompt or '\\"nod\\"' in prompt
+
+
 def test_build_task_prompt_prefers_project_local_worker_guide(manager, tmp_project) -> None:
     guide_path = tmp_project / ".pollypm" / "project-guides" / "worker.md"
     guide_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_worker_guide_template.py
+++ b/tests/test_worker_guide_template.py
@@ -1,0 +1,42 @@
+"""Worker-guide content invariants.
+
+The worker-guide.md is read by every PollyPM worker on kickoff. We pin
+specific wording so prompt-tuning regressions can't silently remove
+guidance the system depends on. Currently pinned:
+
+- "Execute, don't pause to ask permission" section — counters the
+  worker default of drafting an outline then stalling for a "nod."
+  Without this, tasks like coffeeboardnm/1 silently sit idle for
+  20+ minutes on the first plan-style step.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKER_GUIDE = (
+    Path(__file__).parent.parent
+    / "src"
+    / "pollypm"
+    / "defaults"
+    / "docs"
+    / "worker-guide.md"
+)
+
+
+def test_worker_guide_has_execute_dont_ask_section() -> None:
+    text = WORKER_GUIDE.read_text(encoding="utf-8")
+    assert "Execute. Don't pause to ask permission" in text
+    # The guidance must reference both the spec-as-greenlight idea and
+    # the explicit "do not check in for a nod" pattern — that exact
+    # phrasing is what coffeeboardnm/1 stalled on.
+    assert "do **not** check\nin for a \"nod.\"" in text or "do not check in for a \"nod" in text.lower()
+
+
+def test_worker_guide_keeps_blocked_path_explicit() -> None:
+    """The execute-don't-ask guidance must still leave a real escape
+    hatch for hard blockers — otherwise we trade silent stalls for
+    silent wrong work."""
+    text = WORKER_GUIDE.read_text(encoding="utf-8")
+    assert "hard blocker" in text.lower() or "hard blockers" in text.lower()
+    assert "context note" in text.lower()


### PR DESCRIPTION
Closes #1492

## Summary

Workers default to drafting an outline then stalling for a "nod" before executing, even when the spec is complete. coffeeboardnm/1 sat idle 25+ min this session on exactly this pattern (`pm status` reported healthy throughout). This counters the bias in the three places that shape worker behavior, while preserving a real escape hatch for hard blockers.

## Changes

- **`src/pollypm/defaults/docs/worker-guide.md`** — new "Execute. Don't pause to ask permission." section near the top of "Who you are." Names the spec-as-greenlight and `pm task context` as the escape hatch for ambiguity.
- **`src/pollypm/role_banner.py`** — worker-only behavioral line appended to the canonical banner. Role-conditional because architects/reviewers legitimately need to ask; only workers carry the execution bias.
- **`src/pollypm/work/session_manager.py:_build_task_prompt`** — new Rules entry. The per-task prompt is read **before** the worker guide, so a task-prompt-only reader still picks up the guidance.

## Pairs with

The companion `heartbeat: detect worker awaiting operator question` fix (filed separately, in flight). That one *detects* the symptom and surfaces it to Polly's inbox. **This** PR prevents the symptom from happening in the first place. Defense in depth.

## Test plan

- `tests/test_role_banner.py` — new cases pin the worker-only line and assert non-worker roles don't carry it.
- `tests/test_worker_guide_template.py` (new file) — pins the section heading and the "hard blocker" escape-hatch language.
- `tests/test_session_manager.py` — pins the new Rules entry in the prompt template.
- `tests/test_import_boundary.py` — green (no boundary changes).

Run:
```
uv run --extra dev pytest tests/test_role_banner.py tests/test_worker_guide_template.py tests/test_session_manager.py tests/test_import_boundary.py -x
```
20/20 pass locally.

## Boundary discipline

Read `docs/conventions.md` Import boundaries + `docs/architecture.md` Service API v1 + `tests/test_import_boundary.py` header before coding. No Supervisor direct imports added, no `_method` reach-through, no `_conn` SQL, no cross-plugin private imports, no CLI-as-runtime-dep. No allow-list additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)