### PR TITLE
worker: add pm send-up CLI for milestone-level progress visibility to polly

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -57,6 +57,7 @@ from pollypm.cli_features.dev import dev_app
 from pollypm.cli_features.maintenance import debug_app, register_maintenance_commands
 from pollypm.cli_features.migrate import register_migrate_commands
 from pollypm.cli_features.projects import register_project_commands
+from pollypm.cli_features.send_up import register_send_up_commands
 from pollypm.cli_features.session_runtime import register_session_runtime_commands
 from pollypm.cli_features.ui import register_ui_commands
 from pollypm.cli_features.update import register_update_commands
@@ -205,6 +206,7 @@ register_upgrade_commands(app)
 register_migrate_commands(app)
 register_worker_commands(app)
 register_session_runtime_commands(app, helpers=sys.modules[__name__])
+register_send_up_commands(app, helpers=sys.modules[__name__])
 
 
 def attach_existing_session(session_name: str) -> int:

--- a/src/pollypm/cli_features/send_up.py
+++ b/src/pollypm/cli_features/send_up.py
@@ -1,0 +1,167 @@
+"""``pm send-up`` — workers post mid-task milestones to the operator inbox.
+
+A worker invokes ``pm send-up "outline drafted, starting render"`` from
+its task pane (or from a script the worker spawns). One inbox card with
+that message lands in the operator's view.
+
+Boundary discipline: this module is a CLI shim. The emit logic lives in
+:mod:`pollypm.worker_milestone` so non-CLI callers can reuse it without
+making the CLI module a runtime dependency target.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import os
+from pathlib import Path
+
+import typer
+
+from pollypm.worker_milestone import emit_worker_milestone
+
+
+def _load_work_service(db: str, task_id: str):
+    """Construct a SQLiteWorkService scoped to ``task_id``'s project.
+
+    Reuses :func:`pollypm.work.cli._svc` because that helper already
+    centralizes db-path resolution, project-root discovery, and the
+    sync-manager wiring. CLI-to-CLI imports are allowed by the
+    boundary rules; non-CLI code must continue to use the typed work
+    service or the service_api facade directly.
+    """
+    from pollypm.work.cli import _project_from_task_id, _svc
+
+    project = _project_from_task_id(task_id)
+    return _svc(db, project=project)
+
+
+def _bind_send_up_command(callback, helpers):
+    """Bind ``helpers`` as the first arg of the callback while preserving
+    Typer's introspectable signature.
+
+    Mirrors the ``_bind_session_command`` helper from the session_runtime
+    feature module after #1502 (functools.partial on the registered
+    callable trips ``typing.get_type_hints``).
+    """
+    sig = inspect.signature(callback)
+    parameters = list(sig.parameters.values())
+    if not parameters:
+        bound_param_name = None
+        new_sig = sig
+    else:
+        bound_param_name = parameters[0].name
+        new_sig = sig.replace(parameters=parameters[1:])
+
+    @functools.wraps(callback)
+    def wrapper(*args, **kwargs):
+        return callback(helpers, *args, **kwargs)
+
+    wrapper.__signature__ = new_sig
+    if bound_param_name is not None:
+        wrapper.__annotations__ = {
+            name: annotation
+            for name, annotation in callback.__annotations__.items()
+            if name != bound_param_name
+        }
+    return wrapper
+
+
+def send_up(
+    helpers,
+    message: str = typer.Argument(
+        ...,
+        help=(
+            "One-line milestone to surface to the operator inbox "
+            "(e.g. 'outline drafted, starting render')."
+        ),
+    ),
+    task: str | None = typer.Option(
+        None,
+        "--task",
+        help=(
+            "Task id (project/number). Falls back to the "
+            "POLLYPM_TASK_ID env var when omitted."
+        ),
+    ),
+    actor: str = typer.Option(
+        "worker",
+        "--actor",
+        help="Sender label recorded on the inbox card (defaults to 'worker').",
+    ),
+    db: str = typer.Option(
+        ".pollypm/state.db",
+        "--db",
+        help="Path to SQLite database.",
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit structured JSON."
+    ),
+) -> None:
+    """Post a milestone update from a worker to the operator inbox.
+
+    Designed for mid-task progress reports. The card is informational —
+    it does NOT block, alert, or wake polly's heartbeat-supervisor.
+    Polly sees it the next time she scans her inbox.
+    """
+    task_id = task or os.environ.get("POLLYPM_TASK_ID") or ""
+    task_id = task_id.strip()
+    if not task_id:
+        typer.echo(
+            "send-up: no task id — pass --task <project/N> or set "
+            "POLLYPM_TASK_ID before invoking.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    text = (message or "").strip()
+    if not text:
+        typer.echo("send-up: message is empty.", err=True)
+        raise typer.Exit(code=1)
+
+    # Load the work service. Mirrors the construction in
+    # ``pollypm.work.cli._svc`` but kept self-contained so this CLI
+    # module doesn't depend on another CLI module (boundary rule:
+    # CLI modules are not runtime dependency targets for non-CLI
+    # code).
+    try:
+        svc = _load_work_service(db, task_id)
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(f"send-up: could not open work service: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    new_card_id = emit_worker_milestone(svc, task_id, text, actor=actor)
+
+    if json_output:
+        import json as _json
+
+        typer.echo(
+            _json.dumps(
+                {
+                    "task_id": task_id,
+                    "message": text,
+                    "card_id": new_card_id,
+                    "deduped": new_card_id is None,
+                }
+            )
+        )
+        return
+
+    if new_card_id is None:
+        typer.echo(
+            "send-up: nothing emitted (recent duplicate, missing task, "
+            "or store transient — see debug log)."
+        )
+        return
+    typer.echo(f"send-up: emitted {new_card_id} for {task_id}.")
+
+
+def register_send_up_commands(app: typer.Typer, *, helpers) -> None:
+    """Register ``pm send-up`` on the root Typer app."""
+    app.command(
+        "send-up",
+        help=(
+            "Workers post mid-task milestone updates to the operator "
+            "inbox. Use --task or POLLYPM_TASK_ID."
+        ),
+    )(_bind_send_up_command(send_up, helpers))

--- a/src/pollypm/defaults/docs/worker-guide.md
+++ b/src/pollypm/defaults/docs/worker-guide.md
@@ -131,6 +131,21 @@ distilled task brief. Then:
 Work on `task/<project>-<number>`. Do **not** commit to `main`. Do **not** edit
 files outside the worktree.
 
+**Tell Polly when you finish a meaningful step.** Long-running tasks
+(rendering, deploying, multi-stage research) look stalled to the
+operator if there's no visible progress. Call `pm send-up` with a
+one-line summary at each milestone:
+
+```
+pm send-up "outline drafted, starting render" --task <project>/<N>
+pm send-up "tests passing, deploying"
+pm send-up "deploy verified, marking done"
+```
+
+The `--task` flag is optional when `POLLYPM_TASK_ID` is set in your
+environment. The card lands in the operator inbox without alerting
+or interrupting Polly's heartbeat — it's pure visibility.
+
 ### 5. Mark the node done with a work output
 
 The `pm task done` command takes a JSON work-output payload. The payload

--- a/src/pollypm/worker_milestone.py
+++ b/src/pollypm/worker_milestone.py
@@ -1,0 +1,193 @@
+"""Emit a `worker_milestone` inbox card from a worker mid-task.
+
+Workers iterate silently between `pm task claim` and `pm task done`. The
+operator (Polly) sees the start and the finish but nothing in between —
+"render started", "research done", "deploy started" all happen inside
+the worker pane and never surface unless the operator asks. That gap is
+why coffeeboardnm/1 looked stalled for 14 minutes during the visual-explainer
+render this past session: real progress was happening; nobody could see it.
+
+This module provides the emit hook backing the ``pm send-up`` CLI: a worker
+can call ``pm send-up "outline drafted, starting render"`` and a single
+inbox card lands in the operator's inbox with that message.
+
+Boundary discipline: this module imports only from
+:mod:`pollypm.work.models` (typed value objects). It does not import any
+plugin, does not reach into private store internals, and does not depend
+on a CLI module.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+_WORKER_MILESTONE_LABEL = "worker_milestone"
+
+# Title summary cap so the inbox subject column stays readable. Full
+# message goes in the body.
+_TITLE_SUMMARY_LEN = 80
+
+# Dedupe window: a worker hammering ``pm send-up`` on the same message
+# (e.g. retry after a transient error) shouldn't spam the operator.
+# 5 minutes is short enough to allow legitimate "still rendering"
+# follow-ups and long enough to suppress accidental repeats.
+_DEDUPE_WINDOW_SECONDS = 300
+
+
+class _WorkerMilestoneSvc(Protocol):
+    """Minimal contract for the work service surface this module touches."""
+
+    def get(self, task_id: str) -> Any: ...
+
+    def list_tasks(self, **kwargs: Any) -> list[Any]: ...
+
+    def create(self, **kwargs: Any) -> Any: ...
+
+
+def _truncate(text: str, limit: int) -> str:
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _build_milestone_title(task_id: str, message: str) -> str:
+    """Build a one-line subject for the inbox card."""
+    summary = _truncate(message, _TITLE_SUMMARY_LEN)
+    return f"{task_id}: {summary}"
+
+
+def _build_milestone_body(task: Any, message: str) -> str:
+    """Build the inbox card body."""
+    parts: list[str] = []
+    title = (getattr(task, "title", "") or "").strip()
+    if title:
+        parts.append(f"**Task:** {task.task_id} — {title}")
+    else:
+        parts.append(f"**Task:** {task.task_id}")
+    parts.append("")
+    parts.append(message.strip())
+    return "\n".join(parts)
+
+
+def _is_recent_duplicate(
+    svc: _WorkerMilestoneSvc,
+    task_id: str,
+    message: str,
+    *,
+    now_seconds: float,
+    window_seconds: float = _DEDUPE_WINDOW_SECONDS,
+) -> bool:
+    """Return True iff the same message was already emitted for ``task_id``
+    within ``window_seconds``.
+
+    Looks at recent tasks under the same project carrying the
+    ``worker_milestone`` label and compares description payloads. Does
+    not raise — a query failure returns False (favor emit over silent
+    drop).
+    """
+    project = task_id.split("/", 1)[0] if "/" in task_id else None
+    if not project:
+        return False
+    try:
+        recent = svc.list_tasks(project=project, limit=20)
+    except Exception:  # noqa: BLE001
+        return False
+    needle = message.strip()
+    for entry in recent:
+        labels = getattr(entry, "labels", None) or []
+        if _WORKER_MILESTONE_LABEL not in labels:
+            continue
+        # The card's body has the task_id + needle; compare on the
+        # message tail so a mismatched task title doesn't defeat
+        # dedup.
+        body = (getattr(entry, "description", "") or "")
+        if needle not in body:
+            continue
+        # Compare timestamps if the entry has a created_at; if it
+        # doesn't, assume "recent enough" since list_tasks ordered
+        # newest-first by convention.
+        created_at = getattr(entry, "created_at", None)
+        if created_at is None:
+            return True
+        try:
+            created_seconds = (
+                created_at.timestamp() if hasattr(created_at, "timestamp")
+                else float(created_at)
+            )
+        except Exception:  # noqa: BLE001
+            return True
+        if (now_seconds - created_seconds) <= window_seconds:
+            return True
+    return False
+
+
+def emit_worker_milestone(
+    svc: _WorkerMilestoneSvc,
+    task_id: str,
+    message: str,
+    *,
+    actor: str | None = None,
+    now_seconds: float | None = None,
+) -> str | None:
+    """Emit a ``worker_milestone`` inbox card. Returns new card id, or None.
+
+    Returns None on:
+    - empty/whitespace ``message``
+    - task lookup failure (the task doesn't exist or the store is
+      transiently unavailable)
+    - recent-duplicate detection
+    - the create call itself failing
+
+    All failures are logged at debug — this is best-effort
+    progress-reporting, never a blocker for the worker's actual work.
+    """
+    text = (message or "").strip()
+    if not text:
+        return None
+    try:
+        try:
+            task = svc.get(task_id)
+        except Exception:  # noqa: BLE001
+            return None
+
+        clock_seconds = now_seconds if now_seconds is not None else time.time()
+        if _is_recent_duplicate(svc, task_id, text, now_seconds=clock_seconds):
+            logger.debug(
+                "worker_milestone dedupe skip for %s: %r", task_id, text[:60]
+            )
+            return None
+
+        title = _build_milestone_title(task.task_id, text)
+        body = _build_milestone_body(task, text)
+
+        # operator is fixed: milestones always surface to polly. The
+        # caller-controlled identity is ``created_by`` (which worker
+        # said it).
+        card = svc.create(
+            title=title,
+            description=body,
+            type="task",
+            project=task.project,
+            flow_template="chat",
+            roles={"requester": "worker", "operator": "polly"},
+            priority="normal",
+            created_by=actor or "worker",
+            labels=[_WORKER_MILESTONE_LABEL],
+        )
+        return getattr(card, "task_id", None)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "worker_milestone emit skipped for %s: %s",
+            task_id,
+            exc,
+            exc_info=True,
+        )
+        return None
+
+
+__all__ = ["emit_worker_milestone"]

