### PR TITLE
fix(observability): log 11 silent except sites in task_assignment_notify + state_reconciliation (#1355 wedge)

### DIFF
--- a/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
@@ -648,6 +648,10 @@ def _storage_closet_window_names(services: Any) -> set[str] | None:
         try:
             session_name = target_session()
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "task_assignment sweep: storage_closet_session_name() raised",
+                exc_info=True,
+            )
             return None
     else:
         session_name = "pollypm-storage-closet"
@@ -1438,6 +1442,11 @@ def _tmux_window_alive_for_task(
             session_name = "pollypm-storage-closet"
         windows = tmux.list_windows(session_name)
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "task_assignment sweep: tmux window probe failed for %s/%s "
+            "— defaulting to alive",
+            project_key, task_number, exc_info=True,
+        )
         return True
     for window in windows or []:
         name = getattr(window, "name", "") or ""
@@ -1470,6 +1479,11 @@ def _consecutive_abandonments_at_active_node(task: Any) -> int:
             reverse=True,
         )
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "task_assignment sweep: execution-visit sort failed; "
+            "circuit-breaker streak treated as 0",
+            exc_info=True,
+        )
         return 0
     streak = 0
     abandoned_value = ExecutionStatus.ABANDONED.value
@@ -1634,6 +1648,11 @@ def _recover_dead_claims(
         try:
             active_tasks.extend(work.list_tasks(project=project_key, work_status=status))
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "task_assignment sweep: circuit-breaker list_tasks(%s, %s) "
+                "failed; skipping status",
+                project_key, status, exc_info=True,
+            )
             continue
     by_outcome = totals["by_outcome"]
     for task in active_tasks:
@@ -1722,7 +1741,11 @@ def _recover_dead_claims(
                     },
                 )
             except Exception:  # noqa: BLE001
-                pass
+                logger.warning(
+                    "task_auto_claim: append_event(worker_session_recovered) "
+                    "failed for %s",
+                    task_id, exc_info=True,
+                )
 
 
 def _auto_claim_next(
@@ -1756,6 +1779,11 @@ def _auto_claim_next(
         try:
             in_progress.extend(work.list_tasks(project=project_key, work_status=status))
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "task_auto_claim: capacity-probe list_tasks(%s, %s) failed; "
+                "treating as no active workers in that status",
+                project_key, status, exc_info=True,
+            )
             continue
     active = [
         task for task in in_progress
@@ -1771,6 +1799,11 @@ def _auto_claim_next(
             project=project_key, work_status=WorkStatus.QUEUED.value,
         )
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "task_auto_claim: queued list_tasks(%s) failed; "
+            "skipping auto-claim tick",
+            project_key, exc_info=True,
+        )
         return
     candidates = [
         task for task in queued
@@ -1812,6 +1845,11 @@ def _auto_claim_next(
                     plan_missing_projects.add(project_key)
                 return
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "task_auto_claim: plan-gate check failed for %s; "
+                "skipping auto-claim tick",
+                project_key, exc_info=True,
+            )
             return
 
     try:
@@ -1842,7 +1880,11 @@ def _auto_claim_next(
                 },
             )
         except Exception:  # noqa: BLE001
-            pass
+            logger.warning(
+                "task_auto_claim: append_event(worker_auto_claimed) failed "
+                "for %s",
+                task_id, exc_info=True,
+            )
 
 
 def _wire_session_manager(svc: Any, project_root: Path, services: Any) -> None:

--- a/src/pollypm/recovery/state_reconciliation.py
+++ b/src/pollypm/recovery/state_reconciliation.py
@@ -54,6 +54,7 @@ unit-test without live sessions or a running work-service.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -62,6 +63,8 @@ from typing import Any
 from pollypm.plan_presence import (
     CANONICAL_PLAN_RELATIVE_PATHS as _PLAN_FILE_CANDIDATES,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # Minimum non-whitespace byte count before a plan file counts as a
@@ -151,6 +154,11 @@ def _plan_ready_notify_recent(
     try:
         rows = query_messages(type="event", since=cutoff_dt, limit=50)
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "state_reconciliation: plan-ready notify query failed for %s; "
+            "treating as no recent notify",
+            project_key, exc_info=True,
+        )
         return False
     if not rows:
         return False
@@ -197,6 +205,11 @@ def _flow_template_for_task(task: Any, work_service: Any) -> Any | None:
             flow_id, project=getattr(task, "project", None),
         )
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "state_reconciliation: flow template lookup failed for %s "
+            "(flow_id=%s); skipping artifact_gate heuristic",
+            getattr(task, "task_id", "?"), flow_id, exc_info=True,
+        )
         return None
 
 


### PR DESCRIPTION
## Summary
Sixth wedge for #1355. Replaces silent `except Exception: pass`/`return`/`continue` with `logger.warning(..., exc_info=True)` at 11 sites in the previously-untouched `task_assignment_notify` plugin (the dedicated wedge flagged by prior agent) and `recovery/state_reconciliation.py`. No behavior change.

Follow-up to #1613 (9 sites), #1620 (12), #1668 (12), #1686 (13), #1699 (13).

## Sites
**`plugins_builtin/task_assignment_notify/handlers/sweep.py` (9):**
- `_storage_closet_window_names`: `storage_closet_session_name()` probe failure (returns None)
- `_tmux_window_alive_for_task`: `tmux.list_windows` failure (defaults alive)
- `_consecutive_abandonments_at_active_node`: execution-visit sort failure (streak=0)
- `_apply_spawn_failure_circuit_breaker`: per-status `list_tasks` failure (continue)
- `_release_stale_worker_claims`: `append_event(worker_session_recovered)` failure
- `_auto_claim_next` capacity probe: `list_tasks` failure (continue)
- `_auto_claim_next` queued lookup: `list_tasks` failure (return)
- `_auto_claim_next` plan gate: `has_acceptable_plan` failure (return)
- `_auto_claim_next`: `append_event(worker_auto_claimed)` failure

**`recovery/state_reconciliation.py` (2; added module `logger`):**
- `_plan_ready_notify_recent`: `query_messages` failure (returns False)
- `_flow_template_for_task`: `work_service.get_flow` failure (returns None)

## Skipped per wedge rules
- `sweep.py` `_close_quietly` (cleanup path)
- `plugin.py:158` `services.work_service.close` (cleanup path)

## Test plan
- [x] `pytest tests/test_state_drift_reconciliation.py tests/test_task_assignment_notify.py tests/test_auto_claim_sweep.py tests/test_task_assignment_fanout.py tests/test_task_assignment_handlers_fd_leak.py tests/test_task_assignment_notify_api_contract.py` → 166 passed
- [ ] CI green

Refs #1355