### PR TITLE
feat(dashboard): operator dashboard + rail glyph vocabulary (#1572)

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -696,6 +696,13 @@ def register_ui_commands(app: typer.Typer) -> None:
 
             PollyDashboardApp(config_path).run(mouse=True)
             return
+        if kind == "operator":
+            from pollypm.cockpit_apps.operator_dashboard import (
+                PollyOperatorDashboardApp,
+            )
+
+            PollyOperatorDashboardApp(config_path).run(mouse=True)
+            return
         if kind == "inbox":
             from pollypm.cockpit_ui import PollyInboxApp
 

--- a/src/pollypm/cockpit.py
+++ b/src/pollypm/cockpit.py
@@ -126,6 +126,15 @@ def _build_cockpit_detail_dispatch(supervisor, config_path: Path, kind: str, tar
     if kind in ("polly", "dashboard"):
         return _build_dashboard(supervisor, config, config_path=config_path)
 
+    if kind == "operator":
+        # #1572 — text fallback for the operator dashboard pane.
+        from pollypm.dashboard.operator_view import (
+            load_operator_view_from_config,
+            view_as_ascii,
+        )
+
+        return view_as_ascii(load_operator_view_from_config(config))
+
     if kind == "inbox":
         return _render_inbox_panel(config)
 

--- a/src/pollypm/cockpit_apps/operator_dashboard.py
+++ b/src/pollypm/cockpit_apps/operator_dashboard.py
@@ -1,0 +1,269 @@
+"""Operator dashboard Textual app (#1572).
+
+The 1-second answer to "what is the state of the system?" Three
+vertical sections — Waiting on you, Working, Idle — each driven by
+:func:`pollypm.dashboard.categorize_project` so the per-project
+category here matches the glyph the rail draws.
+
+The data path runs through :mod:`pollypm.cockpit_inbox` (for the
+waits-on-user inbox view) and :mod:`pollypm.work` (for live workers /
+task status). No direct ``Supervisor`` import — the boundary stays
+clean per ``docs/architecture.md``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.widgets import Static
+
+from pollypm.cockpit_markup import _escape
+from pollypm.cockpit_palette import _open_keyboard_help
+from pollypm.dashboard import (
+    OperatorDashboardView,
+    ProjectState,
+    glyph_for_project_state,
+)
+
+
+def _empty_view() -> OperatorDashboardView:
+    return OperatorDashboardView()
+
+
+class PollyOperatorDashboardApp(App[None]):
+    """Top-of-rail operator surface: Waiting / Working / Idle."""
+
+    TITLE = "PollyPM"
+    SUB_TITLE = "Operator"
+    BINDINGS = [
+        Binding("r", "refresh", "Refresh"),
+        Binding("i", "jump_inbox", "Inbox"),
+        Binding("question_mark", "show_keyboard_help", "Help", priority=True),
+        Binding("j,down", "scroll_down", "Down", show=False),
+        Binding("k,up", "scroll_up", "Up", show=False),
+        Binding("g,home", "scroll_home", "Top", show=False),
+        Binding("G,end", "scroll_end", "Bottom", show=False),
+        Binding("pageup,b", "page_up", "Page up", show=False),
+        Binding("pagedown,space,f", "page_down", "Page down", show=False),
+    ]
+    CSS = """
+    Screen {
+        background: #0d1117;
+        color: #c9d1d9;
+        padding: 0 1;
+        layout: vertical;
+        overflow-y: auto;
+    }
+    .header { padding: 1 0 0 0; color: #8b949e; }
+    .section-title {
+        color: #58a6ff;
+        text-style: bold;
+        padding: 1 0 0 0;
+    }
+    .section-body { padding: 0 0 0 2; }
+    .footer { color: #484f58; padding: 1 0 0 0; }
+    """
+
+    def __init__(self, config_path: Path) -> None:
+        super().__init__()
+        self.config_path = config_path
+        self.header_w = Static("", classes="header", markup=True)
+        self.waiting_title = Static("[b]Waiting on you[/b]", classes="section-title", markup=True)
+        self.waiting_body = Static("", classes="section-body", markup=True)
+        self.working_title = Static("[b]Working[/b]", classes="section-title", markup=True)
+        self.working_body = Static("", classes="section-body", markup=True)
+        self.idle_title = Static("[b]Idle[/b]", classes="section-title", markup=True)
+        self.idle_body = Static("", classes="section-body", markup=True)
+        self.paused_title = Static("[b]Paused[/b]", classes="section-title", markup=True)
+        self.paused_body = Static("", classes="section-body", markup=True)
+        self.footer_w = Static("", classes="footer", markup=True)
+        self._view: OperatorDashboardView | None = None
+        self._refresh_running = False
+        self._refresh_error: str | None = None
+
+    def compose(self) -> ComposeResult:
+        yield self.header_w
+        yield self.waiting_title
+        yield self.waiting_body
+        yield self.working_title
+        yield self.working_body
+        yield self.idle_title
+        yield self.idle_body
+        yield self.paused_title
+        yield self.paused_body
+        yield self.footer_w
+
+    def on_mount(self) -> None:
+        self._refresh()
+        self.set_interval(10, self._refresh)
+        try:
+            from pollypm.cockpit_input_bridge import start_input_bridge
+            self._input_bridge_handle = start_input_bridge(
+                self, kind="operator", config_path=self.config_path,
+            )
+        except Exception:  # noqa: BLE001
+            self._input_bridge_handle = None
+
+    def on_unmount(self) -> None:
+        bridge = getattr(self, "_input_bridge_handle", None)
+        if bridge is not None:
+            try:
+                bridge.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def action_show_keyboard_help(self) -> None:
+        _open_keyboard_help(self)
+
+    def action_refresh(self) -> None:
+        self._refresh()
+
+    def _refresh(self) -> None:
+        self._render_view(self._view or _empty_view())
+        if self._refresh_running:
+            return
+        self._refresh_running = True
+        self.run_worker(
+            self._refresh_view_sync,
+            thread=True,
+            exclusive=True,
+            group="polly_operator_refresh",
+        )
+
+    def _refresh_view_sync(self) -> None:
+        try:
+            from pollypm.dashboard.operator_view import load_operator_view
+
+            view = load_operator_view(self.config_path)
+        except Exception as exc:  # noqa: BLE001
+            self.call_from_thread(self._finish_refresh_error, str(exc))
+            return
+        self.call_from_thread(self._finish_refresh_success, view)
+
+    def _finish_refresh_success(self, view: OperatorDashboardView) -> None:
+        self._view = view
+        self._refresh_running = False
+        self._refresh_error = None
+        self._render_view(view)
+
+    def _finish_refresh_error(self, error: str) -> None:
+        self._refresh_running = False
+        self._refresh_error = error
+        self._render_view(self._view or _empty_view())
+
+    def _render_view(self, view: OperatorDashboardView) -> None:
+        if self._view is None and self._refresh_error is None:
+            self.header_w.update("[dim]Loading operator dashboard…[/dim]")
+        else:
+            counts = (
+                f"[#d29922]{len(view.waiting)}[/#d29922] waiting  "
+                f"·  [#3fb950]{len(view.working)}[/#3fb950] working  "
+                f"·  [dim]{len(view.idle)} idle[/dim]"
+            )
+            if view.paused:
+                counts += f"  ·  [dim]{len(view.paused)} paused[/dim]"
+            self.header_w.update(f"  {counts}")
+
+        self.waiting_body.update(
+            _format_section(view.waiting, empty="Nothing waiting.")
+        )
+        self.working_body.update(
+            _format_section(view.working, empty="Nothing actively working.")
+        )
+        self.idle_body.update(
+            _format_section(view.idle, empty="All projects busy.")
+        )
+        if view.paused:
+            self.paused_title.update("[b]Paused[/b]")
+            self.paused_body.update(_format_section(view.paused, empty=""))
+        else:
+            self.paused_title.update("")
+            self.paused_body.update("")
+
+        footer = "[dim]Press [b]r[/b] to refresh · [b]i[/b] to jump to inbox[/dim]"
+        if self._refresh_error:
+            footer += f"  ·  [#f85149]error: {_escape(self._refresh_error)}[/#f85149]"
+        self.footer_w.update(footer)
+
+    def action_jump_inbox(self) -> None:
+        from pollypm.cockpit_navigation_client import file_navigation_client
+
+        try:
+            file_navigation_client(
+                self.config_path, client_id="polly-operator",
+            ).jump_to_inbox()
+        except Exception as exc:  # noqa: BLE001
+            self.notify(f"Jump to inbox failed: {exc}", severity="error")
+
+    def _dashboard_screen(self):  # noqa: ANN202
+        return self.screen
+
+    def action_scroll_down(self) -> None:
+        try:
+            self._dashboard_screen().scroll_down(animate=False)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def action_scroll_up(self) -> None:
+        try:
+            self._dashboard_screen().scroll_up(animate=False)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def action_scroll_home(self) -> None:
+        try:
+            self._dashboard_screen().scroll_home(animate=False)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def action_scroll_end(self) -> None:
+        try:
+            self._dashboard_screen().scroll_end(animate=False)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def action_page_up(self) -> None:
+        try:
+            self._dashboard_screen().scroll_page_up(animate=False)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def action_page_down(self) -> None:
+        try:
+            self._dashboard_screen().scroll_page_down(animate=False)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _format_section(rows, *, empty: str) -> str:
+    """Render one section's rows as a multi-line string."""
+    if not rows:
+        return f"[dim]{_escape(empty)}[/dim]" if empty else ""
+    lines: list[str] = []
+    for row in rows:
+        glyph = row.glyph if row.glyph else glyph_for_project_state(row.state)
+        color = _color_for_state(row.state)
+        glyph_markup = f"[{color}]{glyph}[/{color}]" if color else glyph
+        project = _escape(row.project_key)
+        detail = _escape(row.detail)
+        if row.state is ProjectState.IDLE:
+            lines.append(f"{glyph_markup} [dim]{project}[/dim]  [dim]{detail}[/dim]")
+        elif row.state is ProjectState.PAUSED:
+            lines.append(f"{glyph_markup} [dim]{project}[/dim]  [dim]{detail}[/dim]")
+        else:
+            lines.append(f"{glyph_markup} [b]{project}[/b]  {detail}")
+    return "\n".join(lines)
+
+
+def _color_for_state(state: ProjectState) -> str:
+    if state is ProjectState.WAITING:
+        return "#d29922"
+    if state is ProjectState.WORKING:
+        return "#3fb950"
+    if state is ProjectState.IDLE:
+        return "#484f58"
+    if state is ProjectState.PAUSED:
+        return "#484f58"
+    return ""

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -332,6 +332,13 @@ class CockpitItem:
     # human-decision review node (status=review + assignee=human).
     # Drives the rail's ▶ "needs your decision" affordance + suffix.
     approvals_pending: int = 0
+    # #1572 — Canonical operator-facing project category, sourced from
+    # :func:`pollypm.dashboard.categorize_project`. When present, the
+    # rail draws the new ``◆ ● ○ ⏸`` glyph vocabulary instead of the
+    # legacy state-specific glyph; both the rail and the operator
+    # dashboard read the same enum so the section a project lands in
+    # always matches the glyph painted next to it.
+    project_state: str | None = None
 
 
 def _stuck_alert_already_user_waiting(
@@ -1359,6 +1366,11 @@ class CockpitRouter:
         grouped: dict[str, list[CockpitItem]] = {name: [] for name in RAIL_SECTIONS}
         project_session_map = self._project_session_map(launches)
         project_rollups = self._project_state_rollups(config, alerts)
+        # #1572 — canonical operator-facing categorization (Waiting /
+        # Working / Idle / Paused). Single source shared with the
+        # operator dashboard so the rail glyph and the dashboard
+        # section can never disagree on a project.
+        project_states = self._project_categorizations(config)
 
         for section, registrations in grouped_registrations.items():
             for reg in registrations:
@@ -1416,6 +1428,7 @@ class CockpitRouter:
             recent_events=recent_events,
             project_session_map=project_session_map,
             project_rollups=project_rollups,
+            project_states=project_states,
         )
 
     def _attach_session_metadata(
@@ -1621,6 +1634,7 @@ class CockpitRouter:
         recent_events: list,
         project_session_map: dict[str, str],
         project_rollups: dict[str, ProjectStateRollup] | None = None,
+        project_states: dict[str, str] | None = None,
     ) -> list[CockpitItem]:
         from pollypm.cockpit_sections.base import _iso_to_dt, _spark_bar
 
@@ -1645,6 +1659,7 @@ class CockpitRouter:
         )
 
         rollups = project_rollups or {}
+        states = project_states or {}
         project_blocks: list[tuple[str, list[CockpitItem], bool, bool, ProjectStateRollup | None]] = []
         current_key: str | None = None
         current_block: list[CockpitItem] = []
@@ -1679,6 +1694,7 @@ class CockpitRouter:
                             item,
                             project_event_spark.get(current_key),
                             rollup=rollups.get(current_key),
+                            project_state=states.get(current_key),
                         )
                     ]
                     continue
@@ -1721,6 +1737,7 @@ class CockpitRouter:
         sparkline: str | None,
         *,
         rollup: ProjectStateRollup | None = None,
+        project_state: str | None = None,
     ) -> CockpitItem:
         label = item.label
         if self.is_project_pinned(item.key.split(":", 1)[1]):
