### PR TITLE
fix(#1367): break service_dependency_manager <-> sqlite_service import cycle

### DIFF
--- a/src/pollypm/work/service_dependency_manager.py
+++ b/src/pollypm/work/service_dependency_manager.py
@@ -1,19 +1,29 @@
 """Dependency manager for the SQLite work service.
 
 Contract:
-- Inputs: a ``SQLiteWorkService`` and task identifiers for dependency
-  relationships and blocker resolution.
+- Inputs: a work-service collaborator (see :class:`_WorkService` below)
+  and task identifiers for dependency relationships and blocker
+  resolution.
 - Outputs: dependency-mutating side effects and dependent-task reads.
 - Side effects: groups the dependency boundary behind one service-owned
   facade so callers do not need to know the helper layout.
 - Invariants: behavior stays delegated to the existing dependency
   helpers; the manager only centralizes the service-facing orchestration.
+
+The facade is parameterised over a structural :class:`typing.Protocol`
+rather than the concrete ``pollypm.work.sqlite_service.SQLiteWorkService``
+class. This breaks the import cycle flagged in #1367 (the service
+top-imports this module, so a reverse type-annotation import — even
+guarded with ``TYPE_CHECKING`` — registers as a cycle in the AST
+boundary scan). ``SQLiteWorkService`` satisfies :class:`_WorkService`
+structurally; no runtime registration or subclass change is required.
 """
 
 from __future__ import annotations
 
+import sqlite3
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import Any, Protocol
 
 from pollypm.work.models import Task
 from pollypm.work.service_dependencies import (
@@ -28,15 +38,44 @@ from pollypm.work.service_dependencies import (
     would_create_cycle,
 )
 
-if TYPE_CHECKING:
-    from pollypm.work.sqlite_service import SQLiteWorkService
+
+class _WorkService(Protocol):
+    """Structural view of the SQLite work service used by the dependency facade.
+
+    Captures the exact slice the underlying dependency helpers reach
+    into so the ``service_dependency_manager <-> sqlite_service`` cycle
+    can be broken without pulling the full concrete class into this
+    module's type graph (#1367 wedge).
+    """
+
+    _conn: sqlite3.Connection
+
+    def _record_transition(
+        self,
+        project: str,
+        task_number: int,
+        from_state: str,
+        to_state: str,
+        actor: str,
+        reason: str,
+    ) -> None: ...
+
+    def _load_task_token_sums_bulk(self) -> Any: ...
+
+    def _row_to_task(self, row: Any, *, token_sums: Any) -> Task: ...
+
+    def _sync_transition(self, task: Task, from_state: str, to_state: str) -> None: ...
+
+    def get(self, task_id: str) -> Task: ...
+
+    def add_context(self, task_id: str, actor: str, body: str) -> None: ...
 
 
 @dataclass(slots=True)
 class WorkDependencyManager:
     """Facade for the dependency/blocking service boundary."""
 
-    service: "SQLiteWorkService"
+    service: _WorkService
 
     def link(self, from_id: str, to_id: str, kind: str) -> None:
         link_tasks(self.service, from_id, to_id, kind)


### PR DESCRIPTION
## Summary
- Ninth wedge for #1367. Breaks the `work.service_dependency_manager` <-> `work.sqlite_service` 2-cycle by replacing the back-edge type annotation with a structural `typing.Protocol`, mirroring #1717's pattern.
- Defines `_WorkService` inside `service_dependency_manager` capturing the exact slice the underlying helpers in `service_dependencies` reach into (`_conn`, `_record_transition`, `_load_task_token_sums_bulk`, `_row_to_task`, `_sync_transition`, `get`, `add_context`). `WorkDependencyManager.service` now references `_WorkService` instead of `"SQLiteWorkService"`.
- `SQLiteWorkService` satisfies the protocol structurally; no runtime registration or subclass change required.

Prior wedges: #1599, #1623, #1628, #1667, #1687, #1696, #1714, #1717.

Four pairs remain on the original list from #1717 (`work.service_* <-> work.sqlite_service`): sync, worker_session_manager, queries, notifications.

## Test plan
- [x] AST scan: `service_dependency_manager` has no `Import` or `ImportFrom` edge to `sqlite_service` at any nesting level.
- [x] Attribute scan: `SQLiteWorkService` defines every method named on `_WorkService`; `_conn` is set in `__init__` so the structural match holds at instance level.
- [x] `tests/test_work_service.py` — 72/72 pass.
- [x] `tests/test_work_dependencies.py` — 18/18 pass (full link/unlink/block/unblock/auto-unblock flow through the facade).
- [x] `tests/test_task_shipped_inbox.py` — 28/28 pass.
- [x] `tests/test_import_boundary.py` — 15/15 pass (one pre-existing tier4 Supervisor-allowlist failure remains, unrelated and deselected).
- [x] End-to-end smoke: real on-disk `SQLiteWorkService.link(...)` plus `queue` round-trips through the Protocol-typed facade, blocks `t2`, and `_dependency_mgr.has_unresolved_blockers` / `.dependents` return the expected results.

Generated with [Claude Code](https://claude.com/claude-code)