### PR TITLE
heartbeat: detect worker awaiting operator question, surface to inbox

### DIFF
--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -834,19 +834,49 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                     classify_stall,
                 )
                 from pollypm.idle_placeholders import (
+                    pane_ends_with_unanswered_question as _pane_ends_with_unanswered_question,
                     pane_is_idle_placeholder as _pane_is_idle_placeholder,
                 )
 
+                _pane_text = context.pane_text or ""
                 stall_ctx = StallContext(
                     role=context.role or "",
                     session_name=context.session_name,
                     has_pending_work=self._has_pending_work(api, context),
-                    pane_is_idle_placeholder=_pane_is_idle_placeholder(
-                        context.pane_text or "",
-                    ),
+                    pane_is_idle_placeholder=_pane_is_idle_placeholder(_pane_text),
+                    awaiting_operator_question=_pane_ends_with_unanswered_question(_pane_text),
                 )
                 stall_class = classify_stall(stall_ctx)
-                if stall_class != "unrecoverable_stall":
+                if stall_class == "awaiting_operator":
+                    # Surface the worker's pending question to the operator
+                    # inbox so polly / the user can see and answer it,
+                    # instead of the pane sitting silently with `pm status`
+                    # reporting healthy. Distinct alert_type from
+                    # ``suspected_loop`` so dedupe and routing don't
+                    # collapse the two categories.
+                    question_text = (stall_ctx.awaiting_operator_question or "").strip()
+                    short_question = question_text
+                    if len(short_question) > 140:
+                        short_question = short_question[:137].rstrip() + "…"
+                    _emit_routed_alert(
+                        api,
+                        session_name=context.session_name,
+                        alert_type="worker_question",
+                        severity="warn",
+                        message=(
+                            f"{context.role or 'session'} "
+                            f"{context.session_name} is waiting for an "
+                            f"operator answer: {short_question}"
+                        ),
+                        subject=f"{context.session_name} asked a question",
+                        suggested_action=(
+                            "Open the worker pane and answer, or `pm send "
+                            f"{context.session_name} \"<answer>\"`."
+                        ),
+                    )
+                    alerts.append("worker_question")
+                    api.clear_alert(context.session_name, "suspected_loop")
+                elif stall_class != "unrecoverable_stall":
                     api.clear_alert(context.session_name, "suspected_loop")
                 else:
                     # #760 — concrete actionable copy: name the role,

--- a/src/pollypm/heartbeats/stall_classifier.py
+++ b/src/pollypm/heartbeats/stall_classifier.py
@@ -38,7 +38,12 @@ from dataclasses import dataclass
 from typing import Literal
 
 
-StallClass = Literal["legitimate_idle", "transient", "unrecoverable_stall"]
+StallClass = Literal[
+    "legitimate_idle",
+    "transient",
+    "unrecoverable_stall",
+    "awaiting_operator",
+]
 
 
 # Roles whose tmux panes are expected to sit idle indefinitely. These
@@ -94,6 +99,16 @@ class StallContext:
     #: regardless of ``has_pending_work`` — work is queued behind the
     #: agent's input cycle, not behind a pane that needs unsticking.
     pane_is_idle_placeholder: bool = False
+    #: When set, the agent's most recent turn ended in a question to
+    #: the operator (e.g., "Ready to proceed when you give the nod —
+    #: anything you want to steer first?") and the pane is sitting at
+    #: the empty prompt waiting for an answer. Promotes the
+    #: classification to :class:`awaiting_operator` so the heartbeat
+    #: can surface the question to the operator's inbox instead of
+    #: silently filing the pane as ``legitimate_idle`` (which is what
+    #: the placeholder short-circuit would otherwise do — the pane
+    #: shows the empty prompt either way).
+    awaiting_operator_question: str | None = None
 
 
 def classify_stall(ctx: StallContext) -> StallClass:
