### PR TITLE
fix(observability): log 15 silent except sites in supervisor/plugin_host/audit (#1355 wedge)

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -271,6 +271,13 @@ def _central_root() -> Path:
 
         return Path(DEFAULT_CONFIG_PATH).parent / "audit"
     except Exception:  # noqa: BLE001 — never fail audit on config errors
+        # #1355: previously silent. Log so a config-resolution failure
+        # doesn't quietly redirect audit output to the home-dir fallback.
+        logger.warning(
+            "audit.log: DEFAULT_CONFIG_PATH resolution failed; "
+            "falling back to ~/.pollypm/audit",
+            exc_info=True,
+        )
         return Path.home() / ".pollypm" / "audit"
 
 

--- a/src/pollypm/plugin_host.py
+++ b/src/pollypm/plugin_host.py
@@ -762,6 +762,11 @@ class ExtensionHost:
         try:
             from importlib.metadata import entry_points
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "plugin_host: importlib.metadata.entry_points import failed; "
+                "skipping entry-point plugin discovery",
+                exc_info=True,
+            )
             return found
         try:
             eps = entry_points(group="pollypm.plugins")
@@ -770,6 +775,11 @@ class ExtensionHost:
             try:
                 eps = entry_points().get("pollypm.plugins", [])  # type: ignore[assignment]
             except Exception:  # noqa: BLE001
+                logger.warning(
+                    "plugin_host: legacy entry_points() fallback failed; "
+                    "skipping entry-point plugin discovery",
+                    exc_info=True,
+                )
                 return found
         except Exception as exc:  # noqa: BLE001
             self._record_error(

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -543,7 +543,10 @@ class Supervisor:
                 payload={"message": message},
             )
         except Exception:  # noqa: BLE001
-            pass
+            logger.warning(
+                "_record_persona_swap_event: record_event failed for scope=%r",
+                scope, exc_info=True,
+            )
 
     # ── Startable lifecycle (driven by CoreRail.start()/stop()) ────────────
 
@@ -1332,6 +1335,10 @@ class Supervisor:
         try:
             data = json.loads(state_path.read_text())
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "_mounted_window_override: failed to read/parse %s",
+                state_path, exc_info=True,
+            )
             return None
         if not isinstance(data, dict):
             return None
@@ -1346,6 +1353,10 @@ class Supervisor:
         try:
             panes = self.session_service.tmux.list_panes(target)
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "_mounted_window_override: list_panes(%s) failed",
+                target, exc_info=True,
+            )
             return None
         if len(panes) < 2:
             return None
@@ -2379,6 +2390,11 @@ class Supervisor:
                 self.config, self.store, launch.account.name,
             )
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "_maybe_raise_capacity_low: "
+                "account_needs_proactive_rollover failed for %s",
+                launch.account.name, exc_info=True,
+            )
             return
         if not needs_roll:
             self._msg_store.clear_alert(launch.session.name, "capacity_low")
@@ -2534,6 +2550,11 @@ class Supervisor:
             health = self.recovery_policy.classify(signals)
             return self.recovery_policy.select_intervention(health, signals, history)
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "_recovery_policy_select: classify/select_intervention "
+                "failed for session=%s failure_type=%s",
+                launch.session.name, failure_type, exc_info=True,
+            )
             return None
 
     def _maybe_recover_session(self, launch: SessionLaunchSpec, *, failure_type: str, failure_message: str) -> None:
@@ -2719,6 +2740,11 @@ class Supervisor:
                 project_key_from_task_id,
             )
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "_maybe_clear_alert_for_terminal_task: "
+                "alert_task_lookup import failed",
+                exc_info=True,
+            )
             return False
 
         alert_type = str(getattr(alert, "alert_type", "") or "")
@@ -4140,6 +4166,11 @@ class Supervisor:
         try:
             pane = self.session_service.tmux.capture_pane(target, lines=120)
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "_pane_already_bootstrapped_as_other_role: "
+                "capture_pane(%s) failed",
+                target, exc_info=True,
+            )
             return False
         if not pane or "CANONICAL ROLE:" not in pane:
             return False
@@ -4256,7 +4287,13 @@ class Supervisor:
                 },
             )
         except Exception:  # noqa: BLE001
