### PR TITLE
Fix #1376 route cockpit_settings_projects sqlite probe via work facade

### DIFF
--- a/src/pollypm/cockpit_settings_projects.py
+++ b/src/pollypm/cockpit_settings_projects.py
@@ -3,9 +3,9 @@
 Contract:
 - Inputs: the loaded PollyPM config plus a relative-age formatter.
 - Outputs: normalized project rows for the settings UI.
-- Side effects: reads project-path metadata and does read-only SQLite
-  queries with a very short timeout so busy project DBs do not stall UI
-  mount.
+- Side effects: reads project-path metadata and a fast, non-blocking
+  task-count probe via the work-service facade so busy project DBs do
+  not stall UI mount.
 - Invariants: callers get best-effort task totals; a locked DB surfaces
   as ``task_total_label='busy'`` instead of blocking the screen.
 """
@@ -14,7 +14,8 @@ from __future__ import annotations
 
 from datetime import datetime as _dt
 from pathlib import Path
-import sqlite3
+
+from pollypm.work.task_state import project_task_total_fast_count
 
 
 def collect_settings_projects(config, *, format_relative_age) -> list[dict]:
@@ -37,7 +38,9 @@ def collect_settings_projects(config, *, format_relative_age) -> list[dict]:
                     last_activity = _project_last_activity(
                         db_path, format_relative_age=format_relative_age
                     )
-                    task_total = _project_task_total(db_path, project_key=key)
+                    task_total = project_task_total_fast_count(
+                        db_path, project_key=key
+                    )
                     if task_total is None:
                         task_total_label = "busy"
                     else:
@@ -70,34 +73,6 @@ def _project_last_activity(db_path: Path, *, format_relative_age) -> str:
     except OSError:
         return ""
     return format_relative_age(_dt.fromtimestamp(mtime).isoformat())
-
-
-def _project_task_total(db_path: Path, *, project_key: str) -> int | None:
-    """Return a task count quickly, or ``None`` if the DB is busy."""
-
-    conn: sqlite3.Connection | None = None
-    try:
-        conn = sqlite3.connect(
-            f"file:{db_path}?mode=ro",
-            uri=True,
-            timeout=0.05,
-        )
-        conn.execute("PRAGMA busy_timeout=50")
-        row = conn.execute(
-            "SELECT COUNT(*) FROM work_tasks WHERE project = ?",
-            (project_key,),
-        ).fetchone()
-        return int(row[0] or 0) if row is not None else 0
-    except sqlite3.OperationalError as exc:
-        message = str(exc).lower()
-        if "locked" in message or "busy" in message:
-            return None
-        return 0
-    except sqlite3.Error:
-        return 0
-    finally:
-        if conn is not None:
-            conn.close()
 
 
 __all__ = ["collect_settings_projects"]

--- a/src/pollypm/storage/work_task_state.py
+++ b/src/pollypm/storage/work_task_state.py
@@ -135,6 +135,67 @@ def task_numbers_with_statuses(
     return []
 
 
+def project_task_total_fast(
+    db_path: Path,
+    *,
+    project_key: str,
+    connect_timeout: float = 0.05,
+    busy_timeout_ms: int = 50,
+) -> int | None:
+    """Return the work-task count for ``project_key`` quickly.
+
+    The settings screen needs a non-blocking probe: ``None`` means the
+    DB is locked/busy and the caller should surface a ``busy`` indicator
+    rather than wait. Any other SQLite error is treated as ``0`` to
+    preserve the previous best-effort UI behavior.
+    """
+    try:
+        if not db_path.exists():
+            return 0
+    except OSError:
+        return 0
+    conn: sqlite3.Connection | None = None
+    try:
+        try:
+            conn = sqlite3.connect(
+                f"file:{db_path}?mode=ro",
+                uri=True,
+                timeout=connect_timeout,
+            )
+        except sqlite3.OperationalError as exc:
+            message = str(exc).lower()
+            if "locked" in message or "busy" in message:
+                return None
+            return 0
+        except sqlite3.Error:
+            return 0
+        try:
+            conn.execute(f"PRAGMA busy_timeout={int(busy_timeout_ms)}")
+        except sqlite3.Error:
+            pass
+        try:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM work_tasks WHERE project = ?",
+                (project_key,),
+            ).fetchone()
+        except sqlite3.OperationalError as exc:
+            message = str(exc).lower()
+            if "locked" in message or "busy" in message:
+                return None
+            return 0
+        except sqlite3.Error:
+            return 0
+        if row is None:
+            return 0
+        try:
+            return int(row[0] or 0)
+        except (TypeError, ValueError):
+            return 0
+    finally:
+        if conn is not None:
+            conn.close()
+
+
 def has_work_task_rows(
     db_path: Path,
     *,

--- a/src/pollypm/work/task_state.py
+++ b/src/pollypm/work/task_state.py
@@ -10,6 +10,7 @@ from pollypm.storage.work_task_state import (
     blocker_chain_statuses,
     has_work_task_rows,
     project_activity_probe,
+    project_task_total_fast,
     task_numbers_with_statuses,
     task_status_probe,
 )
@@ -73,6 +74,20 @@ def has_work_tasks_in_db(
 ) -> bool:
     """Return whether a work DB has task rows without exposing SQLite to callers."""
     return has_work_task_rows(Path(db_path), project_key=project_key)
+
+
+def project_task_total_fast_count(
+    db_path: Path,
+    *,
+    project_key: str,
+) -> int | None:
+    """Return a project's work-task count quickly, or ``None`` if the DB is busy.
+
+    The settings screen uses this to render a fast task total without
+    blocking the UI mount on a locked DB; ``None`` lets callers surface
+    a ``busy`` label instead of waiting on the writer.
+    """
+    return project_task_total_fast(Path(db_path), project_key=project_key)
 
 
 def project_activity(
@@ -179,6 +194,7 @@ __all__ = [
     "has_work_tasks_in_db",
     "parse_task_window_name",
     "project_activity",
+    "project_task_total_fast_count",
     "task_window_terminal_or_missing",
     "user_waiting_task_ids",
 ]

--- a/tests/test_plugin_boundary_conformance.py
+++ b/tests/test_plugin_boundary_conformance.py
@@ -95,6 +95,7 @@ def test_transition_query_plugin_handlers_do_not_open_sqlite_directly() -> None:
 def test_work_task_query_callers_do_not_open_sqlite_directly() -> None:
     """Issue #1376: UI/plugin callers route work-task reads via facades."""
     rels = (
+        "src/pollypm/cockpit_settings_projects.py",
         "src/pollypm/dashboard_data.py",
         "src/pollypm/plugins_builtin/project_planning/cli/project.py",
     )


