### PR TITLE
fix(observability): surface 9 silent except Exception sites (#1355 wedge)

### DIFF
--- a/src/pollypm/rail_daemon_reaper.py
+++ b/src/pollypm/rail_daemon_reaper.py
@@ -357,7 +357,14 @@ def _emit_audit(
             },
         )
     except Exception:  # noqa: BLE001
-        pass
+        # #1355: previously silent. A failed audit emit on rail reap
+        # means we lose the record of why the rail daemon was killed —
+        # log the failure so we know the audit path itself is broken.
+        logger.warning(
+            "daemon.reaped audit emit failed for rail_daemon pid=%s",
+            pid,
+            exc_info=True,
+        )
 
 
 def _pid_alive(pid: int) -> bool:

--- a/src/pollypm/rail_daemon_supervisor.py
+++ b/src/pollypm/rail_daemon_supervisor.py
@@ -782,7 +782,15 @@ def _emit_revival_audit(
             },
         )
     except Exception:  # noqa: BLE001
-        pass
+        # #1355: previously silent. A failed audit emit on rail revive
+        # means we lose the record of supervisor recovery decisions —
+        # log so we know the audit path itself is broken.
+        logger.warning(
+            "daemon.revived audit emit failed (state=%s, revived=%s)",
+            decision.state,
+            revived,
+            exc_info=True,
+        )
 
 
 def _wait_for_child_pid(

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -1175,7 +1175,13 @@ class Supervisor:
                         f"Session {launch.session.name} failed to stabilize during bootstrap: {exc}",
                     )
                 except Exception:  # noqa: BLE001
-                    pass
+                    # #1355: previously silent. Surface to logs so a broken
+                    # msg_store / schema drift stops swallowing stabilize bugs.
+                    logger.warning(
+                        "bootstrap stabilize failed to record alert for %s",
+                        launch.session.name,
+                        exc_info=True,
+                    )
 
         threads = []
         for launch, tgt in targets:
@@ -1236,7 +1242,14 @@ class Supervisor:
                 if w.name == window_name:
                     return w.pane_id
         except Exception:  # noqa: BLE001
-            pass
+            # #1355: previously silent. A tmux failure here is a real
+            # symptom (dead server, perms) — log so it surfaces.
+            logger.warning(
+                "resolve_pane_id failed for session=%s window=%s",
+                session_name,
+                window_name,
+                exc_info=True,
+            )
         return None
 
     def _record_launch(self, launch: SessionLaunchSpec) -> None:
@@ -1491,7 +1504,12 @@ class Supervisor:
                 try:
                     self._msg_store.clear_alert("heartbeat", "fd_exhaustion_pending")
                 except Exception:  # noqa: BLE001
-                    pass
+                    # #1355: previously silent. A stuck fd-pressure alert
+                    # is operator-visible; log so we know clear_alert broke.
+                    logger.warning(
+                        "fd_exhaustion_pending clear_alert failed",
+                        exc_info=True,
+                    )
         except Exception:  # noqa: BLE001
             # Sweep is best-effort — never let it crash the heartbeat tick.
             return
@@ -2140,7 +2158,14 @@ class Supervisor:
                         from pollypm.atomic_io import atomic_write_json
                         atomic_write_json(state_path, state)
             except Exception:  # noqa: BLE001
-                pass
+                # #1355: previously silent. JSON parse error or atomic
+                # write failure here means cockpit_state is corrupt or
+                # the disk write path is broken — both worth knowing.
+                logger.warning(
+                    "cockpit_state read/clear failed for %s",
+                    launch.session.name,
+                    exc_info=True,
+                )
         # Session not found anywhere — raise a clear error
         raise RuntimeError(
             f"Session '{launch.session.name}' (window '{launch.window_name}') not found in "
@@ -3489,7 +3514,15 @@ class Supervisor:
                 try:
                     self.launch_session(session_name)
                 except Exception:
-                    pass
+                    # #1355: previously silent. This is the second of two
+                    # launch attempts during account-recovery. If both
+                    # fail, the session stays degraded — surface the
+                    # follow-up failure so we know recovery is broken.
+                    logger.warning(
+                        "launch_session retry after collision failed for %s",
+                        session_name,
+                        exc_info=True,
+                    )
         except Exception:
             self.store.upsert_session_runtime(
                 session_name=session_name,
@@ -4149,7 +4182,14 @@ class Supervisor:
                 },
             )
         except Exception:  # noqa: BLE001
