### PR TITLE
fix(#1694): initialize plugin host in standalone cockpit-pane processes

### DIFF
--- a/src/pollypm/cli_features/ui.py
+++ b/src/pollypm/cli_features/ui.py
@@ -591,6 +591,57 @@ def _enforce_migration_gate(config_path: Path) -> None:
     _migrations.require_no_pending_or_exit(config.project.state_db)
 
 
+def _initialize_plugin_host_for_pane(config_path: Path) -> None:
+    """Bootstrap the plugin host in a standalone ``pm cockpit-pane`` process.
+
+    Cockpit panes launched as right-pane children (``pm cockpit-pane
+    activity``, ``pm cockpit-pane project <key>``, ...) run in their own
+    Python process. Per-process registration seams — e.g.
+    :mod:`pollypm.activity_projector_registry` (#1363),
+    :mod:`pollypm.approval_notifications` (#1597),
+    :mod:`pollypm.briefings_registry` (#1621),
+    :mod:`pollypm.maintenance_handlers_registry` (#1626) — keep their
+    ``_factory`` in module state, so initializing the plugin host in the
+    rail process does not populate a child cockpit-pane process.
+
+    Without this call a fresh ``pm cockpit-pane activity`` starts with
+    no projector registered and the activity feed / project-dashboard
+    activity panel render empty even when the built-in plugin is
+    installed (#1694).
+
+    Mirrors :meth:`pollypm.cockpit_rail.CockpitRail._rail_registry` —
+    swallows config-load + initialize failures so a broken plugin can
+    never block the standalone pane from starting.
+    """
+    try:
+        from pollypm.config import load_config
+        from pollypm.plugin_host import extension_host_for_root
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Failed to import plugin host for cockpit-pane init (#1694)",
+            exc_info=True,
+        )
+        return
+    try:
+        config = load_config(config_path)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Failed to load config for cockpit-pane plugin init (#1694)",
+            exc_info=True,
+        )
+        return
+    try:
+        host = extension_host_for_root(str(config.project.root_dir.resolve()))
+        host.initialize_plugins(config=config)
+    except Exception:  # noqa: BLE001
+        # Mirror the rail's tolerance: degraded plugins surface via
+        # ``pm plugins show``; don't block the pane from launching.
+        logger.warning(
+            "Plugin host initialization failed in cockpit-pane (#1694)",
+            exc_info=True,
+        )
+
+
 def _warn_on_plugin_load_errors(config_path: Path) -> None:
     """Emit a stderr WARNING at cockpit boot if any plugin failed to load.
 
@@ -707,6 +758,13 @@ def register_ui_commands(app: typer.Typer) -> None:
     ) -> None:
         _enforce_migration_gate(config_path)
         _install_cockpit_debug_log_handler(config_path)
+        # #1694 — standalone cockpit panes run in their own process, so
+        # registration seams (activity projector, approval notifications,
+        # briefings, maintenance handlers) need the plugin host
+        # initialized here. Without this, panes like ``activity`` and
+        # ``project`` render empty even when their backing plugin is
+        # installed.
+        _initialize_plugin_host_for_pane(config_path)
         if kind == "settings" and target:
             from pollypm.cockpit_ui import PollyProjectSettingsApp
 

--- a/tests/test_cockpit_pane_app.py
+++ b/tests/test_cockpit_pane_app.py
@@ -1,6 +1,55 @@
 from pathlib import Path
 
 
+def test_initialize_plugin_host_for_pane_registers_activity_projector(
+    tmp_path: Path,
+) -> None:
+    """#1694 — a standalone ``pm cockpit-pane`` process runs in its own
+    Python process, so the per-process registration seam in
+    :mod:`pollypm.activity_projector_registry` starts empty. The
+    cockpit-pane CLI helper must initialize the plugin host so the
+    built-in ``activity_feed`` plugin populates the registry; otherwise
+    standalone activity / project panes render an empty feed even when
+    the plugin is installed.
+    """
+    from pollypm import activity_projector_registry
+    from pollypm.cli_features.ui import _initialize_plugin_host_for_pane
+
+    # Make a config that resolves a real ``root_dir`` so ``ExtensionHost``
+    # can find the built-in plugin tree (it's keyed off ``root_dir``).
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        '[project]\nname = "sample"\n\n[pollypm]\ncontroller_account = ""\n'
+    )
+
+    # Clear the registry to simulate a cold cockpit-pane process —
+    # ``register_activity_projector_factory(None)`` is the documented
+    # test hook for "plugin not yet initialized in this process".
+    activity_projector_registry.register_activity_projector_factory(None)
+    assert activity_projector_registry.get_activity_projector_factory() is None
+
+    _initialize_plugin_host_for_pane(config_path)
+
+    assert activity_projector_registry.get_activity_projector_factory() is not None, (
+        "standalone cockpit-pane init must register the activity-projector "
+        "factory (#1694) — otherwise the activity feed renders empty"
+    )
+
+
+def test_initialize_plugin_host_for_pane_swallows_config_load_failure(
+    tmp_path: Path,
+) -> None:
+    """The helper must never block the pane from launching — config load
+    failures and plugin init exceptions are best-effort, matching the
+    cockpit rail's tolerance. See ``cockpit_rail._rail_registry``.
+    """
+    from pollypm.cli_features.ui import _initialize_plugin_host_for_pane
+
+    missing_config = tmp_path / "does_not_exist.toml"
+    # No assertion needed: the contract is "must not raise".
+    _initialize_plugin_host_for_pane(missing_config)
+
+
 def test_cockpit_ui_reexports_pane_app() -> None:
     from pollypm.cockpit_apps.pane import PollyCockpitPaneApp as DirectPaneApp
     from pollypm.cockpit_ui import PollyCockpitPaneApp as CompatPaneApp


### PR DESCRIPTION
## Summary

Fixes #1694 — standalone `pm cockpit-pane activity` and `pm cockpit-pane project` panes never populated the activity-projector registration seam (#1363), so the activity feed and project-dashboard activity panel rendered empty even when the built-in `activity_feed` plugin was installed.

- Adds `_initialize_plugin_host_for_pane(config_path)` helper in `cli_features/ui.py` that mirrors `cockpit_rail._rail_registry`'s init pattern (loads config, gets the extension host, calls `initialize_plugins`, swallows failures so a broken plugin can't block the pane from launching).
- Wires the helper into the `cockpit_pane` CLI entrypoint alongside the existing migration gate + debug log handler.
- The fix also covers the parallel registration seams in the same family (approval notifications #1597, briefings #1621, maintenance handlers #1626) since they all share the module-level `_factory` shape.

## Test plan

- [x] New unit test asserts `_initialize_plugin_host_for_pane(...)` registers the activity-projector factory from a cold registry state.
- [x] New unit test asserts the helper is best-effort and does not raise on missing/invalid config.
- [x] `tests/test_cockpit_pane_app.py`, `tests/test_dashboard_activity_cache.py`, `tests/test_plugins.py`, `tests/test_cockpit_pane_reaper.py`, `tests/test_activity_feed_panel.py`, `tests/test_cockpit_input_bridge.py` all pass (138 tests).
- [ ] Manual: `pm cockpit-pane activity` in a project with the built-in `activity_feed` plugin now shows recent events instead of an empty table.