### PR TITLE
Fix #1649 activity feed initial render via run_worker

### DIFF
--- a/src/pollypm/cockpit_activity.py
+++ b/src/pollypm/cockpit_activity.py
@@ -352,6 +352,15 @@ class PollyActivityFeedApp(App[None]):
         self._open_entry_id: str | None = None
         self._follow_on: bool = False
         self._follow_timer = None
+        # #1649 — cold-boot off-thread gather. ``_initial_load_running``
+        # gates the follow-mode tick + manual refresh so we don't race
+        # the worker's ``call_from_thread`` completion against a parallel
+        # sync gather. ``_initial_load_done`` flips to True after the
+        # first gather completes (success or failure) so subsequent
+        # refresh calls fall back to the synchronous path used by tests
+        # that monkeypatch ``_gather``.
+        self._initial_load_running: bool = False
+        self._initial_load_done: bool = False
 
     def _load_config(self):
         if self._config is None:
@@ -374,7 +383,15 @@ class PollyActivityFeedApp(App[None]):
         self.detail.display = False
         self.filter_input.value = self._filter_fuzzy
         self.table.focus()
-        self._refresh()
+        # #1649 — initial activity-feed gather opens the events DB and
+        # projects entries on the Textual asyncio main thread, blocking
+        # the first paint while sqlite IO finishes. Paint a "Loading
+        # activity…" skeleton immediately, then run ``_gather`` on a
+        # worker thread and apply the result back via
+        # ``call_from_thread``. Follow-mode ticks + manual refresh
+        # also go off-thread (see ``_refresh`` / ``_follow_tick``).
+        self._paint_loading_skeleton()
+        self._schedule_initial_load()
         # Alert toast surface removed in #956 — alerts already appear
         # as activity rows in the table below.
 
@@ -419,7 +436,73 @@ class PollyActivityFeedApp(App[None]):
             limit=self.INITIAL_LIMIT,
         )
 
