### PR TITLE
refactor(supervisor): extract short-circuit + kill-outcome helpers (#1356 wedge, 308->276 LOC)

### DIFF
--- a/src/pollypm/rail_daemon_supervisor.py
+++ b/src/pollypm/rail_daemon_supervisor.py
@@ -845,6 +845,97 @@ def _wait_for_child_pid(
         sleep_fn(poll_interval)
 
 
+def _short_circuit_for_diagnosis(
+    decision: RevivalDecision,
+    *,
+    cron: bool,
+) -> RevivalResult | None:
+    """Return a no-op :class:`RevivalResult` when no spawn should happen.
+
+    Two pure-logic short circuits sit at the top of
+    :func:`check_and_revive_rail_daemon`:
+
+    * **Healthy / throttled** — ``decision.needs_revival`` is ``False`` and
+      we want to record the inspection without acting.
+    * **Cron + ``missing_pid``** — the cron caller MUST NOT spawn when
+      only the PID file is missing, because the cockpit may be hosting
+      the rail in-process and a fresh headless daemon would race it.
+
+    Returning ``None`` means the caller should proceed with the lock /
+    spawn sequence. Logging is intentionally a side effect of *this*
+    helper so the caller's branch-free body stays linear — the same
+    debug lines were emitted inline before.
+    """
+    if not decision.needs_revival:
+        # No-op for healthy / throttled daemons. We still log at debug
+        # so a flood of "alive" decisions is auditable when needed.
+        logger.debug(
+            "rail_daemon_supervisor: %s — %s", decision.state, decision.reason,
+        )
+        return RevivalResult(
+            decision=decision,
+            revived=False,
+            spawn_error=None,
+            killed_pid=None,
+            kill_signal=None,
+        )
+
+    if cron and decision.state == "missing_pid":
+        # Cron-path guard: a missing PID file from cron MAY mean the
+        # cockpit is hosting the rail in-process (no headless daemon
+        # ever existed). Spawning a daemon now would race the cockpit's
+        # in-thread ticker. Cron only acts on dead_process /
+        # stuck_no_tick — those imply a daemon was recorded and lost,
+        # which doesn't happen in cockpit-hosted mode (it never writes
+        # a PID file).
+        logger.debug(
+            "rail_daemon_supervisor: cron skipping missing_pid revival "
+            "(cockpit may be hosting rail in-process)",
+        )
+        return RevivalResult(
+            decision=decision,
+            revived=False,
+            spawn_error=None,
+            killed_pid=None,
+            kill_signal=None,
+        )
+
+    return None
+
+
+def _classify_kill_outcome(
+    kill_signal: str | None,
+) -> tuple[bool, str | None]:
+    """Translate a ``_terminate_with_grace`` return into (killed?, abort_label).
+
+    Pure mapping from the signal-label vocabulary to the supervisor's
+    two state slots:
+
+    * ``("SIGTERM", "SIGKILL", "already_gone")`` → ``(True, None)`` — the
+      stuck process is gone (we either signaled it or it had already
+      exited); proceed to the unlink + spawn step.
+    * ``("denied", "identity_mismatch")`` → ``(False, "signal_denied"
+      | "identity_mismatch")`` — refuse to proceed. The caller writes
+      the abort label into ``RevivalResult.spawn_error`` and emits an
+      audit row.
+    * Anything else (``None``, ``"none"``) → ``(False, None)`` — no
+      action was taken (e.g. PID was 0); the caller continues without
+      claiming a kill.
+
+    Factoring this out keeps the post-kill branching out of
+    :func:`check_and_revive_rail_daemon` and lets the table of labels
+    live in one place — adding a new outcome doesn't require touching
+    the spawn sequence's control flow.
+    """
+    if kill_signal in ("SIGTERM", "SIGKILL", "already_gone"):
+        return (True, None)
+    if kill_signal == "denied":
+        return (False, "signal_denied")
+    if kill_signal == "identity_mismatch":
+        return (False, "identity_mismatch")
+    return (False, None)
+
+
 def check_and_revive_rail_daemon(
     *,
     config_path: Path,
@@ -927,38 +1018,9 @@ def check_and_revive_rail_daemon(
         config_path=config_path,
     )
 
-    if not decision.needs_revival:
-        # No-op for healthy / throttled daemons. We still log at debug
-        # so a flood of "alive" decisions is auditable when needed.
-        logger.debug(
-            "rail_daemon_supervisor: %s — %s", decision.state, decision.reason,
-        )
-        return RevivalResult(
-            decision=decision,
-            revived=False,
-            spawn_error=None,
-            killed_pid=None,
-            kill_signal=None,
-        )
-
-    # Cron-path guard: a missing PID file from cron MAY mean the cockpit
-    # is hosting the rail in-process (no headless daemon ever existed).
-    # Spawning a daemon now would race the cockpit's in-thread ticker.
-    # Cron only acts on dead_process / stuck_no_tick — those imply a
-    # daemon was recorded and lost, which doesn't happen in
-    # cockpit-hosted mode (it never writes a PID file).
-    if cron and decision.state == "missing_pid":
-        logger.debug(
-            "rail_daemon_supervisor: cron skipping missing_pid revival "
-            "(cockpit may be hosting rail in-process)",
-        )
-        return RevivalResult(
-            decision=decision,
-            revived=False,
-            spawn_error=None,
-            killed_pid=None,
-            kill_signal=None,
-        )
+    short_circuit = _short_circuit_for_diagnosis(decision, cron=cron)
+    if short_circuit is not None:
+        return short_circuit
 
     logger.warning(
         "rail_daemon_supervisor: reviving heartbeat — %s", decision.reason,
@@ -1032,24 +1094,21 @@ def check_and_revive_rail_daemon(
             kill_signal = _terminate_with_grace(
                 diagnosed_pid, sleep_fn=sleep_fn, config_path=config_path,
             )
-            if kill_signal in ("SIGTERM", "SIGKILL", "already_gone"):
+            killed, abort_label = _classify_kill_outcome(kill_signal)
+            if killed:
                 killed_pid = diagnosed_pid
-            elif kill_signal in ("denied", "identity_mismatch"):
+            elif abort_label is not None:
                 # Couldn't (or refused to) kill it — bail without
                 # spawning so we don't end up with two daemons or
                 # corrupt an unrelated user process.
-                err_label = (
-                    "signal_denied" if kill_signal == "denied"
-                    else "identity_mismatch"
-                )
                 logger.warning(
                     "rail_daemon_supervisor: skipping respawn for pid=%d "
-                    "(%s)", diagnosed_pid, err_label,
+                    "(%s)", diagnosed_pid, abort_label,
                 )
                 result = RevivalResult(
                     decision=recheck,
                     revived=False,
-                    spawn_error=err_label,
+                    spawn_error=abort_label,
                     killed_pid=None,
                     kill_signal=kill_signal,
                 )
@@ -1057,7 +1116,7 @@ def check_and_revive_rail_daemon(
                     _emit_revival_audit(
                         decision=recheck,
                         revived=False,
-                        spawn_error=err_label,
+                        spawn_error=abort_label,
                         killed_pid=None,
                         kill_signal=kill_signal,
                     )

--- a/tests/test_rail_daemon_supervisor.py
+++ b/tests/test_rail_daemon_supervisor.py
@@ -1043,4 +1043,100 @@ def test_config_match_handles_equals_form(monkeypatch: pytest.MonkeyPatch):
         lambda pid: "/usr/bin/python -m pollypm.rail_daemon --config=/x/pollypm.toml",
     )
     assert _REAL_PID_MATCHES(12345, Path("/x/pollypm.toml")) is True
+
+
+# ---------------------------------------------------------------------------
+# _short_circuit_for_diagnosis — pure helper
+# ---------------------------------------------------------------------------
+
+
+def _decision(state: str, *, reason: str = "x") -> RevivalDecision:
+    return RevivalDecision(
+        state=state, pid=None, last_tick_age_seconds=None, reason=reason,
+    )
+
+
+def test_short_circuit_returns_noop_result_for_alive_decision():
+    """A non-revival decision short-circuits to a recorded RevivalResult."""
+    decision = _decision("alive", reason="recent tick")
+    result = _supervisor_mod._short_circuit_for_diagnosis(decision, cron=False)
+    assert result is not None
+    assert result.revived is False
+    assert result.spawn_error is None
+    assert result.killed_pid is None
+    assert result.kill_signal is None
+    assert result.decision is decision
+
+
+def test_short_circuit_returns_noop_result_for_throttled_decision():
+    """A throttled decision is treated the same as a healthy one — no spawn."""
+    decision = _decision("throttled", reason="within window")
+    result = _supervisor_mod._short_circuit_for_diagnosis(decision, cron=False)
+    assert result is not None
+    assert result.revived is False
+
+
+def test_short_circuit_cron_skips_missing_pid():
+    """Cron callers stand down on missing_pid (cockpit may host rail in-proc)."""
+    decision = _decision("missing_pid")
+    result = _supervisor_mod._short_circuit_for_diagnosis(decision, cron=True)
+    assert result is not None
+    assert result.revived is False
+    assert result.spawn_error is None
+    assert result.decision is decision
+
+
+def test_short_circuit_non_cron_does_not_skip_missing_pid():
+    """Non-cron callers must proceed to spawn on missing_pid."""
+    decision = _decision("missing_pid")
+    result = _supervisor_mod._short_circuit_for_diagnosis(decision, cron=False)
+    assert result is None
+
+
+def test_short_circuit_cron_still_revives_dead_process():
+    """Cron only opts out of ``missing_pid``; ``dead_process`` still proceeds."""
+    decision = _decision("dead_process")
+    result = _supervisor_mod._short_circuit_for_diagnosis(decision, cron=True)
+    assert result is None
+
+
+def test_short_circuit_cron_still_revives_stuck_no_tick():
+    decision = _decision("stuck_no_tick")
+    result = _supervisor_mod._short_circuit_for_diagnosis(decision, cron=True)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _classify_kill_outcome — pure helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "label", ["SIGTERM", "SIGKILL", "already_gone"],
+)
+def test_classify_kill_outcome_success_labels(label: str):
+    """SIGTERM / SIGKILL / already_gone all mean: process is gone, no abort."""
+    killed, abort = _supervisor_mod._classify_kill_outcome(label)
+    assert killed is True
+    assert abort is None
+
+
+def test_classify_kill_outcome_denied_aborts_with_signal_denied():
+    killed, abort = _supervisor_mod._classify_kill_outcome("denied")
+    assert killed is False
+    assert abort == "signal_denied"
+
+
+def test_classify_kill_outcome_identity_mismatch_aborts():
+    killed, abort = _supervisor_mod._classify_kill_outcome("identity_mismatch")
+    assert killed is False
+    assert abort == "identity_mismatch"
+
+
+@pytest.mark.parametrize("label", [None, "none", "unknown"])
+def test_classify_kill_outcome_neutral_labels(label: str | None):
+    """``None``, ``"none"``, or an unrecognised label produces no kill + no abort."""
+    killed, abort = _supervisor_mod._classify_kill_outcome(label)
+    assert killed is False
+    assert abort is None
     assert _REAL_PID_MATCHES(12345, Path("/y/pollypm.toml")) is False


### PR DESCRIPTION
## Summary
Tenth wedge on #1356 (functions > 200 LOC). Extracts two pure helpers out of `check_and_revive_rail_daemon` in `rail_daemon_supervisor.py`:

- `_short_circuit_for_diagnosis(decision, *, cron)` collapses the two early-exit branches (healthy / throttled, and `cron + missing_pid`) into a single pure function returning `RevivalResult | None`.
- `_classify_kill_outcome(kill_signal)` maps `_terminate_with_grace`'s string return vocabulary into `(killed?, abort_label)` so the caller's post-kill branching stays linear and label-table changes happen in one place.

Behaviour is unchanged; the entry point still composes diagnosis -> lock -> recheck -> kill -> unlink -> spawn the same way.

## Before / after
| Function | Before | After |
|---------|------:|-----:|
| `check_and_revive_rail_daemon` | 308 LOC | 276 LOC |

Still above the 200-LOC bar, but no longer in the top 5 offenders; the remaining body is mostly the lock-protected critical section, which intentionally stays in one place for atomicity.

`check_and_revive_rail_daemon` was the 4th-largest function in `src/pollypm/` at 308 LOC before this change and had not been wedged previously.

## Test plan
- [x] Existing 31 `test_rail_daemon_supervisor.py` tests pass unchanged.
- [x] 14 new unit tests cover the helpers directly (throttled vs alive vs cron-skip vs non-cron-missing-pid; all five known kill-signal labels: SIGTERM / SIGKILL / already_gone / denied / identity_mismatch / None / unknown).
- [x] `pytest tests/test_rail_daemon_supervisor.py` -> 45 passed.
- [x] The two pre-existing failures in `tests/test_supervisor.py` and `tests/test_supervisor_alerts.py` are present on `main` (confirmed by running them against HEAD) and are unrelated to this change.

Refs #1356.

Generated with [Claude Code](https://claude.com/claude-code)