### PR TITLE
Fix #1520 rail glyph reflects user-action-waiting state

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -354,6 +354,39 @@ def _stuck_alert_already_user_waiting(
     return bool(task_id) and task_id in user_waiting_task_ids
 
 
+def _alert_type_is_user_action_waiting(alert_type: str | None) -> bool:
+    """True when ``alert_type`` represents a "Waiting on you:" decision.
+
+    Mirrors the actionability filter in
+    ``cockpit_ui._dashboard_active_worker``: an alert is "Waiting on you"
+    when it is non-empty AND not classified as operational by
+    :func:`pollypm.cockpit_alerts.is_operational_alert`. The dashboard
+    banner uses the same filter to drive ``_alert_banner_copy`` ("Waiting
+    on you: ..."); using it here keeps the rail glyph and the banner
+    consistent — if the banner says "Waiting on you", the rail says
+    "Waiting on you" too.
+
+    Surfaceable operational alerts (``stuck_on_task:``,
+    ``no_session_for_assignment:``, ``recovery_limit``) are explicitly
+    re-classified as user-actionable by ``is_operational_alert`` (via
+    ``is_surfaceable_operational_alert``), so they correctly surface on
+    the rail.
+
+    Used by :meth:`_indicator` (#1520) to render a "needs attention"
+    glyph on the project rail row, overriding the idle ``♡·`` /
+    active-worker ``♥·`` heartbeat pair so a project waiting on the user
+    no longer reads as quiet or merely-busy.
+    """
+    if not alert_type:
+        return False
+    # Local import to avoid a cycle: cockpit_alerts pulls in textual,
+    # which is fine at call time but heavier than the rail module wants
+    # at import time (the rail loads in every cockpit pane).
+    from pollypm.cockpit_alerts import is_operational_alert
+
+    return not is_operational_alert(alert_type)
+
+
 def _selected_project_key(selected: object) -> str | None:
     """Extract the project key from the ``selected`` cockpit state."""
     if not isinstance(selected, str) or not selected.startswith("project:"):
@@ -4248,6 +4281,23 @@ class PollyCockpitRail:
                     else PALETTE["alert_indicator"]
                 )
                 return "\u25b2", color
+            # #1520 \u2014 A "Waiting on you:" alert family on the project's
+            # sessions (plan_missing, worker_question, recovery_limit,
+            # auth_broken, stuck_on_task:, no_session_for_assignment:,
+            # etc.) outranks both the project-rollup glyphs *and* the
+            # heartbeat \u2665\u00b7/\u2661\u00b7 pair below. The dashboard banner already
+            # says "Waiting on you: ..." for these; the rail must mirror
+            # that signal so the user can see at a glance which projects
+            # owe them a decision instead of drilling into each one. Use
+            # the same \u25c6 glyph the dashboard pill renders for "needs
+            # attention" so the rail and the banner agree visually;
+            # warn_indicator (amber) reads as "user action" not
+            # "operational fault" (which keeps the \u25b2 triangle above).
+            # Operational alerts (``pane:*``, ``unmanaged_window:*``)
+            # are filtered out by ``_alert_type_is_user_action_waiting``
+            # \u2014 the worker's stuck \u26a0 glyph already covers them.
+            if _alert_type_is_user_action_waiting(item.alert_type):
+                return "\u25c6", PALETTE["warn_indicator"]
             if item.state == "project-yellow":
                 # #1092 \u2014 use \u25c6 to match the dashboard's "needs attention"
                 # diamond. ``\u2022`` (U+2022) and the idle ``\u00b7`` (U+00B7) are

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -150,7 +150,12 @@ from pollypm.cockpit_navigation_client import (
     cockpit_navigation_queue_path,
     file_navigation_client,
 )
-from pollypm.cockpit_rail import CockpitItem, CockpitPresence, CockpitRouter
+from pollypm.cockpit_rail import (
+    CockpitItem,
+    CockpitPresence,
+    CockpitRouter,
+    _alert_type_is_user_action_waiting,
+)
 
 
 import re as _re
@@ -765,6 +770,21 @@ class RailItem(ListItem):
                 return "▶", "#ff5f6d"
             if self.item.state == "project-red":
                 return "▲", alert_color
