### PR TITLE
fix(cockpit): make park idempotent against same-named storage windows (#1635)

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -193,9 +193,18 @@ EVENT_SESSION_PROVISIONED = "session.provisioned"
 #   ``action="skipped_live_duplicates"`` fires instead. Metadata:
 #   ``storage_session``, ``window_name``, ``killed_index`` (kill path)
 #   or ``live_duplicates`` (skip path), ``kept_indices``.
+# * ``EVENT_COCKPIT_PARK_SKIPPED_EXISTING`` — fires when
+#   ``_park_mounted_session`` detects that the storage closet already
+#   has a live window of the same name and refuses to call
+#   ``tmux break-pane`` (which would otherwise create a duplicate-named
+#   second window — the upstream root cause of #1635). Status
+#   ``"warn"``. Metadata: ``session_name``, ``window_name``,
+#   ``storage_session``, ``live_duplicate_indices``,
+#   ``dead_duplicate_indices``, ``reason``.
 EVENT_COCKPIT_SESSION_PARKED = "cockpit.session_parked"
 EVENT_COCKPIT_SESSION_RESPAWNED = "cockpit.session_respawned"
 EVENT_COCKPIT_DUPLICATE_WINDOW_KILLED = "cockpit.duplicate_window_killed"
+EVENT_COCKPIT_PARK_SKIPPED_EXISTING = "cockpit.park_skipped_existing"
 # #1570 — emitted once per row that ``pm inbox backfill-kinds --commit``
 # reclassifies from ``kind='legacy'`` to a real
 # :class:`pollypm.inbox.kind.InboxItemKind`. Carries ``msg_id``,
@@ -583,6 +592,7 @@ __all__ = [
     "EVENT_COCKPIT_SESSION_PARKED",
     "EVENT_COCKPIT_SESSION_RESPAWNED",
     "EVENT_COCKPIT_DUPLICATE_WINDOW_KILLED",
+    "EVENT_COCKPIT_PARK_SKIPPED_EXISTING",
     "EVENT_INBOX_KIND_BACKFILLED",
     "AuditEvent",
     "central_log_path",

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -3812,6 +3812,66 @@ class CockpitRouter:
             self._release_cockpit_lease(supervisor, mounted_session)
             return
         storage_session = supervisor.storage_closet_session_name()
+        try:
+            storage_windows_before = self.tmux.list_windows(storage_session)
+        except Exception:  # noqa: BLE001
+            storage_windows_before = []
+        # #1635 — make break-pane idempotent against existing duplicates.
+        # Prior behavior unconditionally called ``tmux break-pane -n
+        # <window_name>``, which silently created a SECOND window with
+        # the same name when one was already present in the storage
+        # closet. The most painful repro: Sam clicks Polly → parks → the
+        # cockpit's right pane is broken into storage as a fresh
+        # ``pm-operator`` even though storage already had a live
+        # ``pm-operator`` window with the in-progress conversation.
+        # On the next mount, #1632's selector picked the wrong one
+        # (both are live) and Sam saw a fresh Polly re-asking the same
+        # 4 onboarding questions — the duplicate window held the
+        # original conversation.
+        existing_same_name = [
+            w for w in storage_windows_before
+            if getattr(w, "name", None) == window_name
+        ]
+        live_existing = [
+            w for w in existing_same_name
+            if self._storage_window_is_live(w)
+        ]
+        dead_existing = [
+            w for w in existing_same_name
+            if not self._storage_window_is_live(w)
+        ]
+        if live_existing:
+            # A live duplicate already owns ``window_name`` in storage —
+            # the existing window IS the persistent home. Skip the
+            # break-pane entirely. The caller's subsequent
+            # ``respawn_pane`` on our right pane will discard the
+            # duplicate process we would otherwise have parked.
+            state.pop("mounted_session", None)
+            state.pop("mounted_identity", None)
+            self._write_state(state)
+            self._release_cockpit_lease(supervisor, mounted_session)
+            self._emit_cockpit_audit(
+                event_name="cockpit.park_skipped_existing",
+                subject=mounted_session,
+                status="warn",
+                metadata={
+                    "session_name": mounted_session,
+                    "window_name": window_name,
+                    "storage_session": storage_session,
+                    "live_duplicate_indices": [w.index for w in live_existing],
+                    "dead_duplicate_indices": [w.index for w in dead_existing],
+                    "reason": "live_existing_storage_window",
+                },
+            )
+            return
+        # Re-occupy any stale (pane-dead) windows that already hold the
+        # name so break-pane lands at the canonical name rather than
+        # falling back to a tmux-generated suffix.
+        for window in dead_existing:
+            try:
+                self.tmux.kill_window(f"{storage_session}:{window.index}")
+            except Exception:  # noqa: BLE001
+                continue
         before = {(window.index, window.name) for window in self.tmux.list_windows(storage_session)}
         self.tmux.break_pane(right_pane_id, storage_session, window_name)
         after = self.tmux.list_windows(storage_session)
@@ -3839,8 +3899,29 @@ class CockpitRouter:
                 "window_name": window_name,
                 "storage_session": storage_session,
                 "storage_windows_after": sorted(w.name for w in after),
+                "reoccupied_dead_indices": [w.index for w in dead_existing],
             },
         )
