### PR TITLE
Fix #1545 surface working-worker context in Current activity panel

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -15258,21 +15258,34 @@ class PollyProjectDashboardApp(App[None]):
     _PM_CONTEXT_REATTACH_WINDOW_SECONDS = 300.0
     # #1539 \u2014 skeleton placeholder bars rendered into each panel body
     # during the cold-fetch window so the panels read as "loading"
-    # rather than "loaded with nothing in them". Two dim block-glyph
-    # bars per panel are enough to look intentionally placeholdered
-    # without flashing. Replaced wholesale by ``_render`` the moment
-    # the worker thread hands data back; layout stays stable across
-    # the swap so content doesn't pop into place.
+    # rather than "loaded with nothing in them". An italic "loading\u2026"
+    # hint plus two dim block-glyph bars per panel reads as
+    # intentionally placeholdered without flashing. Replaced wholesale
+    # by ``_render`` the moment the worker thread hands data back;
+    # layout stays stable across the swap so content doesn't pop into
+    # place.
+    #
+    # #1539 v2 \u2014 the original ``#1e2730`` bar color was almost
+    # indistinguishable from the panel background ``#111820``, so the
+    # bars rendered invisible and the panels still read as "loaded but
+    # empty" for the full 8\u201312s cold-fetch window. Bumped the bar
+    # color to ``#2a3a4a`` (visible-but-muted, brighter than the
+    # scrollbar track) and prepended an explicit italic
+    # ``loading project dashboard\u2026`` hint so the busy state is legible
+    # even on terminals that crush the dim block glyphs.
     _SKELETON_BAR_LONG = "\u2588" * 24
     _SKELETON_BAR_SHORT = "\u2588" * 14
+    _SKELETON_HINT = "[#6b7a88][i]loading project dashboard\u2026[/i][/]"
     _SKELETON_TWO_LINE = (
-        f"[#1e2730]{_SKELETON_BAR_LONG}[/]\n"
-        f"[#1e2730]{_SKELETON_BAR_SHORT}[/]"
+        f"{_SKELETON_HINT}\n"
+        f"[#2a3a4a]{_SKELETON_BAR_LONG}[/]\n"
+        f"[#2a3a4a]{_SKELETON_BAR_SHORT}[/]"
     )
     _SKELETON_THREE_LINE = (
-        f"[#1e2730]{_SKELETON_BAR_LONG}[/]\n"
-        f"[#1e2730]{_SKELETON_BAR_SHORT}[/]\n"
-        f"[#1e2730]{_SKELETON_BAR_LONG}[/]"
+        f"{_SKELETON_HINT}\n"
+        f"[#2a3a4a]{_SKELETON_BAR_LONG}[/]\n"
+        f"[#2a3a4a]{_SKELETON_BAR_SHORT}[/]\n"
+        f"[#2a3a4a]{_SKELETON_BAR_LONG}[/]"
     )
 
     def __init__(self, config_path: Path, project_key: str) -> None:
@@ -16543,6 +16556,34 @@ class PollyProjectDashboardApp(App[None]):
                     "  [#f0c45a]\u25c6[/#f0c45a] Waiting on your "
                     "response \u2014 a permission prompt is open."
                 )
+            elif activity == "working":
+                # #1545 \u2014 architect / worker is heartbeat-alive and the
+                # pane is moving, but no task is claimed in_progress in
+                # the work-service DB (architects rarely own tasks;
+                # workers can work ahead of a queued claim). Without a
+                # context line the panel reads as just "\u25cf architect 30s"
+                # which feels empty \u2014 coffeeboardnm hit exactly this
+                # while ``architect_coffeeboardnm`` had been building
+                # for 8 minutes. Surface the most recent activity-feed
+                # entry so the operator sees what the session is doing
+                # right now; fall back to a plain "working ahead" note
+                # if the feed is empty.
+                entries = getattr(data, "activity_entries", None) or []
+                latest = entries[0] if entries else None
+                summary = ""
+                if latest:
+                    summary = self._sanitize_activity_summary(
+                        str(latest.get("summary") or "").strip(),
+                    )
+                if summary:
+                    lines.append(
+                        f"  [dim]\u21b3 {_escape(summary)}[/dim]",
+                    )
+                else:
+                    lines.append(
+                        "  [dim]Working ahead \u2014 no claimed task "
+                        "yet.[/dim]",
+                    )
             return "\n".join(lines)
         if data.action_items:
             item = data.action_items[0]
@@ -16595,6 +16636,21 @@ class PollyProjectDashboardApp(App[None]):
             return (
                 "[dim]No worker active right now.[/dim]\n"
                 "  Work is on hold — see Task pipeline for the hold reason."
+            )
+        # #1545 — when a plan-shaped done task is awaiting review the
+        # banner advertises ``Plan's ready — Press → to review`` but
+        # the now-section used to fall through to "Idle" which directly
+        # contradicted the banner. Mirror the banner so both surfaces
+        # tell the same story.
+        plan_task_summary = getattr(data, "plan_task_summary", None) or None
+        if plan_task_summary:
+            title = (
+                str(plan_task_summary.get("title") or "").strip()
+                or "the plan"
+            )
+            return (
+                "[#f0c45a]◆[/#f0c45a] Plan's ready for your review.\n"
+                f"  [dim]↳ {_escape(title)}[/dim]"
             )
         return "[dim]Idle. No tasks in flight and no user action needed.[/dim]"
 

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -3650,6 +3650,112 @@ def test_now_body_keeps_in_action_for_working_worker() -> None:
     assert "standing by" not in rendered
 
 
