### PR TITLE
fix(observability): log 12 silent except Exception sites in audit/storage/dashboard (#1355 wedge)

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -407,6 +407,15 @@ def emit(
         try:
             line = json.dumps(record, ensure_ascii=False, separators=(",", ":"))
         except Exception:  # noqa: BLE001
+            # #1355: previously silent. Even the stripped fallback failed
+            # to serialize — log so a dropped audit event leaves a trail
+            # instead of vanishing.
+            logger.warning(
+                "audit.emit: stripped record still not serializable for %s/%s; dropping",
+                project,
+                event,
+                exc_info=True,
+            )
             return
 
     # Per-project log first (authoritative), central tail second

--- a/src/pollypm/dashboard/categorization.py
+++ b/src/pollypm/dashboard/categorization.py
@@ -31,12 +31,15 @@ app, CLI, tests).
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Iterable, Protocol
 
 from pollypm.inbox import awaits_user
 from pollypm.inbox.kind import InboxItemKind, coerce_kind
+
+logger = logging.getLogger(__name__)
 
 
 class ProjectState(Enum):
@@ -193,6 +196,14 @@ def categorize_project(
     try:
         tasks = work_service.list_tasks(project=project_key)
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. A failed list_tasks here drops the
+        # project into IDLE — log so a broken work-service stops
+        # masquerading as "quiet".
+        logger.warning(
+            "categorize_project: list_tasks failed for %s",
+            project_key,
+            exc_info=True,
+        )
         tasks = []
 
     # #1542 — an ``on_hold`` task makes the project ◆ "needs attention"
@@ -211,6 +222,14 @@ def categorize_project(
             project=project_key, active_only=True,
         )
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. A failed worker query here means the
+        # project is mis-categorized as IDLE while workers are running —
+        # log so the live-worker probe doesn't silently break.
+        logger.warning(
+            "categorize_project: list_worker_sessions failed for %s",
+            project_key,
+            exc_info=True,
+        )
         live_workers = []
     if live_workers:
         return ProjectState.WORKING
@@ -345,6 +364,14 @@ def what_working(
             project=project_key, active_only=True,
         ))
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. A failed worker query here drops the
+        # dashboard line to "Active" without a name — log so the
+        # what_working probe doesn't silently degrade.
+        logger.warning(
+            "what_working: list_worker_sessions failed for %s",
+            project_key,
+            exc_info=True,
+        )
         workers = []
 
     if workers:
@@ -358,6 +385,15 @@ def what_working(
                 task = work_service.get(f"{project_key}/{task_number}")
                 title = _task_title(task)
             except Exception:  # noqa: BLE001
+                # #1355: previously silent. A failed task fetch here just
+                # drops the title from the dashboard line — log so a
+                # broken get() doesn't silently strip context.
+                logger.warning(
+                    "what_working: get(%s/%s) failed",
+                    project_key,
+                    task_number,
+                    exc_info=True,
+                )
                 title = ""
         if title:
             return _truncate(f"{agent}: {title}")
@@ -366,6 +402,14 @@ def what_working(
     try:
         tasks = list(work_service.list_tasks(project=project_key))
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. The no-worker branch falls through to
+        # "Active" when list_tasks fails — log so the working-task
+        # fallback doesn't silently lose status detail.
+        logger.warning(
+            "what_working: list_tasks failed for %s",
+            project_key,
+            exc_info=True,
+        )
         tasks = []
     for task in tasks:
         status = _task_status(task)
@@ -424,6 +468,14 @@ def _project_last_activity(
     try:
         tasks = list(work_service.list_tasks(project=project_key))
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. A failed list_tasks here means the
+        # Idle row shows no last-activity timestamp — log so the empty
+        # cell isn't masking a broken query.
+        logger.warning(
+            "last_activity: list_tasks failed for %s",
+            project_key,
+            exc_info=True,
+        )
         tasks = []
     best = ""
     for task in tasks:

--- a/src/pollypm/dashboard/operator_view.py
+++ b/src/pollypm/dashboard/operator_view.py
@@ -13,6 +13,7 @@ per-project DB so paused-with-work projects still surface.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
@@ -27,6 +28,8 @@ from pollypm.dashboard.categorization import (
     what_working,
     why_waiting,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -90,6 +93,13 @@ def _waiting_items_by_project(config) -> dict[str, list]:  # noqa: ANN001
     try:
         items = pm_inbox_awaits_user_list(config)
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. A failure here means the dashboard
+        # quietly shows zero waiting items for the whole workspace —
+        # log so a broken inbox query is debuggable.
+        logger.warning(
+            "operator_view: pm_inbox_awaits_user_list failed; dashboard will show no waiting items",
+            exc_info=True,
+        )
         items = []
     for item in items:
         key = (
@@ -125,10 +135,28 @@ def _open_work_service(scan: _ProjectScan):  # noqa: ANN202
                 db_path=db_path, project_path=scan.project_path,
             )
         except Exception:  # noqa: BLE001
+            # #1355: previously silent. A failed open here silently skips
+            # this DB candidate — log so a bad workspace/legacy path is
+            # debuggable instead of "the project just disappears".
+            logger.warning(
+                "operator_view: create_work_service failed for %s (project=%s)",
+                db_path,
+                scan.project_key,
+                exc_info=True,
+            )
             continue
         try:
             tasks = svc.list_tasks(project=scan.project_key)
         except Exception:  # noqa: BLE001
+            # #1355: previously silent. An empty task list here drops us
+            # to fallback selection; log so a broken list_tasks doesn't
+            # masquerade as "no work in this DB".
+            logger.warning(
+                "operator_view: list_tasks failed for project=%s db=%s",
+                scan.project_key,
+                db_path,
+                exc_info=True,
+            )
             tasks = []
         if tasks:
             if fallback is not None and fallback is not svc:

--- a/src/pollypm/storage/inbox_action_preview.py
+++ b/src/pollypm/storage/inbox_action_preview.py
@@ -10,11 +10,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
+import logging
 from pathlib import Path
 import re
 import sqlite3
 import tomllib
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 WORKSPACE_DB_KEY = "__workspace__"
@@ -106,6 +109,14 @@ def load_fast_inbox_action_preview(
     try:
         raw = tomllib.loads(config_path.read_text())
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. A malformed config silently disables
+        # the fast preview path; log so config corruption is debuggable
+        # instead of "the cockpit just feels slow".
+        logger.warning(
+            "inbox_action_preview: failed to read config at %s",
+            config_path,
+            exc_info=True,
+        )
         return None
     sources, known_projects = _message_sources(raw, config_path=config_path)
     if not sources:
@@ -180,6 +191,14 @@ def _query_message_rows(db_path: Path, *, limit: int) -> list[dict[str, object]]
     try:
         conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=0.2)
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. A failed RO open here drops the source
+        # from the preview entirely — log so DB perms / WAL drift surface
+        # instead of silently shrinking the inbox.
+        logger.warning(
+            "inbox_action_preview: failed to open %s for preview",
+            db_path,
+            exc_info=True,
+        )
         return []
     conn.row_factory = sqlite3.Row
     try:


### PR DESCRIPTION
## Summary

Second wedge for #1355 — replace silent `except Exception: pass`/`return` with `logger.warning(..., exc_info=True)` at 12 sites in `audit/`, `storage/`, and `dashboard/` modules. Behavior unchanged: every except already absorbed the exception; this PR just adds observability so previously-invisible failures stop being silent.

Follow-up to #1613 (which did 9 sites in supervisor/rail-daemon). 1066 total sites tracked in #1355; this wedge chips off another 12.

## Touched sites

- **`audit/log.py`**: stripped-record JSON serialize fallback (drops audit event on second failure)
- **`storage/inbox_action_preview.py`**: tomllib config parse failure, sqlite3 RO connect failure
- **`dashboard/operator_view.py`**: `pm_inbox_awaits_user_list` failure, `create_work_service` per-DB candidate failure, `list_tasks` failure
- **`dashboard/categorization.py`** (6 sites):
  - `list_tasks` in `categorize_project`
  - `list_worker_sessions` in `categorize_project`
  - `list_worker_sessions` in `what_working`
  - `work_service.get` for task title in `what_working`
  - `list_tasks` fallback in `what_working`
  - `list_tasks` in `_project_last_activity`

## Skipped on this pass

- `audit/watchdog.py` — all 8 sites already log via `logger.debug` + `exc_info`
- `audit/log.py:264` — returns sensible fallback path, not silent
- `storage/sqlite_pragmas.py` — diagnostic probes where failure-mode IS the observability (returns structured `key=value` string)
- `storage/legacy_per_project_db.py:332` — already logs
- `storage/state.py:646` — re-raises after rollback, not silent
- `operator_view.py:228,287` + `inbox_action_preview.py:208,322` — genuine cleanup paths (`.close()` and isoformat fallback)
- `inbox/` — no silent `except Exception` sites

## Test plan

- [x] Existing `tests/test_dashboard_categorization.py`, `tests/test_dashboard_operator_view.py`, `tests/test_audit_log.py`, `tests/test_cockpit_right_pane_command.py` pass (65 tests)
- [x] Wider sweep over `audit|dashboard|categori|operator|inbox_action` keyword: 237 pass, 1 unrelated pre-existing failure (`test_render_project_dashboard_integration` — confirmed fails on `main` without these changes)
- [x] Behavior unchanged: each except still absorbs the exception and falls through to the same downstream code; only addition is the `logger.warning(..., exc_info=True)` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)