+
+    def _storage_window_is_live(self, window) -> bool:
+        """Return True iff ``window``'s pane is alive and running a provider.
+
+        #1635 — mirrors :meth:`_select_storage_window_for_mount`'s
+        live-provider definition (``claude`` / ``codex`` / ``node``) so
+        the park-skip guard and the mount selector agree on what counts
+        as a live duplicate. A pane reporting any other ``pane_current_command``
+        (or marked ``pane_dead``) is treated as not-live and a fresh
+        break-pane will re-occupy the name.
+        """
+        if getattr(window, "pane_dead", False):
+            return False
+        cmd = getattr(window, "pane_current_command", "") or ""
+        if cmd in {"node", "claude", "codex"}:
+            return True
+        # Version-string fallback mirrors ``_is_live_provider_pane``.
+        if cmd and all(c.isdigit() or c == "." for c in cmd):
+            return True
+        return False
 
     # Roles that should NEVER be auto-detected as mounted via CWD fallback.
     # These are background roles — if the user is looking at a pane, it's

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4217,6 +4217,289 @@ def test_cockpit_router_parks_mounted_task_worker(monkeypatch, tmp_path: Path) -
     assert calls["released"] == ("task-demo-7", "cockpit")
 
 
+def test_cockpit_router_park_skips_when_live_duplicate_exists(monkeypatch, tmp_path: Path) -> None:
+    """#1635 — ``_park_mounted_session`` must NOT call ``tmux break-pane``
+    when the storage closet already holds a live window of the same
+    name. Prior behavior unconditionally broke the cockpit's right
+    pane into storage as a fresh ``pm-operator`` window, leaving two
+    same-named windows in storage; #1632's mount selector then often
+    picked the wrong one and the user saw a fresh Polly re-asking the
+    same onboarding questions.
+
+    Regression contract:
+      * ``break_pane`` is never called when a live duplicate exists.
+      * ``rename_window`` is never called.
+      * mounted-session state and cockpit lease are still released.
+      * A ``cockpit.park_skipped_existing`` audit event fires with the
+        live-duplicate indices captured in metadata.
+      * Calling ``_park_mounted_session`` a second time is still a
+        no-op — only one ``pm-operator`` window remains in storage
+        (park → park again → still one window).
+    """
+    calls: dict[str, object] = {}
+    audit_events: list[dict[str, object]] = []
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+
+    class FakeSupervisor:
+        def plan_launches(self):
+            return []
+
+        def storage_closet_session_name(self) -> str:
+            return "pollypm-storage-closet"
+
+        def release_lease(self, session_name: str, expected_owner: str | None = None) -> None:
+            calls.setdefault("released", []).append((session_name, expected_owner))
+
+    class FakeWindow:
+        def __init__(
+            self,
+            index: int,
+            name: str,
+            command: str = "",
+            pane_dead: bool = False,
+        ) -> None:
+            self.index = index
+            self.name = name
+            self.pane_current_command = command
+            self.pane_dead = pane_dead
+
+    class FakePane:
+        def __init__(self, pane_id: str, pane_left: int, command: str) -> None:
+            self.pane_id = pane_id
+            self.pane_left = pane_left
+            self.pane_current_command = command
+            self.pane_dead = False
+
+    storage_state = {
+        "windows": [
+            # The persistent home — a live Polly conversation already
+            # parked in the closet from a prior session.
+            FakeWindow(1, "pm-operator", command="claude"),
+        ],
+    }
+
+    class FakeTmux:
+        def list_panes(self, target: str):
+            return [
+                FakePane("%1", 0, "uv"),
+                FakePane("%2", 30, "node"),
+            ]
+
+        def list_windows(self, target: str):
+            assert target == "pollypm-storage-closet"
+            return list(storage_state["windows"])
+
+        def break_pane(self, source: str, target_session: str, window_name: str) -> None:
+            # Mirror real tmux: append a new window with the requested name.
+            calls.setdefault("break", []).append((source, target_session, window_name))
+            next_index = max(
+                (w.index for w in storage_state["windows"]),
+                default=0,
+            ) + 1
+            storage_state["windows"].append(
+                FakeWindow(next_index, window_name, command="claude")
+            )
+
+        def rename_window(self, target: str, name: str) -> None:
+            calls.setdefault("renamed", []).append((target, name))
+
+        def kill_window(self, target: str) -> None:
+            calls.setdefault("killed", []).append(target)
+            # Drop matching window by "session:index" suffix.
+            suffix = target.split(":", 1)[1]
+            try:
+                idx = int(suffix)
+            except ValueError:
+                return
+            storage_state["windows"] = [
+                w for w in storage_state["windows"] if w.index != idx
+            ]
+
+    router = CockpitRouter(config_path)
+    router.tmux = FakeTmux()  # type: ignore[assignment]
+    monkeypatch.setattr(router, "_load_supervisor", lambda fresh=False: FakeSupervisor())
+    monkeypatch.setattr(
+        router,
+        "_mounted_window_name",
+        lambda supervisor, session_name: "pm-operator",
+    )
+    monkeypatch.setattr(
+        router,
+        "_emit_cockpit_audit",
+        lambda *, event_name, subject, status, metadata: audit_events.append(
+            {
+                "event_name": event_name,
+                "subject": subject,
+                "status": status,
+                "metadata": metadata,
+            }
+        ),
+    )
+    router._write_state({"mounted_session": "operator-pm", "right_pane_id": "%2"})
+
+    # First park: storage already has a LIVE pm-operator window. The
+    # park must be a no-op (no break-pane, no rename) to prevent the
+    # upstream duplicate creation.
+    router._park_mounted_session(FakeSupervisor(), "pollypm:PollyPM")
+
+    assert "break" not in calls, "break-pane must not run when a live duplicate exists"
+    assert "renamed" not in calls
+    assert calls["released"] == [("operator-pm", "cockpit")]
+    assert len(storage_state["windows"]) == 1
+    assert storage_state["windows"][0].name == "pm-operator"
+
+    skip_events = [e for e in audit_events if e["event_name"] == "cockpit.park_skipped_existing"]
+    assert len(skip_events) == 1
+    skip = skip_events[0]
+    assert skip["subject"] == "operator-pm"
+    assert skip["status"] == "warn"
+    assert skip["metadata"]["live_duplicate_indices"] == [1]
+    assert skip["metadata"]["window_name"] == "pm-operator"
+    assert skip["metadata"]["storage_session"] == "pollypm-storage-closet"
+
+    # State is cleared so the next mount won't think we still own the
+    # cockpit right pane.
+    state = router._load_state()
+    assert "mounted_session" not in state
+    assert "mounted_identity" not in state
+
+    # Park again — same conditions, still a no-op, still ONE window.
+    router._write_state({"mounted_session": "operator-pm", "right_pane_id": "%2"})
+    router._park_mounted_session(FakeSupervisor(), "pollypm:PollyPM")
+
+    assert "break" not in calls
+    assert len(storage_state["windows"]) == 1, (
+        "park → park again must leave exactly one pm-operator window — "
+        "regression for #1635 duplicate-window creation"
+    )
+
+
+def test_cockpit_router_park_reoccupies_dead_storage_window(monkeypatch, tmp_path: Path) -> None:
+    """#1635 — when the storage closet has a stale (pane-dead) window
+    of the same name, ``_park_mounted_session`` kills the dead window
+    BEFORE calling ``tmux break-pane`` so the freshly-parked pane
+    re-occupies the canonical name instead of landing as a second,
+    duplicate-named window.
+    """
+    calls: dict[str, object] = {}
+    audit_events: list[dict[str, object]] = []
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\nbase_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+
+    class FakeSupervisor:
+        def plan_launches(self):
+            return []
+
+        def storage_closet_session_name(self) -> str:
+            return "pollypm-storage-closet"
+
+        def release_lease(self, session_name: str, expected_owner: str | None = None) -> None:
+            calls["released"] = (session_name, expected_owner)
+
+    class FakeWindow:
+        def __init__(
+            self,
+            index: int,
+            name: str,
+            command: str = "",
+            pane_dead: bool = False,
+        ) -> None:
+            self.index = index
+            self.name = name
+            self.pane_current_command = command
+            self.pane_dead = pane_dead
+
+    class FakePane:
+        def __init__(self, pane_id: str, pane_left: int, command: str) -> None:
+            self.pane_id = pane_id
+            self.pane_left = pane_left
+            self.pane_current_command = command
+            self.pane_dead = False
+
+    storage_state = {
+        "windows": [
+            FakeWindow(1, "pm-operator", command="zsh", pane_dead=True),
+        ],
+    }
+
+    class FakeTmux:
+        def list_panes(self, target: str):
+            return [
+                FakePane("%1", 0, "uv"),
+                FakePane("%2", 30, "node"),
+            ]
+
+        def list_windows(self, target: str):
+            return list(storage_state["windows"])
+
+        def break_pane(self, source: str, target_session: str, window_name: str) -> None:
+            calls["break"] = (source, target_session, window_name)
+            next_index = max(
+                (w.index for w in storage_state["windows"]),
+                default=0,
+            ) + 1
+            storage_state["windows"].append(
+                FakeWindow(next_index, window_name, command="claude")
+            )
+
+        def rename_window(self, target: str, name: str) -> None:
+            calls.setdefault("renamed", []).append((target, name))
+
+        def kill_window(self, target: str) -> None:
+            calls.setdefault("killed", []).append(target)
+            suffix = target.split(":", 1)[1]
+            try:
+                idx = int(suffix)
+            except ValueError:
+                return
+            storage_state["windows"] = [
+                w for w in storage_state["windows"] if w.index != idx
+            ]
+
+    router = CockpitRouter(config_path)
+    router.tmux = FakeTmux()  # type: ignore[assignment]
+    monkeypatch.setattr(router, "_load_supervisor", lambda fresh=False: FakeSupervisor())
+    monkeypatch.setattr(
+        router,
+        "_mounted_window_name",
+        lambda supervisor, session_name: "pm-operator",
+    )
+    monkeypatch.setattr(
+        router,
+        "_emit_cockpit_audit",
+        lambda *, event_name, subject, status, metadata: audit_events.append(
+            {
+                "event_name": event_name,
+                "subject": subject,
+                "status": status,
+                "metadata": metadata,
+            }
+        ),
+    )
+    router._write_state({"mounted_session": "operator-pm", "right_pane_id": "%2"})
+
+    router._park_mounted_session(FakeSupervisor(), "pollypm:PollyPM")
+
+    # The dead storage window must be killed first.
+    assert calls["killed"] == ["pollypm-storage-closet:1"]
+    # Then break-pane proceeds with the canonical name.
+    assert calls["break"] == ("%2", "pollypm-storage-closet", "pm-operator")
+    # And only one pm-operator window remains.
+    names = [w.name for w in storage_state["windows"]]
+    assert names.count("pm-operator") == 1
+
+    park_events = [e for e in audit_events if e["event_name"] == "cockpit.session_parked"]
+    assert len(park_events) == 1
+    assert park_events[0]["metadata"]["reoccupied_dead_indices"] == [1]
+    # No skip event fires when there are no live duplicates.
+    assert not any(e["event_name"] == "cockpit.park_skipped_existing" for e in audit_events)
+
+
 def test_cockpit_router_validation_releases_stale_cockpit_lease(monkeypatch, tmp_path: Path) -> None:
     calls: dict[str, object] = {}
     config_path = tmp_path / "pollypm.toml"


