### PR TITLE
feat(cli): add `pm project remove <key>` command (#1561)

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -650,6 +650,110 @@ def rename_cmd(
 
 
 # ---------------------------------------------------------------------------
+# pm project remove (#1561)
+# ---------------------------------------------------------------------------
+
+
+def _count_active_tasks(project_key: str, config_path: Path) -> int:
+    """Return the number of non-terminal work-service tasks for ``project_key``.
+
+    Best-effort: if the workspace work DB is missing or unreadable, we
+    return ``0`` rather than blocking removal — the user can still pass
+    ``--force`` to bypass the prompt either way, and refusing to remove
+    a TOML entry because we can't *read* the state DB would be worse
+    than letting the user proceed.
+    """
+    try:
+        from pollypm.work import create_work_service
+
+        with create_work_service(project_key=project_key) as svc:
+            return len(svc.list_nonterminal_tasks(project=project_key))
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+@project_app.command("remove")
+def remove_cmd(
+    project_key: str = typer.Argument(
+        ...,
+        help="Project key to remove from the [projects] section.",
+    ),
+    force: bool = typer.Option(
+        False, "--force", "-f",
+        help=(
+            "Skip the active-task confirmation prompt. Required for "
+            "non-interactive removal when the project has queued or "
+            "in-flight tasks."
+        ),
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y",
+        help="Non-interactive: auto-accept the confirmation prompt.",
+    ),
+    config_path: Path = typer.Option(
+        DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path.",
+    ),
+) -> None:
+    """Remove a project from ``pollypm.toml``'s ``[projects]`` section.
+
+    Mirrors ``pm project new`` (#1561). The underlying core function
+    (:func:`pollypm.projects.remove_project`) only edits the TOML config —
+    work-service rows, tmux sessions, and worktree directories are NOT
+    touched. See issue #1561 for the full cascade-teardown plan; this
+    command is the narrow first step.
+
+    Refuses if the project is still referenced by enabled
+    ``[sessions.*]`` entries (the core function's invariant).
+
+    If the project has queued or in-flight tasks in the work DB, prompts
+    for confirmation. Pass ``--force`` to skip the prompt (e.g. for
+    scripted removal), or ``--yes`` to auto-accept it.
+    """
+    from pollypm.projects import remove_project
+
+    path = _require_config(config_path)
+    config = load_config(path)
+    if project_key not in config.projects:
+        typer.echo(f"Unknown project: {project_key}", err=True)
+        raise typer.Exit(code=1)
+
+    active = _count_active_tasks(project_key, path)
+    if active > 0 and not force:
+        task_word = "task" if active == 1 else "tasks"
+        typer.echo(
+            f"Project '{project_key}' has {active} queued or in-flight "
+            f"{task_word} in the work DB."
+        )
+        if yes:
+            proceed = True
+        else:
+            proceed = typer.confirm(
+                f"Remove '{project_key}' from pollypm.toml anyway? "
+                "(work-service rows will be left in place)",
+                default=False,
+            )
+        if not proceed:
+            typer.echo("Aborted. No changes made.")
+            raise typer.Exit(code=1)
+
+    try:
+        removed = remove_project(path, project_key)
+    except typer.BadParameter as exc:
+        typer.echo(f"Error: {exc.message}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(
+        f"Removed project '{removed.key}' from {path}"
+    )
+    if active > 0:
+        typer.echo(
+            f"Note: {active} work-service task(s) for '{removed.key}' "
+            "were left in place. See issue #1561 for the full "
+            "teardown recipe."
+        )
+
+
+# ---------------------------------------------------------------------------
 # pm project plan
 # ---------------------------------------------------------------------------
 

--- a/tests/test_project_remove_cli.py
+++ b/tests/test_project_remove_cli.py
@@ -1,0 +1,217 @@
+"""Tests for ``pm project remove`` (#1561).
+
+Narrow scope: surface the existing ``remove_project`` core function as a
+``pm project remove <key>`` CLI command. Mirrors the ``pm project new``
+pattern. The command refuses when the project has queued or in-flight
+work-service tasks unless ``--force`` (or ``--yes``) is supplied.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm.plugins_builtin.project_planning.cli.project import project_app
+
+
+runner = CliRunner()
+
+
+def _write_config(
+    config_path: Path,
+    *,
+    workspace_root: Path,
+    project_path: Path,
+    slug: str,
+    extra_sessions: str = "",
+) -> None:
+    config_path.write_text(
+        "[project]\n"
+        'tmux_session = "pollypm-test"\n'
+        f'workspace_root = "{workspace_root}"\n'
+        "\n"
+        f'[projects.{slug}]\n'
+        f'key = "{slug}"\n'
+        'name = "Demo"\n'
+        f'path = "{project_path}"\n'
+        f"{extra_sessions}"
+    )
+
+
+@pytest.fixture
+def env(tmp_path: Path) -> dict:
+    workspace_root = tmp_path / "dev"
+    workspace_root.mkdir()
+    project_path = workspace_root / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(
+        config_path,
+        workspace_root=workspace_root,
+        project_path=project_path,
+        slug="demo",
+    )
+    return {
+        "config_path": config_path,
+        "project_path": project_path,
+        "workspace_root": workspace_root,
+    }
+
+
+def _load_cfg(config_path: Path):
+    from pollypm.config import load_config
+    return load_config(config_path)
+
+
+# --------------------------------------------------------------------------
+# Happy path: no active tasks → removes without prompting.
+# --------------------------------------------------------------------------
+
+
+def test_cli_remove_happy_path(env) -> None:
+    target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with patch(target, return_value=0):
+        result = runner.invoke(
+            project_app,
+            ["remove", "demo", "--config", str(env["config_path"])],
+        )
+    assert result.exit_code == 0, result.output
+    assert "Removed project 'demo'" in result.output
+
+    config = _load_cfg(env["config_path"])
+    assert "demo" not in config.projects
+
+
+# --------------------------------------------------------------------------
+# Unknown project → exit(1) with a clear error.
+# --------------------------------------------------------------------------
+
+
+def test_cli_remove_unknown_project_errors_cleanly(env) -> None:
+    result = runner.invoke(
+        project_app,
+        ["remove", "does_not_exist", "--config", str(env["config_path"])],
+    )
+    assert result.exit_code == 1, result.output
+    assert "Unknown project" in result.output
+
+
+# --------------------------------------------------------------------------
+# Active tasks: refuses without confirmation; --force bypasses.
+# --------------------------------------------------------------------------
+
+
+def test_cli_remove_aborts_with_active_tasks_and_no_force(env) -> None:
+    target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with patch(target, return_value=3):
+        # CliRunner sends an empty stdin → typer.confirm reads "" → False.
+        result = runner.invoke(
+            project_app,
+            ["remove", "demo", "--config", str(env["config_path"])],
+            input="n\n",
+        )
+    assert result.exit_code == 1, result.output
+    assert "3 queued or in-flight tasks" in result.output
+    assert "Aborted" in result.output
+
+    # Config is untouched.
+    config = _load_cfg(env["config_path"])
+    assert "demo" in config.projects
+
+
+def test_cli_remove_force_bypasses_active_task_prompt(env) -> None:
+    target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with patch(target, return_value=2):
+        result = runner.invoke(
+            project_app,
+            [
+                "remove", "demo", "--force",
+                "--config", str(env["config_path"]),
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert "Removed project 'demo'" in result.output
+    # The follow-up note about orphan rows should fire when active>0.
+    assert "left in place" in result.output
+
+    config = _load_cfg(env["config_path"])
+    assert "demo" not in config.projects
+
+
+def test_cli_remove_yes_accepts_active_task_prompt(env) -> None:
+    target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with patch(target, return_value=1):
+        result = runner.invoke(
+            project_app,
+            [
+                "remove", "demo", "--yes",
+                "--config", str(env["config_path"]),
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    # Singular noun agreement.
+    assert "1 queued or in-flight task" in result.output
+
+    config = _load_cfg(env["config_path"])
+    assert "demo" not in config.projects
+
+
+# --------------------------------------------------------------------------
+# Session-reference refusal propagates from the core function.
+# --------------------------------------------------------------------------
+
+
+def test_cli_remove_refuses_when_project_still_has_sessions(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "dev"
+    workspace_root.mkdir()
+    project_path = workspace_root / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(
+        config_path,
+        workspace_root=workspace_root,
+        project_path=project_path,
+        slug="demo",
+        extra_sessions=(
+            "[sessions.architect_demo]\n"
+            'role = "architect"\n'
+            'provider = "claude"\n'
+            'account = "claude_main"\n'
+            'cwd = "."\n'
+            'project = "demo"\n'
+            'window_name = "architect-demo"\n'
+            "\n"
+            "[accounts.claude_main]\n"
+            'provider = "claude"\n'
+            'home = "/tmp/claude_home"\n'
+        ),
+    )
+    target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with patch(target, return_value=0):
+        result = runner.invoke(
+            project_app,
+            [
+                "remove", "demo", "--force",
+                "--config", str(config_path),
+            ],
+        )
+    assert result.exit_code == 1, result.output
+    assert "still used by session" in result.output
+
+    config = _load_cfg(config_path)
+    assert "demo" in config.projects


### PR DESCRIPTION
## Summary

- Adds `pm project remove <project_key>` — surfaces the existing `remove_project` core function as a CLI command (issue #1561), mirroring `pm project new`.
- Refuses to remove a project that still has queued or in-flight work-service tasks unless `--force` (or `--yes` for non-interactive accept) is passed; refusal on enabled session references propagates from the core function.
- Narrow scope by design — this is the first step toward the full teardown cascade described in #1561. State.db rows, tmux sessions, and worktree directories are **not** touched yet; the command surfaces a follow-up note when active tasks were left behind.

## Test plan

- [x] `pytest tests/test_project_remove_cli.py` (6 new tests, all pass)
- [x] `pytest -k "project_remove or project_rename or project_planning_cli or project_new"` (67 tests, all pass)
- [x] `pm project --help` lists `remove` alongside `new`, `rename`, `plan`, `replan`

## Tests added

- Happy path (no active tasks) removes the project cleanly.
- Unknown project key → exit(1) with `Unknown project` message.
- Active tasks + no `--force` + decline → aborts, config untouched.
- `--force` bypasses the active-task prompt and surfaces the "left in place" follow-up note.
- `--yes` accepts the active-task prompt non-interactively (singular noun agreement).
- Session-reference refusal from the core function surfaces as exit(1) with the existing `still used by session:` message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)