### PR TITLE
fix(#1367): break service_worker_session_manager <-> sqlite_service import cycle

### DIFF
--- a/src/pollypm/work/service_worker_session_manager.py
+++ b/src/pollypm/work/service_worker_session_manager.py
@@ -12,8 +12,9 @@ Contract:
 
 from __future__ import annotations
 
+import sqlite3
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import Protocol
 
 from pollypm.work.models import WorkerSessionRecord
 from pollypm.work.service_worker_sessions import (
@@ -27,15 +28,27 @@ from pollypm.work.service_worker_sessions import (
     upsert_worker_session,
 )
 
-if TYPE_CHECKING:
-    from pollypm.work.sqlite_service import SQLiteWorkService
+
+class _WorkService(Protocol):
+    """Structural slice of ``SQLiteWorkService`` used by the worker-session
+    helpers.
+
+    The helpers in :mod:`pollypm.work.service_worker_sessions` only reach
+    into ``service._conn`` to run the ``work_sessions`` DDL / CRUD. Typing
+    against this Protocol lets the manager annotate ``service`` without a
+    back-edge ``TYPE_CHECKING`` import of :class:`SQLiteWorkService`,
+    which breaks the ``service_worker_session_manager`` <->
+    ``sqlite_service`` cycle (#1367).
+    """
+
+    _conn: sqlite3.Connection
 
 
 @dataclass(slots=True)
 class WorkSessionManager:
     """Facade for worker-session persistence."""
 
-    service: "SQLiteWorkService"
+    service: _WorkService
 
     WORK_SESSIONS_DDL = _WORK_SESSIONS_DDL
 


### PR DESCRIPTION
## Summary

Tenth wedge for #1367. Breaks the `work.service_worker_session_manager` <-> `work.sqlite_service` 2-cycle by replacing the back-edge type annotation with a structural Protocol, mirroring #1717 / #1722.

- The cycle: `sqlite_service` top-imports `WorkSessionManager` (real, wires `self._worker_session_mgr = WorkSessionManager(self)` in `__init__`), and `service_worker_session_manager` did a `TYPE_CHECKING` import of `SQLiteWorkService` purely to annotate the dataclass field `service: "SQLiteWorkService"`.
- Define a local `_WorkService` `typing.Protocol` capturing the exact slice the underlying helpers in `service_worker_sessions` reach into: `_conn: sqlite3.Connection`. That is the entire surface every helper touches (`service._conn.execute(...)` + `service._conn.commit()`).
- `SQLiteWorkService` satisfies the protocol structurally; no runtime registration or subclass change required.

Prior wedges: #1599, #1623, #1628, #1667, #1687, #1696, #1714, #1717, #1722.

## Test plan

- [x] AST scan: `service_worker_session_manager` has zero Import / ImportFrom edges to `sqlite_service` at any nesting level.
- [x] `tests/test_work_service.py` - 70/70 pass.
- [x] `tests/test_session_manager.py` + `tests/test_worker_session_gap.py` - 61/61 pass (full worker-session lifecycle).
- [x] `tests/test_work_dependencies.py` - 18/18 pass.
- [x] `tests/test_task_shipped_inbox.py` - 28/28 pass.
- [x] `tests/test_import_boundary.py` - 15/16 pass (1 pre-existing `tier4` Supervisor-allowlist failure remains, unrelated and deselected).
- [x] End-to-end smoke: real on-disk `SQLiteWorkService` constructs `WorkSessionManager(self)` and round-trips `upsert` / `get` / `list` / `update_tokens` / `mark_ended` / `end` through the Protocol-typed facade. `mgr.service is svc` confirms the structural match holds at instance level.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>