### PR TITLE
Fix #1543 rail surfaces "N more" indicator when overflowing

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -4113,6 +4113,16 @@ class PollyCockpitRail:
         self._ticker_started_at = time.monotonic()
         self._last_items: list[CockpitItem] = []
         self._slogan_phase = 0
+        # #1543 — body scroll offset (in lines) when the rail can't fit
+        # every item on the current terminal height. ``None`` means "auto
+        # scroll to keep the selected item in view"; an int pins the
+        # offset (PgUp/PgDn). Reset to auto on every selection change so
+        # j/k navigation still keeps the cursor visible.
+        self._scroll_offset: int | None = None
+        # Cached on the last ``_render`` so PgUp/PgDn can clamp against
+        # the actual overflow size without re-running the layout pass.
+        self._last_body_total = 0
+        self._last_body_visible = 0
 
     def run(self) -> None:
         fd = sys.stdin.fileno()
@@ -4222,7 +4232,35 @@ class PollyCockpitRail:
             self.router.route_selected("settings")
             self.selected_key = "settings"
             return True
+        # #1543 — PgUp/PgDn (and ctrl+b/ctrl+f) page the rail body when
+        # the project list overflows the terminal height. Falls back to
+        # ``_move`` selection navigation when the body fits, so the keys
+        # do something predictable in either mode.
+        if key in {b"\x1b[5~", b"\x02"}:  # PgUp / Ctrl-B
+            self._page_scroll(-1, items)
+            return True
+        if key in {b"\x1b[6~", b"\x06"}:  # PgDn / Ctrl-F
+            self._page_scroll(1, items)
+            return True
         return True
+
+    def _page_scroll(self, direction: int, items: list[CockpitItem]) -> None:
+        """Scroll the rail body by one page, or skip selection if the
+        body isn't overflowing. Sets ``_scroll_offset`` so the next
+        ``_render`` honors the user's pinned position; a subsequent j/k
+        navigation that lands outside the window restores auto-scroll.
+        """
+        total = self._last_body_total
+        visible = self._last_body_visible
+        if total <= visible or visible <= 0:
+            # Body fits — page keys act as bigger jumps for selection.
+            self._move(direction * max(1, visible - 1), items)
+            return
+        window = max(1, visible - 1)
+        max_offset = max(0, total - window)
+        current = self._scroll_offset if self._scroll_offset is not None else 0
+        new_offset = max(0, min(max_offset, current + direction * window))
+        self._scroll_offset = new_offset
 
     def _send_key_to_settings_pane(self, key: str) -> None:
         delivered = None
@@ -4251,9 +4289,13 @@ class PollyCockpitRail:
         except ValueError:
             self.selected_key = keys[0]
             self.router.set_selected_key(self.selected_key)
+            self._scroll_offset = None
             return
         self.selected_key = keys[(index + delta) % len(keys)]
         self.router.set_selected_key(self.selected_key)
+        # #1543 — j/k selection moves resume auto-scroll so the selected
+        # item is always brought back into view. PgUp/PgDn re-pin.
+        self._scroll_offset = None
 
     def _select_first(self, items: list[CockpitItem]) -> None:
         for item in items:
@@ -4303,60 +4345,105 @@ class PollyCockpitRail:
         size = shutil.get_terminal_size((30, 24))
         width = max(16, size.columns)
         height = max(8, size.lines)
-        lines: list[RenderRow] = []
+        header: list[RenderRow] = []
+        body: list[RenderRow] = []
+        # Parallel to ``body``: row idx -> body_items index, or None for
+        # blank lines + ``-- projects --`` separators. Drives the
+        # auto-scroll logic so the selected item stays in view (#1543).
+        body_item_index: list[int | None] = []
+        footer: list[RenderRow] = []
         pad = " " * GUTTER
 
         # ── Wordmark (centered)
-        lines.append(RenderRow(""))
+        header.append(RenderRow(""))
         wm0 = ASCII_POLLY[0]
         wm1 = ASCII_POLLY[1]
