### PR TITLE
Fix #1533 regression: action_open_plan(force=True) bypasses no-plan-file bail

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -17425,7 +17425,7 @@ class PollyProjectDashboardApp(App[None]):
             # names the task and the action bar still lets the user
             # approve / reject / chat.
             if not self._plan_view_mode:
-                self.action_open_plan()
+                self.action_open_plan(force=True)
             self.notify(
                 "Plan task is done but no markdown plan file is on "
                 "disk — opening the review surface anyway. Check the "
@@ -17446,16 +17446,23 @@ class PollyProjectDashboardApp(App[None]):
                 severity="information", timeout=4.0,
             )
 
-    def action_open_plan(self) -> None:
+    def action_open_plan(self, *, force: bool = False) -> None:
         """Toggle plan-view mode — plan.md takes over the body.
 
         When no plan exists, friendly-notify instead of flipping a mode
         with nothing to show. Project-local ``[planner].enforce_plan
         = false`` projects get a different toast that surfaces the
         explicit bypass rather than nudging as if a plan is missing.
+
+        ``force=True`` (used by ``action_review_plan`` after #1533) skips
+        the no-plan-file early-bail so a plan task that lives somewhere
+        other than the canonical markdown locations (HTML deliverable,
+        external URL, task description as plan summary) still gets the
+        plan-view surface — which now renders the task description +
+        deliverable URL when no markdown is on disk.
         """
         data = self.data
-        if data is None or data.plan_path is None:
+        if not force and (data is None or data.plan_path is None):
             if data is not None and not getattr(data, "enforce_plan", True):
                 self.notify(
                     "Plan not required for this project "
@@ -17467,6 +17474,8 @@ class PollyProjectDashboardApp(App[None]):
                     "No plan file yet for this project.",
                     severity="warning", timeout=2.0,
                 )
+            return
+        if data is None:
             return
         self._plan_view_mode = not self._plan_view_mode
         other_section_ids = (


### PR DESCRIPTION
Hot-fix for the regression Sam hit immediately after #1533 deployed: pressing → on the CoffeeBoardNM dashboard fired both the green 'opening the surface anyway' notify AND the yellow 'No plan file yet' notify, with no actual plan-view mode flip — because `action_open_plan` itself bails when `data.plan_path is None`.

Adds a `force` kwarg. `action_review_plan` calls `self.action_open_plan(force=True)` for the explicit review gesture; the toggle proceeds with empty plan_text. The existing `p` keystroke (manual toggle) keeps its friendly bail.

Tests: 12 passing in `-k 'action_open_plan or action_review_plan or plan_view'` (the one pre-existing failure also fails on main).

Test plan:
- [ ] After merge: `pm update` + restart + open CoffeeBoardNM dashboard + press → — should land on the plan-view surface (header + sparse body + action bar), with only the green 'opening anyway' notify (no yellow 'no plan file').

🤖 Generated with [Claude Code](https://claude.com/claude-code)