### PR TITLE
fix(cockpit): import InboxItemKind under TYPE_CHECKING (#1651)

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pollypm.cockpit_inbox_sources import (
     _inbox_db_sources,
@@ -42,6 +42,9 @@ from pollypm.cockpit_worker_identity import (
 )
 from pollypm.heartbeats.snapshots import read_recent_heartbeat_snapshot
 from pollypm.inbox_message_refs import row_project_refs as _row_project_refs
+
+if TYPE_CHECKING:
+    from pollypm.inbox.kind import InboxItemKind
 
 __all__ = (
     # Re-exported leaf helpers (now live in pollypm.cockpit_inbox_sources)


### PR DESCRIPTION
## Summary
- Fixes #1651 — `pm_inbox_filtered_list` annotated `kind_filter` with `\"InboxItemKind | None\"` but never imported the name at module scope, so `ruff --select F821` flagged the file and `typing.get_type_hints(...)` could not resolve the annotation.
- Adds `TYPE_CHECKING` to the `typing` import and pulls `InboxItemKind` in under `if TYPE_CHECKING:` so the type contract is explicit at module scope without reintroducing the import-cycle guard from the #1623 refactor.
- Leaves the existing runtime `from pollypm.inbox.kind import InboxItemKind, coerce_kind` inside the function body in place — it is still needed for the enum comparisons during filtering.

## Test plan
- [x] `uv run python -c "from pollypm import cockpit_inbox"` succeeds
- [x] `uv tool run ruff check src/pollypm/cockpit_inbox.py --select F821 -q` exits 0
- [ ] CI lint/type gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)