### PR TITLE
Fix #1589 plan-review approval commits even when plan_task is already done

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import gc
 import asyncio
 import json
+import logging
 import os
 import resource
 import webbrowser
@@ -38,6 +39,8 @@ try:
         resource.setrlimit(resource.RLIMIT_NOFILE, (min(4096, _hard), _hard))
 except (ValueError, OSError):
     pass
+
+logger = logging.getLogger(__name__)
 
 from rich.text import Text
 from textual import events, on
@@ -11351,8 +11354,16 @@ class PollyInboxApp(App[None]):
         actor_name = pending["actor_name"]
         is_message_item = pending["is_message_item"]
         item = pending["item"]
+        logger.info(
+            "plan_review.commit start task_id=%s plan_task_id=%s actor=%s",
+            task_id, plan_task_id, actor_name,
+        )
         svc = self._resolve_inbox_svc(item, plan_task_id)
         if svc is None:
+            logger.warning(
+                "plan_review.commit could-not-open-db task_id=%s plan_task_id=%s",
+                task_id, plan_task_id,
+            )
             self.notify(
                 "Could not open project database for plan task.",
                 severity="error",
@@ -11360,10 +11371,42 @@ class PollyInboxApp(App[None]):
             return
         first_shipped_created = False
         try:
-            svc.approve(plan_task_id, actor_name, None)
-            first_shipped_created = bool(
-                getattr(svc, "last_first_shipped_created", False)
-            )
+            # #1589 — backstop-emitted plan_review rows (work/plan_review_emit.py)
+            # reference a plan_task that is ALREADY at work_status=done.
+            # ``svc.approve`` requires REVIEW status and raises
+            # ``InvalidTransitionError`` otherwise — the celebration toast
+            # would fire while the row stayed in the inbox indefinitely.
+            # Detect the terminal case up-front and skip the approve call,
+            # but still archive the inbox row so the keystroke clears the
+            # action lens.
+            plan_task_terminal = False
+            try:
+                plan_task = svc.get(plan_task_id)
+                status = getattr(plan_task, "work_status", None)
+                status_value = getattr(status, "value", status)
+                plan_task_terminal = status_value in {"done", "cancelled"}
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "plan_review.commit pre-approve get(%s) failed",
+                    plan_task_id, exc_info=True,
+                )
+            if plan_task_terminal:
+                logger.info(
+                    "plan_review.commit plan_task already terminal "
+                    "task_id=%s plan_task_id=%s — skipping svc.approve, "
+                    "archiving inbox row only",
+                    task_id, plan_task_id,
+                )
+            else:
+                svc.approve(plan_task_id, actor_name, None)
+                logger.info(
+                    "plan_review.commit svc.approve succeeded "
+                    "task_id=%s plan_task_id=%s",
+                    task_id, plan_task_id,
+                )
+                first_shipped_created = bool(
+                    getattr(svc, "last_first_shipped_created", False)
+                )
             if is_message_item:
                 try:
                     svc.add_context(
@@ -11373,8 +11416,16 @@ class PollyInboxApp(App[None]):
                         entry_type="plan_review_approved",
                     )
                 except Exception:  # noqa: BLE001
-                    pass
+                    logger.debug(
+                        "plan_review.commit add_context on plan_task failed",
+                        exc_info=True,
+                    )
         except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "plan_review.commit svc.approve failed task_id=%s "
+                "plan_task_id=%s exc=%r",
+                task_id, plan_task_id, exc, exc_info=True,
+            )
             self.notify(f"Approve failed: {exc}", severity="error")
             return
         finally:
@@ -11406,13 +11457,26 @@ class PollyInboxApp(App[None]):
                         entry_type="plan_review_approved",
                     )
                     svc.archive_task(task_id, actor=actor_name)
+                    logger.info(
+                        "plan_review.commit archived inbox row task_id=%s",
+                        task_id,
+                    )
                 except Exception:  # noqa: BLE001
-                    pass
+                    logger.warning(
+                        "plan_review.commit archive_task failed task_id=%s",
+                        task_id, exc_info=True,
+                    )
                 finally:
                     try:
                         svc.close()
                     except Exception:  # noqa: BLE001
                         pass
