### PR TITLE
refactor(activity_feed): break plugin <-> feed_panel cycle (refs #1367)

### DIFF
--- a/src/pollypm/plugins_builtin/activity_feed/cockpit/feed_panel.py
+++ b/src/pollypm/plugins_builtin/activity_feed/cockpit/feed_panel.py
@@ -32,7 +32,9 @@ from pollypm.plugins_builtin.activity_feed.handlers.event_projector import (
     EventProjector,
     FeedEntry,
 )
-from pollypm.plugins_builtin.activity_feed.plugin import build_projector
+from pollypm.plugins_builtin.activity_feed.projector_factory import (
+    build_projector,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/pollypm/plugins_builtin/activity_feed/plugin.py
+++ b/src/pollypm/plugins_builtin/activity_feed/plugin.py
@@ -30,45 +30,19 @@ from pollypm.plugin_api.v1 import (
     PollyPMPlugin,
     RailContext,
 )
+from pollypm.plugins_builtin.activity_feed.cockpit.feed_panel import (
+    new_event_count,
+)
 from pollypm.plugins_builtin.activity_feed.handlers.event_projector import (
     EventProjector,
     FeedEntry,
 )
+from pollypm.plugins_builtin.activity_feed.projector_factory import (
+    _collect_work_db_paths,
+    build_projector,
+)
 
 logger = logging.getLogger(__name__)
-
-
-def _collect_work_db_paths(config: Any) -> list[tuple[str, Any]]:
-    """Build the list of (project_key, work_db_path) for the projector.
-
-    Missing config, missing projects, or missing work DBs are tolerated
-    — the projector checks path existence before querying.
-    """
-    result: list[tuple[str, Any]] = []
-    if config is None:
-        return result
-    projects = getattr(config, "projects", None) or {}
-    for key, project in projects.items():
-        project_path = getattr(project, "path", None)
-        if project_path is None:
-            continue
-        result.append((str(key), project_path / ".pollypm" / "state.db"))
-    return result
-
-
-def build_projector(config: Any) -> EventProjector | None:
-    """Construct an :class:`EventProjector` wired to the active config.
-
-    Returns ``None`` if no state DB is configured (typical in test
-    harnesses with stub configs). Callers treat ``None`` as "no feed
-    available" and show an empty panel.
-    """
-    if config is None:
-        return None
-    state_db = getattr(getattr(config, "project", None), "state_db", None)
-    if state_db is None:
-        return None
-    return EventProjector(state_db, _collect_work_db_paths(config))
 
 
 _LAST_SEEN_FILE_NAME = "activity_feed_last_seen"
@@ -122,13 +96,6 @@ def _badge_provider_factory(config: Any):
     def _provider(_ctx: RailContext) -> str | None:
         projector = build_projector(config)
         if projector is None:
-            return None
-        try:
-            from pollypm.plugins_builtin.activity_feed.cockpit.feed_panel import (
-                new_event_count,
-            )
-        except Exception:  # noqa: BLE001
-            logger.debug("activity_feed: badge helper import failed", exc_info=True)
             return None
         last_seen = _load_last_seen_id(config)
         count = new_event_count(projector, last_seen)

--- a/src/pollypm/plugins_builtin/activity_feed/projector_factory.py
+++ b/src/pollypm/plugins_builtin/activity_feed/projector_factory.py
@@ -1,0 +1,52 @@
+"""Construct :class:`EventProjector` instances from a host config.
+
+Extracted from ``plugin.py`` to break the import cycle between the
+plugin entrypoint and ``cockpit/feed_panel.py``: the panel needs
+``build_projector`` at module import time, while the plugin needs the
+panel's badge helpers — moving the factory here lets both sides import
+from a leaf module without lazy imports (#1367).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pollypm.plugins_builtin.activity_feed.handlers.event_projector import (
+    EventProjector,
+)
+
+
+def _collect_work_db_paths(config: Any) -> list[tuple[str, Any]]:
+    """Build the list of (project_key, work_db_path) for the projector.
+
+    Missing config, missing projects, or missing work DBs are tolerated
+    — the projector checks path existence before querying.
+    """
+    result: list[tuple[str, Any]] = []
+    if config is None:
+        return result
+    projects = getattr(config, "projects", None) or {}
+    for key, project in projects.items():
+        project_path = getattr(project, "path", None)
+        if project_path is None:
+            continue
+        result.append((str(key), project_path / ".pollypm" / "state.db"))
+    return result
+
+
+def build_projector(config: Any) -> EventProjector | None:
+    """Construct an :class:`EventProjector` wired to the active config.
+
+    Returns ``None`` if no state DB is configured (typical in test
+    harnesses with stub configs). Callers treat ``None`` as "no feed
+    available" and show an empty panel.
+    """
+    if config is None:
+        return None
+    state_db = getattr(getattr(config, "project", None), "state_db", None)
+    if state_db is None:
+        return None
+    return EventProjector(state_db, _collect_work_db_paths(config))
+
+
+__all__ = ["build_projector"]


### PR DESCRIPTION
## Summary
- Breaks the `pollypm.plugins_builtin.activity_feed.plugin` <-> `...activity_feed.cockpit.feed_panel` circular import pair listed in #1367.
- Extracts `build_projector` + `_collect_work_db_paths` into a new leaf module `pollypm.plugins_builtin.activity_feed.projector_factory`. Both sides now import the factory from the leaf; the lazy `new_event_count` import inside the rail badge provider is removed.
- `plugin.py` re-exports `build_projector` for backwards compatibility, so existing callers in `cockpit_ui`, `cockpit_inbox`, `plugins_builtin/activity_feed/cli.py`, and the test suite continue to work unchanged.

Partial slice only — issue stays open via `Refs #1367`. Six pairs remain (cockpit_inbox/cockpit_inbox_items, cockpit_palette/cockpit_ui, cockpit_rail/cockpit, onboarding/onboarding_tui, and two `work.sqlite_service` pairs).

## Test plan
- [x] `pytest tests/test_activity_feed_panel.py tests/test_activity_feed_projector.py tests/test_activity_feed_cli.py` — 63 passed
- [x] Both import orderings work fresh: `import plugin` then `import feed_panel`, and reverse
- [x] Re-ran the AST-based cycle scan from the issue: count drops from 7 -> 6 pairs

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>