### PR TITLE
feat(cli): pm project remove --purge-sessions cascades tmux + config teardown (#1561)

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -672,6 +672,81 @@ def _count_active_tasks(project_key: str, config_path: Path) -> int:
         return 0
 
 
+def _sessions_for_project(config_path: Path, project_key: str) -> list[str]:
+    """Return all ``[sessions.*]`` names whose ``project`` matches ``project_key``.
+
+    Includes both enabled and disabled sessions — ``--purge-sessions``
+    sweeps the whole project namespace regardless, so a user who toggled
+    a session off without deleting it still gets a clean teardown.
+    """
+    config = load_config(config_path)
+    return [
+        session.name
+        for session in config.sessions.values()
+        if session.project == project_key
+    ]
+
+
+def _purge_project_sessions(
+    config_path: Path,
+    project_key: str,
+    *,
+    dry_run: bool = False,
+) -> list[tuple[str, bool, bool]]:
+    """Kill + delete every ``[sessions.*]`` entry tied to ``project_key``.
+
+    Returns a list of ``(session_name, tmux_was_live, killed_ok)`` tuples
+    in config order. Best-effort throughout — a missing tmux server,
+    already-dead session, or write failure on one session never aborts
+    the rest of the sweep. In ``dry_run`` mode no mutations are made;
+    the live/kill flags reflect what *would* happen.
+
+    Why kill at the tmux layer first: ``remove_project`` refuses while
+    enabled ``[sessions.*]`` entries reference the project (see
+    ``projects.py:remove_project``). Pulling the config entry without
+    killing tmux first would leave orphan worker processes attached to
+    a project that no longer exists in the config — exactly the
+    leaked-worker mode #1561's issue body calls out.
+    """
+    from pollypm.config import write_config
+    from pollypm.session_services import create_tmux_client
+
+    config = load_config(config_path)
+    matches = [
+        s for s in config.sessions.values() if s.project == project_key
+    ]
+    if not matches:
+        return []
+
+    tmux = create_tmux_client()
+    results: list[tuple[str, bool, bool]] = []
+    for session in matches:
+        try:
+            live = tmux.has_session(session.name)
+        except Exception:  # noqa: BLE001
+            live = False
+        killed = False
+        if not dry_run and live:
+            try:
+                killed = bool(tmux.kill_session(session.name))
+            except Exception:  # noqa: BLE001
+                killed = False
+        results.append((session.name, live, killed))
+
+    if dry_run:
+        return results
+
+    # Mutate the config: drop every session we just killed (or attempted
+    # to). We do this even when the tmux kill failed so a stuck/missing
+    # tmux server doesn't block the config cleanup — the user can always
+    # re-run ``pm reset`` to mop up tmux state, but they can't recover
+    # if the [sessions.*] entries stay and block ``remove_project``.
+    for session in matches:
+        config.sessions.pop(session.name, None)
+    write_config(config, config_path, force=True)
+    return results
+
+
 @project_app.command("remove")
 def remove_cmd(
     project_key: str = typer.Argument(
@@ -690,6 +765,23 @@ def remove_cmd(
         False, "--yes", "-y",
         help="Non-interactive: auto-accept the confirmation prompt.",
     ),
+    purge_sessions: bool = typer.Option(
+        False, "--purge-sessions",
+        help=(
+            "Kill every tmux session tied to this project and drop the "
+            "corresponding [sessions.*] entries before removal. Without "
+            "this flag, ``remove_project`` refuses when any session "
+            "references the project (see issue #1561)."
+        ),
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run",
+        help=(
+            "Preview the teardown plan without mutating anything. "
+            "Lists the project, any [sessions.*] entries that would be "
+            "torn down, and whether each tmux session is currently live."
+        ),
+    ),
     config_path: Path = typer.Option(
         DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path.",
     ),
@@ -698,12 +790,18 @@ def remove_cmd(
 
     Mirrors ``pm project new`` (#1561). The underlying core function
     (:func:`pollypm.projects.remove_project`) only edits the TOML config —
-    work-service rows, tmux sessions, and worktree directories are NOT
-    touched. See issue #1561 for the full cascade-teardown plan; this
-    command is the narrow first step.
+    work-service rows and worktree directories are NOT touched. See
+    issue #1561 for the full cascade-teardown plan.
 
-    Refuses if the project is still referenced by enabled
-    ``[sessions.*]`` entries (the core function's invariant).
+    With ``--purge-sessions`` this command also kills every tmux session
+    tied to the project (architect/reviewer/worker/advisor/…) and drops
+    the matching ``[sessions.*]`` entries so ``remove_project`` no
+    longer refuses on session references. Without ``--purge-sessions``,
+    the core function's session-reference invariant still applies.
+
+    With ``--dry-run`` the command prints the teardown plan
+    (project + sessions that would be killed and removed) and exits
+    without mutating anything.
 
     If the project has queued or in-flight tasks in the work DB, prompts
     for confirmation. Pass ``--force`` to skip the prompt (e.g. for
@@ -717,7 +815,46 @@ def remove_cmd(
         typer.echo(f"Unknown project: {project_key}", err=True)
         raise typer.Exit(code=1)
 
+    project_entry = config.projects[project_key]
     active = _count_active_tasks(project_key, path)
+    session_names = _sessions_for_project(path, project_key)
+
+    # ------------------------------------------------------------------
+    # Dry-run: print the plan and exit 0 without mutating anything.
+    # ------------------------------------------------------------------
+    if dry_run:
+        typer.echo(f"Dry run: would remove project '{project_key}'.")
+        typer.echo(f"  path:    {project_entry.path}")
+        if active > 0:
+            task_word = "task" if active == 1 else "tasks"
+            typer.echo(
+                f"  active:  {active} queued/in-flight work-service "
+                f"{task_word} (would be left in place)"
+            )
+        if session_names:
+            preview = _purge_project_sessions(
+                path, project_key, dry_run=True,
+            )
+            if purge_sessions:
+                typer.echo("  sessions to purge:")
+            else:
+                typer.echo(
+                    "  sessions referencing project "
+                    "(use --purge-sessions to tear down):"
+                )
+            for name, live, _killed in preview:
+                state = "live" if live else "stale"
+                typer.echo(f"    - {name} ({state})")
+        else:
+            typer.echo("  sessions: (none)")
+        if session_names and not purge_sessions:
+            typer.echo(
+                "Note: remove_project will refuse while sessions are "
+                "enabled. Re-run with --purge-sessions to tear them down."
+            )
+        typer.echo("Re-run without --dry-run to apply.")
+        return
+
     if active > 0 and not force:
         task_word = "task" if active == 1 else "tasks"
         typer.echo(
@@ -735,6 +872,27 @@ def remove_cmd(
         if not proceed:
             typer.echo("Aborted. No changes made.")
             raise typer.Exit(code=1)
+
+    # Kill + drop project-scoped sessions BEFORE calling
+    # ``remove_project`` so its session-reference invariant doesn't
+    # refuse the removal. Best-effort — see ``_purge_project_sessions``.
+    purged: list[tuple[str, bool, bool]] = []
+    if purge_sessions and session_names:
+        purged = _purge_project_sessions(path, project_key)
+        for name, live, killed in purged:
+            if live and killed:
+                typer.echo(f"Killed tmux session {name} and dropped config entry.")
+            elif live and not killed:
+                typer.echo(
+                    f"Dropped [sessions.{name}] from config; tmux kill "
+                    "failed (session may still be running — run "
+                    "`tmux kill-session -t " + name + "` manually)."
+                )
+            else:
+                typer.echo(
+                    f"Dropped [sessions.{name}] from config "
+                    "(tmux session was not running)."
+                )
 
     try:
         removed = remove_project(path, project_key)

--- a/tests/test_project_remove_cli.py
+++ b/tests/test_project_remove_cli.py
@@ -215,3 +215,278 @@ def test_cli_remove_refuses_when_project_still_has_sessions(tmp_path: Path) -> N
 
     config = _load_cfg(config_path)
     assert "demo" in config.projects
+
+
+# --------------------------------------------------------------------------
+# --purge-sessions cascade: kill tmux + drop [sessions.*] entries so the
+# core function's session-reference invariant no longer refuses removal.
+# --------------------------------------------------------------------------
+
+
+def _project_with_sessions_config(
+    tmp_path: Path, *, sessions_block: str
+) -> tuple[Path, Path]:
+    workspace_root = tmp_path / "dev"
+    workspace_root.mkdir()
+    project_path = workspace_root / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(
+        config_path,
+        workspace_root=workspace_root,
+        project_path=project_path,
+        slug="demo",
+        extra_sessions=(
+            sessions_block
+            + "\n[accounts.claude_main]\n"
+            'provider = "claude"\n'
+            'home = "/tmp/claude_home"\n'
+        ),
+    )
+    return config_path, project_path
+
+
+def test_cli_remove_purge_sessions_kills_tmux_and_drops_entries(
+    tmp_path: Path,
+) -> None:
+    """--purge-sessions tears down tmux + config so removal succeeds."""
+    config_path, _ = _project_with_sessions_config(
+        tmp_path,
+        sessions_block=(
+            "[sessions.architect_demo]\n"
+            'role = "architect"\n'
+            'provider = "claude"\n'
+            'account = "claude_main"\n'
+            'cwd = "."\n'
+            'project = "demo"\n'
+            'window_name = "architect-demo"\n'
+            "\n"
+            "[sessions.reviewer_demo]\n"
+            'role = "reviewer"\n'
+            'provider = "claude"\n'
+            'account = "claude_main"\n'
+            'cwd = "."\n'
+            'project = "demo"\n'
+            'window_name = "reviewer-demo"\n'
+        ),
+    )
+
+    fake_tmux = type(
+        "FakeTmux", (), {
+            "has_session": lambda self, name: True,
+            "kill_session": lambda self, name: True,
+        },
+    )()
+    count_target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    tmux_target = (
+        "pollypm.plugins_builtin.project_planning.cli.project.create_tmux_client"
+    )
+    # ``create_tmux_client`` is imported lazily inside
+    # ``_purge_project_sessions``; patch the module the lazy import resolves
+    # against (the source module) since the local symbol isn't bound at
+    # import time of project.py.
+    with (
+        patch(count_target, return_value=0),
+        patch(
+            "pollypm.session_services.create_tmux_client",
+            return_value=fake_tmux,
+        ),
+    ):
+        result = runner.invoke(
+            project_app,
+            [
+                "remove", "demo", "--purge-sessions",
+                "--config", str(config_path),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Killed tmux session architect_demo" in result.output
+    assert "Killed tmux session reviewer_demo" in result.output
+    assert "Removed project 'demo'" in result.output
+
+    config = _load_cfg(config_path)
+    assert "demo" not in config.projects
+    assert "architect_demo" not in config.sessions
+    assert "reviewer_demo" not in config.sessions
+
+    # Patch reference to silence unused warning when local stub is unused.
+    _ = tmux_target
+
+
+def test_cli_remove_purge_sessions_handles_already_dead_tmux(
+    tmp_path: Path,
+) -> None:
+    """--purge-sessions still drops config entries when tmux session is gone."""
+    config_path, _ = _project_with_sessions_config(
+        tmp_path,
+        sessions_block=(
+            "[sessions.architect_demo]\n"
+            'role = "architect"\n'
+            'provider = "claude"\n'
+            'account = "claude_main"\n'
+            'cwd = "."\n'
+            'project = "demo"\n'
+            'window_name = "architect-demo"\n'
+        ),
+    )
+
+    fake_tmux = type(
+        "FakeTmux", (), {
+            "has_session": lambda self, name: False,
+            "kill_session": lambda self, name: False,
+        },
+    )()
+    count_target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with (
+        patch(count_target, return_value=0),
+        patch(
+            "pollypm.session_services.create_tmux_client",
+            return_value=fake_tmux,
+        ),
+    ):
+        result = runner.invoke(
+            project_app,
+            [
+                "remove", "demo", "--purge-sessions",
+                "--config", str(config_path),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "tmux session was not running" in result.output
+    assert "Removed project 'demo'" in result.output
+
+    config = _load_cfg(config_path)
+    assert "demo" not in config.projects
+    assert "architect_demo" not in config.sessions
+
+
+# --------------------------------------------------------------------------
+# --dry-run: prints the teardown plan, mutates nothing.
+# --------------------------------------------------------------------------
+
+
+def test_cli_remove_dry_run_with_no_sessions(env) -> None:
+    target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with patch(target, return_value=0):
+        result = runner.invoke(
+            project_app,
+            [
+                "remove", "demo", "--dry-run",
+                "--config", str(env["config_path"]),
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert "Dry run: would remove project 'demo'" in result.output
+    assert "sessions: (none)" in result.output
+    assert "Re-run without --dry-run to apply." in result.output
+
+    # Nothing mutated.
+    config = _load_cfg(env["config_path"])
+    assert "demo" in config.projects
+
+
+def test_cli_remove_dry_run_lists_sessions_without_killing(tmp_path: Path) -> None:
+    config_path, _ = _project_with_sessions_config(
+        tmp_path,
+        sessions_block=(
+            "[sessions.architect_demo]\n"
+            'role = "architect"\n'
+            'provider = "claude"\n'
+            'account = "claude_main"\n'
+            'cwd = "."\n'
+            'project = "demo"\n'
+            'window_name = "architect-demo"\n'
+        ),
+    )
+
+    fake_tmux = type(
+        "FakeTmux", (), {
+            "has_session": lambda self, name: True,
+            # If this ever fires the dry-run guard is broken.
+            "kill_session": lambda self, name: (_ for _ in ()).throw(
+                AssertionError("kill_session must not run in --dry-run")
+            ),
+        },
+    )()
+    count_target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with (
+        patch(count_target, return_value=2),
+        patch(
+            "pollypm.session_services.create_tmux_client",
+            return_value=fake_tmux,
+        ),
+    ):
+        result = runner.invoke(
+            project_app,
+            [
+                "remove", "demo", "--dry-run", "--purge-sessions",
+                "--config", str(config_path),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Dry run: would remove project 'demo'" in result.output
+    assert "sessions to purge:" in result.output
+    assert "architect_demo (live)" in result.output
+    assert "2 queued/in-flight" in result.output
+
+    # Nothing mutated.
+    config = _load_cfg(config_path)
+    assert "demo" in config.projects
+    assert "architect_demo" in config.sessions
+
+
+def test_cli_remove_dry_run_warns_when_sessions_present_without_purge(
+    tmp_path: Path,
+) -> None:
+    config_path, _ = _project_with_sessions_config(
+        tmp_path,
+        sessions_block=(
+            "[sessions.architect_demo]\n"
+            'role = "architect"\n'
+            'provider = "claude"\n'
+            'account = "claude_main"\n'
+            'cwd = "."\n'
+            'project = "demo"\n'
+            'window_name = "architect-demo"\n'
+        ),
+    )
+
+    fake_tmux = type(
+        "FakeTmux", (), {
+            "has_session": lambda self, name: False,
+            "kill_session": lambda self, name: False,
+        },
+    )()
+    count_target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with (
+        patch(count_target, return_value=0),
+        patch(
+            "pollypm.session_services.create_tmux_client",
+            return_value=fake_tmux,
+        ),
+    ):
+        result = runner.invoke(
+            project_app,
+            [
+                "remove", "demo", "--dry-run",
+                "--config", str(config_path),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "use --purge-sessions to tear down" in result.output
+    assert "remove_project will refuse" in result.output


### PR DESCRIPTION
## Summary

Continues #1561 beyond the bare-command wedge (#1603). Adds the highest-impact piece of the cascade teardown: tmux session + `[sessions.*]` entry cleanup, so `pm project remove` actually stops running workers instead of leaving them orphaned against a config-less project.

- **`--purge-sessions`**: kills every tmux session whose `[sessions.*]` entry references the project (architect / reviewer / worker / advisor / …) and drops the corresponding config entries. Without it, `remove_project` still refuses on session references — preserving the pre-existing safe-by-default invariant.
- **`--dry-run`**: prints the teardown plan (project path + live/stale status of every tied session) and exits without mutating anything. Pairs with `--purge-sessions` to preview the kill set.

## Why this piece first

The issue body's step 2 + step 3 ("edit TOML to drop session blocks" + "kill tmux sessions outside pm") are the most painful manual steps and the most likely to leave orphans — workers still running against a project that no longer exists in config. State.db row teardown and worktree-dir cleanup are higher-effort follow-ups and don't unblock the `russell` re-init pattern the issue calls out.

Tmux + config mutations are best-effort: a dead tmux server or a single stuck session never aborts the rest of the sweep, and config entries get dropped even when the tmux kill fails (so a wedged tmux server can't permanently block project removal).

## Test plan

- [x] `pytest tests/test_project_remove_cli.py` (11 tests, all pass — 6 pre-existing + 5 new)
- [x] `pytest -k "project_remove or project_rename or project_planning_cli or project_new"` (72 tests, all pass)
- [x] `pytest -k "project_remove or project_rename or project_session"` (29 tests, all pass)

## New tests

- `--purge-sessions` happy path: 2 sessions (architect + reviewer), both tmux-live → kills both, drops both from config, removes project.
- `--purge-sessions` when tmux sessions already dead → still drops config entries; reports "tmux session was not running".
- `--dry-run` with no sessions → prints `sessions: (none)`, mutates nothing.
- `--dry-run --purge-sessions` with live sessions → prints "sessions to purge" + "(live)" markers, asserts `kill_session` never fires (would `raise AssertionError` if called), config untouched.
- `--dry-run` without `--purge-sessions` when sessions present → prints "use --purge-sessions to tear down" and "remove_project will refuse" hint.

## Follow-ups still open from #1561

- state.db row teardown (`work_tasks`, `work_transitions`, `work_sessions`, `events`, `inbox_messages`, …)
- `.pollypm/worktrees/<project>_*/` directory cleanup
- `pm project reinit <key>` (remove + re-add wrapper)
- Runbook docs in `.pollypm/docs/reference/operator-runbook.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)