### PR TITLE
refactor(cockpit): extract SettingsData into sibling module (#1354)

### DIFF
--- a/src/pollypm/cockpit_settings_data.py
+++ b/src/pollypm/cockpit_settings_data.py
@@ -1,0 +1,64 @@
+"""Settings-screen data snapshot used by the cockpit settings pane.
+
+Contract:
+- Inputs: nine keyword arguments — ``accounts``, ``projects``, ``roles``,
+  ``heartbeat``, ``plugins``, ``planner``, ``inbox``, ``about``, and
+  ``errors`` — each a list shaped to match what the settings sections
+  render.
+- Outputs: a ``SettingsData`` instance with the same nine attributes,
+  declared via ``__slots__`` for memory + typo discipline.
+- Side effects: none. Pure container.
+- Invariants: this module owns one data class and nothing else; it has
+  no dependency on Textual, cockpit state, or services. Keep it
+  data-only so tests can construct an instance without mounting a
+  screen.
+- Allowed dependencies: stdlib only.
+- Public: ``SettingsData`` is re-exported via ``cockpit_ui`` for
+  back-compat (see #1354).
+
+Wedge of the cockpit_ui.py god-module split tracked by #1354.
+"""
+
+from __future__ import annotations
+
+
+class SettingsData:
+    """Snapshot of everything the settings screen renders — gathered once."""
+
+    __slots__ = (
+        "accounts",
+        "projects",
+        "roles",
+        "heartbeat",
+        "plugins",
+        "planner",
+        "inbox",
+        "about",
+        "errors",
+    )
+
+    def __init__(
+        self,
+        *,
+        accounts: list[dict],
+        projects: list[dict],
+        roles: list[dict],
+        heartbeat: list[tuple[str, str]],
+        plugins: list[dict],
+        planner: list[tuple[str, str]],
+        inbox: list[tuple[str, str]],
+        about: list[tuple[str, str]],
+        errors: list[str],
+    ) -> None:
+        self.accounts = accounts
+        self.projects = projects
+        self.roles = roles
+        self.heartbeat = heartbeat
+        self.plugins = plugins
+        self.planner = planner
+        self.inbox = inbox
+        self.about = about
+        self.errors = errors
+
+
+__all__ = ["SettingsData"]

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -105,6 +105,9 @@ from pollypm.cockpit_settings_confirm import (  # noqa: F401  (re-exported)
 from pollypm.cockpit_inbox_rollup_item import (  # noqa: F401  (re-exported)
     _RollupItem,
 )
+from pollypm.cockpit_settings_data import (  # noqa: F401  (re-exported)
+    SettingsData,
+)
 from pollypm.cockpit_live_chat_notice import (
     LIVE_CHAT_NETWORK_DEAD_TMUX_MESSAGE,
     clear_live_chat_network_dead_notice,
@@ -3764,45 +3767,6 @@ def _format_recent_task(task: object) -> str:
         bits.append(f"[dim]{_escape(str(status))}[/dim]")
     bits.append(f"[dim]{_escape(title)}[/dim]")
     return " · ".join(bits)
-
-
-class SettingsData:
-    """Snapshot of everything the settings screen renders — gathered once."""
-
-    __slots__ = (
-        "accounts",
-        "projects",
-        "roles",
-        "heartbeat",
-        "plugins",
-        "planner",
-        "inbox",
-        "about",
-        "errors",
-    )
-
-    def __init__(
-        self,
-        *,
-        accounts: list[dict],
-        projects: list[dict],
-        roles: list[dict],
-        heartbeat: list[tuple[str, str]],
-        plugins: list[dict],
-        planner: list[tuple[str, str]],
-        inbox: list[tuple[str, str]],
-        about: list[tuple[str, str]],
-        errors: list[str],
-    ) -> None:
-        self.accounts = accounts
-        self.projects = projects
-        self.roles = roles
-        self.heartbeat = heartbeat
-        self.plugins = plugins
-        self.planner = planner
-        self.inbox = inbox
-        self.about = about
-        self.errors = errors
 
 
 def _collect_recent_tasks_by_account(


### PR DESCRIPTION
## Summary
- Seventh wedge of the cockpit_ui.py god-module split tracked by #1354.
- Moves `SettingsData` (38 LOC, pure data-only container with `__slots__`) into a new `src/pollypm/cockpit_settings_data.py` sibling and re-exports it via `cockpit_ui` for back-compat.
- `cockpit_ui.py` drops from 18,651 to 18,615 LOC; in-file diff is 3 inserts / 39 deletes — well under the 200-line wedge budget.

`SettingsData` was an ideal candidate: zero external dependencies (no Textual, no services, no cross-class refs), only constructed in one place in `cockpit_ui` (`_gather_settings_data`), and consumed by `PollySettingsPaneApp` plus the sibling `cockpit_settings_accounts.py` (which already documents it by name in its docstring).

Prior extractions:
- `_InboxProjectPickerModal` (#1606)
- `_FirstShippedCelebrationModal` (#1618)
- `_SettingsConfirmModal` (#1670)
- `_AlertDetailModal` (#1688)
- `_SettingsAccountReassignModal` (#1689)
- `_RollupItem` (#1700)

## Test plan
- [x] `pytest tests/test_cockpit_settings_projects.py tests/test_project_settings_ui.py tests/test_settings_ui.py` (32 passed)
- [x] `pytest tests/test_cockpit_inbox_ui.py` (86 passed — broader smoke that the cockpit_ui import graph is intact)
- [x] `python -c "from pollypm.cockpit_ui import SettingsData"` — shim re-export works
- [x] `python -c "from pollypm.cockpit_settings_data import SettingsData; SettingsData(accounts=[], projects=[], roles=[], heartbeat=[], plugins=[], planner=[], inbox=[], about=[], errors=[])"` — direct construction works

Refs #1354.

Generated with [Claude Code](https://claude.com/claude-code)