### PR TITLE
fix(#1363): decouple cockpit activity panels from activity_feed plugin

### DIFF
--- a/src/pollypm/activity_projector_registry.py
+++ b/src/pollypm/activity_projector_registry.py
@@ -1,0 +1,93 @@
+"""Core seam for resolving the activity-feed projector.
+
+Contract:
+- Inputs: a host ``config`` (anything with ``project.state_db`` and a
+  ``projects`` mapping — typically a ``Config``).
+- Outputs: an :class:`EventProjector`-shaped object, or ``None`` when
+  no factory is registered or the factory itself returns ``None``.
+- Side effects: none — the projector reads from per-project SQLite DBs
+  lazily on ``project()`` calls.
+- Invariants: when no factory is registered, callers see ``None`` and
+  degrade to an empty feed (the dashboard panel and ``cockpit_inbox``
+  full-screen view both already handle this).
+
+Boundary note:
+This module is core — it must not import from ``pollypm.plugins_builtin``.
+``cockpit_inbox.py`` and ``cockpit_ui.py`` (dashboard + activity panel)
+read the live feed through :func:`build_activity_projector` without
+taking a hard import on the optional ``activity_feed`` plugin. The
+``activity_feed`` plugin installs its projector factory here during
+plugin ``initialize``.
+
+Mirrors the registration-seam pattern established in
+:mod:`pollypm.approval_notifications` (#1597),
+:mod:`pollypm.briefings_registry` (#1621), and
+:mod:`pollypm.maintenance_handlers_registry` (#1626). See #1363 for the
+full boundary-debt roll-up.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+
+logger = logging.getLogger(__name__)
+
+
+# Factory signature: ``(config) -> EventProjector | None``. We type as
+# ``Any`` to avoid pulling the projector class — which lives in the
+# plugin tree — into the core seam.
+ActivityProjectorFactory = Callable[[Any], Any]
+
+
+_factory: ActivityProjectorFactory | None = None
+
+
+def register_activity_projector_factory(
+    factory: ActivityProjectorFactory | None,
+) -> None:
+    """Install (or clear) the projector factory.
+
+    Called by the ``activity_feed`` plugin during ``initialize`` so
+    cockpit surfaces can resolve a projector without importing from the
+    optional plugin tree. Pass ``factory=None`` to clear (used by tests
+    that want to simulate the plugin being absent).
+    """
+    global _factory
+    _factory = factory
+
+
+def get_activity_projector_factory() -> ActivityProjectorFactory | None:
+    """Return the registered factory, or ``None`` when no provider is installed."""
+    return _factory
+
+
+def build_activity_projector(config: Any) -> Any | None:
+    """Resolve an activity-feed projector for ``config``.
+
+    Returns ``None`` when no factory is registered (plugin disabled /
+    missing) or when the factory itself returns ``None`` (e.g. config
+    without a state DB). Callers must treat ``None`` as "no feed
+    available" and degrade to an empty view.
+
+    Any exception raised by the factory is re-raised so callers can
+    surface the failure in their own format. Both current consumers
+    wrap the call in a broad ``try/except`` that returns an empty list,
+    so the runtime contract is "either a projector or an empty feed".
+    """
+    if _factory is None:
+        logger.debug(
+            "activity_projector_registry: no factory registered; "
+            "returning None (activity_feed plugin disabled?)",
+        )
+        return None
+    return _factory(config)
+
+
+__all__ = [
+    "ActivityProjectorFactory",
+    "build_activity_projector",
+    "get_activity_projector_factory",
+    "register_activity_projector_factory",
+]

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -1449,11 +1449,14 @@ def _gather_activity_feed(
     empty list rather than propagating the error. The Textual screen
     surfaces the empty state as a friendly placeholder.
     """
+    # #1363 — resolve the projector via the core registration seam so
+    # this surface stays plugin-agnostic. ``build_activity_projector``
+    # returns ``None`` when the ``activity_feed`` plugin isn't loaded.
     try:
-        from pollypm.plugins_builtin.activity_feed.plugin import build_projector
+        from pollypm.activity_projector_registry import build_activity_projector
     except Exception:  # noqa: BLE001
         return []
-    projector = build_projector(config)
+    projector = build_activity_projector(config)
     if projector is None:
         return []
     try:

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -14706,8 +14706,11 @@ def _dashboard_activity(
     cache + tests can reason about shape without pulling in the
     projector's import graph.
     """
+    # #1363 — resolve the projector via the core registration seam so
+    # the dashboard stays plugin-agnostic. ``build_activity_projector``
+    # returns ``None`` when the ``activity_feed`` plugin isn't loaded.
     try:
-        from pollypm.plugins_builtin.activity_feed.plugin import build_projector
+        from pollypm.activity_projector_registry import build_activity_projector
     except Exception:  # noqa: BLE001
         return []
     try:
@@ -14729,7 +14732,7 @@ def _dashboard_activity(
     if cached is not None:
         _DASHBOARD_ACTIVITY_CACHE.move_to_end(cache_key)
         return cached
-    projector = build_projector(config)
+    projector = build_activity_projector(config)
     if projector is None:
         return []
     # #920 — pass every alias so projects whose config key (e.g.

--- a/src/pollypm/plugins_builtin/activity_feed/plugin.py
+++ b/src/pollypm/plugins_builtin/activity_feed/plugin.py
@@ -24,6 +24,9 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from pollypm.activity_projector_registry import (
+    register_activity_projector_factory,
+)
 from pollypm.plugin_api.v1 import (
     Capability,
     PanelSpec,
@@ -157,7 +160,18 @@ def _initialize(api: Any) -> None:
     so the plugin manifest does NOT need the reserved-section flag.
     Per spec §3 precedence: core_rail_items owns 0-99, plugins start at
     100 — we take index 30 in ``workflows`` which is open territory.
+
+    Also installs :func:`build_projector` in
+    :mod:`pollypm.activity_projector_registry` so cockpit surfaces
+    (dashboard panel, full-screen activity view) can resolve a projector
+    without importing from the optional plugin tree (#1363).
     """
+    # #1363 — expose the projector factory to core via the registration
+    # seam. With this plugin disabled, the dashboard / activity-panel
+    # callers get ``None`` and render an empty feed (their existing
+    # graceful-degrade path).
+    register_activity_projector_factory(build_projector)
+
     config = api.config
     state_db = None
     if config is not None:

--- a/tests/test_dashboard_activity_cache.py
+++ b/tests/test_dashboard_activity_cache.py
@@ -56,12 +56,12 @@ def test_cache_short_circuits_on_repeat_call(tmp_path: Path) -> None:
         return None
 
     with patch("pollypm.cockpit_ui.load_config", lambda _: _config(project)), patch(
-        "pollypm.plugins_builtin.activity_feed.plugin.build_projector", boom,
+        "pollypm.activity_projector_registry.build_activity_projector", boom,
     ):
         result = _dashboard_activity(config_path, "demo", limit=10)
 
     assert result == [{"summary": "cached"}]
-    assert build_count["n"] == 0, "cache hit must skip build_projector"
+    assert build_count["n"] == 0, "cache hit must skip build_activity_projector"
 
 
 def test_cache_invalidates_when_db_mtime_changes(tmp_path: Path) -> None:

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -186,6 +186,14 @@ _MORNING_BRIEFING_PLUGIN_PREFIX = "pollypm.plugins_builtin.morning_briefing"
 # directly (see #1363, sibling of #1597 / #1621).
 _DOCTOR_FILE = "src/pollypm/doctor.py"
 _CORE_RECURRING_PLUGIN_PREFIX = "pollypm.plugins_builtin.core_recurring"
+# The cockpit dashboard's activity panel and the full-screen activity
+# inbox view both resolve a feed projector through
+# :func:`pollypm.activity_projector_registry.build_activity_projector`
+# instead of importing ``build_projector`` from the ``activity_feed``
+# plugin directly (see #1363, sibling of #1597 / #1621 / #1626).
+_COCKPIT_UI_FILE = "src/pollypm/cockpit_ui.py"
+_COCKPIT_INBOX_FILE = "src/pollypm/cockpit_inbox.py"
+_ACTIVITY_FEED_PLUGIN_MODULE = "pollypm.plugins_builtin.activity_feed.plugin"
 
 
 def _imports_module(source_file: Path, module: str) -> bool:
@@ -290,6 +298,40 @@ def test_doctor_does_not_import_core_recurring_plugin() -> None:
         f"{_CORE_RECURRING_PLUGIN_PREFIX}; use "
         "pollypm.maintenance_handlers_registry.invoke_maintenance_handler "
         "instead so the plugin stays optional."
+    )
+
+
+def test_cockpit_does_not_import_activity_feed_plugin_for_projector() -> None:
+    """Cockpit surfaces resolve the activity projector via the core seam.
+
+    :func:`pollypm.activity_projector_registry.build_activity_projector`
+    is the sanctioned read path. The ``activity_feed`` plugin installs
+    its ``build_projector`` factory during ``initialize``; if the
+    dashboard panel (``cockpit_ui._dashboard_activity``) or the full-
+    screen activity inbox (``cockpit_inbox._fetch_activity_entries``)
+    reach into the plugin tree directly we lose the "plugin is optional"
+    contract — fail loudly so the seam stays clean.
+
+    Other ``activity_feed`` submodules (e.g. ``cockpit.feed_panel``
+    Textual widgets) are intentionally NOT covered here — those are
+    UI-rendering helpers tracked under a separate slice of #1363.
+    """
+    root = _project_root()
+    offenders: list[str] = []
+    for rel in (_COCKPIT_UI_FILE, _COCKPIT_INBOX_FILE):
+        source_file = root / rel
+        assert source_file.exists(), (
+            f"Expected {rel} to exist — boundary test needs updating if "
+            "the file moved."
+        )
+        if _imports_module(source_file, _ACTIVITY_FEED_PLUGIN_MODULE):
+            offenders.append(rel)
+    assert not offenders, (
+        "Cockpit surfaces must not import `build_projector` from "
+        f"{_ACTIVITY_FEED_PLUGIN_MODULE}; use "
+        "pollypm.activity_projector_registry.build_activity_projector "
+        "instead so the plugin stays optional. Offenders:\n  - "
+        + "\n  - ".join(offenders)
     )
 
 


### PR DESCRIPTION
## Summary

Fourth wedge for #1363 after #1597, #1621, and #1626. Removes the
``cockpit_ui._dashboard_activity`` and ``cockpit_inbox._fetch_activity_entries``
hard imports on ``pollypm.plugins_builtin.activity_feed.plugin.build_projector``.

- New ``pollypm.activity_projector_registry`` exposes ``register_activity_projector_factory(...)`` / ``build_activity_projector(config)``; the ``activity_feed`` plugin installs its factory there from ``_initialize``.
- Both cockpit consumers route through the registry seam — when the plugin is disabled they get ``None`` and degrade through their existing empty-feed paths.
- ``tests/test_import_boundary.py`` gains ``test_cockpit_does_not_import_activity_feed_plugin_for_projector`` so regressions fail loudly.
- ``tests/test_dashboard_activity_cache.py`` now patches the registry seam (the only test that reached into the plugin-module symbol).

## Test plan

- [x] ``pytest tests/test_import_boundary.py --deselect ...test_supervisor_import_allowlist_matches_reality`` — 11 passed (the deselected case is a pre-existing failure on ``main`` from ``cli_features/tier4.py``, unrelated).
- [x] ``pytest tests/test_activity_feed_projector.py tests/test_activity_feed_ui.py tests/test_dashboard_activity_cache.py`` — 52 passed.
- [x] ``pytest tests/test_activity_feed_cli.py tests/test_cockpit_dashboard.py`` — 27 passed.
- [x] Verified the two ``test_project_dashboard_ui.py`` flakes that surface in the full suite are pre-existing on ``main`` (perf-budget + inbox-hint copy assertions, both unrelated to this slice).

Generated with [Claude Code](https://claude.com/claude-code).