### PR TITLE
feat(inbox): backfill kind for legacy rows via heuristic (#1570)

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -196,6 +196,15 @@ EVENT_SESSION_PROVISIONED = "session.provisioned"
 EVENT_COCKPIT_SESSION_PARKED = "cockpit.session_parked"
 EVENT_COCKPIT_SESSION_RESPAWNED = "cockpit.session_respawned"
 EVENT_COCKPIT_DUPLICATE_WINDOW_KILLED = "cockpit.duplicate_window_killed"
+# #1570 — emitted once per row that ``pm inbox backfill-kinds --commit``
+# reclassifies from ``kind='legacy'`` to a real
+# :class:`pollypm.inbox.kind.InboxItemKind`. Carries ``msg_id``,
+# ``old_kind`` (always ``"legacy"``), ``new_kind``, and ``heuristic``
+# (the label of the matched rule in
+# :mod:`pollypm.inbox.backfill_heuristics`) so an operator can later
+# answer "why did this row become completion_fyi?" by tail-grepping
+# the audit log instead of re-running the heuristic.
+EVENT_INBOX_KIND_BACKFILLED = "inbox.kind_backfilled"
 
 
 @dataclass(slots=True, frozen=True)
@@ -565,6 +574,7 @@ __all__ = [
     "EVENT_COCKPIT_SESSION_PARKED",
     "EVENT_COCKPIT_SESSION_RESPAWNED",
     "EVENT_COCKPIT_DUPLICATE_WINDOW_KILLED",
+    "EVENT_INBOX_KIND_BACKFILLED",
     "AuditEvent",
     "central_log_path",
     "emit",

--- a/src/pollypm/inbox/backfill_heuristics.py
+++ b/src/pollypm/inbox/backfill_heuristics.py
@@ -1,0 +1,155 @@
+"""Heuristic classifier for legacy inbox rows (#1570).
+
+Pre-#1565 messages all surface with ``kind='legacy'`` because the
+column did not exist when they were written. The
+:func:`pollypm.inbox.awaits_user` predicate treats ``legacy`` as
+"awaits user" so nothing is silently hidden during the migration
+window — but the dashboard's "Waiting on you" section then lumps
+~133 historical rows together. This module is the one-time pass
+that reclassifies those rows by matching title + sender + project
+patterns observed in the real inbox.
+
+Pure leaf: depends only on the :class:`InboxItemKind` enum so it
+can be imported from the CLI command + tests without dragging in
+any DB layer. The CLI is the only writer; this module decides what
+the new kind should be but never touches storage.
+
+Heuristic order is significant — the first match wins. The order
+mirrors the precedence in #1570's spec:
+
+1. completion-shaped titles (``complete`` / ``done`` /
+   ``resubmitted``) → :attr:`InboxItemKind.COMPLETION_FYI`
+2. self-bug-report titles (``Misrouted`` / ``bogus`` / ``proj/1`` /
+   ``Repeated stale``) → :attr:`InboxItemKind.SELF_BUG_REPORT`
+3. plan-review titles (``Plan ready for review`` prefix) →
+   :attr:`InboxItemKind.PLAN_REVIEW_PENDING`
+4. polly-authored digest into the inbox project →
+   :attr:`InboxItemKind.MANUAL_DECISION`
+5. audit-watchdog action dispatches →
+   :attr:`InboxItemKind.WATCHDOG_OPERATOR_DISPATCH`
+6. unmatched → ``None`` (leave the row as legacy; the awaits-user
+   predicate still surfaces it for manual triage)
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from pollypm.inbox.kind import InboxItemKind
+
+
+# Title-contract tags that :func:`apply_title_contract` stamps onto
+# every stored ``messages.subject`` (see :mod:`pollypm.store.title_contract`).
+# Heuristics in this module are written against the user's authored title,
+# not the wire format, so we strip the tag before matching — otherwise
+# ``"Plan ready for review"`` would never match a row whose stored
+# subject is ``"[Action] Plan ready for review …"``.
+_TITLE_CONTRACT_TAG_RE = re.compile(
+    r"^\s*\[(?:action|fyi|audit|alert|task|note)\]\s*[:\-—]*\s*",
+    re.IGNORECASE,
+)
+
+
+def _strip_title_contract_tag(title: str) -> str:
+    """Drop a leading title-contract tag from ``title``, if present."""
+    return _TITLE_CONTRACT_TAG_RE.sub("", title or "", count=1)
+
+
+@dataclass(slots=True, frozen=True)
+class Classification:
+    """Result of a successful classification.
+
+    ``heuristic`` is the human-readable label of the matched rule —
+    surfaced in CLI output and stamped onto the audit-log metadata
+    so an operator can later answer "why did this row become
+    completion_fyi?" by tail-grepping the audit log.
+    """
+
+    kind: InboxItemKind
+    heuristic: str
+
+
+# Substrings (case-insensitive) that flag a "task is done" announcement.
+_COMPLETION_TOKENS = ("complete", "done", "resubmitted")
+
+# Substrings (case-insensitive) that flag Polly filing a bug report
+# about her own system. ``proj/1`` is a particularly common giveaway:
+# Polly's first-ever misroute went to a dummy ``proj/1`` task that
+# does not exist.
+_SELF_BUG_REPORT_TOKENS = ("misrouted", "bogus", "proj/1", "repeated stale")
+
+_PLAN_REVIEW_PREFIX = "plan ready for review"
+
+
+def classify_legacy(
+    *,
+    title: str,
+    sender: str,
+    project: str,
+) -> Classification | None:
+    """Map a legacy inbox row to a new :class:`InboxItemKind`.
+
+    Returns ``None`` when no heuristic matches. The CLI uses ``None``
+    as the signal to leave the row's ``kind`` at ``legacy`` and add
+    it to the unmatched-row count — never as an excuse to guess.
+
+    Inputs are normalised to lowercase before matching so producers
+    that capitalise inconsistently (Polly mixes ``Complete`` /
+    ``complete``) still classify uniformly.
+
+    Args:
+        title: the row's subject / title text.
+        sender: the row's ``sender`` column (typically ``"polly"`` /
+            ``"audit_watchdog"`` / a worker session name).
+        project: the row's ``scope`` / project key. The polly-digest
+            heuristic requires the literal string ``"inbox"`` here.
+    """
+    raw_title_l = (title or "").lower()
+    title_l = _strip_title_contract_tag(title or "").lower()
+    sender_l = (sender or "").lower()
+    project_l = (project or "").lower()
+
+    for token in _COMPLETION_TOKENS:
+        if token in title_l:
+            return Classification(
+                kind=InboxItemKind.COMPLETION_FYI,
+                heuristic=f"title_contains:{token}",
+            )
+
+    for token in _SELF_BUG_REPORT_TOKENS:
+        if token in title_l:
+            return Classification(
+                kind=InboxItemKind.SELF_BUG_REPORT,
+                heuristic=f"title_contains:{token}",
+            )
+
+    if title_l.startswith(_PLAN_REVIEW_PREFIX):
+        return Classification(
+            kind=InboxItemKind.PLAN_REVIEW_PENDING,
+            heuristic="title_prefix:plan_ready_for_review",
+        )
+
+    if (
+        "digest:" in title_l
+        and sender_l == "polly"
+        and project_l == "inbox"
+    ):
+        return Classification(
+            kind=InboxItemKind.MANUAL_DECISION,
+            heuristic="polly_digest_in_inbox_project",
+        )
+
+    # The audit_watchdog emit site stamps its rows with the ``[Action]``
+    # title-contract tag, so we deliberately check the raw (unstripped)
+    # title — the tag IS the "Action" signal here, not user prose.
+    if sender_l == "audit_watchdog" and "action" in raw_title_l:
+        return Classification(
+            kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH,
+            heuristic="audit_watchdog_action",
+        )
+
+    return None
+
+
+__all__ = ["Classification", "classify_legacy"]

--- a/src/pollypm/work/inbox_cli.py
+++ b/src/pollypm/work/inbox_cli.py
@@ -20,7 +20,8 @@ import typer
 
 from pollypm.cli_help import help_with_examples
 from pollypm.inbox import awaits_user
-from pollypm.inbox.kind import coerce_kind as _coerce_inbox_kind
+from pollypm.inbox.backfill_heuristics import Classification, classify_legacy
+from pollypm.inbox.kind import InboxItemKind, coerce_kind as _coerce_inbox_kind
 from pollypm.inbox_message_refs import unknown_project_refs
 from pollypm.work.cli import (
     _DB_OPTION,
@@ -1034,3 +1035,256 @@ def _bulk_archive_deleted_project_messages(*, db: str, dry_run: bool) -> None:
         typer.echo(f"Failed to archive {len(failures)}:", err=True)
         for mid, reason in failures[:5]:
             typer.echo(f"  msg:{mid}: {reason}", err=True)
+
+
+# ---------------------------------------------------------------------------
+# pm inbox backfill-kinds — one-time legacy-row reclassification (#1570).
+#
+# The ``kind`` column landed in #1565 with ``'legacy'`` as the default for
+# every pre-existing row. The :func:`pollypm.inbox.awaits_user` predicate
+# treats ``legacy`` as "awaits user" so the migration window doesn't hide
+# work; this command is the one-time pass that runs the heuristics from
+# :mod:`pollypm.inbox.backfill_heuristics` against every legacy message and
+# moves the matched rows onto a real kind. Unmatched rows stay legacy and
+# remain visible to the predicate.
+# ---------------------------------------------------------------------------
+
+
+_BACKFILL_HINT = (
+    "Re-run with --commit to apply; unmatched rows stay legacy and "
+    "remain visible to the awaits_user predicate."
+)
+
+
+def _legacy_message_rows(
+    db_path: str,
+    *,
+    project: str | None,
+) -> list[dict[str, Any]]:
+    """Return every open user-facing message still tagged ``kind='legacy'``.
+
+    Scope mirrors ``pm inbox`` (recipient=user, the same three message
+    types) so the backfill operates over exactly the population the
+    dashboard's "Waiting on you" section would otherwise lump together.
+    Closed rows are ignored — they are archive, not inbox.
+
+    ``query_messages`` does not accept ``kind`` as a server-side filter,
+    so we trim in Python after the call. The volume is bounded (low
+    hundreds for the original 2026-05-17 sample); a wider filter would
+    require widening :meth:`SQLAlchemyStore.query_messages` and is out
+    of scope for the one-shot migration helper.
+    """
+    from pollypm.store import SQLAlchemyStore
+
+    store = SQLAlchemyStore(f"sqlite:///{db_path}")
+    try:
+        filters: dict[str, Any] = dict(
+            recipient="user",
+            state="open",
+            type=["notify", "inbox_task", "alert"],
+        )
+        if project:
+            filters["scope"] = project
+        rows = store.query_messages(**filters)
+    finally:
+        store.close()
+
+    legacy_rows: list[dict[str, Any]] = []
+    for row in rows:
+        kind_value = _coerce_inbox_kind(row.get("kind"))
+        if kind_value is InboxItemKind.LEGACY:
+            legacy_rows.append(row)
+    return legacy_rows
+
+
+def _row_classification(
+    row: dict[str, Any],
+) -> Classification | None:
+    """Run the heuristic against one row's title / sender / scope."""
+    return classify_legacy(
+        title=str(row.get("subject") or ""),
+        sender=str(row.get("sender") or ""),
+        project=str(row.get("scope") or ""),
+    )
+
+
+def _title_preview(title: str, limit: int = 60) -> str:
+    text = (title or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+def _apply_kind_update(
+    db_path: str,
+    *,
+    msg_id: int,
+    new_kind: InboxItemKind,
+) -> None:
+    """Persist a single ``messages.kind`` reclassification."""
+    from pollypm.store import SQLAlchemyStore
+
+    store = SQLAlchemyStore(f"sqlite:///{db_path}")
+    try:
+        store.update_message(msg_id, kind=new_kind.value)
+    finally:
+        store.close()
+
+
+def _emit_backfill_audit(
+    *,
+    project: str,
+    msg_id: int,
+    new_kind: InboxItemKind,
+    heuristic: str,
+) -> None:
+    """Audit-log one reclassification. Best-effort — never raises."""
+    from pollypm.audit.log import EVENT_INBOX_KIND_BACKFILLED, emit
+
+    emit(
+        event=EVENT_INBOX_KIND_BACKFILLED,
+        project=project or "",
+        subject=f"msg:{msg_id}",
+        actor="user",
+        status="ok",
+        metadata={
+            "old_kind": InboxItemKind.LEGACY.value,
+            "new_kind": new_kind.value,
+            "heuristic": heuristic,
+        },
+    )
+
+
+@inbox_app.command(
+    "backfill-kinds",
+    help=(
+        "One-time backfill of ``kind`` for inbox rows that still carry "
+        "``kind='legacy'`` (#1570). Dry-run by default — pass --commit "
+        "to actually mutate. Idempotent: rows already on a non-legacy "
+        "kind are skipped."
+    ),
+)
+def backfill_kinds(
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help=(
+            "Classify every legacy row and print what would change "
+            "without writing to the DB. This is the default behaviour "
+            "when neither --dry-run nor --commit is passed — the flag "
+            "exists so an automation can make the intent explicit."
+        ),
+    ),
+    commit: bool = typer.Option(
+        False,
+        "--commit",
+        help=(
+            "Apply the reclassification. Required for any DB mutation "
+            "— mutually exclusive with --dry-run."
+        ),
+    ),
+    project: str | None = _PROJECT_OPTION,
+    db: str = _DB_OPTION,
+) -> None:
+    """Reclassify legacy inbox rows by heuristic.
+
+    Heuristics live in :mod:`pollypm.inbox.backfill_heuristics` and
+    are applied in spec order; unmatched rows stay legacy. Every
+    committed row emits one ``inbox.kind_backfilled`` audit event
+    with the old kind, new kind, and matched heuristic name.
+    """
+    if commit and dry_run:
+        typer.echo(
+            "Error: --commit and --dry-run are mutually exclusive.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    # Default = dry-run. --commit is the explicit opt-in to mutation.
+    effective_commit = bool(commit)
+
+    db_path = _resolve_db_path(db, project=project)
+
+    try:
+        rows = _legacy_message_rows(db_path, project=project)
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(
+            f"Error: failed to read legacy inbox rows ({exc}).",
+            err=True,
+        )
+        raise typer.Exit(code=1) from exc
+
+    if not rows:
+        typer.echo("No legacy inbox rows to reclassify.")
+        return
+
+    mode_label = "commit" if effective_commit else "dry-run"
+    typer.echo(
+        f"Scanning {len(rows)} legacy inbox row(s) "
+        f"({mode_label})."
+    )
+    typer.echo(
+        f"{'ID':<12} {'Project':<18} {'Heuristic → New kind':<48} Title"
+    )
+    typer.echo("-" * 110)
+
+    matched = 0
+    unmatched = 0
+    failures: list[tuple[int, str]] = []
+    for row in rows:
+        msg_id_raw = row.get("id")
+        if msg_id_raw is None:
+            continue
+        msg_id = int(msg_id_raw)
+        scope = str(row.get("scope") or "-")
+        title_preview = _title_preview(str(row.get("subject") or ""))
+        classification = _row_classification(row)
+        if classification is None:
+            unmatched += 1
+            typer.echo(
+                f"msg:{msg_id:<8} {scope:<18} {'(unmatched, stays legacy)':<48} "
+                f"{title_preview}"
+            )
+            continue
+
+        matched += 1
+        action = (
+            f"{classification.heuristic} → {classification.kind.value}"
+        )
+        typer.echo(
+            f"msg:{msg_id:<8} {scope:<18} {action:<48} {title_preview}"
+        )
+
+        if not effective_commit:
+            continue
+
+        try:
+            _apply_kind_update(
+                db_path, msg_id=msg_id, new_kind=classification.kind,
+            )
+        except Exception as exc:  # noqa: BLE001
+            failures.append((msg_id, str(exc)))
+            continue
+        _emit_backfill_audit(
+            project=scope,
+            msg_id=msg_id,
+            new_kind=classification.kind,
+            heuristic=classification.heuristic,
+        )
+
+    typer.echo("-" * 110)
+    if effective_commit:
+        typer.echo(
+            f"Reclassified {matched} row(s); {unmatched} unmatched."
+        )
+        if failures:
+            typer.echo(
+                f"Failed to update {len(failures)} row(s):", err=True,
+            )
+            for mid, reason in failures[:5]:
+                typer.echo(f"  msg:{mid}: {reason}", err=True)
+    else:
+        typer.echo(
+            f"Would reclassify {matched} row(s); {unmatched} unmatched."
+        )
+    typer.echo(_BACKFILL_HINT)

--- a/tests/test_cli_inbox_backfill.py
+++ b/tests/test_cli_inbox_backfill.py
@@ -1,0 +1,356 @@
+"""Integration tests for ``pm inbox backfill-kinds`` (#1570).
+
+Covers the four invariants the issue calls out:
+
+* Dry-run (default) classifies but never writes.
+* ``--commit`` writes, emits one audit event per row, and reports
+  the unmatched count.
+* Idempotence — a second commit run reclassifies zero rows because
+  the first run already moved them off ``legacy``.
+* Mutually exclusive flags are refused with a non-zero exit code.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm.audit.log import EVENT_INBOX_KIND_BACKFILLED, central_log_path
+from pollypm.inbox.kind import InboxItemKind, coerce_kind
+from pollypm.store import SQLAlchemyStore
+from pollypm.work.inbox_cli import inbox_app
+
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_audit_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    """Redirect the central-tail root so tests never touch ~/.pollypm/."""
+    audit_home = tmp_path / "audit-home"
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+    return audit_home
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_legacy_message(
+    db_path: Path,
+    *,
+    subject: str,
+    sender: str = "polly",
+    scope: str = "demo",
+    msg_type: str = "notify",
+) -> int:
+    """Insert a single legacy-kind message and return its row id.
+
+    ``enqueue_message`` defaults ``kind`` to ``'legacy'`` precisely to
+    model the pre-#1565 state we're backfilling here.
+    """
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    store = SQLAlchemyStore(f"sqlite:///{db_path}")
+    try:
+        return store.enqueue_message(
+            type=msg_type,
+            tier="immediate",
+            recipient="user",
+            sender=sender,
+            subject=subject,
+            body="body content",
+            scope=scope,
+        )
+    finally:
+        store.close()
+
+
+def _read_kind(db_path: Path, msg_id: int) -> InboxItemKind:
+    store = SQLAlchemyStore(f"sqlite:///{db_path}")
+    try:
+        rows = store.query_messages(recipient="user")
+    finally:
+        store.close()
+    match = next((row for row in rows if row.get("id") == msg_id), None)
+    assert match is not None, f"msg:{msg_id} missing after backfill"
+    return coerce_kind(match.get("kind"))
+
+
+def _seed_full_sample(db_path: Path) -> dict[str, int]:
+    """Seed one row per heuristic + two unmatched rows.
+
+    Returns a mapping of label → message id so assertions can pin
+    each row by intent without re-querying the DB.
+    """
+    return {
+        "completion": _seed_legacy_message(
+            db_path,
+            subject="Web API phase 1 complete",
+            sender="polly",
+            scope="demo",
+        ),
+        "self_bug": _seed_legacy_message(
+            db_path,
+            subject="Misrouted Polly notification (3rd today)",
+            sender="polly",
+            scope="demo",
+        ),
+        "plan_review": _seed_legacy_message(
+            db_path,
+            subject="Plan ready for review — demo/12",
+            sender="architect",
+            scope="demo",
+        ),
+        "manual_decision": _seed_legacy_message(
+            db_path,
+            subject="Digest: 7 open findings need your call",
+            sender="polly",
+            scope="inbox",
+        ),
+        "watchdog": _seed_legacy_message(
+            db_path,
+            subject="[Action] queue_without_motion needs review",
+            sender="audit_watchdog",
+            scope="demo",
+        ),
+        "unmatched_a": _seed_legacy_message(
+            db_path,
+            subject="Random one-off note from a worker",
+            sender="worker-7",
+            scope="demo",
+        ),
+        "unmatched_b": _seed_legacy_message(
+            db_path,
+            subject="Heartbeat tick at 12:30",
+            sender="heartbeat",
+            scope="demo",
+        ),
+    }
+
+
+def _audit_lines_for_project(audit_home: Path, project: str) -> list[dict]:
+    """Return decoded audit-event records for ``project`` from the central tail."""
+    path = central_log_path(project)
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_classifies_but_writes_nothing(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    ids = _seed_full_sample(db_path)
+
+    # No --commit and no --dry-run — the default branch is dry-run.
+    result = runner.invoke(
+        inbox_app, ["backfill-kinds", "--db", str(db_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Would reclassify 5 row(s); 2 unmatched." in result.output
+    assert "Re-run with --commit" in result.output
+    # Each classified row is printed with its heuristic + new kind.
+    assert "completion_fyi" in result.output
+    assert "self_bug_report" in result.output
+    assert "plan_review_pending" in result.output
+    assert "manual_decision" in result.output
+    assert "watchdog_operator_dispatch" in result.output
+    # Unmatched rows are flagged separately.
+    assert "(unmatched, stays legacy)" in result.output
+
+    # DB state must be untouched.
+    for label, msg_id in ids.items():
+        assert _read_kind(db_path, msg_id) is InboxItemKind.LEGACY, label
+
+
+def test_explicit_dry_run_flag_behaves_the_same(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    _seed_full_sample(db_path)
+
+    result = runner.invoke(
+        inbox_app, ["backfill-kinds", "--dry-run", "--db", str(db_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Would reclassify" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Commit
+# ---------------------------------------------------------------------------
+
+
+def test_commit_writes_audit_events_and_updates_kinds(
+    tmp_path: Path, _isolate_audit_home: Path,
+) -> None:
+    db_path = tmp_path / "state.db"
+    ids = _seed_full_sample(db_path)
+
+    result = runner.invoke(
+        inbox_app, ["backfill-kinds", "--commit", "--db", str(db_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Reclassified 5 row(s); 2 unmatched." in result.output
+
+    # Each matched row landed on its expected kind.
+    assert _read_kind(db_path, ids["completion"]) is InboxItemKind.COMPLETION_FYI
+    assert _read_kind(db_path, ids["self_bug"]) is InboxItemKind.SELF_BUG_REPORT
+    assert _read_kind(db_path, ids["plan_review"]) is InboxItemKind.PLAN_REVIEW_PENDING
+    assert _read_kind(db_path, ids["manual_decision"]) is InboxItemKind.MANUAL_DECISION
+    assert _read_kind(db_path, ids["watchdog"]) is InboxItemKind.WATCHDOG_OPERATOR_DISPATCH
+    # Unmatched rows stay legacy.
+    assert _read_kind(db_path, ids["unmatched_a"]) is InboxItemKind.LEGACY
+    assert _read_kind(db_path, ids["unmatched_b"]) is InboxItemKind.LEGACY
+
+    # Audit log carries one inbox.kind_backfilled per matched row, split
+    # across the per-project central tails (demo + inbox).
+    demo_events = [
+        e for e in _audit_lines_for_project(_isolate_audit_home, "demo")
+        if e.get("event") == EVENT_INBOX_KIND_BACKFILLED
+    ]
+    inbox_events = [
+        e for e in _audit_lines_for_project(_isolate_audit_home, "inbox")
+        if e.get("event") == EVENT_INBOX_KIND_BACKFILLED
+    ]
+    assert len(demo_events) == 4
+    assert len(inbox_events) == 1
+
+    # Each event carries the contracted metadata shape.
+    for event in demo_events + inbox_events:
+        meta = event["metadata"]
+        assert meta["old_kind"] == InboxItemKind.LEGACY.value
+        assert meta["new_kind"] in {k.value for k in InboxItemKind}
+        assert meta["heuristic"]
+        assert event["subject"].startswith("msg:")
+        assert event["actor"] == "user"
+        assert event["status"] == "ok"
+
+
+def test_commit_is_idempotent(
+    tmp_path: Path, _isolate_audit_home: Path,
+) -> None:
+    db_path = tmp_path / "state.db"
+    _seed_full_sample(db_path)
+
+    first = runner.invoke(
+        inbox_app, ["backfill-kinds", "--commit", "--db", str(db_path)],
+    )
+    assert first.exit_code == 0, first.output
+    assert "Reclassified 5 row(s); 2 unmatched." in first.output
+
+    second = runner.invoke(
+        inbox_app, ["backfill-kinds", "--commit", "--db", str(db_path)],
+    )
+    assert second.exit_code == 0, second.output
+    # The two remaining legacy rows are still scanned but only re-printed
+    # as unmatched; nothing reclassifies on the second pass.
+    assert "Reclassified 0 row(s); 2 unmatched." in second.output
+
+
+def test_dry_run_after_commit_reports_remaining_legacy_rows(
+    tmp_path: Path, _isolate_audit_home: Path,
+) -> None:
+    db_path = tmp_path / "state.db"
+    _seed_full_sample(db_path)
+    runner.invoke(
+        inbox_app, ["backfill-kinds", "--commit", "--db", str(db_path)],
+    )
+
+    result = runner.invoke(
+        inbox_app, ["backfill-kinds", "--db", str(db_path)],
+    )
+    assert result.exit_code == 0, result.output
+    # Two legacy rows remain (the unmatched ones); both still print.
+    assert "Would reclassify 0 row(s); 2 unmatched." in result.output
+
+
+# ---------------------------------------------------------------------------
+# Project filter
+# ---------------------------------------------------------------------------
+
+
+def test_project_filter_scopes_to_one_project(
+    tmp_path: Path, _isolate_audit_home: Path,
+) -> None:
+    db_path = tmp_path / "state.db"
+    demo_id = _seed_legacy_message(
+        db_path,
+        subject="Web API phase 1 complete",
+        sender="polly",
+        scope="demo",
+    )
+    other_id = _seed_legacy_message(
+        db_path,
+        subject="Web API phase 2 complete",
+        sender="polly",
+        scope="other",
+    )
+
+    result = runner.invoke(
+        inbox_app,
+        [
+            "backfill-kinds", "--commit",
+            "--project", "demo",
+            "--db", str(db_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    assert _read_kind(db_path, demo_id) is InboxItemKind.COMPLETION_FYI
+    # The other-project row is untouched because the --project filter
+    # excluded it from the scan.
+    assert _read_kind(db_path, other_id) is InboxItemKind.LEGACY
+
+
+# ---------------------------------------------------------------------------
+# Flag validation
+# ---------------------------------------------------------------------------
+
+
+def test_commit_and_dry_run_are_mutually_exclusive(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    _seed_legacy_message(db_path, subject="Random row", sender="worker", scope="demo")
+
+    result = runner.invoke(
+        inbox_app,
+        ["backfill-kinds", "--commit", "--dry-run", "--db", str(db_path)],
+    )
+    assert result.exit_code == 2
+    assert "mutually exclusive" in result.output
+
+
+def test_empty_db_reports_no_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    # Touch the DB by inserting a non-legacy row, then closing it so the
+    # backfill scan finds zero legacy rows.
+    msg_id = _seed_legacy_message(
+        db_path, subject="Plan ready for review — alpha/1",
+        sender="architect", scope="alpha",
+    )
+    # Manually flip its kind off legacy so the scan finds nothing.
+    store = SQLAlchemyStore(f"sqlite:///{db_path}")
+    try:
+        store.update_message(msg_id, kind=InboxItemKind.PLAN_REVIEW_PENDING.value)
+    finally:
+        store.close()
+
+    result = runner.invoke(
+        inbox_app, ["backfill-kinds", "--db", str(db_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "No legacy inbox rows to reclassify." in result.output

--- a/tests/test_inbox_backfill_heuristics.py
+++ b/tests/test_inbox_backfill_heuristics.py
@@ -1,0 +1,235 @@
+"""Per-heuristic unit tests for ``classify_legacy`` (#1570).
+
+Locks in the spec order so a refactor cannot silently shuffle
+priorities. Each heuristic gets a positive case (the canonical
+shape) and a negative case (a row that looks similar but should
+not match), plus a top-level test that an unmatched row returns
+``None`` so the CLI's "leave it legacy" branch keeps working.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pollypm.inbox.backfill_heuristics import (
+    Classification,
+    classify_legacy,
+)
+from pollypm.inbox.kind import InboxItemKind
+
+
+# ---------------------------------------------------------------------------
+# 1. completion_fyi — title contains complete / done / resubmitted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "Tier-4 cascade Complete",
+        "Web API phase 1 complete",
+        "Done: morning test sweep",
+        "PR resubmitted after rebase",
+        "RESUBMITTED to fix conflict",
+    ],
+)
+def test_completion_titles_classify_completion_fyi(title: str) -> None:
+    out = classify_legacy(title=title, sender="polly", project="demo")
+    assert out is not None
+    assert out.kind is InboxItemKind.COMPLETION_FYI
+    assert "title_contains:" in out.heuristic
+
+
+def test_completion_token_must_be_present() -> None:
+    """A title without completion tokens should not hit the rule."""
+    out = classify_legacy(
+        title="Please review the new spec draft",
+        sender="polly",
+        project="demo",
+    )
+    assert out is None or out.kind is not InboxItemKind.COMPLETION_FYI
+
+
+# ---------------------------------------------------------------------------
+# 2. self_bug_report — title contains misrouted / bogus / proj/1 / repeated stale
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "Misrouted Polly notification",
+        "Bogus task surfaced again",
+        "Heartbeat fired against proj/1 (no such project)",
+        "Repeated stale review ping (3rd this hour)",
+    ],
+)
+def test_self_bug_report_titles_classify_self_bug_report(title: str) -> None:
+    out = classify_legacy(title=title, sender="polly", project="demo")
+    assert out is not None
+    assert out.kind is InboxItemKind.SELF_BUG_REPORT
+
+
+def test_self_bug_report_does_not_swallow_unrelated_titles() -> None:
+    out = classify_legacy(
+        title="New approval request from architect",
+        sender="polly",
+        project="demo",
+    )
+    assert out is None or out.kind is not InboxItemKind.SELF_BUG_REPORT
+
+
+# ---------------------------------------------------------------------------
+# 3. plan_review_pending — title starts with "Plan ready for review"
+# ---------------------------------------------------------------------------
+
+
+def test_plan_ready_for_review_prefix_classifies_plan_review_pending() -> None:
+    out = classify_legacy(
+        title="Plan ready for review — demo/12",
+        sender="architect",
+        project="demo",
+    )
+    assert out is not None
+    assert out.kind is InboxItemKind.PLAN_REVIEW_PENDING
+
+
+def test_plan_ready_for_review_must_be_a_prefix() -> None:
+    """A row that merely mentions plan-review mid-string shouldn't match."""
+    out = classify_legacy(
+        title="Reminder: plan ready for review was sent yesterday",
+        sender="polly",
+        project="demo",
+    )
+    assert out is None or out.kind is not InboxItemKind.PLAN_REVIEW_PENDING
+
+
+# ---------------------------------------------------------------------------
+# 4. manual_decision — Polly-authored digest into the inbox project
+# ---------------------------------------------------------------------------
+
+
+def test_polly_digest_in_inbox_classifies_manual_decision() -> None:
+    out = classify_legacy(
+        title="Digest: 7 open findings need your call",
+        sender="polly",
+        project="inbox",
+    )
+    assert out is not None
+    assert out.kind is InboxItemKind.MANUAL_DECISION
+
+
+def test_polly_digest_must_be_in_inbox_project() -> None:
+    """Same title + sender but a real project key — not a manual_decision."""
+    out = classify_legacy(
+        title="Digest: 7 open findings need your call",
+        sender="polly",
+        project="savethenovel",
+    )
+    assert out is None or out.kind is not InboxItemKind.MANUAL_DECISION
+
+
+def test_polly_digest_must_come_from_polly() -> None:
+    out = classify_legacy(
+        title="Digest: 7 open findings need your call",
+        sender="audit_watchdog",
+        project="inbox",
+    )
+    assert out is None or out.kind is not InboxItemKind.MANUAL_DECISION
+
+
+# ---------------------------------------------------------------------------
+# 5. watchdog_operator_dispatch — audit_watchdog sender + Action in title
+# ---------------------------------------------------------------------------
+
+
+def test_audit_watchdog_action_classifies_watchdog_operator_dispatch() -> None:
+    out = classify_legacy(
+        title="[Action] queue_without_motion needs review",
+        sender="audit_watchdog",
+        project="demo",
+    )
+    assert out is not None
+    assert out.kind is InboxItemKind.WATCHDOG_OPERATOR_DISPATCH
+
+
+def test_audit_watchdog_without_action_does_not_classify() -> None:
+    out = classify_legacy(
+        title="Heartbeat tick at 12:30",
+        sender="audit_watchdog",
+        project="demo",
+    )
+    assert out is None
+
+
+def test_action_title_without_audit_watchdog_sender_does_not_classify() -> None:
+    """Other senders writing 'Action' must not be misattributed."""
+    out = classify_legacy(
+        title="Action item: refresh credentials",
+        sender="polly",
+        project="demo",
+    )
+    # Polly's "Action" message must not be tagged as watchdog dispatch.
+    if out is not None:
+        assert out.kind is not InboxItemKind.WATCHDOG_OPERATOR_DISPATCH
+
+
+# ---------------------------------------------------------------------------
+# Unmatched rows
+# ---------------------------------------------------------------------------
+
+
+def test_unmatched_row_returns_none() -> None:
+    out = classify_legacy(
+        title="Random one-off note from a worker",
+        sender="worker-7",
+        project="demo",
+    )
+    assert out is None
+
+
+def test_empty_inputs_return_none() -> None:
+    assert classify_legacy(title="", sender="", project="") is None
+
+
+# ---------------------------------------------------------------------------
+# Spec order — first matching rule wins
+# ---------------------------------------------------------------------------
+
+
+def test_completion_wins_over_self_bug_report_when_both_match() -> None:
+    """Order matters — completion wins because it precedes self-bug-report."""
+    out = classify_legacy(
+        title="proj/1 task complete (bogus row)",
+        sender="polly",
+        project="demo",
+    )
+    assert out is not None
+    assert out.kind is InboxItemKind.COMPLETION_FYI
+
+
+def test_self_bug_report_wins_over_plan_review_prefix() -> None:
+    """A bogus-tagged Plan-ready row should still be flagged as bug noise."""
+    out = classify_legacy(
+        title="bogus Plan ready for review (mis-routed)",
+        sender="architect",
+        project="demo",
+    )
+    assert out is not None
+    assert out.kind is InboxItemKind.SELF_BUG_REPORT
+
+
+# ---------------------------------------------------------------------------
+# Return shape
+# ---------------------------------------------------------------------------
+
+
+def test_classification_carries_heuristic_label() -> None:
+    out = classify_legacy(
+        title="Plan ready for review — alpha/3",
+        sender="architect",
+        project="alpha",
+    )
+    assert isinstance(out, Classification)
+    assert out.heuristic
+    assert out.kind is InboxItemKind.PLAN_REVIEW_PENDING


