### PR TITLE
fix(cockpit): emit cockpit.* audit events under _workspace key (#1593)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -2354,6 +2354,15 @@ class CockpitRouter:
 
         Imported lazily so a missing/broken audit-log module never
         blocks rail navigation.
+
+        #1593 — uses the ``_workspace`` project key (mirroring
+        ``rail_daemon_supervisor._emit_revival_audit`` and
+        ``rail_daemon_reaper._emit_audit``) because the cockpit rail is
+        not scoped to a single project. ``audit.log.emit`` skips the
+        central-tail write when ``project`` is falsy, and these emits
+        pass ``project_path=None`` (no per-project log), so an empty
+        ``project`` silently drops the event entirely — which is what
+        caused the overnight protocol's #1562 watch to read zero.
         """
         try:
             from pollypm.audit.log import emit as audit_emit
@@ -2362,7 +2371,7 @@ class CockpitRouter:
         try:
             audit_emit(
                 event=event_name,
-                project="",
+                project="_workspace",
                 subject=subject,
                 actor="cockpit-rail",
                 status=status,

--- a/tests/test_cockpit_rail_duplicate_window_cleanup.py
+++ b/tests/test_cockpit_rail_duplicate_window_cleanup.py
@@ -16,6 +16,9 @@ These tests pin the new contract:
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from pollypm.cockpit_rail import CockpitRouter
 from pollypm.tmux.client import TmuxWindow
 
@@ -130,3 +133,48 @@ def test_cleanup_tolerates_list_windows_failure() -> None:
 
     # Must not raise.
     router._cleanup_duplicate_windows("pm-storage-closet")
+
+
+def test_emit_cockpit_audit_lands_in_workspace_central_tail(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """#1593 — emits must land somewhere a `grep` can find them.
+
+    ``audit.log.emit`` skips the central-tail write when ``project`` is
+    falsy. ``_emit_cockpit_audit`` does not pass ``project_path``, so an
+    empty ``project`` silently drops the event. The fix is to use
+    ``"_workspace"`` (matching ``rail_daemon_supervisor`` /
+    ``rail_daemon_reaper``). This pins that landing path so the next
+    time someone "simplifies" the project key, the
+    overnight-protocol watch stays observable.
+    """
+    audit_home = tmp_path / "audit"
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+    router = CockpitRouter.__new__(CockpitRouter)
+    router._emit_cockpit_audit(
+        event_name="cockpit.session_respawned",
+        subject="pm-operator",
+        status="warn",
+        metadata={"reason": "test"},
+    )
+
+    workspace_log = audit_home / "_workspace.jsonl"
+    assert workspace_log.exists(), (
+        f"cockpit audit emit must land in central tail; "
+        f"contents of {audit_home}: "
+        f"{[p.name for p in audit_home.iterdir()] if audit_home.exists() else 'missing'}"
+    )
+    lines = [
+        json.loads(line)
+        for line in workspace_log.read_text().splitlines()
+        if line.strip()
+    ]
+    assert len(lines) == 1
+    record = lines[0]
+    assert record["event"] == "cockpit.session_respawned"
+    assert record["project"] == "_workspace"
+    assert record["subject"] == "pm-operator"
+    assert record["status"] == "warn"
+    assert record["actor"] == "cockpit-rail"
+    assert record["metadata"] == {"reason": "test"}


### PR DESCRIPTION
## Summary
- PR #1563 added three new `cockpit.*` audit events as the smoking-gun metric for the #1562 conversation-wipe overnight watch. Zero of them have landed across 5.6M audit entries.
- Root cause: `_emit_cockpit_audit` passed `project=""` and no `project_path`. `audit.log.emit` only writes the central tail when `project` is truthy, so the event was silently dropped on every call.
- Fix: use the `"_workspace"` project key (the established convention for cross-project events, matching `rail_daemon_supervisor._emit_revival_audit` and `rail_daemon_reaper._emit_audit`). Events now land in `~/.pollypm/audit/_workspace.jsonl`, where the overnight protocol's `grep` can find them.

## Diagnosis vs. hypotheses in the issue
The issue listed 5 hypotheses. The actual cause is hypothesis (4): "the audit emit silently swallows the call when the project context isn't available." Specifically, `audit.log.emit` line 437:

```python
if project:
    try:
        _append_line(central_log_path(project), line)
```

A falsy `project` skips central-tail write. The cockpit emit also passed no `project_path`, so the per-project log path (gated by `if project_path is not None`) was also skipped. Net: every cockpit.* emit was a no-op.

## Why `_workspace` and not a real project key
The cockpit rail is not scoped to one project — it's the workspace-wide tmux layout. `rail_daemon_supervisor` and `rail_daemon_reaper` already use `project="_workspace"` for the same reason. Keeping the convention means `grep '"event":"cockpit' ~/.pollypm/audit/_workspace.jsonl` works the same way as the existing `daemon.revived` grep, and reads via `read_events("_workspace")` keep working.

## Test plan
- [x] New regression test asserts an emit lands in the central tail under `_workspace.jsonl` with the expected event/project/subject/status/actor/metadata fields.
- [x] All 6 tests in `tests/test_cockpit_rail_duplicate_window_cleanup.py` pass (5 existing + 1 new).
- [x] All 22 tests in `tests/test_audit_log.py` pass.
- [ ] After install, verify a rail-switch-and-back produces a non-zero count: `grep -c '"event":"cockpit.session' ~/.pollypm/audit/_workspace.jsonl`.

Closes #1593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)