### PR TITLE
feat(inbox): tag emit sites with InboxItemKind (#1567, #1568)

### DIFF
--- a/issues/01-ready/0059-project-pollypm-has-7-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/01-ready/0059-project-pollypm-has-7-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,0 +1,26 @@
+# Project pollypm has 7 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+
+TIER HANDOFF
+
+Question: Project pollypm is wedged in a way the architect can't unstick. What structural change do you want to apply?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+  - pollypm/50
+  - pollypm/53
+  - pollypm/54
+  - pollypm/55
+  - pollypm/57
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+  - pollypm/50: 2026-05-14T07:28:30.002865+00:00
+  - pollypm/53: 2026-05-14T07:36:20.413078+00:00
+  - pollypm/54: 2026-05-14T07:36:20.596332+00:00
+  - pollypm/55: 2026-05-14T08:11:30.135498+00:00
+  - pollypm/57: 2026-05-14T13:09:45.817542+00:00
+- last_activity_at: None
+- last_activity_event: 
+- threshold_seconds: 1800

--- a/issues/01-ready/0061-canceled-duplicate-bikepath-watchdog-drafts.md
+++ b/issues/01-ready/0061-canceled-duplicate-bikepath-watchdog-drafts.md
@@ -1,0 +1,7 @@
+# Canceled duplicate bikepath watchdog drafts
+
+**Action taken:** Canceled bikepath/31, bikepath/32, and bikepath/33.
+
+**Why:** All three were duplicate watchdog tier-handoff drafts for the same stalled queue condition. bikepath/30 is already queued as the active escalation, so promoting these would create redundant operator work.
+
+**Verify:** Run `pm task status bikepath/31`, `pm task status bikepath/32`, and `pm task status bikepath/33`; each should show `cancelled`. Run `pm task status bikepath/30` to see the active queued handoff.

--- a/issues/05-completed/0060-project-pollypm-has-7-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/05-completed/0060-project-pollypm-has-7-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,0 +1,26 @@
+# [CANCELLED] Project pollypm has 7 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+
+TIER HANDOFF
+
+Question: Project pollypm is wedged in a way the architect can't unstick. What structural change do you want to apply?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+  - pollypm/50
+  - pollypm/53
+  - pollypm/54
+  - pollypm/55
+  - pollypm/57
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+  - pollypm/50: 2026-05-14T07:28:30.002865+00:00
+  - pollypm/53: 2026-05-14T07:36:20.413078+00:00
+  - pollypm/54: 2026-05-14T07:36:20.596332+00:00
+  - pollypm/55: 2026-05-14T08:11:30.135498+00:00
+  - pollypm/57: 2026-05-14T13:09:45.817542+00:00
+- last_activity_at: None
+- last_activity_event: 
+- threshold_seconds: 1800

--- a/src/pollypm/cli_features/session_runtime.py
+++ b/src/pollypm/cli_features/session_runtime.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import typer
 
 from pollypm.config import DEFAULT_CONFIG_PATH
+from pollypm.inbox.kind import InboxItemKind
 
 _TASK_ID_PATTERN = re.compile(r"\b([A-Za-z0-9_.-]+/\d+)\b")
 
@@ -647,6 +648,34 @@ def send(
     typer.echo(f"Sent input to {session_name}")
 
 
+def _kind_for_notify(
+    labels: list[str],
+    *,
+    requester: str,
+    user_prompt_payload: dict | None,
+) -> str:
+    """Pick the inbox ``kind`` for a ``pm notify`` emit (#1567/#1568).
+
+    Most ``pm notify`` calls land with no label hint, and the caller is
+    a human (the architect, Polly herself, etc.) typing free-form text
+    — those stay ``legacy`` so the predicate's fail-open default keeps
+    them visible until #1570 backfills. Only label-keyed shapes that
+    map cleanly onto an actionable kind get explicit retraining here:
+
+    * ``plan_review`` label → ``plan_review_pending`` (architect's
+      canonical ``pm notify --label plan_review`` handoff).
+    * ``--user-prompt-json`` payload routed at ``requester=user`` →
+      ``pm_question_unanswered`` (producer explicitly built an Action
+      Needed card with a question for the user).
+    """
+    label_set = {label for label in labels if isinstance(label, str)}
+    if "plan_review" in label_set:
+        return InboxItemKind.PLAN_REVIEW_PENDING.value
+    if user_prompt_payload is not None and requester == "user":
+        return InboxItemKind.PM_QUESTION_UNANSWERED.value
+    return InboxItemKind.LEGACY.value
+
+
 def notify(
     helpers,
     subject: str = typer.Argument(..., help="Short title for the inbox item."),
@@ -996,6 +1025,11 @@ def notify(
         else None
     )
 
+    notify_kind = _kind_for_notify(
+        label_list,
+        requester=requester_role,
+        user_prompt_payload=user_prompt_payload,
+    )
     try:
         if existing_dedup_row is not None:
             # Bump path — caller signaled "this is the same alert
@@ -1030,6 +1064,7 @@ def notify(
                 labels=label_list or None,
                 payload=seeded_payload,
                 state="closed" if resolved_priority == "immediate" else tier_state,
+                kind=notify_kind,
             )
     except Exception as exc:  # noqa: BLE001
         typer.echo(f"Failed to enqueue notify message: {exc}", err=True)
@@ -1064,6 +1099,7 @@ def notify(
                 priority="high",
                 created_by=actor,
                 labels=task_labels,
+                kind=notify_kind,
             )
             inbox_task_id = task.task_id
             store = SQLAlchemyStore(f"sqlite:///{db_path}")

--- a/src/pollypm/notification_staging.py
+++ b/src/pollypm/notification_staging.py
@@ -49,6 +49,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from pollypm.inbox.kind import InboxItemKind
+
 logger = logging.getLogger(__name__)
 
 
@@ -326,6 +328,7 @@ def flush_milestone_digest(
         priority="normal",
         created_by=actor,
         labels=labels,
+        kind=InboxItemKind.MANUAL_DECISION.value,
     )
 
     # Persist each staged row as a ``rollup_item`` context entry so the
@@ -587,6 +590,7 @@ def check_regression_on_reopen(
             roles={"requester": "user", "operator": actor},
             priority="high",
             created_by=actor,
+            kind=InboxItemKind.MANUAL_DECISION.value,
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning("regression notify failed for %s: %s", task_id, exc)

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -32,6 +32,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from pollypm.inbox.kind import InboxItemKind
 from pollypm.audit.watchdog import (
     ESCALATION_THROTTLE_SECONDS,
     OPERATOR_DISPATCH_THROTTLE_SECONDS,
@@ -1662,6 +1663,7 @@ def _create_operator_inbox_task(
                 labels=["notify", "watchdog"],
                 payload=seeded_payload,
                 state="closed",
+                kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
             )
     finally:
         store.close()
@@ -1689,6 +1691,7 @@ def _create_operator_inbox_task(
             priority="high",
             created_by="audit_watchdog",
             labels=task_labels,
+            kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
         )
         inbox_task_id = task.task_id
         store2 = SQLAlchemyStore(f"sqlite:///{db_path}")
@@ -1835,6 +1838,7 @@ def _create_operator_tier4_inbox_task(
                 labels=["notify", "watchdog", "tier4"],
                 payload=seeded_payload,
                 state="closed",
+                kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
             )
     finally:
         store.close()
@@ -1863,6 +1867,7 @@ def _create_operator_tier4_inbox_task(
             priority="high",
             created_by="audit_watchdog",
             labels=task_labels,
+            kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
         )
         inbox_task_id = task.task_id
         store2 = SQLAlchemyStore(f"sqlite:///{db_path}")
@@ -2305,6 +2310,7 @@ def _route_tier4_to_terminal(
                 "forensics_path": handoff.forensics_path,
             },
             state="closed",
+            kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
         )
         return bool(message_id)
     except Exception:  # noqa: BLE001

--- a/src/pollypm/plugins_builtin/core_recurring/sweeps.py
+++ b/src/pollypm/plugins_builtin/core_recurring/sweeps.py
@@ -6,6 +6,8 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from pollypm.inbox.kind import InboxItemKind
+
 from .shared import (
     _close_msg_store,
     _load_config_and_store,
@@ -693,6 +695,9 @@ def _emit_pane_pattern_inbox_item(
     ]
 
     try:
+        # Pane-pattern findings (zombie sessions, idle prompts, …) go
+        # to Polly to recover, not to the user. Activity-event tier on
+        # the user-facing surface.
         inbox_task = work_service.create(
             title=title,
             description=body,
@@ -703,6 +708,7 @@ def _emit_pane_pattern_inbox_item(
             priority="normal",
             created_by=session_name,
             labels=labels,
+            kind=InboxItemKind.ACTIVITY_EVENT.value,
         )
     except Exception:  # noqa: BLE001
         logger.debug(

--- a/src/pollypm/plugins_builtin/project_planning/proposals.py
+++ b/src/pollypm/plugins_builtin/project_planning/proposals.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 
+from pollypm.inbox.kind import InboxItemKind
+
 
 # Severity values accepted on a proposal. Kept deliberately short so the
 # label suffix stays readable in the inbox row.
@@ -200,6 +202,7 @@ def emit_proposals(
             priority="normal",
             created_by="architect",
             labels=labels,
+            kind=InboxItemKind.APPROVAL_REQUEST.value,
         )
         created.append(task.task_id)
     return created

--- a/src/pollypm/project_status_summary.py
+++ b/src/pollypm/project_status_summary.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any, Iterable
 
+from pollypm.inbox.kind import InboxItemKind
+
 
 @dataclass(slots=True)
 class ProjectBlockerSummary:
@@ -211,6 +213,7 @@ def record_project_blocker_summary(
                 f"blocker_event:{event_id}",
             ],
             requires_human_review=False,
+            kind=InboxItemKind.MANUAL_DECISION.value,
         )
         task_id = task.task_id
         store.update_message(event_id, payload={**payload, "task_id": task_id})

--- a/src/pollypm/recovery/worker_turn_end.py
+++ b/src/pollypm/recovery/worker_turn_end.py
@@ -36,6 +36,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from pollypm.inbox.kind import InboxItemKind
+
 logger = logging.getLogger(__name__)
 
 
@@ -314,6 +316,10 @@ def create_blocking_question_inbox_item(
     labels = [label for label in labels if label]
 
     try:
+        # operator is the PM persona (default ``polly``), not the user
+        # — Polly resolves the blocker; she only escalates to the user
+        # if she can't. Tag as activity_event so it stays out of the
+        # user-facing "Waiting on you" list.
         inbox_task = work_service.create(
             title=title,
             description=body,
@@ -324,6 +330,7 @@ def create_blocking_question_inbox_item(
             priority="normal",
             created_by=session_name,
             labels=labels,
+            kind=InboxItemKind.ACTIVITY_EVENT.value,
         )
     except Exception:  # noqa: BLE001
         logger.exception(

--- a/src/pollypm/rejection_feedback.py
+++ b/src/pollypm/rejection_feedback.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pollypm.inbox.kind import InboxItemKind
+
 FEEDBACK_LABEL = "review_feedback"
 TASK_LABEL_PREFIX = "task:"
 PROJECT_LABEL_PREFIX = "project:"
@@ -64,6 +66,7 @@ def emit_rejection_feedback(work_service, *, task, reviewer: str, reason: str):
             f"{TASK_LABEL_PREFIX}{task.task_id}",
             f"{PROJECT_LABEL_PREFIX}{getattr(task, 'project', '') or 'inbox'}",
         ],
+        kind=InboxItemKind.MANUAL_DECISION.value,
     )
 
 

--- a/src/pollypm/task_shipped.py
+++ b/src/pollypm/task_shipped.py
@@ -23,6 +23,7 @@ import logging
 import re
 from typing import Any, Protocol
 
+from pollypm.inbox.kind import InboxItemKind
 from pollypm.work.models import ArtifactKind
 
 logger = logging.getLogger(__name__)
@@ -213,6 +214,7 @@ def emit_task_shipped_card(
             priority="normal",
             created_by=actor or "polly",
             labels=labels,
+            kind=InboxItemKind.COMPLETION_FYI.value,
         )
         return getattr(card, "task_id", None)
     except Exception as exc:  # noqa: BLE001

--- a/src/pollypm/work/plan_review_emit.py
+++ b/src/pollypm/work/plan_review_emit.py
@@ -47,6 +47,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from pollypm.inbox.kind import InboxItemKind
 from pollypm.work.models import WorkStatus
 
 logger = logging.getLogger(__name__)
@@ -325,6 +326,7 @@ def emit_plan_review_for_task(
                     "backstop_source": "plan_review_emit",
                 },
                 state="closed",  # mirrors session_runtime.notify for immediate tier
+                kind=InboxItemKind.PLAN_REVIEW_PENDING.value,
             )
         except Exception as exc:  # noqa: BLE001
             logger.debug(
@@ -371,6 +373,7 @@ def emit_plan_review_for_task(
             priority="high",
             created_by=actor or "audit_watchdog",
             labels=deduped,
+            kind=InboxItemKind.PLAN_REVIEW_PENDING.value,
         )
         inbox_task_id = getattr(new_task, "task_id", None)
     except Exception as exc:  # noqa: BLE001

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -60,7 +60,7 @@ from pollypm.signal_routing import (  # noqa: E402
 register_routed_emitter("work_service")
 
 from pollypm.atomic_io import atomic_write_json
-from pollypm.inbox.kind import coerce_kind as _coerce_inbox_kind
+from pollypm.inbox.kind import InboxItemKind, coerce_kind as _coerce_inbox_kind
 from pollypm.work.flow_engine import resolve_flow
 from pollypm.work.gates import GateRegistry, evaluate_gates
 from pollypm.work.models import (
@@ -667,6 +667,7 @@ def _record_first_shipped_activity(
             body=body,
             scope="polly",
             payload=payload,
+            kind=InboxItemKind.COMPLETION_FYI.value,
         )
     finally:
         store.close()
@@ -1906,6 +1907,7 @@ class SQLiteWorkService:
                 label,
             ],
             requires_human_review=False,
+            kind=InboxItemKind.APPROVAL_REQUEST.value,
         )
 
     def approve_human_review(

--- a/src/pollypm/worker_milestone.py
+++ b/src/pollypm/worker_milestone.py
@@ -23,6 +23,8 @@ import logging
 import time
 from typing import Any, Protocol
 
+from pollypm.inbox.kind import InboxItemKind
+
 logger = logging.getLogger(__name__)
 
 _WORKER_MILESTONE_LABEL = "worker_milestone"
@@ -167,7 +169,8 @@ def emit_worker_milestone(
 
         # operator is fixed: milestones always surface to polly. The
         # caller-controlled identity is ``created_by`` (which worker
-        # said it).
+        # said it). Polly is the addressee, not the user, so this is
+        # an informational activity-event on the user-facing surface.
         card = svc.create(
             title=title,
             description=body,
@@ -178,6 +181,7 @@ def emit_worker_milestone(
             priority="normal",
             created_by=actor or "worker",
             labels=[_WORKER_MILESTONE_LABEL],
+            kind=InboxItemKind.ACTIVITY_EVENT.value,
         )
         return getattr(card, "task_id", None)
     except Exception as exc:  # noqa: BLE001

--- a/tests/test_inbox_kind_emit_sites.py
+++ b/tests/test_inbox_kind_emit_sites.py
@@ -1,0 +1,670 @@
+"""Per-emit-site ``kind`` retraining tests (#1567, #1568).
+
+The :class:`InboxItemKind` enum landed in #1565 and the canonical
+:func:`awaits_user` predicate in #1566 — both rely on every inbox emit
+site stamping the right ``kind`` at construction time. This file pins
+the chosen kind value per emit site so a future refactor can't silently
+drift one back to ``legacy`` (the safe-default that would round-trip as
+"awaits user" forever).
+
+Grouping: one test per emit site, asserting the stored ``kind`` on the
+row that site produces. Where the site emits both a message + a work
+task, both are checked because the awaits-user predicate runs over both
+tables.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pollypm.inbox.kind import InboxItemKind
+from pollypm.store import SQLAlchemyStore
+
+
+# ---------------------------------------------------------------------------
+# Shared in-memory work-service fake
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _CreatedTask:
+    task_id: str
+    kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+class _RecordingWorkService:
+    """Captures every ``create()`` call so tests can assert ``kind``."""
+
+    def __init__(self) -> None:
+        self.creates: list[dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> _CreatedTask:
+        self.creates.append(kwargs)
+        return _CreatedTask(task_id="demo/1", kwargs=dict(kwargs))
+
+
+# ---------------------------------------------------------------------------
+# task_shipped — emit_task_shipped_card → completion_fyi
+# ---------------------------------------------------------------------------
+
+
+def test_task_shipped_card_is_tagged_completion_fyi() -> None:
+    from pollypm.task_shipped import emit_task_shipped_card
+
+    @dataclass
+    class _Artifact:
+        kind: Any
+        ref: str = ""
+        external_ref: str = ""
+        description: str = ""
+
+    @dataclass
+    class _WorkOutput:
+        summary: str = ""
+        artifacts: list[Any] = field(default_factory=list)
+
+    @dataclass
+    class _Execution:
+        work_output: Any | None = None
+
+    @dataclass
+    class _Task:
+        task_id: str
+        project: str
+        title: str
+
+    svc = _RecordingWorkService()
+    work_output = _WorkOutput(summary="phase one shipped")
+    execution = _Execution(work_output=work_output)
+    task = _Task(task_id="demo/1", project="demo", title="Build feature")
+
+    svc.get = lambda _tid: task  # type: ignore[assignment]
+    svc.get_execution = lambda _tid: [execution]  # type: ignore[assignment]
+
+    emit_task_shipped_card(svc, "demo/1", actor="polly")
+
+    assert len(svc.creates) == 1
+    assert svc.creates[0]["kind"] == InboxItemKind.COMPLETION_FYI.value
+
+
+# ---------------------------------------------------------------------------
+# worker_milestone — emit_worker_milestone → activity_event (polly addressee)
+# ---------------------------------------------------------------------------
+
+
+def test_worker_milestone_card_is_tagged_activity_event() -> None:
+    from pollypm.work.models import Priority, Task, WorkStatus
+    from pollypm.worker_milestone import emit_worker_milestone
+
+    fake_task = Task(
+        project="demo",
+        task_number=2,
+        title="Migrate cache",
+        type="task",
+        flow_template_id="standard",
+        flow_template_version=1,
+        work_status=WorkStatus.IN_PROGRESS,
+        priority=Priority.NORMAL,
+    )
+
+    svc = _RecordingWorkService()
+    svc.get = lambda _tid: fake_task  # type: ignore[assignment]
+    svc.list_tasks = lambda **_: []  # type: ignore[assignment]
+
+    emit_worker_milestone(
+        svc, "demo/2", message="cache migration midpoint", actor="worker",
+    )
+
+    assert len(svc.creates) == 1
+    assert svc.creates[0]["kind"] == InboxItemKind.ACTIVITY_EVENT.value
+
+
+# ---------------------------------------------------------------------------
+# proposals — emit_proposals → approval_request
+# ---------------------------------------------------------------------------
+
+
+def test_emit_proposals_is_tagged_approval_request(tmp_path: Path) -> None:
+    from pollypm.plugins_builtin.project_planning.proposals import (
+        ImprovementProposal,
+        emit_proposals,
+    )
+
+    svc = _RecordingWorkService()
+    proposals = [
+        ImprovementProposal(
+            title="Add caching layer",
+            rationale="Cache hot read path",
+            severity="advisory",
+        ),
+    ]
+
+    emit_proposals(
+        svc,
+        project_key="demo",
+        proposals=proposals,
+        memory_path=tmp_path / "planner_memory.json",
+    )
+
+    assert len(svc.creates) == 1
+    assert svc.creates[0]["kind"] == InboxItemKind.APPROVAL_REQUEST.value
+
+
+# ---------------------------------------------------------------------------
+# rejection_feedback — emit_rejection_feedback → manual_decision
+# ---------------------------------------------------------------------------
+
+
+def test_emit_rejection_feedback_is_tagged_manual_decision() -> None:
+    from pollypm.rejection_feedback import emit_rejection_feedback
+    from pollypm.work.models import Priority, Task, WorkStatus
+
+    task = Task(
+        project="demo",
+        task_number=3,
+        title="Refactor module",
+        type="task",
+        flow_template_id="standard",
+        flow_template_version=1,
+        work_status=WorkStatus.IN_PROGRESS,
+        priority=Priority.NORMAL,
+        current_node_id="code_review",
+    )
+
+    svc = _RecordingWorkService()
+    emit_rejection_feedback(
+        svc, task=task, reviewer="reviewer", reason="needs more tests",
+    )
+
+    assert len(svc.creates) == 1
+    assert svc.creates[0]["kind"] == InboxItemKind.MANUAL_DECISION.value
+
+
+# ---------------------------------------------------------------------------
+# notification_staging — flush_milestone_digest → manual_decision
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _DigestCandidate:
+    payload: dict[str, Any]
+    subject: str = "phase shipped"
+    body: str = "details"
+    actor: str = "worker"
+    created_at: str = "2026-05-13T12:00:00+00:00"
+
+
+class _DigestRollupSvc(_RecordingWorkService):
+    def __init__(self, candidates: list[_DigestCandidate]) -> None:
+        super().__init__()
+        self._candidates = candidates
+        self._flushed: list[Any] = []
+        self._contexts: list[tuple[str, str]] = []
+
+    def list_digest_rollup_candidates(self, **_: Any) -> list[_DigestCandidate]:
+        return list(self._candidates)
+
+    def mark_rollup_candidates_flushed(self, candidates, **_: Any) -> None:
+        self._flushed.append(candidates)
+
+    def add_context(self, task_id: str, actor: str, blob: str, **_: Any) -> None:
+        self._contexts.append((task_id, blob))
+
+
+def test_flush_milestone_digest_is_tagged_manual_decision(tmp_path: Path) -> None:
+    from pollypm.notification_staging import flush_milestone_digest
+
+    candidates = [_DigestCandidate(payload={"project": "demo"})]
+    svc = _DigestRollupSvc(candidates)
+    flush_milestone_digest(
+        svc,
+        project="demo",
+        milestone_key="milestones/01-core",
+        actor="polly",
+        project_path=tmp_path,
+    )
+
+    assert len(svc.creates) == 1
+    assert svc.creates[0]["kind"] == InboxItemKind.MANUAL_DECISION.value
+
+
+def test_check_regression_on_reopen_is_tagged_manual_decision() -> None:
+    from pollypm.notification_staging import check_regression_on_reopen
+
+    class _Svc(_RecordingWorkService):
+        def find_flushed_rollup_milestone(self, **_: Any) -> str:
+            return "milestones/01-core"
+
+    svc = _Svc()
+    check_regression_on_reopen(
+        svc,
+        project="demo",
+        task_id="demo/9",
+        from_state="done",
+        to_state="in_progress",
+        actor="polly",
+    )
+
+    assert len(svc.creates) == 1
+    assert svc.creates[0]["kind"] == InboxItemKind.MANUAL_DECISION.value
+
+
+# ---------------------------------------------------------------------------
+# project_status_summary — blocker summary → manual_decision
+# ---------------------------------------------------------------------------
+
+
+def test_record_blocker_summary_user_owner_is_tagged_manual_decision() -> None:
+    from pollypm.project_status_summary import (
+        ProjectBlockerSummary,
+        record_project_blocker_summary,
+    )
+
+    class _StubStore:
+        def __init__(self) -> None:
+            self.events: list[dict[str, Any]] = []
+            self.updates: list[Any] = []
+
+        def record_event(self, project, actor, subject, payload=None) -> int:
+            self.events.append({
+                "project": project, "actor": actor,
+                "subject": subject, "payload": payload,
+            })
+            return 7
+
+        def update_message(self, *args: Any, **kwargs: Any) -> None:
+            self.updates.append((args, kwargs))
+
+    store = _StubStore()
+    svc = _RecordingWorkService()
+    summary = ProjectBlockerSummary(
+        project="demo",
+        reason="awaiting product decision on rollout",
+        owner="user",
+        required_actions=["confirm rollout window"],
+        affected_tasks=["demo/4"],
+        unblock_condition="user confirms",
+    )
+    record_project_blocker_summary(
+        store=store, work_service=svc, summary=summary,
+    )
+
+    assert len(svc.creates) == 1
+    assert svc.creates[0]["kind"] == InboxItemKind.MANUAL_DECISION.value
+
+
+# ---------------------------------------------------------------------------
+# worker_turn_end — blocking_question → activity_event (polly addressee)
+# ---------------------------------------------------------------------------
+
+
+def test_blocking_question_is_tagged_activity_event() -> None:
+    from pollypm.recovery.worker_turn_end import (
+        create_blocking_question_inbox_item,
+    )
+    from pollypm.work.models import Priority, Task, WorkStatus
+
+    fake_task = Task(
+        project="demo",
+        task_number=5,
+        title="Pipeline",
+        type="task",
+        flow_template_id="standard",
+        flow_template_version=1,
+        work_status=WorkStatus.IN_PROGRESS,
+        priority=Priority.NORMAL,
+    )
+
+    svc = _RecordingWorkService()
+    create_blocking_question_inbox_item(
+        fake_task,
+        "worker-demo",
+        "Should the migration drop the legacy column?",
+        svc,
+    )
+
+    assert len(svc.creates) == 1
+    assert svc.creates[0]["kind"] == InboxItemKind.ACTIVITY_EVENT.value
+
+
+# ---------------------------------------------------------------------------
+# core_recurring.sweeps.pane_text_classify → activity_event
+# ---------------------------------------------------------------------------
+
+
+def test_pane_text_classify_inbox_task_is_tagged_activity_event() -> None:
+    from pollypm.plugins_builtin.core_recurring import sweeps
+
+    svc = _RecordingWorkService()
+    svc.list_tasks = lambda **_: []  # type: ignore[assignment]
+    sweeps._emit_pane_pattern_inbox_item(
+        work_service=svc,
+        session_name="worker-demo",
+        rule_name="context_full",
+        pane_text="approaching limit",
+        msg_store=None,
+    )
+    assert len(svc.creates) == 1
+    assert svc.creates[0]["kind"] == InboxItemKind.ACTIVITY_EVENT.value
+
+
+# ---------------------------------------------------------------------------
+# plan_review_emit — backstop emit → plan_review_pending
+# ---------------------------------------------------------------------------
+
+
+def test_plan_review_emit_stamps_plan_review_pending(tmp_path: Path) -> None:
+    from pollypm.work.plan_review_emit import emit_plan_review_for_task
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    db_path = tmp_path / ".pollypm" / "state.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    svc = SQLiteWorkService(db_path=db_path, project_path=tmp_path)
+    try:
+        plan_task = svc.create(
+            title="Plan demo",
+            description="plan task body",
+            type="task",
+            project="demo",
+            flow_template="chat",
+            roles={"requester": "user", "operator": "architect"},
+            priority="high",
+            created_by="tester",
+            labels=["poc-plan"],
+        )
+        new_task_id = emit_plan_review_for_task(
+            svc=svc, task=svc.get(plan_task.task_id),
+            actor="audit_watchdog", requester="user",
+        )
+    finally:
+        svc.close()
+    assert new_task_id is not None
+
+    # Work-task row kind.
+    svc2 = SQLiteWorkService(db_path=db_path, project_path=tmp_path)
+    try:
+        new_task = svc2.get(new_task_id)
+        assert new_task.kind is InboxItemKind.PLAN_REVIEW_PENDING
+    finally:
+        svc2.close()
+
+    # Messages row kind.
+    store = SQLAlchemyStore(f"sqlite:///{db_path}")
+    try:
+        msgs = store.query_messages(scope="demo")
+        plan_msgs = [m for m in msgs if (m.get("type") or "") == "notify"]
+        assert plan_msgs, "expected plan_review notify message"
+        assert all(
+            m["kind"] == InboxItemKind.PLAN_REVIEW_PENDING.value
+            for m in plan_msgs
+        )
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# audit_watchdog._create_operator_inbox_task (tier 3) → watchdog_operator_dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_tier3_operator_inbox_task_is_tagged_watchdog_operator_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pollypm.plugins_builtin.core_recurring import audit_watchdog
+
+    # Direct ``resolve_work_db_path`` at the tmp project so the helper
+    # writes through the test workspace, not the user's $HOME. The
+    # function imports ``resolve_work_db_path`` inline so the patch
+    # target is its public module path.
+    project_path = tmp_path / "proj"
+    project_path.mkdir()
+    (project_path / ".pollypm").mkdir()
+    db_path = project_path / ".pollypm" / "state.db"
+
+    monkeypatch.setattr(
+        "pollypm.work.db_resolver.resolve_work_db_path",
+        lambda *_a, **_k: db_path,
+    )
+
+    task_id = audit_watchdog._create_operator_inbox_task(
+        project_key="demo",
+        project_path=project_path,
+        subject="watchdog: queue_without_motion on demo/1",
+        body="TIER HANDOFF\n...",
+        dedup_key="watchdog-operator:queue_without_motion:demo:demo/1",
+    )
+    assert task_id is not None
+
+    # Messages row.
+    store = SQLAlchemyStore(f"sqlite:///{db_path}")
+    try:
+        msgs = store.query_messages(scope="demo")
+        notifies = [m for m in msgs if (m.get("type") or "") == "notify"]
+        assert notifies, "expected operator-dispatch notify row"
+        assert all(
+            m["kind"] == InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value
+            for m in notifies
+        )
+    finally:
+        store.close()
+
+    # Work-task row.
+    from pollypm.work.sqlite_service import SQLiteWorkService
+    svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+    try:
+        task = svc.get(task_id)
+        assert task.kind is InboxItemKind.WATCHDOG_OPERATOR_DISPATCH
+    finally:
+        svc.close()
+
+
+# ---------------------------------------------------------------------------
+# audit_watchdog._create_operator_tier4_inbox_task → watchdog_operator_dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_tier4_operator_inbox_task_is_tagged_watchdog_operator_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pollypm.plugins_builtin.core_recurring import audit_watchdog
+
+    project_path = tmp_path / "proj"
+    project_path.mkdir()
+    (project_path / ".pollypm").mkdir()
+    db_path = project_path / ".pollypm" / "state.db"
+
+    # tier-4 path imports ``_resolve_db_path`` from pollypm.work.cli.
+    monkeypatch.setattr(
+        "pollypm.work.cli._resolve_db_path",
+        lambda *_a, **_k: db_path,
+    )
+
+    task_id = audit_watchdog._create_operator_tier4_inbox_task(
+        project_key="demo",
+        project_path=project_path,
+        subject="watchdog tier4: queue_without_motion on demo",
+        body="TIER 4 BROADER AUTHORITY DISPATCH\n...",
+        dedup_key="watchdog-operator-tier4:rule:demo:hash",
+    )
+    assert task_id is not None
+
+    store = SQLAlchemyStore(f"sqlite:///{db_path}")
+    try:
+        msgs = store.query_messages(scope="demo")
+        notifies = [m for m in msgs if (m.get("type") or "") == "notify"]
+        assert notifies
+        assert all(
+            m["kind"] == InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value
+            for m in notifies
+        )
+    finally:
+        store.close()
+
+    from pollypm.work.sqlite_service import SQLiteWorkService
+    svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+    try:
+        task = svc.get(task_id)
+        assert task.kind is InboxItemKind.WATCHDOG_OPERATOR_DISPATCH
+    finally:
+        svc.close()
+
+
+# ---------------------------------------------------------------------------
+# audit_watchdog._route_tier4_to_terminal urgent handoff →
+# watchdog_operator_dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_tier4_terminal_urgent_handoff_is_tagged_watchdog_operator_dispatch(
+    tmp_path: Path,
+) -> None:
+    from datetime import UTC, datetime
+    from pollypm.plugins_builtin.core_recurring import audit_watchdog
+
+    db_path = tmp_path / "state.db"
+    msg_store = SQLAlchemyStore(f"sqlite:///{db_path}")
+    try:
+        class _Services:
+            state_store = None
+
+        services = _Services()
+        services.msg_store = msg_store  # type: ignore[attr-defined]
+
+        @dataclass
+        class _State:
+            tier4_entered_at: datetime
+            project: str
+            rule: str
+            root_cause_hash: str
+
+        state = _State(
+            tier4_entered_at=datetime.now(UTC),
+            project="demo",
+            rule="queue_without_motion",
+            root_cause_hash="hash123",
+        )
+        ok = audit_watchdog._route_tier4_to_terminal(
+            state=state, services=services, now=datetime.now(UTC),
+        )
+        assert ok is True
+
+        msgs = msg_store.query_messages(scope="demo")
+        notifies = [m for m in msgs if (m.get("type") or "") == "notify"]
+        assert notifies, "expected urgent terminal handoff"
+        assert all(
+            m["kind"] == InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value
+            for m in notifies
+        )
+    finally:
+        msg_store.close()
+
+
+# ---------------------------------------------------------------------------
+# pm notify CLI — label-keyed kind selection
+# ---------------------------------------------------------------------------
+
+
+def test_notify_kind_helper_picks_plan_review_pending_for_plan_review_label() -> None:
+    from pollypm.cli_features.session_runtime import _kind_for_notify
+
+    assert _kind_for_notify(
+        ["plan_review", "project:demo"],
+        requester="user",
+        user_prompt_payload=None,
+    ) == InboxItemKind.PLAN_REVIEW_PENDING.value
+
+
+def test_notify_kind_helper_picks_pm_question_for_user_prompt_payload() -> None:
+    from pollypm.cli_features.session_runtime import _kind_for_notify
+
+    payload = {"summary": "please decide", "question": "go or no-go?"}
+    assert _kind_for_notify(
+        [],
+        requester="user",
+        user_prompt_payload=payload,
+    ) == InboxItemKind.PM_QUESTION_UNANSWERED.value
+
+
+def test_notify_kind_helper_defaults_to_legacy_for_freeform_notify() -> None:
+    from pollypm.cli_features.session_runtime import _kind_for_notify
+
+    assert _kind_for_notify(
+        [], requester="user", user_prompt_payload=None,
+    ) == InboxItemKind.LEGACY.value
+
+
+def test_notify_kind_helper_polly_recipient_with_payload_stays_legacy() -> None:
+    """``--requester polly`` routes inbox to Polly, not the user — the
+    structured user_prompt is informational on the user surface."""
+    from pollypm.cli_features.session_runtime import _kind_for_notify
+
+    payload = {"summary": "fyi"}
+    assert _kind_for_notify(
+        [], requester="polly", user_prompt_payload=payload,
+    ) == InboxItemKind.LEGACY.value
+
+
+# ---------------------------------------------------------------------------
+# work_tasks ensure_human_review_request_task → approval_request
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_human_review_request_task_is_tagged_approval_request(
+    tmp_path: Path,
+) -> None:
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    db_path = tmp_path / "state.db"
+    svc = SQLiteWorkService(db_path=db_path, project_path=tmp_path)
+    try:
+        target = svc.create(
+            title="Implement feature",
+            description="Do the thing",
+            type="task",
+            project="demo",
+            flow_template="standard",
+            roles={"worker": "worker", "reviewer": "reviewer"},
+            requires_human_review=True,
+            created_by="tester",
+        )
+        review_task = svc.ensure_human_review_request_task(
+            target.task_id, actor="polly",
+        )
+        assert review_task.kind is InboxItemKind.APPROVAL_REQUEST
+    finally:
+        svc.close()
+
+
+# ---------------------------------------------------------------------------
+# first_shipped milestone → completion_fyi
+# ---------------------------------------------------------------------------
+
+
+def test_record_first_shipped_activity_is_tagged_completion_fyi(
+    tmp_path: Path,
+) -> None:
+    from pollypm.work.sqlite_service import _record_first_shipped_activity
+
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    (project_path / ".pollypm").mkdir()
+    _record_first_shipped_activity(
+        project_path=project_path,
+        project_key="demo",
+    )
+
+    db_path = project_path / ".pollypm" / "state.db"
+    store = SQLAlchemyStore(f"sqlite:///{db_path}")
+    try:
+        msgs = store.query_messages(scope="polly")
+        shipped = [m for m in msgs if (m.get("subject") or "") .endswith("first_shipped") or "first_shipped" in (m.get("subject") or "")]
+        assert shipped, "expected first_shipped row"
+        assert all(
+            m["kind"] == InboxItemKind.COMPLETION_FYI.value for m in shipped
+        )
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary

Retrain every inbox-shaped emit site onto the structured `kind`
discriminator from #1565 so the canonical `awaits_user` predicate
(#1566) returns the right answer per row. Foundation for the operator
dashboard epic (#1564).

Closes #1567
Closes #1568
Refs #1564

## Emit sites touched

**Actionable (#1567)**

| Site | File | Kind |
|---|---|---|
| Plan-review backstop emit (message + task) | `src/pollypm/work/plan_review_emit.py` | `plan_review_pending` |
| `pm notify --label plan_review` (architect handoff) | `src/pollypm/cli_features/session_runtime.py` | `plan_review_pending` |
| `pm notify` with `--user-prompt-json` + `requester=user` | `src/pollypm/cli_features/session_runtime.py` | `pm_question_unanswered` |
| `emit_proposals` (improvement proposals) | `src/pollypm/plugins_builtin/project_planning/proposals.py` | `approval_request` |
| `ensure_human_review_request_task` | `src/pollypm/work/sqlite_service.py` | `approval_request` |
| Tier-3 operator inbox (message + task) | `src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py` | `watchdog_operator_dispatch` |
| Tier-4 operator inbox (message + task) | `src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py` | `watchdog_operator_dispatch` |
| Tier-4 terminal urgent handoff | `src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py` | `watchdog_operator_dispatch` |
| `record_project_blocker_summary` (user owner) | `src/pollypm/project_status_summary.py` | `manual_decision` |
| `flush_milestone_digest` (milestone rollup) | `src/pollypm/notification_staging.py` | `manual_decision` |
| `check_regression_on_reopen` | `src/pollypm/notification_staging.py` | `manual_decision` |
| `emit_rejection_feedback` (operator=user) | `src/pollypm/rejection_feedback.py` | `manual_decision` |

**Informational (#1568)**

| Site | File | Kind |
|---|---|---|
| `emit_task_shipped_card` | `src/pollypm/task_shipped.py` | `completion_fyi` |
| `_record_first_shipped_activity` | `src/pollypm/work/sqlite_service.py` | `completion_fyi` |
| `emit_worker_milestone` (polly addressee) | `src/pollypm/worker_milestone.py` | `activity_event` |
| `create_blocking_question_inbox_item` (polly addressee) | `src/pollypm/recovery/worker_turn_end.py` | `activity_event` |
| `_emit_pane_pattern_inbox_item` (polly addressee) | `src/pollypm/plugins_builtin/core_recurring/sweeps.py` | `activity_event` |

## Sites intentionally left as `legacy`

- **`upsert_alert` callers** (`supervisor_alerts.py`, `version_check.py`,
  `task_assignment_notify.py`, `error_notifications.py`,
  `supervisor.py`'s alert-raising paths). `upsert_alert` is a thin
  wrapper over `upsert_message`; alert semantics span actionable
  (recovery_limit, auth_broken) and informational (heartbeat
  observations). Per the per-emit-site rule, the wrapper can't compute
  the kind, and threading a kind through every caller would be a
  cross-cutting change. The predicate's fail-open `legacy = awaits_user`
  default keeps these visible until #1570 backfills with a smarter
  per-alert-type rule.
- **`pm notify` without a recognized label or `--user-prompt-json`** —
  the same "human-typed via pm notify" surprise that #1569 flagged.
  Producers vary too widely to classify generically; the label-keyed
  cases above handle the cases we can pin down.

## Out of scope (per the issue)

- Bug-reporter routing (#1569 already shipped).
- Backfill of existing rows (#1570).
- Rail badge wiring (#1571, parallel).
- New `Supervisor` allow-list entries (none added — boundary intact).

## Test plan

- [x] `uv run pytest tests/test_inbox_kind_emit_sites.py` — 19 new tests pass.
- [x] `uv run pytest tests/test_audit_watchdog.py tests/test_heartbeat_cascade_foundation.py tests/test_heartbeat_cascade_tier4.py tests/test_plan_review*.py tests/test_inbox*.py tests/test_audit_log.py` — 468 baseline tests pass.
- [x] Targeted suite over every touched file + related (`tests/test_task_shipped_inbox.py`, `tests/test_rejection_feedback.py`, `tests/test_improvement_proposals.py`, `tests/test_project_status_summary.py`, `tests/test_cli_notify.py`, `tests/test_notification_tiering.py`, `tests/test_work_approval.py`, `tests/test_cockpit_first_shipped.py`, `tests/test_worker_turn_end_reprompt.py`, …) — 850 tests pass.
- [x] Pre-existing failures on main (`test_import_boundary` tier4 allowlist; `test_project_dashboard_ui`; `test_morning_briefing_gather` ordering flakes; `test_inbox_aggregator_workspace_root::test_aggregator_skips_fyi_messages` — all present before this PR) confirmed unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)