### PR TITLE
Fix #1534 plan-review surface renders description + deliverable URL

### DIFF
--- a/src/pollypm/cockpit_sections/plan_review.py
+++ b/src/pollypm/cockpit_sections/plan_review.py
@@ -46,7 +46,7 @@ from pollypm.cockpit_sections.base import (
 # Back`` for tests + non-Rich consumers — see ``render_plan_review_action_bar_plain``.
 
 _ACTION_BAR_PLAIN = (
-    "[a] Approve   [c] Chat to refine   [d] Deny   [esc] Back"
+    "[a] Approve   [c] Chat to refine   [d] Deny   [b] Open in browser   [esc] Back"
 )
 
 # Header strip colours — keep narrow enough to render inside the
@@ -73,6 +73,7 @@ def render_plan_review_action_bar() -> str:
         "[bold green][a][/bold green] [bold]Approve[/bold]",
         "[bold cyan][c][/bold cyan] Chat to refine",
         "[bold red][d][/bold red] Deny",
+        "[bold green][b][/bold green] Open in browser",
         "[bold]\\[esc][/bold] Back",
     ]
     return _DASHBOARD_BULLET + "   ".join(parts)
@@ -284,11 +285,15 @@ def render_plan_review_surface(
     """
     # Lazy import — `_md_to_rich` lives in ``cockpit_ui`` which already
     # imports from ``cockpit_sections``; importing it at module level
-    # creates a circular dependency.
+    # creates a circular dependency. ``_plan_task_first_paragraph`` and
+    # ``_plan_task_deliverable_url`` (#1518) are reused here so the
+    # description-fallback / deliverable-URL extraction stays canonical.
     from pollypm.cockpit_ui import (
         _extract_plan_judgment_calls,
         _extract_plan_summary_block,
         _md_to_rich,
+        _plan_task_deliverable_url,
+        _plan_task_first_paragraph,
     )
 
     summary = _extract_plan_summary_block(plan_text or "")
@@ -301,6 +306,19 @@ def render_plan_review_surface(
         project_key=project_key, task=task,
     ))
     out.append(_DASHBOARD_BULLET + "─" * (_DASHBOARD_DIVIDER_WIDTH - 2))
+
+    # 1b) Live deliverable URL (#1534, Part B). Renders right under the
+    # header strip when the resolved task carries an ``external_refs`` /
+    # label / description URL — the worker shipped a real artifact and
+    # the user wants a one-glance affordance to open it. Bold + green
+    # to match the positive-action palette used by the [a] Approve
+    # button + the #1531 review CTA banner.
+    deliverable_url = _plan_task_deliverable_url(task) if task is not None else None
+    if deliverable_url:
+        out.append(
+            _DASHBOARD_BULLET
+            + f"[bold green]Live deliverable:[/bold green] {deliverable_url}"
+        )
     out.append("")
 
     # 2) Summary section.
@@ -320,14 +338,26 @@ def render_plan_review_surface(
         out.append(_DASHBOARD_BULLET + "(no judgment calls flagged)")
     out.append("")
 
-    # 4) Plan body.
+    # 4) Plan body. When the plan_text is empty BUT the resolved task
+    # carries a description (#1534, Part A) — the watchdog backstop
+    # shape where the worker's plan summary lives only on the task row
+    # — render its first paragraph as the body fallback. Otherwise
+    # keep the "(plan body is empty)" placeholder.
     out.append(_dashboard_divider("Plan body"))
     if body_rest:
         rendered = _md_to_rich(body_rest)
         for line in rendered.splitlines():
             out.append(_DASHBOARD_BULLET + line)
     else:
-        out.append(_DASHBOARD_BULLET + "(plan body is empty)")
+        description = (
+            getattr(task, "description", "") or "" if task is not None else ""
+        )
+        fallback_para = _plan_task_first_paragraph(description) if description else ""
+        if fallback_para:
+            for line in fallback_para.splitlines():
+                out.append(_DASHBOARD_BULLET + line)
+        else:
+            out.append(_DASHBOARD_BULLET + "(plan body is empty)")
     out.append("")
 
     # 5) Action bar.

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -24,6 +24,7 @@ import asyncio
 import json
 import os
 import resource
+import webbrowser
 from collections import OrderedDict
 from pathlib import Path
 import subprocess
@@ -14661,6 +14662,14 @@ class PollyProjectDashboardApp(App[None]):
         # banner CTA advertises this keystroke (mirrors the inbox →
         # gesture for "drill in"); ``r`` stays bound to refresh.
         Binding("right", "review_plan", "Review plan", show=False),
+        # #1534 — ``b`` opens the plan task's deliverable URL in the
+        # system browser (when the resolved plan-review task carries
+        # one via ``external_refs`` / labels / description). ``o`` was
+        # already bound to ``open_editor`` for plan.md, so we use ``b``
+        # ("Browser") for the URL affordance — the surface action bar
+        # advertises the keystroke + the binding no-ops with a friendly
+        # notify when no deliverable URL is available.
+        Binding("b", "open_deliverable_url", "Open deliverable", show=False),
         # ``u`` rolls back a pending plan-review approval; falls
         # through to refresh when there is nothing pending (the legacy
         # ``u`` binding co-existed with ``r`` for refresh).
@@ -17570,6 +17579,57 @@ class PollyProjectDashboardApp(App[None]):
         import platform
         cmd = "open" if platform.system() == "Darwin" else "xdg-open"
         subprocess.run([cmd, str(path)], check=False)
+
+    def action_open_deliverable_url(self) -> None:
+        """``b`` — open the plan task's deliverable URL in the system browser.
+
+        #1534 — when the project's actionable plan-review task carries a
+        deliverable URL (via ``external_refs`` / labels / description),
+        the plan-review surface advertises ``[b] Open in browser``.
+        We resolve the URL the same way the surface does (#1518's
+        ``_plan_task_deliverable_url``) so the keystroke maps to the
+        URL the user just read on screen.
+
+        No-ops with a friendly notify when there's no plan task or no
+        URL to open — pressing ``b`` outside a plan-review context
+        shouldn't be silent.
+        """
+        url = self._resolve_plan_review_deliverable_url()
+        if not url:
+            self.notify(
+                "No deliverable URL on this plan task.",
+                severity="information", timeout=2.0,
+            )
+            return
+        try:
+            webbrowser.open(url)
+        except Exception as exc:  # noqa: BLE001
+            self.notify(
+                f"Open failed: {exc}", severity="error", timeout=3.0,
+            )
+            return
+        self.notify(
+            f"Opened {url}", severity="information", timeout=2.0,
+        )
+
+    def _resolve_plan_review_deliverable_url(self) -> str | None:
+        """Return the deliverable URL for the surfaced plan-review task.
+
+        Reads ``data.plan_task_summary["deliverable_url"]`` — already
+        extracted by :func:`_dashboard_done_plan_task` via
+        ``_plan_task_deliverable_url``. The summary is the canonical
+        carrier for plan-task deliverables on this screen so we don't
+        re-walk the work_tasks rows here.
+        """
+        data = self.data
+        if data is None:
+            return None
+        summary = getattr(data, "plan_task_summary", None) or None
+        if isinstance(summary, dict):
+            url = summary.get("deliverable_url")
+            if isinstance(url, str) and url.startswith(("http://", "https://")):
+                return url
+        return None
 
     # ── Plan-view scroll helpers (active when ``_plan_view_mode`` is on) ──
 

--- a/tests/test_cockpit_plan_review_surface.py
+++ b/tests/test_cockpit_plan_review_surface.py
@@ -59,6 +59,8 @@ class _PlanReviewFakeTask:
         updated_at: datetime | None = None,
         created_at: datetime | None = None,
         labels: list[str] | None = None,
+        description: str = "",
+        external_refs: dict[str, str] | None = None,
     ) -> None:
         self.task_number = task_number
         self.task_id = task_id or f"proj/{task_number}"
@@ -74,6 +76,8 @@ class _PlanReviewFakeTask:
         self.labels = labels or []
         self.transitions = []
         self.executions = []
+        self.description = description
+        self.external_refs = external_refs or {}
 
 
 SAMPLE_PLAN = """# Project plan
@@ -277,6 +281,17 @@ class TestActionBar:
         assert "[d] Deny" in bar
         assert "[esc] Back" in bar
 
+    def test_plain_action_bar_includes_open_in_browser(self):
+        """#1534 — plain bar advertises the [b] Open in browser hotkey."""
+        bar = render_plan_review_action_bar_plain()
+        assert "[b] Open in browser" in bar
+
+    def test_rich_action_bar_includes_open_in_browser(self):
+        """#1534 — rich bar surfaces the [b] Open in browser button."""
+        bar = render_plan_review_action_bar()
+        assert "[bold green][b][/bold green]" in bar
+        assert "Open in browser" in bar
+
     def test_rich_action_bar_uses_distinct_colors_per_action(self):
         """Each label uses bold + a colour token so it reads as a button.
 
@@ -392,6 +407,83 @@ class TestRenderPlanReviewSurface:
         assert "[a] Approve" in out
         assert "[esc] Back" in out
 
+    def test_surface_renders_description_when_no_plan_text(self):
+        """#1534, Part A — empty plan_text + non-empty description.
+
+        The plan-review surface should fall back to the task's first
+        description paragraph in the Plan body section, not leave the
+        '(plan body is empty)' placeholder. Watchdog-emitted backstop
+        plan-review tasks (coffeeboardnm shape) carry their plan
+        summary on the task description, not in a markdown file.
+        """
+        description = (
+            "We sweep every NM event May–Jul 2026 and rank by signal "
+            "density. The first deliverable is a static HTML board with "
+            "the top venues + dates."
+        )
+        task = _PlanReviewFakeTask(
+            task_number=1, description=description,
+        )
+        out = render_plan_review_surface(
+            project_key="coffeeboardnm",
+            project_name="CoffeeBoardNM",
+            task=task,
+            plan_text="",
+        )
+        assert "We sweep every NM event May" in out
+        # Placeholder must be replaced by the description paragraph.
+        assert "(plan body is empty)" not in out
+
+    def test_surface_keeps_placeholder_when_no_plan_and_no_description(self):
+        """#1534, Part A — empty plan_text + empty description keeps the
+        '(plan body is empty)' placeholder (no fabricated fallback)."""
+        task = _PlanReviewFakeTask(task_number=2, description="")
+        out = render_plan_review_surface(
+            project_key="proj", project_name="P", task=task, plan_text="",
+        )
+        assert "(plan body is empty)" in out
+
+    def test_surface_renders_deliverable_url_under_header(self):
+        """#1534, Part B — deliverable URL renders right under the header strip.
+
+        ``_plan_task_deliverable_url`` looks at ``external_refs`` first,
+        so ``external_refs={"deliverable": "<url>"}`` is the canonical
+        carrier — a single 'Live deliverable: <url>' line should appear
+        between the header divider and the Summary section.
+        """
+        url = "https://coffeeboardnm.itsalive.co"
+        task = _PlanReviewFakeTask(
+            task_number=1, external_refs={"deliverable": url},
+        )
+        out = render_plan_review_surface(
+            project_key="coffeeboardnm",
+            project_name="CoffeeBoardNM",
+            task=task,
+            plan_text="",
+        )
+        # "Live deliverable:" + URL on the same line. The label is
+        # wrapped in Rich-markup so we don't lock the test to the
+        # exact tag form — just assert the visible text + URL appear
+        # together.
+        assert "Live deliverable:" in out
+        assert url in out
+        # The line should land before the Summary section divider —
+        # confirms placement under the header strip rather than buried
+        # in the body.
+        deliverable_idx = out.find("Live deliverable:")
+        summary_idx = out.find("Summary")
+        assert deliverable_idx != -1
+        assert summary_idx != -1
+        assert deliverable_idx < summary_idx
+
+    def test_surface_omits_deliverable_line_when_no_url(self):
+        """#1534, Part B — no URL anywhere → no Live deliverable line."""
+        task = _PlanReviewFakeTask(task_number=3)
+        out = render_plan_review_surface(
+            project_key="proj", project_name="P", task=task, plan_text="",
+        )
+        assert "Live deliverable:" not in out
+
     def test_surface_summary_judgment_not_duplicated_in_body(self):
         """The plan body section drops the summary + judgment headers.
 
@@ -424,7 +516,7 @@ class TestRenderPlanReviewSurface:
             project_key="proj", project_name="P", task=task, plan_text=SAMPLE_PLAN,
         )
         for line in out.splitlines():
-            assert len(line) <= 200, (
+            assert len(line) <= 220, (
                 f"surface line too wide for narrow mode: {len(line)} -> {line!r}"
             )
         # Even in narrow terminals the action bar + header are visible.

--- a/tests/test_project_dashboard_plan_viewer.py
+++ b/tests/test_project_dashboard_plan_viewer.py
@@ -393,3 +393,67 @@ def test_o_opens_plan_in_editor(env, app, monkeypatch) -> None:
             assert opened, "expected _open_external to be called for plan.md"
             assert opened[-1] == plan_path
     _run(body())
+
+
+# ---------------------------------------------------------------------------
+# 9. ``b`` opens the plan-task deliverable URL in the system browser (#1534)
+# ---------------------------------------------------------------------------
+
+
+def test_b_opens_deliverable_url_in_browser(env, app, monkeypatch) -> None:
+    """#1534 — ``b`` calls ``webbrowser.open`` with the plan task's URL.
+
+    The plan-review surface advertises ``[b] Open in browser`` when the
+    surfaced task carries a ``deliverable_url`` (extracted via
+    ``_plan_task_deliverable_url`` and stored on
+    ``data.plan_task_summary``). Pressing ``b`` should call the
+    platform URL handler with that URL — no editor shell-out, no path
+    munging.
+    """
+    async def body() -> None:
+        async with app.run_test(size=(140, 50)) as pilot:
+            await pilot.pause()
+            assert app.data is not None
+            # Inject a plan_task_summary with a deliverable URL —
+            # the actual gather path is exercised by other tests; here
+            # we want to assert the keybinding wiring.
+            app.data.plan_task_summary = {
+                "task_id": "demo/1",
+                "task_number": 1,
+                "project": "demo",
+                "title": "POC plan",
+                "summary": "ship the explainer",
+                "deliverable_url": "https://example.test/plan-explainer",
+                "updated_at": "2026-04-30T00:00:00+00:00",
+            }
+            opened: list[str] = []
+            monkeypatch.setattr(
+                "pollypm.cockpit_ui.webbrowser.open",
+                lambda url, *a, **kw: opened.append(url) or True,
+            )
+            await pilot.press("b")
+            await pilot.pause()
+            assert opened == ["https://example.test/plan-explainer"]
+    _run(body())
+
+
+def test_b_no_op_when_no_deliverable_url(env, app, monkeypatch) -> None:
+    """#1534 — ``b`` is a friendly no-op when no plan-task URL is present.
+
+    No plan_task_summary, or one without a deliverable_url, must not
+    crash and must not call the platform URL handler.
+    """
+    async def body() -> None:
+        async with app.run_test(size=(140, 50)) as pilot:
+            await pilot.pause()
+            assert app.data is not None
+            app.data.plan_task_summary = None
+            opened: list[str] = []
+            monkeypatch.setattr(
+                "pollypm.cockpit_ui.webbrowser.open",
+                lambda url, *a, **kw: opened.append(url) or True,
+            )
+            await pilot.press("b")
+            await pilot.pause()
+            assert opened == []
+    _run(body())


### PR DESCRIPTION
## Summary

- **Part A** — when ``render_plan_review_surface`` sees an empty ``plan_text`` but the resolved task carries a description, render its first paragraph (via ``_plan_task_first_paragraph`` from #1518) in the Plan body section instead of the ``(plan body is empty)`` placeholder. The ``_plan_task_first_paragraph`` and ``_plan_task_deliverable_url`` helpers are lazy-imported to dodge the cockpit_ui ↔ cockpit_sections circular dep (matches the existing ``_md_to_rich`` pattern).
- **Part B** — when ``_plan_task_deliverable_url`` yields a URL on the resolved task, render a prominent ``Live deliverable: <url>`` line right under the header strip (bold green, matching the positive-action palette used by the ``[a] Approve`` button + the #1531 review CTA banner). Action bar grows ``[b] Open in browser``; pressing ``b`` on the project dashboard calls ``webbrowser.open`` with the URL pulled from ``data.plan_task_summary``.
- **Part C is skipped** per the issue body's recommendation — HTML deliverables surface via Parts A + B (description + URL) instead of being rendered inline.

## Keybinding choice

``o`` is already bound to ``open_editor`` (opens plan.md in the system editor) on ``PollyProjectDashboardApp``, so the issue's suggested ``o`` would collide. ``v`` is documented as removed (#1405). I picked ``b`` for "Browser" — it's unbound on this screen and reads naturally for "Open in browser". The plan-review action bar copy (rich + plain) and the dashboard binding both match.

## Tests

New tests:
- ``tests/test_cockpit_plan_review_surface.py`` — Part A: description renders when no plan_text; placeholder kept when both empty. Part B: ``Live deliverable: <url>`` appears between the header strip and the Summary section; absent when no URL.
- ``tests/test_cockpit_plan_review_surface.py`` — action bar (rich + plain) advertises ``[b] Open in browser``.
- ``tests/test_project_dashboard_plan_viewer.py`` — pressing ``b`` calls ``webbrowser.open`` with the URL stored on ``data.plan_task_summary``; pressing ``b`` with no plan_task_summary is a friendly no-op (no crash, no call).

The narrow-mode width assertion (``test_surface_renders_in_narrow_terminal``) bumped from 200 → 220 chars to accommodate the additional rich-markup-wrapped action button — the rendered (non-markup) width is well within the budget; the test comment already noted that rich tags don't render visibly.

## Test plan

- [x] ``uv run pytest tests/test_cockpit_plan_review_surface.py`` — 32 pass
- [x] ``uv run pytest tests/test_project_dashboard_plan_viewer.py -k "b_opens or b_no_op"`` — 2 pass
- [x] ``uv run pytest tests/ -k 'plan_review or render_plan or _plan_task or action_review' --deselect tests/test_keyboard_help.py::test_modal_surfaces_plan_review_keys_when_selected`` — 143 pass (the deselected test is a pre-existing failure on main, unrelated to #1534)
- [x] ``uv run pytest tests/test_project_dashboard_plan_viewer.py`` — 12 pass + 1 pre-existing failure (``test_aux_files_listed_in_plan_body``, called out in the spec)
- [ ] **Manual smoke**: run the cockpit against ``coffeeboardnm`` (the live evidence project), drill into the project, press ``→`` to open the plan-review surface, verify (a) the description shows in the Plan body, (b) the ``Live deliverable: https://coffeeboardnm.itsalive.co`` line appears at the top, (c) ``b`` opens the URL in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)