-            pass
+            # #1355: previously silent. If the persona-swap diagnostic
+            # event can't be recorded the operator-visible signal is
+            # lost — log so we don't blindly trust the audit trail.
+            logger.warning(
+                "persona_swap_detected event record failed (pre-send guard, role=%s)",
+                role,
+                exc_info=True,
+            )
         return True
 
     def _target_window_matches_launch(

--- a/src/pollypm/supervisor_alerts.py
+++ b/src/pollypm/supervisor_alerts.py
@@ -466,7 +466,14 @@ def _maybe_nudge_reviewer_review(
             force=lease is not None and lease.owner != "human",
         )
     except Exception:  # noqa: BLE001
-        pass
+        # #1355: previously silent. If the reviewer-nudge send fails,
+        # review work can stall indefinitely — surface so we can spot
+        # broken send_input / pane resolution paths.
+        _logger.warning(
+            "reviewer review nudge send_input failed for %s",
+            launch.session.name,
+            exc_info=True,
+        )
 
 
 _FRESH_CONTEXT_CONTRACT = (


### PR DESCRIPTION
## Summary

Wedge for #1355 — replaces silent `except Exception: pass` with `logger.warning(..., exc_info=True)` at 9 reliability-critical sites in supervisor / rail-daemon code. **Behavior unchanged**: every except already absorbed the exception; this PR just adds observability for what was previously silent so genuine bugs (msg_store schema drift, tmux death, broken audit emit) stop being invisible.

Per the #1355 plan: phased cleanup, no sweeping rewrite. Out-of-scope sites (cockpit_ui.py — handled by #1354 module split; pure best-effort cleanup paths like `store.close()` / `rail.stop()` / dropped-event audit) left untouched.

## Touched sites

- `src/pollypm/supervisor.py`
  - bootstrap stabilize alert record (`_stabilize_one` fallback)
  - `_resolve_pane_id` tmux failure
  - `fd_exhaustion_pending` `clear_alert` retraction
  - cockpit_state read/clear failure during stale-pane invalidation
  - `launch_session` retry after window-name collision in account-recovery
  - pre-send `persona_swap_detected` event record
- `src/pollypm/supervisor_alerts.py`
  - `_maybe_nudge_reviewer_review` `send_input` failure
- `src/pollypm/rail_daemon_reaper.py`
  - `daemon.reaped` audit emit failure
- `src/pollypm/rail_daemon_supervisor.py`
  - `daemon.revived` audit emit failure

## Test plan

- [x] All touched sites still swallow the exception (no behavior change) and propagate via `logger.warning` with `exc_info=True`.
- [x] `pytest -k "supervisor or rail_daemon"` — 237 passed, 3 pre-existing failures (verified against base branch, unrelated to this PR: `test_import_boundary` for tier4.py, `test_bootstrap_returns_before_provider_stabilization_finishes`, `test_supervisor_alert_helper_updates_and_nudges` — the latter two are pre-existing nudge-text mismatches).
- [x] `ruff check` on touched files: only pre-existing E402 warnings, no new lint issues.
- [ ] Manual verification: trigger one of the formerly-silent paths (e.g. force `msg_store.upsert_alert` to raise) and confirm a `WARNING` line lands in the rail-daemon log with traceback.

Refs #1355.

Generated with [Claude Code](https://claude.com/claude-code)