### PR TITLE
fix(#1367): break service_notifications <-> sqlite_service cycle

### DIFF
--- a/src/pollypm/work/_safe_json.py
+++ b/src/pollypm/work/_safe_json.py
@@ -1,0 +1,65 @@
+"""Defensive JSON-column decode helpers for the work database.
+
+Contract:
+- Inputs: raw values read from SQLite JSON columns (typically ``str``
+  payloads serialised by producers, but defensively any object).
+- Outputs: a guaranteed-dict (`_safe_json_dict`) or guaranteed-list
+  (`_safe_json_list`) result, with corrupt / wrong-shape payloads
+  coerced to the appropriate empty container.
+- Side effects: none — pure decoders.
+- Invariants: never raises on malformed input. Producers always write
+  the expected shape, but a hand-edited or legacy DB row could land an
+  empty string, ``null``, scalar, or wrong container; downstream
+  callers do ``parsed.get(...)`` / ``for x in parsed`` and would crash
+  on those shapes. These helpers degrade a single corrupt row
+  gracefully rather than propagating the crash out of the caller's
+  loop.
+
+Leaf module: this file deliberately has no internal imports beyond
+``json`` so it can be imported from any work-service submodule
+(including ``sqlite_service`` and the boundary-owned ``service_*``
+helpers) without forming an import cycle (#1367 wedge).
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def _safe_json_dict(raw: object) -> dict:
+    """Decode a JSON column expected to be a dict, defensively.
+
+    Producers always serialise dicts (``json.dumps(template.roles)`` etc.),
+    but a hand-edited or legacy DB row could land an empty string,
+    null, list, or scalar. Downstream callers do ``parsed.get(...)``
+    and would AttributeError on those shapes — propagating the crash
+    out of the caller's loop. Coerce non-dict shapes to ``{}`` so a
+    single corrupt row degrades gracefully.
+
+    Mirrors the ``_safe_payload`` / ``_safe_tags`` helpers in
+    ``pollypm.storage.state`` (cycles 107-109 corrupt-payload defenses).
+    """
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _safe_json_list(raw: object) -> list:
+    """Decode a JSON column expected to be a list, defensively.
+
+    Companion to ``_safe_json_dict`` for ``labels`` / ``relevant_files``
+    / ``gates`` columns. Coerces non-list shapes (dict/string/null/int)
+    back to ``[]`` so consumers iterating the result don't iterate the
+    wrong thing (e.g. a string would yield characters).
+    """
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return []
+    return parsed if isinstance(parsed, list) else []

--- a/src/pollypm/work/service_notifications.py
+++ b/src/pollypm/work/service_notifications.py
@@ -1,13 +1,27 @@
 """Notification staging ownership for the SQLite work service.
 
 Contract:
-- Inputs: a ``SQLiteWorkService`` plus typed notification metadata.
+- Inputs: a work-service collaborator (see :class:`_WorkService` below)
+  plus typed notification metadata.
 - Outputs: staged notification ids, typed digest candidates, and prune
   summaries.
 - Side effects: writes the legacy ``notification_staging`` table and
   closes staged rows in the unified ``messages`` table.
 - Invariants: callers never need ``svc._conn`` or ad-hoc DB URL
   reconstruction to manage staged digest state.
+
+The helpers in this module are parameterised over a structural
+:class:`typing.Protocol` rather than the concrete
+``pollypm.work.sqlite_service.SQLiteWorkService`` class. This breaks
+the import cycle flagged in #1367 (the service top-imports this module,
+so a reverse type-annotation import — even guarded with
+``TYPE_CHECKING`` — registers as a cycle in the AST boundary scan).
+The corrupt-payload-defense helper ``_safe_json_dict`` previously
+imported lazily from ``sqlite_service`` now lives in the leaf
+``pollypm.work._safe_json`` module, so the top-level dependency edge
+can be removed entirely. ``SQLiteWorkService`` satisfies
+:class:`_WorkService` structurally; no runtime registration or subclass
+change is required.
 """
 
 from __future__ import annotations
@@ -15,14 +29,32 @@ from __future__ import annotations
 import json
 import sqlite3
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any, Protocol
 
 from pollypm.store import SQLAlchemyStore
 from pollypm.store.registry import get_store_by_url
+from pollypm.work._safe_json import _safe_json_dict
 from pollypm.work.models import DigestRollupCandidate
 
-if TYPE_CHECKING:
-    from pollypm.work.sqlite_service import SQLiteWorkService
+
+class _WorkService(Protocol):
+    """Structural view of the SQLite work service used by notification helpers.
+
+    Captures the exact slice these helpers reach into so the
+    ``service_notifications <-> sqlite_service`` cycle can be broken
+    without pulling the full concrete class into this module's type
+    graph (#1367 wedge).
+
+    - ``_conn`` — every helper drives ``execute``/``commit`` against
+      the work-DB connection.
+    - ``_db_path`` — ``_message_store`` reconstructs the ``sqlite:///``
+      URL to fetch the SQLAlchemy store for the unified ``messages``
+      table.
+    """
+
+    _conn: sqlite3.Connection
+    _db_path: Path
 
 
 def _ensure_staging_table(conn: sqlite3.Connection) -> None:
@@ -49,12 +81,12 @@ def _ensure_staging_table(conn: sqlite3.Connection) -> None:
     )
 
 
-def _message_store(service: "SQLiteWorkService") -> SQLAlchemyStore:
+def _message_store(service: _WorkService) -> SQLAlchemyStore:
     return get_store_by_url(f"sqlite:///{service._db_path}")  # type: ignore[return-value]
 
 
 def stage_notification_row(
-    service: "SQLiteWorkService",
+    service: _WorkService,
     *,
     project: str,
     subject: str,
@@ -94,7 +126,7 @@ def stage_notification_row(
 
 
 def list_digest_rollup_candidates(
-    service: "SQLiteWorkService",
+    service: _WorkService,
     *,
     project: str,
     milestone_key: str | None,
@@ -117,7 +149,6 @@ def list_digest_rollup_candidates(
             (project, milestone_key),
         ).fetchall()
 
-    from pollypm.work.sqlite_service import _safe_json_dict
     merged = [
         DigestRollupCandidate(
             source="legacy",
@@ -170,7 +201,7 @@ def list_digest_rollup_candidates(
 
 
 def mark_rollup_candidates_flushed(
-    service: "SQLiteWorkService",
+    service: _WorkService,
     candidates: list[DigestRollupCandidate],
     *,
     rollup_task_id: str,
@@ -198,7 +229,7 @@ def mark_rollup_candidates_flushed(
 
 
 def has_old_pending_digest_rows(
-    service: "SQLiteWorkService",
+    service: _WorkService,
     *,
     project: str,
     milestone_key: str | None,
@@ -224,7 +255,7 @@ def has_old_pending_digest_rows(
 
 
 def find_flushed_rollup_milestone(
-    service: "SQLiteWorkService",
+    service: _WorkService,
     *,
     task_id: str,
 ) -> str | None:
@@ -244,7 +275,7 @@ def find_flushed_rollup_milestone(
 
 
 def prune_staged_notifications(
-    service: "SQLiteWorkService",
+    service: _WorkService,
     *,
     retain_days: int = 30,
 ) -> dict[str, int]:

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -178,7 +178,8 @@ def _row_get(row: object, column: str, default: object = None) -> object:
     inserts via legacy column lists — doesn't ``IndexError`` here.
     Production DBs always carry the column post-``create_work_tables``,
     but the helper preserves the corrupt-payload-defense pattern used
-    by ``_safe_json_dict`` / ``_safe_json_list`` below.
+    by ``_safe_json_dict`` / ``_safe_json_list`` (re-exported below
+    from ``pollypm.work._safe_json``).
     """
     try:
         keys = row.keys()
@@ -193,43 +194,14 @@ def _row_get(row: object, column: str, default: object = None) -> object:
     return default
 
 
-def _safe_json_dict(raw: object) -> dict:
-    """Decode a JSON column expected to be a dict, defensively.
-
-    Producers always serialise dicts (``json.dumps(template.roles)`` etc.),
-    but a hand-edited or legacy DB row could land an empty string,
-    null, list, or scalar. Downstream callers do ``parsed.get(...)``
-    and would AttributeError on those shapes — propagating the crash
-    out of the caller's loop. Coerce non-dict shapes to ``{}`` so a
-    single corrupt row degrades gracefully.
-
-    Mirrors the ``_safe_payload`` / ``_safe_tags`` helpers in
-    ``pollypm.storage.state`` (cycles 107-109 corrupt-payload defenses).
-    """
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except (TypeError, ValueError):
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
-
-
-def _safe_json_list(raw: object) -> list:
-    """Decode a JSON column expected to be a list, defensively.
-
-    Companion to ``_safe_json_dict`` for ``labels`` / ``relevant_files``
-    / ``gates`` columns. Coerces non-list shapes (dict/string/null/int)
-    back to ``[]`` so consumers iterating the result don't iterate the
-    wrong thing (e.g. a string would yield characters).
-    """
-    if not raw:
-        return []
-    try:
-        parsed = json.loads(raw)
-    except (TypeError, ValueError):
-        return []
-    return parsed if isinstance(parsed, list) else []
+# ``_safe_json_dict`` / ``_safe_json_list`` were defined inline here
+# through cycle 113 but were lazily imported by ``service_notifications``
+# / ``service_queries`` (both top-imported by this module), forming a
+# cycle that #1367 is wedging out. The helpers now live in the leaf
+# ``pollypm.work._safe_json`` module — re-exported here under the same
+# private names so existing references (``_safe_json_dict(row[...])``
+# below, plus any external callers) keep working unchanged.
+from pollypm.work._safe_json import _safe_json_dict, _safe_json_list  # noqa: E402
 
 
 _POLLYPM_GENERATED_DOC_FILES = frozenset({


### PR DESCRIPTION
## Summary

Twelfth wedge for #1367. Breaks the `work.service_notifications` <-> `work.sqlite_service` 2-cycle.

Two-part fix per #1729's wedge note:

- New leaf `pollypm.work._safe_json` module holds `_safe_json_dict` / `_safe_json_list` (only imports `json`). `sqlite_service` re-exports both names so external callers and the seven in-file sites keep working unchanged.
- `service_notifications` defines a structural `_WorkService` `Protocol` (`_conn`, `_db_path`) and drops both the `TYPE_CHECKING` import and the lazy runtime `from pollypm.work.sqlite_service import _safe_json_dict` inside `list_digest_rollup_candidates`.

`SQLiteWorkService` satisfies `_WorkService` structurally; no runtime registration or subclass change required.

## Test plan

- [x] AST scan: `service_notifications` has no Import/ImportFrom edge to `sqlite_service` at any nesting level
- [x] `tests/test_work_service.py` - 70/70 pass
- [x] `tests/` -k "notification or digest or rollup" - 121/121 pass
- [x] `tests/test_next_task_corrupt_roles.py` - 4/4 pass (corrupt-row defenses for `labels`/`relevant_files`/`roles`/`external_refs` after the move)
- [x] `tests/test_import_boundary.py` - 15/16 pass (the 1 failure is the pre-existing tier4 Supervisor-allowlist issue, unrelated)
- [x] Re-export identity check: `sqlite_service._safe_json_dict is _safe_json._safe_json_dict`
- [x] End-to-end smoke: `stage_notification_row` -> `list_digest_rollup_candidates` -> `has_old_pending_digest_rows` -> `prune_staged_notifications` round-trip on a real on-disk service through the Protocol-typed facade
- [x] `ruff check` on touched files clean; `sqlite_service.py` E402 count unchanged (15 -> 15, all pre-existing)

## Remaining work

`service_queries` is the last `work.service_* <-> sqlite_service` pair. It also has the same lazy `_safe_json_dict` import and can now consume the new leaf module the same way.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>