### PR TITLE
Fix #1528 prune_sessions keeps synthetic-scope alerts open

### DIFF
--- a/src/pollypm/storage/state.py
+++ b/src/pollypm/storage/state.py
@@ -1203,6 +1203,16 @@ class StateStore:
                 f"DELETE FROM leases WHERE session_name NOT IN ({placeholders})",
                 params,
             )
+            # #1528 — synthetic alert scopes (``plan_gate-<project>``
+            # for ``plan_missing``; ``task_assignment`` /
+            # ``worker-<project>`` for ``no_session*``) intentionally are
+            # not in the launch plan's ``valid_session_names``. The
+            # task_assignment sweep is the sole owner of these alerts;
+            # closing them here on every session-prune tick was the
+            # third closer behind the #1524 banner flash, hidden behind
+            # ``_sweep_stale_alerts`` (#1526) and the post-sweep clear
+            # (#1525). Keep them open so the owning sweep can refresh
+            # or clear them on its own cadence.
             self.execute(
                 f"""
                 UPDATE messages
@@ -1210,6 +1220,8 @@ class StateStore:
                 WHERE type = 'alert'
                   AND state = 'open'
                   AND scope NOT IN ({placeholders})
+                  AND sender NOT IN ('plan_missing', 'no_session')
+                  AND sender NOT LIKE 'no_session_for_assignment:%'
                 """,
                 (now, now, *sorted(valid_session_names)),
             )
@@ -1231,11 +1243,16 @@ class StateStore:
         else:
             self.execute("DELETE FROM sessions")
             self.execute("DELETE FROM leases")
+            # #1528 — same exclusion as the populated branch above:
+            # synthetic-scope alerts owned by the task_assignment sweep
+            # must outlive a no-session-tracked tick.
             self.execute(
                 """
                 UPDATE messages
                 SET state = 'closed', closed_at = ?, updated_at = ?
                 WHERE type = 'alert' AND state = 'open'
+                  AND sender NOT IN ('plan_missing', 'no_session')
+                  AND sender NOT LIKE 'no_session_for_assignment:%'
                 """,
                 (now, now),
             )

--- a/tests/test_cancel_clears_no_session_alerts.py
+++ b/tests/test_cancel_clears_no_session_alerts.py
@@ -628,6 +628,78 @@ class TestStaleAlertGuardIntact:
             "Without this guard the #1524 banner flash returns."
         )
 
+    def test_prune_sessions_skips_synthetic_alert_scopes(self, tmp_path):
+        """``StateStore.prune_sessions`` (#1528) must NOT close alerts
+        whose ``sender`` is one of the synthetic-scope alert types
+        owned by the task_assignment sweep (``plan_missing`` /
+        ``no_session`` / ``no_session_for_assignment:*``). These alerts
+        live on synthetic session scopes (``plan_gate-<project>``,
+        ``worker-<project>``, ``task_assignment``) that are
+        intentionally never in the launch plan's
+        ``valid_session_names`` — the existing prune SQL would close
+        them on every reconciliation tick, which was the third closer
+        behind the #1524 banner flash.
+        """
+        from pollypm.storage.state import StateStore
+
+        store = StateStore(tmp_path / "prune.db")
+        store.upsert_alert(
+            "plan_gate-coffeeboardnm",
+            "plan_missing",
+            "warn",
+            "no plan",
+        )
+        store.upsert_alert(
+            "task_assignment",
+            "no_session_for_assignment:coffeeboardnm/29",
+            "warn",
+            "no worker",
+        )
+        store.upsert_alert(
+            "worker-coffeeboardnm",
+            "no_session",
+            "warn",
+            "no worker session",
+        )
+        # Sanity: a non-synthetic alert we WANT pruned still gets
+        # closed when its scope isn't in valid_session_names.
+        store.upsert_alert(
+            "ghost-session",
+            "pane_dead",
+            "warn",
+            "ghost",
+        )
+
+        before = {
+            (a.session_name, a.alert_type) for a in store.open_alerts()
+        }
+        assert ("plan_gate-coffeeboardnm", "plan_missing") in before
+        assert ("ghost-session", "pane_dead") in before
+
+        # Prune to a set that excludes ALL the scopes above. Without
+        # the #1528 exclusion this would close every alert.
+        store.prune_sessions({"some-real-session"})
+
+        after = {
+            (a.session_name, a.alert_type) for a in store.open_alerts()
+        }
+        assert ("plan_gate-coffeeboardnm", "plan_missing") in after, (
+            "#1528: plan_missing alert should outlive prune_sessions"
+        )
+        assert (
+            "task_assignment",
+            "no_session_for_assignment:coffeeboardnm/29",
+        ) in after, (
+            "#1528: no_session_for_assignment:* alert should outlive "
+            "prune_sessions"
+        )
+        assert ("worker-coffeeboardnm", "no_session") in after, (
+            "#1528: no_session alert should outlive prune_sessions"
+        )
+        assert ("ghost-session", "pane_dead") not in after, (
+            "Ghost alerts on real-but-removed sessions still get pruned"
+        )
+
 
 # ---------------------------------------------------------------------------
 # #953 — approve clears the per-task no_session alert on review-exit


### PR DESCRIPTION
Closes #1528.

Third closer behind the #1524 banner flash. After #1525 (Part A precompute) and #1526 (`_sweep_stale_alerts` plan_missing exclusion), `clear_alert` was correctly skipping plan-gated projects — but the alert row still kept transitioning to `state='closed'` every ~30s.

`grep "state = 'closed'"` on the codebase pointed at `StateStore.prune_sessions` (storage/state.py:1206-1215), which closes via direct SQL UPDATE instead of going through `clear_alert`. The existing stack-trace instrumentation didn't catch it because it was on `clear_alert`, not on the SQL path.

`prune_sessions` closes any alert whose `scope NOT IN valid_session_names`. Synthetic alert scopes — `plan_gate-<project>`, `task_assignment`, `worker-<project>` — are intentionally never in the launch plan, so this UPDATE closed them on every reconciliation tick. Same bug shape as #919 / #1526; same fix pattern: exclude by alert sender.

## Verification

* Pre-fix: instrumented run showed precompute correctly identified `coffeeboardnm` and `savethenovel` as plan-gated, and `clear_alert` was correctly NOT firing for those scopes. Yet the messages table churned a new alert row for `plan_gate-coffeeboardnm` every ~30s.
* Post-fix tested in 29 unit tests passing (`TestStaleAlertGuardIntact` + `test_memory_scope_tiers`).
* Manual reproduction needs `pm update` + full restart: see "test plan" below.

## Test plan

- [x] Targeted unit tests pass.
- [ ] After merge: `pm update`; **kill all `pm cockpit` / `pm heartbeat` / `pm rail_daemon` / `pm up` processes**; `rm -rf /Users/sam/.local/share/uv/tools/pollypm/lib/python3.13/site-packages/pollypm/__pycache__/`; `pm up`. (The pyc nuke + full kill is critical — earlier verification cycles failed because long-running daemons cached old module bytecode.)
- [ ] Watch the `coffeeboardnm` dashboard banner for 2 minutes — should stay stable on "Waiting on you: this project has no plan yet" without flashing to "Queued: 1 task waiting for a worker".
- [ ] Confirm `messages` stable: `sqlite3 ~/.pollypm/state.db "SELECT id, state, datetime(updated_at) FROM messages WHERE type='alert' AND scope='plan_gate-coffeeboardnm' ORDER BY id DESC LIMIT 5"` should show one stable open row across multiple ticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)