### PR TITLE
Fix #1376 route doctor.py state-DB probes via storage facade

### DIFF
--- a/src/pollypm/doctor.py
+++ b/src/pollypm/doctor.py
@@ -25,6 +25,10 @@ Design notes
 - No imports of ``supervisor.py``, ``work/session_manager.py``,
   ``work/sqlite_service.py``, ``plugin_api/v1.py``, or
   ``memory_backends/*`` — per the spec's hard constraints.
+- No direct SQLite imports or connections — the doctor sits above the
+  storage layer (#1376). Read-only state-DB probes go through
+  :mod:`pollypm.storage.doctor_state_probes`; the SQLAlchemy store is
+  used for richer queries.
 """
 
 from __future__ import annotations
@@ -36,7 +40,6 @@ import re
 import shlex
 import shutil
 import socket
-import sqlite3
 import subprocess
 import sys
 import time
@@ -49,6 +52,12 @@ from typing import Any, Callable, Iterable
 
 from pollypm.models import AccountConfig, ModelAssignment, PollyPMConfig, ProjectSettings, ProviderKind
 from pollypm.service_api import PollyPMService
+from pollypm.storage.doctor_state_probes import (
+    applied_schema_version_ro,
+    count_work_tasks_ro,
+    session_window_names_ro,
+    sessions_row_count_ro,
+)
 
 # Allow ``pollypm.doctor`` to host internal submodules while keeping the
 # public import path stable as a module-level facade.
@@ -616,25 +625,12 @@ def _latest_work_migration_version() -> int | None:
 def _applied_version_from_sqlite(db_path: Path, table: str) -> int | None:
     """Return ``MAX(version)`` from a schema-version table, or ``None``.
 
-    Uses read-only access (``mode=ro``) so we never mutate a missing DB.
-    Returns ``None`` if the DB or the table does not exist — the caller
-    interprets that as "no migrations applied yet".
+    Thin shim over
+    :func:`pollypm.storage.doctor_state_probes.applied_schema_version_ro` —
+    kept for backwards compatibility with anything that imported the
+    private helper. New callers should use the storage facade directly.
     """
-    if not db_path.is_file():
-        return None
-    uri = f"file:{db_path}?mode=ro"
-    try:
-        conn = sqlite3.connect(uri, uri=True, timeout=1.0)
-    except sqlite3.Error:
-        return None
-    try:
-        try:
-            row = conn.execute(f"SELECT COALESCE(MAX(version), 0) FROM {table}").fetchone()
-        except sqlite3.Error:
-            return None
-        return int(row[0]) if row and row[0] is not None else 0
-    finally:
-        conn.close()
+    return applied_schema_version_ro(db_path, table)
 
 
 def _workspace_state_db_path(config: PollyPMConfig | None = None) -> Path | None:
@@ -1094,60 +1090,26 @@ def check_db_layout_canonical() -> CheckResult:
 def _count_work_tasks_ro(db_path: Path) -> int | None:
     """Return ``COUNT(*) FROM work_tasks`` on ``db_path``, or ``None``.
 
-    Returns ``None`` when the file is missing OR when the ``work_tasks``
-    table does not exist on it. Returns 0 when the table exists but is
-    empty. Read-only access (``mode=ro``) — never mutates the DB,
-    never holds a write lock; safe to run against a live cockpit DB.
+    Thin shim over
+    :func:`pollypm.storage.doctor_state_probes.count_work_tasks_ro` —
+    preserved as a module-private name because the dual-DB drift check
+    below references it and several tests rely on the wrapped function
+    being attached to the ``doctor`` module.
     """
-    if not db_path.is_file():
-        return None
-    uri = f"file:{db_path}?mode=ro"
-    try:
-        conn = sqlite3.connect(uri, uri=True, timeout=1.0)
-    except sqlite3.Error:
-        return None
-    try:
-        try:
-            row = conn.execute(
-                "SELECT name FROM sqlite_master "
-                "WHERE type='table' AND name='work_tasks'"
-            ).fetchone()
-        except sqlite3.Error:
-            return None
-        if row is None:
-            return None
-        try:
-            row = conn.execute("SELECT COUNT(*) FROM work_tasks").fetchone()
-        except sqlite3.Error:
-            return None
-        return int(row[0]) if row and row[0] is not None else 0
-    finally:
-        conn.close()
+    return count_work_tasks_ro(db_path)
 
 
 def _has_messages_table_ro(db_path: Path) -> bool:
     """Return True when ``db_path`` is a messages-side DB (has ``messages``).
 
-    Read-only probe; returns False on any open / read failure.
+    Thin shim over
+    :func:`pollypm.storage.doctor_state_probes.has_messages_table_ro`;
+    preserved for the same backwards-compatibility reason as
+    :func:`_count_work_tasks_ro`.
     """
-    if not db_path.is_file():
-        return False
-    uri = f"file:{db_path}?mode=ro"
-    try:
-        conn = sqlite3.connect(uri, uri=True, timeout=1.0)
-    except sqlite3.Error:
-        return False
-    try:
-        try:
-            row = conn.execute(
-                "SELECT name FROM sqlite_master "
-                "WHERE type='table' AND name='messages'"
-            ).fetchone()
-        except sqlite3.Error:
-            return False
-        return row is not None
-    finally:
-        conn.close()
+    from pollypm.storage.doctor_state_probes import has_messages_table_ro
+
+    return has_messages_table_ro(db_path)
 
 
 def _messages_side_db_path(config: PollyPMConfig | None = None) -> Path | None:
@@ -2855,15 +2817,6 @@ def check_task_assignment_sweeper_dbs() -> CheckResult:
     )
 
 
-def _open_state_db_ro(db_path: Path) -> sqlite3.Connection | None:
-    if not db_path.is_file():
-        return None
-    try:
-        return sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=1.0)
-    except sqlite3.Error:
-        return None
-
-
 def _primary_state_db() -> Path | None:
     """First tracked-project state.db, or None.
 
@@ -2968,17 +2921,13 @@ def check_sessions_table_populated() -> CheckResult:
     db_path = _supervisor_state_db() or _primary_state_db()
     if db_path is None:
         return _skip("sessions-table check skipped (no state.db)")
-    conn = _open_state_db_ro(db_path)
-    if conn is None:
-        return _skip(f"sessions-table check skipped (cannot open {db_path})")
-    try:
-        try:
-            row = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
-        except sqlite3.Error:
-            return _skip("sessions-table check skipped (table missing)")
-        count = int(row[0]) if row and row[0] is not None else 0
-    finally:
-        conn.close()
+    count = sessions_row_count_ro(db_path)
+    if count is None:
+        # ``None`` covers both "cannot open" and "table missing" — the
+        # facade collapses them, which matches the prior skip behaviour.
+        return _skip(
+            "sessions-table check skipped (cannot open / table missing)"
+        )
 
     def _fix() -> tuple[bool, str]:
         # Run repair_sessions_table via a transient supervisor.
@@ -3705,19 +3654,14 @@ def check_sessions_table_vs_tmux() -> CheckResult:
     db_path = _supervisor_state_db() or _primary_state_db()
     if db_path is None:
         return _skip("session-drift check skipped (no state.db)")
-    conn = _open_state_db_ro(db_path)
-    if conn is None:
-        return _skip("session-drift check skipped (db unreadable)")
-    db_windows: set[str] = set()
-    try:
-        try:
-            for row in conn.execute("SELECT window_name FROM sessions"):
-                if row and row[0]:
-                    db_windows.add(str(row[0]))
-        except sqlite3.Error:
-            return _skip("session-drift check skipped (sessions table missing)")
-    finally:
-        conn.close()
+    db_windows = session_window_names_ro(db_path)
+    if db_windows is None:
+        # ``None`` covers both "db unreadable" and "sessions table
+        # missing" — collapse the two skip messages so the doctor still
+        # exits cleanly without leaking the storage-layer distinction.
+        return _skip(
+            "session-drift check skipped (db unreadable / table missing)"
+        )
 
     # We only flag tmux windows that the supervisor *should* have
     # registered: those whose name matches a known PollyPM role prefix.

--- a/src/pollypm/storage/doctor_state_probes.py
+++ b/src/pollypm/storage/doctor_state_probes.py
@@ -1,0 +1,191 @@
+"""Read-only state-DB probes used by ``pm doctor``.
+
+The ``pollypm.doctor`` module surfaces a handful of small SQLite reads
+against ``state.db`` (schema_version, work_schema_version, work_tasks
+counts, sessions table inspection, messages-table presence). Per #1376
+those reads should not be issued from the doctor module directly — it
+sits above the storage layer and is not allowed to ``import sqlite3``
+or open files via ``sqlite3.connect`` (the plugin-boundary contract
+audited by
+``tests/test_plugin_boundary_conformance.py::test_work_task_query_callers_do_not_open_sqlite_directly``).
+
+Every probe here is:
+
+* **read-only** (``file:<path>?mode=ro`` URI) — never mutates the DB,
+  never holds a write lock; safe to run against live cockpit DBs;
+* **best-effort** — missing file, missing table, or any
+  ``sqlite3.Error`` returns the documented sentinel (``None``, ``False``,
+  or ``0``) instead of propagating;
+* **short busy_timeout** — a 1s ``timeout`` on the connect plus the
+  standard workspace pragmas (``busy_timeout=...``) so a doctor run
+  never blocks behind a JobWorkerPool writer.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+
+from pollypm.storage.sqlite_pragmas import apply_workspace_pragmas
+
+logger = logging.getLogger(__name__)
+
+
+def _connect_readonly(db_path: Path) -> sqlite3.Connection | None:
+    """Open ``db_path`` read-only or return ``None``.
+
+    Returns ``None`` when the file does not exist or the connect call
+    raises any ``sqlite3.Error``. Applies the workspace pragmas
+    (``busy_timeout``) so concurrent writers don't starve the probe.
+    """
+    if not db_path.is_file():
+        return None
+    uri = f"file:{db_path}?mode=ro"
+    try:
+        conn = sqlite3.connect(uri, uri=True, timeout=1.0)
+    except sqlite3.Error as exc:
+        logger.debug(
+            "doctor_state_probes: connect failed for %s: %s", db_path, exc,
+        )
+        return None
+    apply_workspace_pragmas(conn, readonly=True)
+    return conn
+
+
+def applied_schema_version_ro(db_path: Path, table: str) -> int | None:
+    """Return ``MAX(version)`` from a schema-version table, or ``None``.
+
+    ``table`` is interpolated into the SQL string because the schema
+    layer keeps two parallel version tables (``schema_version`` and
+    ``work_schema_version``) and SQLite parameter binding does not
+    support table identifiers. Callers pass the table name from a
+    fixed set inside ``doctor.py`` — never user input.
+
+    Returns ``None`` when the DB file is missing, the connect fails, or
+    the table does not exist. Returns ``0`` when the table is present
+    but empty (no migrations applied yet).
+    """
+    conn = _connect_readonly(db_path)
+    if conn is None:
+        return None
+    try:
+        try:
+            row = conn.execute(
+                f"SELECT COALESCE(MAX(version), 0) FROM {table}"
+            ).fetchone()
+        except sqlite3.Error:
+            return None
+        return int(row[0]) if row and row[0] is not None else 0
+    finally:
+        conn.close()
+
+
+def count_work_tasks_ro(db_path: Path) -> int | None:
+    """Return ``COUNT(*) FROM work_tasks`` on ``db_path``, or ``None``.
+
+    Returns ``None`` when the file is missing OR when the ``work_tasks``
+    table does not exist on it. Returns ``0`` when the table exists but
+    is empty. Used by the dual-DB drift probe to tell "no work tables
+    on this file" apart from "tables present but empty".
+    """
+    conn = _connect_readonly(db_path)
+    if conn is None:
+        return None
+    try:
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='work_tasks'"
+            ).fetchone()
+        except sqlite3.Error:
+            return None
+        if row is None:
+            return None
+        try:
+            row = conn.execute("SELECT COUNT(*) FROM work_tasks").fetchone()
+        except sqlite3.Error:
+            return None
+        return int(row[0]) if row and row[0] is not None else 0
+    finally:
+        conn.close()
+
+
+def has_messages_table_ro(db_path: Path) -> bool:
+    """Return ``True`` when ``db_path`` carries a ``messages`` table.
+
+    Read-only probe used by the dual-DB drift check to decide whether a
+    given state.db is the messages-side DB. Returns ``False`` on any
+    open / read failure.
+    """
+    conn = _connect_readonly(db_path)
+    if conn is None:
+        return False
+    try:
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='messages'"
+            ).fetchone()
+        except sqlite3.Error:
+            return False
+        return row is not None
+    finally:
+        conn.close()
+
+
+def sessions_row_count_ro(db_path: Path) -> int | None:
+    """Return ``COUNT(*) FROM sessions`` on ``db_path``, or ``None``.
+
+    Returns ``None`` when the DB file cannot be opened or the
+    ``sessions`` table does not exist (a fresh install before
+    ``Supervisor.start()`` runs ``repair_sessions_table()``). Returns
+    ``0`` when the table exists but is empty — the
+    ``check_sessions_table_populated`` doctor check treats that as a
+    distinct fail signal so the operator gets a clear "repair didn't
+    run" hint instead of a silent skip.
+    """
+    conn = _connect_readonly(db_path)
+    if conn is None:
+        return None
+    try:
+        try:
+            row = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
+        except sqlite3.Error:
+            return None
+        return int(row[0]) if row and row[0] is not None else 0
+    finally:
+        conn.close()
+
+
+def session_window_names_ro(db_path: Path) -> set[str] | None:
+    """Return the set of ``window_name`` values in ``sessions``, or ``None``.
+
+    Returns ``None`` when the DB cannot be opened or the ``sessions``
+    table is missing — distinct from the empty-set case (table present,
+    no rows) so the session-drift doctor check can skip cleanly when
+    the table itself has not been provisioned yet.
+    """
+    conn = _connect_readonly(db_path)
+    if conn is None:
+        return None
+    try:
+        windows: set[str] = set()
+        try:
+            for row in conn.execute("SELECT window_name FROM sessions"):
+                if row and row[0]:
+                    windows.add(str(row[0]))
+        except sqlite3.Error:
+            return None
+        return windows
+    finally:
+        conn.close()
+
+
+__all__ = [
+    "applied_schema_version_ro",
+    "count_work_tasks_ro",
+    "has_messages_table_ro",
+    "sessions_row_count_ro",
+    "session_window_names_ro",
+]

--- a/tests/test_plugin_boundary_conformance.py
+++ b/tests/test_plugin_boundary_conformance.py
@@ -98,6 +98,7 @@ def test_work_task_query_callers_do_not_open_sqlite_directly() -> None:
         "src/pollypm/cockpit_settings_projects.py",
         "src/pollypm/cockpit_sections/base.py",
         "src/pollypm/dashboard_data.py",
+        "src/pollypm/doctor.py",
         "src/pollypm/plugins_builtin/project_planning/cli/project.py",
     )
     offenders: list[str] = []


### PR DESCRIPTION
## Summary

Third wedge for #1376 after #1596 (`cockpit_settings_projects.py`) and #1617 (`cockpit_sections/base.py`). Removes the direct `sqlite3.connect()` calls and the `import sqlite3` from `src/pollypm/doctor.py` so the doctor module no longer reaches across the plugin boundary into SQLite internals.

- New `pollypm.storage.doctor_state_probes` module owns the five read-only state-DB probes the doctor needs (`applied_schema_version_ro`, `count_work_tasks_ro`, `has_messages_table_ro`, `sessions_row_count_ro`, `session_window_names_ro`). All probes are read-only (`mode=ro` URI), best-effort (missing file / table → documented sentinel), and apply the standard workspace pragmas so a doctor run never blocks behind a JobWorkerPool writer.
- The module-private wrappers in `doctor.py` (`_applied_version_from_sqlite`, `_count_work_tasks_ro`, `_has_messages_table_ro`) are kept as thin delegators so anything monkey-patching them in tests keeps working; `_open_state_db_ro` was deleted because both callers needed only one specific query (sessions count, window names), not a raw connection.
- `tests/test_plugin_boundary_conformance.py::test_work_task_query_callers_do_not_open_sqlite_directly` now lists `doctor.py` so a future regression fails loudly.

Remaining #1376 scope: `cockpit.py`, `cockpit_ui.py`. (`backup.py` is acceptable per the issue — backup tooling can know SQLite format.)

## Test plan

- [x] `tests/test_plugin_boundary_conformance.py` — 16 passed; new `doctor.py` entry exercises the regression guard.
- [x] `tests/test_doctor.py` — 75 passed.
- [x] `tests/test_doctor_dual_db_health.py` — 15 passed (uses `_count_work_tasks_ro` / `_has_messages_table_ro` through monkey-patched config helpers).
- [x] `tests/test_doctor_enhancements.py` — 104 passed (covers sessions-table / session-drift / migration checks).
- [x] Direct smoke of the new facade against an in-memory DB: missing-file / missing-table / populated / emptied transitions all return the documented sentinels.