### PR TITLE
fix(cockpit_ui): drop unused ModalScreen import after modal extraction (#1695)

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -47,7 +47,6 @@ from textual import events, on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
-from textual.screen import ModalScreen
 from textual.widgets import (
     Button,
     DataTable,


### PR DESCRIPTION
## Summary
- Removes stale `from textual.screen import ModalScreen` from `src/pollypm/cockpit_ui.py`
- Modal classes were extracted to sibling modules in the #1354 wedge chain (#1606/#1618/#1670/#1688/#1689/#1700), leaving the import unused

Closes #1695

## Test plan
- [x] `uv run --extra dev ruff check src/pollypm/cockpit_ui.py --select F401` no longer reports `ModalScreen` (only the pre-existing `os` F401 remains, as noted in the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)