### PR TITLE
fix(#1716): suppress inbox blocked-summary nag when plan-ready pill active

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -17336,7 +17336,30 @@ class PollyProjectDashboardApp(App[None]):
             for item in data.action_items[:2]
             if _PROJECT_TASK_REF_RE.fullmatch(str(item.get("primary_ref") or ""))
         ]
-        if count == 0 and not data.action_items and not blocked_total and not on_hold_total:
+        # #1716 — when the top-of-page banner already says "Plan ready —
+        # your turn" (#1715), the plan-ready pill IS the unblock; the
+        # Inbox section directly underneath used to still render the
+        # "Blocked, but summary missing / Press c to ask the PM" nag for
+        # projects that also had a blocked task on disk. That contradicts
+        # the banner and tells Sam to do something the plan-ready handoff
+        # already answers. Treat plan-ready state as making ``blocked``
+        # an inert byproduct for the inbox copy: the user just needs to
+        # review/approve the plan via the banner CTA. Suppress the
+        # blocked-rooted Inbox copy and render the normal "Inbox is
+        # clear" placeholder when nothing else is pending.
+        plan_ready_active = (
+            (getattr(data, "status_label", "") == "plan ready")
+            or (
+                bool(getattr(data, "plan_path", None))
+                and not any(
+                    item.get("is_plan_review")
+                    for item in (data.action_items or [])
+                )
+            )
+        )
+        if count == 0 and not data.action_items and not on_hold_total and (
+            not blocked_total or plan_ready_active
+        ):
             return "[dim]Inbox is clear for this project.[/dim]"
         lines: list[str] = []
         if data.action_items:
@@ -17450,8 +17473,25 @@ class PollyProjectDashboardApp(App[None]):
             # behind #10 (review) and #13 (in_progress); the project
             # is moving, not halted. Don't claim "summary missing" for
             # what is actually healthy dep ordering.
+            # #1716 — likewise suppress when the plan-ready pill from
+            # #1715 is showing: the banner's "Plan ready — your turn"
+            # CTA already tells Sam the project's next step, and
+            # rendering the blocked-summary-missing nag directly under
+            # it reads as the panel contradicting itself.
+            plan_ready_active = (
+                (getattr(data, "status_label", "") == "plan ready")
+                or (
+                    bool(getattr(data, "plan_path", None))
+                    and not any(
+                        item.get("is_plan_review")
+                        for item in (getattr(data, "action_items", []) or [])
+                    )
+                )
+            )
             existing_blocker = _existing_blocker_context(data)
-            if (
+            if plan_ready_active:
+                pass
+            elif (
                 existing_blocker is None
                 and not _blocked_only_on_progressing_deps(data)
             ):

--- a/tests/test_project_dashboard_ui.py
+++ b/tests/test_project_dashboard_ui.py
@@ -4969,6 +4969,87 @@ def test_inbox_remainder_keeps_nag_with_no_blocker_signal(
     assert "ask the PM for a blocker summary" in body
 
 
+def test_inbox_body_clear_when_plan_ready_pill_active_with_blocked_task(
+    dashboard_app,
+) -> None:
+    """#1716 — when the dashboard's top banner already says ``Plan ready
+    — your turn`` (the #1715 state, ``status_label == "plan ready"``),
+    the Inbox section directly below it must not contradict it with the
+    ``Blocked, but summary missing / Press c to ask the PM`` nag. With
+    no other inbox signal, render the normal "Inbox is clear" copy."""
+    from types import SimpleNamespace
+
+    fake_data = SimpleNamespace(
+        project_key="demo",
+        inbox_count=0,
+        status_label="plan ready",
+        plan_path=Path("/tmp/demo/docs/plan/plan.md"),
+        task_counts={"blocked": 1, "on_hold": 0},
+        task_buckets={
+            "blocked": [
+                {
+                    "task_id": "demo/3",
+                    "task_number": 3,
+                    "summary": "",
+                    "blocker_explicit": False,
+                    "hold_reason": "",
+                },
+            ],
+            "on_hold": [],
+        },
+        action_items=[],
+        inbox_top=[],
+    )
+    body = dashboard_app._render_inbox_body(fake_data)
+    assert "summary missing" not in body.lower()
+    assert "ask the PM for a blocker summary" not in body
+    assert "Inbox is clear for this project" in body
+
+
+def test_inbox_remainder_suppresses_blocked_nag_when_plan_ready_active(
+    dashboard_app,
+) -> None:
+    """#1716 — even when other signals push us past the early-return in
+    ``_render_inbox_body`` (e.g. an inbox top preview), the
+    ``_render_inbox_remainder`` blocked-summary-missing copy must still
+    be suppressed when the plan-ready pill is active."""
+    from types import SimpleNamespace
+
+    fake_data = SimpleNamespace(
+        project_key="demo",
+        inbox_count=1,
+        status_label="plan ready",
+        plan_path=Path("/tmp/demo/docs/plan/plan.md"),
+        task_counts={"blocked": 1, "on_hold": 0},
+        task_buckets={
+            "blocked": [
+                {
+                    "task_id": "demo/3",
+                    "task_number": 3,
+                    "summary": "",
+                    "blocker_explicit": False,
+                    "hold_reason": "",
+                },
+            ],
+            "on_hold": [],
+        },
+        action_items=[],
+        inbox_top=[
+            {
+                "task_id": "demo/note",
+                "primary_ref": "",
+                "title": "Status update",
+                "needs_action": False,
+                "updated_at": "2026-05-17T17:00:00",
+                "triage_label": "",
+            },
+        ],
+    )
+    body = dashboard_app._render_inbox_remainder(fake_data)
+    assert "summary missing" not in body.lower()
+    assert "ask the PM for a blocker summary" not in body
+
+
 def test_action_chat_pm_routes_to_existing_on_hold_task(
     dashboard_app,
 ) -> None:


### PR DESCRIPTION
## Summary
- Fixes #1716. When the dashboard's banner already shows "Plan ready — your turn" (the #1715 state), the Inbox section directly below it must not contradict that with the "Blocked, but summary missing / Press c to ask the PM" placeholder. The plan-ready pill IS the unblock.
- Adds a `plan_ready_active` predicate (true when `data.status_label == "plan ready"`, or `data.plan_path` is truthy and no `plan_review` action card is pending). In `_render_inbox_body`, the early-return path now emits "Inbox is clear for this project" when blocked is the only otherwise-blocking signal but the plan-ready pill is active. In `_render_inbox_remainder`, the same guard short-circuits the `elif blocked_total:` branch so the blocked-summary-missing copy is suppressed even when other inbox preview rows kept us past the early-return.
- Adds two regression tests in `tests/test_project_dashboard_ui.py`: one for the early-return path (no inbox count, blocked task, plan-ready) and one for the remainder path (with an inbox preview row keeping us past the early-return).

## Test plan
- [x] `pytest tests/test_project_dashboard_ui.py -k "inbox or blocker or blocked or summary_missing or plan_ready"` — 38 passed.
- [x] Full `tests/test_project_dashboard_ui.py` — 179 passed, 1 unrelated flake (`test_recent_activity_strips_in_project_task_prefix_and_action_tag`, passes in isolation, picks up "loading project dashboard…" placeholder when run in suite — pre-existing).
- [x] `pytest tests/test_cockpit_plan_section.py` — 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)