### PR TITLE
feat(cli): pm project reinit + operator-runbook teardown recipe (#1561)

### DIFF
--- a/src/pollypm/defaults/docs/reference/operator-runbook.md
+++ b/src/pollypm/defaults/docs/reference/operator-runbook.md
@@ -4,20 +4,20 @@ Step-by-step procedures for common operations.
 
 ## Table of Contents
 
-| Procedure | Line |
-|-----------|------|
-| Delegate Work to a Worker | 20 |
-| Review Worker Output | 42 |
-| Switch a Worker's Provider (Claude ↔ Codex) | 58 |
-| Start a New Worker | 76 |
-| Restart a Stuck Worker | 85 |
-| Add a New Project | 97 |
-| Send a Message to the User | 108 |
-| Respond to an Inbox Item | 124 |
-| Deploy a Site with ItsAlive | 134 |
-| Handle a Heartbeat Escalation | 152 |
-| Check System Health | 166 |
-| Understand Background Maintenance | 202 |
+- Delegate Work to a Worker
+- Review Worker Output
+- Switch a Worker's Provider (Claude ↔ Codex)
+- Start a New Worker
+- Restart a Stuck Worker
+- Add a New Project
+- Remove a Project
+- Reinitialize a Project (blow it away and start over)
+- Send a Message to the User
+- Respond to an Inbox Item
+- Deploy a Site with ItsAlive
+- Handle a Heartbeat Escalation
+- Check System Health
+- Understand Background Maintenance
 
 ## Delegate Work to a Worker
 
@@ -129,6 +129,117 @@ pm task create "<title>" -p <project_key> -d "<description>" -f standard
 pm task queue <project_key>/<number>
 # A worker session spawns automatically when the task is claimed.
 ```
+
+## Remove a Project
+
+`pm project remove <key>` tears down a project end-to-end. The default form
+only edits `pollypm.toml`; the `--purge-*` flags cascade through the
+adjacent state surfaces. Always start with `--dry-run` to confirm the
+plan.
+
+```bash
+# 1. Preview what would be torn down.
+pm project remove russell --dry-run \
+    --purge-sessions --purge-state --purge-worktrees
+```
+
+The dry-run output lists each surface separately so you can see exactly
+what will be deleted before you commit:
+
+- `sessions to purge:` — `[sessions.*]` blocks tied to this project,
+  with a `(live)` or `(stale)` marker per tmux session.
+- `state.db rows to purge:` — per-table counts in the workspace
+  `state.db` (work_tasks, messages, worktrees, audit history, …).
+- `worktree directories to purge:` — `<project>/.pollypm/worktrees/`
+  subdirs, with a `[dirty]` marker on any worktree with uncommitted
+  changes.
+
+Once the plan looks right, re-run without `--dry-run` and pass `--yes`
+(or `--force`) to skip the destructive-action prompts:
+
+```bash
+# 2. Apply the cascade.
+pm project remove russell --yes \
+    --purge-sessions --purge-state --purge-worktrees
+```
+
+### What each flag does
+
+| Flag | Effect |
+|------|--------|
+| (no flags) | Only removes the `[projects.<key>]` config entry. Refuses while `[sessions.*]` blocks reference the project. State.db rows, audit history, and worktree dirs are left in place. |
+| `--purge-sessions` | Kills every tmux session tied to the project and drops the matching `[sessions.*]` entries. Required when sessions reference the project — otherwise `remove_project` refuses. |
+| `--purge-state` | Deletes every state.db row tied to the project (work_tasks, messages, audit_outbox, notification_staging, worktrees, architect_resume_tokens, token_usage, …) and removes the central audit-tail JSONL at `~/.pollypm/audit/<key>.jsonl`. |
+| `--purge-worktrees` | Removes every git worktree under `<project>/.pollypm/worktrees/`. Uses `git worktree remove` for registered worktrees, `shutil.rmtree` for stale dirs. Refuses dirty worktrees unless `--force-discard-worktree-changes` is also set. |
+| `--force-discard-worktree-changes` | Pairs with `--purge-worktrees`. Runs `git worktree remove --force` so dirty worktrees are removed and the local branch ref is dropped. |
+| `--force` | Skips the active-task confirmation prompt (queued or in-flight work-service tasks). Does NOT auto-accept the `--purge-state` or `--purge-worktrees` destructive prompts — use `--yes` for those. |
+| `--yes` / `-y` | Auto-accepts every confirmation prompt. Required for fully scripted removal. |
+
+### Destructive-action ordering
+
+The cascade always runs in this order, with each step gating the next:
+
+1. **Active-task gate.** Refuses (or prompts) when there are queued or
+   in-flight work-service tasks. `--force` bypasses the prompt.
+2. **Sessions.** With `--purge-sessions`, tmux sessions are killed first
+   so workers don't keep writing to a project that's about to disappear.
+   `[sessions.*]` entries drop next.
+3. **State.db rows.** With `--purge-state`, the SQLite sweep runs BEFORE
+   the TOML edit. A failure here aborts without touching the config so
+   the rows-vs-config asymmetry can only point one way (issue #1673).
+4. **Worktree directories.** With `--purge-worktrees`, dirs under
+   `.pollypm/worktrees/` are removed. Dirty worktrees are skipped unless
+   `--force-discard-worktree-changes` is set.
+5. **Config entry.** `remove_project` strips `[projects.<key>]` last.
+
+If any earlier step fails, the project entry stays in `pollypm.toml` so
+you can investigate and retry. The reverse is never true — the config
+is the last surface to mutate.
+
+### When to use `pm project remove` vs `pm project reinit`
+
+- Use **`pm project remove`** when the directory is also going away (you
+  archived the repo, moved it, or are migrating to a different
+  workspace_root). Pair with the `--purge-*` flags for a clean teardown.
+- Use **`pm project reinit`** (next section) when the directory stays
+  but PollyPM's local state for it is broken or stale. Skips the manual
+  re-`pm project new` step.
+
+## Reinitialize a Project (blow it away and start over)
+
+`pm project reinit <key>` is the shorthand for "remove + re-register with
+the same path and slug". The high-traffic case: the working tree was
+wiped & rebuilt by hand and PollyPM's local state is out of sync.
+
+```bash
+# Preview first.
+pm project reinit russell --dry-run
+
+# Apply.
+pm project reinit russell --yes
+```
+
+This is equivalent to:
+
+```bash
+pm project remove russell --yes \
+    --purge-sessions --purge-state --purge-worktrees
+pm project new <path-from-the-removed-entry> \
+    --slug russell --skip-planner
+```
+
+The full cascade — sessions, state.db rows, worktrees, config entry —
+runs in the same order documented in **Destructive-action ordering**
+above. Step 5 (re-register) re-runs `ensure_project_scaffold` on the
+path so the standard `.pollypm/` directory layout reappears.
+
+`reinit` refuses to re-register when the project directory no longer
+exists on disk; in that case it leaves the project removed and points
+you at `pm project new`.
+
+`--force-discard-worktree-changes` is supported for the same reason as
+`pm project remove`: dirty worktrees are skipped by default, set this
+flag to remove them anyway.
 
 ## Send a Message to the User
 

--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -1529,6 +1529,303 @@ def remove_cmd(
 
 
 # ---------------------------------------------------------------------------
+# pm project reinit (#1561)
+# ---------------------------------------------------------------------------
+
+
+@project_app.command("reinit")
+def reinit_cmd(
+    project_key: str = typer.Argument(
+        ...,
+        help="Project key to reinitialize (remove + re-register).",
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y",
+        help=(
+            "Non-interactive: auto-accept the destructive confirmation "
+            "prompt. Required when there are active tasks, state.db "
+            "rows, or worktrees to purge."
+        ),
+    ),
+    force_discard_worktree_changes: bool = typer.Option(
+        False, "--force-discard-worktree-changes",
+        help=(
+            "Discard uncommitted changes in worktrees instead of "
+            "refusing to remove them. Pairs with ``git worktree remove "
+            "--force``."
+        ),
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run",
+        help=(
+            "Preview the reinit plan without mutating anything. Lists "
+            "what would be torn down and the path that would be "
+            "re-registered."
+        ),
+    ),
+    config_path: Path = typer.Option(
+        DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path.",
+    ),
+) -> None:
+    """Remove + re-register a project in one step ("blow it away and start over").
+
+    Thin wrapper around ``pm project remove --purge-sessions --purge-state
+    --purge-worktrees`` followed by ``register_project`` with the same
+    slug and workspace path. The high-traffic use case (#1561): the
+    operator wiped & rebuilt the working tree by hand and now wants
+    PollyPM caught up cleanly without invariant orphans.
+
+    The cascade ordering mirrors ``pm project remove``:
+
+    1. Kill tmux sessions + drop ``[sessions.*]`` entries.
+    2. Delete state.db rows + audit-tail JSONL.
+    3. Remove ``<project>/.pollypm/worktrees/`` subdirs.
+    4. Remove the ``[projects.<key>]`` config entry.
+    5. Re-register the same path under the same slug.
+
+    Step 5 also re-runs ``ensure_project_scaffold`` on the path, so the
+    standard ``.pollypm/`` directory layout reappears after the wipe.
+
+    With ``--dry-run`` the plan is printed and nothing mutates. Pass
+    ``--yes`` for non-interactive use; without it, the cascade prompts
+    once before deleting state.db rows and once before removing
+    worktree directories (same gates as ``pm project remove``).
+    """
+    from pollypm.projects import register_project, remove_project
+
+    path = _require_config(config_path)
+    config = load_config(path)
+    if project_key not in config.projects:
+        typer.echo(f"Unknown project: {project_key}", err=True)
+        raise typer.Exit(code=1)
+
+    project_entry = config.projects[project_key]
+    project_path = Path(project_entry.path)
+    project_name = project_entry.name
+    active = _count_active_tasks(project_key, path)
+    session_names = _sessions_for_project(path, project_key)
+
+    # ------------------------------------------------------------------
+    # Dry-run: print the plan and exit 0 without mutating anything.
+    # The shape mirrors ``pm project remove --dry-run`` so an operator
+    # who reaches for ``reinit`` after experimenting with ``remove``
+    # sees a familiar layout.
+    # ------------------------------------------------------------------
+    if dry_run:
+        typer.echo(f"Dry run: would reinit project '{project_key}'.")
+        typer.echo(f"  path:    {project_path}")
+        if active > 0:
+            task_word = "task" if active == 1 else "tasks"
+            typer.echo(
+                f"  active:  {active} queued/in-flight work-service "
+                f"{task_word} (will be deleted)"
+            )
+        if session_names:
+            preview = _purge_project_sessions(path, project_key, dry_run=True)
+            typer.echo("  sessions to purge:")
+            for name, live, _killed in preview:
+                state = "live" if live else "stale"
+                typer.echo(f"    - {name} ({state})")
+        else:
+            typer.echo("  sessions: (none)")
+
+        state_counts = _count_project_state_rows(path, project_key)
+        nonzero = {
+            table: n for table, n in state_counts.items() if n > 0
+        }
+        if nonzero:
+            typer.echo("  state.db rows to purge:")
+            for table, n in sorted(nonzero.items()):
+                noun = (
+                    "file" if table == "audit_tail"
+                    else ("row" if n == 1 else "rows")
+                )
+                typer.echo(f"    - {table}: {n} {noun}")
+        else:
+            typer.echo("  state.db rows: (none)")
+
+        wt_preview = _purge_project_worktrees(path, project_key, dry_run=True)
+        if wt_preview:
+            typer.echo("  worktree directories to purge:")
+            for wt_path, is_git, dirty, _ok, _reason in wt_preview:
+                kind = "git" if is_git else "stale"
+                dirty_marker = " [dirty]" if dirty else ""
+                typer.echo(f"    - {wt_path} ({kind}){dirty_marker}")
+            dirty_count = sum(1 for _p, _g, d, _o, _r in wt_preview if d)
+            if dirty_count > 0 and not force_discard_worktree_changes:
+                typer.echo(
+                    f"Note: {dirty_count} worktree(s) have uncommitted "
+                    "changes and will be skipped. Pass "
+                    "--force-discard-worktree-changes to remove anyway."
+                )
+        else:
+            typer.echo("  worktree directories: (none)")
+
+        typer.echo(
+            f"  re-register: {project_key} at {project_path}"
+        )
+        typer.echo("Re-run without --dry-run to apply.")
+        return
+
+    # ------------------------------------------------------------------
+    # Single destructive-action gate. ``reinit`` is unambiguously
+    # destructive — there's no "register fresh, leave the old around"
+    # variant — so one confirmation covers the whole cascade. Skipped
+    # with ``--yes``.
+    # ------------------------------------------------------------------
+    if not yes:
+        typer.echo(
+            f"Reinit will tear down project '{project_key}' "
+            f"(sessions, state.db rows, worktrees, config entry) "
+            f"and re-register it at {project_path}."
+        )
+        proceed = typer.confirm(
+            f"Permanently reinit '{project_key}'?",
+            default=False,
+        )
+        if not proceed:
+            typer.echo("Aborted. No changes made.")
+            raise typer.Exit(code=1)
+
+    # ------------------------------------------------------------------
+    # Step 1: kill tmux sessions + drop [sessions.*] entries.
+    # Mirrors ``remove_cmd``'s --purge-sessions branch.
+    # ------------------------------------------------------------------
+    if session_names:
+        purged = _purge_project_sessions(path, project_key)
+        for name, live, killed in purged:
+            if live and killed:
+                typer.echo(f"Killed tmux session {name} and dropped config entry.")
+            elif live and not killed:
+                typer.echo(
+                    f"Dropped [sessions.{name}] from config; tmux kill "
+                    "failed (session may still be running — run "
+                    "`tmux kill-session -t " + name + "` manually)."
+                )
+            else:
+                typer.echo(
+                    f"Dropped [sessions.{name}] from config "
+                    "(tmux session was not running)."
+                )
+
+    # ------------------------------------------------------------------
+    # Step 2: state.db row teardown + audit tail. Hard failure here
+    # aborts BEFORE ``remove_project`` (issue #1673 — keep the config
+    # in sync with the rows). Same exit code + message as
+    # ``remove_cmd``.
+    # ------------------------------------------------------------------
+    state_counts = _count_project_state_rows(path, project_key)
+    total_rows = sum(
+        n for table, n in state_counts.items() if table != "audit_tail"
+    )
+    if total_rows > 0 or state_counts.get("audit_tail", 0) > 0:
+        try:
+            state_summary = _purge_project_state(path, project_key)
+        except _PurgeStateError as exc:
+            typer.echo(
+                f"Error: state.db purge failed for '{project_key}': "
+                f"{exc}",
+                err=True,
+            )
+            typer.echo(
+                "Aborted. Project entry left in pollypm.toml so you "
+                "can retry once the DB is reachable.",
+                err=True,
+            )
+            raise typer.Exit(code=1) from exc
+        removed_total = sum(
+            n for table, n in state_summary.items()
+            if table != "audit_tail"
+        )
+        typer.echo(
+            f"Deleted {removed_total} state.db row(s) for "
+            f"'{project_key}' across "
+            f"{sum(1 for n in state_summary.values() if n > 0)} "
+            "table(s)."
+        )
+        if state_summary.get("audit_tail", 0) > 0:
+            typer.echo(
+                f"Removed central audit-tail JSONL for '{project_key}'."
+            )
+
+    # ------------------------------------------------------------------
+    # Step 3: worktree directory teardown. Same shape as
+    # ``remove_cmd``'s --purge-worktrees branch. Failures here don't
+    # abort — leftover worktree dirs are recoverable with a manual
+    # ``git worktree remove`` later.
+    # ------------------------------------------------------------------
+    wt_preview = _purge_project_worktrees(path, project_key, dry_run=True)
+    if wt_preview:
+        wt_results = _purge_project_worktrees(
+            path, project_key,
+            force_discard_changes=force_discard_worktree_changes,
+        )
+        removed_count = sum(1 for _p, _g, _d, ok, _r in wt_results if ok)
+        skipped_dirty = [
+            p for p, _g, _d, ok, reason in wt_results
+            if not ok and reason == "dirty"
+        ]
+        failed = [
+            (p, reason) for p, _g, _d, ok, reason in wt_results
+            if not ok and reason != "dirty"
+        ]
+        typer.echo(
+            f"Removed {removed_count} worktree director"
+            f"{'y' if removed_count == 1 else 'ies'} for '{project_key}'."
+        )
+        for p in skipped_dirty:
+            typer.echo(
+                f"  Skipped (uncommitted changes): {p} — re-run with "
+                "--force-discard-worktree-changes to discard."
+            )
+        for p, reason in failed:
+            typer.echo(f"  Failed to remove {p} ({reason}).")
+
+    # ------------------------------------------------------------------
+    # Step 4: remove [projects.<key>] from the config.
+    # ------------------------------------------------------------------
+    try:
+        removed = remove_project(path, project_key)
+    except typer.BadParameter as exc:
+        typer.echo(f"Error: {exc.message}", err=True)
+        raise typer.Exit(code=1) from exc
+    typer.echo(f"Removed project '{removed.key}' from {path}")
+
+    # ------------------------------------------------------------------
+    # Step 5: re-register the project under the same slug + path. The
+    # path must still exist on disk — ``reinit`` is "blow away PollyPM
+    # state, keep the working tree". If the operator also wiped the
+    # repo directory, they should use ``pm project new`` instead.
+    # ------------------------------------------------------------------
+    if not project_path.exists() or not project_path.is_dir():
+        typer.echo(
+            f"Error: project path {project_path} no longer exists. "
+            f"The project was removed; re-create the directory and run "
+            f"`pm project new {project_path}` to register from scratch.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        reregistered = register_project(
+            path, project_path, name=project_name, slug=project_key,
+        )
+    except typer.BadParameter as exc:
+        typer.echo(f"Error: {exc.message}", err=True)
+        typer.echo(
+            "The project was removed but re-registration failed. Run "
+            f"`pm project new {project_path}` to finish.",
+            err=True,
+        )
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(
+        f"Reinit complete: re-registered '{reregistered.key}' at "
+        f"{reregistered.path}."
+    )
+
+
+# ---------------------------------------------------------------------------
 # pm project plan
 # ---------------------------------------------------------------------------
 

--- a/tests/test_project_remove_cli.py
+++ b/tests/test_project_remove_cli.py
@@ -1580,3 +1580,292 @@ def test_cli_remove_purge_state_aborts_when_db_purge_fails(
 
     # Audit tail untouched (purge bailed before audit cleanup too).
     assert tail_path.exists()
+
+
+# --------------------------------------------------------------------------
+# pm project reinit (#1561 wedge #5)
+#
+# ``reinit`` is the "blow it away and start over" shorthand: it runs the
+# same destructive cascade as ``pm project remove --purge-sessions
+# --purge-state --purge-worktrees`` and then re-registers the same path
+# under the same slug. Tests mirror the remove tests, with an extra
+# assertion that the re-registered project is present in the post-state.
+# --------------------------------------------------------------------------
+
+
+def test_cli_reinit_happy_path_reregisters(env) -> None:
+    """No sessions/rows/worktrees → reinit removes and re-adds cleanly."""
+    target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with patch(target, return_value=0):
+        result = runner.invoke(
+            project_app,
+            [
+                "reinit", "demo", "--yes",
+                "--config", str(env["config_path"]),
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert "Removed project 'demo'" in result.output
+    assert "Reinit complete" in result.output
+    assert "re-registered 'demo'" in result.output
+
+    # Project entry is back under the same slug + path.
+    config = _load_cfg(env["config_path"])
+    assert "demo" in config.projects
+    assert Path(config.projects["demo"].path).resolve() == (
+        env["project_path"].resolve()
+    )
+
+
+def test_cli_reinit_unknown_project_errors_cleanly(env) -> None:
+    result = runner.invoke(
+        project_app,
+        ["reinit", "does_not_exist", "--config", str(env["config_path"])],
+    )
+    assert result.exit_code == 1, result.output
+    assert "Unknown project" in result.output
+
+
+def test_cli_reinit_aborts_without_yes(env) -> None:
+    """Default prompt rejects → no mutation."""
+    target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with patch(target, return_value=0):
+        result = runner.invoke(
+            project_app,
+            ["reinit", "demo", "--config", str(env["config_path"])],
+            input="n\n",
+        )
+    assert result.exit_code == 1, result.output
+    assert "Permanently reinit 'demo'?" in result.output
+    assert "Aborted" in result.output
+
+    # Project entry still present.
+    config = _load_cfg(env["config_path"])
+    assert "demo" in config.projects
+
+
+def test_cli_reinit_dry_run_mutates_nothing(env) -> None:
+    target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with patch(target, return_value=0):
+        result = runner.invoke(
+            project_app,
+            [
+                "reinit", "demo", "--dry-run",
+                "--config", str(env["config_path"]),
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert "Dry run: would reinit project 'demo'" in result.output
+    assert "re-register: demo at" in result.output
+    assert "Re-run without --dry-run to apply." in result.output
+
+    # Nothing mutated.
+    config = _load_cfg(env["config_path"])
+    assert "demo" in config.projects
+
+
+def test_cli_reinit_cascades_sessions_state_and_worktrees(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reinit tears down every wedge surface and then re-registers."""
+    # Build a config with sessions referencing the project.
+    workspace_root = tmp_path / "dev"
+    workspace_root.mkdir()
+    project_path = workspace_root / "demo"
+    project_path.mkdir()
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(
+        config_path,
+        workspace_root=workspace_root,
+        project_path=project_path,
+        slug="demo",
+        extra_sessions=(
+            "[sessions.architect_demo]\n"
+            'role = "architect"\n'
+            'provider = "claude"\n'
+            'account = "claude_main"\n'
+            'cwd = "."\n'
+            'project = "demo"\n'
+            'window_name = "architect-demo"\n'
+            "\n[accounts.claude_main]\n"
+            'provider = "claude"\n'
+            'home = "/tmp/claude_home"\n'
+        ),
+    )
+    _init_git_project(project_path)
+    wt_a = _seed_worktree(project_path, "architect-demo", "demo-arch")
+
+    audit_home = tmp_path / "audit"
+    audit_home.mkdir()
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+    _seed_state_db_rows(config_path, "demo", task_count=2)
+    tail_path = _audit_tail_for("demo", audit_home=audit_home)
+    tail_path.write_text('{"event": "seeded"}\n')
+
+    fake_tmux = type(
+        "FakeTmux", (), {
+            "has_session": lambda self, name: True,
+            "kill_session": lambda self, name: True,
+        },
+    )()
+    count_target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with (
+        patch(count_target, return_value=0),
+        patch(
+            "pollypm.session_services.create_tmux_client",
+            return_value=fake_tmux,
+        ),
+    ):
+        result = runner.invoke(
+            project_app,
+            [
+                "reinit", "demo", "--yes",
+                "--config", str(config_path),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    # Sessions purged.
+    assert "Killed tmux session architect_demo" in result.output
+    # State rows purged.
+    assert "Deleted" in result.output
+    assert "state.db row" in result.output
+    # Worktrees purged.
+    assert "Removed 1 worktree director" in result.output
+    assert not wt_a.exists()
+    # Audit tail purged.
+    assert not tail_path.exists()
+    # Project removed THEN re-registered.
+    assert "Removed project 'demo'" in result.output
+    assert "Reinit complete" in result.output
+
+    config = _load_cfg(config_path)
+    assert "demo" in config.projects
+    assert "architect_demo" not in config.sessions
+
+
+def test_cli_reinit_aborts_when_project_path_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the project directory is gone, reinit refuses to re-register."""
+    workspace_root = tmp_path / "dev"
+    workspace_root.mkdir()
+    project_path = workspace_root / "demo"
+    project_path.mkdir()
+    (project_path / ".git").mkdir()
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(
+        config_path,
+        workspace_root=workspace_root,
+        project_path=project_path,
+        slug="demo",
+    )
+
+    # Wipe the directory AFTER config write but BEFORE invocation, so the
+    # remove phase finds the entry but the re-register phase trips on the
+    # missing path.
+    import shutil
+    shutil.rmtree(project_path)
+
+    count_target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with patch(count_target, return_value=0):
+        result = runner.invoke(
+            project_app,
+            [
+                "reinit", "demo", "--yes",
+                "--config", str(config_path),
+            ],
+        )
+
+    assert result.exit_code == 1, result.output
+    assert "no longer exists" in result.output
+    assert "pm project new" in result.output
+
+    # The remove phase still ran — project entry is gone.
+    config = _load_cfg(config_path)
+    assert "demo" not in config.projects
+
+
+def test_cli_reinit_dry_run_lists_full_cascade(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dry-run surfaces sessions, state rows, and worktrees in one preview."""
+    workspace_root = tmp_path / "dev"
+    workspace_root.mkdir()
+    project_path = workspace_root / "demo"
+    project_path.mkdir()
+    config_path = tmp_path / "pollypm.toml"
+    _write_config(
+        config_path,
+        workspace_root=workspace_root,
+        project_path=project_path,
+        slug="demo",
+        extra_sessions=(
+            "[sessions.architect_demo]\n"
+            'role = "architect"\n'
+            'provider = "claude"\n'
+            'account = "claude_main"\n'
+            'cwd = "."\n'
+            'project = "demo"\n'
+            'window_name = "architect-demo"\n'
+            "\n[accounts.claude_main]\n"
+            'provider = "claude"\n'
+            'home = "/tmp/claude_home"\n'
+        ),
+    )
+    _init_git_project(project_path)
+    _seed_worktree(project_path, "architect-demo", "demo-arch")
+
+    audit_home = tmp_path / "audit"
+    audit_home.mkdir()
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+    _seed_state_db_rows(config_path, "demo", task_count=1)
+
+    fake_tmux = type(
+        "FakeTmux", (), {
+            "has_session": lambda self, name: True,
+            # Dry-run must not actually kill.
+            "kill_session": lambda self, name: (_ for _ in ()).throw(
+                AssertionError("kill_session must not run in --dry-run")
+            ),
+        },
+    )()
+    count_target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with (
+        patch(count_target, return_value=2),
+        patch(
+            "pollypm.session_services.create_tmux_client",
+            return_value=fake_tmux,
+        ),
+    ):
+        result = runner.invoke(
+            project_app,
+            [
+                "reinit", "demo", "--dry-run",
+                "--config", str(config_path),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "sessions to purge:" in result.output
+    assert "architect_demo (live)" in result.output
+    assert "state.db rows to purge:" in result.output
+    assert "worktree directories to purge:" in result.output
+    assert "re-register: demo at" in result.output
+
+    # Nothing mutated.
+    config = _load_cfg(config_path)
+    assert "demo" in config.projects
+    assert "architect_demo" in config.sessions


### PR DESCRIPTION
## Summary

- New `pm project reinit <key>` command — single-step wrapper around `pm project remove --purge-sessions --purge-state --purge-worktrees` + `register_project` for the "blow this away and start over" workflow (#1561 last wedge).
- Extends `docs/reference/operator-runbook.md` with a full project-teardown recipe: when to use `pm project remove`, what each `--purge-*` flag does, the destructive-action ordering, the dry-run workflow, and the new `reinit` shorthand.

Closes #1561. The prior wedges shipped the underlying machinery (#1603, #1619, #1671, #1681, #1685); this PR exposes the high-traffic case (`reinit`) and documents the recipe.

### Acceptance criteria check (#1561)

- [x] One CLI command tears down a project end-to-end without leaving orphans (`pm project remove --purge-sessions --purge-state --purge-worktrees`, shipped in earlier wedges).
- [x] `--dry-run` prints the full teardown plan.
- [x] `--force` / `--yes` required for destructive prompts.
- [x] `reinit` is a thin wrapper: remove + re-register.
- [x] Recipe documented in the operator runbook.

## Test plan

- [x] 7 new reinit tests (happy path, unknown project, abort without --yes, dry-run, full cascade with sessions+state+worktrees, missing path after remove, dry-run lists full cascade)
- [x] Full `test_project_remove_cli.py` suite still passes (48 tests)
- [x] Adjacent test files still pass (`test_plugins.py`, `test_account_project_removal_plurals.py`)
- [x] `pm project reinit --help` renders, `reinit` shows up in `project_app.registered_commands`

🤖 Generated with [Claude Code](https://claude.com/claude-code)