### PR TITLE
fix(cli): abort project remove when --purge-worktrees skips dirty worktrees (#1692)

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -1027,6 +1027,31 @@ def _enumerate_project_worktree_dirs(project_path: Path) -> list[Path]:
     return out
 
 
+class _PurgeWorktreesError(RuntimeError):
+    """Raised when ``_purge_project_worktrees`` left a dirty worktree behind.
+
+    Signals that one or more worktrees were skipped because they had
+    uncommitted changes and ``--force-discard-worktree-changes`` was not
+    supplied. The caller MUST abort before ``remove_project`` so the
+    TOML config doesn't drift relative to the still-on-disk worktree
+    debris (see issue #1692 — previously this case silently stripped
+    the project entry while leaving the dirty directories behind, so
+    re-running the same command couldn't resolve the project path).
+
+    Carries the partial result list on ``.results`` so the caller can
+    still surface the per-entry summary (rows removed, rows failed)
+    before exiting.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        results: list[tuple[Path, bool, bool, bool, str]],
+    ) -> None:
+        super().__init__(message)
+        self.results = results
+
+
 def _purge_project_worktrees(
     config_path: Path,
     project_key: str,
@@ -1119,6 +1144,26 @@ def _purge_project_worktrees(
             except (subprocess.TimeoutExpired, OSError):
                 pass
         results.append((wt_path, is_git, dirty, removed_ok, reason))
+
+    # Hard refusal: any worktree skipped because it was dirty (and the
+    # operator hadn't passed --force-discard-worktree-changes) means
+    # the on-disk debris is NOT gone. Raise so the caller aborts BEFORE
+    # ``remove_project`` strips the project entry from pollypm.toml —
+    # otherwise the dirty worktrees become orphans the operator can't
+    # reach via the config (issue #1692). Dry-run never raises.
+    if not dry_run:
+        skipped_dirty = [
+            p for p, _g, _d, ok, reason in results
+            if not ok and reason == "dirty"
+        ]
+        if skipped_dirty:
+            joined = ", ".join(str(p) for p in skipped_dirty)
+            raise _PurgeWorktreesError(
+                f"refusing to strip project entry: {len(skipped_dirty)} "
+                f"worktree(s) with uncommitted changes were skipped "
+                f"({joined})",
+                results,
+            )
     return results
 
 
@@ -1486,10 +1531,20 @@ def remove_cmd(
                 if not proceed:
                     typer.echo("Aborted. No changes made.")
                     raise typer.Exit(code=1)
-            wt_results = _purge_project_worktrees(
-                path, project_key,
-                force_discard_changes=force_discard_worktree_changes,
-            )
+            wt_purge_failed = False
+            try:
+                wt_results = _purge_project_worktrees(
+                    path, project_key,
+                    force_discard_changes=force_discard_worktree_changes,
+                )
+            except _PurgeWorktreesError as exc:
+                # Dirty worktrees were skipped. Surface the same
+                # per-entry summary as the happy path, then abort BEFORE
+                # ``remove_project`` so the project entry survives in
+                # pollypm.toml and the operator can retry (issue #1692).
+                wt_results = exc.results
+                wt_purge_failed = True
+
             removed_count = sum(1 for _p, _g, _d, ok, _r in wt_results if ok)
             skipped_dirty = [
                 p for p, _g, _d, ok, reason in wt_results
@@ -1510,6 +1565,21 @@ def remove_cmd(
                 )
             for p, reason in failed:
                 typer.echo(f"  Failed to remove {p} ({reason}).")
+
+            if wt_purge_failed:
+                typer.echo(
+                    f"Error: --purge-worktrees left {len(skipped_dirty)} "
+                    f"dirty worktree(s) in place for '{project_key}'.",
+                    err=True,
+                )
+                typer.echo(
+                    "Aborted. Project entry left in pollypm.toml so you "
+                    "can retry once the worktrees are clean (or re-run "
+                    "with --force-discard-worktree-changes to discard "
+                    "the changes).",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
 
     try:
         removed = remove_project(path, project_key)

--- a/tests/test_project_remove_cli.py
+++ b/tests/test_project_remove_cli.py
@@ -1122,9 +1122,15 @@ def test_purge_project_worktrees_dry_run_is_noop(env) -> None:
 
 
 def test_purge_project_worktrees_refuses_dirty_without_force(env) -> None:
-    """Dirty worktrees are skipped unless ``force_discard_changes`` is set."""
+    """Dirty worktrees raise ``_PurgeWorktreesError`` so the caller aborts.
+
+    See issue #1692 — pre-fix this returned ``[(…, "dirty")]`` and the
+    CLI still went on to strip the project entry from pollypm.toml,
+    leaving the dirty worktree directories orphaned.
+    """
     from pollypm.plugins_builtin.project_planning.cli.project import (
         _purge_project_worktrees,
+        _PurgeWorktreesError,
     )
 
     _init_git_project(env["project_path"])
@@ -1132,8 +1138,10 @@ def test_purge_project_worktrees_refuses_dirty_without_force(env) -> None:
     # Mutate a tracked file so git status reports dirty.
     (wt_a / "README").write_text("dirty\n")
 
-    results = _purge_project_worktrees(env["config_path"], "demo")
+    with pytest.raises(_PurgeWorktreesError) as exc_info:
+        _purge_project_worktrees(env["config_path"], "demo")
 
+    results = exc_info.value.results
     assert len(results) == 1
     path, is_git, dirty, ok, reason = results[0]
     assert dirty is True
@@ -1240,7 +1248,13 @@ def test_cli_remove_purge_worktrees_prompts_without_force(env) -> None:
 
 
 def test_cli_remove_purge_worktrees_skips_dirty_without_force(env) -> None:
-    """Dirty worktrees are reported as skipped, not removed."""
+    """Dirty worktrees abort the cascade and the project entry survives.
+
+    Issue #1692 — previously the CLI reported the skipped worktree but
+    still called ``remove_project`` afterward, stripping the project
+    entry while leaving the dirty worktree on disk. The recoverable
+    behaviour is: exit 1, keep the project entry, surface the skip.
+    """
     _init_git_project(env["project_path"])
     wt_a = _seed_worktree(env["project_path"], "architect-demo", "demo-arch")
     (wt_a / "README").write_text("local changes\n")
@@ -1257,11 +1271,53 @@ def test_cli_remove_purge_worktrees_skips_dirty_without_force(env) -> None:
             ],
         )
 
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 1, result.output
     assert "Skipped (uncommitted changes)" in result.output
     assert "--force-discard-worktree-changes" in result.output
     # Dirty worktree still exists.
     assert wt_a.exists()
+    # And the project entry must still be in the config so the operator
+    # can retry — that's the whole point of the abort (issue #1692).
+    config = _load_cfg(env["config_path"])
+    assert "demo" in config.projects
+    # The TOML-strip line from ``remove_project`` must not have fired.
+    assert "Removed project 'demo'" not in result.output
+
+
+def test_cli_remove_purge_worktrees_mixed_clean_and_dirty_aborts(env) -> None:
+    """Mixed cohort: clean worktrees still removed, dirty trip the abort.
+
+    Regression for issue #1692. The clean worktree must still get cleaned
+    up (best-effort row sweep is preserved) but the project entry stays
+    in ``pollypm.toml`` so the operator can retry — and the second pass
+    can still resolve the project path off the surviving entry.
+    """
+    _init_git_project(env["project_path"])
+    wt_clean = _seed_worktree(env["project_path"], "architect-clean", "clean")
+    wt_dirty = _seed_worktree(env["project_path"], "architect-dirty", "dirty")
+    (wt_dirty / "README").write_text("local changes\n")
+
+    count_target = (
+        "pollypm.plugins_builtin.project_planning.cli.project._count_active_tasks"
+    )
+    with patch(count_target, return_value=0):
+        result = runner.invoke(
+            project_app,
+            [
+                "remove", "demo", "--purge-worktrees", "--yes",
+                "--config", str(env["config_path"]),
+            ],
+        )
+
+    assert result.exit_code == 1, result.output
+    # Clean one got swept.
+    assert not wt_clean.exists()
+    # Dirty one survived.
+    assert wt_dirty.exists()
+    # Project entry survives — re-run is possible.
+    config = _load_cfg(env["config_path"])
+    assert "demo" in config.projects
+    assert "Removed project 'demo'" not in result.output
 
 
 def test_cli_remove_purge_worktrees_force_discard_removes_dirty(env) -> None:


### PR DESCRIPTION
## Summary

- Fixes #1692 — regression from #1685 where `pm project remove --purge-worktrees` stripped the project entry from `pollypm.toml` even when worktree purge was skipped because the worktrees were dirty (and `--force-discard-worktree-changes` was not supplied). After that, the on-disk worktree debris was orphaned and re-running the same command returned `[]` from `_purge_project_worktrees` because the project path could no longer be resolved.
- Mirrors the #1680 pattern: a new `_PurgeWorktreesError` sentinel carrying the partial per-entry results, raised by `_purge_project_worktrees` after a non-dry-run pass when any worktree was skipped as dirty. `remove_cmd` catches it, prints the same Removed / Skipped / Failed summary lines, then exits 1 with a clear error BEFORE `remove_project` touches the TOML — leaving the project entry intact so the operator can retry once the worktrees are clean (or pass `--force-discard-worktree-changes`).

## Test plan

- [x] `pytest tests/test_project_remove_cli.py` — 42 tests pass.
- [x] `pytest tests/ -k "project_remove or project_planning or purge or worktree"` — 247 tests pass.
- [x] Updated regression test `test_purge_project_worktrees_refuses_dirty_without_force` now asserts `_PurgeWorktreesError` is raised and carries the partial results.
- [x] Updated `test_cli_remove_purge_worktrees_skips_dirty_without_force` now asserts exit code 1, that the project entry survives in `pollypm.toml`, and that the `Removed project 'demo'` line never fires.
- [x] New `test_cli_remove_purge_worktrees_mixed_clean_and_dirty_aborts` covers the mixed cohort — clean worktrees still get swept, dirty ones trip the abort, project entry survives.

Closes #1692.

Generated with [Claude Code](https://claude.com/claude-code)