### PR TITLE
fix(#1363): decouple approval_notifications from human_notify plugin

### DIFF
--- a/src/pollypm/approval_notifications.py
+++ b/src/pollypm/approval_notifications.py
@@ -2,28 +2,88 @@
 
 Contract:
 - Inputs: a reviewed ``Task`` plus a UI ``notify`` callback.
-- Outputs: a stable approval toast message, and best-effort macOS banner
-  delivery when Notification Center is available.
+- Outputs: a stable approval toast message, and best-effort OS banner
+  delivery when a notification adapter has been registered (typically
+  by the ``human_notify`` plugin).
 - Side effects: emits a Textual toast immediately and may queue an OS
-  notification on Darwin hosts.
+  notification when an adapter is registered.
 - Invariants: approval flows format the same message everywhere and never
   fail the underlying approval action when notification delivery flakes.
+
+Boundary note:
+This module is core — it must not import from ``pollypm.plugins_builtin``.
+The OS-level adapter is resolved through :func:`register_default_os_adapter`
+so the ``human_notify`` plugin (or any third-party replacement) can plug
+in without core taking a hard dependency on the optional plugin tree.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Callable
-
-from pollypm.plugins_builtin.human_notify.macos import MacOsNotifyAdapter
+from typing import TYPE_CHECKING, Callable, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from pollypm.plugins_builtin.human_notify.protocol import HumanNotifyAdapter
     from pollypm.work.models import Task
 
 
 NotifyCallback = Callable[..., None]
 _TOAST_TIMEOUT_SECONDS = 5.0
+
+
+@runtime_checkable
+class OsApprovalNotifier(Protocol):
+    """Minimal OS-notification contract for the approval flow.
+
+    Mirrors the public surface of the ``human_notify`` plugin's
+    ``HumanNotifyAdapter`` but lives in core so this module doesn't
+    reach into the plugin tree. Plugin adapters that already satisfy
+    ``HumanNotifyAdapter`` structurally satisfy this Protocol too.
+    """
+
+    def is_available(self) -> bool:
+        """Return True iff this adapter can deliver a banner right now."""
+        ...
+
+    def notify(
+        self,
+        *,
+        title: str,
+        body: str,
+        task_id: str,
+        project: str,
+    ) -> None:
+        """Deliver a single approval banner."""
+        ...
+
+
+# Module-level registration slot. The ``human_notify`` plugin (or a
+# replacement) installs its OS adapter factory here during plugin
+# ``initialize``; when nothing is registered, the approval flow still
+# emits the in-cockpit toast but skips the OS banner.
+_default_os_adapter_factory: Callable[[], OsApprovalNotifier] | None = None
+
+
+def register_default_os_adapter(
+    factory: Callable[[], OsApprovalNotifier] | None,
+) -> None:
+    """Install (or clear) the default OS-notification adapter factory.
+
+    Called by the ``human_notify`` plugin during ``initialize`` so
+    ``notify_task_approved`` can deliver banners without a hard import
+    on the plugin tree. Pass ``None`` to clear (used by tests).
+    """
+    global _default_os_adapter_factory
+    _default_os_adapter_factory = factory
+
+
+def _resolve_default_os_adapter() -> OsApprovalNotifier | None:
+    factory = _default_os_adapter_factory
+    if factory is None:
+        return None
+    try:
+        return factory()
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def format_task_approval_message(
@@ -37,8 +97,8 @@ def format_task_approval_message(
         approved_at or datetime.now(UTC),
     )
     if shipped_in:
-        return f"\u2713 {task.task_id} approved - shipped in {shipped_in}"
-    return f"\u2713 {task.task_id} approved"
+        return f"✓ {task.task_id} approved - shipped in {shipped_in}"
+    return f"✓ {task.task_id} approved"
 
 
 def notify_task_approved(
@@ -46,13 +106,21 @@ def notify_task_approved(
     *,
     notify: NotifyCallback,
     approved_at: datetime | None = None,
-    os_adapter: "HumanNotifyAdapter | None" = None,
+    os_adapter: "OsApprovalNotifier | None" = None,
 ) -> str:
-    """Emit the in-cockpit toast and best-effort macOS banner."""
+    """Emit the in-cockpit toast and best-effort OS banner.
+
+    The OS banner is delivered through ``os_adapter`` when the caller
+    supplies one (tests, custom flows); otherwise the registered
+    default adapter is consulted. With no registered adapter the
+    banner is skipped silently — the toast still fires.
+    """
     message = format_task_approval_message(task, approved_at=approved_at)
     notify(message, severity="information", timeout=_TOAST_TIMEOUT_SECONDS)
 
-    adapter = os_adapter or MacOsNotifyAdapter()
+    adapter = os_adapter if os_adapter is not None else _resolve_default_os_adapter()
+    if adapter is None:
+        return message
     try:
         available = adapter.is_available()
     except Exception:  # noqa: BLE001
@@ -104,6 +172,8 @@ def _coerce_utc(value: datetime | None) -> datetime | None:
 
 
 __all__ = [
+    "OsApprovalNotifier",
     "format_task_approval_message",
     "notify_task_approved",
+    "register_default_os_adapter",
 ]

--- a/src/pollypm/plugins_builtin/human_notify/plugin.py
+++ b/src/pollypm/plugins_builtin/human_notify/plugin.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pollypm.approval_notifications import register_default_os_adapter
 from pollypm.plugin_api.v1 import Capability, PluginAPI, PollyPMPlugin
 from pollypm.plugins_builtin.human_notify.cockpit import CockpitNotifyAdapter
 from pollypm.plugins_builtin.human_notify.dispatcher import dispatch
@@ -198,6 +199,11 @@ def _initialize(api: PluginAPI) -> None:
     global _ADAPTERS
     _ADAPTERS = _load_adapters(api)
     _task_assignment_bus.register_listener(_in_process_listener)
+    # Wire the macOS adapter as the default OS-banner channel for the
+    # core approval flow (see ``pollypm.approval_notifications``). Core
+    # used to import ``MacOsNotifyAdapter`` directly; the registration
+    # seam removes that import and keeps the plugin truly optional.
+    register_default_os_adapter(MacOsNotifyAdapter)
     n_adapters = len(_ADAPTERS)
     adapter_word = "adapter" if n_adapters == 1 else "adapters"
     logger.info(

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -170,6 +170,11 @@ _PLAN_PRESENCE_PLUGIN_MODULE = (
 _TASK_ASSIGNMENT_NOTIFY_API_MODULE = (
     "pollypm.plugins_builtin.task_assignment_notify.api"
 )
+# ``approval_notifications`` lives in core; it must resolve the OS
+# adapter via :func:`pollypm.approval_notifications.register_default_os_adapter`
+# instead of reaching into the optional plugin tree.
+_APPROVAL_NOTIFICATIONS_FILE = "src/pollypm/approval_notifications.py"
+_HUMAN_NOTIFY_PLUGIN_PREFIX = "pollypm.plugins_builtin.human_notify"
 
 
 def _imports_module(source_file: Path, module: str) -> bool:
@@ -180,6 +185,21 @@ def _imports_module(source_file: Path, module: str) -> bool:
         if isinstance(node, ast.Import):
             for alias in node.names:
                 if alias.name == module or alias.name.startswith(f"{module}."):
+                    return True
+    return False
+
+
+def _imports_module_or_subpackage(source_file: Path, prefix: str) -> bool:
+    """True iff ``source_file`` imports ``prefix`` or any of its submodules."""
+    tree = ast.parse(source_file.read_text(encoding="utf-8"), filename=str(source_file))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == prefix or module.startswith(f"{prefix}."):
+                return True
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == prefix or alias.name.startswith(f"{prefix}."):
                     return True
     return False
 
@@ -208,6 +228,30 @@ def test_non_plugin_sources_do_not_import_task_assignment_notify_api() -> None:
         if _imports_module(source_file, _TASK_ASSIGNMENT_NOTIFY_API_MODULE):
             offenders.append(rel)
     assert offenders == []
+
+
+def test_approval_notifications_does_not_import_human_notify_plugin() -> None:
+    """Core approval flow must not reach into the human_notify plugin.
+
+    The OS adapter is installed via
+    :func:`pollypm.approval_notifications.register_default_os_adapter`
+    during plugin initialize. Any direct import from
+    ``pollypm.plugins_builtin.human_notify`` re-couples core to the
+    optional plugin tree — fail loudly so the seam stays clean.
+    """
+    root = _project_root()
+    source_file = root / _APPROVAL_NOTIFICATIONS_FILE
+    assert source_file.exists(), (
+        f"Expected {_APPROVAL_NOTIFICATIONS_FILE} to exist — boundary test "
+        "needs updating if the file moved."
+    )
+    assert not _imports_module_or_subpackage(
+        source_file, _HUMAN_NOTIFY_PLUGIN_PREFIX
+    ), (
+        f"{_APPROVAL_NOTIFICATIONS_FILE} must not import from "
+        f"{_HUMAN_NOTIFY_PLUGIN_PREFIX}; use register_default_os_adapter "
+        "instead so the plugin stays optional."
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Picks one violation from #1363 (core modules importing from `plugins_builtin/`) and refactors it with a dependency-injection seam.

- `src/pollypm/approval_notifications.py` used to top-level import `MacOsNotifyAdapter` and reference `HumanNotifyAdapter` (TYPE_CHECKING) from `pollypm.plugins_builtin.human_notify` — a core module hard-coupled to an "optional" plugin.
- Replaced with `register_default_os_adapter()` + a local `OsApprovalNotifier` Protocol. The `human_notify` plugin installs its `MacOsNotifyAdapter` during `initialize(api)`. With no plugin loaded, the in-cockpit toast still fires and the OS banner is skipped — which is what "optional" should mean.
- Added `test_approval_notifications_does_not_import_human_notify_plugin` to `tests/test_import_boundary.py` so the seam stays clean.

Scope deliberately narrow per the multi-PR strategy in #1363 — this is the cleanest single violation (`human_notify`, one top-level + one TYPE_CHECKING import). The activity_feed / project_planning / task_assignment_notify / morning_briefing clusters remain open.

## Test plan

- [x] `pytest tests/test_import_boundary.py tests/test_approval_notifications.py tests/test_human_notify.py tests/test_plugins.py tests/test_plugin_interop.py tests/test_plugin_boundary_conformance.py tests/test_plan_approval_celebration.py` — 107 pass
- [x] New boundary test passes
- [x] `python -c "import pollypm.approval_notifications"` clean (no plugins_builtin import at load time)
- [x] `python -c "from pollypm.plugins_builtin.human_notify.plugin import plugin"` still loads

Pre-existing unrelated failure on this worktree's main: `test_supervisor_import_allowlist_matches_reality` flags `src/pollypm/cli_features/tier4.py` — verified present on `main` before these changes; out of scope.

Closes part of #1363.