-        lines.append(RenderRow(wm0.center(width)[:width], fg=PALETTE["wordmark_hi"], bold=True))
-        lines.append(RenderRow(wm1.center(width)[:width], fg=PALETTE["wordmark_lo"]))
-        lines.append(RenderRow(""))
+        header.append(RenderRow(wm0.center(width)[:width], fg=PALETTE["wordmark_hi"], bold=True))
+        header.append(RenderRow(wm1.center(width)[:width], fg=PALETTE["wordmark_lo"]))
+        header.append(RenderRow(""))
 
         # ── Slogan (centered)
         slogan = self._current_slogan()
         sc = self._slogan_color()
-        lines.append(RenderRow(slogan[0].center(width)[:width], fg=sc))
-        lines.append(RenderRow(slogan[1].center(width)[:width], fg=sc))
-        lines.append(RenderRow(""))
+        header.append(RenderRow(slogan[0].center(width)[:width], fg=sc))
+        header.append(RenderRow(slogan[1].center(width)[:width], fg=sc))
+        header.append(RenderRow(""))
 
-        # ── Section: navigation
+        # ── Body: navigation rows (scrollable when the rail can't fit)
         settings_item = next((item for item in items if item.key == "settings"), None)
         body_items = [item for item in items if item.key != "settings"]
         active_view = self.router.selected_key()
 
         first_project = True
-        for item in body_items:
+        for item_idx, item in enumerate(body_items):
             if item.key.startswith("project:") and first_project:
-                lines.append(RenderRow(""))
-                lines.append(self._section_header("projects", width))
+                body.append(RenderRow(""))
+                body_item_index.append(None)
+                body.append(self._section_header("projects", width))
+                body_item_index.append(None)
                 first_project = False
-            lines.append(self._item_row(item, width, active_view))
+            body.append(self._item_row(item, width, active_view))
+            body_item_index.append(item_idx)
 
-        # ── Spacer + settings at bottom
-        if settings_item is not None:
-            target_lines = len(lines) + 4  # section header + blank + item + hint
-            while len(lines) < height - target_lines + len(lines):
-                if len(lines) >= height - 4:
-                    break
-                lines.append(RenderRow(""))
-            lines.append(RenderRow(""))
-            lines.append(self._section_header("system", width))
-            lines.append(self._item_row(settings_item, width, active_view))
-
+        # ── Footer: settings, ticker, hint (pinned to bottom)
         ticker_text = self._event_ticker_text()
-        reserve = 3 if ticker_text else 2
-        while len(lines) < height - reserve:
-            lines.append(RenderRow(""))
-        lines.append(RenderRow(""))
+        if settings_item is not None:
+            footer.append(RenderRow(""))
+            footer.append(self._section_header("system", width))
+            footer.append(self._item_row(settings_item, width, active_view))
+        footer.append(RenderRow(""))
         if ticker_text:
-            lines.append(RenderRow(ticker_text[:width], fg=PALETTE["hint"]))
+            footer.append(RenderRow(ticker_text[:width], fg=PALETTE["hint"]))
         # Compact hint: full keymap is one ``?`` away (#790). Width
         # budget is the 30-col rail, so drop everything but the most
         # frequently-used actions.
         hint = f"{pad}j/k \u21b5open \u00b7 ? help \u00b7 q quit"
