### PR TITLE
cockpit: emit task_shipped inbox card on pm task done with deliverable URL

### DIFF
--- a/src/pollypm/task_shipped.py
+++ b/src/pollypm/task_shipped.py
@@ -1,0 +1,228 @@
+"""Emit a 'task shipped' inbox card on pm task done.
+
+When a worker completes a task via ``pm task done --output ...``, the work
+output may include artifacts like commit SHAs and external action URLs
+(deploy links). This module observes that transition and emits a single
+inbox notification with the deliverable surface — URL prominent, commit
+SHAs listed, summary quoted.
+
+The aim is the "magic" side of pm: when work ships, the operator sees a
+delivery card in their inbox without having to ask "is it done?". The
+data is read from the worker's reported ``WorkOutput`` artifacts — no
+plugin imports, no scraping. Workers that don't populate artifacts get
+a plain summary card; workers that do populate get a richer one.
+
+Boundary discipline: this module only imports from
+:mod:`pollypm.work.models` (typed value objects). It does not import
+from any plugin and does not reach into private store internals.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Protocol
+
+from pollypm.work.models import ArtifactKind
+
+logger = logging.getLogger(__name__)
+
+# URL pattern is conservative on purpose: we only surface http(s) links,
+# and we trim a few common trailing punctuation characters that show up
+# when URLs land at the end of free-form descriptions.
+_URL_RE = re.compile(r"https?://[^\s\)<>]+")
+_URL_TRAILING_TRIM = ".,;:!?)"
+
+# Cap commit SHA display length. Full SHAs in a notification card are
+# noise; the short form is enough to grep / `git show` without
+# overwhelming the inbox subject.
+_SHA_DISPLAY_LEN = 12
+
+# Cap the title summary so it fits the inbox subject column. The full
+# summary still appears in the body.
+_TITLE_SUMMARY_LEN = 80
+
+_TASK_SHIPPED_LABEL = "task_shipped"
+_HAS_DELIVERABLE_URL_LABEL = "has_deliverable_url"
+
+
+class _TaskShippedSvc(Protocol):
+    """Minimal contract — what the emit hook needs from the work service.
+
+    The transition hook in ``service_transitions.on_task_done`` already
+    holds an ``SQLiteWorkService``; this protocol just documents the
+    methods we touch so the function is independently mockable in
+    tests.
+    """
+
+    def get(self, task_id: str) -> Any: ...
+    def get_execution(self, task_id: str) -> list[Any]: ...
+    def create(self, **kwargs: Any) -> Any: ...
+
+
+def _latest_work_output(svc: _TaskShippedSvc, task_id: str) -> Any | None:
+    """Return the work_output of the most recent execution, or None.
+
+    Walks executions newest-first and returns the first one with a
+    populated ``work_output``. Returns None when there are no
+    executions, none have a work_output, or the lookup itself fails.
+    """
+    try:
+        executions = svc.get_execution(task_id)
+    except Exception:  # noqa: BLE001
+        return None
+    for execution in reversed(executions):
+        wo = getattr(execution, "work_output", None)
+        if wo is not None:
+            return wo
+    return None
+
+
+def _trim_url(url: str) -> str:
+    while url and url[-1] in _URL_TRAILING_TRIM:
+        url = url[:-1]
+    return url
+
+
+def _extract_commit_refs(work_output: Any) -> list[str]:
+    """Pull commit SHAs from artifacts of kind COMMIT, short-formatted."""
+    refs: list[str] = []
+    for art in getattr(work_output, "artifacts", None) or []:
+        if getattr(art, "kind", None) != ArtifactKind.COMMIT:
+            continue
+        ref = getattr(art, "ref", None) or getattr(art, "external_ref", None)
+        if not ref:
+            continue
+        refs.append(str(ref)[:_SHA_DISPLAY_LEN])
+    return refs
+
+
+def _extract_deploy_urls(work_output: Any) -> list[str]:
+    """Pull http(s) URLs from artifacts of kind ACTION.
+
+    URLs may sit in either ``external_ref`` (preferred) or be embedded
+    in ``description``. We extract from both, deduping in order.
+    """
+    urls: list[str] = []
+    seen: set[str] = set()
+    for art in getattr(work_output, "artifacts", None) or []:
+        if getattr(art, "kind", None) != ArtifactKind.ACTION:
+            continue
+        ref = (getattr(art, "external_ref", None) or "").strip()
+        if ref.startswith(("http://", "https://")):
+            url = _trim_url(ref)
+            if url not in seen:
+                seen.add(url)
+                urls.append(url)
+            continue
+        desc = getattr(art, "description", None) or ""
+        for match in _URL_RE.findall(desc):
+            url = _trim_url(match)
+            if url not in seen:
+                seen.add(url)
+                urls.append(url)
+    return urls
+
+
+def _build_card_title(task_id: str, summary: str, deploys: list[str]) -> str:
+    """Compose the inbox subject line.
+
+    Priority: shipped marker → deploy URL (if any, primary) → summary
+    (if no deploy). The deploy URL is the most actionable signal so it
+    earns the subject; commit SHAs are body-only.
+    """
+    parts = [f"✓ {task_id} SHIPPED"]
+    if deploys:
+        parts.append(deploys[0])
+    elif summary:
+        parts.append(summary[:_TITLE_SUMMARY_LEN])
+    return " — ".join(parts)
+
+
+def _build_card_body(
+    task_title: str,
+    summary: str,
+    deploys: list[str],
+    commits: list[str],
+) -> str:
+    lines: list[str] = []
+    if task_title:
+        lines.append(task_title)
+        lines.append("")
+    if summary:
+        lines.append(summary)
+        lines.append("")
+    if deploys:
+        lines.append("**Deployed:**")
+        lines.extend(f"- {url}" for url in deploys)
+        lines.append("")
+    if commits:
+        lines.append("**Commits:** " + ", ".join(f"`{c}`" for c in commits))
+    return "\n".join(lines).rstrip() or task_title or ""
+
+
+def emit_task_shipped_card(
+    svc: _TaskShippedSvc,
+    task_id: str,
+    actor: str,
+) -> str | None:
+    """Create the operator inbox card announcing a shipped task.
+
+    Returns the new card's task_id, or None if there's nothing to
+    announce (no work_output, lookup failure, or emit failure). This
+    function is best-effort — it logs and swallows so a broken inbox
+    surface never blocks the primary task_done transition.
+
+    The card itself is a chat-flow task with a stable label set
+    (``task_shipped``, plus ``has_deliverable_url`` when applicable)
+    so the cockpit inbox renderer can recognize it without parsing
+    the body.
+    """
+    try:
+        work_output = _latest_work_output(svc, task_id)
+        if work_output is None:
+            return None
+        try:
+            task = svc.get(task_id)
+        except Exception:  # noqa: BLE001
+            return None
+
+        summary = (getattr(work_output, "summary", "") or "").strip()
+        commits = _extract_commit_refs(work_output)
+        deploys = _extract_deploy_urls(work_output)
+
+        title = _build_card_title(task.task_id, summary, deploys)
+        body = _build_card_body(
+            getattr(task, "title", "") or "",
+            summary,
+            deploys,
+            commits,
+        )
+
+        labels = [_TASK_SHIPPED_LABEL]
+        if deploys:
+            labels.append(_HAS_DELIVERABLE_URL_LABEL)
+
+        card = svc.create(
+            title=title,
+            description=body,
+            type="task",
+            project=task.project,
+            flow_template="chat",
+            roles={"requester": "user", "operator": actor or "polly"},
+            priority="normal",
+            created_by=actor or "polly",
+            labels=labels,
+        )
+        return getattr(card, "task_id", None)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "task_shipped emit skipped for %s: %s",
+            task_id,
+            exc,
+            exc_info=True,
+        )
+        return None
+
+
+__all__ = ["emit_task_shipped_card"]

--- a/src/pollypm/work/service_transitions.py
+++ b/src/pollypm/work/service_transitions.py
@@ -133,6 +133,18 @@ def on_task_done(service: "SQLiteWorkService", task_id: str, actor: str) -> None
             exc_info=True,
         )
 
+    try:
+        from pollypm.task_shipped import emit_task_shipped_card
+
+        emit_task_shipped_card(service, task_id, actor or "polly")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "task_shipped card emit skipped for %s: %s",
+            task_id,
+            exc,
+            exc_info=True,
+        )
+
 
 def on_task_transition(
     service: "SQLiteWorkService",

--- a/tests/test_task_shipped_inbox.py
+++ b/tests/test_task_shipped_inbox.py
@@ -1,0 +1,449 @@
+"""Tests for ``pollypm.task_shipped.emit_task_shipped_card``.
+
+These tests focus on the emit hook itself — what gets pulled from the
+worker's WorkOutput, how the card is shaped, and that the function is
+robust to missing/empty data. The hook is wired into the
+``service_transitions.on_task_done`` flow; the wire-up is exercised by
+the integration test at the bottom.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pollypm.task_shipped import (
+    _build_card_body,
+    _build_card_title,
+    _extract_commit_refs,
+    _extract_deploy_urls,
+    _latest_work_output,
+    emit_task_shipped_card,
+)
+from pollypm.work.models import (
+    Artifact,
+    ArtifactKind,
+    OutputType,
+    WorkOutput,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeExecution:
+    work_output: Any | None = None
+
+
+@dataclass
+class _FakeTask:
+    task_id: str
+    title: str
+    project: str
+
+
+@dataclass
+class _FakeCard:
+    task_id: str
+
+
+class _FakeSvc:
+    """Minimal stand-in for SQLiteWorkService that records create() calls."""
+
+    def __init__(
+        self,
+        executions: list[_FakeExecution],
+        task: _FakeTask,
+        *,
+        get_execution_raises: Exception | None = None,
+        get_raises: Exception | None = None,
+        create_raises: Exception | None = None,
+    ) -> None:
+        self._executions = executions
+        self._task = task
+        self._get_execution_raises = get_execution_raises
+        self._get_raises = get_raises
+        self._create_raises = create_raises
+        self.create_calls: list[dict] = []
+
+    def get_execution(self, task_id: str) -> list[_FakeExecution]:
+        if self._get_execution_raises is not None:
+            raise self._get_execution_raises
+        return self._executions
+
+    def get(self, task_id: str) -> _FakeTask:
+        if self._get_raises is not None:
+            raise self._get_raises
+        return self._task
+
+    def create(self, **kwargs: Any) -> _FakeCard:
+        if self._create_raises is not None:
+            raise self._create_raises
+        self.create_calls.append(kwargs)
+        return _FakeCard(task_id=f"{kwargs['project']}/card-{len(self.create_calls)}")
+
+
+def _wo(
+    summary: str = "shipped",
+    *,
+    output_type: OutputType = OutputType.MIXED,
+    artifacts: list[Artifact] | None = None,
+) -> WorkOutput:
+    return WorkOutput(
+        type=output_type,
+        summary=summary,
+        artifacts=list(artifacts or []),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCommitRefs:
+    def test_pulls_from_commit_artifacts(self) -> None:
+        wo = _wo(
+            artifacts=[
+                Artifact(kind=ArtifactKind.COMMIT, ref="abcdef0123456789", description="land"),
+                Artifact(kind=ArtifactKind.NOTE, description="not a commit"),
+                Artifact(kind=ArtifactKind.COMMIT, ref="0123abc4567890", description="bugfix"),
+            ],
+        )
+        assert _extract_commit_refs(wo) == ["abcdef012345", "0123abc45678"]
+
+    def test_falls_back_to_external_ref(self) -> None:
+        wo = _wo(
+            artifacts=[
+                Artifact(kind=ArtifactKind.COMMIT, external_ref="0123456789abcdef", description="x"),
+            ],
+        )
+        assert _extract_commit_refs(wo) == ["0123456789ab"]
+
+    def test_skips_when_no_ref(self) -> None:
+        wo = _wo(artifacts=[Artifact(kind=ArtifactKind.COMMIT, description="missing ref")])
+        assert _extract_commit_refs(wo) == []
+
+    def test_empty_artifacts(self) -> None:
+        assert _extract_commit_refs(_wo(artifacts=[])) == []
+
+
+class TestExtractDeployUrls:
+    def test_action_external_ref(self) -> None:
+        wo = _wo(
+            artifacts=[
+                Artifact(
+                    kind=ArtifactKind.ACTION,
+                    description="deploy",
+                    external_ref="https://coffeeboardnm.itsalive.co",
+                ),
+            ],
+        )
+        assert _extract_deploy_urls(wo) == ["https://coffeeboardnm.itsalive.co"]
+
+    def test_extracts_url_from_description_when_no_external_ref(self) -> None:
+        wo = _wo(
+            artifacts=[
+                Artifact(
+                    kind=ArtifactKind.ACTION,
+                    description="Live at https://example.test/page (verified ok=True).",
+                ),
+            ],
+        )
+        assert _extract_deploy_urls(wo) == ["https://example.test/page"]
+
+    def test_dedupes_repeats(self) -> None:
+        wo = _wo(
+            artifacts=[
+                Artifact(
+                    kind=ArtifactKind.ACTION,
+                    description="x",
+                    external_ref="https://example.test",
+                ),
+                Artifact(
+                    kind=ArtifactKind.ACTION,
+                    description="see https://example.test for more",
+                ),
+            ],
+        )
+        assert _extract_deploy_urls(wo) == ["https://example.test"]
+
+    def test_only_action_artifacts(self) -> None:
+        wo = _wo(
+            artifacts=[
+                Artifact(
+                    kind=ArtifactKind.NOTE,
+                    description="see https://nope.test",
+                ),
+                Artifact(kind=ArtifactKind.COMMIT, ref="abc1234", description="land"),
+            ],
+        )
+        assert _extract_deploy_urls(wo) == []
+
+    def test_trims_trailing_punctuation(self) -> None:
+        wo = _wo(
+            artifacts=[
+                Artifact(
+                    kind=ArtifactKind.ACTION,
+                    description="deploy at https://example.test/ok.",
+                ),
+            ],
+        )
+        assert _extract_deploy_urls(wo) == ["https://example.test/ok"]
+
+
+class TestLatestWorkOutput:
+    def test_returns_most_recent(self) -> None:
+        first = _wo(summary="old")
+        second = _wo(summary="new")
+        svc = _FakeSvc(
+            executions=[_FakeExecution(first), _FakeExecution(second)],
+            task=_FakeTask("p/1", "t", "p"),
+        )
+        result = _latest_work_output(svc, "p/1")
+        assert result is second
+
+    def test_skips_executions_without_output(self) -> None:
+        only = _wo(summary="only")
+        svc = _FakeSvc(
+            executions=[_FakeExecution(only), _FakeExecution(None)],
+            task=_FakeTask("p/1", "t", "p"),
+        )
+        # reversed walk hits the None first; should skip and find ``only``.
+        assert _latest_work_output(svc, "p/1") is only
+
+    def test_returns_none_on_lookup_error(self) -> None:
+        svc = _FakeSvc(
+            executions=[],
+            task=_FakeTask("p/1", "t", "p"),
+            get_execution_raises=RuntimeError("boom"),
+        )
+        assert _latest_work_output(svc, "p/1") is None
+
+    def test_returns_none_when_no_executions(self) -> None:
+        svc = _FakeSvc(executions=[], task=_FakeTask("p/1", "t", "p"))
+        assert _latest_work_output(svc, "p/1") is None
+
+
+class TestBuildCardTitle:
+    def test_url_takes_priority_over_summary(self) -> None:
+        title = _build_card_title(
+            "demo/1", "did the thing", ["https://example.test"]
+        )
+        assert title == "✓ demo/1 SHIPPED — https://example.test"
+
+    def test_falls_back_to_summary_when_no_url(self) -> None:
+        title = _build_card_title("demo/1", "did the thing", [])
+        assert title == "✓ demo/1 SHIPPED — did the thing"
+
+    def test_truncates_long_summary(self) -> None:
+        long_summary = "x" * 200
+        title = _build_card_title("demo/1", long_summary, [])
+        assert title.endswith("x" * 80)
+        assert "x" * 81 not in title
+
+    def test_just_marker_when_neither(self) -> None:
+        assert _build_card_title("demo/1", "", []) == "✓ demo/1 SHIPPED"
+
+
+class TestBuildCardBody:
+    def test_full_card(self) -> None:
+        body = _build_card_body(
+            "Build the POC plan",
+            "delivered",
+            ["https://example.test"],
+            ["abc1234567"],
+        )
+        assert "Build the POC plan" in body
+        assert "delivered" in body
+        assert "**Deployed:**" in body
+        assert "- https://example.test" in body
+        assert "**Commits:** `abc1234567`" in body
+
+    def test_no_commits_no_url(self) -> None:
+        body = _build_card_body("Build the POC", "summary text", [], [])
+        assert "Deployed" not in body
+        assert "Commits" not in body
+        assert "summary text" in body
+        assert "Build the POC" in body
+
+
+# ---------------------------------------------------------------------------
+# emit_task_shipped_card behavior
+# ---------------------------------------------------------------------------
+
+
+class TestEmitTaskShippedCard:
+    def test_emits_card_with_url_and_commit(self) -> None:
+        wo = _wo(
+            summary="POC plan rendered, deployed, verified ok=True",
+            artifacts=[
+                Artifact(kind=ArtifactKind.COMMIT, ref="abc12345678abc", description="land"),
+                Artifact(
+                    kind=ArtifactKind.ACTION,
+                    description="deployed",
+                    external_ref="https://coffeeboardnm.itsalive.co",
+                ),
+            ],
+        )
+        svc = _FakeSvc(
+            executions=[_FakeExecution(wo)],
+            task=_FakeTask(
+                task_id="coffeeboardnm/1",
+                title="POC plan: ingest every NM event May–Jul 2026",
+                project="coffeeboardnm",
+            ),
+        )
+
+        result = emit_task_shipped_card(svc, "coffeeboardnm/1", "polly")
+
+        assert result == "coffeeboardnm/card-1"
+        assert len(svc.create_calls) == 1
+        call = svc.create_calls[0]
+        assert "coffeeboardnm/1 SHIPPED" in call["title"]
+        assert "https://coffeeboardnm.itsalive.co" in call["title"]
+        assert "https://coffeeboardnm.itsalive.co" in call["description"]
+        assert "abc12345678a" in call["description"]
+        assert "task_shipped" in call["labels"]
+        assert "has_deliverable_url" in call["labels"]
+        assert call["flow_template"] == "chat"
+        assert call["project"] == "coffeeboardnm"
+        assert call["roles"] == {"requester": "user", "operator": "polly"}
+
+    def test_no_emit_when_no_work_output(self) -> None:
+        svc = _FakeSvc(
+            executions=[_FakeExecution(None)],
+            task=_FakeTask("p/1", "t", "p"),
+        )
+        result = emit_task_shipped_card(svc, "p/1", "polly")
+        assert result is None
+        assert svc.create_calls == []
+
+    def test_no_emit_when_no_executions(self) -> None:
+        svc = _FakeSvc(executions=[], task=_FakeTask("p/1", "t", "p"))
+        result = emit_task_shipped_card(svc, "p/1", "polly")
+        assert result is None
+        assert svc.create_calls == []
+
+    def test_emits_summary_only_when_no_artifacts(self) -> None:
+        # A worker that calls pm task done with just a summary still
+        # gets a delivery card — graceful absence of richer signal.
+        wo = _wo(summary="documentation written")
+        svc = _FakeSvc(
+            executions=[_FakeExecution(wo)],
+            task=_FakeTask("docs/3", "Update README", "docs"),
+        )
+
+        result = emit_task_shipped_card(svc, "docs/3", "polly")
+        assert result == "docs/card-1"
+        call = svc.create_calls[0]
+        assert call["title"] == "✓ docs/3 SHIPPED — documentation written"
+        assert "has_deliverable_url" not in call["labels"]
+        assert "task_shipped" in call["labels"]
+
+    def test_swallows_create_failure(self) -> None:
+        wo = _wo(summary="done")
+        svc = _FakeSvc(
+            executions=[_FakeExecution(wo)],
+            task=_FakeTask("p/1", "t", "p"),
+            create_raises=RuntimeError("inbox down"),
+        )
+        # Best-effort: the transition path must not raise.
+        result = emit_task_shipped_card(svc, "p/1", "polly")
+        assert result is None
+
+    def test_swallows_get_failure(self) -> None:
+        wo = _wo(summary="done")
+        svc = _FakeSvc(
+            executions=[_FakeExecution(wo)],
+            task=_FakeTask("p/1", "t", "p"),
+            get_raises=RuntimeError("db gone"),
+        )
+        result = emit_task_shipped_card(svc, "p/1", "polly")
+        assert result is None
+        assert svc.create_calls == []
+
+    def test_actor_default_polly(self) -> None:
+        wo = _wo(summary="done")
+        svc = _FakeSvc(
+            executions=[_FakeExecution(wo)],
+            task=_FakeTask("p/1", "t", "p"),
+        )
+        emit_task_shipped_card(svc, "p/1", "")
+        assert svc.create_calls[0]["roles"]["operator"] == "polly"
+
+
+# ---------------------------------------------------------------------------
+# Wire-up: on_task_done invokes emit_task_shipped_card
+# ---------------------------------------------------------------------------
+
+
+class TestOnTaskDoneWireup:
+    def test_on_task_done_calls_emit_after_digest_flush(self, monkeypatch) -> None:
+        from pollypm.work import service_transitions
+
+        flush_calls: list[tuple] = []
+        emit_calls: list[tuple] = []
+
+        def fake_flush(svc, **kwargs):  # noqa: ANN001
+            flush_calls.append((kwargs.get("project"), kwargs.get("actor")))
+            return None
+
+        def fake_emit(svc, task_id, actor):  # noqa: ANN001
+            emit_calls.append((task_id, actor))
+            return "p/card-1"
+
+        monkeypatch.setattr(
+            "pollypm.notification_staging.check_and_flush_on_done", fake_flush
+        )
+        monkeypatch.setattr(
+            "pollypm.task_shipped.emit_task_shipped_card", fake_emit
+        )
+
+        @dataclass
+        class _Task:
+            project: str
+            task_id: str
+
+        class _Svc:
+            _project_path = None
+
+            def get(self, task_id):  # noqa: ANN001
+                return _Task(project="p", task_id=task_id)
+
+        service_transitions.on_task_done(_Svc(), "p/1", "polly")
+
+        assert flush_calls == [("p", "polly")]
+        assert emit_calls == [("p/1", "polly")]
+
+    def test_on_task_done_swallows_emit_failure(self, monkeypatch) -> None:
+        from pollypm.work import service_transitions
+
+        def boom(svc, task_id, actor):  # noqa: ANN001
+            raise RuntimeError("inbox surface broken")
+
+        # Make digest flush a no-op so we isolate the emit failure.
+        monkeypatch.setattr(
+            "pollypm.notification_staging.check_and_flush_on_done",
+            lambda svc, **k: None,
+        )
+        monkeypatch.setattr(
+            "pollypm.task_shipped.emit_task_shipped_card", boom
+        )
+
+        @dataclass
+        class _Task:
+            project: str
+            task_id: str
+
+        class _Svc:
+            _project_path = None
+
+            def get(self, task_id):  # noqa: ANN001
+                return _Task(project="p", task_id=task_id)
+
+        # Must not raise — this is the protective swallow.
+        service_transitions.on_task_done(_Svc(), "p/1", "polly")


### PR DESCRIPTION
Closes #1501

## Summary

When a worker finishes via `pm task done --output ...` and ships a deliverable, the cockpit operator inbox should announce it proactively — URL prominent, summary quoted, commit SHAs listed — instead of leaving the operator to ask "is it done?". Live tonight, coffeeboardnm/1 shipped a verified live page (https://coffeeboardnm.itsalive.co, ok=True) and nothing in the cockpit inbox said so. This PR fixes that gap.

## Changes

- **`src/pollypm/task_shipped.py`** (new) — `emit_task_shipped_card(svc, task_id, actor)` reads the most recent execution's `WorkOutput`, pulls commit SHAs from `Artifact(kind=COMMIT)` and deploy URLs from `Artifact(kind=ACTION)` (either `external_ref` or http(s) URLs embedded in `description`), and creates a chat-flow inbox task with stable labels (`task_shipped`, plus `has_deliverable_url` when a URL is present).
- **`src/pollypm/work/service_transitions.py`** — hook the emit from `on_task_done` after the existing notification-staging digest flush. Wrapped in try/except; failures are logged at debug. The transition path is never blocked by an inbox-surface fault.

## Card shape

- **Title:** `✓ <task_id> SHIPPED — <url-or-summary>` (URL takes precedence; summary truncated to 80 chars when used)
- **Body:** task title → worker summary → `**Deployed:**` URL list → `**Commits:**` short-SHA list
- **Labels:** `task_shipped` (always), `has_deliverable_url` (when ≥1 URL extracted)
- **Roles:** `requester=user`, `operator=<actor or polly>` — same shape as `pm notify`'s inbox-visible row

The cockpit inbox renderer can detect these by label without parsing the body.

## Boundary discipline

Read `docs/conventions.md` Import boundaries + `docs/architecture.md` Service API v1 + `tests/test_import_boundary.py` header before coding. The new module imports only `pollypm.work.models` (typed value objects). No Supervisor direct-import additions, no `_method` reach-through, no `_conn` SQL, no cross-plugin private imports, no CLI-as-runtime-dep, no allow-list additions.

The "itsalive deploy URL" path is intentionally non-coupled: the worker already populates `external_ref` with the URL when calling `pm task done --output '{"artifacts": [{"kind": "action", "external_ref": "https://..."}]}'`. We just read what the worker reported. Itsalive-attached projects work without any new cross-plugin imports.

## Test plan

- `tests/test_task_shipped_inbox.py` (new):
  - Helper extractors: commit refs (multiple kinds, fallback to `external_ref`, skip when no ref), deploy URLs (external_ref vs description, dedup, skip non-ACTION kinds, trim trailing punctuation).
  - `_latest_work_output`: returns most recent, skips None executions, handles lookup error, handles no executions.
  - Title/body builders: URL priority, summary fallback, long-summary truncation.
  - `emit_task_shipped_card`: full card with URL+commit, summary-only card, graceful absence when no `WorkOutput`, swallow on `create()` failure, swallow on `get()` failure, actor default to `polly`.
  - Wire-up: `on_task_done` invokes the emit after digest flush, and a raising emit does NOT break the transition path.

```
uv run --extra dev pytest tests/test_task_shipped_inbox.py tests/test_import_boundary.py -x
```

36/36 pass locally. Broader sweep (`test_work_approval`, `test_notification_tiering`, `test_flow_progression`) — 133/133 pass.

## Activation

This PR is **activation-required for the full visual verify** — the cockpit inbox renderer's behavior on the new label is the user-facing surface. The unit tests pin the data shape and emit hook; activation confirms the card renders with the URL prominent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)