### PR TITLE
cockpit: auto-redraw rail on focus-regain + periodic stale-paint tick

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -1854,6 +1854,12 @@ class PollyCockpitApp(App[None]):
     _LAYOUT_CHECK_INTERVAL = 38  # ~30s at 0.8s/tick
     # Force GC every ~2 minutes
     _GC_INTERVAL = 150
+    # Stale-paint defensive refresh: tmux focus loss / SIGWINCH drops can
+    # leave Textual without a redraw signal even though widget state is
+    # current. Force a non-layout refresh on this cadence so the rail
+    # recovers within a few seconds without operator intervention. See
+    # the rail-died report — detach + reattach was the manual workaround.
+    _STALE_PAINT_INTERVAL = 5  # ~4s at 0.8s/tick
 
     def _tick(self) -> None:
         self._tick_count += 1
@@ -1926,6 +1932,15 @@ class PollyCockpitApp(App[None]):
         if self._tick_count % self._LAYOUT_CHECK_INTERVAL == 0:
             try:
                 self._enforce_rail_width()
+            except Exception:  # noqa: BLE001
+                pass
+        # Stale-paint defense: force a Textual repaint every few ticks
+        # so the rail recovers from focus-loss / disconnect / SIGWINCH
+        # drops where Textual's own redraw signal got lost. layout=False
+        # because we only need a paint, not a reflow.
+        if self._tick_count % self._STALE_PAINT_INTERVAL == 0:
+            try:
+                self.refresh(layout=False)
             except Exception:  # noqa: BLE001
                 pass
 
@@ -3109,6 +3124,19 @@ class PollyCockpitApp(App[None]):
         self._recover_cockpit_render(force_render=False)
 
     def on_resize(self, _event: events.Resize) -> None:
+        self.call_after_refresh(self._recover_after_resize)
+
+    def on_app_focus(self, _event: events.AppFocus) -> None:
+        """Force a full rail redraw when the tmux pane regains focus.
+
+        When the tmux client disconnects/reattaches, the user switches
+        away to another pane and back, or any other event drops the
+        Textual redraw signal, the rail can be left visibly blank
+        even though widget state is current and rail-daemon is alive.
+        Detach + reattach has been the manual workaround. Hooking
+        AppFocus restores the rail automatically the moment the pane
+        is observed again.
+        """
         self.call_after_refresh(self._recover_after_resize)
 
     def _recover_after_resize(self) -> None:

--- a/tests/test_cockpit_rail_redraw.py
+++ b/tests/test_cockpit_rail_redraw.py
@@ -1,0 +1,96 @@
+"""Regression sentinels for the cockpit rail redraw recovery (#XXXX).
+
+The cockpit's left rail can stale visibly when tmux drops a redraw
+signal (focus loss, client reattach, SIGWINCH delivered to the wrong
+pane). The user's documented workaround was detach + reattach; these
+tests pin the auto-recovery so the workaround stays unnecessary.
+
+Two recovery paths are pinned:
+
+1. **Periodic stale-paint refresh** in ``_tick``: at the configured
+   ``_STALE_PAINT_INTERVAL`` cadence, the rail App calls
+   ``self.refresh(layout=False)`` defensively. This catches the case
+   where Textual believes no widgets need a repaint but tmux has
+   dropped the buffer.
+
+2. **AppFocus handler**: when the tmux pane regains focus,
+   ``on_app_focus`` fires the same recovery path as ``on_resize``
+   (force a layout refresh + ``_recover_cockpit_render``). This catches
+   the user-visible "switched panes and back, rail is blank" case.
+
+Both are non-invasive — they pile on extra repaints, not rebuilds.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from pollypm.cockpit_ui import PollyCockpitApp
+
+
+def test_stale_paint_interval_constant_present() -> None:
+    """The cadence constant must exist so ``_tick`` can read it."""
+    assert hasattr(PollyCockpitApp, "_STALE_PAINT_INTERVAL")
+    interval = PollyCockpitApp._STALE_PAINT_INTERVAL
+    assert isinstance(interval, int)
+    # ~4s at the 0.8s tick rate gives a reasonable ceiling on
+    # how long a staled rail can stay visibly blank.
+    assert 1 <= interval <= 20, f"_STALE_PAINT_INTERVAL={interval} feels off"
+
+
+def test_tick_calls_refresh_at_stale_paint_cadence() -> None:
+    """The defensive refresh call must run at ``_STALE_PAINT_INTERVAL``."""
+    interval = PollyCockpitApp._STALE_PAINT_INTERVAL
+    # Inspect the source of ``_tick`` for the gated refresh call. Using
+    # source inspection rather than a full Textual harness because
+    # constructing a real PollyCockpitApp pulls in a config + supervisor
+    # graph that's unreasonable for a unit test.
+    src = inspect.getsource(PollyCockpitApp._tick)
+    assert "_STALE_PAINT_INTERVAL" in src, (
+        "_tick must reference _STALE_PAINT_INTERVAL — the defensive refresh "
+        "is the entire point of this regression."
+    )
+    assert "self.refresh(" in src, (
+        "_tick must call self.refresh() somewhere; without it the rail "
+        "cannot recover from a dropped redraw signal."
+    )
+
+
+def test_on_app_focus_handler_exists() -> None:
+    """AppFocus must trigger the same recovery path as Resize."""
+    assert hasattr(PollyCockpitApp, "on_app_focus"), (
+        "PollyCockpitApp must define on_app_focus to recover the rail "
+        "when the tmux pane regains focus."
+    )
+    handler = PollyCockpitApp.on_app_focus
+    sig = inspect.signature(handler)
+    # (self, event) — accept the AppFocus event positionally.
+    params = list(sig.parameters.values())
+    assert len(params) >= 2, (
+        f"on_app_focus must accept an event argument; got {sig}"
+    )
+
+
+def test_on_app_focus_calls_recovery_path() -> None:
+    """The focus handler must funnel through the same recovery as resize."""
+    src = inspect.getsource(PollyCockpitApp.on_app_focus)
+    # The body should defer through ``call_after_refresh`` so the
+    # recovery doesn't re-enter the event loop synchronously, and it
+    # should target ``_recover_after_resize`` (the existing function
+    # that drives ``_recover_cockpit_render(force_render=True)``).
+    assert "call_after_refresh" in src, (
+        "on_app_focus should defer recovery via call_after_refresh, "
+        "matching the on_resize pattern."
+    )
+    assert "_recover_after_resize" in src, (
+        "on_app_focus should reuse _recover_after_resize so both paths "
+        "share the same force-redraw recovery."
+    )
+
+
+def test_on_resize_handler_unchanged() -> None:
+    """The pre-existing resize recovery path must still be wired."""
+    assert hasattr(PollyCockpitApp, "on_resize")
+    src = inspect.getsource(PollyCockpitApp.on_resize)
+    assert "call_after_refresh" in src
+    assert "_recover_after_resize" in src


### PR DESCRIPTION
Closes #1497

## Summary

Tmux focus-loss / client reattach / SIGWINCH drops can leave the cockpit's left rail visibly blank even though widget state is current and `rail-daemon` is alive. The user's manual workaround was tmux detach + reattach (forces a full re-render). This wires two non-invasive auto-recovery paths so the workaround stops being needed.

## Changes

- **`src/pollypm/cockpit_ui.py`**:
  - New `_STALE_PAINT_INTERVAL = 5` class constant on `PollyCockpitApp` (~4s at the 0.8s tick).
  - `_tick` now calls `self.refresh(layout=False)` on that cadence — defensive non-layout repaint that catches any dropped Textual redraw signal within a few seconds. Cheap; doesn't reflow the list.
  - New `on_app_focus(self, _event: events.AppFocus)` handler. Forwards to `call_after_refresh(self._recover_after_resize)` — the same recovery path `on_resize` already uses (`_recover_cockpit_render(force_render=True)`). Restores the rail the moment the pane is observed again.

- **`tests/test_cockpit_rail_redraw.py`** (new): regression sentinels via source inspection — assert the constant exists, `_tick` references it + calls `self.refresh()`, `on_app_focus` exists and funnels through `_recover_after_resize`. Source inspection rather than a full Textual harness because constructing a real `PollyCockpitApp` pulls in a config + supervisor graph that's unreasonable for unit scope.

## Test plan

```
uv run --extra dev pytest tests/test_cockpit_rail_redraw.py tests/test_import_boundary.py tests/test_cockpit.py -x
```

Local: 5/5 new + 8/8 boundary + 186/186 cockpit smoke (= 199/199) pass.

## Activation-required for full verify

This touches `cockpit_ui.py`. Reviewer should activate (`uv tool install --reinstall .` + `pm reset --force` + `pm up --phantom-client`) and confirm:

- After ~4s of any rail oddity (e.g., shrunk pane, switched away and back, killed+reattached client), the rail is redrawn — no manual detach+reattach needed.
- Focus-out doesn't cause flashes during normal use (the refresh is `layout=False` and gated on the existing 0.8s tick — should be invisible during steady state).

## Boundary discipline

Read `docs/conventions.md` Import boundaries + `docs/architecture.md` Service API v1 + `tests/test_import_boundary.py` header before coding. No Supervisor direct imports added, no `_method` reach-through, no `_conn` SQL, no cross-plugin private imports, no CLI-as-runtime-dep. No allow-list additions. `tests/test_import_boundary.py` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)