### PR TITLE
feat(cli): pm cli-reference --json dumps Typer command tree (#1629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Added, Changed, and Removed.
 ## [Unreleased]
 
 ### Added
+- `pm cli-reference --json` dumps the full Typer command tree (commands,
+  subcommands, flags, types, help text, defaults) as a single JSON
+  document. Lets autonomous agents grep one structured surface instead
+  of recursively walking `--help` pages. Third wedge of #1629 after
+  the auto-role default (#1637) and task context/transitions
+  inspection CLIs (#1669).
 - `pm serve --port N [--host H] [--allow-remote]` runs the new Web API
   server (FastAPI) as a peer to the cockpit. Reads the same `state.db`
   / `audit.jsonl` via `pollypm.work.factory.create_work_service`

--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -500,6 +500,39 @@ def shortcuts() -> None:
     typer.echo(render_shortcuts_text())
 
 
+@app.command("cli-reference")
+def cli_reference(
+    output_json: bool = typer.Option(
+        False,
+        "--json",
+        help=(
+            "Emit the command tree as JSON (the only supported format). "
+            "Reserved for forward compatibility; required today so the "
+            "command's contract stays explicit."
+        ),
+    ),
+) -> None:
+    """Dump the full Typer command tree (commands, flags, types, help) as JSON.
+
+    Designed for agents that would otherwise grep through ``--help``
+    pages. The schema is documented in
+    :mod:`pollypm.cli_reference`; consumers should treat unknown fields
+    as informational and rely on ``commands``, ``subcommands``,
+    ``params``, ``name``, ``opts``, ``type``, ``required``, and
+    ``multiple`` as the stable surface.
+    """
+    if not output_json:
+        typer.echo(
+            "pm cli-reference currently only supports --json output. "
+            "Re-run with `pm cli-reference --json`.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    from pollypm.cli_reference import build_cli_reference
+
+    _emit_json(build_cli_reference(app))
+
+
 _ROLE_GUIDES = {
     # role: (repo-relative path, packaged-resource path under pollypm/, title)
     "worker": (

--- a/src/pollypm/cli_reference.py
+++ b/src/pollypm/cli_reference.py
@@ -1,0 +1,167 @@
+"""Introspect the PollyPM Typer app into a machine-readable schema.
+
+Contract:
+- Inputs: the root ``typer.Typer`` app (or any Typer app for testing).
+- Outputs: a nested dict shaped as documented in :func:`build_cli_reference`
+  — commands, subcommands, parameter metadata. JSON-serialisable.
+- Side effects: none. Pure inspection over the click command tree.
+- Invariants: never imports cockpit / TUI surfaces; safe to call from any
+  process. Returns a dict whose only leaf types are ``str``, ``bool``,
+  ``int``, ``list``, ``dict``, or ``None`` so it round-trips through
+  ``json.dumps`` without a custom encoder.
+- Allowed dependencies: ``typer``, ``click``.
+- Private: helpers prefixed with ``_``.
+
+This is the third wedge of #1629 (agent ergonomics): autonomous agents
+can grep one ``pm cli-reference --json`` dump instead of recursively
+walking ``--help`` pages. Hidden commands / parameters are skipped so
+the schema mirrors what end-users actually see.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+import typer
+import typer.main
+
+
+def build_cli_reference(app: typer.Typer) -> dict[str, Any]:
+    """Walk ``app``'s command tree and return a JSON-serialisable schema.
+
+    Output shape::
+
+        {
+          "commands": {
+            "<name>": <command-node> | <group-node>,
+            ...
+          }
+        }
+
+    A command node looks like::
+
+        {
+          "help": "...",
+          "params": [
+            {"name": "title", "param_type": "argument", "type": "str",
+             "required": true, "multiple": false, "help": "...",
+             "default": null, "opts": ["title"]},
+            ...
+          ]
+        }
+
+    A group node has ``"subcommands"`` instead of ``"params"``::
+
+        {"help": "...", "subcommands": {"<sub>": <command-node>, ...}}
+    """
+    root = typer.main.get_command(app)
+    return {"commands": _walk_group_children(root)}
+
+
+def _walk_group_children(group: click.Group) -> dict[str, Any]:
+    """Return a ``{name: node}`` dict for the visible subcommands of ``group``."""
+    children: dict[str, Any] = {}
+    for name in sorted(group.commands):
+        cmd = group.commands[name]
+        if getattr(cmd, "hidden", False):
+            continue
+        children[name] = _describe_command(cmd)
+    return children
+
+
+def _describe_command(cmd: click.Command) -> dict[str, Any]:
+    """Describe one command node — recurses into ``click.Group`` subcommands.
+
+    Typer surfaces a single-callback subapp as a ``click.Group`` with no
+    registered subcommands but params on the group itself (e.g. ``pm
+    activity --follow``). We emit ``params`` for those alongside the
+    (empty) ``subcommands`` so callers don't have to special-case the
+    "group with no children" shape.
+    """
+    node: dict[str, Any] = {"help": _help_text(cmd)}
+    params = [
+        entry for entry in (_describe_param(p) for p in cmd.params) if entry is not None
+    ]
+    if isinstance(cmd, click.Group):
+        node["subcommands"] = _walk_group_children(cmd)
+        if params:
+            node["params"] = params
+    else:
+        node["params"] = params
+    return node
+
+
+def _describe_param(param: click.Parameter) -> dict[str, Any] | None:
+    """Render a single click parameter as a JSON-friendly dict.
+
+    Returns ``None`` for hidden params (Typer's auto-injected shell
+    completion options when surfaced as hidden, etc.). Click's
+    ``click.Argument`` does not carry a ``hidden`` attribute, so the
+    guard only really fires for options.
+    """
+    if getattr(param, "hidden", False):
+        return None
+
+    if isinstance(param, click.Argument):
+        param_type = "argument"
+    elif isinstance(param, click.Option):
+        param_type = "option"
+    else:  # Defensive: future click extensions.
+        param_type = type(param).__name__.lower()
+
+    return {
+        "name": param.name,
+        "param_type": param_type,
+        "type": _type_name(param.type),
+        "required": bool(getattr(param, "required", False)),
+        "multiple": bool(getattr(param, "multiple", False)),
+        "is_flag": bool(getattr(param, "is_flag", False)),
+        "opts": list(param.opts),
+        "default": _normalize_default(param.default),
+        "help": _help_text(param),
+    }
+
+
+def _help_text(obj: object) -> str | None:
+    """Pull help text from a click command/param, preferring long form."""
+    text = getattr(obj, "help", None) or getattr(obj, "short_help", None)
+    if not text:
+        return None
+    return str(text).strip() or None
+
+
+def _type_name(param_type: click.ParamType | None) -> str:
+    """Map a click param type to a stable short name.
+
+    Click exposes ``ParamType.name`` for the common cases ("text",
+    "integer", "boolean", "path", ...). We normalise a couple of those
+    to Python-ish names so agents can pattern-match on familiar terms.
+    """
+    if param_type is None:
+        return "str"
+    name = getattr(param_type, "name", None) or type(param_type).__name__
+    return {
+        "text": "str",
+        "integer": "int",
+        "integer range": "int",
+        "float range": "float",
+        "boolean": "bool",
+    }.get(name, name)
+
+
+def _normalize_default(value: object) -> object:
+    """Coerce a click parameter default into a JSON-friendly value.
+
+    Click stores ``None`` for "no default"; Typer sometimes stores
+    callables / sentinels for eager options. Anything we cannot safely
+    serialise becomes its ``repr`` so the schema stays JSON-clean while
+    still surfacing *something* observable.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_normalize_default(item) for item in value]
+    return repr(value)

--- a/tests/test_cli_reference.py
+++ b/tests/test_cli_reference.py
@@ -1,0 +1,149 @@
+"""Tests for ``pm cli-reference --json`` and the underlying introspection.
+
+The introspection helper is the contract — the CLI command is a thin
+wrapper. Tests cover both, plus a smoke test against the real
+``pollypm.cli.app`` so a regression in any registered subapp surfaces
+here.
+"""
+
+from __future__ import annotations
+
+import json
+
+import typer
+from typer.testing import CliRunner
+
+import pollypm.cli as cli
+from pollypm.cli_reference import build_cli_reference
+
+
+def _make_fixture_app() -> typer.Typer:
+    """Return a small Typer app that exercises every schema branch."""
+    app = typer.Typer(help="Fixture app for cli-reference tests.")
+
+    sub = typer.Typer(help="Sub group.")
+    app.add_typer(sub, name="sub")
+
+    @sub.command("create")
+    def _create(
+        title: str = typer.Argument(..., help="Title arg."),
+        role: list[str] = typer.Option(  # noqa: B008 — Typer pattern
+            None, "--role", "-r", help="Repeatable role.",
+        ),
+        force: bool = typer.Option(
+            False, "--force", help="Boolean flag.",
+        ),
+        limit: int = typer.Option(
+            10, "--limit", help="Numeric option.",
+        ),
+    ) -> None:
+        """Fixture create command."""
+        _ = (title, role, force, limit)
+
+    @app.command("flat")
+    def _flat(
+        target: str = typer.Argument(..., help="Required positional."),
+    ) -> None:
+        """A flat root-level command."""
+        _ = target
+
+    @app.command("hidden-cmd", hidden=True)
+    def _hidden() -> None:
+        """Should not appear in the reference."""
+
+    # A group with no subcommands but with params (Typer single-callback
+    # pattern, e.g. `pm activity --follow`).
+    leaf_group = typer.Typer(help="Leaf-style group.", invoke_without_command=True)
+    app.add_typer(leaf_group, name="leaf")
+
+    @leaf_group.callback(invoke_without_command=True)
+    def _leaf_cb(
+        follow: bool = typer.Option(False, "--follow", "-f", help="Tail mode."),
+    ) -> None:
+        _ = follow
+
+    return app
+
+
+def test_build_cli_reference_schema_for_fixture_app() -> None:
+    app = _make_fixture_app()
+    schema = build_cli_reference(app)
+
+    # Top-level commands sorted, hidden command absent.
+    assert "commands" in schema
+    names = list(schema["commands"].keys())
+    assert names == sorted(names)
+    assert "hidden-cmd" not in names
+    assert {"sub", "flat", "leaf"}.issubset(set(names))
+
+    # Flat command exposes its single required argument.
+    flat = schema["commands"]["flat"]
+    assert flat["help"] == "A flat root-level command."
+    assert "subcommands" not in flat
+    assert flat["params"][0] == {
+        "name": "target",
+        "param_type": "argument",
+        "type": "str",
+        "required": True,
+        "multiple": False,
+        "is_flag": False,
+        "opts": ["target"],
+        "default": None,
+        "help": "Required positional.",
+    }
+
+    # Sub group recurses; create subcommand exposes all params with the
+    # right shapes.
+    sub = schema["commands"]["sub"]
+    assert "subcommands" in sub
+    create = sub["subcommands"]["create"]
+    by_name = {p["name"]: p for p in create["params"]}
+    assert by_name["title"]["required"] is True
+    assert by_name["title"]["param_type"] == "argument"
+    assert by_name["role"]["multiple"] is True
+    assert by_name["role"]["param_type"] == "option"
+    assert by_name["role"]["opts"] == ["--role", "-r"]
+    assert by_name["force"]["type"] == "bool"
+    assert by_name["force"]["is_flag"] is True
+    assert by_name["limit"]["type"] == "int"
+    assert by_name["limit"]["default"] == 10
+
+    # Leaf group: empty subcommands AND surfaced callback params.
+    leaf = schema["commands"]["leaf"]
+    assert leaf["subcommands"] == {}
+    leaf_param_names = {p["name"] for p in leaf["params"]}
+    assert "follow" in leaf_param_names
+
+
+def test_build_cli_reference_output_is_json_serialisable() -> None:
+    """The schema must round-trip through ``json.dumps`` with no encoder."""
+    schema = build_cli_reference(_make_fixture_app())
+    # Will raise TypeError if any non-JSON-native leaves leaked through.
+    blob = json.dumps(schema)
+    assert json.loads(blob) == schema
+
+
+def test_cli_reference_command_emits_json() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["cli-reference", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert "commands" in payload
+    # Spot-check a few known commands ship in the dump.
+    for expected in ("task", "inbox", "project", "cli-reference"):
+        assert expected in payload["commands"], expected
+    # task is a group, and its subcommands include `create`.
+    task = payload["commands"]["task"]
+    assert "subcommands" in task
+    assert "create" in task["subcommands"]
+    create = task["subcommands"]["create"]
+    create_param_names = {p["name"] for p in create["params"]}
+    assert {"title", "project", "role"}.issubset(create_param_names)
+
+
+def test_cli_reference_without_json_flag_exits_nonzero() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["cli-reference"])
+    assert result.exit_code == 2
+    assert "--json" in result.output


### PR DESCRIPTION
## Summary

Third wedge of #1629 (agent ergonomics) after #1637 (auto-role default) and #1669 (task context/transitions inspection CLIs).

- New ``pm cli-reference --json`` walks the registered Typer app via ``typer.main.get_command`` and emits a JSON schema covering commands, subcommands, params (arguments + options), types, defaults, help text, ``required``, ``multiple``, and ``is_flag``. Autonomous agents can grep this single dump instead of recursing through ``--help`` pages.
- Walker + schema docs live in new ``pollypm.cli_reference`` so the CLI command stays a thin wrapper. Hidden commands / params are skipped so the schema mirrors what end-users see.
- Group-with-no-subcommands (Typer single-callback subapp pattern, e.g. ``pm activity --follow``) surfaces params alongside the empty ``subcommands`` dict so consumers don't have to special-case it.
- Re-runs without ``--json`` exit 2 with guidance; the flag is required today so the contract stays explicit and the command can later grow other output formats.

## Test plan

- [x] ``uv run python -m pytest tests/test_cli_reference.py`` (4 tests: fixture-app schema branches, JSON round-trip, end-to-end ``pm cli-reference --json`` against the real app, no-flag exit code).
- [x] ``uv run python -m pytest tests/test_cli.py tests/test_cli_shortcuts.py tests/test_cli_help_examples.py tests/test_pm_cli_registration.py`` — 58 passed, includes the import-discipline test confirming ``cli-reference`` doesn't pull heavy modules at import time.
- [x] ``uv run pm cli-reference --json | python -c 'import json,sys; json.load(sys.stdin)'`` succeeds; sample inspection of ``commands.task.subcommands.create.params`` shows the expected ``title`` / ``--project`` / ``--role`` (multiple=true) shape.