### PR TITLE
Fix #1581 register 'advisor' in role_routing

### DIFF
--- a/src/pollypm/role_routing.py
+++ b/src/pollypm/role_routing.py
@@ -11,12 +11,13 @@ from pollypm.models import ModelAssignment, PollyPMConfig, ProviderKind
 
 
 _log = logging.getLogger(__name__)
-_ROLE_KEYS = ("operator_pm", "architect", "worker", "reviewer")
+_ROLE_KEYS = ("operator_pm", "architect", "worker", "reviewer", "advisor")
 _FALLBACK_ASSIGNMENTS: dict[str, ModelAssignment] = {
     "operator_pm": ModelAssignment(alias="codex-gpt-5.4"),
     "architect": ModelAssignment(alias="opus-4.7"),
     "worker": ModelAssignment(alias="codex-gpt-5.4"),
     "reviewer": ModelAssignment(alias="sonnet-4.6"),
+    "advisor": ModelAssignment(alias="opus-4.7"),
 }
 
 


### PR DESCRIPTION
## Summary

- Adds `"advisor"` to `_ROLE_KEYS` and a `_FALLBACK_ASSIGNMENTS["advisor"]` entry in `src/pollypm/role_routing.py`.
- Fixes #1581: `audit_watchdog._self_heal_role_session_missing` was raising `ValueError: Unknown role 'advisor'` on every tick (~53 failures/day, one per project every 30-50s), silently breaking watchdog auto-spawn of advisor lanes.
- Aliased to `opus-4.7` (matches `architect` fallback) — advisor work is reasoning-heavy (project trajectory review, stall/blocker detection, structural insights) and the advisor plugin doesn't specify its own model, so it inherits the role default.

## Why opus-4.7?

The advisor plugin (`src/pollypm/plugins_builtin/advisor/`) has no explicit model/alias references — it just emits a `roles={"advisor": "advisor"}` task and lets `role_routing` pick the model. The advisor profile is a "structural quality filter" persona that reviews recent activity and emits insights only when warranted. That matches the architect's reasoning profile more than the worker's execution profile, so opus-4.7 is the natural default. Per-project/global config overrides still work via the existing precedence chain.

## Test plan

- [x] `uv run --extra dev pytest tests/test_role_routing.py tests/test_audit_watchdog.py -x` — 101 passed
- [ ] Confirm watchdog `role-lane spawn failed for <project>/advisor` warnings stop appearing in errors.log after merge

## Scope

Smallest possible change: 2 lines added (one key in `_ROLE_KEYS`, one entry in `_FALLBACK_ASSIGNMENTS`). No refactors, no new imports, no boundary changes.