### PR TITLE
fix(#1367): break event_buffer <-> sqlalchemy_store import cycle

### DIFF
--- a/src/pollypm/store/event_buffer.py
+++ b/src/pollypm/store/event_buffer.py
@@ -35,19 +35,33 @@ import logging
 import queue
 import signal
 import threading
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any, Protocol
 
 from sqlalchemy import insert
+from sqlalchemy.engine import Connection
 
 from pollypm.storage.sqlite_pragmas import retry_on_database_locked
 from pollypm.store.schema import messages
 
-if TYPE_CHECKING:  # pragma: no cover - import cycle guard
-    from pollypm.store.sqlalchemy_store import SQLAlchemyStore
-
 
 logger = logging.getLogger(__name__)
+
+
+class _TransactionalStore(Protocol):
+    """Structural type for the slice of the store the buffer actually uses.
+
+    The buffer only needs a writer-scoped ``transaction()`` context manager
+    yielding a SQLAlchemy :class:`~sqlalchemy.engine.Connection`. Declaring
+    that surface as a :class:`Protocol` lets ``event_buffer`` stay decoupled
+    from :class:`pollypm.store.sqlalchemy_store.SQLAlchemyStore` — the
+    previous TYPE_CHECKING back-reference is what put the two modules in a
+    static-graph 2-cycle (#1367). :class:`SQLAlchemyStore` satisfies this
+    protocol structurally; no runtime registration is required.
+    """
+
+    def transaction(self) -> AbstractContextManager[Connection]: ...
 
 
 # Module-level guard so multiple ``EventBuffer`` instances in the same
@@ -114,7 +128,7 @@ class EventBuffer:
 
     def __init__(
         self,
-        store: "SQLAlchemyStore",
+        store: _TransactionalStore,
         *,
         batch_size: int = 100,
         flush_interval: float = 0.1,


### PR DESCRIPTION
## Summary

Sixth wedge for #1367. Breaks the `store.event_buffer` <-> `store.sqlalchemy_store` 2-cycle by inverting the dependency.

The cycle was:
- `pollypm.store.event_buffer` did a `TYPE_CHECKING` import of `SQLAlchemyStore` (used only to annotate `EventBuffer.__init__`'s `store` parameter).
- `pollypm.store.sqlalchemy_store` does a top-level import of `EventBuffer` so it can lazily provision the background drainer.

Introduce a small `_TransactionalStore` `typing.Protocol` inside `event_buffer` that captures the single slice the buffer actually consumes (`transaction()` yielding a SQLAlchemy `Connection`). The buffer now depends only on a structural type; the import edge from `event_buffer` to `sqlalchemy_store` is gone. `SQLAlchemyStore` satisfies the protocol structurally — no runtime registration or subclass change required.

Prior wedges: #1599 (activity_feed.plugin <-> feed_panel), #1623 (cockpit_inbox <-> items), #1628 (cockpit_alerts <-> palette + collapsed 8-module SCC), #1667 (plugin_host <-> plugin_validate), #1687 (provider_sdk <-> providers.base).

## Test plan

- [x] AST scan confirms `event_buffer` no longer has any ImportFrom edge to `sqlalchemy_store` (only `pollypm.storage.sqlite_pragmas` + `pollypm.store.schema` remain)
- [x] `tests/test_event_buffer.py` — 9/10 pass (the one pre-existing failure on main is an unrelated `importlib.metadata.entry_points(group=)` shim, not touched here)
- [x] `tests/test_sqlalchemy_store_error_plurals.py` — 7/7 pass
- [x] `tests/test_sqlalchemy_store_corrupt_payload.py` — passes
- [x] `tests/test_import_boundary.py` — 13/14 pass (only pre-existing `tier4.py` Supervisor-allowlist failure remains, unrelated to this change)
- [x] End-to-end smoke: `EventBuffer(SQLAlchemyStore(...)).append(...).close()` flushes a row through `transaction()` against a real on-disk SQLite

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>