### PR TITLE
Fix #1511 plan-review coverage + self-healing watchdog

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -91,6 +91,7 @@ __all__ = [
     "RULE_WORKER_SESSION_DEAD_LOOP",
     "RULE_TASK_ON_HOLD_STALE",
     "RULE_DUPLICATE_ADVISOR_TASKS",
+    "RULE_PLAN_REVIEW_MISSING",
     "ON_HOLD_HUMAN_NEEDED_TAG",
     "ON_HOLD_ARCHITECT_TAG",
     "scan_events",
@@ -142,6 +143,14 @@ RULE_TASK_ON_HOLD_STALE = "task_on_hold_stale"
 # created one. This rule is the detector — the cleanup runs from the
 # cadence handler which holds a work-service handle.
 RULE_DUPLICATE_ADVISOR_TASKS = "duplicate_advisor_tasks"
+# #1511 — plan-review coverage gap. A plan-shaped task (label: ``poc-plan``
+# / ``plan`` / ``project-plan``) reached ``done`` outside the
+# ``plan_project`` flow, so the architect's reflection node (#1399) never
+# fired and no ``plan_review`` inbox card was emitted. The watchdog
+# backfills the missing card via the same code path the post-done hook
+# uses; idempotent because both call sites probe the messages table for
+# an existing plan_review row before writing.
+RULE_PLAN_REVIEW_MISSING = "plan_review_missing"
 
 # Reason-string tags reviewers use to hint the watchdog routing. The
 # default (no tag) is architect-actionable. ``ON_HOLD_HUMAN_NEEDED_TAG``
@@ -232,6 +241,11 @@ class WatchdogConfig:
     # same task within ``dead_loop_window_seconds`` count as a loop.
     dead_loop_threshold: int = 3
     dead_loop_window_seconds: int = 600
+    # #1511 — plan_review_missing: how far back to look for plan-shaped
+    # ``done`` tasks when scanning for a missing plan_review row. 14 days
+    # is wide enough to catch plans the user genuinely hasn't reviewed
+    # yet without re-firing forever on long-since-abandoned drafts.
+    plan_review_lookback_seconds: int = 14 * 24 * 60 * 60
 
 
 @dataclass(slots=True, frozen=True)
@@ -1409,6 +1423,103 @@ def _detect_duplicate_advisor_tasks(
 
 
 # ---------------------------------------------------------------------------
+# Plan-review missing detector (#1511)
+# ---------------------------------------------------------------------------
+
+
+def _detect_plan_review_missing(
+    *,
+    now: datetime,
+    config: WatchdogConfig,
+    done_plan_tasks: Sequence[Any] | None = None,
+    plan_review_present: Any = None,
+) -> list[Finding]:
+    """Rule 9 (#1511): plan-shaped done task with no ``plan_review`` row.
+
+    The architect's reflection node (#1399) only fires inside the
+    ``plan_project`` flow. Plan-shaped tasks built on the ``standard``
+    flow (or any other) reach ``done`` with no ``plan_review`` inbox
+    card, so the cockpit's 2-line approval surface stays silent. This
+    detector finds those stranded tasks and emits a finding so the
+    cadence handler can backfill the missing card via the same emit
+    path :mod:`pollypm.work.plan_review_emit` uses on the post-done
+    hook (Part A of the #1511 fix).
+
+    Inputs are passed in by the scan caller so this function stays
+    pure / unit-testable:
+
+    * ``done_plan_tasks`` — already filtered to ``work_status=done`` +
+      plan-shaped labels + non-plan_project flow + ``created_at`` within
+      ``plan_review_lookback_seconds``. The cadence handler builds this
+      list via ``svc.list_tasks(work_status='done', project=...)`` +
+      :func:`pollypm.work.plan_review_emit.task_is_eligible_for_backstop`.
+    * ``plan_review_present`` — a callable taking ``(project,
+      plan_task_id)`` and returning True if a plan_review message
+      already exists. Tests pass a ``set``-backed lambda; production
+      passes :func:`pollypm.work.plan_review_emit.already_has_plan_review_message`.
+
+    Both inputs default to None — the detector then no-ops, which is
+    the right default when the caller can't enumerate done tasks /
+    probe the messages table.
+    """
+    findings: list[Finding] = []
+    if not done_plan_tasks:
+        return findings
+    if plan_review_present is None:
+        return findings
+    cutoff = now - timedelta(seconds=config.plan_review_lookback_seconds)
+    for task in done_plan_tasks:
+        project = getattr(task, "project", "") or ""
+        task_number = getattr(task, "task_number", None)
+        if not project or task_number is None:
+            continue
+        plan_task_id = f"{project}/{task_number}"
+        created_at = getattr(task, "created_at", None)
+        if isinstance(created_at, datetime):
+            ts = created_at if created_at.tzinfo is not None else created_at.replace(
+                tzinfo=timezone.utc,
+            )
+            if ts < cutoff:
+                continue
+        try:
+            already_present = bool(plan_review_present(project, plan_task_id))
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "plan_review_missing: probe failed for %s",
+                plan_task_id, exc_info=True,
+            )
+            continue
+        if already_present:
+            continue
+        labels = list(getattr(task, "labels", None) or [])
+        flow_id = getattr(task, "flow_template_id", "") or ""
+        findings.append(Finding(
+            rule=RULE_PLAN_REVIEW_MISSING,
+            project=project,
+            subject=plan_task_id,
+            message=(
+                f"Plan-shaped task {plan_task_id} (flow={flow_id or '?'}) "
+                f"reached done with no plan_review inbox card."
+            ),
+            recommendation=(
+                f"Backfill via plan_review_emit.emit_plan_review_for_task "
+                f"so the cockpit approval surface renders for {plan_task_id}."
+            ),
+            metadata={
+                "plan_task_id": plan_task_id,
+                "flow_template_id": flow_id,
+                "labels": labels,
+                "created_at": (
+                    created_at.isoformat() if isinstance(created_at, datetime)
+                    else None
+                ),
+                "detected_via": "state",
+            },
+        ))
+    return findings
+
+
+# ---------------------------------------------------------------------------
 # Public API — scan_events / scan_project
 # ---------------------------------------------------------------------------
 
@@ -1421,6 +1532,8 @@ def scan_events(
     open_tasks: Sequence[Any] | None = None,
     storage_window_names: Sequence[str] | None = None,
     project: str = "",
+    done_plan_tasks: Sequence[Any] | None = None,
+    plan_review_present: Any = None,
 ) -> list[Finding]:
     """Run every detection rule against ``events`` and return findings.
 
@@ -1445,6 +1558,14 @@ def scan_events(
             pure function.
         project: project key — only used by ``role_session_missing``
             when the open_task rows don't carry it.
+        done_plan_tasks: completed plan-shaped tasks for the
+            ``plan_review_missing`` rule (#1511). Passed in by the
+            cadence handler so the detector stays pure. ``None`` disables
+            the rule (the right default for unit tests).
+        plan_review_present: callable ``(project, plan_task_id) -> bool``
+            that returns True iff a ``plan_review`` message already exists
+            in the messages table for that task. ``None`` disables the
+            ``plan_review_missing`` rule.
     """
     if config is None:
         config = WatchdogConfig()
@@ -1489,6 +1610,12 @@ def scan_events(
     # ``open_tasks`` alone (it's a write-time invariant violation, not
     # a temporal pattern).
     findings.extend(_detect_duplicate_advisor_tasks(open_tasks=open_tasks))
+    findings.extend(_detect_plan_review_missing(
+        now=now,
+        config=config,
+        done_plan_tasks=done_plan_tasks,
+        plan_review_present=plan_review_present,
+    ))
     return findings
 
 
@@ -1500,6 +1627,8 @@ def scan_project(
     config: WatchdogConfig | None = None,
     open_tasks: Sequence[Any] | None = None,
     storage_window_names: Sequence[str] | None = None,
+    done_plan_tasks: Sequence[Any] | None = None,
+    plan_review_present: Any = None,
 ) -> list[Finding]:
     """Read audit events for ``project`` and scan them.
 
@@ -1509,9 +1638,10 @@ def scan_project(
     source-preference rules).
 
     ``open_tasks`` and ``storage_window_names`` are pass-through inputs
-    for the auto-unstick rules (#1414); when omitted those rules become
-    no-ops, which is the right default for callers that only have audit
-    events on hand.
+    for the auto-unstick rules (#1414); ``done_plan_tasks`` +
+    ``plan_review_present`` are pass-through for the plan_review_missing
+    rule (#1511). When omitted those rules become no-ops, which is the
+    right default for callers that only have audit events on hand.
     """
     from pollypm.audit.log import read_events
 
@@ -1537,6 +1667,8 @@ def scan_project(
         open_tasks=open_tasks,
         storage_window_names=storage_window_names,
         project=project,
+        done_plan_tasks=done_plan_tasks,
+        plan_review_present=plan_review_present,
     )
 
 
@@ -1831,6 +1963,33 @@ def format_unstick_brief(finding: Finding) -> str:
             "(b) reassign the task to a role that IS present, "
             "(c) escalate to user via `pm notify` if the spawn failure is "
             "persistent (config / auth / quota)."
+        )
+    elif finding.rule == RULE_PLAN_REVIEW_MISSING:
+        plan_task_id = meta.get("plan_task_id") or subject
+        flow_id = meta.get("flow_template_id") or "<unknown>"
+        labels = meta.get("labels") or []
+        created_at = meta.get("created_at")
+        lines.append("Stuck for: plan_review never emitted")
+        lines.append("Observed evidence:")
+        lines.append(
+            f"- Plan-shaped task {plan_task_id} reached done on flow={flow_id}"
+        )
+        if labels:
+            label_preview = ", ".join(str(label) for label in labels[:6])
+            lines.append(f"- Labels: {label_preview}")
+        if created_at:
+            lines.append(f"- Created at: {created_at}")
+        lines.append(
+            "- The cockpit's plan_review approval card needs a "
+            "messages-table row with labels=[plan_review, "
+            f"plan_task:{plan_task_id}] but none exists."
+        )
+        lines.append("")
+        lines.append(
+            "Your job: the watchdog will backfill the plan_review row on "
+            "this tick via plan_review_emit.emit_plan_review_for_task. "
+            "No manual action required unless the backfill itself fails "
+            "in the cadence logs."
         )
     elif finding.rule == RULE_WORKER_SESSION_DEAD_LOOP:
         reap_count = meta.get("reap_count") or "?"

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -34,6 +34,7 @@ from pollypm.audit.watchdog import (
     ESCALATION_THROTTLE_SECONDS,
     Finding,
     RULE_DUPLICATE_ADVISOR_TASKS,
+    RULE_PLAN_REVIEW_MISSING,
     RULE_ROLE_SESSION_MISSING,
     RULE_STUCK_DRAFT,
     RULE_TASK_ON_HOLD_STALE,
@@ -150,6 +151,146 @@ def _config_from_payload(payload: dict[str, Any]) -> WatchdogConfig:
         except (TypeError, ValueError):
             continue
     return WatchdogConfig(**kwargs) if kwargs else WatchdogConfig()
+
+
+def _gather_done_plan_tasks(
+    project_key: str, project_path: Path | None,
+) -> list[Any]:
+    """Best-effort load of recent ``done`` plan-shaped tasks for ``project_key``.
+
+    Powers the ``plan_review_missing`` rule (#1511). Filters to:
+
+    * ``work_status=done``
+    * Plan-shaped labels (poc-plan / plan / project-plan)
+    * Non-plan_project flow (``plan_project`` / ``critique_flow`` already
+      emit plan_review through their reflection nodes)
+
+    Returns an empty list on any failure — the watchdog rule then no-ops
+    for that project, which is safer than firing false-positive findings.
+    """
+    try:
+        from pollypm.work import create_work_service
+        from pollypm.work.models import WorkStatus
+        from pollypm.work.plan_review_emit import task_is_eligible_for_backstop
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: plan-review imports failed", exc_info=True,
+        )
+        return []
+    try:
+        with create_work_service(
+            project_path=project_path,
+            project_key=project_key,
+        ) as svc:
+            list_fn = getattr(svc, "list_tasks", None)
+            if not callable(list_fn):
+                return []
+            tasks = list(
+                list_fn(work_status=WorkStatus.DONE.value, project=project_key)
+            )
+            return [task for task in tasks if task_is_eligible_for_backstop(task)]
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: done-plan-task load failed for %s",
+            project_key, exc_info=True,
+        )
+        return []
+
+
+def _make_plan_review_probe(project_key: str, project_path: Path | None):
+    """Return a ``(project, plan_task_id) -> bool`` probe over the messages table.
+
+    Resolves the canonical workspace state DB through the work-service
+    factory (same path :func:`_gather_open_tasks` uses) so the probe
+    queries the same ``messages`` table the cockpit inbox renders from.
+    """
+    try:
+        from pollypm.work import create_work_service
+        from pollypm.work.plan_review_emit import already_has_plan_review_message
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: plan-review probe imports failed", exc_info=True,
+        )
+        return None
+    try:
+        # Resolve the DB path via a short-lived service open. Avoids
+        # plumbing the resolver directly here.
+        with create_work_service(
+            project_path=project_path,
+            project_key=project_key,
+        ) as svc:
+            db_path = getattr(svc, "_db_path", None)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: probe db_path resolve failed for %s",
+            project_key, exc_info=True,
+        )
+        return None
+    if db_path is None:
+        return None
+    resolved_db_path = Path(db_path)
+
+    def _probe(project: str, plan_task_id: str) -> bool:
+        return already_has_plan_review_message(
+            db_path=resolved_db_path,
+            project=project,
+            plan_task_id=plan_task_id,
+        )
+
+    return _probe
+
+
+def _backfill_plan_review_for_finding(
+    finding: Finding,
+    *,
+    project_key: str,
+    project_path: Path | None,
+) -> str | None:
+    """Emit the missing plan_review row for a ``plan_review_missing`` finding.
+
+    Best-effort — any failure is logged and swallowed. Returns the new
+    inbox task id on success, ``None`` on skip / failure. Idempotent
+    because :func:`emit_plan_review_for_task` re-checks the messages
+    table before writing.
+    """
+    plan_task_id = (finding.metadata or {}).get("plan_task_id") or finding.subject
+    if not plan_task_id:
+        return None
+    try:
+        from pollypm.work import create_work_service
+        from pollypm.work.plan_review_emit import emit_plan_review_for_task
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: backfill imports failed", exc_info=True,
+        )
+        return None
+    try:
+        with create_work_service(
+            project_path=project_path,
+            project_key=project_key,
+        ) as svc:
+            try:
+                task = svc.get(plan_task_id)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "audit.watchdog: get(%s) failed during plan_review backfill",
+                    plan_task_id, exc_info=True,
+                )
+                return None
+            if task is None:
+                return None
+            return emit_plan_review_for_task(
+                svc=svc,
+                task=task,
+                actor="audit_watchdog",
+                requester="user",
+            )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: plan_review backfill failed for %s",
+            plan_task_id, exc_info=True,
+        )
+        return None
 
 
 def _gather_open_tasks(project_key: str, project_path: Path | None) -> list[Any]:
