### PR TITLE
polish(banner): consistent PM naming + warmer no-plan and calm-state copy (#1540 #1541 #1542-pm-name)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ Added, Changed, and Removed.
   "N alerts" to "N needs action" so it no longer disagrees with `pm
   alerts`, which lists every open alert (including operational
   heartbeat noise the dashboard intentionally filters out). #999.
+- Project dashboard banner uses the configured PM persona (Archie,
+  Cole, ...) consistently. The "no plan yet" state reframes from the
+  red `◆ alert` framing to a soft `◇ next step` and reads
+  `Press c to plan this with <PM>`; the calm-project banner replaces
+  the syslog-style `architect_bikepath (architect) is alive but
+  standing by — no task in flight` with `<PM> is here when you need
+  them. Press c to chat or p to plan.`. The footer hides `p plan`
+  for projects with no plan on disk so the keystroke doesn't lead to
+  an empty surface. The topbar omits the `PM:` meta entirely when no
+  persona is configured (vs the old `PM: Project PM` placeholder).
+  #1540 #1541 #1542.
 
 ## [1.0.0] - 2026-04-20
 

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -11822,6 +11822,7 @@ class ProjectDashboardData:
         "project_name",
         "project_path",
         "persona_name",
+        "pm_persona",
         "pm_label",
         "exists_on_disk",
         "status_dot",
@@ -11856,6 +11857,7 @@ class ProjectDashboardData:
         project_path: Path | None,
         persona_name: str | None,
         pm_label: str,
+        pm_persona: str | None = None,
         exists_on_disk: bool,
         status_dot: str,
         status_color: str,
@@ -11884,6 +11886,7 @@ class ProjectDashboardData:
         self.project_name = project_name
         self.project_path = project_path
         self.persona_name = persona_name
+        self.pm_persona = pm_persona
         self.pm_label = pm_label
         self.exists_on_disk = exists_on_disk
         self.status_dot = status_dot
@@ -14103,6 +14106,12 @@ def _gather_project_dashboard(
         else (getattr(project, "name", None) or project_key)
     )
     persona = getattr(project, "persona_name", None)
+    # #1555 (MED-2) — banner copy must match the topbar PM, not the raw
+    # project persona. ``_project_pm_persona`` already encodes the
+    # architect-session override (architect routing wins over the
+    # project-level ``persona_name``); use the same effective PM name
+    # everywhere the banner names a teammate.
+    pm_persona = _project_pm_persona(config, project_key, project)
     pm_label = _project_pm_label(config, project_key, project)
 
     exists_on_disk = bool(
@@ -14202,6 +14211,7 @@ def _gather_project_dashboard(
         project_name=name,
         project_path=project_path if exists_on_disk else None,
         persona_name=persona if isinstance(persona, str) else None,
+        pm_persona=pm_persona,
         pm_label=pm_label,
         exists_on_disk=exists_on_disk,
         status_dot=status_dot,
@@ -15425,9 +15435,32 @@ class PollyProjectDashboardApp(App[None]):
         summary = self._render_project_state_banner(data, counts)
         self.action_bar.remove_class("-attention")
         self.action_bar.remove_class("-critical")
-        if data.alert_count or _project_hold_failure_summary(data):
+        # #1555 (MED-1) — the soft ``plan_missing``-no-summary state
+        # renders the calm "Press c to plan this with <PM>" lede and
+        # intentionally drops the ``· N alert`` count from the banner
+        # copy. Treating that exact state as ``-critical`` (red border,
+        # red background) contradicts the soft framing — the action
+        # pill yells while the banner sentence is a gentle invitation.
+        # Demote that one state to ``-attention`` so the styling matches
+        # the copy. (Other plan_missing-with-summary cases stay critical
+        # because they still surface a plan-ready action.)
+        alert_types = list(getattr(data, "alert_types", []) or [])
+        plan_summary = getattr(data, "plan_task_summary", None)
+        soft_plan_missing = (
+            alert_types == ["plan_missing"]
+            and not plan_summary
+            and not data.action_items
+        )
+        hold_failure = _project_hold_failure_summary(data)
+        if (data.alert_count and not soft_plan_missing) or hold_failure:
             self.action_bar.add_class("-critical")
-        elif data.action_items or review_count or data.inbox_count or on_hold_count:
+        elif (
+            data.action_items
+            or review_count
+            or data.inbox_count
+            or on_hold_count
+            or soft_plan_missing
+        ):
             self.action_bar.add_class("-attention")
         self.action_bar.update(f"[b]{_escape(summary)}[/b]")
         self._update_review_cta(data)
@@ -15542,11 +15575,21 @@ class PollyProjectDashboardApp(App[None]):
             # ("press a to review") when the family is unmapped — never
             # to a dead-end string that implies the system is going to
             # handle this on its own.
+            # #1555 (MED-2) — name the effective PM (architect persona
+            # when an architect session is routing this project), not
+            # the raw project ``persona_name``. The topbar uses the same
+            # effective lookup; the banner must match so a project with
+            # ``persona_name="Bea"`` running an architect session reads
+            # ``Press c to plan this with Archie`` (not ``Bea``).
+            pm_persona = (
+                getattr(data, "pm_persona", None)
+                or getattr(data, "persona_name", None)
+            )
             specific = _alert_banner_copy(
                 getattr(data, "alert_types", []) or [],
                 int(data.alert_count),
                 plan_task_summary=getattr(data, "plan_task_summary", None),
-                persona_name=getattr(data, "persona_name", None),
+                persona_name=pm_persona,
             )
             if specific:
                 # #1540 — drop the trailing ``· 1 alert`` for the
@@ -15640,21 +15683,37 @@ class PollyProjectDashboardApp(App[None]):
                     # of saying "nothing to do" with no next step.
                     # Reframe as a short, warm note that names the
                     # PM persona and ends with an actionable CTA.
+                    #
+                    # #1555 (MED-2) — name the effective PM (matches
+                    # topbar) instead of the raw project persona.
                     persona = (
-                        getattr(data, "persona_name", None) or ""
+                        getattr(data, "pm_persona", None)
+                        or getattr(data, "persona_name", None)
+                        or ""
                     ).strip()
+                    # #1555 (MED-3) — the footer hides the ``p plan``
+                    # keystroke when there is no plan_path AND no
+                    # plan_task_summary (because ``p`` would open an
+                    # empty plan surface). The banner CTA must agree:
+                    # advertising ``p to plan`` here points at the same
+                    # dead-end the footer just hid. Drop ``or p to
+                    # plan`` for that exact state; ``c`` (chat the PM
+                    # to plan it) is the live affordance.
+                    has_plan_route = bool(
+                        getattr(data, "plan_path", None)
+                        or getattr(data, "plan_task_summary", None)
+                    )
+                    cta = (
+                        "Press c to chat or p to plan."
+                        if has_plan_route
+                        else "Press c to chat."
+                    )
                     if persona:
-                        return (
-                            f"{persona} is here when you need them. "
-                            f"Press c to chat or p to plan."
-                        )
+                        return f"{persona} is here when you need them. {cta}"
                     # Fallback when no persona is configured: keep
                     # the calm-but-inviting tone without inventing a
                     # name (and without leaking the worker key).
-                    return (
-                        "All caught up. "
-                        "Press c to chat or p to plan."
-                    )
+                    return f"All caught up. {cta}"
                 # Fall through to queued/blocked/review banners below
                 # so the user-facing category leads.
             else:

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -7025,8 +7025,16 @@ def _project_pm_persona(config: object, project_key: str, project: object) -> st
 
 
 def _project_pm_label(config: object, project_key: str, project: object) -> str:
+    """Return the topbar PM label, e.g. ``"PM: Archie"``.
+
+    When the project has no persona configured we return ``""`` instead
+    of the placeholder ``"PM: Project PM"``; the caller is expected to
+    skip rendering an empty PM meta. #1542 — ``media`` rendered
+    ``PM: Project PM`` while every other project showed a real PM
+    name; the placeholder leaked into the UI.
+    """
     persona = _project_pm_persona(config, project_key, project)
-    return f"PM: {persona}" if persona else "PM: Project PM"
+    return f"PM: {persona}" if persona else ""
 
 
 def _resolve_pm_target(config_path: Path, project_key: str | None) -> tuple[str, str]:
@@ -11757,6 +11765,21 @@ def _dashboard_status(
         and "plan_missing" in alert_types
     ):
         return ("\u25c6", "#3ddc84", "plan ready")
+    # #1540 \u2014 a fresh project with no plan yet is the *default* early
+    # state, not a problem the user is failing at. Reframe the
+    # ``plan_missing`` (no-summary) alert as ``\u25c7 next step``
+    # instead of the red ``\u25c6 alert`` framing the cockpit uses
+    # for genuine problems. ``alert_types`` may carry other entries
+    # alongside ``plan_missing`` \u2014 only soften when ``plan_missing``
+    # is the *only* family in play (otherwise a real problem would
+    # be masked by next-step framing).
+    if (
+        alert_count
+        and alert_types
+        and list(alert_types) == ["plan_missing"]
+        and not plan_task_summary
+    ):
+        return ("\u25c7", "#97a6b2", "next step")
     if alert_count:
         return ("\u25c6", "#f85149", "alert")
     if active_worker is not None:
@@ -14279,6 +14302,7 @@ def _alert_banner_copy(
     alert_count: int,
     *,
     plan_task_summary: dict | None = None,
+    persona_name: str | None = None,
 ) -> str | None:
     """Return banner copy describing the alerts waiting on the user.
 
@@ -14351,9 +14375,14 @@ def _alert_banner_copy(
                 f"Plan's ready — {title}. Press → to review together"
                 f"{other_part}"
             )
+        # #1540 — name the PM (Archie/Cole/...) when one is configured
+        # so the banner reads as an invitation to a teammate, not a
+        # mechanical "ask the PM" nag. The fallback keeps the previous
+        # anonymous wording when no persona is set so the affordance
+        # ("press c") still routes correctly.
+        pm_label = (persona_name or "").strip() or "the PM"
         return (
-            f"This project has no plan yet — press c to ask the PM to "
-            f"plan it{other_part}"
+            f"Press c to plan this with {pm_label}{other_part}"
         )
     if family == "no_session_for_assignment":
         return (
@@ -14705,6 +14734,14 @@ class PollyProjectDashboardApp(App[None]):
 
     _DEFAULT_HINT = (
         "c chat \u00b7 p plan \u00b7 i inbox \u00b7 l log \u00b7 q home"
+    )
+    # #1540 \u2014 when the project has no plan yet, ``p plan`` opens an
+    # empty plan-review surface. Hide the keystroke from the footer
+    # so the user isn't told to press ``p`` and walked into a dead-
+    # end. The banner CTA still routes them via ``c`` to chat with
+    # the PM, which is the actual plan-creation flow.
+    _NO_PLAN_HINT = (
+        "c chat \u00b7 i inbox \u00b7 l log \u00b7 q home"
     )
     _ACTION_HINT = (
         "1 primary \u00b7 2 secondary \u00b7 3 reply \u00b7 c chat "
@@ -15225,9 +15262,16 @@ class PollyProjectDashboardApp(App[None]):
             return
 
         # ── Top bar ──
+        # #1542 — when no persona is configured, ``data.pm_label`` is
+        # the empty string (rather than the old ``"PM: Project PM"``
+        # placeholder). Drop the meta in that case so the topbar reads
+        # cleanly as just the project name.
         title = f"[#eef6ff][b]{_escape(data.project_name)}[/b][/#eef6ff]"
-        meta = f"[#97a6b2]{_escape(data.pm_label)}[/#97a6b2]"
-        self.topbar.update(f"{title}   {meta}")
+        if data.pm_label:
+            meta = f"[#97a6b2]{_escape(data.pm_label)}[/#97a6b2]"
+            self.topbar.update(f"{title}   {meta}")
+        else:
+            self.topbar.update(title)
 
         status_markup = (
             f"[{data.status_color}]{data.status_dot}[/] "
@@ -15337,6 +15381,15 @@ class PollyProjectDashboardApp(App[None]):
                 if visible_action_count > 1
                 else self._ACTION_HINT
             )
+        elif (
+            not getattr(data, "plan_path", None)
+            and not getattr(data, "plan_task_summary", None)
+        ):
+            # #1540 — no plan file on disk and no plan-shaped done
+            # task → ``p plan`` would open an empty plan surface.
+            # Hide the keystroke so the footer doesn't advertise a
+            # dead-end. Banner CTA already points users to ``c``.
+            hint = self._NO_PLAN_HINT
         else:
             hint = self._DEFAULT_HINT
         self.hint.update(hint)
@@ -15493,8 +15546,22 @@ class PollyProjectDashboardApp(App[None]):
                 getattr(data, "alert_types", []) or [],
                 int(data.alert_count),
                 plan_task_summary=getattr(data, "plan_task_summary", None),
+                persona_name=getattr(data, "persona_name", None),
             )
             if specific:
+                # #1540 — drop the trailing ``· 1 alert`` for the
+                # plan_missing-no-summary "next step" state. The
+                # "no plan yet" framing is the default early state,
+                # not an alert the user should be chastised for. The
+                # action-bar pill still surfaces the count for users
+                # who want it; the banner stays clean.
+                alert_types = list(getattr(data, "alert_types", []) or [])
+                plan_summary = getattr(data, "plan_task_summary", None)
+                if (
+                    alert_types == ["plan_missing"]
+                    and not plan_summary
+                ):
+                    return specific
                 return f"{specific}{count_suffix}"
         # On-hold tasks must outrank an active background worker. Today
         # media renders ``Moving now: worker_media is active · 1 on
@@ -15567,9 +15634,26 @@ class PollyProjectDashboardApp(App[None]):
                 blocked = int(data.task_counts.get("blocked", 0))
                 review = int(data.task_counts.get("review", 0))
                 if not (queued or blocked or review):
+                    # #1541 — the calm-project banner used to leak
+                    # worker internals (``architect_bikepath
+                    # (architect)``) and stack four redundant ways
+                    # of saying "nothing to do" with no next step.
+                    # Reframe as a short, warm note that names the
+                    # PM persona and ends with an actionable CTA.
+                    persona = (
+                        getattr(data, "persona_name", None) or ""
+                    ).strip()
+                    if persona:
+                        return (
+                            f"{persona} is here when you need them. "
+                            f"Press c to chat or p to plan."
+                        )
+                    # Fallback when no persona is configured: keep
+                    # the calm-but-inviting tone without inventing a
+                    # name (and without leaking the worker key).
                     return (
-                        f"{session} ({role}) is alive but standing by "
-                        f"— no task in flight{count_suffix}"
+                        "All caught up. "
+                        "Press c to chat or p to plan."
                     )
                 # Fall through to queued/blocked/review banners below
                 # so the user-facing category leads.

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -1259,6 +1259,251 @@ def test_banner_celebrates_with_only_task_id_when_title_missing() -> None:
     assert "coffeeboardnm/1" in banner
 
 
+def test_action_bar_soft_plan_missing_state_is_not_critical(
+    dashboard_env, dashboard_app,
+) -> None:
+    """#1555 (MED-1) — the soft ``plan_missing``-no-summary state
+    renders the calm "Press c to plan this with <PM>" lede and drops
+    the trailing ``· N alert`` count from the banner copy. Treating
+    that exact state as ``-critical`` (red border, red background)
+    contradicts the soft framing and mismatches the status pill (which
+    #1540 already routes to ``next step`` for the same state). The
+    action bar must demote to ``-attention`` so the styling matches
+    the copy.
+    """
+    from types import SimpleNamespace
+
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+
+    class _FakeBar:
+        def __init__(self) -> None:
+            self._classes: set[str] = set()
+
+        def remove_class(self, name: str) -> None:
+            self._classes.discard(name)
+
+        def add_class(self, name: str) -> None:
+            self._classes.add(name)
+
+        def update(self, _text: str) -> None:
+            pass
+
+        def has_class(self, name: str) -> bool:
+            return name in self._classes
+
+    app.action_bar = _FakeBar()
+    # Stub out the review CTA path so _update_action_bar's call into
+    # _update_review_cta doesn't need a real widget tree.
+    app._update_review_cta = lambda _data: None
+
+    fake_data = SimpleNamespace(
+        action_items=[],
+        alert_count=1,
+        alert_types=["plan_missing"],
+        active_worker=None,
+        task_counts={},
+        task_buckets={"on_hold": [], "review": []},
+        inbox_count=0,
+        plan_task_summary=None,
+        persona_name="Archie",
+        pm_persona="Archie",
+    )
+    app._update_action_bar(fake_data)
+    assert not app.action_bar.has_class("-critical"), (
+        "soft plan_missing-no-summary state must not get -critical "
+        "styling — banner copy is calm, pill is yellow"
+    )
+    # Demote to -attention so the bar still reads as something to do
+    # (without yelling).
+    assert app.action_bar.has_class("-attention")
+
+
+def test_action_bar_other_alerts_still_critical() -> None:
+    """#1555 (MED-1) — the demotion above is *only* for the soft
+    plan_missing-no-summary state. Every other alert family
+    (recovery_limit, auth_broken, worker_question, ...) still goes
+    critical so the user sees red on real failure modes.
+    """
+    from types import SimpleNamespace
+
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+
+    class _FakeBar:
+        def __init__(self) -> None:
+            self._classes: set[str] = set()
+
+        def remove_class(self, name: str) -> None:
+            self._classes.discard(name)
+
+        def add_class(self, name: str) -> None:
+            self._classes.add(name)
+
+        def update(self, _text: str) -> None:
+            pass
+
+        def has_class(self, name: str) -> bool:
+            return name in self._classes
+
+    app.action_bar = _FakeBar()
+    app._update_review_cta = lambda _data: None
+
+    fake_data = SimpleNamespace(
+        action_items=[],
+        alert_count=1,
+        alert_types=["recovery_limit"],
+        active_worker=None,
+        task_counts={},
+        task_buckets={"on_hold": [], "review": []},
+        inbox_count=0,
+        plan_task_summary=None,
+        persona_name=None,
+        pm_persona=None,
+    )
+    app._update_action_bar(fake_data)
+    assert app.action_bar.has_class("-critical")
+
+
+def test_banner_no_plan_uses_pm_persona_for_architect_session() -> None:
+    """#1555 (MED-2) — the no-plan banner names the *effective* PM
+    (the one the topbar shows), not the raw project ``persona_name``.
+
+    Repro: a project configured with ``persona_name="Bea"`` is being
+    routed by an architect session (the architect persona overrides
+    the project-level PM in ``_project_pm_persona``). The topbar reads
+    ``PM: Archie``; before this fix the banner read
+    ``Press c to plan this with Bea`` — two different teammate names
+    on one screen for the same project.
+
+    The fix populates ``ProjectDashboardData.pm_persona`` from
+    ``_project_pm_persona`` (the same helper the topbar uses) and the
+    banner reads from there.
+    """
+    from types import SimpleNamespace
+
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+    fake_data = SimpleNamespace(
+        action_items=[],
+        alert_count=1,
+        alert_types=["plan_missing"],
+        active_worker=None,
+        task_counts={},
+        task_buckets={"on_hold": [], "review": []},
+        inbox_count=0,
+        plan_task_summary=None,
+        # Raw project persona (what the topbar would have shown if no
+        # architect session was routing) — must NOT appear in the
+        # banner because the architect routing wins.
+        persona_name="Bea",
+        # Effective PM, matches what _project_pm_label puts in the
+        # topbar.
+        pm_persona="Archie",
+    )
+    banner = app._render_project_state_banner(fake_data, "▸ 1 alert")
+    assert "Archie" in banner, (
+        f"banner must use effective PM persona: {banner!r}"
+    )
+    assert "Bea" not in banner, (
+        f"banner leaked raw project persona instead of effective PM: "
+        f"{banner!r}"
+    )
+
+
+def test_calm_banner_drops_p_to_plan_when_no_plan_route() -> None:
+    """#1555 (MED-3) — the calm-idle banner must not advertise the
+    ``p to plan`` shortcut when there is no plan_path on disk AND no
+    plan_task_summary. The footer hint already hides ``p plan`` for
+    that exact state (because pressing ``p`` opens an empty plan
+    surface — a dead-end); the banner has to agree.
+    """
+    from types import SimpleNamespace
+
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+    fake_data = SimpleNamespace(
+        action_items=[],
+        alert_count=0,
+        active_worker={
+            "session_name": "architect_bikepath",
+            "role": "architect",
+            "activity": "idle",
+        },
+        task_counts={},
+        task_buckets={"on_hold": []},
+        inbox_count=0,
+        persona_name=None,
+        pm_persona=None,
+        plan_path=None,
+        plan_task_summary=None,
+    )
+    banner = app._render_project_state_banner(fake_data, "▸ Clear")
+    # Still a CTA (banner shouldn't read as a dead-end).
+    assert "Press c to chat" in banner
+    # But ``p to plan`` would point at an empty plan surface — drop it.
+    assert "p to plan" not in banner, (
+        f"calm banner advertised dead-end p shortcut: {banner!r}"
+    )
+
+
+def test_calm_banner_keeps_p_to_plan_when_plan_path_exists() -> None:
+    """#1555 (MED-3) — the inverse: when there IS a plan file on disk
+    (or a plan_task_summary), pressing ``p`` lands on a real plan
+    surface, so the calm banner keeps the ``p to plan`` advertisement.
+    """
+    from types import SimpleNamespace
+
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+    fake_data_with_plan_file = SimpleNamespace(
+        action_items=[],
+        alert_count=0,
+        active_worker={
+            "session_name": "architect_bikepath",
+            "role": "architect",
+            "activity": "idle",
+        },
+        task_counts={},
+        task_buckets={"on_hold": []},
+        inbox_count=0,
+        persona_name=None,
+        pm_persona=None,
+        plan_path=Path("/tmp/plan.md"),
+        plan_task_summary=None,
+    )
+    banner_a = app._render_project_state_banner(
+        fake_data_with_plan_file, "▸ Clear",
+    )
+    assert "p to plan" in banner_a
+
+    fake_data_with_plan_summary = SimpleNamespace(
+        action_items=[],
+        alert_count=0,
+        active_worker={
+            "session_name": "architect_bikepath",
+            "role": "architect",
+            "activity": "idle",
+        },
+        task_counts={},
+        task_buckets={"on_hold": []},
+        inbox_count=0,
+        persona_name=None,
+        pm_persona=None,
+        plan_path=None,
+        plan_task_summary={"task_id": "demo/1", "title": "POC plan"},
+    )
+    banner_b = app._render_project_state_banner(
+        fake_data_with_plan_summary, "▸ Clear",
+    )
+    assert "p to plan" in banner_b
+
+
 def test_status_yellow_when_task_is_on_hold(
     dashboard_env, dashboard_app,
 ) -> None:
@@ -3538,6 +3783,12 @@ def test_banner_does_not_claim_in_action_for_idle_worker() -> None:
         task_buckets={"on_hold": []},
         inbox_count=0,
         persona_name=None,
+        # #1555 (MED-3) — populate plan_path so the calm CTA still
+        # advertises ``p to plan``. Without a plan route the CTA
+        # correctly drops ``p to plan`` (footer hides the keystroke
+        # too); a separate test covers that no-plan variant.
+        plan_path=Path("/tmp/plan.md"),
+        plan_task_summary=None,
     )
     banner = app._render_project_state_banner(fake_data, "▸ Clear")
     assert "Moving now" not in banner

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -774,13 +774,22 @@ def _run(coro) -> None:
 
 
 def test_topbar_renders_name_and_default_pm(dashboard_env, dashboard_app) -> None:
-    """With no persona configured the top bar uses a neutral PM label."""
+    """With no persona configured the top bar omits the PM meta entirely.
+
+    #1542 — ``media`` rendered ``PM: Project PM`` while every other
+    project showed a real PM name; the placeholder leaked into the UI.
+    Hiding the meta when no persona is set is the smaller change vs
+    auto-naming.
+    """
     async def body() -> None:
         async with dashboard_app.run_test(size=(140, 50)) as pilot:
             await pilot.pause()
             topbar_text = str(dashboard_app.topbar.render())
             assert "Demo" in topbar_text
-            assert "PM: Project PM" in topbar_text
+            # No persona → no ``PM:`` prefix at all (vs the old
+            # ``PM: Project PM`` placeholder).
+            assert "PM:" not in topbar_text
+            assert "Project PM" not in topbar_text
     _run(body())
 
 
@@ -1162,11 +1171,11 @@ def test_banner_celebrates_when_plan_task_summary_present() -> None:
 
 
 def test_banner_falls_through_when_plan_task_summary_absent() -> None:
-    """#1531 — without a ``plan_task_summary``, the ``plan_missing``
-    alert keeps the original "ask the PM to plan" framing — but does
-    NOT lie about a plan being absent / present, and the new copy
-    drops the redundant "Waiting on you:" prefix while keeping the
-    affordance ("press c").
+    """#1531/#1540 — without a ``plan_task_summary``, the
+    ``plan_missing`` alert frames the state as a *next step* (not an
+    "alert" the user is failing at). Banner does NOT claim a plan
+    exists, keeps the ``c`` affordance, and drops the trailing
+    ``· N alert`` count for this one specific state.
     """
     from types import SimpleNamespace
 
@@ -1182,15 +1191,45 @@ def test_banner_falls_through_when_plan_task_summary_absent() -> None:
         task_buckets={"on_hold": [], "review": []},
         inbox_count=0,
         plan_task_summary=None,
+        persona_name=None,
     )
     banner = app._render_project_state_banner(fake_data, "▸ 1 alert")
     # Must NOT claim the plan is ready when it isn't.
     assert "Plan's ready" not in banner
     # Affordance: still routes to ``c`` (chat the PM to plan).
-    assert "press c" in banner
+    assert "Press c" in banner or "press c" in banner
     # Avoid the misleading "press a to review" ambiguous instruction
     # that was the trap.
     assert "press a to review" not in banner
+    # #1540 — no trailing count_suffix on this state; the "no plan"
+    # state is the default early state, not a "1 alert".
+    assert "1 alert" not in banner
+
+
+def test_banner_no_plan_uses_persona_name_when_set() -> None:
+    """#1540 — when a persona is configured (Archie/Cole/...) the
+    no-plan banner names the PM instead of saying "the PM".
+    """
+    from types import SimpleNamespace
+
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+    fake_data = SimpleNamespace(
+        action_items=[],
+        alert_count=1,
+        alert_types=["plan_missing"],
+        active_worker=None,
+        task_counts={},
+        task_buckets={"on_hold": [], "review": []},
+        inbox_count=0,
+        plan_task_summary=None,
+        persona_name="Archie",
+    )
+    banner = app._render_project_state_banner(fake_data, "▸ 1 alert")
+    assert "Archie" in banner
+    # Anonymous fallback must NOT leak when a persona is set.
+    assert "the PM" not in banner
 
 
 def test_banner_celebrates_with_only_task_id_when_title_missing() -> None:
@@ -3418,11 +3457,18 @@ def test_status_pill_celebrates_plan_ready_when_plan_task_summary_present() -> N
     assert dot == "◆"
 
 
-def test_status_pill_falls_back_to_red_alert_without_plan_task_summary() -> None:
-    """#1536 — ``plan_missing`` family WITHOUT a ``plan_task_summary``
-    keeps the existing red ``alert`` palette. The summary signal is what
-    distinguishes a plan-ready celebration from an actual missing-plan
-    debt."""
+def test_status_pill_reads_next_step_for_plan_missing_without_summary() -> None:
+    """#1540 — ``plan_missing`` family WITHOUT a ``plan_task_summary``
+    is the *default early state* for a freshly-registered project, not
+    a problem the user is failing at. Reframe the pill as a soft
+    ``◇ next step`` instead of the red ``◆ alert`` framing the
+    cockpit uses for genuine problems.
+
+    Supersedes #1536's red-alert framing for this specific case;
+    real alert families (recovery_limit, auth_broken, ...) still hit
+    the red ``alert`` path — see
+    ``test_status_pill_keeps_red_alert_for_non_plan_missing_families``.
+    """
     from pollypm.cockpit_ui import _dashboard_status
 
     dot, color, label = _dashboard_status(
@@ -3433,9 +3479,11 @@ def test_status_pill_falls_back_to_red_alert_without_plan_task_summary() -> None
         plan_task_summary=None,
         alert_types=["plan_missing"],
     )
-    assert label == "alert"
-    assert color == "#f85149"  # the existing red alert palette
-    assert dot == "◆"
+    assert label == "next step"
+    # Soft grey/blue rather than the red alert palette.
+    assert color != "#f85149"
+    # Open diamond to signal the soft state.
+    assert dot == "◇"
 
 
 def test_status_pill_keeps_red_alert_for_non_plan_missing_families() -> None:
@@ -3467,6 +3515,11 @@ def test_banner_does_not_claim_in_action_for_idle_worker() -> None:
     "standing by." The fix routes ``idle`` to a standby banner and
     falls through to category banners (queued/blocked/review) when
     other work is waiting.
+
+    #1541 — the banner copy was reframed as a calm-but-inviting
+    note (no worker internals, ends with a CTA). Test now asserts
+    the negative shape ("Moving now"/"is active" must not appear)
+    plus the new positive shape (CTA points at ``c``/``p``).
     """
     from types import SimpleNamespace
 
@@ -3484,11 +3537,18 @@ def test_banner_does_not_claim_in_action_for_idle_worker() -> None:
         task_counts={},
         task_buckets={"on_hold": []},
         inbox_count=0,
+        persona_name=None,
     )
     banner = app._render_project_state_banner(fake_data, "▸ Clear")
     assert "Moving now" not in banner
     assert "is active" not in banner
-    assert "standing by" in banner
+    # #1541 — the worker key + role tag must not leak into copy.
+    assert "architect_bikepath" not in banner
+    assert "(architect)" not in banner
+    # #1541 — the banner ends with an actionable CTA so a calm
+    # project doesn't read as a dead-end.
+    assert "Press c to chat" in banner
+    assert "p to plan" in banner
 
 
 def test_banner_says_waiting_on_you_for_permission_prompt() -> None:


### PR DESCRIPTION
## Summary

Three banner-shape polish issues stack on the cockpit project dashboard:

- **savethenovel (#1540)** renders the no-plan-yet state as a red ``◆ alert`` trailing ``· 1 alert``, framing a default early state as a problem the user is failing at. Banner says "ask the PM to plan it" while the header says ``PM: Archie`` — the helper is anonymous in the very moment we should be inviting them onto a plan.
- **bikepath (#1541)** calm-project banner reads ``architect_bikepath (architect) is alive but standing by — no task in flight · Clear · no approvals, alerts, or user actions``: worker key + role tag leak past the named PM, four ways of saying "nothing to do" stack with no CTA.
- **media (#1542)** topbar shows ``PM: Project PM`` while every other project surfaces a real PM name — placeholder leaked into the UI.

This PR is **just the banner-copy / topbar / footer slice**. Other parts of #1542 (rail glyph, wrap indent, truncated decision) are owned by parallel subagents and are untouched.

Refs #1540 #1541 #1542. Sam triages — not auto-closing.

## Before / after

### #1540 — savethenovel "no plan yet"

| Where | Before | After |
|---|---|---|
| Section header | ``◆ alert`` (red, ``#f85149``) | ``◇ next step`` (soft grey, ``#97a6b2``) |
| Banner body (no persona) | ``This project has no plan yet — press c to ask the PM to plan it`` | ``Press c to plan this with the PM`` |
| Banner body (persona = Archie) | ``This project has no plan yet — press c to ask the PM to plan it`` | ``Press c to plan this with Archie`` |
| Trailing meta | `` · 1 alert`` | (dropped — the no-plan-yet state isn't an "alert") |
| Footer | ``c chat · p plan · i inbox · l log · q home`` | ``c chat · i inbox · l log · q home`` (``p plan`` hidden — would lead to an empty plan surface) |

Real alert families (``recovery_limit``, ``auth_broken``, ``worker_question``, …) still hit the existing red ``◆ alert`` palette. Only ``plan_missing`` *without* a ``plan_task_summary`` is reframed as next-step.

### #1541 — bikepath calm project

| Where | Before | After |
|---|---|---|
| Banner (persona = Archie) | ``architect_bikepath (architect) is alive but standing by — no task in flight · Clear · no approvals, alerts, or user actions`` | ``Archie is here when you need them. Press c to chat or p to plan.`` |
| Banner (no persona) | ``architect_bikepath (architect) is alive but standing by — no task in flight · Clear · no approvals, alerts, or user actions`` | ``All caught up. Press c to chat or p to plan.`` |

### #1542-pm-name — media topbar

| Where | Before | After |
|---|---|---|
| Topbar (no persona) | ``media   PM: Project PM`` | ``media`` (PM meta hidden when no persona is configured) |
| Topbar (persona = Cole) | ``coffeeboardnm   PM: Cole`` (unchanged) | ``coffeeboardnm   PM: Cole`` |

## Spec call to sanity-check before merging

The constraint asked for the smaller-change between auto-naming the missing-persona case vs hiding the ``PM:`` prefix entirely. **I picked hiding** — it's a one-line change in ``_project_pm_label`` + a topbar branch, with no need to plumb a name generator through project creation. Auto-naming is still on the table if Sam prefers a non-empty ``PM:`` slot; flag and I'll switch. The ``_resolve_pm_target`` fallback (used by inbox detail headers, PM-jump notifications, etc.) is **untouched** — it still returns ``"Project PM"`` so those out-of-scope surfaces aren't disturbed.

## Test-update strategy

Format-string tests that asserted exact banner literals were updated to match the new copy. No assertions were weakened beyond what the new copy semantically supports:

- ``test_topbar_renders_name_and_default_pm`` — was ``assert "PM: Project PM" in topbar_text``; now asserts ``"PM:" not in topbar_text`` and ``"Project PM" not in topbar_text``. Test docstring updated to explain the #1542 reframe.
- ``test_banner_falls_through_when_plan_task_summary_absent`` — was ``assert "press c" in banner``; now ``assert "Press c" in banner or "press c" in banner`` (capitalisation changed) plus a new ``assert "1 alert" not in banner`` to lock the dropped-trailing-count behaviour from #1540.
- New ``test_banner_no_plan_uses_persona_name_when_set`` — covers the persona-substitution path.
- ``test_banner_does_not_claim_in_action_for_idle_worker`` — was ``assert "standing by" in banner``; now asserts ``"architect_bikepath" not in banner``, ``"(architect)" not in banner``, ``"Press c to chat" in banner``, and ``"p to plan" in banner`` to cover the #1541 reframe.
- ``test_status_pill_falls_back_to_red_alert_without_plan_task_summary`` → renamed ``test_status_pill_reads_next_step_for_plan_missing_without_summary`` with the new ``◇ / next step / soft palette`` expectation.

The companion ``test_status_pill_keeps_red_alert_for_non_plan_missing_families`` is unchanged — confirms real alert families still hit the red palette.

## Test plan

- [x] Targeted tests covering changed copy: ``test_topbar_renders_name_and_default_pm``, ``test_topbar_uses_configured_persona``, ``test_banner_falls_through_when_plan_task_summary_absent``, ``test_banner_no_plan_uses_persona_name_when_set``, ``test_banner_does_not_claim_in_action_for_idle_worker``, ``test_status_pill_reads_next_step_for_plan_missing_without_summary``, ``test_status_pill_keeps_red_alert_for_non_plan_missing_families``, ``test_status_pill_uses_activity_classification`` — all pass.
- [x] Cockpit-adjacent modules: ``test_cockpit.py``, ``test_cockpit_inbox_ui.py``, ``test_cockpit_rail_alert_metadata.py``, ``test_core_rail_items.py``, ``test_activity_feed_panel.py`` — 332 passed.
- [x] Full ``tests/test_project_dashboard_ui.py`` runs — *new* failures match flakes already present on main (``data is None`` async-pause races on integration tests). The set of failing tests differs run-to-run; no test I edited is in the flake set; main without my changes shows 5–10 flake failures from the same pool.
- [ ] Full repo suite running on this branch (started; ``-q`` mode buffers output until end). Sam can re-run before merge if needed.
- [ ] Sam to verify on live ``savethenovel`` / ``bikepath`` / ``media`` projects.

## Hard rules

- No ``--no-verify``, no ``--amend``, no force-push.
- Did not touch: rail-glyph computation, rail-truncation, dashboard "Current activity" panel population, plan-ready alert clearing, dashboard-rejects-non-tracked-project logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)