### PR TITLE
fix(cockpit): repeat click on mounted session is a no-op (#1647)

### DIFF
--- a/src/pollypm/cockpit_mount_identity.py
+++ b/src/pollypm/cockpit_mount_identity.py
@@ -226,16 +226,21 @@ def verify_mount_against_tmux(
 ) -> bool:
     """Return True iff tmux state matches the mounted identity.
 
-    Three checks, all must pass:
+    Two required checks plus a *conditional* third:
 
     1. The recorded ``right_pane_id`` still appears in the cockpit
        window's pane list.
     2. The pane's current command looks like a live provider — not a
        dead shell.
-    3. The expected storage-closet window with name
-       ``expected_window_name`` exists and (if recorded) sits at
-       ``window_index``. This catches the case where a window was
-       renamed or re-indexed under us.
+    3. *Conditional* — if a storage-closet window with name
+       ``expected_window_name`` is present, it must sit at the
+       recorded ``window_index`` (when one was recorded). When the
+       window is **absent**, that's accepted: a mounted pane lives
+       in the cockpit, not the storage closet, so ``join-pane``
+       typically destroys the now-empty source window. Requiring
+       its continued presence would force every repeat click on an
+       already-mounted session through the slow park→remount path
+       (#1647).
 
     Returns False on any mismatch, signalling "tear down and remount".
     """
@@ -254,10 +259,18 @@ def verify_mount_against_tmux(
         if not cmd or not all(c.isdigit() or c == "." for c in cmd):
             return False
 
-    # 3. Expected storage-closet window present (and at the recorded
-    # index, when one was recorded). The window_index check guards
-    # against tmux reindexing after a window was killed earlier in
-    # the list.
+    # 3. Storage-closet window check (conditional).
+    #
+    # When the session is currently mounted into the cockpit via
+    # ``join-pane``, the source storage window is normally gone —
+    # tmux destroys windows with no remaining panes. Treat "window
+    # absent" as consistent with "the pane is in the cockpit", and
+    # only reject when the window is *present at a different index*
+    # than the one we recorded (config-edit / manual rename /
+    # reindex after another window was killed). #1647 — without
+    # this carve-out a repeat click on an already-mounted session
+    # took the slow park→remount path because check 3 always
+    # failed once the source window was joined away.
     window = next(
         (
             w for w in storage_windows
@@ -265,9 +278,7 @@ def verify_mount_against_tmux(
         ),
         None,
     )
-    if window is None:
-        return False
-    if mounted.window_index is not None:
+    if window is not None and mounted.window_index is not None:
         actual_index = getattr(window, "index", None)
         if actual_index is not None and actual_index != mounted.window_index:
             return False

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -3663,6 +3663,34 @@ class CockpitRouter:
                 ):
                     return  # tmux confirms the persisted identity
                 # Mismatch — fall through to tear-down + remount fresh.
+                # #1647 — emit forensics so future rail-latency triage
+                # can see *which* predicate failed (pane gone vs. dead
+                # shell vs. storage-window reindex) instead of guessing
+                # from a stopwatch.
+                try:
+                    self._emit_cockpit_audit(
+                        event_name="cockpit.mount_verify_failed",
+                        subject=session_name,
+                        status="info",
+                        metadata={
+                            "session_name": session_name,
+                            "rail_key": persisted.rail_key,
+                            "expected_window_name": (
+                                persisted.expected_window_name
+                            ),
+                            "recorded_right_pane_id": persisted.right_pane_id,
+                            "recorded_window_index": persisted.window_index,
+                            "cockpit_pane_ids": [
+                                getattr(p, "pane_id", None) for p in panes
+                            ],
+                            "storage_window_names": [
+                                getattr(w, "name", None)
+                                for w in storage_windows
+                            ],
+                        },
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
         self._park_mounted_session(supervisor, window_target)
         self._cleanup_extra_panes(window_target)
         left_pane_id = self._left_pane_id(window_target)

--- a/tests/test_cockpit_mount_identity.py
+++ b/tests/test_cockpit_mount_identity.py
@@ -190,9 +190,32 @@ def test_verify_against_tmux_fails_when_pane_killed() -> None:
     )
 
 
-def test_verify_against_tmux_fails_when_window_renamed() -> None:
-    """Storage closet window expected to be ``pm-operator`` is gone
-    (renamed or never spawned). Caller must remount."""
+def test_verify_against_tmux_passes_when_storage_window_absent() -> None:
+    """#1647 — a mounted live session lives in the cockpit window, not
+    the storage closet. ``join-pane`` typically destroys the
+    now-empty source window; requiring it to remain would force every
+    repeat click on the already-mounted session through park→remount
+    (~10s of tmux churn). When the right pane id + live-provider
+    command both agree with the persisted record, the mount is valid
+    even with the storage window absent."""
+    mounted = MountedIdentity(
+        rail_key="polly", session_name="operator",
+        role="operator-pm", expected_window_name="pm-operator",
+        right_pane_id="%5", window_index=3, mounted_at="2026-04-26T15:00:00+00:00",
+    )
+    panes = [_pane("%5", "claude")]
+    storage_windows = [_window("pm-reviewer", 4)]  # pm-operator absent
+    assert verify_mount_against_tmux(
+        mounted, panes=panes, storage_windows=storage_windows,
+    )
+
+
+def test_verify_against_tmux_passes_when_storage_window_renamed() -> None:
+    """Twin of the absent-window case: after ``join-pane`` destroys the
+    empty source window, a *different* window may end up bearing a
+    similar-but-not-matching name. The mounted pane is still live in
+    the cockpit, so the mount is valid (no rename of the joined pane
+    occurred). #1647."""
     mounted = MountedIdentity(
         rail_key="polly", session_name="operator",
         role="operator-pm", expected_window_name="pm-operator",
@@ -200,7 +223,7 @@ def test_verify_against_tmux_fails_when_window_renamed() -> None:
     )
     panes = [_pane("%5", "claude")]
     storage_windows = [_window("pm-operator-renamed", 3)]
-    assert not verify_mount_against_tmux(
+    assert verify_mount_against_tmux(
         mounted, panes=panes, storage_windows=storage_windows,
     )
 
@@ -208,7 +231,11 @@ def test_verify_against_tmux_fails_when_window_renamed() -> None:
 def test_verify_against_tmux_fails_when_window_reindexed() -> None:
     """Window name still matches but it's at a different index — tmux
     reindexed after another window was killed. The recorded mount no
-    longer corresponds to the right window number."""
+    longer corresponds to the right window number.
+
+    Distinct from "window absent" (#1647 carve-out): a *present*
+    window at the wrong index implies a duplicate/orphan storage
+    window we should not silently endorse, so we remount fresh."""
     mounted = MountedIdentity(
         rail_key="polly", session_name="operator",
         role="operator-pm", expected_window_name="pm-operator",
@@ -218,6 +245,39 @@ def test_verify_against_tmux_fails_when_window_reindexed() -> None:
     storage_windows = [_window("pm-operator", 5)]  # was 3, now 5
     assert not verify_mount_against_tmux(
         mounted, panes=panes, storage_windows=storage_windows,
+    )
+
+
+def test_verify_against_tmux_passes_for_repeat_click_on_mounted_session() -> None:
+    """#1647 end-to-end shape — the exact scenario from the issue:
+
+    The user has already mounted Polly (or Russell, or PM Chat). The
+    persisted ``mounted_identity`` agrees with the request. The
+    cockpit right pane is live with ``claude``/``codex``. The source
+    storage window is gone because ``join-pane`` consumed it.
+
+    Verification must succeed so ``_show_live_session`` short-circuits
+    instead of calling ``_park_mounted_session`` + a fresh remount
+    (which costs multiple ``list-windows`` / ``break-pane`` /
+    ``join-pane`` / resize / state-write round-trips against tmux).
+    """
+    mounted = MountedIdentity(
+        rail_key="polly", session_name="operator",
+        role="operator-pm", expected_window_name="pm-operator",
+        right_pane_id="%5", window_index=3,
+        mounted_at="2026-04-26T15:00:00+00:00",
+    )
+    cockpit_panes = [_pane("%4", "tmux"), _pane("%5", "claude")]
+    # The storage closet has every *other* window — operator's was
+    # consumed by join-pane when the mount completed.
+    storage_windows_after_join = [
+        _window("pm-reviewer", 4),
+        _window("pm-worker", 6),
+    ]
+    assert verify_mount_against_tmux(
+        mounted,
+        panes=cockpit_panes,
+        storage_windows=storage_windows_after_join,
     )
 
 


### PR DESCRIPTION
Closes #1647.

## Summary
- `verify_mount_against_tmux` required the source storage-closet window to still exist, but `join-pane` typically destroys that window when it consumes the only source pane. So every repeat click on Polly / Russell / a mounted PM Chat took the slow `_park_mounted_session` + fresh remount path (list-windows / break-pane / join-pane / resize / state-write).
- Loosen check 3 in `verify_mount_against_tmux` to treat "storage window absent" as consistent with "pane is currently joined into the cockpit". Window-present-at-a-different-index still fails (that path catches duplicate/orphan storage windows from park-collisions, see #1631).
- Add a `cockpit.mount_verify_failed` audit emit so future rail-latency triage shows *which* predicate failed instead of needing a stopwatch.

## Test plan
- [x] `pytest tests/test_cockpit_mount_identity.py -v` (18 passed, including new regression tests for #1647)
- [x] `pytest tests/ -k "cockpit_rail or cockpit_mount"` (116 passed, 2 xfailed)
- [ ] Manual: open cockpit, click Polly twice — second click should be a no-op (no pane churn, no remount logs)
- [ ] Manual: rename a storage-closet window while a different session is mounted — clicking the renamed-window session should still remount cleanly (window absent at expected name path)

## Notes
The `cockpit.mount_verify_failed` audit only fires when verification *actually fails* and we're about to park+remount, so it won't add noise on the happy path. It's best-effort wrapped to ensure it never blocks rail navigation.

Generated with [Claude Code](https://claude.com/claude-code)