-        lines.append(RenderRow(hint[:width], fg=PALETTE["hint"]))
+        footer.append(RenderRow(hint[:width], fg=PALETTE["hint"]))
+
+        # ── Compose: header + body (with overflow handling) + footer.
+        # #1543 — when the body doesn't fit at the current terminal
+        # height, the old renderer silently truncated rows that fell
+        # past ``height``. A short laptop window could hide 11 of 12
+        # projects with no indicator. We now scroll the body within a
+        # bounded window so the selected item stays visible and a
+        # one-line overflow hint advertises the hidden rows.
+        body_budget = height - len(header) - len(footer)
+        if body_budget < 1:
+            body_budget = 1
+
+        if len(body) > body_budget:
+            window = max(1, body_budget - 1)  # reserve a row for the indicator
+            selected_row = self._row_for_selected(body_item_index, body_items)
+            offset = self._resolve_scroll_offset(
+                selected_row=selected_row,
+                total=len(body),
+                window=window,
+            )
+            self._scroll_offset = offset
+            slice_above = offset
+            slice_below = len(body) - offset - window
+            visible_body = list(body[offset : offset + window])
+            visible_body.append(
+                self._overflow_indicator_row(
+                    above=slice_above, below=slice_below, width=width,
+                )
+            )
+        else:
+            # Body fits — drop any pinned scroll offset so the next
+            # overflow lands at the natural auto-scroll position.
+            self._scroll_offset = None
+            visible_body = body
+
+        self._last_body_total = len(body)
+        self._last_body_visible = body_budget
+
+        lines: list[RenderRow] = []
+        lines.extend(header)
+        lines.extend(visible_body)
+        # Pad with blank rows so the footer sticks to the terminal bottom.
+        while len(lines) + len(footer) < height:
+            lines.append(RenderRow(""))
+        lines.extend(footer)
 
         # ── Flush
         bg = PALETTE["bg"]
@@ -4371,6 +4458,67 @@ class PollyCockpitRail:
                     self._write(_sgr(row) + row.text.ljust(width)[:width] + "\x1b[0m\r\n")
             else:
                 self._write(clear_line + "\r\n")
+
+    def _row_for_selected(
+        self,
+        body_item_index: list[int | None],
+        body_items: list[CockpitItem],
+    ) -> int | None:
+        """Return the body-row index of the currently selected item, or
+        ``None`` if the selection isn't a body row (e.g. ``settings``).
+        """
+        for row_idx, item_idx in enumerate(body_item_index):
+            if item_idx is None:
+                continue
+            if body_items[item_idx].key == self.selected_key:
+                return row_idx
+        return None
+
+    def _resolve_scroll_offset(
+        self,
+        *,
+        selected_row: int | None,
+        total: int,
+        window: int,
+    ) -> int:
+        """Pick the scroll offset that keeps the selected row in view.
+
+        Honors a pinned ``self._scroll_offset`` (set by PgUp/PgDn) when
+        possible; otherwise auto-scrolls so the selected row stays
+        visible. Clamps within ``[0, max_offset]``.
+        """
+        max_offset = max(0, total - window)
+        pinned = self._scroll_offset
+        if pinned is not None:
+            return max(0, min(pinned, max_offset))
+        if selected_row is None:
+            return 0
+        if selected_row < window:
+            return 0
+        # Scroll so the selected row sits near the bottom of the window;
+        # leaves the user a hint that more rows live above.
+        return min(max_offset, selected_row - window + 1)
+
+    def _overflow_indicator_row(
+        self, *, above: int, below: int, width: int,
+    ) -> "RenderRow":
+        """Build a visible "N more above/below" hint for the rail body.
+
+        Reclaims the user's mental model when the rail can't fit every
+        project on the current terminal height (#1543). Uses the inbox
+        amber tone so the indicator reads as a navigation hint, not an
+        alert.
+        """
+        pad = " " * GUTTER
+        if above and below:
+            text = f"{pad}↕ {above} above · {below} below"
+        elif below:
+            text = f"{pad}▼ {below} more · j to scroll"
+        elif above:
+            text = f"{pad}▲ {above} more · k to scroll"
+        else:
+            text = ""
+        return RenderRow(text[:width], fg=PALETTE["inbox_has"], bold=True)
 
     # Heartbeat ticks and token-ledger syncs flood the events stream
     # but carry no user-facing signal (#793, #876). Mirrors the

