### PR TITLE
fix(observability): log 13 silent except Exception sites in cli/cockpit_apps (#1355 wedge)

### DIFF
--- a/src/pollypm/cli_features/alerts.py
+++ b/src/pollypm/cli_features/alerts.py
@@ -12,6 +12,7 @@ Contract:
 from __future__ import annotations
 
 import json
+import logging
 import os
 import shutil
 import subprocess
@@ -21,6 +22,8 @@ import typer
 
 from pollypm.cli_help import help_with_examples
 from pollypm.config import DEFAULT_CONFIG_PATH
+
+logger = logging.getLogger(__name__)
 
 
 # Alert taxonomy (#788):
@@ -111,7 +114,10 @@ def heartbeat(
     try:
         cli_mod._revive_rail_daemon_if_dead(config_path)
     except Exception:  # noqa: BLE001
-        pass
+        logger.warning(
+            "Failed to revive rail daemon during heartbeat sweep (#1355)",
+            exc_info=True,
+        )
     alerts = supervisor.run_heartbeat(snapshot_lines=snapshot_lines)
     tick_result = cli_mod._tick_core_rail_if_available(supervisor)
     cli_mod._drain_and_stop_core_rail_if_available(

--- a/src/pollypm/cli_features/maintenance.py
+++ b/src/pollypm/cli_features/maintenance.py
@@ -12,6 +12,7 @@ Contract:
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 import subprocess
 from collections import OrderedDict
@@ -31,6 +32,8 @@ from pollypm.errors import format_config_not_found_error
 from pollypm.models import ProviderKind
 from pollypm.transcript_ledger import token_usage_costs
 from pollypm.worktrees import list_worktrees as list_project_worktrees
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -353,7 +356,10 @@ def doctor(
             },
         )
     except Exception:  # noqa: BLE001 — audit must never break CLI
-        pass
+        logger.warning(
+            "Failed to emit audit row for pm doctor (#1355)",
+            exc_info=True,
+        )
 
     raise typer.Exit(code=0 if report.ok else 1)
 
@@ -1036,7 +1042,10 @@ def restore_cmd(
                 "restored DB may be overwritten by the live cockpit."
             )
     except Exception:
-        pass
+        logger.warning(
+            "Failed to probe tmux session before restore (#1355)",
+            exc_info=True,
+        )
 
     try:
         result = backup_mod.execute_restore(plan)

--- a/src/pollypm/cli_features/session_runtime.py
+++ b/src/pollypm/cli_features/session_runtime.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import functools
 import inspect
 import json
+import logging
 import os
 import re
 import sys
@@ -25,6 +26,8 @@ import typer
 
 from pollypm.config import DEFAULT_CONFIG_PATH
 from pollypm.inbox.kind import InboxItemKind
+
+logger = logging.getLogger(__name__)
 
 _TASK_ID_PATTERN = re.compile(r"\b([A-Za-z0-9_.-]+/\d+)\b")
 
@@ -346,7 +349,10 @@ def reset(
         )
         supervisor.store.commit()
     except Exception:  # noqa: BLE001
-        pass
+        logger.warning(
+            "Failed to clear leases/session_runtime/open alerts during reset (#1355)",
+            exc_info=True,
+        )
     session_word = "session" if len(sessions_to_kill) == 1 else "sessions"
     typer.echo(
         f"Killed {len(sessions_to_kill)} {session_word}: {', '.join(sessions_to_kill)}"

--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -25,6 +25,8 @@ from pollypm.cockpit_live_chat_notice import (
 )
 from pollypm.config import DEFAULT_CONFIG_PATH
 
+logger = logging.getLogger(__name__)
+
 _RIGHT_PANE_BRIDGE_BYPASS_ESCAPE_TOKENS = frozenset({"<esc>", "esc", "escape"})
 _LIVE_RIGHT_PANE_INPUT_STICKY = "live_right_pane_input_sticky"
 _HELP_MODAL_BRIDGE_KIND = "help_modal_bridge_kind"
@@ -164,6 +166,10 @@ def _remember_help_modal_bridge(
         state[_HELP_MODAL_OPENED_AT] = time.time()
         router._write_state(state)
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "Failed to persist help-modal bridge state (#1355)",
+            exc_info=True,
+        )
         return
 
 
@@ -187,6 +193,10 @@ def _clear_help_modal_bridge(config_path: Path) -> None:
         if changed:
             router._write_state(state)
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "Failed to clear help-modal bridge state (#1355)",
+            exc_info=True,
+        )
         return
 
 
@@ -435,6 +445,10 @@ def _set_live_right_pane_input_sticky(router: object, active: bool) -> None:
             state.pop(_LIVE_RIGHT_PANE_INPUT_STICKY, None)
         write_state(state)
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "Failed to update live right-pane input sticky state (#1355)",
+            exc_info=True,
+        )
         return
 
 
@@ -543,6 +557,10 @@ def _install_cockpit_debug_log_handler(config_path: Path) -> None:
     except OSError:
         return
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "Failed to attach cockpit debug log rotating handler (#1355)",
+            exc_info=True,
+        )
         return
     handler.setLevel(logging.INFO)
     handler.setFormatter(
@@ -565,6 +583,10 @@ def _enforce_migration_gate(config_path: Path) -> None:
         from pollypm.config import load_config
         config = load_config(config_path)
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "Failed to load config for cockpit migration gate (#1355)",
+            exc_info=True,
+        )
         return
     _migrations.require_no_pending_or_exit(config.project.state_db)
 
