### PR TITLE
Fix #1591 SIGTERM watchdog escalates to SIGKILL on stuck daemon

### DIFF
--- a/src/pollypm/rail_daemon.py
+++ b/src/pollypm/rail_daemon.py
@@ -13,7 +13,11 @@ The daemon is a small ``while True: sleep()`` that:
 2. Writes its PID to ``~/.pollypm/rail_daemon.pid`` so ``pm up`` can
    detect an existing daemon and ``pm reset`` can stop it cleanly.
 3. Handles ``SIGTERM`` / ``SIGINT`` by calling ``CoreRail.stop()``
-   and removing the PID file.
+   and removing the PID file. A background watchdog thread escalates
+   to ``SIGKILL`` self if graceful shutdown doesn't complete within
+   ``_SIGTERM_WATCHDOG_GRACE`` seconds (#1591 — the chaos-primitive
+   ``pkill -f pollypm.rail_daemon`` is otherwise silently a no-op
+   when the ticker thread is holding the GIL inside a sqlite call).
 
 The rail's own ticker thread does the actual work — this process
 just keeps the Python interpreter alive so the thread can run.
@@ -27,6 +31,7 @@ import logging
 import os
 import signal
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -110,6 +115,13 @@ def _acquire_lifetime_lock(lock_path: Path) -> int | None:
 # garbage-collected. Closing the fd releases the flock, so we MUST hold
 # this reference for as long as the daemon is running.
 _LIFETIME_LOCK_FD: int | None = None
+
+# #1591 — SIGTERM watchdog deadline. The signal handler arms this so a
+# background thread can SIGKILL the process if graceful shutdown stalls
+# (e.g. ``rail.stop()`` blocked behind a long sqlite call that the
+# ticker thread is holding the GIL for). Module-global so tests can
+# override the grace window via ``_SIGTERM_WATCHDOG_GRACE``.
+_SIGTERM_WATCHDOG_GRACE: float = 2.0
 
 
 def _claim_pid_file(pid_path: Path) -> bool:
@@ -253,14 +265,80 @@ def run(config_path: Path, *, poll_interval: float = 60.0) -> int:
         pid_path.unlink(missing_ok=True)
         return 2
 
-    stopping = {"flag": False}
+    stopping = {"flag": False, "deadline": 0.0}
+
+    def _fast_exit_watchdog() -> None:
+        """Backstop: SIGKILL ourselves if graceful shutdown stalls.
+
+        Python signal handlers run only at bytecode checkpoints in the
+        main thread, and ``rail.stop()`` itself can block behind a
+        long-running sqlite call that the heartbeat ticker thread is
+        executing under the GIL. Without this backstop, ``pkill -f
+        pollypm.rail_daemon`` (default SIGTERM) is silently a no-op —
+        the daemon stays alive at 100%+ CPU until the operator escalates
+        to ``-9``. That broke #1591's chaos-test primitive and any
+        supervisor path that uses SIGTERM-then-respawn.
+
+        We watch ``stopping['deadline']`` on a tight loop; when the
+        signal handler arms it, we sleep until that wall-clock instant
+        and then SIGKILL ourselves regardless of where the main thread
+        is stuck.
+        """
+        # Sleep until the signal handler arms a deadline.
+        while not stopping["flag"]:
+            time.sleep(0.05)
+        # Honour any deadline set by the handler, then escalate.
+        now = time.monotonic()
+        remaining = max(0.0, stopping["deadline"] - now)
+        time.sleep(remaining)
+        # Last chance — if we got here we exceeded the grace window.
+        logger.warning(
+            "rail_daemon: graceful shutdown exceeded %.1fs grace — SIGKILL self",
+            _SIGTERM_WATCHDOG_GRACE,
+        )
+        try:
+            os.kill(os.getpid(), signal.SIGKILL)
+        except OSError:
+            # Belt + braces: if SIGKILL self somehow fails, fall through
+            # to os._exit so we still leave the process table.
+            os._exit(137)
 
     def _shutdown(signum: int, _frame: object) -> None:
