### PR TITLE
fix(#1363): decouple dashboard from morning_briefing plugin

### DIFF
--- a/src/pollypm/briefings_registry.py
+++ b/src/pollypm/briefings_registry.py
@@ -1,0 +1,108 @@
+"""Core seam for surfacing morning-briefing inbox entries on the dashboard.
+
+Contract:
+- Inputs: a base directory + filter knobs (``status``, ``limit``).
+- Outputs: an iterable of briefing-entry-shaped objects, newest first.
+- Side effects: read-only — this seam never writes briefings.
+- Invariants: when no provider is registered, returns an empty list so
+  the dashboard renders without the briefing banner instead of erroring.
+
+Boundary note:
+This module is core — it must not import from ``pollypm.plugins_builtin``.
+The actual briefing-inbox implementation lives in the ``morning_briefing``
+plugin; it installs its ``list_briefings`` at plugin ``initialize`` time
+via :func:`register_briefing_provider`. The dashboard reads through
+:func:`list_briefings` so disabling the plugin downgrades the briefing
+banner to "absent" rather than breaking imports.
+
+Mirrors the registration-seam pattern established in
+:mod:`pollypm.approval_notifications` (see #1597 / #1363).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable, Iterable, Protocol, runtime_checkable
+
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class BriefingEntryLike(Protocol):
+    """Duck-typed briefing entry the dashboard renders.
+
+    The dashboard only reads ``created_at`` (ISO string) and
+    ``date_local`` (``YYYY-MM-DD``). Anything that exposes those two
+    attributes is rendered correctly — third-party briefing plugins can
+    swap their own dataclass in without depending on the
+    ``morning_briefing`` plugin's :class:`BriefingEntry` type.
+    """
+
+    @property
+    def created_at(self) -> str: ...
+
+    @property
+    def date_local(self) -> str: ...
+
+
+BriefingProvider = Callable[..., Iterable[BriefingEntryLike]]
+
+
+# Module-level registration slot. The ``morning_briefing`` plugin (or
+# a replacement) installs its ``list_briefings`` here during plugin
+# ``initialize``; when nothing is registered, ``list_briefings`` below
+# returns an empty list so the dashboard's briefing banner is simply
+# absent instead of raising.
+_briefing_provider: BriefingProvider | None = None
+
+
+def register_briefing_provider(provider: BriefingProvider | None) -> None:
+    """Install (or clear) the default briefing-inbox provider.
+
+    Called by the ``morning_briefing`` plugin during ``initialize`` so
+    the dashboard can surface briefings without taking a hard import on
+    the plugin tree. Pass ``None`` to clear (used by tests).
+
+    ``provider`` must accept ``(base_dir, *, status=..., limit=...)``
+    and return briefing entries newest-first. The expected signature
+    matches :func:`pollypm.plugins_builtin.morning_briefing.inbox.list_briefings`
+    exactly; mismatches are caught at call time and logged.
+    """
+    global _briefing_provider
+    _briefing_provider = provider
+
+
+def list_briefings(
+    base_dir: Path,
+    *,
+    status: str = "open",
+    limit: int | None = None,
+) -> list[BriefingEntryLike]:
+    """Return briefings via the registered provider, or ``[]`` if none.
+
+    Errors from the provider are logged and swallowed — a flaky plugin
+    must never break the dashboard render. The dashboard treats "no
+    entries" identically to "plugin not loaded".
+    """
+    provider = _briefing_provider
+    if provider is None:
+        return []
+    try:
+        return list(provider(base_dir, status=status, limit=limit))
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "briefings_registry: provider failed (base_dir=%s, status=%s)",
+            base_dir,
+            status,
+        )
+        return []
+
+
+__all__ = [
+    "BriefingEntryLike",
+    "BriefingProvider",
+    "list_briefings",
+    "register_briefing_provider",
+]

--- a/src/pollypm/cockpit_sections/dashboard.py
+++ b/src/pollypm/cockpit_sections/dashboard.py
@@ -499,7 +499,11 @@ def _render_account_usage_lines(rows: list[DashboardAccountUsage]) -> list[str]:
 
 
 def _recent_briefing_entry(base_dir: Path, *, now: datetime, status: str):
-    from pollypm.plugins_builtin.morning_briefing.inbox import list_briefings
+    # Resolved through the core registration seam (#1363) so the
+    # dashboard doesn't import from ``plugins_builtin``. With no
+    # provider registered (e.g. ``morning_briefing`` plugin disabled),
+    # ``list_briefings`` returns ``[]`` and the banner is simply absent.
+    from pollypm.briefings_registry import list_briefings
 
     for entry in list_briefings(base_dir, status=status, limit=8):
         created_at = _iso_to_dt(getattr(entry, "created_at", ""))

--- a/src/pollypm/plugins_builtin/morning_briefing/plugin.py
+++ b/src/pollypm/plugins_builtin/morning_briefing/plugin.py
@@ -22,9 +22,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from pollypm.briefings_registry import register_briefing_provider
 from pollypm.plugin_api.v1 import (
     Capability,
     JobHandlerAPI,
+    PluginAPI,
     PollyPMPlugin,
     RosterAPI,
 )
@@ -32,7 +34,10 @@ from pollypm.agent_profiles.defaults import StaticPromptProfile
 from pollypm.plugins_builtin.morning_briefing.handlers.briefing_tick import (
     briefing_tick_handler,
 )
-from pollypm.plugins_builtin.morning_briefing.inbox import briefing_sweep_handler
+from pollypm.plugins_builtin.morning_briefing.inbox import (
+    briefing_sweep_handler,
+    list_briefings,
+)
 
 
 _HERALD_PROFILE_PATH = Path(__file__).parent / "profiles" / "herald.md"
@@ -69,6 +74,19 @@ def _register_handlers(api: JobHandlerAPI) -> None:
         max_attempts=1,
         timeout_seconds=30.0,
     )
+
+
+def _initialize(api: PluginAPI) -> None:
+    """Wire the briefing-inbox provider for core dashboard reads.
+
+    The dashboard surfaces briefings through
+    :func:`pollypm.briefings_registry.list_briefings` so core never
+    imports from this plugin. We register the real implementation here
+    during plugin initialize; with the plugin disabled the dashboard
+    sees no provider and renders without a briefing banner (#1363).
+    """
+    del api  # unused — the dashboard reads briefings off the filesystem
+    register_briefing_provider(list_briefings)
 
 
 def _register_roster(api: RosterAPI) -> None:
@@ -111,4 +129,5 @@ plugin = PollyPMPlugin(
     },
     register_handlers=_register_handlers,
     register_roster=_register_roster,
+    initialize=_initialize,
 )

--- a/tests/test_cockpit_dashboard.py
+++ b/tests/test_cockpit_dashboard.py
@@ -5,6 +5,9 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
+from pollypm.briefings_registry import register_briefing_provider
 from pollypm.cockpit import _build_cockpit_detail_dispatch
 from pollypm.cockpit_sections.dashboard import (
     DashboardAccountUsage,
@@ -21,11 +24,32 @@ from pollypm.cockpit_sections.dashboard import (
 from pollypm.plugins_builtin.morning_briefing.handlers.synthesize import (
     BriefingDraft,
 )
-from pollypm.plugins_builtin.morning_briefing.inbox import emit_briefing
+from pollypm.plugins_builtin.morning_briefing.inbox import (
+    emit_briefing,
+    list_briefings,
+)
 from pollypm.storage.state import AccountUsageRecord, TokenUsageHourlyRecord
 
 
 NOW = datetime(2026, 4, 21, 15, 0, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _register_morning_briefing_provider():
+    """Install the morning_briefing inbox reader for dashboard tests.
+
+    Production wires this through the plugin's ``initialize`` hook
+    (see ``pollypm.plugins_builtin.morning_briefing.plugin``). The
+    plugin host doesn't run in these unit tests, so we register the
+    real reader directly so ``_briefing_banner`` resolves the same
+    way it does at runtime. Cleared after each test so a missing
+    registration doesn't leak across modules.
+    """
+    register_briefing_provider(list_briefings)
+    try:
+        yield
+    finally:
+        register_briefing_provider(None)
 
 
 @dataclass

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -175,6 +175,11 @@ _TASK_ASSIGNMENT_NOTIFY_API_MODULE = (
 # instead of reaching into the optional plugin tree.
 _APPROVAL_NOTIFICATIONS_FILE = "src/pollypm/approval_notifications.py"
 _HUMAN_NOTIFY_PLUGIN_PREFIX = "pollypm.plugins_builtin.human_notify"
+# The dashboard reads briefings through the
+# :mod:`pollypm.briefings_registry` seam, not the morning_briefing
+# plugin directly (see #1363, sibling of #1597).
+_DASHBOARD_SECTION_FILE = "src/pollypm/cockpit_sections/dashboard.py"
+_MORNING_BRIEFING_PLUGIN_PREFIX = "pollypm.plugins_builtin.morning_briefing"
 
 
 def _imports_module(source_file: Path, module: str) -> bool:
@@ -228,6 +233,31 @@ def test_non_plugin_sources_do_not_import_task_assignment_notify_api() -> None:
         if _imports_module(source_file, _TASK_ASSIGNMENT_NOTIFY_API_MODULE):
             offenders.append(rel)
     assert offenders == []
+
+
+def test_dashboard_does_not_import_morning_briefing_plugin() -> None:
+    """The dashboard surfaces briefings via the core registry seam.
+
+    :func:`pollypm.briefings_registry.list_briefings` is the sanctioned
+    read path. The ``morning_briefing`` plugin installs its real
+    ``list_briefings`` during ``initialize``; if the dashboard reaches
+    into the plugin tree directly we lose the "plugin is optional"
+    contract — fail loudly so the seam stays clean.
+    """
+    root = _project_root()
+    source_file = root / _DASHBOARD_SECTION_FILE
+    assert source_file.exists(), (
+        f"Expected {_DASHBOARD_SECTION_FILE} to exist — boundary test "
+        "needs updating if the file moved."
+    )
+    assert not _imports_module_or_subpackage(
+        source_file, _MORNING_BRIEFING_PLUGIN_PREFIX
+    ), (
+        f"{_DASHBOARD_SECTION_FILE} must not import from "
+        f"{_MORNING_BRIEFING_PLUGIN_PREFIX}; use "
+        "pollypm.briefings_registry.list_briefings instead so the "
+        "plugin stays optional."
+    )
 
 
 def test_approval_notifications_does_not_import_human_notify_plugin() -> None:


### PR DESCRIPTION
## Summary

- Picks the next contained violation from #1363 after #1597 — the dashboard banner read path used to lazy-import `pollypm.plugins_builtin.morning_briefing.inbox.list_briefings` directly from `cockpit_sections/dashboard.py`, a core surface reaching into the optional plugin tree.
- Introduces `pollypm.briefings_registry` as the registration seam, mirroring the pattern from `approval_notifications` (#1597). The `morning_briefing` plugin installs its `list_briefings` during plugin `initialize`; with no provider registered the registry returns an empty list so the dashboard simply renders without the briefing banner instead of erroring on import.
- Adds `test_dashboard_does_not_import_morning_briefing_plugin` to `tests/test_import_boundary.py` so regressions fail loudly.

Scope deliberately narrow per the multi-PR strategy in #1363 — the `activity_feed`, `project_planning` (already mostly hoisted), `task_assignment_notify`, and `core_recurring` clusters remain open.

## Test plan

- [x] `pytest tests/test_cockpit_dashboard.py tests/test_morning_briefing_inbox.py tests/test_import_boundary.py tests/test_plugins.py tests/test_plugin_interop.py tests/test_plugin_boundary_conformance.py` — 106 pass
- [x] New boundary test passes
- [x] Verified at runtime that importing `pollypm.cockpit_sections.dashboard` does **not** load any `pollypm.plugins_builtin.morning_briefing` submodule
- [x] Verified registry behavior: unregistered returns `[]`; registered delegates; provider exceptions are caught + logged + return `[]`

Pre-existing unrelated failure on this worktree's main: `test_supervisor_import_allowlist_matches_reality` flags `src/pollypm/cli_features/tier4.py` — same out-of-scope failure noted in #1597. The plan-viewer / project-dashboard-UI Textual test failures are pre-existing on main too (verified by stashing my changes and re-running).

Closes part of #1363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)