### PR TITLE
Fix #1531 plan-ready banner celebrates + CTA button opens surface

### DIFF
--- a/src/pollypm/cockpit_sections/plan_review.py
+++ b/src/pollypm/cockpit_sections/plan_review.py
@@ -101,6 +101,100 @@ def find_plan_review_task(tasks: list) -> object | None:
     return candidates[0]
 
 
+def _plan_task_label_ref(task) -> str | None:
+    """Extract ``plan_task:<project>/<n>`` ref from a backstop task's labels."""
+    labels = getattr(task, "labels", None) or []
+    for label in labels:
+        text = str(label or "")
+        if text.startswith("plan_task:"):
+            ref = text[len("plan_task:"):].strip()
+            if "/" in ref:
+                return ref
+    return None
+
+
+def _resolve_plan_task_for_backstop(
+    backstop_task, all_tasks: list,
+) -> object:
+    """Return the underlying plan task referenced by a backstop emit row.
+
+    The #1511 backstop creates a ``chat``-flow notify-only stub labeled
+    ``plan_review`` + ``plan_task:<project>/<n>``. The drilldown surface
+    needs the *real* plan task (the one whose plan body the user wants
+    to read) so the header strip names the right task number / persona
+    and the surface reads like the canonical #1399 reflection emit.
+
+    Falls back to the backstop task itself when the referenced plan
+    task can't be located (so the surface still renders something the
+    user can act on rather than disappearing).
+    """
+    ref = _plan_task_label_ref(backstop_task)
+    if not ref:
+        return backstop_task
+    for t in all_tasks or []:
+        if getattr(t, "task_id", None) == ref:
+            return t
+    return backstop_task
+
+
+def find_actionable_plan_review_task(tasks: list) -> object | None:
+    """Return the task that should drive the plan-review surface, or None.
+
+    #1531 — broader matcher than :func:`find_plan_review_task`. Used by
+    the drilldown render so projects whose plan-review row was emitted
+    by the #1511 watchdog backstop (chat-flow ``done`` stub, NOT
+    ``plan_project`` flow at ``user_approval``) still surface the
+    review UI. The earlier matcher only matched the canonical
+    ``plan_project`` reflection node and left every backstop-covered
+    project structurally unreachable from the dashboard.
+
+    Resolution order:
+
+    1. The canonical match (review status + user_approval node).
+       Returned as-is — that's the architect's reflection emit.
+    2. A task carrying ``plan_review`` + ``plan_task:<id>`` labels
+       whose work_status is not archived. We resolve to the *referenced*
+       plan task (so the surface header / persona / age read as the
+       plan, not the backstop notify stub), falling back to the
+       backstop task itself when the ref can't be located.
+
+    Returns ``None`` when no plan-review-shaped task is present.
+    """
+    canonical = find_plan_review_task(tasks)
+    if canonical is not None:
+        return canonical
+    # Backstop fallback: any task carrying both ``plan_review`` and a
+    # ``plan_task:<id>`` ref. Sort by updated_at so multiple stale
+    # stubs pick the freshest one.
+    #
+    # Note: ``archive_task`` flips a chat-flow row to ``done`` (no
+    # distinct archived status exists), so we can't filter dismissed
+    # rows by status alone. The cockpit inbox already filters
+    # already-handled plan_review messages via #1103's per-render
+    # phantom sweep; relying on that keeps the matcher narrow.
+    candidates: list = []
+    for t in tasks or []:
+        labels = {str(lbl or "") for lbl in (getattr(t, "labels", None) or [])}
+        if "plan_review" not in labels:
+            continue
+        if not any(lbl.startswith("plan_task:") for lbl in labels):
+            continue
+        # Skip cancelled rows — those were explicitly dismissed.
+        status = getattr(t, "work_status", None)
+        status_value = getattr(status, "value", status)
+        if status_value == "cancelled":
+            continue
+        candidates.append(t)
+    if not candidates:
+        return None
+    candidates.sort(
+        key=lambda t: _iso_to_dt(getattr(t, "updated_at", None)) or 0,
+        reverse=True,
+    )
+    backstop = candidates[0]
+    return _resolve_plan_task_for_backstop(backstop, tasks)
+
+
 def _resolve_architect_persona(task) -> str:
     """Pull the architect persona from the task's roles → assignee → fallback."""
     roles = getattr(task, "roles", None) or {}

--- a/src/pollypm/cockpit_sections/project_dashboard.py
+++ b/src/pollypm/cockpit_sections/project_dashboard.py
@@ -25,7 +25,7 @@ from pollypm.cockpit_sections.health import format_project_health_scorecard
 from pollypm.cockpit_sections.in_flight import _section_in_flight
 from pollypm.cockpit_sections.insights import _section_insights
 from pollypm.cockpit_sections.plan_review import (
-    find_plan_review_task,
+    find_actionable_plan_review_task,
     load_plan_text,
     render_plan_review_surface,
 )
