### PR TITLE
refactor(cockpit): extract route-control hooks into sibling module (#1354)

### DIFF
--- a/src/pollypm/cockpit_route_controls.py
+++ b/src/pollypm/cockpit_route_controls.py
@@ -1,0 +1,59 @@
+"""Navigation route controls used by the cockpit rail.
+
+Contract:
+- Inputs: a ``NavigationCommand`` (rail click / keypress key) consumed by
+  ``NavigationController``. ``_CockpitRouteWindowApplier`` also takes the
+  owning ``PollyCockpitApp`` instance at construction so its ``apply``
+  method can defer to ``_route_selected_with_deadline``.
+- Outputs: ``_CockpitRouteContentResolver.resolve`` returns a
+  ``NavigationContent`` wrapping the rail key — the router still owns
+  full content resolution during this integration step, so the resolver
+  is intentionally a thin pass-through. ``_CockpitRouteWindowApplier.apply``
+  returns whatever string ``_route_selected_with_deadline`` produces
+  (the resolved route key after the deadline check fires).
+- Side effects: ``_CockpitRouteWindowApplier.apply`` delegates to the
+  owning app, so any side effect comes from there (window swap,
+  acknowledgement bookkeeping, etc.). Neither class touches global state.
+- Invariants: this module owns the two thin route-control hooks the
+  navigation controller binds to, and nothing else. Construction lives
+  in ``cockpit_ui`` (so the bound app reference stays out of import-cycle
+  territory).
+- Allowed dependencies: ``NavigationCommand`` / ``NavigationContent``
+  from ``pollypm.cockpit_navigation``; ``PollyCockpitApp`` is referenced
+  only as a forward string for typing.
+- Private: both classes are underscore-prefixed and re-exported via
+  ``cockpit_ui`` for back-compat (see #1354).
+
+Wedge of the cockpit_ui.py god-module split tracked by #1354.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pollypm.cockpit_navigation import NavigationCommand, NavigationContent
+
+if TYPE_CHECKING:
+    from pollypm.cockpit_ui import PollyCockpitApp
+
+
+class _CockpitRouteContentResolver:
+    """Navigation resolver for the root cockpit rail.
+
+    The router still owns full content resolution during this integration
+    step; the navigation controller owns acknowledgement/cancellation state.
+    """
+
+    def resolve(self, request: NavigationCommand) -> NavigationContent:
+        return NavigationContent(request.key)
+
+
+class _CockpitRouteWindowApplier:
+    def __init__(self, app: "PollyCockpitApp") -> None:
+        self._app = app
+
+    def apply(self, request: NavigationCommand, _content: object) -> str:
+        return self._app._route_selected_with_deadline(request.key)
+
+
+__all__ = ["_CockpitRouteContentResolver", "_CockpitRouteWindowApplier"]

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -120,6 +120,10 @@ from pollypm.cockpit_rail_listview import (  # noqa: F401  (re-exported)
 from pollypm.cockpit_rail_item import (  # noqa: F401  (re-exported)
     RailItem,
 )
+from pollypm.cockpit_route_controls import (  # noqa: F401  (re-exported)
+    _CockpitRouteContentResolver,
+    _CockpitRouteWindowApplier,
+)
 from pollypm.cockpit_live_chat_notice import (
     LIVE_CHAT_NETWORK_DEAD_TMUX_MESSAGE,
     clear_live_chat_network_dead_notice,
@@ -215,25 +219,6 @@ _PLAN_REVIEW_UNAVAILABLE_HINT_RE = _re.compile(
     _re.IGNORECASE,
 )
 _PLAN_REVIEW_DISCUSSION_ENTRY_TYPE = "plan_review_discussed"
-
-
-class _CockpitRouteContentResolver:
-    """Navigation resolver for the root cockpit rail.
-
-    The router still owns full content resolution during this integration
-    step; the navigation controller owns acknowledgement/cancellation state.
-    """
-
-    def resolve(self, request: NavigationCommand) -> NavigationContent:
-        return NavigationContent(request.key)
-
-
-class _CockpitRouteWindowApplier:
-    def __init__(self, app: "PollyCockpitApp") -> None:
-        self._app = app
-
-    def apply(self, request: NavigationCommand, _content: object) -> str:
-        return self._app._route_selected_with_deadline(request.key)
 
 
 def _md_to_rich(text: str) -> str:


### PR DESCRIPTION
## Summary
Eleventh wedge of the `cockpit_ui.py` god-module split tracked by #1354 — picked per #1732's follow-up note (largest remaining clean self-contained slice; remaining queued candidates are App classes that need staged extraction of owned helpers).

- Extracts the two thin navigation route-control classes — `_CockpitRouteContentResolver` (the pass-through resolver) and `_CockpitRouteWindowApplier` (the `_route_selected_with_deadline` delegator) — into a new sibling module `src/pollypm/cockpit_route_controls.py` with a re-export shim left in `cockpit_ui.py`.
- `_CockpitRouteWindowApplier` keeps its `PollyCockpitApp` parameter as a forward-string annotation (resolved under `TYPE_CHECKING`) so the new module imports cleanly without an import cycle.
- Both classes are constructed inside `PollyCockpitApp` (`cockpit_ui.py` lines 808/809 and 2683/2684) so internal usages keep resolving via the shim.
- `cockpit_ui.py`: 18,303 -> 18,288 LOC (-15).
- Diff in `cockpit_ui.py`: 4 inserts / 19 deletes.

## Test plan
- [x] `pytest tests/test_cockpit.py` — 196 passed.
- [x] `pytest tests/test_cockpit_navigation.py tests/test_cockpit_rail_alert_wrap.py` — 8 passed.
- [x] `from pollypm.cockpit_ui import _CockpitRouteContentResolver, _CockpitRouteWindowApplier` resolves to the new sibling module (`__module__` reports `pollypm.cockpit_route_controls`).
- [x] Smoke: `_CockpitRouteContentResolver().resolve(NavigationCommand(1, "inbox"))` returns `NavigationContent("inbox")`; `_CockpitRouteWindowApplier(stub).apply(...)` delegates to `stub._route_selected_with_deadline`.

Closes part of #1354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)