### PR TITLE
Fix #1536 banner pill goes green for plan-ready + APPROVE button block on surface

### DIFF
--- a/src/pollypm/cockpit_sections/plan_review.py
+++ b/src/pollypm/cockpit_sections/plan_review.py
@@ -79,6 +79,48 @@ def render_plan_review_action_bar() -> str:
     return _DASHBOARD_BULLET + "   ".join(parts)
 
 
+def render_plan_review_approve_button() -> str:
+    """Render the prominent APPROVE button block (#1536).
+
+    A bordered, full-width green block sitting above the inline action
+    bar. Visually mirrors the dashboard ``proj-review-cta`` button from
+    #1531 (bold + green palette) so the dashboard banner CTA and the
+    surface APPROVE button read as a single celebratory affordance.
+
+    The inline action bar (``render_plan_review_action_bar``) STAYS as
+    the secondary affordance for chat / deny / open-browser. This block
+    is the primary CTA — it advertises ``[a]`` because that's still the
+    keybinding that approves; only the visual rendering changes.
+
+    Width matches ``_DASHBOARD_DIVIDER_WIDTH`` so it lines up with the
+    section dividers above it (same visual rhythm as the rest of the
+    surface).
+    """
+    # The bordered block uses ``_DASHBOARD_DIVIDER_WIDTH`` (72 visible
+    # cols) so it lines up with the section dividers above it. Inner
+    # width is the divider width minus two border chars on either side.
+    inner_width = _DASHBOARD_DIVIDER_WIDTH - 4
+    # Visible label width (Rich tags + the escaped ``\[`` collapse to
+    # ``[a] APPROVE — Ship this plan`` once rendered).
+    visible_label = "[a] APPROVE — Ship this plan"
+    left_pad = 2
+    right_pad = max(0, inner_width - len(visible_label) - left_pad)
+    top = "╭" + "─" * inner_width + "╮"
+    bot = "╰" + "─" * inner_width + "╯"
+    mid = (
+        "│"
+        + " " * left_pad
+        + "[bold green]\\[a] APPROVE — Ship this plan[/bold green]"
+        + " " * right_pad
+        + "│"
+    )
+    return (
+        _DASHBOARD_BULLET + top + "\n"
+        + _DASHBOARD_BULLET + mid + "\n"
+        + _DASHBOARD_BULLET + bot
+    )
+
+
 def find_plan_review_task(tasks: list) -> object | None:
     """Return the first task in ``status=review`` parked at user_approval.
 
@@ -360,8 +402,26 @@ def render_plan_review_surface(
             out.append(_DASHBOARD_BULLET + "(plan body is empty)")
     out.append("")
 
-    # 5) Action bar.
+    # 5) Actions section.
+    #
+    # Primary CTA: a prominent APPROVE button block (#1536) — bordered,
+    # full-width, green so it visually mirrors the dashboard banner CTA
+    # from #1531. The keybinding is still ``a`` (the inline bar still
+    # advertises it) — only the visual emphasis changes.
+    #
+    # Don't render the APPROVE block when the task is already in a
+    # terminal-and-dismissed state (``cancelled``). A ``done`` plan task
+    # IS still approvable from the user's perspective — the watchdog
+    # backstop emits done stubs that the user hasn't actually approved
+    # yet (matching the same signal that drives the dashboard CTA in
+    # #1531). For ``review`` (canonical), ``done`` (backstop), or any
+    # other non-cancelled status, render the APPROVE block.
     out.append(_dashboard_divider("Actions"))
+    status = getattr(task, "work_status", None) if task is not None else None
+    status_value = getattr(status, "value", status)
+    if status_value != "cancelled":
+        out.append(render_plan_review_approve_button())
+        out.append("")
     out.append(render_plan_review_action_bar())
     out.append(_DASHBOARD_BULLET + "(plain) " + render_plan_review_action_bar_plain())
 

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -11724,6 +11724,8 @@ def _dashboard_status(
     blocker_count: int = 0,
     on_hold_count: int = 0,
     in_progress_count: int = 0,
+    plan_task_summary: dict | None = None,
+    alert_types: list[str] | None = None,
 ) -> tuple[str, str, str]:
     """Return (dot, colour, label) for the top-bar project status light.
 
