### PR TITLE
Fix #1541 Current activity panel uses PM name, not worker key

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -16448,6 +16448,29 @@ class PollyProjectDashboardApp(App[None]):
             sess_raw = w.get("session_name") or ""
             role_raw = w.get("role") or "worker"
             activity = str(w.get("activity") or "working")
+            in_flight = data.task_buckets.get("in_progress", [])
+            # #1541 \u2014 when the project is calm (idle worker, no in-flight
+            # task, no action card), prefer the configured PM persona
+            # over the raw role / session key. The topbar already names
+            # the PM (``PM: Archie``); the Current activity panel must
+            # not re-introduce ``architect`` or ``architect_bikepath``
+            # one line below. Other activity branches (working /
+            # awaiting_user / in-flight task surfaced) keep the
+            # role-based identity so the operator still sees which
+            # session is doing the work.
+            pm_persona = (
+                getattr(data, "pm_persona", None)
+                or getattr(data, "persona_name", None)
+                or ""
+            )
+            pm_persona = pm_persona.strip() if isinstance(pm_persona, str) else ""
+            calm_state = (
+                activity == "idle"
+                and not in_flight
+                and not data.action_items
+            )
+            if calm_state and pm_persona:
+                identity_markup = f"[b]{_escape(pm_persona)}[/b]"
             # Collapse "<role>_<project_key>" sessions on their own
             # project's dashboard down to just the role \u2014 both the
             # role name and the project context are already implicit
@@ -16455,7 +16478,7 @@ class PollyProjectDashboardApp(App[None]):
             # ``architect_polly_remote  architect`` repeats info the
             # operator already has. Leave any session_name with extra
             # information (task-N, workerN, ad-hoc names) unchanged.
-            if sess_raw in {role_raw, f"{role_raw}_{self.project_key}"}:
+            elif sess_raw in {role_raw, f"{role_raw}_{self.project_key}"}:
                 identity_markup = f"[b]{_escape(role_raw)}[/b]"
             else:
                 identity_markup = (
@@ -16483,7 +16506,6 @@ class PollyProjectDashboardApp(App[None]):
                 f"{dot_markup} {identity_markup}{age_part}{state_tail}",
             ]
             # Surface the top-most in-flight task as context.
-            in_flight = data.task_buckets.get("in_progress", [])
             if in_flight:
                 t = in_flight[0]
                 num = t.get("task_number")
@@ -16533,11 +16555,25 @@ class PollyProjectDashboardApp(App[None]):
                 # \u2026 standing by." The dashboard had no way to show
                 # this, so it implied work was happening. Spell out
                 # the actual state instead.
-                lines.append(
-                    "  [dim]No task in flight. The session is alive "
-                    "but not progressing work \u2014 it will pick up the "
-                    "next queued task or wait for instructions.[/dim]"
-                )
+                #
+                # #1541 \u2014 drop the syslog-style "The session is alive
+                # but not progressing work" phrasing in favour of a
+                # warmer, PM-named note that invites a next step.
+                # The topbar already names the PM; this line echoes
+                # the same identity so the operator sees one voice,
+                # not "Archie" up top and "the session" below.
+                if pm_persona:
+                    lines.append(
+                        f"  [dim]{_escape(pm_persona)} is ready when "
+                        "you want to pick something up \u2014 press [b]c[/b] "
+                        "to chat or [b]p[/b] to plan.[/dim]"
+                    )
+                else:
+                    lines.append(
+                        "  [dim]Ready when you want to pick something "
+                        "up \u2014 press [b]c[/b] to chat or [b]p[/b] to "
+                        "plan.[/dim]"
+                    )
             elif activity == "awaiting_user":
                 lines.append(
                     "  [#f0c45a]\u25c6[/#f0c45a] Waiting on your "

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -3562,6 +3562,12 @@ def test_now_body_says_standing_by_for_idle_worker() -> None:
     must NOT be rendered as ``in action``. The dashboard renders the
     standby state explicitly so the user knows the session is alive
     but not progressing work (#990).
+
+    #1541 — the calm-state copy was reworded to drop the syslog feel
+    ("The session is alive but not progressing work") and the raw
+    worker key + role tag ("architect_bikepath (architect)"). The
+    section header still flags ``standing by`` and uses the grey
+    glyph, but the trailing line invites a next step via ``c``/``p``.
     """
     from types import SimpleNamespace
     from pollypm.cockpit_ui import PollyProjectDashboardApp
@@ -3581,12 +3587,24 @@ def test_now_body_says_standing_by_for_idle_worker() -> None:
             "blocked": [], "on_hold": [], "done": [],
         },
         task_counts={},
+        pm_persona="Archie",
+        persona_name="Archie",
     )
     rendered = app._render_now_body(fake_data)
     assert "standing by" in rendered
     # Yellow/grey dot, NOT the green ● that signals "active".
     assert "[#3ddc84]●[/#3ddc84]" not in rendered
-    assert "not progressing" in rendered
+    # #1541 — name the PM, not the raw role / session key.
+    assert "Archie" in rendered
+    assert "architect_bikepath" not in rendered
+    # Use the role tag only outside the calm-state branch — the
+    # identity line must not surface ``architect`` either, since the
+    # topbar already named the PM as Archie.
+    assert "[b]architect[/b]" not in rendered
+    # #1541 — syslog phrasing is gone; the line invites a next step.
+    assert "not progressing" not in rendered
+    assert "The session is alive" not in rendered
+    assert "press [b]c[/b]" in rendered
 
 
 def test_now_body_says_waiting_on_input_for_permission_prompt() -> None:


### PR DESCRIPTION
## Summary

- The status banner above the Current activity panel was already reworded for #1541 in commit 184141c4 (``Archie is here when you need them.``), but the Current activity panel directly below still rendered the raw worker role + a syslog-shaped second line — exactly the leak the issue called out, just one section lower on the page.
- ``_render_now_body`` now swaps in the PM persona (``Archie``, ``Polly``, etc.) for the calm-state identity line and rewords the trailing copy to a warm one-liner that invites a next step (``press c to chat or p to plan``). Working / awaiting_user / in-flight-task branches are untouched so the operator still sees which session is doing real work.
- Updated ``test_now_body_says_standing_by_for_idle_worker`` to assert the PM name is present, the raw role / session key are absent, and the syslog phrasing is gone in favour of the new CTA.

## Test plan

- [x] ``pytest tests/test_project_dashboard_ui.py -k "now_body or banner_does_not_claim or banner_no_plan or now_body_says or banner_says_waiting"`` — 10 passed locally.
- [x] Confirmed the 3 ``run_test``-based banner failures (``test_waiting_on_you_banner_*``) are pre-existing on baseline (Textual mount failure unrelated to this change).
- [ ] On a calm project (e.g. ``bikepath``), verify the Current activity panel now reads ``○ Archie  <age>  standing by`` followed by ``Archie is ready when you want to pick something up — press c to chat or p to plan.``

🤖 Generated with [Claude Code](https://claude.com/claude-code)