### PR TITLE
pm task approve: recover from pre-merge 'would be overwritten' on safe files

### DIFF
--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -23,6 +23,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sqlite3
 import subprocess
 from datetime import UTC, datetime
@@ -239,6 +240,38 @@ _POLLYPM_GENERATED_DOC_FILES = frozenset({
     "deprecated-facts.md",
     "history-import-questions.md",
 })
+
+
+_OVERWRITE_BY_MERGE_PATTERN = re.compile(
+    r"Your local changes to the following files would be overwritten by"
+    r" (?:merge|checkout):\s*\n((?:[^\n]*\n)+?)(?=\nPlease|\nAborting|\Z)",
+    re.MULTILINE,
+)
+
+
+def _parse_overwrite_files_from_stderr(stderr: str) -> list[str]:
+    """Parse git's "Your local changes ... would be overwritten by merge" stderr.
+
+    Returns the list of file paths git refused to overwrite, or an empty list
+    if the stderr doesn't match that error shape. Git emits the file list as
+    indented lines between the leading message and the trailing
+    "Please commit your changes or stash them" / "Aborting" / EOF.
+    """
+    if not stderr:
+        return []
+    match = _OVERWRITE_BY_MERGE_PATTERN.search(stderr)
+    if not match:
+        return []
+    block = match.group(1)
+    files: list[str] = []
+    for raw in block.splitlines():
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        if stripped.startswith(("Please ", "Aborting")):
+            break
+        files.append(stripped)
+    return files
 
 
 def _gitignore_without_pollypm_entry(text: str) -> tuple[str, ...]:
@@ -3376,6 +3409,33 @@ class SQLiteWorkService:
         )
         if merge.returncode == 0:
             return
+
+        # #1496: git's pre-merge dirty-tree check sometimes refuses to even
+        # *start* the merge with "Your local changes to the following files
+        # would be overwritten by merge: <file>" — emitted before any
+        # MERGE_HEAD or conflict state exists. The python dirty gate above
+        # admits scaffold-only diffs (e.g. ``.gitignore`` carrying
+        # ``.pollypm/``), but git's merge engine doesn't share that
+        # allowance. When every refused file is in
+        # ``_UNION_SAFE_MERGE_FILES`` (where the merge result naturally
+        # supersedes either side), reset the working copies to HEAD and
+        # retry — the union-safe resolver below picks up any actual
+        # add/add conflict that surfaces during the proper merge.
+        overwrite_refused = _parse_overwrite_files_from_stderr(merge.stderr)
+        if overwrite_refused and all(
+            f in self._UNION_SAFE_MERGE_FILES for f in overwrite_refused
+        ):
+            for refused in overwrite_refused:
+                self._git_run(
+                    project_path, "checkout", "HEAD", "--", refused
+                )
+            merge = self._git_run(
+                project_path,
+                "-c", "merge.conflictStyle=diff3",
+                "merge", "--no-ff", "--no-edit", task_branch,
+            )
+            if merge.returncode == 0:
+                return
 
         # Merge produced conflicts. Inspect them: if every conflict is on a
         # union-safe file, resolve each via line-union and commit. Otherwise

