### PR TITLE
fix(observability): log 13 silent except sites in recovery/plugins/providers (#1355 wedge)

### DIFF
--- a/src/pollypm/plugins_builtin/activity_feed/handlers/event_projector.py
+++ b/src/pollypm/plugins_builtin/activity_feed/handlers/event_projector.py
@@ -335,6 +335,10 @@ class EventProjector:
         try:
             from pollypm.store.registry import get_store_by_url
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "activity_feed: failed to import store registry",
+                exc_info=True,
+            )
             return []
 
         try:

--- a/src/pollypm/plugins_builtin/core_rail_items/plugin.py
+++ b/src/pollypm/plugins_builtin/core_rail_items/plugin.py
@@ -177,6 +177,10 @@ def _live_chat_network_dead_state(ctx: RailContext) -> str | None:
 
         notice = current_live_chat_network_dead_notice(ctx.cockpit_state)
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "core_rail_items: live_chat_network_dead notice probe raised",
+            exc_info=True,
+        )
         return None
     return f"! {notice}" if notice else None
 

--- a/src/pollypm/plugins_builtin/default_launch_planner/planner.py
+++ b/src/pollypm/plugins_builtin/default_launch_planner/planner.py
@@ -294,7 +294,12 @@ class DefaultLaunchPlanner:
                     try:
                         ctx.store.set_session_runtime(session.name, effective_account="")
                     except Exception:  # noqa: BLE001
-                        pass
+                        _log.warning(
+                            "default_launch_planner: clearing stale "
+                            "effective_account for %s failed",
+                            session.name,
+                            exc_info=True,
+                        )
         if session.role in _ROUTED_ROLES:
             project_key = None if session.role == "operator-pm" else session.project
             routed_assignment = resolve_role_assignment(

--- a/src/pollypm/plugins_builtin/human_notify/plugin.py
+++ b/src/pollypm/plugins_builtin/human_notify/plugin.py
@@ -107,6 +107,11 @@ def _read_webhook_from_toml(config: Any) -> dict:
         with open(config_path, "rb") as fh:
             raw = tomllib.load(fh)
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "human_notify: failed to read webhook config from %s",
+            config_path,
+            exc_info=True,
+        )
         return {}
     section = raw.get("human_notify", {})
     if not isinstance(section, dict):
@@ -128,7 +133,11 @@ def _resolve_store(api: PluginAPI) -> Any | None:
         if config is not None:
             return get_store(config)
     except Exception:  # noqa: BLE001
-        pass
+        logger.warning(
+            "human_notify: unified Store lookup failed; falling back to "
+            "legacy StateStore",
+            exc_info=True,
+        )
     try:
         from pollypm.storage.state import StateStore
 
@@ -137,6 +146,10 @@ def _resolve_store(api: PluginAPI) -> Any | None:
             return None
         return StateStore(config.project.state_db)
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "human_notify: legacy StateStore fallback failed",
+            exc_info=True,
+        )
         return None
 
 

--- a/src/pollypm/plugins_builtin/itsalive/plugin.py
+++ b/src/pollypm/plugins_builtin/itsalive/plugin.py
@@ -66,7 +66,11 @@ def _resolve_project_root(payload: dict[str, Any]) -> Path:
         if config_path.exists():
             return load_config(config_path).project.root_dir
     except Exception:  # noqa: BLE001
-        pass
+        logger.warning(
+            "itsalive: project root resolution from config failed; "
+            "falling back to cwd",
+            exc_info=True,
+        )
     return Path.cwd()
 
 

--- a/src/pollypm/providers/claude/detect.py
+++ b/src/pollypm/providers/claude/detect.py
@@ -23,11 +23,14 @@ delegate here; the behavior is identical.
 from __future__ import annotations
 
 import json
+import logging
 import re
 import subprocess
 from pathlib import Path
 
 from .env import isolated_env_with_os_environ