-            pass
+            # #1355: previously silent. Log so a failed audit-trail
+            # record_event doesn't quietly drop the persona-swap signal.
+            logger.warning(
+                "persona_swap_detected event record failed "
+                "(target-window guard): %s",
+                details, exc_info=True,
+            )
         return False
 
     def _assert_session_launch_matches(
@@ -4302,7 +4339,13 @@ class Supervisor:
                     },
                 )
             except Exception:  # noqa: BLE001
-                pass
+                # #1355: previously silent. Log before re-raising so a
+                # failed audit-trail emit doesn't quietly drop the signal.
+                logger.warning(
+                    "persona_swap_detected event record failed "
+                    "(no-launch path): session_name=%r",
+                    session_name, exc_info=True,
+                )
             raise RuntimeError(
                 f"persona_swap_detected: no launch for session_name={session_name!r}"
             ) from exc
@@ -4343,7 +4386,13 @@ class Supervisor:
                     payload={"message": details},
                 )
             except Exception:  # noqa: BLE001
-                pass
+                # #1355: previously silent. Log before re-raising so the
+                # diagnostic record_event failure isn't hidden.
+                logger.warning(
+                    "persona_swap_detected event record failed "
+                    "(session_name mismatch): %s",
+                    details, exc_info=True,
+                )
             raise RuntimeError(f"persona_swap_detected: {details}")
 
     def _assert_target_window_matches_session(
@@ -4389,6 +4438,11 @@ class Supervisor:
         try:
             panes = self.session_service.tmux.list_panes(target)
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "_assert_target_window_matches_session: "
+                "list_panes(%s) failed for session_name=%r",
+                target, session_name, exc_info=True,
+            )
             return
         if not panes:
             return
@@ -4417,7 +4471,13 @@ class Supervisor:
                 },
             )
         except Exception:  # noqa: BLE001
-            pass
+            # #1355: previously silent. Log before re-raising so a
+            # failed audit-trail emit doesn't quietly drop the signal.
+            logger.warning(
+                "persona_swap_detected event record failed "
+                "(prepare-target guard): %s",
+                details, exc_info=True,
+            )
         raise RuntimeError(f"persona_swap_detected: {details}")
 
     def _prepare_initial_input(


### PR DESCRIPTION
## Summary

Eighth wedge for #1355 — replace silent `except Exception: pass`/`return` sites with `logger.warning(..., exc_info=True)` at 15 sites.

Behavior unchanged: same return values, same control flow (raises that followed the swallowed event-record still raise); only adds tracebacks to logs so swallowed failures stop being invisible.

Follow-up to #1613 (9), #1620 (12), #1668 (12), #1686 (13), #1699 (13), #1712 (11), #1723 (10).

## Sites

**supervisor.py (12):**
- `_record_persona_swap_event`: record_event failure -> pass
- `_mounted_window_override`: cockpit_state.json parse failure -> None
- `_mounted_window_override`: list_panes failure -> None
- `_maybe_raise_capacity_low`: account_needs_proactive_rollover failure -> return
- `_recovery_policy_select`: classify/select_intervention failure -> None
- `_maybe_clear_alert_for_terminal_task`: alert_task_lookup import failure -> False
- `_pane_already_bootstrapped_as_other_role`: capture_pane failure -> False
- persona_swap_detected event record (target-window guard) -> pass+return False
- persona_swap_detected event record (no-launch path) -> pass+re-raise
- persona_swap_detected event record (session_name mismatch) -> pass+re-raise
- `_assert_target_window_matches_session`: list_panes failure -> return
- persona_swap_detected event record (prepare-target guard) -> pass+re-raise

**plugin_host.py (2) in `_discover_entry_points`:**
- `importlib.metadata.entry_points` import failure -> returns []
- legacy `entry_points()` fallback failure -> returns []

**audit/log.py (1):**
- `_audit_root`: `DEFAULT_CONFIG_PATH` resolution failure -> fallback to `~/.pollypm/audit`

## Intentionally skipped (per wedge rules)

- `cockpit_apps/operator_dashboard.py` focus()/scroll/list-clear (UI safety)
- `cockpit_apps/dashboard.py` bridge.stop() and scroll guards
- supervisor.py finally-close paths

## Test plan
- [x] `pytest tests/test_supervisor.py tests/test_supervisor_alerts.py tests/test_audit_log.py tests/test_audit_log_docs.py tests/test_plugins.py tests/test_plugin_interop.py tests/test_plugin_validate.py` — 199 pass (2 pre-existing failures on `main` are unrelated to this wedge)
- [x] `ruff check` — 24 errors pre-existed, none added

Generated with [Claude Code](https://claude.com/claude-code)