### PR TITLE
refactor(cockpit): extract _FirstShippedCelebrationModal into sibling module (#1354)

### DIFF
--- a/src/pollypm/cockpit_first_shipped.py
+++ b/src/pollypm/cockpit_first_shipped.py
@@ -1,0 +1,116 @@
+"""First-shipped celebration modal (extracted from ``cockpit_ui``).
+
+Contract:
+- Inputs: the host ``App`` instance (for ``_celebrate_first_shipped``)
+  used only to ``notify`` and ``push_screen`` the modal.
+- Outputs: a short-lived ``ModalScreen`` that animates a confetti frame
+  and auto-dismisses after ~2 seconds.
+- Side effects: emits a single ``notify`` toast and optionally pushes
+  the modal; honours ``POLLY_NO_CONFETTI=1`` to suppress the modal
+  while keeping the toast (used by smoke / no-TTY environments).
+- Invariants: this module owns one widget class and one helper only;
+  shared cockpit state stays in its original homes.
+- Allowed dependencies: Textual primitives, ``os`` for the env switch.
+- Private: ``_FirstShippedCelebrationModal`` and
+  ``_celebrate_first_shipped`` are underscore-prefixed and re-exported
+  via ``cockpit_ui`` for back-compat (see #1354).
+
+Wedge of the cockpit_ui.py god-module split tracked by #1354.
+"""
+
+from __future__ import annotations
+
+import os
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+
+_FIRST_SHIPPED_FRAMES = (
+    "  ✨   🎉   ✨\n🎊  First PR shipped  🎊\n  ✨   🎉   ✨",
+    "🎉   ✨   🎊   ✨\n  First PR shipped\n✨   🎊   ✨   🎉",
+    "  🎊   ✨   🎉\n🎉  First PR shipped  🎉\n  ✨   🎊   ✨",
+)
+
+
+class _FirstShippedCelebrationModal(ModalScreen[None]):
+    """Short-lived modal that celebrates the first shipped task."""
+
+    DEFAULT_CSS = """
+    #first-shipped-modal {
+        width: 60;
+        padding: 1 2;
+        border: round #6fcf97;
+        background: #102019;
+        color: #effaf3;
+    }
+    #first-shipped-title {
+        text-align: center;
+        margin-bottom: 1;
+    }
+    #first-shipped-confetti {
+        text-align: center;
+        color: #ffd166;
+        height: auto;
+    }
+    #first-shipped-hint {
+        text-align: center;
+        color: #93a7b3;
+        margin-top: 1;
+    }
+    """
+
+    BINDINGS = [Binding("escape", "dismiss", "Dismiss", show=False)]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._frame_index = 0
+
+    def compose(self) -> ComposeResult:  # pragma: no cover - Textual harness
+        with Vertical(id="first-shipped-modal"):
+            yield Static("First PR shipped", id="first-shipped-title")
+            yield Static(_FIRST_SHIPPED_FRAMES[0], id="first-shipped-confetti", markup=True)
+            yield Static(
+                "Recorded once and pinned in Activity.",
+                id="first-shipped-hint",
+            )
+
+    def on_mount(self) -> None:  # pragma: no cover - Textual harness
+        try:
+            self.set_interval(0.16, self._advance_frame)
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            self.set_timer(2.0, self.dismiss)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _advance_frame(self) -> None:
+        self._frame_index = (self._frame_index + 1) % len(_FIRST_SHIPPED_FRAMES)
+        try:
+            self.query_one("#first-shipped-confetti", Static).update(
+                _FIRST_SHIPPED_FRAMES[self._frame_index],
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _celebrate_first_shipped(app) -> None:
+    """Announce the one-time shipped milestone in whichever cockpit view approved it."""
+    app.notify("🎉 First PR shipped. Nicely done.", severity="information", timeout=2.0)
+    if os.getenv("POLLY_NO_CONFETTI") == "1":
+        return
+    try:
+        app.push_screen(_FirstShippedCelebrationModal())
+    except Exception:  # noqa: BLE001
+        pass
+
+
+__all__ = [
+    "_FIRST_SHIPPED_FRAMES",
+    "_FirstShippedCelebrationModal",
+    "_celebrate_first_shipped",
+]

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -86,6 +86,11 @@ from pollypm.cockpit_inbox_items import (
     message_row_to_inbox_entry,
     task_to_inbox_entry,
 )
+from pollypm.cockpit_first_shipped import (  # noqa: F401  (re-exported)
+    _FIRST_SHIPPED_FRAMES,
+    _FirstShippedCelebrationModal,
+    _celebrate_first_shipped,
+)
 from pollypm.cockpit_inbox_project_picker import (  # noqa: F401  (re-exported)
     _InboxProjectPickerModal,
 )
@@ -249,86 +254,6 @@ ASCII_POLLY = "\n".join(
 )
 
 POLLY_TAGLINE = "Plans first.\nChaos later."
-
-
-_FIRST_SHIPPED_FRAMES = (
-    "  ✨   🎉   ✨\n🎊  First PR shipped  🎊\n  ✨   🎉   ✨",
-    "🎉   ✨   🎊   ✨\n  First PR shipped\n✨   🎊   ✨   🎉",
-    "  🎊   ✨   🎉\n🎉  First PR shipped  🎉\n  ✨   🎊   ✨",
-)
-
-
-class _FirstShippedCelebrationModal(ModalScreen[None]):
-    """Short-lived modal that celebrates the first shipped task."""
-
-    DEFAULT_CSS = """
-    #first-shipped-modal {
-        width: 60;
-        padding: 1 2;
-        border: round #6fcf97;
-        background: #102019;
-        color: #effaf3;
-    }
-    #first-shipped-title {
-        text-align: center;
-        margin-bottom: 1;
-    }
-    #first-shipped-confetti {
-        text-align: center;
-        color: #ffd166;
-        height: auto;
-    }
-    #first-shipped-hint {
-        text-align: center;
-        color: #93a7b3;
-        margin-top: 1;
-    }
-    """
-
-    BINDINGS = [Binding("escape", "dismiss", "Dismiss", show=False)]
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._frame_index = 0
-
-    def compose(self) -> ComposeResult:  # pragma: no cover - Textual harness
-        with Vertical(id="first-shipped-modal"):
-            yield Static("First PR shipped", id="first-shipped-title")
-            yield Static(_FIRST_SHIPPED_FRAMES[0], id="first-shipped-confetti", markup=True)
-            yield Static(
-                "Recorded once and pinned in Activity.",
-                id="first-shipped-hint",
-            )
-
-    def on_mount(self) -> None:  # pragma: no cover - Textual harness
-        try:
-            self.set_interval(0.16, self._advance_frame)
-        except Exception:  # noqa: BLE001
-            pass
-        try:
-            self.set_timer(2.0, self.dismiss)
-        except Exception:  # noqa: BLE001
-            pass
-
-    def _advance_frame(self) -> None:
-        self._frame_index = (self._frame_index + 1) % len(_FIRST_SHIPPED_FRAMES)
-        try:
-            self.query_one("#first-shipped-confetti", Static).update(
-                _FIRST_SHIPPED_FRAMES[self._frame_index],
-            )
-        except Exception:  # noqa: BLE001
-            pass
-
-
-def _celebrate_first_shipped(app) -> None:
-    """Announce the one-time shipped milestone in whichever cockpit view approved it."""
-    app.notify("🎉 First PR shipped. Nicely done.", severity="information", timeout=2.0)
-    if os.getenv("POLLY_NO_CONFETTI") == "1":
-        return
-    try:
-        app.push_screen(_FirstShippedCelebrationModal())
-    except Exception:  # noqa: BLE001
-        pass
 
 
 class _AlertDetailModal(ModalScreen[str | None]):


### PR DESCRIPTION
## Summary
- Second wedge of the cockpit_ui.py god-module split tracked by #1354 (after #1606).
- Moves the ~70-LOC `_FirstShippedCelebrationModal` plus its companion `_FIRST_SHIPPED_FRAMES` tuple and `_celebrate_first_shipped` helper into a new sibling module `src/pollypm/cockpit_first_shipped.py`. The celebration surface is self-contained, so co-locating the helper keeps the boundary clean rather than leaving the helper orphaned in cockpit_ui.
- Leaves a re-export shim in `cockpit_ui.py` so the existing call site and `tests/test_cockpit_first_shipped.py` (which imports `_celebrate_first_shipped` from `pollypm.cockpit_ui`) keep working unchanged.

cockpit_ui.py: 18945 -> 18870 LOC (-75); diff in cockpit_ui.py is 85 lines (well under the 200-line wedge budget).

## Test plan
- [x] `pytest tests/test_cockpit_first_shipped.py` - 2 passed (covers both `POLLY_NO_CONFETTI=1` short-circuit and the modal push path).
- [x] `pytest tests/test_keyboard_help.py` - 26 passed (the single `test_modal_surfaces_plan_review_keys_when_selected` failure reproduces on `main` and is unrelated to this diff, same as PR #1606 noted).
- [x] `python -c "from pollypm.cockpit_ui import _celebrate_first_shipped, _FirstShippedCelebrationModal, _FIRST_SHIPPED_FRAMES"` - shim re-export resolves.
- [x] AST parses cleanly on both files.

Generated with [Claude Code](https://claude.com/claude-code)