### PR TITLE
fix(observability): log 10 silent except sites in providers/recovery (#1355 wedge)

### DIFF
--- a/src/pollypm/providers/codex/detect.py
+++ b/src/pollypm/providers/codex/detect.py
@@ -23,8 +23,11 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 import re
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def _decode_jwt_payload(token: str) -> dict[str, object]:
@@ -61,6 +64,10 @@ def detect_codex_email(home: Path) -> str | None:
         email = payload.get("email")
         return str(email).lower() if isinstance(email, str) and email else None
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "codex.detect: failed to parse %s; treating as not logged in",
+            auth_path, exc_info=True,
+        )
         return None
 
 

--- a/src/pollypm/recovery/no_session_spawn.py
+++ b/src/pollypm/recovery/no_session_spawn.py
@@ -378,11 +378,19 @@ def _spawn(
         )
         from pollypm.config import load_config
     except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "no_session_spawn: worker/config import failed for %s/%s",
+            role, project, exc_info=True,
+        )
         return False, f"import failed: {exc}"
 
     try:
         config = load_config(config_path)
     except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "no_session_spawn: load_config(%s) failed for %s/%s",
+            config_path, role, project, exc_info=True,
+        )
         return False, f"load_config failed: {exc}"
 
     # If a session for (role, project) already exists in config, just
@@ -408,11 +416,19 @@ def _spawn(
                 role=role,
             )
     except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "no_session_spawn: create_worker_session failed for %s/%s",
+            role, project, exc_info=True,
+        )
         return False, f"create_worker_session failed: {exc}"
 
     try:
         launch_worker_session(config_path, session.name)
     except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "no_session_spawn: launch_worker_session failed for %s",
+            session.name, exc_info=True,
+        )
         return False, f"launch_worker_session failed: {exc}"
 
     return True, f"session={session.name}"

--- a/src/pollypm/recovery/reviewer_provisioning.py
+++ b/src/pollypm/recovery/reviewer_provisioning.py
@@ -140,11 +140,19 @@ def ensure_reviewer_session_for_project(
     try:
         from pollypm.config import load_config
     except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "reviewer_provisioning: config import failed for %s",
+            project_key, exc_info=True,
+        )
         return False, f"import failed: {exc}"
 
     try:
         config = load_config(config_path)
     except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "reviewer_provisioning: load_config(%s) failed for %s",
+            config_path, project_key, exc_info=True,
+        )
         return False, f"load_config failed: {exc}"
 
     project = getattr(config, "projects", {}).get(project_key)
@@ -164,6 +172,10 @@ def ensure_reviewer_session_for_project(
     try:
         from pollypm.workers import create_worker_session, launch_worker_session
     except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "reviewer_provisioning: pollypm.workers import failed for %s",
+            project_key, exc_info=True,
+        )
         return False, f"import workers failed: {exc}"
 
     try:

--- a/src/pollypm/recovery/worker_turn_end.py
+++ b/src/pollypm/recovery/worker_turn_end.py
@@ -244,6 +244,11 @@ def _resolve_pm_actor(task: Any, config: Any) -> str:
         projects = getattr(config, "projects", {}) or {}
         project = projects.get(project_key)
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "worker_turn_end: config.projects lookup failed for %s; "
+            "defaulting pm actor to 'polly'",
+            project_key, exc_info=True,
+        )
         return "polly"
     if project is None:
         return "polly"
@@ -503,6 +508,10 @@ def load_transcript_tail(
                 )
                 return data[-tail_chars:]
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "worker_turn_end: transcript-file fallback read failed for %s",
+                session_name, exc_info=True,
+            )
             return ""
     return ""
 


### PR DESCRIPTION
## Summary
Seventh wedge for #1355. Replaces silent `except Exception: pass`/`return` with `logger.warning(..., exc_info=True)` at 10 sites across providers/recovery. Pure observability — same return values, same control flow.

Follow-up to #1613 (9), #1620 (12), #1668 (12), #1686 (13), #1699 (13), #1712 (11). Running total ~80 sites converted.

## Sites
- `providers/codex/detect.py` (1; added module logger): auth.json parse failure
- `recovery/no_session_spawn.py` (4): `_spawn()` import/config/create/launch failures
- `recovery/reviewer_provisioning.py` (3): import + load_config failures in `ensure_reviewer_session_for_project`
- `recovery/worker_turn_end.py` (2): `_resolve_pm_actor` config probe + `load_transcript_tail` file fallback

Cleanup/close paths intentionally skipped per established wedge rules (`task_assignment_notify/plugin.py:158`, `handlers/sweep.py:2019`).

## Test plan
- [x] `pytest tests/test_reviewer_provisioning.py tests/test_no_session_auto_recovery.py tests/test_worker_turn_end_reprompt.py tests/providers/ tests/test_onboarding_ux.py` -> 130 passed
- [x] `py_compile` of all edited files
- [x] Manual diff review — every site is non-cleanup and still preserves its prior return value

Refs #1355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)