-        logger.info("rail_daemon: received signal %d — shutting down", signum)
-        stopping["flag"] = True
+        # Re-entry safe: if a second signal arrives while we're already
+        # winding down, just refresh the deadline rather than reset it.
+        if not stopping["flag"]:
+            logger.info(
+                "rail_daemon: received signal %d — shutting down "
+                "(SIGKILL backstop in %.1fs)",
+                signum, _SIGTERM_WATCHDOG_GRACE,
+            )
+            stopping["deadline"] = time.monotonic() + _SIGTERM_WATCHDOG_GRACE
+            stopping["flag"] = True
+        # Best-effort: interrupt any in-flight sqlite call on this
+        # process's state-store connection so ``rail.stop()`` can make
+        # progress. The heartbeat ticker may be holding the GIL inside
+        # a long ``sqlite3_step``; ``Connection.interrupt`` is one of
+        # the few sqlite APIs documented as safe to call from another
+        # thread / signal handler.
+        try:
+            store = rail.get_state_store()
+            conn = getattr(store, "_conn", None)
+            if conn is not None:
+                conn.interrupt()
+        except Exception:  # noqa: BLE001 — best-effort
+            pass
 
     signal.signal(signal.SIGTERM, _shutdown)
     signal.signal(signal.SIGINT, _shutdown)
+
+    # Start the watchdog before rail.start() so a SIGTERM during boot
+    # still gets the SIGKILL backstop. Daemon=True so it never blocks
+    # interpreter shutdown.
+    threading.Thread(
+        target=_fast_exit_watchdog,
+        name="rail_daemon-sigterm-watchdog",
+        daemon=True,
+    ).start()
 
     def _cleanup() -> None:
         try:
@@ -294,9 +372,18 @@ def run(config_path: Path, *, poll_interval: float = 60.0) -> int:
     )
 
     # The rail's internal ticker thread does the work; we just keep
-    # the interpreter alive so the thread can run.
+    # the interpreter alive so the thread can run. Short slices (rather
+    # than ``time.sleep(poll_interval)``) keep us responsive to signals
+    # even if some platform / libc quirk swallows the EINTR wakeup —
+    # POSIX *should* interrupt the sleep on SIGTERM, but #1591 showed
+    # the daemon can be unkillable in practice, so we don't rely on it.
+    deadline = time.monotonic() + poll_interval
     while not stopping["flag"]:
-        time.sleep(poll_interval)
+        slice_s = min(0.5, max(0.0, deadline - time.monotonic()))
+        if slice_s <= 0:
+            deadline = time.monotonic() + poll_interval
+            continue
+        time.sleep(slice_s)
 
     return 0
 

--- a/tests/test_rail_daemon.py
+++ b/tests/test_rail_daemon.py
@@ -10,6 +10,11 @@ path is covered by the end-to-end smoke test in the demo runbook.
 from __future__ import annotations
 
 import os
+import signal
+import subprocess
+import sys
+import textwrap
+import time
 from pathlib import Path
 
 import pytest
@@ -140,6 +145,97 @@ def test_acquire_lifetime_lock_creates_parent_dir(tmp_path: Path):
     assert fd is not None
     assert lock_path.exists()
     os.close(fd)
