### PR TITLE
refactor(cockpit): break cockpit_inbox <-> cockpit_inbox_items cycle (refs #1367)

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -29,6 +29,10 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Literal
 
+from pollypm.cockpit_inbox_sources import (
+    _inbox_db_sources,
+    _row_is_dev_channel,
+)
 from pollypm.config import load_config
 from pollypm.cockpit_task_priority import priority_glyph, priority_rank
 from pollypm.cockpit_sections.base import _STATUS_ICONS
@@ -38,6 +42,12 @@ from pollypm.cockpit_worker_identity import (
 )
 from pollypm.heartbeats.snapshots import read_recent_heartbeat_snapshot
 from pollypm.inbox_message_refs import row_project_refs as _row_project_refs
+
+__all__ = (
+    # Re-exported leaf helpers (now live in pollypm.cockpit_inbox_sources)
+    "_inbox_db_sources",
+    "_row_is_dev_channel",
+)
 
 
 def _timestamp_sort_value(value) -> float:
@@ -112,68 +122,6 @@ def _render_work_service_issues(project: object) -> str:
         lines.append("No tasks found.")
 
     return "\n".join(lines)
-
-
-def _inbox_db_sources(config) -> list[tuple[str | None, Path, Path]]:
-    """Return ``(project_key, db_path, project_path)`` for every inbox source.
-
-    Includes the per-project ``.pollypm/state.db`` for every registered
-    project **and** the workspace-root ``<workspace_root>/.pollypm/state.db``
-    — the latter is where ``pm notify`` (with defaults) lands items that
-    don't belong to any one project (#271). Duplicates are dropped so a
-    project whose path happens to equal the workspace root is scanned once.
-
-    Note: this helper INCLUDES non-tracked projects on purpose — the
-    inbox cockpit panel and rail badge surface all registered projects
-    so a user can triage messages even before running ``pm init-tracker``.
-    The recovery prompt + morning-briefing surfaces filter to tracked
-    only; they have a different invariant (cycles 85/86/87).
-
-    ``project_key`` is ``None`` for the workspace-root source; callers that
-    need a project filter treat ``None`` as "no filter".
-    """
-    sources: list[tuple[str | None, Path, Path]] = []
-    seen: set[Path] = set()
-    for project_key, project in getattr(config, "projects", {}).items():
-        project_path = Path(project.path)
-        db_path = project_path / ".pollypm" / "state.db"
-        resolved = db_path.resolve() if db_path.exists() else db_path
-        if resolved in seen:
-            continue
-        seen.add(resolved)
-        sources.append((project_key, db_path, project_path))
-
-    workspace_root = getattr(getattr(config, "project", None), "workspace_root", None)
-    if workspace_root is not None:
-        ws_path = Path(workspace_root)
-        ws_db = ws_path / ".pollypm" / "state.db"
-        resolved = ws_db.resolve() if ws_db.exists() else ws_db
-        if resolved not in seen:
-            seen.add(resolved)
-            sources.append((None, ws_db, ws_path))
-    return sources
-
-
-def _row_is_dev_channel(labels_raw: object) -> bool:
-    """Return True if the message's labels list contains ``channel:dev``.
-
-    Accepts the raw column value (JSON string or list) since
-    ``Store.query_messages`` may surface either depending on the
-    engine. Any other channel (or no explicit channel) is treated as
-    user-facing. See #754.
-    """
-    import json as _json
-    labels: list[str] = []
-    if isinstance(labels_raw, list):
-        labels = [str(x) for x in labels_raw]
-    elif isinstance(labels_raw, str) and labels_raw:
-        try:
-            parsed = _json.loads(labels_raw)
-            if isinstance(parsed, list):
-                labels = [str(x) for x in parsed]
-        except ValueError:
-            labels = []
-    return "channel:dev" in labels
 
 
 def pm_inbox_awaits_user_list(config) -> list[object]:

--- a/src/pollypm/cockpit_inbox_items.py
+++ b/src/pollypm/cockpit_inbox_items.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import re
 from typing import Any
 
-from pollypm.cockpit_inbox import _inbox_db_sources, _row_is_dev_channel
+from pollypm.cockpit_inbox_sources import _inbox_db_sources, _row_is_dev_channel
 from pollypm.inbox.kind import InboxItemKind, coerce_kind
 from pollypm.rejection_feedback import (
     feedback_target_task_id,

--- a/src/pollypm/cockpit_inbox_sources.py
+++ b/src/pollypm/cockpit_inbox_sources.py
@@ -1,0 +1,87 @@
+"""Leaf helpers for enumerating inbox source DBs + classifying rows.
+
+Extracted from :mod:`pollypm.cockpit_inbox` to break a circular import
+with :mod:`pollypm.cockpit_inbox_items` (refs #1367). Both modules pulled
+``_inbox_db_sources`` / ``_row_is_dev_channel`` from each other; hoisting
+them to a leaf module lets both sides import from here without cycling.
+
+Contract:
+- Inputs: a cockpit ``Config``-like object (for ``_inbox_db_sources``) or
+  a raw labels column value (for ``_row_is_dev_channel``).
+- Outputs: a list of ``(project_key, db_path, project_path)`` triples
+  covering every inbox SQLite source, and a boolean for whether a row's
+  ``labels`` mark it as a dev-channel message.
+- Side effects: ``_inbox_db_sources`` calls ``Path.resolve()`` on each
+  candidate DB path; nothing writes.
+- Invariants: order is "every registered project, then the workspace
+  root" with duplicates removed by resolved path. Non-tracked projects
+  are intentionally included — see the docstring on ``_inbox_db_sources``
+  for why the cockpit inbox + rail badge differ from the recovery /
+  briefing surfaces (cycles 85/86/87, see ``project_tracked_filter_asymmetry``).
+"""
+
+from __future__ import annotations
+
+import json as _json
+from pathlib import Path
+
+
+def _inbox_db_sources(config) -> list[tuple[str | None, Path, Path]]:
+    """Return ``(project_key, db_path, project_path)`` for every inbox source.
+
+    Includes the per-project ``.pollypm/state.db`` for every registered
+    project **and** the workspace-root ``<workspace_root>/.pollypm/state.db``
+    — the latter is where ``pm notify`` (with defaults) lands items that
+    don't belong to any one project (#271). Duplicates are dropped so a
+    project whose path happens to equal the workspace root is scanned once.
+
+    Note: this helper INCLUDES non-tracked projects on purpose — the
+    inbox cockpit panel and rail badge surface all registered projects
+    so a user can triage messages even before running ``pm init-tracker``.
+    The recovery prompt + morning-briefing surfaces filter to tracked
+    only; they have a different invariant (cycles 85/86/87).
+
+    ``project_key`` is ``None`` for the workspace-root source; callers that
+    need a project filter treat ``None`` as "no filter".
+    """
+    sources: list[tuple[str | None, Path, Path]] = []
+    seen: set[Path] = set()
+    for project_key, project in getattr(config, "projects", {}).items():
+        project_path = Path(project.path)
+        db_path = project_path / ".pollypm" / "state.db"
+        resolved = db_path.resolve() if db_path.exists() else db_path
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        sources.append((project_key, db_path, project_path))
+
+    workspace_root = getattr(getattr(config, "project", None), "workspace_root", None)
+    if workspace_root is not None:
+        ws_path = Path(workspace_root)
+        ws_db = ws_path / ".pollypm" / "state.db"
+        resolved = ws_db.resolve() if ws_db.exists() else ws_db
+        if resolved not in seen:
+            seen.add(resolved)
+            sources.append((None, ws_db, ws_path))
+    return sources
+
+
+def _row_is_dev_channel(labels_raw: object) -> bool:
+    """Return True if the message's labels list contains ``channel:dev``.
+
+    Accepts the raw column value (JSON string or list) since
+    ``Store.query_messages`` may surface either depending on the
+    engine. Any other channel (or no explicit channel) is treated as
+    user-facing. See #754.
+    """
+    labels: list[str] = []
+    if isinstance(labels_raw, list):
+        labels = [str(x) for x in labels_raw]
+    elif isinstance(labels_raw, str) and labels_raw:
+        try:
+            parsed = _json.loads(labels_raw)
+            if isinstance(parsed, list):
+                labels = [str(x) for x in parsed]
+        except ValueError:
+            labels = []
+    return "channel:dev" in labels

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -13718,7 +13718,7 @@ def _dashboard_inbox(
         from pollypm.store import SQLAlchemyStore
         from pollypm.work import create_work_service
         from pollypm.work.inbox_view import inbox_tasks
-        from pollypm.cockpit_inbox import _row_is_dev_channel
+        from pollypm.cockpit_inbox_sources import _row_is_dev_channel
     except Exception:  # noqa: BLE001
         return 0, [], []
     try:


### PR DESCRIPTION
## Summary
- Breaks the `pollypm.cockpit_inbox <-> pollypm.cockpit_inbox_items` circular import pair listed in #1367.
- Extracts `_inbox_db_sources` + `_row_is_dev_channel` (pure-stdlib leaf helpers) into a new `pollypm.cockpit_inbox_sources` module. Both sides now import from the leaf; the top-level `cockpit_inbox_items -> cockpit_inbox` edge is removed.
- `cockpit_inbox` re-exports both helpers via `__all__` so existing callers (the `cockpit.py` re-export, tests importing from `pollypm.cockpit_inbox`) continue to work. `cockpit_ui._get_dashboard_inbox_data` redirected to the leaf so its lazy-import workaround no longer crosses the (former) cycle.

Partial slice only — issue stays open via `Refs #1367`. Five pairs remain (cockpit_palette/cockpit_ui, cockpit_rail/cockpit, onboarding/onboarding_tui, and two `work.sqlite_service` pairs).

## Test plan
- [x] `pytest tests/test_cockpit_inbox_threads.py tests/test_inbox_default_lens.py tests/test_bulk_inbox_context.py tests/test_rail_badge_awaits_user.py tests/test_cockpit_inbox_ui.py tests/test_worker_roster_ui.py` — 128 passed
- [x] Both import orderings work fresh: `import cockpit_inbox` then `import cockpit_inbox_items`, and reverse
- [x] Activity-feed regression test (the previously broken pair from #1599) still passes — `pytest tests/test_activity_feed_*.py` — 63 passed
- [x] AST-based cycle scan from the issue: total pairs drops from 29 to 28; no remaining pair involves `cockpit_inbox*`

The 3 pre-existing dashboard-UI failures (`test_tmux_pane_window_methods_stay_inside_allowlist`, `test_render_project_dashboard_integration`, `test_inbox_section_omits_need_action_count_when_cards_show_full_set`) and the textual UI flakes in `test_project_dashboard_ui.py` reproduce on `main` without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)