### PR TITLE
Fix #1518 Plan section recognizes done plan-shaped tasks

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -11335,6 +11335,166 @@ def _dashboard_plan_path(project_path: Path) -> Path | None:
     return None
 
 
+# URL-shaped match used to harvest a deliverable hint from a done plan
+# task's external_refs / labels / description. We trim a couple of
+# trailing punctuation characters that show up when URLs land at the
+# end of free-form prose. Mirrors the conservative pattern in
+# ``task_shipped._URL_RE``.
+_PLAN_TASK_URL_RE = _re.compile(r"https?://[^\s\)<>]+")
+_PLAN_TASK_URL_TRAILING_TRIM = ".,;:!?)"
+
+
+def _plan_task_first_paragraph(description: str, *, limit: int = 280) -> str:
+    """Return the first paragraph (or sentence) of a plan-task description.
+
+    Used by the Plan section when there is no plan file but a done
+    plan-shaped task carries a description. Keeps the surface compact —
+    one paragraph capped at ``limit`` chars — so the dashboard pane
+    doesn't overflow for tasks with long bodies.
+    """
+    text = (description or "").strip()
+    if not text:
+        return ""
+    para = text.split("\n\n", 1)[0].strip()
+    if len(para) > limit:
+        para = para[: limit - 1].rstrip() + "…"
+    return para
+
+
+def _plan_task_deliverable_url(task: object) -> str | None:
+    """Return a URL hint for a done plan task, or None.
+
+    Looks at (in order): ``external_refs`` values, label values that
+    parse as URLs (``url:<href>`` form first, then any label that is
+    itself a URL), and finally the task description body. Conservative
+    on purpose — we only return ``http(s)`` URLs.
+    """
+    refs = getattr(task, "external_refs", None) or {}
+    if isinstance(refs, dict):
+        # Stable iteration so deterministic across runs; prefer keys
+        # that read as deliverable-y over arbitrary refs.
+        preferred_keys = (
+            "deliverable",
+            "deliverable_url",
+            "report",
+            "report_url",
+            "url",
+        )
+        for key in preferred_keys:
+            value = refs.get(key)
+            if isinstance(value, str) and value.startswith(("http://", "https://")):
+                return value
+        for value in refs.values():
+            if isinstance(value, str) and value.startswith(("http://", "https://")):
+                return value
+    labels = getattr(task, "labels", None) or []
+    for label in labels:
+        if not isinstance(label, str):
+            continue
+        if label.startswith("url:"):
+            candidate = label[len("url:"):].strip()
+            if candidate.startswith(("http://", "https://")):
+                return candidate
+        if label.startswith(("http://", "https://")):
+            return label
+    description = getattr(task, "description", "") or ""
+    match = _PLAN_TASK_URL_RE.search(description)
+    if match:
+        url = match.group(0)
+        while url and url[-1] in _PLAN_TASK_URL_TRAILING_TRIM:
+            url = url[:-1]
+        if url:
+            return url
+    return None
+
+
+def _dashboard_done_plan_task(
+    config: object, project_key: str, project_path: Path,
+) -> dict | None:
+    """Return a summary of the most recent done plan-shaped task, or None.
+
+    A "plan-shaped" task is one matching the conservative label-based
+    heuristic in :func:`pollypm.work.plan_review_emit.task_is_eligible_for_backstop`
+    (re-used here, do not duplicate). When the dashboard's Plan section
+    sees no plan file on disk, this is the fallback that lets it
+    surface "the plan task is done — open it" instead of the
+    "No plan yet" empty state (#1518).
+
+    Returns a small dict with the task identity, title, first-paragraph
+    description, and any deliverable URL hint we could harvest from
+    ``external_refs`` / labels / description. Returns ``None`` when no
+    plan-shaped done task exists, or when the work-service is
+    unreachable (no DB on disk yet, import fails, …) — callers fall
+    back to the file-only behavior.
+    """
+    db_paths = _dashboard_task_db_paths(config, project_path)
+    if not db_paths:
+        return None
+    try:
+        from pollypm.work import create_work_service
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        from pollypm.work.plan_review_emit import task_is_eligible_for_backstop
+    except Exception:  # noqa: BLE001
+        return None
+
+    aliases = _project_storage_aliases(config, project_key)
+    best_task: object | None = None
+    best_updated: str = ""
+    for db_path in db_paths:
+        db_aliases = list(aliases)
+        try:
+            for discovered in _dashboard_discover_db_aliases(db_path, aliases):
+                if discovered not in db_aliases:
+                    db_aliases.append(discovered)
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            with create_work_service(
+                db_path=db_path, project_path=project_path,
+            ) as svc:
+                seen_ids: set[str] = set()
+                for alias in db_aliases:
+                    try:
+                        rows = svc.list_tasks(project=alias) or []
+                    except Exception:  # noqa: BLE001
+                        continue
+                    for found in rows:
+                        tid = getattr(found, "task_id", None)
+                        if not tid or tid in seen_ids:
+                            continue
+                        seen_ids.add(tid)
+                        if not task_is_eligible_for_backstop(found):
+                            continue
+                        updated = getattr(found, "updated_at", "") or ""
+                        if hasattr(updated, "isoformat"):
+                            updated = updated.isoformat()
+                        updated_s = str(updated)
+                        if best_task is None or updated_s > best_updated:
+                            best_task = found
+                            best_updated = updated_s
+        except Exception:  # noqa: BLE001
+            continue
+
+    if best_task is None:
+        return None
+
+    task_id = getattr(best_task, "task_id", None)
+    if not task_id:
+        return None
+    description = getattr(best_task, "description", "") or ""
+    return {
+        "task_id": task_id,
+        "task_number": getattr(best_task, "task_number", None),
+        "project": getattr(best_task, "project", "") or "",
+        "title": getattr(best_task, "title", "") or "",
+        "summary": _plan_task_first_paragraph(description),
+        "deliverable_url": _plan_task_deliverable_url(best_task),
+        "updated_at": best_updated,
+    }
+
+
 def _dashboard_plan_explainer(project_path: Path, project_key: str) -> Path | None:
     for rel in _PLAN_EXPLAINER_CANDIDATES_FMT:
         p = project_path / rel.format(key=project_key)
