### PR TITLE
fix(cockpit): paint right pane first on healthy static routes (#1646)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -3231,15 +3231,26 @@ class CockpitRouter:
             return False
         state = self._load_state()
         config = self._load_config()
+        window_target = f"{config.project.tmux_session}:{self._COCKPIT_WINDOW}"
         has_mount_state = (
             isinstance(state.get("mounted_session"), str)
             or isinstance(state.get("mounted_identity"), dict)
         )
+        # #1646 — list panes ONCE up front and reuse the result for
+        # both the mounted-live-pane check and the fast-path layout
+        # probe inside the window manager. Without this, the static
+        # route blocked the user-visible ``respawn_pane`` paint behind
+        # multiple synchronous tmux subprocess calls (list_panes +
+        # ensure_layout's repair chain), each gated by the 15s default
+        # timeout. In the common case (cockpit layout is already
+        # healthy), reusing this single ``list_panes`` keeps the
+        # static route at two tmux subprocess calls total.
+        try:
+            panes = self.tmux.list_panes(window_target)
+        except Exception:  # noqa: BLE001
+            panes = None
         if has_mount_state:
-            window_target = f"{config.project.tmux_session}:{self._COCKPIT_WINDOW}"
-            try:
-                panes = self.tmux.list_panes(window_target)
-            except Exception:  # noqa: BLE001
+            if panes is None:
                 return False
             right_pane_id = state.get("right_pane_id")
             right_pane = next(
@@ -3268,12 +3279,26 @@ class CockpitRouter:
             self.tmux,
         )
         right_pane_id = state.get("right_pane_id")
-        result = manager.show_static(
-            self._right_pane_command(key),
-            CockpitWindowState(
-                right_pane_id=right_pane_id if isinstance(right_pane_id, str) else None,
-            ),
+        window_state = CockpitWindowState(
+            right_pane_id=right_pane_id if isinstance(right_pane_id, str) else None,
         )
+        command = self._right_pane_command(key)
+        # #1646 — fast path: when the existing panes already form a
+        # valid two-pane layout (rail on left, content on right, no
+        # dead panes, persisted right pane id matches), respawn the
+        # right pane immediately rather than gating the user-visible
+        # paint on ``ensure_layout``'s repair chain. The slow
+        # ``show_static`` path stays available for genuinely degraded
+        # layouts (and for safety when ``list_panes`` itself failed).
+        result = None
+        if panes is not None:
+            result = manager.try_show_static_fast(
+                command,
+                window_state,
+                panes=panes,
+            )
+        if result is None:
+            result = manager.show_static(command, window_state)
         if not result.ok:
             self._handle_invalid_static_route(result)
         self._write_window_state(result.state, base=state)

--- a/src/pollypm/cockpit_window_manager.py
+++ b/src/pollypm/cockpit_window_manager.py
@@ -356,6 +356,66 @@ class CockpitWindowManager:
         state = state.cleared_mount().with_right(right_id)
         return self._result(state, actions)
 
+    def try_show_static_fast(
+        self,
+        command: str,
+        state: CockpitWindowState | None = None,
+        *,
+        panes: Sequence[Any] | None = None,
+    ) -> CockpitWindowResult | None:
+        """#1646 — paint the right pane FIRST when the layout is already healthy.
+
+        Returns a ``CockpitWindowResult`` with action
+        ``respawn_static_fast:<id>`` when the existing cockpit panes
+        already form a valid two-pane layout (rail on left, content on
+        right, no dead panes, persisted right pane id matches the
+        rightmost live pane). In that common case we skip the
+        :meth:`ensure_layout` repair chain (1-4 extra ``list_panes``
+        subprocess calls plus possible repair/swap/resize calls) and
+        dispatch only the single ``respawn_pane`` that the user
+        actually perceives.
+
+        Returns ``None`` when fast-path preconditions are not met; the
+        caller should fall back to :meth:`show_static`, which performs
+        the full layout repair before respawning.
+        """
+        state = state or CockpitWindowState()
+        right_pane_id = state.right_pane_id
+        if not right_pane_id:
+            return None
+        if panes is None:
+            panes = self.tmux.list_panes(self.spec.window_target)
+        classification = self.classify_panes(panes)
+        if classification.dead_panes:
+            return None
+        if len(classification.live_panes) != 2:
+            return None
+        if classification.rail_pane is None:
+            return None
+        if classification.left_pane is not classification.rail_pane:
+            return None
+        if classification.content_pane is None:
+            return None
+        if classification.right_pane is not classification.content_pane:
+            return None
+        content_id = _pane_id(classification.content_pane)
+        if content_id != right_pane_id:
+            return None
+        self.tmux.respawn_pane(right_pane_id, command)
+        actions = (f"respawn_static_fast:{right_pane_id}",)
+        new_state = state.cleared_mount().with_right(right_pane_id)
+        postcondition = CockpitPostcondition(
+            valid=True,
+            errors=(),
+            left_pane_id=_pane_id(classification.left_pane),
+            right_pane_id=right_pane_id,
+        )
+        return CockpitWindowResult(
+            state=new_state,
+            actions=actions,
+            postcondition=postcondition,
+        )
+
     def join_live_from_storage(
         self,
         live: LivePaneSpec,

--- a/tests/test_cockpit_window_manager.py
+++ b/tests/test_cockpit_window_manager.py
@@ -451,6 +451,101 @@ def test_show_static_respawns_right_and_clears_mounted_state() -> None:
     assert ("respawn_pane", (right_id, "pm cockpit-pane project demo")) in tmux.calls
 
 
+def test_try_show_static_fast_skips_ensure_layout_when_layout_is_healthy() -> None:
+    # #1646 — when the cockpit already has a healthy two-pane layout,
+    # the static route must paint the right pane immediately via a
+    # single ``respawn_pane`` call rather than running
+    # ``ensure_layout``'s multi-step repair chain first.
+    tmux = FakeTmux()
+    window = tmux.add_window("pollypm", "PollyPM", [("uv", 0), ("pm", 100)])
+    right_id = window.panes[1].pane_id
+    manager = _manager(tmux)
+    panes = tmux.list_panes("pollypm:PollyPM")
+    tmux.calls.clear()  # Only count subprocess calls made by the fast path.
+
+    result = manager.try_show_static_fast(
+        "pm cockpit-pane settings",
+        CockpitWindowState(right_pane_id=right_id),
+        panes=panes,
+    )
+
+    assert result is not None
+    assert result.ok
+    assert result.actions == (f"respawn_static_fast:{right_id}",)
+    assert result.state == CockpitWindowState(right_pane_id=right_id)
+    # Only one tmux subprocess call — the user-visible respawn_pane.
+    # No extra list_panes / resize / swap chain from ensure_layout.
+    assert tmux.calls == [
+        ("respawn_pane", (right_id, "pm cockpit-pane settings")),
+    ]
+
+
+def test_try_show_static_fast_returns_none_when_right_pane_id_missing() -> None:
+    # Without a persisted right_pane_id we cannot guarantee that the
+    # rightmost pane is the one the user thinks they're updating;
+    # caller must fall back to the full show_static repair chain.
+    tmux = FakeTmux()
+    tmux.add_window("pollypm", "PollyPM", [("uv", 0), ("pm", 100)])
+    manager = _manager(tmux)
+
+    result = manager.try_show_static_fast(
+        "pm cockpit-pane settings",
+        CockpitWindowState(right_pane_id=None),
+    )
+
+    assert result is None
+
+
+def test_try_show_static_fast_returns_none_when_right_pane_id_stale() -> None:
+    # If the persisted right_pane_id no longer matches any live pane,
+    # the layout is desynced and the fast path must defer to the full
+    # ensure_layout repair.
+    tmux = FakeTmux()
+    tmux.add_window("pollypm", "PollyPM", [("uv", 0), ("pm", 100)])
+    manager = _manager(tmux)
+
+    result = manager.try_show_static_fast(
+        "pm cockpit-pane settings",
+        CockpitWindowState(right_pane_id="%stale"),
+    )
+
+    assert result is None
+
+
+def test_try_show_static_fast_returns_none_when_dead_pane_present() -> None:
+    # Dead panes mean the layout needs repair; respawning the right
+    # pane alone would leave the dead one behind. Defer to show_static.
+    tmux = FakeTmux()
+    window = tmux.add_window(
+        "pollypm",
+        "PollyPM",
+        [("uv", 0, 30, False), ("pm", 40, 80, False), ("bash", 130, 80, True)],
+    )
+    right_id = window.panes[1].pane_id
+    manager = _manager(tmux)
+
+    result = manager.try_show_static_fast(
+        "pm cockpit-pane settings",
+        CockpitWindowState(right_pane_id=right_id),
+    )
+
+    assert result is None
+
+
+def test_try_show_static_fast_returns_none_when_only_one_pane() -> None:
+    tmux = FakeTmux()
+    window = tmux.add_window("pollypm", "PollyPM", [("uv", 0, 180, False)])
+    only_id = window.panes[0].pane_id
+    manager = _manager(tmux)
+
+    result = manager.try_show_static_fast(
+        "pm cockpit-pane settings",
+        CockpitWindowState(right_pane_id=only_id),
+    )
+
+    assert result is None
+
+
 def test_join_live_from_storage_uses_window_index_and_sets_mount_state() -> None:
     tmux = FakeTmux()
     cockpit = tmux.add_window("pollypm", "PollyPM", [("uv", 0), ("pm", 100)])


### PR DESCRIPTION
## Summary
- Static rail clicks (Dashboard, Inbox, Activity, Workers, Metrics, Settings, Operator) no longer wait on the multi-step `ensure_layout` repair chain before the right pane repaints. When the cockpit layout is already healthy, the user-visible `respawn_pane` is dispatched first.
- Adds `CockpitWindowManager.try_show_static_fast`: probes supplied panes against the healthy-layout invariants (two live panes, rail on left, content on right, no dead panes, persisted right_pane_id matches the rightmost pane) and on match calls `respawn_pane` directly, skipping the 1-4 extra `list_panes` and possible repair/swap/resize tmux subprocess calls.
- `CockpitRouter._route_supervisor_free_static` now lists panes once up front and reuses the result for both the mounted-live-pane check and the fast-path probe; falls back to the original `show_static` (full `ensure_layout`) when preconditions are not met or `list_panes` itself failed.

Fixes #1646. Child of #1634.

## Why
Every static rail click was previously serialised through:
1. `list_panes` (in `_route_supervisor_free_static`, only when has_mount_state)
2. `show_static` → `ensure_layout`: 1-4 more `list_panes` calls + possible `_repair_dead_panes`, `_repair_single_pane`, `_split_content_pane`, `swap_pane`, `_resize_rail`
3. Finally `respawn_pane` — the actual user-visible paint.

Each subprocess is gated by tmux's 15s default timeout (`pollypm/tmux/client.py:89`). On a slow/wedged tmux server this matched the 10+ second click-to-content delay reported in #1646. The worker thread off-loading from #1655 was correct but didn't address the synchronous serialization inside the worker. In the common case the fast path collapses the static route to two tmux subprocess calls total: `list_panes` + `respawn_pane`.

## Test plan
- [x] `pytest tests/test_cockpit_window_manager.py tests/test_cockpit_rail_routes.py tests/test_cockpit_static_fast_path_sets.py` — 29 passed (24 existing + 5 new)
- [x] `pytest -k "cockpit_rail or cockpit_window or static_fast"` — 126 passed, 2 xfailed
- [ ] Manual: click Dashboard / Inbox / Activity / Workers / Metrics / Settings / Operator with healthy layout; right pane repaints immediately.
- [ ] Manual: click static destination after a layout-degrading event (dead pane, single pane); confirm slow-path `show_static` recovers via existing `_handle_invalid_static_route` / `_heal_layout_after_route`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)