### PR TITLE
fix(#1710): PM Chat banner celebrates plan-on-disk instead of nagging

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -12112,6 +12112,7 @@ def _dashboard_status(
     in_progress_count: int = 0,
     plan_task_summary: dict | None = None,
     alert_types: list[str] | None = None,
+    plan_on_disk: bool = False,
 ) -> tuple[str, str, str]:
     """Return (dot, colour, label) for the top-bar project status light.
 
@@ -12141,6 +12142,23 @@ def _dashboard_status(
         and plan_task_summary
         and alert_types
         and "plan_missing" in alert_types
+    ):
+        return ("\u25c6", "#3ddc84", "plan ready")
+    # #1710 \u2014 the plan file is on disk (canonical path OR the worktree
+    # fallback from #1709) but no ``plan_task_summary`` reached the
+    # backstop matcher (e.g. the plan task is a ``plan_project`` flow
+    # which the backstop intentionally excludes). The previous predicate
+    # routed this to ``\u25c7 next step`` + "Press c to plan", telling Sam to
+    # plan a project that already has a plan ready. Treat a plan on
+    # disk as the same teammate-handoff signal a ``plan_task_summary``
+    # provides so the pill reads ``\u25c6 plan ready`` and the banner CTA
+    # celebrates instead of nagging.
+    if (
+        alert_count
+        and plan_on_disk
+        and alert_types
+        and "plan_missing" in alert_types
+        and not plan_task_summary
     ):
         return ("\u25c6", "#3ddc84", "plan ready")
     # #1540 \u2014 a fresh project with no plan yet is the *default* early
@@ -14618,6 +14636,7 @@ def _gather_project_dashboard_fast(
         in_progress_count=in_progress_count,
         plan_task_summary=plan_task_summary,
         alert_types=alert_types,
+        plan_on_disk=plan_path is not None,
     )
 
     # Resolve effective enforce_plan with the same precedence the rail
@@ -14703,6 +14722,7 @@ def _augment_project_dashboard_secondary(
         in_progress_count=in_progress_count,
         plan_task_summary=data.plan_task_summary,
         alert_types=alert_types,
+        plan_on_disk=getattr(data, "plan_path", None) is not None,
     )
     data.activity_entries = activity_entries
     data.active_worker = active_worker
@@ -14806,6 +14826,9 @@ def _alert_banner_copy(
     *,
     plan_task_summary: dict | None = None,
     persona_name: str | None = None,
+    plan_on_disk: bool = False,
+    queued_count: int = 0,
+    blocked_count: int = 0,
 ) -> str | None:
     """Return banner copy describing the alerts waiting on the user.
 
@@ -14877,6 +14900,34 @@ def _alert_banner_copy(
             return (
                 f"Plan's ready — {title}. Press → to review together"
                 f"{other_part}"
+            )
+        # #1710 — the plan file is on disk (canonical or worktree-
+        # fallback path from #1709) but the backstop matcher didn't
+        # see a ``plan_task_summary`` (typically because the plan was
+        # produced by a ``plan_project`` flow that's excluded from
+        # backstop emission). Telling Sam to "Press c to plan this"
+        # at that point sends him to chat about planning a project
+        # that's already planned. Celebrate the handoff and route him
+        # to the plan-viewer (``p``) + approve (``A``) keystrokes
+        # instead.
+        if plan_on_disk:
+            pm_label = (persona_name or "").strip() or "the PM"
+            task_parts: list[str] = []
+            if queued_count:
+                task_parts.append(
+                    f"{queued_count} task"
+                    + ("s" if queued_count != 1 else "")
+                    + " queued"
+                )
+            if blocked_count:
+                task_parts.append(
+                    f"{blocked_count} blocked"
+                )
+            task_tail = (" · " + ", ".join(task_parts)) if task_parts else ""
+            return (
+                f"Plan ready — your turn. {pm_label} has finished "
+                f"planning{task_tail}. Press p to review · A to "
+                f"approve and kick off"
             )
         # #1540 — name the PM (Archie/Cole/...) when one is configured
         # so the banner reads as an invitation to a teammate, not a
@@ -15206,7 +15257,10 @@ class PollyProjectDashboardApp(App[None]):
         # this drilldown. When one is present we run the plan-approval
         # celebration flow (10s undo + persona toast). Otherwise we
         # fall through to the legacy alerts view.
+        # #1710 — the plan-on-disk banner CTA advertises capital ``A``
+        # (mirrors the inbox plan-review surface), so bind both.
         Binding("a", "approve_or_alerts", "Approve / Alerts", show=False),
+        Binding("A", "approve_or_alerts", "Approve / Alerts", show=False),
         # #1531 — ``→`` opens the plan-review surface (full plan body
         # inline) when a plan-shaped done task is awaiting review. The
         # banner CTA advertises this keystroke (mirrors the inbox →
@@ -15567,10 +15621,65 @@ class PollyProjectDashboardApp(App[None]):
         10s undo + persona celebration toast the inbox uses. When no
         plan_review card is present we fall back to the legacy alert
         list view that ``a`` historically opened.
+
+        #1710 — when the banner's plan-on-disk celebratory CTA is
+        showing (plan file exists, no actionable plan_review task), the
+        plan has already been approved at some point — the
+        ``plan_missing`` alert is stale relative to the work the
+        architect already shipped. Surface a notify that names that
+        state so Sam isn't dropped into the alert list with no context.
         """
         if self._approve_first_plan_review_if_present():
             return
+        if self._notify_plan_already_approved_if_applicable():
+            return
         self.action_view_alerts()
+
+    def _notify_plan_already_approved_if_applicable(self) -> bool:
+        """Surface a 'plan already approved' notify in the #1710 state.
+
+        Fires when the banner's "Plan ready — your turn" copy is
+        showing — i.e. the alert family is exclusively ``plan_missing``,
+        no ``plan_task_summary`` reached the dashboard, but the plan
+        file IS on disk (canonical path OR the worktree fallback from
+        #1709). In that state the plan has already been approved and
+        the alert is stale; ``A`` should explain that rather than open
+        the alert list.
+
+        Returns True iff a notify was emitted (caller should stop).
+        """
+        data = getattr(self, "data", None)
+        if data is None:
+            return False
+        alert_types = list(getattr(data, "alert_types", []) or [])
+        plan_summary = getattr(data, "plan_task_summary", None)
+        plan_on_disk = bool(getattr(data, "plan_path", None))
+        if not (
+            alert_types == ["plan_missing"]
+            and not plan_summary
+            and plan_on_disk
+        ):
+            return False
+        counts = getattr(data, "task_counts", {}) or {}
+        queued = int(counts.get("queued", 0))
+        blocked = int(counts.get("blocked", 0))
+        tail_parts: list[str] = []
+        if queued:
+            tail_parts.append(
+                f"{queued} task" + ("s" if queued != 1 else "") + " queued"
+            )
+        if blocked:
+            tail_parts.append(
+                f"{blocked} blocked on required inputs"
+            )
+        tail = (" · " + ", ".join(tail_parts)) if tail_parts else ""
+        self.notify(
+            f"Plan already approved{tail}. Press p to review the plan, "
+            "c to chat with the PM about required inputs.",
+            severity="information",
+            timeout=6.0,
+        )
+        return True
 
     def action_undo_plan_approval_or_refresh(self) -> None:
         """``u`` — undo a pending plan approval, or fall back to refresh."""
@@ -16232,11 +16341,24 @@ class PollyProjectDashboardApp(App[None]):
                 getattr(data, "pm_persona", None)
                 or getattr(data, "persona_name", None)
             )
+            # #1710 — plumb the on-disk plan signal into the banner so a
+            # ``plan_missing`` alert with no ``plan_task_summary`` but
+            # an actual plan file (canonical OR worktree-fallback path
+            # from #1709) can switch from the "Press c to plan" nag to
+            # the "Plan ready — press p to review" celebration. Without
+            # this branch a project whose plan_project flow finished
+            # ``done`` reads as "go plan this project" because the
+            # backstop matcher intentionally excludes that flow.
+            plan_on_disk = bool(getattr(data, "plan_path", None))
+            counts = getattr(data, "task_counts", {}) or {}
             specific = _alert_banner_copy(
                 getattr(data, "alert_types", []) or [],
                 int(data.alert_count),
                 plan_task_summary=getattr(data, "plan_task_summary", None),
                 persona_name=pm_persona,
+                plan_on_disk=plan_on_disk,
+                queued_count=int(counts.get("queued", 0)),
+                blocked_count=int(counts.get("blocked", 0)),
             )
             if specific:
                 # #1540 — drop the trailing ``· 1 alert`` for the
@@ -16245,6 +16367,9 @@ class PollyProjectDashboardApp(App[None]):
                 # not an alert the user should be chastised for. The
                 # action-bar pill still surfaces the count for users
                 # who want it; the banner stays clean.
+                # #1710 — same suppression for the plan-on-disk
+                # celebratory CTA so the banner doesn't trail "· 1
+                # alert" after a Plan-ready handoff.
                 alert_types = list(getattr(data, "alert_types", []) or [])
                 plan_summary = getattr(data, "plan_task_summary", None)
                 if (

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -1267,6 +1267,128 @@ def test_banner_celebrates_with_only_task_id_when_title_missing() -> None:
     assert "coffeeboardnm/1" in banner
 
 
+def test_banner_plan_on_disk_overrides_press_c_to_plan(tmp_path) -> None:
+    """#1710 — when a ``plan_missing`` alert fires AND no
+    ``plan_task_summary`` reached the backstop matcher BUT the plan
+    file is on disk (canonical or worktree fallback from #1709), the
+    banner must celebrate the handoff and advertise ``p`` / ``A``
+    instead of nagging Sam to "Press c to plan this project."
+    """
+    from types import SimpleNamespace
+
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    plan_path = tmp_path / "plan.md"
+    plan_path.write_text("# Plan\n\n## Goals\n\nShip v1.\n", encoding="utf-8")
+
+    app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+    fake_data = SimpleNamespace(
+        action_items=[],
+        alert_count=1,
+        alert_types=["plan_missing"],
+        active_worker=None,
+        task_counts={"queued": 9, "blocked": 2},
+        task_buckets={"on_hold": [], "review": []},
+        inbox_count=0,
+        plan_task_summary=None,
+        persona_name="Archie",
+        plan_path=plan_path,
+    )
+    banner = app._render_project_state_banner(fake_data, "▸ 1 alert")
+    # The bug being fixed: never tell Sam to plan a project that's
+    # already been planned.
+    assert "Press c to plan" not in banner
+    # Celebratory copy + PM name.
+    assert "Plan ready" in banner
+    assert "Archie" in banner
+    # Affordances advertised in the issue body.
+    assert "press p" in banner.lower()
+    assert " A " in banner or "A to approve" in banner
+    # Task counts surface so Sam sees what's queued up.
+    assert "9 task" in banner
+    assert "2 blocked" in banner
+    # #1710 mirrors #1540 — no trailing "· 1 alert" on the soft state.
+    assert "1 alert" not in banner
+
+
+def test_banner_plan_on_disk_falls_through_for_other_alerts(
+    tmp_path,
+) -> None:
+    """#1710 — the plan-on-disk celebratory CTA must only kick in for
+    pure ``plan_missing`` alerts. A genuine alert family (e.g.
+    ``worker_question``) must still route to the regular "press a"
+    banner, even if a plan happens to be on disk.
+    """
+    from types import SimpleNamespace
+
+    from pollypm.cockpit_ui import PollyProjectDashboardApp
+
+    plan_path = tmp_path / "plan.md"
+    plan_path.write_text("# Plan\n", encoding="utf-8")
+
+    app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+    fake_data = SimpleNamespace(
+        action_items=[],
+        alert_count=1,
+        alert_types=["worker_question"],
+        active_worker=None,
+        task_counts={"queued": 1},
+        task_buckets={"on_hold": [], "review": []},
+        inbox_count=0,
+        plan_task_summary=None,
+        persona_name="Archie",
+        plan_path=plan_path,
+    )
+    banner = app._render_project_state_banner(fake_data, "▸ 1 alert")
+    # Must not borrow plan-ready copy for an unrelated alert family.
+    assert "Plan ready" not in banner
+    # Worker-question banner still routes via the legacy ``a`` action.
+    assert "press a" in banner.lower()
+
+
+def test_status_pill_plan_ready_when_plan_on_disk_without_summary() -> None:
+    """#1710 — the project status pill must read ``◆ plan ready``
+    (green) when a ``plan_missing`` alert fires with no
+    ``plan_task_summary`` but the plan IS on disk. Showing
+    ``◇ next step`` in that state contradicts the celebratory banner
+    introduced for the same bug.
+    """
+    from pollypm.cockpit_ui import _dashboard_status
+
+    dot, color, label = _dashboard_status(
+        active_worker=None,
+        inbox_count=0,
+        alert_count=1,
+        idle_minutes=None,
+        plan_task_summary=None,
+        alert_types=["plan_missing"],
+        plan_on_disk=True,
+    )
+    assert label == "plan ready"
+    assert color == "#3ddc84"
+    assert dot == "◆"
+
+
+def test_status_pill_still_next_step_without_plan_on_disk() -> None:
+    """#1710 — the soft ``◇ next step`` pill stays in place for the
+    pre-plan case (no summary, no plan on disk). The new branch must
+    only activate when a plan file genuinely exists.
+    """
+    from pollypm.cockpit_ui import _dashboard_status
+
+    dot, color, label = _dashboard_status(
+        active_worker=None,
+        inbox_count=0,
+        alert_count=1,
+        idle_minutes=None,
+        plan_task_summary=None,
+        alert_types=["plan_missing"],
+        plan_on_disk=False,
+    )
+    assert label == "next step"
+    assert dot == "◇"
+
+
 def test_action_bar_soft_plan_missing_state_is_not_critical(
     dashboard_env, dashboard_app,
 ) -> None:


### PR DESCRIPTION
## Summary
- Adds a `plan_on_disk` predicate to `_alert_banner_copy` and `_dashboard_status` so the Textual project dashboard recognizes "plan file exists on disk" as the same teammate-handoff signal a `plan_task_summary` provides.
- When `plan_missing` alert fires with no `plan_task_summary` BUT `data.plan_path` is set (canonical OR #1709 worktree fallback), the banner switches from "Press c to plan this with Archie" to "Plan ready — your turn. Archie has finished planning · N tasks queued, M blocked. Press p to review · A to approve and kick off" and the status pill flips from "◇ next step" to "◆ plan ready" (green).
- Binds capital `A` on the dashboard so the advertised keystroke isn't a dead key; in the new state with no actionable plan_review card, `A` notifies "Plan already approved · workers..." instead of dropping Sam into the alert list.

## Why the previous predicate missed
`_dashboard_done_plan_task` builds the `plan_task_summary` via `task_is_eligible_for_backstop`, which intentionally excludes `plan_project` flow tasks (they have their own reflection node). SamBlog's plan task is a `plan_project` flow that reached `done`, so the summary arrives None and the banner fell through to the "no plan yet" CTA even though the plan markdown was sitting on disk.

## Files changed
- `src/pollypm/cockpit_ui.py` — new `plan_on_disk` parameter on `_alert_banner_copy` + `_dashboard_status`; plumbed through both `_gather_project_dashboard_fast` and `_augment_project_dashboard_secondary` callsites and the `_render_project_state_banner` dispatch. Capital-A binding + `_notify_plan_already_approved_if_applicable` helper for the new A-key fallback.
- `tests/test_project_dashboard_ui.py` — 4 new regression tests: celebratory banner activates, falls through cleanly on unrelated alert families, pill flips to "plan ready", soft "next step" pill is preserved when no plan is on disk.

## Test plan
- [x] `pytest tests/test_project_dashboard_ui.py -k "1710 or plan_on_disk"` — 4/4 passing
- [x] Existing banner / soft-plan-missing tests still pass (no SimpleNamespace currently sets `plan_path`, so the new predicate stays False and the legacy paths are unchanged)
- [ ] Manual verify: `pm reset --force && pm up --phantom-client`, open SamBlog from rail, capture pane 0.1 — should read "Plan ready — your turn" not "Press c to plan."

🤖 Generated with [Claude Code](https://claude.com/claude-code)