### PR TITLE
feat(rail): paint diamond glyph when PM ends turn (#1633)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -4752,6 +4752,22 @@ class PollyCockpitRail:
         return row
 
     def _indicator(self, item: CockpitItem) -> tuple[str, _C | None]:
+        # #1633 — PM-turn-ended override. When the workspace operator
+        # ("polly") or a project's architect persona has finished its
+        # turn and is waiting on the user, paint the "needs attention"
+        # ◆ glyph regardless of any other heartbeat / project-rollup
+        # signal. Sits at the top so it outranks the legacy
+        # heartbeat / working glyphs but below operational faults
+        # (project-red / approvals-pending) which still own the row.
+        if self._pm_turn_ended_for_item(item) and not item.state.startswith("!"):
+            if item.key == "polly":
+                return "◆", PALETTE["inbox_has"]
+            if (
+                item.key.startswith("project:")
+                and item.state != "project-red"
+                and item.approvals_pending == 0
+            ):
+                return "◆", PALETTE["inbox_has"]
         if item.key.startswith("project:"):
             # #1390 — Approval-pending takes precedence over the rollup
             # color so a project parked at user_approval reads as "act
@@ -4871,6 +4887,39 @@ class PollyCockpitRail:
         if item.state == "sub":
             return " ", None
         return "\u25cb", PALETTE["idle"]
+
+    def _pm_turn_ended_for_item(self, item: CockpitItem) -> bool:
+        """True when a PM persona attached to ``item`` is awaiting the user.
+
+        Drives the #1633 ``◆`` glyph override. Consults the on-disk
+        state file populated by the recurring ``pm.turn_classify`` sweep
+        — never re-runs the heuristic from the render path. Safe to
+        call on every row; the file read is one small JSON load and
+        the lookup falls through to ``False`` on any error so a missing
+        / corrupted state file degrades to "no override" rather than
+        breaking rail rendering.
+        """
+        try:
+            from pollypm.pm_turn_state import is_turn_ended
+        except Exception:  # noqa: BLE001
+            return False
+        try:
+            if item.key == "polly":
+                return is_turn_ended("operator")
+            if item.key.startswith("project:") and item.key.count(":") == 1:
+                project_key = item.key.split(":", 1)[1]
+                # Per-project PM is the architect session. Project keys
+                # may use ``-`` or ``_`` separators (session names sanitize
+                # ``-`` to ``_``); check both forms so the lookup matches
+                # the session name the detector recorded.
+                alias = project_key.replace("-", "_")
+                return (
+                    is_turn_ended(f"architect_{project_key}")
+                    or is_turn_ended(f"architect_{alias}")
+                )
+        except Exception:  # noqa: BLE001
+            return False
+        return False
 
     def _session_work_glyph(
         self,

--- a/src/pollypm/plugins_builtin/core_recurring/sweeps.py
+++ b/src/pollypm/plugins_builtin/core_recurring/sweeps.py
@@ -486,6 +486,7 @@ def _pane_text_classify_body(
     alerts_cleared = 0
     inbox_items_emitted = 0
     capture_failures = 0
+    pm_turn_transitions = 0  # #1633 — active → ended PM turn flips this tick.
     match_counts: dict[str, int] = {name: 0 for name in all_rule_names}
 
     try:
@@ -524,6 +525,28 @@ def _pane_text_classify_body(
                 session_name, exc_info=True,
             )
             continue
+
+        # #1633 — detect PM-persona turn-ended transitions inline so we
+        # piggyback on the existing pane capture rather than spinning a
+        # second sweep. ``record_turn_state`` emits the ``pm.turn_ended``
+        # audit event exactly once per active → ended transition and
+        # persists the per-session state for the rail glyph override.
+        try:
+            from pollypm.pm_turn_state import (
+                detect_pm_turn_ended,
+                is_pm_session,
+                record_turn_state,
+            )
+
+            if is_pm_session(session_name):
+                turn_ended = detect_pm_turn_ended(pane_text)
+                if record_turn_state(session_name, turn_ended=turn_ended):
+                    pm_turn_transitions += 1
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "pane_text_classify: pm_turn_state record failed for %s",
+                session_name, exc_info=True,
+            )
 
         for rule_name in all_rule_names:
             alert_type = f"pane:{rule_name}"
@@ -609,6 +632,10 @@ def _pane_text_classify_body(
         "inbox_items_emitted": inbox_items_emitted,
         "capture_failures": capture_failures,
         "match_counts": match_counts,
+        # #1633 — count of PM personas that just transitioned to
+        # awaiting-user this tick. Each non-zero value corresponds to
+        # one ``pm.turn_ended`` audit event.
+        "pm_turn_transitions": pm_turn_transitions,
     }
 
 

--- a/src/pollypm/pm_turn_state.py
+++ b/src/pollypm/pm_turn_state.py
@@ -1,0 +1,256 @@
+"""Detect + record "PM persona ended its turn" transitions (#1633).
+
+The smallest defensible wedge for the "no signal when Polly/PM is
+waiting on the user" gap:
+
+* :func:`is_pm_session` — true for the workspace operator (``operator``)
+  and per-project architect sessions (``architect_<project>``). Workers,
+  reviewers, and heartbeat are deliberately excluded: their idleness
+  doesn't mean the user owes them a reply.
+
+* :func:`detect_pm_turn_ended` — pane-text predicate. Reuses the
+  existing Claude empty-``❯`` / Codex idle-placeholder detectors from
+  :mod:`pollypm.idle_placeholders`. An empty input prompt on a PM
+  pane is the canonical signal that the agent finished its turn and
+  is awaiting the user.
+
+* :func:`record_turn_state` — persists per-session state to
+  ``~/.pollypm/pm_turn_state.json``. Emits a ``pm.turn_ended`` audit
+  event on the active → ended transition (one event per transition,
+  not per poll), so the cockpit and downstream observers can later
+  badge / notify without re-running the heuristic. Symmetrically
+  records the ended → active transition without an audit emit (we
+  only care about the moment attention is needed).
+
+* :func:`is_turn_ended` — for the rail glyph code to consume. Returns
+  True iff the last recorded state for ``session_name`` was "turn
+  ended" (i.e., the agent is currently waiting on the user).
+
+The state file is best-effort: a missing / unreadable file means
+"no PM sessions are currently flagged ended" — the next poll will
+re-populate it. We deliberately do NOT persist into the state DB
+because the rail's glyph path is hot and the state-DB connection
+isn't always available from the recurring handler.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from pollypm.idle_placeholders import (
+    pane_shows_claude_empty_prompt,
+    pane_shows_codex_idle_placeholder,
+)
+
+logger = logging.getLogger(__name__)
+
+# Audit event name for the active → ended transition. Stable string —
+# downstream observers (cockpit rail glyph override, future OS notifier,
+# future topbar pill) pin this.
+EVENT_PM_TURN_ENDED = "pm.turn_ended"
+
+# Override hook for tests. When set, the state file lives under
+# ``$POLLYPM_PM_TURN_STATE_HOME/pm_turn_state.json``.
+_HOME_ENV = "POLLYPM_PM_TURN_STATE_HOME"
+
+
+def _state_path() -> Path:
+    """Return the JSON state file path.
+
+    Mirrors :func:`pollypm.audit.log._central_root` — uses
+    ``DEFAULT_CONFIG_PATH.parent`` (typically ``~/.pollypm``) so a
+    custom config home stays internally consistent. Tests override
+    via ``$POLLYPM_PM_TURN_STATE_HOME``.
+    """
+    override = os.environ.get(_HOME_ENV)
+    if override:
+        return Path(override).expanduser() / "pm_turn_state.json"
+    try:
+        from pollypm.config import DEFAULT_CONFIG_PATH
+
+        return Path(DEFAULT_CONFIG_PATH).parent / "pm_turn_state.json"
+    except Exception:  # noqa: BLE001 — config errors never break detection
+        return Path.home() / ".pollypm" / "pm_turn_state.json"
+
+
+def is_pm_session(session_name: str) -> bool:
+    """True iff ``session_name`` is a PM-facing persona.
+
+    PM personas are sessions whose conversational turn ends with the
+    user owing the next reply:
+
+    * ``operator`` — the workspace-level Polly chat.
+    * ``architect_<project>`` — per-project PM persona.
+
+    Workers (``worker_*``), reviewers (``reviewer`` / ``reviewer_*``),
+    and heartbeat (``heartbeat``) are autonomous and intentionally
+    excluded — the user doesn't ack their turn-end (#1633 scope).
+    """
+    if not session_name:
+        return False
+    if session_name == "operator":
+        return True
+    if session_name.startswith("architect_") or session_name.startswith("architect-"):
+        return True
+    return False
+
+
+def detect_pm_turn_ended(pane_text: str) -> bool:
+    """True iff the pane snapshot shows the PM agent waiting for input.
+
+    Reuses the existing prompt-marker detectors:
+
+    * Claude CLI: standalone ``❯`` at the input box with no body.
+    * Codex CLI: rotating idle-placeholder hints in the input box.
+
+    Both are the canonical "agent finished its turn" signal — they
+    only appear when the model has emitted a complete response and
+    the input box is empty waiting for the next user prompt.
+    """
+    if not pane_text:
+        return False
+    return (
+        pane_shows_claude_empty_prompt(pane_text)
+        or pane_shows_codex_idle_placeholder(pane_text)
+    )
+
+
+def _load_state() -> dict[str, Any]:
+    """Read the state file. Returns an empty dict on any failure."""
+    path = _state_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    except OSError as exc:
+        logger.debug("pm_turn_state: read failed for %s: %s", path, exc)
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.debug("pm_turn_state: parse failed for %s: %s", path, exc)
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def _write_state(data: dict[str, Any]) -> None:
+    """Atomically replace the state file. Best-effort — never raises."""
+    path = _state_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.debug("pm_turn_state: mkdir failed for %s: %s", path, exc)
+        return
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_text(
+            json.dumps(data, sort_keys=True, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        os.replace(tmp, path)
+    except OSError as exc:
+        logger.debug("pm_turn_state: write failed for %s: %s", path, exc)
+        # Best-effort cleanup of the tmp file.
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+
+
+def _emit_turn_ended_audit(session_name: str) -> None:
+    """Best-effort ``pm.turn_ended`` audit emit.
+
+    Lazy-imported so a missing / broken audit module never blocks the
+    detection sweep (mirrors :meth:`PollyCockpitRail._emit_audit`).
+    The project key is ``_workspace`` because the operator is not
+    scoped to a single project; per-project architects could carry
+    their project key but we keep one shape for downstream consumers.
+    """
+    try:
+        from pollypm.audit.log import emit as audit_emit
+    except Exception:  # noqa: BLE001
+        return
+    try:
+        audit_emit(
+            event=EVENT_PM_TURN_ENDED,
+            project="_workspace",
+            subject=session_name,
+            actor="pm_turn_state",
+            status="ok",
+            metadata={"session": session_name},
+        )
+    except Exception:  # noqa: BLE001
+        return
+
+
+def record_turn_state(session_name: str, *, turn_ended: bool) -> bool:
+    """Persist the current turn state for ``session_name``.
+
+    Returns True iff this call flipped the state from active to ended
+    (i.e., the user just became responsible for the next move) and
+    therefore emitted a ``pm.turn_ended`` audit event. Repeated calls
+    with the same state are idempotent and emit nothing.
+    """
+    if not is_pm_session(session_name):
+        return False
+    data = _load_state()
+    sessions = data.get("sessions")
+    if not isinstance(sessions, dict):
+        sessions = {}
+    prev = sessions.get(session_name)
+    prev_ended = bool(prev.get("turn_ended")) if isinstance(prev, dict) else False
+    transitioned = (not prev_ended) and turn_ended
+
+    sessions[session_name] = {"turn_ended": bool(turn_ended)}
+    data["sessions"] = sessions
+    _write_state(data)
+
+    if transitioned:
+        _emit_turn_ended_audit(session_name)
+    return transitioned
+
+
+def is_turn_ended(session_name: str) -> bool:
+    """True iff the most-recently-recorded state is "turn ended".
+
+    Cheap (one JSON read). The rail's ``_indicator`` calls this on
+    every render to decide whether to paint ``◆`` (awaits user) over
+    the normal heartbeat / working glyph for a PM row.
+    """
+    if not is_pm_session(session_name):
+        return False
+    data = _load_state()
+    sessions = data.get("sessions")
+    if not isinstance(sessions, dict):
+        return False
+    entry = sessions.get(session_name)
+    if not isinstance(entry, dict):
+        return False
+    return bool(entry.get("turn_ended"))
+
+
+def clear_state() -> None:
+    """Remove the state file. Used by tests."""
+    path = _state_path()
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.debug("pm_turn_state: clear failed for %s: %s", path, exc)
+
+
+__all__ = [
+    "EVENT_PM_TURN_ENDED",
+    "is_pm_session",
+    "detect_pm_turn_ended",
+    "record_turn_state",
+    "is_turn_ended",
+    "clear_state",
+]

--- a/tests/test_pm_turn_state.py
+++ b/tests/test_pm_turn_state.py
@@ -1,0 +1,227 @@
+"""Tests for the PM turn-ended detector + rail glyph override (#1633)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pollypm.cockpit_rail import CockpitItem, PollyCockpitRail
+from pollypm import pm_turn_state
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the state file + audit log under a fresh tmpdir per test."""
+    state_home = tmp_path / "pollypm_state"
+    state_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("POLLYPM_PM_TURN_STATE_HOME", str(state_home))
+    audit_home = tmp_path / "pollypm_audit"
+    audit_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+    return state_home
+
+
+def _rail() -> PollyCockpitRail:
+    """Build a rail instance without running it (no I/O, no config load)."""
+    return PollyCockpitRail.__new__(PollyCockpitRail)
+
+
+def _polly_item(*, state: str = "live") -> CockpitItem:
+    return CockpitItem(key="polly", label="Polly", state=state)
+
+
+def _project_item(
+    *,
+    project_state: str | None = None,
+    state: str = "project-green",
+    approvals_pending: int = 0,
+    alert_severity: str | None = None,
+) -> CockpitItem:
+    return CockpitItem(
+        key="project:demo",
+        label="demo",
+        state=state,
+        project_state=project_state,
+        approvals_pending=approvals_pending,
+        alert_severity=alert_severity,
+    )
+
+
+# ── pm_turn_state primitives ──────────────────────────────────────────
+
+
+def test_is_pm_session_recognizes_operator() -> None:
+    assert pm_turn_state.is_pm_session("operator") is True
+
+
+def test_is_pm_session_recognizes_architect() -> None:
+    assert pm_turn_state.is_pm_session("architect_demo") is True
+    assert pm_turn_state.is_pm_session("architect-demo") is True
+
+
+def test_is_pm_session_rejects_worker_and_reviewer() -> None:
+    assert pm_turn_state.is_pm_session("worker_demo") is False
+    assert pm_turn_state.is_pm_session("reviewer") is False
+    assert pm_turn_state.is_pm_session("heartbeat") is False
+    assert pm_turn_state.is_pm_session("") is False
+
+
+def test_detect_pm_turn_ended_claude_empty_prompt() -> None:
+    pane = "\n".join([
+        "Some earlier assistant content here.",
+        "──────────────────────────",
+        "❯",
+        "  ⏵⏵ accept edits on  shift+tab to cycle",
+    ])
+    assert pm_turn_state.detect_pm_turn_ended(pane) is True
+
+
+def test_detect_pm_turn_ended_codex_placeholder() -> None:
+    pane = "\n".join([
+        "Some earlier content",
+        "› Improve documentation in @filename",
+    ])
+    assert pm_turn_state.detect_pm_turn_ended(pane) is True
+
+
+def test_detect_pm_turn_ended_false_on_mid_turn_content() -> None:
+    pane = "\n".join([
+        "Working on the task right now…",
+        "❯ pasted user message here",
+    ])
+    assert pm_turn_state.detect_pm_turn_ended(pane) is False
+
+
+def test_record_turn_state_emits_audit_on_active_to_ended_transition(
+    _isolated_state_home: Path,
+) -> None:
+    transitioned = pm_turn_state.record_turn_state("operator", turn_ended=True)
+    assert transitioned is True
+
+    # The audit file should now contain exactly one pm.turn_ended event.
+    audit_path = (
+        Path(_isolated_state_home).parent / "pollypm_audit" / "_workspace.jsonl"
+    )
+    assert audit_path.exists(), "audit emit did not create the central log"
+    lines = audit_path.read_text(encoding="utf-8").splitlines()
+    matching = [json.loads(line) for line in lines if line.strip()]
+    matching = [evt for evt in matching if evt.get("event") == "pm.turn_ended"]
+    assert len(matching) == 1
+    assert matching[0]["subject"] == "operator"
+
+
+def test_record_turn_state_is_idempotent_on_steady_state(
+    _isolated_state_home: Path,
+) -> None:
+    """Repeated ended → ended calls emit at most one audit event."""
+    assert pm_turn_state.record_turn_state("operator", turn_ended=True) is True
+    # Second call with same state — no transition, no new audit emit.
+    assert pm_turn_state.record_turn_state("operator", turn_ended=True) is False
+    assert pm_turn_state.record_turn_state("operator", turn_ended=True) is False
+
+    audit_path = (
+        Path(_isolated_state_home).parent / "pollypm_audit" / "_workspace.jsonl"
+    )
+    lines = audit_path.read_text(encoding="utf-8").splitlines()
+    matching = [json.loads(line) for line in lines if line.strip()]
+    matching = [evt for evt in matching if evt.get("event") == "pm.turn_ended"]
+    assert len(matching) == 1, "duplicate audit emits on steady-state ticks"
+
+
+def test_record_turn_state_re_emits_on_re_transition(
+    _isolated_state_home: Path,
+) -> None:
+    """ended → active → ended fires a fresh audit event."""
+    assert pm_turn_state.record_turn_state("operator", turn_ended=True) is True
+    # User responded — PM is active again.
+    assert pm_turn_state.record_turn_state("operator", turn_ended=False) is False
+    # PM finished its next turn — fresh transition, fresh audit.
+    assert pm_turn_state.record_turn_state("operator", turn_ended=True) is True
+
+
+def test_record_turn_state_ignores_non_pm_sessions(
+    _isolated_state_home: Path,
+) -> None:
+    assert (
+        pm_turn_state.record_turn_state("worker_demo", turn_ended=True) is False
+    )
+    assert pm_turn_state.is_turn_ended("worker_demo") is False
+
+
+def test_is_turn_ended_reads_persisted_state(
+    _isolated_state_home: Path,
+) -> None:
+    pm_turn_state.record_turn_state("operator", turn_ended=True)
+    assert pm_turn_state.is_turn_ended("operator") is True
+    pm_turn_state.record_turn_state("operator", turn_ended=False)
+    assert pm_turn_state.is_turn_ended("operator") is False
+
+
+# ── Rail glyph override (the load-bearing user-visible contract) ─────
+
+
+def test_rail_glyph_polly_paints_diamond_when_turn_ended(
+    _isolated_state_home: Path,
+) -> None:
+    """Polly row paints ◆ once the audit event records turn-ended."""
+    pm_turn_state.record_turn_state("operator", turn_ended=True)
+    glyph, _color = _rail()._indicator(_polly_item(state="live"))
+    assert glyph == "◆"
+
+
+def test_rail_glyph_polly_no_override_when_turn_active(
+    _isolated_state_home: Path,
+) -> None:
+    """Without a recorded turn-ended event, Polly keeps her normal glyph."""
+    # No record at all — file doesn't exist yet.
+    glyph, _color = _rail()._indicator(_polly_item(state="idle"))
+    assert glyph != "◆"
+
+
+def test_rail_glyph_polly_clears_when_user_replies(
+    _isolated_state_home: Path,
+) -> None:
+    """Once the PM is mid-turn again, the rail drops the ◆ override."""
+    pm_turn_state.record_turn_state("operator", turn_ended=True)
+    pm_turn_state.record_turn_state("operator", turn_ended=False)
+    glyph, _color = _rail()._indicator(_polly_item(state="live"))
+    assert glyph != "◆"
+
+
+def test_rail_glyph_project_paints_diamond_for_architect_turn_ended(
+    _isolated_state_home: Path,
+) -> None:
+    """A project's per-project architect finishing its turn lights the row."""
+    pm_turn_state.record_turn_state("architect_demo", turn_ended=True)
+    glyph, _color = _rail()._indicator(_project_item(project_state="working"))
+    assert glyph == "◆"
+
+
+def test_rail_glyph_operational_red_still_wins_over_turn_ended(
+    _isolated_state_home: Path,
+) -> None:
+    """Operational fault keeps its ▲ even when a PM turn just ended."""
+    pm_turn_state.record_turn_state("architect_demo", turn_ended=True)
+    item = _project_item(
+        state="project-red",
+        project_state="waiting",
+        alert_severity="error",
+    )
+    glyph, _color = _rail()._indicator(item)
+    assert glyph == "▲"
+
+
+def test_rail_glyph_approvals_pending_still_wins_over_turn_ended(
+    _isolated_state_home: Path,
+) -> None:
+    """The ▶ approvals affordance still outranks the PM turn glyph."""
+    pm_turn_state.record_turn_state("architect_demo", turn_ended=True)
+    item = _project_item(
+        state="project-green",
+        project_state="working",
+        approvals_pending=2,
+    )
+    glyph, _color = _rail()._indicator(item)
+    assert glyph == "▶"


### PR DESCRIPTION
## Summary
- Detects when the operator (Polly) or any per-project architect persona finishes its turn and is sitting at an empty input prompt, then emits a `pm.turn_ended` audit event exactly once per active → ended transition.
- Paints the `◆` "awaits user" glyph on the rail row for that PM, yielding to the existing `▲` (operational fault) and `▶` (approvals pending) precedence so nothing user-actionable gets hidden.
- Piggybacks on the existing `pane.classify` 30s sweep — no new tmux capture cycle, no new recurring handler.

## Scope
- Only PM-facing personas (`operator`, `architect_<project>`). Workers, reviewers, and heartbeat are intentionally excluded.
- OS notifications + topbar pill deferred to follow-ups (kept this wedge small).

## Test plan
- [x] `tests/test_pm_turn_state.py` — 17 new tests covering the detector, audit-emit transition semantics (only on active → ended, idempotent on steady-state, re-fires after a clear), and rail glyph override (overrides normal heartbeat glyph, yields to operational red + approvals-pending).
- [x] `tests/test_cockpit_rail_operator_glyphs.py` — existing #1572 regression suite still green.
- [x] All 384 rail-tagged tests pass.
- [x] All `pane_text_classify` tests pass.

Fixes #1633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)