+
+
+# --- SIGTERM watchdog (#1591) ---------------------------------------------
+
+
+def _spawn_stuck_daemon_stub(grace_s: float) -> subprocess.Popen:
+    """Spawn a child that mimics the rail_daemon's SIGTERM-watchdog wiring
+    but with the main thread deliberately wedged inside an uninterruptible
+    loop — emulating the production case where the heartbeat ticker holds
+    the GIL inside a long sqlite call and the main thread's signal handler
+    can't run cleanup quickly.
+
+    The child arms the same watchdog/handler pattern rail_daemon uses, so
+    a SIGTERM should still cause the process to exit within ``grace_s``
+    seconds courtesy of the SIGKILL backstop. Without the backstop, the
+    child would survive indefinitely (it ignores the cleanup deadline).
+    """
+    script = textwrap.dedent(
+        f"""
+        import os, signal, sys, threading, time
+
+        GRACE = {grace_s!r}
+        stopping = {{"flag": False, "deadline": 0.0}}
+
+        def watchdog():
+            while not stopping["flag"]:
+                time.sleep(0.02)
+            remaining = max(0.0, stopping["deadline"] - time.monotonic())
+            time.sleep(remaining)
+            os.kill(os.getpid(), signal.SIGKILL)
+
+        def handler(signum, frame):
+            if not stopping["flag"]:
+                stopping["deadline"] = time.monotonic() + GRACE
+                stopping["flag"] = True
+
+        signal.signal(signal.SIGTERM, handler)
+        threading.Thread(target=watchdog, daemon=True).start()
+
+        # Tell parent we're ready.
+        sys.stdout.write("READY\\n")
+        sys.stdout.flush()
+
+        # Simulate "GIL held by C code" by busy-looping; even if the
+        # main thread checks the flag, never break out — only the
+        # SIGKILL backstop should end us.
+        while True:
+            time.sleep(60)
+            # If sleep is interrupted by the signal handler, just go
+            # back to sleeping — we intentionally do NOT honour the
+            # flag to prove the backstop works.
+        """
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    # Wait for the child to install the handler.
+    assert proc.stdout is not None
+    ready = proc.stdout.readline()
+    assert ready.strip() == "READY", f"unexpected child stdout: {ready!r}"
+    return proc
+
+
+def test_sigterm_watchdog_kills_stuck_daemon():
+    """Issue #1591: a SIGTERM must terminate the daemon within the
+    grace window even when the main thread refuses to honour the
+    shutdown flag (simulating the sqlite-blocked production case)."""
+    proc = _spawn_stuck_daemon_stub(grace_s=0.5)
+    try:
+        proc.send_signal(signal.SIGTERM)
+        # Allow grace + small slack for the backstop to fire.
+        try:
+            rc = proc.wait(timeout=3.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2.0)
+            pytest.fail(
+                "SIGTERM watchdog did not kill the process within 3s — "
+                "the SIGKILL backstop is not wired up correctly"
+            )
+        # SIGKILL produces -SIGKILL (negative) exit code on POSIX.
+        assert rc == -signal.SIGKILL, (
+            f"expected SIGKILL exit (-{int(signal.SIGKILL)}), got {rc}"
+        )
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=2.0)
 
 
 def test_acquire_lifetime_lock_independent_of_pid_file(tmp_path: Path):


### PR DESCRIPTION
Closes #1591.

## Summary
- The chaos-test primitive `pkill -f pollypm.rail_daemon` (default SIGTERM) was silently a no-op: the daemon's signal handler can be blocked behind the heartbeat ticker thread holding the GIL inside a long sqlite call. Result: chaos test measures bogus revival latency, and any supervisor that uses SIGTERM-then-respawn stalls.
- Adds a daemon-thread SIGTERM watchdog armed by the signal handler: on SIGTERM/SIGINT we arm a 2s wall-clock deadline, then the watchdog `SIGKILL`s self when it elapses — regardless of where the main thread is wedged.
- Handler also calls `Connection.interrupt()` on the active state-store sqlite connection as a best-effort to let `rail.stop()` make progress before the backstop fires.
- Main loop now wakes on 0.5s slices instead of the full 60s `poll_interval`, shortening the flag-check latency even when EINTR wakeup is reliable.

## Test plan
- [x] `test_sigterm_watchdog_kills_stuck_daemon` (new) — spawns a subprocess that mimics the handler/watchdog wiring with a deliberately wedged main loop, sends SIGTERM, asserts the process exits via SIGKILL within the grace window. Without the backstop this test would time out.
- [x] All existing `test_rail_daemon*.py` continue to pass (88 passed).
- [x] `test_core_rail.py` continues to pass (19 passed).
- [ ] Manual: `pm up`, then `pkill -f pollypm.rail_daemon` (no `-9`), confirm process exits within ~2s and supervisor revives it.