### PR TITLE
Fix #1485 dedupe inbox d (jump-to-PM) re-entry

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -8281,6 +8281,13 @@ class PollyInboxApp(App[None]):
     # the instance attribute to a near-zero value to drive the commit
     # synchronously without sleeping for the full window.
     _approve_undo_window_seconds: float = 10.0
+    # #1485 follow-up to #1447/#1451 — inbox ``d`` (jump-to-PM) re-entry
+    # window. Mirrors :class:`PollyProjectDashboardApp`'s constant so the
+    # same (cockpit_key, context_line) dedupe behavior covers both surfaces:
+    # the dashboard ``c`` keybind AND the inbox ``d`` keybind. Repeated
+    # presses within this window route the cockpit back to the PM pane
+    # but skip the ``send-keys`` injection so chat history stays clean.
+    _PM_CONTEXT_REATTACH_WINDOW_SECONDS: float = 300.0
     # Show the first ``ROLLUP_DEFAULT_VISIBLE`` items of a rollup, collapse
     # the rest behind an expand keybind so a 40-item digest doesn't flood
     # the detail pane.
@@ -8405,6 +8412,13 @@ class PollyInboxApp(App[None]):
         self._pending_plan_approval_timer = None
         self._pending_plan_approval_sparkle_timer = None
         self._pending_plan_approval_countdown_timer = None
+        # #1485 (follow-up to #1447/#1451) — most-recent ``d`` dispatch
+        # (cockpit_key, context_line, monotonic_sent_at). Used by
+        # :meth:`_should_reattach_pm_context` to skip re-injecting the
+        # same context line into Polly's chat when the user bounces back
+        # to the inbox and presses ``d`` again within the re-attach
+        # window. Mirrors the dashboard-side state added by #1451.
+        self._last_pm_context_dispatch: tuple[str, str, float] | None = None
 
     def compose(self) -> ComposeResult:
         yield self.filter_bar
@@ -10504,14 +10518,31 @@ class PollyInboxApp(App[None]):
         plan_review_discussion_item=None,
         plan_review_discussion_task_id: str | None = None,
     ) -> None:
-        """Worker-thread body: route cockpit + inject the context line."""
+        """Worker-thread body: route cockpit + inject the context line.
+
+        #1485 (follow-up to #1447/#1451): if the same
+        ``(cockpit_key, context_line)`` was dispatched within
+        :attr:`_PM_CONTEXT_REATTACH_WINDOW_SECONDS`, route the cockpit
+        right pane back to the PM but skip the ``send-keys`` injection
+        so Polly's chat history doesn't fill with duplicate context
+        lines on every inbox bounce-back. Mirrors the dashboard-side
+        dedupe added by #1451 for the ``c`` keybind.
+        """
+        now = self._pm_dispatch_now()
+        reattach = self._should_reattach_pm_context(
+            cockpit_key, context_line, now,
+        )
         try:
-            self._perform_pm_dispatch(cockpit_key, context_line)
+            if reattach:
+                self._route_pm_target(cockpit_key)
+            else:
+                self._perform_pm_dispatch(cockpit_key, context_line)
         except Exception as exc:  # noqa: BLE001
             self.call_from_thread(
                 self.notify, f"Jump to PM failed: {exc}", severity="error",
             )
             return
