### PR TITLE
fix(cockpit): pick live-provider pane when storage has duplicate windows (#1631)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -2342,6 +2342,79 @@ class CockpitRouter:
                     },
                 )
 
+    def _select_storage_window_for_mount(
+        self,
+        storage_windows: list,
+        window_name: str,
+        session_name: str,
+    ):
+        """Pick which storage-closet window to mount when duplicates exist.
+
+        #1631 — the rail historically used ``next(w for w in windows if
+        w.name == window_name)``, which deterministically picked the
+        lowest-index window. When park-collisions left two ``pm-operator``
+        windows in the closet (one stale, one with the user's live Polly
+        conversation), the lowest-index pick was often the wrong one —
+        the user clicked Polly and got a fresh ``claude`` session while
+        their in-progress conversation was left orphaned in the second
+        window. #1563's conservative cleanup correctly refused to kill
+        either (both live), so the orphan persisted but the user-visible
+        damage was already done.
+
+        Selection rules:
+          * No matches → ``None``. Caller falls back to spawning fresh.
+          * Exactly one match → return it. Common path, no audit noise.
+          * Multiple matches → prefer the window whose pane is currently
+            running a live provider (``claude`` / ``codex`` / ``node``).
+            Ties broken by lowest index (deterministic). Emit a
+            ``cockpit.duplicate_resolution`` event explaining the choice
+            so forensics can trace which window won and why. **Do not**
+            kill the loser — #1563's conservative cleanup will reap it
+            once its pane dies.
+        """
+        matches = [w for w in storage_windows if getattr(w, "name", None) == window_name]
+        if not matches:
+            return None
+        if len(matches) == 1:
+            return matches[0]
+        live_provider = {"claude", "codex", "node"}
+        live_matches = [
+            w for w in matches
+            if (getattr(w, "pane_current_command", "") or "") in live_provider
+            and not getattr(w, "pane_dead", False)
+        ]
+        # Prefer live provider panes; fall back to any non-dead pane;
+        # last-resort fall back to the first match (caller still gets a
+        # usable target rather than a hard failure).
+        candidates = (
+            live_matches
+            or [w for w in matches if not getattr(w, "pane_dead", False)]
+            or matches
+        )
+        chosen = min(candidates, key=lambda w: getattr(w, "index", 0))
+        self._emit_cockpit_audit(
+            event_name="cockpit.duplicate_resolution",
+            subject=window_name,
+            status="warn",
+            metadata={
+                "session_name": session_name,
+                "window_name": window_name,
+                "all_indices": [getattr(w, "index", None) for w in matches],
+                "live_provider_indices": [getattr(w, "index", None) for w in live_matches],
+                "chosen_index": getattr(chosen, "index", None),
+                "chosen_pane_id": getattr(chosen, "pane_id", None),
+                "chosen_command": getattr(chosen, "pane_current_command", None),
+                "reason": (
+                    "live_provider_pane"
+                    if chosen in live_matches
+                    else "non_dead_fallback"
+                    if not getattr(chosen, "pane_dead", False)
+                    else "first_match_fallback"
+                ),
+            },
+        )
+        return chosen
+
     def _emit_cockpit_audit(
         self,
         *,
@@ -2677,7 +2750,13 @@ class CockpitRouter:
             storage = supervisor.storage_closet_session_name()
             try:
                 storage_windows = self.tmux.list_windows(storage)
-                target_win = next((w for w in storage_windows if w.name == window_name), None)
+                # #1631 — same duplicate-window logic as ``_show_live_session``.
+                # Task windows can also accumulate park-collision duplicates;
+                # the user clicking a task expects their in-progress worker,
+                # not a fresh placeholder.
+                target_win = self._select_storage_window_for_mount(
+                    storage_windows, window_name, window_name,
+                )
                 if target_win is not None:
                     self._park_mounted_session(supervisor, window_target)
                     self._cleanup_extra_panes(window_target)
@@ -3277,12 +3356,14 @@ class CockpitRouter:
                     item for item in launches
                     if item.session.name == session_name
                 )
