### PR TITLE
fix(#1363): decouple tier4 CLI from core_recurring plugin

### DIFF
--- a/src/pollypm/cli_features/tier4.py
+++ b/src/pollypm/cli_features/tier4.py
@@ -220,10 +220,8 @@ def self_promote(
         )
         return
 
-    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
-        _dispatch_to_operator_tier4,
-    )
-    outcome = _dispatch_to_operator_tier4(
+    from pollypm.tier4_actions_registry import dispatch_to_operator_tier4
+    outcome = dispatch_to_operator_tier4(
         finding,
         project_path=None,
         now=now,
@@ -234,6 +232,12 @@ def self_promote(
     typer.echo(
         f"self-promote outcome={outcome} root_cause_hash={rch}"
     )
+    if outcome == "unavailable":
+        typer.echo(
+            "tier-4 dispatch unavailable (core_recurring plugin not loaded).",
+            err=True,
+        )
+        raise typer.Exit(code=6)
     if outcome == "send_failed":
         raise typer.Exit(code=5)
 
@@ -293,14 +297,17 @@ def clear(
     now = _now()
     cleared = tracker.clear(root_cause_hash_value, now=now, reason=reason)
     if cleared:
-        from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
-            _emit_tier4_demoted,
-        )
-        _emit_tier4_demoted(
+        from pollypm.tier4_actions_registry import emit_tier4_demoted
+        emitted = emit_tier4_demoted(
             project=state.project,
             root_cause_hash_value=root_cause_hash_value,
             reason=reason,
         )
+        if not emitted:
+            logger.debug(
+                "tier4 cli: emit_tier4_demoted unavailable for %s",
+                root_cause_hash_value,
+            )
         typer.echo(f"cleared {root_cause_hash_value} ({reason}).")
     else:
         typer.echo(f"clear no-op for {root_cause_hash_value}.")
@@ -369,9 +376,7 @@ def _system_action(
 
     Returns 0 on success, 1 on bounce failure.
     """
-    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
-        emit_tier4_global_action,
-    )
+    from pollypm.tier4_actions_registry import emit_tier4_global_action
     push_delivered = emit_tier4_global_action(
         action=action_name,
         root_cause_hash_value=root_cause_hash_value,

--- a/src/pollypm/plugins_builtin/core_recurring/plugin.py
+++ b/src/pollypm/plugins_builtin/core_recurring/plugin.py
@@ -11,6 +11,11 @@ from pollypm.maintenance_handlers_registry import (
     LOG_ROTATE,
     register_maintenance_handler,
 )
+from pollypm.tier4_actions_registry import (
+    register_dispatch_to_operator_tier4,
+    register_emit_tier4_demoted,
+    register_emit_tier4_global_action,
+)
 from pollypm.plugin_api.v1 import (
     Capability,
     JobHandlerAPI,
@@ -46,7 +51,10 @@ from pollypm.plugins_builtin.core_recurring.shared import (  # noqa: F401
 from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
     AUDIT_WATCHDOG_HANDLER_NAME,
     AUDIT_WATCHDOG_SCHEDULE,
+    _dispatch_to_operator_tier4,
+    _emit_tier4_demoted,
     audit_watchdog_handler,
+    emit_tier4_global_action,
 )
 from pollypm.plugins_builtin.core_recurring.blocked_chain import (
     blocked_chain_sweep_handler,
@@ -568,21 +576,26 @@ def _register_roster(api: RosterAPI) -> None:
 
 
 def _initialize(api: PluginAPI) -> None:
-    """Expose one-off entry points for the maintenance handlers (#1363).
+    """Expose one-off entry points for maintenance + tier-4 actions (#1363).
 
     ``doctor.py`` invokes ``agent_worktree.prune`` and ``log.rotate``
     directly as ``--fix`` actions instead of waiting for the next
-    cadence tick. Registering them in
-    :mod:`pollypm.maintenance_handlers_registry` lets the doctor resolve
-    them without importing from the optional plugin tree — when this
-    plugin isn't loaded the doctor reports the fix as "unavailable" and
-    keeps working.
+    cadence tick. ``cli_features/tier4.py`` (the ``pm tier4`` /
+    ``pm system`` command groups) invokes the tier-4 dispatch + audit
+    emit helpers. Registering all of them via core seams lets the
+    callers resolve them without importing from the optional plugin
+    tree — when this plugin isn't loaded the doctor reports the fix as
+    "unavailable" and ``pm tier4`` / ``pm system`` surface a clear
+    "tier-4 actions unavailable" message instead of crashing on import.
 
     Idempotent — safe to call again if the rail re-initializes plugins.
     """
-    del api  # unused — the registry is module-level state
+    del api  # unused — the registries are module-level state
     register_maintenance_handler(AGENT_WORKTREE_PRUNE, agent_worktree_prune_handler)
     register_maintenance_handler(LOG_ROTATE, log_rotate_handler)
+    register_dispatch_to_operator_tier4(_dispatch_to_operator_tier4)
+    register_emit_tier4_demoted(_emit_tier4_demoted)
+    register_emit_tier4_global_action(emit_tier4_global_action)
 
 
 plugin = PollyPMPlugin(

--- a/src/pollypm/tier4_actions_registry.py
+++ b/src/pollypm/tier4_actions_registry.py
@@ -1,0 +1,259 @@
+"""Core seam for tier-4 cascade actions exposed to the CLI.
+
+Contract:
+- Inputs: kwargs matching the original ``audit_watchdog`` callables
+  (a :class:`Finding` + dispatch context for ``dispatch_to_operator_tier4``;
+  audit metadata for ``emit_tier4_demoted`` and ``emit_tier4_global_action``).
+- Outputs: the underlying callable's return value, or a documented
+  degraded default (``"unavailable"`` / ``None`` / ``False``) when no
+  provider is registered.
+- Side effects: whatever the registered handler does (tracker mutations,
+  audit-log writes, inbox writes, desktop notifications). All handlers are
+  best-effort and isolated from each other — a failure in one does not
+  cascade into another.
+- Invariants: when no provider is registered, callers see the documented
+  degraded default and can surface a "feature unavailable" message rather
+  than crashing on import.
+
+Boundary note:
+This module is core — it must not import from ``pollypm.plugins_builtin``.
+``pm tier4 self-promote``, ``pm tier4 clear``, and ``pm system restart-*``
+all resolve tier-4 actions through this registry instead of taking a
+hard import on the optional ``core_recurring`` plugin tree. The
+``core_recurring`` plugin installs the real callables here during
+plugin ``initialize``.
+
+Mirrors the registration-seam pattern established in
+:mod:`pollypm.approval_notifications` (#1597),
+:mod:`pollypm.briefings_registry` (#1621), and
+:mod:`pollypm.maintenance_handlers_registry` (#1626). See #1363 for the
+full boundary-debt roll-up.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Protocols — describe the shape each registered callable must satisfy.
+# ---------------------------------------------------------------------------
+
+
+class DispatchToOperatorTier4(Protocol):
+    """Tier-4 dispatch callable signature.
+
+    Mirrors ``audit_watchdog._dispatch_to_operator_tier4``: routes a
+    finding to broader-authority Polly. Returns a status string
+    (``"dispatched"`` / ``"throttled"`` / ``"send_failed"``).
+    """
+
+    def __call__(
+        self,
+        finding: Any,
+        *,
+        project_path: Path | None,
+        now: datetime,
+        promotion_path: str,
+        justification: str = ...,
+        tracker: Any | None = ...,
+    ) -> str: ...
+
+
+class EmitTier4Demoted(Protocol):
+    """``audit.tier4_demoted`` audit-emit callable signature."""
+
+    def __call__(
+        self,
+        *,
+        project: str,
+        root_cause_hash_value: str,
+        reason: str,
+        project_path: Path | None = ...,
+    ) -> None: ...
+
+
+class EmitTier4GlobalAction(Protocol):
+    """``audit.tier4_global_action`` audit-emit + push callable signature.
+
+    Returns ``True`` iff at least one notifier accepted the payload.
+    """
+
+    def __call__(
+        self,
+        *,
+        action: str,
+        root_cause_hash_value: str,
+        actor: str = ...,
+        metadata: dict[str, Any] | None = ...,
+        project_path: Path | None = ...,
+        project: str = ...,
+        push_title: str | None = ...,
+        push_body: str | None = ...,
+    ) -> bool: ...
+
+
+# ---------------------------------------------------------------------------
+# Module-level registration slots.
+# ---------------------------------------------------------------------------
+
+_dispatch_to_operator_tier4: DispatchToOperatorTier4 | None = None
+_emit_tier4_demoted: EmitTier4Demoted | None = None
+_emit_tier4_global_action: EmitTier4GlobalAction | None = None
+
+
+# ---------------------------------------------------------------------------
+# Registration entry points (called by the plugin's ``_initialize``).
+# ---------------------------------------------------------------------------
+
+
+def register_dispatch_to_operator_tier4(
+    handler: DispatchToOperatorTier4 | None,
+) -> None:
+    """Install (or clear) the tier-4 dispatch callable.
+
+    Pass ``None`` to clear (used by tests).
+    """
+    global _dispatch_to_operator_tier4
+    _dispatch_to_operator_tier4 = handler
+
+
+def register_emit_tier4_demoted(handler: EmitTier4Demoted | None) -> None:
+    """Install (or clear) the ``audit.tier4_demoted`` emit callable."""
+    global _emit_tier4_demoted
+    _emit_tier4_demoted = handler
+
+
+def register_emit_tier4_global_action(
+    handler: EmitTier4GlobalAction | None,
+) -> None:
+    """Install (or clear) the ``audit.tier4_global_action`` emit callable."""
+    global _emit_tier4_global_action
+    _emit_tier4_global_action = handler
+
+
+# ---------------------------------------------------------------------------
+# Resolution entry points (called by the CLI).
+# ---------------------------------------------------------------------------
+
+
+def dispatch_to_operator_tier4(
+    finding: Any,
+    *,
+    project_path: Path | None,
+    now: datetime,
+    promotion_path: str,
+    justification: str = "",
+    tracker: Any | None = None,
+) -> str:
+    """Invoke the registered tier-4 dispatch callable.
+
+    Returns the underlying status string on success, ``"unavailable"``
+    when no provider is registered. The CLI treats ``"unavailable"`` as
+    "plugin disabled" and surfaces a non-zero exit code with a clear
+    message rather than crashing on import.
+    """
+    handler = _dispatch_to_operator_tier4
+    if handler is None:
+        logger.debug(
+            "tier4_actions_registry: no dispatch_to_operator_tier4 provider"
+        )
+        return "unavailable"
+    return handler(
+        finding,
+        project_path=project_path,
+        now=now,
+        promotion_path=promotion_path,
+        justification=justification,
+        tracker=tracker,
+    )
+
+
+def emit_tier4_demoted(
+    *,
+    project: str,
+    root_cause_hash_value: str,
+    reason: str,
+    project_path: Path | None = None,
+) -> bool:
+    """Invoke the registered ``audit.tier4_demoted`` emit callable.
+
+    Returns ``True`` if a provider was registered (audit emit is
+    best-effort inside the handler itself), ``False`` if no provider is
+    registered so the caller can note the degraded state. Never raises.
+    """
+    handler = _emit_tier4_demoted
+    if handler is None:
+        logger.debug(
+            "tier4_actions_registry: no emit_tier4_demoted provider"
+        )
+        return False
+    try:
+        handler(
+            project=project,
+            root_cause_hash_value=root_cause_hash_value,
+            reason=reason,
+            project_path=project_path,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "tier4_actions_registry: emit_tier4_demoted handler failed",
+            exc_info=True,
+        )
+        return False
+    return True
+
+
+def emit_tier4_global_action(
+    *,
+    action: str,
+    root_cause_hash_value: str,
+    actor: str = "polly",
+    metadata: dict[str, Any] | None = None,
+    project_path: Path | None = None,
+    project: str = "",
+    push_title: str | None = None,
+    push_body: str | None = None,
+) -> bool:
+    """Invoke the registered ``audit.tier4_global_action`` emit callable.
+
+    Returns ``True`` iff a notifier accepted the push payload (mirrors
+    the underlying handler's contract). Returns ``False`` and logs at
+    DEBUG when no provider is registered so the CLI can still print a
+    machine-readable status line.
+    """
+    handler = _emit_tier4_global_action
+    if handler is None:
+        logger.debug(
+            "tier4_actions_registry: no emit_tier4_global_action provider"
+        )
+        return False
+    return handler(
+        action=action,
+        root_cause_hash_value=root_cause_hash_value,
+        actor=actor,
+        metadata=metadata,
+        project_path=project_path,
+        project=project,
+        push_title=push_title,
+        push_body=push_body,
+    )
+
+
+__all__ = [
+    "DispatchToOperatorTier4",
+    "EmitTier4Demoted",
+    "EmitTier4GlobalAction",
+    "dispatch_to_operator_tier4",
+    "emit_tier4_demoted",
+    "emit_tier4_global_action",
+    "register_dispatch_to_operator_tier4",
+    "register_emit_tier4_demoted",
+    "register_emit_tier4_global_action",
+]

--- a/tests/test_heartbeat_cascade_tier4.py
+++ b/tests/test_heartbeat_cascade_tier4.py
@@ -851,11 +851,19 @@ def test_system_helper_accepts_env_flag(
         tier4_mod, "_resolve_storage_closet_session",
         lambda: "polly-storage",
     )
-    # Stub the desktop notifier path.
+    # Install the cadence emitter through the registry seam (the CLI no
+    # longer reaches into the plugin tree directly per #1363). Stub the
+    # desktop notifier path so the test doesn't shell out to osascript.
     import pollypm.plugins_builtin.core_recurring.audit_watchdog as cadence
+    from pollypm import tier4_actions_registry
     monkeypatch.setattr(
         cadence, "_send_tier4_global_action_push",
         lambda **_kw: True,
+    )
+    monkeypatch.setattr(
+        tier4_actions_registry,
+        "_emit_tier4_global_action",
+        cadence.emit_tier4_global_action,
     )
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_import_boundary.py
+++ b/tests/test_import_boundary.py
@@ -214,6 +214,12 @@ _SUPERVISOR_FILE = "src/pollypm/supervisor.py"
 _DEFAULT_LAUNCH_PLANNER_PLUGIN_PREFIX = (
     "pollypm.plugins_builtin.default_launch_planner"
 )
+# The ``pm tier4`` / ``pm system`` CLI surfaces resolve tier-4 dispatch
+# and audit-emit helpers through :mod:`pollypm.tier4_actions_registry`
+# instead of reaching into the optional ``core_recurring`` plugin
+# directly. (#1363, sibling of #1597 / #1621 / #1626 / #1672 / #1682 /
+# #1702.)
+_TIER4_CLI_FILE = "src/pollypm/cli_features/tier4.py"
 
 
 def _imports_module(source_file: Path, module: str) -> bool:
@@ -405,6 +411,34 @@ def test_supervisor_does_not_import_default_launch_planner_plugin() -> None:
         f"{_DEFAULT_LAUNCH_PLANNER_PLUGIN_PREFIX}; import "
         "DefaultLaunchPlannerContext from pollypm.launch_planner_protocol "
         "instead so the plugin stays optional."
+    )
+
+
+def test_tier4_cli_does_not_import_core_recurring_plugin() -> None:
+    """``pm tier4`` / ``pm system`` resolve tier-4 actions via the core seam.
+
+    :mod:`pollypm.tier4_actions_registry` is the sanctioned read path for
+    ``dispatch_to_operator_tier4``, ``emit_tier4_demoted``, and
+    ``emit_tier4_global_action``. The ``core_recurring`` plugin installs
+    the real callables during ``initialize``; if ``cli_features/tier4.py``
+    reaches into the plugin tree directly we re-couple core to an
+    "optional" plugin and the CLI stops degrading cleanly when the
+    plugin is disabled. Fail loudly so the seam stays clean.
+    """
+    root = _project_root()
+    source_file = root / _TIER4_CLI_FILE
+    assert source_file.exists(), (
+        f"Expected {_TIER4_CLI_FILE} to exist — boundary test "
+        "needs updating if the file moved."
+    )
+    assert not _imports_module_or_subpackage(
+        source_file, _CORE_RECURRING_PLUGIN_PREFIX
+    ), (
+        f"{_TIER4_CLI_FILE} must not import from "
+        f"{_CORE_RECURRING_PLUGIN_PREFIX}; use "
+        "pollypm.tier4_actions_registry (dispatch_to_operator_tier4, "
+        "emit_tier4_demoted, emit_tier4_global_action) instead so the "
+        "plugin stays optional."
     )
 
 


### PR DESCRIPTION
## Summary

Seventh wedge for #1363 after #1597, #1621, #1626, #1672, #1682, and #1702. `cli_features/tier4.py` lazy-imported `_dispatch_to_operator_tier4`, `_emit_tier4_demoted`, and `emit_tier4_global_action` from `pollypm.plugins_builtin.core_recurring.audit_watchdog` to drive `pm tier4 self-promote`, `pm tier4 clear`, and `pm system restart-*`. The `pm` CLI is core and must not reach into the optional plugin tree to deliver tier-4 cascade actions.

- Introduces `pollypm.tier4_actions_registry` as the registration seam, mirroring `pollypm.maintenance_handlers_registry` (#1626). The `core_recurring` plugin installs all three callables during its existing `_initialize` hook; with the plugin disabled, the CLI surfaces `outcome=unavailable` (self-promote, new exit code 6) and degraded push delivery (system restart) instead of crashing on import.
- The registry resolvers fall back to documented no-ops (`"unavailable"` / `False`) when no provider is registered, so the CLI keeps working end-to-end.
- Updates `test_system_helper_accepts_env_flag` to install the cadence emitter through the registry seam so the test still exercises the end-to-end push path post-decouple.
- Adds `test_tier4_cli_does_not_import_core_recurring_plugin` to `tests/test_import_boundary.py` so regressions fail loudly.

Boundary count: 14 -> 11 remaining `from pollypm.plugins_builtin` violations outside the plugin tree (this wedge clears the `tier4.py` cluster of 3). Remaining clusters: `cli.py` top-level CLI registration (5, the documented plugin-host edge per #1363), `cockpit_ui` `project_planning` (3), `cockpit_activity` + `cockpit` `activity_feed.feed_panel` (3).

## Test plan

- [x] `pytest tests/test_import_boundary.py -k 'not test_supervisor_import_allowlist_matches_reality'` - 15/15 green; new `test_tier4_cli_does_not_import_core_recurring_plugin` passes.
- [x] `pytest tests/test_heartbeat_cascade_tier4.py` - 49/49 green (covers the existing tier-4 cascade behaviour, including the updated `test_system_helper_accepts_env_flag` that now installs the cadence emitter through the registry).
- [x] `pytest tests/test_plugins.py tests/test_plugin_boundary_conformance.py tests/test_plugin_interop.py` - 67/67 green.
- [x] `pytest tests/test_doctor.py tests/test_doctor_enhancements.py` - 245/246 green (`test_doctor_performance_budget` is the pre-existing live-host perf-budget smoke test unrelated to this slice).
- [x] Smoke-verified: `import pollypm.tier4_actions_registry` loads zero `plugins_builtin` modules - it is a leaf core module.
- [x] Smoke-verified: `src/pollypm/cli_features/tier4.py` no longer contains the string `pollypm.plugins_builtin`.

Pre-existing unrelated failure on this worktree's `main`: `test_supervisor_import_allowlist_matches_reality` flags `src/pollypm/cli_features/tier4.py` for its `from pollypm.supervisor import Supervisor` reach inside `_resolve_storage_closet_session` - same out-of-scope failure noted in #1597, #1621, #1626, #1672, #1682, and #1702.

Closes part of #1363.

Generated with [Claude Code](https://claude.com/claude-code)