+            # #1520 — A "Waiting on you:" alert family on the project's
+            # sessions (plan_missing, worker_question, recovery_limit,
+            # auth_broken, stuck_on_task:, no_session_for_assignment:,
+            # etc.) outranks both the project-rollup glyphs *and* the
+            # heartbeat ♥·/♡· pair below. The dashboard banner already
+            # says "Waiting on you:" for these; the rail must mirror
+            # that signal so the user can see at a glance which projects
+            # owe them a decision. Same ◆ glyph the dashboard pill uses
+            # for "needs attention". Operational alerts (``pane:*``)
+            # are filtered out by ``_alert_type_is_user_action_waiting``
+            # — the worker's stuck ⚠ glyph already covers them.
+            if _alert_type_is_user_action_waiting(
+                getattr(self.item, "alert_type", None)
+            ):
+                return "◆", "#f0a030"
             if self.item.state == "project-yellow":
                 # #1092 — use ◆ to match the dashboard's "needs attention"
                 # diamond. ``•`` and the idle ``·`` are visually

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -1042,6 +1042,223 @@ def test_cockpit_raw_rail_on_hold_affordance_fits_narrow_pane() -> None:
     assert "(2⚠)" in row.text
 
 
+def test_alert_type_is_user_action_waiting_classifies_families() -> None:
+    """#1520 — the helper that drives the new rail glyph must agree with
+    the dashboard banner's actionability filter: every "Waiting on you:"
+    alert family in ``cockpit_ui._alert_banner_copy`` must classify as
+    actionable, and operational alert prefixes (``pane:`` /
+    ``unmanaged_window:``) must classify as not actionable so the rail
+    doesn't double-render the worker's ⚠ stuck glyph as ◆.
+    """
+    from pollypm.cockpit_rail import _alert_type_is_user_action_waiting
+
+    # Empty / None — never user-action waiting.
+    assert _alert_type_is_user_action_waiting(None) is False
+    assert _alert_type_is_user_action_waiting("") is False
+
+    # Banner-copy "Waiting on you:" families — every one must surface.
+    assert _alert_type_is_user_action_waiting("plan_missing") is True
+    assert _alert_type_is_user_action_waiting("worker_question") is True
+    assert _alert_type_is_user_action_waiting("auth_broken") is True
+    # Surfaceable operational prefixes (cli_features.alerts) — actionable.
+    assert _alert_type_is_user_action_waiting("recovery_limit") is True
+    assert _alert_type_is_user_action_waiting("stuck_on_task:demo/3") is True
+    assert (
+        _alert_type_is_user_action_waiting("no_session_for_assignment:demo/3")
+        is True
+    )
+
+    # Operational prefixes — NOT actionable; the worker's ⚠ stuck glyph
+    # already covers these via ``_session_work_glyph``.
+    assert _alert_type_is_user_action_waiting("pane:auth_expired") is False
+    assert _alert_type_is_user_action_waiting("pane:permission_prompt") is False
+    assert _alert_type_is_user_action_waiting("unmanaged_window:foo") is False
+    assert _alert_type_is_user_action_waiting("suspected_loop") is False
+
+
+def test_cockpit_raw_rail_user_action_waiting_overrides_idle_session_glyph() -> None:
+    """#1520 — A project carrying a "Waiting on you:" alert family
+    (plan_missing, worker_question, recovery_limit, ...) must surface
+    the ◆ "needs attention" glyph on the rail, not the heartbeat ``♡·``
+    pair, so the user can see at a glance that the project owes them
+    a decision. Reproduces the coffeeboardnm symptom: an idle worker
+    session on a project with an open plan_missing alert was reading
+    as quiet (♡·) even though the dashboard banner said "Waiting on you:
+    this project has no plan yet".
+    """
+    rail = PollyCockpitRail.__new__(PollyCockpitRail)
+    rail.selected_key = "polly"
+    rail.spinner_index = 0
+
+    glyph, _color = rail._indicator(
+        CockpitItem(
+            "project:coffeeboardnm",
+            "CoffeeBoardNM",
+            "ready",
+            session_name="worker_coffeeboardnm",
+            work_state="idle",
+            heartbeat_at="2026-05-08T16:00:00+00:00",
+            alert_severity="warn",
+            alert_type="plan_missing",
+        ),
+    )
+
+    assert glyph == "◆"
+    # The heartbeat pair must NOT leak through — the whole point of
+    # this glyph is to *not* read as a quiet idle worker.
+    assert "♡" not in glyph
+    assert "♥" not in glyph
+
+
+def test_cockpit_raw_rail_user_action_waiting_overrides_active_worker_glyph() -> None:
+    """#1520 — Decision-pending must outrank an active worker. A worker
+    actively heartbeating on a project that *also* has a "Waiting on you:"
+    alert is, from the user's perspective, blocked on the user's input —
+    the worker's progress is irrelevant until the user acts. The rail
+    glyph must reflect the decision, not the spinner.
+    """
+    rail = PollyCockpitRail.__new__(PollyCockpitRail)
+    rail.selected_key = "polly"
+    rail.spinner_index = 0
+
+    glyph, _color = rail._indicator(
+        CockpitItem(
+            "project:coffeeboardnm",
+            "CoffeeBoardNM",
+            "● live",
+            session_name="worker_coffeeboardnm",
+            work_state="writing",
+            heartbeat_at="2026-05-08T16:00:00+00:00",
+            alert_severity="warn",
+            alert_type="worker_question",
+        ),
+    )
+
+    assert glyph == "◆"
+    # The active-worker pulse must NOT leak through.
+    assert "♥" not in glyph
+
+
+def test_cockpit_raw_rail_active_worker_keeps_heartbeat_glyph_without_alert() -> None:
+    """#1520 — guard against over-reach: a project with an active worker
+    but *no* attached alert keeps its existing ``♥·`` / ``♡·`` heartbeat
+    indicator. The new branch only fires when ``alert_type`` is set.
+    """
+    class _FakeTmux:
+        def current_session_name(self) -> str | None:
+            return "pollypm"
+
+        def list_clients(self, session_name: str) -> str:
+            del session_name
+            return "client"
+
+    rail = PollyCockpitRail.__new__(PollyCockpitRail)
+    rail.selected_key = "polly"
+    rail.spinner_index = 0
+    rail.presence = CockpitPresence(_FakeTmux())
+
+    glyph, _color = rail._indicator(
+        CockpitItem(
+            "project:demo",
+            "Demo",
+            "ready",
+            session_name="worker_demo",
+            work_state="writing",
+            heartbeat_at="2026-04-21T23:00:00+00:00",
+            alert_severity=None,
+            alert_type=None,
+        ),
+    )
+
+    # Active worker → heartbeat-paired writing glyph (♡ + spinner / …).
+    assert glyph != "◆"
+    assert "♡" in glyph or "♥" in glyph
+
+
+def test_cockpit_raw_rail_idle_project_without_alert_stays_idle() -> None:
+    """#1520 — guard against over-reach: a project row with neither a
+    session nor an alert falls through to the existing idle ``○`` glyph,
+    unchanged. The new branch only fires when ``alert_type`` is set.
+    """
+    rail = PollyCockpitRail.__new__(PollyCockpitRail)
+    rail.selected_key = "polly"
+    rail.spinner_index = 0
+
+    glyph, _color = rail._indicator(
+        CockpitItem(
+            "project:savethenovel",
+            "savethenovel",
+            "idle",
+        ),
+    )
+
+    assert glyph == "○"
+
+
+def test_cockpit_raw_rail_user_action_waiting_does_not_override_operational_red() -> None:
+    """#1520 — operational fault (project-red) keeps its dedicated ▲
+    triangle. The supervisor raises ``project-red`` only for genuinely
+    broken states (``stuck_on_task:`` on a non-user-waiting task,
+    ``no_session_for_assignment``, etc.), and the triangle's job is
+    "something is broken, the system needs help". Replacing it with the
+    user-action diamond would lose that signal.
+    """
+    rail = PollyCockpitRail.__new__(PollyCockpitRail)
+    rail.selected_key = "polly"
+    rail.spinner_index = 0
+
+    glyph, _color = rail._indicator(
+        CockpitItem(
+            "project:demo",
+            "Demo",
+            "project-red",
+            alert_severity="error",
+            alert_type="no_session_for_assignment:demo/3",
+        ),
+    )
+
+    assert glyph == "▲"
+
+
+def test_cockpit_ui_rail_item_user_action_waiting_overrides_idle_session_glyph(
+    monkeypatch,
+) -> None:
+    """#1520 — Textual ``RailItem`` mirror of the raw-rail check: a project
+    with an attached "Waiting on you:" alert renders ◆, not the
+    heartbeat ♡· pair.
+    """
+    monkeypatch.setattr(RailItem, "update_body", lambda self: None)
+
+    class _FakeTmux:
+        def current_session_name(self) -> str | None:
+            return "pollypm"
+
+        def list_clients(self, session_name: str) -> str:
+            del session_name
+            return "client"
+
+    presence = CockpitPresence(_FakeTmux())
+    item = RailItem(
+        CockpitItem(
+            "project:coffeeboardnm",
+            "CoffeeBoardNM",
+            "ready",
+            session_name="worker_coffeeboardnm",
+            work_state="idle",
+            heartbeat_at="2026-05-08T16:00:00+00:00",
+            alert_severity="warn",
+            alert_type="plan_missing",
+        ),
+        active_view=False,
+        presence=presence,
+    )
+
+    glyph, _color = item._indicator()
+    assert glyph == "◆"
+    assert "♡" not in glyph
+    assert "♥" not in glyph
+
+
 def test_cockpit_rail_session_indicator_combines_pulse_and_work_glyph(monkeypatch, tmp_path: Path) -> None:
     config_path = tmp_path / "pollypm.toml"
     config_path.write_text(


### PR DESCRIPTION
## Summary

Fixes #1520 — projects with an open "Waiting on you:" alert (plan_missing, worker_question, recovery_limit, auth_broken, stuck_on_task:, no_session_for_assignment:, etc.) read on the rail with the same idle ``♡·`` heartbeat glyph as quiet projects, even though the project dashboard banner correctly flags them as needing the user's attention. The user has to drill into each project to discover which ones owe them a decision — a violation of the ["When I open Polly, I need to be able to see exactly what I am responsible to do next"](https://github.com/samhotchkiss/pollypm/issues/1520) principle.

## What changed

- New helper ``_alert_type_is_user_action_waiting`` (cockpit_rail.py) mirrors the actionability filter in ``cockpit_ui._dashboard_active_worker``: ``alert_type`` is non-empty AND ``is_operational_alert(alert_type)`` is False. Surfaceable operational prefixes (``stuck_on_task:``, ``no_session_for_assignment:``, ``recovery_limit``) correctly count as actionable; pure-operational ``pane:*`` / ``unmanaged_window:*`` stay out because the worker's existing ``! stuck`` ⚠ glyph already covers them.
- Both ``_indicator`` paths (the raw ``PollyCockpitRail`` and the Textual ``RailItem`` in cockpit_ui.py) gain a new branch that fires when the project row carries an actionable alert_type. The branch returns the same ``◆`` "needs attention" diamond the dashboard pill (``_dashboard_status``) already renders for the same condition, so the rail glyph and the banner agree visually.

## Glyph choice

``◆`` (U+25C6) — same diamond the dashboard ``_dashboard_status`` pill returns for ``inbox_count or on_hold_count``, and the same diamond the rail ``project-yellow`` rollup uses today for held tasks. Reusing ``◆`` (rather than inventing a new char) keeps the rail and the dashboard banner in lock-step: if the banner says "Waiting on you", the rail says "Waiting on you" too, with the same shape. Color is ``warn_indicator`` (amber, ``#f0c05a``) to mark "user action" and stay distinct from the ``▲`` (red triangle) used for operational faults (``project-red``).

## Priority order

Inserted between the existing ``project-red`` (``▲``) branch and the project-rollup / heartbeat fall-through. So:

1. ``approvals_pending > 0`` → ``▶`` (act-on-me, unchanged)
2. ``project-red`` → ``▲`` (operational fault, unchanged)
3. **NEW**: actionable alert_type → ``◆`` (waiting on you)
4. ``project-yellow`` / ``project-green`` / ``project-working`` (unchanged)
5. ``session_name + work_state`` → ``♥·`` / ``♡·`` heartbeat pair (unchanged)

The decision-pending state outranks both the project rollup and the heartbeat indicator. A worker actively heartbeating on a project that owes the user a decision now reads as ``◆`` (decision waiting), not ``♥◜`` (active) — the user's input is the pivot until they act, regardless of whether a worker happens to be turning underneath. (Per #1520 spec: "a worker doing work AND a pending decision means the decision is the user-facing pivot".)

## No watchdog / self-healing

This is a render-priority bug — the alert is already attached to the project row by ``_attach_alert_metadata``; the rail just wasn't surfacing it. Once the new branch consults the right signal, every paint self-heals.

## Test plan

- [x] ``uv run pytest tests/ -k 'rail or glyph or cockpit_project_state'`` — 292 passed (was 286; the 6 new render-path tests are matched by the keyword filter; the 7th classifier test ran in a focused invocation).
- [x] Classifier-level coverage: every "Waiting on you:" family from ``_alert_banner_copy``, every surfaceable operational prefix, and every plain operational prefix.
- [x] Render-path coverage for the four scenarios spelled out in #1520:
  - idle session + plan_missing alert → ``◆`` (the coffeeboardnm repro)
  - active worker + worker_question alert → ``◆`` (decision outranks active)
  - active worker + no alert → ``♡◜`` / ``♥…`` (heartbeat path unchanged)
  - idle project + no alert → ``○`` (idle path unchanged)
  - operational ``project-red`` + alert → ``▲`` (operational fault still wins)
- [x] Both ``_indicator`` paths covered (raw ``PollyCockpitRail`` and Textual ``RailItem``).
- [x] ``uv run ruff check`` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)