@@ -130,7 +130,14 @@ def _render_project_dashboard(
     # ``user_approval``, swap the regular dashboard for the dedicated
     # plan-review surface (full plan body + visible action bar). When
     # nothing is pending, fall through to the regular dashboard below.
-    plan_review_task = find_plan_review_task(tasks)
+    #
+    # #1531 — the matcher is now ``find_actionable_plan_review_task``
+    # so projects whose plan-review row was emitted by the #1511
+    # watchdog backstop (chat-flow ``done`` stub) ALSO surface the
+    # review UI. Without this loosening the new interface was
+    # structurally unreachable for every project the watchdog
+    # backfilled.
+    plan_review_task = find_actionable_plan_review_task(tasks)
     if plan_review_task is not None:
         plan_text = load_plan_text(project.path)
         return render_plan_review_surface(

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -9798,6 +9798,16 @@ class PollyInboxApp(App[None]):
         item = self._item_for_id(task_id)
         if item is None:
             return
+        # #1531 — ``a`` on a plan_review inbox card opens the plan-review
+        # surface instead of archiving. The dashboard banner (``Plan's
+        # ready — <title>. Press → to review together``) advertises
+        # ``a``-to-review semantics; archiving on the same gesture
+        # destroys the only route into the plan-review surface that
+        # shipped in #1400/#1401. This keeps archive working for every
+        # other inbox row type — only plan_review rows redirect.
+        if _is_plan_review_task(item):
+            self._jump_to_plan_review_project(item)
+            return
         if not is_task_inbox_entry(item):
             try:
                 from pollypm.store import SQLAlchemyStore
@@ -14245,7 +14255,12 @@ def _project_dashboard_signature(
     )
 
 
-def _alert_banner_copy(alert_types: list[str], alert_count: int) -> str | None:
+def _alert_banner_copy(
+    alert_types: list[str],
+    alert_count: int,
+    *,
+    plan_task_summary: dict | None = None,
+) -> str | None:
     """Return banner copy describing the alerts waiting on the user.
 
     #1512 — replaces the generic "Polly needs to inspect a project issue"
@@ -14253,6 +14268,12 @@ def _alert_banner_copy(alert_types: list[str], alert_count: int) -> str | None:
     event; the banner names the alert family and tells the user how to
     reach the action surface (the ``a`` keybinding routes to Metrics →
     Alerts) so the dashboard never reads as a dead-end.
+
+    #1531 — when ``plan_task_summary`` is non-null on a ``plan_missing``
+    alert, the plan is already done and waiting on review. Switch the
+    copy from "Waiting on you" debt-collector framing to a celebratory
+    "Plan's ready" lead so the moment reads as a teammate handing the
+    user a finished draft.
 
     Returns ``None`` when there is nothing to show.
     """
@@ -14296,9 +14317,24 @@ def _alert_banner_copy(alert_types: list[str], alert_count: int) -> str | None:
             f"the account{other_part}"
         )
     if family == "plan_missing":
+        # #1531 — celebratory lead when a plan-shaped done task is
+        # awaiting review. The earlier "no plan yet" copy lied on
+        # exactly this case (the plan EXISTS — task #N reached done)
+        # and primed the user for a debt-collector tone instead of a
+        # teammate handoff.
+        if plan_task_summary:
+            title = (
+                str(plan_task_summary.get("title") or "").strip()
+                or str(plan_task_summary.get("task_id") or "").strip()
+                or "the plan"
+            )
+            return (
+                f"Plan's ready — {title}. Press → to review together"
+                f"{other_part}"
+            )
         return (
-            f"Waiting on you: this project has no plan yet — press a to "
-            f"review, or c to ask the PM to plan{other_part}"
+            f"This project has no plan yet — press c to ask the PM to "
+            f"plan it{other_part}"
         )
     if family == "no_session_for_assignment":
         return (
@@ -14433,6 +14469,25 @@ class PollyProjectDashboardApp(App[None]):
         border: round #8d3137;
     }
     #proj-action-bar.-hover {
+        border: round #5b8aff;
+    }
+    /* #1531 — celebratory plan-review CTA. Sits directly under the
+       banner so banner + button read as a single "Plan's ready /
+       Review the plan together" affordance. The bold-reverse styling
+       on the inner Static text mirrors the dashboard action-bar
+       button pattern; the CTA itself uses a subtle highlight border
+       so it reads as actionable without yelling for attention. */
+    #proj-review-cta {
+        margin-top: 0;
+        padding: 0 1;
+        background: #1a2e1c;
+        color: #b6f0c0;
+        border: round #2c5b32;
+    }
+    #proj-review-cta.-hidden {
+        display: none;
+    }
+    #proj-review-cta:hover {
         border: round #5b8aff;
     }
     #proj-inbox-section.-hover {
@@ -14601,6 +14656,11 @@ class PollyProjectDashboardApp(App[None]):
         # celebration flow (10s undo + persona toast). Otherwise we
         # fall through to the legacy alerts view.
         Binding("a", "approve_or_alerts", "Approve / Alerts", show=False),
+        # #1531 — ``→`` opens the plan-review surface (full plan body
+        # inline) when a plan-shaped done task is awaiting review. The
+        # banner CTA advertises this keystroke (mirrors the inbox →
+        # gesture for "drill in"); ``r`` stays bound to refresh.
+        Binding("right", "review_plan", "Review plan", show=False),
         # ``u`` rolls back a pending plan-review approval; falls
         # through to refresh when there is nothing pending (the legacy
         # ``u`` binding co-existed with ``r`` for refresh).
@@ -14644,6 +14704,18 @@ class PollyProjectDashboardApp(App[None]):
         self.topbar = Static("", id="proj-topbar", markup=True)
         self.status_line = Static("", id="proj-status", markup=True)
         self.action_bar = Static("", id="proj-action-bar", markup=True)