@@ -585,6 +607,10 @@ def _warn_on_plugin_load_errors(config_path: Path) -> None:
         from pollypm.service_api import collect_plugin_load_errors
         errors = collect_plugin_load_errors(config_path)
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "Failed to collect plugin load errors for cockpit boot warning (#1355)",
+            exc_info=True,
+        )
         return
     if not errors:
         return

--- a/src/pollypm/cockpit_apps/dashboard.py
+++ b/src/pollypm/cockpit_apps/dashboard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from textual.app import App, ComposeResult
@@ -11,6 +12,8 @@ from textual.widgets import Static
 from pollypm.cockpit_markup import _escape
 from pollypm.cockpit_navigation_client import file_navigation_client
 from pollypm.cockpit_palette import _open_keyboard_help
+
+logger = logging.getLogger(__name__)
 
 
 class PollyDashboardApp(App[None]):
@@ -100,6 +103,11 @@ class PollyDashboardApp(App[None]):
                 self, kind="dashboard", config_path=self.config_path,
             )
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to start dashboard input bridge; "
+                "automation key-send disabled (#1355)",
+                exc_info=True,
+            )
             self._input_bridge_handle = None
 
     def on_unmount(self) -> None:

--- a/src/pollypm/cockpit_apps/operator_dashboard.py
+++ b/src/pollypm/cockpit_apps/operator_dashboard.py
@@ -13,6 +13,7 @@ clean per ``docs/architecture.md``.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from textual import on
@@ -28,6 +29,8 @@ from pollypm.dashboard import (
     ProjectState,
     glyph_for_project_state,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _empty_view() -> OperatorDashboardView:
@@ -147,6 +150,11 @@ class PollyOperatorDashboardApp(App[None]):
                 self, kind="operator", config_path=self.config_path,
             )
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to start operator dashboard input bridge; "
+                "automation key-send disabled (#1355)",
+                exc_info=True,
+            )
             self._input_bridge_handle = None
 
     def _paint_skeleton(self) -> None:

--- a/src/pollypm/cockpit_apps/pane.py
+++ b/src/pollypm/cockpit_apps/pane.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from textual.app import App, ComposeResult
 from textual.widgets import Static
 
 from pollypm.cockpit import build_cockpit_detail
+
+logger = logging.getLogger(__name__)
 
 
 class PollyCockpitPaneApp(App[None]):
@@ -50,6 +53,12 @@ class PollyCockpitPaneApp(App[None]):
                 config_path=self.config_path,
             )
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to start cockpit pane input bridge (kind=%s); "
+                "automation key-send disabled (#1355)",
+                self.kind,
+                exc_info=True,
+            )
             self._input_bridge_handle = None
 
     def on_unmount(self) -> None:


### PR DESCRIPTION
## Summary
- Fourth wedge for #1355 — replace silent `except Exception: pass`/`return` with `logger.warning(..., exc_info=True)` at 13 sites across `cli_features/` and `cockpit_apps/`.
- Behavior unchanged: every except already swallowed the exception; this adds observability so previously-invisible failures (rail-daemon revival, audit emits on `pm doctor`, restore preflight, reset DB cleanup, help-modal bridge state I/O, cockpit-pane input bridges, migration-gate boot, plugin-load-error collection) leave a trail.
- Follow-up to #1613 (9 sites), #1620 (12 sites), #1668 (12 sites).

## Sites touched
- `cli_features/alerts.py`: `heartbeat` rail-daemon revive
- `cli_features/maintenance.py`: `pm doctor` audit emit; `pm restore` tmux probe preflight
- `cli_features/session_runtime.py`: `pm reset` DB cleanup (leases/session_runtime/open alerts)
- `cli_features/ui.py`: 6 sites — help-modal bridge state read/write, sticky right-pane input write, cockpit debug log handler, migration gate, plugin-load-error collection
- `cockpit_apps/dashboard.py`: dashboard input bridge start
- `cockpit_apps/operator_dashboard.py`: operator dashboard input bridge start
- `cockpit_apps/pane.py`: fallback pane input bridge start

## Skipped (matches prior wedge rules)
- UI fallback paths (Textual focus/clear/scroll/cursor handlers) — fires on every key, low-risk presentation degradation
- Cleanup paths (`.stop()`) per the wedge rules
- Hot-path keyboard routing wrappers where logging on each failure would spam

## Test plan
- [x] `python -c "from pollypm.cli_features import alerts, maintenance, session_runtime, ui; from pollypm.cockpit_apps import dashboard, operator_dashboard, pane"` — imports clean
- [x] `python -m pollypm --help` — CLI loads
- [x] `pytest tests/ -k "alerts or maintenance or session_runtime or operator_dashboard"` — 113 passed, 1 pre-existing failure (test_supervisor_alerts.py, unrelated to this PR; reproduces on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)