### PR TITLE
fix(#1677): reword heartbeat docstring to clear Supervisor reach-through gate

### DIFF
--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -1114,7 +1114,7 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         """Detect and react to mid-flight persona drift (#757).
 
         Kickoff-time swaps are caught by
-        ``supervisor._assert_session_launch_matches``; this catches sessions
+        :meth:`Supervisor._assert_session_launch_matches`; this catches sessions
         whose identity drifted AFTER kickoff (e.g. a prompt-injection loop,
         or a session reading a wrong-role control-prompts file). Conservative:
         only fires on strong identity-claim phrasings, never on casual

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -484,6 +484,24 @@ def test_no_supervisor_private_reach_through() -> None:
     )
 
 
+def test_supervisor_reach_pattern_skips_capitalized_class_refs() -> None:
+    """Regression for #1677: docstring class references must not trip the gate.
+
+    The reach-through scanner is intended to flag *runtime* attribute access
+    like ``supervisor._foo``, not documentation that references the
+    :class:`Supervisor` class itself (e.g. ``Supervisor._assert_...`` in a
+    docstring ``:meth:`` cross-ref). The pattern is case-sensitive on the
+    leading ``s`` for exactly this reason; if that ever changes, every
+    Sphinx-style class reference would suddenly be an offender.
+    """
+    # Capitalized class references in docstrings — must NOT match.
+    assert _SUPERVISOR_REACH_PATTERN.search("Supervisor._assert_session_launch_matches") is None
+    assert _SUPERVISOR_REACH_PATTERN.search(":meth:`Supervisor._foo`") is None
+    # Lowercase variable reach-through — MUST match.
+    assert _SUPERVISOR_REACH_PATTERN.search("supervisor._assert_session_launch_matches(x)") is not None
+    assert _SUPERVISOR_REACH_PATTERN.search("self.supervisor._window_map()") is not None
+
+
 # ---------------------------------------------------------------------------
 # Guardrail 3: private SQLite connection reach-through
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reword the `_handle_persona_drift` docstring in `src/pollypm/heartbeats/local.py` so the reference to `Supervisor._assert_session_launch_matches` uses the capitalized class form (via a `:meth:` cross-ref). The boundary scanner is case-sensitive on the leading `s` for exactly this reason, so the docstring no longer trips `test_no_supervisor_private_reach_through`.
- Add `test_supervisor_reach_pattern_skips_capitalized_class_refs` to pin that scanner behavior so future refactors fail fast if the pattern is ever broadened to match class references.

Picked option (a) — keep helpers private, fix the docstring — as the smaller fix. There's no runtime reach-through; the line was always documentation.

Fixes #1677.

## Test plan
- [x] `uv run --extra dev pytest tests/test_import_boundary.py::test_no_supervisor_private_reach_through tests/test_import_boundary.py::test_supervisor_reach_pattern_skips_capitalized_class_refs -v` — both pass.
- [x] Confirmed the two other failures in `tests/test_import_boundary.py` / `tests/test_plugin_boundary_conformance.py` predate this branch (reproduced on plain `main`).