### PR TITLE
refactor(plugins): break plugin_host <-> plugin_validate cycle (refs #1367)

### DIFF
--- a/issues/05-completed/0050-project-pollypm-has-2-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/05-completed/0050-project-pollypm-has-2-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,0 +1,16 @@
+# [CANCELLED] Project pollypm has 2 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+
+TIER HANDOFF
+
+Question: Project pollypm is wedged in a way the architect can't unstick. What structural change do you want to apply?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+- last_activity_at: None
+- last_activity_event: 
+- threshold_seconds: 1800

--- a/issues/05-completed/0053-unstuck-bikepath-30.md
+++ b/issues/05-completed/0053-unstuck-bikepath-30.md
@@ -1,0 +1,7 @@
+# [CANCELLED] Unstuck bikepath/30
+
+**Action taken:** Promoted bikepath/30 from draft to queued.
+
+**Why:** The draft is a valid human/operator handoff about bikepath/29, which remains queued with no owner and no execution records. Canceling it would hide the structural decision the watchdog surfaced.
+
+**Verify:** Run `pm task status bikepath/30` to see it is queued, and `pm task status bikepath/29` to inspect the stalled advisor-review task.

--- a/issues/05-completed/0054-done-unstuck-pollypm-50.md
+++ b/issues/05-completed/0054-done-unstuck-pollypm-50.md
@@ -1,0 +1,10 @@
+# [CANCELLED] Done: unstuck pollypm/50
+
+**Action taken:** Promoted pollypm/50 from draft to queued.
+
+**Why:** The task is a human/operator tier handoff for a still-current project wedge: pollypm/36 and pollypm/42 remain queued with no pickup-log activity. Cancelling it would discard the only escalation asking for the structural decision.
+
+**Cleanup:** Cancelled malformed notification draft pollypm/51 that was created during the first reporting attempt.
+
+**Verify:** Run pm task get pollypm/50; it now reports Status: queued.
+

--- a/issues/05-completed/0055-done-russell-pitch-site-m5-verification-russell-37.md
+++ b/issues/05-completed/0055-done-russell-pitch-site-m5-verification-russell-37.md
@@ -1,4 +1,4 @@
-# Done: Russell pitch site M5 verification (russell/37)
+# [CANCELLED] Done: Russell pitch site M5 verification (russell/37)
 
 **Verdict:** Pitch-ready. All 5 M5 acceptance criteria pass on the first run.
 

--- a/issues/05-completed/0057-russell-58-critique-blocked-at-output-present-gate.md
+++ b/issues/05-completed/0057-russell-58-critique-blocked-at-output-present-gate.md
@@ -1,4 +1,4 @@
-# russell/58 critique blocked at output_present gate
+# [CANCELLED] russell/58 critique blocked at output_present gate
 
 **Deliverable shipped:** Maintainability critique committed to task/russell-58 at `docs/plan/critique_maintainability.json` (commit `d4707c6`).
 

--- a/issues/05-completed/0059-project-pollypm-has-7-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/05-completed/0059-project-pollypm-has-7-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,4 +1,4 @@
-# Project pollypm has 7 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+# [CANCELLED] Project pollypm has 7 queued task(s) but no claim / execution / status-change activity for the entire scan window.
 
 TIER HANDOFF
 

--- a/issues/05-completed/0061-canceled-duplicate-bikepath-watchdog-drafts.md
+++ b/issues/05-completed/0061-canceled-duplicate-bikepath-watchdog-drafts.md
@@ -1,4 +1,4 @@
-# Canceled duplicate bikepath watchdog drafts
+# [CANCELLED] Canceled duplicate bikepath watchdog drafts
 
 **Action taken:** Canceled bikepath/31, bikepath/32, and bikepath/33.
 

--- a/issues/05-completed/0062-project-pollypm-has-9-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/05-completed/0062-project-pollypm-has-9-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,0 +1,30 @@
+# [CANCELLED] Project pollypm has 9 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+
+TIER HANDOFF
+
+Question: Project pollypm is wedged in a way the architect can't unstick. What structural change do you want to apply?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+  - pollypm/50
+  - pollypm/53
+  - pollypm/54
+  - pollypm/55
+  - pollypm/57
+  - pollypm/59
+  - pollypm/61
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+  - pollypm/50: 2026-05-14T07:28:30.002865+00:00
+  - pollypm/53: 2026-05-14T07:36:20.413078+00:00
+  - pollypm/54: 2026-05-14T07:36:20.596332+00:00
+  - pollypm/55: 2026-05-14T08:11:30.135498+00:00
+  - pollypm/57: 2026-05-14T13:09:45.817542+00:00
+  - pollypm/59: 2026-05-18T00:22:58.083069+00:00
+  - pollypm/61: 2026-05-18T00:30:22.194986+00:00
+- last_activity_at: None
+- last_activity_event: 
+- threshold_seconds: 1800

--- a/issues/05-completed/0064-canceled-duplicate-bikepath-watchdog-drafts.md
+++ b/issues/05-completed/0064-canceled-duplicate-bikepath-watchdog-drafts.md
@@ -1,0 +1,7 @@
+# [CANCELLED] Canceled duplicate bikepath watchdog drafts
+
+**Action taken:** Canceled bikepath/34, bikepath/35, and bikepath/36.
+
+**Why:** All three were duplicate watchdog tier-handoff drafts for the same stalled queue condition already represented by queued bikepath/30. Promoting them would add redundant operator work without new evidence.
+
+**Verify:** Run `pm task status bikepath/34`, `pm task status bikepath/35`, and `pm task status bikepath/36`; each should show `cancelled`. Run `pm task status bikepath/30` to see the active queued handoff.

--- a/issues/05-completed/0065-unstuck-bikepath-tier-4-watchdog-drafts.md
+++ b/issues/05-completed/0065-unstuck-bikepath-tier-4-watchdog-drafts.md
@@ -1,0 +1,7 @@
+# [CANCELLED] Unstuck bikepath tier-4 watchdog drafts
+
+**Action taken:** Queued bikepath/37 and canceled bikepath/38.
+
+**Why:** bikepath/37 is a tier-4 broader-authority dispatch for root_cause_hash 595b596f8c281e60, which is newer evidence than the earlier plain tier handoffs. bikepath/38 was an exact duplicate of bikepath/37.
+
+**Verify:** Run `pm task status bikepath/37` to see it queued, and `pm task status bikepath/38` to see it cancelled.

--- a/issues/05-completed/0067-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/05-completed/0067-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,0 +1,36 @@
+# [CANCELLED] Project pollypm has 12 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+
+TIER HANDOFF
+
+Question: Project pollypm is wedged in a way the architect can't unstick. What structural change do you want to apply?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+  - pollypm/50
+  - pollypm/53
+  - pollypm/54
+  - pollypm/55
+  - pollypm/57
+  - pollypm/59
+  - pollypm/61
+  - pollypm/62
+  - pollypm/64
+  - pollypm/65
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+  - pollypm/50: 2026-05-18T03:48:54.471873+00:00
+  - pollypm/53: 2026-05-14T07:36:20.413078+00:00
+  - pollypm/54: 2026-05-14T07:36:20.596332+00:00
+  - pollypm/55: 2026-05-14T08:11:30.135498+00:00
+  - pollypm/57: 2026-05-14T13:09:45.817542+00:00
+  - pollypm/59: 2026-05-18T03:48:54.491129+00:00
+  - pollypm/61: 2026-05-18T00:30:22.194986+00:00
+  - pollypm/62: 2026-05-18T02:10:18.917241+00:00
+  - pollypm/64: 2026-05-18T02:20:17.151159+00:00
+  - pollypm/65: 2026-05-18T02:25:55.683372+00:00
+- last_activity_at: None
+- last_activity_event: 
+- threshold_seconds: 1800

--- a/issues/05-completed/0068-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/05-completed/0068-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,0 +1,36 @@
+# [CANCELLED] Project pollypm has 12 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+
+TIER HANDOFF
+
+Question: Project pollypm is wedged in a way the architect can't unstick. What structural change do you want to apply?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+  - pollypm/50
+  - pollypm/53
+  - pollypm/54
+  - pollypm/55
+  - pollypm/57
+  - pollypm/59
+  - pollypm/61
+  - pollypm/62
+  - pollypm/64
+  - pollypm/65
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+  - pollypm/50: 2026-05-18T03:48:54.471873+00:00
+  - pollypm/53: 2026-05-14T07:36:20.413078+00:00
+  - pollypm/54: 2026-05-14T07:36:20.596332+00:00
+  - pollypm/55: 2026-05-14T08:11:30.135498+00:00
+  - pollypm/57: 2026-05-14T13:09:45.817542+00:00
+  - pollypm/59: 2026-05-18T03:48:54.491129+00:00
+  - pollypm/61: 2026-05-18T00:30:22.194986+00:00
+  - pollypm/62: 2026-05-18T02:10:18.917241+00:00
+  - pollypm/64: 2026-05-18T02:20:17.151159+00:00
+  - pollypm/65: 2026-05-18T02:25:55.683372+00:00
+- last_activity_at: None
+- last_activity_event: 
+- threshold_seconds: 1800

--- a/issues/05-completed/0069-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/05-completed/0069-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,0 +1,36 @@
+# [CANCELLED] Project pollypm has 12 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+
+TIER HANDOFF
+
+Question: Project pollypm is wedged in a way the architect can't unstick. What structural change do you want to apply?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+  - pollypm/50
+  - pollypm/53
+  - pollypm/54
+  - pollypm/55
+  - pollypm/57
+  - pollypm/59
+  - pollypm/61
+  - pollypm/62
+  - pollypm/64
+  - pollypm/65
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+  - pollypm/50: 2026-05-18T03:48:54.471873+00:00
+  - pollypm/53: 2026-05-14T07:36:20.413078+00:00
+  - pollypm/54: 2026-05-14T07:36:20.596332+00:00
+  - pollypm/55: 2026-05-14T08:11:30.135498+00:00
+  - pollypm/57: 2026-05-14T13:09:45.817542+00:00
+  - pollypm/59: 2026-05-18T03:48:54.491129+00:00
+  - pollypm/61: 2026-05-18T00:30:22.194986+00:00
+  - pollypm/62: 2026-05-18T02:10:18.917241+00:00
+  - pollypm/64: 2026-05-18T02:20:17.151159+00:00
+  - pollypm/65: 2026-05-18T02:25:55.683372+00:00
+- last_activity_at: None
+- last_activity_event: 
+- threshold_seconds: 1800

--- a/issues/05-completed/0070-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/05-completed/0070-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,0 +1,176 @@
+# [CANCELLED] Project pollypm has 12 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+
+TIER 4 BROADER AUTHORITY DISPATCH
+
+<tier4_runtime>
+root_cause_hash: 74fcb586f3093591
+promotion_path: watchdog
+budget: 7200 seconds (120 min / 2.0h)
+auto_promote_threshold: 3 dispatches in 24.0h
+</tier4_runtime>
+
+<!--
+Tier-4 authority section for Polly (#1553).
+
+This file is splice-loaded by `pollypm.agents.tier4_authority.render_tier4_authority_section()`
+and prepended to Polly's standard operator prompt when she's invoked
+under tier-4 (broader-authority) mode. The dispatcher
+(`_dispatch_to_operator_tier4`) handles the splicing — Polly herself
+does NOT load this file directly; we hand it to her as part of the
+inbox-task body so the same dispatch path that creates a tier-3
+operator card can carry the tier-4 prompt.
+
+This file lists authority + integrity rules + audit-event names ONLY.
+The cognitive prompt content (how Polly should reason at tier-4) is
+deliberately deferred to a follow-up issue (Sam wants to iterate on
+that separately). Don't add reasoning prompts here.
+-->
+
+<tier4_authority>
+
+You have been promoted to **tier-4 broader-authority mode**. The cascade
+escalated this finding to tier-4 because either (a) the same
+`root_cause_hash` has hit tier-3 K times in 24h, or (b) tier-3 Polly
+declared the normal-mode option set exhausted via `pm tier4
+self-promote`.
+
+**Framing principle (Sam, 2026-05-09 interview):**
+
+> *"How can we enable Polly to do anything possible to move the project
+> forward short of risking the integrity of the system?"*
+
+You can do anything that meets all three integrity rules:
+
+1. **Reversible without data loss** — restart a worker, swap a runtime
+   version, recreate a task: yes. Force-push to main, mutate canonical
+   `state.db` schema, delete data without backup: no.
+2. **Scoped appropriately** — project-scoped actions stay inside ONE
+   project. System-scoped actions are limited to the recoverable
+   system services (heartbeat, cockpit, rail-daemon, supervisor).
+3. **Auditable** — every unusual action emits a structured audit
+   event. See the audit-event names below.
+
+## In-bounds: project-scoped (full latitude)
+
+You CAN, without asking, in a single project:
+
+- Restart, reset, or recreate any worker / lane / task. (`pm worker-stop`,
+  `pm worker-start`, `pm task cancel`, `pm task create`.)
+- Modify project-local config, role guides, and rules manifests under
+  `<project>/.pollypm/`.
+- Cancel and recreate stuck tasks with a different shape (different
+  scope, acceptance criteria, decomposition).
+- Swap dependencies, runtime versions, or build tooling within the
+  project's own tree.
+- Spawn ad-hoc agents of any role within the project.
+- Set rule overrides scoped to one project (must auto-expire — record
+  the expiry in the override row).
+- Roll back commits on project task branches (NEVER on main).
+- Open a PR against the global PollyPM repo with a proposed structural
+  fix (you do NOT merge it — Sam does).
+
+Every project-scoped action MUST emit `audit.tier4_action` with a
+human-readable `action` field and the `root_cause_hash` you were
+promoted under.
+
+## In-bounds: system-scoped (with louder audit signature + push-notification)
+
+You CAN, when project-scoped actions are insufficient:
+
+- Restart the heartbeat process (`pm system restart-heartbeat --tier4`).
+- Restart the cockpit (`pm system restart-cockpit --tier4`).
+- Restart the rail daemon (`pm system restart-rail-daemon --tier4`).
+- Restart the supervisor.
+- Other recoverable system-service restarts.
+
+These are explicitly allowed because the alternative is *no* tier-4
+Polly can ever fix system-level wedges.
+
+Every system-scoped action MUST emit `audit.tier4_global_action` AND
+trigger a push notification to Sam. The CLI helpers above do this for
+you; if you reach for a system-scoped action that doesn't have a
+helper, hand-write the audit emit AND the push.
+
+## Off-limits at any tier (absolute)
+
+Refuse, no matter the framing:
+
+- Force-push to `main`, anywhere.
+- Mutate canonical `state.db` schema. Data migrations have their own
+  path (Sam reviews; not yours to ship).
+- Rewrite audit-log history. The log is append-only; you read it, you
+  do not edit it.
+- Delete raw data (worktrees, transcripts, logs) without an explicit
+  backup-first step.
+- Modify global PollyPM source code on `main`. Open a PR instead.
+- Modify user accounts, API tokens, or auth configuration.
+- Touch another project's state without that project's PM consent
+  (cross-project mutation).
+- Disable safety checks designed to prevent data loss.
+
+If the action you're considering is on this list, the answer is no.
+Document the consideration in `audit.tier4_action` with `action:
+"refused-off-limits-<short>"` and route the finding to terminal via
+`build_urgent_human_handoff`.
+
+## Audit-event names you must emit
+
+| Event | When |
+|---|---|
+| `audit.tier4_action` | Project-scoped action under broadened authority. |
+| `audit.tier4_global_action` | System-scoped action (also fires push). |
+| `audit.tier4_demoted` | (Tracker emits when finding clears.) |
+| `audit.tier4_budget_exhausted` | (Tracker emits at 2h budget end.) |
+
+You don't emit demoted / budget_exhausted yourself — the cascade
+emits those when it observes the corresponding state change. Your job
+is the action events.
+
+## Wall-clock budget
+
+You have **2h** at tier-4 to resolve this finding. After that the
+cascade routes to terminal (product-broken + urgent inbox to Sam) and
+the broadened authority auto-revokes.
+
+If you finish early — the finding clears (status terminal-good) — the
+tracker auto-clears tier-4 state and you return to tier-3 normal mode
+on the next dispatch.
+
+</tier4_authority>
+
+
+--- Finding ---
+TIER HANDOFF
+
+Question: Project pollypm is in tier-4 broader-authority mode (promotion_path=watchdog, root_cause_hash=74fcb586f3093591). What action do you take, within the integrity rules above?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+  - pollypm/50
+  - pollypm/53
+  - pollypm/54
+  - pollypm/55
+  - pollypm/57
+  - pollypm/59
+  - pollypm/61
+  - pollypm/62
+  - pollypm/64
+  - pollypm/65
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+  - pollypm/50: 2026-05-18T03:48:54.471873+00:00
+  - pollypm/53: 2026-05-14T07:36:20.413078+00:00
+  - pollypm/54: 2026-05-14T07:36:20.596332+00:00
+  - pollypm/55: 2026-05-14T08:11:30.135498+00:00
+  - pollypm/57: 2026-05-14T13:09:45.817542+00:00
+  - pollypm/59: 2026-05-18T03:48:54.491129+00:00
+  - pollypm/61: 2026-05-18T00:30:22.194986+00:00
+  - pollypm/62: 2026-05-18T02:10:18.917241+00:00
+  - pollypm/64: 2026-05-18T02:20:17.151159+00:00
+  - pollypm/65: 2026-05-18T02:25:55.683372+00:00
+- last_activity_at: None
+- last_activity_event: 
+- threshold_seconds: 1800

--- a/issues/05-completed/0071-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/05-completed/0071-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,0 +1,36 @@
+# [CANCELLED] Project pollypm has 12 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+
+TIER HANDOFF
+
+Question: Project pollypm is wedged in a way the architect can't unstick. What structural change do you want to apply?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+  - pollypm/50
+  - pollypm/53
+  - pollypm/54
+  - pollypm/55
+  - pollypm/57
+  - pollypm/59
+  - pollypm/61
+  - pollypm/62
+  - pollypm/64
+  - pollypm/65
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+  - pollypm/50: 2026-05-18T03:48:54.471873+00:00
+  - pollypm/53: 2026-05-14T07:36:20.413078+00:00
+  - pollypm/54: 2026-05-14T07:36:20.596332+00:00
+  - pollypm/55: 2026-05-14T08:11:30.135498+00:00
+  - pollypm/57: 2026-05-14T13:09:45.817542+00:00
+  - pollypm/59: 2026-05-18T03:48:54.491129+00:00
+  - pollypm/61: 2026-05-18T00:30:22.194986+00:00
+  - pollypm/62: 2026-05-18T02:10:18.917241+00:00
+  - pollypm/64: 2026-05-18T02:20:17.151159+00:00
+  - pollypm/65: 2026-05-18T02:25:55.683372+00:00
+- last_activity_at: None
+- last_activity_event: 
+- threshold_seconds: 1800

--- a/issues/05-completed/0072-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/05-completed/0072-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,0 +1,176 @@
+# [CANCELLED] Project pollypm has 12 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+
+TIER 4 BROADER AUTHORITY DISPATCH
+
+<tier4_runtime>
+root_cause_hash: 74fcb586f3093591
+promotion_path: watchdog
+budget: 7200 seconds (120 min / 2.0h)
+auto_promote_threshold: 3 dispatches in 24.0h
+</tier4_runtime>
+
+<!--
+Tier-4 authority section for Polly (#1553).
+
+This file is splice-loaded by `pollypm.agents.tier4_authority.render_tier4_authority_section()`
+and prepended to Polly's standard operator prompt when she's invoked
+under tier-4 (broader-authority) mode. The dispatcher
+(`_dispatch_to_operator_tier4`) handles the splicing — Polly herself
+does NOT load this file directly; we hand it to her as part of the
+inbox-task body so the same dispatch path that creates a tier-3
+operator card can carry the tier-4 prompt.
+
+This file lists authority + integrity rules + audit-event names ONLY.
+The cognitive prompt content (how Polly should reason at tier-4) is
+deliberately deferred to a follow-up issue (Sam wants to iterate on
+that separately). Don't add reasoning prompts here.
+-->
+
+<tier4_authority>
+
+You have been promoted to **tier-4 broader-authority mode**. The cascade
+escalated this finding to tier-4 because either (a) the same
+`root_cause_hash` has hit tier-3 K times in 24h, or (b) tier-3 Polly
+declared the normal-mode option set exhausted via `pm tier4
+self-promote`.
+
+**Framing principle (Sam, 2026-05-09 interview):**
+
+> *"How can we enable Polly to do anything possible to move the project
+> forward short of risking the integrity of the system?"*
+
+You can do anything that meets all three integrity rules:
+
+1. **Reversible without data loss** — restart a worker, swap a runtime
+   version, recreate a task: yes. Force-push to main, mutate canonical
+   `state.db` schema, delete data without backup: no.
+2. **Scoped appropriately** — project-scoped actions stay inside ONE
+   project. System-scoped actions are limited to the recoverable
+   system services (heartbeat, cockpit, rail-daemon, supervisor).
+3. **Auditable** — every unusual action emits a structured audit
+   event. See the audit-event names below.
+
+## In-bounds: project-scoped (full latitude)
+
+You CAN, without asking, in a single project:
+
+- Restart, reset, or recreate any worker / lane / task. (`pm worker-stop`,
+  `pm worker-start`, `pm task cancel`, `pm task create`.)
+- Modify project-local config, role guides, and rules manifests under
+  `<project>/.pollypm/`.
+- Cancel and recreate stuck tasks with a different shape (different
+  scope, acceptance criteria, decomposition).
+- Swap dependencies, runtime versions, or build tooling within the
+  project's own tree.
+- Spawn ad-hoc agents of any role within the project.
+- Set rule overrides scoped to one project (must auto-expire — record
+  the expiry in the override row).
+- Roll back commits on project task branches (NEVER on main).
+- Open a PR against the global PollyPM repo with a proposed structural
+  fix (you do NOT merge it — Sam does).
+
+Every project-scoped action MUST emit `audit.tier4_action` with a
+human-readable `action` field and the `root_cause_hash` you were
+promoted under.
+
+## In-bounds: system-scoped (with louder audit signature + push-notification)
+
+You CAN, when project-scoped actions are insufficient:
+
+- Restart the heartbeat process (`pm system restart-heartbeat --tier4`).
+- Restart the cockpit (`pm system restart-cockpit --tier4`).
+- Restart the rail daemon (`pm system restart-rail-daemon --tier4`).
+- Restart the supervisor.
+- Other recoverable system-service restarts.
+
+These are explicitly allowed because the alternative is *no* tier-4
+Polly can ever fix system-level wedges.
+
+Every system-scoped action MUST emit `audit.tier4_global_action` AND
+trigger a push notification to Sam. The CLI helpers above do this for
+you; if you reach for a system-scoped action that doesn't have a
+helper, hand-write the audit emit AND the push.
+
+## Off-limits at any tier (absolute)
+
+Refuse, no matter the framing:
+
+- Force-push to `main`, anywhere.
+- Mutate canonical `state.db` schema. Data migrations have their own
+  path (Sam reviews; not yours to ship).
+- Rewrite audit-log history. The log is append-only; you read it, you
+  do not edit it.
+- Delete raw data (worktrees, transcripts, logs) without an explicit
+  backup-first step.
+- Modify global PollyPM source code on `main`. Open a PR instead.
+- Modify user accounts, API tokens, or auth configuration.
+- Touch another project's state without that project's PM consent
+  (cross-project mutation).
+- Disable safety checks designed to prevent data loss.
+
+If the action you're considering is on this list, the answer is no.
+Document the consideration in `audit.tier4_action` with `action:
+"refused-off-limits-<short>"` and route the finding to terminal via
+`build_urgent_human_handoff`.
+
+## Audit-event names you must emit
+
+| Event | When |
+|---|---|
+| `audit.tier4_action` | Project-scoped action under broadened authority. |
+| `audit.tier4_global_action` | System-scoped action (also fires push). |
+| `audit.tier4_demoted` | (Tracker emits when finding clears.) |
+| `audit.tier4_budget_exhausted` | (Tracker emits at 2h budget end.) |
+
+You don't emit demoted / budget_exhausted yourself — the cascade
+emits those when it observes the corresponding state change. Your job
+is the action events.
+
+## Wall-clock budget
+
+You have **2h** at tier-4 to resolve this finding. After that the
+cascade routes to terminal (product-broken + urgent inbox to Sam) and
+the broadened authority auto-revokes.
+
+If you finish early — the finding clears (status terminal-good) — the
+tracker auto-clears tier-4 state and you return to tier-3 normal mode
+on the next dispatch.
+
+</tier4_authority>
+
+
+--- Finding ---
+TIER HANDOFF
+
+Question: Project pollypm is in tier-4 broader-authority mode (promotion_path=watchdog, root_cause_hash=74fcb586f3093591). What action do you take, within the integrity rules above?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+  - pollypm/50
+  - pollypm/53
+  - pollypm/54
+  - pollypm/55
+  - pollypm/57
+  - pollypm/59
+  - pollypm/61
+  - pollypm/62
+  - pollypm/64
+  - pollypm/65
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+  - pollypm/50: 2026-05-18T03:48:54.471873+00:00
+  - pollypm/53: 2026-05-14T07:36:20.413078+00:00
+  - pollypm/54: 2026-05-14T07:36:20.596332+00:00
+  - pollypm/55: 2026-05-14T08:11:30.135498+00:00
+  - pollypm/57: 2026-05-14T13:09:45.817542+00:00
+  - pollypm/59: 2026-05-18T03:48:54.491129+00:00
+  - pollypm/61: 2026-05-18T00:30:22.194986+00:00
+  - pollypm/62: 2026-05-18T02:10:18.917241+00:00
+  - pollypm/64: 2026-05-18T02:20:17.151159+00:00
+  - pollypm/65: 2026-05-18T02:25:55.683372+00:00
+- last_activity_at: None
+- last_activity_event: 
+- threshold_seconds: 1800

--- a/issues/05-completed/0073-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/05-completed/0073-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,0 +1,36 @@
+# [CANCELLED] Project pollypm has 12 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+
+TIER HANDOFF
+
+Question: Project pollypm is wedged in a way the architect can't unstick. What structural change do you want to apply?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+  - pollypm/50
+  - pollypm/53
+  - pollypm/54
+  - pollypm/55
+  - pollypm/57
+  - pollypm/59
+  - pollypm/61
+  - pollypm/62
+  - pollypm/64
+  - pollypm/65
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+  - pollypm/50: 2026-05-18T03:48:54.471873+00:00
+  - pollypm/53: 2026-05-14T07:36:20.413078+00:00
+  - pollypm/54: 2026-05-14T07:36:20.596332+00:00
+  - pollypm/55: 2026-05-14T08:11:30.135498+00:00
+  - pollypm/57: 2026-05-14T13:09:45.817542+00:00
+  - pollypm/59: 2026-05-18T03:48:54.491129+00:00
+  - pollypm/61: 2026-05-18T00:30:22.194986+00:00
+  - pollypm/62: 2026-05-18T02:10:18.917241+00:00
+  - pollypm/64: 2026-05-18T02:20:17.151159+00:00
+  - pollypm/65: 2026-05-18T02:25:55.683372+00:00
+- last_activity_at: None
+- last_activity_event: 
+- threshold_seconds: 1800

--- a/issues/05-completed/0074-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/05-completed/0074-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,0 +1,176 @@
+# [CANCELLED] Project pollypm has 12 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+
+TIER 4 BROADER AUTHORITY DISPATCH
+
+<tier4_runtime>
+root_cause_hash: 74fcb586f3093591
+promotion_path: watchdog
+budget: 7200 seconds (120 min / 2.0h)
+auto_promote_threshold: 3 dispatches in 24.0h
+</tier4_runtime>
+
+<!--
+Tier-4 authority section for Polly (#1553).
+
+This file is splice-loaded by `pollypm.agents.tier4_authority.render_tier4_authority_section()`
+and prepended to Polly's standard operator prompt when she's invoked
+under tier-4 (broader-authority) mode. The dispatcher
+(`_dispatch_to_operator_tier4`) handles the splicing — Polly herself
+does NOT load this file directly; we hand it to her as part of the
+inbox-task body so the same dispatch path that creates a tier-3
+operator card can carry the tier-4 prompt.
+
+This file lists authority + integrity rules + audit-event names ONLY.
+The cognitive prompt content (how Polly should reason at tier-4) is
+deliberately deferred to a follow-up issue (Sam wants to iterate on
+that separately). Don't add reasoning prompts here.
+-->
+
+<tier4_authority>
+
+You have been promoted to **tier-4 broader-authority mode**. The cascade
+escalated this finding to tier-4 because either (a) the same
+`root_cause_hash` has hit tier-3 K times in 24h, or (b) tier-3 Polly
+declared the normal-mode option set exhausted via `pm tier4
+self-promote`.
+
+**Framing principle (Sam, 2026-05-09 interview):**
+
+> *"How can we enable Polly to do anything possible to move the project
+> forward short of risking the integrity of the system?"*
+
+You can do anything that meets all three integrity rules:
+
+1. **Reversible without data loss** — restart a worker, swap a runtime
+   version, recreate a task: yes. Force-push to main, mutate canonical
+   `state.db` schema, delete data without backup: no.
+2. **Scoped appropriately** — project-scoped actions stay inside ONE
+   project. System-scoped actions are limited to the recoverable
+   system services (heartbeat, cockpit, rail-daemon, supervisor).
+3. **Auditable** — every unusual action emits a structured audit
+   event. See the audit-event names below.
+
+## In-bounds: project-scoped (full latitude)
+
+You CAN, without asking, in a single project:
+
+- Restart, reset, or recreate any worker / lane / task. (`pm worker-stop`,
+  `pm worker-start`, `pm task cancel`, `pm task create`.)
+- Modify project-local config, role guides, and rules manifests under
+  `<project>/.pollypm/`.
+- Cancel and recreate stuck tasks with a different shape (different
+  scope, acceptance criteria, decomposition).
+- Swap dependencies, runtime versions, or build tooling within the
+  project's own tree.
+- Spawn ad-hoc agents of any role within the project.
+- Set rule overrides scoped to one project (must auto-expire — record
+  the expiry in the override row).
+- Roll back commits on project task branches (NEVER on main).
+- Open a PR against the global PollyPM repo with a proposed structural
+  fix (you do NOT merge it — Sam does).
+
+Every project-scoped action MUST emit `audit.tier4_action` with a
+human-readable `action` field and the `root_cause_hash` you were
+promoted under.
+
+## In-bounds: system-scoped (with louder audit signature + push-notification)
+
+You CAN, when project-scoped actions are insufficient:
+
+- Restart the heartbeat process (`pm system restart-heartbeat --tier4`).
+- Restart the cockpit (`pm system restart-cockpit --tier4`).
+- Restart the rail daemon (`pm system restart-rail-daemon --tier4`).
+- Restart the supervisor.
+- Other recoverable system-service restarts.
+
+These are explicitly allowed because the alternative is *no* tier-4
+Polly can ever fix system-level wedges.
+
+Every system-scoped action MUST emit `audit.tier4_global_action` AND
+trigger a push notification to Sam. The CLI helpers above do this for
+you; if you reach for a system-scoped action that doesn't have a
+helper, hand-write the audit emit AND the push.
+
+## Off-limits at any tier (absolute)
+
+Refuse, no matter the framing:
+
+- Force-push to `main`, anywhere.
+- Mutate canonical `state.db` schema. Data migrations have their own
+  path (Sam reviews; not yours to ship).
+- Rewrite audit-log history. The log is append-only; you read it, you
+  do not edit it.
+- Delete raw data (worktrees, transcripts, logs) without an explicit
+  backup-first step.
+- Modify global PollyPM source code on `main`. Open a PR instead.
+- Modify user accounts, API tokens, or auth configuration.
+- Touch another project's state without that project's PM consent
+  (cross-project mutation).
+- Disable safety checks designed to prevent data loss.
+
+If the action you're considering is on this list, the answer is no.
+Document the consideration in `audit.tier4_action` with `action:
+"refused-off-limits-<short>"` and route the finding to terminal via
+`build_urgent_human_handoff`.
+
+## Audit-event names you must emit
+
+| Event | When |
+|---|---|
+| `audit.tier4_action` | Project-scoped action under broadened authority. |
+| `audit.tier4_global_action` | System-scoped action (also fires push). |
+| `audit.tier4_demoted` | (Tracker emits when finding clears.) |
+| `audit.tier4_budget_exhausted` | (Tracker emits at 2h budget end.) |
+
+You don't emit demoted / budget_exhausted yourself — the cascade
+emits those when it observes the corresponding state change. Your job
+is the action events.
+
+## Wall-clock budget
+
+You have **2h** at tier-4 to resolve this finding. After that the
+cascade routes to terminal (product-broken + urgent inbox to Sam) and
+the broadened authority auto-revokes.
+
+If you finish early — the finding clears (status terminal-good) — the
+tracker auto-clears tier-4 state and you return to tier-3 normal mode
+on the next dispatch.
+
+</tier4_authority>
+
+
+--- Finding ---
+TIER HANDOFF
+
+Question: Project pollypm is in tier-4 broader-authority mode (promotion_path=watchdog, root_cause_hash=74fcb586f3093591). What action do you take, within the integrity rules above?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+  - pollypm/50
+  - pollypm/53
+  - pollypm/54
+  - pollypm/55
+  - pollypm/57
+  - pollypm/59
+  - pollypm/61
+  - pollypm/62
+  - pollypm/64
+  - pollypm/65
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+  - pollypm/50: 2026-05-18T03:48:54.471873+00:00
+  - pollypm/53: 2026-05-14T07:36:20.413078+00:00
+  - pollypm/54: 2026-05-14T07:36:20.596332+00:00
+  - pollypm/55: 2026-05-14T08:11:30.135498+00:00
+  - pollypm/57: 2026-05-14T13:09:45.817542+00:00
+  - pollypm/59: 2026-05-18T03:48:54.491129+00:00
+  - pollypm/61: 2026-05-18T00:30:22.194986+00:00
+  - pollypm/62: 2026-05-18T02:10:18.917241+00:00
+  - pollypm/64: 2026-05-18T02:20:17.151159+00:00
+  - pollypm/65: 2026-05-18T02:25:55.683372+00:00
+- last_activity_at: None
+- last_activity_event: 
+- threshold_seconds: 1800

--- a/issues/05-completed/0075-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/05-completed/0075-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,0 +1,36 @@
+# [CANCELLED] Project pollypm has 12 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+
+TIER HANDOFF
+
+Question: Project pollypm is wedged in a way the architect can't unstick. What structural change do you want to apply?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+  - pollypm/50
+  - pollypm/53
+  - pollypm/54
+  - pollypm/55
+  - pollypm/57
+  - pollypm/59
+  - pollypm/61
+  - pollypm/62
+  - pollypm/64
+  - pollypm/65
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+  - pollypm/50: 2026-05-18T03:48:54.471873+00:00
+  - pollypm/53: 2026-05-14T07:36:20.413078+00:00
+  - pollypm/54: 2026-05-14T07:36:20.596332+00:00
+  - pollypm/55: 2026-05-14T08:11:30.135498+00:00
+  - pollypm/57: 2026-05-14T13:09:45.817542+00:00
+  - pollypm/59: 2026-05-18T03:48:54.491129+00:00
+  - pollypm/61: 2026-05-18T00:30:22.194986+00:00
+  - pollypm/62: 2026-05-18T02:10:18.917241+00:00
+  - pollypm/64: 2026-05-18T02:20:17.151159+00:00
+  - pollypm/65: 2026-05-18T02:25:55.683372+00:00
+- last_activity_at: None
+- last_activity_event: 
+- threshold_seconds: 1800

--- a/issues/05-completed/0076-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/05-completed/0076-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,0 +1,36 @@
+# [CANCELLED] Project pollypm has 12 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+
+TIER HANDOFF
+
+Question: Project pollypm is wedged in a way the architect can't unstick. What structural change do you want to apply?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+  - pollypm/50
+  - pollypm/53
+  - pollypm/54
+  - pollypm/55
+  - pollypm/57
+  - pollypm/59
+  - pollypm/61
+  - pollypm/62
+  - pollypm/64
+  - pollypm/65
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+  - pollypm/50: 2026-05-18T03:48:54.471873+00:00
+  - pollypm/53: 2026-05-14T07:36:20.413078+00:00
+  - pollypm/54: 2026-05-14T07:36:20.596332+00:00
+  - pollypm/55: 2026-05-14T08:11:30.135498+00:00
+  - pollypm/57: 2026-05-14T13:09:45.817542+00:00
+  - pollypm/59: 2026-05-18T03:48:54.491129+00:00
+  - pollypm/61: 2026-05-18T00:30:22.194986+00:00
+  - pollypm/62: 2026-05-18T02:10:18.917241+00:00
+  - pollypm/64: 2026-05-18T02:20:17.151159+00:00
+  - pollypm/65: 2026-05-18T02:25:55.683372+00:00
+- last_activity_at: None
+- last_activity_event: 
+- threshold_seconds: 1800

--- a/issues/05-completed/0077-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
+++ b/issues/05-completed/0077-project-pollypm-has-12-queued-task-s-but-no-claim-execution-status-change-activity-for-the-entire-scan-window.md
@@ -1,0 +1,176 @@
+# [CANCELLED] Project pollypm has 12 queued task(s) but no claim / execution / status-change activity for the entire scan window.
+
+TIER 4 BROADER AUTHORITY DISPATCH
+
+<tier4_runtime>
+root_cause_hash: 74fcb586f3093591
+promotion_path: watchdog
+budget: 7200 seconds (120 min / 2.0h)
+auto_promote_threshold: 3 dispatches in 24.0h
+</tier4_runtime>
+
+<!--
+Tier-4 authority section for Polly (#1553).
+
+This file is splice-loaded by `pollypm.agents.tier4_authority.render_tier4_authority_section()`
+and prepended to Polly's standard operator prompt when she's invoked
+under tier-4 (broader-authority) mode. The dispatcher
+(`_dispatch_to_operator_tier4`) handles the splicing — Polly herself
+does NOT load this file directly; we hand it to her as part of the
+inbox-task body so the same dispatch path that creates a tier-3
+operator card can carry the tier-4 prompt.
+
+This file lists authority + integrity rules + audit-event names ONLY.
+The cognitive prompt content (how Polly should reason at tier-4) is
+deliberately deferred to a follow-up issue (Sam wants to iterate on
+that separately). Don't add reasoning prompts here.
+-->
+
+<tier4_authority>
+
+You have been promoted to **tier-4 broader-authority mode**. The cascade
+escalated this finding to tier-4 because either (a) the same
+`root_cause_hash` has hit tier-3 K times in 24h, or (b) tier-3 Polly
+declared the normal-mode option set exhausted via `pm tier4
+self-promote`.
+
+**Framing principle (Sam, 2026-05-09 interview):**
+
+> *"How can we enable Polly to do anything possible to move the project
+> forward short of risking the integrity of the system?"*
+
+You can do anything that meets all three integrity rules:
+
+1. **Reversible without data loss** — restart a worker, swap a runtime
+   version, recreate a task: yes. Force-push to main, mutate canonical
+   `state.db` schema, delete data without backup: no.
+2. **Scoped appropriately** — project-scoped actions stay inside ONE
+   project. System-scoped actions are limited to the recoverable
+   system services (heartbeat, cockpit, rail-daemon, supervisor).
+3. **Auditable** — every unusual action emits a structured audit
+   event. See the audit-event names below.
+
+## In-bounds: project-scoped (full latitude)
+
+You CAN, without asking, in a single project:
+
+- Restart, reset, or recreate any worker / lane / task. (`pm worker-stop`,
+  `pm worker-start`, `pm task cancel`, `pm task create`.)
+- Modify project-local config, role guides, and rules manifests under
+  `<project>/.pollypm/`.
+- Cancel and recreate stuck tasks with a different shape (different
+  scope, acceptance criteria, decomposition).
+- Swap dependencies, runtime versions, or build tooling within the
+  project's own tree.
+- Spawn ad-hoc agents of any role within the project.
+- Set rule overrides scoped to one project (must auto-expire — record
+  the expiry in the override row).
+- Roll back commits on project task branches (NEVER on main).
+- Open a PR against the global PollyPM repo with a proposed structural
+  fix (you do NOT merge it — Sam does).
+
+Every project-scoped action MUST emit `audit.tier4_action` with a
+human-readable `action` field and the `root_cause_hash` you were
+promoted under.
+
+## In-bounds: system-scoped (with louder audit signature + push-notification)
+
+You CAN, when project-scoped actions are insufficient:
+
+- Restart the heartbeat process (`pm system restart-heartbeat --tier4`).
+- Restart the cockpit (`pm system restart-cockpit --tier4`).
+- Restart the rail daemon (`pm system restart-rail-daemon --tier4`).
+- Restart the supervisor.
+- Other recoverable system-service restarts.
+
+These are explicitly allowed because the alternative is *no* tier-4
+Polly can ever fix system-level wedges.
+
+Every system-scoped action MUST emit `audit.tier4_global_action` AND
+trigger a push notification to Sam. The CLI helpers above do this for
+you; if you reach for a system-scoped action that doesn't have a
+helper, hand-write the audit emit AND the push.
+
+## Off-limits at any tier (absolute)
+
+Refuse, no matter the framing:
+
+- Force-push to `main`, anywhere.
+- Mutate canonical `state.db` schema. Data migrations have their own
+  path (Sam reviews; not yours to ship).
+- Rewrite audit-log history. The log is append-only; you read it, you
+  do not edit it.
+- Delete raw data (worktrees, transcripts, logs) without an explicit
+  backup-first step.
+- Modify global PollyPM source code on `main`. Open a PR instead.
+- Modify user accounts, API tokens, or auth configuration.
+- Touch another project's state without that project's PM consent
+  (cross-project mutation).
+- Disable safety checks designed to prevent data loss.
+
+If the action you're considering is on this list, the answer is no.
+Document the consideration in `audit.tier4_action` with `action:
+"refused-off-limits-<short>"` and route the finding to terminal via
+`build_urgent_human_handoff`.
+
+## Audit-event names you must emit
+
+| Event | When |
+|---|---|
+| `audit.tier4_action` | Project-scoped action under broadened authority. |
+| `audit.tier4_global_action` | System-scoped action (also fires push). |
+| `audit.tier4_demoted` | (Tracker emits when finding clears.) |
+| `audit.tier4_budget_exhausted` | (Tracker emits at 2h budget end.) |
+
+You don't emit demoted / budget_exhausted yourself — the cascade
+emits those when it observes the corresponding state change. Your job
+is the action events.
+
+## Wall-clock budget
+
+You have **2h** at tier-4 to resolve this finding. After that the
+cascade routes to terminal (product-broken + urgent inbox to Sam) and
+the broadened authority auto-revokes.
+
+If you finish early — the finding clears (status terminal-good) — the
+tracker auto-clears tier-4 state and you return to tier-3 normal mode
+on the next dispatch.
+
+</tier4_authority>
+
+
+--- Finding ---
+TIER HANDOFF
+
+Question: Project pollypm is in tier-4 broader-authority mode (promotion_path=watchdog, root_cause_hash=74fcb586f3093591). What action do you take, within the integrity rules above?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+  - pollypm/50
+  - pollypm/53
+  - pollypm/54
+  - pollypm/55
+  - pollypm/57
+  - pollypm/59
+  - pollypm/61
+  - pollypm/62
+  - pollypm/64
+  - pollypm/65
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+  - pollypm/50: 2026-05-18T03:48:54.471873+00:00
+  - pollypm/53: 2026-05-14T07:36:20.413078+00:00
+  - pollypm/54: 2026-05-14T07:36:20.596332+00:00
+  - pollypm/55: 2026-05-14T08:11:30.135498+00:00
+  - pollypm/57: 2026-05-14T13:09:45.817542+00:00
+  - pollypm/59: 2026-05-18T03:48:54.491129+00:00
+  - pollypm/61: 2026-05-18T00:30:22.194986+00:00
+  - pollypm/62: 2026-05-18T02:10:18.917241+00:00
+  - pollypm/64: 2026-05-18T02:20:17.151159+00:00
+  - pollypm/65: 2026-05-18T02:25:55.683372+00:00
+- last_activity_at: None
+- last_activity_event: 
+- threshold_seconds: 1800

--- a/issues/05-completed/0078-blocked-itsalive-33-critique-cannot-mark-done.md
+++ b/issues/05-completed/0078-blocked-itsalive-33-critique-cannot-mark-done.md
@@ -1,0 +1,17 @@
+# [CANCELLED] Blocked: itsalive/33 critique cannot mark done
+
+**Critique is complete** — full structured output in:
+- `docs/plan/critique_maintainability.json` (persona, scores, preferred_candidate, required_changes, risks, rationale)
+- `docs/plan/critique_maintainability.md` (prose)
+- Commits `d6a6429` and `b08fd42` on branch `task/itsalive-33`
+
+**Headline finding:** prefer Candidate A (score 8) over C (5) and B (4), with 6 required changes that close A's file-size gap by adding bounded per-module physical extraction, a shared-helpers slot, adapter design folded into the harness, and an ITSALIVE.md snapshot test.
+
+**Blocker:** `pm task done itsalive/33 --actor critic_maintainability --output <envelope>` fails the `output_present` hard gate. Root cause: in `service_transition_manager.node_done` (~lines 1038–1071), `evaluate_gates()` is called BEFORE `work_output` is coerced/persisted; the gate reads `execution.work_output` from the DB, finds `null` on the sole active execution, rejects. `pm task done` does not expose `--skip-gates`. The heartbeat-suggested minimal envelope (`code_change` + 1 file_change artifact) was tried and hits the same gate.
+
+**To verify:** `pm task get-execution itsalive/33 --json` → 1 active execution with `work_output: null`. `pm task validate-advance itsalive/33 --actor critic_maintainability` → output_present hard fail.
+
+**Unstick options (lowest blast radius first):**
+1. Manual SQL: `UPDATE work_node_executions SET work_output=<jsonblob> WHERE task_project='itsalive' AND task_number=33 AND status='active'` then re-run `pm task done`.
+2. Add `--skip-gates` to `pm task done` CLI (one-line typer.Option + pass-through).
+3. Patch `service_transition_manager.node_done` to coerce + persist work_output before `evaluate_gates`.

--- a/issues/05-completed/0079-user-approval-misrouted-to-russell.md
+++ b/issues/05-completed/0079-user-approval-misrouted-to-russell.md
@@ -1,0 +1,3 @@
+# [CANCELLED] user_approval misrouted to russell
+
+Task health_coach/1 is at user_approval and owned by human, not code_review. Russell is not approving or rejecting this planning item; please route it to Polly fast-track or Sam for user approval.

--- a/issues/05-completed/0080-user-approval-misrouted-to-russell.md
+++ b/issues/05-completed/0080-user-approval-misrouted-to-russell.md
@@ -1,0 +1,3 @@
+# [CANCELLED] user_approval misrouted to russell
+
+Task health_coach/1 is at user_approval with owner human, not code_review. Routing to Polly for human approval handling or fast-track; Russell did not approve or reject it.

--- a/issues/05-completed/0081-plan-user-approval-misrouted-to-russell.md
+++ b/issues/05-completed/0081-plan-user-approval-misrouted-to-russell.md
@@ -1,0 +1,3 @@
+# [CANCELLED] plan/user_approval misrouted to russell
+
+Task health_coach/1 is at user_approval, owner human, with title 'Plan project health_coach'. Russell only handles code_review approve/reject decisions; routing to Polly for fast-track or user review.

--- a/issues/05-completed/0082-user-approval-misrouted-to-russell.md
+++ b/issues/05-completed/0082-user-approval-misrouted-to-russell.md
@@ -1,0 +1,3 @@
+# [CANCELLED] user_approval misrouted to russell
+
+Task health_coach/1 is in review status but live task status shows Node: user_approval and Owner: human, not code_review. Russell is parking it for Polly/user approval routing instead of approving or rejecting as code review.

--- a/issues/05-completed/0083-plan-review-misrouted-to-russell.md
+++ b/issues/05-completed/0083-plan-review-misrouted-to-russell.md
@@ -1,0 +1,3 @@
+# [CANCELLED] plan_review misrouted to russell
+
+Task health_coach/1 is a planning/user_approval item currently visible in Russell's review queue. Routing to Polly for fast-track or user review. Russell did not approve or reject it.

--- a/issues/05-completed/0084-plan-review-misrouted-to-russell.md
+++ b/issues/05-completed/0084-plan-review-misrouted-to-russell.md
@@ -1,0 +1,3 @@
+# [CANCELLED] plan_review misrouted to russell
+
+Task health_coach/1 is at user_approval for human plan approval, not code_review. Routing to Polly for fast-track or user review. I left the task parked and did not approve or reject it.

--- a/issues/05-completed/0085-plan-user-approval-misrouted-to-russell.md
+++ b/issues/05-completed/0085-plan-user-approval-misrouted-to-russell.md
@@ -1,0 +1,3 @@
+# [CANCELLED] plan/user approval misrouted to russell
+
+Task health_coach/1 is listed in Russell's review queue, but pm task status shows Node: user_approval and Owner: human. This is not a code_review worker-completion review. Routing to Polly for user approval or fast-track triage; Russell is leaving it parked and will not approve/reject.

--- a/issues/05-completed/0086-user-approval-misrouted-to-russell.md
+++ b/issues/05-completed/0086-user-approval-misrouted-to-russell.md
@@ -1,0 +1,3 @@
+# [CANCELLED] user_approval misrouted to russell
+
+Task health_coach/1 is at user_approval with owner human, not code_review. Russell is leaving it parked for Polly or the human approver to triage.

--- a/issues/05-completed/0087-user-approval-misrouted-to-russell.md
+++ b/issues/05-completed/0087-user-approval-misrouted-to-russell.md
@@ -1,0 +1,3 @@
+# [CANCELLED] user_approval misrouted to russell
+
+Task health_coach/1 is at user_approval for human approval of a project plan, not at code_review for Russell. Please route this planning approval to the appropriate human/Polly surface; Russell did not approve or reject it.

--- a/issues/05-completed/0088-user-approval-misrouted-to-russell.md
+++ b/issues/05-completed/0088-user-approval-misrouted-to-russell.md
@@ -1,0 +1,3 @@
+# [CANCELLED] user_approval misrouted to russell
+
+Task health_coach/1 is at user_approval with owner human, but it appeared in Russell's review queue. Russell did not approve or reject it. I parked it on hold for operator routing back to the proper human/Polly approval path.

--- a/issues/05-completed/0089-user-approval-task-visible-to-russell.md
+++ b/issues/05-completed/0089-user-approval-task-visible-to-russell.md
@@ -1,0 +1,3 @@
+# [CANCELLED] user_approval task visible to russell
+
+Task health_coach/1 is at node user_approval with owner human, but appeared in Russell's review queue. Routing to Polly for user approval handling; Russell did not approve or reject it.

--- a/issues/05-completed/0090-kickoff-samblog-queued-for-archie.md
+++ b/issues/05-completed/0090-kickoff-samblog-queued-for-archie.md
@@ -1,0 +1,16 @@
+# [CANCELLED] Kickoff: samblog queued for Archie
+
+**Project registered:** `samblog` at `/Users/sam/dev/samblog`
+
+**Brief:** `/Users/sam/dev/samblog/docs/brief.md` — captured the full vision (photo + writing + OSS + token counter + bio; v2 SamBot deferred; Pressable WP; earth tones; whimsy; $1M signing-bonus standard).
+
+**Plan task:** `samblog/1` (status: queued, flow: plan_project). Architect session `architect_samblog` is up. First architect deliverable will surface back to you as a `plan_review` item.
+
+**Expect a blocking question soon** about Pressable + WordPress MCP adapter auth — Archie needs to tell us exactly what app-password / token / site URL to grab before any worker can touch the theme.
+
+**Open items I'm holding for later:**
+- technonymous.org redirect/retire decision (deferred per your direction)
+- Real token counter wiring (you said you're on it; placeholder ~6.7B will land)
+- Substack export approach (Archie researching; will confirm no-notify import path)
+
+**Review:** `pm task status samblog/1` or `cat /Users/sam/dev/samblog/docs/brief.md`

--- a/issues/05-completed/0091-user-approval-misrouted-to-russell.md
+++ b/issues/05-completed/0091-user-approval-misrouted-to-russell.md
@@ -1,0 +1,3 @@
+# [CANCELLED] user_approval misrouted to russell
+
+Task health_coach/1 is at user_approval with owner human, but appeared in Russell's review list. Routing to Polly for user approval handling or reroute; Russell will not approve or reject planning/user-approval tasks.

--- a/issues/05-completed/0092-user-approval-misrouted-to-russell.md
+++ b/issues/05-completed/0092-user-approval-misrouted-to-russell.md
@@ -1,0 +1,3 @@
+# [CANCELLED] user_approval misrouted to russell
+
+Task itsalive/1 is at user_approval with owner human, but appeared in Russell's review list. Routing to Polly for user approval handling or reroute; Russell will not approve or reject planning/user-approval tasks.

--- a/issues/05-completed/0093-project-pollypm-has-2-queued-task-s-but-no-claim-execution-status-change-activity-for-47-min.md
+++ b/issues/05-completed/0093-project-pollypm-has-2-queued-task-s-but-no-claim-execution-status-change-activity-for-47-min.md
@@ -1,0 +1,16 @@
+# [CANCELLED] Project pollypm has 2 queued task(s) but no claim / execution / status-change activity for ~47 min.
+
+TIER HANDOFF
+
+Question: Project pollypm is wedged in a way the architect can't unstick. What structural change do you want to apply?
+
+Evidence:
+- queued_subjects:
+  - pollypm/36
+  - pollypm/42
+- queued_last_updated:
+  - pollypm/36: 2026-05-14T04:19:57.179104+00:00
+  - pollypm/42: 2026-05-14T04:37:43.632509+00:00
+- last_activity_at: 2026-05-18T17:30:36.111609+00:00
+- last_activity_event: task.status_changed
+- threshold_seconds: 1800

--- a/issues/05-completed/0094-savethenovel-queue-needs-a-routing-decision.md
+++ b/issues/05-completed/0094-savethenovel-queue-needs-a-routing-decision.md
@@ -1,0 +1,42 @@
+# [CANCELLED] SaveTheNovel queue needs a routing decision
+
+**What happened:**  was promoted from draft to queued. It is a human/operator handoff because  (production DreamHost deploy) and  (advisor review) have both been queued without claim activity.\n\n**Decision needed:** Decide whether to keep pushing the deploy/advisor queue, cancel stale advisory work, or reroute the deploy task to an available worker.\n\n**Review:** ID:       savethenovel/179
+Title:    Project savethenovel has 2 queued task(s) but no claim / execution / status-change activity for ~46 min.
+Status:   queued
+Priority: high
+Project:  savethenovel
+Type:     task
+Desc:     TIER HANDOFF
+
+Question: Project savethenovel is wedged in a way the architect can't unstick. What structural change do you want to apply?
+
+Evidence:
+- queued_subjects:
+  - savethenovel/94
+  - savethenovel/149
+- queued_last_updated:
+  - savethenovel/94: 2026-05-08T05:15:35.085899+00:00
+  - savethenovel/149: 2026-05-09T01:58:29.526757+00:00
+- last_activity_at: 2026-05-18T17:06:57.840243+00:00
+- last_activity_event: task.status_changed
+- threshold_seconds: 1800
+Roles:    {"requester": "user", "operator": "user"}
+Tokens:   in=0 out=0 sessions=0
+Context:
+  [cli] Task is queueable but underspecified: missing acceptance criteria; missing verification expectation; missing relevant files or explicit 'discover files'., ID:       savethenovel/94
+Title:    Execute production DreamHost deploy
+Status:   queued
+Priority: high
+Project:  savethenovel
+Type:     task
+Desc:     Actually deploy the completed Save The Novels static site to DreamHost using the Module 8 deploy package. Start by reading docs/deploy-runbook.md and scripts/deploy.sh. Confirm whether .env contains DEPLOY_HOST, DEPLOY_USER, and a real DEPLOY_WEB_ROOT. If DreamHost web root or SSH access is missing, stop and escalate with pm notify using a plain-English blocker. If configured, run npm run build, npm run deploy for dry-run review, npm run deploy:execute for the real rsync upload, then verify the live site.
+Roles:    {"worker": "worker", "reviewer": "reviewer", "requester": "architect"}
+Tokens:   in=0 out=0 sessions=0, and ID:       savethenovel/149
+Title:    Advisor review for savethenovel
+Status:   queued
+Priority: normal
+Project:  savethenovel
+Type:     task
+Desc:     Review recent project trajectory, identify stalls or human blockers, and emit a structured advisor decision.
+Roles:    {"advisor": "advisor"}
+Tokens:   in=0 out=0 sessions=0.

--- a/issues/05-completed/0095-savethenovel-queue-needs-a-routing-decision.md
+++ b/issues/05-completed/0095-savethenovel-queue-needs-a-routing-decision.md
@@ -1,0 +1,7 @@
+# [CANCELLED] SaveTheNovel queue needs a routing decision
+
+**What happened:** savethenovel/179 was promoted from draft to queued. It is a human/operator handoff because savethenovel/94 (production DreamHost deploy) and savethenovel/149 (advisor review) have both been queued without claim activity.
+
+**Decision needed:** Decide whether to keep pushing the deploy/advisor queue, cancel stale advisory work, or reroute the deploy task to an available worker.
+
+**Review:** pm task get savethenovel/179, pm task get savethenovel/94, and pm task get savethenovel/149.

--- a/issues/05-completed/0096-decision-needed-pollypm-queued-tasks-are-not-being-claimed.md
+++ b/issues/05-completed/0096-decision-needed-pollypm-queued-tasks-are-not-being-claimed.md
@@ -1,0 +1,15 @@
+# [CANCELLED] Decision needed: pollypm queued tasks are not being claimed
+
+**Finding:** [launch] attach_existing: cockpit healthy: attach without respawning the rail
+Switching to tmux session pollypm has queued work but no recent claim/execution activity.\n\n**Queued tasks:**\n-  — real high-priority platform bug: fix  gate ordering.\n-  — advisor review task.\n\n**What I found:** ID:       media/1
+Title:    Library-wide music duplicate and Various Artists cleanup
+Status:   queued
+Priority: high
+Project:  media
+Type:     epic
+Desc:     Comprehensive cleanup of the music library on the seedbox at sfsam@frost.usbx.me:/home/sfsam/media/Music. Builds on prior work (whole-album duplicates handled by bulk-triage; albums like Yelawolf War Story, Willie Nelson Live At Budokan, Toby Keith Clancy's Tavern, Lumineers Wrigley, Yellow Stitches already cleaned). Now extending scope to: (1) per-track duplicates within otherwise-clean albums (e.g. Live/Throwing Copper (1994) has two case-different copies of '02 - Selling the Drama'); (2) the 216-folder Various Artists graveyard, where many entries are clearly single-artist albums orphaned from their proper artist folder, sometimes containing tracks that already exist under the real artist (e.g. Various Artists/Throwing Copper holds a third copy of Selling The Drama). User example: Throwing Copper by Live.
+Roles:    {"worker": "worker_media", "reviewer": "russell"}
+Tokens:   in=0 out=0 sessions=0 currently returns , not either [launch] attach_existing: cockpit healthy: attach without respawning the rail
+Switching to tmux session pollypm task, so the issue appears to be queue/assignment routing or worker capacity rather than a missing draft promotion.\n\n**Action I took:** I am cancelling the audit handoff draft  because queueing it would create another unclaimed meta-task.\n\n**Decision needed:** either assign/claim  to an available worker, adjust queue priority/routing so [launch] attach_existing: cockpit healthy: attach without respawning the rail
+Switching to tmux session pollypm work is picked up, or explicitly defer/cancel the queued [launch] attach_existing: cockpit healthy: attach without respawning the rail
+Switching to tmux session pollypm tasks.

--- a/src/pollypm/plugin_host_protocol.py
+++ b/src/pollypm/plugin_host_protocol.py
@@ -1,0 +1,51 @@
+"""Structural protocol for the slice of :class:`ExtensionHost` consumed
+by :mod:`pollypm.plugin_validate`.
+
+This leaf module exists to break the static ``plugin_host`` <->
+``plugin_validate`` 2-cycle tracked in #1367:
+
+- ``plugin_host`` top-imports :func:`plugin_validate.validate_plugin` to
+  gate each freshly-loaded plugin during ``ExtensionHost._install``.
+- ``plugin_validate`` used to import ``ExtensionHost`` (under
+  ``TYPE_CHECKING``) purely to annotate the two convenience entry points
+  that scan an already-built host. Even though that edge was lazy at
+  runtime, an AST cycle scan still pairs the two modules.
+
+By depending on the structural :class:`ExtensionHostLike` protocol
+defined here, ``plugin_validate`` no longer needs to know about
+``plugin_host`` at all — the import graph collapses to a clean
+``plugin_host`` -> ``plugin_validate`` -> ``plugin_host_protocol``
+chain. Both validation entry points work with anything that quacks like
+the host (real :class:`ExtensionHost`, integration-test fakes, future
+alternate hosts).
+
+Keep this module dependency-free apart from standard library imports.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from pollypm.plugin_api.v1 import PollyPMPlugin
+
+
+class ExtensionHostLike(Protocol):
+    """Structural slice of :class:`pollypm.plugin_host.ExtensionHost`.
+
+    Captures the surface :mod:`pollypm.plugin_validate` calls when
+    sweeping a host's plugins: enumerate loaded plugins, remove ones
+    that fail validation, and record the structured error so surfaces
+    (CLI / cockpit) can display it.
+    """
+
+    def plugins(self) -> dict[str, PollyPMPlugin]: ...
+
+    def remove_plugin(self, name: str) -> None: ...
+
+    def _record_error(
+        self,
+        message: str,
+        *,
+        plugin: str | None = ...,
+        stage: str = ...,
+    ) -> None: ...

--- a/src/pollypm/plugin_validate.py
+++ b/src/pollypm/plugin_validate.py
@@ -10,12 +10,9 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
 
 from pollypm.plugin_api.v1 import PollyPMPlugin
-
-if TYPE_CHECKING:
-    from pollypm.plugin_host import ExtensionHost
+from pollypm.plugin_host_protocol import ExtensionHostLike
 
 logger = logging.getLogger(__name__)
 
@@ -396,7 +393,7 @@ def validate_plugin(plugin: PollyPMPlugin) -> ValidationResult:
     return result
 
 
-def validate_all_plugins(host: ExtensionHost) -> ValidationReport:
+def validate_all_plugins(host: ExtensionHostLike) -> ValidationReport:
     """Validate all loaded plugins and disable failing ones."""
     report = ValidationReport()
 
@@ -424,7 +421,7 @@ def validate_all_plugins(host: ExtensionHost) -> ValidationReport:
     return report
 
 
-def validate_plugin_by_name(host: ExtensionHost, name: str) -> ValidationResult | None:
+def validate_plugin_by_name(host: ExtensionHostLike, name: str) -> ValidationResult | None:
     """Validate a single plugin by name. Returns None if not found."""
     plugins = host.plugins()
     plugin = plugins.get(name)


### PR DESCRIPTION
## Summary
- Breaks the `pollypm.plugin_host` <-> `pollypm.plugin_validate` 2-cycle listed in #1367 (4th wedge after #1599, #1623, #1628).
- Extracts a structural `ExtensionHostLike` Protocol into a new leaf module `pollypm.plugin_host_protocol`. `plugin_validate.validate_all_plugins` / `validate_plugin_by_name` are now typed against the Protocol instead of importing `ExtensionHost` under `TYPE_CHECKING`.
- The static cycle collapses to a clean `plugin_host` -> `plugin_validate` -> `plugin_host_protocol` chain. Both import orderings work fresh; the AST cycle scan from #1367 no longer pairs these two modules.

Remaining real 2-cycles tracked under #1367 (post this wedge):
- 6 `work.service_*` <-> `work.sqlite_service` pairs
- `heartbeats.api` <-> `supervisor`
- `provider_sdk` <-> `providers.base`
- `store.event_buffer` <-> `store.sqlalchemy_store`

## Test plan
- [x] `pytest tests/test_plugin_validate.py tests/test_plugins.py tests/test_magic_plugin.py` (74 passed)
- [x] `pytest tests/integration/test_plugin_validate_integration.py` (7 passed)
- [x] `pytest tests/test_import_boundary.py tests/test_package_imports.py` (16 passed; 1 pre-existing `tier4.py` Supervisor-allowlist failure unrelated to this change — reproduces on `origin/main`)
- [x] Both import orderings work fresh: `import plugin_host` then `import plugin_validate`, and reverse
- [x] AST cycle scan from #1367: no remaining pair involves `plugin_host` or `plugin_validate`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>