--- a/tests/test_task_approve_merge_gitignore.py
+++ b/tests/test_task_approve_merge_gitignore.py
@@ -1,0 +1,293 @@
+"""Regression coverage for #1496 — pm task approve recurrent .gitignore conflicts.
+
+Two layers of coverage:
+
+1. Unit tests for ``_parse_overwrite_files_from_stderr`` against canned
+   git stderr shapes (clean parse, multi-file, edge cases).
+2. Integration test exercising ``_auto_merge_approved_task_branch``
+   end-to-end on a real fixture repo where ``main`` and the task branch
+   each added different lines to ``.gitignore`` — the historical failure
+   mode that left coffeeboardnm/1 stuck.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from pollypm.work.models import Task, TaskType
+from pollypm.work.sqlite_service import (
+    SQLiteWorkService,
+    _parse_overwrite_files_from_stderr,
+)
+
+
+# ---------------------------------------------------------------------------
+# _parse_overwrite_files_from_stderr — unit
+# ---------------------------------------------------------------------------
+
+
+def test_parse_overwrite_files_single_file() -> None:
+    stderr = (
+        "error: Your local changes to the following files would be overwritten by merge:\n"
+        "\t.gitignore\n"
+        "Please commit your changes or stash them before you merge.\n"
+        "Aborting\n"
+    )
+    assert _parse_overwrite_files_from_stderr(stderr) == [".gitignore"]
+
+
+def test_parse_overwrite_files_multiple_files() -> None:
+    stderr = (
+        "error: Your local changes to the following files would be overwritten by merge:\n"
+        "\t.gitignore\n"
+        "\t.dockerignore\n"
+        "\tdocs/CHANGELOG.md\n"
+        "Please commit your changes or stash them before you merge.\n"
+        "Aborting\n"
+    )
+    assert _parse_overwrite_files_from_stderr(stderr) == [
+        ".gitignore",
+        ".dockerignore",
+        "docs/CHANGELOG.md",
+    ]
+
+
+def test_parse_overwrite_files_checkout_variant() -> None:
+    """``git checkout`` uses the same shape with "by checkout" instead."""
+    stderr = (
+        "error: Your local changes to the following files would be overwritten by checkout:\n"
+        "\t.gitignore\n"
+        "Aborting\n"
+    )
+    assert _parse_overwrite_files_from_stderr(stderr) == [".gitignore"]
+
+
+def test_parse_overwrite_files_no_match_returns_empty() -> None:
+    """Genuine merge conflicts (not pre-merge dirty refusal) don't match."""
+    stderr = (
+        "Auto-merging .gitignore\n"
+        "CONFLICT (add/add): Merge conflict in .gitignore\n"
+        "Automatic merge failed; fix conflicts and then commit the result.\n"
+    )
+    assert _parse_overwrite_files_from_stderr(stderr) == []
+
+
+def test_parse_overwrite_files_empty_stderr() -> None:
+    assert _parse_overwrite_files_from_stderr("") == []
+    assert _parse_overwrite_files_from_stderr("   \n  ") == []
+
+
+# ---------------------------------------------------------------------------
+# _auto_merge_approved_task_branch — integration on a real fixture repo
+# ---------------------------------------------------------------------------
+
+
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run a git command in ``cwd`` and return the CompletedProcess."""
+    env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _make_fixture_repo(
+    tmp_path: Path,
+    *,
+    main_gitignore: str,
+    task_gitignore: str,
+    base_gitignore: str = "# base\n",
+) -> Path:
+    """Initialize a fixture project repo with diverging ``.gitignore``.
+
+    History: ``base_gitignore`` committed on main (the merge base), then
+    ``main`` adds its own ignore line and ``task/proj-1`` adds its own
+    on top of base. Closely mirrors the coffeeboardnm/1 shape from #1496.
+    """
+    project = tmp_path / "fixture-proj"
+    project.mkdir()
+    _git("init", "-q", "-b", "main", cwd=project)
+    _git("config", "user.email", "test@example.com", cwd=project)
+    _git("config", "user.name", "Test", cwd=project)
+    _git("config", "commit.gpgsign", "false", cwd=project)
+
+    (project / ".gitignore").write_text(base_gitignore)
+    (project / "README.md").write_text("# fixture\n")
+    _git("add", ".", cwd=project)
+    _git("commit", "-q", "-m", "base", cwd=project)
+
+    # Task branch adds task-specific ignore.
+    _git("checkout", "-q", "-b", "task/proj-1", cwd=project)
+    (project / ".gitignore").write_text(task_gitignore)
+    _git("add", ".gitignore", cwd=project)
+    _git("commit", "-q", "-m", "task: ignore task-only path", cwd=project)
+
+    # Main advances independently with its own ignore line.
+    _git("checkout", "-q", "main", cwd=project)
+    (project / ".gitignore").write_text(main_gitignore)
+    _git("add", ".gitignore", cwd=project)
+    _git("commit", "-q", "-m", "main: ignore main-only path", cwd=project)
+
+    return project
+
+
+class _FixtureService(SQLiteWorkService):
+    """Subclass that pins the project path resolver to a known dir."""
+
+    def __init__(self, project_path: Path) -> None:
+        self._fixture_project_path = project_path
+
+    def _resolve_project_path(self, _project: str) -> Path | None:  # type: ignore[override]
+        return self._fixture_project_path
+
+
+def _make_task(project_slug: str = "proj", number: int = 1) -> Task:
+    return Task(
+        project=project_slug,
+        task_number=number,
+        title="fixture",
+        type=TaskType.TASK,
+    )
+
+
+def test_auto_merge_succeeds_for_additive_gitignore_divergence(tmp_path: Path) -> None:
+    """The historical coffeeboardnm/1 shape: both sides added different lines.
+
+    Should auto-resolve via the existing union-safe logic — this test pins
+    that the happy path keeps working alongside the new pre-merge recovery.
+    """
+    project_path = _make_fixture_repo(
+        tmp_path,
+        base_gitignore="# base\n",
+        main_gitignore="# base\nmain-only-path\n",
+        task_gitignore="# base\ntask-only-path\n",
+    )
+    svc = _FixtureService(project_path)
+    svc._auto_merge_approved_task_branch(_make_task())
+
+    merged = (project_path / ".gitignore").read_text()
+    assert "main-only-path" in merged
+    assert "task-only-path" in merged
+
+    # No leftover stash, no merge state.
+    assert not (project_path / ".git" / "MERGE_HEAD").exists()
+    stash = subprocess.run(
+        ["git", "-C", str(project_path), "stash", "list"],
+        check=True, capture_output=True, text=True,
+    )
+    assert stash.stdout.strip() == ""
+
+
+def test_auto_merge_recovers_from_pre_merge_overwrite_via_monkeypatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct exercise of the new pre-merge "would be overwritten" recovery
+    path. We monkeypatch the merge subprocess to mimic git's pre-merge
+    dirty-tree refusal on the first attempt, then return success on retry —
+    asserts the recovery resets the offending safe file and re-attempts.
+    """
+    project_path = _make_fixture_repo(
+        tmp_path,
+        base_gitignore="# base\n",
+        main_gitignore="# base\nmain-only-path\n",
+        task_gitignore="# base\ntask-only-path\n",
+    )
+
+    svc = _FixtureService(project_path)
+    real_git_run = SQLiteWorkService._git_run.__get__(svc)
+    merge_attempts: list[list[str]] = []
+    checkout_seen: list[list[str]] = []
+
+    fake_overwrite_stderr = (
+        "error: Your local changes to the following files would be"
+        " overwritten by merge:\n"
+        "\t.gitignore\n"
+        "Please commit your changes or stash them before you merge.\n"
+        "Aborting\n"
+    )
+
+    def faux_git_run(self, project_path_arg: Path, *args: str):
+        # First non-ff merge attempt → fake the overwrite refusal.
+        # All other commands (status, ff_only, checkout, retry merge) → real.
+        is_no_ff_merge = (
+            "merge" in args
+            and "--no-ff" in args
+            and "--no-edit" in args
+        )
+        if is_no_ff_merge:
+            merge_attempts.append(list(args))
+            if len(merge_attempts) == 1:
+                return subprocess.CompletedProcess(
+                    args=["git"] + list(args),
+                    returncode=1,
+                    stdout="",
+                    stderr=fake_overwrite_stderr,
+                )
+        if "checkout" in args and "HEAD" in args:
+            checkout_seen.append(list(args))
+        return real_git_run(project_path_arg, *args)
+
+    monkeypatch.setattr(_FixtureService, "_git_run", faux_git_run)
+
+    svc._auto_merge_approved_task_branch(_make_task())
+
+    # Recovery ran: the checkout reset the refused safe file.
+    assert any(
+        "checkout" in c and "HEAD" in c and ".gitignore" in c
+        for c in checkout_seen
+    ), f"expected ``git checkout HEAD -- .gitignore`` reset, saw {checkout_seen}"
+    # Two no-ff merge attempts: original (faked failure) + retry.
+    assert len(merge_attempts) == 2, (
+        f"expected one retry after recovery, got {len(merge_attempts)}"
+    )
+    # Final state: both ignore lines present.
+    merged = (project_path / ".gitignore").read_text()
+    assert "main-only-path" in merged
+    assert "task-only-path" in merged
+
+
+def test_auto_merge_preserves_ignored_scratch_files(
+    tmp_path: Path,
+) -> None:
+    """Operator's ignored scratch files survive an approve merge —
+    porcelain skips them, the merge's working-tree side never sees them."""
+    project_path = _make_fixture_repo(
+        tmp_path,
+        base_gitignore="# base\n",
+        main_gitignore="# base\nmain-only-path\n",
+        task_gitignore="# base\ntask-only-path\n",
+    )
+
+    # The dirty-tree gate requires all dirty entries to be PollyPM scaffold.
+    # Untracked files outside the allowlist trigger ValidationError, so we
+    # only seed an ignored scratch file (porcelain skips ignored entries).
+    (project_path / ".gitignore").write_text(
+        "# base\nmain-only-path\nscratch/\n"
+    )
+    _git("add", ".gitignore", cwd=project_path)
+    _git("commit", "-q", "-m", "ignore scratch dir", cwd=project_path)
+
+    scratch = project_path / "scratch"
+    scratch.mkdir()
+    (scratch / "notes.txt").write_text("operator notes — DO NOT TOUCH\n")
+
+    svc = _FixtureService(project_path)
+    svc._auto_merge_approved_task_branch(_make_task())
+
+    # Operator's scratch file untouched.
+    assert (scratch / "notes.txt").read_text() == (
+        "operator notes — DO NOT TOUCH\n"
+    )
+
+    merged = (project_path / ".gitignore").read_text()
+    assert "main-only-path" in merged
+    assert "task-only-path" in merged
+    assert "scratch/" in merged