@@ -123,6 +138,18 @@ def classify_stall(ctx: StallContext) -> StallClass:
     """
     role = (ctx.role or "").strip()
     session_name = (ctx.session_name or "").strip()
+
+    # An empty Claude prompt + a fresh question to the operator means
+    # the agent is alive-but-blocked: it finished its turn waiting for
+    # the operator to answer, but ``pm status`` would otherwise short-
+    # circuit to ``legitimate_idle`` via the placeholder check below
+    # and the question would never reach the inbox. ``awaiting_operator``
+    # is its own bucket — heartbeat surfaces it to the operator without
+    # the nudge/restart remediation ladder ``unrecoverable_stall``
+    # would invoke (the agent is fine; the operator just missed the
+    # cue).
+    if ctx.awaiting_operator_question:
+        return "awaiting_operator"
 
     # #1010 — placeholder-showing pane is alive-but-idle. The Codex
     # rotating-suggestion hint and the Claude empty-``❯`` prompt are

--- a/src/pollypm/idle_placeholders.py
+++ b/src/pollypm/idle_placeholders.py
@@ -183,6 +183,125 @@ def pane_is_idle_placeholder(pane_text: str) -> bool:
     )
 
 
+# Phrase fragments that, in combination with sitting at the empty
+# Claude prompt, flag the agent as "awaiting an operator answer."
+# Lower-cased substring match against the joined assistant block.
+# Conservative list — we want to catch the obvious "ready to proceed?"
+# / "shall I?" patterns, not any text that happens to use a question
+# mark.
+_QUESTION_PATTERNS: tuple[str, ...] = (
+    "ready to proceed",
+    "should i ",
+    "should i?",
+    "shall i ",
+    "shall i?",
+    "would you ",
+    "do you want ",
+    "anything you want",
+    "anything else you ",
+    "want me to ",
+    "may i ",
+    "let me know ",
+    "let me know if",
+    "ok to proceed",
+    "okay to proceed",
+    "give the nod",
+)
+
+
+def pane_ends_with_unanswered_question(pane_text: str) -> str | None:
+    """Return the agent's question text iff the pane ends awaiting one.
+
+    Detects the exact failure-mode the heartbeat would otherwise miss:
+    the worker (or any Claude-CLI session) has just emitted a turn
+    that ends in a question to the operator and is now sitting at the
+    empty ``❯`` prompt waiting for an answer. ``pm status`` reports
+    ``healthy`` (the session is alive and responsive), but no work is
+    happening and the operator has no idea anything was asked.
+
+    Returns the joined assistant text (trimmed) when:
+
+    1. The pane tail is the Claude empty-``❯`` prompt — i.e., agent
+       finished its turn and is awaiting input.
+    2. The most recent assistant block (lines above the prompt, before
+       the previous user message) ends in a question pattern: either
+       a literal ``?``, or one of the recognized phrase fragments
+       (``"ready to proceed"``, ``"should I"``, ``"shall I"``, etc.).
+
+    Returns ``None`` otherwise — including when the agent is mid-turn,
+    when the assistant's last block has no question pattern, or when a
+    fresh user input line sits between the question and the prompt
+    (operator already answered).
+    """
+    if not pane_text:
+        return None
+    if not pane_shows_claude_empty_prompt(pane_text):
+        return None
+
+    collected: list[str] = []
+    for raw_line in reversed(pane_text.splitlines()):
+        line = raw_line.strip()
+        if not line:
+            continue
+        lower = line.lower()
+        # Skip Claude TUI footer chrome (mirrors pane_shows_claude_empty_prompt).
+        if (
+            "bypass permissions" in lower
+            or "shift+tab to cycle" in lower
+            or "ctrl+t to" in lower
+            or line.startswith("⏵⏵")  # ⏵⏵
+        ):
+            continue
+        # Skip box-drawing horizontal rules (── ━).
+        if set(line) <= {"─", "━", " "}:
+            continue
+        # Skip the empty prompt line itself.
+        if line.startswith("❯") and not line.lstrip("❯").strip():
+            continue
+        # Skip Claude's status spinner artifacts: ``✻ Cogitated for 1m 34s``,
+        # ``✶ Sautéed…``, ``✽ Rendering…`` etc.
+        if line.startswith(("✻", "✶", "✽", "·")):
+            continue
+        # Skip Codex rotating placeholder hints if they sit below the
+        # assistant block (rare in Claude panes but defensive).
+        if is_codex_idle_placeholder(line):
+            continue
+        # A user-input line (``❯`` followed by content) means the operator
+        # already answered — there is no unanswered question.
+        if line.startswith("❯") and line.lstrip("❯").strip():
+            return None
+        # Reached the assistant block's first line (``⏺ <text>`` marker).
+        if line.startswith("⏺"):
+            content = line.lstrip("⏺").strip()
+            if content:
+                collected.append(content)
+            break
+        # Regular content line within the assistant block.
+        collected.append(line)
+        # Cap walk distance to keep this O(1) on huge panes.
+        if len(collected) >= 40:
+            break
+
+    if not collected:
+        return None
+
+    # Reverse to forward order; join with single spaces (multi-line
+    # paragraphs render as one continuous string for substring match).
+    block_text = " ".join(reversed(collected))
+    block_lower = block_text.lower()
+
+    has_question_mark = "?" in block_text
+    has_pattern = any(pattern in block_lower for pattern in _QUESTION_PATTERNS)
+    if not (has_question_mark or has_pattern):
+        return None
+
+    # Trim for inbox-display friendliness. Keep the tail since the
+    # question typically sits at the end of the block.
+    if len(block_text) > 280:
+        return "…" + block_text[-279:]
+    return block_text
+
+
 __all__ = [
     "CODEX_IDLE_PLACEHOLDERS",
     "is_codex_idle_placeholder",
@@ -190,4 +309,5 @@ __all__ = [
     "pane_shows_claude_empty_prompt",
     "pane_shows_no_tasks_available",
     "pane_is_idle_placeholder",
+    "pane_ends_with_unanswered_question",
 ]

--- a/src/pollypm/supervisor_alerts.py
+++ b/src/pollypm/supervisor_alerts.py
@@ -259,9 +259,11 @@ def _update_alerts(
                 has_pending_work_for_session,
             )
             from pollypm.idle_placeholders import (
+                pane_ends_with_unanswered_question as _pane_ends_with_unanswered_question,
                 pane_is_idle_placeholder as _pane_is_idle_placeholder,
             )
 
+            _pane_text_for_classify = pane_text or ""
             stall_class = classify_stall(
                 StallContext(
                     role=launch.session.role or "",
@@ -270,11 +272,52 @@ def _update_alerts(
                         supervisor.config, session_name,
                     ),
                     pane_is_idle_placeholder=_pane_is_idle_placeholder(
-                        pane_text or "",
+                        _pane_text_for_classify,
+                    ),
+                    awaiting_operator_question=_pane_ends_with_unanswered_question(
+                        _pane_text_for_classify,
                     ),
                 )
             )
-            if stall_class != "unrecoverable_stall":
+            if stall_class == "awaiting_operator":
+                # The agent finished its turn with a question and is
+                # sitting at the empty prompt. Surface the question so
+                # the operator sees it instead of `pm status` reporting
+                # ``healthy`` while the worker silently waits.
+                _question = (
+                    _pane_ends_with_unanswered_question(_pane_text_for_classify)
+                    or ""
+                ).strip()
+                _short_q = _question if len(_question) <= 140 else (
+                    _question[:137].rstrip() + "…"
+                )
+                _question_body = (
+                    f"{launch.session.role or 'session'} {session_name} "
+                    f"is waiting for an operator answer: {_short_q}"
+                )
+                _route_signal(
+                    _envelope_for_alert(
+                        source="supervisor_alerts",
+                        alert_type="worker_question",
+                        severity_label="warn",
+                        session_name=session_name,
+                        subject=f"{session_name} asked a question",
+                        body=_question_body,
+                        suggested_action=(
+                            "Open the worker pane and answer, or `pm send "
+                            f"{session_name} \"<answer>\"`."
+                        ),
+                    )
+                )
+                supervisor.msg_store.upsert_alert(
+                    session_name,
+                    "worker_question",
+                    "warn",
+                    _question_body,
+                )
+                active_alerts.append("worker_question")
+                supervisor.msg_store.clear_alert(session_name, "suspected_loop")
+            elif stall_class != "unrecoverable_stall":
                 supervisor.msg_store.clear_alert(session_name, "suspected_loop")
             else:
                 # #760 — action-forward copy matching the heartbeat path.

--- a/tests/test_stall_classifier.py
+++ b/tests/test_stall_classifier.py
@@ -118,6 +118,156 @@ def test_transient_signals_dont_apply_when_user_gate_holds() -> None:
     )
 
 
+def test_awaiting_operator_question_promotes_to_awaiting_operator() -> None:
+    """When the agent's last turn ends with a question to the operator
+    (pane sitting at empty ``❯`` prompt), classify_stall must return
+    ``awaiting_operator`` so the heartbeat surfaces the question to
+    the operator's inbox — instead of letting the placeholder short-
+    circuit silently file the pane as ``legitimate_idle``.
+    """
+    ctx = _ctx(
+        role="worker",
+        has_pending_work=True,
+        pane_is_idle_placeholder=True,
+        awaiting_operator_question=(
+            "Ready to proceed when you give the nod — "
+            "anything you want to steer first?"
+        ),
+    )
+    assert classify_stall(ctx) == "awaiting_operator"
+
+
+def test_awaiting_operator_takes_priority_over_legitimate_idle_paths() -> None:
+    """Even an architect or a control-name session with a pending
+    question must surface — the question signal beats the role-based
+    legitimate_idle promotion. Architects asking the user a question
+    is exactly the kind of thing the operator needs to see.
+    """
+    architect_ctx = _ctx(
+        role="architect",
+        has_pending_work=True,
+        pane_is_idle_placeholder=True,
+        awaiting_operator_question="Should I include venue X in scope?",
+    )
+    assert classify_stall(architect_ctx) == "awaiting_operator"
+
+    pollypm_worker_ctx = _ctx(
+        role="worker",
+        session_name="worker_pollypm",
+        has_pending_work=True,
+        pane_is_idle_placeholder=True,
+        awaiting_operator_question="Ready to proceed?",
+    )
+    assert classify_stall(pollypm_worker_ctx) == "awaiting_operator"
+
+
+def test_no_question_preserves_legitimate_idle_behavior() -> None:
+    """Regression guard: placeholder + no question text must still
+    classify as ``legitimate_idle``. The new awaiting_operator branch
+    fires only when the question text is present.
+    """
+    ctx = _ctx(
+        role="worker",
+        has_pending_work=True,
+        pane_is_idle_placeholder=True,
+        awaiting_operator_question=None,
+    )
+    assert classify_stall(ctx) == "legitimate_idle"
+
+
+def test_pane_ends_with_unanswered_question_detects_coffeeboardnm_pattern() -> None:
+    """The exact regression: coffeeboardnm worker emitted a "Ready to
+    proceed when you give the nod — anything you want to steer first?"
+    turn and sat at the empty ``❯`` prompt. Detector must return the
+    question text so the heartbeat can surface it.
+    """
+    from pollypm.idle_placeholders import pane_ends_with_unanswered_question
+
+    pane_text = "\n".join([
+        "⏺ Hi — settled in.",
+        "",
+        "  Where I am: worktree coffeeboardnm-1, task implement node.",
+        "",
+        "  Plan, roughly: read SKILL → research NM venues → outline → render.",
+        "",
+        "  Ready to proceed when you give the nod — anything you want "
+        "to steer first (scope, depth, visual style, \"skip section X\")?",
+        "",
+        "✻ Cogitated for 1m 34s",
+        "",
+        "──────────────────────────────────────────────────────",
+        "❯ ",
+        "──────────────────────────────────────────────────────",
+        "  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+    ])
+
+    result = pane_ends_with_unanswered_question(pane_text)
+    assert result is not None
+    assert "ready to proceed" in result.lower()
+    assert "?" in result
+
+
+def test_pane_ends_with_unanswered_question_none_for_normal_idle() -> None:
+    """An idle empty prompt with no recent question pattern (e.g., the
+    worker just finished a task and is awaiting next-task input)
+    must NOT trigger awaiting_operator.
+    """
+    from pollypm.idle_placeholders import pane_ends_with_unanswered_question
+
+    pane_text = "\n".join([
+        "⏺ Task coffeeboardnm/1 complete. Deployed to coffeeboardnm.itsalive.co.",
+        "",
+        "✻ Cooked for 3m 12s",
+        "",
+        "──────────────────────────────────────────────────────",
+        "❯ ",
+        "──────────────────────────────────────────────────────",
+        "  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+    ])
+
+    assert pane_ends_with_unanswered_question(pane_text) is None
+
+
+def test_pane_ends_with_unanswered_question_skips_when_already_answered() -> None:
+    """If a user-input line (``❯ <text>``) sits between the question
+    and the prompt, the operator already answered — don't re-surface.
+    """
+    from pollypm.idle_placeholders import pane_ends_with_unanswered_question
+
+    pane_text = "\n".join([
+        "⏺ Should I proceed?",
+        "",
+        "✻ Cogitated for 12s",
+        "",
+        "❯ go ahead",
+        "",
+        "──────────────────────────────────────────────────────",
+        "❯ ",
+        "──────────────────────────────────────────────────────",
+        "  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+    ])
+
+    assert pane_ends_with_unanswered_question(pane_text) is None
+
+
+def test_pane_ends_with_unanswered_question_none_when_pane_is_mid_turn() -> None:
+    """If the pane shows a status spinner / no empty prompt at the
+    tail, the agent is mid-turn — not awaiting an answer.
+    """
+    from pollypm.idle_placeholders import pane_ends_with_unanswered_question
+
+    pane_text = "\n".join([
+        "⏺ Should I proceed?",
+        "",
+        "⏺ Bash(pm task get coffeeboardnm/1)",
+        "  ⎿  ID: coffeeboardnm/1 — POC plan",
+        "",
+        "✶ Cooking… (12s · ↓ 1.2k tokens · still thinking)",
+    ])
+
+    assert pane_ends_with_unanswered_question(pane_text) is None
+
+
 def test_alert_channel_classifies_three_tiers() -> None:
     """#765 — public alert-channel policy. Operational alerts never
     earn a toast; informational alerts don't either; only


