### PR TITLE
refactor(cockpit): break cockpit_alerts <-> cockpit_palette cycle (refs #1367)

### DIFF
--- a/src/pollypm/cockpit_alerts.py
+++ b/src/pollypm/cockpit_alerts.py
@@ -19,7 +19,6 @@ import enum
 from textual.app import App
 
 from pollypm.cli_features.alerts import is_surfaceable_operational_alert
-from pollypm.cockpit_palette import _palette_nav
 
 
 # #765 — Operational alert types never become toasts. They're heartbeat
@@ -166,7 +165,19 @@ def alert_should_toast(alert_type: str) -> bool:
 
 
 def _resolve_palette_nav():
-    """Preserve the legacy ``pollypm.cockpit_ui`` monkeypatch seam."""
+    """Preserve the legacy ``pollypm.cockpit_ui`` monkeypatch seam.
+
+    ``_palette_nav`` is imported lazily here (rather than at module load)
+    to keep this module a leaf of the cockpit import graph — the
+    previous top-level import closed the
+    ``cockpit_palette -> cockpit -> ... -> signal_routing ->
+    cockpit_alerts -> cockpit_palette`` cycle tracked by #1367.
+    """
+    # Local import: this function is only ever called at runtime
+    # (from ``_action_view_alerts``), so deferring the import has no
+    # cost while severing the static cycle.
+    from pollypm.cockpit_palette import _palette_nav
+
     try:
         from pollypm import cockpit_ui
     except Exception:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- Invert the weakest edge in the 8-module SCC connecting `cockpit_palette` -> `cockpit` -> `service_api` -> `service_api.v1` -> `supervisor` -> `supervisor_alerts` -> `signal_routing` -> `cockpit_alerts` -> `cockpit_palette`.
- `cockpit_alerts._resolve_palette_nav` was the sole caller of `cockpit_palette._palette_nav` and is only invoked at runtime from `_action_view_alerts`. Pushing the import inside the resolver costs nothing while severing the static cycle.
- AST cycle scan confirms the full SCC of 12 modules (pollypm.cockpit*, pollypm.signal_routing, pollypm.supervisor*, pollypm.service_api*, pollypm.workers, pollypm.schedulers*) collapses with this one edge inverted. Five 2-cycles tracked under #1367 remain (mostly `work.service_*` <-> `work.sqlite_service` and `heartbeats.api` <-> `supervisor`).

## Test plan
- [x] `pytest tests/test_cockpit_alert_actions.py tests/test_signal_routing.py tests/test_stall_classifier.py tests/test_import_boundary.py tests/test_package_imports.py` (68 passed)
- [x] `pytest tests/test_cockpit*.py` (285 passed; one pre-existing failure in `test_tmux_pane_window_methods_stay_inside_allowlist` unrelated to this change, verified by stashing)
- [x] AST scanner: no remaining cycle through `cockpit_palette`, `cockpit_alerts`, `signal_routing`, or `cockpit`

Related: #1599 (activity_feed.plugin <-> feed_panel), #1623 (cockpit_inbox <-> cockpit_inbox_items)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>