### PR DESCRIPTION
Closes #1496

## Summary

`pm task approve <task>` was silently blocking on every project where the worker's `task/<slug>-N` branch and `main` had each added different lines to `.gitignore`. The python dirty-tree gate (`_status_is_only_pollypm_scaffold`) admits the case, but git's merge engine has its own pre-merge guard that doesn't share that allowance — so `git merge` errors out with `error: Your local changes to the following files would be overwritten by merge: .gitignore` *before* any `MERGE_HEAD` or conflict state exists. The existing union-safe resolver (`_resolve_union_safe_conflict`) was never reached.

Live repro tonight: coffeeboardnm/1 shipped a deliverable (live URL verified, `pm itsalive verify ok=True`) but the task state machine was stuck in `review` because three approve attempts each created an auto-stash (`preserve-main-gitignore-before-coffeeboardnm-1-approve-{,2}`, `preserve-reviewer-gitignore-before-coffeeboardnm-1-approve`) and never advanced.

## Fix

When `git merge --no-ff` fails before producing conflict state, parse the refused-files list from stderr. If every refused file is in `_UNION_SAFE_MERGE_FILES`, reset those files to HEAD (`git checkout HEAD -- <file>`) and retry the merge. The union-safe resolver then handles any actual add/add conflict that surfaces during the proper merge.