### PR DESCRIPTION
Refs #1376

Partial slice of #1376. Removes the last direct `sqlite3.connect()` from
`src/pollypm/cockpit_settings_projects.py` — the settings screen's fast
task-count probe now goes through a new `pollypm.work.task_state.project_task_total_fast_count`
facade, backed by `pollypm.storage.work_task_state.project_task_total_fast`.
SQL/table ownership stays in the storage layer; the UI no longer knows
the `work_tasks` schema or the read-only URI shape.

The `None`-means-busy contract that lets the settings screen render
`task_total_label='busy'` without blocking the mount is preserved.

`tests/test_plugin_boundary_conformance.py::test_work_task_query_callers_do_not_open_sqlite_directly`
now includes `cockpit_settings_projects.py` so a future regression fails
loudly.

## Summary
- New storage-owned `project_task_total_fast(db_path, project_key=...)` returning `int | None`
- New work facade `project_task_total_fast_count(...)` re-exporting it
- `cockpit_settings_projects` calls the facade; no more `import sqlite3`
- Boundary test extended to guard the new caller

Remaining #1376 scope: `backup.py`, `cockpit.py`, `cockpit_sections/base.py`, `cockpit_ui.py`, `doctor.py`.

## Test plan
- [x] `uv run --extra dev pytest tests/test_cockpit_settings_projects.py tests/test_plugin_boundary_conformance.py` (18 passed)
- [x] Verified preserved busy-vs-empty semantics via `test_collect_settings_projects_marks_busy_db_without_blocking`
- [x] `from pollypm.work.task_state import project_task_total_fast_count` smoke-imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)