### PR TITLE
fix(cockpit): add operator to static fast-path sets (#1648)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -798,7 +798,7 @@ class CockpitRouter:
     _LEFT_PANE_WIDTH = 30  # default; actual value persisted in cockpit state.
     _STATE_WRITE_DEBOUNCE_SECONDS = 0.25
     _SUPERVISOR_FREE_STATIC_KEYS = frozenset(
-        {"dashboard", "inbox", "workers", "metrics", "activity", "settings"},
+        {"dashboard", "inbox", "workers", "metrics", "activity", "settings", "operator"},
     )
 
     def __init__(self, config_path: Path) -> None:

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -3091,7 +3091,7 @@ class PollyCockpitApp(App[None]):
     # this set — pressing Enter on a project should expand its
     # sub-items immediately (#1192).
     _STATIC_RAIL_KEYS = frozenset(
-        {"dashboard", "inbox", "workers", "metrics", "activity", "settings", "polly"},
+        {"dashboard", "inbox", "workers", "metrics", "activity", "settings", "polly", "operator"},
     )
 
     # Monotonically-increasing click counter (#967). Each click bumps

--- a/tests/test_cockpit_static_fast_path_sets.py
+++ b/tests/test_cockpit_static_fast_path_sets.py
@@ -1,0 +1,57 @@
+"""#1648 — Operator dashboard belongs in the cockpit's static fast-path sets.
+
+``operator`` is a registered ``StaticViewRoute`` (see
+:mod:`pollypm.cockpit_rail_routes`), so clicking it must take the same
+optimistic, supervisor-free render path that Dashboard / Inbox /
+Activity already use. The two relevant sets are:
+
+* ``CockpitRouter._SUPERVISOR_FREE_STATIC_KEYS`` — gates whether the
+  route worker skips loading the supervisor and ``ensure_cockpit_layout``
+  before showing a static pane.
+* ``PollyCockpitApp._STATIC_RAIL_KEYS`` — gates whether the rail click
+  applies the cheap optimistic active-marker update vs. doing a heavy
+  synchronous ``_refresh_rows``.
+
+These tests just assert membership; the integration paths that *use*
+the sets are covered by the broader cockpit suite.
+"""
+
+from __future__ import annotations
+
+from pollypm.cockpit_rail import CockpitRouter
+from pollypm.cockpit_rail_routes import resolve_static_view_route
+from pollypm.cockpit_ui import PollyCockpitApp
+
+
+def test_operator_is_registered_as_static_route() -> None:
+    """Guard against the static-route registry drifting out from under us."""
+    route = resolve_static_view_route("operator")
+    assert route is not None
+    assert route.kind == "operator"
+    assert route.selected_key == "operator"
+
+
+def test_operator_in_supervisor_free_static_keys() -> None:
+    """Operator clicks must skip supervisor/layout work like Dashboard."""
+    assert "operator" in CockpitRouter._SUPERVISOR_FREE_STATIC_KEYS
+
+
+def test_operator_in_static_rail_keys() -> None:
+    """Operator clicks must use the optimistic active-marker path,
+    not the heavy synchronous ``_refresh_rows`` rebuild."""
+    assert "operator" in PollyCockpitApp._STATIC_RAIL_KEYS
+
+
+def test_all_registered_static_kinds_are_fast_path() -> None:
+    """Catch the same drift for any future static route — every
+    registered static view kind should be on the fast paths so its
+    click feels as snappy as the existing static destinations.
+
+    Excludes ``activity`` because it is resolved dynamically via the
+    ``activity:<project_key>`` form rather than the bare key, and
+    ``polly`` (a live session, not a static view) is intentionally on
+    ``_STATIC_RAIL_KEYS`` but not ``_SUPERVISOR_FREE_STATIC_KEYS``.
+    """
+    static_kinds = {"dashboard", "inbox", "workers", "metrics", "settings", "operator"}
+    assert static_kinds <= CockpitRouter._SUPERVISOR_FREE_STATIC_KEYS
+    assert static_kinds <= PollyCockpitApp._STATIC_RAIL_KEYS


### PR DESCRIPTION
## Summary
- Add `"operator"` to `CockpitRouter._SUPERVISOR_FREE_STATIC_KEYS` so operator clicks skip supervisor load and `ensure_cockpit_layout` like Dashboard / Inbox / Activity.
- Add `"operator"` to `PollyCockpitApp._STATIC_RAIL_KEYS` so the click applies the cheap optimistic active-marker update instead of a heavy synchronous `_refresh_rows`.
- Add `tests/test_cockpit_static_fast_path_sets.py` asserting membership plus a guard that every registered static-view kind is on both fast paths.

Fixes #1648. Child of #1634.

## Test plan
- [x] `pytest tests/test_cockpit_static_fast_path_sets.py tests/test_cockpit_rail_routes.py tests/test_cockpit_rail_operator_glyphs.py tests/test_dashboard_categorization.py tests/test_operator_dashboard_pilot.py` (53 passed)
- [ ] Manual: click Operator from a cold cockpit (no mounted live pane) and confirm no supervisor/layout churn in logs.
- [ ] Manual: click Operator with a mounted live pane and confirm `_route_supervisor_free_static` still parks correctly (early-returns `False` when a live provider pane is mounted).