### PR TITLE
fix(#1363): decouple doctor from core_recurring plugin

### DIFF
--- a/src/pollypm/doctor.py
+++ b/src/pollypm/doctor.py
@@ -3318,17 +3318,25 @@ def _invoke_prune_handler() -> tuple[bool, str]:
     Bypasses the scheduler so the prune runs immediately rather than
     waiting for the next hourly tick. The handler is idempotent —
     calling it when nothing is prunable is a cheap no-op.
+
+    Resolved through :mod:`pollypm.maintenance_handlers_registry` so
+    ``doctor`` never imports from ``pollypm.plugins_builtin`` directly
+    (#1363).
     """
+    from pollypm.maintenance_handlers_registry import (
+        AGENT_WORKTREE_PRUNE,
+        invoke_maintenance_handler,
+    )
+
     try:
-        from pollypm.plugins_builtin.core_recurring.plugin import (
-            agent_worktree_prune_handler,
-        )
-    except Exception as exc:  # noqa: BLE001
-        return (False, f"import failed: {exc}")
-    try:
-        result = agent_worktree_prune_handler({})
+        result = invoke_maintenance_handler(AGENT_WORKTREE_PRUNE, {})
     except Exception as exc:  # noqa: BLE001
         return (False, f"prune handler failed: {exc}")
+    if result is None:
+        return (
+            False,
+            "prune handler unavailable (core_recurring plugin not loaded)",
+        )
     pruned = int(result.get("pruned", 0)) if isinstance(result, dict) else 0
     errors = int(result.get("errors", 0)) if isinstance(result, dict) else 0
     warned = int(result.get("warned_stale", 0)) if isinstance(result, dict) else 0
@@ -3406,15 +3414,25 @@ def _invoke_log_rotate_handler(logs_dir: Path) -> tuple[bool, str]:
     rotates files past the threshold and prunes retention-exceeded
     siblings; calling it when nothing is over-threshold is a cheap
     no-op.
+
+    Resolved through :mod:`pollypm.maintenance_handlers_registry` so
+    ``doctor`` never imports from ``pollypm.plugins_builtin`` directly
+    (#1363).
     """
+    from pollypm.maintenance_handlers_registry import (
+        LOG_ROTATE,
+        invoke_maintenance_handler,
+    )
+
     try:
-        from pollypm.plugins_builtin.core_recurring.plugin import log_rotate_handler
-    except Exception as exc:  # noqa: BLE001
-        return (False, f"import failed: {exc}")
-    try:
-        result = log_rotate_handler({"logs_dir": str(logs_dir)})
+        result = invoke_maintenance_handler(LOG_ROTATE, {"logs_dir": str(logs_dir)})
     except Exception as exc:  # noqa: BLE001
         return (False, f"log.rotate handler failed: {exc}")
+    if result is None:
+        return (
+            False,
+            "log.rotate handler unavailable (core_recurring plugin not loaded)",
+        )
     rotated = int(result.get("rotated", 0)) if isinstance(result, dict) else 0
     deleted = int(result.get("deleted", 0)) if isinstance(result, dict) else 0
     errors = int(result.get("errors", 0)) if isinstance(result, dict) else 0

--- a/src/pollypm/maintenance_handlers_registry.py
+++ b/src/pollypm/maintenance_handlers_registry.py
@@ -1,0 +1,102 @@
+"""Core seam for one-off invocation of recurring maintenance handlers.
+
+Contract:
+- Inputs: a handler name (``"agent_worktree.prune"`` or ``"log.rotate"``)
+  plus a JSON-shaped payload dict.
+- Outputs: the handler's result dict, or ``None`` when no provider is
+  registered (plugin disabled / missing).
+- Side effects: whatever the underlying handler does (filesystem prunes,
+  log rotation). Handlers themselves are idempotent — invoking them when
+  nothing's prunable is a cheap no-op.
+- Invariants: when no provider is registered, callers see ``None`` and
+  can degrade gracefully (the doctor fix-fn reports "handler unavailable"
+  rather than crashing).
+
+Boundary note:
+This module is core — it must not import from ``pollypm.plugins_builtin``.
+``doctor.py`` calls the registered handlers as part of its ``--fix`` flow
+without taking a hard import on the optional ``core_recurring`` plugin.
+The ``core_recurring`` plugin installs its ``agent_worktree_prune_handler``
+and ``log_rotate_handler`` here during plugin ``initialize``.
+
+Mirrors the registration-seam pattern established in
+:mod:`pollypm.approval_notifications` (#1597) and
+:mod:`pollypm.briefings_registry` (#1621). See #1363 for the full
+boundary-debt roll-up.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+
+logger = logging.getLogger(__name__)
+
+
+MaintenanceHandler = Callable[[dict[str, Any]], dict[str, Any]]
+
+
+# Handler names mirror the cadence-roster handler names the
+# ``core_recurring`` plugin already registers with the job queue. We keep
+# them as string constants so the doctor and the plugin can agree on the
+# slot without sharing a Python import.
+AGENT_WORKTREE_PRUNE = "agent_worktree.prune"
+LOG_ROTATE = "log.rotate"
+
+
+_handlers: dict[str, MaintenanceHandler] = {}
+
+
+def register_maintenance_handler(
+    name: str, handler: MaintenanceHandler | None
+) -> None:
+    """Install (or clear) a one-off maintenance handler under ``name``.
+
+    Called by the ``core_recurring`` plugin during ``initialize`` so the
+    doctor's ``--fix`` flow can invoke a handler immediately without
+    waiting for the next cadence tick. Pass ``handler=None`` to clear
+    (used by tests).
+    """
+    if handler is None:
+        _handlers.pop(name, None)
+        return
+    _handlers[name] = handler
+
+
+def get_maintenance_handler(name: str) -> MaintenanceHandler | None:
+    """Return the handler registered under ``name`` or ``None``.
+
+    Returning ``None`` is the documented "plugin disabled / not loaded"
+    signal — callers must treat it as a degraded-but-OK state.
+    """
+    return _handlers.get(name)
+
+
+def invoke_maintenance_handler(
+    name: str, payload: dict[str, Any] | None = None
+) -> dict[str, Any] | None:
+    """Invoke the handler registered under ``name``.
+
+    Returns the handler's result dict on success, ``None`` when no
+    handler is registered, and re-raises any exception raised by the
+    handler so callers can surface the failure in their own format
+    (e.g. the doctor's ``(ok, message)`` tuple).
+    """
+    handler = _handlers.get(name)
+    if handler is None:
+        logger.debug(
+            "maintenance_handlers_registry: no provider for %s", name
+        )
+        return None
+    return handler(payload or {})
+
+
+__all__ = [
+    "AGENT_WORKTREE_PRUNE",
+    "LOG_ROTATE",
+    "MaintenanceHandler",
+    "get_maintenance_handler",
+    "invoke_maintenance_handler",
+    "register_maintenance_handler",
+]

--- a/src/pollypm/plugins_builtin/core_recurring/plugin.py
+++ b/src/pollypm/plugins_builtin/core_recurring/plugin.py
@@ -6,7 +6,18 @@ import logging
 import threading
 from typing import Any
 
-from pollypm.plugin_api.v1 import Capability, JobHandlerAPI, PollyPMPlugin, RosterAPI
+from pollypm.maintenance_handlers_registry import (
+    AGENT_WORKTREE_PRUNE,
+    LOG_ROTATE,
+    register_maintenance_handler,
+)
+from pollypm.plugin_api.v1 import (
+    Capability,
+    JobHandlerAPI,
+    PluginAPI,
+    PollyPMPlugin,
+    RosterAPI,
+)
 
 from pollypm.plugins_builtin.core_recurring.maintenance import (
     AUDIT_EVENT_SUBJECTS,
@@ -556,6 +567,24 @@ def _register_roster(api: RosterAPI) -> None:
     )
 
 
+def _initialize(api: PluginAPI) -> None:
+    """Expose one-off entry points for the maintenance handlers (#1363).
+
+    ``doctor.py`` invokes ``agent_worktree.prune`` and ``log.rotate``
+    directly as ``--fix`` actions instead of waiting for the next
+    cadence tick. Registering them in
+    :mod:`pollypm.maintenance_handlers_registry` lets the doctor resolve
+    them without importing from the optional plugin tree — when this
+    plugin isn't loaded the doctor reports the fix as "unavailable" and
+    keeps working.
+
+    Idempotent — safe to call again if the rail re-initializes plugins.
+    """
+    del api  # unused — the registry is module-level state
+    register_maintenance_handler(AGENT_WORKTREE_PRUNE, agent_worktree_prune_handler)
+    register_maintenance_handler(LOG_ROTATE, log_rotate_handler)
+
+
 plugin = PollyPMPlugin(
     name="core_recurring",
     version="0.1.0",
@@ -589,4 +618,5 @@ plugin = PollyPMPlugin(
     ),
     register_handlers=_register_handlers,
     register_roster=_register_roster,
+    initialize=_initialize,
 )

--- a/tests/test_doctor_enhancements.py
+++ b/tests/test_doctor_enhancements.py
@@ -1343,8 +1343,10 @@ def test_agent_worktree_count_fix_invokes_prune(
         called["n"] += 1
         return {"pruned": 3, "skipped_active": 0, "warned_stale": 0, "errors": 0}
 
-    import pollypm.plugins_builtin.core_recurring.plugin as rec_plugin
-    monkeypatch.setattr(rec_plugin, "agent_worktree_prune_handler", _fake_handler)
+    from pollypm import maintenance_handlers_registry as reg
+    # Swap in an isolated handler map so the registration is auto-rolled
+    # back by monkeypatch and doesn't leak between tests.
+    monkeypatch.setattr(reg, "_handlers", {reg.AGENT_WORKTREE_PRUNE: _fake_handler})
     success, message = result.fix_fn()
     assert success
     assert called["n"] == 1
@@ -1370,8 +1372,8 @@ def test_logs_dir_size_fix_invokes_rotate(
         called["payload"] = payload
         return {"rotated": 1, "deleted": 0, "errors": 0}
 
-    import pollypm.plugins_builtin.core_recurring.plugin as rec_plugin
-    monkeypatch.setattr(rec_plugin, "log_rotate_handler", _fake_handler)
+    from pollypm import maintenance_handlers_registry as reg
+    monkeypatch.setattr(reg, "_handlers", {reg.LOG_ROTATE: _fake_handler})
     success, message = result.fix_fn()
     assert success
     # The fix passes the resolved logs_dir in the payload so the handler
@@ -1392,12 +1394,16 @@ def test_log_rotate_handler_message_pluralisation(
     awkward singular boundary. Lock the literal out of both the all-
     singular and all-plural cases.
     """
-    import pollypm.plugins_builtin.core_recurring.plugin as rec_plugin
+    from pollypm import maintenance_handlers_registry as reg
 
     monkeypatch.setattr(
-        rec_plugin,
-        "log_rotate_handler",
-        lambda payload: {"rotated": 1, "deleted": 1, "errors": 1},
+        reg,
+        "_handlers",
+        {
+            reg.LOG_ROTATE: lambda payload: {
+                "rotated": 1, "deleted": 1, "errors": 1,
+            },
+        },
     )
     success, message = doctor._invoke_log_rotate_handler(tmp_path)
     assert not success
@@ -1407,9 +1413,13 @@ def test_log_rotate_handler_message_pluralisation(
     assert "(s)" not in message
 
     monkeypatch.setattr(
-        rec_plugin,
-        "log_rotate_handler",
-        lambda payload: {"rotated": 4, "deleted": 2, "errors": 0},
+        reg,
+        "_handlers",
+        {
+            reg.LOG_ROTATE: lambda payload: {
+                "rotated": 4, "deleted": 2, "errors": 0,
+            },
+        },
     )
     success, message = doctor._invoke_log_rotate_handler(tmp_path)
     assert success
@@ -1428,12 +1438,16 @@ def test_prune_handler_message_pluralisation(
     line, original prose was ``pruned 1 merged worktree(s), 0 stale
     unmerged retained, 1 error(s)`` at the singular boundary.
     """
-    import pollypm.plugins_builtin.core_recurring.plugin as rec_plugin
+    from pollypm import maintenance_handlers_registry as reg
 
     monkeypatch.setattr(
-        rec_plugin,
-        "agent_worktree_prune_handler",
-        lambda payload: {"pruned": 1, "warned_stale": 0, "errors": 1},
+        reg,
+        "_handlers",
+        {
+            reg.AGENT_WORKTREE_PRUNE: lambda payload: {
+                "pruned": 1, "warned_stale": 0, "errors": 1,
+            },
+        },
     )
     success, message = doctor._invoke_prune_handler()
     assert not success
@@ -1442,9 +1456,13 @@ def test_prune_handler_message_pluralisation(
     assert "(s)" not in message
 
     monkeypatch.setattr(
-        rec_plugin,
-        "agent_worktree_prune_handler",
-        lambda payload: {"pruned": 5, "warned_stale": 0, "errors": 0},
+        reg,
+        "_handlers",
+        {
+            reg.AGENT_WORKTREE_PRUNE: lambda payload: {
+                "pruned": 5, "warned_stale": 0, "errors": 0,
+            },
+        },
     )
     success, message = doctor._invoke_prune_handler()
     assert success
@@ -1809,15 +1827,19 @@ def test_fix_cli_real_handlers_no_op_surfaces_unverified(
     big.write_bytes(b"x" * (doctor._LOGS_WARN_BYTES + 1))
     monkeypatch.setattr(doctor, "_logs_dir_candidates", lambda: [logs_dir])
 
-    import pollypm.plugins_builtin.core_recurring.plugin as plugin_mod
+    from pollypm import maintenance_handlers_registry as reg
 
     monkeypatch.setattr(
-        plugin_mod, "agent_worktree_prune_handler",
-        lambda payload: {"pruned": 0, "errors": 0, "warned_stale": 0},
-    )
-    monkeypatch.setattr(
-        plugin_mod, "log_rotate_handler",
-        lambda payload: {"rotated": 0, "deleted": 0, "errors": 0},
+        reg,
+        "_handlers",
+        {
+            reg.AGENT_WORKTREE_PRUNE: (
+                lambda payload: {"pruned": 0, "errors": 0, "warned_stale": 0}
+            ),
+            reg.LOG_ROTATE: (
+                lambda payload: {"rotated": 0, "deleted": 0, "errors": 0}
+            ),
+        },
     )
 
     monkeypatch.setattr(

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -180,6 +180,12 @@ _HUMAN_NOTIFY_PLUGIN_PREFIX = "pollypm.plugins_builtin.human_notify"
 # plugin directly (see #1363, sibling of #1597).
 _DASHBOARD_SECTION_FILE = "src/pollypm/cockpit_sections/dashboard.py"
 _MORNING_BRIEFING_PLUGIN_PREFIX = "pollypm.plugins_builtin.morning_briefing"
+# ``doctor`` invokes the ``agent_worktree.prune`` / ``log.rotate``
+# maintenance handlers via :mod:`pollypm.maintenance_handlers_registry`
+# so it never imports from the optional ``core_recurring`` plugin
+# directly (see #1363, sibling of #1597 / #1621).
+_DOCTOR_FILE = "src/pollypm/doctor.py"
+_CORE_RECURRING_PLUGIN_PREFIX = "pollypm.plugins_builtin.core_recurring"
 
 
 def _imports_module(source_file: Path, module: str) -> bool:
@@ -257,6 +263,33 @@ def test_dashboard_does_not_import_morning_briefing_plugin() -> None:
         f"{_MORNING_BRIEFING_PLUGIN_PREFIX}; use "
         "pollypm.briefings_registry.list_briefings instead so the "
         "plugin stays optional."
+    )
+
+
+def test_doctor_does_not_import_core_recurring_plugin() -> None:
+    """``pm doctor`` invokes maintenance handlers through the core registry.
+
+    :mod:`pollypm.maintenance_handlers_registry` is the sanctioned read
+    path for ``agent_worktree.prune`` and ``log.rotate``. The
+    ``core_recurring`` plugin installs the real handlers during
+    ``initialize``; if ``doctor.py`` reaches into the plugin tree
+    directly we re-couple core to an "optional" plugin and the
+    ``--fix`` flow stops degrading cleanly when the plugin is disabled.
+    Fail loudly so the seam stays clean.
+    """
+    root = _project_root()
+    source_file = root / _DOCTOR_FILE
+    assert source_file.exists(), (
+        f"Expected {_DOCTOR_FILE} to exist — boundary test "
+        "needs updating if the file moved."
+    )
+    assert not _imports_module_or_subpackage(
+        source_file, _CORE_RECURRING_PLUGIN_PREFIX
+    ), (
+        f"{_DOCTOR_FILE} must not import from "
+        f"{_CORE_RECURRING_PLUGIN_PREFIX}; use "
+        "pollypm.maintenance_handlers_registry.invoke_maintenance_handler "
+        "instead so the plugin stays optional."
     )
 
 


### PR DESCRIPTION
## Summary

- Picks the next contained violation from #1363 after #1597 (`approval_notifications` → `human_notify`) and #1621 (`dashboard` → `morning_briefing`). `doctor.py` used to lazy-import `agent_worktree_prune_handler` / `log_rotate_handler` directly from `pollypm.plugins_builtin.core_recurring.plugin` for its `--fix` flow — a core surface taking a hard dependency on an "optional" plugin.
- Introduces `pollypm.maintenance_handlers_registry` as the registration seam, mirroring the patterns established in the two prior wedges. The `core_recurring` plugin installs its `agent_worktree.prune` and `log.rotate` handlers via a new `_initialize` hook; with the plugin disabled the doctor reports `--fix` as "handler unavailable (core_recurring plugin not loaded)" instead of crashing on import.
- Adds `test_doctor_does_not_import_core_recurring_plugin` to `tests/test_import_boundary.py` so regressions fail loudly. Updates the five doctor `--fix` tests that used to monkeypatch the handler symbol on the plugin module to instead inject through the registry's `_handlers` slot.

Scope deliberately narrow per the multi-PR strategy in #1363 — the `activity_feed` (14 callsites across 5 files), `task_assignment_notify`, and `default_launch_planner` clusters remain open.

## Test plan

- [x] `pytest tests/test_doctor.py tests/test_doctor_enhancements.py tests/test_plugins.py tests/test_plugin_interop.py tests/test_plugin_boundary_conformance.py tests/test_import_boundary.py` — 256 pass, 1 pre-existing failure
- [x] New boundary test `test_doctor_does_not_import_core_recurring_plugin` passes
- [x] Smoke-verified: importing `pollypm.doctor` does **not** load any `pollypm.plugins_builtin.core_recurring` submodule
- [x] Smoke-verified registry behavior: unregistered returns `None` (doctor surfaces "handler unavailable"); registered delegates; handler exceptions re-raise so the doctor reports `prune handler failed: <exc>`

Pre-existing unrelated failure on this worktree's main: `test_supervisor_import_allowlist_matches_reality` flags `src/pollypm/cli_features/tier4.py` — same out-of-scope failure noted in #1597 and #1621.

Closes part of #1363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)