### PR TITLE
fix(#1367): break heartbeats.api <-> supervisor import cycle

### DIFF
--- a/src/pollypm/heartbeats/api.py
+++ b/src/pollypm/heartbeats/api.py
@@ -4,19 +4,55 @@ import json
 from dataclasses import asdict
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Any, Protocol
 
 from pollypm.atomic_io import atomic_write_json
 from pollypm.checkpoints import record_checkpoint, snapshot_hash, write_mechanical_checkpoint
 from pollypm.heartbeats.base import HeartbeatCursor, HeartbeatSessionContext, HeartbeatUnmanagedWindow
 from pollypm.heartbeats.types import Alert
 
-if TYPE_CHECKING:
-    from pollypm.supervisor import Supervisor
+
+class _SupervisorHost(Protocol):
+    """Structural type for the slice of the Supervisor the heartbeat API uses.
+
+    The heartbeat API only needs a small, stable surface on its host
+    (launch plan + tmux window enumeration, snapshot writing, store /
+    msg_store routing, recovery dispatch, and session-input delivery).
+    Declaring that surface as a :class:`Protocol` lets ``heartbeats.api``
+    stay decoupled from :mod:`pollypm.supervisor` — the previous
+    TYPE_CHECKING back-reference is what put the two modules in a
+    static-graph 2-cycle (#1367). :class:`pollypm.supervisor.Supervisor`
+    satisfies this protocol structurally; no runtime registration is
+    required.
+
+    Returns are typed as :class:`typing.Any` so concrete dataclass /
+    runtime types (``SessionLaunchSpec``, ``TmuxWindow``, ``StateStore``,
+    ``MessageStore``, ``PollyPMConfig`` …) do not need to be re-imported
+    here — that would just push the cycle elsewhere.
+    """
+
+    # Attribute access used by the heartbeat API.
+    store: Any
+    msg_store: Any
+    config: Any
+    session_service: Any
+
+    # Method surface.
+    def plan_launches(self) -> Any: ...
+    def console_window_name(self) -> str: ...
+    def window_map(self) -> Any: ...
+    def launch_by_session(self, session_name: str) -> Any: ...
+    def tmux_session_for_launch(self, launch: Any) -> str: ...
+    def write_snapshot(self, window: Any, snapshot_lines: int) -> tuple[Path, str]: ...
+    def open_alerts(self) -> Any: ...
+    def maybe_recover_session(
+        self, launch: Any, *, failure_type: str, failure_message: str
+    ) -> None: ...
+    def send_input(self, session_name: str, text: str, *, owner: str = ...) -> None: ...
 
 
 class SupervisorHeartbeatAPI:
-    def __init__(self, supervisor: Supervisor, *, snapshot_lines: int = 200) -> None:
+    def __init__(self, supervisor: _SupervisorHost, *, snapshot_lines: int = 200) -> None:
         self.supervisor = supervisor
         self.snapshot_lines = snapshot_lines
         self._contexts = self._build_contexts()

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -62,7 +62,6 @@ _SUPERVISOR_IMPORT_ALLOWLIST: frozenset[str] = frozenset(
         # TODO(#179+): Remaining internal integration points that still need
         # a direct Supervisor — migrate each onto CoreRail / service_api as
         # the rail grows (tracked under the decomposition meta-issue).
-        "src/pollypm/heartbeats/api.py",
         "src/pollypm/job_runner.py",
         "src/pollypm/plugins_builtin/core_recurring/plugin.py",
         "src/pollypm/schedulers/base.py",


### PR DESCRIPTION
## Summary

Seventh wedge for #1367. Breaks the `pollypm.heartbeats.api` <-> `pollypm.supervisor` static-import 2-cycle.

- `heartbeats.api` previously held a TYPE_CHECKING back-reference to `Supervisor` purely to annotate the constructor parameter; `supervisor.py` top-imports `SupervisorHeartbeatAPI`. That's the same shape as the event_buffer wedge (#1696).
- Replace the back-reference with a `_SupervisorHost` `typing.Protocol` capturing the slice the API actually uses (`store` / `msg_store` / `config` / `session_service` attrs, plus `plan_launches`, `console_window_name`, `window_map`, `launch_by_session`, `tmux_session_for_launch`, `write_snapshot`, `open_alerts`, `maybe_recover_session`, `send_input`).
- Drop `src/pollypm/heartbeats/api.py` from `_SUPERVISOR_IMPORT_ALLOWLIST` in `tests/test_import_boundary.py` — it no longer imports `Supervisor`, so the `*_has_no_stale_entries` guardrail would otherwise fail.

Returns in the Protocol are typed as `Any` so concrete dataclass / runtime types (`SessionLaunchSpec`, `TmuxWindow`, `StateStore`, `MessageStore`, `PollyPMConfig` …) don't need to be re-imported here — that would just push the cycle elsewhere. `Supervisor` satisfies the protocol structurally; no runtime registration is required.

## Test plan

- [x] `pollypm.heartbeats.api` ImportFrom edges no longer reference `pollypm.supervisor` (AST scan)
- [x] `Supervisor` exposes every method named in the protocol surface (instance attrs `store` / `msg_store` / `config` / `session_service` are duck-checked at runtime; tests construct real Supervisor instances and pass through `SupervisorHeartbeatAPI`)
- [x] `tests/test_heartbeat_plugin_api.py` (9/9)
- [x] `tests/test_heartbeat_progress_signal.py`
- [x] `tests/test_workers.py`, `tests/test_task_assignment_notify_api_contract.py`
- [x] `tests/test_heartbeats_local_classify*.py`, `tests/test_heartbeat_role_respawn.py`, `tests/test_heartbeat_sweep_summary_plural.py`, `tests/test_stall_classifier.py`
- [x] `tests/test_import_boundary.py` all guardrails pass except a pre-existing `cli_features/tier4.py` regression on main (unrelated to this PR — confirmed by stash + re-run on the parent commit)

Refs #1367.

Pair broken: `heartbeats.api <-> supervisor`.

Previous wedges: activity_feed.plugin <-> feed_panel; cockpit_inbox <-> cockpit_inbox_items; cockpit_alerts <-> cockpit_palette; plugin_host <-> plugin_validate; provider_sdk <-> providers.base; store.event_buffer <-> store.sqlalchemy_store.

Remaining per #1367: 6 `work.service_*` <-> `work.sqlite_service` pairs (plus heartbeats.local <-> supervisor and schedulers.base <-> supervisor in the supervisor cluster).

Generated with [Claude Code](https://claude.com/claude-code).