### PR TITLE
fix(#1363): migrate non-plugin callers off activity_feed.summaries shim

### DIFF
--- a/src/pollypm/cli_features/workers.py
+++ b/src/pollypm/cli_features/workers.py
@@ -237,7 +237,7 @@ def register_worker_commands(app: typer.Typer) -> None:
     ) -> None:
         """Stop a worker and mark it disabled so the heartbeat won't recover it."""
         from pollypm import cli as cli_mod
-        from pollypm.plugins_builtin.activity_feed.summaries import activity_summary
+        from pollypm.events.summaries import activity_summary
 
         supervisor = cli_mod._load_supervisor(config_path)
         session = supervisor.config.sessions.get(session_name)

--- a/src/pollypm/heartbeats/api.py
+++ b/src/pollypm/heartbeats/api.py
@@ -268,7 +268,7 @@ class SupervisorHeartbeatAPI:
                 ),
                 owner="heartbeat",
             )
-            from pollypm.plugins_builtin.activity_feed.summaries import (
+            from pollypm.events.summaries import (
                 activity_summary,
             )
 

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -597,7 +597,7 @@ class LocalHeartbeatBackend(HeartbeatBackend):
             except Exception as exc:  # noqa: BLE001
                 # Log and continue — don't let one session abort the entire sweep
                 try:
-                    from pollypm.plugins_builtin.activity_feed.summaries import (
+                    from pollypm.events.summaries import (
                         activity_summary,
                     )
 
@@ -617,7 +617,7 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                     )
                 except Exception:  # noqa: BLE001
                     pass
-        from pollypm.plugins_builtin.activity_feed.summaries import activity_summary
+        from pollypm.events.summaries import activity_summary
 
         open_alerts = api.open_alerts()
         alerts_n = len(open_alerts)
@@ -724,7 +724,7 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                 subject=f"Unmanaged tmux window: {window.window_name}",
             )
             if alert_type not in existing_alert_types:
-                from pollypm.plugins_builtin.activity_feed.summaries import (
+                from pollypm.events.summaries import (
                     activity_summary,
                 )
 
@@ -1414,7 +1414,7 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                 owner="heartbeat",
             )
             try:
-                from pollypm.plugins_builtin.activity_feed.summaries import (
+                from pollypm.events.summaries import (
                     activity_summary,
                 )
 
@@ -1490,7 +1490,7 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                     "Open Workers and restart the stalled session."
                 ),
             )
