### PR TITLE
Fix #1526 _sweep_stale_alerts no longer orphan-clears plan_missing

### DIFF
--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -2584,9 +2584,21 @@ class Supervisor:
                 # produced a false-clean: open on the first sweep,
                 # cleared on the second even though no worker
                 # process exists. Leave them alone.
+                #
+                # #1526 — ``plan_missing`` has the same shape: the
+                # task_assignment sweep emits it on a synthetic
+                # ``plan_gate-<project>`` session that is intentionally
+                # never in the launch plan. Without this exclusion the
+                # heartbeat closes the alert on every tick and the
+                # task_assignment sweep re-emits it ~30s later, producing
+                # the #1524 banner flash that #1525's Part A precompute
+                # could not reach (the precompute fixed the *owning*
+                # sweep's clear path; this generic stale-alert sweep is
+                # the unrelated second closer).
                 if (
                     alert_type == "no_session"
                     or alert_type.startswith("no_session_for_assignment:")
+                    or alert_type == "plan_missing"
                 ):
                     continue
                 if session_name in tracked:

--- a/tests/test_cancel_clears_no_session_alerts.py
+++ b/tests/test_cancel_clears_no_session_alerts.py
@@ -607,6 +607,27 @@ class TestStaleAlertGuardIntact:
             "missing from _sweep_stale_alerts."
         )
 
+    def test_supervisor_sweep_stale_alerts_skips_plan_missing(self):
+        """``Supervisor._sweep_stale_alerts`` (#1526) must skip
+        ``plan_missing`` alerts. They are emitted by the task_assignment
+        sweep on the synthetic ``plan_gate-<project>`` session name,
+        which is intentionally never in the launch plan. Regressing
+        this guard re-introduces the #1524 banner flash: the heartbeat
+        closes the alert every tick and the task_assignment sweep
+        re-emits it ~30s later.
+        """
+        from pollypm import supervisor as supervisor_mod
+        import inspect
+
+        source = inspect.getsource(supervisor_mod.Supervisor._sweep_stale_alerts)
+
+        assert 'alert_type == "plan_missing"' in source, (
+            "#1526 guard for plan_missing alert_type missing from "
+            "_sweep_stale_alerts — the task_assignment sweep is the sole "
+            "owner of these alerts and must keep clearing them itself. "
+            "Without this guard the #1524 banner flash returns."
+        )
+
 
 # ---------------------------------------------------------------------------
 # #953 — approve clears the per-task no_session alert on review-exit


### PR DESCRIPTION
Closes #1526.

Root cause of the #1524 banner flash that #1525 Part A could not reach. Stack-trace instrumentation showed `Supervisor._sweep_stale_alerts` (the generic "if session_name not in launch plan, clear it" predicate that runs on every heartbeat tick) was closing plan_missing alerts every tick because their synthetic `plan_gate-<project>` session name is intentionally never in the launch plan. The task_assignment sweep then re-emitted the alert on its next 30s tick.

`supervisor.py:2587-2591` already has the right exclusion shape for `no_session` / `no_session_for_assignment:*` (#919). `plan_missing` has the identical synthetic-session shape — adding it to the same exclusion list closes the second closer.

## Why this didn't show up in #1525

#1525 fixed the *owning* sweep's clear path (the task_assignment sweep's post-loop `_clear_plan_missing_alert` call). That fix works — manually invoking `task_assignment_sweep_handler({})` keeps the alert stable. The banner flash continued because of an unrelated second closer in a different module.

## Verification

- 46 tests pass in `tests/test_cancel_clears_no_session_alerts.py`, `tests/test_supervisor_alerts.py`, `tests/test_ghost_project_alerts.py`.
- New test pinned to `TestStaleAlertGuardIntact::test_supervisor_sweep_stale_alerts_skips_plan_missing` — source-level guard assertion (mirrors the existing #919 test pattern).

## Test plan

- [x] Targeted unit tests pass.
- [ ] After merge: `pm update`, kill all `pm up` / `pm cockpit` / `pm heartbeat` processes, re-run `pm up`, then watch `coffeeboardnm` dashboard banner for 2 minutes — should stay stable on "Waiting on you: this project has no plan yet" without flashing to "Queued: 1 task waiting for a worker".
- [ ] Confirm `messages` table no longer churns plan_gate-coffeeboardnm rows: `sqlite3 ~/.pollypm/state.db "SELECT id, state, datetime(updated_at) FROM messages WHERE type='alert' AND scope='plan_gate-coffeeboardnm' ORDER BY id DESC LIMIT 10"` should show one stable open row with bumped updated_at on each tick.

## Live evidence (from #1526 issue body)

```
=== SQLAlchemyStore.clear_alert(plan_missing) for plan_gate-coffeeboardnm who_cleared=system at 2026-05-09T02:25:20.371921+00:00 ===
  ...
  File "pollypm/cli_features/alerts.py", line 106, in heartbeat
    alerts = supervisor.run_heartbeat(snapshot_lines=snapshot_lines)
  File "pollypm/supervisor.py", line 1557, in run_heartbeat
    self._sweep_stale_alerts(
  File "pollypm/supervisor.py", line 2604, in _sweep_stale_alerts
    self._msg_store.clear_alert(session_name, alert.alert_type)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)