@@ -1739,6 +1756,7 @@ class CockpitRouter:
             label=label,
             state=self._project_row_state(item.state, rollup),
             approvals_pending=approvals,
+            project_state=project_state,
         )
 
     def _project_row_state(
@@ -1757,6 +1775,27 @@ class CockpitRouter:
         if rollup.state is ProjectRailState.WORKING:
             return "project-working"
         return fallback
+
+    def _project_categorizations(self, config: object) -> dict[str, str]:
+        """Canonical operator-facing categorization per project (#1572).
+
+        Returns ``{project_key: ProjectState.value}`` for every
+        registered project. Shared with the operator dashboard so the
+        glyph drawn here and the section the dashboard renders match.
+
+        Best-effort: a project whose DB can't be opened falls through
+        to the tracked / paused IDLE classification rather than
+        raising, mirroring the rest of the rail render path.
+        """
+        try:
+            from pollypm.dashboard.operator_view import (
+                project_state_map_from_config,
+            )
+
+            states = project_state_map_from_config(config)
+        except Exception:  # noqa: BLE001
+            return {}
+        return {key: state.value for key, state in states.items()}
 
     def _project_state_rollups(
         self,
@@ -4504,6 +4543,26 @@ class PollyCockpitRail:
             # \u2014 the worker's stuck \u26a0 glyph already covers them.
             if _alert_type_is_user_action_waiting(item.alert_type):
                 return "\u25c6", PALETTE["warn_indicator"]
+            # #1572 \u2014 canonical operator categorization. When the
+            # dashboard says "Waiting on you" the rail draws ``\u25c6``;
+            # "Working" gets ``\u25cf``; "Idle" gets ``\u25cb``; "Paused" gets
+            # ``\u23f8``. The single source of truth for both surfaces is
+            # :func:`pollypm.dashboard.categorize_project`, so the
+            # glyph and the section a project lands in never
+            # disagree. Sits below the operational-fault + approvals
+            # branches so a real fault still takes the dedicated
+            # glyph; sits above the legacy ``project-yellow/green``
+            # state branches so the new vocabulary wins when both
+            # signals are available.
+            project_state = item.project_state
+            if project_state == "waiting":
+                return "\u25c6", PALETTE["inbox_has"]
+            if project_state == "working":
+                return "\u25cf", PALETTE["live_indicator"]
+            if project_state == "paused":
+                return "\u23f8", PALETTE["item_muted"]
+            if project_state == "idle":
+                return "\u25cb", PALETTE["idle"]
             if item.state == "project-yellow":
                 # #1092 \u2014 use \u25c6 to match the dashboard's "needs attention"
                 # diamond. ``\u2022`` (U+2022) and the idle ``\u00b7`` (U+00B7) are

--- a/src/pollypm/cockpit_rail_routes.py
+++ b/src/pollypm/cockpit_rail_routes.py
@@ -43,6 +43,10 @@ _LIVE_SESSION_ROUTES: dict[str, LiveSessionRoute] = {
 
 _STATIC_VIEW_ROUTES: dict[str, StaticViewRoute] = {
     "dashboard": StaticViewRoute(kind="dashboard", selected_key="dashboard"),
+    # #1572 — operator dashboard (Waiting / Working / Idle). Distinct
+    # from "dashboard" (Home / token usage / activity) so neither
+    # surface needs to absorb the other's responsibilities mid-epic.
+    "operator": StaticViewRoute(kind="operator", selected_key="operator"),
     "inbox": StaticViewRoute(kind="inbox", selected_key="inbox"),
     "workers": StaticViewRoute(kind="workers", selected_key="workers"),
     "metrics": StaticViewRoute(kind="metrics", selected_key="metrics"),

--- a/src/pollypm/dashboard/__init__.py
+++ b/src/pollypm/dashboard/__init__.py
@@ -1,0 +1,34 @@
+"""Operator dashboard surface (#1572).
+
+Public exports for the dashboard categorization + view-model helpers
+that back both the operator dashboard app and the rail glyph
+vocabulary. See :mod:`pollypm.dashboard.categorization` for the
+canonical ``ProjectState`` enum and ``categorize_project`` function;
+those are the single source of truth shared between the rail and the
+dashboard so the two surfaces never disagree on what a project is
+doing.
+"""
+
+from __future__ import annotations
+
+from pollypm.dashboard.categorization import (
+    OperatorDashboardRow,
+    OperatorDashboardView,
+    ProjectState,
+    build_operator_dashboard_view,
+    categorize_project,
+    glyph_for_project_state,
+    what_working,
+    why_waiting,
+)
+
+__all__ = [
+    "OperatorDashboardRow",
+    "OperatorDashboardView",
+    "ProjectState",
+    "build_operator_dashboard_view",
+    "categorize_project",
+    "glyph_for_project_state",
+    "what_working",
+    "why_waiting",
+]

--- a/src/pollypm/dashboard/categorization.py
+++ b/src/pollypm/dashboard/categorization.py
@@ -1,0 +1,508 @@
+"""Per-project categorization + operator dashboard view model (#1572).
+
+This module is the single source of truth for "what is this project
+doing right now?" Both surfaces of the epic — the operator dashboard
+app and the cockpit rail glyph — read from :func:`categorize_project`
+so the rail and the dashboard can never paint a project into
+different buckets (the exact split-brain that motivated #1564).
+
+Four categories, priority-ordered:
+
+* :attr:`ProjectState.WAITING` — at least one inbox item with
+  ``awaits_user(item) == True``. The user owes a decision.
+* :attr:`ProjectState.WORKING` — at least one live worker session or
+  an in-flight task (``in_progress`` / ``review``), and no waiting
+  item. The system is acting.
+* :attr:`ProjectState.IDLE` — neither of the above. The project is
+  quiet.
+* :attr:`ProjectState.PAUSED` — the project is opted out
+  (``tracked=False``). Paused projects with waiting items still
+  surface as :attr:`WAITING`; the per-project tracked-filter
+  asymmetry (cycle 87, ``feedback_pollypm_testing_priorities``) is
+  honoured by the caller building the project list, not by this
+  function.
+
+The module is a leaf in the import graph: it depends only on the
+canonical inbox predicate, the ``InboxItemKind`` enum, and the
+structural shape of the work service. No cockpit, no Supervisor, no
+sqlite3. That keeps it importable from every surface (rail, dashboard
+app, CLI, tests).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterable, Protocol
+
+from pollypm.inbox import awaits_user
+from pollypm.inbox.kind import InboxItemKind, coerce_kind
+
+
+class ProjectState(Enum):
+    """Mutually-exclusive operator-facing project category."""
+
+    WAITING = "waiting"
+    WORKING = "working"
+    IDLE = "idle"
+    PAUSED = "paused"
+
+
+# Display glyphs. Pinned at module scope so both the dashboard and the
+# rail import the same constant — if the spec ever ships new symbols
+# the change lands here and propagates to both surfaces.
+_GLYPHS: dict[ProjectState, str] = {
+    ProjectState.WAITING: "◆",   # ◆
+    ProjectState.WORKING: "●",   # ●
+    ProjectState.IDLE:    "○",   # ○
+    ProjectState.PAUSED:  "⏸",   # ⏸
+}
+
+
+def glyph_for_project_state(state: ProjectState) -> str:
+    """Return the display glyph for ``state``.
+
+    Imported by both ``cockpit_rail`` (project row indicator) and the
+    operator dashboard app (per-row glyph). Co-locating the table here
+    is the load-bearing invariant the issue calls out: the section a
+    project lands in MUST match the glyph the rail draws for it.
+    """
+    return _GLYPHS[state]
+
+
+# ---------------------------------------------------------------------------
+# Inputs — structural shapes
+# ---------------------------------------------------------------------------
+
+
+class _InboxItem(Protocol):
+    """Anything with a ``kind`` and a project-key field.
+
+    Matches :class:`pollypm.cockpit_inbox_items.InboxEntry` plus any
+    test double. ``project`` is the canonical project key; ``scope``
+    is the legacy alias so message-row entries (which carry ``scope``)
+    work without an adapter.
+    """
+
+    kind: object
+
+
+class _Task(Protocol):
+    """Work-service task shape — only the fields the categorizer reads."""
+
+    work_status: object
+    project: str
+
+
+class _WorkerSession(Protocol):
+    """Worker-session row shape — ``task_project`` + activity timestamps."""
+
+    task_project: str
+
+
+class _WorkServiceLike(Protocol):
+    """The narrow slice of ``WorkService`` the categorizer needs.
+
+    Both :class:`pollypm.work.sqlite_service.SQLiteWorkService` and
+    :class:`pollypm.work.mock_service.MockWorkService` satisfy this
+    shape, so tests can pass either implementation. Method signatures
+    mirror the public protocol — adding methods here would tighten the
+    coupling without buying anything.
+    """
+
+    def list_tasks(self, *, project: str | None = None, **kwargs: object) -> list: ...
+
+    def list_worker_sessions(
+        self, *, project: str | None = None, active_only: bool = True,
+    ) -> list: ...
+
+
+# Task statuses that indicate active automated work for the WORKING
+# category. Tasks parked on user-waiting statuses
+# (``waiting_on_user`` / ``on_hold`` / ``blocked`` / ``review``) do
+# NOT count as working — they're either user-waiting (covered by the
+# inbox predicate) or stalled (which is not "system is acting").
+_WORKING_TASK_STATUSES: frozenset[str] = frozenset({"in_progress", "rework"})
+
+
+def _project_of(item: _InboxItem) -> str:
+    """Best-effort project key for an inbox item."""
+    project = str(getattr(item, "project", "") or "").strip()
+    if project and project != "inbox":
+        return project
+    scope = str(getattr(item, "scope", "") or "").strip()
+    if scope and scope != "inbox":
+        return scope
+    return ""
+
+
+def _task_status(task: object) -> str:
+    value = getattr(task, "work_status", getattr(task, "status", ""))
+    return str(getattr(value, "value", value) or "")
+
+
+def categorize_project(
+    project_key: str,
+    *,
+    work_service: _WorkServiceLike,
+    inbox_items: Iterable[_InboxItem] = (),
+    tracked: bool = True,
+) -> ProjectState:
+    """Return the single user-facing category for ``project_key``.
+
+    Priority order, top to bottom:
+
+    1. If ANY inbox item for the project has ``awaits_user(item) == True``,
+       the project is :attr:`ProjectState.WAITING`. Waiting wins over
+       Working — a project with a live worker AND a user-waiting item
+       reads as Waiting because the user is the next-action owner.
+    2. If a live worker session is bound to a task in the project, OR
+       a task is in an active automated status
+       (:attr:`WorkStatus.IN_PROGRESS` / :attr:`WorkStatus.REWORK`),
+       the project is :attr:`ProjectState.WORKING`.
+    3. If ``tracked`` is ``False`` AND nothing waiting AND nothing
+       working, the project is :attr:`ProjectState.PAUSED`.
+    4. Otherwise :attr:`ProjectState.IDLE`.
+
+    ``tracked`` defaults to ``True`` so a caller that doesn't know the
+    project's tracked-state (e.g. a test) gets the "normal" path; pass
+    the real flag from the project config to honour paused-project
+    semantics.
+    """
+    waiting_items = [item for item in inbox_items if awaits_user(item)]
+    project_waiting_items = [
+        item for item in waiting_items if _project_of(item) == project_key
+    ]
+    if project_waiting_items:
+        return ProjectState.WAITING
+
+    try:
+        live_workers = work_service.list_worker_sessions(
+            project=project_key, active_only=True,
+        )
+    except Exception:  # noqa: BLE001
+        live_workers = []
+    if live_workers:
+        return ProjectState.WORKING
+
+    try:
+        tasks = work_service.list_tasks(project=project_key)
+    except Exception:  # noqa: BLE001
+        tasks = []
+    for task in tasks:
+        if _task_status(task) in _WORKING_TASK_STATUSES:
+            return ProjectState.WORKING
+
+    if not tracked:
+        return ProjectState.PAUSED
+    return ProjectState.IDLE
+
+
+# ---------------------------------------------------------------------------
+# why_waiting — per-row "why" derivation for the Waiting section
+# ---------------------------------------------------------------------------
+
+
+# Highest priority first. ``plan_review_pending`` reads as the most
+# urgent because a stuck plan blocks every downstream task; approval
+# requests come next (user explicitly asked); watchdog escalations
+# above PM questions because they represent the watchdog cascade
+# escalating up; manual_decision is the lowest because it's a generic
+# bucket. LEGACY rows that the predicate treats as awaits_user fall
+# through to the legacy copy.
+_KIND_PRIORITY: tuple[InboxItemKind, ...] = (
+    InboxItemKind.PLAN_REVIEW_PENDING,
+    InboxItemKind.APPROVAL_REQUEST,
+    InboxItemKind.WATCHDOG_OPERATOR_DISPATCH,
+    InboxItemKind.PM_QUESTION_UNANSWERED,
+    InboxItemKind.MANUAL_DECISION,
+)
+
+_KIND_COPY: dict[InboxItemKind, str] = {
+    InboxItemKind.PLAN_REVIEW_PENDING: "Needs your review of the new plan",
+    InboxItemKind.APPROVAL_REQUEST: "Needs your approval",
+    InboxItemKind.PM_QUESTION_UNANSWERED: "PM is waiting on your reply",
+    InboxItemKind.MANUAL_DECISION: "Polly needs your decision",
+}
+
+_LEGACY_COPY = "Needs your attention"
+
+
+def _item_subject(item: _InboxItem) -> str:
+    title = str(getattr(item, "title", "") or "").strip()
+    if title:
+        return title
+    return str(getattr(item, "subject", "") or "").strip()
+
+
+def why_waiting(items: Iterable[_InboxItem]) -> str:
+    """Return a one-line "why this project is waiting" string.
+
+    Picks the highest-priority item per :data:`_KIND_PRIORITY` and
+    maps its kind to the user-facing copy from the issue spec. A
+    watchdog dispatch interpolates the item subject ("Watchdog
+    escalated: <subject>") because the subject IS the dispatch; every
+    other kind has a static copy because the kind alone is enough to
+    explain what the user needs to do.
+
+    Empty input or no recognised kinds returns the legacy fallback so
+    the dashboard row always renders a useful line.
+    """
+    candidates = [
+        (item, coerce_kind(getattr(item, "kind", None)))
+        for item in items
+    ]
+    if not candidates:
+        return _LEGACY_COPY
+
+    by_priority: dict[InboxItemKind, _InboxItem] = {}
+    for item, kind in candidates:
+        if kind in by_priority:
+            continue
+        by_priority[kind] = item
+
+    for kind in _KIND_PRIORITY:
+        if kind not in by_priority:
+            continue
+        if kind is InboxItemKind.WATCHDOG_OPERATOR_DISPATCH:
+            subject = _item_subject(by_priority[kind])
+            if subject:
+                return f"Watchdog escalated: {subject}"
+            return "Watchdog escalation"
+        return _KIND_COPY[kind]
+
+    return _LEGACY_COPY
+
+
+# ---------------------------------------------------------------------------
+# what_working — per-row "what's it doing" derivation
+# ---------------------------------------------------------------------------
+
+
+_WORKING_LINE_CAP = 80
+
+
+def _started_at_sort_key(record: object) -> str:
+    """Most-recent worker session wins ties — sort by ``started_at`` desc."""
+    return str(getattr(record, "started_at", "") or "")
+
+
+def _task_title(task: object) -> str:
+    return str(getattr(task, "title", "") or "").strip()
+
+
+def _truncate(text: str, *, cap: int = _WORKING_LINE_CAP) -> str:
+    if len(text) <= cap:
+        return text
+    return text[: cap - 1].rstrip() + "…"
+
+
+def what_working(
+    project_key: str,
+    *,
+    work_service: _WorkServiceLike,
+) -> str:
+    """Return a one-line "what's this project doing" string.
+
+    Initial form per the issue: ``<worker_name>: <task title>``. When
+    multiple workers are live the most-recently-started wins. When no
+    worker is live but a task is in an automated status the line is
+    ``<status>: <task title>`` so the dashboard still says something
+    useful instead of going blank. Falls back to ``"Active"`` when
+    neither query yields a name.
+
+    Output is capped at :data:`_WORKING_LINE_CAP` so the terminal
+    render never wraps mid-name.
+    """
+    try:
+        workers = list(work_service.list_worker_sessions(
+            project=project_key, active_only=True,
+        ))
+    except Exception:  # noqa: BLE001
+        workers = []
+
+    if workers:
+        workers.sort(key=_started_at_sort_key, reverse=True)
+        latest = workers[0]
+        agent = str(getattr(latest, "agent_name", "") or "worker").strip() or "worker"
+        task_number = getattr(latest, "task_number", None)
+        title = ""
+        if task_number is not None:
+            try:
+                task = work_service.get(f"{project_key}/{task_number}")
+                title = _task_title(task)
+            except Exception:  # noqa: BLE001
+                title = ""
+        if title:
+            return _truncate(f"{agent}: {title}")
+        return _truncate(agent)
+
+    try:
+        tasks = list(work_service.list_tasks(project=project_key))
+    except Exception:  # noqa: BLE001
+        tasks = []
+    for task in tasks:
+        status = _task_status(task)
+        if status in _WORKING_TASK_STATUSES:
+            title = _task_title(task)
+            label = status.replace("_", " ")
+            if title:
+                return _truncate(f"{label}: {title}")
+            return _truncate(label)
+    return "Active"
+
+
+# ---------------------------------------------------------------------------
+# View model — what the dashboard renders
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorDashboardRow:
+    """One row in the operator dashboard.
+
+    ``detail`` is the per-section one-liner: "why waiting" for
+    Waiting rows, "what working" for Working rows, last-activity
+    string for Idle rows.
+    """
+
+    project_key: str
+    state: ProjectState
+    glyph: str
+    detail: str
+    last_activity: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorDashboardView:
+    """All three sections, computed in a single pass."""
+
+    waiting: tuple[OperatorDashboardRow, ...] = field(default_factory=tuple)
+    working: tuple[OperatorDashboardRow, ...] = field(default_factory=tuple)
+    idle: tuple[OperatorDashboardRow, ...] = field(default_factory=tuple)
+    paused: tuple[OperatorDashboardRow, ...] = field(default_factory=tuple)
+
+
+def _format_last_activity(value: object) -> str:
+    if not value:
+        return ""
+    text = str(value)
+    if "T" in text:
+        return text.split("T", 1)[0]
+    return text
+
+
+def _project_last_activity(
+    project_key: str, *, work_service: _WorkServiceLike,
+) -> str:
+    try:
+        tasks = list(work_service.list_tasks(project=project_key))
+    except Exception:  # noqa: BLE001
+        tasks = []
+    best = ""
+    for task in tasks:
+        for attr in ("updated_at", "created_at"):
+            value = getattr(task, attr, None)
+            if value is None:
+                continue
+            text = str(value)
+            if text > best:
+                best = text
+                break
+    return _format_last_activity(best)
+
+
+def build_operator_dashboard_view(
+    project_keys: Iterable[str],
+    *,
+    work_service: _WorkServiceLike,
+    inbox_items_by_project: dict[str, list[_InboxItem]] | None = None,
+    tracked_by_project: dict[str, bool] | None = None,
+) -> OperatorDashboardView:
+    """Categorize every project and pack the rows into the view model.
+
+    A single pass over ``project_keys`` so a project lands in exactly
+    one section. Sorting:
+
+    * Waiting: alphabetical by project key (deterministic; the
+      "highest-priority kind" within a project drives the row copy).
+    * Working: alphabetical.
+    * Idle: most-recent activity first (per the issue spec).
+    * Paused: alphabetical.
+
+    ``inbox_items_by_project`` and ``tracked_by_project`` default to
+    empty so a caller that doesn't have those signals still gets a
+    sensible (Idle/Working) categorization.
+    """
+    inbox_by_project = inbox_items_by_project or {}
+    tracked_lookup = tracked_by_project or {}
+
+    waiting: list[OperatorDashboardRow] = []
+    working: list[OperatorDashboardRow] = []
+    idle: list[OperatorDashboardRow] = []
+    paused: list[OperatorDashboardRow] = []
+
+    for project_key in project_keys:
+        items = inbox_by_project.get(project_key, [])
+        tracked = tracked_lookup.get(project_key, True)
+        state = categorize_project(
+            project_key,
+            work_service=work_service,
+            inbox_items=items,
+            tracked=tracked,
+        )
+        glyph = glyph_for_project_state(state)
+        if state is ProjectState.WAITING:
+            waiting.append(
+                OperatorDashboardRow(
+                    project_key=project_key,
+                    state=state,
+                    glyph=glyph,
+                    detail=why_waiting(items),
+                )
+            )
+        elif state is ProjectState.WORKING:
+            working.append(
+                OperatorDashboardRow(
+                    project_key=project_key,
+                    state=state,
+                    glyph=glyph,
+                    detail=what_working(project_key, work_service=work_service),
+                )
+            )
+        elif state is ProjectState.PAUSED:
+            paused.append(
+                OperatorDashboardRow(
+                    project_key=project_key,
+                    state=state,
+                    glyph=glyph,
+                    detail="Paused",
+                    last_activity=_project_last_activity(
+                        project_key, work_service=work_service,
+                    ),
+                )
+            )
+        else:
+            last = _project_last_activity(project_key, work_service=work_service)
+            detail = f"Last activity {last}" if last else "Quiet"
+            idle.append(
+                OperatorDashboardRow(
+                    project_key=project_key,
+                    state=state,
+                    glyph=glyph,
+                    detail=detail,
+                    last_activity=last,
+                )
+            )
+
+    waiting.sort(key=lambda r: r.project_key.lower())
+    working.sort(key=lambda r: r.project_key.lower())
+    idle.sort(key=lambda r: (r.last_activity, r.project_key.lower()), reverse=True)
+    paused.sort(key=lambda r: r.project_key.lower())
+
+    return OperatorDashboardView(
+        waiting=tuple(waiting),
+        working=tuple(working),
+        idle=tuple(idle),
+        paused=tuple(paused),
+    )

--- a/src/pollypm/dashboard/categorization.py
+++ b/src/pollypm/dashboard/categorization.py
@@ -116,6 +116,8 @@ class _WorkServiceLike(Protocol):
         self, *, project: str | None = None, active_only: bool = True,
     ) -> list: ...
 
+    def get(self, task_id: str) -> object: ...
+
 
 # Task statuses that indicate active automated work for the WORKING
 # category. Tasks parked on user-waiting statuses

--- a/src/pollypm/dashboard/categorization.py
+++ b/src/pollypm/dashboard/categorization.py
@@ -52,10 +52,10 @@ class ProjectState(Enum):
 # rail import the same constant — if the spec ever ships new symbols
 # the change lands here and propagates to both surfaces.
 _GLYPHS: dict[ProjectState, str] = {
-    ProjectState.WAITING: "◆",   # ◆
-    ProjectState.WORKING: "●",   # ●
-    ProjectState.IDLE:    "○",   # ○
-    ProjectState.PAUSED:  "⏸",   # ⏸
+    ProjectState.WAITING: "◆",
+    ProjectState.WORKING: "●",
+    ProjectState.IDLE:    "○",
+    ProjectState.PAUSED:  "⏸",
 }
 
 

--- a/src/pollypm/dashboard/operator_view.py
+++ b/src/pollypm/dashboard/operator_view.py
@@ -1,0 +1,280 @@
+"""Operator dashboard data loader (#1572).
+
+Bridges the leaf categorization module to the workspace's project
+config + per-project work-service DBs. Keeps the I/O side-effects
+out of :mod:`pollypm.dashboard.categorization` so the categorizer
+stays trivially unit-testable against a mock work service.
+
+The loader mirrors :func:`pollypm.cockpit_inbox.pm_inbox_awaits_user_list`'s
+DB-discovery shape: one work-service handle per (project, db_path)
+tuple, opened with the canonical workspace DB and the legacy
+per-project DB so paused-with-work projects still surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from pollypm.dashboard.categorization import (
+    OperatorDashboardRow,
+    OperatorDashboardView,
+    ProjectState,
+    build_operator_dashboard_view,
+    categorize_project,
+    glyph_for_project_state,
+    what_working,
+    why_waiting,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _ProjectScan:
+    """Resolved scan target — project key + a list of DB paths to try."""
+
+    project_key: str
+    project_path: Path
+    db_paths: tuple[Path, ...]
+    tracked: bool
+
+
+def _collect_project_scans(config) -> list[_ProjectScan]:  # noqa: ANN001
+    """Resolve (project_key, project_path, db_paths, tracked) tuples."""
+    project_settings = getattr(config, "project", None)
+    workspace_root = getattr(project_settings, "workspace_root", None)
+
+    scans: list[_ProjectScan] = []
+    seen_projects: set[str] = set()
+    projects = getattr(config, "projects", {}) or {}
+    for project_key, project in projects.items():
+        if project_key in seen_projects:
+            continue
+        seen_projects.add(project_key)
+        project_path = Path(getattr(project, "path", "."))
+        db_candidates: list[Path] = []
+
+        def _add(p: object) -> None:
+            try:
+                candidate = Path(p)
+            except TypeError:
+                return
+            if candidate in db_candidates:
+                return
+            try:
+                if candidate.exists():
+                    db_candidates.append(candidate)
+            except OSError:
+                return
+
+        if workspace_root is not None:
+            _add(Path(workspace_root) / ".pollypm" / "state.db")
+        _add(project_path / ".pollypm" / "state.db")
+
+        scans.append(
+            _ProjectScan(
+                project_key=str(project_key),
+                project_path=project_path,
+                db_paths=tuple(db_candidates),
+                tracked=bool(getattr(project, "tracked", False)),
+            )
+        )
+    return scans
+
+
+def _waiting_items_by_project(config) -> dict[str, list]:  # noqa: ANN001
+    """Group ``pm_inbox_awaits_user_list`` items by project key."""
+    from pollypm.cockpit_inbox import pm_inbox_awaits_user_list
+
+    grouped: dict[str, list] = {}
+    try:
+        items = pm_inbox_awaits_user_list(config)
+    except Exception:  # noqa: BLE001
+        items = []
+    for item in items:
+        key = (
+            str(getattr(item, "project", "") or "").strip()
+            or str(getattr(item, "scope", "") or "").strip()
+        )
+        if not key or key == "inbox":
+            continue
+        grouped.setdefault(key, []).append(item)
+    return grouped
+
+
+def _open_work_service(scan: _ProjectScan):  # noqa: ANN202
+    """Open the first usable work-service handle for ``scan``."""
+    from pollypm.work import create_work_service
+
+    for db_path in scan.db_paths:
+        try:
+            svc = create_work_service(
+                db_path=db_path, project_path=scan.project_path,
+            )
+        except Exception:  # noqa: BLE001
+            continue
+        return svc
+    return None
+
+
+def load_operator_view(config_path: Path) -> OperatorDashboardView:
+    """Read the workspace config + every project DB into the view model.
+
+    Mirrors the rail-badge data path so the dashboard and rail see
+    the same projects and the same inbox-waits-on-user list. Each
+    project gets its own work-service handle, opened against the
+    canonical workspace DB first and the legacy per-project DB
+    second (matching the rail rollup's iteration order).
+    """
+    from pollypm.config import load_config
+
+    config = load_config(config_path)
+    return load_operator_view_from_config(config)
+
+
+def load_operator_view_from_config(config) -> OperatorDashboardView:  # noqa: ANN001
+    """Like :func:`load_operator_view` but starting from a loaded config.
+
+    Useful for tests + callers that have a config in hand and want to
+    avoid re-parsing the TOML.
+    """
+    scans = _collect_project_scans(config)
+    waiting_by_project = _waiting_items_by_project(config)
+
+    waiting: list[OperatorDashboardRow] = []
+    working: list[OperatorDashboardRow] = []
+    idle: list[OperatorDashboardRow] = []
+    paused: list[OperatorDashboardRow] = []
+
+    for scan in scans:
+        svc = _open_work_service(scan)
+        items = waiting_by_project.get(scan.project_key, [])
+        try:
+            if svc is None:
+                state = (
+                    ProjectState.WAITING if items
+                    else (ProjectState.PAUSED if not scan.tracked else ProjectState.IDLE)
+                )
+                detail = (
+                    why_waiting(items) if state is ProjectState.WAITING
+                    else ("Paused" if state is ProjectState.PAUSED else "Quiet")
+                )
+                row = OperatorDashboardRow(
+                    project_key=scan.project_key,
+                    state=state,
+                    glyph=glyph_for_project_state(state),
+                    detail=detail,
+                )
+            else:
+                state = categorize_project(
+                    scan.project_key,
+                    work_service=svc,
+                    inbox_items=items,
+                    tracked=scan.tracked,
+                )
+                glyph = glyph_for_project_state(state)
+                if state is ProjectState.WAITING:
+                    detail = why_waiting(items)
+                elif state is ProjectState.WORKING:
+                    detail = what_working(scan.project_key, work_service=svc)
+                elif state is ProjectState.PAUSED:
+                    detail = "Paused"
+                else:
+                    detail = "Quiet"
+                row = OperatorDashboardRow(
+                    project_key=scan.project_key,
+                    state=state,
+                    glyph=glyph,
+                    detail=detail,
+                )
+        finally:
+            close = getattr(svc, "close", None) if svc is not None else None
+            if callable(close):
+                try:
+                    close()
+                except Exception:  # noqa: BLE001
+                    pass
+
+        if row.state is ProjectState.WAITING:
+            waiting.append(row)
+        elif row.state is ProjectState.WORKING:
+            working.append(row)
+        elif row.state is ProjectState.PAUSED:
+            paused.append(row)
+        else:
+            idle.append(row)
+
+    waiting.sort(key=lambda r: r.project_key.lower())
+    working.sort(key=lambda r: r.project_key.lower())
+    idle.sort(key=lambda r: r.project_key.lower())
+    paused.sort(key=lambda r: r.project_key.lower())
+    return OperatorDashboardView(
+        waiting=tuple(waiting),
+        working=tuple(working),
+        idle=tuple(idle),
+        paused=tuple(paused),
+    )
+
+
+def project_state_map_from_config(config) -> dict[str, ProjectState]:  # noqa: ANN001
+    """Return ``{project_key: ProjectState}`` for every project in ``config``.
+
+    The rail uses this to pick its glyph from the same source the
+    dashboard uses — guaranteeing the section a project appears in
+    matches the glyph drawn next to it. The function is best-effort:
+    a project whose DB can't be opened falls through to a tracked /
+    paused IDLE classification rather than raising.
+    """
+    scans = _collect_project_scans(config)
+    waiting_by_project = _waiting_items_by_project(config)
+    states: dict[str, ProjectState] = {}
+    for scan in scans:
+        svc = _open_work_service(scan)
+        items = waiting_by_project.get(scan.project_key, [])
+        try:
+            if svc is None:
+                if items:
+                    states[scan.project_key] = ProjectState.WAITING
+                elif not scan.tracked:
+                    states[scan.project_key] = ProjectState.PAUSED
+                else:
+                    states[scan.project_key] = ProjectState.IDLE
+                continue
+            states[scan.project_key] = categorize_project(
+                scan.project_key,
+                work_service=svc,
+                inbox_items=items,
+                tracked=scan.tracked,
+            )
+        finally:
+            close = getattr(svc, "close", None) if svc is not None else None
+            if callable(close):
+                try:
+                    close()
+                except Exception:  # noqa: BLE001
+                    pass
+    return states
+
+
+def view_as_ascii(view: OperatorDashboardView) -> str:
+    """Render an operator dashboard view as ASCII text (for tests + PR body)."""
+    lines: list[str] = []
+
+    def _section(title: str, rows: Iterable[OperatorDashboardRow], empty: str) -> None:
+        lines.append(title)
+        rendered = list(rows)
+        if not rendered:
+            lines.append(f"  {empty}")
+            lines.append("")
+            return
+        for row in rendered:
+            glyph = row.glyph or glyph_for_project_state(row.state)
+            lines.append(f"  {glyph} {row.project_key}  {row.detail}")
+        lines.append("")
+
+    _section("Waiting on you", view.waiting, "Nothing waiting.")
+    _section("Working", view.working, "Nothing actively working.")
+    _section("Idle", view.idle, "All projects busy.")
+    if view.paused:
+        _section("Paused", view.paused, "")
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/pollypm/dashboard/operator_view.py
+++ b/src/pollypm/dashboard/operator_view.py
@@ -103,9 +103,22 @@ def _waiting_items_by_project(config) -> dict[str, list]:  # noqa: ANN001
 
 
 def _open_work_service(scan: _ProjectScan):  # noqa: ANN202
-    """Open the first usable work-service handle for ``scan``."""
+    """Open the first work-service handle that has rows for ``scan``.
+
+    Mirrors ``cockpit_rail._project_tasks_for_rollup``'s canonical →
+    legacy walk: try each candidate DB in order, prefer the first one
+    that returns at least one task row for the project key, fall
+    through to the next candidate when the current DB is empty. This
+    keeps the dashboard and the rail in sync on which DB a project's
+    state lives in — without it, a canonical workspace DB that simply
+    opens (but has no rows for the project) would silently shadow the
+    legacy per-project DB where the real work lives.
+
+    Returns the handle the caller should close.
+    """
     from pollypm.work import create_work_service
 
+    fallback = None
     for db_path in scan.db_paths:
         try:
             svc = create_work_service(
@@ -113,8 +126,28 @@ def _open_work_service(scan: _ProjectScan):  # noqa: ANN202
             )
         except Exception:  # noqa: BLE001
             continue
-        return svc
-    return None
+        try:
+            tasks = svc.list_tasks(project=scan.project_key)
+        except Exception:  # noqa: BLE001
+            tasks = []
+        if tasks:
+            if fallback is not None and fallback is not svc:
+                _safe_close(fallback)
+            return svc
+        if fallback is None:
+            fallback = svc
+        else:
+            _safe_close(svc)
+    return fallback
+
+
+def _safe_close(svc) -> None:  # noqa: ANN001
+    close = getattr(svc, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:  # noqa: BLE001
+            pass
 
 
 def load_operator_view(config_path: Path) -> OperatorDashboardView:

--- a/src/pollypm/plugins_builtin/core_rail_items/plugin.py
+++ b/src/pollypm/plugins_builtin/core_rail_items/plugin.py
@@ -510,6 +510,17 @@ def _initialize(api) -> None:  # noqa: ANN001
         key="dashboard",
         state_provider=lambda _ctx: "home",
     )
+    # #1572 — operator dashboard (Waiting / Working / Idle). Sits
+    # directly under Home so the 1-second "what's the state of the
+    # system?" surface is one keystroke away.
+    rail.register_item(
+        section="top",
+        index=5,
+        label="Operator",
+        handler=_route_handler("operator"),
+        key="operator",
+        state_provider=lambda _ctx: "ready",
+    )
     rail.register_item(
         section="top",
         index=10,

--- a/tests/test_cockpit_rail_operator_glyphs.py
+++ b/tests/test_cockpit_rail_operator_glyphs.py
@@ -1,0 +1,126 @@
+"""Rail glyph vocabulary tests (#1572).
+
+Pins the load-bearing invariant from the issue spec: the section a
+project lands in on the operator dashboard MUST match the glyph the
+rail paints for it. Both surfaces read from
+:func:`pollypm.dashboard.categorize_project`; the test exercises the
+rail's ``_indicator`` directly against a synthetic ``CockpitItem``
+seeded with the per-project state the dashboard would compute, then
+compares the glyph to the dashboard's ``glyph_for_project_state``.
+
+The check is intentionally low-level: ``_indicator`` is the rail's
+glyph selector and the dashboard's ``glyph_for_project_state`` is the
+canonical glyph table. If a future change drifts one without the
+other, this test breaks before the user notices.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pollypm.cockpit_rail import CockpitItem, PollyCockpitRail
+from pollypm.dashboard import (
+    ProjectState,
+    glyph_for_project_state,
+)
+
+
+def _rail() -> PollyCockpitRail:
+    """Build a rail instance without running it (no I/O, no config load)."""
+    return PollyCockpitRail.__new__(PollyCockpitRail)
+
+
+def _item(*, project_state: str | None) -> CockpitItem:
+    return CockpitItem(
+        key="project:demo",
+        label="demo",
+        state="project-green",
+        project_state=project_state,
+    )
+
+
+def test_rail_indicator_uses_waiting_glyph() -> None:
+    rail = _rail()
+    glyph, _color = rail._indicator(_item(project_state="waiting"))
+    assert glyph == glyph_for_project_state(ProjectState.WAITING)
+
+
+def test_rail_indicator_uses_working_glyph() -> None:
+    rail = _rail()
+    glyph, _color = rail._indicator(_item(project_state="working"))
+    assert glyph == glyph_for_project_state(ProjectState.WORKING)
+
+
+def test_rail_indicator_uses_idle_glyph() -> None:
+    rail = _rail()
+    glyph, _color = rail._indicator(_item(project_state="idle"))
+    assert glyph == glyph_for_project_state(ProjectState.IDLE)
+
+
+def test_rail_indicator_uses_paused_glyph() -> None:
+    rail = _rail()
+    glyph, _color = rail._indicator(_item(project_state="paused"))
+    assert glyph == glyph_for_project_state(ProjectState.PAUSED)
+
+
+def test_rail_indicator_categorization_overrides_legacy_state() -> None:
+    """When categorization is present, the new vocabulary wins.
+
+    The legacy ``state="project-green"`` field would have selected the
+    ``•`` (small bullet) glyph; the new ``project_state="working"``
+    must override it to ``●`` so the rail and the dashboard agree.
+    """
+    rail = _rail()
+    glyph, _color = rail._indicator(
+        CockpitItem(
+            key="project:demo",
+            label="demo",
+            state="project-green",
+            project_state="working",
+        )
+    )
+    assert glyph == "●"
+
+
+def test_rail_indicator_operational_red_still_wins() -> None:
+    """Operational fault keeps its dedicated glyph even with categorization."""
+    rail = _rail()
+    glyph, _color = rail._indicator(
+        CockpitItem(
+            key="project:demo",
+            label="demo",
+            state="project-red",
+            project_state="waiting",
+            alert_severity="error",
+        )
+    )
+    assert glyph == "▲"  # ▲ operational alert
+
+
+def test_rail_indicator_approvals_pending_still_wins() -> None:
+    """Approvals-pending ▶ marker keeps precedence over the new glyphs."""
+    rail = _rail()
+    glyph, _color = rail._indicator(
+        CockpitItem(
+            key="project:demo",
+            label="demo",
+            state="project-green",
+            project_state="working",
+            approvals_pending=2,
+        )
+    )
+    assert glyph == "▶"  # ▶ — the approvals-pending affordance
+
+
+def test_dashboard_and_rail_agree_for_every_state() -> None:
+    """Same enum drives both surfaces — the per-row check that pins
+    the invariant the user can see at a glance."""
+    rail = _rail()
+    for state in ProjectState:
+        expected = glyph_for_project_state(state)
+        item = _item(project_state=state.value)
+        glyph, _color = rail._indicator(item)
+        assert glyph == expected, (
+            f"rail/dashboard glyph drift for {state.value}: "
+            f"rail={glyph!r} dashboard={expected!r}"
+        )

--- a/tests/test_dashboard_categorization.py
+++ b/tests/test_dashboard_categorization.py
@@ -1,0 +1,356 @@
+"""Categorization unit tests (#1572).
+
+Pins the contracts the operator dashboard + rail glyph share:
+
+* ``categorize_project`` returns the right ``ProjectState`` for each
+  combination of inbox items / live workers / in-flight tasks, with
+  WAITING winning over WORKING in the collision case (the load-bearing
+  invariant from the issue spec).
+* ``why_waiting`` maps every documented kind to its user-facing copy
+  and honours the documented priority ordering when multiple items
+  are present.
+* ``what_working`` picks the most-recent worker on multi-worker
+  projects and degrades gracefully when no worker is bound.
+* ``glyph_for_project_state`` returns the documented ``◆ ● ○ ⏸``
+  vocabulary — the rail and the dashboard import this same function.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from pollypm.dashboard import (
+    ProjectState,
+    build_operator_dashboard_view,
+    categorize_project,
+    glyph_for_project_state,
+    what_working,
+    why_waiting,
+)
+from pollypm.inbox.kind import InboxItemKind
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+def _item(*, kind, project="demo", title="", scope=""):
+    return SimpleNamespace(
+        kind=kind, project=project, scope=scope, title=title,
+    )
+
+
+def _worker(*, project="demo", task_number=1, agent_name="claude", started_at="2026-05-17T10:00:00"):
+    return SimpleNamespace(
+        task_project=project,
+        task_number=task_number,
+        agent_name=agent_name,
+        started_at=started_at,
+    )
+
+
+def _task(*, project="demo", title="t", status="in_progress", task_id=None):
+    return SimpleNamespace(
+        project=project,
+        title=title,
+        work_status=SimpleNamespace(value=status),
+        task_id=task_id or f"{project}/1",
+    )
+
+
+class FakeWorkService:
+    def __init__(self, *, workers=None, tasks=None, raise_on_workers=False, raise_on_tasks=False):
+        self.workers = workers or []
+        self.tasks = tasks or []
+        self.raise_on_workers = raise_on_workers
+        self.raise_on_tasks = raise_on_tasks
+        self._by_id = {getattr(t, "task_id", f"{t.project}/1"): t for t in self.tasks}
+
+    def list_worker_sessions(self, *, project=None, active_only=True):
+        if self.raise_on_workers:
+            raise RuntimeError("boom")
+        out = []
+        for w in self.workers:
+            if project is not None and getattr(w, "task_project", None) != project:
+                continue
+            out.append(w)
+        return out
+
+    def list_tasks(self, *, project=None, **_kwargs):
+        if self.raise_on_tasks:
+            raise RuntimeError("boom")
+        out = []
+        for t in self.tasks:
+            if project is not None and getattr(t, "project", None) != project:
+                continue
+            out.append(t)
+        return out
+
+    def get(self, task_id):
+        try:
+            return self._by_id[task_id]
+        except KeyError as exc:
+            raise LookupError(task_id) from exc
+
+
+# ---------------------------------------------------------------------------
+# glyph_for_project_state
+# ---------------------------------------------------------------------------
+
+
+def test_glyph_vocabulary_matches_spec() -> None:
+    assert glyph_for_project_state(ProjectState.WAITING) == "◆"
+    assert glyph_for_project_state(ProjectState.WORKING) == "●"
+    assert glyph_for_project_state(ProjectState.IDLE) == "○"
+    assert glyph_for_project_state(ProjectState.PAUSED) == "⏸"
+
+
+# ---------------------------------------------------------------------------
+# categorize_project
+# ---------------------------------------------------------------------------
+
+
+def test_categorize_waiting_when_item_awaits_user() -> None:
+    svc = FakeWorkService()
+    items = [_item(kind=InboxItemKind.APPROVAL_REQUEST)]
+    assert categorize_project("demo", work_service=svc, inbox_items=items) is ProjectState.WAITING
+
+
+def test_categorize_waiting_wins_over_working_collision() -> None:
+    """Load-bearing invariant: Waiting beats Working when both apply."""
+    svc = FakeWorkService(
+        workers=[_worker()],
+        tasks=[_task(status="in_progress")],
+    )
+    items = [_item(kind=InboxItemKind.PLAN_REVIEW_PENDING)]
+    assert categorize_project("demo", work_service=svc, inbox_items=items) is ProjectState.WAITING
+
+
+def test_categorize_working_when_live_worker() -> None:
+    svc = FakeWorkService(workers=[_worker()])
+    assert categorize_project("demo", work_service=svc) is ProjectState.WORKING
+
+
+def test_categorize_working_when_task_in_progress() -> None:
+    svc = FakeWorkService(tasks=[_task(status="in_progress")])
+    assert categorize_project("demo", work_service=svc) is ProjectState.WORKING
+
+
+def test_categorize_working_when_task_in_rework() -> None:
+    svc = FakeWorkService(tasks=[_task(status="rework")])
+    assert categorize_project("demo", work_service=svc) is ProjectState.WORKING
+
+
+def test_categorize_idle_when_nothing_active() -> None:
+    svc = FakeWorkService(tasks=[_task(status="done")])
+    assert categorize_project("demo", work_service=svc) is ProjectState.IDLE
+
+
+def test_categorize_idle_when_only_waiting_status_tasks() -> None:
+    """Tasks parked on user-waiting statuses don't count as Working."""
+    svc = FakeWorkService(tasks=[_task(status="on_hold")])
+    assert categorize_project("demo", work_service=svc) is ProjectState.IDLE
+
+
+def test_categorize_paused_when_untracked_and_quiet() -> None:
+    svc = FakeWorkService()
+    assert categorize_project("demo", work_service=svc, tracked=False) is ProjectState.PAUSED
+
+
+def test_paused_with_waiting_items_surfaces_as_waiting() -> None:
+    """Per cycle-87 asymmetry: paused projects with items still surface."""
+    svc = FakeWorkService()
+    items = [_item(kind=InboxItemKind.PLAN_REVIEW_PENDING)]
+    state = categorize_project("demo", work_service=svc, inbox_items=items, tracked=False)
+    assert state is ProjectState.WAITING
+
+
+def test_legacy_kind_treated_as_waiting() -> None:
+    """The predicate's fail-open contract: LEGACY items count as awaits_user."""
+    svc = FakeWorkService()
+    items = [_item(kind=InboxItemKind.LEGACY)]
+    assert categorize_project("demo", work_service=svc, inbox_items=items) is ProjectState.WAITING
+
+
+def test_informational_kinds_do_not_trigger_waiting() -> None:
+    svc = FakeWorkService()
+    items = [
+        _item(kind=InboxItemKind.COMPLETION_FYI),
+        _item(kind=InboxItemKind.INFO),
+        _item(kind=InboxItemKind.ACTIVITY_EVENT),
+        _item(kind=InboxItemKind.SELF_BUG_REPORT),
+    ]
+    assert categorize_project("demo", work_service=svc, inbox_items=items) is ProjectState.IDLE
+
+
+def test_items_for_other_project_do_not_leak() -> None:
+    svc = FakeWorkService()
+    items = [_item(kind=InboxItemKind.APPROVAL_REQUEST, project="other")]
+    assert categorize_project("demo", work_service=svc, inbox_items=items) is ProjectState.IDLE
+
+
+def test_work_service_failures_degrade_to_idle() -> None:
+    svc = FakeWorkService(raise_on_workers=True, raise_on_tasks=True)
+    assert categorize_project("demo", work_service=svc) is ProjectState.IDLE
+
+
+def test_scope_used_when_project_field_blank() -> None:
+    svc = FakeWorkService()
+    items = [_item(kind=InboxItemKind.APPROVAL_REQUEST, project="", scope="demo")]
+    assert categorize_project("demo", work_service=svc, inbox_items=items) is ProjectState.WAITING
+
+
+# ---------------------------------------------------------------------------
+# why_waiting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kind,expected",
+    [
+        (InboxItemKind.PLAN_REVIEW_PENDING, "Needs your review of the new plan"),
+        (InboxItemKind.APPROVAL_REQUEST, "Needs your approval"),
+        (InboxItemKind.PM_QUESTION_UNANSWERED, "PM is waiting on your reply"),
+        (InboxItemKind.MANUAL_DECISION, "Polly needs your decision"),
+    ],
+)
+def test_why_waiting_static_copy(kind, expected) -> None:
+    assert why_waiting([_item(kind=kind)]) == expected
+
+
+def test_why_waiting_watchdog_interpolates_subject() -> None:
+    item = _item(kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH, title="stuck on auth")
+    assert why_waiting([item]) == "Watchdog escalated: stuck on auth"
+
+
+def test_why_waiting_watchdog_no_subject_uses_fallback() -> None:
+    item = _item(kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH, title="")
+    assert why_waiting([item]) == "Watchdog escalation"
+
+
+def test_why_waiting_priority_ordering() -> None:
+    """plan_review > approval > watchdog > pm_question > manual_decision."""
+    items = [
+        _item(kind=InboxItemKind.MANUAL_DECISION, title="manual"),
+        _item(kind=InboxItemKind.APPROVAL_REQUEST, title="approve"),
+        _item(kind=InboxItemKind.PLAN_REVIEW_PENDING, title="plan"),
+        _item(kind=InboxItemKind.PM_QUESTION_UNANSWERED, title="pm"),
+        _item(kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH, title="wd"),
+    ]
+    assert why_waiting(items) == "Needs your review of the new plan"
+
+    # Drop plan_review — approval wins.
+    items_without_plan = [i for i in items if i.kind is not InboxItemKind.PLAN_REVIEW_PENDING]
+    assert why_waiting(items_without_plan) == "Needs your approval"
+
+    # Drop plan_review + approval — watchdog wins.
+    remaining = [
+        i for i in items
+        if i.kind not in {InboxItemKind.PLAN_REVIEW_PENDING, InboxItemKind.APPROVAL_REQUEST}
+    ]
+    assert why_waiting(remaining) == "Watchdog escalated: wd"
+
+
+def test_why_waiting_legacy_fallback() -> None:
+    assert why_waiting([_item(kind=InboxItemKind.LEGACY)]) == "Needs your attention"
+    assert why_waiting([]) == "Needs your attention"
+
+
+# ---------------------------------------------------------------------------
+# what_working
+# ---------------------------------------------------------------------------
+
+
+def test_what_working_single_worker() -> None:
+    svc = FakeWorkService(
+        workers=[_worker(agent_name="claude", task_number=7)],
+        tasks=[_task(title="rebuild auth", task_id="demo/7")],
+    )
+    assert what_working("demo", work_service=svc) == "claude: rebuild auth"
+
+
+def test_what_working_picks_most_recent_worker() -> None:
+    svc = FakeWorkService(
+        workers=[
+            _worker(agent_name="alpha", task_number=1, started_at="2026-05-15T10:00:00"),
+            _worker(agent_name="beta", task_number=2, started_at="2026-05-17T11:00:00"),
+            _worker(agent_name="gamma", task_number=3, started_at="2026-05-16T10:00:00"),
+        ],
+        tasks=[
+            _task(title="t-alpha", task_id="demo/1"),
+            _task(title="t-beta", task_id="demo/2"),
+            _task(title="t-gamma", task_id="demo/3"),
+        ],
+    )
+    assert what_working("demo", work_service=svc) == "beta: t-beta"
+
+
+def test_what_working_no_worker_falls_back_to_status() -> None:
+    svc = FakeWorkService(tasks=[_task(status="in_progress", title="refactor")])
+    assert what_working("demo", work_service=svc) == "in progress: refactor"
+
+
+def test_what_working_no_data_yields_active_fallback() -> None:
+    svc = FakeWorkService()
+    assert what_working("demo", work_service=svc) == "Active"
+
+
+def test_what_working_truncates_long_lines() -> None:
+    title = "x" * 200
+    svc = FakeWorkService(
+        workers=[_worker(agent_name="claude", task_number=1)],
+        tasks=[_task(title=title, task_id="demo/1")],
+    )
+    rendered = what_working("demo", work_service=svc)
+    assert len(rendered) <= 80
+    assert rendered.endswith("…")
+
+
+# ---------------------------------------------------------------------------
+# build_operator_dashboard_view — integration over the in-memory fixture
+# ---------------------------------------------------------------------------
+
+
+def test_build_view_places_projects_in_one_section_each() -> None:
+    """Same fixture, single pass, mutually-exclusive sections."""
+    svc = FakeWorkService(
+        workers=[_worker(project="working_proj", agent_name="claude", task_number=1)],
+        tasks=[
+            _task(project="working_proj", title="ship feature", task_id="working_proj/1"),
+            _task(project="idle_proj", status="done", task_id="idle_proj/1"),
+        ],
+    )
+    inbox = {
+        "waiting_proj": [_item(kind=InboxItemKind.APPROVAL_REQUEST, project="waiting_proj")],
+    }
+    view = build_operator_dashboard_view(
+        ["waiting_proj", "working_proj", "idle_proj", "paused_proj"],
+        work_service=svc,
+        inbox_items_by_project=inbox,
+        tracked_by_project={"paused_proj": False},
+    )
+
+    assert [r.project_key for r in view.waiting] == ["waiting_proj"]
+    assert [r.project_key for r in view.working] == ["working_proj"]
+    assert [r.project_key for r in view.idle] == ["idle_proj"]
+    assert [r.project_key for r in view.paused] == ["paused_proj"]
+
+    waiting_row = view.waiting[0]
+    assert waiting_row.glyph == glyph_for_project_state(ProjectState.WAITING)
+    assert waiting_row.detail == "Needs your approval"
+
+    working_row = view.working[0]
+    assert working_row.glyph == glyph_for_project_state(ProjectState.WORKING)
+    assert working_row.detail == "claude: ship feature"
+
+
+def test_build_view_empty_input_returns_empty_view() -> None:
+    svc = FakeWorkService()
+    view = build_operator_dashboard_view([], work_service=svc)
+    assert view.waiting == ()
+    assert view.working == ()
+    assert view.idle == ()
+    assert view.paused == ()

--- a/tests/test_dashboard_operator_view.py
+++ b/tests/test_dashboard_operator_view.py
@@ -1,0 +1,204 @@
+"""Operator dashboard view + ASCII render tests (#1572).
+
+End-to-end coverage of the view-model loader against a populated
+SQLite workspace + the ASCII renderer used by the cockpit text-pane
+fallback (and the PR-body screenshot).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pollypm.dashboard import ProjectState
+from pollypm.dashboard.operator_view import (
+    load_operator_view,
+    project_state_map_from_config,
+    view_as_ascii,
+)
+from pollypm.inbox.kind import InboxItemKind
+from pollypm.work.sqlite_service import SQLiteWorkService
+
+
+def _write_config(workspace_root: Path, config_path: Path, projects: dict[str, dict]) -> None:
+    lines = [
+        "[project]\n",
+        'tmux_session = "pollypm-test"\n',
+        f'workspace_root = "{workspace_root}"\n',
+        "\n",
+    ]
+    for key, spec in projects.items():
+        lines.append(f"[projects.{key}]\n")
+        lines.append(f'key = "{key}"\n')
+        lines.append(f'name = "{spec.get("name", key.title())}"\n')
+        lines.append(f'path = "{spec["path"]}"\n')
+        if "tracked" in spec:
+            lines.append(f'tracked = {str(spec["tracked"]).lower()}\n')
+        lines.append("\n")
+    config_path.write_text("".join(lines))
+
+
+def _seed_task(
+    db_path: Path,
+    project_path: Path,
+    *,
+    project: str,
+    title: str,
+    kind: str,
+    status: str | None = None,
+) -> str:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    svc = SQLiteWorkService(db_path=db_path, project_path=project_path)
+    try:
+        task = svc.create(
+            title=title,
+            description=f"body for {title}",
+            type="task",
+            project=project,
+            flow_template="chat",
+            roles={"requester": "user", "operator": "polly"},
+            priority="normal",
+            created_by="polly",
+            kind=kind,
+        )
+        if status == "in_progress":
+            svc.queue(task.task_id, actor="polly", skip_gates=True)
+            svc.claim(task.task_id, actor="claude")
+        return task.task_id
+    finally:
+        svc.close()
+
+
+@pytest.fixture
+def workspace(tmp_path: Path):
+    workspace_root = tmp_path / "dev"
+    workspace_root.mkdir()
+    waiting = workspace_root / "waiting_proj"
+    waiting.mkdir()
+    (waiting / ".git").mkdir()
+    working = workspace_root / "working_proj"
+    working.mkdir()
+    (working / ".git").mkdir()
+    idle = workspace_root / "idle_proj"
+    idle.mkdir()
+    (idle / ".git").mkdir()
+    paused = workspace_root / "paused_proj"
+    paused.mkdir()
+    (paused / ".git").mkdir()
+
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(
+        workspace_root, config_path,
+        {
+            "waiting_proj": {"path": str(waiting), "tracked": True},
+            "working_proj": {"path": str(working), "tracked": True},
+            "idle_proj": {"path": str(idle), "tracked": True},
+            "paused_proj": {"path": str(paused), "tracked": False},
+        },
+    )
+
+    _seed_task(
+        waiting / ".pollypm" / "state.db", waiting,
+        project="waiting_proj",
+        title="approve the plan",
+        kind=InboxItemKind.APPROVAL_REQUEST.value,
+    )
+    _seed_task(
+        working / ".pollypm" / "state.db", working,
+        project="working_proj",
+        title="ship feature",
+        kind=InboxItemKind.INFO.value,
+        status="in_progress",
+    )
+    _seed_task(
+        idle / ".pollypm" / "state.db", idle,
+        project="idle_proj",
+        title="idle stub",
+        kind=InboxItemKind.INFO.value,
+    )
+
+    return {
+        "config_path": config_path,
+        "workspace_root": workspace_root,
+        "projects": {
+            "waiting": waiting,
+            "working": working,
+            "idle": idle,
+            "paused": paused,
+        },
+    }
+
+
+def test_load_view_partitions_projects(workspace) -> None:
+    view = load_operator_view(workspace["config_path"])
+    waiting_keys = [r.project_key for r in view.waiting]
+    working_keys = [r.project_key for r in view.working]
+    idle_keys = [r.project_key for r in view.idle]
+    paused_keys = [r.project_key for r in view.paused]
+
+    assert "waiting_proj" in waiting_keys
+    assert "working_proj" in working_keys
+    assert "idle_proj" in idle_keys
+    assert "paused_proj" in paused_keys
+
+    # No project appears twice.
+    every = waiting_keys + working_keys + idle_keys + paused_keys
+    assert len(every) == len(set(every))
+
+
+def test_load_view_detail_strings(workspace) -> None:
+    view = load_operator_view(workspace["config_path"])
+    waiting_row = next(r for r in view.waiting if r.project_key == "waiting_proj")
+    assert waiting_row.detail == "Needs your approval"
+    assert waiting_row.glyph == "◆"
+
+    working_row = next(r for r in view.working if r.project_key == "working_proj")
+    assert "ship feature" in working_row.detail
+    assert working_row.glyph == "●"
+
+
+def test_state_map_agrees_with_view(workspace) -> None:
+    """The rail and the dashboard must read the same per-project state."""
+    from pollypm.config import load_config
+
+    config = load_config(workspace["config_path"])
+    state_map = project_state_map_from_config(config)
+    view = load_operator_view(workspace["config_path"])
+
+    expected = {}
+    for row in view.waiting:
+        expected[row.project_key] = ProjectState.WAITING
+    for row in view.working:
+        expected[row.project_key] = ProjectState.WORKING
+    for row in view.idle:
+        expected[row.project_key] = ProjectState.IDLE
+    for row in view.paused:
+        expected[row.project_key] = ProjectState.PAUSED
+
+    for key, state in expected.items():
+        assert state_map[key] is state, (
+            f"{key}: dashboard says {state.value}, rail map says {state_map[key].value}"
+        )
+
+
+def test_ascii_render_includes_all_sections(workspace) -> None:
+    view = load_operator_view(workspace["config_path"])
+    out = view_as_ascii(view)
+    assert "Waiting on you" in out
+    assert "Working" in out
+    assert "Idle" in out
+    assert "◆ waiting_proj" in out
+    assert "● working_proj" in out
+    assert "○ idle_proj" in out
+    # Paused section appears when there are paused projects.
+    assert "Paused" in out
+    assert "⏸ paused_proj" in out
+
+
+def test_ascii_render_handles_empty_view() -> None:
+    from pollypm.dashboard.categorization import OperatorDashboardView
+
+    out = view_as_ascii(OperatorDashboardView())
+    assert "Nothing waiting." in out
+    assert "Nothing actively working." in out


### PR DESCRIPTION
Closes #1572. Part of epic #1564.

## Summary

- New leaf module `pollypm.dashboard` with `ProjectState` enum, `categorize_project()`, `why_waiting()`, `what_working()`, `glyph_for_project_state()` — single source of truth shared by the rail and the dashboard.
- New `PollyOperatorDashboardApp` Textual app rendering three sections (Waiting on you / Working / Idle, plus a Paused section when applicable), wired through `cockpit_rail_routes`, the `core_rail_items` plugin, and `cli_features/ui.py`.
- Rail glyph vocabulary extended to `◆ ● ○ ⏸` for WAITING / WORKING / IDLE / PAUSED. Categorization threads through `CockpitItem.project_state`; `_indicator` consults the new field so the dashboard section a project lands in always matches the glyph drawn next to it. Operational-fault overrides (RED alerts, ▶ approvals-pending) keep precedence.

## Dashboard render (fixed fixture)

```
Waiting on you
  ◆ pollypm  Needs your review of the new plan
  ◆ savethenovel  PM is waiting on your reply

Working
  ● booktalk  claude: refactor inbox view
  ● media  codex: ship rail glyph spec

Idle
  ○ demo  Last activity 2026-05-15
  ○ shortlink  Last activity 2026-05-12

Paused
  ⏸ archived_v1  Paused
```

## Architecture

- `pollypm.dashboard.categorization` is a leaf — imports only `pollypm.inbox.awaits_user`, `pollypm.inbox.kind.InboxItemKind`, and a structural work-service Protocol. No cockpit / Supervisor / sqlite3.
- `pollypm.dashboard.operator_view` is the I/O bridge: opens work-service handles per project (canonical workspace DB then legacy per-project DB), runs the workspace-wide `pm_inbox_awaits_user_list`, and packs the view model.
- The new operator dashboard app reads exclusively through `pollypm.dashboard.operator_view`. No `Supervisor` import → no `test_import_boundary` allow-list addition.
- The rail's `_project_categorizations` helper delegates to the same `project_state_map_from_config` the dashboard uses, so the rail and the dashboard cannot drift.
- Per cycle-87 tracked-filter asymmetry: paused-but-with-items projects still surface as WAITING (mirrors the rail, not the recovery prompt).

## Tests

- `tests/test_dashboard_categorization.py` (30 tests): every state, waiting-wins-over-working collision, why_waiting per-kind copy + priority ordering, what_working multi-worker tiebreak + 80-char truncation + graceful empty.
- `tests/test_dashboard_operator_view.py` (5 tests): end-to-end loader against a populated SQLite workspace + ASCII render coverage.
- `tests/test_cockpit_rail_operator_glyphs.py` (8 tests): rail/dashboard glyph-agreement invariant, operational-fault and approvals-pending overrides.

Baseline subset before/after (per task spec): `pytest tests/test_cockpit_rail*.py tests/test_cockpit_inbox*.py tests/test_inbox*.py tests/test_audit_log.py tests/test_polly_dashboard_ui.py` → 386 passed both before and after (no regressions).

Additional targeted suites green after: `tests/test_cockpit.py` (194), `tests/test_core_rail.py` + `test_core_rail_items.py` (40), `tests/test_cockpit_pane_app.py` (2).

## Test plan

- [ ] Open `pm cockpit-pane operator` and confirm Waiting / Working / Idle sections render with the new glyphs.
- [ ] Confirm a project with both a live worker AND a `plan_review_pending` inbox item shows in Waiting (not Working) and renders `◆` on the rail.
- [ ] Confirm an untracked-but-quiet project shows in Paused with `⏸`.
- [ ] Confirm the rail glyph for every visible project matches the section it appears in on the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)