### PR TITLE
fix(#1363): move DefaultLaunchPlannerContext to core protocol module

### DIFF
--- a/src/pollypm/launch_planner_protocol.py
+++ b/src/pollypm/launch_planner_protocol.py
@@ -1,0 +1,60 @@
+"""Core protocol surface for launch planners.
+
+This leaf module owns :class:`DefaultLaunchPlannerContext` — the dataclass
+that callers (today: :class:`pollypm.supervisor.Supervisor`) hand to the
+default launch planner factory when resolving a planner through the
+plugin host.
+
+Boundary note
+-------------
+
+The default planner ships as a built-in plugin under
+``pollypm.plugins_builtin.default_launch_planner``, but the *context*
+the planner receives is fundamentally the host's contract — it spells
+out which callables the host promises to provide. Keeping that contract
+in core means :mod:`pollypm.supervisor` can build the context object
+without importing from the optional plugin tree, preserving the
+"plugin is optional" invariant tracked under #1363 (siblings: #1597 /
+#1621 / #1626 / #1672 / #1682).
+
+The plugin's own ``planner.py`` module re-exports
+``DefaultLaunchPlannerContext`` from here for back-compat with any
+out-of-tree planners that built against the previous public surface.
+
+Keep this module dependency-light: importing from heavyweight modules
+would defeat the seam.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable
+
+from pollypm.models import AccountConfig, SessionConfig
+from pollypm.providers.base import LaunchCommand
+
+if TYPE_CHECKING:
+    from pollypm.config import PollyPMConfig
+    from pollypm.storage.state import StateStore
+
+
+@dataclass(slots=True)
+class DefaultLaunchPlannerContext:
+    """Callables the default planner needs from its host.
+
+    The planner doesn't own auth-sync, worker sandboxing, or agent
+    profile resolution — those live elsewhere (Supervisor today). The
+    context threads the relevant callables through so the planner can
+    call them without a hard Supervisor dependency.
+    """
+
+    config: "PollyPMConfig"
+    store: "StateStore"
+    readonly_state: bool
+    effective_account: Callable[[SessionConfig, AccountConfig], AccountConfig]
+    apply_role_launch_restrictions: Callable[[SessionConfig, LaunchCommand], LaunchCommand]
+    resolve_profile_prompt: Callable[[SessionConfig, AccountConfig], str | None]
+    storage_closet_session_name: Callable[[], str]
+
+
+__all__ = ["DefaultLaunchPlannerContext"]

--- a/src/pollypm/plugins_builtin/default_launch_planner/planner.py
+++ b/src/pollypm/plugins_builtin/default_launch_planner/planner.py
@@ -16,12 +16,13 @@ stays a clean seam we can swap later.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import replace
 import logging
 import os
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
+from pollypm.launch_planner_protocol import DefaultLaunchPlannerContext
 from pollypm.models import AccountConfig, ProviderKind, SessionConfig, SessionLaunchSpec
 from pollypm.projects import ensure_session_lock
 from pollypm.providers import get_provider
@@ -132,23 +133,13 @@ def _first_account_for_provider(
     return None
 
 
-@dataclass(slots=True)
-class DefaultLaunchPlannerContext:
-    """Callables the default planner needs from its host.
-
-    The planner doesn't own auth-sync, worker sandboxing, or agent
-    profile resolution — those live elsewhere (Supervisor today). The
-    context threads the relevant callables through so the planner can
-    call them without a hard Supervisor dependency.
-    """
-
-    config: "PollyPMConfig"
-    store: "StateStore"
-    readonly_state: bool
-    effective_account: Callable[[SessionConfig, AccountConfig], AccountConfig]
-    apply_role_launch_restrictions: Callable[[SessionConfig, LaunchCommand], LaunchCommand]
-    resolve_profile_prompt: Callable[[SessionConfig, AccountConfig], str | None]
-    storage_closet_session_name: Callable[[], str]
+# ``DefaultLaunchPlannerContext`` is owned by the core protocol module
+# (:mod:`pollypm.launch_planner_protocol`) and re-exported here for
+# back-compat — historical callers (and out-of-tree planners that
+# subclassed off this surface) imported the dataclass from this module.
+# Re-imported at module top so the public name remains
+# ``pollypm.plugins_builtin.default_launch_planner.planner.DefaultLaunchPlannerContext``.
+# See #1363 for the boundary roll-up.
 
 
 class DefaultLaunchPlanner:

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -427,7 +427,7 @@ class Supervisor:
         name (``"default"``). Future work can thread a config-driven
         planner name through here.
         """
-        from pollypm.plugins_builtin.default_launch_planner.planner import (
+        from pollypm.launch_planner_protocol import (
             DefaultLaunchPlannerContext,
         )
 

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -204,6 +204,17 @@ _ACTIVITY_FEED_PLUGIN_MODULE = "pollypm.plugins_builtin.activity_feed.plugin"
 _ACTIVITY_FEED_SUMMARIES_PLUGIN_MODULE = (
     "pollypm.plugins_builtin.activity_feed.summaries"
 )
+# ``Supervisor`` resolves the default launch planner through the plugin
+# host, but the planner's context dataclass is fundamentally the host's
+# contract — it must be available from a core module so the supervisor
+# never has to reach into the optional plugin tree to build it. The
+# canonical home is :mod:`pollypm.launch_planner_protocol`; the plugin
+# re-exports for back-compat. (#1363, sibling of #1597 / #1621 / #1626 /
+# #1672 / #1682.)
+_SUPERVISOR_FILE = "src/pollypm/supervisor.py"
+_DEFAULT_LAUNCH_PLANNER_PLUGIN_PREFIX = (
+    "pollypm.plugins_builtin.default_launch_planner"
+)
 
 
 def _imports_module(source_file: Path, module: str) -> bool:
@@ -369,6 +380,32 @@ def test_non_plugin_sources_do_not_import_activity_feed_summaries_shim() -> None
         "`activity_summary` from pollypm.events.summaries (the canonical "
         "path) instead so the plugin stays optional. Offenders:\n  - "
         + "\n  - ".join(offenders)
+    )
+
+
+def test_supervisor_does_not_import_default_launch_planner_plugin() -> None:
+    """``Supervisor`` builds the planner context from the core protocol module.
+
+    :class:`pollypm.launch_planner_protocol.DefaultLaunchPlannerContext`
+    is the sanctioned source. The default planner ships as a built-in
+    plugin and is resolved through the plugin host, but the *context*
+    dataclass is the host's contract — reaching into the plugin tree to
+    import it would re-couple ``Supervisor`` to an "optional" plugin and
+    break the seam. Fail loudly so the boundary stays clean.
+    """
+    root = _project_root()
+    source_file = root / _SUPERVISOR_FILE
+    assert source_file.exists(), (
+        f"Expected {_SUPERVISOR_FILE} to exist — boundary test "
+        "needs updating if the file moved."
+    )
+    assert not _imports_module_or_subpackage(
+        source_file, _DEFAULT_LAUNCH_PLANNER_PLUGIN_PREFIX
+    ), (
+        f"{_SUPERVISOR_FILE} must not import from "
+        f"{_DEFAULT_LAUNCH_PLANNER_PLUGIN_PREFIX}; import "
+        "DefaultLaunchPlannerContext from pollypm.launch_planner_protocol "
+        "instead so the plugin stays optional."
     )
 
 


### PR DESCRIPTION
## Summary

Sixth wedge for #1363, after #1597 (approval_notifications→human_notify), #1621 (dashboard→morning_briefing), #1626 (doctor→core_recurring), #1672 (cockpit→activity_feed projector), and #1682 (canonical events.summaries).

`Supervisor._build_launch_planner` lazily imported `DefaultLaunchPlannerContext` from `pollypm.plugins_builtin.default_launch_planner.planner` to construct the context handed to the planner factory. The planner itself ships as a built-in plugin and is resolved through the plugin host (correct), but the context dataclass is fundamentally the *host's* contract — it spells out which callables the supervisor promises the planner. Reaching into the optional plugin tree to import it re-coupled core to a "plugin" and broke the boundary.

- Introduces `pollypm.launch_planner_protocol` as the canonical home for `DefaultLaunchPlannerContext` — a leaf module with no runtime deps beyond `pollypm.models` and `pollypm.providers.base`.
- The `default_launch_planner` plugin re-imports the dataclass at module top so the public name `pollypm.plugins_builtin.default_launch_planner.planner.DefaultLaunchPlannerContext` keeps working for out-of-tree subclasses (and the existing `test_launch_planner` suite, which imports from the plugin path, continues to pass unchanged).
- Adds `test_supervisor_does_not_import_default_launch_planner_plugin` to `tests/test_import_boundary.py` so regressions fail loudly.

Boundary count: 15 → 14 remaining `from pollypm.plugins_builtin` violations outside the plugin tree. Remaining clusters (project_planning proposals in cockpit_ui, activity_feed render helpers, core_recurring tier4 helpers, top-level CLI registration in cli.py) are tracked under future wedges.

## Test plan

- [x] `pytest tests/test_import_boundary.py::test_supervisor_does_not_import_default_launch_planner_plugin` — new boundary guard passes.
- [x] `pytest tests/test_launch_planner.py` — 10/10 green (existing suite, imports `DefaultLaunchPlannerContext` from the plugin path via the re-export).
- [x] `pytest tests/test_import_boundary.py` — all 14 boundary tests pass (one pre-existing failure in `test_supervisor_import_allowlist_matches_reality` re `cli_features/tier4.py` is unrelated to this PR).
- [x] `grep -rn 'from pollypm.plugins_builtin' src/pollypm/ | grep -v 'src/pollypm/plugins_builtin/'` — 14 hits, down from 15 (supervisor.py entry gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)