### PR TITLE
fix(cockpit): mount selector falls back to architect-<project> for PM Chat (#1636)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -2342,11 +2342,31 @@ class CockpitRouter:
                     },
                 )
 
+    # #1636 — when the rail mount target is a project's PM persona but
+    # the literal ``window_name`` (taken from ``launch.window_name``) is
+    # not present in storage, the live PM conversation may be running
+    # under a sibling window-name pattern. PollyPM uses
+    # ``architect-<project>`` as the canonical PM-persona window for
+    # non-Polly projects (#1056 documents the hyphen vs underscore drift
+    # between session.name and window_name); workers and Polly-style PM
+    # panes use ``worker-<project>`` and ``pm-<project>``. Ordering here
+    # is "PM persona first" — architect over worker — because Sam's
+    # bikepath repro shows the architect window is what holds the
+    # ongoing conversation while a stale or never-launched worker
+    # session entry can make the literal lookup return None.
+    _PROJECT_PM_WINDOW_PREFIXES: tuple[str, ...] = (
+        "architect-",
+        "pm-",
+        "worker-",
+    )
+
     def _select_storage_window_for_mount(
         self,
         storage_windows: list,
         window_name: str,
         session_name: str,
+        *,
+        project_key: str | None = None,
     ):
         """Pick which storage-closet window to mount when duplicates exist.
 
@@ -2371,6 +2391,78 @@ class CockpitRouter:
             so forensics can trace which window won and why. **Do not**
             kill the loser — #1563's conservative cleanup will reap it
             once its pane dies.
+
+        #1636 — when ``project_key`` is supplied and the literal
+        ``window_name`` produces no match, fall back to project-PM
+        sibling patterns (``architect-<project>``, ``pm-<project>``,
+        ``worker-<project>``) and re-run the live-provider selection.
+        This catches the case where the rail item is a project's PM
+        chat, ``launch.window_name`` is ``worker-<project>`` (or absent
+        from the planner entirely), but the live conversation is in
+        ``architect-<project>`` — Sam's bikepath repro. Emits a
+        ``cockpit.project_pm_fallback_match`` audit event so forensics
+        can see when the fallback fired and which sibling won.
+        """
+        result = self._select_named_storage_window(
+            storage_windows,
+            window_name=window_name,
+            session_name=session_name,
+        )
+        if result is not None or not project_key:
+            return result
+        # #1636 — sibling-pattern fallback. Order matters: ``architect-``
+        # is the canonical PM persona for non-Polly projects, so try it
+        # first even though ``launch.window_name`` may have pointed at a
+        # ``worker-`` sibling.
+        for prefix in self._PROJECT_PM_WINDOW_PREFIXES:
+            sibling_name = f"{prefix}{project_key}"
+            if sibling_name == window_name:
+                continue  # already tried above
+            sibling = self._select_named_storage_window(
+                storage_windows,
+                window_name=sibling_name,
+                session_name=session_name,
+            )
+            if sibling is None:
+                continue
+            # Only accept the sibling when its pane is actually running
+            # a live provider — a stale empty placeholder of the same
+            # name is worse than letting the caller's fallback path
+            # spawn fresh, because the join would tear down the user's
+            # cockpit pane to mount an idle shell.
+            cmd = (getattr(sibling, "pane_current_command", "") or "")
+            if cmd not in {"claude", "codex", "node"} or getattr(sibling, "pane_dead", False):
+                continue
+            self._emit_cockpit_audit(
+                event_name="cockpit.project_pm_fallback_match",
+                subject=window_name,
+                status="warn",
+                metadata={
+                    "session_name": session_name,
+                    "requested_window_name": window_name,
+                    "matched_window_name": sibling_name,
+                    "matched_index": getattr(sibling, "index", None),
+                    "matched_pane_id": getattr(sibling, "pane_id", None),
+                    "matched_command": cmd,
+                    "project_key": project_key,
+                    "reason": "project_pm_sibling_pattern",
+                },
+            )
+            return sibling
+        return None
+
+    def _select_named_storage_window(
+        self,
+        storage_windows: list,
+        *,
+        window_name: str,
+        session_name: str,
+    ):
+        """Inner helper: pick a single window by exact ``window_name``.
+
+        Encapsulates the original #1631 selection logic so the #1636
+        sibling-pattern fallback can reuse it for each candidate name
+        without duplicating the live-provider preference / audit emit.
         """
         matches = [w for w in storage_windows if getattr(w, "name", None) == window_name]
         if not matches:
