### PR TITLE
feat(task): context/transitions inspection CLIs (#1629)

### DIFF
--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -1523,13 +1523,109 @@ def task_validate_advance(
 @task_app.command("context")
 def task_context(
     task_id: str = typer.Argument(..., help="Task ID (project/number)"),
-    text: str = typer.Argument(..., help="Context message text"),
+    text: str | None = typer.Argument(
+        None,
+        help=(
+            "Context message text. When omitted, list existing context "
+            "entries instead of adding a new one."
+        ),
+    ),
     actor: str = typer.Option("worker", "--actor", help="Actor"),
+    limit: int | None = typer.Option(
+        None,
+        "--limit",
+        min=1,
+        help="(list mode) Cap the number of entries returned.",
+    ),
+    entry_type: str | None = typer.Option(
+        None,
+        "--entry-type",
+        help=(
+            "(list mode) Filter by entry_type (e.g. note, reply, read, "
+            "sweeper_ping)."
+        ),
+    ),
+    show_internal: bool = typer.Option(
+        False,
+        "--show-internal",
+        help=(
+            "(list mode) Include infrastructure context entries "
+            "(sweeper pings, etc.) that are filtered by default."
+        ),
+    ),
     db: str = _DB_OPTION,
     output_json: bool = _JSON_OPTION,
 ) -> None:
-    """Add a context entry to a task."""
+    """Add or list context entries on a task.
+
+    When ``text`` is provided, the entry is appended (legacy behaviour).
+    When omitted, the command prints the task's context log so operators
+    and agents can inspect ``work_context_entries`` without dropping into
+    sqlite3.
+    """
     svc = _svc(db, project=_project_from_task_id(task_id))
+
+    if text is None:
+        # Inspection mode — list entries.
+        entries = _run(
+            svc.get_context, task_id, limit=limit, entry_type=entry_type,
+        )
+        # ``get_context`` returns DESC (most-recent first); reverse to
+        # render chronologically so readers can follow the conversation.
+        entries = list(reversed(entries))
+        visible = _filter_visible_context(
+            entries, show_internal=show_internal,
+        )
+        hidden_count = len(entries) - len(visible)
+
+        if output_json:
+            payload = {
+                "task_id": task_id,
+                "entries": [
+                    {
+                        "actor": e.actor,
+                        "text": e.text,
+                        "timestamp": str(e.timestamp),
+                        "entry_type": e.entry_type,
+                    }
+                    for e in visible
+                ],
+            }
+            if hidden_count:
+                payload["hidden_internal_context_count"] = hidden_count
+            typer.echo(json.dumps(payload, indent=2))
+            return
+
+        if not visible:
+            if hidden_count:
+                typer.echo(
+                    f"No visible context entries on {task_id} "
+                    f"({hidden_count} internal "
+                    f"{'entry' if hidden_count == 1 else 'entries'} "
+                    f"hidden — pass --show-internal to see)."
+                )
+            else:
+                typer.echo(f"No context entries on {task_id}.")
+            return
+
+        typer.echo(
+            f"{'Timestamp':<26} {'Actor':<14} {'Type':<14} Text"
+        )
+        typer.echo("-" * 80)
+        for e in visible:
+            typer.echo(
+                f"{str(e.timestamp):<26} {e.actor:<14} "
+                f"{e.entry_type:<14} {e.text}"
+            )
+        if hidden_count:
+            typer.echo(
+                f"  ({hidden_count} internal "
+                f"{'entry' if hidden_count == 1 else 'entries'} "
+                f"hidden — pass --show-internal to see)"
+            )
+        return
+
+    # Add mode (legacy positional API).
     entry = svc.add_context(task_id, actor, text)
     if output_json:
         typer.echo(json.dumps({
@@ -1539,6 +1635,69 @@ def task_context(
         }, indent=2))
     else:
         typer.echo(f"Added context to {task_id}")
+
+
+@task_app.command("transitions")
+def task_transitions(
+    task_id: str = typer.Argument(..., help="Task ID (project/number)"),
+    limit: int | None = typer.Option(
+        None,
+        "--limit",
+        min=1,
+        help="Cap the number of transitions returned (most recent first).",
+    ),
+    db: str = _DB_OPTION,
+    output_json: bool = _JSON_OPTION,
+) -> None:
+    """List work_status transitions for a task.
+
+    Replaces ``sqlite3 ... SELECT * FROM work_transitions WHERE ...`` so
+    Polly and autonomous agents can audit task lifecycle without falling
+    through to the raw DB.
+    """
+    svc = _svc(db, project=_project_from_task_id(task_id))
+    task = _run(svc.get, task_id)
+    transitions = list(task.transitions or [])
+
+    # Service hydrates transitions ASC (chronological). Default render is
+    # chronological too; ``--limit`` slices the most recent tail so a
+    # capped view still shows the latest activity.
+    if limit is not None and limit < len(transitions):
+        transitions = transitions[-limit:]
+
+    if output_json:
+        payload = {
+            "task_id": task_id,
+            "transitions": [
+                {
+                    "from_state": t.from_state,
+                    "to_state": t.to_state,
+                    "actor": t.actor,
+                    "timestamp": str(t.timestamp),
+                    "reason": t.reason,
+                }
+                for t in transitions
+            ],
+        }
+        typer.echo(json.dumps(payload, indent=2))
+        return
+
+    if not transitions:
+        typer.echo(f"No transitions recorded on {task_id}.")
+        return
+
+    typer.echo(
+        f"{'Timestamp':<26} {'From':<14} {'To':<14} "
+        f"{'Actor':<14} Reason"
+    )
+    typer.echo("-" * 90)
+    for t in transitions:
+        reason = t.reason or ""
+        from_state = t.from_state or "(none)"
+        typer.echo(
+            f"{str(t.timestamp):<26} {from_state:<14} "
+            f"{t.to_state:<14} {t.actor:<14} {reason}"
+        )
 
 
 @task_app.command("backfill-review-summaries")

--- a/tests/test_work_cli.py
+++ b/tests/test_work_cli.py
@@ -856,6 +856,186 @@ class TestCliContext:
         assert "Hello context" in result.output
 
 
+class TestCliContextInspection:
+    """``pm task context <task_id>`` without a ``text`` argument lists
+    entries instead of adding one — replaces raw sqlite SELECTs for
+    Polly/agent introspection.
+    """
+
+    def test_list_mode_renders_table(self, db_path):
+        _create_task(db_path, title="Inspect ctx task")
+        runner.invoke(
+            task_app,
+            ["context", "proj/1", "first entry", "--db", db_path],
+        )
+        runner.invoke(
+            task_app,
+            ["context", "proj/1", "second entry", "--db", db_path],
+        )
+
+        result = runner.invoke(task_app, ["context", "proj/1", "--db", db_path])
+        assert result.exit_code == 0, result.output
+        assert "first entry" in result.output
+        assert "second entry" in result.output
+        # Header row present.
+        assert "Timestamp" in result.output
+        assert "Actor" in result.output
+
+    def test_list_mode_empty_task(self, db_path):
+        _create_task(db_path, title="No ctx task")
+
+        result = runner.invoke(task_app, ["context", "proj/1", "--db", db_path])
+        assert result.exit_code == 0, result.output
+        assert "No context entries on proj/1" in result.output
+
+    def test_list_mode_json(self, db_path):
+        _create_task(db_path, title="Inspect ctx json")
+        runner.invoke(
+            task_app,
+            ["context", "proj/1", "hello", "--actor", "worker-x",
+             "--db", db_path],
+        )
+
+        result = runner.invoke(
+            task_app, ["context", "proj/1", "--json", "--db", db_path],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["task_id"] == "proj/1"
+        assert len(payload["entries"]) == 1
+        assert payload["entries"][0]["actor"] == "worker-x"
+        assert payload["entries"][0]["text"] == "hello"
+        assert payload["entries"][0]["entry_type"] == "note"
+
+    def test_list_mode_filters_sweeper_pings_by_default(self, db_path):
+        from pollypm.plugins_builtin.task_assignment_notify.handlers.sweep import (
+            SWEEPER_PING_CONTEXT_ENTRY_TYPE,
+        )
+        from pollypm.work.sqlite_service import SQLiteWorkService
+
+        _create_task(db_path, title="Filter sweeper")
+        svc = SQLiteWorkService(db_path=db_path)
+        try:
+            svc.add_context(
+                "proj/1", "sweeper", "task_assignment.sweep:sent",
+                entry_type=SWEEPER_PING_CONTEXT_ENTRY_TYPE,
+            )
+            svc.add_context("proj/1", "worker", "real entry", entry_type="note")
+        finally:
+            svc.close()
+
+        result = runner.invoke(task_app, ["context", "proj/1", "--db", db_path])
+        assert result.exit_code == 0, result.output
+        assert "real entry" in result.output
+        assert "task_assignment.sweep:sent" not in result.output
+        assert "hidden" in result.output  # hint about hidden internal rows
+
+        # ``--show-internal`` reveals everything.
+        result = runner.invoke(
+            task_app,
+            ["context", "proj/1", "--show-internal", "--db", db_path],
+        )
+        assert result.exit_code == 0, result.output
+        assert "task_assignment.sweep:sent" in result.output
+
+    def test_list_mode_entry_type_filter(self, db_path):
+        from pollypm.work.sqlite_service import SQLiteWorkService
+
+        _create_task(db_path, title="entry_type filter")
+        svc = SQLiteWorkService(db_path=db_path)
+        try:
+            svc.add_context("proj/1", "worker", "note one", entry_type="note")
+            svc.add_context("proj/1", "user", "reply one", entry_type="reply")
+        finally:
+            svc.close()
+
+        result = runner.invoke(
+            task_app,
+            ["context", "proj/1", "--entry-type", "reply",
+             "--json", "--db", db_path],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        texts = [e["text"] for e in payload["entries"]]
+        assert texts == ["reply one"]
+
+
+class TestCliTransitions:
+    """``pm task transitions <task_id>`` exposes ``work_transitions``
+    rows so Polly and agents can audit lifecycle without sqlite3.
+    """
+
+    def _drive_some_transitions(self, db_path):
+        _create_task(db_path, title="Transition task")
+        # draft -> queued
+        r = runner.invoke(task_app, ["queue", "proj/1", "--db", db_path])
+        assert r.exit_code == 0, r.output
+        # queued -> in_progress
+        r = runner.invoke(
+            task_app,
+            ["claim", "proj/1", "--actor", "agent-1", "--db", db_path],
+        )
+        assert r.exit_code == 0, r.output
+
+    def test_transitions_table(self, db_path):
+        self._drive_some_transitions(db_path)
+
+        result = runner.invoke(
+            task_app, ["transitions", "proj/1", "--db", db_path],
+        )
+        assert result.exit_code == 0, result.output
+        # Should mention the new states from our drive sequence.
+        assert "queued" in result.output
+        assert "in_progress" in result.output
+        # Header row.
+        assert "From" in result.output
+        assert "To" in result.output
+
+    def test_transitions_json(self, db_path):
+        self._drive_some_transitions(db_path)
+
+        result = runner.invoke(
+            task_app, ["transitions", "proj/1", "--json", "--db", db_path],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["task_id"] == "proj/1"
+        transitions = payload["transitions"]
+        assert len(transitions) >= 2
+        states = [(t["from_state"], t["to_state"]) for t in transitions]
+        assert ("draft", "queued") in states
+        assert ("queued", "in_progress") in states
+
+    def test_transitions_empty_when_draft(self, db_path):
+        _create_task(db_path, title="No transitions yet")
+
+        result = runner.invoke(
+            task_app, ["transitions", "proj/1", "--db", db_path],
+        )
+        assert result.exit_code == 0, result.output
+        assert "No transitions recorded on proj/1" in result.output
+
+    def test_transitions_limit_keeps_most_recent(self, db_path):
+        self._drive_some_transitions(db_path)
+
+        result = runner.invoke(
+            task_app,
+            ["transitions", "proj/1", "--limit", "1",
+             "--json", "--db", db_path],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert len(payload["transitions"]) == 1
+        # Newest tail kept.
+        assert payload["transitions"][0]["to_state"] == "in_progress"
+
+    def test_transitions_unknown_task(self, db_path):
+        result = runner.invoke(
+            task_app, ["transitions", "proj/999", "--db", db_path],
+        )
+        assert result.exit_code == 1
+
+
 class TestCliSweeperContextFiltering:
     """``pm task get`` / ``pm task status`` should hide infrastructure
     sweeper-ping context rows by default — they drown user-visible


### PR DESCRIPTION
## Summary
- `pm task context <task_id>` without a `text` arg now **lists** entries (table or `--json`) with `--limit`, `--entry-type`, and `--show-internal` filters. Adding semantics (`pm task context <id> <text>`) preserved.
- New `pm task transitions <task_id>` exposes `work_transitions` rows in table or `--json` form, with `--limit` keeping the most recent tail.
- Lets Polly / autonomous agents audit task lifecycle + context logs without falling through to `sqlite3` SELECTs.

## Why
Deferred wedge from #1637 (which landed the auto-role default for `pm task create`). Per the parent issue #1629, agents and Polly were dropping into raw sqlite to inspect `work_context_entries` / `work_transitions` — these inspection CLIs close that gap.

## Scope
Narrow, additive:
- `task context`: `text` becomes optional. When omitted, list. The existing positional `text` add-mode is untouched (`TestCliContext::test_cli_context` still passes verbatim).
- `task transitions`: new command. Hydrates via `svc.get(task_id).transitions` so it goes through the same `_run` error-rendering path as `pm task get`.
- Default context-list view filters sweeper pings (mirrors `pm task get` / `pm task status` behaviour from #1035) so the inspection surface matches the rest of the CLI.

## Still deferred from #1629
- `pollypm cli-reference --json`
- `docs/agent-handbook.md`

## Test plan
- [x] `pytest tests/test_work_cli.py` — 70 passed (was 60 + 10 new tests covering both commands: list mode table/JSON/empty/sweeper-filter/entry-type filter; transitions table/JSON/empty/limit/unknown-task error)
- [x] `pytest tests/test_cli_help_examples.py` — 35 passed
- [x] Manual `--help` check: both commands appear under `pm task --help`; argument/option help text reads cleanly
- [x] Pre-existing failures in `tests/test_project_dashboard_ui.py` (skeleton-paint timing) verified to occur on `main` as well — unrelated

Generated with [Claude Code](https://claude.com/claude-code)