### PR TITLE
fix(observability): log 12 silent except Exception sites in work/cockpit/recurring (#1355 wedge)

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -1328,6 +1328,15 @@ class PollyCockpitApp(App[None]):
                 self, kind="cockpit", config_path=self.config_path,
             )
         except Exception:  # noqa: BLE001
+            # #1355: previously silent. A failed input-bridge boot
+            # breaks `pm cockpit-send-key` / automation routing
+            # without any signal to the user — log so the disabled
+            # surface is at least diagnosable.
+            logger.warning(
+                "cockpit: input bridge start failed; "
+                "automation key-send is disabled",
+                exc_info=True,
+            )
             self._input_bridge_handle = None
         # Textual's first render after mount reflows panes and can stretch the
         # rail past the persisted width. Re-enforce the rail width on a short
@@ -1699,6 +1708,16 @@ class PollyCockpitApp(App[None]):
         try:
             supervisor = self.router._load_supervisor()
         except Exception:  # noqa: BLE001
+            # #1355: previously silent. Failing to load the supervisor
+            # here means the cockpit boots without an in-process rail
+            # AND without the external daemon (we already gated above) —
+            # i.e. no autonomous sweeps. Log so the silent skip stops
+            # masking config / DB problems.
+            logger.warning(
+                "cockpit: supervisor load failed; "
+                "in-process HeartbeatRail not started",
+                exc_info=True,
+            )
             return
         rail = getattr(supervisor, "core_rail", None)
         if rail is None:

--- a/src/pollypm/plugins_builtin/core_recurring/maintenance.py
+++ b/src/pollypm/plugins_builtin/core_recurring/maintenance.py
@@ -103,6 +103,15 @@ def _resolve_handler_timeouts() -> dict[str, float]:
         from pollypm.config import DEFAULT_CONFIG_PATH, resolve_config_path
         from pollypm.plugin_host import extension_host_for_root
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. Falling back to the 600s floor
+        # for every handler is a real degradation (slower stuck-claim
+        # recovery, no per-handler precision); log so an import-time
+        # break doesn't silently widen the sweep's blast radius.
+        logger.warning(
+            "stuck_claims.sweep: handler-timeout imports failed; "
+            "using fallback floor",
+            exc_info=True,
+        )
         return {}
     try:
         config_path = resolve_config_path(DEFAULT_CONFIG_PATH)
@@ -112,10 +121,24 @@ def _resolve_handler_timeouts() -> dict[str, float]:
         host = extension_host_for_root(str(config_path.parent))
         registry = host.job_handler_registry()
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. An unreachable plugin host means
+        # the sweep uses the 600s floor for every job. Log so a
+        # broken host wiring stops hiding behind quiet degradation.
+        logger.warning(
+            "stuck_claims.sweep: plugin host unreachable; "
+            "using fallback floor",
+            exc_info=True,
+        )
         return {}
     try:
         snapshot = registry.snapshot()
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. Same degradation as above.
+        logger.warning(
+            "stuck_claims.sweep: registry.snapshot() failed; "
+            "using fallback floor",
+            exc_info=True,
+        )
         return {}
     result: dict[str, float] = {}
     for name, spec in snapshot.items():

--- a/src/pollypm/plugins_builtin/core_recurring/shared.py
+++ b/src/pollypm/plugins_builtin/core_recurring/shared.py
@@ -86,6 +86,15 @@ def _open_alert_exists(
                 limit=1,
             )
         except Exception:  # noqa: BLE001
+            # #1355: previously silent. Treating a query failure as
+            # "no open alert" causes the sweep to re-raise the same
+            # alert next tick — a tight loop dressed up as quiet. Log.
+            logger.warning(
+                "open_alert_exists: msg_store query failed for %s/%s",
+                session_name,
+                alert_type,
+                exc_info=True,
+            )
             return False
         return bool(rows)
 
