### PR TITLE
feat(heartbeat): self-recovery loop — liveness check + auto-respawn + launchd KeepAlive (#1546-followup)

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -70,6 +70,16 @@ EVENT_SOCKET_REAPED = "socket.reaped"
 # can quantify how often the field machine is accumulating sibling
 # daemons without scraping ``rail_daemon.log``.
 EVENT_DAEMON_REAPED = "daemon.reaped"
+# #1546-followup — emitted by ``rail_daemon_supervisor`` when the
+# layer-2 watchdog (cockpit periodic timer or ``pm heartbeat`` cron
+# path) detects a dead/stuck rail daemon and respawns it. Carries
+# ``role`` (``"rail"``), ``state`` (the diagnose decision label),
+# ``previous_pid``, ``last_tick_age_s``, ``revived``, ``spawn_error``,
+# and ``kill_signal``. Lets operators quantify how often the layer-2
+# supervisor catches a dead daemon — chronic revivals indicate a real
+# problem (OOM, leak, crash-loop) that needs investigation, not just
+# trust in the supervisor.
+EVENT_DAEMON_REVIVED = "daemon.revived"
 # #1398 — plan task evolution. ``plan.version_incremented`` fires when
 # a plan task is refined in place (same task_id, version bump);
 # ``plan.successor_created`` fires when a replan creates a new task
@@ -486,6 +496,8 @@ __all__ = [
     "EVENT_WATCHDOG_TIER3_DISPATCH_FAILED",
     "EVENT_WATCHDOG_WORKER_LANE_SPAWNED",
     "EVENT_WATCHDOG_PROJECT_TRACKED_MODE_REPAIRED",
+    "EVENT_DAEMON_REAPED",
+    "EVENT_DAEMON_REVIVED",
     "AuditEvent",
     "central_log_path",
     "emit",

--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -1088,6 +1088,44 @@ def _spawn_rail_daemon(config_path: Path) -> None:
         )
 
 
+#: Module-level state for the cron-path rail-daemon liveness check.
+#: Persists across the (short-lived) ``pm heartbeat`` invocation only —
+#: cron spawns a fresh process every minute, so this never accumulates
+#: a stale value. Cockpit's analogous state lives on the App instance.
+_LAST_CRON_RAIL_REVIVAL_AT = None
+
+
+def _revive_rail_daemon_if_dead(config_path: Path) -> None:
+    """Spawn a fresh rail daemon when the existing one is dead/stuck.
+
+    Called from the ``pm heartbeat`` cron path as defense-in-depth.
+    The cockpit's periodic timer is the primary supervisor; this is
+    the second layer that fires even when the cockpit is itself dead.
+
+    Best-effort. Swallows all exceptions so a crashed liveness check
+    never breaks the heartbeat sweep that follows.
+    """
+    global _LAST_CRON_RAIL_REVIVAL_AT
+    try:
+        from pollypm.rail_daemon_supervisor import revive_if_needed
+        from pollypm.config import load_config
+
+        cfg = load_config(config_path)
+        pid_path = _rail_daemon_pid_path()
+        result = revive_if_needed(
+            config_path=config_path,
+            state_db_path=cfg.project.state_db,
+            pid_path=pid_path,
+            last_revival_at=_LAST_CRON_RAIL_REVIVAL_AT,
+        )
+    except Exception:  # noqa: BLE001
+        return
+    if result.revived:
+        from datetime import UTC, datetime as _dt
+
+        _LAST_CRON_RAIL_REVIVAL_AT = _dt.now(UTC)
+
+
 def _spawn_phantom_client(session_name: str) -> bool:
     """Spawn a detached pty-backed ``tmux attach`` client to keep the
     cockpit's input loop alive when no real terminal is attached (#1109).

--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -1117,6 +1117,12 @@ def _revive_rail_daemon_if_dead(config_path: Path) -> None:
             state_db_path=cfg.project.state_db,
             pid_path=pid_path,
             last_revival_at=_LAST_CRON_RAIL_REVIVAL_AT,
+            # #1556 review: cron must NOT spawn a daemon on missing_pid
+            # — the cockpit may be hosting the rail in-process. Cron
+            # still acts on dead_process / stuck_no_tick (those imply
+            # a daemon WAS recorded and lost, which doesn't happen in
+            # cockpit-hosted mode).
+            cron=True,
         )
     except Exception:  # noqa: BLE001
         return

--- a/src/pollypm/cli_features/alerts.py
+++ b/src/pollypm/cli_features/alerts.py
@@ -103,6 +103,15 @@ def heartbeat(
     from pollypm import cli as cli_mod
 
     supervisor = cli_mod._load_supervisor(config_path)
+    # #1546-followup — defense-in-depth rail-daemon liveness check.
+    # The cockpit's periodic timer is the primary watcher when it's
+    # open; this cron-driven path covers the case where the cockpit
+    # itself is dead so nothing else would notice a stale daemon.
+    # Best-effort: never blocks the heartbeat sweep.
+    try:
+        cli_mod._revive_rail_daemon_if_dead(config_path)
+    except Exception:  # noqa: BLE001
+        pass
     alerts = supervisor.run_heartbeat(snapshot_lines=snapshot_lines)
     tick_result = cli_mod._tick_core_rail_if_available(supervisor)
     cli_mod._drain_and_stop_core_rail_if_available(
@@ -276,6 +285,116 @@ def heartbeat_uninstall() -> None:
     new_crontab = "\n".join(lines) + "\n" if lines else ""
     subprocess.run(["crontab", "-"], input=new_crontab, text=True, check=True)
     typer.echo("Removed heartbeat cron job.")
+
+
+@heartbeat_app.command(
+    "install-launchd",
+    help=(
+        "Install a macOS LaunchAgent that auto-restarts pollypm.rail_daemon. "
+        "Layer-3 supervision: launchd watches the rail daemon process, "
+        "respawns it if it dies, and starts it on machine boot."
+    ),
+)
+def heartbeat_install_launchd(
+    config_path: Path = typer.Option(
+        DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."
+    ),
+    label: str = typer.Option(
+        "com.pollypm.rail-daemon", "--label",
+        help="LaunchAgent label (defaults to com.pollypm.rail-daemon).",
+    ),
+    load: bool = typer.Option(
+        True, "--load/--no-load",
+        help="Run launchctl bootstrap immediately after installing (default: yes).",
+    ),
+) -> None:
+    """Install ``~/Library/LaunchAgents/<label>.plist`` for the rail daemon."""
+    from pollypm.rail_daemon_launchd import install_launchd_keepalive
+
+    try:
+        plist_path = install_launchd_keepalive(
+            config_path=config_path, label=label, load=load,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise typer.BadParameter(f"Failed to install LaunchAgent: {exc}") from exc
+
+    typer.echo(f"Installed {plist_path}")
+    if load:
+        typer.echo(
+            f"Loaded {label} via launchctl. The rail daemon will be "
+            "auto-restarted if it crashes and on every login."
+        )
+    else:
+        typer.echo(
+            f"To activate: launchctl bootstrap gui/$(id -u) {plist_path}"
+        )
+
+
+@heartbeat_app.command(
+    "uninstall-launchd",
+    help=(
+        "Remove the macOS LaunchAgent that supervises pollypm.rail_daemon. "
+        "Stops the daemon (if launchd-managed) and unlinks the plist."
+    ),
+)
+def heartbeat_uninstall_launchd(
+    label: str = typer.Option(
+        "com.pollypm.rail-daemon", "--label",
+        help="LaunchAgent label to remove (defaults to com.pollypm.rail-daemon).",
+    ),
+) -> None:
+    """Remove the rail-daemon LaunchAgent and unload it."""
+    from pollypm.rail_daemon_launchd import uninstall_launchd_keepalive
+
+    removed = uninstall_launchd_keepalive(label=label)
+    if removed:
+        typer.echo(f"Removed LaunchAgent {label}.")
+    else:
+        typer.echo(f"No LaunchAgent named {label} was installed.")
+
+
+@heartbeat_app.command(
+    "status",
+    help=(
+        "Diagnose the rail daemon's liveness without taking any action. "
+        "Mirrors the periodic check that the cockpit / cron path "
+        "performs, so operators can see what the supervisor sees."
+    ),
+)
+def heartbeat_status(
+    config_path: Path = typer.Option(
+        DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit structured JSON."),
+) -> None:
+    """Print the rail daemon's diagnosis (alive / missing / dead / stuck)."""
+    from pollypm import cli as cli_mod
+    from pollypm.config import load_config
+    from pollypm.rail_daemon_supervisor import (
+        diagnose_rail_daemon, query_last_heartbeat_iso,
+    )
+
+    cfg = load_config(config_path)
+    pid_path = cli_mod._rail_daemon_pid_path()
+    last_tick_iso = query_last_heartbeat_iso(cfg.project.state_db)
+    decision = diagnose_rail_daemon(
+        pid_path=pid_path, last_tick_iso=last_tick_iso,
+    )
+    if json_output:
+        cli_mod._emit_json({
+            "state": decision.state,
+            "pid": decision.pid,
+            "last_tick_age_seconds": decision.last_tick_age_seconds,
+            "reason": decision.reason,
+            "needs_revival": decision.needs_revival,
+        })
+        return
+    label = "alive" if decision.state == "alive" else "DEGRADED"
+    typer.echo(f"rail_daemon: {label} ({decision.state})")
+    typer.echo(f"  pid: {decision.pid}")
+    if decision.last_tick_age_seconds is not None:
+        typer.echo(f"  last tick: {decision.last_tick_age_seconds:.0f}s ago")
+    typer.echo(f"  {decision.reason}")
 
 
 @heartbeat_app.command(

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -29,7 +29,7 @@ from collections import OrderedDict
 from pathlib import Path
 import subprocess
 import time
-from typing import Callable, TYPE_CHECKING
+from typing import Any, Callable, TYPE_CHECKING
 
 # Raise FD limit early — the cockpit opens many subprocesses and file handles.
 try:
@@ -1322,6 +1322,32 @@ class PollyCockpitApp(App[None]):
         )
         self._route_status_hint: str | None = None
         self._transient_notice_active = False
+        # #1546-followup — rail_daemon self-recovery state. Tracks the
+        # most recent revival attempt (so the throttle in
+        # ``rail_daemon_supervisor.diagnose_rail_daemon`` actually
+        # throttles across periodic-timer calls) and the most recent
+        # decision (so the rail can render a "rail daemon respawning"
+        # alert if revivals are happening repeatedly). ``Any`` rather
+        # than ``datetime`` so we don't have to add a top-level
+        # datetime import to ``cockpit_ui.py`` (every other use is
+        # imported lazily inside its method).
+        self._last_rail_revival_at: Any = None
+        self._last_rail_decision_state: str | None = None
+        # Captured at mount time inside ``_start_core_rail``. ``True``
+        # means a live rail_daemon held the PID file when the cockpit
+        # booted, so the cockpit deferred to it rather than starting
+        # its own in-process HeartbeatRail. The liveness watcher only
+        # respawns in that mode — running the watcher in cockpit-
+        # hosted mode would race the cockpit's own ticker thread.
+        self._rail_daemon_was_external: bool = False
+
+    #: Cadence for the rail_daemon liveness check. Long enough that the
+    #: heartbeat's own internal retry handles transient stalls before
+    #: this layer interferes (the in-thread ``_tick_loop`` retries on
+    #: every interval — default 15s — and ``stale_tick_seconds`` is
+    #: 180s) but short enough that a dead daemon is revived within a
+    #: minute. Tunable with ``POLLYPM_RAIL_LIVENESS_INTERVAL_SECONDS``.
+    RAIL_LIVENESS_CHECK_INTERVAL_SECONDS = 60
 
     def compose(self) -> ComposeResult:
         with Vertical():
@@ -1368,6 +1394,21 @@ class PollyCockpitApp(App[None]):
         # Failures here are non-fatal — the TUI still works, just
         # without autonomous sweeps. See issue #268 Gap A.
         self._start_core_rail()
+        # #1546-followup — layer-2 watchdog: periodically check that
+        # the headless ``pollypm.rail_daemon`` is alive AND ticking. If
+        # it died (OOM, sandbox kill, segfault) or is wedged (no
+        # heartbeat event for 180s), respawn it. The cockpit is the
+        # natural place for this layer because it's the longest-lived
+        # in-process Python that *isn't* the rail daemon — i.e. the
+        # only viable external supervisor when launchd isn't installed.
+        # Tunable cadence via ``POLLYPM_RAIL_LIVENESS_INTERVAL_SECONDS``.
+        try:
+            interval = self._resolve_rail_liveness_interval()
+            self.set_interval(interval, self._tick_rail_liveness)
+        except Exception:  # noqa: BLE001
+            # Setting up a periodic timer should never block boot;
+            # fall through silently if Textual rejects the call.
+            logger.debug("rail_liveness timer install failed", exc_info=True)
         # Alert toast surface removed in #956 — the rail still shows
         # alert badges and ``a`` still opens the alert list.
         self.call_after_refresh(self._show_palette_tip_once)
@@ -1700,6 +1741,11 @@ class PollyCockpitApp(App[None]):
         ``pm cockpit`` at ~200% CPU for hours on 2026-04-20.
         """
         if self._rail_daemon_alive():
+            # Capture the boot-time decision so the rail-liveness
+            # watcher (which fires every 60s after this) only respawns
+            # the daemon in modes where the cockpit deferred to it.
+            # See ``_cockpit_uses_external_rail_daemon`` (#1546-followup).
+            self._rail_daemon_was_external = True
             return
         try:
             supervisor = self.router._load_supervisor()
@@ -1738,6 +1784,111 @@ class PollyCockpitApp(App[None]):
         except PermissionError:
             # Different user owns the PID — treat as alive from our POV.
             return True
+
+    def _resolve_rail_liveness_interval(self) -> float:
+        """Resolve the rail-daemon liveness check cadence in seconds.
+
+        Reads ``POLLYPM_RAIL_LIVENESS_INTERVAL_SECONDS`` so tests +
+        operators can dial it down without a code edit. Falls back to
+        :attr:`RAIL_LIVENESS_CHECK_INTERVAL_SECONDS`. Negative or
+        non-numeric values fall back to the class default.
+        """
+        import os as _os
+
+        raw = _os.environ.get("POLLYPM_RAIL_LIVENESS_INTERVAL_SECONDS")
+        if not raw:
+            return float(self.RAIL_LIVENESS_CHECK_INTERVAL_SECONDS)
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return float(self.RAIL_LIVENESS_CHECK_INTERVAL_SECONDS)
+        if value <= 0:
+            return float(self.RAIL_LIVENESS_CHECK_INTERVAL_SECONDS)
+        return value
+
+    def _tick_rail_liveness(self) -> None:
+        """Periodic: revive ``pollypm.rail_daemon`` if it's dead/stuck.
+
+        Best-effort: any exception is swallowed so a transient failure
+        (DB lock, permission glitch) doesn't kill the periodic timer
+        for the rest of the cockpit's lifetime. The next tick retries.
+
+        Skips itself when the cockpit is hosting an in-process
+        ``HeartbeatRail`` (no headless daemon configured) — there's
+        nothing to revive in that mode; the in-thread retry covers
+        single-tick crashes and a process-level death of the cockpit
+        is a launchd / user-restart concern, not this layer's.
+        """
+        from pathlib import Path as _Path
+
+        from pollypm.rail_daemon_supervisor import revive_if_needed
+
+        # If the cockpit is the rail's host (rather than a separate
+        # rail_daemon process), skip — see _start_core_rail.
+        if not self._cockpit_uses_external_rail_daemon():
+            return
+
+        try:
+            home = _Path.home() / ".pollypm"
+            pid_path = home / "rail_daemon.pid"
+            # Resolve the workspace state.db path via the supervisor
+            # if we can; fall back to the conventional location so the
+            # liveness check still works on a half-mounted cockpit.
+            state_db = self._resolve_state_db_path() or (home / "state.db")
+            result = revive_if_needed(
+                config_path=self.config_path,
+                state_db_path=state_db,
+                pid_path=pid_path,
+                last_revival_at=self._last_rail_revival_at,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("rail_liveness tick failed", exc_info=True)
+            return
+
+        self._last_rail_decision_state = result.decision.state
+        if result.revived:
+            from datetime import UTC, datetime as _dt
+
+            self._last_rail_revival_at = _dt.now(UTC)
+            logger.warning(
+                "cockpit: revived rail_daemon (%s) — %s",
+                result.decision.state, result.decision.reason,
+            )
+
+    def _cockpit_uses_external_rail_daemon(self) -> bool:
+        """True iff the layout uses a separate ``pollypm.rail_daemon``.
+
+        Returns the boot-time captured value from ``_start_core_rail``
+        — set to True only when a live rail_daemon held the PID file
+        when the cockpit mounted, and the cockpit consequently DID
+        NOT start its own in-process ``HeartbeatRail``. In that case
+        respawning the daemon when it dies is safe: there's no other
+        ticker for it to race.
+
+        When the cockpit booted into its own in-process rail (no
+        daemon at boot, or daemon was dead and the cockpit took over),
+        respawning a daemon now would create a second concurrent
+        ticker — the exact contention failure ``_start_core_rail``
+        warns about. So we leave it alone.
+
+        The boot-time decision is intentionally sticky for the lifetime
+        of this cockpit process. If the user manually starts a daemon
+        via ``pm up`` mid-session, they've opted in to a manual
+        recovery path and we don't try to second-guess. The next
+        cockpit restart re-evaluates.
+        """
+        return self._rail_daemon_was_external
+
+    def _resolve_state_db_path(self):
+        """Return the workspace state.db path, or ``None`` if unresolvable."""
+        try:
+            supervisor = self.router._load_supervisor()
+        except Exception:  # noqa: BLE001
+            return None
+        try:
+            return supervisor.config.project.state_db
+        except Exception:  # noqa: BLE001
+            return None
 
     def _enforce_rail_width_once(self) -> None:
         try:

--- a/src/pollypm/rail_daemon.py
+++ b/src/pollypm/rail_daemon.py
@@ -38,11 +38,25 @@ def _pid_file(home: Path) -> Path:
 
 
 def _claim_pid_file(pid_path: Path) -> bool:
-    """Write our PID if no live daemon already holds the file.
+    """Atomically write our PID iff no live daemon already holds the file.
+
+    The supervisor's flock at the parent layer is the primary guard
+    against duplicate spawns, but it cannot help when two daemons are
+    started by completely independent paths (two ``pm up`` invocations,
+    cron tick that bypasses the supervisor, launchd KeepAlive racing a
+    cockpit revive). Belt-and-suspenders: this claim itself uses
+    ``O_EXCL`` so two children that both pass the initial existence
+    check still see exactly one winner — the loser gets ``FileExistsError``
+    and exits cleanly, leaving the original holder undisturbed.
+
+    A stale PID file (process no longer exists) is overwritten. The
+    overwrite path is racy on its own — two callers can both observe
+    the stale file, both unlink, both ``O_EXCL`` create — but exactly
+    one will win the create, so the duplicate-spawn outcome is
+    impossible regardless.
 
     Returns True on successful claim, False when a live daemon
-    already owns the slot. A stale PID file (process no longer
-    exists) is overwritten.
+    already owns the slot.
     """
     if pid_path.exists():
         try:
@@ -51,8 +65,38 @@ def _claim_pid_file(pid_path: Path) -> bool:
             existing = 0
         if existing > 0 and _pid_alive(existing):
             return False
+        # Stale file — clear it so our O_EXCL create below can succeed.
+        # ``missing_ok`` is fine; another concurrent reaper may have
+        # already unlinked it.
+        try:
+            pid_path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            # Best-effort cleanup; the O_EXCL below will surface any
+            # genuine issue as a FileExistsError → False.
+            pass
     pid_path.parent.mkdir(parents=True, exist_ok=True)
-    pid_path.write_text(str(os.getpid()))
+    # ``O_EXCL | O_CREAT`` guarantees that two simultaneous claimers
+    # see exactly one success: the loser hits ``FileExistsError`` and
+    # bails (the daemon's caller logs and exits). Without this, two
+    # daemons can both observe a missing file, both ``write_text``,
+    # and the second write silently overwrites — leaving two live
+    # tickers with only one named in the PID file.
+    try:
+        fd = os.open(
+            str(pid_path),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o644,
+        )
+    except FileExistsError:
+        return False
+    except OSError:
+        return False
+    try:
+        os.write(fd, str(os.getpid()).encode("ascii"))
+    finally:
+        os.close(fd)
     return True
 
 

--- a/src/pollypm/rail_daemon_launchd.py
+++ b/src/pollypm/rail_daemon_launchd.py
@@ -1,0 +1,270 @@
+"""Layer-3 supervision: macOS LaunchAgent for ``pollypm.rail_daemon``.
+
+Why a third layer
+-----------------
+PollyPM's heartbeat supervision has three nested layers:
+
+1. **Tick-loop retry (in-thread)** — :class:`HeartbeatRail._tick_loop`
+   wraps each tick in try/except so a single bad tick can't take the
+   loop down. Handles transient errors like SQLite WAL contention.
+2. **External process supervision (rail_daemon_supervisor)** — the
+   cockpit periodic timer + ``pm heartbeat`` cron path call
+   :func:`pollypm.rail_daemon_supervisor.check_and_revive_rail_daemon`
+   to detect a dead/stuck daemon and respawn it. Handles process-
+   level death (OOM, segfault, sandbox kill).
+3. **OS-level supervision (this module)** — launchd watches the rail
+   daemon process and restarts it if it dies, AND launches it
+   automatically on machine boot. Handles the cases layer-2 can't:
+   the cockpit isn't open, the user just rebooted, or the cron job
+   itself isn't installed.
+
+Layer 3 is opt-in because writing to ``~/Library/LaunchAgents/`` is a
+user-level action that not every operator wants the CLI to do without
+asking. Once installed, layer 3 is the strongest guarantee available
+without root: launchd ``KeepAlive=true`` guarantees the daemon stays
+running modulo system shutdown / explicit ``launchctl unload``.
+
+Plist shape
+-----------
+A minimal ``KeepAlive`` LaunchAgent. Key choices:
+
+* ``KeepAlive: true`` — restart the daemon any time it exits, regardless
+  of exit code. We *want* aggressive restarts; the rail-daemon side
+  refuses to start if another live daemon already holds the PID file
+  (``rail_daemon._claim_pid_file``), so a doubled restart is harmless.
+* ``RunAtLoad: true`` — boot the daemon as soon as the user logs in,
+  not just when something else asks for it.
+* ``ThrottleInterval: 30`` — backoff for crash loops. Without this a
+  daemon that dies-on-boot due to a config error gets respawned in a
+  CPU-pinning tight loop. Mirrors the in-process throttle in
+  :mod:`pollypm.rail_daemon_supervisor` (60s) but lets launchd come
+  back faster than the in-process supervisor for legitimate restarts.
+* ``StandardOutPath`` / ``StandardErrorPath`` → ``~/.pollypm/rail_daemon.log``
+  so output lands in the same file ``cli._spawn_rail_daemon`` writes to.
+  Operators don't have to learn a second log location.
+
+Tests
+-----
+``install_launchd_keepalive`` and ``uninstall_launchd_keepalive`` both
+take injectable ``launchctl_runner`` + ``plist_dir`` so unit tests can
+stub the OS-level call without writing to the user's real
+``~/Library/LaunchAgents/`` directory.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import plistlib
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "DEFAULT_LABEL",
+    "DEFAULT_THROTTLE_INTERVAL_SECONDS",
+    "build_plist_dict",
+    "install_launchd_keepalive",
+    "plist_path_for_label",
+    "uninstall_launchd_keepalive",
+]
+
+
+DEFAULT_LABEL = "com.pollypm.rail-daemon"
+DEFAULT_THROTTLE_INTERVAL_SECONDS = 30
+
+
+# ---------------------------------------------------------------------------
+# Plist construction
+# ---------------------------------------------------------------------------
+
+
+def plist_path_for_label(label: str, *, plist_dir: Path | None = None) -> Path:
+    """Resolve the on-disk plist location for a given LaunchAgent label.
+
+    Defaults to ``~/Library/LaunchAgents/<label>.plist``. ``plist_dir``
+    is injectable so tests don't have to write to the real LaunchAgents
+    directory.
+    """
+    base = plist_dir or (Path.home() / "Library" / "LaunchAgents")
+    return base / f"{label}.plist"
+
+
+def build_plist_dict(
+    *,
+    label: str = DEFAULT_LABEL,
+    config_path: Path,
+    python_executable: Path | str | None = None,
+    log_path: Path | None = None,
+    throttle_interval: int = DEFAULT_THROTTLE_INTERVAL_SECONDS,
+) -> dict:
+    """Build the dict that ``plistlib.dumps`` will serialize.
+
+    Public so tests can assert the shape directly without round-tripping
+    through plistlib (which is a separate concern — we're testing what
+    we'd ask launchd to do, not whether plistlib can serialize a dict).
+    """
+    python = str(python_executable or sys.executable)
+    log = str(log_path or (Path.home() / ".pollypm" / "rail_daemon.log"))
+    program_args = [
+        python, "-m", "pollypm.rail_daemon",
+        "--config", str(config_path),
+    ]
+    return {
+        "Label": label,
+        "ProgramArguments": program_args,
+        # KeepAlive=true → restart on any exit. The rail-daemon's own
+        # PID-file claim lock guards against doubled instances.
+        "KeepAlive": True,
+        # Boot at user login, not just when another agent requests it.
+        "RunAtLoad": True,
+        # Backoff on crash loops; respects launchd's documented minimum
+        # of 10s. We pick 30s to match the supervisor module's mental
+        # model (process-level liveness checks every 60s; if launchd
+        # restarts twice that fast, the supervisor's throttle prevents
+        # double-spawning).
+        "ThrottleInterval": int(throttle_interval),
+        "StandardOutPath": log,
+        "StandardErrorPath": log,
+        # Set the working directory to the user's home so any relative
+        # path the daemon ever uses resolves against a writable dir.
+        "WorkingDirectory": str(Path.home()),
+        # launchd processes don't inherit the user's shell PATH; the
+        # rail daemon shells out to ``ps`` and ``tmux`` indirectly, so
+        # we set a sane default. ``cli._spawn_rail_daemon`` already
+        # works without this because it inherits the parent shell's
+        # PATH; in launchd land we have to set it ourselves.
+        "EnvironmentVariables": {
+            "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+            "HOME": str(Path.home()),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Install / uninstall
+# ---------------------------------------------------------------------------
+
+
+# Type alias for an injectable launchctl runner — tests pass a fake.
+LaunchctlRunner = Callable[[list[str]], subprocess.CompletedProcess]
+
+
+def _default_launchctl_runner(argv: list[str]) -> subprocess.CompletedProcess:
+    """Run ``launchctl`` and return the completed process.
+
+    ``check=False`` so callers can inspect ``returncode`` for the
+    permissive "already loaded / not loaded" cases without us raising.
+    """
+    return subprocess.run(
+        argv, capture_output=True, text=True, check=False, timeout=10.0,
+    )
+
+
+def install_launchd_keepalive(
+    *,
+    config_path: Path,
+    label: str = DEFAULT_LABEL,
+    plist_dir: Path | None = None,
+    python_executable: Path | str | None = None,
+    log_path: Path | None = None,
+    throttle_interval: int = DEFAULT_THROTTLE_INTERVAL_SECONDS,
+    load: bool = True,
+    launchctl_runner: LaunchctlRunner | None = None,
+) -> Path:
+    """Write the plist and (optionally) bootstrap it via launchctl.
+
+    Returns the path to the written plist.
+
+    Failures during ``launchctl bootstrap`` are logged but don't raise
+    — the file is still on disk and the user can load it manually with
+    the printed command. We never raise on the launchctl call because
+    "already bootstrapped" is a normal case (re-installing) and the
+    exit code mirrors that.
+
+    Args:
+        config_path: forwarded as ``--config`` to ``pollypm.rail_daemon``.
+        label: LaunchAgent ``Label``. Reverse-DNS conventional.
+        plist_dir: where to write the plist (default
+            ``~/Library/LaunchAgents``). Injectable for tests.
+        python_executable: which Python to invoke. Defaults to
+            :attr:`sys.executable` (the interpreter running ``pm``),
+            which respects whatever virtualenv the user installed
+            PollyPM into.
+        log_path: where launchd should redirect stdout/stderr.
+            Defaults to ``~/.pollypm/rail_daemon.log`` so it lines up
+            with ``cli._spawn_rail_daemon``'s log path.
+        throttle_interval: launchd backoff between respawns.
+        load: when True, call ``launchctl bootstrap gui/<uid>`` so the
+            agent starts immediately. When False, the user has to run
+            ``launchctl bootstrap`` themselves — useful for scripted
+            installs that want to defer activation.
+        launchctl_runner: override the launchctl invocation. Tests
+            pass a fake to avoid mutating the user's real launchd state.
+    """
+    plist_path = plist_path_for_label(label, plist_dir=plist_dir)
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    plist_dict = build_plist_dict(
+        label=label,
+        config_path=config_path,
+        python_executable=python_executable,
+        log_path=log_path,
+        throttle_interval=throttle_interval,
+    )
+    plist_bytes = plistlib.dumps(plist_dict, fmt=plistlib.FMT_XML)
+    plist_path.write_bytes(plist_bytes)
+
+    if load:
+        runner = launchctl_runner or _default_launchctl_runner
+        if shutil.which("launchctl") is not None or launchctl_runner is not None:
+            uid = os.getuid()
+            domain = f"gui/{uid}"
+            # If a previous version is loaded, bootstrap will fail with
+            # "service already loaded". Bootout first, ignore errors.
+            runner(["launchctl", "bootout", domain, str(plist_path)])
+            result = runner(["launchctl", "bootstrap", domain, str(plist_path)])
+            if result.returncode != 0:
+                logger.warning(
+                    "rail_daemon_launchd: bootstrap returncode=%d stderr=%s",
+                    result.returncode, (result.stderr or "").strip(),
+                )
+
+    return plist_path
+
+
+def uninstall_launchd_keepalive(
+    *,
+    label: str = DEFAULT_LABEL,
+    plist_dir: Path | None = None,
+    launchctl_runner: LaunchctlRunner | None = None,
+) -> bool:
+    """Bootout and unlink the plist for ``label``.
+
+    Returns True iff the plist file existed (and was therefore removed).
+    Bootout failures are logged and ignored — the goal is to leave the
+    user with no plist file. If the file was never installed the call
+    is a quiet no-op.
+    """
+    plist_path = plist_path_for_label(label, plist_dir=plist_dir)
+    if not plist_path.exists():
+        return False
+
+    runner = launchctl_runner or _default_launchctl_runner
+    if shutil.which("launchctl") is not None or launchctl_runner is not None:
+        uid = os.getuid()
+        domain = f"gui/{uid}"
+        result = runner(["launchctl", "bootout", domain, str(plist_path)])
+        if result.returncode != 0:
+            # Most common case: the agent wasn't loaded. Log at debug.
+            logger.debug(
+                "rail_daemon_launchd: bootout returncode=%d stderr=%s",
+                result.returncode, (result.stderr or "").strip(),
+            )
+
+    plist_path.unlink(missing_ok=True)
+    return True

--- a/src/pollypm/rail_daemon_supervisor.py
+++ b/src/pollypm/rail_daemon_supervisor.py
@@ -85,6 +85,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shlex
 import signal
 import subprocess
 import time
@@ -125,6 +126,17 @@ DEFAULT_REVIVAL_THROTTLE_SECONDS = 60.0
 #: own SIGTERM handler tears down ``CoreRail`` synchronously and exits
 #: in well under this window when it's responsive at all.
 DEFAULT_SIGTERM_GRACE_SECONDS = 3.0
+
+#: How long to wait for a freshly-spawned daemon to write its PID file
+#: while we still hold the supervisor lock. The real spawner is a
+#: detached ``Popen`` that returns immediately — the child still has
+#: to import its modules, claim the PID file, and start the rail.
+#: Without this wait, the lock is released before the child writes
+#: ``rail_daemon.pid`` and a second supervisor can re-diagnose
+#: ``missing_pid`` and spawn again. 5s comfortably covers cold-import
+#: latency on the slowest field machines we've measured (~1-2s) without
+#: making cron callers block longer than their tick budget.
+DEFAULT_CHILD_PID_WAIT_SECONDS = 5.0
 
 
 # ---------------------------------------------------------------------------
@@ -254,21 +266,82 @@ def _read_pid_command_line(pid: int) -> str | None:
     return text or None
 
 
+def _extract_config_arg(argv: list[str]) -> str | None:
+    """Return the ``--config`` value from ``argv``, or ``None`` if absent.
+
+    Handles both shapes:
+    * ``--config /path/to/cfg`` (two argv elements)
+    * ``--config=/path/to/cfg`` (single argv element)
+
+    Operates on parsed argv elements — substring matching across the
+    whole joined cmdline would let a path that merely *contains*
+    ``--config`` (e.g. ``/workspace/--config-test/...``) spoof the
+    match.
+    """
+    for i, tok in enumerate(argv):
+        if tok == "--config":
+            if i + 1 < len(argv):
+                return argv[i + 1]
+            return None
+        if tok.startswith("--config="):
+            return tok.split("=", 1)[1]
+    return None
+
+
+def _resolve_for_compare(path: Path | str) -> Path:
+    """Return a resolved Path for cross-process comparison.
+
+    Uses ``Path.resolve(strict=False)`` so that paths inside ephemeral
+    test directories (which may be on different mount points) still
+    compare equal across the supervisor and a daemon argv. Falls back
+    to ``Path(path)`` if resolution itself raises (e.g. permission
+    error walking a symlink chain).
+    """
+    try:
+        return Path(path).resolve(strict=False)
+    except (OSError, RuntimeError):
+        return Path(path)
+
+
+def _is_default_config(config_path: Path | None) -> bool:
+    """True iff ``config_path`` resolves to the global default.
+
+    A daemon spawned with no explicit ``--config`` is using
+    :data:`pollypm.config.DEFAULT_CONFIG_PATH`. Matching that daemon
+    against a non-default supervisor would let one workspace's
+    supervisor SIGTERM a different workspace's default-config daemon.
+    """
+    if config_path is None:
+        # Caller didn't give us a config to enforce — accept either way.
+        return True
+    try:
+        from pollypm.config import DEFAULT_CONFIG_PATH as _default
+    except Exception:  # noqa: BLE001
+        # If we can't import the default for some reason, fail safe and
+        # decline to treat any config as default — the no-config daemon
+        # path will reject, which is the conservative answer.
+        return False
+    return _resolve_for_compare(config_path) == _resolve_for_compare(_default)
+
+
 def _pid_matches_daemon(pid: int, config_path: Path | None) -> bool:
     """True iff ``pid``'s command line looks like our rail daemon.
 
     Matches ``pollypm.rail_daemon`` (or the path-form ``pollypm/rail_daemon``
     in case ``ps`` reports the script path rather than the ``-m`` form)
-    in the argv. When ``config_path`` is provided AND the daemon's argv
-    carries an explicit ``--config <path>``, the path must also match —
-    a stray daemon for a different workspace must NOT be killed by this
-    supervisor.
+    in the argv. When ``config_path`` is provided we require one of:
 
-    A daemon spawned with no ``--config`` flag (using its default) still
-    matches when ``config_path`` is the workspace default — we accept
-    the absence of an explicit ``--config`` argument as compatible with
-    any config_path so old daemons predating the explicit flag still
-    register as ours.
+    * The daemon's argv carries an explicit ``--config <path>`` whose
+      resolved value equals the resolved ``config_path``.
+    * The daemon has NO ``--config`` flag (default-config daemon) AND
+      ``config_path`` itself resolves to :data:`DEFAULT_CONFIG_PATH`.
+
+    The second case is the only safe interpretation of a no-``--config``
+    daemon: it's pinned to the default config, so a non-default
+    supervisor must NOT claim it as theirs. Without this, a workspace
+    whose ``config_path`` is ``/workspace/A/.pollypm/config.yaml`` would
+    misidentify a separate user's default-config daemon as ours and
+    eventually SIGTERM it.
 
     Returns ``False`` on any read error — callers must treat that as
     "not our daemon" and skip signaling. Better to leave a possibly-stale
@@ -277,25 +350,43 @@ def _pid_matches_daemon(pid: int, config_path: Path | None) -> bool:
     cmdline = _read_pid_command_line(pid)
     if not cmdline:
         return False
+    # Tokenize argv properly. ``shlex.split`` handles quoted paths-with-
+    # spaces; on parse failure (truncated cmdline, weird shell escapes)
+    # fall back to whitespace split — still better than substring on
+    # the whole string for the entry-point check below.
+    try:
+        argv = shlex.split(cmdline, posix=True)
+    except ValueError:
+        argv = cmdline.split()
+
     # Must look like the rail_daemon entry point. Both forms appear in
     # the wild: ``-m pollypm.rail_daemon`` (our spawn) and the eager
     # ``python /path/to/pollypm/rail_daemon.py`` form some launchers
-    # produce on macOS.
-    if "pollypm.rail_daemon" not in cmdline and "pollypm/rail_daemon" not in cmdline:
+    # produce on macOS. Match on argv tokens — a plain substring on
+    # the joined cmdline could be spoofed by a process whose argv
+    # happens to mention the string in a comment / log path.
+    def _looks_like_entry_point(tok: str) -> bool:
+        if tok == "pollypm.rail_daemon":
+            return True
+        # Path form, possibly absolute, possibly with .py suffix.
+        return "pollypm/rail_daemon" in tok or "pollypm\\rail_daemon" in tok
+
+    if not any(_looks_like_entry_point(t) for t in argv):
         return False
+
     if config_path is None:
         return True
-    # Only enforce config match when the daemon actually carries a
-    # ``--config`` flag. A daemon launched with the implicit default
-    # is compatible with any caller pointing at that same default.
-    if "--config" not in cmdline:
-        return True
-    expected = str(config_path)
-    # Conservative substring match — argv joined by spaces, paths can
-    # contain spaces, so we accept any occurrence of the resolved
-    # config path in the cmdline. A mismatched workspace's path won't
-    # appear in our daemon's argv.
-    return expected in cmdline
+
+    daemon_cfg = _extract_config_arg(argv)
+    if daemon_cfg is None:
+        # Implicit-default daemon. Only ours when our own config_path
+        # IS the default — otherwise it belongs to a different
+        # (default-config) workspace and we must not signal it.
+        return _is_default_config(config_path)
+
+    # Both sides explicit — compare resolved Paths so symlinks /
+    # relative components don't cause spurious mismatches.
+    return _resolve_for_compare(daemon_cfg) == _resolve_for_compare(config_path)
 
 
 def _parse_iso_age_seconds(iso_text: str | None, *, now: datetime | None = None) -> float | None:
@@ -694,6 +785,58 @@ def _emit_revival_audit(
         pass
 
 
+def _wait_for_child_pid(
+    pid_path: Path,
+    config_path: Path | None,
+    *,
+    timeout_seconds: float = DEFAULT_CHILD_PID_WAIT_SECONDS,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    poll_interval: float = 0.05,
+) -> int | None:
+    """Block until ``pid_path`` names a live, matching daemon (or timeout).
+
+    The default ``spawn_fn`` is :func:`pollypm.cli._spawn_rail_daemon`,
+    which returns as soon as ``Popen`` succeeds — long before the child
+    has imported ``pollypm.rail_daemon`` and written its PID file. If
+    we release the supervisor lock the moment ``spawn_fn`` returns, a
+    second supervisor can acquire the lock, observe ``missing_pid``,
+    and spawn a *second* daemon. Holding the lock until the child has
+    written a matching PID file closes that race.
+
+    "Matching" means: the file contains a positive int, that PID is
+    alive, and :func:`_pid_matches_daemon` accepts it (entry-point +
+    config check). A different PID (e.g. left over from a stuck
+    daemon we just SIGTERM'd that hasn't been cleaned up yet) is
+    treated as not-yet-arrived and we keep polling.
+
+    Returns the matching PID on success, or ``None`` on timeout. The
+    caller MUST log + release the lock either way — never deadlock.
+    """
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    last_seen: int | None = None
+    while True:
+        pid = _read_pid(pid_path)
+        if pid is not None and pid > 0 and _pid_is_alive(pid):
+            if _pid_matches_daemon(pid, config_path):
+                return pid
+            last_seen = pid
+        if time.monotonic() >= deadline:
+            if last_seen is not None:
+                logger.warning(
+                    "rail_daemon_supervisor: child PID file %s named "
+                    "pid=%d but identity check rejected it within %.1fs",
+                    pid_path, last_seen, timeout_seconds,
+                )
+            else:
+                logger.warning(
+                    "rail_daemon_supervisor: child did not write %s "
+                    "within %.1fs after spawn — releasing lock anyway",
+                    pid_path, timeout_seconds,
+                )
+            return None
+        sleep_fn(poll_interval)
+
+
 def check_and_revive_rail_daemon(
     *,
     config_path: Path,
@@ -708,6 +851,7 @@ def check_and_revive_rail_daemon(
     emit_audit: bool = True,
     cron: bool = False,
     lock_timeout_seconds: float = 5.0,
+    child_wait_seconds: float = DEFAULT_CHILD_PID_WAIT_SECONDS,
 ) -> RevivalResult:
     """Diagnose the rail daemon and respawn it if it's dead / stuck.
 
@@ -750,6 +894,16 @@ def check_and_revive_rail_daemon(
             concurrent-revival race that would otherwise spawn two
             daemons. Default 5s — covers the SIGTERM grace + spawn
             latency without making the caller block forever.
+        child_wait_seconds: how long, after ``spawn_fn`` returns, to
+            keep holding the lock while we wait for the freshly-
+            spawned child to write a matching PID file. The default
+            spawner is a detached ``Popen`` that returns BEFORE the
+            child has imported and claimed the PID file — releasing
+            the lock immediately would let a second supervisor
+            re-diagnose ``missing_pid`` and spawn again. Default
+            :data:`DEFAULT_CHILD_PID_WAIT_SECONDS` (5s). On timeout
+            we log + release anyway so a buggy spawner can never
+            deadlock the supervisor.
 
     Returns:
         :class:`RevivalResult` carrying the diagnosis, whether a spawn
@@ -942,6 +1096,38 @@ def check_and_revive_rail_daemon(
         except Exception as exc:  # noqa: BLE001
             spawn_error = f"{type(exc).__name__}: {exc}"
             logger.exception("rail_daemon_supervisor: spawn failed")
+
+        # Step 4: wait — still under the supervisor lock — for the
+        # freshly-spawned child to write a matching PID file. The real
+        # spawner is a detached ``Popen`` that returns immediately; if
+        # we release the lock now, a sibling supervisor can re-diagnose
+        # ``missing_pid`` and spawn a *second* daemon before this child
+        # gets to ``_claim_pid_file``. The wait is bounded
+        # (``child_wait_seconds``) so a buggy spawner can't deadlock us.
+        # Skipped if ``spawner`` itself raised — there is no child to
+        # wait for, and the existing "revived=False" reporting is correct.
+        if spawn_error is None:
+            confirmed_pid = _wait_for_child_pid(
+                pid_path,
+                config_path,
+                timeout_seconds=child_wait_seconds,
+                sleep_fn=sleep_fn,
+            )
+            if confirmed_pid is None:
+                # Don't flip revived=False — the spawn itself succeeded
+                # from our POV (Popen returned 0). But we did NOT
+                # observe the child claim the PID file before the
+                # timeout, so warn loudly so operators see chronic
+                # cases (slow imports, container OOM-on-boot, etc).
+                # Subsequent supervisor cycles will diagnose
+                # missing_pid / dead_process and recover the layer
+                # below us.
+                logger.warning(
+                    "rail_daemon_supervisor: spawned daemon did not "
+                    "register a PID at %s within %.1fs — proceeding "
+                    "but next cycle may re-spawn",
+                    pid_path, child_wait_seconds,
+                )
 
         revived = spawn_error is None
         result = RevivalResult(

--- a/src/pollypm/rail_daemon_supervisor.py
+++ b/src/pollypm/rail_daemon_supervisor.py
@@ -86,11 +86,13 @@ from __future__ import annotations
 import logging
 import os
 import signal
+import subprocess
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Iterator
 
 logger = logging.getLogger(__name__)
 
@@ -205,6 +207,97 @@ def _pid_is_alive(pid: int) -> bool:
     return True
 
 
+def _read_pid_command_line(pid: int) -> str | None:
+    """Return the full command line of ``pid`` as a single string.
+
+    Used by :func:`_pid_matches_daemon` to verify that a recorded PID is
+    still our rail daemon process — catching the PID-reuse hazard where
+    the original daemon died and the kernel reassigned its PID to an
+    unrelated user process. Without this check, the supervisor would
+    happily SIGTERM whatever happened to land at that number.
+
+    Strategy:
+    1. On Linux, read ``/proc/<pid>/cmdline`` directly. NUL-separated
+       argv joined with spaces. Cheapest and avoids forking ``ps``.
+    2. On macOS (no ``/proc``) or if the proc read fails, shell out to
+       ``ps -p <pid> -o args=`` — portable to both platforms and
+       returns the full argv as a single column.
+    3. Returns ``None`` on any error (caller treats unknown identity
+       as "not our daemon" and skips signaling — fail-safe).
+    """
+    if pid <= 0:
+        return None
+
+    proc_cmdline = Path(f"/proc/{pid}/cmdline")
+    try:
+        if proc_cmdline.exists():
+            raw = proc_cmdline.read_bytes()
+            if raw:
+                # cmdline is NUL-separated argv; join with space for matching.
+                return raw.replace(b"\x00", b" ").decode("utf-8", "replace").strip()
+            # Empty cmdline → kernel thread or zombie; not our daemon.
+            return None
+    except OSError:
+        # Fall through to ps fallback.
+        pass
+
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "args="],
+            capture_output=True, text=True, check=False, timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    text = (result.stdout or "").strip()
+    return text or None
+
+
+def _pid_matches_daemon(pid: int, config_path: Path | None) -> bool:
+    """True iff ``pid``'s command line looks like our rail daemon.
+
+    Matches ``pollypm.rail_daemon`` (or the path-form ``pollypm/rail_daemon``
+    in case ``ps`` reports the script path rather than the ``-m`` form)
+    in the argv. When ``config_path`` is provided AND the daemon's argv
+    carries an explicit ``--config <path>``, the path must also match —
+    a stray daemon for a different workspace must NOT be killed by this
+    supervisor.
+
+    A daemon spawned with no ``--config`` flag (using its default) still
+    matches when ``config_path`` is the workspace default — we accept
+    the absence of an explicit ``--config`` argument as compatible with
+    any config_path so old daemons predating the explicit flag still
+    register as ours.
+
+    Returns ``False`` on any read error — callers must treat that as
+    "not our daemon" and skip signaling. Better to leave a possibly-stale
+    PID file alone than to SIGTERM an innocent process.
+    """
+    cmdline = _read_pid_command_line(pid)
+    if not cmdline:
+        return False
+    # Must look like the rail_daemon entry point. Both forms appear in
+    # the wild: ``-m pollypm.rail_daemon`` (our spawn) and the eager
+    # ``python /path/to/pollypm/rail_daemon.py`` form some launchers
+    # produce on macOS.
+    if "pollypm.rail_daemon" not in cmdline and "pollypm/rail_daemon" not in cmdline:
+        return False
+    if config_path is None:
+        return True
+    # Only enforce config match when the daemon actually carries a
+    # ``--config`` flag. A daemon launched with the implicit default
+    # is compatible with any caller pointing at that same default.
+    if "--config" not in cmdline:
+        return True
+    expected = str(config_path)
+    # Conservative substring match — argv joined by spaces, paths can
+    # contain spaces, so we accept any occurrence of the resolved
+    # config path in the cmdline. A mismatched workspace's path won't
+    # appear in our daemon's argv.
+    return expected in cmdline
+
+
 def _parse_iso_age_seconds(iso_text: str | None, *, now: datetime | None = None) -> float | None:
     """Return ``now - iso_text`` in seconds, or ``None`` on parse error.
 
@@ -236,6 +329,7 @@ def diagnose_rail_daemon(
     now: datetime | None = None,
     stale_tick_seconds: float = DEFAULT_STALE_TICK_SECONDS,
     throttle_seconds: float = DEFAULT_REVIVAL_THROTTLE_SECONDS,
+    config_path: Path | None = None,
 ) -> RevivalDecision:
     """Decide whether the rail daemon needs reviving — pure function.
 
@@ -276,7 +370,9 @@ def diagnose_rail_daemon(
         if elapsed < throttle_seconds:
             # Still inspect process state so the decision carries a
             # useful diagnosis, but the state is sticky to throttled.
-            sub_state = _classify_state(pid, last_age, stale_tick_seconds)
+            sub_state = _classify_state(
+                pid, last_age, stale_tick_seconds, config_path=config_path,
+            )
             return RevivalDecision(
                 state="throttled",
                 pid=pid,
@@ -287,7 +383,9 @@ def diagnose_rail_daemon(
                 ),
             )
 
-    state = _classify_state(pid, last_age, stale_tick_seconds)
+    state = _classify_state(
+        pid, last_age, stale_tick_seconds, config_path=config_path,
+    )
     reason = _explain(state, pid, last_age, stale_tick_seconds)
     return RevivalDecision(
         state=state,
@@ -301,11 +399,27 @@ def _classify_state(
     pid: int | None,
     last_tick_age: float | None,
     stale_tick_seconds: float,
+    *,
+    config_path: Path | None = None,
 ) -> str:
-    """Map (pid, last_tick_age) → state label (no throttling concerns)."""
+    """Map (pid, last_tick_age) → state label (no throttling concerns).
+
+    PID identity is verified before any "alive but stale" classification
+    can promote a PID to a kill candidate: if the live PID's argv does
+    not look like our rail daemon (likely PID reuse after the original
+    daemon died), we classify it as ``dead_process`` so the upstream
+    supervisor SKIPS the SIGTERM step entirely. Killing the wrong PID
+    would terminate an unrelated user process — that's worse than
+    failing to revive a daemon for one extra cycle.
+    """
     if pid is None:
         return "missing_pid"
     if not _pid_is_alive(pid):
+        return "dead_process"
+    # The PID is alive — but is it OUR daemon? A PID-reuse hazard
+    # exists when the original daemon died and the kernel handed the
+    # number to an unrelated process. Verify identity via the cmdline.
+    if not _pid_matches_daemon(pid, config_path):
         return "dead_process"
     if last_tick_age is not None and last_tick_age > stale_tick_seconds:
         return "stuck_no_tick"
@@ -355,17 +469,34 @@ def _terminate_with_grace(
     *,
     grace_seconds: float = DEFAULT_SIGTERM_GRACE_SECONDS,
     sleep_fn: Callable[[float], None] = time.sleep,
+    config_path: Path | None = None,
 ) -> str:
     """SIGTERM, wait, SIGKILL if needed. Mirrors ``rail_daemon_reaper``.
 
     Returns the signal label that ultimately took, or ``"already_gone"``
-    if the process was gone before we sent anything, or ``"denied"`` if
-    we lacked permission. ``"none"`` if ``pid <= 0``.
+    if the process was gone before we sent anything, ``"denied"`` if
+    we lacked permission, ``"identity_mismatch"`` if the PID's cmdline
+    does not look like our daemon (PID-reuse hazard — refuse to
+    signal), or ``"none"`` if ``pid <= 0``.
+
+    The identity check is a SAFETY GUARD: it's possible for the original
+    daemon to die between diagnosis and termination, and for the kernel
+    to immediately reassign that PID to an unrelated process. SIGTERMing
+    that process would kill a user's editor / shell / whatever — far
+    worse than failing to revive the daemon. We re-verify identity here
+    in case the diagnose layer was bypassed or raced.
     """
     if pid <= 0:
         return "none"
     if not _pid_is_alive(pid):
         return "already_gone"
+    if not _pid_matches_daemon(pid, config_path):
+        logger.warning(
+            "rail_daemon_supervisor: refusing to signal pid=%d — cmdline "
+            "does not match our rail daemon (PID-reuse safety guard)",
+            pid,
+        )
+        return "identity_mismatch"
     try:
         os.kill(pid, signal.SIGTERM)
     except ProcessLookupError:
@@ -384,6 +515,18 @@ def _terminate_with_grace(
             return "SIGTERM"
         sleep_fn(poll_interval)
 
+    # Re-verify identity before SIGKILL: it's possible (rare but real)
+    # that our daemon SIGTERM-exited and the PID was reused by an
+    # unrelated process within the grace window. SIGKILL is unblockable
+    # so the cost of a wrong target is permanent.
+    if not _pid_matches_daemon(pid, config_path):
+        logger.warning(
+            "rail_daemon_supervisor: pid=%d no longer matches daemon "
+            "cmdline at SIGKILL stage; treating as already_gone",
+            pid,
+        )
+        return "SIGTERM"
+
     try:
         os.kill(pid, signal.SIGKILL)
     except ProcessLookupError:
@@ -391,6 +534,122 @@ def _terminate_with_grace(
     except PermissionError:
         return "denied"
     return "SIGKILL"
+
+
+@contextmanager
+def _supervisor_lock(
+    pid_path: Path,
+    *,
+    timeout_seconds: float = 5.0,
+) -> Iterator[bool]:
+    """Acquire an exclusive cross-process lock around a revival critical section.
+
+    The supervisor's diagnose → kill → unlink → spawn sequence is NOT
+    atomic. Without a lock, two callers (cockpit periodic timer + cron
+    ``pm heartbeat`` + a manual ``pm up``) can race: both diagnose
+    "missing PID", one spawns successfully, and the second proceeds to
+    unlink the freshly-written PID file and spawn ANOTHER daemon. The
+    field outcome is two daemons running, both ticking the same DB —
+    exactly the contention the rail daemon's PID-file lock was meant
+    to prevent (but at the spawn-attempt layer, before the new daemon
+    even gets to claim the PID file).
+
+    Implementation: ``fcntl.flock`` (BSD-style advisory lock) on a
+    sibling lockfile ``<pid_path>.supervisor.lock``. ``flock`` is per-fd,
+    so each process gets its own contention point and the kernel
+    serializes acquisitions. Timeout via non-blocking acquire + sleep
+    polling rather than ``LOCK_EX`` blocking, so a runaway holder can't
+    pin the supervisor forever.
+
+    Yields ``True`` when the lock was acquired, ``False`` when the
+    timeout expired. Callers MUST treat ``False`` as "another supervisor
+    is active; do nothing this cycle" — re-running diagnosis after a
+    timeout would invite the same race we're trying to prevent.
+    """
+    lock_path = pid_path.with_name(pid_path.name + ".supervisor.lock")
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        # If we can't even create the parent, fall through; the open
+        # below will raise and we'll yield False.
+        pass
+
+    try:
+        import fcntl  # POSIX-only; supervisor is intended for macOS / Linux.
+    except ImportError:
+        # Non-POSIX: fall back to a best-effort O_EXCL lockfile pattern.
+        yield from _supervisor_lock_oexcl(lock_path, timeout_seconds)
+        return
+
+    fd: int | None = None
+    try:
+        fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+    except OSError as exc:
+        logger.debug("supervisor lock open failed: %s", exc)
+        yield False
+        return
+
+    acquired = False
+    deadline = time.monotonic() + timeout_seconds
+    poll = 0.05
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    break
+                time.sleep(poll)
+        yield acquired
+    finally:
+        if acquired:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _supervisor_lock_oexcl(
+    lock_path: Path,
+    timeout_seconds: float,
+) -> Iterator[bool]:
+    """O_EXCL fallback for platforms without fcntl (mainly Windows).
+
+    Less robust than flock — a crashed holder leaves a stale file that
+    must time out — but the supervisor's flock path is the supported
+    one. This exists so the import doesn't blow up on hypothetical
+    non-POSIX environments.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    fd: int | None = None
+    while True:
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600)
+            break
+        except FileExistsError:
+            if time.monotonic() >= deadline:
+                yield False
+                return
+            time.sleep(0.05)
+    try:
+        yield True
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            lock_path.unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 def _emit_revival_audit(
@@ -447,6 +706,8 @@ def check_and_revive_rail_daemon(
     spawn_fn: Callable[[Path], None] | None = None,
     sleep_fn: Callable[[float], None] = time.sleep,
     emit_audit: bool = True,
+    cron: bool = False,
+    lock_timeout_seconds: float = 5.0,
 ) -> RevivalResult:
     """Diagnose the rail daemon and respawn it if it's dead / stuck.
 
@@ -475,6 +736,20 @@ def check_and_revive_rail_daemon(
         emit_audit: when ``False``, skip the ``daemon.revived`` audit
             emit (used by tests that don't want to write to the real
             audit log).
+        cron: when ``True``, the caller is the ``pm heartbeat`` cron
+            path (NOT the cockpit periodic timer). In that mode, a
+            ``missing_pid`` decision is downgraded to a no-op: the
+            cockpit may be hosting an in-process ``HeartbeatRail``
+            (which leaves no PID file by design), and spawning a
+            headless daemon now would create a second concurrent
+            ticker. Cron still acts on ``dead_process`` / ``stuck_no_tick``
+            — those mean a daemon WAS recorded but isn't running, which
+            never happens under cockpit-hosted mode.
+        lock_timeout_seconds: how long to wait for the supervisor lock
+            before giving up this cycle. The lock prevents a
+            concurrent-revival race that would otherwise spawn two
+            daemons. Default 5s — covers the SIGTERM grace + spawn
+            latency without making the caller block forever.
 
     Returns:
         :class:`RevivalResult` carrying the diagnosis, whether a spawn
@@ -487,6 +762,7 @@ def check_and_revive_rail_daemon(
         now=now,
         stale_tick_seconds=stale_tick_seconds,
         throttle_seconds=throttle_seconds,
+        config_path=config_path,
     )
 
     if not decision.needs_revival:
@@ -503,86 +779,187 @@ def check_and_revive_rail_daemon(
             kill_signal=None,
         )
 
+    # Cron-path guard: a missing PID file from cron MAY mean the cockpit
+    # is hosting the rail in-process (no headless daemon ever existed).
+    # Spawning a daemon now would race the cockpit's in-thread ticker.
+    # Cron only acts on dead_process / stuck_no_tick — those imply a
+    # daemon was recorded and lost, which doesn't happen in
+    # cockpit-hosted mode (it never writes a PID file).
+    if cron and decision.state == "missing_pid":
+        logger.debug(
+            "rail_daemon_supervisor: cron skipping missing_pid revival "
+            "(cockpit may be hosting rail in-process)",
+        )
+        return RevivalResult(
+            decision=decision,
+            revived=False,
+            spawn_error=None,
+            killed_pid=None,
+            kill_signal=None,
+        )
+
     logger.warning(
         "rail_daemon_supervisor: reviving heartbeat — %s", decision.reason,
     )
 
-    # Step 1: clean up the dead/stuck process. ``stuck_no_tick`` means
-    # the PID is alive but unresponsive; we SIGTERM it so the new
-    # daemon can claim the PID file. ``dead_process`` and
-    # ``missing_pid`` skip this entirely.
-    killed_pid: int | None = None
-    kill_signal: str | None = None
-    if decision.state == "stuck_no_tick" and decision.pid is not None:
-        kill_signal = _terminate_with_grace(decision.pid, sleep_fn=sleep_fn)
-        if kill_signal in ("SIGTERM", "SIGKILL", "already_gone"):
-            killed_pid = decision.pid
-        elif kill_signal == "denied":
-            # Couldn't kill it — bail without spawning so we don't end
-            # up with two daemons fighting for the same DB.
-            logger.warning(
-                "rail_daemon_supervisor: cannot signal pid=%d (permission "
-                "denied); skipping respawn — manual intervention required",
-                decision.pid,
+    # Wrap the kill/unlink/spawn critical section in a cross-process
+    # lock so two concurrent supervisors (cockpit + cron, or two
+    # consecutive cron ticks while a previous spawn is in flight) can't
+    # produce duplicate daemons. Without this, both callers would
+    # diagnose missing/dead, one spawns, the other unlinks the new
+    # PID file and spawns again — leaving two tickers fighting over
+    # the same DB.
+    with _supervisor_lock(pid_path, timeout_seconds=lock_timeout_seconds) as locked:
+        if not locked:
+            logger.info(
+                "rail_daemon_supervisor: another supervisor holds the lock "
+                "(%.1fs timeout); skipping this cycle",
+                lock_timeout_seconds,
             )
-            result = RevivalResult(
+            return RevivalResult(
                 decision=decision,
                 revived=False,
-                spawn_error="signal_denied",
+                spawn_error="lock_busy",
                 killed_pid=None,
-                kill_signal=kill_signal,
+                kill_signal=None,
             )
-            if emit_audit:
-                _emit_revival_audit(
-                    decision=decision,
+
+        # Re-check liveness inside the lock. Another supervisor that
+        # held the lock when we started waiting may have already
+        # spawned a fresh daemon — in that case the PID file now points
+        # at a live, healthy process and we must NOT proceed. Without
+        # this re-check we'd diagnose-stale + spawn anyway and end up
+        # with two daemons.
+        recheck = diagnose_rail_daemon(
+            pid_path=pid_path,
+            last_tick_iso=last_tick_iso,
+            # last_revival_at is intentionally None here so the recheck
+            # reflects current process state without re-applying the
+            # caller's throttle window.
+            last_revival_at=None,
+            now=now,
+            stale_tick_seconds=stale_tick_seconds,
+            throttle_seconds=throttle_seconds,
+            config_path=config_path,
+        )
+        if not recheck.needs_revival:
+            logger.info(
+                "rail_daemon_supervisor: post-lock recheck shows %s — "
+                "another supervisor must have already revived; standing down",
+                recheck.state,
+            )
+            return RevivalResult(
+                decision=recheck,
+                revived=False,
+                spawn_error=None,
+                killed_pid=None,
+                kill_signal=None,
+            )
+
+        # Use the recheck's PID (which reflects current state) for any
+        # signaling — the original ``decision.pid`` may be stale.
+        diagnosed_pid = recheck.pid
+
+        # Step 1: clean up the dead/stuck process. ``stuck_no_tick``
+        # means the PID is alive but unresponsive; SIGTERM it so the
+        # new daemon can claim the PID file. ``dead_process`` and
+        # ``missing_pid`` skip this entirely.
+        killed_pid: int | None = None
+        kill_signal: str | None = None
+        if recheck.state == "stuck_no_tick" and diagnosed_pid is not None:
+            kill_signal = _terminate_with_grace(
+                diagnosed_pid, sleep_fn=sleep_fn, config_path=config_path,
+            )
+            if kill_signal in ("SIGTERM", "SIGKILL", "already_gone"):
+                killed_pid = diagnosed_pid
+            elif kill_signal in ("denied", "identity_mismatch"):
+                # Couldn't (or refused to) kill it — bail without
+                # spawning so we don't end up with two daemons or
+                # corrupt an unrelated user process.
+                err_label = (
+                    "signal_denied" if kill_signal == "denied"
+                    else "identity_mismatch"
+                )
+                logger.warning(
+                    "rail_daemon_supervisor: skipping respawn for pid=%d "
+                    "(%s)", diagnosed_pid, err_label,
+                )
+                result = RevivalResult(
+                    decision=recheck,
                     revived=False,
-                    spawn_error="signal_denied",
+                    spawn_error=err_label,
                     killed_pid=None,
                     kill_signal=kill_signal,
                 )
-            return result
+                if emit_audit:
+                    _emit_revival_audit(
+                        decision=recheck,
+                        revived=False,
+                        spawn_error=err_label,
+                        killed_pid=None,
+                        kill_signal=kill_signal,
+                    )
+                return result
 
-    # Step 2: clear stale PID file. ``rail_daemon._claim_pid_file``
-    # already overwrites stale files but only when the stored PID is
-    # confirmed dead; for ``stuck_no_tick`` we just killed the PID, so
-    # the file we want gone may still claim "alive" between the kill
-    # and the new daemon's first os.kill probe. Belt-and-suspenders.
-    try:
-        if pid_path.exists():
-            pid_path.unlink(missing_ok=True)
-    except OSError as exc:
-        logger.warning(
-            "rail_daemon_supervisor: could not unlink %s: %s — "
-            "_claim_pid_file should still recover", pid_path, exc,
-        )
+        # Step 2: compare-and-unlink. Only unlink the PID file if it
+        # still names the PID we diagnosed (or is unreadable / empty).
+        # If a concurrent supervisor already overwrote it with a fresh
+        # daemon's PID — which we'd see as a different number — we
+        # MUST NOT clobber that file: doing so removes the freshly-
+        # spawned daemon's ownership marker and the next caller will
+        # spawn ANOTHER daemon.
+        try:
+            if pid_path.exists():
+                current_pid = _read_pid(pid_path)
+                if current_pid is None or current_pid == diagnosed_pid:
+                    pid_path.unlink(missing_ok=True)
+                else:
+                    logger.warning(
+                        "rail_daemon_supervisor: pid_path now points at "
+                        "pid=%d (was %s); a concurrent supervisor must "
+                        "have spawned — standing down",
+                        current_pid, diagnosed_pid,
+                    )
+                    return RevivalResult(
+                        decision=recheck,
+                        revived=False,
+                        spawn_error=None,
+                        killed_pid=killed_pid,
+                        kill_signal=kill_signal,
+                    )
+        except OSError as exc:
+            logger.warning(
+                "rail_daemon_supervisor: could not unlink %s: %s — "
+                "_claim_pid_file should still recover", pid_path, exc,
+            )
 
-    # Step 3: spawn the new daemon. Default to the cli helper that
-    # ``pm up`` uses; tests inject a mock.
-    spawner = spawn_fn or _default_spawn_fn()
-    spawn_error: str | None = None
-    try:
-        spawner(config_path)
-    except Exception as exc:  # noqa: BLE001
-        spawn_error = f"{type(exc).__name__}: {exc}"
-        logger.exception("rail_daemon_supervisor: spawn failed")
+        # Step 3: spawn the new daemon. Default to the cli helper that
+        # ``pm up`` uses; tests inject a mock.
+        spawner = spawn_fn or _default_spawn_fn()
+        spawn_error: str | None = None
+        try:
+            spawner(config_path)
+        except Exception as exc:  # noqa: BLE001
+            spawn_error = f"{type(exc).__name__}: {exc}"
+            logger.exception("rail_daemon_supervisor: spawn failed")
 
-    revived = spawn_error is None
-    result = RevivalResult(
-        decision=decision,
-        revived=revived,
-        spawn_error=spawn_error,
-        killed_pid=killed_pid,
-        kill_signal=kill_signal,
-    )
-    if emit_audit:
-        _emit_revival_audit(
-            decision=decision,
+        revived = spawn_error is None
+        result = RevivalResult(
+            decision=recheck,
             revived=revived,
             spawn_error=spawn_error,
             killed_pid=killed_pid,
             kill_signal=kill_signal,
         )
-    return result
+        if emit_audit:
+            _emit_revival_audit(
+                decision=recheck,
+                revived=revived,
+                spawn_error=spawn_error,
+                killed_pid=killed_pid,
+                kill_signal=kill_signal,
+            )
+        return result
 
 
 def _default_spawn_fn() -> Callable[[Path], None]:

--- a/src/pollypm/rail_daemon_supervisor.py
+++ b/src/pollypm/rail_daemon_supervisor.py
@@ -1,0 +1,656 @@
+"""Self-recovery for the headless ``pollypm.rail_daemon`` heartbeat.
+
+Background
+----------
+PollyPM's heartbeat (cadence sweeps for ``session.health_sweep``,
+``audit_watchdog.tick``, ``advisor.tick`` etc) lives in the ``HeartbeatRail``
+ticker thread inside the ``pollypm.rail_daemon`` Python process.
+
+The rail's internal ``_tick_loop`` already wraps each ``tick()`` in a
+try/except so a single bad tick can't take the loop down — but if the
+*process* dies (OOM, sandbox kill, segfault in a C extension, ``pm
+reset --force`` racing the daemon's ``atexit`` handler, …) nothing
+detects the death and respawns it. The cockpit only spawns the daemon
+once at boot via ``cli._spawn_rail_daemon`` and then trusts it to stay
+alive for the rest of the session. When that trust is broken, queued
+tasks pile up unclaimed and the cascade goes silent.
+
+This is the **meta-watchdog problem**: the heartbeat can't watchdog
+itself. Self-recovery for the heartbeat process specifically needs an
+external supervisor. This module is that supervisor.
+
+Two staleness signals
+---------------------
+We treat the heartbeat as dead when either is true:
+
+1. **Process-level**: ``rail_daemon.pid`` is missing or names a PID
+   that is no longer a live process. The cli already checks the first
+   half (``cli._rail_daemon_live``); we add the second.
+2. **Tick-level**: the most recent ``messages`` row scoped to
+   ``heartbeat`` is older than ``stale_tick_seconds`` (default 180s).
+   The ``session.health_sweep`` cadence is ``@every 10s`` and emits a
+   heartbeat event every sweep, so 180s = ~18 missed sweeps means the
+   daemon is alive in name only — likely wedged on a SQLite lock,
+   pinned by a runaway plugin handler, or otherwise stuck in a way
+   the in-thread ``_tick_loop`` retry can't escape.
+
+Both signals are checked from outside the daemon's process — we never
+ask the daemon to confirm its own health. (That would defeat the
+point of an external supervisor.)
+
+Recovery action
+---------------
+When dead, we:
+
+1. Try to SIGTERM the existing PID (in case it's a zombie holding the
+   pid file). Wait briefly. Escalate to SIGKILL only if the process is
+   genuinely stuck — the rail's own shutdown handler removes the file
+   on graceful termination.
+2. Unlink the stale ``rail_daemon.pid`` so ``_claim_pid_file`` won't
+   bail when the new daemon boots.
+3. Spawn a fresh daemon via the same ``cli._spawn_rail_daemon`` path
+   ``pm up`` uses. Best-effort — failures are surfaced but don't raise
+   so the calling supervisor (cockpit periodic timer, ``pm heartbeat``
+   cron) can still complete its primary job.
+4. Emit ``daemon.revived`` audit event so operators can quantify
+   how often the field machine accumulates revivals (chronic revivals
+   indicate a real OOM / leak / loop, not just transient death).
+
+Throttle
+--------
+Revival is throttled to once per 60s by default. Without throttling,
+a daemon that dies-on-boot (e.g. broken plugin) gets respawned in a
+tight loop, burning CPU and filling logs without making progress. The
+throttle window is short enough that the user notices recovery within
+a minute, but long enough that the next revival has time to actually
+boot before another one fires.
+
+Where this is wired
+-------------------
+* **Cockpit periodic timer** — every 60s the cockpit calls
+  :func:`check_and_revive_rail_daemon`. This is the layer-2 watcher;
+  it watches the rail daemon (layer 1) which watches the cadence
+  handlers (layer 0).
+* **``pm heartbeat`` cron path** — every minute when cron fires
+  ``pm heartbeat``, the same check runs. This is defense-in-depth:
+  the cron path keeps the daemon alive even when the cockpit isn't
+  open or has itself crashed.
+
+Layer 3 (launchd KeepAlive watching the cockpit / launching the rail
+daemon directly on machine boot) is a separate opt-in surface — see
+``cli_features/rail_launchd.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "RevivalDecision",
+    "RevivalResult",
+    "DEFAULT_STALE_TICK_SECONDS",
+    "DEFAULT_REVIVAL_THROTTLE_SECONDS",
+    "DEFAULT_SIGTERM_GRACE_SECONDS",
+    "check_and_revive_rail_daemon",
+    "diagnose_rail_daemon",
+    "should_revive",
+]
+
+
+#: Tick-level staleness threshold. The cadence-sweep handler runs every
+#: 10s, so 180s ≈ 18 missed sweeps. Empirically this is well past the
+#: range where a temporarily-busy daemon catches up; anything older is
+#: a wedge / dead process.
+DEFAULT_STALE_TICK_SECONDS = 180.0
+
+#: Minimum gap between two revival attempts for the same workspace.
+#: Prevents a respawn loop when the daemon is dying-on-boot due to a
+#: persistent error (e.g. a plugin that crashes during initialise).
+DEFAULT_REVIVAL_THROTTLE_SECONDS = 60.0
+
+#: SIGTERM → SIGKILL grace window for a zombie / stuck PID. Mirrors
+#: ``rail_daemon_reaper._SIGTERM_GRACE_S`` for consistency. The rail's
+#: own SIGTERM handler tears down ``CoreRail`` synchronously and exits
+#: in well under this window when it's responsive at all.
+DEFAULT_SIGTERM_GRACE_SECONDS = 3.0
+
+
+# ---------------------------------------------------------------------------
+# Decision shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RevivalDecision:
+    """Outcome of inspecting the rail daemon — separate from acting on it.
+
+    Splitting "diagnose" from "revive" lets tests assert the diagnosis
+    pure-functionally without spawning processes, and lets callers log
+    a healthy daemon's status without paying the spawn-side cost.
+    """
+
+    # ``"alive"`` (no action), ``"missing_pid"``, ``"dead_process"``,
+    # ``"stuck_no_tick"``, or ``"throttled"``.
+    state: str
+    pid: int | None
+    last_tick_age_seconds: float | None
+    reason: str
+
+    @property
+    def needs_revival(self) -> bool:
+        """True iff the caller should attempt to spawn a new daemon."""
+        return self.state in {"missing_pid", "dead_process", "stuck_no_tick"}
+
+
+@dataclass(frozen=True, slots=True)
+class RevivalResult:
+    """Side-effecting outcome of :func:`check_and_revive_rail_daemon`."""
+
+    decision: RevivalDecision
+    revived: bool
+    spawn_error: str | None
+    killed_pid: int | None
+    kill_signal: str | None  # ``"SIGTERM"`` / ``"SIGKILL"`` / ``"already_gone"`` / ``None``
+
+
+# ---------------------------------------------------------------------------
+# Diagnosis (pure)
+# ---------------------------------------------------------------------------
+
+
+def _read_pid(pid_path: Path) -> int | None:
+    """Return the int PID stored in ``pid_path`` or ``None`` if unreadable.
+
+    Mirrors :func:`pollypm.cli._rail_daemon_live` parsing — we deliberately
+    don't share the helper because the cli copy unlinks stale files as a
+    side effect, which is not appropriate for a pure-diagnosis call.
+    """
+    try:
+        text = pid_path.read_text().strip()
+    except (FileNotFoundError, OSError):
+        return None
+    if not text:
+        return None
+    try:
+        pid = int(text)
+    except ValueError:
+        return None
+    return pid if pid > 0 else None
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """``os.kill(pid, 0)`` wrapper that treats ``EPERM`` as alive."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Belongs to another user; treat as alive — we never touch
+        # processes we don't own from this supervisor.
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _parse_iso_age_seconds(iso_text: str | None, *, now: datetime | None = None) -> float | None:
+    """Return ``now - iso_text`` in seconds, or ``None`` on parse error.
+
+    Tolerates the trailing ``Z`` suffix that older ``messages.created_at``
+    rows use as well as the modern ``+00:00`` offset shape.
+    """
+    if not iso_text:
+        return None
+    text = iso_text.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        ts = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    reference = now or datetime.now(UTC)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=UTC)
+    return max(0.0, (reference - ts).total_seconds())
+
+
+def diagnose_rail_daemon(
+    *,
+    pid_path: Path,
+    last_tick_iso: str | None,
+    last_revival_at: datetime | None = None,
+    now: datetime | None = None,
+    stale_tick_seconds: float = DEFAULT_STALE_TICK_SECONDS,
+    throttle_seconds: float = DEFAULT_REVIVAL_THROTTLE_SECONDS,
+) -> RevivalDecision:
+    """Decide whether the rail daemon needs reviving — pure function.
+
+    Args:
+        pid_path: location of ``rail_daemon.pid`` (typically
+            ``~/.pollypm/rail_daemon.pid``).
+        last_tick_iso: ISO timestamp of the most recent ``scope=heartbeat``
+            event in ``state.db``. Pass ``None`` when the database has
+            no rows yet (fresh install — we still revive on the
+            process-level signal).
+        last_revival_at: when this supervisor last revived the daemon.
+            Pass ``None`` on first call. Used to throttle.
+        now: clock injection point (default ``datetime.now(UTC)``).
+        stale_tick_seconds: age beyond which a tick-level signal flags
+            the daemon as wedged. Default :data:`DEFAULT_STALE_TICK_SECONDS`.
+        throttle_seconds: minimum gap between revivals. Default
+            :data:`DEFAULT_REVIVAL_THROTTLE_SECONDS`.
+
+    Returns:
+        :class:`RevivalDecision` describing the daemon's state. The
+        caller invokes :func:`check_and_revive_rail_daemon` to act on
+        a decision with ``needs_revival == True``.
+    """
+    reference = now or datetime.now(UTC)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=UTC)
+
+    pid = _read_pid(pid_path)
+    last_age = _parse_iso_age_seconds(last_tick_iso, now=reference)
+
+    # Throttle gate: even when the daemon looks dead, refuse to spawn
+    # if we revived it less than ``throttle_seconds`` ago. Always
+    # reports as ``"throttled"`` so callers can log the back-off.
+    if last_revival_at is not None:
+        if last_revival_at.tzinfo is None:
+            last_revival_at = last_revival_at.replace(tzinfo=UTC)
+        elapsed = (reference - last_revival_at).total_seconds()
+        if elapsed < throttle_seconds:
+            # Still inspect process state so the decision carries a
+            # useful diagnosis, but the state is sticky to throttled.
+            sub_state = _classify_state(pid, last_age, stale_tick_seconds)
+            return RevivalDecision(
+                state="throttled",
+                pid=pid,
+                last_tick_age_seconds=last_age,
+                reason=(
+                    f"would-revive ({sub_state}) but last revival was "
+                    f"{elapsed:.0f}s ago (< throttle {throttle_seconds:.0f}s)"
+                ),
+            )
+
+    state = _classify_state(pid, last_age, stale_tick_seconds)
+    reason = _explain(state, pid, last_age, stale_tick_seconds)
+    return RevivalDecision(
+        state=state,
+        pid=pid,
+        last_tick_age_seconds=last_age,
+        reason=reason,
+    )
+
+
+def _classify_state(
+    pid: int | None,
+    last_tick_age: float | None,
+    stale_tick_seconds: float,
+) -> str:
+    """Map (pid, last_tick_age) → state label (no throttling concerns)."""
+    if pid is None:
+        return "missing_pid"
+    if not _pid_is_alive(pid):
+        return "dead_process"
+    if last_tick_age is not None and last_tick_age > stale_tick_seconds:
+        return "stuck_no_tick"
+    return "alive"
+
+
+def _explain(
+    state: str,
+    pid: int | None,
+    last_tick_age: float | None,
+    stale_tick_seconds: float,
+) -> str:
+    if state == "alive":
+        if last_tick_age is not None:
+            return (
+                f"pid={pid} alive, last heartbeat tick {last_tick_age:.0f}s ago"
+            )
+        return f"pid={pid} alive (no tick history yet — fresh boot)"
+    if state == "missing_pid":
+        return "no rail_daemon.pid file (cockpit never spawned the daemon, or it crashed before writing)"
+    if state == "dead_process":
+        return f"pid={pid} from rail_daemon.pid is no longer a live process"
+    if state == "stuck_no_tick":
+        return (
+            f"pid={pid} alive but last heartbeat tick is {last_tick_age:.0f}s "
+            f"old (> {stale_tick_seconds:.0f}s threshold) — wedged"
+        )
+    return state
+
+
+def should_revive(decision: RevivalDecision) -> bool:
+    """Public wrapper around :attr:`RevivalDecision.needs_revival`.
+
+    Exposed as a top-level helper so callers don't have to import the
+    dataclass just to branch on the result.
+    """
+    return decision.needs_revival
+
+
+# ---------------------------------------------------------------------------
+# Action (side-effecting)
+# ---------------------------------------------------------------------------
+
+
+def _terminate_with_grace(
+    pid: int,
+    *,
+    grace_seconds: float = DEFAULT_SIGTERM_GRACE_SECONDS,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> str:
+    """SIGTERM, wait, SIGKILL if needed. Mirrors ``rail_daemon_reaper``.
+
+    Returns the signal label that ultimately took, or ``"already_gone"``
+    if the process was gone before we sent anything, or ``"denied"`` if
+    we lacked permission. ``"none"`` if ``pid <= 0``.
+    """
+    if pid <= 0:
+        return "none"
+    if not _pid_is_alive(pid):
+        return "already_gone"
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return "already_gone"
+    except PermissionError:
+        logger.warning(
+            "rail_daemon_supervisor: SIGTERM denied for pid=%d (not our process)",
+            pid,
+        )
+        return "denied"
+
+    deadline = time.monotonic() + grace_seconds
+    poll_interval = 0.1
+    while time.monotonic() < deadline:
+        if not _pid_is_alive(pid):
+            return "SIGTERM"
+        sleep_fn(poll_interval)
+
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return "SIGTERM"
+    except PermissionError:
+        return "denied"
+    return "SIGKILL"
+
+
+def _emit_revival_audit(
+    *,
+    decision: RevivalDecision,
+    revived: bool,
+    spawn_error: str | None,
+    killed_pid: int | None,
+    kill_signal: str | None,
+) -> None:
+    """Best-effort ``daemon.revived`` audit emit.
+
+    Mirrors :func:`pollypm.rail_daemon_reaper._emit_audit` — never
+    raises, uses the ``_workspace`` project key because the rail
+    daemon belongs to no single project.
+    """
+    try:
+        from pollypm.audit import emit as _audit_emit
+        from pollypm.audit.log import EVENT_DAEMON_REVIVED
+    except Exception:  # noqa: BLE001
+        return
+    try:
+        _audit_emit(
+            event=EVENT_DAEMON_REVIVED,
+            project="_workspace",
+            subject=f"rail_daemon/{decision.pid or 'none'}",
+            actor="system",
+            status="warn" if revived else "ok",
+            metadata={
+                "role": "rail",
+                "state": decision.state,
+                "reason": decision.reason,
+                "previous_pid": decision.pid,
+                "last_tick_age_s": decision.last_tick_age_seconds,
+                "revived": revived,
+                "spawn_error": spawn_error,
+                "killed_pid": killed_pid,
+                "kill_signal": kill_signal,
+            },
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def check_and_revive_rail_daemon(
+    *,
+    config_path: Path,
+    pid_path: Path,
+    last_tick_iso: str | None,
+    last_revival_at: datetime | None,
+    now: datetime | None = None,
+    stale_tick_seconds: float = DEFAULT_STALE_TICK_SECONDS,
+    throttle_seconds: float = DEFAULT_REVIVAL_THROTTLE_SECONDS,
+    spawn_fn: Callable[[Path], None] | None = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    emit_audit: bool = True,
+) -> RevivalResult:
+    """Diagnose the rail daemon and respawn it if it's dead / stuck.
+
+    The single entry point for layer-2 supervision. Safe to call from
+    any process (cockpit periodic timer, ``pm heartbeat`` cron, tests)
+    — concurrency between callers is bounded by the daemon's own
+    PID-file lock (``rail_daemon._claim_pid_file``), so a duplicate
+    spawn won't produce two live daemons.
+
+    Args:
+        config_path: ``~/.pollypm/pollypm.toml`` (or the test override).
+            Forwarded to :func:`pollypm.cli._spawn_rail_daemon` so the
+            new daemon points at the same workspace.
+        pid_path: location of ``rail_daemon.pid``.
+        last_tick_iso: most recent ``scope=heartbeat`` ISO timestamp.
+            Caller queries ``StateStore.last_heartbeat_at()``.
+        last_revival_at: when this supervisor last revived. Pass
+            ``None`` on first call; the caller persists this across
+            calls (e.g. as a Cockpit attribute).
+        now: clock injection point.
+        stale_tick_seconds, throttle_seconds: see :func:`diagnose_rail_daemon`.
+        spawn_fn: spawner callable (default
+            :func:`pollypm.cli._spawn_rail_daemon`). Tests inject a
+            mock so they don't actually spawn detached subprocesses.
+        sleep_fn: sleep injection for SIGTERM grace window.
+        emit_audit: when ``False``, skip the ``daemon.revived`` audit
+            emit (used by tests that don't want to write to the real
+            audit log).
+
+    Returns:
+        :class:`RevivalResult` carrying the diagnosis, whether a spawn
+        was attempted, and any signal / spawn error details.
+    """
+    decision = diagnose_rail_daemon(
+        pid_path=pid_path,
+        last_tick_iso=last_tick_iso,
+        last_revival_at=last_revival_at,
+        now=now,
+        stale_tick_seconds=stale_tick_seconds,
+        throttle_seconds=throttle_seconds,
+    )
+
+    if not decision.needs_revival:
+        # No-op for healthy / throttled daemons. We still log at debug
+        # so a flood of "alive" decisions is auditable when needed.
+        logger.debug(
+            "rail_daemon_supervisor: %s — %s", decision.state, decision.reason,
+        )
+        return RevivalResult(
+            decision=decision,
+            revived=False,
+            spawn_error=None,
+            killed_pid=None,
+            kill_signal=None,
+        )
+
+    logger.warning(
+        "rail_daemon_supervisor: reviving heartbeat — %s", decision.reason,
+    )
+
+    # Step 1: clean up the dead/stuck process. ``stuck_no_tick`` means
+    # the PID is alive but unresponsive; we SIGTERM it so the new
+    # daemon can claim the PID file. ``dead_process`` and
+    # ``missing_pid`` skip this entirely.
+    killed_pid: int | None = None
+    kill_signal: str | None = None
+    if decision.state == "stuck_no_tick" and decision.pid is not None:
+        kill_signal = _terminate_with_grace(decision.pid, sleep_fn=sleep_fn)
+        if kill_signal in ("SIGTERM", "SIGKILL", "already_gone"):
+            killed_pid = decision.pid
+        elif kill_signal == "denied":
+            # Couldn't kill it — bail without spawning so we don't end
+            # up with two daemons fighting for the same DB.
+            logger.warning(
+                "rail_daemon_supervisor: cannot signal pid=%d (permission "
+                "denied); skipping respawn — manual intervention required",
+                decision.pid,
+            )
+            result = RevivalResult(
+                decision=decision,
+                revived=False,
+                spawn_error="signal_denied",
+                killed_pid=None,
+                kill_signal=kill_signal,
+            )
+            if emit_audit:
+                _emit_revival_audit(
+                    decision=decision,
+                    revived=False,
+                    spawn_error="signal_denied",
+                    killed_pid=None,
+                    kill_signal=kill_signal,
+                )
+            return result
+
+    # Step 2: clear stale PID file. ``rail_daemon._claim_pid_file``
+    # already overwrites stale files but only when the stored PID is
+    # confirmed dead; for ``stuck_no_tick`` we just killed the PID, so
+    # the file we want gone may still claim "alive" between the kill
+    # and the new daemon's first os.kill probe. Belt-and-suspenders.
+    try:
+        if pid_path.exists():
+            pid_path.unlink(missing_ok=True)
+    except OSError as exc:
+        logger.warning(
+            "rail_daemon_supervisor: could not unlink %s: %s — "
+            "_claim_pid_file should still recover", pid_path, exc,
+        )
+
+    # Step 3: spawn the new daemon. Default to the cli helper that
+    # ``pm up`` uses; tests inject a mock.
+    spawner = spawn_fn or _default_spawn_fn()
+    spawn_error: str | None = None
+    try:
+        spawner(config_path)
+    except Exception as exc:  # noqa: BLE001
+        spawn_error = f"{type(exc).__name__}: {exc}"
+        logger.exception("rail_daemon_supervisor: spawn failed")
+
+    revived = spawn_error is None
+    result = RevivalResult(
+        decision=decision,
+        revived=revived,
+        spawn_error=spawn_error,
+        killed_pid=killed_pid,
+        kill_signal=kill_signal,
+    )
+    if emit_audit:
+        _emit_revival_audit(
+            decision=decision,
+            revived=revived,
+            spawn_error=spawn_error,
+            killed_pid=killed_pid,
+            kill_signal=kill_signal,
+        )
+    return result
+
+
+def _default_spawn_fn() -> Callable[[Path], None]:
+    """Resolve the cli's ``_spawn_rail_daemon`` lazily.
+
+    Lazy import keeps ``rail_daemon_supervisor`` importable from CLI
+    boot helpers without pulling in the full ``cli`` module's
+    typer-decorated surface.
+    """
+    from pollypm import cli as _cli
+
+    return _cli._spawn_rail_daemon
+
+
+# ---------------------------------------------------------------------------
+# Convenience helpers for callers (cockpit / cli)
+# ---------------------------------------------------------------------------
+
+
+def query_last_heartbeat_iso(state_db_path: Path) -> str | None:
+    """Open the StateStore read-only and return ``last_heartbeat_at()``.
+
+    Returns ``None`` when the DB doesn't exist (fresh install) or any
+    error occurs — callers must treat ``None`` as "no tick history",
+    not "tick stale".
+    """
+    if not state_db_path.exists():
+        return None
+    try:
+        from pollypm.storage.state import StateStore
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        store = StateStore(state_db_path, readonly=True)
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        return store.last_heartbeat_at()
+    except Exception:  # noqa: BLE001
+        return None
+    finally:
+        try:
+            close = getattr(store, "close", None)
+            if callable(close):
+                close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def revive_if_needed(
+    *,
+    config_path: Path,
+    state_db_path: Path,
+    pid_path: Path,
+    last_revival_at: datetime | None,
+    **kwargs: Any,
+) -> RevivalResult:
+    """One-call wrapper that resolves the tick signal from state.db.
+
+    Designed for periodic-timer callers (cockpit, ``pm heartbeat``) so
+    they only need to remember the four paths + their persisted
+    ``last_revival_at`` between calls.
+    """
+    last_tick_iso = query_last_heartbeat_iso(state_db_path)
+    return check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=last_tick_iso,
+        last_revival_at=last_revival_at,
+        **kwargs,
+    )

--- a/tests/test_cockpit_rail_liveness_wiring.py
+++ b/tests/test_cockpit_rail_liveness_wiring.py
@@ -1,0 +1,155 @@
+"""Smoke test for the cockpit's rail-daemon liveness watchdog wiring.
+
+The full PollyCockpitApp can't be exercised without a Textual harness +
+the supervisor stack, so this test focuses on the small surface that
+``_tick_rail_liveness`` and its helpers expose:
+
+* The periodic-cadence env-var override actually wins.
+* ``_cockpit_uses_external_rail_daemon`` only returns True when the
+  PID file exists — i.e. it skips the in-process rail mode (where
+  respawning a daemon would race the cockpit's own ticker thread).
+* ``_resolve_rail_liveness_interval`` falls back cleanly on garbage.
+
+We don't unit-test ``_tick_rail_liveness`` itself — it delegates to
+:func:`rail_daemon_supervisor.revive_if_needed`, which has its own
+:mod:`tests.test_rail_daemon_supervisor` coverage.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pollypm.cockpit_ui import PollyCockpitApp
+
+
+class _StubRouter:
+    """Minimal CockpitRouter stub so the App ctor doesn't blow up."""
+
+    def __init__(self) -> None:
+        self.tmux = object()
+
+    def selected_key(self) -> str:
+        return "dashboard"
+
+
+@pytest.fixture
+def isolated_app(monkeypatch, tmp_path: Path) -> PollyCockpitApp:
+    """Construct a PollyCockpitApp without running ``on_mount``.
+
+    Patches every collaborator the constructor expects so we get a
+    bare object we can poke at — the actual UI never mounts.
+    """
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text("")
+
+    monkeypatch.setattr("pollypm.cockpit_ui.CockpitRouter", lambda *a, **k: _StubRouter())
+    monkeypatch.setattr("pollypm.cockpit_ui.CockpitPresence", lambda *a, **k: object())
+
+    class _StubService:
+        def __init__(self, *a, **k) -> None:
+            pass
+
+    monkeypatch.setattr("pollypm.service_api.PollyPMService", _StubService)
+
+    app = PollyCockpitApp(config_path)
+    return app
+
+
+def test_resolve_interval_uses_class_default(isolated_app, monkeypatch):
+    monkeypatch.delenv("POLLYPM_RAIL_LIVENESS_INTERVAL_SECONDS", raising=False)
+    assert isolated_app._resolve_rail_liveness_interval() == float(
+        PollyCockpitApp.RAIL_LIVENESS_CHECK_INTERVAL_SECONDS
+    )
+
+
+def test_resolve_interval_honours_env(isolated_app, monkeypatch):
+    monkeypatch.setenv("POLLYPM_RAIL_LIVENESS_INTERVAL_SECONDS", "5")
+    assert isolated_app._resolve_rail_liveness_interval() == 5.0
+
+
+def test_resolve_interval_garbage_falls_back(isolated_app, monkeypatch):
+    monkeypatch.setenv("POLLYPM_RAIL_LIVENESS_INTERVAL_SECONDS", "not-a-number")
+    assert isolated_app._resolve_rail_liveness_interval() == float(
+        PollyCockpitApp.RAIL_LIVENESS_CHECK_INTERVAL_SECONDS
+    )
+
+
+def test_resolve_interval_negative_falls_back(isolated_app, monkeypatch):
+    monkeypatch.setenv("POLLYPM_RAIL_LIVENESS_INTERVAL_SECONDS", "-10")
+    assert isolated_app._resolve_rail_liveness_interval() == float(
+        PollyCockpitApp.RAIL_LIVENESS_CHECK_INTERVAL_SECONDS
+    )
+
+
+def test_uses_external_rail_daemon_returns_boot_capture_true(isolated_app):
+    """Boot-time captured ``True`` means the cockpit deferred to a daemon."""
+    isolated_app._rail_daemon_was_external = True
+    assert isolated_app._cockpit_uses_external_rail_daemon() is True
+
+
+def test_uses_external_rail_daemon_default_is_false(isolated_app):
+    """Without a boot-time capture (cockpit-hosted mode) the gate is False."""
+    assert isolated_app._rail_daemon_was_external is False
+    assert isolated_app._cockpit_uses_external_rail_daemon() is False
+
+
+def test_tick_rail_liveness_skips_when_cockpit_hosted(
+    isolated_app, monkeypatch,
+):
+    """When the cockpit is hosting the rail the tick MUST NOT call ``revive_if_needed``.
+
+    Running the watcher in cockpit-hosted mode would race the
+    cockpit's own ticker thread (the contention failure described in
+    ``_start_core_rail``).
+    """
+    isolated_app._rail_daemon_was_external = False  # cockpit-hosted
+    called: list[bool] = []
+
+    def _fake_revive(**kwargs):
+        called.append(True)
+        raise AssertionError("revive_if_needed must not run in cockpit-hosted mode")
+
+    monkeypatch.setattr(
+        "pollypm.rail_daemon_supervisor.revive_if_needed", _fake_revive,
+    )
+
+    # Method should swallow without raising and without calling the helper.
+    isolated_app._tick_rail_liveness()
+    assert called == []
+
+
+def test_tick_rail_liveness_invokes_revive_in_external_mode(
+    isolated_app, monkeypatch, tmp_path: Path,
+):
+    """When a daemon was alive at boot, the tick DOES call ``revive_if_needed``."""
+    isolated_app._rail_daemon_was_external = True
+
+    captured: dict[str, object] = {}
+
+    def _fake_revive(**kwargs):
+        captured.update(kwargs)
+        # Return a stub RevivalResult that signals "alive" so the
+        # tick treats this as a no-op revival.
+        from pollypm.rail_daemon_supervisor import RevivalDecision, RevivalResult
+        return RevivalResult(
+            decision=RevivalDecision(
+                state="alive",
+                pid=12345,
+                last_tick_age_seconds=10.0,
+                reason="pid alive",
+            ),
+            revived=False,
+            spawn_error=None,
+            killed_pid=None,
+            kill_signal=None,
+        )
+
+    monkeypatch.setattr(
+        "pollypm.rail_daemon_supervisor.revive_if_needed", _fake_revive,
+    )
+
+    isolated_app._tick_rail_liveness()
+    assert "config_path" in captured
+    assert "pid_path" in captured

--- a/tests/test_rail_daemon_launchd.py
+++ b/tests/test_rail_daemon_launchd.py
@@ -1,0 +1,234 @@
+"""Tests for :mod:`pollypm.rail_daemon_launchd` (layer-3 supervision).
+
+These tests never write to the user's real ``~/Library/LaunchAgents/``
+or actually invoke ``launchctl``. Both are stubbed via the
+``plist_dir`` and ``launchctl_runner`` injection points.
+"""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from pollypm.rail_daemon_launchd import (
+    DEFAULT_LABEL,
+    DEFAULT_THROTTLE_INTERVAL_SECONDS,
+    build_plist_dict,
+    install_launchd_keepalive,
+    plist_path_for_label,
+    uninstall_launchd_keepalive,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _LaunchctlSpy:
+    """Captures every ``launchctl`` invocation a test triggers."""
+
+    def __init__(self, returncode: int = 0, stderr: str = "") -> None:
+        self.calls: list[list[str]] = []
+        self.returncode = returncode
+        self.stderr = stderr
+
+    def __call__(self, argv: list[str]) -> subprocess.CompletedProcess:
+        self.calls.append(argv)
+        return subprocess.CompletedProcess(
+            args=argv, returncode=self.returncode, stdout="", stderr=self.stderr,
+        )
+
+
+# ---------------------------------------------------------------------------
+# build_plist_dict
+# ---------------------------------------------------------------------------
+
+
+def test_plist_has_keep_alive_and_run_at_load():
+    plist = build_plist_dict(
+        label=DEFAULT_LABEL,
+        config_path=Path("/Users/sam/.pollypm/pollypm.toml"),
+    )
+    assert plist["KeepAlive"] is True
+    assert plist["RunAtLoad"] is True
+
+
+def test_plist_program_args_include_config_path():
+    plist = build_plist_dict(
+        label=DEFAULT_LABEL,
+        config_path=Path("/tmp/test/pollypm.toml"),
+        python_executable="/usr/bin/python3",
+    )
+    args = plist["ProgramArguments"]
+    assert args[0] == "/usr/bin/python3"
+    assert args[1] == "-m"
+    assert args[2] == "pollypm.rail_daemon"
+    assert "--config" in args
+    assert "/tmp/test/pollypm.toml" in args
+
+
+def test_plist_label_is_propagated():
+    plist = build_plist_dict(
+        label="com.example.test",
+        config_path=Path("/tmp/cfg.toml"),
+    )
+    assert plist["Label"] == "com.example.test"
+
+
+def test_plist_throttle_interval_default():
+    plist = build_plist_dict(
+        label=DEFAULT_LABEL, config_path=Path("/tmp/cfg.toml"),
+    )
+    assert plist["ThrottleInterval"] == DEFAULT_THROTTLE_INTERVAL_SECONDS
+
+
+def test_plist_log_path_default(tmp_path: Path):
+    plist = build_plist_dict(
+        label=DEFAULT_LABEL, config_path=Path("/tmp/cfg.toml"),
+    )
+    # The default log path is the same one ``cli._spawn_rail_daemon``
+    # writes to — operators don't have to track two log files.
+    assert plist["StandardOutPath"].endswith(".pollypm/rail_daemon.log")
+    assert plist["StandardErrorPath"] == plist["StandardOutPath"]
+
+
+def test_plist_serializes_with_plistlib(tmp_path: Path):
+    """The shape we build must round-trip through ``plistlib.dumps``."""
+    plist = build_plist_dict(
+        label=DEFAULT_LABEL, config_path=tmp_path / "pollypm.toml",
+    )
+    raw = plistlib.dumps(plist)
+    parsed = plistlib.loads(raw)
+    assert parsed["Label"] == DEFAULT_LABEL
+    assert parsed["KeepAlive"] is True
+
+
+# ---------------------------------------------------------------------------
+# install_launchd_keepalive
+# ---------------------------------------------------------------------------
+
+
+def test_install_writes_plist_file(tmp_path: Path):
+    spy = _LaunchctlSpy()
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text("")
+    plist_dir = tmp_path / "LaunchAgents"
+
+    plist_path = install_launchd_keepalive(
+        config_path=config_path,
+        plist_dir=plist_dir,
+        launchctl_runner=spy,
+    )
+
+    assert plist_path.exists()
+    assert plist_path == plist_dir / f"{DEFAULT_LABEL}.plist"
+    parsed = plistlib.loads(plist_path.read_bytes())
+    assert parsed["Label"] == DEFAULT_LABEL
+
+
+def test_install_calls_launchctl_bootout_then_bootstrap(tmp_path: Path):
+    """We bootout first to handle re-installs cleanly."""
+    spy = _LaunchctlSpy()
+    config_path = tmp_path / "pollypm.toml"
+    plist_dir = tmp_path / "LaunchAgents"
+
+    install_launchd_keepalive(
+        config_path=config_path,
+        plist_dir=plist_dir,
+        launchctl_runner=spy,
+    )
+
+    assert len(spy.calls) == 2
+    assert spy.calls[0][1] == "bootout"
+    assert spy.calls[1][1] == "bootstrap"
+
+
+def test_install_with_load_false_skips_launchctl(tmp_path: Path):
+    spy = _LaunchctlSpy()
+    config_path = tmp_path / "pollypm.toml"
+    plist_dir = tmp_path / "LaunchAgents"
+
+    install_launchd_keepalive(
+        config_path=config_path,
+        plist_dir=plist_dir,
+        launchctl_runner=spy,
+        load=False,
+    )
+
+    assert spy.calls == []
+
+
+def test_install_creates_parent_directory(tmp_path: Path):
+    """Tolerate a fresh user account without ``~/Library/LaunchAgents``."""
+    spy = _LaunchctlSpy()
+    config_path = tmp_path / "pollypm.toml"
+    plist_dir = tmp_path / "deeply" / "nested" / "LaunchAgents"
+
+    plist_path = install_launchd_keepalive(
+        config_path=config_path,
+        plist_dir=plist_dir,
+        launchctl_runner=spy,
+    )
+
+    assert plist_path.exists()
+    assert plist_dir.exists()
+
+
+def test_install_returncode_nonzero_does_not_raise(tmp_path: Path):
+    spy = _LaunchctlSpy(returncode=5, stderr="already loaded")
+    config_path = tmp_path / "pollypm.toml"
+    plist_dir = tmp_path / "LaunchAgents"
+
+    # Should not raise — bootstrap returncode is informational, not fatal.
+    plist_path = install_launchd_keepalive(
+        config_path=config_path,
+        plist_dir=plist_dir,
+        launchctl_runner=spy,
+    )
+    assert plist_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# uninstall_launchd_keepalive
+# ---------------------------------------------------------------------------
+
+
+def test_uninstall_removes_plist_and_calls_bootout(tmp_path: Path):
+    spy = _LaunchctlSpy()
+    config_path = tmp_path / "pollypm.toml"
+    plist_dir = tmp_path / "LaunchAgents"
+    install_launchd_keepalive(
+        config_path=config_path, plist_dir=plist_dir, launchctl_runner=spy,
+    )
+    assert (plist_dir / f"{DEFAULT_LABEL}.plist").exists()
+
+    spy.calls.clear()
+    removed = uninstall_launchd_keepalive(
+        plist_dir=plist_dir, launchctl_runner=spy,
+    )
+    assert removed is True
+    assert not (plist_dir / f"{DEFAULT_LABEL}.plist").exists()
+    assert any(c[1] == "bootout" for c in spy.calls)
+
+
+def test_uninstall_when_no_plist_returns_false(tmp_path: Path):
+    spy = _LaunchctlSpy()
+    plist_dir = tmp_path / "LaunchAgents"
+    plist_dir.mkdir()
+
+    removed = uninstall_launchd_keepalive(
+        plist_dir=plist_dir, launchctl_runner=spy,
+    )
+    assert removed is False
+    assert spy.calls == []
+
+
+def test_plist_path_for_label_default():
+    path = plist_path_for_label("com.example.thing")
+    assert path.name == "com.example.thing.plist"
+    assert "LaunchAgents" in str(path)

--- a/tests/test_rail_daemon_supervisor.py
+++ b/tests/test_rail_daemon_supervisor.py
@@ -10,6 +10,12 @@ in N seconds) and respawn it. Tests focus on:
 * The revival path actually invoking the spawn callback exactly once
   per qualifying decision.
 * Permission-denied paths bailing without fanning out.
+* PID-identity verification preventing accidental kills of unrelated
+  user processes whose PID was reused after the daemon died.
+* Concurrent-revival lock preventing two callers from spawning two
+  daemons via a unlink-then-spawn race.
+* Cron path opting out of ``missing_pid`` revival so it doesn't race
+  the cockpit's in-process rail.
 
 We never spawn a real ``pollypm.rail_daemon`` process here — the
 spawn callable is always injected.
@@ -18,11 +24,13 @@ spawn callable is always injected.
 from __future__ import annotations
 
 import os
+import threading
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 
+import pollypm.rail_daemon_supervisor as _supervisor_mod
 from pollypm.rail_daemon_supervisor import (
     DEFAULT_REVIVAL_THROTTLE_SECONDS,
     DEFAULT_STALE_TICK_SECONDS,
@@ -31,6 +39,23 @@ from pollypm.rail_daemon_supervisor import (
     diagnose_rail_daemon,
     should_revive,
 )
+
+
+@pytest.fixture(autouse=True)
+def _stub_pid_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default identity check: any live PID looks like our daemon.
+
+    The supervisor verifies a live PID's argv to avoid signaling an
+    unrelated process whose PID was reused. Unit tests use
+    ``os.getpid()`` (the pytest process) as a stand-in for "alive PID";
+    pytest's argv obviously doesn't match ``pollypm.rail_daemon``, so
+    without this override every "alive" test would classify as
+    ``dead_process``. Tests that exercise the identity check explicitly
+    re-patch this helper.
+    """
+    monkeypatch.setattr(
+        _supervisor_mod, "_pid_matches_daemon", lambda pid, cfg: True,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -405,3 +430,351 @@ def test_revive_idempotent_under_throttle(tmp_path: Path):
     assert second.revived is False
     assert second.decision.state == "throttled"
     assert len(spawner.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL-1 — PID identity verification
+# ---------------------------------------------------------------------------
+#
+# The supervisor records a PID and later signals it. Between record and
+# signal, the original daemon can die and the kernel can hand the same
+# PID number to an unrelated user process (an editor, a shell, anything).
+# Without identity verification, ``revive_if_needed`` would SIGTERM that
+# innocent process. These tests pin the safety guard.
+
+
+def test_unrelated_live_pid_classified_as_dead_not_stuck(
+    tmp_path: Path, now_utc: datetime, monkeypatch: pytest.MonkeyPatch,
+):
+    """A live PID whose argv is NOT our daemon must classify as dead_process.
+
+    The autouse stub above forces identity match; this test overrides
+    it to simulate the real-world PID-reuse case where the recorded
+    PID is now an unrelated process. The supervisor MUST NOT classify
+    that as ``stuck_no_tick`` — doing so would queue it for SIGTERM.
+    """
+    monkeypatch.setattr(
+        _supervisor_mod, "_pid_matches_daemon", lambda pid, cfg: False,
+    )
+    pid_path = tmp_path / "rail_daemon.pid"
+    pid_path.write_text(str(os.getpid()))  # live PID, but NOT our daemon
+    stale_tick = _iso_seconds_ago(now_utc, DEFAULT_STALE_TICK_SECONDS + 60)
+    decision = diagnose_rail_daemon(
+        pid_path=pid_path,
+        last_tick_iso=stale_tick,
+        now=now_utc,
+        config_path=tmp_path / "pollypm.toml",
+    )
+    # Without the identity check this would be ``stuck_no_tick`` and a
+    # SIGTERM would follow. With the check, it's ``dead_process`` —
+    # safe: the action path skips signaling for dead_process entirely.
+    assert decision.state == "dead_process"
+    assert decision.needs_revival is True
+
+
+def test_revive_skips_signaling_when_pid_identity_mismatches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+):
+    """Even if classify-state was bypassed, the action path re-checks identity.
+
+    Belt-and-suspenders: if a bug or race promotes a non-daemon PID to
+    ``stuck_no_tick``, the terminate helper still verifies identity
+    before sending SIGTERM and reports ``identity_mismatch`` instead.
+    """
+    config_path = tmp_path / "pollypm.toml"
+    pid_path = tmp_path / "rail_daemon.pid"
+    pid_path.write_text(str(os.getpid()))
+    spawner = _SpawnRecorder()
+
+    # Force the classifier to say "stuck_no_tick" even though the PID
+    # isn't our daemon. The terminate helper must still refuse to kill.
+    monkeypatch.setattr(
+        _supervisor_mod, "_pid_matches_daemon", lambda pid, cfg: False,
+    )
+
+    sent_signals: list[tuple[int, int]] = []
+    real_kill = os.kill
+
+    def tracking_kill(pid: int, sig: int) -> None:
+        sent_signals.append((pid, sig))
+        if sig == 0:
+            return real_kill(pid, sig)
+        # Don't actually signal; test cares whether we ATTEMPTED to kill.
+
+    monkeypatch.setattr(_supervisor_mod.os, "kill", tracking_kill)
+
+    # Synthesize the stuck_no_tick path by passing a stale tick — but
+    # because identity returns False, classify_state will say
+    # dead_process. To test the terminate helper directly, call it.
+    result_signal = _supervisor_mod._terminate_with_grace(
+        os.getpid(),
+        sleep_fn=lambda _s: None,
+        config_path=config_path,
+    )
+    assert result_signal == "identity_mismatch"
+    # Only the os.kill(pid, 0) liveness probe is allowed; no SIGTERM.
+    real_signals = [sig for (_pid, sig) in sent_signals if sig != 0]
+    assert real_signals == [], f"unexpected signals sent: {real_signals!r}"
+
+
+# Resolve the real (unstubbed) helper once at module load so identity-
+# helper tests can call it directly. The autouse fixture replaces the
+# attribute on the module; this captured reference dodges that.
+_REAL_PID_MATCHES = _supervisor_mod._pid_matches_daemon
+
+
+def test_pid_matches_daemon_uses_cmdline(monkeypatch: pytest.MonkeyPatch):
+    """``_pid_matches_daemon`` must consult cmdline, not just liveness.
+
+    Verifies the helper inspects the recorded process's argv (via
+    ``/proc/<pid>/cmdline`` on Linux or ``ps -p <pid> -o args=`` on
+    macOS / fallback) and rejects PIDs whose argv lacks the
+    ``pollypm.rail_daemon`` marker.
+    """
+    # Stub the cmdline reader so we can exercise the helper's matching
+    # logic on synthetic argv strings without spawning real processes.
+    monkeypatch.setattr(
+        _supervisor_mod,
+        "_read_pid_command_line",
+        lambda pid: "/usr/bin/vim /tmp/notes.md",
+    )
+    assert _REAL_PID_MATCHES(12345, Path("/x/pollypm.toml")) is False
+
+    monkeypatch.setattr(
+        _supervisor_mod,
+        "_read_pid_command_line",
+        lambda pid: "/usr/bin/python -m pollypm.rail_daemon --config /x/pollypm.toml",
+    )
+    assert _REAL_PID_MATCHES(12345, Path("/x/pollypm.toml")) is True
+
+    # Same daemon, but a DIFFERENT workspace's config — must not match.
+    monkeypatch.setattr(
+        _supervisor_mod,
+        "_read_pid_command_line",
+        lambda pid: "/usr/bin/python -m pollypm.rail_daemon --config /y/pollypm.toml",
+    )
+    assert _REAL_PID_MATCHES(12345, Path("/x/pollypm.toml")) is False
+
+    # Daemon with no explicit --config (legacy default) — accept as ours.
+    monkeypatch.setattr(
+        _supervisor_mod,
+        "_read_pid_command_line",
+        lambda pid: "/usr/bin/python -m pollypm.rail_daemon",
+    )
+    assert _REAL_PID_MATCHES(12345, Path("/x/pollypm.toml")) is True
+
+    # No cmdline available at all (process gone, ps failed) — fail safe.
+    monkeypatch.setattr(
+        _supervisor_mod, "_read_pid_command_line", lambda pid: None,
+    )
+    assert _REAL_PID_MATCHES(12345, Path("/x/pollypm.toml")) is False
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL-2 — concurrent revival must produce exactly one spawn
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_revival_spawns_exactly_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+):
+    """Two threads racing into ``check_and_revive_rail_daemon`` → one spawn.
+
+    Without the supervisor lock this race produces TWO spawns: both
+    threads diagnose missing_pid, both unlink, both invoke the spawner.
+    The fix wraps the kill-unlink-spawn critical section in a
+    cross-process flock; this test exercises the in-process equivalent
+    (flock is per-fd so one process with two threads still serializes).
+
+    Determinism: each thread blocks on a barrier until both are armed,
+    then both call the supervisor. The lock is the only thing
+    serializing them — no sleeps required.
+    """
+    config_path = tmp_path / "pollypm.toml"
+    pid_path = tmp_path / "rail_daemon.pid"
+
+    spawn_calls: list[Path] = []
+    spawn_lock = threading.Lock()
+    barrier = threading.Barrier(2)
+
+    def spawner(cfg: Path) -> None:
+        # The first spawn must write a fresh PID file so the SECOND
+        # thread (when it eventually gets the lock) sees a healthy
+        # daemon and stands down.
+        with spawn_lock:
+            spawn_calls.append(cfg)
+            pid_path.write_text(str(os.getpid()))
+
+    results: list = [None, None]
+
+    def runner(idx: int) -> None:
+        barrier.wait()  # release both threads simultaneously
+        results[idx] = check_and_revive_rail_daemon(
+            config_path=config_path,
+            pid_path=pid_path,
+            last_tick_iso=None,
+            last_revival_at=None,
+            spawn_fn=spawner,
+            emit_audit=False,
+        )
+
+    t1 = threading.Thread(target=runner, args=(0,))
+    t2 = threading.Thread(target=runner, args=(1,))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+    assert not t1.is_alive() and not t2.is_alive()
+
+    # CRITICAL: only one of the two callers may have actually spawned.
+    assert len(spawn_calls) == 1, (
+        f"expected exactly one spawn under lock, got {len(spawn_calls)}"
+    )
+    revived_count = sum(1 for r in results if r and r.revived)
+    assert revived_count == 1
+    # The other caller should have observed a healthy / no-need state.
+    standby = next(r for r in results if r is not None and not r.revived)
+    assert standby.spawn_error in (None, "lock_busy")
+
+
+def test_post_lock_recheck_stands_down_when_daemon_revived_concurrently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+):
+    """If a sibling supervisor spawned while we waited on the lock, stand down.
+
+    Critical-2 has two layers of defense: the flock serializes callers,
+    and the post-lock recheck verifies the world hasn't changed while
+    we waited. This test exercises the recheck independently — we
+    pretend to acquire the lock cleanly but a fresh PID file appeared
+    between the initial diagnose and the body of the critical section.
+    """
+    config_path = tmp_path / "pollypm.toml"
+    pid_path = tmp_path / "rail_daemon.pid"
+    # Initial state: dead PID, original diagnose says dead_process.
+    pid_path.write_text("999999")
+    spawner = _SpawnRecorder()
+
+    # Stage the world: AFTER the initial diagnose runs but BEFORE the
+    # post-lock recheck, replace the PID file with a fresh "alive" PID
+    # (using our pytest PID + the autouse identity stub which says any
+    # live PID matches). The recheck should now classify as ``alive``
+    # and bail without calling the spawner or unlinking anything.
+    real_diagnose = _supervisor_mod.diagnose_rail_daemon
+    diagnose_count = {"n": 0}
+
+    def staged_diagnose(**kw):
+        diagnose_count["n"] += 1
+        if diagnose_count["n"] == 2:
+            # Simulate a concurrent supervisor having just spawned a
+            # daemon: replace the PID file before recheck reads it.
+            pid_path.write_text(str(os.getpid()))
+        return real_diagnose(**kw)
+
+    monkeypatch.setattr(_supervisor_mod, "diagnose_rail_daemon", staged_diagnose)
+
+    result = check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=None,
+        last_revival_at=None,
+        spawn_fn=spawner,
+        emit_audit=False,
+    )
+
+    # Post-lock recheck must detect the fresh daemon and stand down.
+    assert spawner.calls == [], (
+        "spawner must not run after a sibling supervisor already revived"
+    )
+    assert result.revived is False
+    # The recheck saw an alive process; reflect that in the result.
+    assert result.decision.state == "alive"
+    # The fresh PID file is preserved — we never reached the unlink step.
+    assert pid_path.exists()
+    assert pid_path.read_text().strip() == str(os.getpid())
+
+
+# ---------------------------------------------------------------------------
+# HIGH-1 — cron path must not spawn when cockpit hosts in-process
+# ---------------------------------------------------------------------------
+
+
+def test_cron_skips_revival_on_missing_pid(tmp_path: Path):
+    """``cron=True`` downgrades ``missing_pid`` to no-op.
+
+    When the cockpit is hosting the rail in-process, no PID file is
+    ever written. A cron-driven heartbeat would diagnose ``missing_pid``
+    and spawn a headless daemon, producing two concurrent tickers.
+    The cron flag prevents that.
+    """
+    config_path = tmp_path / "pollypm.toml"
+    pid_path = tmp_path / "rail_daemon.pid"  # never created
+    spawner = _SpawnRecorder()
+
+    result = check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=None,
+        last_revival_at=None,
+        spawn_fn=spawner,
+        emit_audit=False,
+        cron=True,
+    )
+
+    assert result.decision.state == "missing_pid"
+    assert result.revived is False
+    assert spawner.calls == [], (
+        "cron must NOT spawn on missing_pid — cockpit may be hosting in-process"
+    )
+
+
+def test_cron_still_revives_dead_process(tmp_path: Path):
+    """``cron=True`` must still recover ``dead_process`` daemons.
+
+    A dead_process diagnosis means a daemon WAS recorded (so the
+    cockpit isn't hosting in-process) but its PID is no longer alive.
+    Cron must revive in that case — that's the failure mode it exists
+    to defend against.
+    """
+    config_path = tmp_path / "pollypm.toml"
+    pid_path = tmp_path / "rail_daemon.pid"
+    pid_path.write_text("999999")  # dead PID
+    spawner = _SpawnRecorder()
+
+    result = check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=None,
+        last_revival_at=None,
+        spawn_fn=spawner,
+        emit_audit=False,
+        cron=True,
+    )
+
+    assert result.decision.state == "dead_process"
+    assert result.revived is True
+    assert spawner.calls == [config_path]
+
+
+def test_non_cron_caller_still_revives_missing_pid(tmp_path: Path):
+    """Default (cockpit) caller still acts on ``missing_pid``.
+
+    The cron guard must NOT regress the cockpit periodic timer's
+    ability to spawn a daemon when there's no PID file at all.
+    """
+    config_path = tmp_path / "pollypm.toml"
+    pid_path = tmp_path / "rail_daemon.pid"  # never created
+    spawner = _SpawnRecorder()
+
+    result = check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=None,
+        last_revival_at=None,
+        spawn_fn=spawner,
+        emit_audit=False,
+        # cron defaults to False
+    )
+
+    assert result.decision.state == "missing_pid"
+    assert result.revived is True
+    assert spawner.calls == [config_path]

--- a/tests/test_rail_daemon_supervisor.py
+++ b/tests/test_rail_daemon_supervisor.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import os
 import threading
+import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -261,22 +262,40 @@ class _SpawnRecorder:
     Records every config_path it was invoked with so tests can assert
     not just "did revival happen" but "did revival happen at all" /
     "with the right config".
+
+    By default the recorder also writes the current pytest PID into
+    ``pid_path`` (when supplied), mimicking a real freshly-spawned
+    daemon claiming its PID file. This is required so the supervisor's
+    post-spawn ``_wait_for_child_pid`` step (which holds the lock until
+    a matching PID lands on disk) returns promptly rather than waiting
+    out the full 5s timeout. Tests that need to model "spawn returned
+    but child never wrote a PID" pass ``write_pid=False``.
     """
 
-    def __init__(self, raise_on_call: bool = False) -> None:
+    def __init__(
+        self,
+        raise_on_call: bool = False,
+        *,
+        pid_path: Path | None = None,
+        write_pid: bool = True,
+    ) -> None:
         self.calls: list[Path] = []
         self.raise_on_call = raise_on_call
+        self.pid_path = pid_path
+        self.write_pid = write_pid
 
     def __call__(self, config_path: Path) -> None:
         self.calls.append(config_path)
         if self.raise_on_call:
             raise RuntimeError("simulated spawn failure")
+        if self.write_pid and self.pid_path is not None:
+            self.pid_path.write_text(str(os.getpid()))
 
 
 def test_revive_calls_spawner_when_pid_missing(tmp_path: Path):
     config_path = tmp_path / "pollypm.toml"
     pid_path = tmp_path / "rail_daemon.pid"
-    spawner = _SpawnRecorder()
+    spawner = _SpawnRecorder(pid_path=pid_path)
 
     result = check_and_revive_rail_daemon(
         config_path=config_path,
@@ -297,7 +316,7 @@ def test_revive_skips_when_alive(tmp_path: Path):
     config_path = tmp_path / "pollypm.toml"
     pid_path = tmp_path / "rail_daemon.pid"
     pid_path.write_text(str(os.getpid()))
-    spawner = _SpawnRecorder()
+    spawner = _SpawnRecorder(pid_path=pid_path)
     last_tick_iso = (datetime.now(UTC) - timedelta(seconds=10)).isoformat()
 
     result = check_and_revive_rail_daemon(
@@ -318,7 +337,7 @@ def test_revive_skips_when_throttled(tmp_path: Path):
     config_path = tmp_path / "pollypm.toml"
     pid_path = tmp_path / "rail_daemon.pid"
     pid_path.write_text("999999")
-    spawner = _SpawnRecorder()
+    spawner = _SpawnRecorder(pid_path=pid_path)
     last_revival = datetime.now(UTC) - timedelta(seconds=5)
 
     result = check_and_revive_rail_daemon(
@@ -341,7 +360,7 @@ def test_revive_unlinks_stale_pid_file(tmp_path: Path):
     pid_path = tmp_path / "rail_daemon.pid"
     # Use our own PID so the supervisor sees "alive but stuck".
     pid_path.write_text(str(os.getpid()))
-    spawner = _SpawnRecorder()
+    spawner = _SpawnRecorder(pid_path=pid_path)
     stale_tick = (datetime.now(UTC) - timedelta(seconds=DEFAULT_STALE_TICK_SECONDS + 60)).isoformat()
 
     # Inject a no-op terminator (we can't actually SIGKILL ourselves
@@ -376,16 +395,20 @@ def test_revive_unlinks_stale_pid_file(tmp_path: Path):
     finally:
         _mod.os.kill = real_kill
 
-    # The pid file is unlinked even though our fake_kill didn't really
-    # kill the process — the unlink is unconditional after the term step.
-    assert not pid_path.exists()
+    # The OLD pid file (containing the stuck PID) is replaced by the
+    # spawner with a fresh PID. The supervisor unlinks the stale entry
+    # before invoking the spawner, and the spawner — modeling
+    # ``_claim_pid_file`` — writes its own PID. The post-revive file
+    # therefore exists and names the spawner's process, not pre-state.
+    assert pid_path.exists()
+    assert pid_path.read_text().strip() == str(os.getpid())
     assert spawner.calls == [config_path]
 
 
 def test_spawn_failure_is_reported(tmp_path: Path):
     config_path = tmp_path / "pollypm.toml"
     pid_path = tmp_path / "rail_daemon.pid"
-    spawner = _SpawnRecorder(raise_on_call=True)
+    spawner = _SpawnRecorder(raise_on_call=True, pid_path=pid_path)
 
     result = check_and_revive_rail_daemon(
         config_path=config_path,
@@ -405,7 +428,7 @@ def test_revive_idempotent_under_throttle(tmp_path: Path):
     """Two back-to-back calls only spawn once because of the throttle."""
     config_path = tmp_path / "pollypm.toml"
     pid_path = tmp_path / "rail_daemon.pid"
-    spawner = _SpawnRecorder()
+    spawner = _SpawnRecorder(pid_path=pid_path)
 
     first = check_and_revive_rail_daemon(
         config_path=config_path,
@@ -484,7 +507,7 @@ def test_revive_skips_signaling_when_pid_identity_mismatches(
     config_path = tmp_path / "pollypm.toml"
     pid_path = tmp_path / "rail_daemon.pid"
     pid_path.write_text(str(os.getpid()))
-    spawner = _SpawnRecorder()
+    spawner = _SpawnRecorder(pid_path=pid_path)
 
     # Force the classifier to say "stuck_no_tick" even though the PID
     # isn't our daemon. The terminate helper must still refuse to kill.
@@ -555,13 +578,22 @@ def test_pid_matches_daemon_uses_cmdline(monkeypatch: pytest.MonkeyPatch):
     )
     assert _REAL_PID_MATCHES(12345, Path("/x/pollypm.toml")) is False
 
-    # Daemon with no explicit --config (legacy default) — accept as ours.
+    # Daemon with no explicit --config (legacy / default-config daemon).
+    # HIGH (#1556 round 2): a no-``--config`` daemon is using the global
+    # default config. A *non-default* supervisor must NOT match it —
+    # they belong to different workspaces.
     monkeypatch.setattr(
         _supervisor_mod,
         "_read_pid_command_line",
         lambda pid: "/usr/bin/python -m pollypm.rail_daemon",
     )
-    assert _REAL_PID_MATCHES(12345, Path("/x/pollypm.toml")) is True
+    assert _REAL_PID_MATCHES(12345, Path("/x/pollypm.toml")) is False
+
+    # ...but the SAME no-``--config`` daemon IS ours when our supervisor's
+    # config_path resolves to the global default. (We compute the
+    # default lazily so the test doesn't have to care where it lives.)
+    from pollypm.config import DEFAULT_CONFIG_PATH as _default_cfg
+    assert _REAL_PID_MATCHES(12345, _default_cfg) is True
 
     # No cmdline available at all (process gone, ps failed) — fail safe.
     monkeypatch.setattr(
@@ -652,7 +684,7 @@ def test_post_lock_recheck_stands_down_when_daemon_revived_concurrently(
     pid_path = tmp_path / "rail_daemon.pid"
     # Initial state: dead PID, original diagnose says dead_process.
     pid_path.write_text("999999")
-    spawner = _SpawnRecorder()
+    spawner = _SpawnRecorder(pid_path=pid_path)
 
     # Stage the world: AFTER the initial diagnose runs but BEFORE the
     # post-lock recheck, replace the PID file with a fresh "alive" PID
@@ -708,7 +740,7 @@ def test_cron_skips_revival_on_missing_pid(tmp_path: Path):
     """
     config_path = tmp_path / "pollypm.toml"
     pid_path = tmp_path / "rail_daemon.pid"  # never created
-    spawner = _SpawnRecorder()
+    spawner = _SpawnRecorder(pid_path=pid_path)
 
     result = check_and_revive_rail_daemon(
         config_path=config_path,
@@ -738,7 +770,7 @@ def test_cron_still_revives_dead_process(tmp_path: Path):
     config_path = tmp_path / "pollypm.toml"
     pid_path = tmp_path / "rail_daemon.pid"
     pid_path.write_text("999999")  # dead PID
-    spawner = _SpawnRecorder()
+    spawner = _SpawnRecorder(pid_path=pid_path)
 
     result = check_and_revive_rail_daemon(
         config_path=config_path,
@@ -763,7 +795,7 @@ def test_non_cron_caller_still_revives_missing_pid(tmp_path: Path):
     """
     config_path = tmp_path / "pollypm.toml"
     pid_path = tmp_path / "rail_daemon.pid"  # never created
-    spawner = _SpawnRecorder()
+    spawner = _SpawnRecorder(pid_path=pid_path)
 
     result = check_and_revive_rail_daemon(
         config_path=config_path,
@@ -778,3 +810,237 @@ def test_non_cron_caller_still_revives_missing_pid(tmp_path: Path):
     assert result.decision.state == "missing_pid"
     assert result.revived is True
     assert spawner.calls == [config_path]
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL (#1556 round 2) — race remains when spawn_fn returns before
+# the child writes its PID file. Lock must be held until the child has
+# claimed the slot (or a timeout elapses and we release anyway).
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_revive_when_spawner_returns_without_writing_pid(
+    tmp_path: Path,
+):
+    """Spawner returns BEFORE child writes PID → second revive must NOT spawn.
+
+    The real spawner is a detached ``Popen`` that returns the moment
+    the OS hands back a process — long before the child has imported
+    the daemon module and called ``_claim_pid_file``. Without the
+    in-lock ``_wait_for_child_pid`` step, a sibling supervisor that
+    grabs the lock during that window will observe ``missing_pid``
+    and spawn a SECOND daemon. The fix holds the lock until the child
+    confirms (or a 5s default timeout fires).
+
+    This test models that race deterministically: a spawner that
+    records the call but never writes a PID file. We use a tiny
+    ``child_wait_seconds`` so the test doesn't actually pay the
+    full timeout — but still long enough to verify the lock-held
+    semantic. The second concurrent caller must observe ``lock_busy``
+    or post-lock recheck == ``missing_pid``-but-no-spawn (depending on
+    timing); critically, the spawner must NOT be invoked twice
+    *during the window where the first call is still inside the lock*.
+    """
+    config_path = tmp_path / "pollypm.toml"
+    pid_path = tmp_path / "rail_daemon.pid"
+
+    # Spawner that, like the real Popen, returns immediately without
+    # writing the PID file. ``write_pid=False`` opts out of the
+    # _SpawnRecorder default that mimics a real claim.
+    spawner = _SpawnRecorder(pid_path=pid_path, write_pid=False)
+
+    # Single-thread scenario first: even when the child never writes,
+    # the supervisor must surface this as a warning + revived=True
+    # (the spawn itself succeeded), and on retry NOT re-spawn while
+    # we're still inside the wait window. We bound the wait to keep
+    # the test fast.
+    result = check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=None,
+        last_revival_at=None,
+        spawn_fn=spawner,
+        sleep_fn=lambda _s: None,  # don't actually sleep during poll
+        emit_audit=False,
+        child_wait_seconds=0.2,  # short: we just want to verify the
+                                  # lock is held for SOME bounded time
+    )
+    # The first call records exactly one spawn — the wait timed out
+    # but the spawn itself was attempted, so revived=True.
+    assert spawner.calls == [config_path]
+    assert result.revived is True
+
+    # Now the racy window: a SECOND concurrent caller (modeled here
+    # as a thread that fires while the first is mid-wait). To exercise
+    # the "lock held during wait" guarantee we run the second call
+    # while a long-wait first call is in flight. The second must hit
+    # the lock-busy timeout — NOT spawn a duplicate.
+    pid_path.unlink(missing_ok=True)  # reset to missing_pid for race
+    spawner_a = _SpawnRecorder(pid_path=pid_path, write_pid=False)
+    spawner_b = _SpawnRecorder(pid_path=pid_path, write_pid=False)
+    barrier = threading.Barrier(2)
+    results: list = [None, None]
+
+    def runner_a() -> None:
+        barrier.wait()
+        results[0] = check_and_revive_rail_daemon(
+            config_path=config_path,
+            pid_path=pid_path,
+            last_tick_iso=None,
+            last_revival_at=None,
+            spawn_fn=spawner_a,
+            sleep_fn=lambda _s: None,
+            emit_audit=False,
+            # Hold the lock for ~1s while the child "fails to write"
+            child_wait_seconds=1.0,
+            lock_timeout_seconds=2.0,
+        )
+
+    def runner_b() -> None:
+        barrier.wait()
+        # Give A a head start so it acquires the lock first.
+        time.sleep(0.05)
+        results[1] = check_and_revive_rail_daemon(
+            config_path=config_path,
+            pid_path=pid_path,
+            last_tick_iso=None,
+            last_revival_at=None,
+            spawn_fn=spawner_b,
+            sleep_fn=lambda _s: None,
+            emit_audit=False,
+            child_wait_seconds=0.1,
+            # B's lock_timeout < A's child_wait so B times out
+            # waiting for the lock instead of spawning.
+            lock_timeout_seconds=0.3,
+        )
+
+    t1 = threading.Thread(target=runner_a)
+    t2 = threading.Thread(target=runner_b)
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+    assert not t1.is_alive() and not t2.is_alive()
+
+    # A spawned exactly once.
+    assert spawner_a.calls == [config_path]
+    # B never invoked its spawner — the lock was still held by A.
+    # This is the central guarantee: even when A's child fails to
+    # write a PID file, B can't slip in and double-spawn.
+    assert spawner_b.calls == [], (
+        "second supervisor must NOT spawn while first holds the lock "
+        "waiting for child PID — race regression"
+    )
+    # B reported lock_busy.
+    assert results[1] is not None
+    assert results[1].spawn_error == "lock_busy"
+
+
+def test_daemon_pid_claim_is_atomic(tmp_path: Path):
+    """Two daemons racing to claim the same PID file → exactly one wins.
+
+    Belt-and-suspenders for the supervisor lock: even if two daemon
+    processes start by entirely independent paths (no shared
+    supervisor lock), the daemon's own ``_claim_pid_file`` uses
+    ``O_EXCL`` to ensure exactly one ends up named in the PID file.
+    The loser sees ``False`` and exits cleanly.
+    """
+    from pollypm.rail_daemon import _claim_pid_file
+
+    pid_path = tmp_path / "rail_daemon.pid"
+    barrier = threading.Barrier(8)
+    outcomes: list[bool] = []
+    outcomes_lock = threading.Lock()
+
+    def claimer() -> None:
+        barrier.wait()
+        ok = _claim_pid_file(pid_path)
+        with outcomes_lock:
+            outcomes.append(ok)
+
+    threads = [threading.Thread(target=claimer) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+        assert not t.is_alive()
+
+    # Exactly one winner — the rest see the file already exists.
+    assert outcomes.count(True) == 1, (
+        f"expected exactly one O_EXCL winner, got {outcomes.count(True)} "
+        f"of {len(outcomes)} (outcomes={outcomes!r})"
+    )
+    # The PID file names exactly one PID — ours.
+    assert pid_path.exists()
+    assert pid_path.read_text().strip() == str(os.getpid())
+
+
+# ---------------------------------------------------------------------------
+# HIGH (#1556 round 2) — config identity matching must not be loose:
+# a non-default-config supervisor must NOT match a default-config daemon.
+# ---------------------------------------------------------------------------
+
+
+def test_non_default_supervisor_does_not_match_default_config_daemon(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Workspace A's supervisor must NOT claim a default-config daemon as ours.
+
+    Scenario: two workspaces on one host. Workspace A's supervisor is
+    configured for ``/workspace/A/.pollypm/config.yaml``. A daemon is
+    running with no ``--config`` flag (using the global default). The
+    old loose substring matcher would treat the no-``--config`` daemon
+    as "compatible with any caller" and accept it as ours — meaning A
+    could SIGTERM workspace B's default-config daemon, or worse,
+    skip respawning A's actually-missing daemon because it thinks the
+    one already running covers it.
+
+    Strict matcher: a no-``--config`` daemon is ONLY ours when our
+    own config_path resolves to the global default.
+    """
+    monkeypatch.setattr(
+        _supervisor_mod,
+        "_read_pid_command_line",
+        lambda pid: "/usr/bin/python -m pollypm.rail_daemon",
+    )
+    workspace_a_cfg = Path("/workspace/A/.pollypm/config.yaml")
+    assert _REAL_PID_MATCHES(12345, workspace_a_cfg) is False, (
+        "default-config daemon must not match a non-default supervisor"
+    )
+
+    # Same daemon, but supervisor IS the global default — match expected.
+    from pollypm.config import DEFAULT_CONFIG_PATH as _default_cfg
+    assert _REAL_PID_MATCHES(12345, _default_cfg) is True
+
+
+def test_config_match_uses_argv_boundary_not_substring(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Path containing the supervisor's config path as a substring → not a match.
+
+    The old matcher used ``expected in cmdline`` which would falsely
+    match e.g. supervisor=/x/pollypm.toml against a daemon running
+    --config /other/contains-/x/pollypm.toml-decoy.yaml. The new
+    matcher tokenizes argv and compares resolved paths element-by-
+    element, so a substring-only collision is rejected.
+    """
+    monkeypatch.setattr(
+        _supervisor_mod,
+        "_read_pid_command_line",
+        lambda pid: (
+            "/usr/bin/python -m pollypm.rail_daemon "
+            "--config /other/contains-x-pollypm.toml-decoy.yaml"
+        ),
+    )
+    assert _REAL_PID_MATCHES(12345, Path("/x/pollypm.toml")) is False
+
+
+def test_config_match_handles_equals_form(monkeypatch: pytest.MonkeyPatch):
+    """``--config=/x.toml`` (single token) parses as well as the two-token form."""
+    monkeypatch.setattr(
+        _supervisor_mod,
+        "_read_pid_command_line",
+        lambda pid: "/usr/bin/python -m pollypm.rail_daemon --config=/x/pollypm.toml",
+    )
+    assert _REAL_PID_MATCHES(12345, Path("/x/pollypm.toml")) is True
+    assert _REAL_PID_MATCHES(12345, Path("/y/pollypm.toml")) is False

--- a/tests/test_rail_daemon_supervisor.py
+++ b/tests/test_rail_daemon_supervisor.py
@@ -1,0 +1,407 @@
+"""Tests for :mod:`pollypm.rail_daemon_supervisor`.
+
+The supervisor is the layer-2 watcher that sits above the rail
+daemon's in-thread tick retry. Its job is to detect a dead/stuck
+daemon (``rail_daemon.pid`` missing, PID dead, or no heartbeat tick
+in N seconds) and respawn it. Tests focus on:
+
+* The diagnosis function being pure: same inputs → same outputs.
+* The throttle preventing respawn loops.
+* The revival path actually invoking the spawn callback exactly once
+  per qualifying decision.
+* Permission-denied paths bailing without fanning out.
+
+We never spawn a real ``pollypm.rail_daemon`` process here — the
+spawn callable is always injected.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from pollypm.rail_daemon_supervisor import (
+    DEFAULT_REVIVAL_THROTTLE_SECONDS,
+    DEFAULT_STALE_TICK_SECONDS,
+    RevivalDecision,
+    check_and_revive_rail_daemon,
+    diagnose_rail_daemon,
+    should_revive,
+)
+
+
+# ---------------------------------------------------------------------------
+# diagnose_rail_daemon — pure logic
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def now_utc() -> datetime:
+    """Fixed reference time for deterministic age math."""
+    return datetime(2026, 5, 9, 12, 0, 0, tzinfo=UTC)
+
+
+def _iso_seconds_ago(now: datetime, seconds: float) -> str:
+    return (now - timedelta(seconds=seconds)).isoformat()
+
+
+def test_missing_pid_file_triggers_revival(tmp_path: Path, now_utc: datetime):
+    pid_path = tmp_path / "rail_daemon.pid"
+    decision = diagnose_rail_daemon(
+        pid_path=pid_path,
+        last_tick_iso=None,
+        now=now_utc,
+    )
+    assert decision.state == "missing_pid"
+    assert decision.needs_revival is True
+    assert "no rail_daemon.pid" in decision.reason
+
+
+def test_dead_pid_triggers_revival(tmp_path: Path, now_utc: datetime):
+    """A PID that no longer exists must be classified as ``dead_process``."""
+    pid_path = tmp_path / "rail_daemon.pid"
+    # 999999 is overwhelmingly unlikely to be live on any real system.
+    pid_path.write_text("999999")
+    decision = diagnose_rail_daemon(
+        pid_path=pid_path,
+        last_tick_iso=None,
+        now=now_utc,
+    )
+    assert decision.state == "dead_process"
+    assert decision.needs_revival is True
+
+
+def test_alive_pid_with_recent_tick_is_alive(tmp_path: Path, now_utc: datetime):
+    """Self-PID (live) plus a 30s-ago tick → ``alive``."""
+    pid_path = tmp_path / "rail_daemon.pid"
+    pid_path.write_text(str(os.getpid()))
+    decision = diagnose_rail_daemon(
+        pid_path=pid_path,
+        last_tick_iso=_iso_seconds_ago(now_utc, 30),
+        now=now_utc,
+    )
+    assert decision.state == "alive"
+    assert decision.needs_revival is False
+    assert decision.last_tick_age_seconds == pytest.approx(30, abs=1)
+
+
+def test_alive_pid_with_stale_tick_is_stuck(tmp_path: Path, now_utc: datetime):
+    """A live PID that hasn't ticked in > threshold is ``stuck_no_tick``."""
+    pid_path = tmp_path / "rail_daemon.pid"
+    pid_path.write_text(str(os.getpid()))
+    stale = DEFAULT_STALE_TICK_SECONDS + 30
+    decision = diagnose_rail_daemon(
+        pid_path=pid_path,
+        last_tick_iso=_iso_seconds_ago(now_utc, stale),
+        now=now_utc,
+    )
+    assert decision.state == "stuck_no_tick"
+    assert decision.needs_revival is True
+    assert decision.last_tick_age_seconds is not None
+    assert decision.last_tick_age_seconds > DEFAULT_STALE_TICK_SECONDS
+
+
+def test_alive_pid_no_tick_history_is_alive(tmp_path: Path, now_utc: datetime):
+    """Fresh boot with no tick history yet must NOT trigger revival.
+
+    The DB is empty when the daemon just started; we shouldn't
+    misclassify "haven't gotten the first tick written yet" as stuck.
+    """
+    pid_path = tmp_path / "rail_daemon.pid"
+    pid_path.write_text(str(os.getpid()))
+    decision = diagnose_rail_daemon(
+        pid_path=pid_path,
+        last_tick_iso=None,
+        now=now_utc,
+    )
+    assert decision.state == "alive"
+    assert decision.needs_revival is False
+
+
+def test_throttle_prevents_immediate_respawn(tmp_path: Path, now_utc: datetime):
+    """A revival 10s ago suppresses any new revival regardless of state."""
+    pid_path = tmp_path / "rail_daemon.pid"
+    # Process is dead AND tick is stale — both signals fire.
+    pid_path.write_text("999999")
+    last_revival = now_utc - timedelta(seconds=10)
+    decision = diagnose_rail_daemon(
+        pid_path=pid_path,
+        last_tick_iso=_iso_seconds_ago(now_utc, 600),
+        last_revival_at=last_revival,
+        now=now_utc,
+    )
+    assert decision.state == "throttled"
+    assert decision.needs_revival is False
+    assert "throttle" in decision.reason
+
+
+def test_throttle_expires_after_window(tmp_path: Path, now_utc: datetime):
+    """A revival > throttle_seconds ago does NOT block a new one."""
+    pid_path = tmp_path / "rail_daemon.pid"
+    pid_path.write_text("999999")
+    last_revival = now_utc - timedelta(seconds=DEFAULT_REVIVAL_THROTTLE_SECONDS + 5)
+    decision = diagnose_rail_daemon(
+        pid_path=pid_path,
+        last_tick_iso=None,
+        last_revival_at=last_revival,
+        now=now_utc,
+    )
+    assert decision.state == "dead_process"
+    assert decision.needs_revival is True
+
+
+def test_pid_file_garbage_treated_as_missing(tmp_path: Path, now_utc: datetime):
+    """A PID file with non-integer contents is treated like an absent file."""
+    pid_path = tmp_path / "rail_daemon.pid"
+    pid_path.write_text("not-a-pid-at-all")
+    decision = diagnose_rail_daemon(
+        pid_path=pid_path,
+        last_tick_iso=None,
+        now=now_utc,
+    )
+    assert decision.state == "missing_pid"
+
+
+def test_pid_file_zero_treated_as_missing(tmp_path: Path, now_utc: datetime):
+    """PID 0 is invalid — treat as no daemon at all."""
+    pid_path = tmp_path / "rail_daemon.pid"
+    pid_path.write_text("0")
+    decision = diagnose_rail_daemon(
+        pid_path=pid_path,
+        last_tick_iso=None,
+        now=now_utc,
+    )
+    assert decision.state == "missing_pid"
+
+
+def test_iso_timestamp_with_z_suffix_parses(tmp_path: Path, now_utc: datetime):
+    """Older ``messages.created_at`` rows use ``Z`` instead of ``+00:00``."""
+    pid_path = tmp_path / "rail_daemon.pid"
+    pid_path.write_text(str(os.getpid()))
+    iso_z = (now_utc - timedelta(seconds=15)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    decision = diagnose_rail_daemon(
+        pid_path=pid_path,
+        last_tick_iso=iso_z,
+        now=now_utc,
+    )
+    assert decision.state == "alive"
+    assert decision.last_tick_age_seconds == pytest.approx(15, abs=1)
+
+
+def test_iso_timestamp_unparseable_treated_as_no_history(
+    tmp_path: Path, now_utc: datetime,
+):
+    """Garbled ``last_tick_iso`` must NOT raise — treat as no history."""
+    pid_path = tmp_path / "rail_daemon.pid"
+    pid_path.write_text(str(os.getpid()))
+    decision = diagnose_rail_daemon(
+        pid_path=pid_path,
+        last_tick_iso="not a real timestamp",
+        now=now_utc,
+    )
+    assert decision.state == "alive"
+    assert decision.last_tick_age_seconds is None
+
+
+def test_should_revive_helper(tmp_path: Path, now_utc: datetime):
+    pid_path = tmp_path / "rail_daemon.pid"
+    pid_path.write_text("999999")
+    decision = diagnose_rail_daemon(
+        pid_path=pid_path,
+        last_tick_iso=None,
+        now=now_utc,
+    )
+    assert should_revive(decision) is True
+
+    pid_path.write_text(str(os.getpid()))
+    healthy = diagnose_rail_daemon(
+        pid_path=pid_path,
+        last_tick_iso=_iso_seconds_ago(now_utc, 5),
+        now=now_utc,
+    )
+    assert should_revive(healthy) is False
+
+
+# ---------------------------------------------------------------------------
+# check_and_revive_rail_daemon — orchestration
+# ---------------------------------------------------------------------------
+
+
+class _SpawnRecorder:
+    """Test double for ``cli._spawn_rail_daemon``.
+
+    Records every config_path it was invoked with so tests can assert
+    not just "did revival happen" but "did revival happen at all" /
+    "with the right config".
+    """
+
+    def __init__(self, raise_on_call: bool = False) -> None:
+        self.calls: list[Path] = []
+        self.raise_on_call = raise_on_call
+
+    def __call__(self, config_path: Path) -> None:
+        self.calls.append(config_path)
+        if self.raise_on_call:
+            raise RuntimeError("simulated spawn failure")
+
+
+def test_revive_calls_spawner_when_pid_missing(tmp_path: Path):
+    config_path = tmp_path / "pollypm.toml"
+    pid_path = tmp_path / "rail_daemon.pid"
+    spawner = _SpawnRecorder()
+
+    result = check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=None,
+        last_revival_at=None,
+        spawn_fn=spawner,
+        emit_audit=False,
+    )
+
+    assert result.revived is True
+    assert result.spawn_error is None
+    assert spawner.calls == [config_path]
+    assert result.decision.state == "missing_pid"
+
+
+def test_revive_skips_when_alive(tmp_path: Path):
+    config_path = tmp_path / "pollypm.toml"
+    pid_path = tmp_path / "rail_daemon.pid"
+    pid_path.write_text(str(os.getpid()))
+    spawner = _SpawnRecorder()
+    last_tick_iso = (datetime.now(UTC) - timedelta(seconds=10)).isoformat()
+
+    result = check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=last_tick_iso,
+        last_revival_at=None,
+        spawn_fn=spawner,
+        emit_audit=False,
+    )
+
+    assert result.revived is False
+    assert spawner.calls == []
+    assert result.decision.state == "alive"
+
+
+def test_revive_skips_when_throttled(tmp_path: Path):
+    config_path = tmp_path / "pollypm.toml"
+    pid_path = tmp_path / "rail_daemon.pid"
+    pid_path.write_text("999999")
+    spawner = _SpawnRecorder()
+    last_revival = datetime.now(UTC) - timedelta(seconds=5)
+
+    result = check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=None,
+        last_revival_at=last_revival,
+        spawn_fn=spawner,
+        emit_audit=False,
+    )
+
+    assert result.revived is False
+    assert result.decision.state == "throttled"
+    assert spawner.calls == []
+
+
+def test_revive_unlinks_stale_pid_file(tmp_path: Path):
+    """``stuck_no_tick`` must clear the PID file before respawning."""
+    config_path = tmp_path / "pollypm.toml"
+    pid_path = tmp_path / "rail_daemon.pid"
+    # Use our own PID so the supervisor sees "alive but stuck".
+    pid_path.write_text(str(os.getpid()))
+    spawner = _SpawnRecorder()
+    stale_tick = (datetime.now(UTC) - timedelta(seconds=DEFAULT_STALE_TICK_SECONDS + 60)).isoformat()
+
+    # Inject a no-op terminator (we can't actually SIGKILL ourselves
+    # in a unit test). The supervisor's signal helper still fires
+    # SIGTERM at our PID — so we patch out the actual kill via a
+    # custom sleep_fn that immediately reports the PID as gone.
+    import pollypm.rail_daemon_supervisor as _mod
+
+    # We call _terminate_with_grace via the supervisor; intercept the
+    # os.kill so we don't actually signal pytest.
+    real_kill = _mod.os.kill
+    def fake_kill(pid: int, sig: int) -> None:
+        # Pretend SIGTERM took: subsequent ``os.kill(pid, 0)`` should
+        # raise ProcessLookupError. Easiest way: track that we sent
+        # the signal and forward 0-checks to the live PID.
+        if sig == 0:
+            return real_kill(pid, sig)
+        # Don't actually kill; treat as accepted.
+        return None
+
+    _mod.os.kill = fake_kill
+    try:
+        result = check_and_revive_rail_daemon(
+            config_path=config_path,
+            pid_path=pid_path,
+            last_tick_iso=stale_tick,
+            last_revival_at=None,
+            spawn_fn=spawner,
+            sleep_fn=lambda _s: None,
+            emit_audit=False,
+        )
+    finally:
+        _mod.os.kill = real_kill
+
+    # The pid file is unlinked even though our fake_kill didn't really
+    # kill the process — the unlink is unconditional after the term step.
+    assert not pid_path.exists()
+    assert spawner.calls == [config_path]
+
+
+def test_spawn_failure_is_reported(tmp_path: Path):
+    config_path = tmp_path / "pollypm.toml"
+    pid_path = tmp_path / "rail_daemon.pid"
+    spawner = _SpawnRecorder(raise_on_call=True)
+
+    result = check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=None,
+        last_revival_at=None,
+        spawn_fn=spawner,
+        emit_audit=False,
+    )
+
+    assert result.revived is False
+    assert result.spawn_error is not None
+    assert "RuntimeError" in result.spawn_error
+
+
+def test_revive_idempotent_under_throttle(tmp_path: Path):
+    """Two back-to-back calls only spawn once because of the throttle."""
+    config_path = tmp_path / "pollypm.toml"
+    pid_path = tmp_path / "rail_daemon.pid"
+    spawner = _SpawnRecorder()
+
+    first = check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=None,
+        last_revival_at=None,
+        spawn_fn=spawner,
+        emit_audit=False,
+    )
+    assert first.revived is True
+
+    # Simulate what the cockpit/cli does: persist last_revival_at and
+    # call again with no time passed.
+    second = check_and_revive_rail_daemon(
+        config_path=config_path,
+        pid_path=pid_path,
+        last_tick_iso=None,
+        last_revival_at=datetime.now(UTC),
+        spawn_fn=spawner,
+        emit_audit=False,
+    )
+    assert second.revived is False
+    assert second.decision.state == "throttled"
+    assert len(spawner.calls) == 1


### PR DESCRIPTION
## Summary

Builds the layer-2 + layer-3 supervision the heartbeat cascade needs to survive process death without human intervention. Three nested layers, each watching the layer below.

`Closes part of #1546` (follow-up to #1552 — does not modify #1552's surface).

## Diagnosis

Sam reported on 2026-05-09 that the `pm-heartbeat` tmux window in `pollypm-storage-closet` was showing only a Claude Code REPL welcome screen and that queued tasks (e.g. `coffeeboardnm/71`, `/72`, `/73`) sat for ~30 minutes unclaimed. Live investigation found:

- **The `pm-heartbeat` Claude REPL pane is intentionally idle.** Per `supervisor.py:333-340` (#1007), the heartbeat tick loop runs as Python in `HeartbeatRail` (a daemon thread inside the cockpit/`rail_daemon` process). Bootstrapping the `pm-heartbeat` pane as a "Heartbeat supervisor" agent tripped Claude's prompt-injection defense (#1005, #1007), so the pane is now observability-only — a dormant REPL the user can use ad-hoc. Direction 2 from #1007: stop trying to bootstrap the pane.
- **The actual heartbeat (`pollypm.rail_daemon` pid 56615) was alive and ticking.** Diagnosed via the new `pm heartbeat status` command:
  ```
  rail_daemon: alive (alive)
    pid: 56615
    last tick: 3s ago
  ```
  `rail_daemon.log` showed continuous role-routing entries every ~30s; `last_heartbeat_at()` from `state.db` returned a timestamp seconds old. No crash signatures, no OOMs, no sandbox failures in `~/.pollypm/errors.log` for the last 24h.
- **What likely caused the queued-task stall** is a separate issue downstream of the heartbeat — maybe a stuck claim-row, a worker-marker race, or a dedupe-key wedge — but is **out of scope** for this PR. The user's principle ("when the recovery loop fails, fix the loop") still applies: this PR builds the recovery-loop-for-the-heartbeat that was missing, so the **next** time the rail daemon truly does die, it self-recovers without needing the user to notice.

The structural gap was real even though the symptom was misdiagnosed: nothing watched the rail daemon. If it had genuinely died (OOM, segfault, sandbox kill, `pm reset --force` racing the daemon's `atexit` handler), the cockpit would never have noticed and queued tasks would have piled up indefinitely. This PR closes that gap.

## Design — what watches the watchdog

Three nested layers, each watching the layer below:

| Layer | What it watches | What it can recover from | Where it lives |
|---|---|---|---|
| 1. **Tick-loop retry** (already existed) | individual `tick()` calls | one bad tick (SQLite WAL contention, plugin handler exception) | `HeartbeatRail._tick_loop` — try/except around each tick |
| 2. **External process supervisor** (NEW) | the rail daemon process | process-level death (OOM, segfault, kill -9) and stuck-but-alive (no tick for 180s) | cockpit periodic timer (60s) + `pm heartbeat` cron path |
| 3. **OS-level supervisor** (NEW, opt-in) | layers 1 + 2 | the cockpit + cron path being themselves dead; machine reboot | macOS LaunchAgent with `KeepAlive=true` |

The "what watches the watchdog" answer at each level:
- Layer 1's watcher is layer 2 — when the tick loop wedges (no tick for 180s), layer 2 kills + respawns.
- Layer 2's watcher is layer 3 — when the cockpit dies AND the cron job isn't installed, launchd respawns the daemon directly.
- Layer 3's watcher is the operating system — `KeepAlive` is OS-enforced.

Layer 2 is the load-bearing change. Layer 3 is opt-in because writing to `~/Library/LaunchAgents/` is a user-level action; the install command makes it explicit.

### Layer 2: `rail_daemon_supervisor`

`src/pollypm/rail_daemon_supervisor.py` (new). Two staleness signals checked from outside the daemon's process:

1. **Process-level**: `rail_daemon.pid` is missing or names a dead PID.
2. **Tick-level**: most recent `messages` row scoped to `heartbeat` is older than `stale_tick_seconds` (default 180s — the cadence sweep runs every 10s, so 180s = ~18 missed sweeps).

Action when dead/stuck:
1. SIGTERM the existing PID (only when `stuck_no_tick`; SIGKILL after 3s grace if needed).
2. Unlink stale `rail_daemon.pid`.
3. Spawn fresh daemon via the existing `cli._spawn_rail_daemon` (the daemon's own `_claim_pid_file` lock guards against doubled instances).
4. Emit `daemon.revived` audit event.

Throttled to one revival per 60s — without throttling, a daemon that dies-on-boot (e.g. broken plugin) gets respawned in a tight loop.

Wired into:
- **Cockpit periodic timer** (60s cadence). Captures the boot-time decision (`_rail_daemon_was_external`) so it only respawns when the cockpit deferred to an external daemon — never in cockpit-hosted-rail mode where respawning would race the cockpit's own ticker thread.
- **`pm heartbeat` cron path** (defense-in-depth — fires every minute even when the cockpit is dead).

### Layer 3: `rail_daemon_launchd`

`src/pollypm/rail_daemon_launchd.py` (new). Builds + installs `~/Library/LaunchAgents/com.pollypm.rail-daemon.plist` with:
- `KeepAlive: true` — restart on any exit.
- `RunAtLoad: true` — boot on login.
- `ThrottleInterval: 30` — backoff for crash loops.
- StandardOut/Err → `~/.pollypm/rail_daemon.log` (same file `cli._spawn_rail_daemon` writes to).

Activated via `pm heartbeat install-launchd` / `pm heartbeat uninstall-launchd`.

### Diagnostic surface

`pm heartbeat status [--json]` (new) — mirrors `diagnose_rail_daemon` so operators can see what the supervisor sees without taking action.

### Audit event

`daemon.revived` (new, symmetric to `daemon.reaped` from #1432). Carries `state`, `previous_pid`, `last_tick_age_s`, `revived`, `spawn_error`, `kill_signal`. Lets operators quantify chronic revivals — frequent revivals indicate a real problem (OOM, leak, crash loop) that needs investigation, not just trust in the supervisor.

## Public API added

- `pollypm.rail_daemon_supervisor`: `RevivalDecision`, `RevivalResult`, `diagnose_rail_daemon`, `check_and_revive_rail_daemon`, `revive_if_needed`, `query_last_heartbeat_iso`, `should_revive`.
- `pollypm.rail_daemon_launchd`: `build_plist_dict`, `install_launchd_keepalive`, `uninstall_launchd_keepalive`, `plist_path_for_label`.
- `pollypm.audit.log.EVENT_DAEMON_REVIVED` constant.
- CLI: `pm heartbeat status`, `pm heartbeat install-launchd`, `pm heartbeat uninstall-launchd`.
- `PollyCockpitApp._tick_rail_liveness`, `_resolve_rail_liveness_interval`, `_cockpit_uses_external_rail_daemon`. Tunable cadence via `POLLYPM_RAIL_LIVENESS_INTERVAL_SECONDS`.

## Test plan

- [x] **40 new tests** — all green:
  - `tests/test_rail_daemon_supervisor.py` (18) — diagnose purity, throttle behaviour, signal failure, spawn-error reporting, idempotence under throttle.
  - `tests/test_rail_daemon_launchd.py` (14) — plist shape, install/uninstall flow, missing `launchctl`, `--no-load` opt-out, returncode handling.
  - `tests/test_cockpit_rail_liveness_wiring.py` (8) — env-var override, garbage fallback, cockpit-hosted-rail skip, external-mode invocation.
- [x] **Existing rail-daemon family tests** still pass: 68 across `test_rail_daemon.py`, `test_rail_daemon_reaper.py`, plus the 32 new tests above.
- [x] **Cockpit / heartbeat tests** still pass: 323/324 in `test_cockpit.py` + `test_supervisor.py` + `test_supervisor_alerts.py` + `test_heartbeat_tick.py` (one pre-existing failure — see below).
- [x] **Live smoke**: `pm heartbeat status` against the running workspace correctly reports `pid=56615 alive, last heartbeat tick 3s ago` — confirms the diagnose path queries `messages` correctly.
- [x] **Manual revival simulation**: in `test_revive_calls_spawner_when_pid_missing`, a missing pid file triggers exactly one spawn-callback invocation; in `test_revive_idempotent_under_throttle`, a back-to-back call returns `throttled` without spawning.

### Pre-existing failures (verified failing on `origin/main` BEFORE this PR; deselected for the broader run)

- `tests/test_cockpit_contract_boundaries.py::test_tmux_pane_window_methods_stay_inside_allowlist` — `list_panes` / `list_windows` allowlist drift in `cli_features/ui.py`, `audit_watchdog.py`, `task_assignment_notify.py`, `worker_marker_reaper.py`. Same offenders as PR #1552 documented.
- `tests/test_packaged_worker_guide.py::test_packaged_worker_guide_matches_canonical` — `docs/worker-guide.md` and the packaged copy under `src/pollypm/defaults/docs/` have diverged on main.
- `tests/test_docs_command_references.py::test_live_doc_command_references_match_cli` — `docs/web-api-spec.md` references `pm serve` / `pm api regen-token` from PR #1551 / #1547.
- `tests/test_supervisor.py::test_bootstrap_returns_before_provider_stabilization_finishes` — also failing on `origin/main` in identical fashion.
- `tests/test_supervisor_alerts.py::test_supervisor_alert_helper_updates_and_nudges` — also failing on `origin/main` (worker nudge string drift; assertion compares stale "you appear stalled" string against the now-canonical "task X is queued" message).

## Out of scope

- **Why the queued tasks actually stalled.** The reported symptom (queued `coffeeboardnm/71`-`/73` sitting unclaimed for 30 min while the rail daemon was healthy) is a downstream issue — likely in the claim-loop, dedupe-key handling, or worker-marker provisioning, but **not** in heartbeat liveness. Worth a separate investigation issue.
- **The misleading dormant `pm-heartbeat` pane.** The Claude REPL screen confused the diagnosis — a future surface improvement could put a static "this pane is observability-only — heartbeat runs in `pollypm.rail_daemon` pid X" message in the pane to reduce confusion. Separate spec.
- **Auto-trigger of layer-3 install on first launch.** Currently opt-in via `pm heartbeat install-launchd`. Could be promoted to a launch-plan action with user consent, but that's a separate UX decision.
- **Detection of degraded-but-alive daemons.** A daemon whose plugin registry shrank silently (handler registration failures during init) still ticks but doesn't fire all roster handlers. That's a tier-2 detection problem (`audit_watchdog`), not a layer-2 supervision problem. The `daemon.revived` event will not catch it.
- **Linux/systemd equivalent of the launchd plist.** Layer 3 is macOS-only today. Sam's machine is macOS so this is fine for v1; a `systemd --user` unit can ship later.

## Spec calls Sam should sanity-check

1. **`stale_tick_seconds=180`**. The cadence sweep is `@every 10s`, so 180s = ~18 missed sweeps. If a busy plugin handler ever blocks the worker pool for >180s legitimately, layer 2 will kill the daemon mid-handler. I picked 180s as a balance between "respond fast to real wedges" and "tolerate slow handlers"; feel free to bump if a chronic false-positive bites.
2. **Throttle of 60s**. Pairs with the cockpit timer cadence (60s) — exactly one revival attempt per cockpit tick. The cron path's separate `_LAST_CRON_RAIL_REVIVAL_AT` module-level state is process-scoped (cron spawns fresh procs every minute, so it never accumulates a stale value).
3. **`KeepAlive: true` (always restart).** I went with the strongest "respawn on any exit" guarantee. The rail daemon's PID-file claim lock prevents doubled instances, so this should be safe — but if you want to gate restarts on a non-zero exit code only, swap to `KeepAlive: { SuccessfulExit: false }`.
4. **`_cockpit_uses_external_rail_daemon` is sticky.** Captured at boot time inside `_start_core_rail` and never re-evaluated. If the user runs `pm up` mid-cockpit-session to start a daemon manually, the cockpit's watcher won't pick it up until next restart. That's intentional (avoids double-ticker race) but worth confirming.
5. **`daemon.revived` carries the previous PID** even though that PID is now dead. Useful for forensics but means the `subject` field of the audit row references a defunct process. If you want a stable per-workspace subject, use `_workspace` instead.
6. **launchd `ThrottleInterval=30`.** macOS's documented minimum is 10s. I picked 30s so layer 3's restart cadence is faster than layer 2's 60s throttle for legitimate restarts, but slow enough that a crash-loop doesn't pin a CPU.

## Reference

- Issue #1546 — heartbeat cascade architecture.
- PR #1552 — tier registry, safety-net probes, tier-3 dispatch foundation. **Does not overlap** — that PR builds the cascade ladder (tier-1 / tier-2 / tier-3 / tier-4); this PR builds the layer-1 / layer-2 / layer-3 supervision that ensures the cascade has a process to **run in**.

Generated with [Claude Code](https://claude.com/claude-code)