+        # #1531 — CTA button shown directly under the banner when a
+        # plan-shaped done task is awaiting review. Hidden by default
+        # via the ``-hidden`` class; ``_update_action_bar`` toggles it
+        # based on ``data.plan_task_summary``. Click + ``→`` keystroke
+        # both fire ``action_review_plan`` so the moment reads as a
+        # single "review the plan together" affordance.
+        self.review_cta = Static(
+            "",
+            id="proj-review-cta",
+            classes="-hidden",
+            markup=True,
+        )
         # #1290 follow-up — empty-state panel surfaces a clear
         # affordance when a project has zero ``work_tasks`` rows.
         # Hidden by default; ``_render`` toggles ``-hidden`` based
@@ -14800,6 +14872,7 @@ class PollyProjectDashboardApp(App[None]):
             yield self.topbar
             yield self.status_line
             yield self.action_bar
+            yield self.review_cta
             with VerticalScroll(id="proj-body"):
                 # #1290 follow-up — empty-state for "registered project
                 # with zero work_tasks rows" sits at the top of the body
@@ -15277,6 +15350,38 @@ class PollyProjectDashboardApp(App[None]):
         elif data.action_items or review_count or data.inbox_count or on_hold_count:
             self.action_bar.add_class("-attention")
         self.action_bar.update(f"[b]{_escape(summary)}[/b]")
+        self._update_review_cta(data)
+
+    def _update_review_cta(self, data: ProjectDashboardData) -> None:
+        """Toggle the ``→ Review the plan together`` CTA under the banner.
+
+        #1531 — when ``data.plan_task_summary`` is non-null the project
+        has a plan-shaped done task awaiting review. The banner copy
+        celebrates the moment ("Plan's ready — <title>"); the CTA below
+        gives the user a single visible button (mouse + keystroke
+        labeled) to land in the plan-review surface without hunting
+        through the inbox.
+
+        When no plan task summary exists the CTA hides so the banner
+        stays a single clean line.
+        """
+        plan_task_summary = getattr(data, "plan_task_summary", None) or None
+        if not plan_task_summary:
+            self.review_cta.add_class("-hidden")
+            self.review_cta.update("")
+            return
+        # Bracket-key advertises the keystroke; bold-reverse styling
+        # mirrors the dashboard action-bar convention so it reads as a
+        # button at-a-glance. Single line so it fits the user's wide
+        # terminal (214x50) without burning vertical space.
+        title = (
+            str(plan_task_summary.get("title") or "").strip()
+            or str(plan_task_summary.get("task_id") or "").strip()
+            or "the plan"
+        )
+        label = f"[→] Review the plan together — {title}"
+        self.review_cta.update(f"[bold reverse] {_escape(label)} [/]")
+        self.review_cta.remove_class("-hidden")
 
     def _render_project_state_banner(
         self, data: ProjectDashboardData, counts: str,
@@ -15360,6 +15465,7 @@ class PollyProjectDashboardApp(App[None]):
             specific = _alert_banner_copy(
                 getattr(data, "alert_types", []) or [],
                 int(data.alert_count),
+                plan_task_summary=getattr(data, "plan_task_summary", None),
             )
             if specific:
                 return f"{specific}{count_suffix}"
@@ -17174,6 +17280,12 @@ class PollyProjectDashboardApp(App[None]):
         event.stop()
         self._route_to_tasks()
 
+    @on(events.Click, "#proj-review-cta")
+    def on_review_cta_click(self, event: events.Click) -> None:
+        """#1531 — clicking the banner CTA opens the plan-review surface."""
+        event.stop()
+        self.action_review_plan()
+
     @on(events.Click, "#proj-plan-section")
     def on_plan_section_click(self, event: events.Click) -> None:
         event.stop()
@@ -17254,6 +17366,73 @@ class PollyProjectDashboardApp(App[None]):
             self.config_path,
             client_id="project-dashboard",
         ).jump_to_activity(self.project_key)