--- a/tests/test_cockpit_rail_overflow_indicator.py
+++ b/tests/test_cockpit_rail_overflow_indicator.py
@@ -1,0 +1,242 @@
+"""#1543 — raw rail must surface a scroll affordance when the project
+list overflows the current terminal height.
+
+Before this guard, ``PollyCockpitRail._render`` silently truncated rows
+that fell past ``shutil.get_terminal_size().lines``. On a short laptop
+window that hid 11 of 12 projects with no indicator — the user thought
+they only had one project.
+
+The fix scrolls the body within a bounded window, keeps the selected
+row in view, and renders a one-line "▼ N more" hint when content is
+hidden. PgUp/PgDn pin the offset so the user can browse off-screen
+rows without losing their selection; subsequent j/k navigation resumes
+auto-scroll.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from pollypm.cockpit_rail import (
+    CockpitItem,
+    PollyCockpitRail,
+    RenderRow,
+)
+
+
+def _make_rail() -> PollyCockpitRail:
+    rail = PollyCockpitRail.__new__(PollyCockpitRail)
+    rail._scroll_offset = None
+    rail._last_body_total = 0
+    rail._last_body_visible = 0
+    rail.selected_key = "project:alpha"
+    return rail
+
+
+def test_resolve_scroll_offset_auto_keeps_selected_visible() -> None:
+    """Auto-scroll lands the selected row near the bottom of the window
+    so the user sees both the highlighted item and a hint of rows above.
+    """
+    rail = _make_rail()
+    # Selected at row 15, window of 5, total of 20: auto offset should
+    # land at 11 so rows 11..15 are visible.
+    offset = rail._resolve_scroll_offset(selected_row=15, total=20, window=5)
+    assert offset == 11
+
+    # Selected near the top — no scroll needed.
+    offset = rail._resolve_scroll_offset(selected_row=2, total=20, window=5)
+    assert offset == 0
+
+    # No body selection (e.g. ``settings`` is active) — pin to top.
+    offset = rail._resolve_scroll_offset(selected_row=None, total=20, window=5)
+    assert offset == 0
+
+
+def test_resolve_scroll_offset_honors_pinned_offset() -> None:
+    """PgUp/PgDn pins an offset; auto-scroll defers until j/k clears it."""
+    rail = _make_rail()
+    rail._scroll_offset = 7
+    offset = rail._resolve_scroll_offset(selected_row=2, total=20, window=5)
+    assert offset == 7  # honors the pin instead of snapping to selection
+    # Out-of-range pin clamps to the valid window.
+    rail._scroll_offset = 99
+    offset = rail._resolve_scroll_offset(selected_row=None, total=20, window=5)
+    assert offset == 15  # 20 - 5
+
+
+def test_overflow_indicator_text_for_both_directions() -> None:
+    """The indicator string must call out hidden rows on either side."""
+    rail = _make_rail()
+    below_only = rail._overflow_indicator_row(above=0, below=11, width=30)
+    assert "11 more" in below_only.text
+    assert "j to scroll" in below_only.text
+
+    above_only = rail._overflow_indicator_row(above=4, below=0, width=30)
+    assert "4 more" in above_only.text
+    assert "k to scroll" in above_only.text
+
+    both = rail._overflow_indicator_row(above=2, below=3, width=30)
+    assert "2 above" in both.text
+    assert "3 below" in both.text
+
+
+def test_move_resets_pinned_scroll_offset() -> None:
+    """j/k selection moves must resume auto-scroll so the selected row
+    is always brought back into view; otherwise PgDn → j leaves the
+    cursor invisible.
+    """
+    rail = _make_rail()
+    rail._scroll_offset = 5
+    rail.router = type("R", (), {"set_selected_key": lambda self, k: None})()
+    items = [
+        CockpitItem(key="dashboard", label="Home", state="idle"),
+        CockpitItem(key="inbox", label="Inbox", state="idle"),
+    ]
+    rail.selected_key = "dashboard"
+    rail._move(1, items)
+    assert rail._scroll_offset is None, (
+        "j/k navigation must clear the pinned scroll offset so the "
+        "selected row is auto-scrolled back into view"
+    )
+
+
+def test_page_scroll_pins_offset_when_body_overflows() -> None:
+    """PgDn pages the visible window forward; PgUp pages it back."""
+    rail = _make_rail()
+    rail._last_body_total = 20
+    rail._last_body_visible = 6  # window is 5 (visible - 1 for indicator)
+    rail._scroll_offset = 0
+    rail._move = lambda *args, **kwargs: None  # type: ignore[assignment]
+
+    rail._page_scroll(1, items=[])
+    assert rail._scroll_offset == 5
+
+    rail._page_scroll(1, items=[])
+    assert rail._scroll_offset == 10
+
+    rail._page_scroll(-1, items=[])
+    assert rail._scroll_offset == 5
+
+    # Clamps at the upper bound.
+    rail._page_scroll(1, items=[])
+    rail._page_scroll(1, items=[])
+    rail._page_scroll(1, items=[])
+    assert rail._scroll_offset == 15  # 20 - 5
+
+
+def test_page_scroll_falls_back_to_move_when_no_overflow() -> None:
+    """When the body fits, PgUp/PgDn act as larger jumps for selection."""
+    rail = _make_rail()
+    rail._last_body_total = 5
+    rail._last_body_visible = 10  # fits with room to spare
+    rail._scroll_offset = None
+    moves: list[int] = []
+    rail._move = lambda delta, items: moves.append(delta)  # type: ignore[assignment]
+    rail._page_scroll(1, items=[])
+    rail._page_scroll(-1, items=[])
+    assert moves == [9, -9]  # max(1, visible - 1) = 9
+
+
+def test_handle_key_routes_pgup_pgdn_to_page_scroll() -> None:
+    """The PgUp/PgDn escape sequences (xterm) must reach ``_page_scroll``."""
+    rail = _make_rail()
+    rail.router = type("R", (), {})()
+    rail.selected_key = "project:alpha"
+    calls: list[int] = []
+    rail._page_scroll = lambda direction, items: calls.append(direction)  # type: ignore[assignment]
+    assert rail._handle_key(b"\x1b[6~", items=[]) is True  # PgDn
+    assert rail._handle_key(b"\x1b[5~", items=[]) is True  # PgUp
+    assert calls == [1, -1]
+
+
+def test_row_for_selected_skips_separator_rows() -> None:
+    """Headers and blank rows shouldn't be mistaken for selectable items."""
+    rail = _make_rail()
+    rail.selected_key = "project:beta"
+    body_items = [
+        CockpitItem(key="dashboard", label="Home", state="idle"),
+        CockpitItem(key="project:alpha", label="Alpha", state="idle"),
+        CockpitItem(key="project:beta", label="Beta", state="idle"),
+    ]
+    # 3 items with a blank row + separator inserted before project:alpha:
+    # rows 0=Home, 1=blank, 2=`-- projects --`, 3=Alpha, 4=Beta
+    body_item_index = [0, None, None, 1, 2]
+    row = rail._row_for_selected(body_item_index, body_items)
+    assert row == 4
+
+
+def test_render_emits_overflow_indicator_when_short_terminal() -> None:
+    """End-to-end: a 12-project rail rendered into a 16-line terminal
+    must produce an "N more" hint row instead of silently dropping the
+    bottom-most projects (#1543 acceptance).
+    """
+    rail = _make_rail()
+    rail.selected_key = "dashboard"
+    rail.spinner_index = 0
+    rail.presence = type("P", (), {"should_animate": lambda self: False})()
+    rail._slogan_phase = 0
+    rail.slogan_started_at = 0.0
+    rail._ticker_started_at = 0.0
+
+    # Stub the router so ``_render`` doesn't touch the live supervisor.
+    rail.router = type("R", (), {
+        "selected_key": lambda self: "dashboard",
+    })()
+    rail._event_ticker_text = lambda: ""  # type: ignore[assignment]
+
+    items = [CockpitItem(key="dashboard", label="Home", state="idle")]
+    items.extend(
+        CockpitItem(key=f"project:p{i}", label=f"Proj {i}", state="idle")
+        for i in range(12)
+    )
+    items.append(CockpitItem(key="settings", label="Settings", state="idle"))
+
+    output: list[str] = []
+    rail._write = lambda text: output.append(text)  # type: ignore[assignment]
+
+    # 16 rows is well below the ~25 the full rail wants — forces overflow.
+    with patch("pollypm.cockpit_rail.shutil.get_terminal_size",
+               return_value=os.terminal_size((30, 16))):
+        rail._render(items)
+
+    rendered = "".join(output)
+    assert "more" in rendered, (
+        "rail must emit a 'N more' overflow indicator when the project "
+        "list can't fit at the current terminal height (#1543); got:\n"
+        + rendered
+    )
+    assert rail._scroll_offset is not None, (
+        "_render must set _scroll_offset when overflow is active so "
+        "_page_scroll has a baseline to advance from"
+    )
+
+
+def test_render_no_indicator_when_terminal_is_tall_enough() -> None:
+    """No overflow → no indicator row (no false-positive nag)."""
+    rail = _make_rail()
+    rail.selected_key = "dashboard"
+    rail.spinner_index = 0
+    rail.presence = type("P", (), {"should_animate": lambda self: False})()
+    rail._slogan_phase = 0
+    rail.slogan_started_at = 0.0
+    rail._ticker_started_at = 0.0
+    rail.router = type("R", (), {
+        "selected_key": lambda self: "dashboard",
+    })()
+    rail._event_ticker_text = lambda: ""  # type: ignore[assignment]
+
+    items = [
+        CockpitItem(key="dashboard", label="Home", state="idle"),
+        CockpitItem(key="settings", label="Settings", state="idle"),
+    ]
+
+    output: list[str] = []
+    rail._write = lambda text: output.append(text)  # type: ignore[assignment]
+    with patch("pollypm.cockpit_rail.shutil.get_terminal_size",
+               return_value=os.terminal_size((30, 40))):
+        rail._render(items)
+    rendered = "".join(output)
+    assert "more · j to scroll" not in rendered
+    assert "more · k to scroll" not in rendered
+    assert rail._scroll_offset is None


