### PR TITLE
feat(task): auto-add worker+reviewer roles for standard flow (#1629)

### DIFF
--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -677,8 +677,30 @@ def task_create(
         k, v = _parse_role(r)
         roles[k] = v
 
+    # #1629 — Sensible-default: when the operator (or agent) runs
+    # ``pm task create`` on the default ``standard`` flow without any
+    # ``--role`` flags, auto-populate worker + reviewer with the
+    # canonical fallback agents. This eliminates the trial-and-error
+    # "Required task roles are missing" loop that Polly + architect
+    # agents hit on every cold-start task creation. The auto-default is
+    # narrowly scoped: only fires for ``flow == "standard"`` AND when
+    # the caller passed zero ``--role`` flags, so existing flows /
+    # explicit assignments are unaffected.
+    auto_added_roles: list[str] = []
+    if flow == "standard" and not roles:
+        roles = {"worker": "worker", "reviewer": "reviewer"}
+        auto_added_roles = ["worker", "reviewer"]
+
     ac_text = "\n".join(acceptance_criteria) if acceptance_criteria else None
     constraints_text = "\n".join(constraints) if constraints else None
+
+    if auto_added_roles and not output_json:
+        typer.echo(
+            "Notice: auto-added required roles: "
+            f"{', '.join(auto_added_roles)} "
+            "(override with --role <role>=<agent>).",
+            err=True,
+        )
 
     svc = _svc(db, project=project)
     task = _run(

--- a/tests/test_work_cli.py
+++ b/tests/test_work_cli.py
@@ -633,11 +633,46 @@ class TestCliJsonOutput:
 
 class TestCliErrors:
     def test_cli_create_missing_roles_shows_fix_without_traceback(self, db_path):
+        # #1629 — the ``standard`` flow now auto-adds worker + reviewer
+        # when no ``--role`` flags are supplied, so the missing-roles
+        # gate has to be exercised against a flow that does NOT
+        # auto-default (the ``bug`` flow also requires worker +
+        # reviewer but isn't covered by the auto-default).
         result = runner.invoke(
             task_app,
             [
                 "create",
                 "Missing roles",
+                "--project",
+                "proj",
+                "--flow",
+                "bug",
+                "--db",
+                db_path,
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Traceback" not in result.output
+        assert "✗ Required task roles are missing." in result.output
+        assert "Why: flow 'bug' requires worker, reviewer." in result.output
+        # Tightened post-savethenovel: the fix-suggestion now spells out
+        # legal agent values and explicitly warns against ``user``.
+        assert "--role worker=<agent> --role reviewer=<agent>" in result.output
+        assert "architect, reviewer, worker, polly, russell, triage" in result.output
+        assert "NOT `user`" in result.output
+
+    def test_cli_create_auto_adds_roles_for_standard_flow(self, db_path):
+        # #1629 — sensible-default for ``pm task create`` on the
+        # ``standard`` flow: when no ``--role`` flags are supplied,
+        # auto-populate worker + reviewer so the agent doesn't have to
+        # trial-and-error its way through the role contract on every
+        # cold-start task creation.
+        result = runner.invoke(
+            task_app,
+            [
+                "create",
+                "Auto-roled task",
                 "--project",
                 "proj",
                 "--flow",
@@ -647,15 +682,48 @@ class TestCliErrors:
             ],
         )
 
+        assert result.exit_code == 0, result.output
+        assert "Created proj/1" in result.output
+        # Notice is on stderr (mixed_stderr default keeps it in output).
+        assert "auto-added required roles: worker, reviewer" in result.output
+
+        # The created task should have worker + reviewer bound so it
+        # can progress through the standard flow without a follow-up
+        # ``pm task update --role``.
+        from pollypm.work.sqlite_service import SQLiteWorkService
+
+        svc = SQLiteWorkService(db_path=db_path)
+        try:
+            task = svc.get("proj/1")
+            assert task.roles.get("worker") == "worker"
+            assert task.roles.get("reviewer") == "reviewer"
+        finally:
+            svc.close()
+
+    def test_cli_create_explicit_role_disables_auto_add(self, db_path):
+        # #1629 — when the operator passes ANY ``--role`` flag, the
+        # auto-default must NOT fire. (Otherwise we'd quietly stomp on
+        # an intentional partial role assignment.)
+        result = runner.invoke(
+            task_app,
+            [
+                "create",
+                "Partial role task",
+                "--project",
+                "proj",
+                "--flow",
+                "standard",
+                "--role",
+                "worker=architect",
+                "--db",
+                db_path,
+            ],
+        )
+
+        # Missing reviewer trips the role-gate (no auto-default).
         assert result.exit_code == 1
-        assert "Traceback" not in result.output
+        assert "auto-added required roles" not in result.output
         assert "✗ Required task roles are missing." in result.output
-        assert "Why: flow 'standard' requires worker, reviewer." in result.output
-        # Tightened post-savethenovel: the fix-suggestion now spells out
-        # legal agent values and explicitly warns against ``user``.
-        assert "--role worker=<agent> --role reviewer=<agent>" in result.output
-        assert "architect, reviewer, worker, polly, russell, triage" in result.output
-        assert "NOT `user`" in result.output
 
     def test_cli_get_missing_task_includes_why_fix_and_suggestion(self, db_path):
         _create_task(db_path, title="Only task")
@@ -765,8 +833,11 @@ class TestCliCreateRoleAgentValidation:
     def test_required_role_gate_still_fires_for_missing_role(self, db_path):
         # When ``--role`` is omitted entirely we should still hit the
         # "Required task roles are missing" gate, not the new
-        # invalid-agent gate.
-        result = self._create(db_path, [])
+        # invalid-agent gate. #1629: ``standard`` flow now auto-adds
+        # roles when ``--role`` is omitted, so exercise the gate via
+        # the ``bug`` flow (which also requires worker + reviewer but
+        # is NOT covered by the auto-default).
+        result = self._create(db_path, [], flow="bug")
         assert result.exit_code == 1
         assert "✗ Required task roles are missing." in result.output
 


### PR DESCRIPTION
## Summary
- `pm task create` on the default `standard` flow now auto-populates `worker` + `reviewer` when no `--role` flags are supplied. Prints a notice line so the operator can override.
- Eliminates the trial-and-error "Required task roles are missing" loop that Polly + architect agents hit on every cold-start task creation (per #1629).
- Narrowly scoped: only fires for `flow == "standard"` AND when zero `--role` flags are passed. Any explicit `--role` (even a partial one) disables the auto-default so intentional assignments aren't stomped on. Other flows keep the existing missing-role gate.

## What's left from #1629
This PR is the smallest defensible wedge (item 1 from the issue prompt). Two items deferred:

- **`task queue --reason` flag-name suggestion fix**: Click's `NoSuchOption` "Did you mean '--json'?" hint comes from Click's built-in Levenshtein suggester, not PollyPM code. Customising per-command requires either a custom Click context or monkeypatching Click's parser — both higher-risk than a v1 RC wedge warrants. Will follow up with a separate PR (possibly: add a `--reason` option to `task queue` that records a context entry, which would simultaneously make the flag useful and short-circuit the suggestion).
- **`pm task context <id>` / `pm task transitions <id>` inspection CLIs** + **agent handbook** + **`cli-reference --json`**: separate larger pieces of work.

Will leave a comment on #1629 tracking the deferred items.

## Test plan
- [x] `pytest tests/test_work_cli.py` — 60 passed
- [x] Added 2 new tests: auto-add succeeds, partial `--role` disables auto-add
- [x] Updated 2 existing tests that exercised the missing-role gate via `--flow standard` to use `--flow bug` instead (same gate, no auto-default)
- [x] Smoke-tested via `CliRunner`: `pm task create "smoke" --project proj` succeeds with notice on stderr

Generated with [Claude Code](https://claude.com/claude-code)