### PR TITLE
fix(#1367): break service_transitions <-> sqlite_service import cycle

### DIFF
--- a/src/pollypm/work/service_transitions.py
+++ b/src/pollypm/work/service_transitions.py
@@ -1,29 +1,76 @@
 """Flow transition helpers for the SQLite work service.
 
 Contract:
-- Inputs: a ``SQLiteWorkService`` plus task ids, flow nodes, and actor
-  metadata.
+- Inputs: a work-service collaborator (see :class:`_WorkService` below)
+  plus task ids, flow nodes, and actor metadata.
 - Outputs: visit counters and post-transition side effects.
 - Side effects: mutates task/execution state and triggers notification
   hooks after commits.
 - Invariants: transition side effects stay owned by the work service.
+
+The helpers in this module are parameterised over a structural
+:class:`typing.Protocol` rather than the concrete
+``pollypm.work.sqlite_service.SQLiteWorkService`` class. This breaks
+the import cycle flagged in #1367 (the service top-imports this module,
+so a reverse type-annotation import — even guarded with
+``TYPE_CHECKING`` — registers as a cycle in the AST boundary scan).
+``SQLiteWorkService`` satisfies :class:`_WorkService` structurally; no
+runtime registration or subclass change is required.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+import sqlite3
+from pathlib import Path
+from typing import Protocol
 
-from pollypm.work.models import ExecutionStatus, FlowTemplate, NodeType, Task, WorkStatus, TERMINAL_STATUSES
+from pollypm.work.models import (
+    ExecutionStatus,
+    FlowNode,
+    FlowTemplate,
+    NodeType,
+    Task,
+    WorkStatus,
+    TERMINAL_STATUSES,
+)
 from pollypm.work.service_support import InvalidTransitionError, _now
 
-if TYPE_CHECKING:
-    from pollypm.work.sqlite_service import SQLiteWorkService
+
+class _WorkService(Protocol):
+    """Structural view of the SQLite work service used by transition helpers.
+
+    Captures the exact slice these helpers reach into so the
+    ``service_transitions <-> sqlite_service`` cycle can be broken without
+    pulling the full concrete class into this module's type graph
+    (#1367 wedge).
+    """
+
+    _conn: sqlite3.Connection
+    _project_path: Path | None
+
+    def _record_transition(
+        self,
+        project: str,
+        task_number: int,
+        from_state: str,
+        to_state: str,
+        actor: str,
+    ) -> None: ...
+
+    def _resolve_node_assignee(self, task: Task, node: FlowNode) -> str | None: ...
+
+    def _check_auto_unblock(self, task_id: str) -> None: ...
+
+    def _on_task_done(self, task_id: str, actor: str) -> None: ...
+
+    def get(self, task_id: str) -> Task: ...
+
 
 logger = logging.getLogger(__name__)
 
 
-def next_visit(service: "SQLiteWorkService", project: str, task_number: int, node_id: str) -> int:
+def next_visit(service: _WorkService, project: str, task_number: int, node_id: str) -> int:
     row = service._conn.execute(
         "SELECT COALESCE(MAX(visit), 0) AS max_v "
         "FROM work_node_executions "
@@ -33,7 +80,7 @@ def next_visit(service: "SQLiteWorkService", project: str, task_number: int, nod
     return row["max_v"] + 1
 
 
-def current_node_visit(service: "SQLiteWorkService", project: str, task_number: int, node_id: str) -> int:
+def current_node_visit(service: _WorkService, project: str, task_number: int, node_id: str) -> int:
     row = service._conn.execute(
         "SELECT COALESCE(MAX(visit), 0) AS max_v "
         "FROM work_node_executions "
@@ -44,7 +91,7 @@ def current_node_visit(service: "SQLiteWorkService", project: str, task_number: 
 
 
 def advance_to_node(
-    service: "SQLiteWorkService",
+    service: _WorkService,
     task: Task,
     flow: FlowTemplate,
     next_node_id: str | None,
@@ -113,7 +160,7 @@ def advance_to_node(
     )
 
 
-def on_task_done(service: "SQLiteWorkService", task_id: str, actor: str) -> None:
+def on_task_done(service: _WorkService, task_id: str, actor: str) -> None:
     try:
         from pollypm.notification_staging import check_and_flush_on_done
 
@@ -169,7 +216,7 @@ def on_task_done(service: "SQLiteWorkService", task_id: str, actor: str) -> None
 
 
 def on_task_transition(
-    service: "SQLiteWorkService",
+    service: _WorkService,
     task_id: str,
     from_state: str,
     to_state: str,
@@ -200,7 +247,7 @@ def on_task_transition(
             )
 
 
-def mark_done(service: "SQLiteWorkService", task_id: str, actor: str):
+def mark_done(service: _WorkService, task_id: str, actor: str) -> Task:
     task = service.get(task_id)
     if task.work_status in TERMINAL_STATUSES:
         raise InvalidTransitionError(


### PR DESCRIPTION
## Summary

Eighth wedge for #1367. Breaks the `work.service_transitions` <-> `work.sqlite_service` 2-cycle by replacing the back-edge type annotation with a structural Protocol.

The cycle was:
- `sqlite_service` top-imports the transition helpers (real, used at module load to wire `_on_task_done` / `_on_task_transition` / `mark_done` into the service).
- `service_transitions` did a `TYPE_CHECKING` import of `SQLiteWorkService` purely to annotate its helper signatures.

Define a `_WorkService` `typing.Protocol` inside `service_transitions` capturing the exact slice the helpers reach into: `_conn`, `_project_path`, `_record_transition`, `_resolve_node_assignee`, `_check_auto_unblock`, `_on_task_done`, and `get(task_id)`. Helper signatures now reference `_WorkService` instead of `"SQLiteWorkService"`. `SQLiteWorkService` satisfies the protocol structurally; no runtime registration or subclass change required. The existing `test_task_shipped_inbox.py` tests already pass a duck-typed `_Svc` stub, which confirms the protocol shape matches what callers actually rely on.

Prior wedges: #1599 (activity_feed.plugin <-> feed_panel), #1623 (cockpit_inbox <-> items), #1628 (cockpit_alerts <-> palette), #1667 (plugin_host <-> plugin_validate), #1687 (provider_sdk <-> providers.base), #1696 (event_buffer <-> sqlalchemy_store), #1714 (heartbeats.api <-> supervisor).

Remaining `work.service_*` <-> `work.sqlite_service` pairs after this lands: 5 (service_sync, service_worker_session_manager, service_queries, service_dependency_manager, service_notifications). Same Protocol pattern should apply.

## Test plan

- [x] AST scan: `service_transitions` has no Import or ImportFrom edge to `sqlite_service` at any nesting level (top or lazy)
- [x] `tests/test_task_shipped_inbox.py` — 28/28 pass (covers the `on_task_done` wire-up with the duck-typed `_Svc`)
- [x] `tests/test_work_service.py` — 70/70 pass (full work-service flow including `mark_done`, node advance, transitions)
- [x] `tests/test_import_boundary.py` — 14/15 pass (only pre-existing `tier4.py` Supervisor-allowlist failure remains, unrelated to this change)
- [x] End-to-end smoke: `SQLiteWorkService.create(...).mark_done(...)` round-trips through the Protocol-typed helpers on a real on-disk SQLite and returns a `WorkStatus.DONE` task

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>