### PR TITLE
Fix action_review_plan opens surface when no markdown plan file on disk

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -17410,16 +17410,28 @@ class PollyProjectDashboardApp(App[None]):
             )
             return
         if data.plan_path is None:
-            # The plan task is done but the plan file wasn't written
-            # to the canonical location. Fall back to the approve flow
-            # directly so the user can still act.
-            if has_plan_review_card and self._approve_first_plan_review_if_present():
-                return
+            # #1531 follow-up — the plan task is done but the plan
+            # file wasn't written to the canonical
+            # ``docs/plan/plan.md`` / ``docs/project-plan.md``
+            # locations. Workers that ship a different artifact (HTML
+            # explainer at ``reports/index.html``, an external URL,
+            # etc.) still produce a reviewable plan; we just don't
+            # have markdown to render. Open plan-view mode anyway so
+            # the user sees the task header + description + action
+            # bar instead of a dead-end notify. The surface render
+            # (``render_plan_review_surface``) handles empty plan_text
+            # gracefully — it emits "(plan body is empty)" placeholders
+            # for sections it can't fill, but the header strip still
+            # names the task and the action bar still lets the user
+            # approve / reject / chat.
+            if not self._plan_view_mode:
+                self.action_open_plan()
             self.notify(
-                "Plan task is done but no plan file was found on "
-                "disk. Press a to approve the plan_review card or i "
-                "to open the inbox.",
-                severity="warning", timeout=3.5,
+                "Plan task is done but no markdown plan file is on "
+                "disk — opening the review surface anyway. Check the "
+                "task description or deliverable URL for the plan "
+                "content.",
+                severity="information", timeout=4.5,
             )
             return
         # Force plan-view mode on (don't toggle — the user explicitly


### PR DESCRIPTION
Follow-up to #1531. After Part B's matcher loosening, the plan-review surface renders for backstop-emitted plan_review tasks — but `action_review_plan` (the `→` keystroke + green CTA button) bails with a 'no plan file found' notify when `_dashboard_plan_path` returns None.

For coffeeboardnm the worker shipped to `reports/index.html` (a visual-explainer HTML deliverable), not the canonical `docs/plan/plan.md`. So the loader returns None and the user sees the warning instead of the surface they were promised by the celebratory banner.

This PR opens the plan-view surface anyway. The render gracefully handles empty plan_text — the user gets the header strip + (empty) sections + action bar, which is strictly better than a notify telling them to look elsewhere.

Also drops the silent auto-approve fall-through. The user clicked 'review', not 'approve' — silently approving without showing them the plan was the wrong default.

Test plan:
- [ ] After merge: `pm update` + full kill + restart + open coffeeboardnm dashboard + press `→` (or click the green CTA) — should land on the plan-review surface (header + empty body + action bar), not the warning notify.
- [ ] Existing review path (with `docs/plan/plan.md` present) still renders the full plan body.

Follow-ups (separate issues if needed):
- Extend `CANONICAL_PLAN_RELATIVE_PATHS` for HTML / external deliverables.
- Surface deliverable URL in the plan-review body so the user can jump to the live artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)