Targeted recovery — does **not** restructure the existing flow, doesn't add a new worktree, doesn't change behavior for non-safe-file conflicts, and is a no-op for the already-working union-safe path.

## Repro from #1496

\`\`\`
✗ Could not auto-merge \`task/coffeeboardnm-1\` into \`main\`. Resolve the repo state and retry approve. Git said: error: Your local changes to the following files would be overwritten by merge:
  .gitignore
  Please commit your changes or stash them before you merge.
  Aborting
\`\`\`

The repeat-attempt history was visible as auto-stashes:

\`\`\`
stash@{0}: On main: preserve-main-gitignore-before-coffeeboardnm-1-approve-2
stash@{1}: On pollypm/coffeeboardnm/reviewer/reviewer_coffeeboardnm: preserve-reviewer-gitignore-before-coffeeboardnm-1-approve
stash@{2}: On main: preserve-main-gitignore-before-coffeeboardnm-1-approve
\`\`\`

## Test plan

`tests/test_task_approve_merge_gitignore.py`:

- `test_parse_overwrite_files_*` (5 cases) — parser against single-file, multi-file, checkout-variant, conflict-only stderr, and empty input.
- `test_auto_merge_succeeds_for_additive_gitignore_divergence` — happy path on a real fixture repo with diverging `.gitignore`. Asserts both lines land in the merged file, no leftover stash, no merge state.
- `test_auto_merge_recovers_from_pre_merge_overwrite_via_monkeypatch` — directly exercises the new recovery: monkeypatches `_git_run` to fake git's "would be overwritten" stderr on the first `--no-ff` attempt, asserts the recovery resets `.gitignore` and the retry merges cleanly.
- `test_auto_merge_preserves_ignored_scratch_files` — ignored operator scratch files survive untouched.

\`\`\`
uv run --extra dev pytest tests/test_task_approve_merge_gitignore.py tests/test_import_boundary.py -x
\`\`\`

8/8 + 8/8 pass locally.

## Boundary discipline

Read `docs/conventions.md` Import boundaries + `docs/architecture.md` Service API v1 + `tests/test_import_boundary.py` header before coding. No new Supervisor direct imports, no `_method` reach-through, no `_conn` SQL added by this change, no cross-plugin private imports, no CLI-as-runtime-dep, no allow-list additions. The new parser is a pure module-level helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)