### PR TITLE
feat(audit): route self-bug-reports to GitHub instead of inbox (#1569)

### DIFF
--- a/src/pollypm/audit/__init__.py
+++ b/src/pollypm/audit/__init__.py
@@ -69,6 +69,16 @@ under that threshold.
 
 from __future__ import annotations
 
+from pollypm.audit.bug_reporter import (
+    BugReportResult,
+    DEFAULT_DEDUP_WINDOW_SECONDS,
+    EVENT_BUG_REPORT_DEDUPED,
+    EVENT_BUG_REPORT_FAILED,
+    EVENT_BUG_REPORT_FILED,
+    SELF_REPORT_LABEL,
+    file_bug_report,
+    file_bug_report_detailed,
+)
 from pollypm.audit.log import (
     AuditEvent,
     central_log_path,
@@ -91,14 +101,22 @@ from pollypm.audit.watchdog import (
 
 __all__ = [
     "AuditEvent",
+    "BugReportResult",
+    "DEFAULT_DEDUP_WINDOW_SECONDS",
     "ESCALATION_THROTTLE_SECONDS",
     "EVENT_AUDIT_FINDING",
+    "EVENT_BUG_REPORT_DEDUPED",
+    "EVENT_BUG_REPORT_FAILED",
+    "EVENT_BUG_REPORT_FILED",
     "EVENT_HEARTBEAT_TICK",
     "Finding",
+    "SELF_REPORT_LABEL",
     "WatchdogConfig",
     "central_log_path",
     "emit",
     "emit_escalation_dispatched",
+    "file_bug_report",
+    "file_bug_report_detailed",
     "format_unstick_brief",
     "project_log_path",
     "read_events",

--- a/src/pollypm/audit/bug_reporter.py
+++ b/src/pollypm/audit/bug_reporter.py
@@ -1,0 +1,476 @@
+"""File PollyPM self-bug-reports as GitHub issues instead of inbox rows (#1569).
+
+When Polly, the heartbeat, or the audit watchdog notices a system bug
+in PollyPM itself (a misrouted review ping, a stale alert, a confusing
+CLI output, etc.), the old flow filed the observation as an inbox
+message via ``pm notify``. Those rows sat alongside the user's
+actionable to-do list, accumulated forever, and forced the user to
+triage system-meta-bugs out of their real work.
+
+This helper provides a single seam for routing those observations to
+GitHub issues instead. Producers call :func:`file_bug_report` with a
+title + body; the helper:
+
+* Looks for an open issue with the same title on the configured
+  ``polly-self-report`` label within ``dedup_window_seconds``.
+* If found, returns the existing issue number (no new issue created).
+* Otherwise invokes ``gh issue create`` and returns the new number.
+* Emits an audit event (:data:`EVENT_BUG_REPORT_FILED`) regardless of
+  whether ``gh`` succeeded — the observation itself is forensically
+  preserved even when the issue tracker is unreachable.
+
+Best-effort: failures (no ``gh`` installed, network down, label
+missing, repo unreachable) log a warning and return ``None``. The
+helper never raises — producers can swap an inbox write for a
+``file_bug_report`` call without adding any new try/except plumbing.
+
+Leaf-module discipline (#1569):
+
+* No imports from cockpit/TUI/Supervisor.
+* No dependency on the inbox schema work (#1565).
+* stdlib + ``pollypm.audit.log`` only.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from pollypm.audit.log import emit as _audit_emit
+
+logger = logging.getLogger(__name__)
+
+# Label applied to every GitHub issue the helper opens. Created via
+# ``gh label create polly-self-report ...`` (see the issue body of
+# #1569 for the canonical command). If the label is missing on the
+# target repo, ``gh issue create`` will reject the call and the helper
+# returns ``None`` — operator action is "create the label", not
+# "fall back to the inbox".
+SELF_REPORT_LABEL = "polly-self-report"
+
+# Default dedup window. One hour matches the heartbeat-tick scale that
+# produces most self-bug observations: a watchdog rule that fires twice
+# in five minutes should collapse to one issue, but a recurrence the
+# next day is worth a fresh report (rate is itself signal).
+DEFAULT_DEDUP_WINDOW_SECONDS = 60 * 60
+
+# Audit event names. Kept in this module so the audit/log.py event
+# enum doesn't grow whenever the bug reporter learns a new state.
+EVENT_BUG_REPORT_FILED = "bug_report.filed"
+EVENT_BUG_REPORT_DEDUPED = "bug_report.deduped"
+EVENT_BUG_REPORT_FAILED = "bug_report.failed"
+
+# Override hook for tests: set ``$POLLYPM_BUG_REPORTER_DISABLED=1`` to
+# short-circuit every call (returns ``None``, no subprocess). The
+# default heartbeat / audit code never sets this; it exists so the
+# test suite can prove a producer was called without spawning a real
+# ``gh`` subprocess.
+_DISABLE_ENV = "POLLYPM_BUG_REPORTER_DISABLED"
+
+# Override hook for tests: set ``$POLLYPM_BUG_REPORTER_REPO=owner/repo``
+# to pin the target repo regardless of git working directory. Without
+# this, ``gh`` resolves the repo from the current directory's git
+# remote, which is fine in production but flaky in tests.
+_REPO_ENV = "POLLYPM_BUG_REPORTER_REPO"
+
+
+@dataclass(slots=True, frozen=True)
+class BugReportResult:
+    """Outcome of a :func:`file_bug_report` call.
+
+    Returned to callers that want to distinguish "I filed a new issue"
+    from "I matched an existing one" — useful for log lines and tests.
+    The simpler :func:`file_bug_report` returns just the issue number
+    so existing call sites stay one-line.
+    """
+
+    issue_number: int
+    created: bool
+    title: str
+
+
+def file_bug_report(
+    *,
+    title: str,
+    body: str,
+    actor: str = "polly",
+    project: str = "",
+    subject: str = "",
+    dedup_window_seconds: int = DEFAULT_DEDUP_WINDOW_SECONDS,
+    extra_labels: tuple[str, ...] = (),
+) -> int | None:
+    """File a PollyPM self-bug-report as a GitHub issue.
+
+    Args:
+        title: Issue title. The dedup query matches on exact title
+            within the window, so callers should produce stable
+            phrasing (no embedded timestamps, no rotating counters).
+        body: Issue body. May include markdown — passed verbatim to
+            ``gh issue create --body``.
+        actor: Who is filing the report. Recorded in the audit event
+            and prepended to the body as a footer so the issue carries
+            the producer identity. Defaults to ``"polly"``.
+        project: PollyPM project key the bug was observed against, or
+            empty string for cross-project / workspace-level bugs.
+            Recorded in audit metadata and added as a project footer.
+        subject: Free-form forensic subject (task id, session name,
+            etc.). Recorded in audit metadata only — not folded into
+            the issue body, since titles already carry enough context.
+        dedup_window_seconds: Suppress duplicate issues with the same
+            title filed within this window. Default 1 hour. Set to 0
+            to disable deduplication (every call opens a fresh issue).
+        extra_labels: Additional labels to attach beyond
+            :data:`SELF_REPORT_LABEL`. The label must already exist
+            on the target repo — ``gh`` rejects unknown labels.
+
+    Returns:
+        Issue number on success (newly created OR matched existing).
+        ``None`` on failure (``gh`` missing, network down, label
+        missing, etc.). Callers MUST treat ``None`` as "issue not
+        filed" but the original observation is still recorded in the
+        audit log so forensic readers can correlate.
+    """
+    result = file_bug_report_detailed(
+        title=title,
+        body=body,
+        actor=actor,
+        project=project,
+        subject=subject,
+        dedup_window_seconds=dedup_window_seconds,
+        extra_labels=extra_labels,
+    )
+    return result.issue_number if result is not None else None
+
+
+def file_bug_report_detailed(
+    *,
+    title: str,
+    body: str,
+    actor: str = "polly",
+    project: str = "",
+    subject: str = "",
+    dedup_window_seconds: int = DEFAULT_DEDUP_WINDOW_SECONDS,
+    extra_labels: tuple[str, ...] = (),
+) -> BugReportResult | None:
+    """Variant of :func:`file_bug_report` that returns the full outcome.
+
+    Same semantics + arguments; returns :class:`BugReportResult` so
+    callers can distinguish ``created`` vs deduped without re-querying
+    GitHub.
+    """
+    clean_title = (title or "").strip()
+    if not clean_title:
+        logger.warning("bug_reporter: refused empty title (actor=%s)", actor)
+        return None
+
+    if os.environ.get(_DISABLE_ENV):
+        # Test hook: producer was called, but don't shell out. Still
+        # emit the audit event so test cases can assert the side
+        # effect happened.
+        _emit_audit(
+            event=EVENT_BUG_REPORT_FAILED,
+            project=project,
+            subject=subject,
+            actor=actor,
+            metadata={
+                "title": clean_title,
+                "error": "disabled_by_env",
+            },
+        )
+        return None
+
+    if not _gh_available():
+        logger.warning(
+            "bug_reporter: gh CLI unavailable, dropping bug report %r",
+            clean_title,
+        )
+        _emit_audit(
+            event=EVENT_BUG_REPORT_FAILED,
+            project=project,
+            subject=subject,
+            actor=actor,
+            metadata={
+                "title": clean_title,
+                "error": "gh_unavailable",
+            },
+        )
+        return None
+
+    if dedup_window_seconds > 0:
+        existing = _find_recent_open_issue(
+            title=clean_title,
+            window_seconds=dedup_window_seconds,
+        )
+        if existing is not None:
+            _emit_audit(
+                event=EVENT_BUG_REPORT_DEDUPED,
+                project=project,
+                subject=subject,
+                actor=actor,
+                metadata={
+                    "title": clean_title,
+                    "issue_number": existing,
+                    "window_seconds": dedup_window_seconds,
+                },
+            )
+            return BugReportResult(
+                issue_number=existing,
+                created=False,
+                title=clean_title,
+            )
+
+    rendered_body = _render_body(
+        body=body or "",
+        actor=actor,
+        project=project,
+        subject=subject,
+    )
+    issue_number = _create_issue(
+        title=clean_title,
+        body=rendered_body,
+        labels=(SELF_REPORT_LABEL, *extra_labels),
+    )
+    if issue_number is None:
+        _emit_audit(
+            event=EVENT_BUG_REPORT_FAILED,
+            project=project,
+            subject=subject,
+            actor=actor,
+            metadata={
+                "title": clean_title,
+                "error": "gh_create_failed",
+            },
+        )
+        return None
+
+    _emit_audit(
+        event=EVENT_BUG_REPORT_FILED,
+        project=project,
+        subject=subject,
+        actor=actor,
+        metadata={
+            "title": clean_title,
+            "issue_number": issue_number,
+        },
+    )
+    return BugReportResult(
+        issue_number=issue_number,
+        created=True,
+        title=clean_title,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _gh_available() -> bool:
+    """Return True iff the ``gh`` CLI is on PATH."""
+    return shutil.which("gh") is not None
+
+
+def _repo_args() -> list[str]:
+    """Return ``["--repo", "<env>"]`` when the override env is set."""
+    repo = os.environ.get(_REPO_ENV, "").strip()
+    if not repo:
+        return []
+    return ["--repo", repo]
+
+
+def _find_recent_open_issue(
+    *,
+    title: str,
+    window_seconds: int,
+) -> int | None:
+    """Return the newest open issue number with the same title in window.
+
+    Queries ``gh issue list --label polly-self-report --state open
+    --search "<title> in:title" --json number,title,createdAt``. The
+    label scope keeps the search tight; the title check rules out
+    partial matches that ``in:title`` would otherwise allow.
+
+    Returns ``None`` on any failure (network down, gh missing, parse
+    error) so the caller falls through to creating a fresh issue —
+    duplicates are a smaller bug than dropped observations.
+    """
+    cmd = [
+        "gh", "issue", "list",
+        "--label", SELF_REPORT_LABEL,
+        "--state", "open",
+        "--search", f"{title} in:title",
+        "--limit", "20",
+        "--json", "number,title,createdAt",
+        *_repo_args(),
+    ]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        logger.debug("bug_reporter: gh issue list raised: %s", exc)
+        return None
+    if proc.returncode != 0:
+        logger.debug(
+            "bug_reporter: gh issue list returned %d: %s",
+            proc.returncode, proc.stderr.strip(),
+        )
+        return None
+    try:
+        rows = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        logger.debug("bug_reporter: gh issue list output not JSON: %s", exc)
+        return None
+    if not isinstance(rows, list):
+        return None
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=window_seconds)
+    best: tuple[datetime, int] | None = None
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        row_title = str(row.get("title") or "")
+        if row_title.strip() != title:
+            continue
+        created_raw = str(row.get("createdAt") or "")
+        created = _parse_iso(created_raw)
+        if created is None:
+            continue
+        if created < cutoff:
+            continue
+        number = row.get("number")
+        if not isinstance(number, int):
+            continue
+        if best is None or created > best[0]:
+            best = (created, number)
+    return best[1] if best is not None else None
+
+
+def _parse_iso(value: str) -> datetime | None:
+    """Parse an ISO-8601 timestamp from ``gh``. ``Z`` suffix is allowed."""
+    if not value:
+        return None
+    try:
+        # gh emits ``2026-05-17T01:02:03Z``; ``fromisoformat`` only
+        # learned ``Z`` in 3.11 — strip explicitly for older runs.
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _create_issue(
+    *,
+    title: str,
+    body: str,
+    labels: tuple[str, ...],
+) -> int | None:
+    """Invoke ``gh issue create`` and parse the issue number from output."""
+    cmd: list[str] = ["gh", "issue", "create", "--title", title, "--body", body]
+    for label in labels:
+        cmd.extend(["--label", label])
+    cmd.extend(_repo_args())
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        logger.warning("bug_reporter: gh issue create raised: %s", exc)
+        return None
+    if proc.returncode != 0:
+        logger.warning(
+            "bug_reporter: gh issue create returned %d: %s",
+            proc.returncode, proc.stderr.strip(),
+        )
+        return None
+    return _parse_issue_number(proc.stdout)
+
+
+def _parse_issue_number(stdout: str) -> int | None:
+    """Extract the trailing ``/issues/<N>`` integer from ``gh`` output.
+
+    ``gh issue create`` prints the URL of the new issue, e.g.
+    ``https://github.com/owner/repo/issues/1572``. We don't import
+    ``re`` for one match — split on the marker token directly.
+    """
+    if not stdout:
+        return None
+    url = stdout.strip().splitlines()[-1].strip()
+    marker = "/issues/"
+    idx = url.rfind(marker)
+    if idx < 0:
+        return None
+    tail = url[idx + len(marker):]
+    # Trim any trailing query string / fragment.
+    for sep in ("?", "#"):
+        if sep in tail:
+            tail = tail.split(sep, 1)[0]
+    try:
+        return int(tail)
+    except ValueError:
+        return None
+
+
+def _render_body(
+    *,
+    body: str,
+    actor: str,
+    project: str,
+    subject: str,
+) -> str:
+    """Append a small forensic footer to the user-supplied body."""
+    parts = [body.rstrip(), ""]
+    parts.append("---")
+    parts.append("Filed automatically by PollyPM's bug_reporter.")
+    parts.append(f"actor: {actor or 'unknown'}")
+    if project:
+        parts.append(f"project: {project}")
+    if subject:
+        parts.append(f"subject: {subject}")
+    return "\n".join(parts).strip() + "\n"
+
+
+def _emit_audit(
+    *,
+    event: str,
+    project: str,
+    subject: str,
+    actor: str,
+    metadata: dict,
+) -> None:
+    """Wrap ``audit.emit`` so a failed audit write never raises."""
+    try:
+        _audit_emit(
+            event=event,
+            project=project or "",
+            subject=subject or "",
+            actor=actor or "",
+            metadata=metadata,
+        )
+    except Exception:  # noqa: BLE001 — audit must never break the reporter
+        logger.debug("bug_reporter: audit emit failed", exc_info=True)
+
+
+__all__ = [
+    "BugReportResult",
+    "DEFAULT_DEDUP_WINDOW_SECONDS",
+    "EVENT_BUG_REPORT_DEDUPED",
+    "EVENT_BUG_REPORT_FAILED",
+    "EVENT_BUG_REPORT_FILED",
+    "SELF_REPORT_LABEL",
+    "file_bug_report",
+    "file_bug_report_detailed",
+]

--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -138,7 +138,12 @@ _NOTIFY_HELP = help_with_examples(
     (
         "Create a work-service inbox item for the human user.\n\n"
         "This is PollyPM's canonical escalation channel for blockers, "
-        "handoffs, and status updates."
+        "handoffs, and status updates.\n\n"
+        "For meta-bugs about PollyPM itself (misrouted ping, stale "
+        "alert, confusing CLI output), use ``pm bug-report`` instead "
+        "(#1569) — those file a GitHub issue with the "
+        "``polly-self-report`` label instead of cluttering the user's "
+        "inbox."
     ),
     [
         (

--- a/src/pollypm/cli_features/session_runtime.py
+++ b/src/pollypm/cli_features/session_runtime.py
@@ -1096,6 +1096,110 @@ def notify(
         typer.echo(str(inbox_task_id or message_id))
 
 
+def bug_report(
+    helpers,
+    title: str = typer.Argument(
+        ...,
+        help=(
+            "One-line summary of the system bug you noticed. Used "
+            "verbatim as the GitHub issue title — keep it stable "
+            "across observations so the helper can dedup repeated "
+            "reports."
+        ),
+    ),
+    body: str = typer.Argument(
+        ...,
+        help=(
+            "Full bug description. Markdown supported. Pass '-' to "
+            "read from stdin (typical: pipe Polly's longer "
+            "explanation in)."
+        ),
+    ),
+    actor: str = typer.Option(
+        "polly",
+        "--actor",
+        help=(
+            "Who noticed the bug. Recorded in the audit log and "
+            "added as a footer on the GitHub issue body."
+        ),
+    ),
+    project: str = typer.Option(
+        "",
+        "--project",
+        "-p",
+        help=(
+            "PollyPM project key the bug was observed against. Leave "
+            "empty for workspace-level / cross-project bugs."
+        ),
+    ),
+    subject: str = typer.Option(
+        "",
+        "--subject",
+        help=(
+            "Free-form forensic subject (task id, session name, "
+            "etc.). Recorded in audit metadata only — the issue "
+            "title is the user-facing surface."
+        ),
+    ),
+    dedup_window: int = typer.Option(
+        3600,
+        "--dedup-window-seconds",
+        help=(
+            "Suppress duplicate issues with the same title filed "
+            "within this many seconds. Default 1 hour. Set to 0 to "
+            "disable deduplication."
+        ),
+    ),
+) -> None:
+    """File a PollyPM self-bug-report as a GitHub issue (#1569).
+
+    Before this command existed, Polly and the heartbeat filed
+    system-bug observations via ``pm notify`` with ``--project inbox``.
+    Those rows ended up in the user's actionable to-do queue, even
+    though every one of them is a meta-bug about PollyPM itself.
+
+    This command routes the observation to a GitHub issue with the
+    ``polly-self-report`` label, where it can be prioritized against
+    other dev work. The user's inbox stays focused on tasks that need
+    a human decision.
+    """
+    from pollypm.audit.bug_reporter import file_bug_report_detailed
+
+    clean_title = (title or "").strip()
+    if not clean_title:
+        typer.echo("Error: title must not be empty.", err=True)
+        raise typer.Exit(code=1)
+
+    if body == "-":
+        body = sys.stdin.read()
+    if not (body or "").strip():
+        typer.echo(
+            "Error: body must not be empty (pass '-' to read from stdin).",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    result = file_bug_report_detailed(
+        title=clean_title,
+        body=body,
+        actor=actor or "polly",
+        project=project or "",
+        subject=subject or "",
+        dedup_window_seconds=max(0, int(dedup_window)),
+    )
+    if result is None:
+        typer.echo(
+            "bug_report: gh CLI unavailable or create failed — "
+            "observation recorded in the audit log only.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    if result.created:
+        typer.echo(f"filed:#{result.issue_number}")
+    else:
+        typer.echo(f"deduped:#{result.issue_number}")
+
+
 def register_session_runtime_commands(app: typer.Typer, *, helpers) -> None:
     app.command(help=helpers._UP_HELP)(_bind_session_command(launch, helpers))
     app.command("rail-daemon")(_bind_session_command(rail_daemon, helpers))
@@ -1130,3 +1234,13 @@ def register_session_runtime_commands(app: typer.Typer, *, helpers) -> None:
     )
     app.command(help=helpers._SEND_HELP)(_bind_session_command(send, helpers))
     app.command(help=helpers._NOTIFY_HELP)(_bind_session_command(notify, helpers))
+    app.command(
+        "bug-report",
+        help=(
+            "File a PollyPM self-bug-report as a GitHub issue with "
+            "the polly-self-report label (#1569). Use this instead "
+            "of ``pm notify`` when reporting meta-bugs about PollyPM "
+            "itself — the user's inbox stays focused on actionable "
+            "tasks."
+        ),
+    )(_bind_session_command(bug_report, helpers))

--- a/src/pollypm/defaults/docs/reference/commands.md
+++ b/src/pollypm/defaults/docs/reference/commands.md
@@ -114,6 +114,7 @@ When you add a project with `pm add-project`, the import runs automatically. Use
 | Command | What it does |
 |---------|-------------|
 | `pm notify "<subject>" "<body>"` | Create an inbox item for the human user |
+| `pm bug-report "<title>" "<body>"` | File a PollyPM self-bug-report as a GitHub issue |
 | `pm mail` | List open inbox items |
 | `pm mail <id>` | Read a message or thread |
 | `pm mail --reply <id> --text "msg"` | Reply to a message (creates thread) |
@@ -125,6 +126,8 @@ When you add a project with `pm add-project`, the import runs automatically. Use
 | `pm discuss <id>` | Jump into live discussion about an inbox message |
 
 **When to use `pm notify`:** Any time you need the human user's input, approval, or attention — and they may not be watching your session. The inbox is the reliable way to reach the user. Don't just ask in chat and hope they see it.
+
+**When to use `pm bug-report` instead of `pm notify`:** When the observation is a meta-bug about PollyPM itself (misrouted ping, stale alert, confusing CLI output, unexpected internal state) rather than something the user needs to decide. `pm bug-report` routes the observation to a GitHub issue with the `polly-self-report` label, keeping the user's inbox focused on actionable tasks (#1569).
 
 **Decision prefixes:**
 - `[Decision]` — Polly made a judgment call. User can review and override.

--- a/tests/test_bug_reporter.py
+++ b/tests/test_bug_reporter.py
@@ -1,0 +1,408 @@
+"""Tests for the self-bug-report → GitHub helper (#1569).
+
+Covers :mod:`pollypm.audit.bug_reporter` — the leaf module that
+routes Polly/heartbeat self-bug-report observations to a GitHub
+issue with the ``polly-self-report`` label instead of dropping them
+into the user's inbox.
+
+Test surface:
+
+* Happy path — ``gh issue create`` runs with the right argv and the
+  helper returns the parsed issue number.
+* Dedup — filing the same title twice within the window only invokes
+  ``gh issue create`` once.
+* Failure modes — no ``gh`` on PATH / non-zero exit / malformed
+  output all return ``None`` and emit an audit event so forensic
+  reads can correlate.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from pollypm.audit import bug_reporter
+
+
+# ---------------------------------------------------------------------------
+# Shared fakes
+# ---------------------------------------------------------------------------
+
+
+def _completed(stdout: str = "", returncode: int = 0, stderr: str = ""):
+    return subprocess.CompletedProcess(
+        args=[],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _isoformat_now_minus(seconds: int) -> str:
+    from datetime import timedelta
+
+    return (
+        datetime.now(timezone.utc) - timedelta(seconds=seconds)
+    ).isoformat().replace("+00:00", "Z")
+
+
+@pytest.fixture(autouse=True)
+def _redirect_audit_home(tmp_path, monkeypatch):
+    """Keep audit writes out of the user's real ``~/.pollypm/audit``."""
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit"))
+    monkeypatch.delenv(bug_reporter._DISABLE_ENV, raising=False)
+    monkeypatch.setenv(bug_reporter._REPO_ENV, "owner/repo")
+
+
+@pytest.fixture
+def _gh_on_path(monkeypatch):
+    """Pretend ``gh`` is installed."""
+    monkeypatch.setattr(
+        bug_reporter, "_gh_available", lambda: True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_creates_issue_and_returns_number(_gh_on_path):
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *_a, **_kw):
+        calls.append(list(cmd))
+        if cmd[:3] == ["gh", "issue", "list"]:
+            # No existing issues to dedup against.
+            return _completed(stdout="[]\n")
+        if cmd[:3] == ["gh", "issue", "create"]:
+            return _completed(
+                stdout="https://github.com/owner/repo/issues/4242\n",
+            )
+        raise AssertionError(f"unexpected subprocess: {cmd!r}")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        number = bug_reporter.file_bug_report(
+            title="Heartbeat respawn loop on tier-3 dispatch",
+            body="Polly noticed the watchdog re-spawned three times in 90s.",
+            actor="heartbeat",
+            project="savethenovel",
+            subject="watchdog-tier3",
+        )
+    assert number == 4242
+
+    create_call = next(
+        c for c in calls if c[:3] == ["gh", "issue", "create"]
+    )
+    # Title + body + label make it onto the argv.
+    assert "--title" in create_call
+    assert (
+        create_call[create_call.index("--title") + 1]
+        == "Heartbeat respawn loop on tier-3 dispatch"
+    )
+    assert "--label" in create_call
+    assert (
+        bug_reporter.SELF_REPORT_LABEL
+        in [create_call[i + 1] for i, v in enumerate(create_call) if v == "--label"]
+    )
+    # Footer was appended to the body.
+    body_arg = create_call[create_call.index("--body") + 1]
+    assert "actor: heartbeat" in body_arg
+    assert "project: savethenovel" in body_arg
+    assert "subject: watchdog-tier3" in body_arg
+
+
+def test_detailed_result_marks_created_true(_gh_on_path):
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return _completed(stdout="[]\n")
+        return _completed(stdout="https://github.com/owner/repo/issues/7\n")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = bug_reporter.file_bug_report_detailed(
+            title="Inbox sweep ran twice in one tick",
+            body="evidence dump",
+        )
+    assert result is not None
+    assert result.created is True
+    assert result.issue_number == 7
+    assert result.title == "Inbox sweep ran twice in one tick"
+
+
+# ---------------------------------------------------------------------------
+# Dedup
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_within_window_skips_create(_gh_on_path):
+    """A matching open issue inside the window short-circuits create."""
+    create_calls: list[list[str]] = []
+
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["gh", "issue", "list"]:
+            payload = [
+                {
+                    "number": 1234,
+                    "title": "Heartbeat respawn loop",
+                    "createdAt": _isoformat_now_minus(5 * 60),
+                },
+            ]
+            return _completed(stdout=json.dumps(payload))
+        if cmd[:3] == ["gh", "issue", "create"]:
+            create_calls.append(list(cmd))
+            return _completed(stdout="https://github.com/owner/repo/issues/9999\n")
+        raise AssertionError(f"unexpected subprocess: {cmd!r}")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = bug_reporter.file_bug_report_detailed(
+            title="Heartbeat respawn loop",
+            body="re-observation",
+        )
+    assert result is not None
+    assert result.created is False
+    assert result.issue_number == 1234
+    assert create_calls == []
+
+
+def test_dedup_skips_match_outside_window(_gh_on_path):
+    """A match older than the window does NOT suppress a fresh create."""
+
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["gh", "issue", "list"]:
+            payload = [
+                {
+                    "number": 11,
+                    "title": "Heartbeat respawn loop",
+                    # 2 hours ago — outside the default 1h window.
+                    "createdAt": _isoformat_now_minus(2 * 60 * 60),
+                },
+            ]
+            return _completed(stdout=json.dumps(payload))
+        return _completed(stdout="https://github.com/owner/repo/issues/55\n")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        number = bug_reporter.file_bug_report(
+            title="Heartbeat respawn loop",
+            body="fresh observation",
+        )
+    assert number == 55
+
+
+def test_dedup_ignores_partial_title_matches(_gh_on_path):
+    """``gh issue list`` ``in:title`` returns substring matches — the helper
+    must only dedup on EXACT title equality, not substring.
+    """
+
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["gh", "issue", "list"]:
+            payload = [
+                {
+                    "number": 9,
+                    "title": "Heartbeat respawn loop on tier-3 (followup)",
+                    "createdAt": _isoformat_now_minus(60),
+                },
+            ]
+            return _completed(stdout=json.dumps(payload))
+        return _completed(stdout="https://github.com/owner/repo/issues/77\n")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        number = bug_reporter.file_bug_report(
+            title="Heartbeat respawn loop",
+            body="x",
+        )
+    assert number == 77  # Not 9 — title differs.
+
+
+def test_dedup_window_zero_always_creates(_gh_on_path):
+    """``dedup_window_seconds=0`` disables dedup — every call creates."""
+    create_calls = 0
+
+    def fake_run(cmd, *_a, **_kw):
+        nonlocal create_calls
+        if cmd[:3] == ["gh", "issue", "list"]:
+            # Should NOT be reached when window=0.
+            raise AssertionError("dedup query fired with window=0")
+        if cmd[:3] == ["gh", "issue", "create"]:
+            create_calls += 1
+            return _completed(stdout=f"https://github.com/owner/repo/issues/{create_calls}\n")
+        raise AssertionError(f"unexpected: {cmd!r}")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        n1 = bug_reporter.file_bug_report(
+            title="Same title", body="x", dedup_window_seconds=0,
+        )
+        n2 = bug_reporter.file_bug_report(
+            title="Same title", body="x", dedup_window_seconds=0,
+        )
+    assert n1 == 1
+    assert n2 == 2
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_gh_missing_returns_none_and_emits_audit(monkeypatch, tmp_path):
+    monkeypatch.setattr(bug_reporter, "_gh_available", lambda: False)
+
+    with patch("subprocess.run") as run_mock:
+        number = bug_reporter.file_bug_report(
+            title="Bug observation",
+            body="x",
+            project="demo",
+        )
+    assert number is None
+    # Helper never shelled out.
+    run_mock.assert_not_called()
+
+    # Audit event was recorded with the error class.
+    from pollypm.audit.log import read_events
+
+    events = read_events("demo")
+    failures = [e for e in events if e.event == bug_reporter.EVENT_BUG_REPORT_FAILED]
+    assert failures, f"expected EVENT_BUG_REPORT_FAILED, got: {[e.event for e in events]}"
+    assert failures[-1].metadata.get("error") == "gh_unavailable"
+
+
+def test_gh_create_non_zero_returns_none(_gh_on_path):
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return _completed(stdout="[]\n")
+        return _completed(
+            stdout="",
+            returncode=1,
+            stderr="GraphQL: label not found",
+        )
+
+    with patch("subprocess.run", side_effect=fake_run):
+        number = bug_reporter.file_bug_report(
+            title="x", body="x", project="demo",
+        )
+    assert number is None
+
+    from pollypm.audit.log import read_events
+
+    events = read_events("demo")
+    failures = [
+        e for e in events if e.event == bug_reporter.EVENT_BUG_REPORT_FAILED
+    ]
+    assert failures[-1].metadata.get("error") == "gh_create_failed"
+
+
+def test_empty_title_refused(_gh_on_path):
+    with patch("subprocess.run") as run_mock:
+        number = bug_reporter.file_bug_report(title="   ", body="x")
+    assert number is None
+    run_mock.assert_not_called()
+
+
+def test_disabled_env_short_circuits(monkeypatch, _gh_on_path):
+    monkeypatch.setenv(bug_reporter._DISABLE_ENV, "1")
+    with patch("subprocess.run") as run_mock:
+        number = bug_reporter.file_bug_report(
+            title="x", body="x", project="demo",
+        )
+    assert number is None
+    run_mock.assert_not_called()
+
+    from pollypm.audit.log import read_events
+
+    events = read_events("demo")
+    failures = [
+        e for e in events if e.event == bug_reporter.EVENT_BUG_REPORT_FAILED
+    ]
+    assert failures[-1].metadata.get("error") == "disabled_by_env"
+
+
+# ---------------------------------------------------------------------------
+# Parsing edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_parse_issue_number_from_url_with_trailing_whitespace():
+    assert (
+        bug_reporter._parse_issue_number(
+            "https://github.com/owner/repo/issues/1234\n"
+        )
+        == 1234
+    )
+
+
+def test_parse_issue_number_returns_none_on_garbage():
+    assert bug_reporter._parse_issue_number("not a url") is None
+    assert bug_reporter._parse_issue_number("") is None
+
+
+def test_parse_issue_number_handles_query_string():
+    assert (
+        bug_reporter._parse_issue_number(
+            "https://github.com/o/r/issues/77?utm_source=cli"
+        )
+        == 77
+    )
+
+
+# ---------------------------------------------------------------------------
+# Audit event on success
+# ---------------------------------------------------------------------------
+
+
+def test_filed_event_carries_issue_number(_gh_on_path):
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return _completed(stdout="[]\n")
+        return _completed(stdout="https://github.com/owner/repo/issues/321\n")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        bug_reporter.file_bug_report(
+            title="audit-trail event check",
+            body="x",
+            project="demo",
+            subject="sub-1",
+        )
+
+    from pollypm.audit.log import read_events
+
+    events = read_events("demo")
+    filed = [
+        e for e in events if e.event == bug_reporter.EVENT_BUG_REPORT_FILED
+    ]
+    assert filed
+    assert filed[-1].metadata.get("issue_number") == 321
+    assert filed[-1].metadata.get("title") == "audit-trail event check"
+    assert filed[-1].subject == "sub-1"
+
+
+def test_deduped_event_carries_issue_number(_gh_on_path):
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["gh", "issue", "list"]:
+            payload = [
+                {
+                    "number": 88,
+                    "title": "dup-title",
+                    "createdAt": _isoformat_now_minus(60),
+                },
+            ]
+            return _completed(stdout=json.dumps(payload))
+        raise AssertionError("create should not run for dedup match")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        number = bug_reporter.file_bug_report(
+            title="dup-title", body="x", project="demo",
+        )
+    assert number == 88
+
+    from pollypm.audit.log import read_events
+
+    events = read_events("demo")
+    dedup = [
+        e for e in events if e.event == bug_reporter.EVENT_BUG_REPORT_DEDUPED
+    ]
+    assert dedup
+    assert dedup[-1].metadata.get("issue_number") == 88

--- a/tests/test_cli_bug_report.py
+++ b/tests/test_cli_bug_report.py
@@ -1,0 +1,187 @@
+"""Tests for the ``pm bug-report`` CLI subcommand (#1569).
+
+Verifies that the CLI:
+
+* Wires through to :func:`pollypm.audit.bug_reporter.file_bug_report_detailed`.
+* Echoes ``filed:#<n>`` on a fresh create and ``deduped:#<n>`` on a
+  dedup match.
+* Refuses empty title / body.
+* Surfaces gh-unavailable as a non-zero exit so caller scripts can
+  branch on the failure.
+* Writes NO inbox row when invoked — the whole point is to bypass the
+  inbox.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import text
+from typer.testing import CliRunner
+
+from pollypm.cli import app as root_app
+from pollypm.store import SQLAlchemyStore
+
+
+runner = CliRunner()
+
+
+def _completed(stdout: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr="",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_audit(tmp_path, monkeypatch):
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit"))
+    monkeypatch.setenv("POLLYPM_BUG_REPORTER_REPO", "owner/repo")
+
+
+@pytest.fixture
+def _gh_available(monkeypatch):
+    from pollypm.audit import bug_reporter
+
+    monkeypatch.setattr(bug_reporter, "_gh_available", lambda: True)
+
+
+def test_cli_filed_echoes_issue_number(_gh_available, tmp_path):
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return _completed(stdout="[]\n")
+        if cmd[:3] == ["gh", "issue", "create"]:
+            return _completed(stdout="https://github.com/owner/repo/issues/1011\n")
+        raise AssertionError(f"unexpected subprocess: {cmd!r}")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = runner.invoke(
+            root_app,
+            [
+                "bug-report",
+                "Inbox panel double-renders on rail switch",
+                "Repro: switch rails 3x, panel doubles.",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert "filed:#1011" in result.output
+
+
+def test_cli_dedup_echoes_existing_number(_gh_available):
+    from datetime import datetime, timedelta, timezone
+
+    recent_iso = (
+        datetime.now(timezone.utc) - timedelta(seconds=60)
+    ).isoformat().replace("+00:00", "Z")
+
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return _completed(
+                stdout=json.dumps(
+                    [
+                        {
+                            "number": 42,
+                            "title": "Same observation",
+                            "createdAt": recent_iso,
+                        }
+                    ]
+                )
+            )
+        raise AssertionError(f"create should not run: {cmd!r}")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = runner.invoke(
+            root_app,
+            ["bug-report", "Same observation", "x"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "deduped:#42" in result.output
+
+
+def test_cli_refuses_empty_title(_gh_available):
+    result = runner.invoke(
+        root_app,
+        ["bug-report", "   ", "body"],
+    )
+    assert result.exit_code != 0
+    assert "title must not be empty" in result.output
+
+
+def test_cli_refuses_empty_body(_gh_available):
+    result = runner.invoke(
+        root_app,
+        ["bug-report", "title", "   "],
+    )
+    assert result.exit_code != 0
+    assert "body must not be empty" in result.output
+
+
+def test_cli_body_from_stdin(_gh_available):
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return _completed(stdout="[]\n")
+        return _completed(stdout="https://github.com/owner/repo/issues/9\n")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = runner.invoke(
+            root_app,
+            ["bug-report", "stdin smoke", "-"],
+            input="multi\nline\nbody\n",
+        )
+    assert result.exit_code == 0, result.output
+    assert "filed:#9" in result.output
+
+
+def test_cli_gh_missing_exits_non_zero(monkeypatch):
+    from pollypm.audit import bug_reporter
+
+    monkeypatch.setattr(bug_reporter, "_gh_available", lambda: False)
+
+    result = runner.invoke(
+        root_app,
+        ["bug-report", "gh-missing", "x"],
+    )
+    assert result.exit_code != 0
+    assert "gh CLI unavailable" in result.output
+
+
+def test_cli_writes_no_inbox_row(_gh_available, tmp_path: Path):
+    """The whole point of the new command is to bypass the inbox.
+
+    Set up a fresh state.db, run ``pm bug-report``, then assert
+    that ``messages`` is empty — the helper went out to GitHub
+    (mocked) and did not enqueue a notify row.
+    """
+    db_path = tmp_path / "state.db"
+
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return _completed(stdout="[]\n")
+        return _completed(stdout="https://github.com/owner/repo/issues/123\n")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = runner.invoke(
+            root_app,
+            ["bug-report", "no-inbox-write", "evidence"],
+        )
+    assert result.exit_code == 0, result.output
+
+    # bug-report does not auto-create the state DB — verify by
+    # creating it manually and confirming no rows exist (the test's
+    # contract is "no inbox row was written", which is trivially
+    # true when no DB was touched).
+    if db_path.exists():
+        store = SQLAlchemyStore(f"sqlite:///{db_path}")
+        try:
+            with store.read_engine.connect() as conn:
+                rows = conn.execute(
+                    text("SELECT count(*) FROM messages")
+                ).scalar() or 0
+            assert rows == 0
+        finally:
+            store.close()
+    # If db_path was not created at all, that's also a pass — the
+    # helper never touched the inbox layer.


### PR DESCRIPTION
Closes #1569. Part of epic #1564.

## Summary

- Adds ``pollypm.audit.bug_reporter`` — a leaf helper that wraps ``gh issue create`` with a ``polly-self-report`` label, deduplicates against open issues with the same title in a configurable window (default 1h), records every attempt in the audit log, and never raises (gh missing / network down → returns ``None``).
- Adds ``pm bug-report "<title>" "<body>"`` — the user-facing CLI seam Polly / heartbeat / shell scripts can call instead of ``pm notify --project inbox`` when reporting meta-bugs about PollyPM itself.
- ``pm notify``'s help text now points operators at ``pm bug-report`` for self-bug observations.
- Operator-runbook docs (``commands.md``) document when to reach for each command.

## Retargeted emit sites

**None of the existing Python emit sites were retargeted.** I audited the candidates called out in #1569's scope:

- ``_maybe_dispatch_to_operator`` (tier-3 queue_without_motion → operator inbox)
- ``_dispatch_to_operator_tier4`` (tier-4 broader-authority leg)
- ``_route_tier4_to_terminal`` (tier-4 urgent human handoff)

Each of those is a legitimate operator escalation — the cadence has decided the user must intervene, and routing them to GitHub instead would *hide* operator-critical events. They stay in the inbox.

The actual noise in the user's inbox today (``Misrouted review ping: proj/1``, ``Repeated stale review ping for polly_remote/12``, etc.) is filed manually by Polly / heartbeat via ``pm notify``. ``pm bug-report`` is the routing fix for those manual callers; subsequent retraining + dashboard work in epic #1564 closes the loop.

## Test plan

- [x] ``uv run pytest tests/test_bug_reporter.py tests/test_cli_bug_report.py`` (22 new tests, all green)
- [x] ``uv run pytest tests/test_audit_watchdog.py tests/test_heartbeat*.py tests/test_cli_notify.py`` — 337 pass, no regressions vs main
- [x] Smoke: ``pm bug-report --help`` renders correctly
- [x] ``polly-self-report`` label created on the repo (``gh label create polly-self-report --description "Filed automatically when PollyPM notices a self-system bug" --color "5319e7"``)
- [x] No new Supervisor imports; helper is stdlib + ``pollypm.audit.log`` only
- [ ] Manual smoke: ``pm bug-report "test report" "body"`` files a real issue end-to-end (verify post-merge in a non-production checkout)

## Architecture notes

- Helper lives at ``src/pollypm/audit/bug_reporter.py`` — re-exported from ``pollypm.audit``.
- No imports from cockpit/TUI/Supervisor; honors the ``test_import_boundary.py`` allow-list (no new entries needed).
- Audit events: ``bug_report.filed``, ``bug_report.deduped``, ``bug_report.failed`` — recorded on every call so forensic readers can correlate even when ``gh`` is unreachable.
- Test hooks: ``POLLYPM_BUG_REPORTER_DISABLED=1`` short-circuits to audit-only; ``POLLYPM_BUG_REPORTER_REPO=owner/repo`` pins the target repo for tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)