### PR TITLE
refactor(cockpit): extract _InboxListItem into sibling module (#1354)

### DIFF
--- a/src/pollypm/cockpit_inbox_list_item.py
+++ b/src/pollypm/cockpit_inbox_list_item.py
@@ -1,0 +1,128 @@
+"""Inbox row ``ListItem`` widget used by the cockpit inbox.
+
+Contract:
+- Inputs: ``row`` (an :class:`InboxThreadRow`), ``is_unread`` (whether the
+  message has been seen), and ``config_path`` (cockpit config path used by
+  the row formatter for project-pin lookups).
+- Outputs: a ``ListItem`` subclass that renders one inbox message row,
+  carrying ``task_id`` / ``task_ref`` / ``row_ref`` / ``is_unread`` for
+  the inbox app's selection & triage paths.
+- Side effects: none beyond mounting a ``Static`` child; ``mark_read``
+  flips classes / re-renders the body in place (no list reflow).
+- Invariants: this module owns one widget class and nothing else; the
+  inbox app handles list-level lifecycle.
+- Allowed dependencies: Textual primitives, ``cockpit_inbox`` for the
+  ``InboxThreadRow`` payload, ``rejection_feedback`` for the
+  feedback-row class hook, and ``cockpit_ui`` via local imports (for
+  the ``_format_inbox_thread_row`` / ``_is_plan_review_task`` /
+  ``_triage_bucket`` helpers — still in the god-module while #1354
+  unwinds, so we lazy-import to avoid the load-time cycle).
+- Private: ``_InboxListItem`` is underscore-prefixed and re-exported via
+  ``cockpit_ui`` for back-compat (see #1354).
+
+Wedge of the cockpit_ui.py god-module split tracked by #1354.
+"""
+
+from __future__ import annotations
+
+from textual.widgets import ListItem, Static
+
+from pollypm.cockpit_inbox import InboxThreadRow
+from pollypm.rejection_feedback import is_rejection_feedback_task
+
+
+class _InboxListItem(ListItem):
+    """One message in the inbox list — carries the task_id + unread flag."""
+
+    def __init__(
+        self,
+        row: InboxThreadRow,
+        *,
+        is_unread: bool,
+        config_path: object | None = None,
+    ) -> None:
+        # Local imports: ``_format_inbox_thread_row`` /
+        # ``_is_plan_review_task`` / ``_triage_bucket`` still live in
+        # ``cockpit_ui``. Importing at module load time would create a
+        # cycle (cockpit_ui imports this module for the re-export shim).
+        from pollypm.cockpit_ui import (
+            _format_inbox_thread_row,
+            _is_plan_review_task,
+            _triage_bucket,
+        )
+
+        self.row_ref = row
+        self.task_id = row.task_id
+        self.task_ref = row.task
+        self.is_unread = is_unread
+        self._config_path = config_path
+        row_classes = "inbox-row reply-row" if row.is_reply else "inbox-row"
+        # Plan-review approval rows get a distinct class so the CSS can
+        # render a heavier border / background — these are decision
+        # cards, not informational pings (#1400).
+        self._is_plan_review = row.is_task and _is_plan_review_task(row.task)
+        if self._is_plan_review:
+            row_classes = f"{row_classes} plan-review-row"
+        self._body = Static(
+            _format_inbox_thread_row(
+                row,
+                is_unread=is_unread,
+                config_path=config_path,
+                show_judgment_calls=False,
+            ),
+            markup=False,
+        )
+        super().__init__(self._body, classes=row_classes)
+        if is_unread:
+            self.add_class("unread")
+        if row.is_task and is_rejection_feedback_task(row.task):
+            self.add_class("rejection-feedback")
+        triage_bucket = _triage_bucket(row.task)
+        if triage_bucket == "action":
+            self.add_class("action-required")
+        elif triage_bucket == "orphaned":
+            self.add_class("orphaned")
+        else:
+            self.add_class("informational")
+
+    def mark_read(self, row: InboxThreadRow | None = None) -> None:
+        """Flip the row to read styling in place (no reflow of the list)."""
+        from pollypm.cockpit_ui import _format_inbox_thread_row
+
+        if self.is_unread is False:
+            return
+        self.is_unread = False
+        self.remove_class("unread")
+        if row is not None:
+            self.row_ref = row
+            self.task_ref = row.task
+        self._body.update(
+            _format_inbox_thread_row(
+                self.row_ref,
+                is_unread=False,
+                config_path=self._config_path,
+            )
+        )
+
+    def set_show_judgment_calls(self, show: bool) -> None:
+        """Re-render the plan_review row with judgment calls toggled.
+
+        No-op on non-plan_review rows — the regular inbox row renderer
+        ignores the flag so calling this on every selection is safe and
+        keeps the rendering pipeline uniform across row kinds.
+        """
+        from pollypm.cockpit_ui import _format_inbox_thread_row
+
+        if not self._is_plan_review:
+            return
+        self._body.update(
+            _format_inbox_thread_row(
+                self.row_ref,
+                is_unread=self.is_unread,
+                config_path=self._config_path,
+                show_judgment_calls=show,
+            )
+        )
+
+
+__all__ = ["_InboxListItem"]

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -105,6 +105,9 @@ from pollypm.cockpit_settings_confirm import (  # noqa: F401  (re-exported)
 from pollypm.cockpit_inbox_rollup_item import (  # noqa: F401  (re-exported)
     _RollupItem,
 )
+from pollypm.cockpit_inbox_list_item import (  # noqa: F401  (re-exported)
+    _InboxListItem,
+)
 from pollypm.cockpit_settings_data import (  # noqa: F401  (re-exported)
     SettingsData,
 )
@@ -7297,86 +7300,6 @@ def _extract_proposal_spec(task, *, labels: list[str] | None = None) -> dict:
     else:
         spec["description"] = body
     return spec
-
-
-class _InboxListItem(ListItem):
-    """One message in the inbox list — carries the task_id + unread flag."""
-
-    def __init__(
-        self,
-        row: InboxThreadRow,
-        *,
-        is_unread: bool,
-        config_path: object | None = None,
-    ) -> None:
-        self.row_ref = row
-        self.task_id = row.task_id
-        self.task_ref = row.task
-        self.is_unread = is_unread
-        self._config_path = config_path
-        row_classes = "inbox-row reply-row" if row.is_reply else "inbox-row"
-        # Plan-review approval rows get a distinct class so the CSS can
-        # render a heavier border / background — these are decision
-        # cards, not informational pings (#1400).
-        self._is_plan_review = row.is_task and _is_plan_review_task(row.task)
-        if self._is_plan_review:
-            row_classes = f"{row_classes} plan-review-row"
-        self._body = Static(
-            _format_inbox_thread_row(
-                row,
-                is_unread=is_unread,
-                config_path=config_path,
-                show_judgment_calls=False,
-            ),
-            markup=False,
-        )
-        super().__init__(self._body, classes=row_classes)
-        if is_unread:
-            self.add_class("unread")
-        if row.is_task and is_rejection_feedback_task(row.task):
-            self.add_class("rejection-feedback")
-        triage_bucket = _triage_bucket(row.task)
-        if triage_bucket == "action":
-            self.add_class("action-required")
-        elif triage_bucket == "orphaned":
-            self.add_class("orphaned")
-        else:
-            self.add_class("informational")
-
-    def mark_read(self, row: InboxThreadRow | None = None) -> None:
-        """Flip the row to read styling in place (no reflow of the list)."""
-        if self.is_unread is False:
-            return
-        self.is_unread = False
-        self.remove_class("unread")
-        if row is not None:
-            self.row_ref = row
-            self.task_ref = row.task
-        self._body.update(
-            _format_inbox_thread_row(
-                self.row_ref,
-                is_unread=False,
-                config_path=self._config_path,
-            )
-        )
-
-    def set_show_judgment_calls(self, show: bool) -> None:
-        """Re-render the plan_review row with judgment calls toggled.
-
-        No-op on non-plan_review rows — the regular inbox row renderer
-        ignores the flag so calling this on every selection is safe and
-        keeps the rendering pipeline uniform across row kinds.
-        """
-        if not self._is_plan_review:
-            return
-        self._body.update(
-            _format_inbox_thread_row(
-                self.row_ref,
-                is_unread=self.is_unread,
-                config_path=self._config_path,
-                show_judgment_calls=show,
-            )
-        )
 
 
 # Inbox lens taxonomy (#1573). The default lens is ``awaits-you`` —


### PR DESCRIPTION
## Summary
- Ninth wedge of the cockpit_ui.py god-module split tracked by #1354.
- Moves `_InboxListItem` (the inbox list-row `ListItem` subclass — carries `task_id`/`task_ref`/`is_unread`, plus the plan-review / rejection-feedback / triage-bucket CSS hooks for #1400 and #1573) into a new `src/pollypm/cockpit_inbox_list_item.py` sibling module.
- Adds a re-export shim in `cockpit_ui` so the inbox app's `isinstance` checks and the test suites that `from pollypm.cockpit_ui import _InboxListItem` keep working unchanged.
- The `_format_inbox_thread_row` / `_is_plan_review_task` / `_triage_bucket` helpers still live in `cockpit_ui`; the new module lazy-imports them from inside `__init__` / `mark_read` / `set_show_judgment_calls` to break the load-time cycle (same pattern the sixth wedge in #1700 used for `_RollupItem`).

## LOC progression
- `cockpit_ui.py`: 18,620 -> 18,543 (-77)
- Net diff: 131 insertions / 80 deletions (well under the <200-line budget)

## Test plan
- [x] `pytest tests/test_inbox_filter.py tests/test_inbox_default_lens.py tests/test_cockpit_inbox_ui.py` (103 passed)
- [x] `pytest -k inbox` (554 passed across inbox + dashboard suites)
- [x] `python -c "from pollypm.cockpit_ui import _InboxListItem; from pollypm.cockpit_inbox_list_item import _InboxListItem as direct; assert _InboxListItem is direct"` (re-export shim verified)

Refs #1354.

Generated with [Claude Code](https://claude.com/claude-code)