@@ -97,6 +106,14 @@ def _open_alert_exists(
     try:
         rows = open_alerts()
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. Same re-raise risk as above on
+        # the state_store fallback path.
+        logger.warning(
+            "open_alert_exists: state_store.open_alerts() failed for %s/%s",
+            session_name,
+            alert_type,
+            exc_info=True,
+        )
         return False
     for row in rows:
         if (
@@ -138,6 +155,15 @@ def sweep_ephemeral_sessions(supervisor: Any, store: Any) -> dict[str, int]:
             launch.session.name for launch in supervisor.plan_launches()
         }
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. Empty planned_names means every
+        # ephemeral session looks unplanned — i.e. the sweep can
+        # mis-classify planned task sessions as zombies. Log so a
+        # broken plan_launches() stops hiding as quiet over-eagerness.
+        logger.warning(
+            "ephemeral_sweep: supervisor.plan_launches() failed; "
+            "treating all sessions as unplanned",
+            exc_info=True,
+        )
         planned_names = set()
 
     session_service = getattr(supervisor, "session_service", None)

--- a/src/pollypm/work/service_queries.py
+++ b/src/pollypm/work/service_queries.py
@@ -11,6 +11,7 @@ Contract:
 from __future__ import annotations
 
 import json
+import logging
 from typing import TYPE_CHECKING
 
 from pollypm.inbox.kind import coerce_kind as _coerce_inbox_kind
@@ -22,6 +23,9 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from pollypm.work.sqlite_service import SQLiteWorkService
+
+
+logger = logging.getLogger(__name__)
 
 
 # #1546 — labels that bypass the product-broken gate. The watchdog's
@@ -377,7 +381,15 @@ def create_task(
                 project_path=service._project_path,
             )
     except Exception:  # noqa: BLE001 — audit must never break creates
-        pass
+        # #1355: previously silent. A failing audit emit on task
+        # creation breaks the forensic reconstruction trail this
+        # block exists to provide. Log so the gap is visible.
+        logger.warning(
+            "task.created audit emit failed for %s/%s",
+            project,
+            task.task_number,
+            exc_info=True,
+        )
     if service._sync:
         external_refs_before_sync = dict(task.external_refs)
         service._sync.on_create(task)

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -614,6 +614,14 @@ def _record_first_shipped_activity(
     try:
         from pollypm.store import SQLAlchemyStore
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. A failed SQLAlchemyStore import
+        # drops the first-shipment celebration without a trace; log
+        # so a broken store package stops masking the milestone.
+        logger.warning(
+            "first_shipped: SQLAlchemyStore import failed for %s",
+            project_key,
+            exc_info=True,
+        )
         return
 
     state_db = project_path / ".pollypm" / "state.db"
@@ -677,6 +685,14 @@ def task_landed_commit(service: _HasExecutions, task_id: str) -> bool:
     try:
         executions = service.get_execution(task_id)
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. A broken get_execution call
+        # forces the "first PR shipped" celebration to skip; log
+        # so we stop swallowing the underlying query failure.
+        logger.warning(
+            "task_landed_commit: get_execution failed for %s",
+            task_id,
+            exc_info=True,
+        )
         return False
     for execution in reversed(executions):
         work_output = getattr(execution, "work_output", None)
@@ -891,6 +907,13 @@ class SQLiteWorkService:
             self._conn.commit()
             return len(rows)
         except Exception:  # noqa: BLE001
+            # #1355: previously silent. A failed audit-outbox flush
+            # leaves rows on disk and rolls back without a trace,
+            # so an ongoing emit-side break never surfaces. Log.
+            logger.warning(
+                "task_delete_audit_outbox flush failed; rolling back",
+                exc_info=True,
+            )
             self._conn.rollback()
             return 0
 


### PR DESCRIPTION
## Summary

Third wedge for #1355 — replace silent `except Exception: pass`/`return` with `logger.warning(..., exc_info=True)` at 12 sites in work-service, core_recurring, and cockpit boot paths. **Behavior unchanged**: every except already absorbed the exception; this PR adds observability so previously-invisible failures stop being silent.

Follow-up to #1613 (9 sites, supervisor/rail-daemon) and #1620 (12 sites, audit/storage/dashboard). ~1048 sites remain in #1355.

## Touched sites

- **`work/sqlite_service.py`** (3 sites):
  - `_record_first_shipped_activity` — `SQLAlchemyStore` import fallback (drops the first-shipment celebration silently)
  - `task_landed_commit` — `service.get_execution` failure (forces celebration to skip)
  - `_flush_task_delete_audit_outbox` — rollback path (leaves outbox rows on disk without trace)

- **`work/service_queries.py`** (1 site, +adds module logger):
  - `create_task` — `task.created` / `plan_successor.created` audit emit failure (breaks forensic reconstruction trail)

- **`plugins_builtin/core_recurring/maintenance.py`** (3 sites in `_resolve_handler_timeouts`):
  - config + plugin_host import failure
  - extension host / registry resolution failure
  - `registry.snapshot()` failure
  - All three now log instead of silently widening stuck-claim recovery to the 600s floor

- **`plugins_builtin/core_recurring/shared.py`** (3 sites):
  - `_open_alert_exists` — `msg_store.query_messages` failure (re-raise loop risk)
  - `_open_alert_exists` — `state_store.open_alerts` failure (same)
  - `sweep_ephemeral_sessions` — `supervisor.plan_launches()` failure (mis-classifies planned sessions as zombies)

- **`cockpit_ui.py`** (2 sites):
  - `on_mount` — input bridge start failure (disables `pm cockpit-send-key` / automation routing)
  - `_start_core_rail` — supervisor load failure (boots cockpit without any rail = no autonomous sweeps)

## Skipped on this pass

- UI fallback paths (Textual `query_one`, refresh, focus) — low-risk presentation degradation
- Cleanup paths (`.close()`, `.stop()`) per the wedge rules
- Sites that already log via `logger.debug` + `exc_info`
- Sites with `noqa: BLE001 — audit must never break X` comments and existing fallback semantics that aren't truly silent (re-raises)

## Test plan

- [x] Targeted tests on touched code paths (`first_shipped`, `task_landed`, `audit_outbox`, `task_created_event`, `open_alert`, `ephemeral`, `stuck_claim`, `input_bridge`, `start_core_rail`, `work_service`): **211 passed**
- [x] `cockpit_ui` / `cockpit_input_bridge` / `rail_liveness` test suites: **65 passed**
- [x] Pre-existing `test_core_recurring_migration::test_roster_registrations_and_cadences` fails on base branch too — unrelated (`cockpit_socket.reap` extra in left set)
- [x] `ruff check` on touched files: 58 pre-existing E402 warnings, **no new lints**
- [x] Python syntax validation across all 5 files passes
- [x] Behavior unchanged: each except still absorbs the exception and falls through to the same downstream code; only addition is `logger.warning(..., exc_info=True)`

Refs #1355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)