+
+    def action_review_plan(self) -> None:
+        """``→`` (or banner CTA click) — open the plan-review surface.
+
+        #1531 — when a plan-shaped done task is awaiting review the
+        banner advertises this keystroke. The handler:
+
+        1. If a plan_review action card is present (the ``a`` flow's
+           target), enter plan-view mode so the full plan body fills
+           the dashboard, then notify the user that ``a`` approves.
+           This matches the cockpit pane's plan-review surface from
+           #1401 — the operator reads the plan top-to-bottom and acts.
+        2. If no plan_review action card is present but a
+           ``plan_task_summary`` exists, still enter plan-view mode
+           (the user wants to review the plan; the review/approve flow
+           may not have its inbox card yet — the watchdog tick will
+           emit it).
+        3. If neither signal is present, friendly-notify so the
+           keystroke isn't silent.
+        """
+        data = self.data
+        if data is None:
+            self.notify(
+                "Dashboard data still loading…",
+                severity="information", timeout=1.5,
+            )
+            return
+        plan_task_summary = getattr(data, "plan_task_summary", None) or None
+        # Either signal is enough to flip into plan-view: the action
+        # card means the inbox emit succeeded; plan_task_summary means
+        # the plan task itself reached done. Both cases benefit from
+        # the user landing on the full plan body.
+        has_plan_review_card = any(
+            isinstance(item, dict) and item.get("is_plan_review")
+            for item in (data.action_items or [])
+        )
+        if not (plan_task_summary or has_plan_review_card):
+            self.notify(
+                "No plan ready for review yet — press p to open the "
+                "plan view.",
+                severity="information", timeout=2.5,
+            )
+            return
+        if data.plan_path is None:
+            # The plan task is done but the plan file wasn't written
+            # to the canonical location. Fall back to the approve flow
+            # directly so the user can still act.
+            if has_plan_review_card and self._approve_first_plan_review_if_present():
+                return
+            self.notify(
+                "Plan task is done but no plan file was found on "
+                "disk. Press a to approve the plan_review card or i "
+                "to open the inbox.",
+                severity="warning", timeout=3.5,
+            )
+            return
+        # Force plan-view mode on (don't toggle — the user explicitly
+        # asked for "review", and a no-op toggle from an already-open
+        # plan view would be confusing).
+        if not self._plan_view_mode:
+            self.action_open_plan()
+        if has_plan_review_card:
+            self.notify(
+                "Plan ready — press a to approve, c to chat, or "
+                "p to close this view.",
+                severity="information", timeout=4.0,
+            )
 
     def action_open_plan(self) -> None:
         """Toggle plan-view mode — plan.md takes over the body.

--- a/tests/test_cockpit_inbox_ui.py
+++ b/tests/test_cockpit_inbox_ui.py
@@ -1594,6 +1594,100 @@ def test_archive_removes_row_and_flips_status(inbox_env, inbox_app) -> None:
     _run(body())
 
 
+def test_a_on_plan_review_row_opens_surface_does_not_archive(
+    inbox_env, inbox_app,
+) -> None:
+    """#1531 — ``a`` on a plan_review row routes to the project drilldown
+    (where the plan-review surface lives), it does NOT archive.
+
+    The dashboard banner advertises the keystroke as "press a to review";
+    the inbox keystroke must mean the same thing or the user follows the
+    instruction and loses the only route into the new plan-review
+    surface (which is exactly what #1531 reproduces in production).
+    """
+    plan_review_id = _seed_self_referential_plan_review(inbox_env["project_path"])
+
+    async def body() -> None:
+        async with inbox_app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            # Locate and select the plan_review row.
+            target_index = None
+            for i, t in enumerate(inbox_app._tasks):
+                if t.task_id == plan_review_id:
+                    target_index = i
+                    break
+            assert target_index is not None
+            inbox_app.list_view.index = target_index
+            inbox_app._selected_task_id = plan_review_id
+            inbox_app._selected_row_key = inbox_app._tasks[target_index].task_id
+
+            jump_calls: list[str] = []
+
+            def fake_jump(item):
+                jump_calls.append(getattr(item, "task_id", ""))
+
+            inbox_app._jump_to_plan_review_project = fake_jump  # type: ignore[method-assign]
+
+            inbox_app.action_archive_selected()
+            await pilot.pause()
+
+            # Surface-jump fired, archive did NOT.
+            assert jump_calls == [plan_review_id]
+            # Row is still present in the inbox tasks (not archived).
+            assert any(t.task_id == plan_review_id for t in inbox_app._tasks)
+
+            # Underlying work_status was not flipped to done by the
+            # archive path.
+            svc = inbox_app._svc_for_task(plan_review_id)
+            try:
+                task = svc.get(plan_review_id)
+            finally:
+                svc.close()
+            # The seeded plan_review row was created queue-eligible — the
+            # archive path would flip it to done. The redirect must
+            # leave the work_status untouched.
+            assert task.work_status.value != "done"
+
+    _run(body())
+
+
+def test_a_on_non_plan_review_row_still_archives(inbox_env, inbox_app) -> None:
+    """#1531 — ``a`` keeps archive semantics for every other inbox row.
+
+    Sanity check that the plan_review redirect doesn't accidentally
+    swallow the regular archive path. Without this, every inbox row
+    would lose the ability to be dismissed.
+    """
+    async def body() -> None:
+        async with inbox_app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            initial_total = len(inbox_app._tasks)
+            assert initial_total >= 1
+
+            jump_calls: list[str] = []
+
+            def fake_jump(item):
+                jump_calls.append(getattr(item, "task_id", ""))
+
+            inbox_app._jump_to_plan_review_project = fake_jump  # type: ignore[method-assign]
+
+            inbox_app.list_view.index = 0
+            await pilot.press("enter")
+            await pilot.pause()
+            target = inbox_app._selected_task_id
+            assert target is not None
+
+            await pilot.press("a")
+            await pilot.pause()
+
+            # Surface-jump did NOT fire; archive did.
+            assert jump_calls == []
+            assert len(inbox_app._tasks) == initial_total - 1
+            assert all(t.task_id != target for t in inbox_app._tasks)
+
+    _run(body())
+
+
 def test_workspace_store_notification_appears_in_inbox(inbox_env, inbox_app) -> None:
     """Workspace-root Store rows are listed alongside task-backed inbox items."""
     _seed_workspace_message(

--- a/tests/test_cockpit_plan_review_surface.py
+++ b/tests/test_cockpit_plan_review_surface.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import pytest
 
 from pollypm.cockpit_sections.plan_review import (
+    find_actionable_plan_review_task,
     find_plan_review_task,
     load_plan_text,
     render_plan_review_action_bar,
@@ -49,6 +50,7 @@ class _PlanReviewFakeTask:
         self,
         *,
         task_number: int = 7,
+        task_id: str | None = None,
         status: str = "review",
         current_node_id: str | None = "user_approval",
         roles: dict[str, str] | None = None,
@@ -56,8 +58,10 @@ class _PlanReviewFakeTask:
         plan_version: int = 1,
         updated_at: datetime | None = None,
         created_at: datetime | None = None,
+        labels: list[str] | None = None,
     ) -> None:
         self.task_number = task_number
+        self.task_id = task_id or f"proj/{task_number}"
         self.work_status = WorkStatus(status)
         self.current_node_id = current_node_id
         self.roles = roles or {}
@@ -67,6 +71,7 @@ class _PlanReviewFakeTask:
         self.created_at = created_at
         self.priority = Priority.NORMAL
         self.title = "plan: review me"
+        self.labels = labels or []
         self.transitions = []
         self.executions = []
 
@@ -136,6 +141,127 @@ class TestFindPlanReviewTask:
             updated_at=datetime.now(UTC),
         )
         assert find_plan_review_task([old, new]) is new
+
+
+# ---------------------------------------------------------------------------
+# find_actionable_plan_review_task (#1531)
+# ---------------------------------------------------------------------------
+
+
+class TestFindActionablePlanReviewTask:
+    """#1531 — broader matcher that covers #1511 backstop emits.
+
+    The canonical matcher only finds ``plan_project`` tasks parked at
+    ``user_approval``. The watchdog backstop creates a ``chat``-flow
+    notify-only stub at ``status=done``, never at ``user_approval`` —
+    so projects backfilled by the watchdog were structurally
+    unreachable from the project drilldown plan-review surface.
+    """
+
+    def test_falls_back_to_canonical_when_present(self):
+        """The architect's reflection emit still wins over backstop rows."""
+        canonical = _PlanReviewFakeTask(
+            task_number=10, current_node_id="user_approval", status="review",
+        )
+        backstop = _PlanReviewFakeTask(
+            task_number=30,
+            task_id="proj/30",
+            current_node_id=None,
+            status="done",
+            labels=["plan_review", "plan_task:proj/1", "notify"],
+        )
+        result = find_actionable_plan_review_task([backstop, canonical])
+        assert result is canonical
+
+    def test_matches_backstop_chat_done_stub(self):
+        """The coffeeboardnm/30-shape: chat-flow done stub with plan_review label."""
+        plan_task = _PlanReviewFakeTask(
+            task_number=1,
+            task_id="coffeeboardnm/1",
+            status="done",
+            current_node_id=None,
+            labels=["poc-plan", "research"],
+        )
+        backstop = _PlanReviewFakeTask(
+            task_number=30,
+            task_id="coffeeboardnm/30",
+            status="done",
+            current_node_id=None,
+            labels=[
+                "plan_review",
+                "project:coffeeboardnm",
+                "plan_task:coffeeboardnm/1",
+                "notify",
+            ],
+        )
+        result = find_actionable_plan_review_task([plan_task, backstop])
+        # Resolves to the underlying plan task so the surface header
+        # reads as the plan, not the backstop notify stub.
+        assert result is plan_task
+
+    def test_returns_none_when_no_plan_review_anywhere(self):
+        regular = _PlanReviewFakeTask(
+            task_number=5,
+            status="done",
+            current_node_id=None,
+            labels=["bug", "infra"],
+        )
+        assert find_actionable_plan_review_task([regular]) is None
+
+    def test_skips_cancelled_backstop_rows(self):
+        """Cancelled plan_review rows aren't actionable — the user dismissed them."""
+        backstop = _PlanReviewFakeTask(
+            task_number=30,
+            task_id="proj/30",
+            status="cancelled",
+            current_node_id=None,
+            labels=["plan_review", "plan_task:proj/1", "notify"],
+        )
+        assert find_actionable_plan_review_task([backstop]) is None
+
+    def test_falls_back_to_backstop_when_plan_task_missing(self):
+        """When the referenced plan task is gone, return the backstop itself."""
+        backstop = _PlanReviewFakeTask(
+            task_number=30,
+            task_id="proj/30",
+            status="done",
+            current_node_id=None,
+            labels=["plan_review", "plan_task:proj/missing", "notify"],
+        )
+        # The referenced ``proj/missing`` plan task isn't in the list —
+        # the backstop itself is still a valid surface trigger.
+        result = find_actionable_plan_review_task([backstop])
+        assert result is backstop
+
+    def test_picks_most_recently_updated_backstop(self):
+        """Multiple backstop stubs — pick the freshest before resolving."""
+        plan_task = _PlanReviewFakeTask(
+            task_number=1, task_id="proj/1", status="done", current_node_id=None,
+        )
+        old = _PlanReviewFakeTask(
+            task_number=20,
+            task_id="proj/20",
+            status="done",
+            current_node_id=None,
+            labels=["plan_review", "plan_task:proj/1"],
+            updated_at=datetime.now(UTC) - timedelta(hours=5),
+        )
+        new = _PlanReviewFakeTask(
+            task_number=30,
+            task_id="proj/30",
+            status="done",
+            current_node_id=None,
+            labels=["plan_review", "plan_task:proj/1"],
+            updated_at=datetime.now(UTC),
+        )
+        result = find_actionable_plan_review_task([plan_task, old, new])
+        # Both backstops resolve to the same plan_task — winner just
+        # needs to be the freshest backstop's resolution.
+        assert result is plan_task
+
+    def test_empty_list_returns_none(self):
+        assert find_actionable_plan_review_task([]) is None
+        assert find_actionable_plan_review_task(None) is None
 
 
 # ---------------------------------------------------------------------------
@@ -470,3 +596,111 @@ class TestOrchestratorTriggers:
         # Plan-review action bar must NOT show on the regular dashboard.
         assert "[a] Approve" not in out
         assert "[c] Chat to refine" not in out
+
+    def test_drilldown_renders_for_backstop_emit_chat_done_stub(
+        self, tmp_path: Path,
+    ):
+        """#1531 — projects whose plan-review row was emitted by the
+        #1511 watchdog backstop (chat-flow ``done`` stub at status=done,
+        NOT ``user_approval``) still render the plan-review surface.
+
+        Reproduces the coffeeboardnm/30 shape: plan task at
+        ``coffeeboardnm/1`` is on the standard flow at ``done`` with
+        plan-shaped labels; the backstop creates a chat-flow notify-
+        only stub at task #30 carrying the ``plan_review`` +
+        ``plan_task:coffeeboardnm/1`` labels. Before this fix the
+        drilldown surface NEVER triggered for such projects (the
+        canonical matcher only matched ``user_approval`` rows).
+        """
+        from pollypm.cockpit_sections.project_dashboard import (
+            _render_project_dashboard,
+        )
+        from pollypm.work.sqlite_service import SQLiteWorkService
+
+        proj_path = tmp_path / "coffeeboardnm"
+        proj_path.mkdir()
+        (proj_path / ".pollypm").mkdir()
+        db_path = proj_path / ".pollypm" / "state.db"
+        with SQLiteWorkService(
+            db_path=db_path, project_path=proj_path,
+        ) as svc:
+            # Plan task — done, plan-shaped, on standard flow.
+            plan_task = svc.create(
+                title="POC plan: ingest every NM event May–Jul 2026",
+                description="plan body lives on disk",
+                type="task",
+                project="coffeeboardnm",
+                flow_template="standard",
+                roles={"worker": "polly", "reviewer": "russell"},
+                priority="normal",
+                created_by="polly",
+                labels=["poc-plan", "research"],
+            )
+            svc.queue(plan_task.task_id, "polly")
+            svc.claim(plan_task.task_id, "worker")
+            # Mark the plan task done via SQL (skip flow execution).
+            import sqlite3
+            conn = sqlite3.connect(str(db_path))
+            try:
+                conn.execute(
+                    "UPDATE work_tasks SET work_status = ? "
+                    "WHERE project = ? AND task_number = ?",
+                    ("done", "coffeeboardnm", plan_task.task_number),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+            # Backstop emit — chat-flow notify stub.
+            backstop_task = svc.create(
+                title="Plan ready for review: coffeeboardnm",
+                description="Plan ready for review (backstop emit).",
+                type="task",
+                project="coffeeboardnm",
+                flow_template="chat",
+                roles={"requester": "user", "operator": "audit_watchdog"},
+                priority="high",
+                created_by="audit_watchdog",
+                labels=[
+                    "plan_review",
+                    "project:coffeeboardnm",
+                    f"plan_task:{plan_task.task_id}",
+                    "notify",
+                ],
+            )
+            conn = sqlite3.connect(str(db_path))
+            try:
+                conn.execute(
+                    "UPDATE work_tasks SET work_status = ? "
+                    "WHERE project = ? AND task_number = ?",
+                    ("done", "coffeeboardnm", backstop_task.task_number),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        plan_dir = proj_path / "docs" / "plan"
+        plan_dir.mkdir(parents=True)
+        (plan_dir / "plan.md").write_text(SAMPLE_PLAN, encoding="utf-8")
+
+        project = _OrchFakeProject(
+            key="coffeeboardnm", path=proj_path, name="CoffeeBoardNM",
+        )
+        out = _render_project_dashboard(
+            project, "coffeeboardnm",
+            tmp_path / "pollypm.toml",
+            _OrchFakeSupervisor(),
+        )
+        assert out is not None
+        # Plan-review surface renders for the BACKSTOP-emitted shape.
+        # Header references the underlying plan task (#1, NOT the
+        # backstop stub at #30) — that's the resolution behavior.
+        assert "Plan: coffeeboardnm/1" in out
+        # Surface body markers.
+        assert "Summary" in out
+        assert "Judgment calls" in out
+        assert "Plan body" in out
+        assert "[a] Approve" in out
+        # Regular dashboard sections are suppressed when the surface
+        # is active.
+        assert "You need to" not in out
+        assert "Quick actions" not in out

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -1123,6 +1123,103 @@ def test_banner_action_items_still_outrank_alert() -> None:
     assert "asking a question" not in banner
 
 
+def test_banner_celebrates_when_plan_task_summary_present() -> None:
+    """#1531 — a ``plan_missing`` alert with a non-null
+    ``plan_task_summary`` reads as a teammate handing off a finished
+    plan, not as a debt collector. The banner names the deliverable,
+    advertises the keystroke that opens the plan-review surface, and
+    drops the misleading "no plan yet" framing entirely.
+    """
+    from types import SimpleNamespace
+
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+    fake_data = SimpleNamespace(
+        action_items=[],
+        alert_count=1,
+        alert_types=["plan_missing"],
+        active_worker=None,
+        task_counts={},
+        task_buckets={"on_hold": [], "review": []},
+        inbox_count=0,
+        plan_task_summary={
+            "task_id": "coffeeboardnm/1",
+            "title": "POC plan: ingest every NM event May–Jul 2026",
+        },
+    )
+    banner = app._render_project_state_banner(fake_data, "▸ 1 alert")
+    assert "Plan's ready" in banner
+    assert "POC plan: ingest every NM event May–Jul 2026" in banner
+    # The keystroke advertised must be the one that actually opens the
+    # plan-review surface. "press a to review" was the trap that #1531
+    # explicitly closes — must not regress.
+    assert "→" in banner
+    assert "no plan yet" not in banner
+    # Tone: collaborative ("together") instead of debt-collector
+    # ("Waiting on you").
+    assert "together" in banner
+
+
+def test_banner_falls_through_when_plan_task_summary_absent() -> None:
+    """#1531 — without a ``plan_task_summary``, the ``plan_missing``
+    alert keeps the original "ask the PM to plan" framing — but does
+    NOT lie about a plan being absent / present, and the new copy
+    drops the redundant "Waiting on you:" prefix while keeping the
+    affordance ("press c").
+    """
+    from types import SimpleNamespace
+
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+    fake_data = SimpleNamespace(
+        action_items=[],
+        alert_count=1,
+        alert_types=["plan_missing"],
+        active_worker=None,
+        task_counts={},
+        task_buckets={"on_hold": [], "review": []},
+        inbox_count=0,
+        plan_task_summary=None,
+    )
+    banner = app._render_project_state_banner(fake_data, "▸ 1 alert")
+    # Must NOT claim the plan is ready when it isn't.
+    assert "Plan's ready" not in banner
+    # Affordance: still routes to ``c`` (chat the PM to plan).
+    assert "press c" in banner
+    # Avoid the misleading "press a to review" ambiguous instruction
+    # that was the trap.
+    assert "press a to review" not in banner
+
+
+def test_banner_celebrates_with_only_task_id_when_title_missing() -> None:
+    """#1531 — degraded plan_task_summary (no title) still celebrates."""
+    from types import SimpleNamespace
+
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+    fake_data = SimpleNamespace(
+        action_items=[],
+        alert_count=1,
+        alert_types=["plan_missing"],
+        active_worker=None,
+        task_counts={},
+        task_buckets={"on_hold": [], "review": []},
+        inbox_count=0,
+        plan_task_summary={
+            "task_id": "coffeeboardnm/1",
+            "title": "",
+        },
+    )
+    banner = app._render_project_state_banner(fake_data, "▸ 1 alert")
+    assert "Plan's ready" in banner
+    # With no title, the banner falls back to the task_id so the user
+    # still gets a routable identifier.
+    assert "coffeeboardnm/1" in banner
+
+
 def test_status_yellow_when_task_is_on_hold(
     dashboard_env, dashboard_app,
 ) -> None:
@@ -5748,3 +5845,116 @@ def test_drafts_pending_panel_mounts_in_compose(tmp_path: Path) -> None:
     assert app.drafts_pending.id == "proj-drafts-pending"
     # Hidden by default (CSS class). The render path toggles it.
     assert "-hidden" in app.drafts_pending.classes
+
+
+# ---------------------------------------------------------------------------
+# #1531 — Plan-ready CTA button
+# ---------------------------------------------------------------------------
+
+
+def test_review_cta_widget_starts_hidden(tmp_path: Path) -> None:
+    """#1531 — the ``[→] Review the plan together`` CTA is hidden until
+    the gather populates ``plan_task_summary``. Without the hidden
+    default the CTA flashes for projects with no plan-shaped done task.
+    """
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    _init_git_repo(project_path)
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(project_path, config_path)
+
+    app = PollyProjectDashboardApp(config_path, "demo")
+    assert app.review_cta is not None
+    assert app.review_cta.id == "proj-review-cta"
+    assert "-hidden" in app.review_cta.classes
+
+
+def test_update_review_cta_shows_button_when_plan_task_summary_present(
+    tmp_path: Path,
+) -> None:
+    """#1531 — feeding a ``ProjectDashboardData`` with a populated
+    ``plan_task_summary`` to ``_update_review_cta`` makes the button
+    visible and renders the review-the-plan-together copy. The label
+    must include the plan title and the keystroke hint so the user
+    can click OR press ``→``.
+    """
+    from types import SimpleNamespace
+
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    _init_git_repo(project_path)
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(project_path, config_path)
+
+    app = PollyProjectDashboardApp(config_path, "demo")
+    data = SimpleNamespace(
+        plan_task_summary={
+            "task_id": "coffeeboardnm/1",
+            "title": "POC plan",
+        },
+    )
+    # Drive the helper directly — avoids needing the full Pilot loop.
+    app._update_review_cta(data)
+    rendered = str(app.review_cta.render())
+    assert "Review the plan together" in rendered
+    assert "POC plan" in rendered
+    assert "→" in rendered
+    assert "-hidden" not in app.review_cta.classes
+
+
+def test_update_review_cta_hides_when_plan_task_summary_absent(
+    tmp_path: Path,
+) -> None:
+    """#1531 — without a ``plan_task_summary`` the CTA stays hidden so
+    the dashboard pane doesn't burn vertical space on a non-actionable
+    button. Mirrors the banner copy fall-through.
+    """
+    from types import SimpleNamespace
+
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    _init_git_repo(project_path)
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(project_path, config_path)
+
+    app = PollyProjectDashboardApp(config_path, "demo")
+    # First populate so we can see the toggle clear it.
+    app._update_review_cta(SimpleNamespace(plan_task_summary={
+        "task_id": "x/1", "title": "t",
+    }))
+    assert "-hidden" not in app.review_cta.classes
+    # Now feed a no-plan-task case and assert the CTA hides again.
+    app._update_review_cta(SimpleNamespace(plan_task_summary=None))
+    assert "-hidden" in app.review_cta.classes
+
+
+def test_review_cta_falls_back_to_task_id_without_title(
+    tmp_path: Path,
+) -> None:
+    """#1531 — degraded summary (no title) still produces a clickable
+    button labeled with the task_id so the user has a routable handle.
+    """
+    from types import SimpleNamespace
+
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    _init_git_repo(project_path)
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(project_path, config_path)
+
+    app = PollyProjectDashboardApp(config_path, "demo")
+    app._update_review_cta(SimpleNamespace(plan_task_summary={
+        "task_id": "demo/3",
+        "title": "",
+    }))
+    rendered = str(app.review_cta.render())
+    assert "demo/3" in rendered
+    assert "Review the plan together" in rendered


### PR DESCRIPTION
Closes #1531.

The dashboard banner read "Waiting on you: this project has no plan yet — press a to review, or c to ask the PM to plan" while a finished plan task sat at done waiting for review, and the plan-review surface that shipped in #1401 was structurally unreachable for projects the #1511 watchdog backfilled. This PR fixes the three layers the issue calls out.

## Part A — celebratory banner + CTA button

* `_alert_banner_copy` (cockpit_ui.py) now accepts an optional `plan_task_summary` kwarg. When the `plan_missing` family fires and a plan-shaped done task exists, the banner reads `Plan's ready — <title>. Press → to review together`. Without a summary the copy simplifies to `press c to ask the PM to plan it` — drops the misleading "no plan yet" prefix.
* New `proj-review-cta` Static widget renders directly under the banner: `[→] Review the plan together — <title>`. Hidden by default; visible whenever `data.plan_task_summary` is non-null. Both click and the `→` keystroke fire the same `action_review_plan` handler.

## Part B — make the keystroke actually open the plan-review surface

**Route taken: matcher-loosening (Option 1).** New `find_actionable_plan_review_task` helper in `cockpit_sections/plan_review.py`:

1. First tries the canonical `find_plan_review_task` (review status + `user_approval` node — architect's reflection emit from #1399).
2. Falls back to any task carrying both `plan_review` and a `plan_task:<id>` label that isn't `cancelled`. Resolves to the *referenced* plan task so the surface header / persona / age read as the plan itself, not the chat-flow notify stub.

The orchestrator (`_render_project_dashboard`) calls the new helper. The existing `find_plan_review_task` is preserved for narrow callers; the loosening only affects the drilldown render.

**Why not Option 2 (fix the backstop emit):** The #1511 backstop deliberately emits a notify-only chat-flow stub that mirrors `pm notify --label plan_review` semantics. Forcing it onto `plan_project` flow at `user_approval` would create a phantom "in-flight" task that doesn't represent a real flow run, and it would change the plan_review_emit contract that #1511's tests already pin. Loosening the matcher is narrower, additive, and self-contained.

## Part C — `a` non-destructive on plan_review inbox cards

`PollyInboxApp.action_archive_selected` now early-returns into `_jump_to_plan_review_project` when the selected row carries the `plan_review` label. Archive semantics are unchanged for every other inbox row type (workspace messages, regular tasks, improvement proposals — all covered by the existing test suite).

## Tests

* `test_banner_celebrates_when_plan_task_summary_present` — celebratory copy + title + `→` hint.
* `test_banner_falls_through_when_plan_task_summary_absent` — fall-through copy keeps `press c` affordance, drops "no plan yet".
* `test_banner_celebrates_with_only_task_id_when_title_missing` — degraded summary still routes.
* `test_review_cta_widget_starts_hidden` / `test_update_review_cta_shows_button_when_plan_task_summary_present` / `test_update_review_cta_hides_when_plan_task_summary_absent` / `test_review_cta_falls_back_to_task_id_without_title` — CTA widget contract.
* `TestFindActionablePlanReviewTask` (7 tests) — matcher prefers canonical, falls back to backstop label match, resolves to the underlying plan task, skips cancelled rows.
* `test_drilldown_renders_for_backstop_emit_chat_done_stub` — full integration: seed a coffeeboardnm/30-shape (plan task #1 done on standard flow + chat-flow backstop stub at #30) → `_render_project_dashboard` returns the plan-review surface.
* `test_a_on_plan_review_row_opens_surface_does_not_archive` — Part C behavioral test.
* `test_a_on_non_plan_review_row_still_archives` — sanity that the redirect doesn't swallow the existing archive path.

All pre-existing tests in `tests/test_cockpit_plan_review_surface.py`, `tests/test_plan_review_emit.py`, `tests/test_audit_watchdog.py`, `tests/test_cancel_clears_no_session_alerts.py`, `tests/test_supervisor_alerts.py`, and `tests/test_cockpit_inbox_ui.py` still pass.

## Test plan

- [x] `uv run --extra dev pytest tests/test_cockpit_plan_review_surface.py tests/test_plan_review_emit.py tests/test_audit_watchdog.py tests/test_cancel_clears_no_session_alerts.py tests/test_supervisor_alerts.py tests/test_cockpit_inbox_ui.py` passes (263/263).
- [x] `uv run --extra dev pytest tests/ -k 'plan_review or plan_presence or alert_banner or dashboard or inbox'` — only failures are 3 pre-existing flakes unrelated to this PR (`test_inbox_section_omits_need_action_count_when_cards_show_full_set`, `test_modal_surfaces_plan_review_keys_when_selected`, `test_aux_files_listed_in_plan_body`, `test_render_project_dashboard_integration` all fail on `main` too).
- [ ] Manual: open coffeeboardnm dashboard in cockpit, verify banner reads "Plan's ready", CTA button visible, pressing → opens plan-review surface.
- [ ] Manual: from inbox, press `a` on a plan_review card, confirm it routes to project drilldown instead of archiving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)