### PR DESCRIPTION
Closes #1570. Part of epic #1564.

## Summary

- `pm inbox backfill-kinds` — dry-run by default, `--commit` to apply, idempotent. Reclassifies pre-#1565 inbox rows whose `kind` is still the migration-default `legacy` so the dashboard's "Waiting on you" section can shrink from ~100+ noise rows down to the real curated set.
- `pollypm.inbox.backfill_heuristics` — pure leaf module (depends only on `InboxItemKind`) holding the spec's title + sender + scope rules. The CLI is the only writer; the heuristic just decides.
- New audit event `inbox.kind_backfilled` (added to `pollypm.audit.log` and exported via `__all__`) — one emission per committed row, carrying `old_kind`, `new_kind`, and matched heuristic label.

## Architecture notes

- Heuristic module is a leaf — no DB, no cockpit, no `Supervisor` imports.
- CLI command lives on the existing `inbox_app` (registered from `pollypm.work.inbox_cli` per #1571's pattern), so no new Typer sub-app and no new `Supervisor` allow-list entry.
- DB access routes through `SQLAlchemyStore.query_messages` + `update_message`; no raw `sqlite3`.
- Scope: the heuristics are written against the **messages** surface (the dominant source of the user-visible 133-row inbox; the heuristic shape — `sender`, `scope`, title prose — is message-flavoured). `work_tasks` rows with `kind='legacy'` would need different signals (no `sender`, no `scope`) and are deliberately out of scope here.

## Sample dry-run output

Against a 7-row test DB (5 representative rows + 2 unmatched):

```
Scanning 7 legacy inbox row(s) (dry-run).
ID           Project            Heuristic → New kind                             Title
--------------------------------------------------------------------------------------------------------------
msg:7        demo               (unmatched, stays legacy)                        [Action] Heartbeat tick at 12:30
msg:6        demo               (unmatched, stays legacy)                        [Action] Random one-off note
msg:5        demo               audit_watchdog_action → watchdog_operator_dispatch [Action] queue_without_motion needs review
msg:4        inbox              polly_digest_in_inbox_project → manual_decision  [Action] Digest: 7 open findings need your call
msg:3        demo               title_prefix:plan_ready_for_review → plan_review_pending [Action] Plan ready for review demo/12
msg:2        demo               title_contains:misrouted → self_bug_report       [Action] Misrouted Polly notification (3rd today)
msg:1        demo               title_contains:complete → completion_fyi         [Action] Web API phase 1 complete
--------------------------------------------------------------------------------------------------------------
Would reclassify 5 row(s); 2 unmatched.
Re-run with --commit to apply; unmatched rows stay legacy and remain visible to the awaits_user predicate.
```

After `--commit`, the same scan reports `Reclassified 5 row(s); 2 unmatched.` and re-running it produces `Reclassified 0 row(s); 2 unmatched.` (idempotence — the 5 already-classified rows are now skipped by the `kind == legacy` filter).

## Test plan

- [x] `tests/test_inbox_backfill_heuristics.py` — per-heuristic true/false branches + spec-order precedence (24 cases).
- [x] `tests/test_cli_inbox_backfill.py` — dry-run-writes-nothing, commit-updates-and-audits, idempotence on repeat commit, `--project` filter scopes to one project, mutually-exclusive `--commit --dry-run` rejected.
- [x] Baseline: `uv run pytest tests/test_audit_log.py tests/test_inbox*.py tests/test_work_service*.py` → all green (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)