### PR DESCRIPTION
## Summary

Fixes #1543. The raw rail (`pm rail`) silently truncated rows past the terminal height — a 12-project install on a short laptop window could hide 11 of 12 projects with no scroll affordance. `PollyCockpitApp` already collapses sub-rows in compact mode (the prior #1543 work), but the raw rail had no equivalent fallback, and even the Textual rail had no explicit "more below" hint once compact mode still overflowed.

`_render` now splits its output into a fixed header (wordmark + slogan), a scrollable body (nav + projects), and a pinned footer (settings + ticker + hint). When the body can't fit:

- Auto-scroll keeps the selected row in view (lands the selection near the bottom of the visible window so the user sees both the highlight and a hint of rows above).
- A single `▼ N more · j to scroll` / `▲ N more · k to scroll` / `↕ N above · M below` row replaces what would otherwise be silent truncation.
- **PgUp/PgDn** (and Ctrl-B/Ctrl-F) pin a scroll offset for browsing off-screen rows; subsequent j/k navigation resumes auto-scroll so the cursor never goes invisible.

## Test plan

- [x] 10 new tests in `tests/test_cockpit_rail_overflow_indicator.py` cover:
  - scroll-offset resolver (auto + pinned + clamping)
  - indicator text for above-only / below-only / both
  - selection moves clear the pinned offset
  - PgUp/PgDn page math + clamp at upper bound
  - PgUp/PgDn fall back to selection moves when the body fits
  - escape-sequence routing (`\x1b[5~` / `\x1b[6~`)
  - separator rows aren't mistaken for selectable items
  - end-to-end `_render` output for a 16-line terminal (indicator appears) vs. a 40-line terminal (no false-positive nag)
- [x] Full rail suite (74 tests across `test_rail_*` + `test_cockpit_rail_*`) still passes
- [ ] Manual: open `pm rail`, shrink terminal until projects spill — confirm `▼ N more · j to scroll` row appears; press PgDn to page through projects; press j to resume auto-scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)