### PR TITLE
fix(#1691): pin purge-state count probe against metacharacter paths

### DIFF
--- a/src/pollypm/storage/sqlite_pragmas.py
+++ b/src/pollypm/storage/sqlite_pragmas.py
@@ -335,5 +335,6 @@ __all__ = [
     "diagnose_unable_to_open",
     "is_database_locked_error",
     "open_workspace_db",
+    "readonly_uri",
     "retry_on_database_locked",
 ]

--- a/tests/test_readonly_uri.py
+++ b/tests/test_readonly_uri.py
@@ -28,6 +28,7 @@ import pytest
 
 from pollypm.storage.doctor_state_probes import count_work_tasks_ro
 from pollypm.storage.legacy_per_project_db import _open_ro
+from pollypm.storage.project_state_purge import count_project_state_rows
 from pollypm.storage.sqlite_pragmas import readonly_uri
 from pollypm.storage.work_session_queries import (
     aggregate_project_session_tokens,
@@ -159,3 +160,29 @@ def test_legacy_per_project_open_ro_handles_metacharacter_paths(
         assert row[0] == 1
     finally:
         conn.close()
+
+
+@pytest.mark.parametrize(
+    "subdir",
+    [
+        "with#hash",
+        "with?query",
+        "mix#and?both",
+    ],
+)
+def test_project_state_purge_count_handles_metacharacter_paths(
+    tmp_path: Path,
+    subdir: str,
+) -> None:
+    """#1691 regression — ``count_project_state_rows`` is the gate for
+    ``pm project remove --purge-state``; if the read-only probe returns
+    zero rows because the workspace path contains ``#``/``?``, the CLI
+    skips the actual DELETE and silently leaves orphaned rows behind.
+    """
+    root = tmp_path / subdir
+    root.mkdir()
+    db = root / "state.db"
+    _seed_state_db(db, project="demo")
+
+    counts = count_project_state_rows(db, "demo")
+    assert counts["work_tasks"] == 1


### PR DESCRIPTION
## Summary
- ``project_state_purge.count_project_state_rows`` was already routed through ``readonly_uri()`` by #1690, but the regression suite for that sweep (tests/test_readonly_uri.py) did not cover the count facade that gates ``pm project remove --purge-state``. Add a parametrized test (``with#hash``, ``with?query``, ``mix#and?both``) so a future raw ``f"file:{path}?mode=ro"`` re-introduction fails CI.
- Export ``readonly_uri`` from ``pollypm.storage.sqlite_pragmas.__all__``. Every storage caller already imports it directly, so it should advertise as part of the module's public surface.

Closes #1691.

## Test plan
- [x] ``pytest tests/test_readonly_uri.py`` — 15 passed (was 12; +3 parametrized cases)
- [x] ``pytest tests/test_project_remove_cli.py`` — 41 passed (no regressions in the CLI shim that consumes the facade)
- [x] Manual repro from the issue body (``TemporaryDirectory(prefix='polly#review?')``) now reports ``direct=1, count=1``