### PR DESCRIPTION
Closes #1493

## Summary

Workers that end a turn with a question to the operator and sit at the empty `❯` prompt now classify as `awaiting_operator` instead of `legitimate_idle`. The heartbeat emits a `worker_question` alert with the question text so polly / the cockpit operator inbox sees it instead of `pm status` silently reporting `healthy`.

## What changed

- **`pollypm.idle_placeholders`** — new `pane_ends_with_unanswered_question(pane_text) -> str | None`. Verifies the pane tail shows the empty `❯` prompt, walks back through the assistant's last block (skipping TUI footer chrome, `✻`/`✶` status spinners, box-drawing rules), returns the joined text iff it ends in a question pattern. Returns `None` when the operator already responded (a `❯ <text>` line sits between the question and the prompt) or when the pane is mid-turn.
- **`pollypm.heartbeats.stall_classifier`** — `StallClass` extended with `awaiting_operator`. `StallContext` gets `awaiting_operator_question: str | None`. `classify_stall` checks the question field *before* the `pane_is_idle_placeholder` short-circuit so the question wins over the silent-idle promotion.
- **`pollypm.heartbeats.local`** + **`pollypm.supervisor_alerts`** — both stall-detection callsites now compute `pane_ends_with_unanswered_question` alongside `pane_is_idle_placeholder` and route an `worker_question` alert via the existing `_emit_routed_alert` / `_route_signal` paths when the new class fires. No new emit infrastructure; existing inbox surface picks it up.

