### PR TITLE
Fix #1592: periodic cockpit-socket reaper on rail heartbeat

### DIFF
--- a/src/pollypm/defaults/docs/reference/operator-runbook.md
+++ b/src/pollypm/defaults/docs/reference/operator-runbook.md
@@ -269,12 +269,19 @@ What an operator sees:
 What runs:
 
 - `pollypm.cockpit_socket_reaper::reap_stale_cockpit_sockets`, called
-  from `pollypm.supervisor.Supervisor._bootstrap_clear_markers`.
+  from `pollypm.supervisor.Supervisor._bootstrap_clear_markers` at
+  bootstrap, and periodically from
+  `pollypm.plugins_builtin.core_recurring.maintenance::cockpit_socket_reap_handler`
+  via the `cockpit_socket.reap` roster entry.
 
 When it runs:
 
 - Once during supervisor bootstrap, before new cockpit or per-task
   worker panes are launched.
+- Every 5 minutes thereafter on the `rail_daemon` / heartbeat thread
+  so a long-lived cockpit doesn't accumulate stale entries between
+  boots (#1592). Live PIDs are never touched, so the periodic sweep
+  is safe alongside running panes.
 
 What it touches:
 

--- a/src/pollypm/plugins_builtin/core_recurring/maintenance.py
+++ b/src/pollypm/plugins_builtin/core_recurring/maintenance.py
@@ -651,6 +651,36 @@ def log_rotate_handler(payload: dict[str, Any]) -> dict[str, Any]:
     return {"rotated": rotated, "deleted": deleted, "errors": errors}
 
 
+def cockpit_socket_reap_handler(payload: dict[str, Any]) -> dict[str, Any]:
+    """Periodically reap stale ``cockpit_inputs/*.sock`` whose owner PID is dead.
+
+    The bootstrap-time call from ``Supervisor._bootstrap_clear_markers``
+    only fires once per ``pm up``. A long-lived cockpit that survives many
+    per-task worker crash + restart cycles accumulates stale sockets
+    (one per crashed pane) until shutdown (#1592). Running the reaper as
+    a recurring handler on the ``rail_daemon`` / heartbeat thread keeps
+    the directory bounded across the lifetime of a single boot.
+
+    Safe to run concurrently with live cockpits and panes: the reaper
+    only unlinks entries whose name encodes a PID that no longer exists,
+    so a live bridge's socket (whose owner PID is alive by definition)
+    is never touched. The same audit + log surfaces fire as at bootstrap.
+
+    ``payload`` accepts an optional ``base_dir`` override (tests). When
+    absent, the active config's ``project.base_dir`` is used.
+    """
+    from pollypm.cockpit_socket_reaper import reap_stale_cockpit_sockets
+
+    base_override = payload.get("base_dir") if isinstance(payload, dict) else None
+    if base_override:
+        base_dir = Path(base_override)
+    else:
+        config = _load_config(payload)
+        base_dir = config.project.base_dir
+    reaped = reap_stale_cockpit_sockets(base_dir)
+    return {"reaped": len(reaped)}
+
+
 def notification_staging_prune_handler(payload: dict[str, Any]) -> dict[str, Any]:
     """Drop flushed + silent notification_staging rows older than 30d."""
     from pollypm.work import create_work_service

--- a/src/pollypm/plugins_builtin/core_recurring/plugin.py
+++ b/src/pollypm/plugins_builtin/core_recurring/plugin.py
@@ -15,6 +15,7 @@ from pollypm.plugins_builtin.core_recurring.maintenance import (
     account_usage_refresh_handler,
     agent_worktree_prune_handler,
     capacity_probe_handler,
+    cockpit_socket_reap_handler,
     db_vacuum_handler,
     log_rotate_handler,
     memory_ttl_sweep_handler,
@@ -429,6 +430,16 @@ def _register_handlers(api: JobHandlerAPI) -> None:
         "log.rotate", log_rotate_handler,
         max_attempts=1, timeout_seconds=120.0,
     )
+    # #1592 — periodic socket reaper so a long-lived cockpit doesn't
+    # accumulate stale ``cockpit_inputs/*.sock`` entries between boots.
+    # The bootstrap call only fires at ``pm up``; without this handler
+    # a cockpit that survives many per-task worker crash + restart
+    # cycles ends up with dozens of orphaned socket files (#1592 saw
+    # 17 in 78+ min). Cheap (single directory walk, ~O(N) syscalls).
+    api.register_handler(
+        "cockpit_socket.reap", cockpit_socket_reap_handler,
+        max_attempts=1, timeout_seconds=60.0,
+    )
     api.register_handler(
         "worktree.state_audit", worktree_state_audit_handler,
         max_attempts=1, timeout_seconds=120.0,
@@ -512,6 +523,13 @@ def _register_roster(api: RosterAPI) -> None:
         "31 * * * *", "log.rotate", {},
         dedupe_key="log.rotate",
     )
+    # #1592 — every 5 min sweep of stale cockpit-input sockets so a
+    # long-lived cockpit doesn't accumulate orphans between boots.
+    # Dedupe so a contended rail tick doesn't pile up identical claims.
+    api.register_recurring(
+        "@every 5m", "cockpit_socket.reap", {},
+        dedupe_key="cockpit_socket.reap",
+    )
     api.register_recurring(
         "@every 10m", "worktree.state_audit", {},
         dedupe_key="worktree.state_audit",
@@ -562,6 +580,7 @@ plugin = PollyPMPlugin(
         Capability(kind="job_handler", name="notification_staging.prune"),
         Capability(kind="job_handler", name="agent_worktree.prune"),
         Capability(kind="job_handler", name="log.rotate"),
+        Capability(kind="job_handler", name="cockpit_socket.reap"),
         Capability(kind="job_handler", name="worktree.state_audit"),
         Capability(kind="job_handler", name="stuck_claims.sweep"),
         Capability(kind="job_handler", name="blocked_chain.sweep"),

--- a/tests/test_cockpit_socket_reaper.py
+++ b/tests/test_cockpit_socket_reaper.py
@@ -279,6 +279,89 @@ def test_emits_socket_reaped_audit_event(
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Periodic recurring-handler reaper (#1592)
+#
+# The bootstrap call fires once at ``pm up``; without a periodic sweep a
+# long-lived cockpit accumulates stale sockets between boots. The
+# ``cockpit_socket.reap`` roster entry runs the same reaper logic on the
+# rail_daemon / heartbeat thread.
+# ---------------------------------------------------------------------------
+
+
+def test_cockpit_socket_reap_handler_unlinks_stale(base_dir: Path) -> None:
+    """The recurring handler reaps stale sockets when called with a base_dir."""
+    from pollypm.plugins_builtin.core_recurring.plugin import (
+        cockpit_socket_reap_handler,
+    )
+
+    dead_pid = _spawn_briefly()
+    stale = base_dir / "cockpit_inputs" / f"cockpit-{dead_pid}.sock"
+    sock = _bind_socket(stale)
+    sock.close()
+    assert stale.exists()
+
+    result = cockpit_socket_reap_handler({"base_dir": str(base_dir)})
+
+    assert result == {"reaped": 1}
+    assert not stale.exists()
+
+
+def test_cockpit_socket_reap_handler_preserves_live(base_dir: Path) -> None:
+    """The recurring handler does not touch sockets owned by live PIDs.
+
+    Critical safety property: the handler runs while the cockpit is alive,
+    so a live bridge's socket must survive every sweep.
+    """
+    from pollypm.plugins_builtin.core_recurring.plugin import (
+        cockpit_socket_reap_handler,
+    )
+
+    live_path = base_dir / "cockpit_inputs" / f"cockpit-{os.getpid()}.sock"
+    sock = _bind_socket(live_path)
+    try:
+        result = cockpit_socket_reap_handler({"base_dir": str(base_dir)})
+        assert result == {"reaped": 0}
+        assert live_path.exists() and live_path.is_socket()
+    finally:
+        sock.close()
+        live_path.unlink(missing_ok=True)
+
+
+def test_cockpit_socket_reap_registered_on_roster_every_5m() -> None:
+    """``cockpit_socket.reap`` is registered as a 5-minute roster entry.
+
+    Without a periodic schedule the bootstrap-only call recreates the
+    #1592 regression: stale sockets pile up over the lifetime of a boot.
+    """
+    from pollypm.heartbeat import Roster
+    from pollypm.heartbeat.roster import EverySchedule
+    from pollypm.plugin_api.v1 import RosterAPI
+    from pollypm.plugins_builtin.core_recurring.plugin import plugin as core_plugin
+
+    roster = Roster()
+    api = RosterAPI(roster, plugin_name="core_recurring")
+    core_plugin.register_roster(api)
+
+    entries = {entry.handler_name: entry for entry in roster.entries}
+    entry = entries.get("cockpit_socket.reap")
+    assert entry is not None, "cockpit_socket.reap missing from roster"
+    assert isinstance(entry.schedule, EverySchedule)
+    assert int(entry.schedule.interval.total_seconds()) == 300
+
+
+def test_cockpit_socket_reap_handler_registered() -> None:
+    """``cockpit_socket.reap`` is wired into the JobHandlerRegistry."""
+    from pollypm.jobs import JobHandlerRegistry
+    from pollypm.plugin_api.v1 import JobHandlerAPI
+    from pollypm.plugins_builtin.core_recurring.plugin import plugin as core_plugin
+
+    registry = JobHandlerRegistry()
+    api = JobHandlerAPI(registry, plugin_name="core_recurring")
+    core_plugin.register_handlers(api)
+    assert "cockpit_socket.reap" in registry.names()
+
+
 def test_bootstrap_path_creates_then_reaps_only_stale(base_dir: Path) -> None:
     """Bootstrap-style flow: bind sockets, kill some "owners" by closing
     + naming them with dead PIDs, run reaper, assert only stale ones


### PR DESCRIPTION
## Summary
- Adds a `cockpit_socket.reap` recurring handler (every 5 min) on the `core_recurring` plugin so a long-lived cockpit doesn't accumulate stale `cockpit_inputs/*.sock` between boots (#1592).
- Root cause was NOT a wedged asyncio loop (the bug report's #1587-equivalent hypothesis): the reaper only ever ran from `Supervisor._bootstrap_clear_markers` once per `pm up`. No periodic schedule existed. The 78+ min gap was just "cockpit has been up for 78+ min."
- Reuses `reap_stale_cockpit_sockets` unchanged, so the safety property (live PIDs are never touched) carries over to the periodic sweep — safe to run alongside live cockpits and panes. Same audit (`socket.reaped`) and log surfaces fire from the periodic path as the bootstrap path.

## Files
- `src/pollypm/plugins_builtin/core_recurring/maintenance.py` — new `cockpit_socket_reap_handler` (accepts `base_dir` override for tests, otherwise uses `config.project.base_dir`).
- `src/pollypm/plugins_builtin/core_recurring/plugin.py` — register handler + roster entry + capability.
- `src/pollypm/defaults/docs/reference/operator-runbook.md` — document the new periodic cadence alongside bootstrap.
- `tests/test_cockpit_socket_reaper.py` — 4 new tests: handler unlinks stale, handler preserves live, roster entry registered at 5 min, handler registered in the JobHandlerRegistry.

## Test plan
- [x] `pytest tests/test_cockpit_socket_reaper.py` (14 passed, including 4 new)
- [x] `pytest tests/test_operator_runbook_maintenance_docs.py` (passes — required terms still present)
- [x] `pytest tests/test_pane_patterns.py tests/test_alerts_gc_overflow_regression.py tests/test_log_rotate.py tests/test_heartbeat_cascade_foundation.py` (91 passed — no regressions in related core_recurring tests)
- [ ] Manual: confirm `~/.pollypm/cockpit_inputs/` count stays bounded over a long-running cockpit by observing `socket.reaped` events firing at 5 min intervals in `~/.pollypm/audit/_workspace.jsonl`.

Closes #1592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)