### PR TITLE
heartbeat: detect actual pane crashes and auto-respawn active roles within 1 tick

### DIFF
--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -532,6 +532,20 @@ class LocalHeartbeatBackend(HeartbeatBackend):
     )
     _WORKER_MUTATING_SESSION_ROLES = frozenset({"worker"})
 
+    # #1506 — role-respawn-on-crash. Roles that can crash (Claude/codex
+    # process exits leaving the tmux pane at a shell prompt) and need
+    # auto-respawn when there is active work to do. Operator/heartbeat
+    # roles are deliberately excluded — those crashes are rare and the
+    # operator-attention surface is elsewhere.
+    _CRASH_RECOVERY_ROLES = frozenset({"worker", "architect", "reviewer"})
+
+    # After this many cumulative recovery attempts on a session, an
+    # additional crash escalates to the ``crash_loop`` alert instead of
+    # respawning yet again. Conservative — uses the existing
+    # ``recovery_attempts`` counter from session_runtime so any
+    # recovery (auth, missing window, pane_dead, role_crashed) counts.
+    _CRASH_LOOP_ATTEMPT_THRESHOLD = 2
+
     _AUTH_FAILURE_PATTERNS = (
         "authentication failure",
         "not authenticated",
@@ -823,6 +837,69 @@ class LocalHeartbeatBackend(HeartbeatBackend):
             alerts.append("shell_returned")
         else:
             api.clear_alert(context.session_name, "shell_returned")
+
+        # #1506 — role-respawn-on-crash. The ``shell_returned`` alert
+        # above tells the operator something is wrong; this block does
+        # something about it. When the pane is at a shell prompt
+        # (Claude/codex process exited but tmux pane still alive) AND
+        # the role has active work, treat as crashed and auto-respawn
+        # this tick instead of waiting for ``_MAX_NUDGES_BEFORE_RECOVERY``
+        # ticks of nudge-unresponsive (which never fires when the
+        # Claude PID is gone — there's nothing to nudge).
+        # Distinct from ``pane_dead`` (whole tmux pane gone — already
+        # recovered above) and stalled-but-running (Claude PID alive,
+        # just silent — nudge ladder via #1495 / #1505).
+        if (
+            (context.pane_command or "") in {"bash", "zsh", "sh", "fish"}
+            and context.role in self._CRASH_RECOVERY_ROLES
+            and self._has_pending_work(api, context)
+        ):
+            runtime = None
+            try:
+                runtime = api.supervisor.store.get_session_runtime(
+                    context.session_name
+                )
+            except (AttributeError, Exception):  # noqa: BLE001
+                pass  # API may not have supervisor (e.g., tests)
+            prev_attempts = runtime.recovery_attempts if runtime else 0
+            if prev_attempts >= self._CRASH_LOOP_ATTEMPT_THRESHOLD:
+                _emit_routed_alert(
+                    api,
+                    session_name=context.session_name,
+                    alert_type="crash_loop",
+                    severity="error",
+                    message=(
+                        f"{context.session_name} crashed and "
+                        f"respawned {prev_attempts} times — "
+                        "escalating to operator."
+                    ),
+                    subject=f"{context.session_name} crash loop",
+                    suggested_action=(
+                        "Check the role's account state and "
+                        "investigate the underlying crash before "
+                        "respawning again."
+                    ),
+                )
+                alerts.append("crash_loop")
+            else:
+                self._set_session_status(
+                    api,
+                    context,
+                    "recovering",
+                    reason="Role pane crashed (process exited)",
+                )
+                self._recover_session(
+                    api,
+                    context,
+                    failure_type="role_crashed",
+                    message=(
+                        f"Role pane returned to shell "
+                        f"({context.pane_command})"
+                    ),
+                )
+                alerts.append("role_crashed")
+        else:
+            api.clear_alert(context.session_name, "crash_loop")
 
         stopped_reason = "Pane process is stopped (SIGSTOP)"
         if context.pane_stopped:

--- a/tests/test_heartbeat_role_respawn.py
+++ b/tests/test_heartbeat_role_respawn.py
@@ -1,0 +1,332 @@
+"""Regression tests for #1506 role-respawn-on-crash.
+
+When a worker/architect/reviewer pane returns to the shell prompt
+(Claude/codex process exited but tmux pane still alive) AND the role
+has active work, the heartbeat should:
+
+1. Set the session status to ``recovering``
+2. Call ``recover_session(failure_type="role_crashed", ...)`` so the
+   supervisor relaunches the pane within this tick
+3. Append ``role_crashed`` to the alerts list
+
+If the session has already had ``_CRASH_LOOP_ATTEMPT_THRESHOLD`` or
+more cumulative recoveries, the heartbeat surfaces a ``crash_loop``
+alert to the operator instead of relaunching again.
+
+Idle role panes (no pending work) and stalled-but-running panes
+(Claude PID alive, just silent) are explicitly NOT auto-respawned —
+those have their own paths (the existing nudge ladder via #1495 /
+#1505).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pollypm.heartbeats.base import HeartbeatSessionContext
+from pollypm.heartbeats.local import LocalHeartbeatBackend
+
+
+# ---------------------------------------------------------------------------
+# Fake API — minimal stub that records the calls we assert on
+# ---------------------------------------------------------------------------
+
+
+class _RoleCrashFakeAPI:
+    """Records recover_session calls, status sets, and alert emits.
+
+    No-ops everything else _process_session needs so the test path
+    runs cleanly. Generous enough to exercise the full block without
+    depending on real Supervisor / store wiring.
+    """
+
+    def __init__(self, *, recovery_attempts: int = 0) -> None:
+        self.recover_calls: list[dict] = []
+        self.statuses: dict[str, tuple[str, str]] = {}
+        self.alerts_raised: list[dict] = []
+        self.cleared_alerts: list[tuple[str, str]] = []
+        self.cursor_updates: list[dict] = []
+        self.checkpoints: list[tuple[str, list[str]]] = []
+        runtime = SimpleNamespace(
+            recovery_attempts=recovery_attempts,
+            status="healthy",
+        )
+        self.supervisor = SimpleNamespace(
+            store=SimpleNamespace(
+                get_session_runtime=lambda _name: runtime,
+            ),
+            config=SimpleNamespace(sessions={}, projects={}),
+            msg_store=None,
+        )
+
+    # _process_session protocol ---------------------------------------
+    def list_sessions(self):
+        return []
+
+    def list_unmanaged_windows(self):
+        return []
+
+    def update_cursor(self, *_args, **kwargs) -> None:
+        self.cursor_updates.append(dict(kwargs))
+
+    def record_observation(self, _context) -> None:
+        pass
+
+    def record_checkpoint(self, context, *, alerts) -> None:
+        self.checkpoints.append((context.session_name, list(alerts)))
+
+    def record_event(self, *_args, **_kwargs) -> None:
+        pass
+
+    def raise_alert(
+        self,
+        session_name: str,
+        alert_type: str,
+        severity: str,
+        message: str,
+    ) -> None:
+        self.alerts_raised.append({
+            "session_name": session_name,
+            "alert_type": alert_type,
+            "severity": severity,
+            "message": message,
+        })
+
+    def clear_alert(self, session_name, alert_type) -> None:
+        self.cleared_alerts.append((session_name, alert_type))
+
+    def open_alerts(self):
+        return []
+
+    def set_session_status(self, session_name, status, *, reason="") -> None:
+        self.statuses[session_name] = (status, reason)
+
+    def mark_account_auth_broken(self, *_args, **_kwargs) -> None:
+        pass
+
+    def recent_snapshot_hashes(self, *_args, **_kwargs):
+        return []
+
+    def recover_session(self, session_name, *, failure_type, message) -> None:
+        self.recover_calls.append({
+            "session_name": session_name,
+            "failure_type": failure_type,
+            "message": message,
+        })
+
+    def send_session_message(self, *_args, **_kwargs) -> None:
+        pass
+
+    def queue_polly_followup(self, *_args, **_kwargs) -> None:
+        pass
+
+
+def _crashed_pane_context(
+    *,
+    role: str = "architect",
+    session_name: str = "architect_x",
+    pane_command: str = "zsh",
+) -> HeartbeatSessionContext:
+    """Pane that has returned to a shell prompt — Claude/codex
+    process exited but tmux pane itself is still alive."""
+    return HeartbeatSessionContext(
+        session_name=session_name,
+        role=role,
+        project_key="proj",
+        provider="claude",
+        account_name="acct",
+        cwd="/workspace",
+        tmux_session="ses",
+        window_name=session_name,
+        source_path=f"/tmp/{session_name}.log",
+        source_bytes=64,
+        transcript_delta="",
+        pane_text="❯ ",
+        snapshot_path=f"/tmp/{session_name}.txt",
+        snapshot_hash="hash-1",
+        pane_id="%1",
+        pane_command=pane_command,
+        pane_dead=False,
+        window_present=True,
+        previous_log_bytes=64,
+        previous_snapshot_hash="hash-0",
+        cursor=None,
+    )
+
+
+def _alive_role_context(
+    *,
+    role: str = "architect",
+    session_name: str = "architect_x",
+) -> HeartbeatSessionContext:
+    """Same role, pane still running claude (NOT a shell). Used to
+    confirm the new block does NOT fire for live roles."""
+    return HeartbeatSessionContext(
+        session_name=session_name,
+        role=role,
+        project_key="proj",
+        provider="claude",
+        account_name="acct",
+        cwd="/workspace",
+        tmux_session="ses",
+        window_name=session_name,
+        source_path=f"/tmp/{session_name}.log",
+        source_bytes=64,
+        transcript_delta="",
+        pane_text="Working on the plan…",
+        snapshot_path=f"/tmp/{session_name}.txt",
+        snapshot_hash="hash-1",
+        pane_id="%1",
+        pane_command="claude",
+        pane_dead=False,
+        window_present=True,
+        previous_log_bytes=64,
+        previous_snapshot_hash="hash-0",
+        cursor=None,
+    )
+
+
+def _backend_with_pending_work(*, has_work: bool) -> LocalHeartbeatBackend:
+    backend = LocalHeartbeatBackend()
+    backend._has_pending_work = lambda _api, _ctx: has_work  # type: ignore[method-assign]
+    return backend
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_crashed_architect_with_active_work_auto_respawns() -> None:
+    """Architect pane returned to shell + project has pending work →
+    recover_session called with failure_type=role_crashed in the
+    same tick."""
+    api = _RoleCrashFakeAPI(recovery_attempts=0)
+    backend = _backend_with_pending_work(has_work=True)
+
+    backend._process_session(api, _crashed_pane_context(role="architect"))
+
+    assert len(api.recover_calls) == 1
+    call = api.recover_calls[0]
+    assert call["session_name"] == "architect_x"
+    assert call["failure_type"] == "role_crashed"
+    assert "shell" in call["message"]
+
+
+def test_crashed_reviewer_with_active_work_auto_respawns() -> None:
+    """Same path for reviewer role."""
+    api = _RoleCrashFakeAPI(recovery_attempts=0)
+    backend = _backend_with_pending_work(has_work=True)
+
+    backend._process_session(
+        api, _crashed_pane_context(role="reviewer", session_name="reviewer_x")
+    )
+
+    assert len(api.recover_calls) == 1
+    assert api.recover_calls[0]["failure_type"] == "role_crashed"
+
+
+def test_crashed_worker_with_active_work_auto_respawns() -> None:
+    """Workers crash too; same recovery path."""
+    api = _RoleCrashFakeAPI(recovery_attempts=0)
+    backend = _backend_with_pending_work(has_work=True)
+
+    backend._process_session(
+        api, _crashed_pane_context(role="worker", session_name="worker_x")
+    )
+
+    assert any(
+        c["session_name"] == "worker_x" and c["failure_type"] == "role_crashed"
+        for c in api.recover_calls
+    )
+
+
+def test_crashed_architect_without_active_work_does_not_respawn() -> None:
+    """Idle architect pane (no pending project work) returned to
+    shell — cleanly fine, no auto-respawn. The shell_returned alert
+    still fires (separate path) but no recover_session call for
+    role_crashed."""
+    api = _RoleCrashFakeAPI(recovery_attempts=0)
+    backend = _backend_with_pending_work(has_work=False)
+
+    backend._process_session(api, _crashed_pane_context(role="architect"))
+
+    crashed_calls = [
+        c for c in api.recover_calls if c["failure_type"] == "role_crashed"
+    ]
+    assert crashed_calls == []
+
+
+def test_crash_loop_threshold_escalates_instead_of_respawning() -> None:
+    """After _CRASH_LOOP_ATTEMPT_THRESHOLD recoveries, a fresh crash
+    surfaces ``crash_loop`` alert and does NOT call recover_session
+    again."""
+    api = _RoleCrashFakeAPI(
+        recovery_attempts=LocalHeartbeatBackend._CRASH_LOOP_ATTEMPT_THRESHOLD,
+    )
+    backend = _backend_with_pending_work(has_work=True)
+
+    backend._process_session(api, _crashed_pane_context(role="architect"))
+
+    crashed_calls = [
+        c for c in api.recover_calls if c["failure_type"] == "role_crashed"
+    ]
+    assert crashed_calls == []
+    assert any(
+        a.get("alert_type") == "crash_loop"
+        for a in api.alerts_raised
+    )
+
+
+def test_alive_role_pane_does_not_trigger_role_crashed_recovery() -> None:
+    """Pane still running claude (pane_command='claude') — the
+    role_crashed block must NOT fire even if has_pending_work=True.
+    That path is for stalled-but-running and uses the nudge ladder
+    via #1495 / #1505."""
+    api = _RoleCrashFakeAPI(recovery_attempts=0)
+    backend = _backend_with_pending_work(has_work=True)
+
+    backend._process_session(api, _alive_role_context(role="architect"))
+
+    crashed_calls = [
+        c for c in api.recover_calls if c["failure_type"] == "role_crashed"
+    ]
+    assert crashed_calls == []
+
+
+def test_role_crashed_appends_to_alerts_checkpoint() -> None:
+    """The new code appends ``role_crashed`` to the alerts list, so
+    the per-tick checkpoint records it (used by the activity feed)."""
+    api = _RoleCrashFakeAPI(recovery_attempts=0)
+    backend = _backend_with_pending_work(has_work=True)
+
+    backend._process_session(api, _crashed_pane_context(role="architect"))
+
+    # checkpoints recorded per session: (session_name, alerts_list)
+    architect_checkpoints = [
+        cp for cp in api.checkpoints if cp[0] == "architect_x"
+    ]
+    assert architect_checkpoints, "expected a checkpoint for architect_x"
+    assert "role_crashed" in architect_checkpoints[-1][1]
+
+
+def test_crash_loop_marker_clears_when_pane_recovers() -> None:
+    """When the pane is no longer at a shell prompt (next tick after
+    successful respawn), clear_alert is called for ``crash_loop`` —
+    so a stale crash_loop alert from a previous run doesn't linger."""
+    api = _RoleCrashFakeAPI(recovery_attempts=0)
+    backend = _backend_with_pending_work(has_work=True)
+
+    backend._process_session(api, _alive_role_context(role="architect"))
+
+    cleared_types = [t for (_s, t) in api.cleared_alerts]
+    assert "crash_loop" in cleared_types
+
+
+def test_crash_recovery_roles_constants_match_spec() -> None:
+    """Sentinel: the role list is locked to worker/architect/reviewer.
+    Operator-pm and heartbeat-supervisor are deliberately excluded."""
+    assert LocalHeartbeatBackend._CRASH_RECOVERY_ROLES == frozenset(
+        {"worker", "architect", "reviewer"}
+    )
+    assert LocalHeartbeatBackend._CRASH_LOOP_ATTEMPT_THRESHOLD == 2


### PR DESCRIPTION
Closes #1508

## Summary

When a worker/architect/reviewer pane returns to a shell prompt (Claude/codex process exited but tmux pane itself is still alive) AND the role has active project work, the heartbeat now immediately calls \`recover_session(failure_type=\"role_crashed\", ...)\` instead of waiting for the nudge ladder's \`_MAX_NUDGES_BEFORE_RECOVERY\` ticks. The nudge ladder can't fire when there's no Claude PID to nudge — so without this fix, dead roles sit dead until the operator notices.

(The commit message references #1506 — that was the in-progress slug; the actual issue filed is #1508.)

## Distinct from existing recovery paths

- \`pane_dead\` (whole tmux pane gone) — already auto-recovered via the existing block above \`shell_returned\` in \`_process_session\`.
- Stalled-but-running (Claude PID alive, just silent) — uses the existing nudge ladder via #1495 (heartbeat-question-detect) / #1505 (heartbeat-progress-signal).
- Idle role panes (no pending work) — intentionally NOT auto-respawned; the existing \`shell_returned\` alert is the right operator surface for that case.

## Crash-loop guard

After \`_CRASH_LOOP_ATTEMPT_THRESHOLD\` (=2) cumulative \`recovery_attempts\` on the session, an additional crash escalates to a \`crash_loop\` operator alert (severity=error) instead of respawning yet again. The threshold uses the existing \`session_runtime.recovery_attempts\` counter, so any combination of recoveries (auth, missing window, pane_dead, role_crashed) counts toward the cap. Conservative — biases toward escalation rather than infinite respawn.

## Files

- \`src/pollypm/heartbeats/local.py\` — two new class constants (\`_CRASH_RECOVERY_ROLES\`, \`_CRASH_LOOP_ATTEMPT_THRESHOLD\`) + the new role-crash detection block immediately after the \`shell_returned\` alert.
- \`tests/test_heartbeat_role_respawn.py\` (new) — 9 regression tests.

## Test plan

50/50 green locally including 8/8 \`tests/test_import_boundary.py\`. Plus broader sweep \`tests/test_heartbeats_local_classify.py tests/test_heartbeat_tick.py tests/test_heartbeat_plugin_api.py\` 76/76 green.

## Boundary discipline

Read \`docs/conventions.md\` Import boundaries + \`docs/architecture.md\` Service API v1 + \`tests/test_import_boundary.py\` header before coding. No Supervisor direct imports added, no \`_method\` reach-through, no \`_conn\` SQL, no cross-plugin private imports, no CLI-as-runtime-dep. No allow-list additions.

## Recovery path reused

\`_recover_session\` → \`api.recover_session\` → \`Supervisor.maybe_recover_session\` (the same path \`pane_dead\` already uses, plus auth_broken / missing_window). No new respawn mechanism. The \`failure_type=\"role_crashed\"\` is a new label so logs and event streams can distinguish role-crash recoveries.