@@ -11741,6 +11743,20 @@ def _dashboard_status(
     # do here").
     if inbox_count or on_hold_count:
         return ("\u25c6", "#f0c45a", "needs attention")
+    # #1536 \u2014 celebratory plan-ready pill. When the alert that fires
+    # is a ``plan_missing`` family AND a plan-shaped done task is already
+    # on the project (``plan_task_summary`` is non-null), the user is
+    # looking at a teammate handoff, not a debt-collector ping. Match
+    # the green palette of the banner CTA (#1531) + the active-worker
+    # pill so the dashboard reads as one coordinated celebration. This
+    # branch must come before the generic red ``alert`` branch below.
+    if (
+        alert_count
+        and plan_task_summary
+        and alert_types
+        and "plan_missing" in alert_types
+    ):
+        return ("\u25c6", "#3ddc84", "plan ready")
     if alert_count:
         return ("\u25c6", "#f85149", "alert")
     if active_worker is not None:
@@ -14140,6 +14156,8 @@ def _gather_project_dashboard(
         blocker_count=blocker_count,
         on_hold_count=on_hold_count,
         in_progress_count=in_progress_count,
+        plan_task_summary=plan_task_summary,
+        alert_types=alert_types,
     )
 
     # Resolve effective enforce_plan with the same precedence the rail

--- a/tests/test_cockpit_plan_review_surface.py
+++ b/tests/test_cockpit_plan_review_surface.py
@@ -32,6 +32,7 @@ from pollypm.cockpit_sections.plan_review import (
     load_plan_text,
     render_plan_review_action_bar,
     render_plan_review_action_bar_plain,
+    render_plan_review_approve_button,
     render_plan_review_header_strip,
     render_plan_review_surface,
 )
@@ -320,6 +321,105 @@ class TestActionBar:
             assert len(line) <= 80, (
                 f"action bar line exceeds 80 cols: {len(line)} -> {line!r}"
             )
+
+
+# ---------------------------------------------------------------------------
+# APPROVE button block (#1536)
+# ---------------------------------------------------------------------------
+
+
+class TestApproveButtonBlock:
+    def test_approve_block_contains_label_and_green_bold_markup(self):
+        """#1536 — the bordered APPROVE block carries bold + green Rich
+        markup so it visually mirrors the dashboard CTA from #1531."""
+        block = render_plan_review_approve_button()
+        assert "APPROVE" in block
+        # Bold + green markup wraps the label.
+        assert "[bold green]" in block
+        assert "[/bold green]" in block
+        # The block is a multi-line bordered box.
+        assert "\n" in block
+        # Box-drawing corner characters (round corners to match the
+        # dashboard CTA visual rhythm).
+        assert "╭" in block
+        assert "╰" in block
+
+    def test_approve_block_advertises_a_keybinding(self):
+        """The button block surfaces the ``[a]`` keybinding so the user
+        knows the keyboard affordance hasn't moved (only the visual
+        emphasis changed)."""
+        block = render_plan_review_approve_button()
+        # ``\\[a]`` because Rich-markup uses ``[`` literally for tags,
+        # so the bracket is escaped.
+        assert "\\[a]" in block
+        assert "Ship this plan" in block
+
+
+class TestApproveButtonInSurface:
+    def test_surface_renders_approve_block_for_review_task(self):
+        """#1536 — a canonical review-state task surfaces the APPROVE
+        button block above the inline action bar."""
+        task = _PlanReviewFakeTask(
+            task_number=11, status="review",
+        )
+        out = render_plan_review_surface(
+            project_key="proj", project_name="P", task=task, plan_text="",
+        )
+        assert "APPROVE" in out
+        assert "╭" in out
+        # Block lands inside the Actions section (after the divider) and
+        # before the inline action bar.
+        actions_idx = out.find("Actions")
+        approve_idx = out.find("APPROVE")
+        action_bar_idx = out.find("[a] Approve")
+        assert actions_idx != -1
+        assert approve_idx != -1
+        assert action_bar_idx != -1
+        assert actions_idx < approve_idx < action_bar_idx
+
+    def test_surface_renders_approve_block_for_done_backstop_task(self):
+        """#1536 — backstop-emitted ``done`` plan-shaped tasks (the
+        coffeeboardnm/30 shape) STILL render the APPROVE block. The
+        ``done`` status here is a stub artifact, not a final state — the
+        user hasn't actually approved the plan yet."""
+        task = _PlanReviewFakeTask(
+            task_number=30, status="done",
+        )
+        out = render_plan_review_surface(
+            project_key="coffeeboardnm",
+            project_name="CoffeeBoardNM",
+            task=task,
+            plan_text="",
+        )
+        assert "APPROVE" in out
+
+    def test_surface_omits_approve_block_for_cancelled_task(self):
+        """#1536 — a cancelled task is genuinely past the approval
+        moment. Don't dangle a CTA the user can't act on."""
+        task = _PlanReviewFakeTask(
+            task_number=12, status="cancelled",
+        )
+        out = render_plan_review_surface(
+            project_key="proj", project_name="P", task=task, plan_text="",
+        )
+        assert "APPROVE" not in out
+        # Inline action bar still renders so the user has a way back.
+        assert "[a] Approve" in out
+
+    def test_surface_keeps_inline_action_bar_alongside_approve_block(self):
+        """The inline action bar is the secondary affordance for chat,
+        deny, open-browser, esc. Adding the APPROVE block must not
+        remove it."""
+        task = _PlanReviewFakeTask(task_number=11)
+        out = render_plan_review_surface(
+            project_key="proj", project_name="P", task=task, plan_text="",
+        )
+        # APPROVE block + inline bar both present.
+        assert "APPROVE" in out
+        assert "[a] Approve" in out
+        assert "[c] Chat to refine" in out
+        assert "[d] Deny" in out
+        assert "[esc] Back" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -3397,6 +3397,69 @@ def test_status_pill_uses_activity_classification() -> None:
     assert dot == "◆"
 
 
+def test_status_pill_celebrates_plan_ready_when_plan_task_summary_present() -> None:
+    """#1536 — a ``plan_missing`` alert with a non-null ``plan_task_summary``
+    means the plan is already done and waiting on review. The pill switches
+    from red ``alert`` to green ``plan ready`` so the dashboard reads as a
+    teammate handoff (matching the celebratory banner copy from #1531)."""
+    from pollypm.cockpit_ui import _dashboard_status
+
+    summary = {"task_id": "proj/1", "title": "POC plan: lipgloss CLI"}
+    dot, color, label = _dashboard_status(
+        None,
+        0,
+        1,
+        None,
+        plan_task_summary=summary,
+        alert_types=["plan_missing"],
+    )
+    assert label == "plan ready"
+    assert color == "#3ddc84"  # match the active-worker green
+    assert dot == "◆"
+
+
+def test_status_pill_falls_back_to_red_alert_without_plan_task_summary() -> None:
+    """#1536 — ``plan_missing`` family WITHOUT a ``plan_task_summary``
+    keeps the existing red ``alert`` palette. The summary signal is what
+    distinguishes a plan-ready celebration from an actual missing-plan
+    debt."""
+    from pollypm.cockpit_ui import _dashboard_status
+
+    dot, color, label = _dashboard_status(
+        None,
+        0,
+        1,
+        None,
+        plan_task_summary=None,
+        alert_types=["plan_missing"],
+    )
+    assert label == "alert"
+    assert color == "#f85149"  # the existing red alert palette
+    assert dot == "◆"
+
+
+def test_status_pill_keeps_red_alert_for_non_plan_missing_families() -> None:
+    """#1536 — only ``plan_missing`` flips green. Other alert families
+    (``recovery_limit``, ``auth_broken``, ``worker_question``, ...) stay
+    on the existing red ``alert`` path even when a ``plan_task_summary``
+    happens to be non-null on the project (e.g. an auth alert on a
+    project that already has a done plan)."""
+    from pollypm.cockpit_ui import _dashboard_status
+
+    summary = {"task_id": "proj/1", "title": "POC plan: lipgloss CLI"}
+    dot, color, label = _dashboard_status(
+        None,
+        0,
+        1,
+        None,
+        plan_task_summary=summary,
+        alert_types=["recovery_limit"],
+    )
+    assert label == "alert"
+    assert color == "#f85149"
+    assert dot == "◆"
+
+
 def test_banner_does_not_claim_in_action_for_idle_worker() -> None:
     """The banner under "Moving now" must not claim an idle worker
     is active. #990 banner read ``Moving now: architect_bikepath


### PR DESCRIPTION
Closes #1536.

Two-part visual polish for the plan-ready handoff so the dashboard pill, banner CTA (from #1531), and the surface APPROVE action all read as a single celebratory affordance instead of mixed alert/celebrate signals.

## Summary

- **Part A — banner pill goes green for plan-ready.** Thread `plan_task_summary` + `alert_types` into `_dashboard_status`; new branch returns `◆ plan ready` in `#3ddc84` (matching the active-worker pill and the #1531 CTA) when the alert family is `plan_missing` AND a plan-shaped done task is on the project. Other alert families keep the existing red `alert` palette.
- **Part B — prominent APPROVE button block on the plan-review surface.** New `render_plan_review_approve_button()` returns a bordered, full-width green block aligned to `_DASHBOARD_DIVIDER_WIDTH`. Visually mirrors the dashboard CTA from #1531 (bold + green). Renders inside the Actions section above the existing inline action bar from #1401/#1534. The keybinding (`a`) is unchanged.
- The APPROVE block is suppressed when the task is `cancelled` (genuinely past the moment). It still shows for `review` (canonical) and `done` (backstop-emit, e.g. coffeeboardnm/30) because the user hasn't actually approved from their perspective.

## Test plan

- [x] `uv run pytest tests/test_cockpit_plan_review_surface.py` — 38/38 pass (6 new).
- [x] `uv run pytest tests/test_project_dashboard_ui.py -k status_pill` — 5/5 pass (3 new).
- [x] `uv run pytest tests/ -k 'dashboard_status or plan_review or approve_button or render_plan'` — 138 passing; the 1 failure (`test_modal_surfaces_plan_review_keys_when_selected`) pre-exists on `main` and is unrelated.
- [ ] Manual verification: open a project with a `plan_missing` alert + done plan task; confirm pill reads green `◆ plan ready` and the surface shows the bordered APPROVE block.

## Tests added

- `test_status_pill_celebrates_plan_ready_when_plan_task_summary_present`
- `test_status_pill_falls_back_to_red_alert_without_plan_task_summary`
- `test_status_pill_keeps_red_alert_for_non_plan_missing_families`
- `TestApproveButtonBlock::test_approve_block_contains_label_and_green_bold_markup`
- `TestApproveButtonBlock::test_approve_block_advertises_a_keybinding`
- `TestApproveButtonInSurface::test_surface_renders_approve_block_for_review_task`
- `TestApproveButtonInSurface::test_surface_renders_approve_block_for_done_backstop_task`
- `TestApproveButtonInSurface::test_surface_omits_approve_block_for_cancelled_task`
- `TestApproveButtonInSurface::test_surface_keeps_inline_action_bar_alongside_approve_block`

🤖 Generated with [Claude Code](https://claude.com/claude-code)