+        self._remember_pm_context_dispatch(cockpit_key, context_line, now)
         if (
             plan_review_discussion_task_id
             and self._record_plan_review_discussion_marker(
@@ -10537,6 +10568,17 @@ class PollyInboxApp(App[None]):
         # pane has focus) advertising the route home, and extend the
         # Textual toast for users glancing at the rail.
         self._surface_back_to_inbox_hint()
+        if reattach:
+            self.call_from_thread(
+                self.notify,
+                (
+                    f"Re-attached to {pm_label} \u2014 chat already has your "
+                    f"context. Ctrl-b \u2190 then I returns to inbox."
+                ),
+                severity="information",
+                timeout=5.0,
+            )
+            return
         self.call_from_thread(
             self.notify,
             (
@@ -10545,6 +10587,39 @@ class PollyInboxApp(App[None]):
             ),
             severity="information",
             timeout=5.0,
+        )
+
+    def _pm_dispatch_now(self) -> float:
+        """Monotonic clock for the inbox re-attach window (#1485).
+
+        Split out so tests can monkeypatch the clock and drive the
+        window deterministically without sleeping.
+        """
+        return time.monotonic()
+
+    def _should_reattach_pm_context(
+        self, cockpit_key: str, context_line: str, now: float,
+    ) -> bool:
+        """True iff the same ``(cockpit_key, context_line)`` is in-window."""
+        last = self._last_pm_context_dispatch
+        if last is None:
+            return False
+        last_cockpit_key, last_context_line, last_sent_at = last
+        if (last_cockpit_key, last_context_line) != (
+            cockpit_key, context_line,
+        ):
+            return False
+        return (
+            now - last_sent_at
+            <= self._PM_CONTEXT_REATTACH_WINDOW_SECONDS
+        )
+
+    def _remember_pm_context_dispatch(
+        self, cockpit_key: str, context_line: str, sent_at: float,
+    ) -> None:
+        """Stash the latest dispatch so the next press can dedupe (#1485)."""
+        self._last_pm_context_dispatch = (
+            cockpit_key, context_line, sent_at,
         )
 
     def _surface_back_to_inbox_hint(self) -> None:
@@ -10660,6 +10735,25 @@ class PollyInboxApp(App[None]):
         a real tmux server. See ``test_cockpit_inbox_ui.py`` for the
         monkeypatch target.
         """
+        router, window_target, right_pane = self._route_pm_target(cockpit_key)
+        if right_pane is None:
+            # Fall back to the window target — tmux resolves to the
+            # active pane, which is almost always the right pane for
+            # cockpit flows post-route.
+            router.tmux.send_keys(window_target, context_line, press_enter=False)
+            return
+        router.tmux.send_keys(right_pane, context_line, press_enter=False)
+
+    def _route_pm_target(
+        self, cockpit_key: str,
+    ) -> tuple[CockpitRouter, str, str | None]:
+        """Route the cockpit right pane without injecting chat context.
+
+        #1485 split-out so the re-attach path in :meth:`_dispatch_to_pm_sync`
+        can reuse the routing (navigate the user back to the PM pane)
+        without re-sending the same context line via ``send-keys``.
+        Mirrors :meth:`PollyProjectDashboardApp._route_pm_target`.
+        """
         from pollypm.dev_network_simulation import raise_if_network_dead
 
         raise_if_network_dead(self.config_path, surface="Inbox discuss with PM")
@@ -10670,13 +10764,7 @@ class PollyInboxApp(App[None]):
             f"{supervisor.config.project.tmux_session}:{router._COCKPIT_WINDOW}"
         )
         right_pane = router._right_pane_id(window_target)
-        if right_pane is None:
-            # Fall back to the window target — tmux resolves to the
-            # active pane, which is almost always the right pane for
-            # cockpit flows post-route.
-            router.tmux.send_keys(window_target, context_line, press_enter=False)
-            return
-        router.tmux.send_keys(right_pane, context_line, press_enter=False)
+        return router, window_target, right_pane
 
     @on(events.Click, ".rollup-item")
     def _on_rollup_item_click(self, event: events.Click) -> None:

--- a/tests/test_cockpit_inbox_ui.py
+++ b/tests/test_cockpit_inbox_ui.py
@@ -2051,6 +2051,68 @@ def test_d_key_dispatches_to_pm_with_context_line(inbox_env, inbox_app) -> None:
     _run(body())
 
 
+def test_d_inbox_dispatch_reattaches_recent_duplicate_context(
+    inbox_app, monkeypatch,
+) -> None:
+    """Repeated inbox ``d`` for same (key,context) skips the re-injection.
+
+    Regression test for #1485 — follow-up to #1447/#1451 covering the
+    inbox path. The dashboard ``c`` keybind already dedupes via #1451;
+    the inbox ``d`` keybind hits the same Polly chat session so the
+    same chat-history-pollution applies. Within
+    ``_PM_CONTEXT_REATTACH_WINDOW_SECONDS`` the cockpit should route
+    back to the PM pane but skip ``_perform_pm_dispatch`` so the
+    context line isn't re-injected.
+    """
+    sent: list[tuple[str, str]] = []
+    routed: list[str] = []
+    notices: list[str] = []
+    now = 100.0
+
+    def fake_dispatch(cockpit_key: str, context_line: str) -> None:
+        sent.append((cockpit_key, context_line))
+
+    def fake_route(cockpit_key: str):
+        routed.append(cockpit_key)
+        return (None, "", None)
+
+    def fake_call_from_thread(fn, *args, **kwargs):
+        fn(*args, **kwargs)
+
+    monkeypatch.setattr(inbox_app, "_perform_pm_dispatch", fake_dispatch)
+    monkeypatch.setattr(inbox_app, "_route_pm_target", fake_route)
+    monkeypatch.setattr(inbox_app, "_pm_dispatch_now", lambda: now)
+    monkeypatch.setattr(inbox_app, "call_from_thread", fake_call_from_thread)
+    monkeypatch.setattr(
+        inbox_app, "_surface_back_to_inbox_hint", lambda: None,
+    )
+    monkeypatch.setattr(
+        inbox_app,
+        "notify",
+        lambda message, **_kw: notices.append(message),
+    )
+
+    cockpit_key = "project:demo:session"
+    context_line = 're: inbox/abc "stub"'
+
+    # First press — sends the context line, records the dispatch.
+    inbox_app._dispatch_to_pm_sync(cockpit_key, context_line, "Project PM")
+    # Second press shortly after — within the window, same key/context:
+    # cockpit re-routes but no new send-keys.
+    now += 30.0
+    inbox_app._dispatch_to_pm_sync(cockpit_key, context_line, "Project PM")
+    # Third press well outside the window — sends again.
+    now += inbox_app._PM_CONTEXT_REATTACH_WINDOW_SECONDS + 1.0
+    inbox_app._dispatch_to_pm_sync(cockpit_key, context_line, "Project PM")
+
+    assert sent == [
+        (cockpit_key, context_line),
+        (cockpit_key, context_line),
+    ]
+    assert routed == [cockpit_key]
+    assert any("Re-attached to" in note for note in notices)
+
+
 def test_d_key_with_persona_routes_to_project_session(tmp_path: Path) -> None:
     """Persona projects dispatch to ``project:<key>:session`` + show PM name."""
     async def body() -> None:


### PR DESCRIPTION
Closes #1485

## Summary

#1485 reported that the Polly chat context line still re-injects on every re-entry, despite #1451 having shipped the dedupe for the dashboard `c` keybind. The issue body called out a likely Cause B variant: "Maybe the user is hitting a different action than `action_chat_pm`". This PR addresses that variant.

Audit of `cockpit_ui.py` confirmed there are two `_dispatch_to_pm_sync` methods:
- `PollyProjectDashboardApp._dispatch_to_pm_sync` (the `c` keybind) — patched by #1451, has dedupe.
- `PollyInboxApp._dispatch_to_pm_sync` (the `d` keybind) — calls the same Polly chat session via `tmux send-keys`, but had no dedupe. Every inbox bounce-back + `d` press re-injected the context line.

Both keybinds land in the same chat history, so the dashboard-side guard alone cannot keep that history clean. This PR mirrors the #1451 pattern on `PollyInboxApp`:

- Track the last `(cockpit_key, context_line, monotonic_sent_at)` on the inbox app instance.
- Within `_PM_CONTEXT_REATTACH_WINDOW_SECONDS` (300s), route the cockpit pane back to the PM but skip the `send-keys` injection.
- Split `_route_pm_target` out of `_perform_pm_dispatch` so the re-attach branch can navigate without re-sending — exactly the split the dashboard uses, keeping the symmetry obvious for the next reader.
- Swap the "Jumped to ..." toast for "Re-attached to ... — chat already has your context." on the re-attach branch so the user can tell the keystroke registered without scanning Polly's pane.

Layer audit: cockpit UI only; no service/store/domain boundary changes. Same surface area as #1451.

## Cause A note

#1485 was labelled `needs-repro` because Codex's triage suspected the running cockpit was still on pre-#1451 code (Cause A). This PR addresses Cause B unconditionally — even after a clean reinstall + reset, the inbox `d` path had no dedupe, so the duplicate-injection behavior would still reproduce via the `d` -> back-to-inbox -> `d` path. If Cause A was the live trigger, this PR is harmless; if Cause B was, this PR closes the gap.

## Tests

- New: `tests/test_cockpit_inbox_ui.py::test_d_inbox_dispatch_reattaches_recent_duplicate_context` — mirrors `test_pm_dispatch_reattaches_recent_duplicate_context` from #1451; asserts that two `_dispatch_to_pm_sync` calls within the window produce only one `_perform_pm_dispatch` (plus one `_route_pm_target`), and a third call after the window re-sends.
- `tests/test_cockpit_inbox_ui.py` — full file (85 tests) still passes.
- `tests/test_plan_review_flow.py` — touches `_dispatch_to_pm_sync` for plan-review primer flow; passes (1 unrelated pre-existing failure confirmed on baseline).

## Test plan

- [ ] On a multi-project setup, press `d` on an inbox row to open Polly; verify the context line lands once.
- [ ] Press `Ctrl-b Left then I` to return to inbox, press `d` again on the same row within 5 minutes; chat should NOT show a duplicate `re: inbox/<N> "..."` line, and the toast should read "Re-attached to ...".
- [ ] Wait 5 minutes (or override `_PM_CONTEXT_REATTACH_WINDOW_SECONDS` to a small value) and re-press `d`; the context line should re-inject and the toast should revert to "Jumped to ...".
- [ ] Press `d` on a different row (different `context_line`) — should send fresh; press `d` on a different project's row — should send fresh.