-            from pollypm.plugins_builtin.activity_feed.summaries import (
+            from pollypm.events.summaries import (
                 activity_summary,
             )
 
@@ -1713,7 +1713,7 @@ class LocalHeartbeatBackend(HeartbeatBackend):
             message = "State the remaining task in one sentence, execute the next step, and report."
         self._send_worker_message(api, context, message, owner="heartbeat")
         try:
-            from pollypm.plugins_builtin.activity_feed.summaries import (
+            from pollypm.events.summaries import (
                 activity_summary,
             )
 
@@ -1775,7 +1775,7 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                 "Yes, proceed. Do the next step you outlined.",
                 owner="heartbeat",
             )
-            from pollypm.plugins_builtin.activity_feed.summaries import (
+            from pollypm.events.summaries import (
                 activity_summary,
             )
 

--- a/src/pollypm/schedulers/inline.py
+++ b/src/pollypm/schedulers/inline.py
@@ -34,7 +34,7 @@ class InlineSchedulerBackend(SchedulerBackend):
         jobs = self._load_jobs(supervisor)
         jobs.append(job)
         self._save_jobs(supervisor, jobs)
-        from pollypm.plugins_builtin.activity_feed.summaries import activity_summary
+        from pollypm.events.summaries import activity_summary
 
         supervisor.msg_store.append_event(
             scope="scheduler",
@@ -80,7 +80,7 @@ class InlineSchedulerBackend(SchedulerBackend):
                     job.status = "pending"
                 else:
                     job.status = "failed"
-                from pollypm.plugins_builtin.activity_feed.summaries import (
+                from pollypm.events.summaries import (
                     activity_summary,
                 )
 
@@ -109,7 +109,7 @@ class InlineSchedulerBackend(SchedulerBackend):
                     job.last_error = None
                 else:
                     job.status = "done"
-                from pollypm.plugins_builtin.activity_feed.summaries import (
+                from pollypm.events.summaries import (
                     activity_summary,
                 )
 

--- a/src/pollypm/service_api/v1.py
+++ b/src/pollypm/service_api/v1.py
@@ -44,7 +44,7 @@ from pollypm.accounts import (
 from pollypm.checkpoints import create_issue_completion_checkpoint, record_checkpoint
 from pollypm.config_patches import apply_preference_patch, detect_preference_patch, list_project_overrides
 from pollypm.config import load_config
-from pollypm.plugins_builtin.activity_feed.summaries import activity_summary
+from pollypm.events.summaries import activity_summary
 from pollypm.itsalive import (
     deploy_site,
     pending_deploys,

--- a/tests/test_activity_feed_cli.py
+++ b/tests/test_activity_feed_cli.py
@@ -23,7 +23,7 @@ from pollypm.plugins_builtin.activity_feed.cli import (
     activity_app,
     parse_duration,
 )
-from pollypm.plugins_builtin.activity_feed.summaries import activity_summary
+from pollypm.events.summaries import activity_summary
 from pollypm.storage.state import StateStore
 
 

--- a/tests/test_activity_feed_panel.py
+++ b/tests/test_activity_feed_panel.py
@@ -36,7 +36,7 @@ from pollypm.plugins_builtin.activity_feed.handlers.event_projector import (
     EventProjector,
     FeedEntry,
 )
-from pollypm.plugins_builtin.activity_feed.summaries import activity_summary
+from pollypm.events.summaries import activity_summary
 from pollypm.storage.state import StateStore
 
 

--- a/tests/test_activity_feed_summaries.py
+++ b/tests/test_activity_feed_summaries.py
@@ -14,7 +14,7 @@ import json
 
 import pytest
 
-from pollypm.plugins_builtin.activity_feed.summaries import activity_summary
+from pollypm.events.summaries import activity_summary
 from pollypm.plugins_builtin.activity_feed.handlers.event_projector import (
     _parse_message,
 )

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -194,6 +194,16 @@ _CORE_RECURRING_PLUGIN_PREFIX = "pollypm.plugins_builtin.core_recurring"
 _COCKPIT_UI_FILE = "src/pollypm/cockpit_ui.py"
 _COCKPIT_INBOX_FILE = "src/pollypm/cockpit_inbox.py"
 _ACTIVITY_FEED_PLUGIN_MODULE = "pollypm.plugins_builtin.activity_feed.plugin"
+# The ``activity_summary`` packer is owned by core
+# (:mod:`pollypm.events.summaries`). The ``activity_feed`` plugin keeps
+# a backward-compat re-export at
+# ``pollypm.plugins_builtin.activity_feed.summaries`` for external plugin
+# consumers, but core (non-plugin) callers must import the canonical
+# path so the optional-plugin contract holds (see #1363, sibling of
+# #1597 / #1621 / #1626 / #1672).
+_ACTIVITY_FEED_SUMMARIES_PLUGIN_MODULE = (
+    "pollypm.plugins_builtin.activity_feed.summaries"
+)
 
 
 def _imports_module(source_file: Path, module: str) -> bool:
@@ -331,6 +341,33 @@ def test_cockpit_does_not_import_activity_feed_plugin_for_projector() -> None:
         f"{_ACTIVITY_FEED_PLUGIN_MODULE}; use "
         "pollypm.activity_projector_registry.build_activity_projector "
         "instead so the plugin stays optional. Offenders:\n  - "
+        + "\n  - ".join(offenders)
+    )
+
+
+def test_non_plugin_sources_do_not_import_activity_feed_summaries_shim() -> None:
+    """``activity_summary`` is owned by core, not the activity_feed plugin.
+
+    The canonical packer lives at
+    :mod:`pollypm.events.summaries`. The plugin keeps a backward-compat
+    re-export so external plugin consumers (and the plugin's own
+    handlers) can import either path, but core (non-plugin) callers must
+    use the canonical path. Reaching into the plugin shim re-couples
+    core to an "optional" plugin — fail loudly so the seam stays clean.
+    """
+    root = _project_root()
+    offenders: list[str] = []
+    for source_file in _iter_source_files(root):
+        rel = _relative_posix(source_file, root)
+        if "/plugins_builtin/" in rel:
+            continue
+        if _imports_module(source_file, _ACTIVITY_FEED_SUMMARIES_PLUGIN_MODULE):
+            offenders.append(rel)
+    assert not offenders, (
+        "Non-plugin sources must not import from "
+        f"{_ACTIVITY_FEED_SUMMARIES_PLUGIN_MODULE}; import "
+        "`activity_summary` from pollypm.events.summaries (the canonical "
+        "path) instead so the plugin stays optional. Offenders:\n  - "
         + "\n  - ".join(offenders)
     )
 


### PR DESCRIPTION
## Summary

Fifth wedge for #1363 after #1597, #1621, #1626, #1672. The
``activity_summary`` packer's canonical home is
``pollypm.events.summaries``; the
``pollypm.plugins_builtin.activity_feed.summaries`` module is a
backward-compat re-export for external plugin consumers. This wedge
migrates the 16 non-plugin call sites onto the canonical path so the
optional-plugin contract holds — disabling ``activity_feed`` no longer
breaks the plugin host / job runner / heartbeats / schedulers /
service_api / CLI emission sites.

- ``src/pollypm/heartbeats/local.py`` (7 sites), ``heartbeats/api.py``,
  ``service_api/v1.py``, ``cli_features/workers.py``,
  ``schedulers/inline.py`` (3 sites) — pure path rewrite, no behaviour
  change.
- ``tests/test_activity_feed_{summaries,cli,panel}.py`` — same rewrite
  so the suite imports through the canonical path.
- ``tests/test_import_boundary.py`` gains
  ``test_non_plugin_sources_do_not_import_activity_feed_summaries_shim``
  so regressions fail loudly. ``plugins_builtin/activity_feed/*`` is
  exempted so the plugin's own handlers can keep importing the shim.

The plugin shim itself stays in place so external plugins that
historically imported from there don't break (#805 contract).

## Test plan

- [x] ``pytest tests/test_import_boundary.py --deselect ...test_supervisor_import_allowlist_matches_reality --deselect ...test_no_supervisor_private_reach_through`` — 11 passed (deselected cases are pre-existing failures on ``main`` from ``heartbeats/local.py:1117`` ``supervisor._assert_session_launch_matches`` reach-through, unrelated to this slice).
- [x] ``pytest tests/test_activity_feed_summaries.py tests/test_activity_feed_cli.py tests/test_activity_feed_panel.py tests/test_activity_feed_projector.py`` — 70 passed.
- [x] ``pytest tests/test_heartbeat_tick.py tests/test_heartbeats_local_classify*.py tests/test_heartbeat_cascade_foundation.py tests/test_heartbeat_sweep_summary_plural.py tests/test_heartbeat_role_respawn.py tests/test_heartbeat_progress_signal.py tests/test_inline_scheduler_corrupt_jobs.py tests/test_scheduler_backend.py tests/test_service_api.py tests/test_workers.py`` — 167 passed.

Generated with [Claude Code](https://claude.com/claude-code).