### PR TITLE
refactor(cockpit): extract _RollupItem into sibling module (#1354)

### DIFF
--- a/src/pollypm/cockpit_inbox_rollup_item.py
+++ b/src/pollypm/cockpit_inbox_rollup_item.py
@@ -1,0 +1,99 @@
+"""Rollup sub-item ``ListItem`` widget used by the cockpit inbox.
+
+Contract:
+- Inputs: ``index`` (slot in the expanded thread), ``item`` (dict payload
+  with ``subject``/``body``/``actor``/``payload``/...), ``expanded``
+  (whether the body is shown), and ``focused`` (whether this is the
+  keyboard-focused row inside the rollup).
+- Outputs: a ``ListItem`` subclass that renders a single sub-item row.
+- Side effects: none beyond mounting a ``Static`` child.
+- Invariants: this module owns one widget class and nothing else; the
+  inbox app handles click/keyboard wiring via its own ``on`` decorator.
+- Allowed dependencies: Textual primitives, ``cockpit_markup`` for the
+  ``_escape``/``_escape_body`` helpers, and ``pollypm.tz`` /
+  ``cockpit_ui._md_to_rich`` via local imports (the latter to avoid an
+  import cycle while ``_md_to_rich`` still lives in ``cockpit_ui``).
+- Private: ``_RollupItem`` is underscore-prefixed and re-exported via
+  ``cockpit_ui`` for back-compat (see #1354).
+
+Wedge of the cockpit_ui.py god-module split tracked by #1354.
+"""
+
+from __future__ import annotations
+
+from textual.widgets import ListItem, Static
+
+from pollypm.cockpit_markup import _escape, _escape_body
+
+
+class _RollupItem(ListItem):
+    """One sub-item in a rollup's expanded thread.
+
+    We inherit ListItem for consistent hover/click semantics, but the
+    widget lives inside a ``Vertical`` (not a ``ListView``), so it
+    behaves as a click target only — no cursor selection. Click emits a
+    ``Clicked`` message which the inbox app handles via ``on``.
+    """
+
+    def __init__(
+        self,
+        *,
+        index: int,
+        item: dict,
+        expanded: bool,
+        focused: bool,
+    ) -> None:
+        self.index = index
+        self.item = item
+        self.expanded = expanded
+        self._body = Static(self._build_text(), markup=True)
+        classes = ["rollup-item"]
+        if expanded:
+            classes.append("-expanded")
+        if focused:
+            classes.append("-focused")
+        super().__init__(self._body, classes=" ".join(classes))
+
+    def _build_text(self) -> str:
+        from pollypm.tz import format_relative
+        # Local import: ``_md_to_rich`` still lives in ``cockpit_ui`` and
+        # importing it at module load time would create a cycle (cockpit_ui
+        # imports this module for the re-export shim).
+        from pollypm.cockpit_ui import _md_to_rich
+        subject = self.item.get("subject") or "(no subject)"
+        created = self.item.get("created_at") or ""
+        age = format_relative(created) if created else ""
+        payload = self.item.get("payload") or {}
+        ref_bits: list[str] = []
+        for key in ("commit", "pr", "pull_request", "url"):
+            val = payload.get(key)
+            if val:
+                ref_bits.append(f"{key}={val}")
+        marker = "\u25bc" if self.expanded else "\u25b8"
+        header = f"[b]{marker} {_escape(subject)}[/b]"
+        if age:
+            header += f"  [dim]{_escape(age)}[/dim]"
+        lines = [header]
+        if ref_bits:
+            separator = " · "
+            lines.append(f"[dim]{_escape(separator.join(ref_bits))}[/dim]")
+        if self.expanded:
+            body = (self.item.get("body") or "").strip()
+            if body:
+                lines.append("")
+                lines.append(_md_to_rich(_escape_body(body)))
+            actor = self.item.get("actor") or ""
+            source_project = self.item.get("source_project") or ""
+            meta_bits: list[str] = []
+            if actor:
+                meta_bits.append(actor)
+            if source_project:
+                meta_bits.append(source_project)
+            if meta_bits:
+                lines.append("")
+                meta_separator = " · "
+                lines.append(f"[dim]{_escape(meta_separator.join(meta_bits))}[/dim]")
+        return "\n".join(lines)
+
+
+__all__ = ["_RollupItem"]

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -103,6 +103,9 @@ from pollypm.cockpit_settings_account_reassign import (  # noqa: F401  (re-expor
 from pollypm.cockpit_settings_confirm import (  # noqa: F401  (re-exported)
     _SettingsConfirmModal,
 )
+from pollypm.cockpit_inbox_rollup_item import (  # noqa: F401  (re-exported)
+    _RollupItem,
+)
 from pollypm.cockpit_live_chat_notice import (
     LIVE_CHAT_NETWORK_DEAD_TMUX_MESSAGE,
     clear_live_chat_network_dead_notice,
@@ -7386,72 +7389,6 @@ def _extract_proposal_spec(task, *, labels: list[str] | None = None) -> dict:
     else:
         spec["description"] = body
     return spec
-
-
-class _RollupItem(ListItem):
-    """One sub-item in a rollup's expanded thread.
-
-    We inherit ListItem for consistent hover/click semantics, but the
-    widget lives inside a ``Vertical`` (not a ``ListView``), so it
-    behaves as a click target only — no cursor selection. Click emits a
-    ``Clicked`` message which the inbox app handles via ``on``.
-    """
-
-    def __init__(
-        self,
-        *,
-        index: int,
-        item: dict,
-        expanded: bool,
-        focused: bool,
-    ) -> None:
-        self.index = index
-        self.item = item
-        self.expanded = expanded
-        self._body = Static(self._build_text(), markup=True)
-        classes = ["rollup-item"]
-        if expanded:
-            classes.append("-expanded")
-        if focused:
-            classes.append("-focused")
-        super().__init__(self._body, classes=" ".join(classes))
-
-    def _build_text(self) -> str:
-        from pollypm.tz import format_relative
-        subject = self.item.get("subject") or "(no subject)"
-        created = self.item.get("created_at") or ""
-        age = format_relative(created) if created else ""
-        payload = self.item.get("payload") or {}
-        ref_bits: list[str] = []
-        for key in ("commit", "pr", "pull_request", "url"):
-            val = payload.get(key)
-            if val:
-                ref_bits.append(f"{key}={val}")
-        marker = "\u25bc" if self.expanded else "\u25b8"
-        header = f"[b]{marker} {_escape(subject)}[/b]"
-        if age:
-            header += f"  [dim]{_escape(age)}[/dim]"
-        lines = [header]
-        if ref_bits:
-            separator = " · "
-            lines.append(f"[dim]{_escape(separator.join(ref_bits))}[/dim]")
-        if self.expanded:
-            body = (self.item.get("body") or "").strip()
-            if body:
-                lines.append("")
-                lines.append(_md_to_rich(_escape_body(body)))
-            actor = self.item.get("actor") or ""
-            source_project = self.item.get("source_project") or ""
-            meta_bits: list[str] = []
-            if actor:
-                meta_bits.append(actor)
-            if source_project:
-                meta_bits.append(source_project)
-            if meta_bits:
-                lines.append("")
-                meta_separator = " · "
-                lines.append(f"[dim]{_escape(meta_separator.join(meta_bits))}[/dim]")
-        return "\n".join(lines)
 
 
 class _InboxListItem(ListItem):


### PR DESCRIPTION
## Summary
- Sixth wedge of the cockpit_ui.py god-module split tracked by #1354.
- Moves `_RollupItem` (66 LOC) into a new `cockpit_inbox_rollup_item.py` and re-exports it via `cockpit_ui` for back-compat.
- `cockpit_ui.py` drops from 18,651 to 18,585 LOC; in-file diff is 3 inserts / 66 deletes.

`_md_to_rich` still lives in `cockpit_ui`, so the new module imports it lazily inside `_build_text` to avoid an import cycle.

Prior extractions:
- `_InboxProjectPickerModal` (#1606)
- `_FirstShippedCelebrationModal` (#1618)
- `_SettingsConfirmModal` (#1670)
- `_AlertDetailModal` (#1688)
- `_SettingsAccountReassignModal` (#1689)

## Test plan
- [x] `pytest tests/test_cockpit_inbox_ui.py -k rollup` (4 passed)
- [x] `pytest tests/test_cockpit_inbox_ui.py` (86 passed)
- [x] `python -c "from pollypm.cockpit_ui import _RollupItem"` — shim re-export works
- [x] Confirmed `_RollupItem._build_text()` round-trips through the lazy `_md_to_rich` import path

Refs #1354.

Generated with [Claude Code](https://claude.com/claude-code)