### PR TITLE
refactor(cockpit): extract _SettingsConfirmModal into sibling module (#1354)

### DIFF
--- a/src/pollypm/cockpit_project_settings.py
+++ b/src/pollypm/cockpit_project_settings.py
@@ -20,11 +20,11 @@ from textual import on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
-from textual.screen import ModalScreen
 from textual.widgets import Button, DataTable, Input, RadioButton, RadioSet, Select, Static
 
 from pollypm.account_usage_sampler import load_cached_account_usage
 from pollypm.config import load_config, write_config
+from pollypm.cockpit_settings_confirm import _SettingsConfirmModal
 from pollypm.cockpit_settings_history import (
     UndoAction,
     consume_settings_history,
@@ -954,60 +954,3 @@ class PollyProjectSettingsApp(App[None]):
 
     def action_show_keyboard_help(self) -> None:
         self._notify("j/k move, Enter apply preview target, u undo, r refresh.")
-
-
-class _SettingsConfirmModal(ModalScreen[bool]):
-    CSS = """
-    Screen {
-        align: center middle;
-    }
-    #settings-confirm {
-        width: 72;
-        height: auto;
-        padding: 1 2;
-        background: $panel;
-        border: heavy $warning;
-    }
-    #settings-confirm-title {
-        padding-bottom: 1;
-        text-style: bold;
-    }
-    #settings-confirm-buttons {
-        height: auto;
-        align-horizontal: right;
-        padding-top: 1;
-    }
-    #settings-confirm-buttons Button {
-        margin-left: 1;
-    }
-    """
-
-    BINDINGS = [Binding("escape", "cancel", "Cancel")]
-
-    def __init__(
-        self,
-        *,
-        title: str,
-        prompt: str,
-        confirm_label: str = "Confirm",
-        cancel_label: str = "Cancel",
-    ) -> None:
-        super().__init__()
-        self._title = title
-        self._prompt = prompt
-        self._confirm_label = confirm_label
-        self._cancel_label = cancel_label
-
-    def compose(self) -> ComposeResult:
-        with Vertical(id="settings-confirm"):
-            yield Static(self._title, id="settings-confirm-title")
-            yield Static(self._prompt)
-            with Horizontal(id="settings-confirm-buttons"):
-                yield Button(self._cancel_label, id="cancel")
-                yield Button(self._confirm_label, variant="primary", id="confirm")
-
-    def on_button_pressed(self, event: Button.Pressed) -> None:
-        self.dismiss(event.button.id == "confirm")
-
-    def action_cancel(self) -> None:
-        self.dismiss(False)

--- a/src/pollypm/cockpit_settings_confirm.py
+++ b/src/pollypm/cockpit_settings_confirm.py
@@ -1,0 +1,87 @@
+"""Generic confirm/cancel modal used by cockpit settings screens.
+
+Contract:
+- Inputs: ``title``, ``prompt``, and optional ``confirm_label`` /
+  ``cancel_label`` strings.
+- Outputs: a ``ModalScreen[bool]`` that resolves to ``True`` on confirm
+  and ``False`` on cancel/escape.
+- Side effects: pushes/dismisses a Textual modal; no I/O of its own.
+- Invariants: this module owns one widget class and nothing else; it
+  has no dependency on cockpit state or services.
+- Allowed dependencies: Textual primitives only.
+- Private: ``_SettingsConfirmModal`` is underscore-prefixed and
+  re-exported via ``cockpit_ui`` for back-compat (see #1354).
+
+Wedge of the cockpit_ui.py god-module split tracked by #1354.
+
+Previously this class was defined identically in both ``cockpit_ui``
+and ``cockpit_project_settings``; this module is now the single home.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static
+
+
+class _SettingsConfirmModal(ModalScreen[bool]):
+    CSS = """
+    Screen {
+        align: center middle;
+    }
+    #settings-confirm {
+        width: 72;
+        height: auto;
+        padding: 1 2;
+        background: $panel;
+        border: heavy $warning;
+    }
+    #settings-confirm-title {
+        padding-bottom: 1;
+        text-style: bold;
+    }
+    #settings-confirm-buttons {
+        height: auto;
+        align-horizontal: right;
+        padding-top: 1;
+    }
+    #settings-confirm-buttons Button {
+        margin-left: 1;
+    }
+    """
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    def __init__(
+        self,
+        *,
+        title: str,
+        prompt: str,
+        confirm_label: str = "Confirm",
+        cancel_label: str = "Cancel",
+    ) -> None:
+        super().__init__()
+        self._title = title
+        self._prompt = prompt
+        self._confirm_label = confirm_label
+        self._cancel_label = cancel_label
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="settings-confirm"):
+            yield Static(self._title, id="settings-confirm-title")
+            yield Static(self._prompt)
+            with Horizontal(id="settings-confirm-buttons"):
+                yield Button(self._cancel_label, id="cancel")
+                yield Button(self._confirm_label, variant="primary", id="confirm")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "confirm")
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)
+
+
+__all__ = ["_SettingsConfirmModal"]

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -94,6 +94,9 @@ from pollypm.cockpit_first_shipped import (  # noqa: F401  (re-exported)
 from pollypm.cockpit_inbox_project_picker import (  # noqa: F401  (re-exported)
     _InboxProjectPickerModal,
 )
+from pollypm.cockpit_settings_confirm import (  # noqa: F401  (re-exported)
+    _SettingsConfirmModal,
+)
 from pollypm.cockpit_live_chat_notice import (
     LIVE_CHAT_NETWORK_DEAD_TMUX_MESSAGE,
     clear_live_chat_network_dead_notice,
@@ -6619,63 +6622,6 @@ class _SettingsAccountReassignModal(ModalScreen[str | None]):
 
     def action_cancel(self) -> None:
         self.dismiss(None)
-
-
-class _SettingsConfirmModal(ModalScreen[bool]):
-    CSS = """
-    Screen {
-        align: center middle;
-    }
-    #settings-confirm {
-        width: 72;
-        height: auto;
-        padding: 1 2;
-        background: $panel;
-        border: heavy $warning;
-    }
-    #settings-confirm-title {
-        padding-bottom: 1;
-        text-style: bold;
-    }
-    #settings-confirm-buttons {
-        height: auto;
-        align-horizontal: right;
-        padding-top: 1;
-    }
-    #settings-confirm-buttons Button {
-        margin-left: 1;
-    }
-    """
-
-    BINDINGS = [Binding("escape", "cancel", "Cancel")]
-
-    def __init__(
-        self,
-        *,
-        title: str,
-        prompt: str,
-        confirm_label: str = "Confirm",
-        cancel_label: str = "Cancel",
-    ) -> None:
-        super().__init__()
-        self._title = title
-        self._prompt = prompt
-        self._confirm_label = confirm_label
-        self._cancel_label = cancel_label
-
-    def compose(self) -> ComposeResult:
-        with Vertical(id="settings-confirm"):
-            yield Static(self._title, id="settings-confirm-title")
-            yield Static(self._prompt)
-            with Horizontal(id="settings-confirm-buttons"):
-                yield Button(self._cancel_label, id="cancel")
-                yield Button(self._confirm_label, variant="primary", id="confirm")
-
-    def on_button_pressed(self, event: Button.Pressed) -> None:
-        self.dismiss(event.button.id == "confirm")
-
-    def action_cancel(self) -> None:
-        self.dismiss(False)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Third wedge of the cockpit_ui.py god-module split tracked by #1354 (after #1606 _InboxProjectPickerModal and #1618 _FirstShippedCelebrationModal).
- Moves the 55-LOC `_SettingsConfirmModal` into a new sibling module `src/pollypm/cockpit_settings_confirm.py`. The class was defined identically in both `cockpit_ui.py` and `cockpit_project_settings.py`, so this also deduplicates ~57 LOC.
- `cockpit_ui.py` keeps an import shim for back-compat; `cockpit_project_settings.py` imports from the new module (and drops its now-unused `textual.screen.ModalScreen` import).

## LOC impact
- `cockpit_ui.py`: 18818 -> 18764 (-54); diff in cockpit_ui.py is 60 lines (well under 200).
- `cockpit_project_settings.py`: 1013 -> 956 (-57).
- New module: 87 lines (including module docstring).

## Test plan
- [x] Settings/cockpit project test slice: `pytest -k "settings or cockpit_project"` -> 162 passed (1 pre-existing failure on `main` deselected: `test_render_project_dashboard_integration`).
- [x] Modal/confirm/inbox slice: `pytest -k "modal or confirm or inbox_filter or inbox_default_lens"` -> 76 passed (1 pre-existing failure on `main`: `test_modal_surfaces_plan_review_keys_when_selected`).
- [x] Import smoke: confirmed `pollypm.cockpit_settings_confirm._SettingsConfirmModal`, `pollypm.cockpit_ui._SettingsConfirmModal`, and `pollypm.cockpit_project_settings._SettingsConfirmModal` all resolve to the same class object.