### PR TITLE
Fix #1376 route cockpit_sections token aggregate via storage facade

### DIFF
--- a/src/pollypm/cockpit_sections/base.py
+++ b/src/pollypm/cockpit_sections/base.py
@@ -168,35 +168,13 @@ def _aggregate_project_tokens(
 ) -> tuple[int, int] | None:
     """SUM(total_input_tokens), SUM(total_output_tokens) for ``project_key``.
 
-    Queries ``work_sessions`` directly \u2014 when #86 lands its aggregate
-    helper we can swap this out for a single method call. Returns
-    ``None`` when the table is missing (old DB) or the query fails, so
-    the Tokens line degrades to "(n/a)" rather than breaking the render.
+    #1376 — the SQL/connection details live in
+    ``pollypm.work.session_queries`` so this section no longer reaches
+    into the raw workspace DB or knows the ``work_sessions`` schema. The
+    ``None``-on-missing-DB / query-failure contract is preserved so the
+    Tokens line still degrades to ``(n/a)`` rather than breaking the
+    render.
     """
-    import sqlite3
+    from pollypm.work.session_queries import project_session_token_totals
 
-    if not db_path.exists():
-        return None
-    try:
-        conn = sqlite3.connect(str(db_path))
-        try:
-            # #1018 — cockpit reader runs alongside JobWorkerPool +
-            # heartbeat writers on the same workspace DB. Apply a short
-            # busy_timeout so a transient lock during a writer's commit
-            # doesn't bubble up as "(n/a)" tokens in the rail.
-            from pollypm.storage.sqlite_pragmas import apply_workspace_pragmas
-
-            apply_workspace_pragmas(conn)
-            row = conn.execute(
-                "SELECT COALESCE(SUM(total_input_tokens), 0), "
-                "       COALESCE(SUM(total_output_tokens), 0) "
-                "FROM work_sessions WHERE task_project = ?",
-                (project_key,),
-            ).fetchone()
-        finally:
-            conn.close()
-    except sqlite3.Error:
-        return None
-    if row is None:
-        return 0, 0
-    return int(row[0] or 0), int(row[1] or 0)
+    return project_session_token_totals(db_path, project_key=project_key)

