### PR TITLE
polish(plan-card): name PM persona in no-plan-yet copy (#1540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ Added, Changed, and Removed.
   an empty surface. The topbar omits the `PM:` meta entirely when no
   persona is configured (vs the old `PM: Project PM` placeholder).
   #1540 #1541 #1542.
+- Project dashboard Plan card empty-state copy names the configured PM
+  persona instead of "the PM" — `No plan yet — Archie will draft one
+  when this project picks up work. Press c in this pane to chat with
+  Archie and ask for a plan now.` Falls back to "the PM" when no
+  persona is configured, matching the banner-copy reframe so the
+  Plan card no longer reads anonymously on the very surface that
+  invites the user to start a plan. #1540 follow-up.
 
 ## [1.0.0] - 2026-04-20
 

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -16827,6 +16827,25 @@ class PollyProjectDashboardApp(App[None]):
                     "Workers can pick up tasks directly without a plan "
                     "ceremony.[/dim]"
                 )
+            # #1540 — name the effective PM in the empty-state copy so
+            # the Plan card matches the banner's warm "Press c to plan
+            # this with <PM>" framing. Falls back to "the PM" when no
+            # persona is configured (matches ``_alert_banner_copy``'s
+            # fallback). The effective PM mirrors the banner/topbar
+            # lookup: ``pm_persona`` (architect session routing) wins
+            # over the raw project ``persona_name``.
+            pm_persona = (
+                getattr(data, "pm_persona", None)
+                or getattr(data, "persona_name", None)
+            )
+            pm_label = (pm_persona or "").strip() if pm_persona else ""
+            if pm_label:
+                return (
+                    f"[dim]No plan yet — {_escape(pm_label)} will draft "
+                    f"one when this project picks up work.\n"
+                    f"Press [b]c[/b] in this pane to chat with "
+                    f"{_escape(pm_label)} and ask for a plan now.[/dim]"
+                )
             return (
                 "[dim]No plan yet — the PM will draft one when this "
                 "project picks up work.\n"

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -5076,6 +5076,81 @@ def test_plan_body_with_enforce_plan_true_uses_default_nudge(dashboard_app) -> N
     assert "Plan not required" not in body
 
 
+def test_plan_body_uses_persona_name_when_set(dashboard_app) -> None:
+    """#1540 — the no-plan-yet Plan card names the PM when a persona
+    is configured. Mirrors the banner's warm "plan this with <PM>"
+    framing so the Plan card stops reading "the PM" anonymously on
+    the very surface where the user is being invited to start a plan.
+    """
+    from types import SimpleNamespace
+
+    fake_data = SimpleNamespace(
+        exists_on_disk=True,
+        plan_path=None,
+        plan_sections=[],
+        plan_aux_files=[],
+        plan_explainer=None,
+        enforce_plan=True,
+        plan_task_summary=None,
+        persona_name="Archie",
+        pm_persona=None,
+    )
+    body = dashboard_app._render_plan_body(fake_data)
+    assert "Archie" in body
+    assert "the PM will draft" not in body
+    assert "chat with the PM" not in body
+    # The structural hints stay — pane focus + chat keystroke.
+    assert "in this pane" in body
+    assert "ask for a plan" in body
+
+
+def test_plan_body_prefers_pm_persona_over_project_persona(dashboard_app) -> None:
+    """#1540 — when an architect session routes the project, the
+    effective PM persona (``pm_persona``) wins over the raw project
+    ``persona_name``. Matches the banner/topbar lookup.
+    """
+    from types import SimpleNamespace
+
+    fake_data = SimpleNamespace(
+        exists_on_disk=True,
+        plan_path=None,
+        plan_sections=[],
+        plan_aux_files=[],
+        plan_explainer=None,
+        enforce_plan=True,
+        plan_task_summary=None,
+        persona_name="Bea",
+        pm_persona="Archie",
+    )
+    body = dashboard_app._render_plan_body(fake_data)
+    assert "Archie" in body
+    assert "Bea" not in body
+
+
+def test_plan_body_falls_back_to_the_pm_without_persona(dashboard_app) -> None:
+    """Without a configured persona, the Plan card still renders the
+    generic "the PM" fallback — no broken substitution artefacts.
+    """
+    from types import SimpleNamespace
+
+    fake_data = SimpleNamespace(
+        exists_on_disk=True,
+        plan_path=None,
+        plan_sections=[],
+        plan_aux_files=[],
+        plan_explainer=None,
+        enforce_plan=True,
+        plan_task_summary=None,
+        persona_name=None,
+        pm_persona=None,
+    )
+    body = dashboard_app._render_plan_body(fake_data)
+    assert "the PM" in body
+    # No empty substitution slots left over.
+    assert "with .\n" not in body
+    assert "chat with  and" not in body
+
+
 # ---------------------------------------------------------------------------
 # #1518 — Plan section recognizes a done plan-shaped task in the work
 # service so the dashboard stops reading "No plan yet" forever for projects


### PR DESCRIPTION
## Summary

Follow-up to #1555. The dashboard banner already reframes the no-plan state with the configured PM persona ("Press c to plan this with Archie"), but the **Plan card body** directly underneath still reads "No plan yet — the PM will draft one ... chat with the PM". The Plan card is the surface that invites the user to start a plan; reading "the PM" anonymously there flattens the warmth the banner just established.

This PR substitutes the effective PM persona into the Plan card empty-state copy, matching the banner/topbar lookup (``pm_persona`` falls back to ``persona_name``).

## Before / after

| Where | Before | After (persona = Archie) | After (no persona) |
|---|---|---|---|
| Plan card body | `No plan yet — the PM will draft one when this project picks up work. Press c in this pane to chat with the PM and ask for a plan now.` | `No plan yet — Archie will draft one when this project picks up work. Press c in this pane to chat with Archie and ask for a plan now.` | (unchanged — still reads "the PM") |

## Test plan

- [x] New: `test_plan_body_uses_persona_name_when_set` — persona substitutes "the PM" in both sentences.
- [x] New: `test_plan_body_prefers_pm_persona_over_project_persona` — architect-session lookup mirrors banner/topbar (``pm_persona`` wins).
- [x] New: `test_plan_body_falls_back_to_the_pm_without_persona` — no persona → unchanged copy, no empty substitution slots.
- [x] Existing `test_plan_body_keeps_no_plan_yet_when_no_file_and_no_task` (#1518) still asserts the fallback copy.
- [x] Existing `test_plan_body_with_enforce_plan_true_uses_default_nudge`, `test_plan_body_with_enforce_plan_false_*`, `test_plan_body_renders_done_plan_task_summary_when_no_file`, `test_plan_body_prefers_file_but_mentions_done_plan_task` — all pass.
- [x] Targeted `-k "plan_body or no_plan_yet"` → 9 passed.
- [ ] Sam to verify live on `savethenovel` (persona = Archie) and any no-plan project without a configured persona.

Pre-existing flake note: `test_plan_empty_state_when_no_plan_file` (and 3 other integration tests) hit the "data is None" async-pause race called out in #1555's test plan. Reproduces on a clean checkout of `main`; unrelated to this change.

## Hard rules

- No `--no-verify`, no `--amend`, no force-push.
- Did not touch banner copy, footer hiding, topbar PM-meta logic, or the `enforce_plan = false` / done-plan-task branches — those landed in #1555.

Refs #1540. Sam triages — not auto-closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)