-    def _refresh(self) -> None:
+    # ------------------------------------------------------------------
+    # Cold-boot + steady-state refresh (#1649). The activity feed
+    # gather opens sqlite + projects entries; running it on the main
+    # asyncio thread blocks first paint. Pattern mirrors #1605 (inbox)
+    # and #1653 (operator dashboard): paint a skeleton, dispatch a
+    # ``run_worker(thread=True)`` gather, marshal the result back via
+    # ``call_from_thread``.
+    # ------------------------------------------------------------------
+
+    def _paint_loading_skeleton(self) -> None:
+        """Render a minimal "Loading…" placeholder before any IO."""
+        try:
+            self.topbar.update("[b #eef6ff]Activity[/b #eef6ff]")
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            self.counters.update("[dim]Loading activity…[/dim]")
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _schedule_initial_load(self) -> None:
+        """Kick the cold-boot gather onto a worker thread."""
+        if self._initial_load_running:
+            return
+        self._initial_load_running = True
+        try:
+            self.run_worker(
+                self._gather_async_sync,
+                thread=True,
+                exclusive=True,
+                group="activity_feed_initial_load",
+            )
+        except Exception:  # noqa: BLE001
+            # Worker dispatch failure (unlikely outside teardown): fall
+            # back to the synchronous gather so the pane still loads.
+            self._initial_load_running = False
+            self._refresh_sync()
+
+    def _gather_async_sync(self) -> None:
+        """Worker-thread body: gather entries, hand back to UI thread."""
+        try:
+            entries = self._gather()
+        except Exception as exc:  # noqa: BLE001
+            self.call_from_thread(self._initial_load_failed, str(exc))
+            return
+        self.call_from_thread(self._initial_load_completed, list(entries))
+
+    def _initial_load_completed(self, entries: list) -> None:
+        self._initial_load_running = False
+        self._initial_load_done = True
+        self._entries = entries[: self.MAX_ROWS_IN_MEMORY]
+        self._render()
+
+    def _initial_load_failed(self, error: str) -> None:
+        self._initial_load_running = False
+        self._initial_load_done = True
+        try:
+            self.topbar.update(
+                f"[#ff5f6d]Error loading activity:[/#ff5f6d] {_escape(error)}"
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _refresh_sync(self) -> None:
+        """Synchronous gather + render (fallback path used on worker
+        dispatch failure and by tests that drive ``_refresh`` directly
+        without spinning a pilot)."""
         try:
             entries = self._gather()
         except Exception as exc:  # noqa: BLE001
@@ -430,11 +513,81 @@ class PollyActivityFeedApp(App[None]):
         self._entries = list(entries)[: self.MAX_ROWS_IN_MEMORY]
         self._render()
 
+    def _refresh(self) -> None:
+        # Cold-boot worker still in flight — don't double-dispatch.
+        if self._initial_load_running:
+            return
+        # Once mounted, do refreshes off-thread too so a slow gather
+        # doesn't freeze the UI on a manual ``R`` press or follow tick.
+        if not self.is_running:
+            # Not yet mounted under a pilot/app loop — fall back to
+            # the synchronous path so __init__-time refreshes (tests)
+            # still work.
+            self._refresh_sync()
+            return
+        try:
+            self.run_worker(
+                self._refresh_async_sync,
+                thread=True,
+                exclusive=True,
+                group="activity_feed_refresh",
+            )
+        except Exception:  # noqa: BLE001
+            self._refresh_sync()
+
+    def _refresh_async_sync(self) -> None:
+        try:
+            entries = self._gather()
+        except Exception as exc:  # noqa: BLE001
+            self.call_from_thread(self._refresh_failed, str(exc))
+            return
+        self.call_from_thread(self._refresh_completed, list(entries))
+
+    def _refresh_completed(self, entries: list) -> None:
+        self._entries = entries[: self.MAX_ROWS_IN_MEMORY]
+        self._render()
+
+    def _refresh_failed(self, error: str) -> None:
+        try:
+            self.topbar.update(
+                f"[#ff5f6d]Error loading activity:[/#ff5f6d] {_escape(error)}"
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
     def _follow_tick(self) -> None:
+        # Don't stack a follow gather on top of an in-flight cold-boot
+        # or manual refresh worker.
+        if self._initial_load_running:
+            return
+        if not self.is_running:
+            self._follow_tick_sync()
+            return
+        try:
+            self.run_worker(
+                self._follow_tick_async_sync,
+                thread=True,
+                exclusive=True,
+                group="activity_feed_follow",
+            )
+        except Exception:  # noqa: BLE001
+            self._follow_tick_sync()
+
+    def _follow_tick_async_sync(self) -> None:
         try:
             fresh = self._gather()
         except Exception:  # noqa: BLE001
             return
+        self.call_from_thread(self._follow_tick_completed, list(fresh))
+
+    def _follow_tick_sync(self) -> None:
+        try:
+            fresh = self._gather()
+        except Exception:  # noqa: BLE001
+            return
+        self._follow_tick_completed(list(fresh))
+
+    def _follow_tick_completed(self, fresh: list) -> None:
         if not fresh:
             return
         seen = {entry.id for entry in self._entries}

--- a/tests/test_activity_feed_ui.py
+++ b/tests/test_activity_feed_ui.py
@@ -773,6 +773,96 @@ def test_empty_feed_renders_without_crashing(
 
 
 # ---------------------------------------------------------------------------
+# 7b. Cold-boot skeleton + off-thread gather (#1649).
+# ---------------------------------------------------------------------------
+
+
+def test_first_paint_is_skeleton_before_gather_completes(
+    activity_env, activity_app,
+) -> None:
+    """Activity feed paints "Loading activity…" before the gather lands.
+
+    Models a slow ``_gather`` by parking it on a ``threading.Event`` and
+    asserts the skeleton + empty table render before the event is
+    released. If ``_gather`` ran on the main asyncio thread (the #1649
+    regression), the skeleton would never paint and the test would
+    deadlock on ``pilot.pause``.
+    """
+    import threading
+    import time
+
+    proceed = threading.Event()
+    started = threading.Event()
+
+    def slow_gather():
+        started.set()
+        # Cap the wait so a regression aborts the suite instead of
+        # hanging forever.
+        proceed.wait(timeout=10.0)
+        return [_make_entry(entry_id="evt:1", summary="late")]
+
+    activity_app._gather = slow_gather  # type: ignore[method-assign]
+
+    async def body() -> None:
+        t0 = time.monotonic()
+        async with activity_app.run_test(size=(160, 40)) as pilot:
+            await pilot.pause()
+            skeleton_elapsed = time.monotonic() - t0
+            counters_text = str(activity_app.counters.render())
+            assert "Loading activity" in counters_text, (
+                f"expected loading skeleton, got: {counters_text!r}"
+            )
+            assert activity_app.table.row_count == 0
+            assert skeleton_elapsed < 2.0, (
+                f"skeleton paint took {skeleton_elapsed*1000:.0f}ms — "
+                "first-paint regression"
+            )
+            # Release the slow gather so the worker can finish.
+            proceed.set()
+            for _ in range(50):
+                await pilot.pause()
+                if activity_app._entries:
+                    break
+            assert activity_app._entries, "gather never completed"
+            assert activity_app.table.row_count == 1
+            assert started.is_set()
+
+    _run(body())
+
+
+def test_initial_gather_runs_off_main_thread(
+    activity_env, activity_app,
+) -> None:
+    """The cold-boot ``_gather`` must run on a worker thread, not the
+    Textual main thread — otherwise sqlite IO would block first paint
+    (regression #1649)."""
+    import threading
+
+    thread_ids: list[int] = []
+    main_thread_id = threading.main_thread().ident
+
+    def recording_gather():
+        thread_ids.append(threading.get_ident())
+        return [_make_entry(entry_id="evt:1", summary="ok")]
+
+    activity_app._gather = recording_gather  # type: ignore[method-assign]
+
+    async def body() -> None:
+        async with activity_app.run_test(size=(160, 40)) as pilot:
+            for _ in range(30):
+                await pilot.pause()
+                if activity_app._entries:
+                    break
+            assert activity_app._entries, "gather never completed"
+            assert thread_ids, "gather never invoked"
+            assert all(tid != main_thread_id for tid in thread_ids), (
+                "gather ran on the main thread — would block first paint"
+            )
+
+    _run(body())
+
+
+# ---------------------------------------------------------------------------
 # 8. Project dashboard `l` keybinding routes activity:<project_key>.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- `PollyActivityFeedApp.on_mount` called `_refresh` synchronously, which opened the events DB and projected the activity feed on the Textual asyncio main thread — leaving the right pane blank/stale every time the rail respawned `pm cockpit-pane activity`.
- Mirror the operator dashboard (#1653) and inbox (#1605) pattern: paint a `Loading activity…` skeleton immediately, then gather via `run_worker(thread=True)` and apply the result back through `call_from_thread`.
- Manual refresh + follow-mode ticks also go off-thread; the cold-boot worker is gated by `_initial_load_running` so we don't double-dispatch.

Fixes #1649. Sibling of #1605/#1653.

## Test plan
- [x] `pytest tests/test_activity_feed_ui.py` (26 passed — 24 existing + 2 new)
- [x] `pytest tests/test_activity_feed_filters.py tests/test_activity_feed_panel.py tests/test_activity_feed_summaries.py tests/test_activity_feed_cli.py` (58 passed)
- [x] `pytest tests/test_cockpit_smoke_render.py` (31 passed)
- [ ] Manual: click Activity from the rail, confirm `Loading activity…` paints in <1s before rows land.

### New regression tests
- `test_first_paint_is_skeleton_before_gather_completes` parks `_gather` on a `threading.Event` and asserts the skeleton paints before the gather is released. Reverting to the synchronous path would deadlock the test.
- `test_initial_gather_runs_off_main_thread` records the thread id the gather runs on and asserts it isn't the asyncio main thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)