@@ -2794,10 +2886,24 @@ class CockpitRouter:
             session_name = self._project_session_map(launches).get(project_key)
             if session_name is not None:
                 if not self._session_available_for_mount(supervisor, session_name, window_target):
-                    try:
-                        supervisor.launch_session(session_name)
-                    except Exception:  # noqa: BLE001
-                        pass
+                    # #1636 — before respawning, check whether a sibling
+                    # PM-persona window (architect/worker/pm) is already
+                    # live in storage for this project. ``launch.window_name``
+                    # may point at a worker window that was never started
+                    # while the architect window (the canonical PM persona
+                    # for non-Polly projects) is actively holding the
+                    # user's conversation. Skipping ``launch_session``
+                    # here is the difference between attaching to that
+                    # live architect via the sibling-pattern fallback in
+                    # ``_select_storage_window_for_mount`` and killing it
+                    # off by spawning a fresh worker with the same name.
+                    if not self._project_pm_sibling_window_live(
+                        supervisor, project_key,
+                    ):
+                        try:
+                            supervisor.launch_session(session_name)
+                        except Exception:  # noqa: BLE001
+                            pass
                 try:
                     self._show_live_session(supervisor, session_name, window_target)
                 except Exception:  # noqa: BLE001
@@ -3364,6 +3470,7 @@ class CockpitRouter:
                     self.tmux.list_windows(storage_session),
                     launch.window_name,
                     session_name,
+                    project_key=project_key,
                 )
                 if target_window is not None:
                     source_pane_id = getattr(target_window, "pane_id", None)
