### PR TITLE
fix(observability): log 7 silent except sites (#1355 wedge)

### DIFF
--- a/src/pollypm/approval_notifications.py
+++ b/src/pollypm/approval_notifications.py
@@ -19,11 +19,14 @@ in without core taking a hard dependency on the optional plugin tree.
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Callable, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from pollypm.work.models import Task
+
+logger = logging.getLogger(__name__)
 
 
 NotifyCallback = Callable[..., None]
@@ -83,6 +86,14 @@ def _resolve_default_os_adapter() -> OsApprovalNotifier | None:
     try:
         return factory()
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. A broken factory disables OS banners
+        # for every approval — log so the plugin owner can spot the
+        # regression without grepping for missing toasts.
+        logger.warning(
+            "approval_notifications: default OS adapter factory raised; "
+            "OS banners disabled for this approval",
+            exc_info=True,
+        )
         return None
 
 
@@ -124,6 +135,15 @@ def notify_task_approved(
     try:
         available = adapter.is_available()
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. Treat adapter probe failures as
+        # unavailable but log — a flaky is_available masks every
+        # subsequent banner without trace.
+        logger.warning(
+            "approval_notifications: OS adapter is_available() raised for %s; "
+            "treating as unavailable",
+            getattr(adapter, "__class__", type(adapter)).__name__,
+            exc_info=True,
+        )
         available = False
     if available:
         adapter.notify(

--- a/src/pollypm/cockpit_first_shipped.py
+++ b/src/pollypm/cockpit_first_shipped.py
@@ -20,6 +20,7 @@ Wedge of the cockpit_ui.py god-module split tracked by #1354.
 
 from __future__ import annotations
 
+import logging
 import os
 
 from textual.app import ComposeResult
@@ -27,6 +28,8 @@ from textual.binding import Binding
 from textual.containers import Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Static
+
+logger = logging.getLogger(__name__)
 
 
 _FIRST_SHIPPED_FRAMES = (
@@ -82,11 +85,24 @@ class _FirstShippedCelebrationModal(ModalScreen[None]):
         try:
             self.set_interval(0.16, self._advance_frame)
         except Exception:  # noqa: BLE001
-            pass
+            # #1355: previously silent. If the confetti animation timer
+            # cannot be installed, log so a static modal doesn't quietly
+            # mask a Textual harness regression.
+            logger.warning(
+                "cockpit_first_shipped: set_interval(_advance_frame) failed; "
+                "modal will not animate",
+                exc_info=True,
+            )
         try:
             self.set_timer(2.0, self.dismiss)
         except Exception:  # noqa: BLE001
-            pass
+            # #1355: previously silent. A failed auto-dismiss timer leaves
+            # the modal sticky — surface so we can spot the harness gap.
+            logger.warning(
+                "cockpit_first_shipped: set_timer(dismiss) failed; "
+                "modal will not auto-dismiss",
+                exc_info=True,
+            )
 
     def _advance_frame(self) -> None:
         self._frame_index = (self._frame_index + 1) % len(_FIRST_SHIPPED_FRAMES)
@@ -95,7 +111,14 @@ class _FirstShippedCelebrationModal(ModalScreen[None]):
                 _FIRST_SHIPPED_FRAMES[self._frame_index],
             )
         except Exception:  # noqa: BLE001
-            pass
+            # #1355: previously silent. A missing confetti node would
+            # otherwise let the animation tick fail every 0.16s without
+            # any signal — log at debug so we still notice in -v runs
+            # but don't spam the operator's normal log on every frame.
+            logger.debug(
+                "cockpit_first_shipped: _advance_frame query_one miss",
+                exc_info=True,
+            )
 
 
 def _celebrate_first_shipped(app) -> None:
@@ -106,7 +129,14 @@ def _celebrate_first_shipped(app) -> None:
     try:
         app.push_screen(_FirstShippedCelebrationModal())
     except Exception:  # noqa: BLE001
-        pass
+        # #1355: previously silent. The toast already fired; log here
+        # so a push_screen regression (e.g. no screen stack on the
+        # smoke harness) doesn't quietly disable the confetti modal.
+        logger.warning(
+            "cockpit_first_shipped: push_screen(_FirstShippedCelebrationModal) "
+            "failed; toast fired but modal skipped",
+            exc_info=True,
+        )
 
 
 __all__ = [

--- a/src/pollypm/supervisor_alerts.py
+++ b/src/pollypm/supervisor_alerts.py
@@ -189,6 +189,15 @@ def _review_tasks_for_project(
                 else:
                     entries.append(f"  - {task.task_id}: {task.title}")
     except Exception:  # noqa: BLE001
+        # #1355: previously silent. A swallowed query here makes the
+        # review nudge skip the project entirely — surface so a broken
+        # DB read doesn't mask review backlog accumulation.
+        _logger.warning(
+            "supervisor_alerts: review-task query failed for %s; "
+            "skipping project in nudge",
+            project_key,
+            exc_info=True,
+        )
         return [], 0
 
     _REVIEW_NUDGE_CACHE[project_key] = (db_mtime, entries, re_review_count)
@@ -591,5 +600,13 @@ def _build_task_nudge(supervisor: SupervisorAlertBoundary, launch: SessionLaunch
                 f"is queued for your project. "
                 "Open Tasks to review the queue; Polly will claim it when worker capacity is available."
             )
-    except Exception:
+    except Exception:  # noqa: BLE001
+        # #1355: previously silent. A failed work-DB resolve / svc.next
+        # quietly disables the task nudge for the project — surface so
+        # a regression doesn't leave queued work invisible.
+        _logger.warning(
+            "supervisor_alerts: task nudge build failed for %s; skipping",
+            launch.session.project,
+            exc_info=True,
+        )
         return None


### PR DESCRIPTION
## Summary
Wedge #10 of #1355. Converts 7 previously silent `except Exception: pass` / `except: return None` sites to `logger.warning(..., exc_info=True)` so failures leave a trace.

- `approval_notifications.py` (2 sites + new module logger): OS adapter factory failure, `is_available()` probe failure.
- `cockpit_first_shipped.py` (4 sites + new module logger): modal `set_interval` / `set_timer` failures, `_advance_frame` query miss (debug-level to avoid per-frame spam), `push_screen` failure.
- `supervisor_alerts.py` (2 sites): review-task query swallow (`_review_tasks_for_project`), task-nudge build swallow (`_build_task_nudge`).

Skips cleanup paths and `error_notifications` (re-entry guard there exists because logging inside the critical-error handler would recurse).

## Test plan
- [x] `python -m py_compile` on all three files
- [x] `ruff check` clean on edited files
- [x] `pytest tests/test_supervisor_alerts.py tests/test_cockpit_first_shipped.py tests/test_approval_notifications.py` — 29 pass; one pre-existing failure (`test_supervisor_alert_helper_updates_and_nudges`) reproduces on `main` and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)