### PR TITLE
feat(rail): badge counts items awaiting user (#1571)

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -176,31 +176,24 @@ def _row_is_dev_channel(labels_raw: object) -> bool:
     return "channel:dev" in labels
 
 
-def _count_inbox_tasks_for_label(config) -> int:
-    """Count actionable inbox items across tracked projects + workspace-root.
+def pm_inbox_awaits_user_list(config) -> list[object]:
+    """Return every inbox entry across the config that ``awaits_user``.
 
-    The cockpit rail is a notification surface, not an activity feed.
-    It should badge work that requires the user, while completion
-    updates and FYI messages stay discoverable inside the inbox's
-    all-messages lens.
+    Single source of truth for "what is waiting on the user across all
+    tracked projects + the workspace root" — the rail badge counts the
+    length of this list (#1571) and ``pm inbox --awaits-user`` renders
+    its rows. The predicate (:func:`pollypm.inbox.awaits_user`) is
+    applied to each candidate row before it lands in the result; the
+    plan-review approval filter (#1107) then drops phantom plan-review
+    rows whose underlying approval has already landed.
 
-    Dedupes:
-    - Tasks by ``task_id`` so a task present in more than one DB counts
-      once.
-    - Messages by their ``(scope, message_id)`` pair — same reason.
-
-    Applies ``_filter_approved_plan_reviews`` so the rail badge tracks
-    the inbox list view: phantom ``plan_review`` rows whose underlying
-    user_approval is already APPROVED don't inflate the count (#1107).
-    Without this filter the rail badge stays stale relative to the list
-    by however many phantom rows are pending sweep, which masked the
-    success of #1103 for several overnight loop ticks.
-
-    The function name is kept for backward compatibility with existing
-    callers; the return value is now an item count, not just a task
-    count.
+    Dedupes tasks by ``task_id`` and messages by ``(scope, message_id)``
+    so a row visible in more than one DB counts once. The function is
+    best-effort: a broken DB / missing source / failed store query
+    degrades a single source rather than raising.
     """
     try:
+        from pollypm.inbox import awaits_user
         from pollypm.work import create_work_service
         from pollypm.work.inbox_view import inbox_tasks
         from pollypm.cockpit_inbox_items import (
@@ -211,15 +204,13 @@ def _count_inbox_tasks_for_label(config) -> int:
             task_to_inbox_entry,
         )
     except Exception:  # noqa: BLE001
-        return 0
+        return []
 
     try:
         from pollypm.store import SQLAlchemyStore
     except Exception:  # noqa: BLE001
         SQLAlchemyStore = None  # type: ignore[assignment]
 
-    seen_task_ids: set[str] = set()
-    seen_message_keys: set[tuple[str, object]] = set()
     # Collect actionable entries so the plan-review filter can drop
     # phantoms before we count. ``_filter_approved_plan_reviews`` needs
     # a per-project ``(db_path, project_path)`` map to resolve refs.
@@ -244,8 +235,7 @@ def _count_inbox_tasks_for_label(config) -> int:
                         task_to_inbox_entry(task, db_path=db_path),
                         known_projects=known_projects,
                     )
-                    if getattr(item, "needs_action", False):
-                        seen_task_ids.add(task.task_id)
+                    if awaits_user(item):
                         task_entries.setdefault(task.task_id, item)
         except Exception:  # noqa: BLE001
             pass
@@ -302,9 +292,8 @@ def _count_inbox_tasks_for_label(config) -> int:
                     ),
                     known_projects=known_projects,
                 )
-                if getattr(item, "needs_action", False):
+                if awaits_user(item):
                     msg_key = (str(scope), row_id)
-                    seen_message_keys.add(msg_key)
                     message_entries.setdefault(msg_key, item)
         finally:
             try:
@@ -317,11 +306,34 @@ def _count_inbox_tasks_for_label(config) -> int:
     # ``load_inbox_entries``).
     collected = list(task_entries.values()) + list(message_entries.values())
     if collected and project_db_paths:
-        kept = _filter_approved_plan_reviews(
-            collected, project_db_paths=project_db_paths,
+        return list(
+            _filter_approved_plan_reviews(
+                collected, project_db_paths=project_db_paths,
+            )
         )
-        return len(kept)
-    return len(seen_task_ids) + len(seen_message_keys)
+    return collected
+
+
+def _count_inbox_tasks_for_label(config) -> int:
+    """Count actionable inbox items across tracked projects + workspace-root.
+
+    The cockpit rail is a notification surface, not an activity feed.
+    It should badge work that requires the user, while completion
+    updates and FYI messages stay discoverable inside the inbox's
+    all-messages lens.
+
+    Rewired in #1571 to read from the canonical
+    :func:`pollypm.inbox.awaits_user` predicate (#1566) via
+    :func:`pm_inbox_awaits_user_list` instead of the legacy
+    ``triage_bucket == "action"`` regex heuristic. Same answer as
+    ``pm inbox --awaits-user`` and the upcoming dashboard "Waiting on
+    you" surface — one predicate, three surfaces.
+
+    The function name is kept for backward compatibility with existing
+    callers; the return value is now an item count, not just a task
+    count.
+    """
+    return len(pm_inbox_awaits_user_list(config))
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/pollypm/work/inbox_cli.py
+++ b/src/pollypm/work/inbox_cli.py
@@ -13,11 +13,13 @@ from __future__ import annotations
 
 import json
 import re
+from types import SimpleNamespace
 from typing import Any
 
 import typer
 
 from pollypm.cli_help import help_with_examples
+from pollypm.inbox import awaits_user
 from pollypm.inbox.kind import coerce_kind as _coerce_inbox_kind
 from pollypm.inbox_message_refs import unknown_project_refs
 from pollypm.work.cli import (
@@ -67,7 +69,10 @@ inbox_app = typer.Typer(
         "Work assigned to the user.",
         [
             ("pm inbox", "list open inbox items"),
-            ("pm inbox show demo/1", "print one inbox task or message"),
+            (
+                "pm inbox --awaits-user",
+                "filter to rows the rail badge counts (#1571)",
+            ),
             ("pm inbox --json", "emit the merged inbox view as JSON"),
         ],
     )
@@ -172,7 +177,10 @@ def inbox_root(
             "one of these and clutters the listing without giving the "
             "user anything actionable to type. The cockpit inbox pane "
             "still surfaces them via its own structured action affordances. "
-            "(#1013, mirrors the ``pm task list`` opt-in shipped in #1003.)"
+            "(#1013, mirrors the ``pm task list`` opt-in shipped in #1003.) "
+            "Prefer ``--awaits-user`` (#1571) when you actually want the "
+            "canonical 'what needs my attention' set — ``--include-inbox`` "
+            "is the wider chat-flow-row lens, not the curated one."
         ),
     ),
     show_all: bool = typer.Option(
@@ -186,6 +194,19 @@ def inbox_root(
             "everything else is collapsed behind a footer count so the "
             "single thing that needs your attention doesn't get buried. "
             "(#1027.)"
+        ),
+    ),
+    awaits_user_only: bool = typer.Option(
+        False,
+        "--awaits-user",
+        help=(
+            "Filter the listing to rows where the canonical "
+            "``pollypm.inbox.awaits_user`` predicate (#1566) returns "
+            "True — the same predicate that drives the cockpit rail "
+            "badge (#1571) and the upcoming dashboard 'Waiting on you' "
+            "section. Use this to sanity-check the badge from the CLI: "
+            "the count printed by ``pm inbox --awaits-user`` matches "
+            "the rail badge on the same DB."
         ),
     ),
 ) -> None:
@@ -264,6 +285,17 @@ def inbox_root(
     if not include_inbox:
         from pollypm.notify_task import is_notify_inbox_task
         tasks = [task for task in tasks if not is_notify_inbox_task(task)]
+
+    # #1571 — narrow to the canonical "awaits user" set. The predicate
+    # reads ``item.kind`` (Task surfaces it as an attribute; for raw
+    # messages we coerce the stored value into a ``kind`` attribute on
+    # a tiny shim so the predicate stays the single source of truth).
+    if awaits_user_only:
+        tasks = [task for task in tasks if awaits_user(task)]
+        display_messages = [
+            m for m in display_messages
+            if awaits_user(SimpleNamespace(kind=m.get("kind")))
+        ]
 
     # #1027 — default-hide pure ``notify``-type messages (completion
     # announcements, heartbeat alerts, "Done:" / "Repeated stale review

--- a/tests/test_inbox_aggregator_workspace_root.py
+++ b/tests/test_inbox_aggregator_workspace_root.py
@@ -159,6 +159,7 @@ def _seed_message(
     subject: str = "[Action] notify title",
     payload: dict | None = None,
     labels: list[str] | None = None,
+    kind: str = "legacy",
 ) -> int:
     """Seed one user-recipient message directly into the unified store."""
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -176,6 +177,7 @@ def _seed_message(
             state=state,
             payload=payload,
             labels=labels,
+            kind=kind,
         )
     finally:
         store.close()
@@ -202,8 +204,17 @@ def test_aggregator_counts_actionable_messages_not_just_tasks(env) -> None:
 
 
 def test_aggregator_skips_fyi_messages(env) -> None:
-    """Completion/FYI notifications should not inflate the rail badge."""
-    _seed_message(env["workspace_db"], scope="inbox", subject="Demo shipped cleanly")
+    """Completion/FYI notifications should not inflate the rail badge.
+
+    Post-#1571 the rail reads from :func:`pollypm.inbox.awaits_user`,
+    which keys on the structured ``kind`` column rather than the old
+    subject regex. The FYI assertion now seeds ``kind=completion_fyi``
+    so the predicate (not heuristic) drops the row.
+    """
+    _seed_message(
+        env["workspace_db"], scope="inbox",
+        subject="Demo shipped cleanly", kind="completion_fyi",
+    )
 
     count = _count_inbox_tasks_for_label(_load_cfg(env["config_path"]))
     assert count == 0, f"expected no actionable messages, got {count}"

--- a/tests/test_rail_badge_awaits_user.py
+++ b/tests/test_rail_badge_awaits_user.py
@@ -1,0 +1,260 @@
+"""Rail badge / CLI / predicate alignment (#1571).
+
+Pins the invariant that motivated the epic (#1564): the rail badge,
+``pm inbox --awaits-user``, and the canonical
+:func:`pollypm.inbox.awaits_user` predicate all return the same count on
+the same DB. Before #1571 the rail badge ran a local
+``triage_bucket == "action"`` regex heuristic while the CLI ran nothing
+of the kind, so the three surfaces disagreed (97 / 44 / 133).
+
+The test setup populates a workspace + a project with a mix of
+:class:`InboxItemKind` values (some user-facing, some informational,
+some legacy). The body of every assertion is the predicate, so any
+regression that re-introduces a parallel "is actionable" definition
+on the rail side fails here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm.cockpit_inbox import (
+    _count_inbox_tasks_for_label,
+    pm_inbox_awaits_user_list,
+)
+from pollypm.inbox import awaits_user
+from pollypm.inbox.kind import InboxItemKind
+from pollypm.work.inbox_cli import inbox_app
+from pollypm.work.sqlite_service import SQLiteWorkService
+
+
+runner = CliRunner()
+
+
+def _write_config(
+    workspace_root: Path, project_path: Path, config_path: Path,
+) -> None:
+    config_path.write_text(
+        "[project]\n"
+        'tmux_session = "pollypm-test"\n'
+        f'workspace_root = "{workspace_root}"\n'
+        "\n"
+        "[projects.demo]\n"
+        'key = "demo"\n'
+        'name = "Demo"\n'
+        f'path = "{project_path}"\n'
+    )
+
+
+def _seed_task(
+    db_path: Path,
+    project_path: Path,
+    *,
+    project: str,
+    title: str,
+    kind: str,
+) -> str:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+    try:
+        task = svc.create(
+            title=title,
+            description=f"body for {title}",
+            type="task",
+            project=project,
+            flow_template="chat",
+            roles={"requester": "user", "operator": "polly"},
+            priority="normal",
+            created_by="polly",
+            kind=kind,
+        )
+        return task.task_id
+    finally:
+        svc.close()
+
+
+def _seed_message(
+    db_path: Path,
+    *,
+    scope: str,
+    subject: str,
+    kind: str,
+) -> int:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    from pollypm.store import SQLAlchemyStore
+    store = SQLAlchemyStore(f"sqlite:///{db_path}")
+    try:
+        return store.enqueue_message(
+            type="notify",
+            tier="immediate",
+            scope=scope,
+            sender="polly",
+            recipient="user",
+            subject=subject,
+            body="body",
+            kind=kind,
+        )
+    finally:
+        store.close()
+
+
+def _load_cfg(config_path: Path):
+    from pollypm.config import load_config
+    return load_config(config_path)
+
+
+@pytest.fixture
+def env(tmp_path: Path):
+    workspace_root = tmp_path / "dev"
+    workspace_root.mkdir()
+    project_path = workspace_root / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(workspace_root, project_path, config_path)
+    return {
+        "workspace_root": workspace_root,
+        "project_path": project_path,
+        "config_path": config_path,
+        "project_db": project_path / ".pollypm" / "state.db",
+        "workspace_db": workspace_root / ".pollypm" / "state.db",
+    }
+
+
+def test_empty_db_badge_and_predicate_both_zero(env) -> None:
+    """A fresh DB with no rows trivially agrees on zero."""
+    config = _load_cfg(env["config_path"])
+    badge = _count_inbox_tasks_for_label(config)
+    listed = pm_inbox_awaits_user_list(config)
+    assert badge == 0
+    assert listed == []
+
+
+def test_mixed_kinds_badge_equals_predicate_count(env) -> None:
+    """Pin the invariant: rail count == predicate-filtered list length.
+
+    Seeds a deliberately mixed bag of inbox rows so the predicate has
+    to do real work: three user-facing tasks (approval_request,
+    pm_question_unanswered, manual_decision), two informational tasks
+    that must NOT count (completion_fyi, info), one legacy task
+    (counts under the migration safety default), and matching message
+    rows on the workspace-root DB.
+    """
+    # Tasks on the per-project DB.
+    _seed_task(
+        env["project_db"], env["project_path"],
+        project="demo", title="approve plan",
+        kind=InboxItemKind.APPROVAL_REQUEST.value,
+    )
+    _seed_task(
+        env["project_db"], env["project_path"],
+        project="demo", title="pm asks something",
+        kind=InboxItemKind.PM_QUESTION_UNANSWERED.value,
+    )
+    _seed_task(
+        env["project_db"], env["project_path"],
+        project="demo", title="manual call",
+        kind=InboxItemKind.MANUAL_DECISION.value,
+    )
+    _seed_task(
+        env["project_db"], env["project_path"],
+        project="demo", title="shipped",
+        kind=InboxItemKind.COMPLETION_FYI.value,
+    )
+    _seed_task(
+        env["project_db"], env["project_path"],
+        project="demo", title="just info",
+        kind=InboxItemKind.INFO.value,
+    )
+    _seed_task(
+        env["project_db"], env["project_path"],
+        project="demo", title="legacy stub",
+        kind=InboxItemKind.LEGACY.value,
+    )
+
+    # Messages on the workspace-root DB — same mix.
+    _seed_message(
+        env["workspace_db"], scope="inbox",
+        subject="watchdog dispatch",
+        kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
+    )
+    _seed_message(
+        env["workspace_db"], scope="inbox",
+        subject="plan ready",
+        kind=InboxItemKind.PLAN_REVIEW_PENDING.value,
+    )
+    _seed_message(
+        env["workspace_db"], scope="inbox",
+        subject="self-bug report",
+        kind=InboxItemKind.SELF_BUG_REPORT.value,
+    )
+    _seed_message(
+        env["workspace_db"], scope="inbox",
+        subject="activity event",
+        kind=InboxItemKind.ACTIVITY_EVENT.value,
+    )
+
+    config = _load_cfg(env["config_path"])
+    badge = _count_inbox_tasks_for_label(config)
+    listed = pm_inbox_awaits_user_list(config)
+    awaits_count = len([item for item in listed if awaits_user(item)])
+
+    # Tasks: 3 user-facing + 1 legacy = 4
+    # Messages: 1 watchdog + 1 plan-review = 2
+    # Total = 6
+    assert badge == 6, f"rail badge expected 6, got {badge}"
+    assert badge == awaits_count, (
+        f"rail badge ({badge}) must equal awaits_user-filtered list "
+        f"length ({awaits_count})"
+    )
+    # ``pm_inbox_awaits_user_list`` already filters; the re-filter in
+    # the assertion above is the invariant the issue spec pins.
+    assert len(listed) == awaits_count
+
+
+def test_cli_awaits_user_flag_matches_predicate(env) -> None:
+    """``pm inbox --awaits-user`` filters the listing to the predicate set.
+
+    Single-DB scope: the CLI operates on one DB at a time so the
+    comparison is against the rows we seed on that DB.
+    """
+    # One user-facing + one informational message in the per-project DB.
+    _seed_message(
+        env["project_db"], scope="demo",
+        subject="approve me",
+        kind=InboxItemKind.APPROVAL_REQUEST.value,
+    )
+    _seed_message(
+        env["project_db"], scope="demo",
+        subject="shipped",
+        kind=InboxItemKind.COMPLETION_FYI.value,
+    )
+
+    # Default ``pm inbox`` (without ``--all``) hides notify-type FYIs
+    # already, but ``--awaits-user`` is the canonical lens — assert
+    # both that the actionable row shows up and the FYI does not.
+    result = runner.invoke(
+        inbox_app, ["--awaits-user", "--all", "--db", str(env["project_db"])],
+    )
+    assert result.exit_code == 0, result.output
+    assert "approve me" in result.output
+    assert "shipped" not in result.output
+
+
+def test_cli_awaits_user_excludes_legacy_when_not_seeded(env) -> None:
+    """A row tagged with an informational kind drops out of the CLI listing."""
+    _seed_message(
+        env["project_db"], scope="demo",
+        subject="just info",
+        kind=InboxItemKind.INFO.value,
+    )
+    result = runner.invoke(
+        inbox_app, ["--awaits-user", "--all", "--db", str(env["project_db"])],
+    )
+    assert result.exit_code == 0, result.output
+    assert "just info" not in result.output
+    # Inbox header still rendered, even on empty result.
+    assert "Inbox:" in result.output


### PR DESCRIPTION
## Summary

- Rewire ``_count_inbox_tasks_for_label`` to delegate to ``pollypm.inbox.awaits_user`` (#1566) instead of the local ``triage_bucket == "action"`` regex heuristic; the rail badge now reads from the canonical predicate so it agrees with the upcoming dashboard "Waiting on you" surface and the new ``pm inbox --awaits-user`` flag.
- Add a ``pm inbox --awaits-user`` CLI flag that filters the listing to rows where the canonical predicate returns True. Use it to sanity-check the rail count from the shell.
- Extract the cross-DB scan into a public ``pm_inbox_awaits_user_list`` helper so the rail badge and the regression test both consume the same predicate-filtered list (no parallel definitions). Update ``--include-inbox``'s docstring to point at ``--awaits-user`` as the canonical "what needs my attention" lens.

## Test plan

- [x] ``uv run pytest tests/test_cockpit_inbox*.py tests/test_inbox*.py tests/test_audit_log.py`` (287 passed; 283 baseline + 4 new)
- [x] ``uv run pytest tests/test_cockpit.py tests/test_cockpit_dashboard.py tests/test_polly_dashboard_ui.py tests/test_core_rail_items.py tests/test_rail_cli.py`` (249 passed; downstream consumers of the badge function)
- [x] New regression: ``tests/test_rail_badge_awaits_user.py`` pins ``_count_inbox_tasks_for_label(config) == len([item for item in pm_inbox_awaits_user_list(config) if awaits_user(item)])`` against a fixed test DB with a mix of ``InboxItemKind`` values.

Closes #1571
Refs #1564