### PR TITLE
Fix #1539 make project-dashboard loading skeleton legible

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -15258,21 +15258,34 @@ class PollyProjectDashboardApp(App[None]):
     _PM_CONTEXT_REATTACH_WINDOW_SECONDS = 300.0
     # #1539 \u2014 skeleton placeholder bars rendered into each panel body
     # during the cold-fetch window so the panels read as "loading"
-    # rather than "loaded with nothing in them". Two dim block-glyph
-    # bars per panel are enough to look intentionally placeholdered
-    # without flashing. Replaced wholesale by ``_render`` the moment
-    # the worker thread hands data back; layout stays stable across
-    # the swap so content doesn't pop into place.
+    # rather than "loaded with nothing in them". An italic
+    # ``loading project dashboard\u2026`` hint plus two dim block-glyph bars
+    # per panel read as intentionally placeholdered without flashing.
+    # Replaced wholesale by ``_render`` the moment the worker thread
+    # hands data back; layout stays stable across the swap so content
+    # doesn't pop into place.
+    #
+    # #1539 v2 \u2014 the original ``#1e2730`` bar color was nearly
+    # indistinguishable from the panel background ``#111820``, so the
+    # bars rendered invisible and the panels still read as "loaded but
+    # empty" for the full 8\u201312s cold-fetch window. Bumped the bar
+    # color to ``#2a3a4a`` (visible-but-muted, brighter than the
+    # scrollbar track) and prepended an explicit italic
+    # ``loading project dashboard\u2026`` hint so the busy state is legible
+    # even on terminals that crush the dim block glyphs.
     _SKELETON_BAR_LONG = "\u2588" * 24
     _SKELETON_BAR_SHORT = "\u2588" * 14
+    _SKELETON_HINT = "[#6b7a88][i]loading project dashboard\u2026[/i][/]"
     _SKELETON_TWO_LINE = (
-        f"[#1e2730]{_SKELETON_BAR_LONG}[/]\n"
-        f"[#1e2730]{_SKELETON_BAR_SHORT}[/]"
+        f"{_SKELETON_HINT}\n"
+        f"[#2a3a4a]{_SKELETON_BAR_LONG}[/]\n"
+        f"[#2a3a4a]{_SKELETON_BAR_SHORT}[/]"
     )
     _SKELETON_THREE_LINE = (
-        f"[#1e2730]{_SKELETON_BAR_LONG}[/]\n"
-        f"[#1e2730]{_SKELETON_BAR_SHORT}[/]\n"
-        f"[#1e2730]{_SKELETON_BAR_LONG}[/]"
+        f"{_SKELETON_HINT}\n"
+        f"[#2a3a4a]{_SKELETON_BAR_LONG}[/]\n"
+        f"[#2a3a4a]{_SKELETON_BAR_SHORT}[/]\n"
+        f"[#2a3a4a]{_SKELETON_BAR_LONG}[/]"
     )
 
     def __init__(self, config_path: Path, project_key: str) -> None:

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -6389,8 +6389,11 @@ def test_render_clears_skeleton_bodies_when_data_is_none(
     assert app.data is None
     app._render()
 
-    # Topbar carries the bail copy.
-    assert "not a tracked project" in str(app.topbar.render())
+    # Topbar carries the bail copy. (#1544 rewrote the copy from
+    # "is not a tracked project" → "no project registered with that
+    # key — run pm project new ..." so the operator sees the concrete
+    # affordance, not data-model jargon.)
+    assert "no project registered with that key" in str(app.topbar.render())
 
     # And every skeleton-seeded body is now blank.
     for label, body in (
@@ -6444,4 +6447,41 @@ def test_first_refresh_failed_clears_skeleton_bodies(
         assert _skeleton_block_glyph_count(rendered) == 0, (
             f"{label}: skeleton bars still visible after first-gather "
             f"failure — got {rendered!r}"
+        )
+
+
+def test_seeded_skeleton_carries_loading_hint(tmp_path: Path) -> None:
+    """#1539 v2 — the original skeleton used ``#1e2730`` bars on a
+    ``#111820`` panel background, which crushed to "invisible" on most
+    terminals and left the panels reading as "loaded but empty" during
+    the 8–12s cold-fetch window. Each seeded body now carries an
+    explicit italic ``loading project dashboard…`` hint plus brighter
+    ``#2a3a4a`` placeholder bars so the busy state is legible even if
+    the dim block glyphs don't render.
+    """
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    project_path = tmp_path / "demo"
+    project_path.mkdir()
+    _init_git_repo(project_path)
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(project_path, config_path)
+
+    app = PollyProjectDashboardApp(config_path, "demo")
+
+    for label, body in (
+        ("now_body", app.now_body),
+        ("pipeline_body", app.pipeline_body),
+        ("plan_body", app.plan_body),
+        ("activity_body", app.activity_body),
+        ("inbox_body", app.inbox_body),
+    ):
+        rendered = str(body.render())
+        assert "loading project dashboard" in rendered, (
+            f"{label}: seeded skeleton missing the explicit "
+            f"'loading project dashboard…' hint — got {rendered!r}"
+        )
+        assert _skeleton_block_glyph_count(rendered) > 0, (
+            f"{label}: seeded skeleton missing the dim placeholder bars "
+            f"— got {rendered!r}"
         )


### PR DESCRIPTION
## Summary
- **#1539 reopens with the same symptom #1558 was supposed to fix.** The original skeleton-bars implementation used color `#1e2730` against a `#111820` panel background — nearly identical greys, so the bars rendered invisible. The fresh-open dashboard still showed empty `Inbox` / `Current activity` panels for 8–12s, reading as "loaded but empty."
- **Fix:** prepend an explicit italic `loading project dashboard…` hint to every seeded body, and bump the bar color to `#2a3a4a` (visible-but-muted) so the placeholder bars actually appear. The hint shows in plain words inside each panel rather than relying on the topbar grey hint the user reported as easy to miss.
- Layout is unchanged — `_render` still overwrites the seeded skeleton wholesale when the worker thread returns. Existing `_clear_skeleton_bodies` bail paths (data-is-None, first-gather-failure) still work because tests assert on block-glyph count.

## Test plan
- [x] New `test_seeded_skeleton_carries_loading_hint` — verifies every seeded body Static carries the `loading project dashboard…` hint and the placeholder bars at `__init__` time.
- [x] Existing `test_render_clears_skeleton_bodies_when_data_is_none` and `test_first_refresh_failed_clears_skeleton_bodies` still pass.
- [x] Fixed a stale assertion in `test_render_clears_skeleton_bodies_when_data_is_none` (#1544 rewrote the bail-path topbar copy but the test wasn't updated — was failing on `main` independently).
- [ ] Manual verification: open a project dashboard cold from the rail, confirm the loading copy + dim bars are visible during the cold-fetch window instead of empty boxes.

## Notes
Related to #1594 (universal pane render latency); that issue's fix is a deeper restructuring (async-worker the SQLite walks). This PR is the cheap polish from #1539's "option 1 — skeleton lines inside each panel" — keeps the layout stable but signals "loading" clearly.

The skeleton placeholder bars are still dim by design (between the scrollbar-track `#2a3340` and the hint color `#3e4c5a`) — they read as intentional placeholders, not as content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)