--- a/src/pollypm/storage/work_session_queries.py
+++ b/src/pollypm/storage/work_session_queries.py
@@ -1,0 +1,69 @@
+"""Read-only ``work_sessions`` aggregate queries.
+
+Presentation/plugin code should not open workspace SQLite files
+directly; this module owns the schema/connection details for small
+projection reads against ``work_sessions``.
+
+The aggregate used by the per-project dashboard's Tokens line lives
+here so the rendering layer (``cockpit_sections``) no longer has to
+``import sqlite3`` or know the table name.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+
+from pollypm.storage.sqlite_pragmas import apply_workspace_pragmas
+
+logger = logging.getLogger(__name__)
+
+
+def aggregate_project_session_tokens(
+    db_path: Path,
+    *,
+    project_key: str,
+) -> tuple[int, int] | None:
+    """Return ``(SUM(total_input_tokens), SUM(total_output_tokens))`` for ``project_key``.
+
+    Returns ``None`` if the DB is missing or the query fails (e.g. the
+    ``work_sessions`` table does not exist on an old workspace) so the
+    Tokens line in the per-project dashboard can degrade to ``(n/a)``
+    instead of breaking the render.
+
+    A short ``busy_timeout`` is applied via the standard workspace
+    pragmas because the cockpit reader runs alongside JobWorkerPool +
+    heartbeat writers on the same DB (#1018).
+    """
+    try:
+        if not db_path.exists():
+            return None
+    except OSError:
+        return None
+    try:
+        conn = sqlite3.connect(str(db_path))
+    except sqlite3.Error as exc:
+        logger.debug(
+            "work_session_queries: connect failed for %s: %s", db_path, exc,
+        )
+        return None
+    try:
+        apply_workspace_pragmas(conn)
+        try:
+            row = conn.execute(
+                "SELECT COALESCE(SUM(total_input_tokens), 0), "
+                "       COALESCE(SUM(total_output_tokens), 0) "
+                "FROM work_sessions WHERE task_project = ?",
+                (project_key,),
+            ).fetchone()
+        except sqlite3.Error:
+            return None
+    finally:
+        conn.close()
+    if row is None:
+        return 0, 0
+    return int(row[0] or 0), int(row[1] or 0)
+
+
+__all__ = ["aggregate_project_session_tokens"]

--- a/src/pollypm/work/session_queries.py
+++ b/src/pollypm/work/session_queries.py
@@ -1,0 +1,34 @@
+"""Read-side aggregates over ``work_sessions`` rows.
+
+Presentation callers (e.g. the per-project dashboard's Tokens line)
+should use these facades instead of opening the workspace SQLite file
+directly. Schema and connection details stay behind
+``pollypm.storage.work_session_queries``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pollypm.storage.work_session_queries import (
+    aggregate_project_session_tokens as _aggregate_project_session_tokens,
+)
+
+
+def project_session_token_totals(
+    db_path: Path,
+    *,
+    project_key: str,
+) -> tuple[int, int] | None:
+    """Return ``(input_tokens, output_tokens)`` summed across worker sessions.
+
+    Returns ``None`` when the workspace DB is missing or the
+    ``work_sessions`` table is absent so the caller can render an
+    ``(n/a)`` fallback rather than break.
+    """
+    return _aggregate_project_session_tokens(
+        Path(db_path), project_key=project_key,
+    )
+
+
+__all__ = ["project_session_token_totals"]

--- a/tests/test_plugin_boundary_conformance.py
+++ b/tests/test_plugin_boundary_conformance.py
@@ -96,6 +96,7 @@ def test_work_task_query_callers_do_not_open_sqlite_directly() -> None:
     """Issue #1376: UI/plugin callers route work-task reads via facades."""
     rels = (
         "src/pollypm/cockpit_settings_projects.py",
+        "src/pollypm/cockpit_sections/base.py",
         "src/pollypm/dashboard_data.py",
         "src/pollypm/plugins_builtin/project_planning/cli/project.py",
     )


### PR DESCRIPTION
Refs #1376

Partial slice of #1376. Removes the direct `sqlite3.connect()` from
`src/pollypm/cockpit_sections/base.py`. The per-project dashboard's
Tokens line now goes through a new `pollypm.work.session_queries.project_session_token_totals`
facade, backed by `pollypm.storage.work_session_queries.aggregate_project_session_tokens`.
SQL/table ownership stays in the storage layer; the rendering section
no longer knows the `work_sessions` schema or has to `import sqlite3`.

The `None`-on-missing-DB / query-failure contract is preserved so the
Tokens line still degrades to `(n/a)` rather than breaking the render.

`tests/test_plugin_boundary_conformance.py::test_work_task_query_callers_do_not_open_sqlite_directly`
now includes `cockpit_sections/base.py` so a future regression fails
loudly.

Remaining #1376 scope: `backup.py`, `cockpit.py`, `cockpit_ui.py`, `doctor.py`.

## Summary
- New storage-owned `aggregate_project_session_tokens(db_path, project_key=...)` returning `tuple[int, int] | None`
- New work facade `project_session_token_totals(...)` re-exporting it
- `cockpit_sections/base._aggregate_project_tokens` calls the facade; no more `import sqlite3` in the section module
- Boundary test extended to guard the new caller

## Test plan
- [x] `uv run --extra dev pytest tests/test_plugin_boundary_conformance.py tests/test_cockpit_project_dashboard.py::TestTokenAggregation` (18 passed)
- [x] `uv run --extra dev pytest tests/test_cockpit_project_dashboard.py --deselect ::test_render_project_dashboard_integration` (54 passed; the deselected test fails on `main` and is unrelated)
- [x] Smoke imports of new modules and missing-DB contract verified

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>