### PR TITLE
fix(cli): abort project remove when --purge-state DB sweep fails (#1673)

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -820,6 +820,16 @@ def _count_project_state_rows(
     return counts
 
 
+class _PurgeStateError(RuntimeError):
+    """Raised when ``_purge_project_state`` cannot commit the row sweep.
+
+    Signals a hard failure (locked DB, corrupt file, unwritable path)
+    that left the rows in place. The caller MUST abort before
+    ``remove_project`` so the TOML config doesn't drift relative to
+    the DB rows (see issue #1673).
+    """
+
+
 def _purge_project_state(
     config_path: Path,
     project_key: str,
@@ -829,14 +839,20 @@ def _purge_project_state(
     """Delete every project-scoped row from the workspace state DB.
 
     Returns a ``{table: removed_count}`` dict (plus ``audit_tail`` for
-    the central-tail JSONL file). In ``dry_run`` mode no mutations
-    happen; the returned counts reflect what WOULD be deleted (the
-    same numbers :func:`_count_project_state_rows` returns).
+    the central-tail JSONL file). The counts reflect rows actually
+    deleted by the committed transaction (via ``cursor.rowcount``),
+    NOT the pre-purge estimate. In ``dry_run`` mode no mutations
+    happen and the returned counts mirror what
+    :func:`_count_project_state_rows` reports.
 
-    Best-effort throughout: a missing DB, missing table, or write
-    failure on one table never aborts the rest of the sweep. The
-    deletes run in a single transaction so a mid-sweep crash leaves
-    state.db in a consistent state.
+    Per-table errors (missing table on a fresh DB, schema drift) are
+    swallowed so they never abort the rest of the sweep; the count
+    for that table falls through as ``0``. A connection-level failure
+    (locked DB, corrupt file, unwritable path) raises
+    :class:`_PurgeStateError` so the caller can abort before
+    ``remove_project`` strips the project from ``pollypm.toml`` (see
+    issue #1673 — the previous best-effort-on-everything behaviour
+    silently desynced the config from the orphaned rows).
 
     Why a single bulk SQL sweep instead of routing through
     ``work_service.delete_task``: per-task deletes would fire
@@ -847,14 +863,23 @@ def _purge_project_state(
     """
     import sqlite3 as _sqlite3
 
-    counts = _count_project_state_rows(config_path, project_key)
     if dry_run:
-        return counts
+        return _count_project_state_rows(config_path, project_key)
+
+    counts: dict[str, int] = {table: 0 for table, _, _ in _STATE_PURGE_TABLES}
+    counts["audit_tail"] = 0
 
     db_path = _workspace_db_path(config_path)
     if db_path and db_path.exists():
         try:
             conn = _sqlite3.connect(db_path)
+        except _sqlite3.Error as exc:
+            # Can't even open the DB. Surface to the caller so it
+            # aborts before touching pollypm.toml.
+            raise _PurgeStateError(
+                f"could not open state.db at {db_path}: {exc}"
+            ) from exc
+        try:
             try:
                 conn.execute("BEGIN IMMEDIATE")
                 for table, where, ptype in _STATE_PURGE_TABLES:
@@ -863,28 +888,38 @@ def _purge_project_state(
                         else (project_key,)
                     )
                     try:
-                        conn.execute(
+                        cur = conn.execute(
                             f"DELETE FROM {table} WHERE {where}", params
                         )
                     except _sqlite3.Error:
-                        # Missing table — skip silently. We already
-                        # counted 0 for it above so the summary line
-                        # stays accurate.
-                        pass
+                        # Missing table on this DB — skip. The count
+                        # stays at 0 for that table; sweep continues.
+                        continue
+                    counts[table] = int(cur.rowcount or 0)
                 conn.commit()
-            finally:
-                conn.close()
-        except _sqlite3.Error:
-            # Pathological case (locked DB, corrupted file). Counts
-            # remain as the pre-sweep estimate so the caller can warn
-            # the user; we don't fabricate success.
-            pass
+            except _sqlite3.Error as exc:
+                # BEGIN failed (locked DB) or COMMIT failed (disk full,
+                # corrupt). Roll back so the partial-state risk is
+                # zero, then signal hard-failure to the caller.
+                try:
+                    conn.rollback()
+                except _sqlite3.Error:
+                    pass
+                raise _PurgeStateError(
+                    f"state.db purge failed for '{project_key}': {exc}"
+                ) from exc
+        finally:
+            conn.close()
 
     # Audit tail file — central-tail JSONL at
     # ~/.pollypm/audit/<project>.jsonl. The per-project log inside
     # ``<project_path>/.pollypm/audit.jsonl`` lives in the project
     # directory, which ``pm project remove`` deliberately leaves on
     # disk (worktree teardown is a separate wedge, see #1561).
+    #
+    # Audit-tail removal is best-effort and runs AFTER the DB commit
+    # so the rows-vs-tail asymmetry only ever points one way: tail
+    # may linger after a successful row purge, never the reverse.
     try:
         from pollypm.audit.log import central_log_path
 
@@ -892,10 +927,11 @@ def _purge_project_state(
         if tail_path.exists():
             try:
                 tail_path.unlink()
+                counts["audit_tail"] = 1
             except OSError:
-                # Best-effort. Leave the count as 1 so the summary
-                # reports "would have removed" but we couldn't.
-                pass
+                # Best-effort. Leave the count at 0 so the summary
+                # truthfully reports nothing was removed.
+                counts["audit_tail"] = 0
     except Exception:  # noqa: BLE001
         pass
 
@@ -1168,7 +1204,9 @@ def remove_cmd(
     # purging first and removing second, a failure on the second
     # step leaves the user with a clearly-orphaned project entry
     # they can retry the remove on; a failure on the first step
-    # exits before touching the config.
+    # (``_PurgeStateError``) exits with code 1 before touching the
+    # config (see issue #1673 — previously this caught the error
+    # silently and stripped the project anyway).
     state_summary: dict[str, int] | None = None
     if purge_state:
         state_counts = _count_project_state_rows(path, project_key)
@@ -1192,7 +1230,23 @@ def remove_cmd(
                 if not proceed:
                     typer.echo("Aborted. No changes made.")
                     raise typer.Exit(code=1)
-            state_summary = _purge_project_state(path, project_key)
+            try:
+                state_summary = _purge_project_state(path, project_key)
+            except _PurgeStateError as exc:
+                # Hard DB failure (locked / corrupt / unwritable).
+                # Abort BEFORE ``remove_project`` so the config doesn't
+                # drift relative to the orphaned rows (issue #1673).
+                typer.echo(
+                    f"Error: state.db purge failed for '{project_key}': "
+                    f"{exc}",
+                    err=True,
+                )
+                typer.echo(
+                    "Aborted. Project entry left in pollypm.toml so you "
+                    "can retry once the DB is reachable.",
+                    err=True,
+                )
+                raise typer.Exit(code=1) from exc
             removed_total = sum(
                 n for table, n in state_summary.items()
                 if table != "audit_tail"

--- a/tests/test_project_remove_cli.py
+++ b/tests/test_project_remove_cli.py
@@ -963,3 +963,140 @@ def test_cli_remove_dry_run_warns_when_state_rows_present_without_purge(
     assert result.exit_code == 0, result.output
     assert "use --purge-state to delete" in result.output
     assert "NOT touched without --purge-state" in result.output
+
+
+# --------------------------------------------------------------------------
+# Regression: #1673 — DB purge failure must NOT strip the TOML project.
+# Before the fix, ``_purge_project_state`` caught ``sqlite3.Error`` and
+# returned the pre-purge counts, so ``remove_cmd`` happily printed
+# "Deleted N rows" and called ``remove_project`` — leaving rows in the
+# DB and the project gone from pollypm.toml. The fix raises a
+# ``_PurgeStateError`` on hard DB failures so the command aborts before
+# touching the config.
+# --------------------------------------------------------------------------
+
+
+def test_purge_project_state_raises_on_db_open_failure(
+    env, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Connection failure surfaces as ``_PurgeStateError`` (#1673)."""
+    import sqlite3
+
+    from pollypm.plugins_builtin.project_planning.cli import (
+        project as project_mod,
+    )
+
+    audit_home = tmp_path / "audit"
+    audit_home.mkdir()
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+    _seed_state_db_rows(env["config_path"], "demo", task_count=2)
+
+    real_connect = sqlite3.connect
+
+    def boom(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    # Patch the sqlite3 module the function imports lazily.
+    monkeypatch.setattr(sqlite3, "connect", boom)
+    try:
+        with pytest.raises(project_mod._PurgeStateError):
+            project_mod._purge_project_state(env["config_path"], "demo")
+    finally:
+        monkeypatch.setattr(sqlite3, "connect", real_connect)
+
+
+def test_purge_project_state_raises_on_commit_failure(
+    env, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mid-transaction failure rolls back and raises (#1673)."""
+    import sqlite3
+
+    from pollypm.plugins_builtin.project_planning.cli import (
+        project as project_mod,
+    )
+
+    audit_home = tmp_path / "audit"
+    audit_home.mkdir()
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+    _seed_state_db_rows(env["config_path"], "demo", task_count=2)
+
+    real_connect = sqlite3.connect
+
+    class _BoomConn:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def execute(self, sql, *args, **kwargs):
+            if sql.strip().upper().startswith("BEGIN"):
+                raise sqlite3.OperationalError("database is locked")
+            return self._inner.execute(sql, *args, **kwargs)
+
+        def commit(self):
+            return self._inner.commit()
+
+        def rollback(self):
+            return self._inner.rollback()
+
+        def close(self):
+            return self._inner.close()
+
+    def wrap(*args, **kwargs):
+        return _BoomConn(real_connect(*args, **kwargs))
+
+    monkeypatch.setattr(sqlite3, "connect", wrap)
+    try:
+        with pytest.raises(project_mod._PurgeStateError):
+            project_mod._purge_project_state(env["config_path"], "demo")
+    finally:
+        monkeypatch.setattr(sqlite3, "connect", real_connect)
+
+    # Rows still present — purge never committed.
+    after = project_mod._count_project_state_rows(env["config_path"], "demo")
+    assert after["work_tasks"] == 2
+
+
+def test_cli_remove_purge_state_aborts_when_db_purge_fails(
+    env, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``pm project remove --purge-state`` does NOT strip TOML on DB failure (#1673)."""
+    from pollypm.plugins_builtin.project_planning.cli import (
+        project as project_mod,
+    )
+
+    audit_home = tmp_path / "audit"
+    audit_home.mkdir()
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+    _seed_state_db_rows(env["config_path"], "demo", task_count=2)
+    tail_path = _audit_tail_for("demo", audit_home=audit_home)
+    tail_path.write_text('{"event": "seeded"}\n')
+
+    def boom(*_args, **_kwargs):
+        raise project_mod._PurgeStateError("simulated locked DB")
+
+    monkeypatch.setattr(project_mod, "_purge_project_state", boom)
+
+    result = runner.invoke(
+        project_app,
+        [
+            "remove", "demo", "--purge-state", "--yes",
+            "--config", str(env["config_path"]),
+        ],
+    )
+
+    # Command must exit non-zero with an explicit error message.
+    assert result.exit_code == 1, result.output
+    assert "state.db purge failed" in result.output
+    assert "Aborted" in result.output
+
+    # CRITICAL: project entry still in pollypm.toml.
+    config = _load_cfg(env["config_path"])
+    assert "demo" in config.projects
+
+    # CRITICAL: no "Removed project" line emitted.
+    assert "Removed project 'demo'" not in result.output
+
+    # Audit tail untouched (purge bailed before audit cleanup too).
+    assert tail_path.exists()


### PR DESCRIPTION
## Summary

- Fixes #1673 — the `pm project remove --purge-state` regression introduced in #1671 where a locked/corrupt state.db would silently swallow the DB error, leaving every row in place AND removing the project from `pollypm.toml`.
- `_purge_project_state` now raises a new `_PurgeStateError` on connection or transaction failure (per-table missing-table errors stay best-effort and skip). It reports actual `cursor.rowcount` deletes instead of pre-purge estimates, and the audit-tail count only flips to 1 when the unlink truly succeeded.
- `remove_cmd` catches `_PurgeStateError` and exits with code 1 + a clear error before calling `remove_project`, so the operator can retry once the DB is reachable.

## Test plan

- [x] `pytest tests/test_project_remove_cli.py` — 25 tests pass (22 prior + 3 new regression tests)
- [x] `pytest tests/ -k "project_remove or project_planning or purge"` — 187 tests pass
- [x] New regression tests:
  - `test_purge_project_state_raises_on_db_open_failure` — `sqlite3.connect` boom -> `_PurgeStateError`
  - `test_purge_project_state_raises_on_commit_failure` — `BEGIN IMMEDIATE` boom -> `_PurgeStateError`, rows still present after
  - `test_cli_remove_purge_state_aborts_when_db_purge_fails` — CLI exits 1, project still in `pollypm.toml`, no "Removed project" line emitted, audit tail untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)