### PR DESCRIPTION
## Summary
- Closes #1635. `_park_mounted_session` previously called `tmux break-pane -n <window_name>` unconditionally, silently creating a SECOND same-named window in the storage closet when one already existed. After #1632 (the mount-side selector that prefers live panes among duplicates), the upstream duplicate creation was still biting — Polly was observed re-asking the same 4 onboarding questions because two `pm-operator` windows held two independent live Polly conversations.
- Pre-check storage for an existing window of the same name and branch:
  - **Live duplicate**: skip `break-pane` entirely, release the lease, clear state, emit a new `cockpit.park_skipped_existing` warn audit event. The existing live storage window IS the persistent home; the cockpit's right pane is the redundant process that the caller's subsequent `respawn_pane` discards.
  - **Dead duplicate(s)**: `kill-window` them first so `break-pane` lands at the canonical name (not a tmux-suffixed fallback). The park event records `reoccupied_dead_indices`.
  - **No duplicate**: unchanged park path.
- Adds `EVENT_COCKPIT_PARK_SKIPPED_EXISTING = "cockpit.park_skipped_existing"` to `pollypm.audit.log`.

## Test plan
- [x] New `test_cockpit_router_park_skips_when_live_duplicate_exists` — simulates "park → park again" with a live `pm-operator` already in storage; asserts `break_pane` is never called, exactly one window remains, and the `cockpit.park_skipped_existing` audit event fires with `live_duplicate_indices=[1]`.
- [x] New `test_cockpit_router_park_reoccupies_dead_storage_window` — asserts dead duplicate is killed first, `break-pane` then runs, and the park event records `reoccupied_dead_indices=[1]`.
- [x] Existing `test_cockpit_router_parks_mounted_task_worker` still passes (no live duplicate → unchanged break-pane + rename flow).
- [x] Full `tests/test_cockpit.py` (196 tests) and `tests/test_audit_watchdog.py` (95 tests) pass.

## Note
Two failures unrelated to this PR (`test_tmux_pane_window_methods_stay_inside_allowlist`, `test_heartbeat_uses_separate_tmux_session`) reproduce on `main` and are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)