+def test_now_body_surfaces_activity_for_working_worker_without_claimed_task() -> None:
+    """#1545 — coffeeboardnm had ``architect_coffeeboardnm`` heartbeat-alive
+    and actively building for ~8 minutes, but the "Current activity" panel
+    rendered as just the identity line because the architect hadn't claimed
+    an ``in_progress`` task (architects rarely own work-service tasks).
+    Surface the most-recent activity-feed summary so the operator sees
+    what the session is actually doing.
+    """
+    from types import SimpleNamespace
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+    app.project_key = "coffeeboardnm"
+    fake_data = SimpleNamespace(
+        active_worker={
+            "session_name": "architect_coffeeboardnm",
+            "role": "architect",
+            "last_heartbeat": "2026-05-17T22:30:00+00:00",
+            "activity": "working",
+        },
+        action_items=[],
+        task_buckets={
+            "queued": [], "in_progress": [], "review": [],
+            "blocked": [], "on_hold": [], "done": [],
+        },
+        task_counts={},
+        activity_entries=[
+            {
+                "timestamp": "2026-05-17T22:29:30+00:00",
+                "actor": "architect",
+                "verb": "noted",
+                "summary": "Added Phase-1 Week-1 ingestion scaffold",
+                "kind": "note",
+            },
+        ],
+    )
+    rendered = app._render_now_body(fake_data)
+    # Working classification → green dot stays.
+    assert "[#3ddc84]●[/#3ddc84]" in rendered
+    # The most-recent activity summary is surfaced as a context line.
+    assert "Phase-1 Week-1 ingestion scaffold" in rendered
+    # No mistaken "Idle" or "standing by" copy.
+    assert "Idle" not in rendered
+    assert "standing by" not in rendered
+
+
+def test_now_body_falls_back_when_working_worker_has_no_activity_feed() -> None:
+    """If the activity feed is empty (fresh project) but the worker is
+    actively progressing, the panel still says something concrete instead
+    of leaving the identity line alone.
+    """
+    from types import SimpleNamespace
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+    app.project_key = "coffeeboardnm"
+    fake_data = SimpleNamespace(
+        active_worker={
+            "session_name": "architect_coffeeboardnm",
+            "role": "architect",
+            "last_heartbeat": "2026-05-17T22:30:00+00:00",
+            "activity": "working",
+        },
+        action_items=[],
+        task_buckets={
+            "queued": [], "in_progress": [], "review": [],
+            "blocked": [], "on_hold": [], "done": [],
+        },
+        task_counts={},
+        activity_entries=[],
+    )
+    rendered = app._render_now_body(fake_data)
+    assert "Working ahead" in rendered
+
+
+def test_now_body_says_plan_ready_when_plan_task_summary_present() -> None:
+    """#1545 — when the banner advertises ``Plan's ready — Press → to
+    review`` but no worker is heartbeat-alive (e.g. the architect session
+    ended after emitting the plan), the now-section used to read
+    ``Idle. No tasks in flight`` which contradicted the banner. Mirror the
+    banner instead so both surfaces tell the same story.
+    """
+    from types import SimpleNamespace
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+    app.project_key = "coffeeboardnm"
+    fake_data = SimpleNamespace(
+        active_worker=None,
+        action_items=[],
+        task_buckets={
+            "queued": [], "in_progress": [], "review": [],
+            "blocked": [], "on_hold": [], "done": [],
+        },
+        task_counts={},
+        plan_task_summary={
+            "task_id": "coffeeboardnm/3",
+            "title": "POC plan: ingest every NM event May-Jul 2026",
+        },
+    )
+    rendered = app._render_now_body(fake_data)
+    assert "Idle" not in rendered
+    assert "Plan's ready" in rendered
+    assert "POC plan: ingest every NM event May-Jul 2026" in rendered
+
+
 def test_status_pill_uses_activity_classification() -> None:
     """The pill colour / label reads the classifier, not just liveness.
 


### PR DESCRIPTION
## Summary

- Fixes #1545: the "Current activity" panel rendered as just the worker identity line when an architect (or worker) was heartbeat-alive with pane movement but no `in_progress` task claimed in the work-service DB — coffeeboardnm hit this with `architect_coffeeboardnm` actively building for ~8 minutes while the panel read empty.
- For a `working` classification with no in-flight task, the panel now surfaces the most recent `activity_entries` summary as a context line; falls back to "Working ahead — no claimed task yet" when the feed is empty.
- For the no-active-worker path, when `plan_task_summary` is non-null we mirror the banner ("Plan's ready for your review") instead of falling through to "Idle. No tasks in flight" which directly contradicted the banner above.

## Test plan

- [x] `test_now_body_surfaces_activity_for_working_worker_without_claimed_task` — working architect with activity entries renders the most recent summary.
- [x] `test_now_body_falls_back_when_working_worker_has_no_activity_feed` — empty feed → "Working ahead" fallback.
- [x] `test_now_body_says_plan_ready_when_plan_task_summary_present` — banner ↔ panel parity when plan task is awaiting review.
- [x] Existing `_render_now_body` tests still pass (idle / awaiting_user / on_hold / in-flight working all unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)