### PR TITLE
fix(observability): log 15 silent except sites in inbox/dashboard/routing (#1355 wedge)

### DIFF
--- a/src/pollypm/cockpit_inbox_items.py
+++ b/src/pollypm/cockpit_inbox_items.py
@@ -683,6 +683,11 @@ def load_inbox_entries(
         try:
             store = SQLAlchemyStore(f"sqlite:///{db_path}")
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "load_inbox_entries: SQLAlchemyStore(%s) init failed; "
+                "skipping message rows for this source",
+                db_path, exc_info=True,
+            )
             store = None
         if store is not None:
             try:
@@ -693,6 +698,11 @@ def load_inbox_entries(
                         type=["notify", "inbox_task", "alert"],
                     )
                 except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "load_inbox_entries: query_messages on %s failed; "
+                        "treating as empty",
+                        db_path, exc_info=True,
+                    )
                     rows = []
                 for row in rows:
                     if _row_is_dev_channel(row.get("labels")):
@@ -716,11 +726,21 @@ def load_inbox_entries(
         try:
             svc = create_work_service(db_path=db_path, project_path=project_path)
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "load_inbox_entries: create_work_service(%s) failed; "
+                "skipping task rows for project=%s",
+                db_path, project_key, exc_info=True,
+            )
             continue
         try:
             try:
                 project_tasks = inbox_tasks(svc, project=project_key)
             except Exception:  # noqa: BLE001
+                logger.warning(
+                    "load_inbox_entries: inbox_tasks(project=%s) failed; "
+                    "treating as empty",
+                    project_key, exc_info=True,
+                )
                 project_tasks = []
             # N+1 escape: pre-fetch read-markers and replies for every
             # task in this project in one query each, then bucket
@@ -731,10 +751,20 @@ def load_inbox_entries(
                     project=project_for_query, entry_type="read",
                 )
             except Exception:  # noqa: BLE001
+                logger.warning(
+                    "load_inbox_entries: task_numbers_with_context_entry"
+                    "(project=%s) failed; treating as empty read-marker set",
+                    project_for_query, exc_info=True,
+                )
                 read_marker_numbers = set()
             try:
                 replies_by_number = svc.bulk_list_replies(project=project_for_query)
             except Exception:  # noqa: BLE001
+                logger.warning(
+                    "load_inbox_entries: bulk_list_replies(project=%s) failed; "
+                    "treating as empty replies map",
+                    project_for_query, exc_info=True,
+                )
                 replies_by_number = {}
             for task in project_tasks:
                 if task.task_id in seen_task_ids:

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -1,6 +1,7 @@
 """Gather dashboard data from git, issues, snapshots, and state."""
 from __future__ import annotations
 
+import logging
 import re
 import subprocess
 from dataclasses import dataclass, field
@@ -10,6 +11,8 @@ from pathlib import Path
 from pollypm.config import load_config
 from pollypm.config import PollyPMConfig
 from pollypm.storage.state import StateStore
+
+logger = logging.getLogger(__name__)
 
 
 # ANSI CSI/OSC escapes plus C0 control chars that can survive in a
@@ -546,6 +549,10 @@ def _count_inbox_tasks(config: PollyPMConfig) -> int:
         from pollypm.work import create_work_service
         from pollypm.work.inbox_view import inbox_tasks
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "_count_inbox_tasks: failed to import work service helpers",
+            exc_info=True,
+        )
         return 0
     total = 0
     for project_key, project in getattr(config, "projects", {}).items():
@@ -567,6 +574,10 @@ def _count_inbox_tasks(config: PollyPMConfig) -> int:
             ) as svc:
                 total += len(inbox_tasks(svc, project=project_key))
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "_count_inbox_tasks: project=%s db=%s inbox lookup failed",
+                project_key, db_path, exc_info=True,
+            )
             continue
     return total
 
@@ -583,6 +594,11 @@ def _count_dashboard_inbox_items(config: PollyPMConfig) -> int:
         from pollypm.cockpit_inbox import _count_inbox_tasks_for_label
         return int(_count_inbox_tasks_for_label(config) or 0)
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "_count_dashboard_inbox_items: registered-project count failed; "
+            "falling back to tracked-only _count_inbox_tasks",
+            exc_info=True,
+        )
         return _count_inbox_tasks(config)
 
 
