### PR TITLE
fix(#1367): break provider_sdk <-> providers.base import cycle

### DIFF
--- a/src/pollypm/provider_sdk.py
+++ b/src/pollypm/provider_sdk.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 from pollypm.models import AccountConfig, SessionConfig
 
 if TYPE_CHECKING:
-    from pollypm.providers.base import LaunchCommand
     from pollypm.tmux.client import TmuxClient
 
 
@@ -17,6 +16,17 @@ class TranscriptSource:
     root: Path
     pattern: str = "*.jsonl"
     description: str = ""
+
+
+@dataclass(slots=True)
+class LaunchCommand:
+    argv: list[str]
+    env: dict[str, str]
+    cwd: Path
+    resume_argv: list[str] | None = None
+    resume_marker: Path | None = None
+    initial_input: str | None = None
+    fresh_launch_marker: Path | None = None
 
 
 @dataclass(slots=True)
@@ -44,13 +54,13 @@ class ProviderAdapterBase(ABC):
         return shutil.which(self.binary) is not None
 
     @abstractmethod
-    def build_launch_command(self, session: SessionConfig, account: AccountConfig) -> "LaunchCommand": ...
+    def build_launch_command(self, session: SessionConfig, account: AccountConfig) -> LaunchCommand: ...
 
     def build_resume_command(
         self,
         session: SessionConfig,
         account: AccountConfig,
-    ) -> "LaunchCommand | None":
+    ) -> LaunchCommand | None:
         return None
 
     def transcript_sources(

--- a/src/pollypm/providers/base.py
+++ b/src/pollypm/providers/base.py
@@ -1,22 +1,24 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from pathlib import Path
 from typing import Protocol
 
 from pollypm.models import AccountConfig, SessionConfig
-from pollypm.provider_sdk import ProviderUsageSnapshot, TranscriptSource
+from pollypm.provider_sdk import (
+    LaunchCommand,
+    ProviderUsageSnapshot,
+    TranscriptSource,
+)
 
-
-@dataclass(slots=True)
-class LaunchCommand:
-    argv: list[str]
-    env: dict[str, str]
-    cwd: Path
-    resume_argv: list[str] | None = None
-    resume_marker: Path | None = None
-    initial_input: str | None = None
-    fresh_launch_marker: Path | None = None
+# ``LaunchCommand`` is defined in :mod:`pollypm.provider_sdk` so that
+# ``provider_sdk`` no longer needs a (formerly-cyclic) TYPE_CHECKING import
+# from this module. Re-exported here for backwards compatibility — many
+# call sites still ``from pollypm.providers.base import LaunchCommand``.
+__all__ = [
+    "LaunchCommand",
+    "ProviderAdapter",
+    "ProviderUsageSnapshot",
+    "TranscriptSource",
+]
 
 
 class ProviderAdapter(Protocol):


### PR DESCRIPTION
## Summary

Fifth wedge for #1367 after #1599 (`activity_feed.plugin` <-> `feed_panel`), #1623 (`cockpit_inbox` <-> `cockpit_inbox_items`), #1628 (`cockpit_alerts` <-> `cockpit_palette`), and #1667 (`plugin_host` <-> `plugin_validate`).

The cycle:

- `pollypm.provider_sdk` did a `TYPE_CHECKING` import of `LaunchCommand` from `pollypm.providers.base` (with quoted forward-refs on `ProviderAdapterBase.build_launch_command` / `build_resume_command`).
- `pollypm.providers.base` did a top-level import of `ProviderUsageSnapshot` / `TranscriptSource` from `pollypm.provider_sdk`.

`LaunchCommand` is a leaf dataclass (no further `pollypm.*` deps) so I moved it into `provider_sdk` and made `providers.base` re-export it. Every existing `from pollypm.providers.base import LaunchCommand` keeps working (supervisor, runtimes, probe_runner, claude/codex adapters, default_launch_planner — none of those files needed changes).

Static import graph after this change:

- `provider_sdk` -> `pollypm.models`, `pollypm.tmux.client` (TYPE_CHECKING). No edge to `providers.base`.
- `providers.base` -> `pollypm.models`, `pollypm.provider_sdk`. One-way.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/test_provider_sdk.py tests/test_runtime.py tests/test_runtime_env.py tests/test_runtime_launcher.py tests/test_launch_planner.py tests/test_launch_executor.py tests/test_launch_state.py tests/test_session_two_phase_launch.py tests/providers/ tests/test_plugins.py tests/test_acct_manager.py tests/test_account_usage_sampler.py tests/test_transcript_ingest.py tests/test_transcript_ledger.py` — 233 passed.
- [x] `PYTHONPATH=src python -m pytest tests/test_supervisor.py tests/test_supervisor_alerts.py` — 97 passed, 2 deselected (both pre-existing failures on `main`: `test_bootstrap_returns_before_provider_stabilization_finishes` and `test_supervisor_alert_helper_updates_and_nudges` reproduce on a clean stash, unrelated to this slice).
- [x] `PYTHONPATH=src python -m pytest tests/test_import_boundary.py` — 10 passed, 2 deselected (the two `Supervisor` allow-list / private-reach-through tests, both pre-existing failures on `main`, same pattern noted in #1672's PR body).
- [x] Verified `pollypm.provider_sdk.LaunchCommand is pollypm.providers.base.LaunchCommand` — the re-export is identity, not a shadow class.

#1628's tracking note listed remaining pairs: 6 `work.service_*` <-> `work.sqlite_service` pairs, `heartbeats.api` <-> `supervisor`, `store.event_buffer` <-> `store.sqlalchemy_store`. This wedge clears `provider_sdk` <-> `providers.base`.

Generated with [Claude Code](https://claude.com/claude-code).