### PR TITLE
fix(#1676): route purge-state DELETE through storage facade

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -704,42 +704,14 @@ def _sessions_for_project(config_path: Path, project_key: str) -> list[str]:
 # State-DB row teardown (#1561 wedge #3)
 # ---------------------------------------------------------------------------
 #
-# Tables that carry project-scoped rows. Listed in delete order so any
-# child-row foreign-key chains (work_tasks references in dependencies /
-# executions / context / transitions / sessions / sync) are pruned BEFORE
-# the parent ``work_tasks`` rows themselves. SQLite enforces FKs only
-# when ``PRAGMA foreign_keys=ON`` is set on the connection — the work
-# service opens connections without it, but we still respect the order
-# so a future enable doesn't bite us.
-#
-# Each entry: (table, where_clause, params_factory). ``params_factory``
-# is called with ``project_key`` and returns the SQL parameter tuple. We
-# keep this as data so the count + delete passes traverse the same list.
-_STATE_PURGE_TABLES: tuple[tuple[str, str, str], ...] = (
-    # Work-service children of work_tasks (FK to work_tasks(project,
-    # task_number)) — these MUST go first or a future FK-enabled
-    # connection would refuse the parent delete.
-    ("work_task_dependencies",
-     "from_project = ? OR to_project = ?", "pair"),
-    ("work_node_executions", "task_project = ?", "single"),
-    ("work_context_entries", "task_project = ?", "single"),
-    ("work_transitions", "task_project = ?", "single"),
-    ("work_sessions", "task_project = ?", "single"),
-    ("work_sync_state", "task_project = ?", "single"),
-    # Parent work_tasks row. The delete trigger fires
-    # ``work_task_delete_audit_outbox`` rows; we drop those next so the
-    # outbox doesn't dangle once the project is gone.
-    ("work_tasks", "project = ?", "single"),
-    ("work_task_delete_audit_outbox", "project = ?", "single"),
-    # Other work-service / notification rows keyed off project.
-    ("notification_staging", "project = ?", "single"),
-    # state.db core tables that scope by project key.
-    ("messages", "scope = ?", "single"),
-    ("worktrees", "project_key = ?", "single"),
-    ("architect_resume_tokens", "project_key = ?", "single"),
-    ("token_samples", "project_key = ?", "single"),
-    ("token_usage_hourly", "project_key = ?", "single"),
-)
+# SQLite row counting + bulk DELETE lives in the storage facade
+# ``pollypm.storage.project_state_purge`` (#1676). The CLI is only
+# responsible for resolving the workspace DB path, the audit-tail
+# JSONL file teardown (non-SQLite), and rendering the operator-facing
+# summary. The plugin CLI deliberately does not open the workspace
+# DB directly — boundary test
+# ``test_work_task_query_callers_do_not_open_sqlite_directly``
+# enforces that for every UI/plugin caller.
 
 
 def _workspace_db_path(config_path: Path) -> Path | None:
@@ -767,47 +739,19 @@ def _count_project_state_rows(
 ) -> dict[str, int]:
     """Return per-table row counts for ``project_key`` in the workspace DB.
 
-    Best-effort: a missing DB, missing table, or read failure yields
-    zero for that table. Used both by the dry-run preview and the
-    post-purge "removed N rows" summary so the two views agree on
-    scope.
-
-    Keys: every table in :data:`_STATE_PURGE_TABLES` plus
-    ``audit_tail`` for the ``~/.pollypm/audit/<key>.jsonl`` file (1
-    when present, 0 when absent — file teardown is not a row count
-    but mirrors the same idea).
+    Thin wrapper that delegates the SQLite work to
+    :func:`pollypm.storage.project_state_purge.count_project_state_rows`
+    and layers on the ``audit_tail`` key for the central-tail JSONL
+    file (``~/.pollypm/audit/<key>.jsonl``). The audit tail is a file,
+    not a row, but the dry-run preview surfaces it alongside the row
+    counts so the operator sees the full teardown footprint in one
+    list.
     """
-    import sqlite3 as _sqlite3
-
-    counts: dict[str, int] = {table: 0 for table, _w, _p in _STATE_PURGE_TABLES}
-    counts["audit_tail"] = 0
+    from pollypm.storage.project_state_purge import count_project_state_rows
 
     db_path = _workspace_db_path(config_path)
-    if db_path and db_path.exists():
-        try:
-            conn = _sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-            try:
-                for table, where, ptype in _STATE_PURGE_TABLES:
-                    params = (
-                        (project_key, project_key) if ptype == "pair"
-                        else (project_key,)
-                    )
-                    try:
-                        cur = conn.execute(
-                            f"SELECT COUNT(*) FROM {table} WHERE {where}",
-                            params,
-                        )
-                        row = cur.fetchone()
-                        counts[table] = int(row[0]) if row else 0
-                    except _sqlite3.Error:
-                        # Table doesn't exist yet (fresh DB, pre-migration,
-                        # or schema drift). Counts as zero — there's
-                        # nothing to delete.
-                        counts[table] = 0
-            finally:
-                conn.close()
-        except _sqlite3.Error:
-            pass
+    counts = count_project_state_rows(db_path, project_key)
+    counts["audit_tail"] = 0
 
     try:
         from pollypm.audit.log import central_log_path
@@ -830,72 +774,38 @@ def _purge_project_state(
 
     Returns a ``{table: removed_count}`` dict (plus ``audit_tail`` for
     the central-tail JSONL file). In ``dry_run`` mode no mutations
-    happen; the returned counts reflect what WOULD be deleted (the
-    same numbers :func:`_count_project_state_rows` returns).
+    happen; the returned counts reflect what WOULD be deleted.
 
-    Best-effort throughout: a missing DB, missing table, or write
-    failure on one table never aborts the rest of the sweep. The
-    deletes run in a single transaction so a mid-sweep crash leaves
-    state.db in a consistent state.
-
-    Why a single bulk SQL sweep instead of routing through
-    ``work_service.delete_task``: per-task deletes would fire
-    cascade-aware audit emits + sync hooks for every row, which is
-    exactly the noise the user is trying to clear. Bulk DELETE
-    silences the side-channels and matches the operator's mental
-    model ("tear it all down, fast").
+    The SQLite bulk DELETE happens inside
+    :func:`pollypm.storage.project_state_purge.purge_project_state_rows`
+    (#1676 — keeps schema/connection knowledge out of the plugin
+    CLI). The audit-tail JSONL teardown is a file operation, so it
+    stays here.
     """
-    import sqlite3 as _sqlite3
-
-    counts = _count_project_state_rows(config_path, project_key)
-    if dry_run:
-        return counts
+    from pollypm.storage.project_state_purge import purge_project_state_rows
 
     db_path = _workspace_db_path(config_path)
-    if db_path and db_path.exists():
-        try:
-            conn = _sqlite3.connect(db_path)
-            try:
-                conn.execute("BEGIN IMMEDIATE")
-                for table, where, ptype in _STATE_PURGE_TABLES:
-                    params = (
-                        (project_key, project_key) if ptype == "pair"
-                        else (project_key,)
-                    )
-                    try:
-                        conn.execute(
-                            f"DELETE FROM {table} WHERE {where}", params
-                        )
-                    except _sqlite3.Error:
-                        # Missing table — skip silently. We already
-                        # counted 0 for it above so the summary line
-                        # stays accurate.
-                        pass
-                conn.commit()
-            finally:
-                conn.close()
-        except _sqlite3.Error:
-            # Pathological case (locked DB, corrupted file). Counts
-            # remain as the pre-sweep estimate so the caller can warn
-            # the user; we don't fabricate success.
-            pass
+    counts = purge_project_state_rows(db_path, project_key, dry_run=dry_run)
 
     # Audit tail file — central-tail JSONL at
     # ~/.pollypm/audit/<project>.jsonl. The per-project log inside
     # ``<project_path>/.pollypm/audit.jsonl`` lives in the project
     # directory, which ``pm project remove`` deliberately leaves on
     # disk (worktree teardown is a separate wedge, see #1561).
+    counts["audit_tail"] = 0
     try:
         from pollypm.audit.log import central_log_path
 
         tail_path = central_log_path(project_key)
         if tail_path.exists():
-            try:
-                tail_path.unlink()
-            except OSError:
-                # Best-effort. Leave the count as 1 so the summary
-                # reports "would have removed" but we couldn't.
-                pass
+            counts["audit_tail"] = 1
+            if not dry_run:
+                try:
+                    tail_path.unlink()
+                except OSError:
+                    # Best-effort. Leave the count as 1 so the summary
+                    # reports "would have removed" but we couldn't.
+                    pass
     except Exception:  # noqa: BLE001
         pass
 

--- a/src/pollypm/storage/project_state_purge.py
+++ b/src/pollypm/storage/project_state_purge.py
@@ -1,0 +1,192 @@
+"""Project-scoped state.db row teardown helpers (#1676).
+
+The ``pm project remove --purge-state`` flow needs to count and bulk-
+delete every row in ``state.db`` tied to a project key. Doing that work
+inside the plugin CLI re-introduced direct ``sqlite3`` imports in
+``plugins_builtin/`` and tripped the boundary test that #1376 set up
+(``test_work_task_query_callers_do_not_open_sqlite_directly``).
+
+This module is the storage-layer facade the CLI calls instead. It owns
+the schema table list, the transactional bulk DELETE, and the
+read-only count probes. The CLI keeps audit-tail file teardown
+(non-SQLite) and resolves the DB path; everything that touches SQLite
+lives here.
+
+Mirrors the ``storage/work_session_queries.py`` pattern from #1617:
+read-only probes open ``file:<path>?mode=ro`` URIs via stdlib
+``sqlite3``; bulk writes open a normal connection inside an explicit
+``BEGIN IMMEDIATE`` so a mid-sweep crash leaves the DB consistent.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# Tables that carry project-scoped rows. Listed in delete order so any
+# child-row foreign-key chains (work_tasks references in dependencies /
+# executions / context / transitions / sessions / sync) are pruned BEFORE
+# the parent ``work_tasks`` rows themselves. SQLite enforces FKs only
+# when ``PRAGMA foreign_keys=ON`` is set on the connection — the work
+# service opens connections without it, but we still respect the order
+# so a future enable doesn't bite us.
+#
+# Each entry: ``(table, where_clause, params_kind)`` where ``params_kind``
+# is ``"single"`` (binds ``project_key`` once) or ``"pair"`` (binds it
+# twice — used by ``work_task_dependencies`` whose WHERE matches
+# from-project OR to-project).
+_STATE_PURGE_TABLES: tuple[tuple[str, str, str], ...] = (
+    # Work-service children of work_tasks (FK to work_tasks(project,
+    # task_number)) — these MUST go first or a future FK-enabled
+    # connection would refuse the parent delete.
+    ("work_task_dependencies",
+     "from_project = ? OR to_project = ?", "pair"),
+    ("work_node_executions", "task_project = ?", "single"),
+    ("work_context_entries", "task_project = ?", "single"),
+    ("work_transitions", "task_project = ?", "single"),
+    ("work_sessions", "task_project = ?", "single"),
+    ("work_sync_state", "task_project = ?", "single"),
+    # Parent work_tasks row. The delete trigger fires
+    # ``work_task_delete_audit_outbox`` rows; we drop those next so the
+    # outbox doesn't dangle once the project is gone.
+    ("work_tasks", "project = ?", "single"),
+    ("work_task_delete_audit_outbox", "project = ?", "single"),
+    # Other work-service / notification rows keyed off project.
+    ("notification_staging", "project = ?", "single"),
+    # state.db core tables that scope by project key.
+    ("messages", "scope = ?", "single"),
+    ("worktrees", "project_key = ?", "single"),
+    ("architect_resume_tokens", "project_key = ?", "single"),
+    ("token_samples", "project_key = ?", "single"),
+    ("token_usage_hourly", "project_key = ?", "single"),
+)
+
+
+def _params_for(project_key: str, kind: str) -> tuple[str, ...]:
+    return (project_key, project_key) if kind == "pair" else (project_key,)
+
+
+def count_project_state_rows(
+    db_path: Path | None,
+    project_key: str,
+) -> dict[str, int]:
+    """Return per-table row counts for ``project_key`` in ``db_path``.
+
+    Best-effort: a missing DB, missing table, or read failure yields
+    zero for that table. The returned dict has one key per entry in
+    :data:`_STATE_PURGE_TABLES`. Callers that also track non-SQLite
+    artefacts (e.g. the central audit-tail JSONL) merge their own keys
+    onto the result.
+    """
+    counts: dict[str, int] = {table: 0 for table, _w, _p in _STATE_PURGE_TABLES}
+
+    if db_path is None or not db_path.exists():
+        return counts
+
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    except sqlite3.Error as exc:
+        logger.debug(
+            "project_state_purge: read-only connect failed for %s: %s",
+            db_path, exc,
+        )
+        return counts
+    try:
+        for table, where, ptype in _STATE_PURGE_TABLES:
+            params = _params_for(project_key, ptype)
+            try:
+                cur = conn.execute(
+                    f"SELECT COUNT(*) FROM {table} WHERE {where}",
+                    params,
+                )
+                row = cur.fetchone()
+                counts[table] = int(row[0]) if row else 0
+            except sqlite3.Error:
+                # Table doesn't exist yet (fresh DB, pre-migration, or
+                # schema drift). Counts as zero — there's nothing to
+                # delete.
+                counts[table] = 0
+    finally:
+        conn.close()
+
+    return counts
+
+
+def purge_project_state_rows(
+    db_path: Path | None,
+    project_key: str,
+    *,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Delete every project-scoped row from ``db_path``.
+
+    Returns a ``{table: removed_count}`` dict (one entry per
+    :data:`_STATE_PURGE_TABLES` table). In ``dry_run`` mode no
+    mutations happen; the returned counts reflect what WOULD be
+    deleted (the same numbers :func:`count_project_state_rows`
+    returns).
+
+    Best-effort throughout: a missing DB, missing table, or write
+    failure on one table never aborts the rest of the sweep. The
+    deletes run in a single ``BEGIN IMMEDIATE`` transaction so a
+    mid-sweep crash leaves the DB consistent.
+
+    Why a single bulk SQL sweep instead of routing through
+    ``work_service.delete_task``: per-task deletes would fire
+    cascade-aware audit emits + sync hooks for every row, which is
+    exactly the noise the user is trying to clear. Bulk DELETE
+    silences the side-channels and matches the operator's mental
+    model ("tear it all down, fast").
+    """
+    counts = count_project_state_rows(db_path, project_key)
+    if dry_run:
+        return counts
+
+    if db_path is None or not db_path.exists():
+        return counts
+
+    try:
+        conn = sqlite3.connect(db_path)
+    except sqlite3.Error as exc:
+        logger.debug(
+            "project_state_purge: write connect failed for %s: %s",
+            db_path, exc,
+        )
+        return counts
+    try:
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            for table, where, ptype in _STATE_PURGE_TABLES:
+                params = _params_for(project_key, ptype)
+                try:
+                    conn.execute(
+                        f"DELETE FROM {table} WHERE {where}", params,
+                    )
+                except sqlite3.Error:
+                    # Missing table — skip silently. We already counted
+                    # 0 for it above so the summary line stays
+                    # accurate.
+                    pass
+            conn.commit()
+        except sqlite3.Error as exc:
+            # Pathological case (locked DB, corrupted file). Counts
+            # remain as the pre-sweep estimate so the caller can warn
+            # the user; we don't fabricate success.
+            logger.debug(
+                "project_state_purge: bulk DELETE failed for %s: %s",
+                db_path, exc,
+            )
+    finally:
+        conn.close()
+
+    return counts
+
+
+__all__ = [
+    "count_project_state_rows",
+    "purge_project_state_rows",
+]

--- a/tests/test_project_remove_cli.py
+++ b/tests/test_project_remove_cli.py
@@ -963,3 +963,109 @@ def test_cli_remove_dry_run_warns_when_state_rows_present_without_purge(
     assert result.exit_code == 0, result.output
     assert "use --purge-state to delete" in result.output
     assert "NOT touched without --purge-state" in result.output
+
+
+# --------------------------------------------------------------------------
+# Storage-facade unit tests (#1676): the bulk DELETE lives in
+# ``pollypm.storage.project_state_purge`` so the plugin CLI no longer
+# imports ``sqlite3`` directly. These exercises pin the facade contract.
+# --------------------------------------------------------------------------
+
+
+def test_storage_facade_count_rows_excludes_audit_tail(
+    env, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Facade returns DB-only keys; ``audit_tail`` is a CLI-layer concern."""
+    from pollypm.plugins_builtin.project_planning.cli.project import (
+        _workspace_db_path,
+    )
+    from pollypm.storage.project_state_purge import (
+        count_project_state_rows,
+    )
+
+    audit_home = tmp_path / "audit"
+    audit_home.mkdir()
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+    _seed_state_db_rows(env["config_path"], "demo", task_count=2)
+    # Audit tail file present, but the facade must not surface it.
+    _audit_tail_for("demo", audit_home=audit_home).write_text("{}\n")
+
+    counts = count_project_state_rows(
+        _workspace_db_path(env["config_path"]), "demo",
+    )
+
+    # DB tables surface real counts.
+    assert counts["work_tasks"] == 2
+    assert counts["messages"] >= 1
+    assert counts["worktrees"] == 1
+    # Facade contract: no audit_tail key (that's the CLI shim's job).
+    assert "audit_tail" not in counts
+
+
+def test_storage_facade_purge_rows_is_transactional(
+    env, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Facade bulk DELETE wipes every seeded row in one pass."""
+    from pollypm.plugins_builtin.project_planning.cli.project import (
+        _workspace_db_path,
+    )
+    from pollypm.storage.project_state_purge import (
+        count_project_state_rows,
+        purge_project_state_rows,
+    )
+
+    audit_home = tmp_path / "audit"
+    audit_home.mkdir()
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+    _seed_state_db_rows(env["config_path"], "demo", task_count=2)
+    db_path = _workspace_db_path(env["config_path"])
+
+    removed = purge_project_state_rows(db_path, "demo")
+    assert removed["work_tasks"] == 2
+
+    # Post-purge: zero rows everywhere.
+    after = count_project_state_rows(db_path, "demo")
+    assert all(n == 0 for n in after.values())
+
+
+def test_storage_facade_purge_rows_dry_run_is_noop(
+    env, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``dry_run=True`` returns would-delete counts without mutating."""
+    from pollypm.plugins_builtin.project_planning.cli.project import (
+        _workspace_db_path,
+    )
+    from pollypm.storage.project_state_purge import (
+        count_project_state_rows,
+        purge_project_state_rows,
+    )
+
+    audit_home = tmp_path / "audit"
+    audit_home.mkdir()
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+    _seed_state_db_rows(env["config_path"], "demo", task_count=3)
+    db_path = _workspace_db_path(env["config_path"])
+
+    preview = purge_project_state_rows(db_path, "demo", dry_run=True)
+    assert preview["work_tasks"] == 3
+
+    # Nothing actually deleted.
+    after = count_project_state_rows(db_path, "demo")
+    assert after["work_tasks"] == 3
+
+
+def test_plugin_cli_does_not_import_sqlite3() -> None:
+    """Regression for #1676: the plugin CLI module must not touch ``sqlite3``.
+
+    Mirrors ``test_work_task_query_callers_do_not_open_sqlite_directly``
+    but lives next to the implementation so the wedge it protects is
+    obvious in the diff history.
+    """
+    from pollypm.plugins_builtin.project_planning.cli import project as cli_mod
+
+    text = Path(cli_mod.__file__).read_text(encoding="utf-8")
+    assert "import sqlite3" not in text
+    assert "sqlite3.connect" not in text


### PR DESCRIPTION
## Summary

Closes #1676. PR #1671 reintroduced ``import sqlite3`` and a 13-table bulk DELETE inside the plugin CLI, tripping the ``test_work_task_query_callers_do_not_open_sqlite_directly`` boundary test that #1376 enforces.

- New storage facade ``pollypm.storage.project_state_purge`` (mirrors the ``work_session_queries`` pattern from #1617) with ``count_project_state_rows`` (RO probe) and ``purge_project_state_rows`` (transactional ``BEGIN IMMEDIATE`` bulk DELETE).
- The plugin CLI's ``_count_project_state_rows`` / ``_purge_project_state`` shrink to thin shims that resolve the workspace DB path, call the facade, and add the ``audit_tail`` JSONL file teardown (file op, not SQLite). No ``sqlite3`` references remain in ``plugins_builtin/project_planning/cli/project.py``.
- Added 4 storage-layer tests pinning the facade contract (DB-only keys, transactional sweep, dry-run is noop, plugin CLI does not import sqlite3).

## Test plan

- [x] ``uv run --extra dev pytest tests/test_plugin_boundary_conformance.py tests/test_project_remove_cli.py -q`` — 42 passed (was failing on ``test_work_task_query_callers_do_not_open_sqlite_directly``).
- [x] Existing ``test_cli_remove_purge_state_full_cascade`` end-to-end still passes; CLI output unchanged.
- [ ] Two unrelated boundary failures (``test_supervisor_import_allowlist_matches_reality``, ``test_no_supervisor_private_reach_through``) pre-exist on main and are out of scope here.

Generated with [Claude Code](https://claude.com/claude-code)