@@ -11608,6 +11768,7 @@ class ProjectDashboardData:
         "plan_aux_files",
         "plan_mtime",
         "plan_stale_reason",
+        "plan_task_summary",
         "activity_entries",
         "inbox_count",
         "inbox_top",
@@ -11641,6 +11802,7 @@ class ProjectDashboardData:
         plan_mtime: float | None,
         plan_stale_reason: str | None,
         activity_entries: list[dict],
+        plan_task_summary: dict | None = None,
         inbox_count: int,
         inbox_top: list[dict],
         action_items: list[dict],
@@ -11668,6 +11830,7 @@ class ProjectDashboardData:
         self.plan_aux_files = plan_aux_files
         self.plan_mtime = plan_mtime
         self.plan_stale_reason = plan_stale_reason
+        self.plan_task_summary = plan_task_summary
         self.activity_entries = activity_entries
         self.inbox_count = inbox_count
         self.inbox_top = inbox_top
@@ -13869,6 +14032,16 @@ def _gather_project_dashboard(
         plan_stale_reason = _dashboard_plan_staleness(
             plan_path, plan_mtime, project_path, project_key,
         )
+        # #1518 — surface a done plan-shaped task to the Plan section
+        # so projects whose plan completed via a non-plan_project flow
+        # don't read "No plan yet" forever. Best-effort: if the work
+        # service is unreachable we fall back to the file-only render.
+        try:
+            plan_task_summary = _dashboard_done_plan_task(
+                config, project_key, project_path,
+            )
+        except Exception:  # noqa: BLE001
+            plan_task_summary = None
         activity_entries = _dashboard_activity(config_path, project_key)
     else:
         counts = {}
@@ -13883,6 +14056,7 @@ def _gather_project_dashboard(
         plan_aux_files = []
         plan_mtime = None
         plan_stale_reason = None
+        plan_task_summary = None
         activity_entries = []
 
     active_worker, alert_count, alert_types = _dashboard_active_worker(
@@ -13937,6 +14111,7 @@ def _gather_project_dashboard(
         plan_aux_files=plan_aux_files,
         plan_mtime=plan_mtime,
         plan_stale_reason=plan_stale_reason,
+        plan_task_summary=plan_task_summary,
         activity_entries=activity_entries,
         inbox_count=inbox_count,
         inbox_top=inbox_top,
@@ -13993,6 +14168,20 @@ def _project_dashboard_signature(
         str(data.plan_path) if data.plan_path else None,
         data.plan_mtime,
         data.plan_stale_reason,
+        # #1518 — done plan-shaped task identity flips the section
+        # from "No plan yet" to a task-summary card; include just the
+        # identity bits so the cache invalidates on the structural
+        # change without churning on description-only edits.
+        (
+            (
+                (getattr(data, "plan_task_summary", None) or {}).get("task_id")
+                or ""
+            ),
+            (
+                (getattr(data, "plan_task_summary", None) or {}).get("updated_at")
+                or ""
+            ),
+        ),
         # Activity tail (newest entries' identity, not their age).
         tuple(
             (e.get("event_type"), e.get("created_at"))
@@ -15706,7 +15895,17 @@ class PollyProjectDashboardApp(App[None]):
     def _render_plan_body(self, data: ProjectDashboardData) -> str:
         if not data.exists_on_disk:
             return "[dim]Virtual project — no plan on disk.[/dim]"
+        # #1518 — a done plan-shaped task in the work service satisfies
+        # "this project has a plan". When the file is also present we
+        # prefer it (it's typically the rendered deliverable) but still
+        # surface the task ID so the user can navigate to the source.
+        # When only the task exists we render its title + first
+        # paragraph + any deliverable URL we could harvest, instead of
+        # the misleading "No plan yet" empty state.
+        plan_task_summary = getattr(data, "plan_task_summary", None) or None
         if data.plan_path is None:
+            if plan_task_summary:
+                return self._render_plan_task_summary(plan_task_summary)
             # Per-project ``[planner].enforce_plan = false`` opts the
             # project out of the planning ceremony entirely (one-off
             # cleanups, single-task scopes). The default "ask the PM to
@@ -15737,9 +15936,49 @@ class PollyProjectDashboardApp(App[None]):
                 lines.append(f"  \u25aa {_escape(title)}")
         else:
             lines.append("  [dim](no H2 sections found)[/dim]")
+        # #1518 \u2014 when a done plan-shaped task also exists alongside
+        # the file, mention the task ID below the TOC so the user can
+        # jump to the source. The file remains the primary surface.
+        if plan_task_summary:
+            task_id = plan_task_summary.get("task_id") or ""
+            if task_id:
+                lines.append("")
+                lines.append(
+                    f"  [dim]Plan task done: [b]{_escape(task_id)}[/b][/dim]"
+                )
         # Visual-explainer prompt removed in #1405 (keybinding broken,
         # deferred for v1+). ``data.plan_explainer`` may still surface
         # via other paths but we no longer advertise the ``v`` shortcut.
+        return "\n".join(lines)
+
+    def _render_plan_task_summary(self, summary: dict) -> str:
+        """Render a Plan section card backed by a done plan-shaped task (#1518).
+
+        Used when there is no plan file on disk but the work service
+        carries a ``done`` plan-shaped task (matching the conservative
+        label heuristic in
+        :func:`pollypm.work.plan_review_emit.task_is_eligible_for_backstop`).
+        Surfaces the task identity, title, first-paragraph description,
+        and any deliverable URL hint we could harvest — so the user
+        sees "the plan exists, here's where it landed" instead of
+        the misleading "No plan yet" empty state.
+        """
+        task_id = summary.get("task_id") or ""
+        title = summary.get("title") or ""
+        body = summary.get("summary") or ""
+        url = summary.get("deliverable_url") or ""
+        lines: list[str] = []
+        header = "[dim]Plan task done"
+        if task_id:
+            header += f" — [b]{_escape(task_id)}[/b]"
+        header += "[/dim]"
+        lines.append(header)
+        if title:
+            lines.append(f"  {_escape(title)}")
+        if body:
+            lines.append(f"  [dim]{_escape(body)}[/dim]")
+        if url:
+            lines.append(f"  [dim]Deliverable:[/dim] {_escape(url)}")
         return "\n".join(lines)
 
     def _render_plan_stale(self, data: ProjectDashboardData) -> str:

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -4472,6 +4472,198 @@ def test_plan_body_with_enforce_plan_true_uses_default_nudge(dashboard_app) -> N
     assert "Plan not required" not in body
 
 
+# ---------------------------------------------------------------------------
+# #1518 — Plan section recognizes a done plan-shaped task in the work
+# service so the dashboard stops reading "No plan yet" forever for projects
+# whose plan completed via a non-plan_project flow (coffeeboardnm, live
+# witness 2026-05-08). Heuristic re-uses
+# ``plan_review_emit.task_is_eligible_for_backstop`` — do NOT duplicate.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_body_renders_done_plan_task_summary_when_no_file(
+    dashboard_app,
+) -> None:
+    """A done plan-shaped task (no plan file) replaces 'No plan yet' (#1518)."""
+    from types import SimpleNamespace
+
+    summary = {
+        "task_id": "coffeeboardnm/1",
+        "task_number": 1,
+        "project": "coffeeboardnm",
+        "title": "Plan the visual explainer POC",
+        "summary": "Outline the deliverable and the build steps.",
+        "deliverable_url": "https://example.com/reports/index.html",
+        "updated_at": "2026-05-08T12:00:00",
+    }
+    fake_data = SimpleNamespace(
+        exists_on_disk=True,
+        plan_path=None,
+        plan_sections=[],
+        plan_aux_files=[],
+        plan_explainer=None,
+        enforce_plan=True,
+        plan_task_summary=summary,
+    )
+    body = dashboard_app._render_plan_body(fake_data)
+    assert "No plan yet" not in body
+    assert "coffeeboardnm/1" in body
+    assert "Plan the visual explainer POC" in body
+    assert "Outline the deliverable" in body
+    assert "https://example.com/reports/index.html" in body
+
+
+def test_plan_body_prefers_file_but_mentions_done_plan_task(
+    dashboard_app, tmp_path,
+) -> None:
+    """When a plan file AND a done plan task exist, prefer the file but
+    still surface the task ID below the TOC so the user can navigate to
+    the source (#1518)."""
+    from types import SimpleNamespace
+
+    plan_path = tmp_path / "docs" / "plan" / "plan.md"
+    plan_path.parent.mkdir(parents=True)
+    plan_path.write_text("# Plan\n\n## One\n")
+    summary = {
+        "task_id": "coffeeboardnm/1",
+        "task_number": 1,
+        "project": "coffeeboardnm",
+        "title": "Plan the visual explainer POC",
+        "summary": "Outline the deliverable and the build steps.",
+        "deliverable_url": "https://example.com/reports/index.html",
+        "updated_at": "2026-05-08T12:00:00",
+    }
+    fake_data = SimpleNamespace(
+        exists_on_disk=True,
+        plan_path=plan_path,
+        plan_sections=["One"],
+        plan_aux_files=[],
+        plan_explainer=None,
+        enforce_plan=True,
+        plan_task_summary=summary,
+    )
+    body = dashboard_app._render_plan_body(fake_data)
+    # H2 outline still drives the primary surface.
+    assert "One" in body
+    # Task ID is surfaced as a footer note.
+    assert "coffeeboardnm/1" in body
+    assert "Plan task done" in body
+    # Empty-state copy must NOT be present — we have a plan file.
+    assert "No plan yet" not in body
+
+
+def test_plan_body_keeps_no_plan_yet_when_no_file_and_no_task(
+    dashboard_app,
+) -> None:
+    """No plan file AND no plan-shaped task → original empty-state copy (#1518)."""
+    from types import SimpleNamespace
+
+    fake_data = SimpleNamespace(
+        exists_on_disk=True,
+        plan_path=None,
+        plan_sections=[],
+        plan_aux_files=[],
+        plan_explainer=None,
+        enforce_plan=True,
+        plan_task_summary=None,
+    )
+    body = dashboard_app._render_plan_body(fake_data)
+    assert "No plan yet" in body
+    assert "PM will draft one" in body
+
+
+def test_dashboard_done_plan_task_reads_from_work_service(tmp_path: Path) -> None:
+    """Integration: seed a done poc-plan task on standard flow; the
+    helper finds it via the work service (#1518)."""
+    project_path = tmp_path / "coffeeboardnm"
+    project_path.mkdir()
+    _init_git_repo(project_path)
+    db_path = project_path / ".pollypm" / "state.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    from pollypm.work.models import (
+        Artifact, ArtifactKind, OutputType, WorkOutput,
+    )
+    with SQLiteWorkService(
+        db_path=db_path, project_path=project_path,
+    ) as svc:
+        svc._auto_merge_approved_task_branch = lambda _t, **_kw: None
+        task = svc.create(
+            title="Plan the explainer",
+            description=(
+                "First paragraph describing the plan.\n\n"
+                "Second paragraph that should not appear."
+            ),
+            type="task",
+            project="coffeeboardnm",
+            flow_template="standard",
+            roles={"worker": "pete", "reviewer": "russell"},
+            priority="normal",
+            created_by="polly",
+            labels=["visual-explainer", "research", "poc-plan"],
+        )
+        svc.queue(task.task_id, "polly")
+        svc.claim(task.task_id, "worker")
+        svc.node_done(
+            task.task_id, "worker",
+            WorkOutput(
+                type=OutputType.CODE_CHANGE,
+                summary="Plan ready",
+                artifacts=[
+                    Artifact(
+                        kind=ArtifactKind.COMMIT,
+                        description="plan",
+                        ref="cafef00d0000",
+                    ),
+                ],
+            ),
+        )
+        svc.approve(task.task_id, "russell")
+
+    # Build a minimal config the helper accepts. Rely on the same
+    # loader the cockpit uses so the alias resolution path matches prod.
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        "[project]\n"
+        f'tmux_session = "pollypm-test"\n'
+        f'workspace_root = "{tmp_path}"\n'
+        "\n"
+        "[projects.coffeeboardnm]\n"
+        'key = "coffeeboardnm"\n'
+        'name = "coffeeboardnm"\n'
+        f'path = "{project_path}"\n'
+    )
+    from pollypm.config import load_config
+    config = load_config(config_path)
+
+    from pollypm.cockpit_ui import _dashboard_done_plan_task
+
+    result = _dashboard_done_plan_task(
+        config, "coffeeboardnm", project_path,
+    )
+    assert result is not None
+    assert result["task_id"] == "coffeeboardnm/1"
+    assert result["title"] == "Plan the explainer"
+    # Only the first paragraph should be surfaced.
+    assert "First paragraph" in result["summary"]
+    assert "Second paragraph" not in result["summary"]
+
+
+def test_dashboard_done_plan_task_returns_none_without_db(tmp_path: Path) -> None:
+    """No state.db → helper returns None (file-only fallback) — does NOT crash (#1518)."""
+    from types import SimpleNamespace
+
+    project_path = tmp_path / "ghost"
+    project_path.mkdir()
+    config = SimpleNamespace(
+        project=SimpleNamespace(workspace_root=tmp_path),
+        projects={"ghost": SimpleNamespace(path=project_path, name="ghost")},
+    )
+    from pollypm.cockpit_ui import _dashboard_done_plan_task
+
+    result = _dashboard_done_plan_task(config, "ghost", project_path)
+    assert result is None
+
+
 def test_action_hint_uses_per_card_form_when_two_cards_visible() -> None:
     """Footer hint must match the live key bindings.
 


### PR DESCRIPTION
## Summary

- Adds a task-aware fallback to the project dashboard's Plan section so it stops reading "No plan yet" forever for projects whose plan completed via a non-`plan_project` flow (live witness: `coffeeboardnm`, task #1 done, labels `["visual-explainer", "research", "poc-plan"]`, deliverable at `reports/index.html`).
- Re-uses `pollypm.work.plan_review_emit.task_is_eligible_for_backstop` (the conservative label-based heuristic that landed in #1515 / PR #1511) — does NOT define a parallel heuristic.
- File-first precedence: when both the plan file and a done plan task exist, the file remains primary and the task ID is surfaced as a footer note. When only the task exists, the section renders task title + first-paragraph description + any deliverable URL we could harvest from `external_refs` / labels / description.

## Implementation

- `_dashboard_done_plan_task(config, project_key, project_path)` — opens the work service via `_dashboard_task_db_paths` (canonical-then-legacy DB order, same as `_dashboard_gather_tasks`) and walks tasks with the project alias union. Returns a small dict `{task_id, project, title, summary, deliverable_url, updated_at}` or `None`.
- `_plan_task_first_paragraph` / `_plan_task_deliverable_url` — small helpers; deliverable URL probes `external_refs` (preferred keys first), then label values that parse as URLs (`url:<href>` form), then a regex over the description body.
- `ProjectDashboardData.plan_task_summary` — new optional field threaded through `_gather_project_dashboard` + the dashboard signature so a fresh task identity invalidates the cached render.
- `_render_plan_body` consults `plan_task_summary` before falling through to the existing empty-state copy. New `_render_plan_task_summary` renders the task-only card.

## Self-healing

Not required — UI render bug, not a state-machine bug. The cockpit re-renders on signature change; once the read path is fixed the dashboard self-heals on next paint. No watchdog touched.

## Failure modes

Best-effort throughout. If the work service is unreachable (no `state.db`, import failure, query exception) the helper returns `None` and the section falls back to today's file-only behavior. No crash paths added.

## Test plan

New tests in `tests/test_project_dashboard_ui.py`:
- [x] `test_plan_body_renders_done_plan_task_summary_when_no_file` — done plan-shaped task replaces "No plan yet" with task title + summary + deliverable URL.
- [x] `test_plan_body_prefers_file_but_mentions_done_plan_task` — file primary, task ID as footer note.
- [x] `test_plan_body_keeps_no_plan_yet_when_no_file_and_no_task` — original empty-state preserved.
- [x] `test_dashboard_done_plan_task_reads_from_work_service` — integration: seed a done `poc-plan` task on `standard` flow via `SQLiteWorkService`; helper finds it and trims the description to the first paragraph.
- [x] `test_dashboard_done_plan_task_returns_none_without_db` — no `state.db` → helper returns `None` (file-only fallback) instead of crashing.

Existing `_dashboard_plan_*` and "No plan yet" tests still pass. The 5 unrelated failures in `tests/ -k 'plan or dashboard or cockpit_ui'` reproduce on `main` without these changes (test-isolation / unrelated text-asserts).

Closes #1518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)