### PR TITLE
Fix #1510 advisor.tick race + self-healing watchdog

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -90,6 +90,7 @@ __all__ = [
     "RULE_ROLE_SESSION_MISSING",
     "RULE_WORKER_SESSION_DEAD_LOOP",
     "RULE_TASK_ON_HOLD_STALE",
+    "RULE_DUPLICATE_ADVISOR_TASKS",
     "ON_HOLD_HUMAN_NEEDED_TAG",
     "ON_HOLD_ARCHITECT_TAG",
     "scan_events",
@@ -133,6 +134,14 @@ RULE_WORKER_SESSION_DEAD_LOOP = "worker_session_dead_loop"
 # reviewer's findings and either fixes them or, if the issue genuinely
 # requires human judgement, calls ``pm notify`` itself.
 RULE_TASK_ON_HOLD_STALE = "task_on_hold_stale"
+# #1510 — duplicate_advisor_tasks catches a pile-up of non-terminal
+# advisor-labeled tasks for the same project. The advisor.tick handler
+# is supposed to enqueue at most one ``advisor_review`` per project at
+# a time; if a tick race or an external write produces multiples, the
+# self-healing path cancels every duplicate except the most recently
+# created one. This rule is the detector — the cleanup runs from the
+# cadence handler which holds a work-service handle.
+RULE_DUPLICATE_ADVISOR_TASKS = "duplicate_advisor_tasks"
 
 # Reason-string tags reviewers use to hint the watchdog routing. The
 # default (no tag) is architect-actionable. ``ON_HOLD_HUMAN_NEEDED_TAG``
@@ -1316,6 +1325,89 @@ def _detect_worker_session_dead_loop(
     return findings
 
 
+def _detect_duplicate_advisor_tasks(
+    *,
+    open_tasks: Sequence[Any] | None,
+) -> list[Finding]:
+    """Rule (#1510): >1 non-terminal advisor-labeled task on the same project.
+
+    The advisor.tick handler enqueues at most one ``advisor_review`` per
+    project per cycle (see ``has_in_progress_advisor_task``). Two ticks
+    racing on the throttle pre-#1510 produced clusters of 2–3 duplicates;
+    even with the lock-based fix, a stale workspace can still carry the
+    historical pile-up. This detector finds the wedge so the cadence
+    handler can cancel every duplicate except the newest one.
+
+    Pure detector — no I/O. The cadence handler does the cancel via the
+    work-service API once the finding lands. ``metadata['duplicate_ids']``
+    enumerates the task ids slated for cleanup so the action path
+    doesn't have to re-walk ``open_tasks``.
+    """
+    if not open_tasks:
+        return []
+
+    by_project: dict[str, list[Any]] = {}
+    for task in open_tasks:
+        labels = list(getattr(task, "labels", []) or [])
+        if "advisor" not in labels:
+            continue
+        status = getattr(task, "work_status", None)
+        status_value = getattr(status, "value", status)
+        if status_value not in ("draft", "queued", "in_progress", "review", "rework"):
+            continue
+        project = getattr(task, "project", "") or ""
+        task_number = getattr(task, "task_number", None)
+        if not project or task_number is None:
+            continue
+        by_project.setdefault(project, []).append(task)
+
+    findings: list[Finding] = []
+    for project, tasks in by_project.items():
+        if len(tasks) <= 1:
+            continue
+        # Sort newest first by created_at, falling back to task_number
+        # so a corrupted timestamp still produces a deterministic
+        # "keep the highest task_number" outcome.
+        def _sort_key(t: Any) -> tuple[Any, int]:
+            created_at = getattr(t, "created_at", None)
+            if created_at is None:
+                # Coerce missing timestamps to epoch so they sort oldest.
+                created_at = datetime.min.replace(tzinfo=timezone.utc)
+            elif getattr(created_at, "tzinfo", None) is None:
+                created_at = created_at.replace(tzinfo=timezone.utc)
+            return (created_at, getattr(t, "task_number", 0) or 0)
+
+        tasks_sorted = sorted(tasks, key=_sort_key, reverse=True)
+        keep = tasks_sorted[0]
+        duplicates = tasks_sorted[1:]
+        keep_id = f"{project}/{getattr(keep, 'task_number', '?')}"
+        duplicate_ids = [
+            f"{project}/{getattr(t, 'task_number', '?')}" for t in duplicates
+        ]
+        findings.append(Finding(
+            rule=RULE_DUPLICATE_ADVISOR_TASKS,
+            project=project,
+            subject=keep_id,
+            message=(
+                f"Project {project} has {len(tasks)} non-terminal "
+                f"advisor-labeled tasks; expected 1. Keeping the newest "
+                f"({keep_id}) and cleaning up "
+                f"{len(duplicates)} duplicate(s)."
+            ),
+            recommendation=(
+                f"The cadence handler will cancel: "
+                f"{', '.join(duplicate_ids)}. No operator action required."
+            ),
+            metadata={
+                "keep_task_id": keep_id,
+                "duplicate_ids": duplicate_ids,
+                "total_count": len(tasks),
+                "detected_via": "state",
+            },
+        ))
+    return findings
+
+
 # ---------------------------------------------------------------------------
 # Public API — scan_events / scan_project
 # ---------------------------------------------------------------------------
@@ -1392,6 +1484,11 @@ def scan_events(
     findings.extend(_detect_worker_session_dead_loop(
         materialised, now=now, config=config,
     ))
+    # #1510 — duplicate advisor tasks. State-only detector; no audit
+    # events required because the wedge is observable from current
+    # ``open_tasks`` alone (it's a write-time invariant violation, not
+    # a temporal pattern).
+    findings.extend(_detect_duplicate_advisor_tasks(open_tasks=open_tasks))
     return findings
 
 

--- a/src/pollypm/plugins_builtin/advisor/handlers/advisor_tick.py
+++ b/src/pollypm/plugins_builtin/advisor/handlers/advisor_tick.py
@@ -20,10 +20,14 @@ is logged and the next project still gets its turn.
 """
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import logging
+import os
+import re
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from pollypm.plugins_builtin.advisor.settings import (
     AdvisorSettings,
@@ -97,6 +101,93 @@ def detect_changes(
     return report.has_changes
 
 
+_SAFE_PROJECT_KEY_RE = re.compile(r"[^A-Za-z0-9_.-]")
+
+
+def _advisor_lock_path(project_key: str) -> Path:
+    """Return the per-project advisor enqueue lock file path.
+
+    The lock lives next to the canonical workspace state.db
+    (``<workspace_root>/.pollypm/state.db``) so every process that
+    writes to that DB also serialises through the same lock. We keep
+    the lock filename ASCII-safe and stable across runs so concurrent
+    ticks land on the same inode.
+
+    Falls back to a cwd-relative ``.pollypm/`` directory when the
+    canonical resolver can't load config (tests, half-bootstrapped
+    workspaces). The lock is best-effort: a lock-acquisition failure
+    is logged and the caller proceeds without serialisation — that
+    preserves the pre-#1510 behaviour rather than silently dropping
+    advisor enqueues.
+    """
+    safe_key = _SAFE_PROJECT_KEY_RE.sub("_", project_key) or "_"
+    try:
+        from pollypm.work.db_resolver import resolve_work_db_path
+
+        db_path = resolve_work_db_path(project=project_key)
+        lock_dir = db_path.parent
+    except Exception:  # noqa: BLE001
+        lock_dir = Path(".pollypm")
+    try:
+        lock_dir.mkdir(parents=True, exist_ok=True)
+    except Exception:  # noqa: BLE001
+        # Best-effort — if we can't create the dir we'll still try to
+        # open(); that may fail and the caller will skip the lock.
+        pass
+    return lock_dir / f"advisor-{safe_key}.lock"
+
+
+@contextlib.contextmanager
+def _advisor_enqueue_lock(project_key: str) -> Iterator[bool]:
+    """Per-project exclusive lock around the advisor throttle+enqueue window.
+
+    Yields ``True`` when the exclusive lock was acquired, ``False`` when
+    we couldn't obtain a lock (filesystem error, fcntl unavailable on a
+    weird platform, etc.). Callers that get ``False`` should still
+    proceed — best-effort throttling is better than dropping the tick.
+
+    The lock file is keyed on (canonical-DB-dir, project_key) so two
+    advisor ticks in the same workspace serialise on the same inode
+    while two workspaces stay independent. ``fcntl.flock`` is process-
+    advisory and survives `fork`, which is exactly what we want for
+    the heartbeat/scheduler split.
+    """
+    lock_path = _advisor_lock_path(project_key)
+    fd: int | None = None
+    try:
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+        except OSError as exc:
+            logger.debug(
+                "advisor: enqueue-lock open failed for %s at %s: %s",
+                project_key, lock_path, exc,
+            )
+            yield False
+            return
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        except OSError as exc:
+            logger.debug(
+                "advisor: enqueue-lock acquire failed for %s: %s",
+                project_key, exc,
+            )
+            yield False
+            return
+        try:
+            yield True
+        finally:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
 def enqueue_advisor_review(
     *,
     project_key: str,
@@ -108,6 +199,16 @@ def enqueue_advisor_review(
 
     Kept as a module-level callable so unit tests can monkeypatch the
     enqueue path without touching the work service.
+
+    #1510: this function holds the authoritative race-safe gate. The
+    high-level ``_should_review`` check is a fast-path; here we take a
+    per-project advisory file lock around (a) a fresh throttle re-check
+    against the canonical work DB and (b) the actual ``create`` +
+    ``queue``. Two ticks racing on the same workspace serialise on the
+    lock, the loser observes the winner's freshly-enqueued task, and
+    short-circuits with ``"skipped": "throttled"``. The check + insert
+    are inside the same lock so a parallel tick cannot interleave a
+    duplicate enqueue between them.
     """
     close_service = False
     if work_service is None:
@@ -125,27 +226,51 @@ def enqueue_advisor_review(
         close_service = True
 
     try:
-        task = work_service.create(
-            title=f"Advisor review for {project_key}",
-            description=(
-                "Review recent project trajectory, identify stalls or human "
-                "blockers, and emit a structured advisor decision."
-            ),
-            type="task",
-            project=project_key,
-            flow_template="advisor_review",
-            roles={"advisor": "advisor"},
-            priority="normal",
-            created_by="advisor.tick",
-            labels=["advisor"],
-            requires_human_review=False,
-        )
-        queued = work_service.queue(task.task_id, "advisor.tick")
-        return {
-            "enqueued": True,
-            "project": project_key,
-            "task_id": queued.task_id,
-        }
+        with _advisor_enqueue_lock(project_key) as acquired:
+            # Re-check the throttle inside the lock. The fast-path in
+            # ``_should_review`` may have read pre-tick state; the
+            # authoritative check happens here so a sibling tick that
+            # already enqueued is observed before we double-write.
+            # Even when ``acquired`` is False (lock open failed), the
+            # re-check is still a strict improvement over no check —
+            # it'll catch all but truly-simultaneous racers.
+            if has_in_progress_advisor_task(
+                project_key=project_key,
+                work_service=work_service,
+                project_path=project_path,
+            ):
+                logger.debug(
+                    "advisor: enqueue skipped for %s — sibling tick "
+                    "already enqueued (lock acquired=%s)",
+                    project_key, acquired,
+                )
+                return {
+                    "enqueued": False,
+                    "skipped": "throttled",
+                    "project": project_key,
+                }
+
+            task = work_service.create(
+                title=f"Advisor review for {project_key}",
+                description=(
+                    "Review recent project trajectory, identify stalls or human "
+                    "blockers, and emit a structured advisor decision."
+                ),
+                type="task",
+                project=project_key,
+                flow_template="advisor_review",
+                roles={"advisor": "advisor"},
+                priority="normal",
+                created_by="advisor.tick",
+                labels=["advisor"],
+                requires_human_review=False,
+            )
+            queued = work_service.queue(task.task_id, "advisor.tick")
+            return {
+                "enqueued": True,
+                "project": project_key,
+                "task_id": queued.task_id,
+            }
     finally:
         if close_service:
             close = getattr(work_service, "close", None)

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -33,6 +33,7 @@ from typing import Any
 from pollypm.audit.watchdog import (
     ESCALATION_THROTTLE_SECONDS,
     Finding,
+    RULE_DUPLICATE_ADVISOR_TASKS,
     RULE_ROLE_SESSION_MISSING,
     RULE_STUCK_DRAFT,
     RULE_TASK_ON_HOLD_STALE,
@@ -528,6 +529,61 @@ def _maybe_dispatch_to_architect(
     return "dispatched"
 
 
+def _self_heal_duplicate_advisor_tasks(
+    finding: Finding,
+    *,
+    project_key: str,
+    project_path: Path | None,
+) -> dict[str, int]:
+    """Cancel every duplicate advisor task except the most-recently-created.
+
+    #1510 self-healing action. The detector already chose which task to
+    keep (``finding.metadata['keep_task_id']``) and which to cancel
+    (``finding.metadata['duplicate_ids']``). We just iterate the list
+    and call ``WorkService.cancel`` for each — using the work-service
+    API rather than raw SQL so cancellation observers (audit emit,
+    sync, alert teardown) all run.
+
+    Returns ``{"cancelled": N, "failed": M}`` for the per-project
+    counters. Best-effort: a per-task failure is logged and we keep
+    going so a single bad row doesn't strand the rest.
+    """
+    counters = {"cancelled": 0, "failed": 0}
+    duplicate_ids: list[str] = list(
+        finding.metadata.get("duplicate_ids") or []
+    )
+    if not duplicate_ids:
+        return counters
+    reason = f"duplicate advisor_review (auto-cleanup #1510)"
+    try:
+        from pollypm.work import create_work_service
+
+        with create_work_service(
+            project_path=project_path,
+            project_key=project_key,
+        ) as svc:
+            for task_id in duplicate_ids:
+                try:
+                    svc.cancel(task_id, "audit_watchdog", reason)
+                    counters["cancelled"] += 1
+                except Exception:  # noqa: BLE001
+                    counters["failed"] += 1
+                    logger.warning(
+                        "audit.watchdog: duplicate-advisor cleanup failed "
+                        "for %s",
+                        task_id, exc_info=True,
+                    )
+    except Exception:  # noqa: BLE001
+        # If we can't even open the work service, mark every duplicate
+        # as failed so the totals reflect the wedge accurately.
+        counters["failed"] += len(duplicate_ids) - counters["cancelled"]
+        logger.warning(
+            "audit.watchdog: duplicate-advisor cleanup could not open "
+            "work service for %s", project_key, exc_info=True,
+        )
+    return counters
+
+
 def _scan_one_project(
     *,
     project_key: str,
@@ -546,6 +602,8 @@ def _scan_one_project(
         "dispatches_sent": 0,
         "dispatches_throttled": 0,
         "dispatches_failed": 0,
+        "advisor_duplicates_cancelled": 0,
+        "advisor_duplicates_failed": 0,
     }
     open_tasks = _gather_open_tasks(project_key, project_path)
     storage_window_names = _gather_storage_windows(storage_closet_name)
@@ -581,6 +639,20 @@ def _scan_one_project(
                 finding.rule, finding.project, finding.subject,
                 finding.message, finding.recommendation,
             )
+        # #1510 — duplicate-advisor cleanup is a self-healing action,
+        # not an architect dispatch. The fix is mechanical (cancel all
+        # but the newest), idempotent across ticks, and doesn't need a
+        # human in the loop, so we run it inline here.
+        if finding.rule == RULE_DUPLICATE_ADVISOR_TASKS:
+            heal = _self_heal_duplicate_advisor_tasks(
+                finding,
+                project_key=project_key,
+                project_path=project_path,
+            )
+            counters["advisor_duplicates_cancelled"] += heal["cancelled"]
+            counters["advisor_duplicates_failed"] += heal["failed"]
+            # Skip dispatch — this rule is auto-healed, not architect-routed.
+            continue
         # #1414 — eligible findings get an architect dispatch on top
         # of the alert. Throttle window is owned by the audit log so
         # repeat dispatches are deduped across cadence-process restarts.
@@ -641,6 +713,8 @@ def audit_watchdog_handler(payload: dict[str, Any]) -> dict[str, Any]:
         "dispatches_sent": 0,
         "dispatches_throttled": 0,
         "dispatches_failed": 0,
+        "advisor_duplicates_cancelled": 0,
+        "advisor_duplicates_failed": 0,
     }
 
     try:

--- a/tests/test_advisor_plugin.py
+++ b/tests/test_advisor_plugin.py
@@ -699,3 +699,215 @@ class TestAdvisorSpamFix:
                 ).fetchall()
             ]
         assert "work_tasks" not in tables
+
+
+# ---------------------------------------------------------------------------
+# advisor.tick race + self-healing watchdog (#1510)
+# ---------------------------------------------------------------------------
+#
+# Pre-fix: ``has_in_progress_advisor_task`` + ``enqueue_advisor_review``
+# were two separate calls. Two concurrent ticks both read pre-tick state
+# and both inserted, producing 2-3 duplicates per cron cycle. The fix
+# wraps the throttle re-check + insert in a per-project file lock and
+# re-checks the throttle inside the lock. ``coffeeboardnm`` had piled up
+# 27 identical advisor_review rows over ~7 hours by the time the issue
+# was filed.
+
+
+class TestAdvisorRaceFix:
+    """Regression coverage for the advisor.tick race fix (#1510)."""
+
+    def _setup_canonical_workspace(
+        self, *, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> Path:
+        canonical = tmp_path / ".pollypm" / "state.db"
+        canonical.parent.mkdir(parents=True, exist_ok=True)
+
+        from pollypm.work import db_resolver as _resolver
+
+        def _fake_resolve(*_args, **_kwargs):
+            canonical.parent.mkdir(parents=True, exist_ok=True)
+            return canonical
+
+        monkeypatch.setattr(_resolver, "resolve_work_db_path", _fake_resolve)
+        return canonical
+
+    def test_concurrent_enqueue_only_creates_one_task(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Two threads racing on ``enqueue_advisor_review`` must produce one task.
+
+        Sentinel: pre-#1510 this test produced 2 rows because the
+        throttle check + insert were not serialised. Post-fix the file
+        lock + in-lock re-check ensures the loser observes the winner's
+        row and short-circuits.
+        """
+        import sqlite3
+        import threading
+
+        project_root = tmp_path / "proj"
+        project_root.mkdir()
+        canonical = self._setup_canonical_workspace(
+            tmp_path=tmp_path, monkeypatch=monkeypatch,
+        )
+
+        from pollypm.plugins_builtin.advisor.handlers.advisor_tick import (
+            enqueue_advisor_review,
+        )
+
+        # Pre-initialize the canonical DB schema so both threads land
+        # on a fully-migrated DB. Real workspaces are always
+        # pre-initialized by the time advisor.tick fires; running
+        # schema migrations concurrently from two threads is a
+        # separate concern (the real workspace state.db has long
+        # since done its bootstrap).
+        from pollypm.work import create_work_service as _seed_factory
+
+        _seed = _seed_factory(project_path=project_root, project_key="proj")
+        _close = getattr(_seed, "close", None)
+        if callable(_close):
+            _close()
+
+        results: list[dict[str, Any]] = []
+        results_lock = threading.Lock()
+        # Barrier so both threads attempt the lock in lockstep.
+        gate = threading.Barrier(2)
+
+        def _runner() -> None:
+            gate.wait()
+            outcome = enqueue_advisor_review(
+                project_key="proj",
+                project_path=project_root,
+                config=None,
+                work_service=None,
+            )
+            with results_lock:
+                results.append(outcome)
+
+        t1 = threading.Thread(target=_runner)
+        t2 = threading.Thread(target=_runner)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+        assert not t1.is_alive()
+        assert not t2.is_alive()
+
+        # Exactly one outcome must report enqueued; the other is throttled.
+        enqueued = [r for r in results if r.get("enqueued")]
+        throttled = [r for r in results if r.get("skipped") == "throttled"]
+        assert len(enqueued) == 1, results
+        assert len(throttled) == 1, results
+
+        # And the canonical DB must hold exactly one queued advisor task.
+        with sqlite3.connect(canonical) as conn:
+            row_count = conn.execute(
+                "SELECT COUNT(*) FROM work_tasks "
+                "WHERE project = 'proj' AND work_status = 'queued'"
+            ).fetchone()[0]
+        assert row_count == 1
+
+    def test_sequential_ticks_are_idempotent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A second tick after a successful enqueue must short-circuit.
+
+        This pins the in-lock re-check: the second call must see the
+        first call's freshly-queued row and return ``skipped=throttled``,
+        not stack a duplicate.
+        """
+        import sqlite3
+
+        project_root = tmp_path / "proj"
+        project_root.mkdir()
+        canonical = self._setup_canonical_workspace(
+            tmp_path=tmp_path, monkeypatch=monkeypatch,
+        )
+
+        from pollypm.plugins_builtin.advisor.handlers.advisor_tick import (
+            enqueue_advisor_review,
+        )
+
+        first = enqueue_advisor_review(
+            project_key="proj",
+            project_path=project_root,
+            config=None,
+            work_service=None,
+        )
+        assert first["enqueued"] is True
+
+        second = enqueue_advisor_review(
+            project_key="proj",
+            project_path=project_root,
+            config=None,
+            work_service=None,
+        )
+        assert second.get("enqueued") is False
+        assert second.get("skipped") == "throttled"
+
+        with sqlite3.connect(canonical) as conn:
+            row_count = conn.execute(
+                "SELECT COUNT(*) FROM work_tasks "
+                "WHERE project = 'proj' AND work_status = 'queued'"
+            ).fetchone()[0]
+        assert row_count == 1
+
+    def test_advisor_tick_handler_double_invocation_single_enqueue(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Integration: two ``advisor_tick_handler({})`` calls in quick
+        succession enqueue exactly one task end-to-end.
+
+        Mirrors the production cluster pattern (#16/#17/#18 within 10s).
+        """
+        import sqlite3
+
+        project_root = tmp_path / "proj"
+        project_root.mkdir()
+        base_dir = project_root / ".pollypm"
+        base_dir.mkdir()
+        canonical = self._setup_canonical_workspace(
+            tmp_path=tmp_path, monkeypatch=monkeypatch,
+        )
+
+        config_path = tmp_path / "pollypm.toml"
+        config_path.write_text("[advisor]\nenabled = true\n")
+
+        cfg = FakeConfig(
+            projects={
+                "proj": FakeKnownProject(
+                    key="proj", path=project_root, tracked=True,
+                )
+            },
+            project=FakeProjectSection(
+                base_dir=base_dir, root_dir=project_root, name="proj",
+            ),
+        )
+        monkeypatch.setattr("pollypm.config.load_config", lambda _p: cfg)
+        monkeypatch.setattr(
+            "pollypm.config.resolve_config_path", lambda _p: config_path,
+        )
+        monkeypatch.setattr(
+            tick_module, "detect_changes",
+            lambda *_args, **_kwargs: True,
+        )
+
+        # Both calls go through the real ``enqueue_advisor_review``
+        # (no monkeypatch on it). The fast-path may say "fire" twice
+        # before either insert completes, but the in-lock re-check
+        # must still ensure only one row lands.
+        first = advisor_tick_handler({"config_path": str(config_path)})
+        second = advisor_tick_handler({"config_path": str(config_path)})
+
+        assert first["fired"] is True
+        assert second["fired"] is True
+        # First tick enqueues; second observes the row and skips.
+        assert "proj" in first["enqueued"]
+        assert second["enqueued"] == []
+
+        with sqlite3.connect(canonical) as conn:
+            row_count = conn.execute(
+                "SELECT COUNT(*) FROM work_tasks "
+                "WHERE project = 'proj' AND work_status = 'queued'"
+            ).fetchone()[0]
+        assert row_count == 1

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -2569,3 +2569,215 @@ def test_state_based_detectors_silent_when_open_tasks_empty(now: datetime) -> No
         )
         for f in findings
     )
+
+
+# ---------------------------------------------------------------------------
+# Rule (#1510): duplicate advisor tasks
+# ---------------------------------------------------------------------------
+
+
+class _AdvisorTask:
+    """Stand-in for ``work.models.Task`` carrying the fields the
+    duplicate-advisor detector reads."""
+
+    class _Status:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+    def __init__(
+        self,
+        *,
+        project: str,
+        task_number: int,
+        work_status: str = "queued",
+        labels: list[str] | None = None,
+        created_at: datetime | None = None,
+    ) -> None:
+        self.project = project
+        self.task_number = task_number
+        self.work_status = self._Status(work_status)
+        self.labels = list(labels or ["advisor"])
+        self.created_at = created_at
+
+
+def test_duplicate_advisor_tasks_detected_and_keep_newest(now: datetime) -> None:
+    """5 non-terminal advisor tasks → finding cancels 4, keeps newest."""
+    from pollypm.audit.watchdog import RULE_DUPLICATE_ADVISOR_TASKS
+
+    tasks = [
+        _AdvisorTask(
+            project="coffeeboardnm",
+            task_number=n,
+            work_status="queued",
+            labels=["advisor"],
+            created_at=now - timedelta(minutes=60 - n * 5),
+        )
+        for n in (16, 17, 18, 24, 27)
+    ]
+    findings = scan_events([], now=now, open_tasks=tasks)
+    matched = [f for f in findings if f.rule == RULE_DUPLICATE_ADVISOR_TASKS]
+    assert len(matched) == 1
+    f = matched[0]
+    assert f.project == "coffeeboardnm"
+    # Newest is task_number=27 (created at now-25 min, latest of the bunch).
+    assert f.subject == "coffeeboardnm/27"
+    assert f.metadata["keep_task_id"] == "coffeeboardnm/27"
+    assert sorted(f.metadata["duplicate_ids"]) == [
+        "coffeeboardnm/16",
+        "coffeeboardnm/17",
+        "coffeeboardnm/18",
+        "coffeeboardnm/24",
+    ]
+    assert f.metadata["total_count"] == 5
+
+
+def test_duplicate_advisor_tasks_silent_with_one_task(now: datetime) -> None:
+    """A single advisor task is the steady state — must not fire."""
+    from pollypm.audit.watchdog import RULE_DUPLICATE_ADVISOR_TASKS
+
+    tasks = [
+        _AdvisorTask(
+            project="coffeeboardnm",
+            task_number=27,
+            work_status="queued",
+            created_at=now - timedelta(minutes=10),
+        )
+    ]
+    findings = scan_events([], now=now, open_tasks=tasks)
+    assert not any(f.rule == RULE_DUPLICATE_ADVISOR_TASKS for f in findings)
+
+
+def test_duplicate_advisor_tasks_ignores_non_advisor_labels(now: datetime) -> None:
+    """Non-advisor tasks with the same project must not be folded in."""
+    from pollypm.audit.watchdog import RULE_DUPLICATE_ADVISOR_TASKS
+
+    tasks = [
+        _AdvisorTask(
+            project="proj",
+            task_number=1,
+            work_status="queued",
+            labels=["advisor"],
+            created_at=now - timedelta(minutes=10),
+        ),
+        _AdvisorTask(
+            project="proj",
+            task_number=2,
+            work_status="queued",
+            labels=["feature"],
+            created_at=now - timedelta(minutes=5),
+        ),
+    ]
+    findings = scan_events([], now=now, open_tasks=tasks)
+    assert not any(f.rule == RULE_DUPLICATE_ADVISOR_TASKS for f in findings)
+
+
+def test_duplicate_advisor_tasks_ignores_terminal_states(now: datetime) -> None:
+    """Cancelled / done duplicates are not counted."""
+    from pollypm.audit.watchdog import RULE_DUPLICATE_ADVISOR_TASKS
+
+    tasks = [
+        _AdvisorTask(
+            project="proj",
+            task_number=1,
+            work_status="cancelled",
+            created_at=now - timedelta(minutes=30),
+        ),
+        _AdvisorTask(
+            project="proj",
+            task_number=2,
+            work_status="queued",
+            created_at=now - timedelta(minutes=5),
+        ),
+    ]
+    findings = scan_events([], now=now, open_tasks=tasks)
+    assert not any(f.rule == RULE_DUPLICATE_ADVISOR_TASKS for f in findings)
+
+
+def test_duplicate_advisor_cleanup_cancels_all_but_newest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cadence handler self-heals: 5 advisor tasks → 4 cancelled, 1 queued."""
+    import sqlite3
+
+    from pollypm.audit.watchdog import (
+        Finding,
+        RULE_DUPLICATE_ADVISOR_TASKS,
+    )
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _self_heal_duplicate_advisor_tasks,
+    )
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    canonical = tmp_path / ".pollypm" / "state.db"
+    canonical.parent.mkdir(parents=True, exist_ok=True)
+
+    from pollypm.work import db_resolver as _resolver
+
+    def _fake_resolve(*_args, **_kwargs):
+        canonical.parent.mkdir(parents=True, exist_ok=True)
+        return canonical
+
+    monkeypatch.setattr(_resolver, "resolve_work_db_path", _fake_resolve)
+
+    # Pre-populate canonical DB with 5 non-terminal advisor tasks.
+    from pollypm.work import create_work_service
+
+    seed = create_work_service(project_path=project_root, project_key="proj")
+    task_ids: list[str] = []
+    try:
+        for i in range(5):
+            task = seed.create(
+                title=f"Advisor review for proj #{i}",
+                description="seed",
+                type="task",
+                project="proj",
+                flow_template="advisor_review",
+                roles={"advisor": "advisor"},
+                priority="normal",
+                created_by="test.seed",
+                labels=["advisor"],
+                requires_human_review=False,
+            )
+            seed.queue(task.task_id, "test.seed")
+            task_ids.append(task.task_id)
+    finally:
+        close = getattr(seed, "close", None)
+        if callable(close):
+            close()
+
+    # Build a Finding the same way the detector would.
+    duplicate_ids = task_ids[:-1]  # all but the last (newest)
+    keep_id = task_ids[-1]
+    finding = Finding(
+        rule=RULE_DUPLICATE_ADVISOR_TASKS,
+        project="proj",
+        subject=keep_id,
+        message="duplicate advisor tasks",
+        recommendation="auto-cleanup",
+        metadata={
+            "keep_task_id": keep_id,
+            "duplicate_ids": duplicate_ids,
+            "total_count": 5,
+        },
+    )
+    counters = _self_heal_duplicate_advisor_tasks(
+        finding,
+        project_key="proj",
+        project_path=project_root,
+    )
+    assert counters == {"cancelled": 4, "failed": 0}
+
+    # Verify final DB state: 4 cancelled, 1 queued.
+    with sqlite3.connect(canonical) as conn:
+        queued = conn.execute(
+            "SELECT COUNT(*) FROM work_tasks "
+            "WHERE project = 'proj' AND work_status = 'queued'"
+        ).fetchone()[0]
+        cancelled = conn.execute(
+            "SELECT COUNT(*) FROM work_tasks "
+            "WHERE project = 'proj' AND work_status = 'cancelled'"
+        ).fetchone()[0]
+    assert queued == 1
+    assert cancelled == 4
+


### PR DESCRIPTION
Closes #1510.

`coffeeboardnm` accumulated 27 identical `Advisor review for coffeeboardnm` tasks in the canonical work DB over ~7 hours because the throttle in `advisor.tick` was racy: two concurrent ticks both read pre-tick state, both decided "no in-flight task," and both called `enqueue_advisor_review`. Per-tick clusters of 2-3 inserts within seconds (e.g. #16/#17/#18 in 10s, #27/#28/#29 in 8s) confirm this.

This PR fixes both halves of the user's brief: (1) the underlying race so the interface stops producing duplicates, and (2) a self-healing watchdog rule so the heartbeat detects + cleans up the wedged state automatically — including the historical pile-up.

## Part A — race-safe throttle (root cause)

`enqueue_advisor_review` now takes a per-project advisory file lock at `<workspace>/.pollypm/advisor-<project>.lock` (using `fcntl.flock`, the same primitive the inline scheduler uses) and re-checks `has_in_progress_advisor_task` inside the lock before inserting. Two concurrent ticks that both pass the fast-path `_should_review` check now serialise on the lock; the loser observes the winner's freshly-queued task and short-circuits with `skipped=throttled` instead of double-writing.

Lock acquisition is best-effort: a lock-open failure logs and proceeds with the strict in-call re-check still in place, so a hostile filesystem can't drop ticks entirely — it just degrades back to the pre-fix race window. The fast-path check is preserved so the lock is rarely contended.

**Why a file lock and not a SQLite transaction?** The throttle reads + the insert both go through the work-service API, which holds its own connection. Wrapping them in a single `BEGIN IMMEDIATE` would require restructuring the work-service surface or reaching into `_conn` from the advisor handler. A workspace-scoped file lock keyed on project gets cross-process serialisation with one `os.open` + `fcntl.flock` and zero new coupling.

## Part B — self-healing watchdog rule

New rule `RULE_DUPLICATE_ADVISOR_TASKS` in `src/pollypm/audit/watchdog.py`. Detector reads `open_tasks` and fires for any project carrying >1 non-terminal advisor-labeled task. State-only rule (no audit-event lookback) because this is a write-time invariant violation, not a temporal pattern.

The cadence handler (`plugins_builtin/core_recurring/audit_watchdog.py`) routes this rule to a new `_self_heal_duplicate_advisor_tasks` action that calls `WorkService.cancel` on every duplicate except the most-recently-created one (sorted by `created_at` desc, with `task_number` tiebreaker). Cleanup uses the work-service API so audit emits, sync, and alert teardowns all run; the cancel reason is `"duplicate advisor_review (auto-cleanup #1510)"` so the action is forensically traceable. New counters `advisor_duplicates_cancelled` / `advisor_duplicates_failed` surface in the cadence return dict for observability.

Idempotent across ticks because each tick recomputes against current state. The rule is **not** added to `_DISPATCHABLE_RULES` — there's no architect dispatch because the cleanup is mechanical and doesn't need a human in the loop.

## Test coverage

`tests/test_advisor_plugin.py::TestAdvisorRaceFix` (3 cases):
- `test_concurrent_enqueue_only_creates_one_task` — two threads racing on `enqueue_advisor_review` produce exactly one task in the canonical DB; one thread reports `enqueued=True`, the other `skipped=throttled`.
- `test_sequential_ticks_are_idempotent` — pins the in-lock re-check.
- `test_advisor_tick_handler_double_invocation_single_enqueue` — integration: two `advisor_tick_handler({})` calls in quick succession enqueue exactly one task end-to-end.

`tests/test_audit_watchdog.py` (5 new cases):
- detector finds dupes, keeps the newest, lists the rest in metadata.
- silent with one task / non-advisor labels / terminal-state rows.
- cadence-handler self-heal cancels 4 of 5 seeded rows in a real SQLite DB and leaves exactly 1 queued.

Full suite: `uv run pytest tests/ -k 'advisor or watchdog'` → 245 passed.

## Test plan

- [ ] Manual: confirm the next heartbeat tick after merge cleans up coffeeboardnm's 27 piled-up rows automatically (no `pm task cancel` required).
- [ ] Manual: confirm new advisor ticks on a clean project still enqueue exactly one task.
- [ ] Audit log: grep for `audit.finding` events with `rule=duplicate_advisor_tasks` and `task.status_changed` events with reason mentioning `auto-cleanup #1510` to verify the trail.

## Notes

- The 27 piled-up rows in production are intentionally not deleted manually — the watchdog will clean them up on the first heartbeat tick after merge, demonstrating the self-healing path end-to-end.
- The lock-acquisition fast-path failure mode (best-effort) was a deliberate design choice over hard-fail because dropping advisor ticks because a filesystem perm bit is wrong is worse than the residual race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)