+            else:
+                logger.warning(
+                    "plan_review.commit could-not-open-inbox-svc to archive "
+                    "task_id=%s",
+                    task_id,
+                )
         self._emit_event(
             task_id, "inbox.plan_review.approved",
             f"{actor_name} approved plan {plan_task_id} via {task_id}",

--- a/tests/test_plan_review_flow.py
+++ b/tests/test_plan_review_flow.py
@@ -1614,6 +1614,90 @@ class TestApproveDeferredUndo:
                 _S.approve = original_approve  # type: ignore[assignment]
         _run(body())
 
+    def test_backstop_emit_plan_task_already_done_archives_without_approve(
+        self, plan_review_env, deferred_inbox_app,
+    ) -> None:
+        """#1589 — when plan_task is already DONE (backstop emit), the
+        approve key still clears the inbox row.
+
+        ``plan_review_emit.py`` emits a plan_review notification card for
+        plan-shaped tasks that reached ``done`` without a plan_review
+        handoff. Calling ``svc.approve`` on a DONE task raises
+        ``InvalidTransitionError`` ("Cannot approve task in 'done' state").
+        Before the #1589 fix, that exception was caught + surfaced via
+        toast but the deferred-commit returned early, leaving the inbox
+        row indefinitely. The row should drop after the undo window
+        elapses regardless of the plan_task's terminal state — the user
+        is acknowledging the card, not transitioning the underlying task.
+        """
+        async def body() -> None:
+            _seed_round_trip(plan_review_env)
+            # Force the plan_task into a terminal state so ``svc.approve``
+            # would raise. We bypass the transition manager (which would
+            # itself complain about the current state) and write the
+            # status column directly — mirrors the backstop case where
+            # the plan_task reached done via a non-plan_project flow.
+            from pollypm.work.sqlite_service import SQLiteWorkService
+            db_path = plan_review_env["project_path"] / ".pollypm" / "state.db"
+            svc_direct = SQLiteWorkService(
+                db_path=db_path,
+                project_path=plan_review_env["project_path"],
+            )
+            try:
+                project, _, number = plan_review_env[
+                    "plan_task_id"
+                ].partition("/")
+                svc_direct._conn.execute(
+                    "UPDATE work_tasks SET work_status = 'done' "
+                    "WHERE project = ? AND task_number = ?",
+                    (project, int(number)),
+                )
+                svc_direct._conn.commit()
+            finally:
+                svc_direct.close()
+
+            approve_calls: list[tuple[str, str]] = []
+            from pollypm.work.sqlite_service import SQLiteWorkService as _S
+            original_approve = _S.approve
+
+            def _spy_approve(self, task_id, actor, reason=None):
+                approve_calls.append((task_id, actor))
+                return original_approve(self, task_id, actor, reason)
+
+            _S.approve = _spy_approve  # type: ignore[assignment]
+            try:
+                async with deferred_inbox_app.run_test(size=(140, 40)) as pilot:
+                    await pilot.pause()
+                    deferred_inbox_app.list_view.index = 0
+                    await pilot.press("enter")
+                    await pilot.pause()
+                    await pilot.press("A")
+                    # Wait past the window so the timer fires.
+                    for _ in range(30):
+                        await pilot.pause(0.05)
+                        if deferred_inbox_app._pending_plan_approval is None:
+                            break
+                    # Pending state cleared after commit.
+                    assert deferred_inbox_app._pending_plan_approval is None
+                    # svc.approve was NOT called against the terminal
+                    # plan_task — the fix skips it for the backstop case.
+                    assert approve_calls == []
+                    # The inbox row was archived (work_status -> done).
+                    svc_check = SQLiteWorkService(
+                        db_path=db_path,
+                        project_path=plan_review_env["project_path"],
+                    )
+                    try:
+                        plan_review_task = svc_check.get(
+                            plan_review_env["plan_review_id"],
+                        )
+                        assert plan_review_task.work_status.value == "done"
+                    finally:
+                        svc_check.close()
+            finally:
+                _S.approve = original_approve  # type: ignore[assignment]
+        _run(body())
+
 
 class TestUndoWindowConstant:
     def test_default_undo_window_is_ten_seconds(self) -> None:


### PR DESCRIPTION
## Summary

- Plan-review approval (`A` in cockpit inbox) silently failed when the row was emitted by the #1511 backstop, leaving the row in the inbox after the 10s undo window. Root cause: the backstop emits a `plan_review` card for plan-shaped tasks that reached `done` on a non-`plan_project` flow; calling `svc.approve(plan_task_id)` on a DONE task raises `InvalidTransitionError`, which was caught and notified, but the early return bypassed the `archive_task` step.
- Detect the terminal plan_task state up-front in `_commit_pending_plan_approval` — if the underlying plan_task is already DONE/CANCELLED, skip the approve call but still archive the inbox row so the keystroke clears the action lens.
- Add diagnostic logging across the deferred-commit boundary so any future approval-cascade failure surfaces in `cockpit_debug.log` instead of dying under a swallowed exception (no logger was imported in `cockpit_ui.py` at all — added `logging.getLogger(__name__)`).

## Test plan

- [x] `tests/test_plan_review_flow.py::TestApproveDeferredUndo` — all 3 (incl. new `test_backstop_emit_plan_task_already_done_archives_without_approve` regression)
- [x] `tests/test_plan_review_flow.py` — 45/46 (1 pre-existing unrelated failure: `test_project_drilldown_plan_review_card_surfaces_plan_summary`)
- [x] `tests/test_inbox*.py tests/test_cockpit_inbox*.py` — 322 pass
- [ ] Live cockpit: press `A` on `coffeeboardnm/1`, wait 13s, confirm row drops from inbox + `cockpit_debug.log` shows `plan_review.commit plan_task already terminal ... skipping svc.approve, archiving inbox row only`.

Fixes #1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)