@@ -604,9 +745,17 @@ def _scan_one_project(
         "dispatches_failed": 0,
         "advisor_duplicates_cancelled": 0,
         "advisor_duplicates_failed": 0,
+        "plan_review_backfilled": 0,
+        "plan_review_backfill_failed": 0,
     }
     open_tasks = _gather_open_tasks(project_key, project_path)
     storage_window_names = _gather_storage_windows(storage_closet_name)
+    done_plan_tasks = _gather_done_plan_tasks(project_key, project_path)
+    plan_review_present = (
+        _make_plan_review_probe(project_key, project_path)
+        if done_plan_tasks
+        else None
+    )
     try:
         findings = scan_project(
             project_key,
@@ -615,6 +764,8 @@ def _scan_one_project(
             config=config,
             open_tasks=open_tasks,
             storage_window_names=storage_window_names,
+            done_plan_tasks=done_plan_tasks,
+            plan_review_present=plan_review_present,
         )
     except Exception:  # noqa: BLE001
         logger.debug(
@@ -652,6 +803,25 @@ def _scan_one_project(
             counters["advisor_duplicates_cancelled"] += heal["cancelled"]
             counters["advisor_duplicates_failed"] += heal["failed"]
             # Skip dispatch — this rule is auto-healed, not architect-routed.
+            continue
+        # #1511 — plan_review_missing findings are self-healing: the
+        # cadence handler emits the missing inbox row via the same
+        # code path the post-done hook uses (Part A). Idempotent because
+        # ``emit_plan_review_for_task`` re-checks the messages table
+        # before writing. No architect dispatch needed; the user sees
+        # the backfilled card directly in their inbox.
+        if finding.rule == RULE_PLAN_REVIEW_MISSING:
+            backfilled = _backfill_plan_review_for_finding(
+                finding,
+                project_key=project_key,
+                project_path=project_path,
+            )
+            if backfilled is not None:
+                counters["plan_review_backfilled"] += 1
+            else:
+                counters["plan_review_backfill_failed"] += 1
+            # Skip the dispatch path for this rule — the architect has
+            # nothing to unstick; the watchdog itself just fixed it.
             continue
         # #1414 — eligible findings get an architect dispatch on top
         # of the alert. Throttle window is owned by the audit log so
@@ -715,6 +885,8 @@ def audit_watchdog_handler(payload: dict[str, Any]) -> dict[str, Any]:
         "dispatches_failed": 0,
         "advisor_duplicates_cancelled": 0,
         "advisor_duplicates_failed": 0,
+        "plan_review_backfilled": 0,
+        "plan_review_backfill_failed": 0,
     }
 
     try:

--- a/src/pollypm/work/plan_review_emit.py
+++ b/src/pollypm/work/plan_review_emit.py
@@ -1,0 +1,462 @@
+"""Backstop emit of ``plan_review`` inbox cards for plan-shaped done tasks (#1511).
+
+Today the only path that emits a ``plan_review`` notify message + inbox
+task is the architect's prompt-driven ``pm notify --label plan_review``
+call inside the ``plan_project`` flow's reflection node (#1399, #1400).
+That works for projects that flow through ``plan_project`` end-to-end,
+but a plan-shaped task built on the ``standard`` (or any other) flow
+reaches ``done`` with no ``plan_review`` inbox row, so the cockpit's
+2-line approval card never renders. ``coffeeboardnm`` was the live
+witness — labels=``["visual-explainer", "research", "poc-plan"]``,
+flow=``standard``, status=``done``, zero ``plan_review`` rows.
+
+This module owns the *backstop* emit:
+
+* :func:`is_plan_shaped_task` — conservative label-based heuristic.
+  Returns True when a task carries a known plan label
+  (``poc-plan`` / ``plan`` / ``project-plan``). Title-based detection
+  was deliberately rejected — false positives that emit a phantom
+  approval card are far worse than false negatives that leave a niche
+  edge case uncovered.
+* :func:`already_has_plan_review_message` — idempotence probe. Looks
+  for an open ``plan_review`` notify message on the workspace ``messages``
+  table whose labels include ``plan_task:<project>/<n>``. Used by both
+  the post-done hook and the watchdog backfill so neither can double-
+  emit.
+* :func:`emit_plan_review_for_task` — best-effort emit. Mirrors the
+  shape that ``cli_features.session_runtime.notify`` produces for the
+  ``--label plan_review --label plan_task:<id>`` invocation: a
+  ``messages`` row + a ``chat`` flow inbox task labeled identically.
+  The task carries ``roles.requester=user``, ``roles.operator=architect``
+  so the cockpit dashboard treats it as a notify-only inbox card and
+  the ``plan_review`` label drives the 2-line render in
+  ``cockpit_ui._format_inbox_plan_review_row``.
+
+The transition hook in :mod:`pollypm.work.service_transitions.on_task_done`
+calls :func:`maybe_emit_plan_review_on_task_done` after the existing
+``check_and_flush_on_done`` + ``emit_task_shipped_card`` hooks. The
+hook is no-op for the ``plan_project`` flow (its reflection node owns
+the canonical emit) and for tasks that already have an open
+plan_review row — both conditions are checked before any write.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from pollypm.work.models import WorkStatus
+
+logger = logging.getLogger(__name__)
+
+
+# Conservative label set — a task carrying any of these labels is treated
+# as "plan-shaped" for the purpose of the backstop emit. The set is
+# deliberately small: every entry has been observed on real plan tasks
+# (``poc-plan`` on coffeeboardnm/1, ``plan`` and ``project-plan`` on
+# pre-#1399 plan_project tasks). Adding a new label here is fine; widening
+# to title heuristics is not — see module docstring.
+PLAN_SHAPED_LABELS: frozenset[str] = frozenset({
+    "poc-plan",
+    "plan",
+    "project-plan",
+})
+
+# Flow templates whose own internal nodes already emit ``plan_review``
+# (the architect's reflection node landed in #1399). The backstop must
+# never duplicate those — Part A is purely *additive* coverage for
+# flows that lack such a node.
+_PLAN_OWNING_FLOWS: frozenset[str] = frozenset({
+    "plan_project",
+    "critique_flow",
+})
+
+# Label set the architect's ``pm notify --label plan_review`` call
+# stamps on the message + task. Mirrors the contract documented in
+# ``src/pollypm/plugins_builtin/project_planning/profiles/architect.md``.
+PLAN_REVIEW_LABEL = "plan_review"
+NOTIFY_LABEL = "notify"
+
+
+def is_plan_shaped_task(task: Any) -> bool:
+    """Return True when ``task`` looks like a plan task by labels.
+
+    Conservative — only label matches count. Title heuristics were
+    rejected because the false-positive cost (phantom approval cards
+    on unrelated done tasks) is much higher than the false-negative
+    cost (one more obscure flow not covered by the backstop).
+    """
+    labels = set(getattr(task, "labels", None) or [])
+    return bool(labels & PLAN_SHAPED_LABELS)
+
+
+def task_is_eligible_for_backstop(task: Any) -> bool:
+    """Return True when ``task`` should get a backstop ``plan_review`` emit.
+
+    Three conditions, all required:
+
+    1. The task is plan-shaped by labels (:func:`is_plan_shaped_task`).
+    2. The task is at ``work_status=done``. Plan-review is meaningful
+       only after the architect's plan task has actually completed.
+    3. The task is NOT on a plan-owning flow (``plan_project`` /
+       ``critique_flow``) — those flows have their own reflection node
+       and we must not duplicate it.
+    """
+    if not is_plan_shaped_task(task):
+        return False
+    status = getattr(task, "work_status", None)
+    status_value = getattr(status, "value", status)
+    if status_value != WorkStatus.DONE.value:
+        return False
+    flow_id = getattr(task, "flow_template_id", "") or ""
+    if flow_id in _PLAN_OWNING_FLOWS:
+        return False
+    return True
+
+
+def _plan_task_label(task_id: str) -> str:
+    return f"plan_task:{task_id}"
+
+
+def already_has_plan_review_message(
+    *,
+    db_path: Path,
+    project: str,
+    plan_task_id: str,
+) -> bool:
+    """Return True iff the workspace ``messages`` table has a plan_review row for the task.
+
+    Scans messages with ``scope=project`` (and the legacy ``scope=inbox``
+    bucket pre-#1425) that carry both the ``plan_review`` label AND a
+    ``plan_task:<plan_task_id>`` sidecar. We deliberately accept any
+    state — open, closed, replayed — because a previously-emitted
+    plan_review row that has since been approved/rejected still
+    constitutes "the user already saw a card for this plan task" and
+    we should not re-surface a fresh card on every cadence tick.
+
+    Best-effort: any error returns False so the emit path proceeds.
+    Idempotence is enforced again at the writer boundary by the
+    work-service ``messages`` table's row-level dedupe within the
+    same transaction; this probe is the cheap pre-check.
+    """
+    try:
+        from pollypm.store import SQLAlchemyStore
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "plan_review_emit: SQLAlchemyStore import failed", exc_info=True,
+        )
+        return False
+    target_label = _plan_task_label(plan_task_id)
+    seen_message_ids: set[Any] = set()
+    try:
+        store = SQLAlchemyStore(f"sqlite:///{db_path}")
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "plan_review_emit: SQLAlchemyStore open failed for %s",
+            db_path, exc_info=True,
+        )
+        return False
+    try:
+        scopes = [project] if project else []
+        if "inbox" not in scopes:
+            scopes.append("inbox")
+        for scope in scopes:
+            try:
+                rows = store.query_messages(scope=scope) or []
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "plan_review_emit: query_messages failed for scope=%s",
+                    scope, exc_info=True,
+                )
+                continue
+            for row in rows:
+                row_id = row.get("id")
+                if row_id is not None:
+                    if row_id in seen_message_ids:
+                        continue
+                    seen_message_ids.add(row_id)
+                if (row.get("type") or "").lower() != "notify":
+                    continue
+                raw_labels = row.get("labels")
+                if isinstance(raw_labels, str):
+                    try:
+                        raw_labels = json.loads(raw_labels)
+                    except (TypeError, ValueError):
+                        raw_labels = []
+                labels = set(raw_labels or [])
+                if PLAN_REVIEW_LABEL in labels and target_label in labels:
+                    return True
+    finally:
+        try:
+            store.close()
+        except Exception:  # noqa: BLE001
+            pass
+    return False
+
+
+def _build_plan_review_body(plan_task_id: str) -> str:
+    """Render the body the architect normally writes via ``pm notify``.
+
+    Mirrors ``profiles/architect.md`` plan_review_handoff template, minus
+    the explainer pointer (the backstop emit doesn't synthesise an HTML
+    explainer — the user opens the project drilldown surface from #1401
+    instead).
+    """
+    return (
+        f"A plan task ({plan_task_id}) reached done without a "
+        f"plan_review handoff (backstop emit, see #1511).\n"
+        "\n"
+        "Open the project drilldown to read the plan and decide whether "
+        "to approve, request changes, or discuss with the PM."
+    )
+
+
+def _build_plan_review_user_prompt(plan_task_id: str) -> dict[str, Any]:
+    return {
+        "summary": "A plan-shaped task completed without a plan_review handoff.",
+        "steps": [
+            "Open the project drilldown plan-review surface.",
+            "Read the plan and any open decisions.",
+            "Approve the plan, request changes, or discuss with the PM.",
+        ],
+        "question": (
+            "Review the plan and decide whether to approve as-is, "
+            "request changes, or discuss further."
+        ),
+        "actions": [
+            {"label": "Review plan", "kind": "review_plan"},
+            {"label": "Open task", "kind": "open_task", "task_id": plan_task_id},
+        ],
+    }
+
+
+def emit_plan_review_for_task(
+    *,
+    svc: Any,
+    task: Any,
+    actor: str = "audit_watchdog",
+    requester: str = "user",
+) -> str | None:
+    """Create the ``plan_review`` message + inbox task for ``task``.
+
+    Mirrors the side-effects of ``pm notify --label plan_review --label
+    plan_task:<id>`` (see :func:`pollypm.cli_features.session_runtime.notify`)
+    so the cockpit inbox renders the row identically to the canonical
+    emit path: a ``messages.notify`` row carrying the ``plan_review`` +
+    ``plan_task:<id>`` labels, plus a chat-flow inbox task with the same
+    labels and ``operator=<actor>`` / ``requester=<requester>`` roles.
+
+    Idempotent — returns ``None`` (and emits nothing) when an existing
+    plan_review row for the same plan_task_id is already present in the
+    messages table. Best-effort on failure: logs and swallows so a
+    broken inbox surface never crashes the transition hook or watchdog
+    cadence.
+
+    Returns the new inbox task_id on first emit, ``None`` on skip /
+    failure.
+    """
+    plan_task_id = getattr(task, "task_id", None)
+    project = getattr(task, "project", "") or ""
+    if not plan_task_id or not project:
+        return None
+    db_path = getattr(svc, "_db_path", None)
+    if db_path is None:
+        logger.debug(
+            "plan_review_emit: svc has no _db_path, skipping for %s", plan_task_id,
+        )
+        return None
+    db_path = Path(db_path)
+
+    if already_has_plan_review_message(
+        db_path=db_path, project=project, plan_task_id=plan_task_id,
+    ):
+        return None
+
+    subject = f"Plan ready for review: {project}"
+    body = _build_plan_review_body(plan_task_id)
+    target_label = _plan_task_label(plan_task_id)
+    labels = [
+        PLAN_REVIEW_LABEL,
+        f"project:{project}",
+        target_label,
+    ]
+    user_prompt = _build_plan_review_user_prompt(plan_task_id)
+
+    # 1. Write the messages row (the canonical persisted record). The
+    # cockpit inbox renderer reads from the messages table; the inbox
+    # task below is the work-service surface that drives the [A]/[D]
+    # keybindings.
+    try:
+        from pollypm.store import SQLAlchemyStore
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "plan_review_emit: SQLAlchemyStore import failed", exc_info=True,
+        )
+        return None
+    try:
+        store = SQLAlchemyStore(f"sqlite:///{db_path}")
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "plan_review_emit: SQLAlchemyStore open failed for %s",
+            db_path, exc_info=True,
+        )
+        return None
+    message_id: int | None = None
+    try:
+        try:
+            message_id = store.enqueue_message(
+                type="notify",
+                tier="immediate",
+                recipient=requester,
+                sender=actor or "audit_watchdog",
+                subject=subject,
+                body=body,
+                scope=project,
+                labels=labels,
+                payload={
+                    "actor": actor or "audit_watchdog",
+                    "project": project,
+                    "milestone_key": None,
+                    "requester": requester,
+                    "user_prompt": user_prompt,
+                    "plan_task_id": plan_task_id,
+                    "backstop_source": "plan_review_emit",
+                },
+                state="closed",  # mirrors session_runtime.notify for immediate tier
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "plan_review_emit: enqueue_message failed for %s: %s",
+                plan_task_id, exc, exc_info=True,
+            )
+            return None
+    finally:
+        try:
+            store.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+    # 2. Create the inbox task. The cockpit's plan-review surfaces
+    # (#1400 / #1401) accept either the message row or the task row;
+    # creating both keeps parity with the canonical ``pm notify`` path
+    # so callers that filter by source ("message" vs "task") see the
+    # same shape regardless of how the row landed.
+    inbox_task_id: str | None = None
+    try:
+        task_labels = [
+            *labels,
+            NOTIFY_LABEL,
+            f"notify_message:{message_id}" if message_id is not None else NOTIFY_LABEL,
+        ]
+        # Drop any duplicate labels while preserving order.
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for label in task_labels:
+            if label in seen:
+                continue
+            seen.add(label)
+            deduped.append(label)
+        new_task = svc.create(
+            title=subject,
+            description=body,
+            type="task",
+            project=project,
+            flow_template="chat",
+            roles={
+                "requester": requester,
+                "operator": actor or "audit_watchdog",
+            },
+            priority="high",
+            created_by=actor or "audit_watchdog",
+            labels=deduped,
+        )
+        inbox_task_id = getattr(new_task, "task_id", None)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "plan_review_emit: svc.create failed for %s: %s",
+            plan_task_id, exc, exc_info=True,
+        )
+        return None
+
+    # 3. Backfill the message payload with the new task_id so the cockpit
+    # renderer can resolve message → task without a label scan.
+    if message_id is not None and inbox_task_id is not None:
+        try:
+            store = SQLAlchemyStore(f"sqlite:///{db_path}")
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "plan_review_emit: SQLAlchemyStore reopen failed for payload backfill",
+                exc_info=True,
+            )
+            return inbox_task_id
+        try:
+            store.update_message(
+                message_id,
+                payload={
+                    "actor": actor or "audit_watchdog",
+                    "project": project,
+                    "milestone_key": None,
+                    "requester": requester,
+                    "user_prompt": user_prompt,
+                    "plan_task_id": plan_task_id,
+                    "task_id": inbox_task_id,
+                    "backstop_source": "plan_review_emit",
+                },
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "plan_review_emit: update_message failed for %s",
+                plan_task_id, exc_info=True,
+            )
+        finally:
+            try:
+                store.close()
+            except Exception:  # noqa: BLE001
+                pass
+    return inbox_task_id
+
+
+def maybe_emit_plan_review_on_task_done(
+    svc: Any,
+    task_id: str,
+    actor: str,
+) -> str | None:
+    """Transition-hook entry point — emit if the just-done task is plan-shaped.
+
+    Called from :func:`pollypm.work.service_transitions.on_task_done`
+    after the existing milestone-flush + task-shipped hooks. No-op for
+    plan_project / critique_flow tasks (their reflection nodes own the
+    canonical emit) and for tasks that already have a plan_review row.
+
+    Best-effort — any failure is logged and swallowed so the primary
+    transition is never blocked.
+    """
+    try:
+        task = svc.get(task_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "plan_review_emit: get(%s) failed: %s",
+            task_id, exc, exc_info=True,
+        )
+        return None
+    if not task_is_eligible_for_backstop(task):
+        return None
+    return emit_plan_review_for_task(
+        svc=svc,
+        task=task,
+        actor=actor or "polly",
+        requester="user",
+    )
+
+
+__all__ = [
+    "PLAN_REVIEW_LABEL",
+    "PLAN_SHAPED_LABELS",
+    "already_has_plan_review_message",
+    "emit_plan_review_for_task",
+    "is_plan_shaped_task",
+    "maybe_emit_plan_review_on_task_done",
+    "task_is_eligible_for_backstop",
+]

--- a/src/pollypm/work/service_transitions.py
+++ b/src/pollypm/work/service_transitions.py
@@ -145,6 +145,28 @@ def on_task_done(service: "SQLiteWorkService", task_id: str, actor: str) -> None
             exc_info=True,
         )
 
+    # #1511 — backstop emit for plan-shaped tasks that finished outside
+    # the ``plan_project`` flow. Plan-review approval cards used to depend
+    # on the architect's reflection node (#1399) firing inside that flow;
+    # tasks completed on ``standard`` / other flows reached done with no
+    # ``plan_review`` row in the messages table, so the cockpit's 2-line
+    # approval card never rendered. The hook is no-op for plan_project
+    # tasks (the reflection node owns the canonical emit) and for tasks
+    # that already have an open plan_review row.
+    try:
+        from pollypm.work.plan_review_emit import (
+            maybe_emit_plan_review_on_task_done,
+        )
+
+        maybe_emit_plan_review_on_task_done(service, task_id, actor or "polly")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "plan_review backstop emit skipped for %s: %s",
+            task_id,
+            exc,
+            exc_info=True,
+        )
+
 
 def on_task_transition(
     service: "SQLiteWorkService",

--- a/tests/test_plan_review_emit.py
+++ b/tests/test_plan_review_emit.py
@@ -1,0 +1,463 @@
+"""Tests for the plan-review backstop emit + watchdog backfill (#1511).
+
+The fix has two surfaces:
+
+* :mod:`pollypm.work.plan_review_emit` — backstop emit invoked from
+  ``service_transitions.on_task_done``. Any plan-shaped task (label
+  ``poc-plan`` / ``plan`` / ``project-plan``) on a non-plan_project
+  flow that reaches done gets a ``plan_review`` notify message + inbox
+  task auto-emitted.
+* :func:`pollypm.audit.watchdog._detect_plan_review_missing` —
+  forensic scan that fires for any tracked project whose recent ``done``
+  plan-shaped task has no matching ``plan_review`` row in the messages
+  table. The cadence handler routes the finding to the same emit path
+  so old projects (coffeeboardnm, the live witness) self-heal on first
+  watchdog tick after the fix lands.
+
+Tests cover three contracts:
+
+1. The post-done hook fires for the standard-flow plan-shaped case and
+   skips for plan_project / non-plan-shaped tasks.
+2. The watchdog detector fires when no plan_review exists and silences
+   when one already does.
+3. Idempotence: running the watchdog twice does not double-emit. The
+   second run sees the first emit's row and no-ops.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pollypm.audit.watchdog import (
+    RULE_PLAN_REVIEW_MISSING,
+    Finding,
+    WatchdogConfig,
+    _detect_plan_review_missing,
+    format_unstick_brief,
+    scan_events,
+)
+from pollypm.work.models import WorkStatus
+from pollypm.work.plan_review_emit import (
+    PLAN_REVIEW_LABEL,
+    PLAN_SHAPED_LABELS,
+    already_has_plan_review_message,
+    emit_plan_review_for_task,
+    is_plan_shaped_task,
+    maybe_emit_plan_review_on_task_done,
+    task_is_eligible_for_backstop,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — fakes for the work service / store
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeTask:
+    project: str
+    task_number: int
+    title: str = "Plan task"
+    labels: list[str] = field(default_factory=list)
+    work_status: WorkStatus = WorkStatus.DONE
+    flow_template_id: str = "standard"
+    created_at: datetime | None = None
+
+    @property
+    def task_id(self) -> str:
+        return f"{self.project}/{self.task_number}"
+
+
+@dataclass
+class _FakeCreatedTask:
+    task_id: str
+
+
+class _FakeSvc:
+    """Minimal stand-in for :class:`SQLiteWorkService`.
+
+    Records ``svc.create`` calls so tests can assert on the inbox task
+    that the emit path produces. ``_db_path`` is used by the emit
+    module to open the messages store; tests pass a tmp_path.
+    """
+
+    def __init__(self, *, db_path: Path, task: _FakeTask) -> None:
+        self._db_path = db_path
+        self._task = task
+        self.create_calls: list[dict[str, Any]] = []
+        self._next_task_number = task.task_number + 100
+
+    def get(self, task_id: str) -> _FakeTask:
+        return self._task
+
+    def create(self, **kwargs: Any) -> _FakeCreatedTask:
+        self.create_calls.append(kwargs)
+        project = kwargs.get("project") or self._task.project
+        number = self._next_task_number
+        self._next_task_number += 1
+        return _FakeCreatedTask(task_id=f"{project}/{number}")
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    """Bare workspace state.db that ``SQLAlchemyStore`` can open.
+
+    The emit path writes through ``store.enqueue_message`` and
+    re-opens to ``store.update_message``; both succeed against an
+    auto-migrating empty DB.
+    """
+    pollypm_dir = tmp_path / ".pollypm"
+    pollypm_dir.mkdir(parents=True, exist_ok=True)
+    return pollypm_dir / "state.db"
+
+
+@pytest.fixture
+def now() -> datetime:
+    return datetime(2026, 5, 8, 17, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Heuristic + eligibility predicates
+# ---------------------------------------------------------------------------
+
+
+def test_plan_shaped_labels_recognised() -> None:
+    """The conservative label set covers the live witnesses."""
+    assert PLAN_SHAPED_LABELS == frozenset({"poc-plan", "plan", "project-plan"})
+    assert is_plan_shaped_task(_FakeTask(project="p", task_number=1, labels=["poc-plan"]))
+    assert is_plan_shaped_task(_FakeTask(project="p", task_number=1, labels=["plan", "x"]))
+    assert is_plan_shaped_task(_FakeTask(project="p", task_number=1, labels=["project-plan"]))
+
+
+def test_non_plan_labels_rejected() -> None:
+    assert not is_plan_shaped_task(
+        _FakeTask(project="p", task_number=1, labels=["bug", "infra"])
+    )
+    assert not is_plan_shaped_task(_FakeTask(project="p", task_number=1, labels=[]))
+
+
+def test_eligibility_requires_done_status() -> None:
+    base_kwargs = dict(project="p", task_number=1, labels=["poc-plan"])
+    assert task_is_eligible_for_backstop(_FakeTask(**base_kwargs))
+    in_progress = _FakeTask(**base_kwargs, work_status=WorkStatus.IN_PROGRESS)
+    assert not task_is_eligible_for_backstop(in_progress)
+
+
+def test_eligibility_excludes_plan_project_flow() -> None:
+    """The reflection node owns the canonical emit on plan_project."""
+    plan_project = _FakeTask(
+        project="p",
+        task_number=1,
+        labels=["poc-plan"],
+        flow_template_id="plan_project",
+    )
+    assert not task_is_eligible_for_backstop(plan_project)
+    standard = _FakeTask(
+        project="p",
+        task_number=1,
+        labels=["poc-plan"],
+        flow_template_id="standard",
+    )
+    assert task_is_eligible_for_backstop(standard)
+
+
+# ---------------------------------------------------------------------------
+# Part A — post-done hook + idempotence
+# ---------------------------------------------------------------------------
+
+
+def test_emit_creates_message_and_task(db_path: Path) -> None:
+    """First emit writes both the messages row and the inbox task."""
+    task = _FakeTask(
+        project="coffeeboardnm",
+        task_number=1,
+        labels=["visual-explainer", "research", "poc-plan"],
+        flow_template_id="standard",
+        work_status=WorkStatus.DONE,
+    )
+    svc = _FakeSvc(db_path=db_path, task=task)
+
+    inbox_task_id = emit_plan_review_for_task(
+        svc=svc, task=task, actor="audit_watchdog", requester="user",
+    )
+
+    # An inbox task was created with the right shape.
+    assert inbox_task_id is not None
+    assert len(svc.create_calls) == 1
+    call = svc.create_calls[0]
+    assert call["title"].startswith("Plan ready for review:")
+    assert call["project"] == "coffeeboardnm"
+    assert call["flow_template"] == "chat"
+    assert call["roles"] == {"requester": "user", "operator": "audit_watchdog"}
+    labels = set(call["labels"])
+    assert PLAN_REVIEW_LABEL in labels
+    assert "plan_task:coffeeboardnm/1" in labels
+    assert "project:coffeeboardnm" in labels
+    assert "notify" in labels
+
+    # And a plan_review message lives in the messages table now.
+    assert already_has_plan_review_message(
+        db_path=db_path,
+        project="coffeeboardnm",
+        plan_task_id="coffeeboardnm/1",
+    )
+
+
+def test_emit_is_idempotent(db_path: Path) -> None:
+    """A second emit for the same plan_task_id no-ops."""
+    task = _FakeTask(
+        project="coffeeboardnm",
+        task_number=1,
+        labels=["poc-plan"],
+        flow_template_id="standard",
+    )
+    svc = _FakeSvc(db_path=db_path, task=task)
+
+    first = emit_plan_review_for_task(svc=svc, task=task)
+    assert first is not None
+    second = emit_plan_review_for_task(svc=svc, task=task)
+    assert second is None
+    # Only the first call created an inbox task; the second short-circuits.
+    assert len(svc.create_calls) == 1
+
+
+def test_maybe_emit_skips_plan_project_flow(db_path: Path) -> None:
+    """The post-done hook is no-op for plan_project tasks."""
+    task = _FakeTask(
+        project="p",
+        task_number=2,
+        labels=["plan", "project-plan"],
+        flow_template_id="plan_project",
+    )
+    svc = _FakeSvc(db_path=db_path, task=task)
+    result = maybe_emit_plan_review_on_task_done(svc, task.task_id, "polly")
+    assert result is None
+    assert svc.create_calls == []
+    assert not already_has_plan_review_message(
+        db_path=db_path, project="p", plan_task_id=task.task_id,
+    )
+
+
+def test_maybe_emit_skips_non_plan_shaped(db_path: Path) -> None:
+    """Tasks without plan-shaped labels are ignored."""
+    task = _FakeTask(
+        project="p",
+        task_number=3,
+        labels=["bug", "infra"],
+        flow_template_id="standard",
+    )
+    svc = _FakeSvc(db_path=db_path, task=task)
+    result = maybe_emit_plan_review_on_task_done(svc, task.task_id, "polly")
+    assert result is None
+    assert svc.create_calls == []
+
+
+def test_maybe_emit_fires_for_standard_flow_plan(db_path: Path) -> None:
+    """The savethenovel/coffeeboardnm class — standard-flow + poc-plan."""
+    task = _FakeTask(
+        project="coffeeboardnm",
+        task_number=1,
+        labels=["visual-explainer", "research", "poc-plan"],
+        flow_template_id="standard",
+    )
+    svc = _FakeSvc(db_path=db_path, task=task)
+
+    result = maybe_emit_plan_review_on_task_done(svc, task.task_id, "polly")
+
+    assert result is not None
+    assert len(svc.create_calls) == 1
+    assert already_has_plan_review_message(
+        db_path=db_path,
+        project="coffeeboardnm",
+        plan_task_id="coffeeboardnm/1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Part B — watchdog detector
+# ---------------------------------------------------------------------------
+
+
+def test_watchdog_fires_when_no_plan_review_present(now: datetime) -> None:
+    """Stranded plan-shaped done task with no plan_review row → finding."""
+    config = WatchdogConfig()
+    task = _FakeTask(
+        project="coffeeboardnm",
+        task_number=1,
+        labels=["poc-plan"],
+        flow_template_id="standard",
+        created_at=now - timedelta(hours=2),
+    )
+    findings = _detect_plan_review_missing(
+        now=now,
+        config=config,
+        done_plan_tasks=[task],
+        plan_review_present=lambda project, task_id: False,
+    )
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.rule == RULE_PLAN_REVIEW_MISSING
+    assert finding.project == "coffeeboardnm"
+    assert finding.subject == "coffeeboardnm/1"
+    assert finding.metadata["plan_task_id"] == "coffeeboardnm/1"
+    assert finding.metadata["flow_template_id"] == "standard"
+
+
+def test_watchdog_silent_when_plan_review_already_present(now: datetime) -> None:
+    """Probe returns True → no finding (idempotence)."""
+    config = WatchdogConfig()
+    task = _FakeTask(
+        project="coffeeboardnm",
+        task_number=1,
+        labels=["poc-plan"],
+        flow_template_id="standard",
+        created_at=now - timedelta(hours=2),
+    )
+    findings = _detect_plan_review_missing(
+        now=now,
+        config=config,
+        done_plan_tasks=[task],
+        plan_review_present=lambda project, task_id: True,
+    )
+    assert findings == []
+
+
+def test_watchdog_silent_when_task_outside_lookback(now: datetime) -> None:
+    """A plan-shaped task created 30 days ago is past the 14-day window."""
+    config = WatchdogConfig()
+    task = _FakeTask(
+        project="oldproj",
+        task_number=1,
+        labels=["plan"],
+        flow_template_id="standard",
+        created_at=now - timedelta(days=30),
+    )
+    findings = _detect_plan_review_missing(
+        now=now,
+        config=config,
+        done_plan_tasks=[task],
+        plan_review_present=lambda project, task_id: False,
+    )
+    assert findings == []
+
+
+def test_watchdog_noop_without_inputs(now: datetime) -> None:
+    """No done_plan_tasks / no probe → detector is a no-op."""
+    config = WatchdogConfig()
+    assert _detect_plan_review_missing(
+        now=now, config=config, done_plan_tasks=None, plan_review_present=None,
+    ) == []
+    assert _detect_plan_review_missing(
+        now=now, config=config, done_plan_tasks=[], plan_review_present=lambda *a: False,
+    ) == []
+
+
+def test_scan_events_threads_plan_review_inputs(now: datetime) -> None:
+    """End-to-end: scan_events forwards the new inputs to the detector."""
+    config = WatchdogConfig()
+    task = _FakeTask(
+        project="coffeeboardnm",
+        task_number=1,
+        labels=["poc-plan"],
+        flow_template_id="standard",
+        created_at=now - timedelta(hours=2),
+    )
+    findings = scan_events(
+        events=[],
+        now=now,
+        config=config,
+        done_plan_tasks=[task],
+        plan_review_present=lambda project, task_id: False,
+    )
+    matched = [f for f in findings if f.rule == RULE_PLAN_REVIEW_MISSING]
+    assert len(matched) == 1
+    assert matched[0].subject == "coffeeboardnm/1"
+
+
+# ---------------------------------------------------------------------------
+# Idempotence: simulating two watchdog ticks
+# ---------------------------------------------------------------------------
+
+
+def test_watchdog_double_run_does_not_double_emit(
+    db_path: Path, now: datetime,
+) -> None:
+    """Two-tick idempotence — Part A backfills, Part B sees the row, silences.
+
+    Models the cadence-handler flow: tick 1 fires the finding, the
+    cadence calls ``emit_plan_review_for_task`` to backfill, and tick 2
+    runs the detector again — the probe now reports True so no second
+    finding fires.
+    """
+    config = WatchdogConfig()
+    task = _FakeTask(
+        project="coffeeboardnm",
+        task_number=1,
+        labels=["poc-plan"],
+        flow_template_id="standard",
+        created_at=now - timedelta(hours=2),
+    )
+    svc = _FakeSvc(db_path=db_path, task=task)
+
+    def probe(project: str, plan_task_id: str) -> bool:
+        return already_has_plan_review_message(
+            db_path=db_path, project=project, plan_task_id=plan_task_id,
+        )
+
+    # Tick 1: finding fires, cadence handler emits the missing card.
+    tick1 = _detect_plan_review_missing(
+        now=now,
+        config=config,
+        done_plan_tasks=[task],
+        plan_review_present=probe,
+    )
+    assert len(tick1) == 1
+    backfilled = emit_plan_review_for_task(svc=svc, task=task, actor="audit_watchdog")
+    assert backfilled is not None
+    assert len(svc.create_calls) == 1
+
+    # Tick 2: same scan, but the probe now returns True so no finding.
+    tick2 = _detect_plan_review_missing(
+        now=now,
+        config=config,
+        done_plan_tasks=[task],
+        plan_review_present=probe,
+    )
+    assert tick2 == []
+
+    # And calling emit again is also idempotent.
+    second_emit = emit_plan_review_for_task(svc=svc, task=task)
+    assert second_emit is None
+    assert len(svc.create_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Brief rendering — ensures the new rule has its tailored block
+# ---------------------------------------------------------------------------
+
+
+def test_format_unstick_brief_includes_plan_review_block() -> None:
+    finding = Finding(
+        rule=RULE_PLAN_REVIEW_MISSING,
+        project="coffeeboardnm",
+        subject="coffeeboardnm/1",
+        message="Plan-shaped task coffeeboardnm/1 reached done with no plan_review.",
+        recommendation="Backfill via plan_review_emit.",
+        metadata={
+            "plan_task_id": "coffeeboardnm/1",
+            "flow_template_id": "standard",
+            "labels": ["poc-plan", "research"],
+            "created_at": "2026-05-01T00:00:00+00:00",
+        },
+    )
+    brief = format_unstick_brief(finding)
+    assert "WATCHDOG ESCALATION" in brief
+    assert "plan_review_missing" in brief
+    assert "coffeeboardnm/1" in brief
+    assert "flow=standard" in brief
+    assert "plan_review_emit" in brief


### PR DESCRIPTION
## Summary

Closes #1511. The plan-review approval surface used to depend on the architect's reflection node inside `plan_project` flow (#1399, #1400). Plan-shaped tasks built on the `standard` flow (or any other) reached `done` with no `plan_review` row in the `messages` table, so the cockpit's 2-line approval card never rendered. `coffeeboardnm` was the live witness — labels=`["visual-explainer", "research", "poc-plan"]`, flow=`standard`, status=`done`, zero `plan_review` messages.

This fix is additive — the existing reflection node behaviour on `plan_project` is untouched.

### Part A — Backstop emit on every task done

- New module `src/pollypm/work/plan_review_emit.py` owns the conservative label-based heuristic (`poc-plan` / `plan` / `project-plan`) plus an idempotent `emit_plan_review_for_task` that mirrors the architect's `pm notify --label plan_review` shape: same `messages` row, same `chat`-flow inbox task, same labels (`plan_review`, `project:<key>`, `plan_task:<project>/<n>`, `notify`).
- Wired into `service_transitions.on_task_done` after the existing milestone-flush + task-shipped hooks via `maybe_emit_plan_review_on_task_done`. No-op for `plan_project` / `critique_flow` (their reflection nodes already own the canonical emit) and for tasks that already have a plan_review row.

### Part B — Self-healing watchdog backfill

- New rule `RULE_PLAN_REVIEW_MISSING` + detector `_detect_plan_review_missing` in `audit.watchdog`. Fires for any tracked project with a `done` plan-shaped task created in the last 14 days lacking a matching `plan_review` message.
- The cadence handler in `plugins_builtin.core_recurring.audit_watchdog` gathers candidate tasks via `svc.list_tasks(work_status='done')` filtered through `task_is_eligible_for_backstop`, builds a probe over the messages table, and on every finding invokes the same `emit_plan_review_for_task` Part A uses. coffeeboardnm self-heals on the first watchdog tick after this lands.
- Per-project counters extended (`plan_review_backfilled`, `plan_review_backfill_failed`) so the cadence outcome surfaces the backfill rate.
- A tailored block was added to `format_unstick_brief` so the new rule renders cleanly in the audit-finding readout, even though the backfill is fully automatic and never dispatches to the architect.

### Idempotence

Both call sites probe the messages table for an existing `plan_review` row labeled `plan_task:<project>/<n>` before writing. The watchdog excludes `plan_review_missing` from the architect-dispatch path because the cadence handler itself is the unstuck action — there's nothing for the architect to do.

### Architectural concern (not blocking)

Plan-shaped detection is fundamentally heuristic; the conservative label allowlist (`poc-plan` / `plan` / `project-plan`) covers the live witnesses but a future "plan-by-other-name" task could still slip through. The long-term fix the issue calls "option 2" — every worker-driven plan task must use `plan_project` flow — would eliminate the heuristic entirely. This PR is the low-risk option 1 backstop; option 2 should follow as its own piece of work once the v1 tag is in.

## Test plan

- [x] `uv run pytest tests/test_plan_review_emit.py` — 16 new tests, all pass
- [x] `uv run pytest tests/test_audit_watchdog.py` — 78 existing tests, all pass
- [x] `uv run pytest tests/test_task_shipped_inbox.py tests/test_plan_presence_gate.py` — 75 tests, all pass
- [x] `uv run pytest tests/ -k 'plan_review or plan_presence or watchdog or notification'` — only pre-existing failures (`test_modal_surfaces_plan_review_keys_when_selected`, unrelated)
- [ ] Live verification: bounce the watchdog cadence on the user's machine and confirm `coffeeboardnm` gets a `plan_review` message backfilled on the next tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)