### PR TITLE
fix(reaper): verify cockpit-pane UID before signalling (#1644)

### DIFF
--- a/src/pollypm/cockpit_pane_reaper.py
+++ b/src/pollypm/cockpit_pane_reaper.py
@@ -29,8 +29,9 @@ Fix
 After the tmux teardown and rail-daemon stop in ``pm reset``, walk
 ``ps -A`` for any ``pollypm cockpit-pane`` cmdline owned by the current
 user and SIGTERM-then-SIGKILL it. The current-user check
-(``effective_uid == os.geteuid()``) is the multi-user safety guard —
-we never signal another login's processes.
+(``uid == os.geteuid()``, taken from the ``ps -o uid`` column) is the
+multi-user safety guard — we never signal another login's processes,
+even when the kernel would permit it (#1644).
 
 Idempotency
 -----------
@@ -95,6 +96,7 @@ class _PaneProcess:
     """Internal: parsed snapshot of a ``ps`` row pointing at a pane."""
 
     pid: int
+    uid: int | None
     age_s: int | None
     cmdline: str
     pane_kind: str | None
@@ -145,6 +147,7 @@ def _extract_pane_kind(cmdline: str) -> str | None:
 def _list_cockpit_pane_procs(
     *,
     ps_runner: "PsRunner | None" = None,
+    current_uid: int | None = None,
 ) -> list[_PaneProcess]:
     """Run ``ps`` and parse out every ``pollypm cockpit-pane`` process.
 
@@ -152,7 +155,16 @@ def _list_cockpit_pane_procs(
     user typing ``pm cockpit-pane --help`` in a shell doesn't get picked
     up as a target (their ``ps`` row would still show ``pm`` as the
     binary, not ``pollypm``).
+
+    Ownership guard (#1644): rows whose ``uid`` column does not match
+    ``current_uid`` (defaulting to :func:`os.geteuid`) are filtered out
+    before they reach the signal path. ``PermissionError`` handling in
+    :func:`_terminate_with_grace` is preserved as defense-in-depth, but
+    this is the primary multi-user safety check — we never even
+    attempt to signal another login's processes.
     """
+    if current_uid is None:
+        current_uid = os.geteuid()
     runner = ps_runner or _default_ps_runner
     try:
         raw = runner()
@@ -166,14 +178,25 @@ def _list_cockpit_pane_procs(
             continue
         if _POLLYPM_NEEDLE not in line or _COCKPIT_PANE_NEEDLE not in line:
             continue
-        # Two splits: pid, etime, then cmdline-as-rest.
-        parts = line.split(None, 2)
-        if len(parts) < 3:
+        # Three splits: pid, uid, etime, then cmdline-as-rest.
+        parts = line.split(None, 3)
+        if len(parts) < 4:
             continue
-        pid_text, etime_text, cmdline = parts
+        pid_text, uid_text, etime_text, cmdline = parts
         try:
             pid = int(pid_text)
         except ValueError:
+            continue
+        try:
+            uid = int(uid_text)
+        except ValueError:
+            # Header row ("PID UID ELAPSED COMMAND") or a malformed
+            # row: drop. We never signal a row whose owner we can't
+            # confirm.
+            continue
+        # Ownership guard: only signal our own user's processes.
+        # This is the documented multi-user safety invariant (#1644).
+        if uid != current_uid:
             continue
         # Skip ourselves — defensive even though the reset CLI is not
         # itself a cockpit-pane process.
@@ -190,6 +213,7 @@ def _list_cockpit_pane_procs(
         out.append(
             _PaneProcess(
                 pid=pid,
+                uid=uid,
                 age_s=_parse_etime(etime_text),
                 cmdline=cmdline,
                 pane_kind=_extract_pane_kind(cmdline),
@@ -201,12 +225,14 @@ def _list_cockpit_pane_procs(
 def _default_ps_runner() -> str:
     """Invoke ``ps`` and return its decoded stdout.
 
-    ``-A`` lists every process; ``-o pid,etime,command`` keeps the
-    output narrow and stable across BSD/Linux. Mirrors
-    :func:`pollypm.rail_daemon_reaper._default_ps_runner`.
+    ``-A`` lists every process; ``-o pid,uid,etime,command`` keeps the
+    output narrow and stable across BSD (macOS) and Linux. The ``uid``
+    column is the numeric real UID and is the ownership signal used by
+    :func:`_list_cockpit_pane_procs` to filter to the current user
+    (#1644).
     """
     completed = subprocess.run(
-        ["ps", "-A", "-o", "pid,etime,command"],
+        ["ps", "-A", "-o", "pid,uid,etime,command"],
         capture_output=True,
         text=True,
         timeout=5.0,
@@ -322,6 +348,7 @@ def reap_orphan_cockpit_panes(
     *,
     ps_runner: PsRunner | None = None,
     sleep_fn: Callable[[float], None] = time.sleep,
+    current_uid: int | None = None,
 ) -> list[ReapedCockpitPane]:
     """Sweep ``ps`` for orphan ``pollypm cockpit-pane`` processes and kill them.
 
@@ -334,12 +361,15 @@ def reap_orphan_cockpit_panes(
         ps_runner: callable returning ``ps`` output. Tests inject a
             fake; production uses :func:`_default_ps_runner`.
         sleep_fn: injectable sleep for the SIGTERM grace window.
+        current_uid: override for the ownership-guard UID (#1644).
+            Defaults to :func:`os.geteuid`. Tests inject a synthetic
+            uid so they can assert on the filter behaviour.
 
     Returns:
         The list of :class:`ReapedCockpitPane` records for processes
         that were signalled, so the caller can log / count.
     """
-    procs = _list_cockpit_pane_procs(ps_runner=ps_runner)
+    procs = _list_cockpit_pane_procs(ps_runner=ps_runner, current_uid=current_uid)
     reaped: list[ReapedCockpitPane] = []
     for proc in procs:
         signal_used = _terminate_with_grace(proc.pid, sleep_fn=sleep_fn)

--- a/tests/test_cockpit_pane_reaper.py
+++ b/tests/test_cockpit_pane_reaper.py
@@ -47,9 +47,22 @@ def _spawn_sentinel() -> subprocess.Popen:
     )
 
 
-def _ps_line(pid: int, etime: str, cmdline: str) -> str:
-    """Format a synthetic ``ps -o pid,etime,command`` line."""
-    return f"  {pid} {etime} {cmdline}"
+def _ps_line(
+    pid: int,
+    etime: str,
+    cmdline: str,
+    *,
+    uid: int | None = None,
+) -> str:
+    """Format a synthetic ``ps -o pid,uid,etime,command`` line.
+
+    Defaults ``uid`` to :func:`os.geteuid` so existing tests get a
+    matching ownership row without the ownership guard rejecting them
+    (#1644). Pass an explicit ``uid`` to model another user's row.
+    """
+    if uid is None:
+        uid = os.geteuid()
+    return f"  {pid} {uid} {etime} {cmdline}"
 
 
 def _make_ps_runner(lines: list[str]):
@@ -287,16 +300,141 @@ def test_reaps_multiple_orphans() -> None:
                 pass
 
 
+def test_skips_rows_owned_by_other_uid(sentinel: subprocess.Popen) -> None:
+    """A ``ps`` row whose ``uid`` column does not match the current
+    user is filtered out before any signal is sent (#1644).
+
+    Multi-user safety guard: even if the kernel would permit the
+    signal (e.g. root-owned reset, or a same-group race), the reaper
+    must not target processes outside the invoking user's UID.
+    """
+    foreign_uid = os.geteuid() + 1000  # Synthetic non-matching uid.
+    ps_runner = _make_ps_runner(
+        [
+            _ps_line(
+                sentinel.pid,
+                "00:01:00",
+                "python -m pollypm cockpit-pane activity",
+                uid=foreign_uid,
+            ),
+        ]
+    )
+
+    reaped = reap_orphan_cockpit_panes(ps_runner=ps_runner)
+
+    assert reaped == []
+    # Sentinel must NOT have been signalled — still running.
+    assert sentinel.poll() is None
+
+
+def test_only_signals_current_user_rows_with_mixed_owners() -> None:
+    """Mixed-owner ``ps`` output reaps only the current-user rows.
+
+    Models a shared host with multiple logins running pollypm: the
+    reaper sees foreign-uid rows but must not signal them.
+    """
+    own = _spawn_sentinel()
+    foreign = _spawn_sentinel()  # Real PID, but we'll label it as foreign uid.
+    try:
+        foreign_uid = os.geteuid() + 1000
+        ps_runner = _make_ps_runner(
+            [
+                _ps_line(
+                    own.pid,
+                    "00:00:05",
+                    "python -m pollypm cockpit-pane activity",
+                ),
+                _ps_line(
+                    foreign.pid,
+                    "00:00:05",
+                    "python -m pollypm cockpit-pane inbox",
+                    uid=foreign_uid,
+                ),
+            ]
+        )
+
+        reaped = reap_orphan_cockpit_panes(ps_runner=ps_runner)
+
+        assert len(reaped) == 1
+        assert reaped[0].pid == own.pid
+        assert reaped[0].pane_kind == "activity"
+
+        own.wait(timeout=5)
+        # Foreign-uid PID must still be alive — the reaper never
+        # signalled it.
+        assert foreign.poll() is None
+    finally:
+        for proc in (own, foreign):
+            if proc.poll() is None:
+                try:
+                    proc.kill()
+                except ProcessLookupError:
+                    pass
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+
+
+def test_current_uid_override_filters_to_supplied_uid() -> None:
+    """The ``current_uid`` kwarg is honoured (covers callers / tests
+    that want to assert without depending on the real geteuid)."""
+    ps_runner = _make_ps_runner(
+        [
+            _ps_line(
+                99990,
+                "00:00:05",
+                "python -m pollypm cockpit-pane activity",
+                uid=4242,
+            ),
+            _ps_line(
+                99991,
+                "00:00:05",
+                "python -m pollypm cockpit-pane inbox",
+                uid=9999,
+            ),
+        ]
+    )
+
+    # current_uid=4242 → only the first row is even considered for
+    # signalling. Neither real PID exists, so both should fall through
+    # the ``already_gone`` path and the result is [], but the key
+    # assertion is that this does NOT raise (i.e. the foreign row
+    # never reaches the signal code).
+    reaped = reap_orphan_cockpit_panes(
+        ps_runner=ps_runner,
+        current_uid=4242,
+    )
+    assert reaped == []
+
+
+def test_malformed_uid_column_skips_row() -> None:
+    """A row with a non-integer ``uid`` column (e.g. the literal
+    ``ps`` header) is dropped — we never signal a row we can't
+    confirm ownership for."""
+    ps_runner = _make_ps_runner(
+        [
+            "  PID   UID     ELAPSED COMMAND",
+            "  123  not_an_int  00:00:05  python -m pollypm cockpit-pane activity",
+        ]
+    )
+
+    reaped = reap_orphan_cockpit_panes(ps_runner=ps_runner)
+    assert reaped == []
+
+
 def test_pane_process_dataclass_is_frozen() -> None:
     """``_PaneProcess`` is the parsed-row snapshot — verify shape so
     future fields don't silently break the parser contract."""
     proc = _PaneProcess(
         pid=1234,
+        uid=501,
         age_s=42,
         cmdline="python -m pollypm cockpit-pane activity",
         pane_kind="activity",
     )
     assert proc.pid == 1234
+    assert proc.uid == 501
     assert proc.pane_kind == "activity"
     with pytest.raises(Exception):  # frozen dataclass → FrozenInstanceError
         proc.pid = 9999  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- Closes #1644. The cockpit-pane reaper (#1598) documented an ``effective_uid == os.geteuid()`` multi-user safety guard but never read or filtered on uid before sending SIGTERM/SIGKILL. On a shared host or under elevated privileges, any visible process whose command line contained both ``pollypm`` and ``cockpit-pane`` could be signalled.
- Switches ``ps -A -o pid,etime,command`` to ``ps -A -o pid,uid,etime,command`` and filters rows to ``os.geteuid()`` inside ``_list_cockpit_pane_procs`` before they reach the signal path. Rows with a malformed ``uid`` column (e.g. the ``ps`` header) are dropped — we never signal a row whose owner we can't confirm. ``PermissionError`` handling stays as defense-in-depth, per the issue's guidance.
- The sole production caller (``cli_features/session_runtime.py``) is unchanged — the new ``current_uid`` kwarg defaults to ``os.geteuid()``.

## Test plan

- [x] ``uv run python -m pytest tests/test_cockpit_pane_reaper.py`` (23 passed)
- [x] New tests: foreign-uid sentinel survives reap, mixed-owner output only reaps the current-user row, ``current_uid`` override is honoured, malformed uid column skipped.
- [x] Smoke ran ``reap_orphan_cockpit_panes()`` against the live system to confirm the new ``ps -o pid,uid,etime,command`` format parses correctly on macOS BSD ``ps``.

Generated with Claude Code