### PR TITLE
fix(cockpit): drop unused InboxItemKind runtime import (#1675)

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -313,7 +313,7 @@ def pm_inbox_filtered_list(
     awaits-user lens still goes through :func:`pm_inbox_awaits_user_list`
     (the canonical predicate is more specific than any single kind).
     """
-    from pollypm.inbox.kind import InboxItemKind, coerce_kind
+    from pollypm.inbox.kind import coerce_kind
 
     try:
         from pollypm.work import create_work_service


### PR DESCRIPTION
## Summary
- Closes #1675. The fix for #1651 left `InboxItemKind` imported inside `pm_inbox_filtered_list` even though the function only uses `coerce_kind` at runtime — the annotation is already covered by the module-level `if TYPE_CHECKING:` import (line 46-47).
- Function-local import in `src/pollypm/cockpit_inbox.py` now just imports `coerce_kind`, clearing the `F401` changed-code lint failure.

## Test plan
- [x] `uv run --extra dev ruff check src/pollypm/cockpit_inbox.py` -> All checks passed
- [x] `uv run --extra dev pytest tests/test_inbox_default_lens.py -x -q` -> 8 passed

Generated with Claude Code