+
+logger = logging.getLogger(__name__)
 
 
 _EMAIL_PATTERN = re.compile(
@@ -76,7 +79,11 @@ def detect_claude_email(home: Path) -> str | None:
             sub = data.get("subscriptionType") or "unknown"
             return f"{method}:{sub}".lower()
         except Exception:  # noqa: BLE001
-            pass
+            logger.warning(
+                "claude.detect: failed to parse `claude auth status --json`; "
+                "falling back to text mode",
+                exc_info=True,
+            )
 
     text_result = subprocess.run(
         ["claude", "auth", "status", "--text"],

--- a/src/pollypm/recovery/worker_turn_end.py
+++ b/src/pollypm/recovery/worker_turn_end.py
@@ -363,7 +363,11 @@ def create_blocking_question_inbox_item(
                 },
             )
         except Exception:  # noqa: BLE001
-            pass
+            logger.warning(
+                "worker_turn_end: blocking_question audit emit failed for %s",
+                session_name,
+                exc_info=True,
+            )
     elif state_store is not None:
         try:
             state_store.record_event(
@@ -372,7 +376,12 @@ def create_blocking_question_inbox_item(
                 message,
             )
         except Exception:  # noqa: BLE001
-            pass
+            logger.warning(
+                "worker_turn_end: blocking_question state_store.record_event "
+                "failed for %s",
+                session_name,
+                exc_info=True,
+            )
     return inbox_task
 
 
@@ -418,14 +427,23 @@ def send_standard_reprompt(
                 payload={"message": message, "task_id": task_id},
             )
         except Exception:  # noqa: BLE001
-            pass
+            logger.warning(
+                "worker_turn_end: worker_reprompted audit emit failed for %s",
+                session_name,
+                exc_info=True,
+            )
     elif state_store is not None:
         try:
             state_store.record_event(
                 session_name, "inbox.worker_reprompted", message,
             )
         except Exception:  # noqa: BLE001
-            pass
+            logger.warning(
+                "worker_turn_end: worker_reprompted state_store.record_event "
+                "failed for %s",
+                session_name,
+                exc_info=True,
+            )
     return True
 
 
@@ -467,7 +485,12 @@ def load_transcript_tail(
             if isinstance(text, str):
                 return text[-tail_chars:]
         except Exception:  # noqa: BLE001
-            pass
+            logger.warning(
+                "worker_turn_end: pane capture failed for %s; "
+                "falling back to transcript file",
+                session_name,
+                exc_info=True,
+            )
     # Transcript-file fallback.
     transcript_fn = getattr(session_service, "transcript", None)
     if callable(transcript_fn):


### PR DESCRIPTION
## Summary
- Fifth wedge for #1355 — replaces silent `except Exception: pass`/`return` with `logger.warning(..., exc_info=True)` at 13 sites across `recovery/`, `providers/`, and `plugins_builtin/`.
- Behavior unchanged: every except already swallowed the exception; this adds observability so previously-invisible failures (audit emit drops, transcript capture flakes, JSON parse stumbles, config-load fallbacks, store registry misses) leave a trail.
- Follow-up to #1613 (9 sites), #1620 (12 sites), #1668 (12 sites), #1686 (13 sites). Running total ~59 of ~1066.

## Sites touched
- `recovery/worker_turn_end.py` (5 sites):
  - `create_blocking_question_inbox_item` — msg_store.append_event and state_store.record_event audit fallbacks
  - `send_standard_reprompt` — same two audit fallbacks for `inbox.worker_reprompted`
  - `load_transcript_tail` — pane-capture failure (still falls through to transcript-file read)
- `providers/claude/detect.py` — `claude auth status --json` parse failure (added module-level logger)
- `plugins_builtin/itsalive/plugin.py` — `_resolve_project_root` config-load fallback to cwd
- `plugins_builtin/default_launch_planner/planner.py` — stale `effective_account` clear in session-runtime
- `plugins_builtin/core_rail_items/plugin.py` — `_live_chat_network_dead_state` notice probe
- `plugins_builtin/human_notify/plugin.py` (3 sites) — webhook TOML load; unified Store lookup; legacy StateStore fallback
- `plugins_builtin/activity_feed/handlers/event_projector.py` — store registry import failure

## Skipped (matches prior wedge rules)
- `tmux/client.py:657` — buffer-delete leak guard, pure cleanup path
- `task_assignment_notify/handlers/sweep.py` (~40 sites) — large surface, deserves a dedicated wedge to keep diff reviewable
- `providers/claude/detect.py` text-mode regex misses — not in an `except` block

## Test plan
- [x] `pytest tests/ -k "worker_turn_end or claude_detect or itsalive or default_launch_planner or core_rail_items or human_notify or activity_feed or event_projector"` — 236 passed
- [x] `ruff check` on all touched files — clean
- [x] Imports clean (`python -c "from pollypm.recovery import worker_turn_end; ..."`)

Refs #1355.

Generated with [Claude Code](https://claude.com/claude-code)