### PR TITLE
pm CLI: replace functools.partial command callbacks with signature-preserving wrappers (fixes #1500)

### DIFF
--- a/src/pollypm/cli_features/session_runtime.py
+++ b/src/pollypm/cli_features/session_runtime.py
@@ -13,7 +13,8 @@ Contract:
 
 from __future__ import annotations
 
-from functools import partial
+import functools
+import inspect
 import json
 import os
 import re
@@ -205,11 +206,37 @@ def _hold_review_tasks_for_notify(
 
 
 def _bind_session_command(callback, helpers):
-    bound = partial(callback, helpers)
-    bound.__name__ = callback.__name__
-    bound.__doc__ = callback.__doc__
-    bound.__module__ = callback.__module__
-    return bound
+    """Bind ``helpers`` as the first arg of ``callback`` while preserving the
+    inspectable signature Typer needs.
+
+    Typer's command-registration path calls :func:`typing.get_type_hints` on
+    the registered callable. ``functools.partial`` objects don't satisfy
+    ``get_type_hints``'s "module/class/method/function" check (Python 3.13's
+    typing.py raises ``TypeError`` on them), so we build a real wrapper
+    function whose signature drops the bound first parameter — Typer then
+    sees a normal function with the user-facing options/arguments only.
+    """
+    sig = inspect.signature(callback)
+    parameters = list(sig.parameters.values())
+    if not parameters:
+        bound_param_name = None
+        new_sig = sig
+    else:
+        bound_param_name = parameters[0].name
+        new_sig = sig.replace(parameters=parameters[1:])
+
+    @functools.wraps(callback)
+    def wrapper(*args, **kwargs):
+        return callback(helpers, *args, **kwargs)
+
+    wrapper.__signature__ = new_sig
+    if bound_param_name is not None:
+        wrapper.__annotations__ = {
+            name: annotation
+            for name, annotation in callback.__annotations__.items()
+            if name != bound_param_name
+        }
+    return wrapper
 
 
 def launch(

--- a/tests/test_pm_cli_registration.py
+++ b/tests/test_pm_cli_registration.py
@@ -1,0 +1,103 @@
+"""Smoke test that catches typer-introspection regressions on command callbacks.
+
+Issue #1500: ``functools.partial`` wrappers on Typer command callbacks tripped
+``typing.get_type_hints`` (Python 3.13's typing.py raises ``TypeError`` because
+partials don't satisfy "module/class/method/function"). The whole pm CLI
+became non-functional on every fresh install. This test re-registers the CLI
+in a clean Typer app and exercises the same introspection path Typer takes
+internally — any future regression that breaks ``inspect.signature`` /
+``get_type_hints`` on a registered command surfaces here at unit-test speed.
+"""
+
+from __future__ import annotations
+
+import inspect
+import typing
+
+import typer
+from typer.testing import CliRunner
+
+import pollypm.cli  # noqa: F401  — import alone must not raise
+from pollypm.cli_features.session_runtime import (
+    _bind_session_command,
+    launch,
+    rail_daemon,
+    register_session_runtime_commands,
+    reset,
+    status,
+)
+
+
+def test_session_runtime_commands_register_without_typer_introspection_error():
+    """Registering and invoking ``--help`` on the CLI must not raise.
+
+    This is the same path ``pm --help`` walks at runtime; a regression that
+    makes the registered callbacks un-introspectable surfaces here.
+    """
+    app = typer.Typer()
+    register_session_runtime_commands(app, helpers=pollypm.cli)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0, result.output
+
+
+def test_bound_session_callback_is_real_function_not_partial():
+    """``_bind_session_command`` must return a real function so that
+    ``typing.get_type_hints`` (which Typer calls internally) succeeds.
+    """
+    bound = _bind_session_command(launch, helpers=pollypm.cli)
+    assert inspect.isfunction(bound), (
+        f"Expected a real function for typer introspection; got {type(bound)!r}"
+    )
+
+    # The smoking gun: this is exactly what typer's get_params_from_function
+    # invokes. It used to raise on functools.partial wrappers.
+    hints = typing.get_type_hints(bound)
+    assert isinstance(hints, dict)
+
+
+def test_bound_session_callback_drops_helpers_parameter_from_signature():
+    """The bound wrapper must hide the first ``helpers`` parameter from typer
+    so that the user-facing signature only shows the typer options.
+    """
+    bound = _bind_session_command(launch, helpers=pollypm.cli)
+    sig = inspect.signature(bound)
+    # ``launch`` declares ``helpers`` as its first parameter; the wrapper
+    # binds it. Only the typer options/arguments should remain visible.
+    assert "helpers" not in sig.parameters
+    # ``launch`` has a ``config_path`` typer option — that should still be
+    # exposed on the bound wrapper.
+    assert "config_path" in sig.parameters
+
+
+def test_bound_session_callback_invokes_underlying_callback_with_helpers():
+    """When invoked, the wrapper must prepend the bound ``helpers`` so the
+    real callback sees its first argument.
+    """
+    captured = {}
+
+    def fake_callback(helpers, x: int = 0) -> int:
+        captured["helpers"] = helpers
+        captured["x"] = x
+        return x * 2
+
+    sentinel_helpers = object()
+    bound = _bind_session_command(fake_callback, helpers=sentinel_helpers)
+    result = bound(x=5)
+    assert result == 10
+    assert captured["helpers"] is sentinel_helpers
+    assert captured["x"] == 5
+
+
+def test_session_runtime_commands_each_have_introspectable_signature():
+    """Every command in ``register_session_runtime_commands`` should pass
+    ``typing.get_type_hints`` after binding — a generalized form of the
+    #1500 regression check.
+    """
+    for callback in (launch, rail_daemon, reset, status):
+        bound = _bind_session_command(callback, helpers=pollypm.cli)
+        hints = typing.get_type_hints(bound)
+        assert isinstance(hints, dict), (
+            f"get_type_hints failed on bound {callback.__name__!r}"
+        )


### PR DESCRIPTION
Closes #1500

## Summary

Typer's command-registration path calls \`typing.get_type_hints\` on each registered callable. Python 3.13's \`typing.py\` rejects \`functools.partial\` objects ("not a module, class, method, or function") — so the \`partial(callback, helpers)\` pattern introduced in #1484 produced a \`TypeError\` at every fresh \`uv tool install --reinstall .\` of pm.

Live repro tonight (post-#1484, post-#1499):

\`\`\`
TypeError: functools.partial(<function launch at 0x...>, <module 'pollypm.cli' from '...'>) is not a module, class, method, or function.
\`\`\`

The fix preserves the spirit of #1484 (closures hoisted out of \`session_runtime\`) without using \`partial\` for the typer-registered callable.

## Fix

\`_bind_session_command\` now returns a real wrapper function instead of a \`partial\`:

- \`__signature__\` drops the bound \`helpers\` parameter so typer sees only the user-facing options/arguments.
- \`__annotations__\` drops \`helpers\` to match.
- \`__name__\`/\`__doc__\`/\`__module__\` preserved via \`functools.wraps\`.

The wrapper closes over \`helpers\` and forwards \`(helpers, *args, **kwargs)\` to the original callback. From typer's introspection point of view it's a normal function — \`get_type_hints\` succeeds.

## Why #1484's review missed this

The merged review claimed "pm --help / notify --help / rail-daemon --help / reset --help / send --help all preserve signatures" — those checks must have run inside the test environment / on already-imported modules, not after a real \`uv tool install --reinstall\` and shell invocation. \`tests/test_session_runtime.py\` tests the bound callable's behavior but not typer's registration path.

This PR adds \`tests/test_pm_cli_registration.py\` which does walk that path (\`typing.get_type_hints\`, \`inspect.signature\`, a Typer-runner-driven \`--help\`) so the regression cannot recur silently.

## Test plan

\`\`\`
uv run --extra dev pytest tests/test_pm_cli_registration.py tests/test_cli.py tests/test_cli_help_examples.py tests/test_session_manager.py tests/test_import_boundary.py
\`\`\`

111/111 pass locally (5 new + 35 cli + 35 cli-help + 27 session_manager + 8 import_boundary).

**Install-time check (the one that proves the regression is gone):**

\`\`\`
uv tool install --reinstall .
pm --help
\`\`\`

Confirmed locally: pm --help renders the usage text instead of crashing on \`get_type_hints\`. Verified before pushing.

## Boundary discipline

Read \`docs/conventions.md\` "Import boundaries (enforced in CI)" + \`docs/architecture.md\` Service API v1 + \`tests/test_import_boundary.py\` header before coding. Changes are entirely internal to \`pollypm.cli_features.session_runtime\` (no Supervisor direct imports added or removed, no \`_conn\` SQL, no cross-plugin imports, no allow-list changes).

8/8 \`tests/test_import_boundary.py\` green.