### PR TITLE
refactor(cockpit): extract _InboxProjectPickerModal into sibling module (#1354)

### DIFF
--- a/src/pollypm/cockpit_inbox_project_picker.py
+++ b/src/pollypm/cockpit_inbox_project_picker.py
@@ -1,0 +1,142 @@
+"""Inbox project-picker modal (extracted from ``cockpit_ui``).
+
+Contract:
+- Inputs: a list of project keys plus the currently-active filter key.
+- Outputs: a ``ModalScreen`` returning the selected key (string) or
+  ``None`` when dismissed via Esc; selecting the active project returns
+  an empty string as the "clear" gesture.
+- Side effects: none beyond standard Textual modal push/dismiss.
+- Invariants: this module owns one widget class only; shared cockpit
+  helpers stay in their original homes.
+- Allowed dependencies: Textual primitives.
+- Private: ``_InboxProjectPickerModal`` is underscore-prefixed and only
+  re-exported via ``cockpit_ui`` for back-compat.
+
+First wedge of the cockpit_ui.py god-module split tracked by #1354.
+"""
+
+from __future__ import annotations
+
+from textual import on
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import ListItem, ListView, Static
+
+
+class _InboxProjectPickerModal(ModalScreen[str | None]):
+    """Tiny modal listing project keys for the ``p`` filter chip.
+
+    Returns the selected key (string) or ``None`` when dismissed via
+    Esc. Selecting the currently-active project clears the chip.
+    """
+
+    CSS = """
+    _InboxProjectPickerModal {
+        align: center middle;
+        background: rgba(0, 0, 0, 0.45);
+    }
+    #ipp-dialog {
+        width: 48;
+        max-width: 90%;
+        height: auto;
+        max-height: 18;
+        padding: 1 1 0 1;
+        background: #141a20;
+        border: round #2a3340;
+    }
+    #ipp-title {
+        height: 1;
+        padding: 0 1;
+        color: #97a6b2;
+    }
+    #ipp-list {
+        height: auto;
+        max-height: 14;
+        background: #141a20;
+        border: none;
+        margin-top: 1;
+        padding: 0;
+    }
+    #ipp-list > .ipp-row {
+        height: 1;
+        padding: 0 1;
+        color: #d6dee5;
+        background: transparent;
+    }
+    #ipp-list > .ipp-row.-highlight {
+        background: #1e2730;
+    }
+    #ipp-hint {
+        height: 1;
+        padding: 0 1;
+        color: #3e4c5a;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Close"),
+        Binding("down,j", "cursor_down", "Down", show=False),
+        Binding("up,k", "cursor_up", "Up", show=False),
+        Binding("enter", "select", "Pick", show=False),
+    ]
+
+    def __init__(self, keys: list[str], current: str | None) -> None:
+        super().__init__()
+        self._keys = list(keys)
+        self._current = current
+        self.list_view = ListView(id="ipp-list")
+        self.title_bar = Static(
+            "[b]Filter by project[/b]", id="ipp-title", markup=True,
+        )
+        self.hint = Static(
+            "[dim]↵ select  ·  esc cancel  ·  pick the active "
+            "project to clear[/dim]",
+            id="ipp-hint", markup=True,
+        )
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="ipp-dialog"):
+            yield self.title_bar
+            yield self.list_view
+            yield self.hint
+
+    def on_mount(self) -> None:
+        for key in self._keys:
+            label = key
+            if key == self._current:
+                label = f"● {key}"
+            self.list_view.append(
+                ListItem(Static(label, markup=False), classes="ipp-row")
+            )
+        self.list_view.index = 0
+        self.list_view.focus()
+
+    def action_cursor_down(self) -> None:
+        self.list_view.action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        self.list_view.action_cursor_up()
+
+    def action_select(self) -> None:
+        idx = self.list_view.index or 0
+        if 0 <= idx < len(self._keys):
+            picked = self._keys[idx]
+            # Picking the current chip again is a "clear" gesture.
+            if picked == self._current:
+                self.dismiss("")
+            else:
+                self.dismiss(picked)
+        else:
+            self.dismiss(None)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    @on(ListView.Selected, "#ipp-list")
+    def _on_row_selected(self, _event: ListView.Selected) -> None:
+        self.action_select()
+
+
+__all__ = ["_InboxProjectPickerModal"]

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -83,6 +83,9 @@ from pollypm.cockpit_inbox_items import (
     message_row_to_inbox_entry,
     task_to_inbox_entry,
 )
+from pollypm.cockpit_inbox_project_picker import (  # noqa: F401  (re-exported)
+    _InboxProjectPickerModal,
+)
 from pollypm.cockpit_live_chat_notice import (
     LIVE_CHAT_NETWORK_DEAD_TMUX_MESSAGE,
     clear_live_chat_network_dead_notice,
@@ -7145,120 +7148,6 @@ def _task_recent_timestamp(task) -> float | None:
         except (TypeError, ValueError):
             continue
     return None
-
-
-class _InboxProjectPickerModal(ModalScreen[str | None]):
-    """Tiny modal listing project keys for the ``p`` filter chip.
-
-    Returns the selected key (string) or ``None`` when dismissed via
-    Esc. Selecting the currently-active project clears the chip.
-    """
-
-    CSS = """
-    _InboxProjectPickerModal {
-        align: center middle;
-        background: rgba(0, 0, 0, 0.45);
-    }
-    #ipp-dialog {
-        width: 48;
-        max-width: 90%;
-        height: auto;
-        max-height: 18;
-        padding: 1 1 0 1;
-        background: #141a20;
-        border: round #2a3340;
-    }
-    #ipp-title {
-        height: 1;
-        padding: 0 1;
-        color: #97a6b2;
-    }
-    #ipp-list {
-        height: auto;
-        max-height: 14;
-        background: #141a20;
-        border: none;
-        margin-top: 1;
-        padding: 0;
-    }
-    #ipp-list > .ipp-row {
-        height: 1;
-        padding: 0 1;
-        color: #d6dee5;
-        background: transparent;
-    }
-    #ipp-list > .ipp-row.-highlight {
-        background: #1e2730;
-    }
-    #ipp-hint {
-        height: 1;
-        padding: 0 1;
-        color: #3e4c5a;
-    }
-    """
-
-    BINDINGS = [
-        Binding("escape", "cancel", "Close"),
-        Binding("down,j", "cursor_down", "Down", show=False),
-        Binding("up,k", "cursor_up", "Up", show=False),
-        Binding("enter", "select", "Pick", show=False),
-    ]
-
-    def __init__(self, keys: list[str], current: str | None) -> None:
-        super().__init__()
-        self._keys = list(keys)
-        self._current = current
-        self.list_view = ListView(id="ipp-list")
-        self.title_bar = Static(
-            "[b]Filter by project[/b]", id="ipp-title", markup=True,
-        )
-        self.hint = Static(
-            "[dim]\u21b5 select  \u00b7  esc cancel  \u00b7  pick the active "
-            "project to clear[/dim]",
-            id="ipp-hint", markup=True,
-        )
-
-    def compose(self) -> ComposeResult:
-        with Vertical(id="ipp-dialog"):
-            yield self.title_bar
-            yield self.list_view
-            yield self.hint
-
-    def on_mount(self) -> None:
-        for key in self._keys:
-            label = key
-            if key == self._current:
-                label = f"\u25cf {key}"
-            self.list_view.append(
-                ListItem(Static(label, markup=False), classes="ipp-row")
-            )
-        self.list_view.index = 0
-        self.list_view.focus()
-
-    def action_cursor_down(self) -> None:
-        self.list_view.action_cursor_down()
-
-    def action_cursor_up(self) -> None:
-        self.list_view.action_cursor_up()
-
-    def action_select(self) -> None:
-        idx = self.list_view.index or 0
-        if 0 <= idx < len(self._keys):
-            picked = self._keys[idx]
-            # Picking the current chip again is a "clear" gesture.
-            if picked == self._current:
-                self.dismiss("")
-            else:
-                self.dismiss(picked)
-        else:
-            self.dismiss(None)
-
-    def action_cancel(self) -> None:
-        self.dismiss(None)
-
-    @on(ListView.Selected, "#ipp-list")
-    def _on_row_selected(self, _event: ListView.Selected) -> None:
-        self.action_select()
 
 
 def _project_pm_persona(config: object, project_key: str, project: object) -> str | None:


### PR DESCRIPTION
## Summary
- First wedge of the cockpit_ui.py god-module split tracked by #1354.
- Moves the ~110-LOC `_InboxProjectPickerModal` (Textual modal for the inbox "filter by project" chip) into a new sibling module `src/pollypm/cockpit_inbox_project_picker.py`.
- Leaves an import shim (`from pollypm.cockpit_inbox_project_picker import _InboxProjectPickerModal`) in `cockpit_ui.py` so the single call site and any external imports keep working unchanged.

cockpit_ui.py: 18481 -> 18370 LOC.

This is intentionally small (117-line diff in cockpit_ui.py, 142-line new file) — many more extractions to follow, one per app/modal class.

## Test plan
- [x] `pytest tests/test_keyboard_help.py` — 26 passed (1 pre-existing failure on `test_modal_surfaces_plan_review_keys_when_selected` is unrelated to this change; reproduced on main before the diff).
- [x] `python -c "from pollypm import cockpit_ui; cockpit_ui._InboxProjectPickerModal"` — re-export resolves.
- [x] AST parses cleanly on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)