### PR TITLE
feat(dashboard): render synthesized plan inline before worktree merge (#1620)

### DIFF
--- a/src/pollypm/cockpit_sections/plan.py
+++ b/src/pollypm/cockpit_sections/plan.py
@@ -1,0 +1,98 @@
+"""Project Plan section for the regular dashboard (#1620).
+
+Surfaces the synthesized plan inline when it exists, with a clear CTA
+banner directing the user to the next action. Renders in two shapes:
+
+1. ``plan_text`` is non-empty (architect's synthesize has emitted a
+   plan): a "◇ Plan ready" banner + preview block + "press p to view
+   full plan" hint. This is the case Sam sees the morning after the
+   architect finishes — he opens his project and the plan is right
+   there waiting for him.
+2. ``plan_text`` is empty: section is suppressed entirely (the regular
+   dashboard sections still render below).
+
+The banner mirrors the operator-dashboard plan-ready glyph (◇) so the
+vocabulary stays consistent across surfaces (#1572).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pollypm.cockpit_sections.base import (
+    _DASHBOARD_BULLET,
+    _DASHBOARD_DIVIDER_WIDTH,
+    _dashboard_divider,
+)
+from pollypm.cockpit_sections.plan_review import load_plan_text
+
+
+# Preview line cap — keeps the section compact on the regular
+# dashboard. The full plan is reachable via the plan-review surface
+# (press ``p``) or by reading the file directly.
+_PLAN_PREVIEW_LINE_LIMIT = 24
+
+
+def _render_plan_ready_banner() -> str:
+    """``◇ Plan ready — your turn`` banner, two lines + actions.
+
+    Visual goal: when Sam opens his project dashboard he sees a clear
+    "the architect has finished, here's what's next" affordance at the
+    top of the Plan section. The banner does NOT replace the
+    plan-review surface — when a ``plan_review`` task is actively
+    parked at user_approval, the orchestrator already switches to the
+    full surface (project_dashboard.py:141). This banner covers the
+    case where the plan exists but the inbox row has been archived /
+    fast-tracked / never emitted — Sam still gets visibility on the
+    plan and a path to act on it.
+    """
+    return (
+        f"{_DASHBOARD_BULLET}[bold green]◇ Plan ready — your turn[/bold green]\n"
+        f"{_DASHBOARD_BULLET}[dim]Press [bold]p[/bold] to open the full "
+        f"plan-review surface · [bold]A[/bold] to approve · [bold]c[/bold] "
+        f"to chat with the PM[/dim]"
+    )
+
+
+def _preview_plan(plan_text: str, *, line_limit: int = _PLAN_PREVIEW_LINE_LIMIT) -> str:
+    """Return the first ``line_limit`` lines of the plan, with a tail hint.
+
+    Strips obvious chrome (blank-only leading lines) and appends a
+    ``…`` marker when the plan was truncated so the user sees there's
+    more to read.
+    """
+    text = (plan_text or "").strip()
+    if not text:
+        return ""
+    lines = text.splitlines()
+    preview = lines[:line_limit]
+    rendered = "\n".join(
+        f"{_DASHBOARD_BULLET}{line}" for line in preview
+    )
+    if len(lines) > line_limit:
+        rendered += (
+            f"\n{_DASHBOARD_BULLET}[dim]… {len(lines) - line_limit} more lines "
+            f"— press p to view full plan[/dim]"
+        )
+    return rendered
+
+
+def _section_plan(project_path: Path) -> list[str]:
+    """Plan section for the regular project dashboard.
+
+    Returns the dividers + banner + preview when a plan exists on disk
+    (or in a worktree via the #1620 fallback). Returns an empty list
+    when there is no plan — callers should not render a divider for an
+    empty section.
+    """
+    plan_text = load_plan_text(project_path)
+    if not plan_text:
+        return []
+    lines: list[str] = [
+        _dashboard_divider("Plan"),
+        _render_plan_ready_banner(),
+        "",
+        _preview_plan(plan_text),
+        "",
+    ]
+    return lines

--- a/src/pollypm/cockpit_sections/project_dashboard.py
+++ b/src/pollypm/cockpit_sections/project_dashboard.py
@@ -24,6 +24,7 @@ from pollypm.cockpit_sections.header import _section_header, _worker_presence
 from pollypm.cockpit_sections.health import format_project_health_scorecard
 from pollypm.cockpit_sections.in_flight import _section_in_flight
 from pollypm.cockpit_sections.insights import _section_insights
+from pollypm.cockpit_sections.plan import _section_plan
 from pollypm.cockpit_sections.plan_review import (
     find_actionable_plan_review_task,
     load_plan_text,
@@ -227,6 +228,12 @@ def _render_project_dashboard(
     out.extend(_section_velocity(tasks, tokens))
 
     out.extend(_section_you_need_to(review, project_alerts, 0))
+    # #1620 — Plan section. Renders the synthesized plan inline when
+    # it exists on disk (or in a worktree via the fallback) so the
+    # user SEES the plan as soon as they open the project dashboard
+    # rather than having to chase the inbox row. Empty section when
+    # no plan is present.
+    out.extend(_section_plan(project.path))
     out.extend(_section_in_flight(in_progress, blocked))
     out.extend(_section_recent(completed))
     out.extend(_section_recent_commits(project.path))

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -11749,7 +11749,71 @@ def _dashboard_plan_path(project_path: Path) -> Path | None:
         p = project_path / rel
         if p.is_file():
             return p
-    return None
+    # #1620 — fallback: the architect writes the plan into its session
+    # worktree (`<project>/.pollypm/worktrees/<session>/<wt>/docs/plan/plan.md`)
+    # and the merge back to the main tree is async; until it lands, the
+    # canonical path above is empty. Scan worktrees for the first
+    # non-trivial plan file so the cockpit can render the plan inline as
+    # soon as synthesize commits, not only after the worktree merge.
+    return _dashboard_plan_path_from_worktrees(project_path)
+
+
+def _dashboard_plan_path_from_worktrees(project_path: Path) -> Path | None:
+    """Fallback plan-path resolver that scans architect worktrees.
+
+    The synthesize / emit stages write ``docs/plan/plan.md`` inside the
+    architect's session worktree. Until that worktree merges back to
+    the project root, the canonical paths in
+    :data:`CANONICAL_PLAN_RELATIVE_PATHS` are empty even though a real
+    plan exists on disk. This walker returns the most-recent
+    non-trivial plan file under ``<project>/.pollypm/worktrees`` so the
+    plan-review surface and inbox detail can render the plan inline
+    without waiting for the merge. Returns ``None`` when no worktree
+    holds a plan file.
+    """
+    worktrees_root = project_path / ".pollypm" / "worktrees"
+    if not worktrees_root.is_dir():
+        return None
+    candidates: list[tuple[float, Path]] = []
+    try:
+        session_dirs = list(worktrees_root.iterdir())
+    except OSError:
+        return None
+    for session_dir in session_dirs:
+        if not session_dir.is_dir():
+            continue
+        # Prefer architect worktrees (they own plan output), but fall
+        # back to any session so a non-standard layout still surfaces.
+        prefer_architect = session_dir.name.startswith("architect")
+        try:
+            wt_dirs = list(session_dir.iterdir())
+        except OSError:
+            continue
+        for wt_dir in wt_dirs:
+            if not wt_dir.is_dir():
+                continue
+            for rel in _PLAN_FILE_CANDIDATES:
+                candidate = wt_dir / rel
+                if not candidate.is_file():
+                    continue
+                try:
+                    size = candidate.stat().st_size
+                    mtime = candidate.stat().st_mtime
+                except OSError:
+                    continue
+                if size < 200:
+                    # Skip placeholder / empty files — match the
+                    # plan-presence gate's "non-trivial" threshold so
+                    # we don't render a stub as "the plan".
+                    continue
+                # Architect worktrees outrank others; encode that into
+                # the sort key with a large additive bias on mtime.
+                rank_bias = 10 ** 12 if prefer_architect else 0
+                candidates.append((mtime + rank_bias, candidate))
+    if not candidates:
+        return None
+    candidates.sort(reverse=True)
+    return candidates[0][1]
 
 
 # URL-shaped match used to harvest a deliverable hint from a done plan

--- a/tests/test_cockpit_plan_review_surface.py
+++ b/tests/test_cockpit_plan_review_surface.py
@@ -643,6 +643,29 @@ class TestLoadPlanText:
         text = load_plan_text(proj)
         assert "introduce a new module to validate URLs" in text
 
+    def test_reads_plan_from_architect_worktree_when_main_absent(
+        self, tmp_path: Path,
+    ):
+        """#1620 — synthesize writes the plan into its session worktree
+        before the merge back to the project root lands. The cockpit
+        should surface the worktree copy so the plan-review surface is
+        readable as soon as the architect commits, not only after the
+        async merge."""
+        proj = tmp_path / "samblog"
+        proj.mkdir()
+        wt_dir = (
+            proj
+            / ".pollypm"
+            / "worktrees"
+            / "architect_samblog"
+            / "samblog-architect-architect_samblog"
+        )
+        (wt_dir / "docs" / "plan").mkdir(parents=True)
+        plan_in_wt = wt_dir / "docs" / "plan" / "plan.md"
+        plan_in_wt.write_text(SAMPLE_PLAN, encoding="utf-8")
+        text = load_plan_text(proj)
+        assert "introduce a new module to validate URLs" in text
+
 
 # ---------------------------------------------------------------------------
 # Orchestrator integration — _render_project_dashboard switches surfaces

--- a/tests/test_cockpit_plan_section.py
+++ b/tests/test_cockpit_plan_section.py
@@ -1,0 +1,111 @@
+"""Tests for the regular dashboard's Plan section (#1620).
+
+The Plan section renders inline on the regular project dashboard when
+a plan exists on disk (or in an architect worktree via the
+:func:`pollypm.cockpit_ui._dashboard_plan_path_from_worktrees`
+fallback). It is suppressed entirely when no plan is present so the
+dashboard stays clean for fresh projects.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pollypm.cockpit_sections.plan import (
+    _preview_plan,
+    _render_plan_ready_banner,
+    _section_plan,
+)
+
+
+SAMPLE_PLAN = """# SamBlog implementation plan
+
+## Summary
+Rebuild sam.blog into a polished personal showcase. V1 includes
+photography, long-form writing, projects, and a token counter.
+SamBot is explicitly excluded from V1.
+
+## Judgment calls
+- MCP access is the first real blocker.
+- Substack importer route is not guaranteed on Pressable.
+- Notification safety is a hard gate.
+
+## Plan
+Phase 0 — Verify Pressable and MCP readiness.
+Phase 1 — Rehearse Substack migration safely.
+Phase 2 — Define content model and IA.
+"""
+
+
+class TestPlanReadyBanner:
+    def test_banner_advertises_p_for_full_plan(self):
+        out = _render_plan_ready_banner()
+        assert "Plan ready" in out
+        assert "p" in out  # the keybinding hint
+        assert "A" in out  # approve hint
+
+    def test_banner_uses_plan_ready_glyph(self):
+        out = _render_plan_ready_banner()
+        # ◇ — matches the operator-dashboard vocabulary (#1572).
+        assert "◇" in out
+
+
+class TestPreviewPlan:
+    def test_returns_empty_for_blank_text(self):
+        assert _preview_plan("") == ""
+        assert _preview_plan("   \n\n") == ""
+
+    def test_renders_first_n_lines(self):
+        out = _preview_plan(SAMPLE_PLAN, line_limit=4)
+        assert "# SamBlog implementation plan" in out
+        # Only the first 4 lines should appear before the tail hint.
+        assert "Phase 0" not in out
+        # And the truncation marker should be present.
+        assert "more lines" in out
+
+    def test_no_truncation_marker_when_under_limit(self):
+        short = "# Title\n\nA short plan."
+        out = _preview_plan(short, line_limit=10)
+        assert "more lines" not in out
+
+
+class TestSectionPlan:
+    def test_empty_when_no_plan_present(self, tmp_path: Path):
+        proj = tmp_path / "fresh"
+        proj.mkdir()
+        assert _section_plan(proj) == []
+
+    def test_renders_section_when_plan_on_disk(self, tmp_path: Path):
+        proj = tmp_path / "ready"
+        (proj / "docs" / "plan").mkdir(parents=True)
+        (proj / "docs" / "plan" / "plan.md").write_text(
+            SAMPLE_PLAN, encoding="utf-8",
+        )
+        out = "\n".join(_section_plan(proj))
+        assert "Plan" in out  # divider
+        assert "Plan ready" in out  # banner
+        assert "SamBlog implementation plan" in out  # body preview
+
+    def test_renders_section_when_plan_in_architect_worktree(
+        self, tmp_path: Path,
+    ):
+        """Sam's flow: the architect commits the plan into its
+        worktree at synthesize time, BEFORE the merge back to the
+        project root lands. The dashboard should still surface the
+        plan so Sam can read it as soon as the architect is done."""
+        proj = tmp_path / "samblog"
+        proj.mkdir()
+        wt = (
+            proj
+            / ".pollypm"
+            / "worktrees"
+            / "architect_samblog"
+            / "samblog-architect-architect_samblog"
+            / "docs"
+            / "plan"
+        )
+        wt.mkdir(parents=True)
+        (wt / "plan.md").write_text(SAMPLE_PLAN, encoding="utf-8")
+        out = "\n".join(_section_plan(proj))
+        assert "Plan ready" in out
+        assert "SamBlog implementation plan" in out


### PR DESCRIPTION
## Summary

When Sam opens his SamBlog project, he should SEE the project plan — but today the inbox plan_review detail says "Plan content is not available on disk yet" and the dashboard's Plan pane says "No plan yet". The plan EXISTS — the architect's synthesize stage committed it into its worktree at `samblog/.pollypm/worktrees/architect_samblog/.../docs/plan/plan.md`. The async merge back to the project root never landed, so every UI surface that looks at `<project>/docs/plan/plan.md` reports an empty plan.

This PR makes the existing rendering machinery find the plan in the worktree:

- **`_dashboard_plan_path`** now falls back to scanning `<project>/.pollypm/worktrees/*/<wt>/docs/plan/plan.md` (preferring `architect_*` worktrees) when canonical paths are absent. The 200-byte non-trivial filter matches the plan-presence gate so stub files don't surface as "the plan."
- **The inbox plan_review detail** (`_plan_content_for_review` → `_dashboard_plan_path`) now renders the plan body inline as soon as synthesize commits.
- **The project drilldown plan-review surface** (`load_plan_text` → `_dashboard_plan_path`) renders the full surface — summary, judgment calls, plan body, action bar — without waiting for the worktree merge.
- **A new "Plan" section** on the regular project dashboard surfaces a "◇ Plan ready — your turn" banner + body preview when the plan exists but the plan-review task is already archived/fast-tracked. Renders nothing (suppressed section) when no plan is present so empty projects stay clean.

## Items shipped (vs the P0 brief)

- **Item 1 (find + persist plan output)** — Item 2 of the brief already required a path resolver; this PR ships that resolver (`_dashboard_plan_path_from_worktrees`) instead of moving files. Persisting synthesize output to a canonical path stays a TODO: the architect's worktree commit is the source of truth, the missing piece is the merge back, which is out of scope for a presentation-layer fix.
- **Item 2 (render plan inline in plan-review detail)** — shipped. Existing `_plan_content_for_review` now resolves to the worktree plan.
- **Item 3 (approve → kick off implementation)** — NOT shipped this PR. The state machine work (queued-task readiness, "you need to provide N inputs" card) is meaningful but doesn't fit the 60-min time-box, and the scope guardrails were explicit: "ship items 2 and 4."
- **Item 4 (project dashboard "plan ready" surface)** — shipped via the new `_section_plan` + the existing plan-review surface fallback. When a plan exists, Sam sees "◇ Plan ready — your turn" with hints for `p` (open full plan), `A` (approve), `c` (chat).

## Verification

Live trace on samblog before/after:

```
$ uv run python -c "from pollypm.cockpit_sections.plan_review import load_plan_text; \
                   from pathlib import Path; \
                   print(len(load_plan_text(Path('/Users/sam/dev/samblog'))))"
20753
```

The full 20K-byte SamBlog plan resolves through the new fallback. Previously this returned `""`.

## Test plan

- [x] `tests/test_cockpit_plan_review_surface.py::TestLoadPlanText::test_reads_plan_from_architect_worktree_when_main_absent` — new
- [x] `tests/test_cockpit_plan_section.py` — full new file, 8 cases covering banner / preview / section gate / worktree fallback
- [x] All 39 existing plan-review-surface tests still pass
- [x] All 98 tests across `test_cockpit_plan_*`, `test_plan_review_emit`, `test_plan_presence_gate` pass
- [ ] Live cockpit verification deferred to avoid `pm reset --force` (user-only operation per project memory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)