### PR TITLE
Fix #1542 rail glyph lies when project has on_hold root task

### DIFF
--- a/src/pollypm/dashboard/categorization.py
+++ b/src/pollypm/dashboard/categorization.py
@@ -123,8 +123,20 @@ class _WorkServiceLike(Protocol):
 # category. Tasks parked on user-waiting statuses
 # (``waiting_on_user`` / ``on_hold`` / ``blocked`` / ``review``) do
 # NOT count as working — they're either user-waiting (covered by the
-# inbox predicate) or stalled (which is not "system is acting").
+# inbox predicate or the ``_WAITING_TASK_STATUSES`` check below) or
+# stalled (which is not "system is acting").
 _WORKING_TASK_STATUSES: frozenset[str] = frozenset({"in_progress", "rework"})
+
+# Task statuses where the user is the next-action owner. An ``on_hold``
+# root task blocks downstream work and reads on the project dashboard
+# as "◆ needs attention" — the user must decide to resume or cancel.
+# #1542 — the rail used to roll these up to IDLE (``○``) because they
+# weren't in ``_WORKING_TASK_STATUSES`` and there was no inbox item
+# tracking them, so the rail glyph contradicted the dashboard banner
+# on the same project key (cf. ``media``: rail says quiet, dashboard
+# says please-look-at-me). Promote ``on_hold`` to WAITING so both
+# surfaces read the same.
+_WAITING_TASK_STATUSES: frozenset[str] = frozenset({"on_hold"})
 
 
 def _project_of(item: _InboxItem) -> str:
@@ -179,6 +191,22 @@ def categorize_project(
         return ProjectState.WAITING
 
     try:
+        tasks = work_service.list_tasks(project=project_key)
+    except Exception:  # noqa: BLE001
+        tasks = []
+
+    # #1542 — an ``on_hold`` task makes the project ◆ "needs attention"
+    # on the dashboard banner; mirror that priority here so the rail
+    # glyph doesn't paint ``○`` (quiet) while the dashboard paints ◆.
+    # Checked BEFORE the live-worker branch because a paused root with
+    # a background worker still active reads as user-owed on the
+    # dashboard pill (``_dashboard_status``: ``on_hold_count`` outranks
+    # active_worker).
+    for task in tasks:
+        if _task_status(task) in _WAITING_TASK_STATUSES:
+            return ProjectState.WAITING
+
+    try:
         live_workers = work_service.list_worker_sessions(
             project=project_key, active_only=True,
         )
@@ -187,10 +215,6 @@ def categorize_project(
     if live_workers:
         return ProjectState.WORKING
 
-    try:
-        tasks = work_service.list_tasks(project=project_key)
-    except Exception:  # noqa: BLE001
-        tasks = []
     for task in tasks:
         if _task_status(task) in _WORKING_TASK_STATUSES:
             return ProjectState.WORKING

--- a/tests/test_dashboard_categorization.py
+++ b/tests/test_dashboard_categorization.py
@@ -149,9 +149,35 @@ def test_categorize_idle_when_nothing_active() -> None:
     assert categorize_project("demo", work_service=svc) is ProjectState.IDLE
 
 
-def test_categorize_idle_when_only_waiting_status_tasks() -> None:
-    """Tasks parked on user-waiting statuses don't count as Working."""
+def test_categorize_waiting_when_task_on_hold() -> None:
+    """#1542 — ``on_hold`` tasks surface as WAITING so the rail glyph
+    matches the dashboard's ``◆ needs attention`` banner. A paused root
+    task is blocking downstream work — the user owes a resume-or-cancel
+    decision even if no inbox item tracks it.
+    """
     svc = FakeWorkService(tasks=[_task(status="on_hold")])
+    assert categorize_project("demo", work_service=svc) is ProjectState.WAITING
+
+
+def test_categorize_waiting_when_on_hold_with_background_worker() -> None:
+    """#1542 — the on_hold priority must outrank a live background
+    worker, mirroring ``_dashboard_status``'s pill priority. Without
+    this the rail would paint ``●`` while the dashboard pill paints
+    ``◆ needs attention``.
+    """
+    svc = FakeWorkService(
+        workers=[_worker()],
+        tasks=[_task(status="on_hold")],
+    )
+    assert categorize_project("demo", work_service=svc) is ProjectState.WAITING
+
+
+def test_categorize_idle_when_only_review_status_tasks() -> None:
+    """``review`` parked tasks don't count as Working (or Waiting via
+    the on_hold short-circuit). They surface via the inbox approval
+    items instead.
+    """
+    svc = FakeWorkService(tasks=[_task(status="review")])
     assert categorize_project("demo", work_service=svc) is ProjectState.IDLE
 
 


### PR DESCRIPTION
## Summary

Closes #1542 (sub-issue 1 — rail glyph contradicts dashboard state).

The rail glyph for a project with a paused root task read as IDLE (`○`) while the dashboard banner for the same project painted `◆ needs attention`. Both surfaces should share a single categorization, but `categorize_project` only treated inbox items (via `awaits_user`) as a waiting signal — an `on_hold` root task with no companion inbox item fell through to IDLE.

This change promotes `on_hold` task status to `ProjectState.WAITING` and checks it BEFORE the live-worker branch (mirroring `_dashboard_status`'s priority where `on_hold_count` outranks an active background worker). The user owes a resume-or-cancel decision either way.

## What about the other sub-issues?

The issue body lists three more sub-issues; on inspection two are already fixed on `main` and the third is intentional taste:

- **Sub-issue 2 (PM name placeholder "Project PM"):** Already fixed — `_project_pm_label` (cockpit_ui.py L7294) returns `""` when no persona, and the dashboard topbar already drops the meta in that case (L15858 — comment cites #1542).
- **Sub-issue 3 (wrap indent on description):** Already fixed via `_wrap_with_hanging_indent` (cockpit_ui.py L578, L17282 — comment cites #1542).
- **Sub-issue 4 (truncated "Decide whether to approve…" line):** Already fixed by lifting the `Decision:` line above the description (cockpit_ui.py L17263 — comment cites #1542).

So this PR completes the only remaining piece — the rail/dashboard glyph mismatch.

## Test plan

- [x] `uv run pytest tests/test_dashboard_categorization.py` — 32 passed (added 2 new tests + reframed 1)
- [x] `uv run pytest tests/test_cockpit_rail_operator_glyphs.py tests/test_cockpit_project_state.py tests/test_cockpit_rail_rollup_db_resolution.py tests/test_core_rail_items.py` — 88 passed
- [ ] Manual: open `media` (or any project with a paused root task) → rail row should now show `◆` matching the dashboard banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)