--- a/tests/test_send_up_cli.py
+++ b/tests/test_send_up_cli.py
@@ -1,0 +1,320 @@
+"""Tests for ``pm send-up`` worker milestone CLI + emit module.
+
+The CLI is a thin shim; the bulk of the behavior lives in
+:mod:`pollypm.worker_milestone`. Tests cover both layers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm.worker_milestone import (
+    _build_milestone_body,
+    _build_milestone_title,
+    _is_recent_duplicate,
+    emit_worker_milestone,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeTask:
+    task_id: str
+    project: str
+    title: str = ""
+
+
+@dataclass
+class _FakeCard:
+    task_id: str
+
+
+@dataclass
+class _ListEntry:
+    description: str
+    labels: list[str] = field(default_factory=list)
+    created_at: float | None = None
+
+
+class _FakeSvc:
+    def __init__(
+        self,
+        task: _FakeTask | None = None,
+        recent: list[_ListEntry] | None = None,
+        *,
+        get_raises: Exception | None = None,
+        list_raises: Exception | None = None,
+        create_raises: Exception | None = None,
+    ) -> None:
+        self._task = task
+        self._recent = recent or []
+        self._get_raises = get_raises
+        self._list_raises = list_raises
+        self._create_raises = create_raises
+        self.create_calls: list[dict] = []
+
+    def get(self, task_id: str) -> _FakeTask:
+        if self._get_raises is not None:
+            raise self._get_raises
+        if self._task is None:
+            raise LookupError(f"no task {task_id}")
+        return self._task
+
+    def list_tasks(self, **kwargs: Any) -> list[_ListEntry]:
+        if self._list_raises is not None:
+            raise self._list_raises
+        return self._recent
+
+    def create(self, **kwargs: Any) -> _FakeCard:
+        if self._create_raises is not None:
+            raise self._create_raises
+        self.create_calls.append(kwargs)
+        return _FakeCard(task_id=f"{kwargs['project']}/card-{len(self.create_calls)}")
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMilestoneTitle:
+    def test_short_message_kept_intact(self) -> None:
+        assert _build_milestone_title("foo/1", "outline ready") == "foo/1: outline ready"
+
+    def test_long_message_truncated_with_ellipsis(self) -> None:
+        msg = "x" * 200
+        out = _build_milestone_title("foo/1", msg)
+        assert out.startswith("foo/1: ")
+        assert out.endswith("…")
+        assert len(out) <= len("foo/1: ") + 80
+
+    def test_message_stripped(self) -> None:
+        assert _build_milestone_title("foo/1", "  hi  ") == "foo/1: hi"
+
+
+class TestBuildMilestoneBody:
+    def test_includes_task_title_when_present(self) -> None:
+        task = _FakeTask(task_id="foo/1", project="foo", title="Render plan")
+        body = _build_milestone_body(task, "outline drafted")
+        assert "foo/1 — Render plan" in body
+        assert "outline drafted" in body
+
+    def test_omits_task_title_when_absent(self) -> None:
+        task = _FakeTask(task_id="foo/1", project="foo", title="")
+        body = _build_milestone_body(task, "outline drafted")
+        assert "foo/1 — " not in body
+        assert "Task:** foo/1" in body
+        assert "outline drafted" in body
+
+
+class TestRecentDuplicate:
+    def test_no_match_when_label_missing(self) -> None:
+        svc = _FakeSvc(recent=[_ListEntry(description="hi", labels=[])])
+        assert _is_recent_duplicate(svc, "foo/1", "hi", now_seconds=1000.0) is False
+
+    def test_match_when_label_and_text_match(self) -> None:
+        svc = _FakeSvc(
+            recent=[
+                _ListEntry(
+                    description="**Task:** foo/1\n\nhi",
+                    labels=["worker_milestone"],
+                    created_at=999.0,
+                )
+            ]
+        )
+        assert _is_recent_duplicate(svc, "foo/1", "hi", now_seconds=1000.0) is True
+
+    def test_outside_window_returns_false(self) -> None:
+        svc = _FakeSvc(
+            recent=[
+                _ListEntry(
+                    description="hi",
+                    labels=["worker_milestone"],
+                    created_at=0.0,
+                )
+            ]
+        )
+        # 1000s ago > 300s default window
+        assert _is_recent_duplicate(svc, "foo/1", "hi", now_seconds=1000.0) is False
+
+    def test_query_failure_emits(self) -> None:
+        svc = _FakeSvc(list_raises=RuntimeError("db down"))
+        assert _is_recent_duplicate(svc, "foo/1", "hi", now_seconds=1000.0) is False
+
+
+# ---------------------------------------------------------------------------
+# emit_worker_milestone behavior
+# ---------------------------------------------------------------------------
+
+
+class TestEmitWorkerMilestone:
+    def test_happy_path_creates_card(self) -> None:
+        task = _FakeTask(task_id="foo/1", project="foo", title="Render plan")
+        svc = _FakeSvc(task=task)
+
+        card_id = emit_worker_milestone(
+            svc, "foo/1", "outline drafted", actor="worker", now_seconds=1000.0
+        )
+
+        assert card_id == "foo/card-1"
+        assert len(svc.create_calls) == 1
+        call = svc.create_calls[0]
+        assert call["project"] == "foo"
+        assert call["title"] == "foo/1: outline drafted"
+        assert "outline drafted" in call["description"]
+        assert call["labels"] == ["worker_milestone"]
+        assert call["created_by"] == "worker"
+        assert call["roles"]["operator"] == "polly"
+        assert call["priority"] == "normal"
+
+    def test_empty_message_no_emit(self) -> None:
+        svc = _FakeSvc(task=_FakeTask("foo/1", "foo"))
+        assert emit_worker_milestone(svc, "foo/1", "   ") is None
+        assert svc.create_calls == []
+
+    def test_missing_task_no_emit(self) -> None:
+        svc = _FakeSvc(task=None, get_raises=LookupError("nope"))
+        assert emit_worker_milestone(svc, "foo/99", "hi") is None
+        assert svc.create_calls == []
+
+    def test_recent_duplicate_no_emit(self) -> None:
+        task = _FakeTask("foo/1", "foo")
+        recent = [
+            _ListEntry(
+                description="**Task:** foo/1\n\nrendering",
+                labels=["worker_milestone"],
+                created_at=999.0,
+            )
+        ]
+        svc = _FakeSvc(task=task, recent=recent)
+
+        assert (
+            emit_worker_milestone(svc, "foo/1", "rendering", now_seconds=1000.0)
+            is None
+        )
+        assert svc.create_calls == []
+
+    def test_create_failure_returns_none(self) -> None:
+        svc = _FakeSvc(
+            task=_FakeTask("foo/1", "foo"),
+            create_raises=RuntimeError("boom"),
+        )
+        assert emit_worker_milestone(svc, "foo/1", "hi") is None
+
+    def test_actor_threaded_through(self) -> None:
+        svc = _FakeSvc(task=_FakeTask("foo/1", "foo"))
+        emit_worker_milestone(svc, "foo/1", "hi", actor="worker_render")
+        call = svc.create_calls[0]
+        assert call["created_by"] == "worker_render"
+        assert call["roles"]["operator"] == "polly"
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+class TestSendUpCli:
+    """Exercise the Typer command via CliRunner with the underlying svc mocked."""
+
+    def _runner_app_and_svc(self, monkeypatch: pytest.MonkeyPatch, **svc_kwargs):
+        import typer
+
+        from pollypm.cli_features import send_up as send_up_mod
+
+        # Build a fresh Typer app and register the send-up command.
+        # A second no-op command is registered so Typer treats this as
+        # a multi-command app — otherwise a single-command Typer app
+        # collapses the command name and fails to recognize ``send-up``
+        # as a subcommand prefix.
+        app = typer.Typer()
+        helpers = type(
+            "H",
+            (),
+            {
+                "_load_supervisor": lambda *a, **k: None,
+                "_discover_config_path": lambda p: p,
+            },
+        )()
+        send_up_mod.register_send_up_commands(app, helpers=helpers)
+
+        @app.command("noop", hidden=True)
+        def _noop() -> None:  # pragma: no cover — keeps app multi-command
+            pass
+
+        svc = _FakeSvc(**svc_kwargs)
+        monkeypatch.setattr(send_up_mod, "_load_work_service", lambda db, tid: svc)
+        return app, svc
+
+    def test_happy_path_emits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        app, svc = self._runner_app_and_svc(
+            monkeypatch, task=_FakeTask("foo/1", "foo")
+        )
+        runner = CliRunner()
+        result = runner.invoke(app, ["send-up", "outline drafted", "--task", "foo/1"])
+        assert result.exit_code == 0, result.output
+        assert "emitted" in result.output
+        assert len(svc.create_calls) == 1
+        assert svc.create_calls[0]["title"] == "foo/1: outline drafted"
+
+    def test_missing_task_id_clean_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Ensure POLLYPM_TASK_ID is not set
+        monkeypatch.delenv("POLLYPM_TASK_ID", raising=False)
+        app, _svc = self._runner_app_and_svc(monkeypatch)
+        runner = CliRunner()
+        result = runner.invoke(app, ["send-up", "hi"])
+        assert result.exit_code == 1
+        assert "no task id" in result.output.lower()
+
+    def test_env_var_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("POLLYPM_TASK_ID", "foo/1")
+        app, svc = self._runner_app_and_svc(
+            monkeypatch, task=_FakeTask("foo/1", "foo")
+        )
+        runner = CliRunner()
+        result = runner.invoke(app, ["send-up", "hi"])
+        assert result.exit_code == 0, result.output
+        assert len(svc.create_calls) == 1
+
+    def test_dedupe_no_emit_path_succeeds_silently(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recent = [
+            _ListEntry(
+                description="**Task:** foo/1\n\nhi",
+                labels=["worker_milestone"],
+                created_at=None,  # treated as recent
+            )
+        ]
+        app, svc = self._runner_app_and_svc(
+            monkeypatch, task=_FakeTask("foo/1", "foo"), recent=recent
+        )
+        runner = CliRunner()
+        result = runner.invoke(app, ["send-up", "hi", "--task", "foo/1"])
+        assert result.exit_code == 0
+        assert "nothing emitted" in result.output
+        assert svc.create_calls == []
+
+    def test_json_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import json
+
+        app, svc = self._runner_app_and_svc(
+            monkeypatch, task=_FakeTask("foo/1", "foo")
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["send-up", "outline drafted", "--task", "foo/1", "--json"]
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["task_id"] == "foo/1"
+        assert payload["card_id"] == "foo/card-1"
+        assert payload["deduped"] is False


### PR DESCRIPTION
Closes #1506

## Summary

Workers iterate silently between `pm task claim` and `pm task done`. The operator (Polly) sees the start and the finish but nothing in between. coffeeboardnm/1 rendered an HTML deliverable for 14m 30s in this session with no operator-visible signal — the work was happening but the user had to ping to confirm.

This adds a single CLI command for workers to opt into surfacing milestones:

```
pm send-up "outline drafted, starting render"
pm send-up "tests passing" --task project/1
pm send-up "deploy verified" --json
```

Each invocation emits a single `worker_milestone` inbox card. Priority=normal, no heartbeat wakeup, no alert. Polly sees it next time she scans her inbox.

## Changes

- **`src/pollypm/worker_milestone.py`** — new isolated emit module. Mirrors the #1503 `task_shipped` pattern: only imports `pollypm.work.models` (no plugin imports, no Supervisor, no `_conn` SQL).
- **`src/pollypm/cli_features/send_up.py`** — Typer command. Uses the **signature-preserving wrapper pattern from #1502**, NOT `functools.partial` (which trips typer's introspection).
- **`src/pollypm/cli.py`** — register new command on the root app.
- **`src/pollypm/defaults/docs/worker-guide.md`** — operator-facing guidance: when to call send-up, sample messages.

## Behavior

- **Auto-detect task id** from `POLLYPM_TASK_ID` env var or `--task <project/N>` flag. Missing → clean error + non-zero exit.
- **5-minute dedupe** on same message + same task. Retry loops don't spam polly. Different message text always emits, so "rendering 25%" / "rendering 50%" / etc. all go through.
- **Best-effort failure mode** — store transient failures, missing-task lookups, and create-failures all return None (no card emitted) without raising. The worker's actual work is never blocked by send-up infrastructure.

## Boundary discipline

Before coding, read `docs/conventions.md` "Import boundaries", `docs/architecture.md` Service API v1 notes, and `tests/test_import_boundary.py` header. The CLI shim imports the emit module (non-CLI). The emit module only touches `pollypm.work.models`. No cross-plugin imports added, no allow-list entries needed, `tests/test_import_boundary.py` 8/8 passes.

The CLI module pattern: helper-binding via `_bind_send_up_command` mirrors `_bind_session_command` from #1502 (functools.wraps + signature manipulation, NOT functools.partial — typer would crash on introspection).

## Test plan

- **`tests/test_send_up_cli.py`** — 20 tests covering:
  - `_build_milestone_title`: short / long-truncate / strip
  - `_build_milestone_body`: with-title / without-title
  - `_is_recent_duplicate`: no-label / match / outside-window / query-failure
  - `emit_worker_milestone`: happy / empty / missing-task / recent-dup / create-fail / actor
  - CLI integration: happy / missing-task-id / env-fallback / dedupe-silent / JSON

- **`tests/test_pm_cli_registration.py`** — existing #1502 sentinels still pass with the new command added.

Run:
```
uv run --extra dev pytest tests/test_send_up_cli.py tests/test_pm_cli_registration.py tests/test_import_boundary.py -x
```
33/33 pass locally.

## Activation

Test-only safe — new isolated CLI shim + new emit module, no cockpit_ui/rail_daemon/cockpit_apps touch. The CLI registration smoke test (5 sentinels including a Typer-runner `--help` invocation) catches the failure mode that bit us with #1484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)