### PR TITLE
Fix #1524 stabilize plan_missing alert + churn watchdog

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -93,6 +93,7 @@ __all__ = [
     "RULE_DUPLICATE_ADVISOR_TASKS",
     "RULE_PLAN_REVIEW_MISSING",
     "RULE_LEGACY_DB_SHADOW",
+    "RULE_PLAN_MISSING_ALERT_CHURN",
     "ON_HOLD_HUMAN_NEEDED_TAG",
     "ON_HOLD_ARCHITECT_TAG",
     "scan_events",
@@ -165,6 +166,16 @@ RULE_PLAN_REVIEW_MISSING = "plan_review_missing"
 # ``state.db.legacy-1004`` only after every row was either copied or
 # matched).
 RULE_LEGACY_DB_SHADOW = "legacy_db_shadow"
+# #1524 — plan_missing alert churn. Part A's deterministic precompute
+# in the task-assignment sweep should keep ``plan_missing`` alerts
+# stable across consecutive ticks; if the same project still racks up
+# multiple emit-clear pairs in a short window, something has regressed
+# and the user is back to seeing the banner flash. The detector is the
+# canary — it does not repair (Part A is the repair) — so future-us
+# notices when the regression returns instead of the user noticing it
+# in the cockpit. Threshold defaults to >=3 clear events on the same
+# ``plan_gate-<project>`` scope inside ``plan_missing_churn_window_seconds``.
+RULE_PLAN_MISSING_ALERT_CHURN = "plan_missing_alert_churn"
 
 # Reason-string tags reviewers use to hint the watchdog routing. The
 # default (no tag) is architect-actionable. ``ON_HOLD_HUMAN_NEEDED_TAG``
@@ -260,6 +271,15 @@ class WatchdogConfig:
     # is wide enough to catch plans the user genuinely hasn't reviewed
     # yet without re-firing forever on long-since-abandoned drafts.
     plan_review_lookback_seconds: int = 14 * 24 * 60 * 60
+    # #1524 — plan_missing alert churn. Window + threshold for the
+    # canary detector that fires when the sweep handler is bouncing
+    # the same plan_missing alert open/closed across consecutive ticks
+    # (the regression Part A repairs). 10 min covers ~12 sweep ticks
+    # at the @every 50s cadence; 3 clears in that window is well above
+    # the steady-state of zero (Part A means the alert refreshes in
+    # place, never closes-and-reopens).
+    plan_missing_churn_window_seconds: int = 600
+    plan_missing_churn_threshold: int = 3
 
 
 @dataclass(slots=True, frozen=True)
@@ -1616,6 +1636,122 @@ def _detect_legacy_db_shadow(
 
 
 # ---------------------------------------------------------------------------
+# Plan_missing alert churn detector (#1524)
+# ---------------------------------------------------------------------------
+
+
+# Project-key extractor for synthetic ``plan_gate-<project>`` scopes.
+# Pinned to a regex so a future scope-rename catches itself in tests.
+_PLAN_GATE_SCOPE_RE = re.compile(r"^plan_gate-(?P<project>.+)$")
+
+
+def _detect_plan_missing_alert_churn(
+    *,
+    now: datetime,
+    config: WatchdogConfig,
+    plan_missing_clears: Sequence[Any] | None = None,
+) -> list[Finding]:
+    """Rule (#1524): a project's ``plan_missing`` alert is being cleared
+    + re-emitted repeatedly inside a short window — the banner-flash
+    regression that Part A of #1524 repairs.
+
+    Pre-#1524 the task-assignment sweep handler had a fragile coupling
+    between the auto-claim loop's side-effect-populated
+    ``plan_missing_projects`` set and the per-project DB clear path.
+    After the per-project legacy DB was drained (post-#1519), a
+    project's ``plan_missing`` alert was being cleared on ticks where
+    the auto-claim path didn't traverse it and re-emitted on the next
+    tick from the workspace-root pass — producing alternating
+    "Waiting on you" / "Queued" banner state and a fresh alert row
+    every other sweep tick. Part A (the deterministic precompute in
+    ``_task_assignment_sweep_body``) is the repair; this detector is
+    the canary that catches the regression returning.
+
+    Pure detector — no I/O. The cadence handler queries the
+    ``messages`` table for ``alert.cleared`` events with
+    ``sender='plan_missing'`` in the configured window and passes the
+    clear records in here (one entry per clear event, exposing
+    ``scope`` and ``cleared_at``). The detector groups by scope,
+    counts clears per project, and emits a finding for each scope at
+    or above ``plan_missing_churn_threshold``.
+
+    Each clear record must expose:
+
+    * ``scope`` — the alert ``scope`` (synthetic
+      ``plan_gate-<project>`` for plan_missing alerts).
+    * ``cleared_at`` — a tz-aware ``datetime`` (or ISO-8601 string)
+      for when the clear landed.
+
+    ``plan_missing_clears=None`` disables the rule (the right default
+    when the cadence caller can't query the messages table).
+    """
+    findings: list[Finding] = []
+    if not plan_missing_clears:
+        return findings
+    cutoff = now - timedelta(seconds=config.plan_missing_churn_window_seconds)
+
+    by_project: dict[str, list[datetime]] = {}
+    for record in plan_missing_clears:
+        scope_value = getattr(record, "scope", None)
+        if not scope_value:
+            continue
+        match = _PLAN_GATE_SCOPE_RE.match(str(scope_value))
+        if match is None:
+            # Non-plan-gate scope — wrong rule for this row.
+            continue
+        project_key = match.group("project")
+        if not project_key:
+            continue
+        cleared_at_raw = getattr(record, "cleared_at", None)
+        cleared_at = _coerce_datetime(cleared_at_raw)
+        if cleared_at is None:
+            continue
+        if cleared_at < cutoff:
+            continue
+        by_project.setdefault(project_key, []).append(cleared_at)
+
+    for project_key, clears in by_project.items():
+        if len(clears) < config.plan_missing_churn_threshold:
+            continue
+        clears.sort()
+        latest_iso = clears[-1].isoformat()
+        first_iso = clears[0].isoformat()
+        scope_str = f"plan_gate-{project_key}"
+        findings.append(Finding(
+            rule=RULE_PLAN_MISSING_ALERT_CHURN,
+            project=project_key,
+            subject=scope_str,
+            message=(
+                f"Project {project_key} had {len(clears)} ``plan_missing`` "
+                f"alert clear events between {first_iso} and {latest_iso} "
+                f"(window: "
+                f"{config.plan_missing_churn_window_seconds // 60} min). "
+                f"The sweep handler is bouncing the alert open/closed each "
+                f"tick — the #1524 banner-flash regression has returned."
+            ),
+            recommendation=(
+                f"Inspect the task-assignment sweep handler "
+                f"(``_task_assignment_sweep_body`` + "
+                f"``_precompute_plan_missing_projects``). The pre-compute "
+                f"step in Part A of #1524 should keep "
+                f"plan_gate-{project_key} stable across consecutive ticks; "
+                f"a regression in that path almost always traces to the "
+                f"per-project DB clear branch firing for a project the "
+                f"precompute should have flagged."
+            ),
+            metadata={
+                "project_key": project_key,
+                "clear_count": len(clears),
+                "window_seconds": config.plan_missing_churn_window_seconds,
+                "first_clear_at": first_iso,
+                "latest_clear_at": latest_iso,
+                "detected_via": "state",
+            },
+        ))
+    return findings
+
+
+# ---------------------------------------------------------------------------
 # Public API — scan_events / scan_project
 # ---------------------------------------------------------------------------
 
@@ -1631,6 +1767,7 @@ def scan_events(
     done_plan_tasks: Sequence[Any] | None = None,
     plan_review_present: Any = None,
     legacy_db_shadows: Sequence[Any] | None = None,
+    plan_missing_clears: Sequence[Any] | None = None,
 ) -> list[Finding]:
     """Run every detection rule against ``events`` and return findings.
 
@@ -1726,6 +1863,15 @@ def scan_events(
     findings.extend(_detect_legacy_db_shadow(
         legacy_db_shadows=legacy_db_shadows,
     ))
+    # #1524 — plan_missing alert churn. State-only detector; the cadence
+    # handler queries the messages table for ``alert.cleared`` events on
+    # ``plan_gate-<project>`` scopes and passes one record per clear in
+    # so this function stays pure.
+    findings.extend(_detect_plan_missing_alert_churn(
+        now=now,
+        config=config,
+        plan_missing_clears=plan_missing_clears,
+    ))
     return findings
 
 
@@ -1740,6 +1886,7 @@ def scan_project(
     done_plan_tasks: Sequence[Any] | None = None,
     plan_review_present: Any = None,
     legacy_db_shadows: Sequence[Any] | None = None,
+    plan_missing_clears: Sequence[Any] | None = None,
 ) -> list[Finding]:
     """Read audit events for ``project`` and scan them.
 
@@ -1752,9 +1899,10 @@ def scan_project(
     for the auto-unstick rules (#1414); ``done_plan_tasks`` +
     ``plan_review_present`` are pass-through for the plan_review_missing
     rule (#1511); ``legacy_db_shadows`` is pass-through for the
-    legacy_db_shadow rule (#1519). When omitted those rules become
-    no-ops, which is the right default for callers that only have
-    audit events on hand.
+    legacy_db_shadow rule (#1519); ``plan_missing_clears`` is
+    pass-through for the plan_missing_alert_churn rule (#1524). When
+    omitted those rules become no-ops, which is the right default for
+    callers that only have audit events on hand.
     """
     from pollypm.audit.log import read_events
 
@@ -1783,6 +1931,7 @@ def scan_project(
         done_plan_tasks=done_plan_tasks,
         plan_review_present=plan_review_present,
         legacy_db_shadows=legacy_db_shadows,
+        plan_missing_clears=plan_missing_clears,
     )
 
 

--- a/src/pollypm/plan_presence.py
+++ b/src/pollypm/plan_presence.py
@@ -558,3 +558,174 @@ def task_bypasses_plan_gate(task: Any) -> bool:
         return True
     labels = getattr(task, "labels", None) or []
     return BYPASS_LABEL in labels
+
+
+def project_has_plan_gated_work(work_service: Any, project_key: str) -> bool:
+    """Return True iff ``project_key`` has any non-terminal queued task
+    that the plan gate would block.
+
+    A project is considered to have plan-gated work iff at least one
+    task on the project is in :class:`WorkStatus.QUEUED` and is NOT
+    exempt via :func:`task_bypasses_plan_gate` (i.e. not a planning
+    flow and not labelled ``bypass_plan_gate``). Review / in-progress
+    tasks already in flight are intentionally excluded — the gate only
+    blocks fresh delegation, not recovery pings on existing work.
+
+    Used by the sweep handler's deterministic plan-missing precompute
+    (#1524): a project with no plan but no queued blocked tasks does
+    not warrant a fresh alert this tick. Pairs with
+    :func:`has_acceptable_plan` — a missing plan only matters when
+    there is work waiting to flow through the gate.
+
+    Returns False on any I/O error so the caller fails closed (no
+    spurious alert when we can't read the DB).
+    """
+    if work_service is None or not project_key:
+        return False
+    try:
+        tasks = work_service.list_tasks(
+            project=project_key,
+            work_status=WorkStatus.QUEUED.value,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "plan_presence: list_tasks(queued) failed for project %s",
+            project_key, exc_info=True,
+        )
+        return False
+    for task in tasks:
+        if task_bypasses_plan_gate(task):
+            continue
+        return True
+    return False
+
+
+def compute_plan_missing_projects(
+    projects: Any,
+    *,
+    work_service_for_project: Any,
+    plan_dir: str = "docs/plan",
+) -> dict[str, str | None]:
+    """Return a mapping of plan-gated project keys to an example blocked task id.
+
+    A project lands in the result iff (a) its plan-presence gate is
+    closed, AND (b) it has at least one queued non-bypass task waiting
+    on the gate. The value is one example queued ``task_id`` (for
+    alert copy) or ``None`` when no example was reachable.
+
+    Issue #1524 — the sweep handler used to derive this set as a side
+    effect of two separate loops (the workspace-root sweep and the
+    per-project auto-claim path), and a project would only land in the
+    set on ticks that happened to traverse the right loop. After the
+    per-project legacy DB was drained (post-#1519) the per-project
+    fallback at the end of the sweep would clear the alert on every
+    other tick, producing the "Waiting on you / Queued" banner flash
+    described in the issue.
+
+    Computing the set up front from a deterministic source (canonical
+    workspace DB) means the same project lands in the set every tick
+    until its plan is approved, so the clear path becomes idempotent.
+
+    Args:
+        projects: an iterable of project records exposing ``key``,
+            ``path``, and (optionally) ``enforce_plan``. Typically
+            ``services.known_projects``.
+        work_service_for_project: a callable taking a project record
+            and returning either an open work-service (canonical
+            workspace DB scoped to the project) or ``None``. The
+            helper closes the returned service before moving on.
+        plan_dir: the configured ``[planner].plan_dir`` value.
+
+    Returns: mapping ``project_key -> example_task_id_or_None``.
+    Projects with no work_service available, no path on disk, no
+    queued blocked tasks, or with the gate explicitly disabled are
+    NOT included even if their plan looks unacceptable — the alert
+    isn't actionable when the user has nothing waiting.
+    """
+    missing: dict[str, str | None] = {}
+    if not projects:
+        return missing
+    for project in projects:
+        project_key = getattr(project, "key", None)
+        project_path = getattr(project, "path", None)
+        if not project_key or project_path is None:
+            continue
+        # Per-project ``enforce_plan`` override: explicit ``False`` means
+        # the gate is disabled and there's no plan_missing condition to
+        # report regardless of plan presence. ``None`` defers to the
+        # global default — the helper assumes the global default is
+        # enforce-on (the caller can drop the project from ``projects``
+        # if the global flag is off).
+        if getattr(project, "enforce_plan", None) is False:
+            continue
+        try:
+            project_work = work_service_for_project(project)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "plan_presence: work_service_for_project failed for %s",
+                project_key, exc_info=True,
+            )
+            continue
+        if project_work is None:
+            continue
+        try:
+            example_task_id = _first_blocked_queued_task_id(
+                project_work, project_key,
+            )
+            if example_task_id is None:
+                continue
+            try:
+                acceptable = has_acceptable_plan(
+                    project_key,
+                    Path(project_path),
+                    project_work,
+                    plan_dir=plan_dir,
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "plan_presence: has_acceptable_plan raised for %s",
+                    project_key, exc_info=True,
+                )
+                acceptable = False
+            if not acceptable:
+                missing[str(project_key)] = example_task_id
+        finally:
+            closer = getattr(project_work, "close", None)
+            if callable(closer):
+                try:
+                    closer()
+                except Exception:  # noqa: BLE001
+                    pass
+    return missing
+
+
+def _first_blocked_queued_task_id(
+    work_service: Any, project_key: str,
+) -> str | None:
+    """Return one queued non-bypass task_id on ``project_key``, or None.
+
+    Companion to :func:`compute_plan_missing_projects` — surfaces a
+    concrete task_id so plan_missing alert copy can name the task the
+    user's planning decision is blocking. Returns ``None`` when no
+    queued non-bypass task exists (so the caller can skip the alert).
+    """
+    if work_service is None or not project_key:
+        return None
+    try:
+        tasks = work_service.list_tasks(
+            project=project_key,
+            work_status=WorkStatus.QUEUED.value,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "plan_presence: list_tasks(queued) failed for %s",
+            project_key, exc_info=True,
+        )
+        return None
+    for task in tasks:
+        if task_bypasses_plan_gate(task):
+            continue
+        task_id = getattr(task, "task_id", None)
+        if task_id:
+            return str(task_id)
+    return None

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -37,6 +37,7 @@ from pollypm.audit.watchdog import (
     Finding,
     RULE_DUPLICATE_ADVISOR_TASKS,
     RULE_LEGACY_DB_SHADOW,
+    RULE_PLAN_MISSING_ALERT_CHURN,
     RULE_PLAN_REVIEW_MISSING,
     RULE_ROLE_SESSION_MISSING,
     RULE_STUCK_DRAFT,
@@ -73,6 +74,21 @@ class _LegacyDbShadow:
     legacy_db: Path
     canonical_row_count: int
     legacy_row_count: int
+
+
+@dataclass(slots=True, frozen=True)
+class _PlanMissingClear:
+    """One ``alert.cleared`` event for a ``plan_missing`` alert (#1524).
+
+    Used by :func:`_gather_plan_missing_clears` to feed the pure
+    ``plan_missing_alert_churn`` detector. ``scope`` mirrors the
+    synthetic ``plan_gate-<project>`` scope the sweep handler uses on
+    the alert; ``cleared_at`` is the message row's ``created_at``
+    timestamp (i.e. when the clear event was recorded).
+    """
+
+    scope: str
+    cleared_at: datetime
 
 
 # #1414 — only the auto-unstick rules are eligible for architect dispatch.
@@ -521,6 +537,96 @@ def _gather_legacy_db_shadows(
     return shadows
 
 
+def _gather_plan_missing_clears(
+    *,
+    services: Any,
+    now: datetime,
+    config: WatchdogConfig,
+) -> list[_PlanMissingClear]:
+    """Return one record per ``alert.cleared`` event for ``plan_missing``
+    alerts inside the churn window.
+
+    #1524 — feeds the pure
+    :func:`pollypm.audit.watchdog._detect_plan_missing_alert_churn`
+    detector. The clear lifecycle is recorded in the ``messages``
+    table (see :meth:`SQLAlchemyStore.clear_alert`): one ``event`` row
+    with ``subject='alert.cleared'`` and ``sender='plan_missing'`` per
+    closed row. We query the messages table over the configured churn
+    window and return one descriptor per match. The detector groups
+    by scope and counts.
+
+    Best-effort: any I/O failure returns an empty list so a transient
+    DB hiccup doesn't fire a false-positive churn finding.
+    """
+    msg_store = getattr(services, "msg_store", None) or getattr(
+        services, "state_store", None,
+    )
+    if msg_store is None:
+        return []
+    query = getattr(msg_store, "query_messages", None)
+    if not callable(query):
+        return []
+    cutoff = now - timedelta(seconds=config.plan_missing_churn_window_seconds)
+    try:
+        rows = query(
+            type="event",
+            sender="plan_missing",
+            since=cutoff,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: plan_missing-clear query failed", exc_info=True,
+        )
+        return []
+
+    clears: list[_PlanMissingClear] = []
+    for row in rows or ():
+        # ``record_event`` stamps subject='alert.cleared' on every clear
+        # event; defensive check in case other event-shaped rows ever
+        # land with sender='plan_missing'.
+        subject_raw = row.get("subject", "") if isinstance(row, dict) else ""
+        if not isinstance(subject_raw, str):
+            continue
+        # Strip the optional ``[Audit]`` / ``[Event]`` title-contract
+        # prefix the store applies to ``subject`` so we still match
+        # rows whose subject was rewritten.
+        subject_text = subject_raw
+        if subject_text.startswith("["):
+            close = subject_text.find("] ")
+            if close > 0:
+                subject_text = subject_text[close + 2:]
+        if subject_text != "alert.cleared":
+            continue
+        scope = row.get("scope", "") if isinstance(row, dict) else ""
+        if not isinstance(scope, str) or not scope:
+            continue
+        if not scope.startswith("plan_gate-"):
+            continue
+        cleared_at_raw = (
+            row.get("created_at") if isinstance(row, dict) else None
+        )
+        cleared_at = _coerce_clear_timestamp(cleared_at_raw)
+        if cleared_at is None:
+            continue
+        if cleared_at < cutoff:
+            continue
+        clears.append(_PlanMissingClear(scope=scope, cleared_at=cleared_at))
+    return clears
+
+
+def _coerce_clear_timestamp(value: Any) -> datetime | None:
+    """Coerce a messages-table timestamp into tz-aware ``datetime``."""
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    if isinstance(value, str) and value:
+        try:
+            ts = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return ts if ts.tzinfo is not None else ts.replace(tzinfo=UTC)
+    return None
+
+
 def _self_heal_legacy_db_shadow(
     finding: Finding,
     *,
@@ -961,6 +1067,7 @@ def _scan_one_project(
     config: WatchdogConfig,
     storage_closet_name: str | None = None,
     legacy_db_shadows: list[_LegacyDbShadow] | None = None,
+    plan_missing_clears: list[_PlanMissingClear] | None = None,
 ) -> dict[str, int]:
     """Scan one project and route every finding. Returns counters."""
     counters = {
@@ -976,6 +1083,7 @@ def _scan_one_project(
         "plan_review_backfill_failed": 0,
         "legacy_db_shadows_migrated": 0,
         "legacy_db_shadows_failed": 0,
+        "plan_missing_churn_detected": 0,
     }
     open_tasks = _gather_open_tasks(project_key, project_path)
     storage_window_names = _gather_storage_windows(storage_closet_name)
@@ -992,6 +1100,14 @@ def _scan_one_project(
         s for s in (legacy_db_shadows or [])
         if s.project_key == project_key
     ]
+    # #1524 — filter the workspace-wide clear list down to this
+    # project's plan_gate-<project> scope so the pure detector only
+    # sees what's in scope for the current scan_project call.
+    expected_scope = f"plan_gate-{project_key}"
+    project_clears: list[_PlanMissingClear] = [
+        c for c in (plan_missing_clears or [])
+        if c.scope == expected_scope
+    ]
     try:
         findings = scan_project(
             project_key,
@@ -1003,6 +1119,7 @@ def _scan_one_project(
             done_plan_tasks=done_plan_tasks,
             plan_review_present=plan_review_present,
             legacy_db_shadows=project_shadows or None,
+            plan_missing_clears=project_clears or None,
         )
     except Exception:  # noqa: BLE001
         logger.debug(
@@ -1075,6 +1192,14 @@ def _scan_one_project(
             counters["legacy_db_shadows_migrated"] += heal["migrated"]
             counters["legacy_db_shadows_failed"] += heal["failed"]
             continue
+        # #1524 — plan_missing_alert_churn is detection-only. The repair
+        # is Part A (the deterministic precompute in the task-assignment
+        # sweep). The finding + alert + audit-log row are the canary so
+        # future-us notices when the regression returns; no architect
+        # dispatch and no self-heal action.
+        if finding.rule == RULE_PLAN_MISSING_ALERT_CHURN:
+            counters["plan_missing_churn_detected"] += 1
+            continue
         # #1414 — eligible findings get an architect dispatch on top
         # of the alert. Throttle window is owned by the audit log so
         # repeat dispatches are deduped across cadence-process restarts.
@@ -1141,6 +1266,7 @@ def audit_watchdog_handler(payload: dict[str, Any]) -> dict[str, Any]:
         "plan_review_backfill_failed": 0,
         "legacy_db_shadows_migrated": 0,
         "legacy_db_shadows_failed": 0,
+        "plan_missing_churn_detected": 0,
     }
 
     try:
@@ -1158,6 +1284,18 @@ def audit_watchdog_handler(payload: dict[str, Any]) -> dict[str, Any]:
                 "audit.watchdog: legacy-db-shadow probe failed", exc_info=True,
             )
             legacy_db_shadows = []
+        # #1524 — gather plan_missing alert.cleared events once per tick
+        # for the churn detector. Single messages-table query per tick;
+        # the per-project scan filters down to its own scope.
+        try:
+            plan_missing_clears = _gather_plan_missing_clears(
+                services=services, now=now, config=config,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "audit.watchdog: plan_missing-clear probe failed", exc_info=True,
+            )
+            plan_missing_clears = []
         for project in services.known_projects or ():
             project_key = getattr(project, "key", None)
             if not project_key or project_key in seen_projects:
@@ -1173,6 +1311,7 @@ def audit_watchdog_handler(payload: dict[str, Any]) -> dict[str, Any]:
                 config=config,
                 storage_closet_name=storage_closet_name,
                 legacy_db_shadows=legacy_db_shadows,
+                plan_missing_clears=plan_missing_clears,
             )
             totals["projects_scanned"] += 1
             for k, v in partial.items():

--- a/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
@@ -48,6 +48,7 @@ from pathlib import Path
 from typing import Any
 
 from pollypm.plan_presence import (
+    compute_plan_missing_projects,
     has_acceptable_plan,
     task_bypasses_plan_gate,
 )
@@ -1872,6 +1873,46 @@ def _wire_session_manager(svc: Any, project_root: Path, services: Any) -> None:
         )
 
 
+def _precompute_plan_missing_projects(services: Any) -> dict[str, str | None]:
+    """Return a mapping of plan-gated project keys → an example queued task_id.
+
+    #1524 — computed up front from the canonical workspace DB so the
+    sweep handler's emit/clear decisions are deterministic across the
+    workspace pass + per-project pass. Without this precompute the set
+    was populated as a side effect of the auto-claim loop, which only
+    runs for projects with ``auto_claim`` enabled and a queued
+    worker-role task — so other plan-gated projects appeared and
+    disappeared from the set tick-to-tick depending on which loop
+    happened to traverse them, producing the banner flash.
+
+    Falls back to an empty mapping on any error so a transient I/O
+    hiccup doesn't accidentally clear every plan_missing alert.
+    """
+    try:
+        global_enforce = bool(getattr(services, "enforce_plan", True))
+        if not global_enforce:
+            return {}
+        known = list(getattr(services, "known_projects", ()) or ())
+        if not known:
+            return {}
+        plan_dir = getattr(services, "plan_dir", "docs/plan") or "docs/plan"
+
+        def _opener(project: Any) -> Any | None:
+            return _open_workspace_project_work_service(project, services)
+
+        return compute_plan_missing_projects(
+            known,
+            work_service_for_project=_opener,
+            plan_dir=plan_dir,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "task_assignment sweep: plan-missing precompute failed",
+            exc_info=True,
+        )
+        return {}
+
+
 def _open_workspace_project_work_service(project: Any, services: Any) -> Any | None:
     """Open the workspace-root DB with a project-specific runtime context."""
     project_path = getattr(project, "path", None)
@@ -2008,8 +2049,24 @@ def _task_assignment_sweep_body(
 
     totals: dict[str, Any] = {"considered": 0, "by_outcome": {}}
     alerted_pairs: set[tuple[str, str]] = set()
-    plan_missing_projects: set[str] = set()
+    # #1524 — pre-compute the set of projects that are plan-gated this
+    # tick so the emit/clear decision is deterministic across the
+    # workspace pass + per-project pass. Pre-#1524 this set was derived
+    # as a side effect of the auto-claim loop, so a project would only
+    # land in it on ticks that happened to traverse the right path.
+    # After the per-project legacy DB was drained (post-#1519) the
+    # per-project fallback then cleared the alert on every other tick,
+    # producing the "Waiting on you / Queued" banner flash described in
+    # the issue. Computing once up front means the clear paths skip
+    # plan-gated projects every tick, regardless of which loop runs.
+    precomputed_missing = _precompute_plan_missing_projects(services)
+    plan_missing_projects: set[str] = set(precomputed_missing.keys())
     plan_decisions: dict[str, bool] = {}
+    # Seed the per-tick gate cache with the precomputed answers so the
+    # workspace + per-project sweeps reuse the deterministic decision
+    # instead of recomputing (and potentially diverging) per task.
+    for missing_project in plan_missing_projects:
+        plan_decisions[missing_project] = False
     # #1053: ``(project, task_number)`` pairs for tasks observed in
     # ``review`` state during this sweep cycle. After the sweep, any
     # open ``review_pending`` alert whose key isn't in this set is
@@ -2017,6 +2074,21 @@ def _task_assignment_sweep_body(
     review_pending_tasks: set[tuple[str, int]] = set()
     projects_scanned = 0
     projects_skipped = 0
+
+    # #1524 — refresh the ``plan_missing`` alert row up front for every
+    # project in the precomputed set. This guarantees the alert stays
+    # open across consecutive ticks even when no queued task is reached
+    # in the per-project sweep body (e.g. legacy per-project DB has
+    # been drained but the canonical DB still has blocked work). The
+    # downstream per-task emit paths still fire to refresh the row when
+    # they encounter the first blocked task; the up-front refresh just
+    # ensures the row exists before any clear path could run.
+    for missing_project, example_task_id in precomputed_missing.items():
+        _emit_plan_missing_alert(
+            services,
+            project=missing_project,
+            example_task_id=example_task_id or missing_project,
+        )
 
     # #1001: clear stale ``no_session*`` alerts whose project key isn't
     # in the live registry. Run before the per-project sweeps so any

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -3060,3 +3060,173 @@ def test_legacy_db_shadow_gather_finds_shadowed_project(tmp_path: Path) -> None:
     assert s.legacy_row_count == 5
     assert s.canonical_db == canonical_db
     assert s.legacy_db == legacy_db
+
+
+# ---------------------------------------------------------------------------
+# Rule (#1524): plan_missing alert churn
+# ---------------------------------------------------------------------------
+
+
+class _PlanMissingClearStub:
+    """Stand-in for the cadence handler's ``_PlanMissingClear`` dataclass.
+
+    Mirrors the duck-typed contract the detector reads: ``scope`` (the
+    synthetic ``plan_gate-<project>`` alert scope) + ``cleared_at``
+    (tz-aware datetime).
+    """
+
+    def __init__(self, *, scope: str, cleared_at: datetime) -> None:
+        self.scope = scope
+        self.cleared_at = cleared_at
+
+
+def test_plan_missing_alert_churn_fires_when_threshold_exceeded(
+    now: datetime,
+) -> None:
+    """#1524 — N+1 clears in the window → finding fires for that project."""
+    from pollypm.audit.watchdog import RULE_PLAN_MISSING_ALERT_CHURN
+
+    config = WatchdogConfig()
+    # Threshold defaults to 3; seed 4 clears in the last 5 minutes for
+    # ``coffeeboardnm`` and 1 clear (not enough) for ``savethenovel``.
+    clears = [
+        _PlanMissingClearStub(
+            scope="plan_gate-coffeeboardnm",
+            cleared_at=now - timedelta(minutes=4),
+        ),
+        _PlanMissingClearStub(
+            scope="plan_gate-coffeeboardnm",
+            cleared_at=now - timedelta(minutes=3),
+        ),
+        _PlanMissingClearStub(
+            scope="plan_gate-coffeeboardnm",
+            cleared_at=now - timedelta(minutes=2),
+        ),
+        _PlanMissingClearStub(
+            scope="plan_gate-coffeeboardnm",
+            cleared_at=now - timedelta(minutes=1),
+        ),
+        _PlanMissingClearStub(
+            scope="plan_gate-savethenovel",
+            cleared_at=now - timedelta(minutes=1),
+        ),
+    ]
+    findings = scan_events(
+        [], now=now, config=config, plan_missing_clears=clears,
+    )
+    matched = [f for f in findings if f.rule == RULE_PLAN_MISSING_ALERT_CHURN]
+    assert len(matched) == 1
+    f = matched[0]
+    assert f.project == "coffeeboardnm"
+    assert f.subject == "plan_gate-coffeeboardnm"
+    assert f.metadata["clear_count"] == 4
+    assert f.metadata["project_key"] == "coffeeboardnm"
+    # Recommendation calls out the producer to inspect.
+    assert "_precompute_plan_missing_projects" in f.recommendation
+
+
+def test_plan_missing_alert_churn_silent_below_threshold(
+    now: datetime,
+) -> None:
+    """Two clears in the window — below the default threshold of 3 — no finding."""
+    from pollypm.audit.watchdog import RULE_PLAN_MISSING_ALERT_CHURN
+
+    config = WatchdogConfig()
+    clears = [
+        _PlanMissingClearStub(
+            scope="plan_gate-demo",
+            cleared_at=now - timedelta(minutes=2),
+        ),
+        _PlanMissingClearStub(
+            scope="plan_gate-demo",
+            cleared_at=now - timedelta(minutes=1),
+        ),
+    ]
+    findings = scan_events(
+        [], now=now, config=config, plan_missing_clears=clears,
+    )
+    assert not any(
+        f.rule == RULE_PLAN_MISSING_ALERT_CHURN for f in findings
+    )
+
+
+def test_plan_missing_alert_churn_drops_clears_outside_window(
+    now: datetime,
+) -> None:
+    """Clears older than the window don't count toward the threshold.
+
+    Three clears total but only one inside the 10-minute window — no finding.
+    """
+    from pollypm.audit.watchdog import RULE_PLAN_MISSING_ALERT_CHURN
+
+    config = WatchdogConfig()
+    clears = [
+        _PlanMissingClearStub(
+            scope="plan_gate-demo",
+            cleared_at=now - timedelta(minutes=30),  # outside
+        ),
+        _PlanMissingClearStub(
+            scope="plan_gate-demo",
+            cleared_at=now - timedelta(minutes=20),  # outside
+        ),
+        _PlanMissingClearStub(
+            scope="plan_gate-demo",
+            cleared_at=now - timedelta(minutes=2),  # inside
+        ),
+    ]
+    findings = scan_events(
+        [], now=now, config=config, plan_missing_clears=clears,
+    )
+    assert not any(
+        f.rule == RULE_PLAN_MISSING_ALERT_CHURN for f in findings
+    )
+
+
+def test_plan_missing_alert_churn_noop_when_input_none(
+    now: datetime,
+) -> None:
+    """``plan_missing_clears=None`` (the default) disables the rule."""
+    from pollypm.audit.watchdog import RULE_PLAN_MISSING_ALERT_CHURN
+
+    findings = scan_events([], now=now)
+    assert not any(
+        f.rule == RULE_PLAN_MISSING_ALERT_CHURN for f in findings
+    )
+
+
+def test_plan_missing_alert_churn_skips_non_plan_gate_scopes(
+    now: datetime,
+) -> None:
+    """Clear records whose scope isn't ``plan_gate-<project>`` are ignored.
+
+    A clear whose scope happens to be ``worker-foo`` (the no_session
+    family lives there) is unrelated to plan-missing churn even if it
+    somehow surfaced through the gather; the regex scope filter drops it.
+    """
+    from pollypm.audit.watchdog import RULE_PLAN_MISSING_ALERT_CHURN
+
+    config = WatchdogConfig()
+    clears = [
+        _PlanMissingClearStub(
+            scope="worker-demo",
+            cleared_at=now - timedelta(minutes=1),
+        ),
+        _PlanMissingClearStub(
+            scope="worker-demo",
+            cleared_at=now - timedelta(minutes=2),
+        ),
+        _PlanMissingClearStub(
+            scope="worker-demo",
+            cleared_at=now - timedelta(minutes=3),
+        ),
+        _PlanMissingClearStub(
+            scope="worker-demo",
+            cleared_at=now - timedelta(minutes=4),
+        ),
+    ]
+    findings = scan_events(
+        [], now=now, config=config, plan_missing_clears=clears,
+    )
+    assert not any(
+        f.rule == RULE_PLAN_MISSING_ALERT_CHURN for f in findings
+    )

--- a/tests/test_plan_presence_gate.py
+++ b/tests/test_plan_presence_gate.py
@@ -1408,3 +1408,247 @@ class TestSweepHandlerGateIntegration:
         assert result["by_outcome"].get("skipped_plan_missing", 0) == 1
 
         store.close()
+
+
+class TestPlanMissingAlertStability1524:
+    """#1524 — plan_missing alert stays stable across consecutive ticks
+    when the canonical workspace DB carries the queued task and the
+    per-project legacy DB has been drained (post-#1519). Pre-fix, the
+    sweep handler's per-project fallback at line 2089-2090 cleared the
+    alert on every other tick because ``plan_missing_projects`` was
+    populated as a side effect of the auto-claim loop, which only ran
+    for projects with auto-claim enabled. The pre-compute step in
+    ``_task_assignment_sweep_body`` makes the set deterministic.
+    """
+
+    def _setup_workspace_db_no_per_project(
+        self, *, tmp_path, project_key, queued_label=None,
+    ):
+        """Workspace DB carries a queued task; the per-project DB is absent.
+
+        Mirrors the post-#1519 coffeeboardnm shape: canonical workspace
+        ``state.db`` has the queued advisor_review (here, a standard
+        impl task — same gate behaviour) and the per-project
+        ``state.db`` has been drained / never created. Returns the
+        workspace_db path and the project_path.
+        """
+        proj_path = tmp_path / project_key
+        proj_path.mkdir()
+        # Ensure the per-project DB does NOT exist — that's the post-
+        # #1519 drain shape we want to reproduce.
+        assert not (proj_path / ".pollypm" / "state.db").exists()
+
+        workspace_db = tmp_path / ".pollypm" / "state.db"
+        workspace_db.parent.mkdir(parents=True, exist_ok=True)
+        bus.clear_listeners()
+        ws_work = SQLiteWorkService(db_path=workspace_db, project_path=tmp_path)
+        try:
+            task = ws_work.create(
+                title="Queued impl on canonical DB",
+                description="x",
+                type="task",
+                project=project_key,
+                flow_template="standard",
+                roles={"worker": "agent-1", "reviewer": "agent-2"},
+                priority="normal",
+                labels=[queued_label] if queued_label else None,
+            )
+            ws_work.queue(task.task_id, "pm")
+        finally:
+            ws_work.close()
+        return workspace_db, proj_path
+
+    def _factory_with_workspace_db(
+        self, *, store, session_svc, workspace_db, tmp_path,
+        project_key, project_path, auto_claim=True,
+    ):
+        def factory():
+            return _RuntimeServices(
+                session_service=session_svc,
+                state_store=store,
+                work_service=SQLiteWorkService(
+                    db_path=workspace_db, project_path=tmp_path,
+                ),
+                project_root=tmp_path,
+                known_projects=(
+                    FakeKnownProject(key=project_key, path=project_path),
+                ),
+                enforce_plan=True,
+                plan_dir="docs/plan",
+                auto_claim=auto_claim,
+            )
+
+        return factory
+
+    def test_alert_id_stable_across_consecutive_ticks_post_drain(
+        self, tmp_path, monkeypatch,
+    ):
+        """Two sweeps in a row, no state change, no per-project DB.
+
+        Pre-#1524: the alert ID changed each tick (clear → re-emit
+        cycle). Post-fix: same row stays open, ``upsert_alert`` just
+        refreshes it.
+        """
+        workspace_db, proj_path = self._setup_workspace_db_no_per_project(
+            tmp_path=tmp_path, project_key="coffeeboardnm",
+        )
+
+        store = StateStore(tmp_path / "workspace_state.db")
+        session_svc = FakeSessionService(handles=[])  # no sessions wired
+
+        _install_fake_loader(monkeypatch, self._factory_with_workspace_db(
+            store=store, session_svc=session_svc,
+            workspace_db=workspace_db, tmp_path=tmp_path,
+            project_key="coffeeboardnm", project_path=proj_path,
+        ))
+
+        first = task_assignment_sweep_handler({})
+        first_alerts = [
+            a for a in store.open_alerts() if a.alert_type == "plan_missing"
+        ]
+        assert len(first_alerts) == 1, first
+        assert first_alerts[0].session_name == "plan_gate-coffeeboardnm"
+        first_alert_id = first_alerts[0].alert_id
+
+        # Second tick — same state.
+        second = task_assignment_sweep_handler({})
+        second_alerts = [
+            a for a in store.open_alerts() if a.alert_type == "plan_missing"
+        ]
+        # Exactly one open alert, and it's the SAME row as before (the
+        # row was refreshed in place, not closed-and-re-opened).
+        assert len(second_alerts) == 1, second
+        assert second_alerts[0].alert_id == first_alert_id, (
+            "plan_missing alert was cleared and re-emitted between ticks; "
+            f"expected stable alert_id {first_alert_id}, got "
+            f"{second_alerts[0].alert_id}. This is the #1524 banner-flash "
+            "regression."
+        )
+        # Result counter still records the project as plan-missing.
+        assert second["plan_missing_alerts"] >= 1
+
+        store.close()
+
+    def test_alert_stable_when_auto_claim_disabled(
+        self, tmp_path, monkeypatch,
+    ):
+        """Pre-fix, the auto-claim loop was the source-of-truth for
+        ``plan_missing_projects``; if auto-claim was disabled (global
+        flag off, or per-project ``auto_claim=false``), the project
+        never landed in the set and the per-project fallback cleared
+        the alert on every tick. The pre-compute step is independent
+        of auto-claim, so the alert stays stable regardless.
+        """
+        workspace_db, proj_path = self._setup_workspace_db_no_per_project(
+            tmp_path=tmp_path, project_key="coffeeboardnm",
+        )
+
+        store = StateStore(tmp_path / "workspace_state.db")
+        session_svc = FakeSessionService(handles=[])
+
+        _install_fake_loader(monkeypatch, self._factory_with_workspace_db(
+            store=store, session_svc=session_svc,
+            workspace_db=workspace_db, tmp_path=tmp_path,
+            project_key="coffeeboardnm", project_path=proj_path,
+            auto_claim=False,  # globally disabled — pre-fix this hid the project
+        ))
+
+        first = task_assignment_sweep_handler({})
+        first_alerts = [
+            a for a in store.open_alerts() if a.alert_type == "plan_missing"
+        ]
+        assert len(first_alerts) == 1, first
+        first_alert_id = first_alerts[0].alert_id
+
+        second = task_assignment_sweep_handler({})
+        second_alerts = [
+            a for a in store.open_alerts() if a.alert_type == "plan_missing"
+        ]
+        assert len(second_alerts) == 1, second
+        assert second_alerts[0].alert_id == first_alert_id, (
+            "plan_missing alert flapped when auto-claim was disabled; "
+            "Part A precompute should not depend on the auto-claim path."
+        )
+
+        store.close()
+
+    def test_no_alert_when_no_queued_blocked_work(
+        self, tmp_path, monkeypatch,
+    ):
+        """A project with no plan but no queued non-bypass tasks does
+        not get a plan_missing alert — the alert isn't actionable when
+        nothing is waiting. (Sanity check for the precompute filter.)
+        """
+        proj_path = tmp_path / "fresh"
+        proj_path.mkdir()
+
+        workspace_db = tmp_path / ".pollypm" / "state.db"
+        workspace_db.parent.mkdir(parents=True, exist_ok=True)
+        # Workspace DB exists but carries no tasks for this project.
+        bus.clear_listeners()
+        ws_work = SQLiteWorkService(db_path=workspace_db, project_path=tmp_path)
+        ws_work.close()
+
+        store = StateStore(tmp_path / "workspace_state.db")
+        session_svc = FakeSessionService(handles=[])
+
+        _install_fake_loader(monkeypatch, self._factory_with_workspace_db(
+            store=store, session_svc=session_svc,
+            workspace_db=workspace_db, tmp_path=tmp_path,
+            project_key="fresh", project_path=proj_path,
+        ))
+
+        result = task_assignment_sweep_handler({})
+
+        plan_missing = [
+            a for a in store.open_alerts() if a.alert_type == "plan_missing"
+        ]
+        assert plan_missing == []
+        assert result.get("plan_missing_alerts", 0) == 0
+
+        store.close()
+
+    def test_compute_plan_missing_projects_helper_is_deterministic(
+        self, tmp_path,
+    ):
+        """Unit-level: the helper returns the same mapping for the same
+        inputs across repeated calls — no hidden mutation of inputs.
+        """
+        from pollypm.plan_presence import compute_plan_missing_projects
+
+        proj_path = tmp_path / "demo"
+        proj_path.mkdir()
+        workspace_db = tmp_path / ".pollypm" / "state.db"
+        workspace_db.parent.mkdir(parents=True, exist_ok=True)
+        bus.clear_listeners()
+        ws_work = SQLiteWorkService(db_path=workspace_db, project_path=tmp_path)
+        try:
+            task = ws_work.create(
+                title="x", description="x", type="task",
+                project="demo", flow_template="standard",
+                roles={"worker": "agent-1", "reviewer": "agent-2"},
+                priority="normal",
+            )
+            ws_work.queue(task.task_id, "pm")
+        finally:
+            ws_work.close()
+
+        def _opener(_project):
+            return SQLiteWorkService(
+                db_path=workspace_db, project_path=tmp_path,
+            )
+
+        projects = (FakeKnownProject(key="demo", path=proj_path),)
+        first = compute_plan_missing_projects(
+            projects, work_service_for_project=_opener,
+        )
+        second = compute_plan_missing_projects(
+            projects, work_service_for_project=_opener,
+        )
+        # Both calls report the project as plan-missing with a concrete
+        # task_id. Same inputs → same shape (the example task may be
+        # any queued non-bypass task; we only assert it's non-empty).
+        assert set(first.keys()) == {"demo"}
+        assert set(second.keys()) == {"demo"}
+        assert first["demo"] is not None
+        assert second["demo"] is not None


### PR DESCRIPTION
## Summary

Fixes #1524 — Project banner + rail glyph flash between "Waiting on you" and "Queued/idle" on every sweep tick.

### Part A — deterministic precompute (the repair)

The sweep handler's plan-gated decision was populated as a side effect of the auto-claim loop, so a project only landed in `plan_missing_projects` on ticks that traversed the right path. After the per-project legacy DB was drained (post-#1519), the per-project fallback at `sweep.py:2089-2090` then cleared the alert on every other tick — producing the banner flash.

- New helper `compute_plan_missing_projects` in `plan_presence.py` walks `services.known_projects`, runs `has_acceptable_plan` against the canonical workspace DB per project, and returns a mapping of plan-gated project keys to an example queued task_id.
- `_task_assignment_sweep_body` calls `_precompute_plan_missing_projects` once at the start of every tick, seeds `plan_missing_projects` + the per-tick gate cache from the result, and refreshes the alert row up front for every project in the set so `upsert_alert` keeps the row stable even when no per-project sweep path reaches the blocked task this tick.
- The clear paths at `sweep.py:2089` and `sweep.py:2125` are unchanged in shape but now skip every plan-gated project deterministically because the set is pre-populated.

### Part B — `plan_missing_alert_churn` watchdog rule (the canary)

Detection-only follow-up — the repair lives in Part A; this rule fires if the regression returns.

- New `RULE_PLAN_MISSING_ALERT_CHURN` in `pollypm/audit/watchdog.py` detects N+ `alert.cleared` events for the same `plan_gate-<project>` scope inside a 10-minute window (defaults: threshold=3, window=600s).
- Cadence handler `pollypm/plugins_builtin/core_recurring/audit_watchdog.py` gathers clears via `query_messages(type='event', sender='plan_missing')` once per tick and passes per-project filtered lists to the pure detector.
- No architect dispatch and no self-heal action; the alert + audit-log row are the canary.

### Notes / concerns

- `upsert_alert` was verified correct: it dedupes on `(scope, recipient, type, sender)` with `state='open'`, refreshing the existing row in place. The "different alert IDs across ticks" the issue observed were caused by `clear_alert` closing the row + the next tick's `upsert_alert` inserting a fresh row, not by `upsert_alert` failing to dedupe. Part A removes the spurious clear, so the alert ID is now stable.
- The new precompute opens one extra workspace-DB connection per known project per tick. The helper closes each connection before moving on; overhead is the same shape as the existing auto-claim loop's `_open_workspace_project_work_service` call. Acceptable on the @every 30s sweep cadence.

## Test plan

- [x] `uv run pytest tests/ -k 'sweep or plan_presence or plan_missing or watchdog or task_assignment'` — 438 passed, 5622 deselected
- [x] New unit tests in `tests/test_plan_presence_gate.py::TestPlanMissingAlertStability1524`:
  - `test_alert_id_stable_across_consecutive_ticks_post_drain` — workspace DB has the queued task, per-project DB drained, two consecutive sweeps keep the same `alert_id` (the regression is "different alert_id between ticks").
  - `test_alert_stable_when_auto_claim_disabled` — pre-fix the auto-claim loop was the source-of-truth; this asserts the precompute path is independent of `auto_claim`.
  - `test_no_alert_when_no_queued_blocked_work` — sanity check that the precompute filter skips projects with nothing waiting.
  - `test_compute_plan_missing_projects_helper_is_deterministic` — pure-function determinism.
- [x] New unit tests in `tests/test_audit_watchdog.py`:
  - `test_plan_missing_alert_churn_fires_when_threshold_exceeded`
  - `test_plan_missing_alert_churn_silent_below_threshold`
  - `test_plan_missing_alert_churn_drops_clears_outside_window`
  - `test_plan_missing_alert_churn_noop_when_input_none`
  - `test_plan_missing_alert_churn_skips_non_plan_gate_scopes`

## Related

- Closes #1524
- Mirrors the self-healing watchdog precedent from #1510, #1511, #1519
- Producer-side fix for the consumer surfaces in #1516 (banner copy) and #1520 (rail glyph)

🤖 Generated with [Claude Code](https://claude.com/claude-code)