-                target_window = next(
-                    (
-                        window for window in self.tmux.list_windows(storage_session)
-                        if window.name == launch.window_name
-                    ),
-                    None,
+                # #1631 — duplicate-aware selection. Freshly-created
+                # workers are unlikely to collide, but a stale window
+                # of the same name (e.g. from a prior aborted launch)
+                # would silently misroute the mount.
+                target_window = self._select_storage_window_for_mount(
+                    self.tmux.list_windows(storage_session),
+                    launch.window_name,
+                    session_name,
                 )
                 if target_window is not None:
                     source_pane_id = getattr(target_window, "pane_id", None)
@@ -3510,10 +3591,13 @@ class CockpitRouter:
                         # Look up the freshly-spawned window's index so
                         # the persisted identity records the
                         # disambiguating index, not just the name.
+                        # #1631 — if a duplicate exists (e.g. an orphan
+                        # left from a park-collision), prefer the live
+                        # provider pane so we don't mount onto the empty
+                        # placeholder and lose the user's conversation.
                         live_windows = self.tmux.list_windows(storage_session)
-                        target_window_for_identity = next(
-                            (w for w in live_windows if w.name == launch.window_name),
-                            None,
+                        target_window_for_identity = self._select_storage_window_for_mount(
+                            live_windows, launch.window_name, session_name,
                         )
                         source_pane_id = (
                             getattr(target_window_for_identity, "pane_id", None)
@@ -3590,11 +3674,17 @@ class CockpitRouter:
             state["right_pane_id"] = self._right_pane_id(window_target)
             self._write_state(state)
             return
-        # Use window index to avoid ambiguity with duplicate window names
+        # Use window index to avoid ambiguity with duplicate window names.
+        # #1631 — when duplicates exist (park-collisions can leave two
+        # ``pm-operator`` windows in the closet, one stale empty and one
+        # with the user's live Polly conversation), pick the one whose
+        # pane is actually running ``claude``/``codex``. The naive
+        # ``next(...)`` here used to grab whatever tmux returned first
+        # (lowest index), which silently mounted onto the empty
+        # placeholder and the user saw a fresh standing-by prompt.
         storage_windows = self.tmux.list_windows(storage_session)
-        target_window = next(
-            (w for w in storage_windows if w.name == launch.window_name),
-            None,
+        target_window = self._select_storage_window_for_mount(
+            storage_windows, launch.window_name, session_name,
         )
         if target_window is None:
             fallback_kind = "polly" if session_name == "operator" else "project"

--- a/tests/test_cockpit_rail_duplicate_resolution.py
+++ b/tests/test_cockpit_rail_duplicate_resolution.py
@@ -1,0 +1,193 @@
+"""#1631 — duplicate-window mount picks the live-provider pane.
+
+When park-collisions leave two ``pm-operator`` windows in the storage
+closet (one stale empty, one with the user's live Polly conversation),
+the rail's mount code must pick the live one. The pre-#1631 mount used
+``next(w for w in windows if w.name == window_name)`` which always
+picked the lowest-index window — and in Sam's repro that was the empty
+placeholder, so clicking back to Polly silently mounted onto a fresh
+``claude`` session and the in-progress conversation was orphaned in the
+other (higher-index) window. #1563's conservative cleanup correctly
+refused to kill either, so the loss became persistent.
+
+These tests pin the new contract for ``_select_storage_window_for_mount``:
+prefer ``claude`` / ``codex`` / ``node`` panes; do not kill the loser;
+emit a ``cockpit.duplicate_resolution`` audit event so forensics can
+trace which window won and why.
+"""
+
+from __future__ import annotations
+
+from pollypm.cockpit_rail import CockpitRouter
+from pollypm.tmux.client import TmuxWindow
+
+
+def _window(
+    *,
+    index: int,
+    name: str,
+    pane_current_command: str = "zsh",
+    pane_dead: bool = False,
+    session: str = "pollypm-storage-closet",
+) -> TmuxWindow:
+    return TmuxWindow(
+        session=session,
+        index=index,
+        name=name,
+        active=False,
+        pane_id=f"%{index}",
+        pane_current_command=pane_current_command,
+        pane_current_path="/tmp",
+        pane_dead=pane_dead,
+        pane_pid=10_000 + index,
+    )
+
+
+def _bare_router() -> CockpitRouter:
+    router = CockpitRouter.__new__(CockpitRouter)
+    return router
+
+
+def _capture_audit(router: CockpitRouter) -> list[dict]:
+    emitted: list[dict] = []
+
+    def _record(*, event_name, subject, status, metadata):
+        emitted.append(
+            {
+                "event": event_name,
+                "subject": subject,
+                "status": status,
+                "metadata": metadata,
+            }
+        )
+
+    router._emit_cockpit_audit = _record  # type: ignore[assignment]
+    return emitted
+
+
+def test_no_match_returns_none() -> None:
+    router = _bare_router()
+    emitted = _capture_audit(router)
+    result = router._select_storage_window_for_mount(
+        [_window(index=0, name="pm-russell")],
+        "pm-operator",
+        "operator",
+    )
+    assert result is None
+    assert emitted == []
+
+
+def test_single_match_returns_it_without_audit() -> None:
+    router = _bare_router()
+    emitted = _capture_audit(router)
+    only = _window(index=1, name="pm-operator", pane_current_command="claude")
+    result = router._select_storage_window_for_mount(
+        [only], "pm-operator", "operator",
+    )
+    assert result is only
+    # No duplicate → no audit noise. Common path.
+    assert emitted == []
+
+
+def test_duplicate_prefers_live_claude_over_empty_placeholder() -> None:
+    """The smoking-gun scenario from #1631.
+
+    Index 1 is an empty placeholder shell. Index 42 is the user's
+    in-progress Polly conversation running ``claude``. The pre-fix code
+    picked index 1 and wiped the conversation. The fix picks index 42.
+    """
+    router = _bare_router()
+    emitted = _capture_audit(router)
+    placeholder = _window(index=1, name="pm-operator", pane_current_command="zsh")
+    live = _window(index=42, name="pm-operator", pane_current_command="claude")
+    result = router._select_storage_window_for_mount(
+        [placeholder, live, _window(index=2, name="pm-russell")],
+        "pm-operator",
+        "operator",
+    )
+    assert result is live
+    assert len(emitted) == 1
+    event = emitted[0]
+    assert event["event"] == "cockpit.duplicate_resolution"
+    assert event["subject"] == "pm-operator"
+    assert event["status"] == "warn"
+    assert event["metadata"]["chosen_index"] == 42
+    assert event["metadata"]["chosen_command"] == "claude"
+    assert event["metadata"]["reason"] == "live_provider_pane"
+    assert sorted(event["metadata"]["all_indices"]) == [1, 42]
+    assert event["metadata"]["live_provider_indices"] == [42]
+
+
+def test_duplicate_prefers_codex_node_pane() -> None:
+    """Codex panes show up as ``node`` in tmux."""
+    router = _bare_router()
+    _capture_audit(router)
+    placeholder = _window(index=0, name="pm-operator", pane_current_command="bash")
+    live = _window(index=5, name="pm-operator", pane_current_command="node")
+    result = router._select_storage_window_for_mount(
+        [placeholder, live], "pm-operator", "operator",
+    )
+    assert result is live
+
+
+def test_duplicate_with_two_live_providers_picks_lowest_index() -> None:
+    """Tie-break: when both windows have a live provider, pick lowest index.
+
+    This is the truly-ambiguous case. Deterministic tie-break keeps
+    behavior reproducible; the operator can investigate via the audit
+    event metadata.
+    """
+    router = _bare_router()
+    emitted = _capture_audit(router)
+    a = _window(index=3, name="pm-operator", pane_current_command="claude")
+    b = _window(index=7, name="pm-operator", pane_current_command="claude")
+    result = router._select_storage_window_for_mount(
+        [b, a], "pm-operator", "operator",
+    )
+    assert result is a  # lower index wins
+    assert emitted[0]["metadata"]["reason"] == "live_provider_pane"
+    assert emitted[0]["metadata"]["chosen_index"] == 3
+
+
+def test_duplicate_with_no_live_provider_falls_back_to_non_dead() -> None:
+    """When neither pane runs claude/codex, prefer the non-dead one.
+
+    This is a degraded-path safety net — the user still gets a usable
+    pane rather than a hard refusal to mount.
+    """
+    router = _bare_router()
+    emitted = _capture_audit(router)
+    dead = _window(index=0, name="pm-operator", pane_current_command="zsh", pane_dead=True)
+    alive_shell = _window(index=8, name="pm-operator", pane_current_command="zsh")
+    result = router._select_storage_window_for_mount(
+        [dead, alive_shell], "pm-operator", "operator",
+    )
+    assert result is alive_shell
+    assert emitted[0]["metadata"]["reason"] == "non_dead_fallback"
+
+
+def test_select_never_kills_loser() -> None:
+    """The selector picks a winner but must NOT kill the loser.
+
+    #1563's conservative cleanup is responsible for reaping the
+    duplicate after its pane dies. The selector only resolves which
+    window to attach to. Killing here re-introduces the #1562 wipe by a
+    different code path.
+    """
+
+    class _TrackingTmux:
+        def __init__(self) -> None:
+            self.killed: list[str] = []
+
+        def kill_window(self, target: str) -> None:
+            self.killed.append(target)
+
+    router = _bare_router()
+    router.tmux = _TrackingTmux()  # type: ignore[attr-defined]
+    _capture_audit(router)
+    placeholder = _window(index=1, name="pm-operator", pane_current_command="zsh")
+    live = _window(index=42, name="pm-operator", pane_current_command="claude")
+    router._select_storage_window_for_mount(
+        [placeholder, live], "pm-operator", "operator",
+    )
+    assert router.tmux.killed == []


### PR DESCRIPTION
## Summary

Closes #1631 — Sam lost an in-progress Polly conversation by clicking away and back. The storage closet had two ``pm-operator`` windows (one stale placeholder, one with the live ``claude`` process), and the rail's mount code picked the wrong one. ``_cleanup_duplicate_windows`` correctly refused to kill either (both live), so the orphan persisted but the wipe was already done.

- Adds ``CockpitRouter._select_storage_window_for_mount`` which picks the duplicate whose pane is currently running ``claude`` / ``codex`` / ``node`` (deterministic tie-break by lowest index).
- Emits ``cockpit.duplicate_resolution`` so the forensics trail shows which window won and why. Does NOT kill the loser — #1563's conservative cleanup reaps it once its pane dies.
- Wires the helper into every rail mount path that resolves a storage-closet window by name: ``_show_live_session`` (main mount + relaunch retry), ``_route_project_selection`` task mount, and the post-create-worker mount in ``create_worker_and_route``.

## What is intentionally not changed
- #1563's conservative-cleanup behavior — still correct, untouched.
- #1595's ``cockpit.session_parked`` / ``cockpit.duplicate_window_killed`` emits — still correct, untouched.
- The duplicate-**creation** root cause is upstream in the park-collision path and not addressed here; this PR makes the mount idempotent so the user-visible wipe stops while the upstream fix lands separately. The loser duplicate becomes a leak that ``pm reset --force`` or the conservative cleanup will reap.

## Before / after — when duplicates can be created
The forensics in the issue show ``live_duplicates=[1, 42]``. Pre-fix: the mount picked window 1 (lowest index, empty placeholder) and the user saw a fresh ``claude`` session. Post-fix: the mount picks window 42 (live ``claude``) so the user's conversation comes back. Duplicates can still appear when ``_park_mounted_session`` calls ``tmux break-pane -n pm-operator`` while a same-named window already exists in the closet (tmux happily creates a second one); the upstream fix for that root cause is out of scope for the P0.

## Test plan
- [x] New regression tests in ``tests/test_cockpit_rail_duplicate_resolution.py`` cover: smoking-gun scenario (index 1 placeholder vs index 42 ``claude`` → picks 42), codex/``node`` panes, two-live tie-break (lowest index), no-live-provider fallback to non-dead, selector never kills any window.
- [x] ``tests/test_cockpit_rail_duplicate_window_cleanup.py`` (existing #1563/#1595 contract): all 6 pass — conservative cleanup behavior unchanged.
- [x] ``tests/test_cockpit_rail_overflow_indicator.py``: all pass.
- [x] ``tests/test_cockpit_rail*.py`` full sweep: 54/54 pass.
- [x] ``tests/test_cockpit.py``: 194/194 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)