@@ -3598,6 +3705,7 @@ class CockpitRouter:
                         live_windows = self.tmux.list_windows(storage_session)
                         target_window_for_identity = self._select_storage_window_for_mount(
                             live_windows, launch.window_name, session_name,
+                            project_key=getattr(launch.session, "project", None),
                         )
                         source_pane_id = (
                             getattr(target_window_for_identity, "pane_id", None)
@@ -3685,6 +3793,7 @@ class CockpitRouter:
         storage_windows = self.tmux.list_windows(storage_session)
         target_window = self._select_storage_window_for_mount(
             storage_windows, launch.window_name, session_name,
+            project_key=getattr(launch.session, "project", None),
         )
         if target_window is None:
             fallback_kind = "polly" if session_name == "operator" else "project"
@@ -3986,6 +4095,52 @@ class CockpitRouter:
         storage_session = supervisor.storage_closet_session_name()
         storage_windows = {window.name for window in self.tmux.list_windows(storage_session)}
         return launch.window_name in storage_windows
+
+    def _project_pm_sibling_window_live(
+        self, supervisor, project_key: str,
+    ) -> bool:
+        """Return True if a PM-persona window for ``project_key`` is live in storage.
+
+        #1636 — the rail's session-mount path treats ``launch.window_name``
+        as the only authoritative pointer to the project's PM. That works
+        for the worker-only case, but bikepath's repro had a stale or
+        unplanned worker entry plus a live ``architect-bikepath`` window
+        holding the ongoing conversation. The literal lookup then
+        triggered ``launch_session`` to "recreate" the missing window,
+        which spawned a fresh codex (PID 45316 in the issue forensics)
+        while the live one (PID 70760) stayed orphaned in storage.
+
+        This pre-check scans the project's canonical PM-persona window
+        names (``architect-<project>``, ``pm-<project>``,
+        ``worker-<project>``) and returns True only when at least one
+        is live — i.e. its pane is running a real provider
+        (``claude`` / ``codex`` / ``node``) and not marked dead. The
+        actual mount happens in ``_show_live_session`` via the
+        sibling-pattern fallback in ``_select_storage_window_for_mount``.
+        """
+        if not project_key:
+            return False
+        try:
+            storage_session = supervisor.storage_closet_session_name()
+        except Exception:  # noqa: BLE001
+            return False
+        try:
+            storage_windows = self.tmux.list_windows(storage_session)
+        except Exception:  # noqa: BLE001
+            return False
+        targets = {
+            f"{prefix}{project_key}" for prefix in self._PROJECT_PM_WINDOW_PREFIXES
+        }
+        live_provider = {"claude", "codex", "node"}
+        for window in storage_windows:
+            if getattr(window, "name", None) not in targets:
+                continue
+            if getattr(window, "pane_dead", False):
+                continue
+            cmd = (getattr(window, "pane_current_command", "") or "")
+            if cmd in live_provider:
+                return True
+        return False
 
     def _show_static_view(
         self,

--- a/tests/test_cockpit_rail_project_pm_fallback.py
+++ b/tests/test_cockpit_rail_project_pm_fallback.py
@@ -1,0 +1,397 @@
+"""#1636 — project PM-persona sibling-pattern fallback for the mount selector.
+
+#1632 / #1631 fixed the cockpit-rail mount path so duplicate ``pm-operator``
+windows in the storage closet resolve to the live one. The fix routes a
+literal ``window_name`` lookup through ``_select_storage_window_for_mount``
+and picks the pane that's actually running ``claude`` / ``codex`` / ``node``.
+
+That left Sam's bikepath repro unfixed: the rail mount target was the
+project's PM chat, but ``launch.window_name`` pointed at ``worker-bikepath``
+(or wasn't present in the planner at all) while the live PM conversation
+lived in ``architect-bikepath``. The literal-only selector returned None,
+the caller respawned a fresh codex, and Sam's 44-minute conversation got
+orphaned in a storage window he could no longer see.
+
+These tests pin the #1636 sibling-pattern fallback: when ``project_key`` is
+supplied and the literal ``window_name`` produces no match, the selector
+tries the project's canonical PM-persona window patterns in priority order
+(``architect-<project>`` first, then ``pm-<project>``, then
+``worker-<project>``) and returns the first one that's running a live
+provider. The selector also exposes a ``_project_pm_sibling_window_live``
+probe so the routing layer can skip ``supervisor.launch_session`` when a
+sibling is already serving the user's conversation.
+"""
+
+from __future__ import annotations
+
+from pollypm.cockpit_rail import CockpitRouter
+from pollypm.tmux.client import TmuxWindow
+
+
+def _window(
+    *,
+    index: int,
+    name: str,
+    pane_current_command: str = "zsh",
+    pane_dead: bool = False,
+    session: str = "pollypm-storage-closet",
+) -> TmuxWindow:
+    return TmuxWindow(
+        session=session,
+        index=index,
+        name=name,
+        active=False,
+        pane_id=f"%{index}",
+        pane_current_command=pane_current_command,
+        pane_current_path="/tmp",
+        pane_dead=pane_dead,
+        pane_pid=10_000 + index,
+    )
+
+
+def _bare_router() -> CockpitRouter:
+    router = CockpitRouter.__new__(CockpitRouter)
+    return router
+
+
+def _capture_audit(router: CockpitRouter) -> list[dict]:
+    emitted: list[dict] = []
+
+    def _record(*, event_name, subject, status, metadata):
+        emitted.append(
+            {
+                "event": event_name,
+                "subject": subject,
+                "status": status,
+                "metadata": metadata,
+            }
+        )
+
+    router._emit_cockpit_audit = _record  # type: ignore[assignment]
+    return emitted
+
+
+def test_no_project_key_keeps_literal_only_behavior() -> None:
+    """Without ``project_key``, the selector behaves exactly as #1631 did.
+
+    Regression guard: callers that don't know the project (Polly,
+    Russell, task windows) must not accidentally pick up an unrelated
+    project's PM window.
+    """
+    router = _bare_router()
+    _capture_audit(router)
+    architect = _window(index=5, name="architect-bikepath", pane_current_command="codex")
+    result = router._select_storage_window_for_mount(
+        [architect], "worker-bikepath", "worker_bikepath",
+    )
+    assert result is None  # no project_key → no fallback
+
+
+def test_project_pm_fallback_prefers_architect_over_worker() -> None:
+    """Sam's bikepath repro.
+
+    ``launch.window_name`` is ``worker-bikepath`` (the planner picked
+    the worker entry) but the live PM conversation is running codex in
+    ``architect-bikepath``. The selector must attach to the architect,
+    not return None and let the caller spawn a fresh codex.
+    """
+    router = _bare_router()
+    emitted = _capture_audit(router)
+    architect = _window(
+        index=38, name="architect-bikepath", pane_current_command="codex",
+    )
+    # An unrelated project's window must not be picked up.
+    unrelated = _window(index=10, name="architect-other", pane_current_command="codex")
+    result = router._select_storage_window_for_mount(
+        [architect, unrelated],
+        "worker-bikepath",
+        "worker_bikepath",
+        project_key="bikepath",
+    )
+    assert result is architect
+    assert len(emitted) == 1
+    event = emitted[0]
+    assert event["event"] == "cockpit.project_pm_fallback_match"
+    assert event["subject"] == "worker-bikepath"
+    assert event["metadata"]["matched_window_name"] == "architect-bikepath"
+    assert event["metadata"]["matched_index"] == 38
+    assert event["metadata"]["matched_command"] == "codex"
+    assert event["metadata"]["project_key"] == "bikepath"
+    assert event["metadata"]["reason"] == "project_pm_sibling_pattern"
+
+
+def test_project_pm_fallback_skips_idle_sibling_shells() -> None:
+    """A stale ``architect-<project>`` shell (zsh, no codex) is worse than None.
+
+    Joining an idle shell would tear down the user's cockpit pane to
+    mount a dead-pane placeholder. The caller's fallback (static project
+    view) is the safer surface.
+    """
+    router = _bare_router()
+    emitted = _capture_audit(router)
+    idle_shell = _window(
+        index=12, name="architect-bikepath", pane_current_command="zsh",
+    )
+    result = router._select_storage_window_for_mount(
+        [idle_shell],
+        "worker-bikepath",
+        "worker_bikepath",
+        project_key="bikepath",
+    )
+    assert result is None
+    # No fallback-match audit because we refused the sibling.
+    fallback_events = [
+        e for e in emitted if e["event"] == "cockpit.project_pm_fallback_match"
+    ]
+    assert fallback_events == []
+
+
+def test_project_pm_fallback_skips_dead_sibling() -> None:
+    """Dead panes are never preferred over a clean None."""
+    router = _bare_router()
+    _capture_audit(router)
+    dead_architect = _window(
+        index=4,
+        name="architect-bikepath",
+        pane_current_command="codex",
+        pane_dead=True,
+    )
+    result = router._select_storage_window_for_mount(
+        [dead_architect],
+        "worker-bikepath",
+        "worker_bikepath",
+        project_key="bikepath",
+    )
+    assert result is None
+
+
+def test_project_pm_fallback_walks_priority_order() -> None:
+    """Architect > pm > worker.
+
+    Worker-name patterns can outnumber architect/pm in a busy project,
+    but the PM persona by convention lives in ``architect-<project>``
+    for non-Polly projects. The ordering test pins that contract.
+    """
+    router = _bare_router()
+    _capture_audit(router)
+    worker = _window(
+        index=2, name="worker-bikepath", pane_current_command="codex",
+    )
+    pm = _window(
+        index=3, name="pm-bikepath", pane_current_command="codex",
+    )
+    architect = _window(
+        index=4, name="architect-bikepath", pane_current_command="codex",
+    )
+    result = router._select_storage_window_for_mount(
+        [worker, pm, architect],
+        "worker-bikepath",  # literal would match worker, but we want architect
+        "worker_bikepath",
+        project_key="bikepath",
+    )
+    # The literal lookup matched ``worker-bikepath`` directly (single
+    # match), so the sibling fallback never fired — this asserts the
+    # fallback only triggers when the literal lookup fails. To force
+    # the architect pick, drop the worker name from storage.
+    assert result is worker
+
+    # Now remove the worker window entirely — the literal lookup fails
+    # and the fallback walks the priority order, picking architect.
+    result_no_worker = router._select_storage_window_for_mount(
+        [pm, architect],
+        "worker-bikepath",
+        "worker_bikepath",
+        project_key="bikepath",
+    )
+    assert result_no_worker is architect
+
+
+def test_project_pm_fallback_falls_through_to_pm_when_no_architect() -> None:
+    """When no architect window exists, fall back to ``pm-<project>``."""
+    router = _bare_router()
+    emitted = _capture_audit(router)
+    pm = _window(
+        index=6, name="pm-bikepath", pane_current_command="codex",
+    )
+    result = router._select_storage_window_for_mount(
+        [pm],
+        "worker-bikepath",
+        "worker_bikepath",
+        project_key="bikepath",
+    )
+    assert result is pm
+    fallback_events = [
+        e for e in emitted if e["event"] == "cockpit.project_pm_fallback_match"
+    ]
+    assert len(fallback_events) == 1
+    assert fallback_events[0]["metadata"]["matched_window_name"] == "pm-bikepath"
+
+
+def test_project_pm_sibling_window_live_finds_architect() -> None:
+    """The pre-mount probe must report True when a live PM sibling exists.
+
+    This is the gate that prevents ``_route_project_selection`` from
+    calling ``supervisor.launch_session`` (which would respawn the
+    planner-named window, killing the live one in the process).
+    """
+    router = _bare_router()
+    architect = _window(
+        index=38, name="architect-bikepath", pane_current_command="codex",
+    )
+
+    class _FakeSupervisor:
+        def storage_closet_session_name(self) -> str:
+            return "pollypm-storage-closet"
+
+    class _FakeTmux:
+        def list_windows(self, _session: str) -> list[TmuxWindow]:
+            return [architect]
+
+    router.tmux = _FakeTmux()  # type: ignore[attr-defined]
+    assert router._project_pm_sibling_window_live(_FakeSupervisor(), "bikepath") is True
+
+
+def test_project_pm_sibling_window_live_ignores_idle_shells() -> None:
+    """An idle ``architect-<project>`` shell does NOT count as a live PM.
+
+    If we treated it as live we'd skip ``launch_session`` and then
+    fail to mount anything useful — the user would see no PM at all,
+    a worse failure than the original respawn.
+    """
+    router = _bare_router()
+    idle_shell = _window(
+        index=12, name="architect-bikepath", pane_current_command="zsh",
+    )
+
+    class _FakeSupervisor:
+        def storage_closet_session_name(self) -> str:
+            return "pollypm-storage-closet"
+
+    class _FakeTmux:
+        def list_windows(self, _session: str) -> list[TmuxWindow]:
+            return [idle_shell]
+
+    router.tmux = _FakeTmux()  # type: ignore[attr-defined]
+    assert router._project_pm_sibling_window_live(_FakeSupervisor(), "bikepath") is False
+
+
+def test_project_pm_sibling_window_live_handles_supervisor_failure() -> None:
+    """Tmux / supervisor exceptions degrade to False, not a hard crash.
+
+    A flaky list_windows call must never block the mount path; the
+    caller will see ``False`` and fall through to its existing
+    ``launch_session`` path — same behavior as before #1636.
+    """
+    router = _bare_router()
+
+    class _FakeSupervisor:
+        def storage_closet_session_name(self) -> str:
+            raise RuntimeError("tmux server gone")
+
+    assert router._project_pm_sibling_window_live(_FakeSupervisor(), "bikepath") is False
+
+
+def test_route_project_selection_skips_launch_when_architect_sibling_is_live() -> None:
+    """#1636 integration regression: bikepath PM from rail → attach to
+    architect-bikepath, do NOT spawn a fresh codex via launch_session.
+
+    Setup matches the issue forensics:
+      * Planner returns ``worker_bikepath`` (worker entry in config).
+      * Worker window is NOT present in storage.
+      * ``architect-bikepath`` IS present in storage, pane running codex
+        (the user's live 44-minute conversation).
+
+    Pre-#1636 behavior: ``_session_available_for_mount`` returns False
+    because ``worker-bikepath`` isn't in storage, so the route calls
+    ``supervisor.launch_session`` which spawns a fresh codex window with
+    the bootstrap prompt — wiping the user's context from view.
+
+    Post-#1636 behavior: the sibling-pattern probe sees the live
+    architect window and short-circuits before ``launch_session`` is
+    called. ``_show_live_session`` (also exercised via the fallback
+    path) is what actually attaches to it.
+    """
+    from pathlib import Path
+
+    from pollypm.cockpit_rail_routes import ProjectRoute
+
+    launch_session_calls: list[str] = []
+    show_live_session_calls: list[tuple[str, str]] = []
+
+    architect_window = _window(
+        index=38, name="architect-bikepath", pane_current_command="codex",
+    )
+
+    class _FakeTmux:
+        def list_windows(self, _session: str) -> list[TmuxWindow]:
+            return [architect_window]
+
+        def send_keys(self, *_a, **_k):  # primer plumbing
+            pass
+
+    class _Sess:
+        name = "worker_bikepath"
+        role = "worker"
+        project = "bikepath"
+
+    class _Launch:
+        session = _Sess()
+        window_name = "worker-bikepath"
+
+    class _Project:
+        key = "bikepath"
+        name = "bikepath"
+        path = Path("/tmp/bikepath")
+        persona_name = None
+
+    class _FakeConfig:
+        projects = {"bikepath": _Project()}
+
+    class _FakeSupervisor:
+        config = _FakeConfig()
+
+        def plan_launches(self):
+            return [_Launch()]
+
+        def storage_closet_session_name(self) -> str:
+            return "pollypm-storage-closet"
+
+        def launch_session(self, session_name: str):
+            launch_session_calls.append(session_name)
+
+    router = _bare_router()
+    router.tmux = _FakeTmux()  # type: ignore[attr-defined]
+    router.config_path = Path("/tmp/pollypm.toml")
+    router._right_pane_id = lambda _window_target: "%right"  # type: ignore[assignment]
+    router._load_state = lambda: {}  # type: ignore[assignment]
+    router._write_state = lambda _data: None  # type: ignore[assignment]
+    router.set_selected_key = lambda _key: None  # type: ignore[assignment]
+    router._show_static_view = lambda *_a, **_k: None  # type: ignore[assignment]
+    router._maybe_prime_project_pm_session = lambda *_a, **_k: None  # type: ignore[assignment]
+
+    def _record_show_live_session(_supervisor, session_name, window_target):
+        show_live_session_calls.append((session_name, window_target))
+
+    router._show_live_session = _record_show_live_session  # type: ignore[assignment]
+
+    # ``_session_available_for_mount`` returns False because the
+    # planner-named ``worker-bikepath`` window doesn't exist in storage
+    # (only ``architect-bikepath`` does). Pre-#1636 this triggered
+    # ``launch_session`` — the regression we're guarding against.
+    supervisor = _FakeSupervisor()
+    router._session_available_for_mount = lambda *_a, **_k: False  # type: ignore[assignment]
+
+    router._route_project_selection(
+        supervisor,
+        "pollypm:PollyPM",
+        ProjectRoute(project_key="bikepath", sub_view="session"),
+    )
+
+    # The critical assertion: launch_session was NOT called, so the
+    # live architect-bikepath codex was not killed off.
+    assert launch_session_calls == [], (
+        "launch_session must be skipped when a live PM sibling exists in storage"
+    )
+    # ``_show_live_session`` is still invoked so the attach happens via
+    # the sibling-pattern fallback inside ``_select_storage_window_for_mount``.
+    assert show_live_session_calls == [("worker_bikepath", "pollypm:PollyPM")]


### PR DESCRIPTION
## Summary
- Fixes #1636: clicking a project's PM chat from the rail spawned a fresh codex in `pollypm:0.1` instead of attaching to the live `architect-<project>` window in the storage closet, wiping the user's in-progress conversation from view (bikepath repro: PID 70760 alive in storage, PID 45316 fresh-bootstrapped in cockpit).
- Extends `_select_storage_window_for_mount` (the #1632 selector) with a project-PM sibling-pattern fallback: when the literal `launch.window_name` produces no match but `project_key` is supplied, try `architect-<project>`, `pm-<project>`, `worker-<project>` in priority order and return the first one whose pane is running `claude` / `codex` / `node`.
- Adds `_project_pm_sibling_window_live` pre-mount probe so `_route_project_selection` skips `supervisor.launch_session` when a live PM sibling is already serving the user's conversation — that's the gate that prevents the fresh-codex spawn from happening at all.
- Updates the three `_select_storage_window_for_mount` call sites in `_show_live_session` (main + relaunch-retry) and `create_worker_and_route` to pass `project_key` so the fallback fires.

## Test plan
- [x] `pytest tests/test_cockpit_rail_project_pm_fallback.py` — 10 new tests (sibling-priority ordering, live-only acceptance, dead-pane guard, integration regression that simulates the bikepath repro and asserts `launch_session` is NOT called).
- [x] `pytest tests/test_cockpit_rail_duplicate_resolution.py` — 7 existing tests still pass (literal-match path unchanged when no `project_key`).
- [x] `pytest tests/test_cockpit.py` — 194 cockpit tests pass.
- [x] Sibling fallback emits `cockpit.project_pm_fallback_match` audit event so forensics can trace when it fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)