### PR TITLE
fix(rail): cache project-state categorization to skip per-tick DB scans (#1642)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -797,6 +797,14 @@ class CockpitRouter:
     _COCKPIT_WINDOW = "PollyPM"
     _LEFT_PANE_WIDTH = 30  # default; actual value persisted in cockpit state.
     _STATE_WRITE_DEBOUNCE_SECONDS = 0.25
+    # #1642 — TTL for the project-state categorization sweep. Pre-#1642
+    # every rail refresh re-opened every project DB + every inbox source
+    # to recompute glyphs; with 0.8s ticks + state-mtime debouncing, a
+    # navigation burst could stack ~5-10 sweeps inside ``rail_refresh``.
+    # Picked at ~1 tick so a freshly-completed task still surfaces on
+    # the next refresh; callers that need stronger freshness clear via
+    # ``_clear_rail_caches`` (which the supervisor reload already does).
+    _PROJECT_CATEGORIZATIONS_TTL_SECONDS = 2.0
     _SUPERVISOR_FREE_STATIC_KEYS = frozenset(
         {"dashboard", "inbox", "workers", "metrics", "activity", "settings"},
     )
@@ -824,6 +832,20 @@ class CockpitRouter:
         # value: (db_mtime, git_mtime, is_active, has_working_task)
         # Skips re-opening SQLite on every 0.8s cockpit tick when nothing changed.
         self._project_activity_cache: dict[str, tuple[float, float, bool, bool]] = {}
+        # #1642 — short-TTL cache for the operator-state categorization that
+        # the rail glyph draws. ``project_state_map_from_config`` opens every
+        # project DB + walks every inbox source; running that on every
+        # rail-refresh tick (or every burst of state-bumps) stacks a
+        # multi-second sweep into the ``rail_refresh`` worker and contends
+        # with route workers / pane loaders. The cache key is
+        # ``(config_identity, dirty_marker)`` so a config reload (which
+        # ``_load_config`` already routes through ``_clear_rail_caches``)
+        # always misses; within a config lifetime entries expire after
+        # ``_PROJECT_CATEGORIZATIONS_TTL_SECONDS`` so freshly-completed work
+        # still surfaces within ~1 tick.
+        self._project_categorizations_cache_key: int | None = None
+        self._project_categorizations_cache: dict[str, str] | None = None
+        self._project_categorizations_cached_at: float = 0.0
 
     def _presence(self) -> CockpitPresence:
         presence = getattr(self, "presence", None)
@@ -854,6 +876,11 @@ class CockpitRouter:
         self._collapsed_sections_cache = None
         self._grouped_rail_cache_key = None
         self._grouped_rail_cache = None
+        # #1642 — also drop the project-state categorization cache so a
+        # supervisor / config reload doesn't keep painting stale glyphs.
+        self._project_categorizations_cache_key = None
+        self._project_categorizations_cache = None
+        self._project_categorizations_cached_at = 0.0
 
     def _config_identity(self, config: object) -> int:
         return id(config)
@@ -1786,7 +1813,27 @@ class CockpitRouter:
         Best-effort: a project whose DB can't be opened falls through
         to the tracked / paused IDLE classification rather than
         raising, mirroring the rest of the rail render path.
+
+        #1642 — Cached with a short TTL keyed on the config identity
+        (which already rolls forward on every config-file mtime change
+        via ``_load_config`` → ``_clear_rail_caches``). The underlying
+        ``project_state_map_from_config`` opens every project DB and
+        every inbox source on each call; running it on every 0.8s
+        rail-refresh tick stacked a multi-second sweep into the
+        ``rail_refresh`` worker and contended with route workers + pane
+        loaders. The TTL collapses navigation-burst refreshes into a
+        single sweep while keeping glyph staleness bounded.
         """
+        cache_key = self._config_identity(config)
+        now = time.monotonic()
+        cached = self._project_categorizations_cache
+        if (
+            cached is not None
+            and self._project_categorizations_cache_key == cache_key
+            and now - self._project_categorizations_cached_at
+            < self._PROJECT_CATEGORIZATIONS_TTL_SECONDS
+        ):
+            return dict(cached)
         try:
             from pollypm.dashboard.operator_view import (
                 project_state_map_from_config,
@@ -1794,8 +1841,18 @@ class CockpitRouter:
 
             states = project_state_map_from_config(config)
         except Exception:  # noqa: BLE001
+            # Best-effort: cache the empty result too so a hard failure
+            # doesn't re-trigger the (expensive, failing) sweep on every
+            # tick until the TTL elapses.
+            self._project_categorizations_cache_key = cache_key
+            self._project_categorizations_cache = {}
+            self._project_categorizations_cached_at = now
             return {}
-        return {key: state.value for key, state in states.items()}
+        result = {key: state.value for key, state in states.items()}
+        self._project_categorizations_cache_key = cache_key
+        self._project_categorizations_cache = result
+        self._project_categorizations_cached_at = now
+        return dict(result)
 
     def _project_state_rollups(
         self,

--- a/src/pollypm/dashboard/operator_view.py
+++ b/src/pollypm/dashboard/operator_view.py
@@ -327,6 +327,35 @@ def load_operator_view_from_config(config) -> OperatorDashboardView:  # noqa: AN
     )
 
 
+def _scan_to_state(
+    scan: _ProjectScan, items: list,
+) -> tuple[str, ProjectState]:
+    """Per-project worker for :func:`project_state_map_from_config`.
+
+    Mirrors :func:`_scan_to_row` but returns only the classification —
+    callers that just want the state map (e.g. the rail's glyph
+    selector) shouldn't pay for ``what_working`` / ``why_waiting``
+    string assembly that the dashboard view consumes.
+    """
+    svc = _open_work_service(scan)
+    try:
+        if svc is None:
+            if items:
+                return scan.project_key, ProjectState.WAITING
+            if not scan.tracked:
+                return scan.project_key, ProjectState.PAUSED
+            return scan.project_key, ProjectState.IDLE
+        return scan.project_key, categorize_project(
+            scan.project_key,
+            work_service=svc,
+            inbox_items=items,
+            tracked=scan.tracked,
+        )
+    finally:
+        if svc is not None:
+            _safe_close(svc)
+
+
 def project_state_map_from_config(config) -> dict[str, ProjectState]:  # noqa: ANN001
     """Return ``{project_key: ProjectState}`` for every project in ``config``.
 
@@ -335,36 +364,40 @@ def project_state_map_from_config(config) -> dict[str, ProjectState]:  # noqa: A
     matches the glyph drawn next to it. The function is best-effort:
     a project whose DB can't be opened falls through to a tracked /
     paused IDLE classification rather than raising.
+
+    #1642 — Per-project sqlite opens run in parallel via the same
+    bounded pool the dashboard loader uses. The rail invokes this
+    inside its ``rail_refresh`` worker and the prior serial loop was
+    the dominant cost on multi-project workspaces; mirroring
+    :func:`load_operator_view_from_config`'s parallel sweep keeps the
+    rail-refresh path within a single project's DB-open latency
+    regardless of project count. The router additionally TTL-caches
+    the result so navigation bursts collapse into one sweep.
     """
     scans = _collect_project_scans(config)
     waiting_by_project = _waiting_items_by_project(config)
-    states: dict[str, ProjectState] = {}
-    for scan in scans:
-        svc = _open_work_service(scan)
-        items = waiting_by_project.get(scan.project_key, [])
-        try:
-            if svc is None:
-                if items:
-                    states[scan.project_key] = ProjectState.WAITING
-                elif not scan.tracked:
-                    states[scan.project_key] = ProjectState.PAUSED
-                else:
-                    states[scan.project_key] = ProjectState.IDLE
-                continue
-            states[scan.project_key] = categorize_project(
-                scan.project_key,
-                work_service=svc,
-                inbox_items=items,
-                tracked=scan.tracked,
+    if not scans:
+        return {}
+    if len(scans) <= 1:
+        pairs = [
+            _scan_to_state(scan, waiting_by_project.get(scan.project_key, []))
+            for scan in scans
+        ]
+    else:
+        max_workers = min(_MAX_PARALLEL_PROJECT_SCANS, len(scans))
+        with ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="operator-state",
+        ) as pool:
+            pairs = list(
+                pool.map(
+                    lambda scan: _scan_to_state(
+                        scan, waiting_by_project.get(scan.project_key, []),
+                    ),
+                    scans,
+                )
             )
-        finally:
-            close = getattr(svc, "close", None) if svc is not None else None
-            if callable(close):
-                try:
-                    close()
-                except Exception:  # noqa: BLE001
-                    pass
-    return states
+    return {key: state for key, state in pairs}
 
 
 def view_as_ascii(view: OperatorDashboardView) -> str:

--- a/tests/test_cockpit_rail_categorization_cache.py
+++ b/tests/test_cockpit_rail_categorization_cache.py
@@ -1,0 +1,147 @@
+"""Tests for the rail's project-state categorization TTL cache (#1642).
+
+Pre-#1642, ``CockpitRouter._project_categorizations`` called through to
+``project_state_map_from_config`` on every rail-refresh tick. That
+function opens every project DB + walks every inbox source, so a
+navigation burst could stack a multi-second sweep inside the
+``rail_refresh`` worker and contend with route workers + pane loaders.
+
+The fix wraps the call in a short-TTL cache keyed on the config
+identity. These tests pin two invariants:
+
+* Within the TTL, repeated calls collapse to a single underlying sweep
+  (no DB re-scans on every tick).
+* The cache is invalidated when ``_clear_rail_caches`` runs — which is
+  the same chokepoint ``_load_config`` already routes config-mtime
+  reloads through.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pollypm.cockpit_rail import CockpitRouter
+from pollypm.dashboard import ProjectState
+
+
+def _router(tmp_path: Path) -> CockpitRouter:
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        "[project]\n"
+        'name = "PollyPM"\n'
+        f'root_dir = "{tmp_path}"\n'
+        'tmux_session = "pollypm"\n'
+        f'base_dir = "{tmp_path / ".pollypm"}"\n'
+    )
+    return CockpitRouter(config_path)
+
+
+def test_project_categorizations_caches_within_ttl(monkeypatch, tmp_path: Path) -> None:
+    """Repeated calls within the TTL must not re-scan project DBs.
+
+    Counts the number of times ``project_state_map_from_config`` is
+    invoked; on a 0.8s-tick cockpit, 10 calls landing inside the cache
+    window must collapse to exactly one underlying sweep.
+    """
+    router = _router(tmp_path)
+    config = object()
+
+    calls: list[object] = []
+
+    def _fake_map(cfg):  # noqa: ANN001, ANN202
+        calls.append(cfg)
+        return {"alpha": ProjectState.WORKING, "beta": ProjectState.IDLE}
+
+    monkeypatch.setattr(
+        "pollypm.dashboard.operator_view.project_state_map_from_config",
+        _fake_map,
+    )
+
+    first = router._project_categorizations(config)
+    for _ in range(9):
+        router._project_categorizations(config)
+
+    assert len(calls) == 1, (
+        "rail re-scanned project DBs within TTL — expected cached result"
+    )
+    assert first == {"alpha": "working", "beta": "idle"}
+
+
+def test_project_categorizations_invalidates_on_cache_clear(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """``_clear_rail_caches`` (called by ``_load_config`` on mtime change)
+    must drop the categorization cache so a reloaded config doesn't keep
+    painting stale glyphs."""
+    router = _router(tmp_path)
+    config = object()
+
+    state = {"map": {"alpha": ProjectState.WORKING}}
+    calls = 0
+
+    def _fake_map(cfg):  # noqa: ANN001, ANN202
+        nonlocal calls
+        calls += 1
+        return state["map"]
+
+    monkeypatch.setattr(
+        "pollypm.dashboard.operator_view.project_state_map_from_config",
+        _fake_map,
+    )
+
+    router._project_categorizations(config)
+    assert calls == 1
+    router._clear_rail_caches()
+    state["map"] = {"alpha": ProjectState.WAITING}
+    result = router._project_categorizations(config)
+    assert calls == 2
+    assert result == {"alpha": "waiting"}
+
+
+def test_project_categorizations_returns_independent_dict(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Callers must not be able to mutate the cached map.
+
+    The rail glues the result onto ``CockpitItem`` rendering; if a
+    caller pops keys (e.g. while walking project rows) the cached map
+    must stay intact for the next tick.
+    """
+    router = _router(tmp_path)
+    config = object()
+
+    monkeypatch.setattr(
+        "pollypm.dashboard.operator_view.project_state_map_from_config",
+        lambda _cfg: {"alpha": ProjectState.WORKING},
+    )
+
+    first = router._project_categorizations(config)
+    first["alpha"] = "MUTATED"
+    second = router._project_categorizations(config)
+    assert second["alpha"] == "working"
+
+
+def test_project_categorizations_caches_empty_on_failure(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """A raising sweep must still be cached as ``{}`` so the rail
+    doesn't re-trigger the (expensive, failing) scan every tick."""
+    router = _router(tmp_path)
+    config = object()
+
+    calls = 0
+
+    def _boom(_cfg):  # noqa: ANN001, ANN202
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("DB unavailable")
+
+    monkeypatch.setattr(
+        "pollypm.dashboard.operator_view.project_state_map_from_config",
+        _boom,
+    )
+
+    result_a = router._project_categorizations(config)
+    result_b = router._project_categorizations(config)
+    assert result_a == {} == result_b
+    assert calls == 1


### PR DESCRIPTION
## Summary

Fixes #1642 — rail refresh was running a full operator-dashboard categorization sweep on every tick (open every project DB + walk every inbox source), stacking multi-second scans inside the `rail_refresh` worker and contending with route workers / pane loaders during navigation.

- `CockpitRouter._project_categorizations` now TTL-caches the result (2s) keyed on config identity, so a navigation burst collapses to one sweep. The cache invalidates through the existing `_clear_rail_caches` chokepoint, which `_load_config` already calls on config-mtime change.
- `project_state_map_from_config` (the underlying scan) now parallelizes per-project sqlite opens with the same bounded pool the dashboard loader uses (was previously the only serial caller in `operator_view.py`).
- Failure path is cached as `{}` so a hard-failing sweep doesn't re-trigger every tick.

## Test plan

- [x] New `tests/test_cockpit_rail_categorization_cache.py` pins: TTL caching, invalidation on `_clear_rail_caches`, defensive copy on read, and empty-cache on failure
- [x] `pytest -k "rail or operator_view or operator_dashboard"` — all 405 related tests pass (one unrelated pre-existing failure in `test_rail_daemon_supervisor::test_daemon_pid_claim_is_atomic`, one in `test_cockpit::test_cockpit_raw_rail_idle_project_without_alert_stays_idle`; both reproduce on main without this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)