## Test plan

- `tests/test_stall_classifier.py` — 7 new cases (all passing):
  - placeholder + question pattern → `awaiting_operator`
  - architect / `worker_pollypm` + question → `awaiting_operator` (priority over their legitimate_idle paths)
  - placeholder + no question → `legitimate_idle` (regression guard)
  - real coffeeboardnm pattern detected
  - normal idle (\"task complete\") returns None
  - already-answered (`❯ go ahead` between question and prompt) returns None
  - mid-turn pane returns None
- `tests/test_import_boundary.py` — green. No allow-list additions.
- 242-test broader sweep across `heartbeat / stall / idle_placeholder / supervisor_alerts` — green.

## Manual reproduction

The exact failure this addresses:

> `task-coffeeboardnm-1` worker emitted \"Ready to proceed when you give the nod — anything you want to steer first (scope, depth, visual style, 'skip section X')?\" and sat at the empty `❯` prompt for 25+ minutes while `pm status` reported `status=healthy running=yes alerts=0`. Polly only intervened after the user manually asked.

After this fix, the heartbeat emits an `worker_question` alert (severity `warn`) with body `\"worker task-coffeeboardnm-1 is waiting for an operator answer: Ready to proceed when you give the nod — anything you want to steer first…\"` and suggested action pointing at `pm send`. The cockpit alert reader picks it up through the standard routed path; polly's inbox surfaces it on the next render.

## Module-boundary check

Touches foundational modules only:

- `src/pollypm/idle_placeholders.py`
- `src/pollypm/heartbeats/stall_classifier.py`
- `src/pollypm/heartbeats/local.py`
- `src/pollypm/supervisor_alerts.py`
- `tests/test_stall_classifier.py`

No plugin imports. No new `from pollypm.supervisor import Supervisor`. No private-attribute reach-through. No direct SQL on `_conn`. `tests/test_import_boundary.py` allow-lists unchanged.

## Note on pre-existing lint

`ruff check src/pollypm/heartbeats/local.py` reports E402 / F401 on lines 268-273 — these are pre-existing on `origin/main` and untouched by this PR; my edits begin at line 834. Worth a separate cleanup PR.