### PR TITLE
fix(inbox): tag watchdog-created tasks + extend backfill to work_tasks (#1564 follow-up)

### DIFF
--- a/src/pollypm/inbox/backfill_heuristics.py
+++ b/src/pollypm/inbox/backfill_heuristics.py
@@ -1,4 +1,4 @@
-"""Heuristic classifier for legacy inbox rows (#1570).
+"""Heuristic classifier for legacy inbox rows (#1570, #1564 follow-up).
 
 Pre-#1565 messages all surface with ``kind='legacy'`` because the
 column did not exist when they were written. The
@@ -8,6 +8,15 @@ window — but the dashboard's "Waiting on you" section then lumps
 ~133 historical rows together. This module is the one-time pass
 that reclassifies those rows by matching title + sender + project
 patterns observed in the real inbox.
+
+Two classifier entry points:
+
+* :func:`classify_legacy` — messages-shaped rows (title / sender /
+  scope). Original surface from #1570.
+* :func:`classify_legacy_task` — work_tasks-shaped rows (title /
+  created_by). Added in the #1564 follow-up so the dashboard's
+  "Watchdog escalated: …" rows (which come from the work_tasks
+  table, not messages) can also be retagged off ``legacy``.
 
 Pure leaf: depends only on the :class:`InboxItemKind` enum so it
 can be imported from the CLI command + tests without dragging in
@@ -29,6 +38,13 @@ mirrors the precedence in #1570's spec:
    :attr:`InboxItemKind.WATCHDOG_OPERATOR_DISPATCH`
 6. unmatched → ``None`` (leave the row as legacy; the awaits-user
    predicate still surfaces it for manual triage)
+
+The task-side classifier (:func:`classify_legacy_task`) is
+deliberately narrower: tasks don't carry a ``sender`` / ``scope``
+pair the way messages do, and the watchdog-created task rows the
+2026-05-17 dashboard surfaced are dominated by the
+queue-without-motion subject. Adding heuristics there that don't
+have field-observed evidence would just guess.
 """
 
 from __future__ import annotations
@@ -152,4 +168,82 @@ def classify_legacy(
     return None
 
 
-__all__ = ["Classification", "classify_legacy"]
+# ---------------------------------------------------------------------------
+# Task-side heuristics (#1564 follow-up)
+# ---------------------------------------------------------------------------
+
+
+# Substring of the queue_without_motion watchdog finding's message —
+# the exact title every legacy ``audit_watchdog``-created task in the
+# field carries when the watchdog escalated a wedged queue to the
+# operator. Match is case-insensitive; only the distinctive middle of
+# the phrase is checked so a future minor copy edit (e.g. "claim or
+# execution") doesn't silently break the rule.
+_WATCHDOG_QUEUE_WITHOUT_MOTION_TOKEN = "queued task"
+_WATCHDOG_QUEUE_WITHOUT_MOTION_TAIL = "claim / execution"
+
+# Watchdog operator-dispatch tasks created via
+# :func:`pollypm.dashboard.categorization.why_waiting` carry the prefix
+# below in any rerouted form. The cockpit copy "Watchdog escalated:"
+# is rendered only — it never ends up in storage — but we include the
+# token so a future producer that does name itself this way is caught.
+_WATCHDOG_ESCALATED_TOKEN = "watchdog escalated"
+
+# Tasks the watchdog files via
+# :func:`pollypm.work.plan_review_emit.emit_plan_review` use the
+# ``"Plan ready for review"`` prefix. Matching this here would
+# duplicate the message-side heuristic; the prefix check below reuses
+# the same constant so the two surfaces classify identically.
+
+
+def classify_legacy_task(
+    *,
+    title: str,
+    created_by: str,
+) -> Classification | None:
+    """Map a legacy ``work_tasks`` row to a new :class:`InboxItemKind`.
+
+    Returns ``None`` when no heuristic matches. The CLI uses ``None``
+    as the signal to leave the row's ``kind`` at ``legacy`` and add
+    it to the unmatched-row count — never as an excuse to guess.
+
+    Args:
+        title: the task's ``title`` column.
+        created_by: the task's ``created_by`` column (e.g.
+            ``"audit_watchdog"`` for watchdog-emitted dispatches).
+    """
+    title_l = (title or "").lower()
+    created_by_l = (created_by or "").lower()
+
+    # Rule 1: watchdog-emitted queue-without-motion escalations →
+    # WATCHDOG_OPERATOR_DISPATCH. Two shapes are matched:
+    # the literal "queued task(s) but no claim / execution …" finding
+    # body, and any future "Watchdog escalated:" prefix.
+    if created_by_l == "audit_watchdog":
+        if (
+            _WATCHDOG_QUEUE_WITHOUT_MOTION_TOKEN in title_l
+            and _WATCHDOG_QUEUE_WITHOUT_MOTION_TAIL in title_l
+        ):
+            return Classification(
+                kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH,
+                heuristic="watchdog_queue_without_motion",
+            )
+        if title_l.startswith(_WATCHDOG_ESCALATED_TOKEN):
+            return Classification(
+                kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH,
+                heuristic="watchdog_escalated_prefix",
+            )
+
+    # Rule 2: plan-review tasks (watchdog or architect emitter) →
+    # PLAN_REVIEW_PENDING. Matches the messages-side prefix rule so
+    # the two surfaces classify a plan-review pair identically.
+    if title_l.startswith(_PLAN_REVIEW_PREFIX):
+        return Classification(
+            kind=InboxItemKind.PLAN_REVIEW_PENDING,
+            heuristic="title_prefix:plan_ready_for_review",
+        )
+
+    return None
+
+
+__all__ = ["Classification", "classify_legacy", "classify_legacy_task"]

--- a/src/pollypm/work/inbox_cli.py
+++ b/src/pollypm/work/inbox_cli.py
@@ -20,7 +20,11 @@ import typer
 
 from pollypm.cli_help import help_with_examples
 from pollypm.inbox import awaits_user
-from pollypm.inbox.backfill_heuristics import Classification, classify_legacy
+from pollypm.inbox.backfill_heuristics import (
+    Classification,
+    classify_legacy,
+    classify_legacy_task,
+)
 from pollypm.inbox.kind import InboxItemKind, coerce_kind as _coerce_inbox_kind
 from pollypm.inbox_message_refs import unknown_project_refs
 from pollypm.work.cli import (
@@ -1134,17 +1138,22 @@ def _apply_kind_update(
 def _emit_backfill_audit(
     *,
     project: str,
-    msg_id: int,
+    subject: str,
     new_kind: InboxItemKind,
     heuristic: str,
 ) -> None:
-    """Audit-log one reclassification. Best-effort — never raises."""
+    """Audit-log one reclassification. Best-effort — never raises.
+
+    ``subject`` is the audit-event subject (``msg:<id>`` for message
+    backfills, ``<project>/<task_number>`` for task backfills) so a
+    forensic read can tell which surface a row came from.
+    """
     from pollypm.audit.log import EVENT_INBOX_KIND_BACKFILLED, emit
 
     emit(
         event=EVENT_INBOX_KIND_BACKFILLED,
         project=project or "",
-        subject=f"msg:{msg_id}",
+        subject=subject,
         actor="user",
         status="ok",
         metadata={
@@ -1155,13 +1164,81 @@ def _emit_backfill_audit(
     )
 
 
+# ---------------------------------------------------------------------------
+# Task-side backfill (work_tasks.kind, #1564 follow-up)
+# ---------------------------------------------------------------------------
+
+
+def _legacy_task_rows(
+    db_path: str,
+    *,
+    project: str | None,
+) -> list[Any]:
+    """Return every non-terminal task still tagged ``kind='legacy'``.
+
+    Mirrors the scope of :func:`_legacy_message_rows` (the population
+    the dashboard's "Waiting on you" section would otherwise lump
+    together). Terminal-state tasks (``done`` / ``cancelled``) are
+    intentionally included: the user's 2026-05-17 dashboard surfaced
+    cancelled ``audit_watchdog`` rows, and the awaits-user predicate
+    treats ``legacy`` as visible regardless of work_status.
+    """
+    from pollypm.work import create_work_service
+
+    from pathlib import Path
+
+    svc = create_work_service(
+        db_path=db_path,
+        project_path=Path(db_path).parent.parent,
+    )
+    try:
+        tasks = svc.list_tasks(project=project)
+    finally:
+        svc.close()
+
+    return [
+        task for task in tasks
+        if getattr(task, "kind", InboxItemKind.LEGACY) is InboxItemKind.LEGACY
+    ]
+
+
+def _task_classification(task: Any) -> Classification | None:
+    """Run the task-side heuristic against one row's title + creator."""
+    return classify_legacy_task(
+        title=str(getattr(task, "title", "") or ""),
+        created_by=str(getattr(task, "created_by", "") or ""),
+    )
+
+
+def _apply_task_kind_update(
+    db_path: str,
+    *,
+    task_id: str,
+    new_kind: InboxItemKind,
+) -> None:
+    """Persist a single ``work_tasks.kind`` reclassification."""
+    from pollypm.work import create_work_service
+
+    from pathlib import Path
+
+    svc = create_work_service(
+        db_path=db_path,
+        project_path=Path(db_path).parent.parent,
+    )
+    try:
+        svc.backfill_kind(task_id, new_kind=new_kind.value)
+    finally:
+        svc.close()
+
+
 @inbox_app.command(
     "backfill-kinds",
     help=(
         "One-time backfill of ``kind`` for inbox rows that still carry "
-        "``kind='legacy'`` (#1570). Dry-run by default — pass --commit "
-        "to actually mutate. Idempotent: rows already on a non-legacy "
-        "kind are skipped."
+        "``kind='legacy'`` (#1570, #1564 follow-up). Scans both the "
+        "messages table and the work_tasks table; dry-run by default — "
+        "pass --commit to actually mutate. Idempotent: rows already on "
+        "a non-legacy kind are skipped."
     ),
 )
 def backfill_kinds(
@@ -1189,9 +1266,12 @@ def backfill_kinds(
     """Reclassify legacy inbox rows by heuristic.
 
     Heuristics live in :mod:`pollypm.inbox.backfill_heuristics` and
-    are applied in spec order; unmatched rows stay legacy. Every
-    committed row emits one ``inbox.kind_backfilled`` audit event
-    with the old kind, new kind, and matched heuristic name.
+    are applied in spec order; unmatched rows stay legacy. Scans the
+    messages table and the work_tasks table; the dry-run report
+    breaks the counts down per surface so the operator can see what
+    each table contributes. Every committed row emits one
+    ``inbox.kind_backfilled`` audit event with the old kind, new
+    kind, and matched heuristic name.
     """
     if commit and dry_run:
         typer.echo(
@@ -1206,7 +1286,7 @@ def backfill_kinds(
     db_path = _resolve_db_path(db, project=project)
 
     try:
-        rows = _legacy_message_rows(db_path, project=project)
+        message_rows = _legacy_message_rows(db_path, project=project)
     except Exception as exc:  # noqa: BLE001
         typer.echo(
             f"Error: failed to read legacy inbox rows ({exc}).",
@@ -1214,77 +1294,151 @@ def backfill_kinds(
         )
         raise typer.Exit(code=1) from exc
 
-    if not rows:
+    try:
+        task_rows = _legacy_task_rows(db_path, project=project)
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(
+            f"Error: failed to read legacy work_task rows ({exc}).",
+            err=True,
+        )
+        raise typer.Exit(code=1) from exc
+
+    if not message_rows and not task_rows:
         typer.echo("No legacy inbox rows to reclassify.")
         return
 
     mode_label = "commit" if effective_commit else "dry-run"
     typer.echo(
-        f"Scanning {len(rows)} legacy inbox row(s) "
-        f"({mode_label})."
+        f"Scanning {len(message_rows)} legacy message row(s) and "
+        f"{len(task_rows)} legacy task row(s) ({mode_label})."
     )
-    typer.echo(
-        f"{'ID':<12} {'Project':<18} {'Heuristic → New kind':<48} Title"
-    )
-    typer.echo("-" * 110)
 
-    matched = 0
-    unmatched = 0
-    failures: list[tuple[int, str]] = []
-    for row in rows:
-        msg_id_raw = row.get("id")
-        if msg_id_raw is None:
-            continue
-        msg_id = int(msg_id_raw)
-        scope = str(row.get("scope") or "-")
-        title_preview = _title_preview(str(row.get("subject") or ""))
-        classification = _row_classification(row)
-        if classification is None:
-            unmatched += 1
-            typer.echo(
-                f"msg:{msg_id:<8} {scope:<18} {'(unmatched, stays legacy)':<48} "
-                f"{title_preview}"
-            )
-            continue
+    msg_matched = msg_unmatched = 0
+    task_matched = task_unmatched = 0
+    msg_failures: list[tuple[int, str]] = []
+    task_failures: list[tuple[str, str]] = []
 
-        matched += 1
-        action = (
-            f"{classification.heuristic} → {classification.kind.value}"
-        )
+    # Messages surface.
+    if message_rows:
+        typer.echo("")
+        typer.echo("Messages:")
         typer.echo(
-            f"msg:{msg_id:<8} {scope:<18} {action:<48} {title_preview}"
+            f"{'ID':<12} {'Project':<18} {'Heuristic → New kind':<48} Title"
         )
+        typer.echo("-" * 110)
+        for row in message_rows:
+            msg_id_raw = row.get("id")
+            if msg_id_raw is None:
+                continue
+            msg_id = int(msg_id_raw)
+            scope = str(row.get("scope") or "-")
+            title_preview = _title_preview(str(row.get("subject") or ""))
+            classification = _row_classification(row)
+            if classification is None:
+                msg_unmatched += 1
+                typer.echo(
+                    f"msg:{msg_id:<8} {scope:<18} {'(unmatched, stays legacy)':<48} "
+                    f"{title_preview}"
+                )
+                continue
 
-        if not effective_commit:
-            continue
-
-        try:
-            _apply_kind_update(
-                db_path, msg_id=msg_id, new_kind=classification.kind,
+            msg_matched += 1
+            action = (
+                f"{classification.heuristic} → {classification.kind.value}"
             )
-        except Exception as exc:  # noqa: BLE001
-            failures.append((msg_id, str(exc)))
-            continue
-        _emit_backfill_audit(
-            project=scope,
-            msg_id=msg_id,
-            new_kind=classification.kind,
-            heuristic=classification.heuristic,
+            typer.echo(
+                f"msg:{msg_id:<8} {scope:<18} {action:<48} {title_preview}"
+            )
+            if not effective_commit:
+                continue
+            try:
+                _apply_kind_update(
+                    db_path, msg_id=msg_id, new_kind=classification.kind,
+                )
+            except Exception as exc:  # noqa: BLE001
+                msg_failures.append((msg_id, str(exc)))
+                continue
+            _emit_backfill_audit(
+                project=scope,
+                subject=f"msg:{msg_id}",
+                new_kind=classification.kind,
+                heuristic=classification.heuristic,
+            )
+
+    # Tasks surface.
+    if task_rows:
+        typer.echo("")
+        typer.echo("Tasks:")
+        typer.echo(
+            f"{'ID':<18} {'Project':<18} {'Heuristic → New kind':<48} Title"
         )
+        typer.echo("-" * 110)
+        for task in task_rows:
+            task_id = str(getattr(task, "task_id", "") or "")
+            if not task_id:
+                continue
+            task_project = str(getattr(task, "project", "") or "-")
+            title_preview = _title_preview(
+                str(getattr(task, "title", "") or "")
+            )
+            classification = _task_classification(task)
+            if classification is None:
+                task_unmatched += 1
+                typer.echo(
+                    f"{task_id:<18} {task_project:<18} "
+                    f"{'(unmatched, stays legacy)':<48} {title_preview}"
+                )
+                continue
+
+            task_matched += 1
+            action = (
+                f"{classification.heuristic} → {classification.kind.value}"
+            )
+            typer.echo(
+                f"{task_id:<18} {task_project:<18} {action:<48} {title_preview}"
+            )
+            if not effective_commit:
+                continue
+            try:
+                _apply_task_kind_update(
+                    db_path,
+                    task_id=task_id,
+                    new_kind=classification.kind,
+                )
+            except Exception as exc:  # noqa: BLE001
+                task_failures.append((task_id, str(exc)))
+                continue
+            _emit_backfill_audit(
+                project=task_project,
+                subject=task_id,
+                new_kind=classification.kind,
+                heuristic=classification.heuristic,
+            )
 
     typer.echo("-" * 110)
+    matched = msg_matched + task_matched
+    unmatched = msg_unmatched + task_unmatched
     if effective_commit:
         typer.echo(
-            f"Reclassified {matched} row(s); {unmatched} unmatched."
+            f"Reclassified {matched} row(s) "
+            f"({msg_matched} message(s), {task_matched} task(s)); "
+            f"{unmatched} unmatched "
+            f"({msg_unmatched} message(s), {task_unmatched} task(s))."
         )
-        if failures:
+        if msg_failures or task_failures:
+            total_failures = len(msg_failures) + len(task_failures)
             typer.echo(
-                f"Failed to update {len(failures)} row(s):", err=True,
+                f"Failed to update {total_failures} row(s):", err=True,
             )
-            for mid, reason in failures[:5]:
+            for mid, reason in msg_failures[:5]:
                 typer.echo(f"  msg:{mid}: {reason}", err=True)
+            for tid, reason in task_failures[:5]:
+                typer.echo(f"  {tid}: {reason}", err=True)
     else:
         typer.echo(
-            f"Would reclassify {matched} row(s); {unmatched} unmatched."
+            f"Would reclassify {matched} row(s) "
+            f"({msg_matched} message(s), {task_matched} task(s)); "
+            f"{unmatched} unmatched "
+            f"({msg_unmatched} message(s), {task_unmatched} task(s))."
         )
     typer.echo(_BACKFILL_HINT)

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -2022,6 +2022,43 @@ class SQLiteWorkService:
         """Update mutable fields on a task."""
         return update_task(self, task_id, **fields)
 
+    def backfill_kind(self, task_id: str, *, new_kind: str) -> Task:
+        """Reclassify a task whose ``kind`` is still ``legacy`` (#1564 follow-up).
+
+        Sibling of :meth:`update` for the one-shot
+        ``pm inbox backfill-kinds`` migration helper. Kept off the
+        general ``update`` allow-list because ``kind`` is the canonical
+        producer-set discriminator (#1565) — once a row carries a
+        real kind, the value is the emit-site contract, not a
+        general-purpose mutable column.
+
+        Refuses to overwrite anything except ``legacy`` so a follow-up
+        run cannot reclassify an already-tagged row.
+        """
+        project, task_number = _parse_task_id(task_id)
+        row = self._conn.execute(
+            "SELECT kind FROM work_tasks "
+            "WHERE project = ? AND task_number = ?",
+            (project, task_number),
+        ).fetchone()
+        if row is None:
+            raise TaskNotFoundError(f"Task '{task_id}' not found.")
+        current = _coerce_inbox_kind(_row_get(row, "kind", None))
+        if current is not InboxItemKind.LEGACY:
+            raise ValidationError(
+                f"Cannot backfill kind on task '{task_id}': "
+                f"current kind is '{current.value}', not 'legacy'."
+            )
+        new_kind_value = _coerce_inbox_kind(new_kind).value
+        self._conn.execute(
+            "UPDATE work_tasks "
+            "SET kind = ?, updated_at = ? "
+            "WHERE project = ? AND task_number = ?",
+            (new_kind_value, _now(), project, task_number),
+        )
+        self._conn.commit()
+        return self.get(task_id)
+
     # ------------------------------------------------------------------
     # State transitions
     # ------------------------------------------------------------------

--- a/tests/test_cli_inbox_backfill.py
+++ b/tests/test_cli_inbox_backfill.py
@@ -161,7 +161,10 @@ def test_dry_run_classifies_but_writes_nothing(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert "Would reclassify 5 row(s); 2 unmatched." in result.output
+    assert (
+        "Would reclassify 5 row(s) (5 message(s), 0 task(s)); "
+        "2 unmatched (2 message(s), 0 task(s))."
+    ) in result.output
     assert "Re-run with --commit" in result.output
     # Each classified row is printed with its heuristic + new kind.
     assert "completion_fyi" in result.output
@@ -205,7 +208,10 @@ def test_commit_writes_audit_events_and_updates_kinds(
     )
 
     assert result.exit_code == 0, result.output
-    assert "Reclassified 5 row(s); 2 unmatched." in result.output
+    assert (
+        "Reclassified 5 row(s) (5 message(s), 0 task(s)); "
+        "2 unmatched (2 message(s), 0 task(s))."
+    ) in result.output
 
     # Each matched row landed on its expected kind.
     assert _read_kind(db_path, ids["completion"]) is InboxItemKind.COMPLETION_FYI
@@ -251,7 +257,10 @@ def test_commit_is_idempotent(
         inbox_app, ["backfill-kinds", "--commit", "--db", str(db_path)],
     )
     assert first.exit_code == 0, first.output
-    assert "Reclassified 5 row(s); 2 unmatched." in first.output
+    assert (
+        "Reclassified 5 row(s) (5 message(s), 0 task(s)); "
+        "2 unmatched (2 message(s), 0 task(s))."
+    ) in first.output
 
     second = runner.invoke(
         inbox_app, ["backfill-kinds", "--commit", "--db", str(db_path)],
@@ -259,7 +268,10 @@ def test_commit_is_idempotent(
     assert second.exit_code == 0, second.output
     # The two remaining legacy rows are still scanned but only re-printed
     # as unmatched; nothing reclassifies on the second pass.
-    assert "Reclassified 0 row(s); 2 unmatched." in second.output
+    assert (
+        "Reclassified 0 row(s) (0 message(s), 0 task(s)); "
+        "2 unmatched (2 message(s), 0 task(s))."
+    ) in second.output
 
 
 def test_dry_run_after_commit_reports_remaining_legacy_rows(
@@ -276,7 +288,10 @@ def test_dry_run_after_commit_reports_remaining_legacy_rows(
     )
     assert result.exit_code == 0, result.output
     # Two legacy rows remain (the unmatched ones); both still print.
-    assert "Would reclassify 0 row(s); 2 unmatched." in result.output
+    assert (
+        "Would reclassify 0 row(s) (0 message(s), 0 task(s)); "
+        "2 unmatched (2 message(s), 0 task(s))."
+    ) in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -354,3 +369,227 @@ def test_empty_db_reports_no_rows(tmp_path: Path) -> None:
     )
     assert result.exit_code == 0, result.output
     assert "No legacy inbox rows to reclassify." in result.output
+
+
+# ---------------------------------------------------------------------------
+# Task-side backfill (#1564 follow-up)
+# ---------------------------------------------------------------------------
+
+
+def _seed_legacy_task(
+    db_path: Path,
+    *,
+    title: str,
+    created_by: str = "audit_watchdog",
+    project: str = "demo",
+) -> str:
+    """Create a draft work_tasks row with ``kind='legacy'`` and return ``task_id``.
+
+    ``SQLiteWorkService.create`` defaults ``kind`` to ``"legacy"`` —
+    which is precisely the pre-#1565 state the backfill targets.
+    """
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    svc = SQLiteWorkService(db_path=db_path, project_path=db_path.parent)
+    try:
+        task = svc.create(
+            title=title,
+            description="seed",
+            type="task",
+            project=project,
+            flow_template="chat",
+            roles={"requester": "user", "operator": "user"},
+            priority="normal",
+            created_by=created_by,
+        )
+    finally:
+        svc.close()
+    return task.task_id
+
+
+def _read_task_kind(db_path: Path, task_id: str) -> InboxItemKind:
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    svc = SQLiteWorkService(db_path=db_path, project_path=db_path.parent)
+    try:
+        return svc.get(task_id).kind
+    finally:
+        svc.close()
+
+
+def test_task_backfill_reclassifies_watchdog_queue_motion_rows(
+    tmp_path: Path, _isolate_audit_home: Path,
+) -> None:
+    db_path = tmp_path / "state.db"
+    watchdog_task = _seed_legacy_task(
+        db_path,
+        title=(
+            "Project savethenovel has 2 queued task(s) but no claim / "
+            "execution / status-change activity for the entire scan window."
+        ),
+        created_by="audit_watchdog",
+        project="savethenovel",
+    )
+    plan_review_task = _seed_legacy_task(
+        db_path,
+        title="Plan ready for review: bikepath",
+        created_by="audit_watchdog",
+        project="bikepath",
+    )
+    other_task = _seed_legacy_task(
+        db_path,
+        title="Refactor session_runtime helper",
+        created_by="polly",
+        project="demo",
+    )
+
+    result = runner.invoke(
+        inbox_app, ["backfill-kinds", "--commit", "--db", str(db_path)],
+    )
+    assert result.exit_code == 0, result.output
+    # Per-surface counts surface in the summary line.
+    assert "0 message(s), 2 task(s)" in result.output
+    # And the dedicated Tasks section actually renders.
+    assert "Tasks:" in result.output
+
+    assert (
+        _read_task_kind(db_path, watchdog_task)
+        is InboxItemKind.WATCHDOG_OPERATOR_DISPATCH
+    )
+    assert (
+        _read_task_kind(db_path, plan_review_task)
+        is InboxItemKind.PLAN_REVIEW_PENDING
+    )
+    # Unmatched task stays legacy.
+    assert _read_task_kind(db_path, other_task) is InboxItemKind.LEGACY
+
+    # Audit log carries one inbox.kind_backfilled per reclassified task,
+    # subject set to the task_id (not msg:<n>).
+    events = [
+        e for e in _audit_lines_for_project(_isolate_audit_home, "savethenovel")
+        if e.get("event") == EVENT_INBOX_KIND_BACKFILLED
+    ]
+    assert len(events) == 1
+    assert events[0]["subject"] == watchdog_task
+    assert events[0]["metadata"]["heuristic"] == "watchdog_queue_without_motion"
+    assert (
+        events[0]["metadata"]["new_kind"]
+        == InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value
+    )
+
+    bikepath_events = [
+        e for e in _audit_lines_for_project(_isolate_audit_home, "bikepath")
+        if e.get("event") == EVENT_INBOX_KIND_BACKFILLED
+    ]
+    assert len(bikepath_events) == 1
+    assert bikepath_events[0]["subject"] == plan_review_task
+
+
+def test_task_backfill_dry_run_writes_nothing(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    watchdog_task = _seed_legacy_task(
+        db_path,
+        title=(
+            "Project demo has 1 queued task(s) but no claim / "
+            "execution / status-change activity for ~5 min."
+        ),
+        created_by="audit_watchdog",
+        project="demo",
+    )
+
+    result = runner.invoke(
+        inbox_app, ["backfill-kinds", "--db", str(db_path)],
+    )
+    assert result.exit_code == 0, result.output
+    # Dry-run summary surfaces counts but writes nothing.
+    assert "Would reclassify 1 row(s)" in result.output
+    assert "0 message(s), 1 task(s)" in result.output
+    assert _read_task_kind(db_path, watchdog_task) is InboxItemKind.LEGACY
+
+
+def test_task_backfill_is_idempotent(
+    tmp_path: Path, _isolate_audit_home: Path,
+) -> None:
+    db_path = tmp_path / "state.db"
+    _seed_legacy_task(
+        db_path,
+        title=(
+            "Project demo has 1 queued task(s) but no claim / "
+            "execution / status-change activity for ~5 min."
+        ),
+        created_by="audit_watchdog",
+        project="demo",
+    )
+
+    first = runner.invoke(
+        inbox_app, ["backfill-kinds", "--commit", "--db", str(db_path)],
+    )
+    assert first.exit_code == 0, first.output
+    assert "Reclassified 1 row(s)" in first.output
+
+    # Second commit: the row is now non-legacy, so the scan finds zero.
+    second = runner.invoke(
+        inbox_app, ["backfill-kinds", "--commit", "--db", str(db_path)],
+    )
+    assert second.exit_code == 0, second.output
+    assert "No legacy inbox rows to reclassify." in second.output
+
+
+def test_task_and_message_backfill_mix_in_single_run(
+    tmp_path: Path, _isolate_audit_home: Path,
+) -> None:
+    """Combined scan reports per-surface counts in one go."""
+    db_path = tmp_path / "state.db"
+    _seed_legacy_message(
+        db_path,
+        subject="Web API phase 1 complete",
+        sender="polly",
+        scope="demo",
+    )
+    _seed_legacy_task(
+        db_path,
+        title=(
+            "Project demo has 1 queued task(s) but no claim / "
+            "execution / status-change activity for ~5 min."
+        ),
+        created_by="audit_watchdog",
+        project="demo",
+    )
+
+    result = runner.invoke(
+        inbox_app, ["backfill-kinds", "--commit", "--db", str(db_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Reclassified 2 row(s) (1 message(s), 1 task(s))" in result.output
+    # Both per-surface sections render.
+    assert "Messages:" in result.output
+    assert "Tasks:" in result.output
+
+
+def test_backfill_kind_refuses_to_overwrite_non_legacy_task(
+    tmp_path: Path,
+) -> None:
+    """SQLiteWorkService.backfill_kind is the lock against accidental re-tagging."""
+    from pollypm.work.sqlite_service import SQLiteWorkService
+    from pollypm.work.service_support import ValidationError
+
+    db_path = tmp_path / "state.db"
+    task_id = _seed_legacy_task(
+        db_path,
+        title="Plan ready for review: demo",
+        created_by="audit_watchdog",
+        project="demo",
+    )
+
+    svc = SQLiteWorkService(db_path=db_path, project_path=db_path.parent)
+    try:
+        svc.backfill_kind(
+            task_id, new_kind=InboxItemKind.PLAN_REVIEW_PENDING.value,
+        )
+        with pytest.raises(ValidationError):
+            svc.backfill_kind(
+                task_id, new_kind=InboxItemKind.COMPLETION_FYI.value,
+            )
+    finally:
+        svc.close()

--- a/tests/test_inbox_backfill_heuristics.py
+++ b/tests/test_inbox_backfill_heuristics.py
@@ -1,10 +1,18 @@
-"""Per-heuristic unit tests for ``classify_legacy`` (#1570).
+"""Per-heuristic unit tests for ``classify_legacy`` (#1570, #1564 follow-up).
 
 Locks in the spec order so a refactor cannot silently shuffle
 priorities. Each heuristic gets a positive case (the canonical
 shape) and a negative case (a row that looks similar but should
 not match), plus a top-level test that an unmatched row returns
 ``None`` so the CLI's "leave it legacy" branch keeps working.
+
+Two surfaces:
+
+* :func:`classify_legacy` — messages-shaped rows (#1570). The first
+  six sections cover its heuristics.
+* :func:`classify_legacy_task` — work_tasks-shaped rows added in the
+  #1564 follow-up so the dashboard's "Watchdog escalated: …" task
+  rows can be retagged off ``legacy``.
 """
 
 from __future__ import annotations
@@ -14,6 +22,7 @@ import pytest
 from pollypm.inbox.backfill_heuristics import (
     Classification,
     classify_legacy,
+    classify_legacy_task,
 )
 from pollypm.inbox.kind import InboxItemKind
 
@@ -233,3 +242,107 @@ def test_classification_carries_heuristic_label() -> None:
     assert isinstance(out, Classification)
     assert out.heuristic
     assert out.kind is InboxItemKind.PLAN_REVIEW_PENDING
+
+
+# ---------------------------------------------------------------------------
+# classify_legacy_task — work_tasks-shaped rows (#1564 follow-up)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        # Verbatim watchdog finding shapes observed in the user's
+        # 2026-05-17 dashboard (queue_without_motion safety-net probe).
+        (
+            "Project savethenovel has 2 queued task(s) but no claim / "
+            "execution / status-change activity for the entire scan window."
+        ),
+        (
+            "Project coffeeboardnm has 4 queued task(s) but no claim / "
+            "execution / status-change activity for ~31 min."
+        ),
+        (
+            "Project pollypm has 1 queued task(s) but no claim / "
+            "execution / status-change activity for the entire scan window."
+        ),
+    ],
+)
+def test_watchdog_queue_without_motion_task_classifies_dispatch(
+    title: str,
+) -> None:
+    out = classify_legacy_task(title=title, created_by="audit_watchdog")
+    assert out is not None
+    assert out.kind is InboxItemKind.WATCHDOG_OPERATOR_DISPATCH
+    assert out.heuristic == "watchdog_queue_without_motion"
+
+
+def test_watchdog_escalated_prefix_classifies_dispatch() -> None:
+    """Defensive: any future producer using the cockpit's render copy is caught."""
+    out = classify_legacy_task(
+        title="Watchdog escalated: queue wedged on demo",
+        created_by="audit_watchdog",
+    )
+    assert out is not None
+    assert out.kind is InboxItemKind.WATCHDOG_OPERATOR_DISPATCH
+    assert out.heuristic == "watchdog_escalated_prefix"
+
+
+def test_queue_motion_pattern_only_matches_audit_watchdog_creator() -> None:
+    """Same title prose from a non-watchdog creator must not be misattributed."""
+    out = classify_legacy_task(
+        title=(
+            "Project demo has 3 queued task(s) but no claim / "
+            "execution / status-change activity for ~5 min."
+        ),
+        created_by="polly",
+    )
+    assert out is None
+
+
+def test_plan_ready_for_review_task_classifies_plan_review_pending() -> None:
+    """Watchdog-emitted plan-review tasks use the same prefix as messages."""
+    out = classify_legacy_task(
+        title="Plan ready for review: coffeeboardnm",
+        created_by="audit_watchdog",
+    )
+    assert out is not None
+    assert out.kind is InboxItemKind.PLAN_REVIEW_PENDING
+    assert out.heuristic == "title_prefix:plan_ready_for_review"
+
+
+def test_plan_ready_for_review_task_from_architect_classifies_too() -> None:
+    """Architect-authored plan-review tasks classify the same way."""
+    out = classify_legacy_task(
+        title="Plan ready for review: bikepath",
+        created_by="architect_bikepath",
+    )
+    assert out is not None
+    assert out.kind is InboxItemKind.PLAN_REVIEW_PENDING
+
+
+def test_unrelated_task_title_returns_none() -> None:
+    """Random task titles must not classify."""
+    out = classify_legacy_task(
+        title="Refactor session_runtime helper",
+        created_by="polly",
+    )
+    assert out is None
+
+
+def test_task_classifier_handles_missing_fields() -> None:
+    """Empty inputs are safe — return None."""
+    assert classify_legacy_task(title="", created_by="") is None
+
+
+def test_task_classifier_watchdog_pattern_is_case_insensitive() -> None:
+    """Capitalisation drift in the finding body shouldn't break the rule."""
+    out = classify_legacy_task(
+        title=(
+            "PROJECT DEMO HAS 5 QUEUED TASK(S) BUT NO CLAIM / "
+            "EXECUTION / STATUS-CHANGE ACTIVITY FOR ~5 MIN."
+        ),
+        created_by="audit_watchdog",
+    )
+    assert out is not None
+    assert out.kind is InboxItemKind.WATCHDOG_OPERATOR_DISPATCH


### PR DESCRIPTION
## Summary

Follow-up to PR #1577 (emit-site tagging) and PR #1578 (messages-table backfill). Closes the dashboard-noise gap that surfaced during user testing of the new operator dashboard (#1564) — the "Waiting on you" section was still showing ~120 legacy ``work_tasks`` rows because PR #1578's backfill heuristic only scanned the messages table.

Refs #1564.

## What changed

**Fix 1 — emit-site audit (no code change required)**

Audited every watchdog task-creation site for missing ``kind=watchdog_operator_dispatch``:

| Site | Status |
|---|---|
| ``audit_watchdog._create_operator_inbox_task`` (tier-3) | Already tagged in #1577. Test at ``tests/test_inbox_kind_emit_sites.py:414``. |
| ``audit_watchdog._create_operator_tier4_inbox_task`` | Already tagged in #1577. Test at line 470. |
| ``audit_watchdog._route_tier4_to_terminal`` | Message-only path, no ``svc.create``. Tagged. Test at line 522. |
| ``plan_review_emit.emit_plan_review_for_task`` | Tagged with ``PLAN_REVIEW_PENDING``. |
| ``sweeps._emit_pane_pattern_inbox_item`` / ``worker_turn_end`` | Polly-recipient, tagged ``ACTIVITY_EVENT``. |

No untagged emit site exists — the dashboard noise is pure pre-migration residue, not a producer bug.

**Fix 2 — extend backfill to ``work_tasks``**

- ``classify_legacy_task`` (new in ``pollypm.inbox.backfill_heuristics``) — matches ``created_by='audit_watchdog'`` + the queue_without_motion finding's title shape → ``watchdog_operator_dispatch``. Also matches the ``"Plan ready for review"`` prefix → ``plan_review_pending``.
- ``SQLiteWorkService.backfill_kind`` (new public method) — refuses to overwrite anything other than ``legacy``. Kept off the general ``update`` allow-list because ``kind`` is the producer-set contract (#1565).
- ``pm inbox backfill-kinds`` — now scans both surfaces, prints per-surface summaries (``"Reclassified N row(s) (X message(s), Y task(s))…"``), and renders dedicated ``Messages:`` / ``Tasks:`` sections so the operator sees what each table contributes.

## Before/after counts (user's local DB)

Snapshot of ``~/dev/.pollypm/state.db`` before and after a ``--commit`` run:

| Surface | Before | After |
|---|---|---|
| ``audit_watchdog`` ``work_tasks.kind = legacy`` | **114** | **0** |
| ``audit_watchdog`` ``work_tasks.kind = watchdog_operator_dispatch`` | 39 | 152 |
| ``architect*`` ``work_tasks.kind = legacy`` | 22 | 16 |
| ``architect*`` ``work_tasks.kind = plan_review_pending`` | 0 | 6 |

Total: **120 task rows reclassified** (113 → ``watchdog_operator_dispatch``, 7 → ``plan_review_pending``). The remaining ``legacy`` work_tasks (treated as awaits-user by the predicate) are non-watchdog producers (``system`` scaffolding, advisor ticks, heartbeat-emitted tasks) deliberately out of scope.

## Architecture notes

- ``pollypm.inbox.backfill_heuristics`` stays a leaf — imports only ``InboxItemKind``.
- ``test_import_boundary.py`` allow-list unchanged. The pre-existing ``tier4.py`` failure flagged in #1577 is unrelated to this PR.
- Heuristic decides, CLI writes, work-service exposes a focused public method. No private-``_conn`` reach-through.
- Idempotent: the ``backfill_kind`` method refuses to overwrite a non-legacy row, so a second commit pass finds zero matching rows in the affected creator-class.

## Test plan

- [x] ``uv run pytest tests/test_inbox_backfill_heuristics.py`` — 34 pass (25 existing + 9 new task-side tests).
- [x] ``uv run pytest tests/test_cli_inbox_backfill.py`` — 13 pass (8 existing updated + 5 new).
- [x] ``uv run pytest tests/test_audit_watchdog.py tests/test_heartbeat_cascade_foundation.py tests/test_inbox*.py tests/test_cli_inbox_backfill.py tests/test_audit_log.py`` — 412 pass, no regressions.
- [x] Manual dry-run on the user's workspace ``state.db`` shows 120 task rows reclassify, 0 message rows newly reclassify (user's prior ``--commit`` already cleared the messages).
- [x] Second ``--commit`` reports ``No legacy inbox rows to reclassify.`` (idempotence holds across both surfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)