@@ -630,6 +646,10 @@ def _recent_inbox_messages(config: PollyPMConfig, *, limit: int = 3) -> list[Inb
         from pollypm.work import create_work_service
         from pollypm.work.inbox_view import inbox_tasks
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "_recent_inbox_messages: failed to import work service helpers",
+            exc_info=True,
+        )
         return []
 
     now = datetime.now(UTC)
@@ -678,6 +698,10 @@ def _recent_inbox_messages(config: PollyPMConfig, *, limit: int = 3) -> list[Inb
                         )
                     )
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "_recent_inbox_messages: project=%s db=%s scan failed",
+                project_key, db_path, exc_info=True,
+            )
             continue
 
     previews.sort(key=lambda item: item.age_seconds)

--- a/src/pollypm/signal_routing.py
+++ b/src/pollypm/signal_routing.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 
 import enum
 import hashlib
+import logging
 import re
 from dataclasses import dataclass, field
 from typing import Iterable, Mapping
@@ -60,6 +61,8 @@ from pollypm.cockpit_alerts import (
     alert_should_toast,
     is_operational_alert,
 )
+
+logger = logging.getLogger(__name__)
 
 
 __all__ = [
@@ -498,10 +501,18 @@ def shared_inbox_count(config: object) -> int:
     try:
         from pollypm.cockpit_inbox import _count_inbox_tasks_for_label
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "shared_inbox_count: failed to import _count_inbox_tasks_for_label",
+            exc_info=True,
+        )
         return 0
     try:
         return _count_inbox_tasks_for_label(config)
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "shared_inbox_count: _count_inbox_tasks_for_label failed",
+            exc_info=True,
+        )
         return 0
 
 

--- a/src/pollypm/task_shipped.py
+++ b/src/pollypm/task_shipped.py
@@ -71,6 +71,10 @@ def _latest_work_output(svc: _TaskShippedSvc, task_id: str) -> Any | None:
     try:
         executions = svc.get_execution(task_id)
     except Exception:  # noqa: BLE001
+        logger.warning(
+            "task_shipped: get_execution(%s) failed; treating as no work_output",
+            task_id, exc_info=True,
+        )
         return None
     for execution in reversed(executions):
         wo = getattr(execution, "work_output", None)
@@ -186,6 +190,10 @@ def emit_task_shipped_card(
         try:
             task = svc.get(task_id)
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "task_shipped: svc.get(%s) failed; skipping shipped card",
+                task_id, exc_info=True,
+            )
             return None
 
         summary = (getattr(work_output, "summary", "") or "").strip()


### PR DESCRIPTION
## Summary

Ninth wedge for #1355 — replace silent `except Exception: pass`/`return` sites with `logger.warning(..., exc_info=True)` at 15 sites. Behavior unchanged: same return values, same control flow; only adds tracebacks so swallowed failures stop being invisible.

Follow-up to #1613, #1620, #1668, #1686, #1699, #1712, #1723, #1728.

Sites covered (15):
- `task_shipped.py` (2): `_latest_work_output` get_execution + `emit_task_shipped_card` svc.get
- `signal_routing.py` (2): `shared_inbox_count` import + invoke
- `dashboard_data.py` (5): `_count_inbox_tasks` (2), `_count_dashboard_inbox_items` fallback, `_recent_inbox_messages` (2)
- `cockpit_inbox_items.py` (6) inside `load_inbox_entries`: SQLAlchemyStore init, query_messages, create_work_service, inbox_tasks, task_numbers_with_context_entry, bulk_list_replies

Adds module-level `logger` to `signal_routing.py` and `dashboard_data.py` (neither had one).

UI safety paths (cockpit_apps/operator_dashboard/dashboard scroll/focus, cockpit_first_shipped modal/timer guards) remain intentionally skipped per the prior wedge rules.

## Test plan

- [x] `uv run pytest tests/test_signal_routing.py tests/test_task_shipped_inbox.py tests/test_dashboard_data_alert_dedup.py tests/test_cockpit_inbox_threads.py tests/test_cockpit_inbox_ui.py` — 164 passed
- [x] `uv run pytest tests/test_polly_dashboard_ui.py tests/test_dashboard_inbox_cache.py tests/test_cockpit_dashboard.py tests/test_cockpit_dashboard_app.py` — 28 passed
- [x] `uv run pytest tests/test_inbox_view.py tests/test_inbox_actions.py tests/test_inbox_show_msg.py tests/test_cli_inbox_backfill.py` — 65 passed
- [x] ruff: no new errors introduced (5 pre-existing E402/F841 unchanged)

[Generated with Claude Code]