### PR TITLE
feat(storage): pg + pgvector foundation — Slice A of #1737

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,19 @@ dev = [
   "openapi-spec-validator>=0.7.0",
   "pytest>=8.4.0",
   "ruff>=0.15.12",
+  # Postgres + pgvector migration tests (#1737, Slice A). The pg
+  # driver itself is a runtime extra so sqlite installs stay slim;
+  # dev installs always pull both so `pytest tests/test_pg_*` runs.
+  "psycopg[binary]>=3.2.0",
+  "psycopg-pool>=3.2.0",
+  "testcontainers[postgres]>=4.8.0",
+]
+# Runtime extra for the postgres backend. Operators flipping
+# ``[storage] backend = "postgres"`` in pollypm.toml must
+# ``uv pip install 'pollypm[postgres]'`` (#1737).
+postgres = [
+  "psycopg[binary]>=3.2.0",
+  "psycopg-pool>=3.2.0",
 ]
 
 [project.scripts]

--- a/src/pollypm/cli_features/maintenance.py
+++ b/src/pollypm/cli_features/maintenance.py
@@ -1060,6 +1060,37 @@ def restore_cmd(
     typer.echo("  pm up                  # relaunch the cockpit")
     typer.echo("  pm doctor              # verify the restored state")
 
+def doctor_pg_connection(
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of the human result.",
+    ),
+) -> None:
+    """Probe the Postgres backend in isolation (issue #1737).
+
+    Equivalent to running only the ``pg-connection`` doctor check.
+    Useful during the migration runbook ("did pg come up?") and as a
+    smoke test after flipping ``[storage] backend = "postgres"``.
+    Exits 0 on pass, 1 on fail. Skipped on sqlite installs exits 0
+    with an informational status line.
+    """
+    from pollypm.doctor import (
+        Check,
+        check_pg_connection,
+        render_human,
+        render_json,
+        run_checks,
+    )
+
+    report = run_checks([Check("pg-connection", check_pg_connection, "install")])
+    if json_output:
+        typer.echo(render_json(report))
+    else:
+        typer.echo(render_human(report))
+    raise typer.Exit(code=0 if report.ok else 1)
+
+
 def register_maintenance_commands(app: typer.Typer) -> None:
     app.command(
         help=help_with_examples(
@@ -1071,6 +1102,15 @@ def register_maintenance_commands(app: typer.Typer) -> None:
             ],
         )
     )(doctor)
+
+    app.command(
+        "doctor-pg-connection",
+        help=(
+            "Probe just the Postgres backend (pg reachable, version "
+            ">= configured min, vector extension present). Skipped "
+            "when [storage] backend is sqlite."
+        ),
+    )(doctor_pg_connection)
 
     app.command(
         help=(

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -7,11 +7,13 @@ from pathlib import Path
 
 from pollypm.models import (
     AccountConfig,
+    EmbeddingSettings,
     EventsRetentionSettings,
     LoggingSettings,
     MemorySettings,
     ModelAssignment,
     KnownProject,
+    PgStorageSettings,
     PlannerSettings,
     PluginSettings,
     ProjectKind,
@@ -580,9 +582,62 @@ def _parse_storage_settings(
         # resolver downstream uses this URL verbatim, so emit an absolute
         # path that survives chdir.
         url_stripped = f"sqlite:///{project.state_db.resolve()}"
+
+    # ``[storage.pg]`` subsection (issue #1737, Slice A). Missing /
+    # malformed → dataclass defaults; fat-fingered types fall through
+    # individually so one bad knob doesn't void the whole block.
+    pg_defaults = PgStorageSettings()
+    pg_raw = storage_raw.get("pg", {})
+    if not isinstance(pg_raw, dict):
+        pg_raw = {}
+    pool_min_raw = pg_raw.get("pool_min", pg_defaults.pool_min)
+    pool_max_raw = pg_raw.get("pool_max", pg_defaults.pool_max)
+    try:
+        pool_min = max(1, int(pool_min_raw))
+    except (TypeError, ValueError):
+        pool_min = pg_defaults.pool_min
+    try:
+        pool_max = max(pool_min, int(pool_max_raw))
+    except (TypeError, ValueError):
+        pool_max = pg_defaults.pool_max
+    min_version_raw = pg_raw.get("min_version", pg_defaults.min_version)
+    if not isinstance(min_version_raw, str) or not min_version_raw.strip():
+        min_version_raw = pg_defaults.min_version
+    dsn_raw = pg_raw.get("dsn", "")
+    if not isinstance(dsn_raw, str):
+        dsn_raw = ""
+    pg_settings = PgStorageSettings(
+        pool_min=pool_min,
+        pool_max=pool_max,
+        min_version=min_version_raw.strip(),
+        dsn=dsn_raw.strip(),
+    )
+
+    # ``[storage.embedding]`` subsection (issue #1737, Slice A).
+    embed_defaults = EmbeddingSettings()
+    embed_raw = storage_raw.get("embedding", {})
+    if not isinstance(embed_raw, dict):
+        embed_raw = {}
+    model_raw = embed_raw.get("model", embed_defaults.model)
+    if not isinstance(model_raw, str) or not model_raw.strip():
+        model_raw = embed_defaults.model
+    provider_raw = embed_raw.get("provider", embed_defaults.provider)
+    if not isinstance(provider_raw, str) or not provider_raw.strip():
+        provider_raw = embed_defaults.provider
+    api_key_env_raw = embed_raw.get("api_key_env", embed_defaults.api_key_env)
+    if not isinstance(api_key_env_raw, str) or not api_key_env_raw.strip():
+        api_key_env_raw = embed_defaults.api_key_env
+    embedding_settings = EmbeddingSettings(
+        model=model_raw.strip(),
+        provider=provider_raw.strip(),
+        api_key_env=api_key_env_raw.strip(),
+    )
+
     return StorageSettings(
         backend=backend_raw.strip(),
         url=url_stripped,
+        pg=pg_settings,
+        embedding=embedding_settings,
     )
 
 

--- a/src/pollypm/defaults/docs/reference/operator-runbook.md
+++ b/src/pollypm/defaults/docs/reference/operator-runbook.md
@@ -470,3 +470,89 @@ What an operator sees:
 - Repeated `worker.session_reaped` events for the same task can trip the
   watchdog's dead-loop rule and route an escalation to the project
   architect.
+
+## Setting up Postgres (issue #1737, Slice A foundation)
+
+PollyPM is migrating from per-project SQLite to a single Postgres
+instance with `pgvector` for semantic recall. Slice A ships the
+foundation — the pool, the schema, and the doctor probe — behind a
+feature flag. The sqlite backend remains the default until the cutover
+PR; the steps below are required only for operators opting into the
+new backend ahead of cutover, or for the test suite that exercises the
+`PgWorkService` skeleton.
+
+### Prerequisites
+
+- Postgres 16 or newer (`pgvector`'s HNSW indexes assume pg 16+).
+- The `vector` extension. Homebrew ships it as a separate formula.
+
+### macOS install
+
+```
+brew install postgresql@17 pgvector
+brew services start postgresql@17
+createdb pollypm
+psql pollypm -c "CREATE EXTENSION vector"
+```
+
+### Linux install (Debian / Ubuntu, pg 16 example)
+
+```
+sudo apt install postgresql-16 postgresql-16-pgvector
+sudo systemctl enable --now postgresql
+sudo -u postgres createdb pollypm
+sudo -u postgres psql pollypm -c "CREATE EXTENSION vector"
+```
+
+### Configure PollyPM to use Postgres
+
+Add to `~/.pollypm/pollypm.toml`:
+
+```toml
+[storage]
+backend = "postgres"
+# Optional — leaving this empty falls through to POLLYPM_PG_DSN, then
+# the default postgresql://localhost:5432/pollypm.
+url = "postgresql://localhost:5432/pollypm"
+
+[storage.pg]
+pool_min = 1
+pool_max = 10
+min_version = "16.0"
+
+[storage.embedding]
+model = "openai:text-embedding-3-small"
+provider = "openai"
+api_key_env = "OPENAI_API_KEY"
+```
+
+Override the DSN per-process with the env var:
+
+```
+export POLLYPM_PG_DSN="postgresql://user:pw@host:5432/pollypm"
+```
+
+`POLLYPM_PG_DSN` wins over `[storage] url`, mirroring `POLLYPM_HOME`.
+
+### Smoke test
+
+Run the pg-only doctor probe — fast feedback whether the cockpit will
+boot against the configured backend:
+
+```
+pm doctor-pg-connection
+```
+
+The check returns `ok` when pg is reachable, the server version is at
+least the configured `min_version`, and the `vector` extension is
+installed. Failures emit the standard three-question doctor message
+with an actionable fix command.
+
+### Flipping the backend back to sqlite
+
+Until the cutover PR lands, the safe rollback is to set `[storage]
+backend = "sqlite"` and restart. Slice A intentionally leaves the
+sqlite implementation in place — no data migration is required when
+the flag is flipped before any pg writes happen. After Slices B–H land
+and the cutover is complete the rollback path runs through the
+pre-cutover snapshot documented in the migration PR notes.

--- a/src/pollypm/doctor.py
+++ b/src/pollypm/doctor.py
@@ -575,6 +575,7 @@ check_installed_version_matches_pyproject = _doctor_install_state.check_installe
 check_config_file = _doctor_install_state.check_config_file
 check_provider_account_configured = _doctor_install_state.check_provider_account_configured
 check_storage_backend = _doctor_install_state.check_storage_backend
+check_pg_connection = _doctor_install_state.check_pg_connection
 check_registered_providers = _doctor_install_state.check_registered_providers
 
 check_builtin_plugin_manifests = _doctor_plugins.check_builtin_plugin_manifests
@@ -3805,6 +3806,9 @@ def _registered_checks() -> list[Check]:
         Check("config-file", check_config_file, "install"),
         Check("provider-account", check_provider_account_configured, "install"),
         Check("storage-backend", check_storage_backend, "install"),
+        # #1737 — pg-connection probe. Skipped on sqlite installs so the
+        # check never falsely fails for users who haven't opted in.
+        Check("pg-connection", check_pg_connection, "install"),
         Check("registered-providers", check_registered_providers, "install"),
         # Plugins
         Check("builtin-plugin-manifests", check_builtin_plugin_manifests, "plugins"),

--- a/src/pollypm/doctor/install_state.py
+++ b/src/pollypm/doctor/install_state.py
@@ -270,3 +270,209 @@ def check_registered_providers() -> doctor.CheckResult:
         f"registered-providers: {', '.join(names)}",
         data={"providers": names},
     )
+
+
+def _parse_pg_server_version(raw: object) -> tuple[int, int] | None:
+    """Parse pg's numeric ``server_version_num`` to ``(major, minor)``.
+
+    Postgres 10+ encodes the version as ``MMMMmm`` (160012 → 16.12).
+    Returns ``None`` for any non-int value so the caller can fail
+    through to the "couldn't read version" branch without raising.
+    """
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return (n // 10000, n % 10000)
+
+
+def check_pg_connection() -> doctor.CheckResult:
+    """Probe the configured Postgres backend (issue #1737, Slice A).
+
+    Runs:
+
+    1. ``SELECT 1`` via the read-only pool (catches "pg not reachable").
+    2. ``SHOW server_version_num`` (verifies pg ≥ configured minimum).
+    3. ``SELECT 1 FROM pg_extension WHERE extname='vector'`` (verifies
+       pgvector is installed — required for embeddings + recall).
+
+    Skipped benignly when ``[storage] backend != "postgres"`` so a
+    sqlite-backed install isn't pestered. Failures emit the standard
+    three-question doctor message with an actionable fix command.
+    """
+    from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+
+    if not DEFAULT_CONFIG_PATH.exists():
+        return doctor._skip("pg-connection skipped (no config)")
+    try:
+        config = load_config(DEFAULT_CONFIG_PATH)
+    except Exception as exc:  # noqa: BLE001
+        return doctor._skip(f"pg-connection skipped (config parse: {exc})")
+
+    backend = config.storage.backend
+    if backend != "postgres":
+        return doctor._skip(
+            f"pg-connection skipped (backend={backend!r})"
+        )
+
+    try:
+        from pollypm.storage.pg_pool import get_ro_pool, resolve_dsn
+    except Exception as exc:  # noqa: BLE001
+        return doctor._fail(
+            "pg pool module unavailable",
+            why=(
+                "The Postgres backend is selected but the pollypm pg "
+                "pool module failed to import — psycopg/psycopg_pool "
+                "are likely missing."
+            ),
+            fix=(
+                "Install the runtime extras —\n"
+                "  uv pip install 'pollypm[postgres]'\n"
+                "Or switch `[storage] backend` back to `sqlite`.\n"
+                "Recheck: pm doctor"
+            ),
+            data={"error": str(exc)},
+        )
+
+    dsn = resolve_dsn(config)
+
+    try:
+        pool = get_ro_pool(config)
+    except Exception as exc:  # noqa: BLE001
+        return doctor._fail(
+            f"pg not reachable at {dsn}",
+            why=(
+                "PollyPM could not open a read-only connection to "
+                "Postgres. The cockpit refuses to start while the "
+                "configured backend is unreachable."
+            ),
+            fix=(
+                "Verify pg is running and the DSN is correct —\n"
+                "  brew services start postgresql@17\n"
+                "  pg_isready\n"
+                f"  psql '{dsn}' -c 'SELECT 1'\n"
+                "Override the DSN with POLLYPM_PG_DSN if needed.\n"
+                "Recheck: pm doctor"
+            ),
+            data={"dsn": dsn, "error": str(exc)},
+        )
+
+    server_version: tuple[int, int] | None = None
+    vector_installed = False
+    select_ok = False
+    try:
+        with pool.connection() as conn, conn.cursor() as cur:
+            cur.execute("SELECT 1")
+            row = cur.fetchone()
+            select_ok = bool(row and int(row[0]) == 1)
+            cur.execute("SHOW server_version_num")
+            row = cur.fetchone()
+            server_version = _parse_pg_server_version(row[0]) if row else None
+            cur.execute(
+                "SELECT 1 FROM pg_extension WHERE extname = 'vector'"
+            )
+            vector_installed = cur.fetchone() is not None
+    except Exception as exc:  # noqa: BLE001
+        return doctor._fail(
+            f"pg probe failed at {dsn}",
+            why=(
+                "Acquired a connection but the SELECT 1 probe raised. "
+                "The pg instance is reachable but not usable for "
+                "PollyPM — most likely an auth, schema, or role issue."
+            ),
+            fix=(
+                f"Investigate with psql '{dsn}'.\n"
+                "Recheck: pm doctor"
+            ),
+            data={"dsn": dsn, "error": str(exc)},
+        )
+
+    if not select_ok:
+        return doctor._fail(
+            f"pg probe returned unexpected payload at {dsn}",
+            why="SELECT 1 returned something other than 1.",
+            fix=(
+                f"Investigate with psql '{dsn}'.\n"
+                "Recheck: pm doctor"
+            ),
+            data={"dsn": dsn},
+        )
+
+    # Parse the configured minimum version (default "16.0"). Tolerant
+    # of "16", "16.0", "16.2.3"; falls back to (16, 0) on a malformed
+    # string so a typo can't trivially pass the gate.
+    min_version_raw = config.storage.pg.min_version or "16.0"
+    parts = [p for p in min_version_raw.split(".") if p.isdigit()]
+    if parts:
+        min_major = int(parts[0])
+        min_minor = int(parts[1]) if len(parts) > 1 else 0
+    else:
+        min_major, min_minor = 16, 0
+    min_version = (min_major, min_minor)
+
+    if server_version is None:
+        return doctor._fail(
+            f"pg version unreadable at {dsn}",
+            why=(
+                "The SHOW server_version_num probe returned a value "
+                "that didn't parse as an integer."
+            ),
+            fix=(
+                f"Investigate with psql '{dsn}'.\n"
+                "Recheck: pm doctor"
+            ),
+            data={"dsn": dsn},
+        )
+
+    if server_version < min_version:
+        version_str = f"{server_version[0]}.{server_version[1]}"
+        min_str = f"{min_version[0]}.{min_version[1]}"
+        return doctor._fail(
+            f"pg version {version_str} < required {min_str}",
+            why=(
+                "PollyPM requires pg "
+                f"{min_str}+ for pgvector HNSW indexes and the "
+                "generated-column tsvector path. Older pg instances "
+                "will silently degrade or fail at migration time."
+            ),
+            fix=(
+                "Upgrade pg —\n"
+                "  brew install postgresql@17\n"
+                "  brew services start postgresql@17\n"
+                "  createdb pollypm\n"
+                "Recheck: pm doctor"
+            ),
+            data={
+                "dsn": dsn,
+                "server_version": version_str,
+                "min_version": min_str,
+            },
+        )
+
+    if not vector_installed:
+        return doctor._fail(
+            f"vector extension missing at {dsn}",
+            why=(
+                "The pgvector extension is required for the "
+                "embeddings table + recall path. Without it the schema "
+                "migrations will fail and pgvector-backed memory "
+                "recall is unavailable."
+            ),
+            fix=(
+                "Install the extension —\n"
+                "  brew install pgvector  # or apt install postgresql-NN-pgvector\n"
+                f'  psql "{dsn}" -c "CREATE EXTENSION vector"\n'
+                "Recheck: pm doctor"
+            ),
+            data={"dsn": dsn},
+        )
+
+    version_str = f"{server_version[0]}.{server_version[1]}"
+    return doctor._ok(
+        f"pg {version_str} reachable at {dsn} (vector extension installed)",
+        data={
+            "dsn": dsn,
+            "server_version": version_str,
+            "vector_installed": True,
+        },
+    )

--- a/src/pollypm/models.py
+++ b/src/pollypm/models.py
@@ -252,6 +252,44 @@ class EventsRetentionSettings:
 
 
 @dataclass(slots=True)
+class PgStorageSettings:
+    """``[storage.pg]`` knobs — pool sizing + DSN override (issue #1737).
+
+    Slice A wires these as config-driven defaults; the
+    :mod:`pollypm.storage.pg_pool` module reads them when constructing
+    the process-wide pool. ``dsn`` is overridden by the
+    ``POLLYPM_PG_DSN`` env var (operator-level escape valve).
+
+    ``min_version`` is consulted by ``pm doctor pg-connection`` to
+    refuse to proceed against an older pg instance; pgvector's HNSW
+    behaviour is robust from pg 16 onward.
+    """
+
+    pool_min: int = 1
+    pool_max: int = 10
+    min_version: str = "16.0"
+    dsn: str = ""
+
+
+@dataclass(slots=True)
+class EmbeddingSettings:
+    """``[storage.embedding]`` knobs — embedding provider for pgvector.
+
+    Slice A only carries the dataclass shape; the writer lands in
+    Slice D. Knobs:
+
+    ``model`` — provider-namespaced model name (``openai:text-embedding-3-small``).
+    ``provider`` — short id used by the resolver (``openai``, ``ollama``, ...).
+    ``api_key_env`` — name of the env var that holds the provider's
+        API key. Defaults to ``OPENAI_API_KEY``.
+    """
+
+    model: str = "openai:text-embedding-3-small"
+    provider: str = "openai"
+    api_key_env: str = "OPENAI_API_KEY"
+
+
+@dataclass(slots=True)
 class StorageSettings:
     """Storage-backend selection from the ``[storage]`` TOML section.
 
@@ -266,10 +304,17 @@ class StorageSettings:
     ``url`` — SQLAlchemy URL passed to the backend constructor. Empty
     string means "derive from ``config.project.state_db``" —
     ``sqlite:///<resolved-state-db-path>``.
+
+    ``pg`` / ``embedding`` — sub-section knobs for the Postgres backend
+    (#1737, Slice A). Defaults are safe to read on a sqlite install —
+    they're only consulted when ``backend == "postgres"`` or the
+    embedding writer fires.
     """
 
     backend: str = "sqlite"
     url: str = ""
+    pg: PgStorageSettings = field(default_factory=PgStorageSettings)
+    embedding: EmbeddingSettings = field(default_factory=EmbeddingSettings)
 
 
 @dataclass(slots=True)

--- a/src/pollypm/storage/pg_migrations.py
+++ b/src/pollypm/storage/pg_migrations.py
@@ -1,0 +1,170 @@
+"""Forward-only Postgres migration applier (issue #1737, Slice A).
+
+The applier reads :data:`pollypm.storage.pg_schema.MIGRATIONS` and applies
+any not yet recorded in ``schema_migrations``. Each migration runs inside
+its own transaction so a partial apply rolls back cleanly.
+
+Slice A ships exactly one migration: ``0001_initial`` (the full schema
+port). Slices B-H append entries to ``MIGRATIONS``; the applier picks
+them up transparently. The applier is **idempotent**: running it twice
+against a fully-applied DB is a no-op (the ``schema_migrations`` row
+already exists, so the version is skipped).
+
+The bookkeeping table itself is bootstrapped before the migration walk
+so the very first run can record its own application.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from pollypm.storage.pg_schema import (
+    EXTENSIONS,
+    MIGRATIONS,
+    SCHEMA_MIGRATIONS_TABLE,
+)
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class MigrationResult:
+    """Summary of an ``apply_migrations`` run.
+
+    ``applied`` lists ``(version, label)`` tuples for migrations that
+    actually ran this invocation. ``already_applied`` mirrors the same
+    shape for migrations the run found pre-recorded. Tests use both
+    lists to assert idempotency.
+    """
+
+    applied: list[tuple[int, str]]
+    already_applied: list[tuple[int, str]]
+
+    @property
+    def did_anything(self) -> bool:
+        return bool(self.applied)
+
+
+def _ensure_bookkeeping(conn) -> None:
+    """Create the ``schema_migrations`` table + extensions if missing.
+
+    Runs outside the per-migration transaction so a bare-empty pg can
+    record migration 0001 in the same transaction it's applied with.
+    The extension bootstrap also has to live here (not inside the
+    per-version DDL) because pg parses each multi-statement DDL pack
+    as a unit, and would refuse to parse ``vector(1536)`` if the type
+    weren't already registered at session scope.
+    """
+    with conn.cursor() as cur:
+        cur.execute(EXTENSIONS)
+        cur.execute(SCHEMA_MIGRATIONS_TABLE)
+    conn.commit()
+
+
+def _applied_versions(conn) -> set[int]:
+    with conn.cursor() as cur:
+        cur.execute("SELECT version FROM schema_migrations")
+        return {int(row[0]) for row in cur.fetchall()}
+
+
+def _validate_migration_order() -> None:
+    """Fail loudly if :data:`MIGRATIONS` is mis-ordered or has gaps.
+
+    A typo'd version (``(3, ...)`` after ``(1, ...)``) would silently
+    skip migration 2 — a class of bug that's catastrophic for forward-
+    only DDL. The applier crashes here before touching pg.
+    """
+    versions = [v for v, _, _ in MIGRATIONS]
+    if not versions:
+        return
+    seen: set[int] = set()
+    for idx, version in enumerate(versions):
+        if version in seen:
+            raise RuntimeError(
+                f"pg_migrations: duplicate migration version {version!r} "
+                f"in MIGRATIONS at index {idx}."
+            )
+        seen.add(version)
+    sorted_versions = sorted(versions)
+    if versions != sorted_versions:
+        raise RuntimeError(
+            "pg_migrations: MIGRATIONS list is not sorted by version; "
+            f"got {versions!r}."
+        )
+    # Gap detection — versions must be 1, 2, 3, ... with no holes.
+    expected = list(range(sorted_versions[0], sorted_versions[-1] + 1))
+    if sorted_versions != expected:
+        missing = sorted(set(expected) - set(sorted_versions))
+        raise RuntimeError(
+            f"pg_migrations: missing migration versions {missing!r}."
+        )
+
+
+def apply_migrations(pool: "ConnectionPool") -> MigrationResult:
+    """Apply every unapplied migration in :data:`MIGRATIONS`.
+
+    Parameters
+    ----------
+    pool:
+        A read-write :class:`psycopg_pool.ConnectionPool`. Typically
+        obtained via :func:`pollypm.storage.pg_pool.get_rw_pool`. The
+        applier acquires one connection from the pool for the whole
+        run; nothing else should write while migrations are in flight
+        (but other readers are fine — pg's MVCC handles the overlap).
+
+    Returns
+    -------
+    MigrationResult
+        Records which versions ran versus which were skipped.
+    """
+    _validate_migration_order()
+
+    with pool.connection() as conn:
+        # psycopg 3 defaults to autocommit=False; we control transactions
+        # explicitly per migration. Make sure autocommit is off so the
+        # ``commit()`` calls below are meaningful.
+        conn.autocommit = False
+        _ensure_bookkeeping(conn)
+
+        applied = _applied_versions(conn)
+        ran: list[tuple[int, str]] = []
+        skipped: list[tuple[int, str]] = []
+
+        for version, label, ddl in MIGRATIONS:
+            if version in applied:
+                skipped.append((version, label))
+                continue
+            logger.info(
+                "pg_migrations: applying version=%d label=%s", version, label,
+            )
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(ddl)
+                    cur.execute(
+                        "INSERT INTO schema_migrations (version, label) "
+                        "VALUES (%s, %s)",
+                        (version, label),
+                    )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                logger.exception(
+                    "pg_migrations: version=%d label=%s failed; rolled back",
+                    version,
+                    label,
+                )
+                raise
+            ran.append((version, label))
+
+        return MigrationResult(applied=ran, already_applied=skipped)
+
+
+__all__ = [
+    "MigrationResult",
+    "apply_migrations",
+]

--- a/src/pollypm/storage/pg_pool.py
+++ b/src/pollypm/storage/pg_pool.py
@@ -1,0 +1,393 @@
+"""Process-wide Postgres connection pool primitives (issue #1737, Slice A).
+
+This module owns the lazy, process-wide :class:`psycopg_pool.ConnectionPool`
+instances that the rest of PollyPM uses to talk to Postgres. Two pools are
+kept side-by-side so accidental writes from read-side facades crash loudly:
+
+* :func:`get_rw_pool` — the canonical read-write pool. Every mutation goes
+  through this one.
+* :func:`get_ro_pool` — a parallel pool that sets
+  ``default_transaction_read_only = on`` at session level. Read-only facades
+  (the storage-layer query helpers, doctor probes, recall) use this so a
+  rogue ``INSERT``/``UPDATE`` fails with ``cannot execute … in a read-only
+  transaction`` instead of silently mutating shared state.
+
+DSN resolution order (highest priority wins):
+
+1. ``POLLYPM_PG_DSN`` env var — operator override / one-shot test runs.
+2. ``[storage] url`` in ``pollypm.toml`` — only when it looks like a pg DSN
+   (``postgresql://...`` / ``postgres://...``); otherwise treated as a
+   sqlite URL and ignored here.
+3. ``[storage.pg] dsn`` in ``pollypm.toml`` (placeholder — the dataclass
+   doesn't expose it yet; honoured if a future config patch wires it).
+4. The built-in default ``postgresql://localhost:5432/pollypm``.
+
+The pools are lazy module-level singletons. :func:`pg_pool_shutdown` is the
+graceful close used by ``pm reset`` / test teardown — calling it is safe
+even when no pool was ever opened.
+
+Slice A scope only — the *consumers* (PgWorkService, the storage facades,
+the doctor check) wire into this module across slices B-G. Slice A's
+contract is just "the primitive exists and behaves correctly", which is
+what the unit tests cover.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+    from pollypm.models import PollyPMConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------- #
+
+DEFAULT_DSN = "postgresql://localhost:5432/pollypm"
+ENV_DSN = "POLLYPM_PG_DSN"
+
+# Pool sizing defaults. The cockpit + rail process is the heaviest caller
+# and runs many concurrent read-side facades, but Sam's solo-operator
+# workload doesn't need a huge pool. min_size=1 keeps idle resource use
+# tiny on first-run installs; max_size=10 leaves headroom for the burst
+# of cockpit refreshes that motivated the migration. Operators tune via
+# ``[storage.pg] pool_min`` / ``[storage.pg] pool_max``.
+DEFAULT_POOL_MIN = 1
+DEFAULT_POOL_MAX = 10
+
+
+# --------------------------------------------------------------------- #
+# Module-level singletons
+# --------------------------------------------------------------------- #
+
+# Both pools are created lazily on first access. The lock guards the
+# creation race only — calls into the pool itself are pool-safe.
+_RW_POOL: "ConnectionPool | None" = None
+_RO_POOL: "ConnectionPool | None" = None
+_POOL_LOCK = threading.Lock()
+
+
+# --------------------------------------------------------------------- #
+# Configuration resolution
+# --------------------------------------------------------------------- #
+
+
+def _looks_like_pg_dsn(value: str) -> bool:
+    """Heuristic: does ``value`` smell like a Postgres DSN?
+
+    The shared ``[storage] url`` knob currently carries a sqlite URL
+    (``sqlite:///...``) for the existing backend. Until the cutover
+    flips the default backend, we don't want the pg pool to try and
+    open a sqlite URL — so we filter on the scheme. Empty strings,
+    ``None``, and non-pg schemes all return False.
+    """
+    if not isinstance(value, str):
+        return False
+    stripped = value.strip()
+    if not stripped:
+        return False
+    lower = stripped.lower()
+    return lower.startswith(("postgresql://", "postgres://", "postgresql+"))
+
+
+def resolve_dsn(config: "PollyPMConfig | None" = None) -> str:
+    """Return the DSN to use, honouring the documented priority order.
+
+    Parameters
+    ----------
+    config:
+        Optional :class:`pollypm.models.PollyPMConfig`. When provided,
+        ``config.storage.url`` is consulted as the second-priority
+        source. Pass ``None`` to resolve purely from env + the built-in
+        default (used by ``pm doctor`` before a config is loaded, and
+        by the tests).
+
+    Returns
+    -------
+    str
+        The resolved DSN. Never empty — callers can pass the result
+        straight into ``psycopg.connect`` or :class:`ConnectionPool`.
+    """
+    env_dsn = os.environ.get(ENV_DSN, "").strip()
+    if env_dsn:
+        return env_dsn
+
+    if config is not None:
+        url = getattr(config.storage, "url", "") or ""
+        if _looks_like_pg_dsn(url):
+            return url.strip()
+
+    return DEFAULT_DSN
+
+
+def resolve_pool_sizing(
+    config: "PollyPMConfig | None" = None,
+) -> tuple[int, int]:
+    """Return ``(min_size, max_size)`` for the pool, honouring config.
+
+    Reads ``[storage.pg] pool_min`` and ``[storage.pg] pool_max`` from
+    the loaded config when they're present and well-typed; falls back
+    to :data:`DEFAULT_POOL_MIN` / :data:`DEFAULT_POOL_MAX` otherwise.
+
+    Slice A intentionally does **not** add the ``[storage.pg]``
+    subsection to the :class:`~pollypm.models.StorageSettings`
+    dataclass — that's a follow-up. The lookup here uses ``getattr``
+    so a future ``StorageSettings.pg`` attribute slots in without a
+    second migration. Until then operators set the env var or accept
+    the defaults.
+    """
+    if config is None:
+        return DEFAULT_POOL_MIN, DEFAULT_POOL_MAX
+
+    pg_section = getattr(config.storage, "pg", None)
+    if pg_section is None:
+        return DEFAULT_POOL_MIN, DEFAULT_POOL_MAX
+
+    raw_min = getattr(pg_section, "pool_min", DEFAULT_POOL_MIN)
+    raw_max = getattr(pg_section, "pool_max", DEFAULT_POOL_MAX)
+    try:
+        min_size = max(1, int(raw_min))
+    except (TypeError, ValueError):
+        min_size = DEFAULT_POOL_MIN
+    try:
+        max_size = max(min_size, int(raw_max))
+    except (TypeError, ValueError):
+        max_size = DEFAULT_POOL_MAX
+
+    return min_size, max_size
+
+
+# --------------------------------------------------------------------- #
+# Pool construction
+# --------------------------------------------------------------------- #
+
+
+def _import_pool():
+    """Late-import :class:`ConnectionPool` so the module imports clean.
+
+    ``psycopg`` / ``psycopg_pool`` are runtime deps for the pg backend
+    only; importing them at module top would force every CLI invocation
+    (sqlite-backed installs included) to pay the import cost and would
+    leak ``ImportError`` into doctor checks that report missing-driver
+    states with their own friendly errors. Localising the import keeps
+    the storage/pg_pool import surface free of side effects on sqlite
+    installs.
+    """
+    try:
+        from psycopg_pool import ConnectionPool
+    except ImportError as exc:  # pragma: no cover - environment-dependent
+        raise RuntimeError(
+            "psycopg_pool is not installed. The postgres backend "
+            "requires `psycopg[binary]` and `psycopg_pool`; install "
+            "them via `uv pip install 'psycopg[binary]' psycopg_pool` "
+            "or switch `[storage] backend` back to `sqlite`."
+        ) from exc
+    return ConnectionPool
+
+
+def _build_pool(
+    dsn: str,
+    *,
+    min_size: int,
+    max_size: int,
+    read_only: bool,
+    application_name: str,
+) -> "ConnectionPool":
+    """Construct a :class:`ConnectionPool` with the documented defaults.
+
+    ``read_only=True`` installs a session-level configure callback
+    that runs ``SET default_transaction_read_only = on`` plus
+    ``SET application_name = ...`` whenever ``psycopg_pool`` adopts a
+    fresh connection. The RW pool only sets ``application_name`` so
+    ``pg_stat_activity`` is readable but writes are still allowed.
+    """
+    ConnectionPool = _import_pool()
+
+    # SQL ``SET`` does not accept parameter placeholders, so we sanitize
+    # the application_name to a tight allow-listed shape and inline it.
+    # The fixed-shape sanitizer below rejects anything outside
+    # ``[A-Za-z0-9._/-]`` so the inlined value cannot smuggle SQL.
+    safe_application_name = _sanitize_application_name(application_name)
+
+    def _configure(conn) -> None:
+        # Stamp application_name so an operator running ``SELECT *
+        # FROM pg_stat_activity`` can tell which PollyPM process owns
+        # which connection. Cheap and removes a real debugging head-
+        # scratcher when multiple PollyPM processes share one DB.
+        with conn.cursor() as cur:
+            cur.execute(f"SET application_name = '{safe_application_name}'")
+            if read_only:
+                cur.execute("SET default_transaction_read_only = on")
+        conn.commit()
+
+    return ConnectionPool(
+        conninfo=dsn,
+        min_size=min_size,
+        max_size=max_size,
+        configure=_configure,
+        open=True,
+        # The ``name`` ends up in psycopg_pool's debug logs — easier
+        # than reading object reprs when both pools are in flight.
+        name=f"pollypm-{'ro' if read_only else 'rw'}",
+    )
+
+
+# --------------------------------------------------------------------- #
+# Public accessors
+# --------------------------------------------------------------------- #
+
+
+def get_rw_pool(config: "PollyPMConfig | None" = None) -> "ConnectionPool":
+    """Return the process-wide read-write Postgres pool.
+
+    Lazy: first call constructs the pool; subsequent calls return the
+    cached instance. The pool is **not** keyed by DSN — at runtime
+    there's exactly one Postgres backing PollyPM. Tests that need a
+    different DSN should call :func:`pg_pool_shutdown` between cases
+    to clear the singleton.
+    """
+    global _RW_POOL
+    if _RW_POOL is not None:
+        return _RW_POOL
+    with _POOL_LOCK:
+        if _RW_POOL is not None:
+            return _RW_POOL
+        dsn = resolve_dsn(config)
+        min_size, max_size = resolve_pool_sizing(config)
+        logger.info(
+            "pg_pool: opening rw pool dsn=%s min=%d max=%d",
+            _safe_dsn(dsn),
+            min_size,
+            max_size,
+        )
+        _RW_POOL = _build_pool(
+            dsn,
+            min_size=min_size,
+            max_size=max_size,
+            read_only=False,
+            application_name="pollypm/rw",
+        )
+        return _RW_POOL
+
+
+def get_ro_pool(config: "PollyPMConfig | None" = None) -> "ConnectionPool":
+    """Return the process-wide read-only Postgres pool.
+
+    Each session run on this pool runs ``SET
+    default_transaction_read_only = on``, so a mistaken write from a
+    read-side facade fails fast with ``cannot execute … in a read-only
+    transaction`` instead of corrupting state.
+    """
+    global _RO_POOL
+    if _RO_POOL is not None:
+        return _RO_POOL
+    with _POOL_LOCK:
+        if _RO_POOL is not None:
+            return _RO_POOL
+        dsn = resolve_dsn(config)
+        min_size, max_size = resolve_pool_sizing(config)
+        logger.info(
+            "pg_pool: opening ro pool dsn=%s min=%d max=%d",
+            _safe_dsn(dsn),
+            min_size,
+            max_size,
+        )
+        _RO_POOL = _build_pool(
+            dsn,
+            min_size=min_size,
+            max_size=max_size,
+            read_only=True,
+            application_name="pollypm/ro",
+        )
+        return _RO_POOL
+
+
+def pg_pool_shutdown() -> None:
+    """Close both pools and clear the singletons. Idempotent.
+
+    Used by ``pm reset`` and the test fixtures. Safe to call when no
+    pool was ever opened (no-op). Calling :func:`get_rw_pool` /
+    :func:`get_ro_pool` after shutdown re-opens fresh instances —
+    that's the intended "between test cases" lifecycle.
+    """
+    global _RW_POOL, _RO_POOL
+    with _POOL_LOCK:
+        pools = [p for p in (_RW_POOL, _RO_POOL) if p is not None]
+        _RW_POOL = None
+        _RO_POOL = None
+    for pool in pools:
+        try:
+            pool.close()
+        except Exception:  # noqa: BLE001 — shutdown must never raise
+            logger.warning("pg_pool: pool close failed", exc_info=True)
+
+
+# --------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------- #
+
+
+_APP_NAME_SAFE_CHARS = set(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._/-"
+)
+
+
+def _sanitize_application_name(value: str) -> str:
+    """Reduce ``value`` to the alphabet pg's SET command can take inline.
+
+    SQL ``SET application_name`` doesn't accept parameter placeholders,
+    so the value is inlined into the configure-time DDL. The sanitizer
+    drops anything outside the allow-listed shape used by PollyPM's
+    own naming (``pollypm/rw``, ``pollypm-test-rw``). On an empty
+    result it returns ``"pollypm"`` so pg_stat_activity always shows
+    something useful.
+    """
+    cleaned = "".join(c for c in value if c in _APP_NAME_SAFE_CHARS)
+    return cleaned or "pollypm"
+
+
+def _safe_dsn(dsn: str) -> str:
+    """Return ``dsn`` with the password redacted for log output.
+
+    psycopg DSNs may include ``postgresql://user:password@host/db``.
+    The naive log line would leak the password to disk — which is
+    embarrassing even for local-only installs. Redaction is best-
+    effort and falls back to "***" when the URL doesn't parse.
+    """
+    try:
+        from urllib.parse import urlsplit, urlunsplit
+
+        parts = urlsplit(dsn)
+        if not parts.password:
+            return dsn
+        netloc = parts.netloc
+        # urlsplit gives us userinfo intact; redact the password slice
+        # without losing the username.
+        userinfo, _, hostinfo = netloc.rpartition("@")
+        user = userinfo.partition(":")[0]
+        new_netloc = f"{user}:***@{hostinfo}" if user else f":***@{hostinfo}"
+        return urlunsplit(parts._replace(netloc=new_netloc))
+    except Exception:  # noqa: BLE001 — never break a log line
+        return "***"
+
+
+__all__ = [
+    "DEFAULT_DSN",
+    "DEFAULT_POOL_MAX",
+    "DEFAULT_POOL_MIN",
+    "ENV_DSN",
+    "get_ro_pool",
+    "get_rw_pool",
+    "pg_pool_shutdown",
+    "resolve_dsn",
+    "resolve_pool_sizing",
+]

--- a/src/pollypm/storage/pg_schema.py
+++ b/src/pollypm/storage/pg_schema.py
@@ -1,0 +1,723 @@
+"""Canonical Postgres schema for PollyPM (issue #1737, Slice A).
+
+This module is the single source of truth for the pg DDL. Slice A ports
+every table from the sqlite shape (``storage/state.py:SCHEMA``,
+``work/schema.py:WORK_SCHEMA``, ``store/schema.py``, plus the
+``notification_staging`` bootstrap in ``notification_staging.py``) into
+pg-native form. Subsequent slices add migrations on top via the
+``schema_migrations`` audit table.
+
+Conventions
+-----------
+
+* JSON columns use ``jsonb`` (not ``text``) so payload filters can hit
+  GIN indexes once Slice C ports the query helpers.
+* ISO-8601 timestamp columns use ``timestamptz`` (not ``text``). Inserts
+  send ``CURRENT_TIMESTAMP``; reads coerce to Python ``datetime`` via
+  psycopg's default adapter.
+* SQLite ``INTEGER`` flag columns become ``boolean`` where the call sites
+  treated them as 0/1 (``requires_human_review``, ``pane_dead``,
+  ``refresh_available``, ``tier4_active``). Counters stay ``bigint`` /
+  ``int``.
+* SQLite auto-increment rowid PKs become ``bigserial``. The sequence
+  reset step (``setval(pg_get_serial_sequence(...), max(id) + 1)``) is
+  Slice E's job — the schema itself just installs the sequences.
+* Inferred FKs from the sqlite shape become enforced
+  ``ON DELETE CASCADE`` constraints in pg. The design doc flagged this
+  as a migration-time validation step; Slice A only installs the
+  constraints, Slice E surfaces orphan rows.
+* FTS5 mirror tables (``messages_fts``, ``memory_entries_fts``) become
+  ``tsvector`` columns plus GIN indexes; Slice D adds the
+  pgvector ``embeddings`` table that complements them.
+* ``project_key`` (per #1737 §2.4) stays a plain ``text`` column on
+  every domain table that currently keys by project — no native
+  partitioning, just a btree index.
+"""
+
+from __future__ import annotations
+
+
+# --------------------------------------------------------------------- #
+# Migration applier — schema_migrations audit table
+# --------------------------------------------------------------------- #
+
+# The applier records every applied DDL pack in this table. Future slices
+# append to ``MIGRATIONS`` below — version 0001 carries the full initial
+# schema; 0002+ are forward-only deltas.
+
+SCHEMA_MIGRATIONS_TABLE = """
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version    int PRIMARY KEY,
+    applied_at timestamptz NOT NULL DEFAULT now(),
+    label      text NOT NULL
+);
+"""
+
+
+# --------------------------------------------------------------------- #
+# Extension bootstrap — runs before any DDL that uses vector(N).
+# --------------------------------------------------------------------- #
+
+EXTENSIONS = """
+CREATE EXTENSION IF NOT EXISTS vector;
+"""
+
+
+# --------------------------------------------------------------------- #
+# Migration 0001 — the full initial schema.
+# --------------------------------------------------------------------- #
+# Split into table groups so a reviewer can map each ``CREATE TABLE`` back
+# to its sqlite origin. The applier runs the whole pack in one
+# transaction; ordering within the pack matters for FK validity.
+
+# --- Group A: operator session / accounts / runtime state. --- #
+_GROUP_OPERATOR = """
+CREATE TABLE IF NOT EXISTS sessions (
+    name        text PRIMARY KEY,
+    role        text NOT NULL,
+    project     text NOT NULL,
+    provider    text NOT NULL,
+    account     text NOT NULL,
+    cwd         text NOT NULL,
+    window_name text NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project);
+
+CREATE TABLE IF NOT EXISTS heartbeats (
+    id            bigserial PRIMARY KEY,
+    session_name  text NOT NULL,
+    tmux_window   text NOT NULL,
+    pane_id       text NOT NULL,
+    pane_command  text NOT NULL,
+    pane_dead     boolean NOT NULL,
+    log_bytes     bigint NOT NULL,
+    snapshot_path text NOT NULL,
+    snapshot_hash text NOT NULL DEFAULT '',
+    created_at    timestamptz NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_heartbeats_session
+    ON heartbeats(session_name, id DESC);
+
+CREATE TABLE IF NOT EXISTS leases (
+    session_name text PRIMARY KEY,
+    owner        text NOT NULL,
+    note         text NOT NULL,
+    updated_at   timestamptz NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS account_usage (
+    account_name  text PRIMARY KEY,
+    provider      text NOT NULL,
+    plan          text NOT NULL,
+    health        text NOT NULL,
+    usage_summary text NOT NULL,
+    raw_text      text NOT NULL,
+    used_pct      int,
+    remaining_pct int,
+    reset_at      timestamptz,
+    period_label  text,
+    updated_at    timestamptz NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS account_runtime (
+    account_name        text PRIMARY KEY,
+    provider            text NOT NULL,
+    status              text NOT NULL,
+    reason              text NOT NULL,
+    available_at        timestamptz,
+    access_expires_at   timestamptz,
+    refresh_available   boolean NOT NULL DEFAULT false,
+    updated_at          timestamptz NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS session_runtime (
+    session_name                 text PRIMARY KEY,
+    status                       text NOT NULL DEFAULT 'healthy',
+    effective_account            text,
+    effective_provider           text,
+    recovery_attempts            int NOT NULL DEFAULT 0,
+    recovery_window_started_at   timestamptz,
+    last_failure_type            text,
+    last_failure_message         text,
+    last_checkpoint_path         text,
+    retry_at                     timestamptz,
+    last_recovered_at            timestamptz,
+    updated_at                   timestamptz NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS checkpoints (
+    id            bigserial PRIMARY KEY,
+    session_name  text NOT NULL,
+    project_key   text NOT NULL,
+    level         text NOT NULL,
+    json_path     text NOT NULL,
+    summary_path  text NOT NULL,
+    snapshot_path text NOT NULL,
+    summary_text  text NOT NULL,
+    created_at    timestamptz NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_checkpoints_project ON checkpoints(project_key);
+
+CREATE TABLE IF NOT EXISTS worktrees (
+    id            bigserial PRIMARY KEY,
+    project_key   text NOT NULL,
+    lane_kind     text NOT NULL,
+    lane_key      text NOT NULL,
+    session_name  text,
+    issue_key     text,
+    path          text NOT NULL,
+    branch        text NOT NULL,
+    status        text NOT NULL,
+    created_at    timestamptz NOT NULL,
+    updated_at    timestamptz NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_worktrees_active
+    ON worktrees(project_key, lane_kind, lane_key, status);
+
+CREATE TABLE IF NOT EXISTS token_samples (
+    session_name      text PRIMARY KEY,
+    account_name      text NOT NULL,
+    provider          text NOT NULL,
+    model_name        text NOT NULL,
+    project_key       text NOT NULL,
+    cumulative_tokens bigint NOT NULL,
+    observed_at       timestamptz NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_token_samples_project ON token_samples(project_key);
+
+CREATE TABLE IF NOT EXISTS token_usage_hourly (
+    hour_bucket  text NOT NULL,
+    account_name text NOT NULL,
+    provider     text NOT NULL,
+    model_name   text NOT NULL,
+    project_key  text NOT NULL,
+    tokens_used  bigint NOT NULL,
+    updated_at   timestamptz NOT NULL,
+    PRIMARY KEY (hour_bucket, account_name, provider, model_name, project_key)
+);
+"""
+
+
+# --- Group B: unified messages / inbox surface. --- #
+_GROUP_MESSAGES = """
+CREATE TABLE IF NOT EXISTS messages (
+    id           bigserial PRIMARY KEY,
+    scope        text NOT NULL,
+    project_key  text NOT NULL DEFAULT '',
+    type         text NOT NULL,
+    tier         text NOT NULL DEFAULT 'immediate',
+    recipient    text NOT NULL,
+    sender       text NOT NULL,
+    state        text NOT NULL DEFAULT 'open',
+    parent_id    bigint,
+    subject      text NOT NULL,
+    body         text NOT NULL DEFAULT '',
+    payload_json jsonb NOT NULL DEFAULT '{}'::jsonb,
+    labels       jsonb NOT NULL DEFAULT '[]'::jsonb,
+    kind         text NOT NULL DEFAULT 'legacy',
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    updated_at   timestamptz NOT NULL DEFAULT now(),
+    closed_at    timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_recipient_state
+    ON messages(recipient, state);
+CREATE INDEX IF NOT EXISTS idx_messages_type_tier
+    ON messages(type, tier);
+CREATE INDEX IF NOT EXISTS idx_messages_scope_created
+    ON messages(scope, created_at);
+CREATE INDEX IF NOT EXISTS idx_messages_project_key
+    ON messages(project_key);
+
+-- Partial unique alert index (mirrors sqlite ``messages_open_alert_uniq``
+-- from #1044). At most one open alert per (scope, type='alert', subject).
+CREATE UNIQUE INDEX IF NOT EXISTS messages_open_alert_uniq
+    ON messages(scope, subject)
+    WHERE type = 'alert' AND state = 'open';
+
+-- GIN indexes for jsonb filter paths.
+CREATE INDEX IF NOT EXISTS idx_messages_payload_json_gin
+    ON messages USING gin (payload_json);
+CREATE INDEX IF NOT EXISTS idx_messages_labels_gin
+    ON messages USING gin (labels);
+
+-- tsvector keyword search (replaces FTS5 ``messages_fts``). Generated
+-- column so writes don't have to maintain a trigger.
+ALTER TABLE messages
+    ADD COLUMN IF NOT EXISTS subject_body_tsv tsvector
+    GENERATED ALWAYS AS (
+        setweight(to_tsvector('english', coalesce(subject, '')), 'A') ||
+        setweight(to_tsvector('english', coalesce(body, '')), 'B')
+    ) STORED;
+CREATE INDEX IF NOT EXISTS idx_messages_tsv_gin
+    ON messages USING gin (subject_body_tsv);
+"""
+
+
+# --- Group C: work-service domain. --- #
+# Faithfully ports work/schema.py:WORK_SCHEMA. FKs that were inferred in
+# sqlite become real ON DELETE CASCADE here. ``kind`` ports the #1565
+# inbox discriminator with the same ``legacy`` default.
+_GROUP_WORK = """
+CREATE TABLE IF NOT EXISTS work_flow_templates (
+    name        text NOT NULL,
+    version     int NOT NULL,
+    description text NOT NULL DEFAULT '',
+    roles       jsonb NOT NULL DEFAULT '{}'::jsonb,
+    start_node  text NOT NULL,
+    is_current  boolean NOT NULL DEFAULT true,
+    created_at  timestamptz NOT NULL,
+    PRIMARY KEY (name, version)
+);
+
+CREATE TABLE IF NOT EXISTS work_flow_nodes (
+    flow_template_name    text NOT NULL,
+    flow_template_version int NOT NULL,
+    node_id               text NOT NULL,
+    name                  text NOT NULL,
+    type                  text NOT NULL,
+    actor_type            text,
+    actor_role            text,
+    agent_name            text,
+    next_node_id          text,
+    reject_node_id        text,
+    gates                 jsonb NOT NULL DEFAULT '[]'::jsonb,
+    PRIMARY KEY (flow_template_name, flow_template_version, node_id),
+    FOREIGN KEY (flow_template_name, flow_template_version)
+        REFERENCES work_flow_templates(name, version)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS work_tasks (
+    project                 text NOT NULL,
+    task_number             int NOT NULL,
+    project_key             text NOT NULL,
+    title                   text NOT NULL,
+    type                    text NOT NULL,
+    labels                  jsonb NOT NULL DEFAULT '[]'::jsonb,
+    work_status             text NOT NULL DEFAULT 'draft',
+    flow_template_id        text NOT NULL,
+    flow_template_version   int NOT NULL DEFAULT 1,
+    current_node_id         text,
+    assignee                text,
+    priority                text NOT NULL DEFAULT 'normal',
+    requires_human_review   boolean NOT NULL DEFAULT false,
+    description             text NOT NULL DEFAULT '',
+    acceptance_criteria     text,
+    constraints             text,
+    relevant_files          jsonb NOT NULL DEFAULT '[]'::jsonb,
+    parent_project          text,
+    parent_task_number      int,
+    supersedes_project      text,
+    supersedes_task_number  int,
+    plan_version            int NOT NULL DEFAULT 1,
+    predecessor_task_id     text,
+    kind                    text NOT NULL DEFAULT 'legacy',
+    roles                   jsonb NOT NULL DEFAULT '{}'::jsonb,
+    external_refs           jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at              timestamptz NOT NULL,
+    created_by              text NOT NULL,
+    updated_at              timestamptz NOT NULL,
+    PRIMARY KEY (project, task_number),
+    -- Self-FKs for the parent / supersedes / predecessor wires. Made
+    -- DEFERRABLE INITIALLY DEFERRED so a parent-child pair created in
+    -- one transaction validates at COMMIT, not row insert.
+    FOREIGN KEY (parent_project, parent_task_number)
+        REFERENCES work_tasks(project, task_number)
+        DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_tasks_status ON work_tasks(work_status);
+CREATE INDEX IF NOT EXISTS idx_work_tasks_project_status
+    ON work_tasks(project, work_status);
+CREATE INDEX IF NOT EXISTS idx_work_tasks_project_key
+    ON work_tasks(project_key);
+CREATE INDEX IF NOT EXISTS idx_work_tasks_assignee
+    ON work_tasks(assignee) WHERE assignee IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_work_tasks_active
+    ON work_tasks(current_node_id) WHERE current_node_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_work_tasks_priority
+    ON work_tasks(priority, work_status);
+CREATE INDEX IF NOT EXISTS idx_work_tasks_predecessor
+    ON work_tasks(predecessor_task_id) WHERE predecessor_task_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_work_tasks_labels_gin
+    ON work_tasks USING gin (labels);
+CREATE INDEX IF NOT EXISTS idx_work_tasks_roles_gin
+    ON work_tasks USING gin (roles);
+CREATE INDEX IF NOT EXISTS idx_work_tasks_external_refs_gin
+    ON work_tasks USING gin (external_refs);
+
+CREATE TABLE IF NOT EXISTS work_task_delete_audit_outbox (
+    id                bigserial PRIMARY KEY,
+    project           text NOT NULL,
+    task_number       int NOT NULL,
+    title             text NOT NULL DEFAULT '',
+    flow_template_id  text NOT NULL DEFAULT '',
+    previous_status   text NOT NULL DEFAULT '',
+    created_by        text NOT NULL DEFAULT '',
+    deleted_at        timestamptz NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_task_delete_audit_outbox_project
+    ON work_task_delete_audit_outbox(project, task_number);
+
+-- Port of the sqlite AFTER DELETE trigger on work_tasks. Same payload —
+-- the JSONL audit flush is unchanged.
+CREATE OR REPLACE FUNCTION work_tasks_delete_audit_outbox_fn()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO work_task_delete_audit_outbox (
+        project, task_number, title, flow_template_id,
+        previous_status, created_by, deleted_at
+    ) VALUES (
+        OLD.project, OLD.task_number, OLD.title, OLD.flow_template_id,
+        OLD.work_status, OLD.created_by, now()
+    );
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_work_tasks_delete_audit_outbox ON work_tasks;
+CREATE TRIGGER trg_work_tasks_delete_audit_outbox
+AFTER DELETE ON work_tasks
+FOR EACH ROW EXECUTE FUNCTION work_tasks_delete_audit_outbox_fn();
+
+CREATE TABLE IF NOT EXISTS work_task_dependencies (
+    from_project     text NOT NULL,
+    from_task_number int NOT NULL,
+    to_project       text NOT NULL,
+    to_task_number   int NOT NULL,
+    kind             text NOT NULL,
+    created_at       timestamptz NOT NULL,
+    PRIMARY KEY (from_project, from_task_number, to_project, to_task_number, kind),
+    FOREIGN KEY (from_project, from_task_number)
+        REFERENCES work_tasks(project, task_number) ON DELETE CASCADE,
+    FOREIGN KEY (to_project, to_task_number)
+        REFERENCES work_tasks(project, task_number) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_deps_to
+    ON work_task_dependencies(to_project, to_task_number);
+CREATE INDEX IF NOT EXISTS idx_work_deps_from
+    ON work_task_dependencies(from_project, from_task_number, kind);
+
+CREATE TABLE IF NOT EXISTS work_node_executions (
+    id              bigserial PRIMARY KEY,
+    task_project    text NOT NULL,
+    task_number     int NOT NULL,
+    node_id         text NOT NULL,
+    visit           int NOT NULL,
+    status          text NOT NULL DEFAULT 'pending',
+    work_output     jsonb,
+    decision        text,
+    decision_reason text,
+    started_at      timestamptz,
+    completed_at    timestamptz,
+    kickoff_sent_at timestamptz,
+    FOREIGN KEY (task_project, task_number)
+        REFERENCES work_tasks(project, task_number) ON DELETE CASCADE,
+    UNIQUE (task_project, task_number, node_id, visit)
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_exec_task
+    ON work_node_executions(task_project, task_number);
+
+CREATE TABLE IF NOT EXISTS work_context_entries (
+    id           bigserial PRIMARY KEY,
+    task_project text NOT NULL,
+    task_number  int NOT NULL,
+    actor        text NOT NULL,
+    text         text NOT NULL,
+    created_at   timestamptz NOT NULL,
+    entry_type   text NOT NULL DEFAULT 'note',
+    FOREIGN KEY (task_project, task_number)
+        REFERENCES work_tasks(project, task_number) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_context_task
+    ON work_context_entries(task_project, task_number, id DESC);
+CREATE INDEX IF NOT EXISTS idx_work_context_entry_type
+    ON work_context_entries(task_project, task_number, entry_type);
+
+CREATE TABLE IF NOT EXISTS work_transitions (
+    id           bigserial PRIMARY KEY,
+    task_project text NOT NULL,
+    task_number  int NOT NULL,
+    from_state   text NOT NULL,
+    to_state     text NOT NULL,
+    actor        text NOT NULL,
+    reason       text,
+    created_at   timestamptz NOT NULL,
+    FOREIGN KEY (task_project, task_number)
+        REFERENCES work_tasks(project, task_number) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_transitions_task
+    ON work_transitions(task_project, task_number, id DESC);
+
+CREATE TABLE IF NOT EXISTS work_sessions (
+    task_project          text NOT NULL,
+    task_number           int NOT NULL,
+    agent_name            text NOT NULL,
+    pane_id               text,
+    worktree_path         text,
+    branch_name           text,
+    started_at            timestamptz NOT NULL,
+    ended_at              timestamptz,
+    total_input_tokens    bigint DEFAULT 0,
+    total_output_tokens   bigint DEFAULT 0,
+    archive_path          text,
+    provider              text,
+    provider_home         text,
+    PRIMARY KEY (task_project, task_number),
+    FOREIGN KEY (task_project, task_number)
+        REFERENCES work_tasks(project, task_number) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS work_sync_state (
+    task_project    text NOT NULL,
+    task_number     int NOT NULL,
+    adapter_name    text NOT NULL,
+    last_synced_at  timestamptz,
+    last_error      text,
+    attempts        int NOT NULL DEFAULT 0,
+    PRIMARY KEY (task_project, task_number, adapter_name),
+    FOREIGN KEY (task_project, task_number)
+        REFERENCES work_tasks(project, task_number) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_sync_state_adapter
+    ON work_sync_state(adapter_name);
+"""
+
+
+# --- Group D: ops / job / memory / workspace. --- #
+_GROUP_OPS = """
+CREATE TABLE IF NOT EXISTS memory_entries (
+    id              bigserial PRIMARY KEY,
+    scope           text NOT NULL,
+    project_key     text NOT NULL DEFAULT '',
+    kind            text NOT NULL,
+    title           text NOT NULL,
+    body            text NOT NULL,
+    tags            text NOT NULL,
+    source          text NOT NULL,
+    file_path       text NOT NULL,
+    summary_path    text NOT NULL,
+    created_at      timestamptz NOT NULL,
+    updated_at      timestamptz NOT NULL,
+    type            text NOT NULL DEFAULT 'project',
+    importance      int NOT NULL DEFAULT 3,
+    superseded_by   bigint,
+    ttl_at          timestamptz,
+    scope_tier      text NOT NULL DEFAULT 'project'
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_entries_scope
+    ON memory_entries(scope, id DESC);
+CREATE INDEX IF NOT EXISTS idx_memory_entries_type
+    ON memory_entries(type);
+CREATE INDEX IF NOT EXISTS idx_memory_entries_tier
+    ON memory_entries(scope_tier);
+CREATE INDEX IF NOT EXISTS idx_memory_entries_project_key
+    ON memory_entries(project_key);
+
+ALTER TABLE memory_entries
+    ADD COLUMN IF NOT EXISTS title_body_tsv tsvector
+    GENERATED ALWAYS AS (
+        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+        setweight(to_tsvector('english', coalesce(body, '')), 'B') ||
+        setweight(to_tsvector('english', coalesce(tags, '')), 'C')
+    ) STORED;
+CREATE INDEX IF NOT EXISTS idx_memory_entries_tsv_gin
+    ON memory_entries USING gin (title_body_tsv);
+
+CREATE TABLE IF NOT EXISTS memory_summaries (
+    id            bigserial PRIMARY KEY,
+    scope         text NOT NULL,
+    summary_text  text NOT NULL,
+    summary_path  text NOT NULL,
+    entry_count   int NOT NULL,
+    created_at    timestamptz NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS work_jobs (
+    id            bigserial PRIMARY KEY,
+    handler_name  text NOT NULL,
+    payload_json  jsonb NOT NULL,
+    status        text NOT NULL DEFAULT 'queued',
+    attempt       int NOT NULL DEFAULT 0,
+    max_attempts  int NOT NULL DEFAULT 3,
+    dedupe_key    text,
+    enqueued_at   timestamptz NOT NULL,
+    run_after     timestamptz NOT NULL,
+    claimed_at    timestamptz,
+    claimed_by    text,
+    finished_at   timestamptz,
+    last_error    text
+);
+
+CREATE INDEX IF NOT EXISTS idx_work_jobs_claim
+    ON work_jobs(status, run_after, id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_work_jobs_dedupe_queued
+    ON work_jobs(dedupe_key)
+    WHERE dedupe_key IS NOT NULL AND status IN ('queued', 'claimed');
+
+CREATE TABLE IF NOT EXISTS architect_resume_tokens (
+    project_key      text PRIMARY KEY,
+    provider         text NOT NULL,
+    session_id       text NOT NULL,
+    captured_at      timestamptz NOT NULL,
+    last_active_at   timestamptz NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS workspace_state (
+    key         text PRIMARY KEY,
+    value_json  jsonb NOT NULL,
+    set_at      timestamptz NOT NULL,
+    set_by      text NOT NULL DEFAULT 'system'
+);
+
+CREATE TABLE IF NOT EXISTS tier4_promotion_state (
+    root_cause_hash            text PRIMARY KEY,
+    project                    text NOT NULL DEFAULT '',
+    rule                       text NOT NULL DEFAULT '',
+    dispatch_history_json      jsonb NOT NULL DEFAULT '[]'::jsonb,
+    last_promotion_at          timestamptz,
+    promotion_path             text,
+    tier4_entered_at           timestamptz,
+    tier4_active               boolean NOT NULL DEFAULT false,
+    last_finding_signature     text NOT NULL DEFAULT '',
+    updated_at                 timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tier4_promotion_state_active
+    ON tier4_promotion_state(tier4_active, tier4_entered_at);
+
+-- Notification staging (#704 retirement is a separate follow-up; port as-is).
+CREATE TABLE IF NOT EXISTS notification_staging (
+    id              bigserial PRIMARY KEY,
+    project         text NOT NULL,
+    subject         text NOT NULL,
+    body            text NOT NULL,
+    actor           text NOT NULL,
+    priority        text NOT NULL,
+    payload_json    jsonb NOT NULL,
+    milestone_key   text,
+    created_at      timestamptz NOT NULL,
+    flushed_at      timestamptz,
+    rollup_task_id  text
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_staging_pending
+    ON notification_staging(project, milestone_key, flushed_at);
+CREATE INDEX IF NOT EXISTS idx_notification_staging_created
+    ON notification_staging(created_at);
+"""
+
+
+# --- Group E: pgvector embeddings (the new memory-recall surface). --- #
+# Slice D wires the writer + recall query; Slice A only installs the
+# table + HNSW index so the schema is complete on day one.
+_GROUP_EMBEDDINGS = """
+CREATE TABLE IF NOT EXISTS embeddings (
+    source_table  text NOT NULL,
+    source_id     text NOT NULL,
+    embedding     vector(1536) NOT NULL,
+    model         text NOT NULL,
+    generated_at  timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (source_table, source_id)
+);
+
+CREATE INDEX IF NOT EXISTS embeddings_hnsw
+    ON embeddings USING hnsw (embedding vector_cosine_ops);
+"""
+
+
+# Combined DDL for migration 0001. The migration applier bootstraps the
+# ``vector`` extension via :data:`EXTENSIONS` BEFORE the per-version
+# transaction starts; pg won't parse ``vector(1536)`` ahead of time
+# otherwise. Order within this pack: operator/messages (no deps), work
+# (FKs reference work_tasks), ops, embeddings last.
+INITIAL_SCHEMA_DDL = "\n".join(
+    [
+        _GROUP_OPERATOR,
+        _GROUP_MESSAGES,
+        _GROUP_WORK,
+        _GROUP_OPS,
+        _GROUP_EMBEDDINGS,
+    ]
+)
+
+
+# --------------------------------------------------------------------- #
+# Migration list — forward-only, append-only.
+# --------------------------------------------------------------------- #
+
+# Each entry is ``(version, label, ddl)``. Versions strictly ascend; gaps
+# are not allowed (the applier crashes loudly on a gap so a missing
+# migration file can't silently skip schema state).
+MIGRATIONS: list[tuple[int, str, str]] = [
+    (1, "0001_initial", INITIAL_SCHEMA_DDL),
+]
+
+
+def all_table_names() -> tuple[str, ...]:
+    """Return the canonical list of table names defined by the schema.
+
+    Used by tests + the doctor sanity probe to verify schema-applied
+    state without hard-coding the list at every callsite. Kept in
+    declaration order so test diffs are stable.
+    """
+    return (
+        # operator
+        "sessions",
+        "heartbeats",
+        "leases",
+        "account_usage",
+        "account_runtime",
+        "session_runtime",
+        "checkpoints",
+        "worktrees",
+        "token_samples",
+        "token_usage_hourly",
+        # messages
+        "messages",
+        # work
+        "work_flow_templates",
+        "work_flow_nodes",
+        "work_tasks",
+        "work_task_delete_audit_outbox",
+        "work_task_dependencies",
+        "work_node_executions",
+        "work_context_entries",
+        "work_transitions",
+        "work_sessions",
+        "work_sync_state",
+        # ops
+        "memory_entries",
+        "memory_summaries",
+        "work_jobs",
+        "architect_resume_tokens",
+        "workspace_state",
+        "tier4_promotion_state",
+        "notification_staging",
+        # embeddings
+        "embeddings",
+        # bookkeeping
+        "schema_migrations",
+    )
+
+
+__all__ = [
+    "EXTENSIONS",
+    "INITIAL_SCHEMA_DDL",
+    "MIGRATIONS",
+    "SCHEMA_MIGRATIONS_TABLE",
+    "all_table_names",
+]

--- a/src/pollypm/work/factory.py
+++ b/src/pollypm/work/factory.py
@@ -1,17 +1,25 @@
-"""Canonical factory for :class:`SQLiteWorkService`.
+"""Canonical factory for the active work-service backend.
 
 This module exists so callers outside ``pollypm.work.*`` do not have to
-know how the work-service DB path is resolved. Every direct
+know how the work-service DB is resolved. Every direct
 ``SQLiteWorkService(...)`` callsite that lives in presentation, plugin,
 or heartbeat code is suspect — see issue #1369. Migrating those callers
 through this factory means the resolver is the single point of truth
 for "where does work data live".
 
-The factory is intentionally tiny: it composes
-:func:`pollypm.work.db_resolver.resolve_work_db_path` with the
-``SQLiteWorkService`` constructor. The audit emit added in #1343 lives
-in the constructor itself, so every path through this factory still
-records ``work_db.opened``.
+Backend dispatch (#1737, Slice A)
+---------------------------------
+
+Reads ``config.storage.backend``:
+
+* ``"sqlite"`` (default) → :class:`pollypm.work.sqlite_service.SQLiteWorkService`,
+  resolved via :func:`pollypm.work.db_resolver.resolve_work_db_path`.
+* ``"postgres"`` → :class:`pollypm.work.pg_service.PgWorkService`, wired
+  against the lazy pool singleton in :mod:`pollypm.storage.pg_pool`.
+
+Any other value falls through to sqlite so a fat-fingered backend
+string doesn't brick the CLI; the doctor's ``storage-backend`` check
+surfaces the typo through its own error path.
 
 Escape valve
 ------------
@@ -19,18 +27,40 @@ A caller that genuinely needs a non-canonical path (legacy migration,
 explicit override, test fixture) may pass ``db_path=...`` directly.
 That keeps the callsite visibly different from the canonical pattern,
 which is the point: "this one is not using the resolver" should never
-be invisible.
+be invisible. ``db_path`` is sqlite-specific and is ignored on the pg
+backend.
 """
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pollypm.config import PollyPMConfig
     from pollypm.work.service_dependencies import SyncManager
-    from pollypm.work.sqlite_service import SQLiteWorkService
+
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_backend(config: "PollyPMConfig | None") -> str:
+    """Return the configured backend string, defaulting to ``"sqlite"``.
+
+    Reads ``config.storage.backend`` defensively — a missing attribute
+    or non-string value falls back to sqlite. The doctor's
+    ``storage-backend`` check surfaces real typos.
+    """
+    if config is None:
+        return "sqlite"
+    storage = getattr(config, "storage", None)
+    if storage is None:
+        return "sqlite"
+    backend = getattr(storage, "backend", "sqlite")
+    if not isinstance(backend, str) or not backend.strip():
+        return "sqlite"
+    return backend.strip()
 
 
 def create_work_service(
@@ -41,37 +71,46 @@ def create_work_service(
     project_key: str | None = None,
     sync_manager: "SyncManager | None" = None,
     session_manager: object | None = None,
-) -> "SQLiteWorkService":
-    """Construct a :class:`SQLiteWorkService` for the canonical work DB.
+) -> Any:
+    """Construct the configured work-service backend.
 
     Parameters
     ----------
     db_path:
-        Explicit DB path override. When ``None`` (the canonical case),
+        Explicit DB path override for the sqlite backend. Ignored on
+        ``backend="postgres"``. When ``None`` (the canonical case),
         the path is resolved via
-        :func:`pollypm.work.db_resolver.resolve_work_db_path`. Pass a
-        value here only when you genuinely need a non-canonical path
-        (legacy migration, tests, explicit ``--db`` overrides).
+        :func:`pollypm.work.db_resolver.resolve_work_db_path`.
     project_path:
         Filesystem path of the project, when known. Forwarded to the
-        service constructor for project-aware operations (gates,
-        activity logs, audit metadata).
+        sqlite service constructor for project-aware operations (gates,
+        activity logs, audit metadata). Ignored on the pg backend until
+        Slice B re-introduces project_path-aware behaviour.
     config:
         Optional pre-loaded :class:`PollyPMConfig`. Forwarded to the
-        resolver to avoid a hidden ``load_config()`` call.
+        resolver / pool factory to avoid hidden ``load_config()`` calls.
     project_key:
         Optional project key. Forwarded to the resolver so it can warn
-        about stale per-project DB files (#1004).
+        about stale per-project DB files (#1004), and to the pg service
+        for the per-row ``project_key`` column.
     sync_manager / session_manager:
-        Forwarded to the constructor for callers that need to inject a
+        Forwarded to the sqlite constructor for callers that need a
         bespoke sync or session manager (the heartbeat does this).
+        Ignored on the pg backend until Slice B.
 
     Returns
     -------
-    SQLiteWorkService
-        The constructed service. Use as a context manager to ensure
-        the underlying connection is closed.
+    object
+        A :class:`pollypm.work.service.WorkService` Protocol-satisfying
+        instance. The concrete type depends on the configured backend.
     """
+    backend = _resolve_backend(config)
+    if backend == "postgres":
+        from pollypm.work.pg_service import PgWorkService
+
+        return PgWorkService(config=config, project_key=project_key)
+
+    # sqlite (the default, and the fallback for unknown backends).
     from pollypm.work.sqlite_service import SQLiteWorkService
 
     resolved_path: Path

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -1,0 +1,794 @@
+"""Postgres-backed work service skeleton (issue #1737, Slice A).
+
+This module is the pg-side counterpart to
+:class:`pollypm.work.sqlite_service.SQLiteWorkService`. Slice A wires the
+constructor + a small read+CRUD subset; the rest of the protocol surface
+fills in across Slices B-H. Callers slot :class:`PgWorkService` through
+the structural Protocols in :mod:`pollypm.work.service` (#1717-#1736), so
+no presentation/plugin code has to change when the cutover flips the
+factory.
+
+Slice A scope
+-------------
+
+Implemented (covered by tests in ``tests/test_pg_work_service.py``):
+
+* ``__init__`` — accepts a pool (or pulls the lazy singleton), runs the
+  migration applier to guarantee schema is up to date.
+* ``get(task_id)`` — single-row fetch.
+* ``list_tasks(project=...)`` — basic filtering on a subset of the
+  protocol's filter fields.
+* ``create(...)`` — minimal create returning a typed :class:`Task`.
+* ``queue(...)`` / ``done(...)`` / ``cancel(...)`` — the three simplest
+  state transitions, all writing through ``work_transitions`` for audit
+  parity with sqlite.
+
+Deferred to Slice B:
+
+* The full transition manager (review / approve / reject / claim chain,
+  worker sessions, kickoff bookkeeping).
+* Context entries, dependencies, flow templates, gates.
+* notification_staging writers (port-as-is per Slice C).
+* sync adapters, audit JSONL emission.
+
+The deferred surface is stubbed with ``NotImplementedError`` carrying
+the three-question message so a premature wire-up fails loud.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from pollypm.inbox.kind import coerce_kind as _coerce_inbox_kind
+from pollypm.work.models import (
+    ContextEntry,
+    FlowNodeExecution,
+    FlowTemplate,
+    GateResult,
+    Priority,
+    Task,
+    TaskType,
+    WorkOutput,
+    WorkStatus,
+    WorkerSessionRecord,
+)
+from pollypm.work.service_support import (
+    InvalidTransitionError,
+    TaskNotFoundError,
+    ValidationError,
+)
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+    from pollypm.models import PollyPMConfig
+
+logger = logging.getLogger(__name__)
+
+
+_NOT_IMPLEMENTED_SLICE_B = (
+    "PgWorkService method not implemented in Slice A. "
+    "The full work-service port lands in Slice B (#1737). "
+    "Fix: keep ``[storage] backend = 'sqlite'`` until Slice B merges, "
+    "or implement the method here if you are wiring Slice B."
+)
+
+
+def _parse_task_id(task_id: str) -> tuple[str, int]:
+    """Split ``project/number`` into ``(project, int(number))``.
+
+    Mirrors :func:`pollypm.work.service_support._parse_task_id` but kept
+    local so the pg service has no implicit coupling to the sqlite
+    helper module — Slice B can lift it out into a shared module if
+    needed.
+    """
+    if "/" not in task_id:
+        raise ValidationError(
+            f"Invalid task id {task_id!r}: expected ``project/number``."
+        )
+    project, _, number = task_id.rpartition("/")
+    try:
+        return project, int(number)
+    except ValueError as exc:
+        raise ValidationError(
+            f"Invalid task id {task_id!r}: number must be an integer."
+        ) from exc
+
+
+def _now_iso() -> datetime:
+    return datetime.now(UTC)
+
+
+def _coerce_status(raw: str) -> WorkStatus:
+    try:
+        return WorkStatus(raw)
+    except ValueError:
+        # Unknown statuses surface as DRAFT so a corrupt row is at least
+        # readable. Matches the sqlite path's tolerant decode.
+        return WorkStatus.DRAFT
+
+
+def _coerce_priority(raw: str) -> Priority:
+    try:
+        return Priority(raw)
+    except ValueError:
+        return Priority.NORMAL
+
+
+def _coerce_type(raw: str) -> TaskType:
+    try:
+        return TaskType(raw)
+    except ValueError:
+        return TaskType.TASK
+
+
+def _json_loads(raw: Any, default: Any) -> Any:
+    """Decode a JSON column tolerantly.
+
+    psycopg returns ``jsonb`` columns as already-decoded Python objects,
+    so most rows skip the ``json.loads`` path. Strings only appear when
+    the column was inserted as text (test seeds, legacy imports). The
+    ``default`` is returned for both ``None`` and decode errors so the
+    caller doesn't have to special-case either.
+    """
+    if raw is None:
+        return default
+    if isinstance(raw, (dict, list)):
+        return raw
+    if isinstance(raw, (bytes, bytearray)):
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return default
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+class PgWorkService:
+    """Postgres-backed work-service implementation (Slice A skeleton).
+
+    The constructor accepts an optional ``pool`` so tests can inject a
+    test-container pool; production callers pass ``None`` and let the
+    module pull :func:`pollypm.storage.pg_pool.get_rw_pool`.
+
+    The structural Protocol the rest of PollyPM consumes is
+    :class:`pollypm.work.service.WorkService` — every method on it must
+    eventually have a concrete implementation here. Slice A ships the
+    minimum subset documented above.
+    """
+
+    def __init__(
+        self,
+        *,
+        pool: "ConnectionPool | None" = None,
+        ro_pool: "ConnectionPool | None" = None,
+        config: "PollyPMConfig | None" = None,
+        project_key: str | None = None,
+        apply_migrations: bool = True,
+    ) -> None:
+        if pool is None:
+            from pollypm.storage.pg_pool import get_rw_pool
+
+            pool = get_rw_pool(config)
+        if ro_pool is None:
+            from pollypm.storage.pg_pool import get_ro_pool
+
+            try:
+                ro_pool = get_ro_pool(config)
+            except Exception:  # noqa: BLE001 - ro pool is optional in Slice A
+                ro_pool = None
+
+        self._pool = pool
+        self._ro_pool = ro_pool
+        self._project_key = project_key or ""
+        # Slice A keeps the same single-process schema-on-open contract
+        # the sqlite service has: open the service, schema is current.
+        # Slice E adds an explicit ``pm storage migrate`` CLI; until
+        # then the constructor is the only writer that runs DDL.
+        if apply_migrations:
+            from pollypm.storage.pg_migrations import apply_migrations as run
+
+            run(self._pool)
+
+        # Match the sqlite service's last-error breadcrumb (#243) so
+        # cockpit code that reads this attribute via Protocol shape
+        # doesn't crash on the pg backend.
+        self.last_provision_error: str | None = None
+        self.last_first_shipped_created: bool = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "PgWorkService":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        # The pool is process-wide and shared; we do not close it on
+        # context exit. Test fixtures call
+        # ``pg_pool.pg_pool_shutdown()`` explicitly.
+        return None
+
+    def close(self) -> None:
+        """No-op — pool lifetime is owned by ``pg_pool``."""
+        return None
+
+    def set_session_manager(self, session_manager: object) -> None:  # noqa: ARG002
+        """Slice A: session manager wiring lands in Slice B."""
+        return None
+
+    # ------------------------------------------------------------------
+    # Read path
+    # ------------------------------------------------------------------
+
+    def get(self, task_id: str) -> Task:
+        """Read one task by its ``project/number`` id."""
+        project, task_number = _parse_task_id(task_id)
+        sql = """
+            SELECT project, task_number, project_key, title, type, labels,
+                   work_status, flow_template_id, flow_template_version,
+                   current_node_id, assignee, priority, requires_human_review,
+                   description, acceptance_criteria, constraints, relevant_files,
+                   parent_project, parent_task_number,
+                   supersedes_project, supersedes_task_number,
+                   plan_version, predecessor_task_id, kind,
+                   roles, external_refs,
+                   created_at, created_by, updated_at
+              FROM work_tasks
+             WHERE project = %s AND task_number = %s
+        """
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, (project, task_number))
+            row = cur.fetchone()
+        if row is None:
+            raise TaskNotFoundError(f"Task '{task_id}' not found.")
+        return self._row_to_task(row)
+
+    def list_tasks(
+        self,
+        *,
+        work_status: str | None = None,
+        owner: str | None = None,  # noqa: ARG002 — Slice B wires owner derivation
+        project: str | None = None,
+        assignee: str | None = None,
+        blocked: bool | None = None,  # noqa: ARG002 — Slice B wires blocked filter
+        type: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[Task]:
+        """Query tasks with optional filters.
+
+        Slice A supports the predicate subset the operator-dashboard
+        smoke tests exercise: ``project``, ``work_status``,
+        ``assignee``, ``type``, ``limit``/``offset``. The remaining
+        filters (``owner``, ``blocked``) are accepted for Protocol
+        parity but ignored — Slice B fills them in once the role
+        derivation + dependency walk port.
+        """
+        where: list[str] = []
+        params: list[object] = []
+        if project is not None:
+            where.append("project = %s")
+            params.append(project)
+        if work_status is not None:
+            where.append("work_status = %s")
+            params.append(work_status)
+        if assignee is not None:
+            where.append("assignee = %s")
+            params.append(assignee)
+        if type is not None:
+            where.append("type = %s")
+            params.append(type)
+        clause = (" WHERE " + " AND ".join(where)) if where else ""
+        order_limit = " ORDER BY project, task_number"
+        if limit is not None:
+            order_limit += f" LIMIT {int(limit)}"
+        if offset is not None:
+            order_limit += f" OFFSET {int(offset)}"
+        sql = (
+            "SELECT project, task_number, project_key, title, type, labels, "
+            "work_status, flow_template_id, flow_template_version, "
+            "current_node_id, assignee, priority, requires_human_review, "
+            "description, acceptance_criteria, constraints, relevant_files, "
+            "parent_project, parent_task_number, "
+            "supersedes_project, supersedes_task_number, "
+            "plan_version, predecessor_task_id, kind, "
+            "roles, external_refs, "
+            "created_at, created_by, updated_at "
+            "FROM work_tasks" + clause + order_limit
+        )
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        return [self._row_to_task(row) for row in rows]
+
+    def _row_to_task(self, row: tuple) -> Task:
+        """Convert a SELECT-* row tuple into a :class:`Task` dataclass.
+
+        Column order MUST match the SELECT list in :meth:`get` and
+        :meth:`list_tasks`. Slice A intentionally does not load
+        executions / context entries / transitions / token sums — those
+        sub-queries land in Slice B alongside the rest of the protocol
+        surface.
+        """
+        (
+            project,
+            task_number,
+            _project_key,
+            title,
+            type_raw,
+            labels_raw,
+            work_status_raw,
+            flow_template_id,
+            flow_template_version,
+            current_node_id,
+            assignee,
+            priority_raw,
+            requires_human_review,
+            description,
+            acceptance_criteria,
+            constraints,
+            relevant_files_raw,
+            parent_project,
+            parent_task_number,
+            supersedes_project,
+            supersedes_task_number,
+            plan_version,
+            predecessor_task_id,
+            kind_raw,
+            roles_raw,
+            external_refs_raw,
+            created_at,
+            created_by,
+            updated_at,
+        ) = row
+        return Task(
+            project=str(project),
+            task_number=int(task_number),
+            title=str(title),
+            type=_coerce_type(str(type_raw)),
+            labels=list(_json_loads(labels_raw, [])),
+            work_status=_coerce_status(str(work_status_raw)),
+            flow_template_id=str(flow_template_id),
+            flow_template_version=int(flow_template_version),
+            current_node_id=current_node_id,
+            assignee=assignee,
+            priority=_coerce_priority(str(priority_raw)),
+            requires_human_review=bool(requires_human_review),
+            description=str(description or ""),
+            acceptance_criteria=acceptance_criteria,
+            constraints=constraints,
+            relevant_files=list(_json_loads(relevant_files_raw, [])),
+            parent_project=parent_project,
+            parent_task_number=(
+                int(parent_task_number) if parent_task_number is not None else None
+            ),
+            supersedes_project=supersedes_project,
+            supersedes_task_number=(
+                int(supersedes_task_number)
+                if supersedes_task_number is not None
+                else None
+            ),
+            plan_version=int(plan_version or 1),
+            predecessor_task_id=predecessor_task_id,
+            kind=_coerce_inbox_kind(kind_raw),
+            roles=dict(_json_loads(roles_raw, {})),
+            external_refs=dict(_json_loads(external_refs_raw, {})),
+            created_at=created_at,
+            created_by=str(created_by or ""),
+            updated_at=updated_at,
+        )
+
+    # ------------------------------------------------------------------
+    # Write path — minimal CRUD trio.
+    # ------------------------------------------------------------------
+
+    def create(
+        self,
+        *,
+        title: str,
+        description: str = "",
+        type: str,
+        project: str,
+        flow_template: str,
+        roles: dict[str, str],
+        priority: str = "normal",
+        created_by: str = "system",
+        acceptance_criteria: str | None = None,
+        constraints: str | None = None,
+        relevant_files: list[str] | None = None,
+        labels: list[str] | None = None,
+        requires_human_review: bool = False,
+        predecessor_task_id: str | None = None,
+        kind: str = "legacy",
+    ) -> Task:
+        """Create a task in ``draft`` state.
+
+        Slice A's create is intentionally minimal — no gate evaluation,
+        no flow-template loading, no audit JSONL emission. The DB
+        insert plus the resulting :class:`Task` round-trip is enough to
+        verify the schema port. Slice B reinstates the full pipeline
+        (gates, audit, sync hooks).
+        """
+        now = _now_iso()
+        kind_value = _coerce_inbox_kind(kind).value
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                # Allocate the next task_number atomically per project.
+                cur.execute(
+                    "SELECT COALESCE(MAX(task_number), 0) + 1 "
+                    "FROM work_tasks WHERE project = %s",
+                    (project,),
+                )
+                task_number = int(cur.fetchone()[0])
+                cur.execute(
+                    "INSERT INTO work_tasks ("
+                    " project, task_number, project_key, title, type, labels, "
+                    " work_status, flow_template_id, flow_template_version, "
+                    " priority, requires_human_review, description, "
+                    " acceptance_criteria, constraints, relevant_files, "
+                    " plan_version, predecessor_task_id, kind, "
+                    " roles, external_refs, created_at, created_by, updated_at"
+                    ") VALUES ("
+                    " %s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s, %s, %s, "
+                    " %s, %s, %s::jsonb, %s, %s, %s, %s::jsonb, %s::jsonb, "
+                    " %s, %s, %s"
+                    ")",
+                    (
+                        project,
+                        task_number,
+                        project,  # project_key mirrors project in Slice A
+                        title,
+                        type,
+                        json.dumps(labels or []),
+                        WorkStatus.DRAFT.value,
+                        flow_template,
+                        1,
+                        priority,
+                        bool(requires_human_review),
+                        description,
+                        acceptance_criteria,
+                        constraints,
+                        json.dumps(relevant_files or []),
+                        1,
+                        predecessor_task_id,
+                        kind_value,
+                        json.dumps(roles or {}),
+                        json.dumps({}),
+                        now,
+                        created_by,
+                        now,
+                    ),
+                )
+            conn.commit()
+        return self.get(f"{project}/{task_number}")
+
+    def queue(
+        self,
+        task_id: str,
+        actor: str,
+        skip_gates: bool = False,  # noqa: ARG002 — Slice B wires gates
+    ) -> Task:
+        """Move a ``draft`` task to ``queued``.
+
+        Slice A skips gate evaluation entirely. The transition row is
+        still written so the audit history is sane.
+        """
+        return self._simple_transition(
+            task_id,
+            from_state=WorkStatus.DRAFT,
+            to_state=WorkStatus.QUEUED,
+            actor=actor,
+        )
+
+    def cancel(self, task_id: str, actor: str, reason: str) -> Task:
+        """Move any non-terminal task to ``cancelled``."""
+        task = self.get(task_id)
+        if task.work_status in (WorkStatus.DONE, WorkStatus.CANCELLED):
+            raise InvalidTransitionError(
+                f"Cannot cancel task in terminal state {task.work_status.value!r}."
+            )
+        return self._simple_transition(
+            task_id,
+            from_state=task.work_status,
+            to_state=WorkStatus.CANCELLED,
+            actor=actor,
+            reason=reason,
+        )
+
+    def mark_done(self, task_id: str, actor: str) -> Task:
+        """Force a task to ``done`` without running the flow.
+
+        Mirrors the sqlite ``mark_done`` escape valve used by admin /
+        recovery paths. Slice A intentionally leaves the full
+        ``node_done`` pipeline (flow advancement, work output coercion,
+        gate replay) to Slice B.
+        """
+        task = self.get(task_id)
+        if task.work_status == WorkStatus.DONE:
+            return task
+        return self._simple_transition(
+            task_id,
+            from_state=task.work_status,
+            to_state=WorkStatus.DONE,
+            actor=actor,
+        )
+
+    def _simple_transition(
+        self,
+        task_id: str,
+        *,
+        from_state: WorkStatus,
+        to_state: WorkStatus,
+        actor: str,
+        reason: str | None = None,
+    ) -> Task:
+        project, task_number = _parse_task_id(task_id)
+        now = _now_iso()
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT work_status FROM work_tasks "
+                    "WHERE project = %s AND task_number = %s",
+                    (project, task_number),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    raise TaskNotFoundError(f"Task '{task_id}' not found.")
+                current = _coerce_status(str(row[0]))
+                # Idempotency: a re-queue against an already-queued task
+                # is a no-op. The sqlite service has the same shape.
+                if current == to_state:
+                    return self.get(task_id)
+                cur.execute(
+                    "UPDATE work_tasks SET work_status = %s, updated_at = %s "
+                    "WHERE project = %s AND task_number = %s",
+                    (to_state.value, now, project, task_number),
+                )
+                cur.execute(
+                    "INSERT INTO work_transitions ("
+                    "task_project, task_number, from_state, to_state, "
+                    "actor, reason, created_at"
+                    ") VALUES (%s, %s, %s, %s, %s, %s, %s)",
+                    (
+                        project,
+                        task_number,
+                        current.value,
+                        to_state.value,
+                        actor,
+                        reason,
+                        now,
+                    ),
+                )
+            conn.commit()
+        return self.get(task_id)
+
+    # ------------------------------------------------------------------
+    # Protocol stubs — Slice B fills these in.
+    # ------------------------------------------------------------------
+
+    def list_nonterminal_tasks(
+        self,
+        *,
+        project: str | None = None,
+    ) -> list[Task]:
+        """Return non-terminal tasks (Slice A: trivial WHERE filter)."""
+        terminals = (WorkStatus.DONE.value, WorkStatus.CANCELLED.value)
+        sql = (
+            "SELECT project, task_number, project_key, title, type, labels, "
+            "work_status, flow_template_id, flow_template_version, "
+            "current_node_id, assignee, priority, requires_human_review, "
+            "description, acceptance_criteria, constraints, relevant_files, "
+            "parent_project, parent_task_number, "
+            "supersedes_project, supersedes_task_number, "
+            "plan_version, predecessor_task_id, kind, roles, external_refs, "
+            "created_at, created_by, updated_at "
+            "FROM work_tasks "
+            "WHERE work_status NOT IN (%s, %s)"
+        )
+        params: list[object] = list(terminals)
+        if project is not None:
+            sql += " AND project = %s"
+            params.append(project)
+        sql += " ORDER BY project, task_number"
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        return [self._row_to_task(row) for row in rows]
+
+    def update(self, task_id: str, **fields: object) -> Task:  # noqa: ARG002
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def increment_plan_version(
+        self,
+        task_id: str,  # noqa: ARG002
+        *,
+        actor: str = "system",  # noqa: ARG002
+        reason: str | None = None,  # noqa: ARG002
+    ) -> Task:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def list_successors(
+        self, predecessor_task_id: str
+    ) -> list[Task]:  # noqa: ARG002
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def claim(
+        self, task_id: str, actor: str, skip_gates: bool = False  # noqa: ARG002
+    ) -> Task:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def next(  # noqa: A003
+        self,
+        *,
+        agent: str | None = None,  # noqa: ARG002
+        project: str | None = None,  # noqa: ARG002
+    ) -> Task | None:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def hold(
+        self, task_id: str, actor: str, reason: str | None = None  # noqa: ARG002
+    ) -> Task:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def resume(self, task_id: str, actor: str) -> Task:  # noqa: ARG002
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def node_done(
+        self,
+        task_id: str,  # noqa: ARG002
+        actor: str,  # noqa: ARG002
+        work_output: WorkOutput | dict | None = None,  # noqa: ARG002
+        skip_gates: bool = False,  # noqa: ARG002
+    ) -> Task:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def approve(
+        self,
+        task_id: str,  # noqa: ARG002
+        actor: str,  # noqa: ARG002
+        reason: str | None = None,  # noqa: ARG002
+        skip_gates: bool = False,  # noqa: ARG002
+        resume_merge: bool = False,  # noqa: ARG002
+    ) -> Task:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def reject(
+        self, task_id: str, actor: str, reason: str  # noqa: ARG002
+    ) -> Task:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def block(
+        self, task_id: str, actor: str, blocker_task_id: str  # noqa: ARG002
+    ) -> Task:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def get_execution(
+        self,
+        task_id: str,  # noqa: ARG002
+        node_id: str | None = None,  # noqa: ARG002
+        visit: int | None = None,  # noqa: ARG002
+    ) -> list[FlowNodeExecution]:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def add_context(
+        self,
+        task_id: str,  # noqa: ARG002
+        actor: str,  # noqa: ARG002
+        text: str,  # noqa: ARG002
+        *,
+        entry_type: str = "note",  # noqa: ARG002
+    ) -> ContextEntry:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def get_context(
+        self,
+        task_id: str,  # noqa: ARG002
+        limit: int | None = None,  # noqa: ARG002
+        since: str | None = None,  # noqa: ARG002
+        entry_type: str | None = None,  # noqa: ARG002
+    ) -> list[ContextEntry]:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def link(
+        self, from_id: str, to_id: str, kind: str  # noqa: ARG002
+    ) -> None:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def unlink(
+        self, from_id: str, to_id: str, kind: str  # noqa: ARG002
+    ) -> None:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def dependents(self, task_id: str) -> list[Task]:  # noqa: ARG002
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def available_flows(
+        self, project: str | None = None  # noqa: ARG002
+    ) -> list[FlowTemplate]:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def get_flow(
+        self, name: str, project: str | None = None  # noqa: ARG002
+    ) -> FlowTemplate:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def validate_advance(
+        self, task_id: str, actor: str  # noqa: ARG002
+    ) -> list[GateResult]:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def sync_status(self, task_id: str) -> dict[str, object]:  # noqa: ARG002
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def trigger_sync(
+        self,
+        task_id: str | None = None,  # noqa: ARG002
+        adapter: str | None = None,  # noqa: ARG002
+    ) -> dict[str, object]:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def state_counts(
+        self, project: str | None = None
+    ) -> dict[str, int]:
+        """Task counts by state (Slice A: simple GROUP BY)."""
+        sql = "SELECT work_status, COUNT(*) FROM work_tasks"
+        params: list[object] = []
+        if project is not None:
+            sql += " WHERE project = %s"
+            params.append(project)
+        sql += " GROUP BY work_status"
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            return {str(row[0]): int(row[1]) for row in cur.fetchall()}
+
+    def my_tasks(self, agent: str) -> list[Task]:  # noqa: ARG002
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def blocked_tasks(
+        self, project: str | None = None  # noqa: ARG002
+    ) -> list[Task]:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def ensure_worker_session_schema(self) -> None:
+        # Schema is installed by the migrations applier — no per-instance
+        # bootstrap needed on the pg backend.
+        return None
+
+    def upsert_worker_session(self, **kwargs: object) -> None:  # noqa: ARG002
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def get_worker_session(
+        self, **kwargs: object  # noqa: ARG002
+    ) -> WorkerSessionRecord | None:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def list_worker_sessions(
+        self, **kwargs: object  # noqa: ARG002
+    ) -> list[WorkerSessionRecord]:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def end_worker_session(self, **kwargs: object) -> None:  # noqa: ARG002
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def mark_worker_session_ended(
+        self, **kwargs: object  # noqa: ARG002
+    ) -> None:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+    def update_worker_session_tokens(
+        self, **kwargs: object  # noqa: ARG002
+    ) -> None:
+        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+
+
+__all__ = ["PgWorkService"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,3 +82,10 @@ def _reset_store_cache_between_tests():
     yield
     if reset_store_cache is not None:
         reset_store_cache()
+
+
+# Pg-backed test fixtures (issue #1737, Slice A). Lives in a sibling
+# module so the heavy testcontainers / psycopg imports stay lazy
+# (``pytest_plugins`` is registered up-front but the fixtures within
+# only do their import work when actually invoked by a test).
+pytest_plugins = ["tests.conftest_pg"]

--- a/tests/conftest_pg.py
+++ b/tests/conftest_pg.py
@@ -1,0 +1,182 @@
+"""Shared fixtures for the pg-backed tests (issue #1737, Slice A).
+
+Imported from ``tests/conftest.py`` via ``pytest_plugins`` so every
+``test_pg_*.py`` module in this directory has access to the
+``_pg_container`` + ``pg_schema_pool`` fixtures without re-importing.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import uuid
+from typing import Iterator
+
+import pytest
+
+
+def _has_docker() -> bool:
+    """Probe for a working Docker daemon without raising."""
+    try:
+        import docker  # type: ignore[import-not-found]
+    except ImportError:
+        return False
+    try:
+        client = docker.from_env()
+        client.ping()
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+def _local_pg_with_vector() -> str | None:
+    """Return a DSN to a local pg with pgvector installed, or None.
+
+    Used as the fallback when Docker isn't available. Tries the env
+    DSN first, then the conventional dev DBs (``pollypm_test``,
+    ``pollypm``); returns the first one that's reachable and has the
+    ``vector`` extension available. Returns None on missing driver or
+    no reachable candidate.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    candidates: list[str] = []
+    env = os.environ.get("POLLYPM_PG_DSN", "").strip()
+    if env:
+        candidates.append(env)
+    candidates.extend(
+        [
+            "postgresql://localhost:5432/pollypm_test",
+            "postgresql://localhost:5432/pollypm",
+        ]
+    )
+    for dsn in candidates:
+        try:
+            conn = psycopg.connect(dsn, connect_timeout=2)
+        except Exception:  # noqa: BLE001
+            continue
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM pg_available_extensions WHERE name = 'vector'"
+                )
+                if cur.fetchone() is None:
+                    continue
+        finally:
+            conn.close()
+        return dsn
+    return None
+
+
+@pytest.fixture(scope="session")
+def _pg_container() -> Iterator[str]:
+    """Yield a DSN to a pg instance with pgvector installed.
+
+    Prefers testcontainers when Docker is available; falls back to a
+    local DSN. Skips the consuming test when neither is reachable.
+    """
+    if _has_docker():
+        try:
+            from testcontainers.postgres import (  # type: ignore[import-not-found]
+                PostgresContainer,
+            )
+        except ImportError:
+            container = None
+        else:
+            container = (
+                PostgresContainer("pgvector/pgvector:pg16")
+                .with_env("POSTGRES_DB", "pollypm")
+                .with_env("POSTGRES_USER", "pollypm")
+                .with_env("POSTGRES_PASSWORD", "pollypm")
+            )
+            container.start()
+            try:
+                dsn = container.get_connection_url().replace(
+                    "postgresql+psycopg2://", "postgresql://"
+                )
+                yield dsn
+                return
+            finally:
+                container.stop()
+
+    dsn = _local_pg_with_vector()
+    if dsn is None:
+        pytest.skip(
+            "no pg container / local pg with vector ext; install Docker "
+            "or set POLLYPM_PG_DSN to a pg with pgvector installed"
+        )
+    yield dsn
+
+
+@pytest.fixture()
+def pg_schema_pool(_pg_container, monkeypatch) -> Iterator[object]:
+    """Per-test pool against a fresh schema namespace.
+
+    Creates ``CREATE SCHEMA test_<uuid>`` and patches the pool factory
+    so every connection sets ``search_path`` to the test schema. Drops
+    the schema on teardown.
+    """
+    monkeypatch.setenv("POLLYPM_PG_DSN", _pg_container)
+
+    from pollypm.storage import pg_pool
+
+    importlib.reload(pg_pool)
+
+    schema = f"test_{uuid.uuid4().hex[:12]}"
+
+    bootstrap = pg_pool.get_rw_pool(None)
+    try:
+        with bootstrap.connection() as conn, conn.cursor() as cur:
+            cur.execute(f'CREATE SCHEMA "{schema}"')
+    finally:
+        pg_pool.pg_pool_shutdown()
+
+    importlib.reload(pg_pool)
+
+    def _build_with_search_path(*args, **kwargs):
+        from psycopg_pool import ConnectionPool
+
+        read_only = kwargs.get("read_only", False)
+        application_name = kwargs.get("application_name", "pollypm/test")
+        safe_app = "".join(
+            c for c in application_name
+            if c.isalnum() or c in "._/-"
+        ) or "pollypm-test"
+
+        def _configure(conn) -> None:
+            with conn.cursor() as cur:
+                cur.execute(f"SET application_name = '{safe_app}'")
+                # ``public`` stays on the path so the ``vector`` type
+                # (installed into ``public`` by ``CREATE EXTENSION``)
+                # resolves from inside the per-test schema. Without
+                # public on the path the embeddings DDL can't see the
+                # vector type.
+                cur.execute(f'SET search_path = "{schema}", public')
+                if read_only:
+                    cur.execute(
+                        "SET default_transaction_read_only = on"
+                    )
+            conn.commit()
+
+        return ConnectionPool(
+            conninfo=args[0],
+            min_size=kwargs["min_size"],
+            max_size=kwargs["max_size"],
+            configure=_configure,
+            open=True,
+            name=f"pollypm-test-{'ro' if read_only else 'rw'}",
+        )
+
+    monkeypatch.setattr(pg_pool, "_build_pool", _build_with_search_path)
+    pool = pg_pool.get_rw_pool(None)
+    try:
+        yield pool
+    finally:
+        pg_pool.pg_pool_shutdown()
+        import psycopg  # type: ignore[import-not-found]
+
+        with psycopg.connect(_pg_container) as conn:
+            with conn.cursor() as cur:
+                cur.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')

--- a/tests/test_pg_pool.py
+++ b/tests/test_pg_pool.py
@@ -1,0 +1,264 @@
+"""Tests for the Postgres connection pool primitives (issue #1737).
+
+The pool tests fan out across two surfaces:
+
+* Pure-Python behaviour that doesn't need a live pg — DSN resolution,
+  pool sizing, env-var override, the "pg DSN smells like sqlite" guard.
+  These run unconditionally.
+* Live-pool lifecycle (open + close + RW/RO separation + bad-DSN error).
+  These need a live pg instance and are skipped automatically when
+  Docker / pg isn't available. Local dev: ``brew services start
+  postgresql@17 && createdb pollypm`` is enough. CI uses the
+  testcontainers fixture in ``tests/test_pg_schema.py``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+
+
+# --------------------------------------------------------------------- #
+# Pure-Python behaviour — no pg required.
+# --------------------------------------------------------------------- #
+
+
+def _reload_pool_module():
+    """Re-import ``pg_pool`` so module-level singletons are fresh.
+
+    Tests mutate env vars + call ``pg_pool_shutdown``; importlib.reload
+    is the cheapest way to reset to a clean module state between cases.
+    """
+    import pollypm.storage.pg_pool as mod
+
+    importlib.reload(mod)
+    return mod
+
+
+def test_resolve_dsn_default_when_no_env_no_config(monkeypatch):
+    monkeypatch.delenv("POLLYPM_PG_DSN", raising=False)
+    mod = _reload_pool_module()
+    assert mod.resolve_dsn(None) == mod.DEFAULT_DSN
+
+
+def test_resolve_dsn_env_wins(monkeypatch):
+    monkeypatch.setenv("POLLYPM_PG_DSN", "postgresql://x:9999/y")
+    mod = _reload_pool_module()
+    assert mod.resolve_dsn(None) == "postgresql://x:9999/y"
+
+
+def test_resolve_dsn_uses_config_url_when_postgres(monkeypatch):
+    monkeypatch.delenv("POLLYPM_PG_DSN", raising=False)
+    mod = _reload_pool_module()
+
+    class _Storage:
+        url = "postgresql://h:5432/db"
+
+    class _Config:
+        storage = _Storage()
+
+    assert mod.resolve_dsn(_Config()) == "postgresql://h:5432/db"
+
+
+def test_resolve_dsn_ignores_sqlite_config_url(monkeypatch):
+    """A sqlite URL in ``[storage] url`` must not leak into pg DSN."""
+    monkeypatch.delenv("POLLYPM_PG_DSN", raising=False)
+    mod = _reload_pool_module()
+
+    class _Storage:
+        url = "sqlite:///tmp/state.db"
+
+    class _Config:
+        storage = _Storage()
+
+    assert mod.resolve_dsn(_Config()) == mod.DEFAULT_DSN
+
+
+def test_resolve_pool_sizing_defaults():
+    mod = _reload_pool_module()
+    assert mod.resolve_pool_sizing(None) == (
+        mod.DEFAULT_POOL_MIN,
+        mod.DEFAULT_POOL_MAX,
+    )
+
+
+def test_resolve_pool_sizing_honours_config():
+    mod = _reload_pool_module()
+
+    class _PgSection:
+        pool_min = 3
+        pool_max = 7
+
+    class _Storage:
+        pg = _PgSection()
+
+    class _Config:
+        storage = _Storage()
+
+    assert mod.resolve_pool_sizing(_Config()) == (3, 7)
+
+
+def test_resolve_pool_sizing_clamps_min_below_one():
+    mod = _reload_pool_module()
+
+    class _PgSection:
+        pool_min = 0
+        pool_max = 5
+
+    class _Storage:
+        pg = _PgSection()
+
+    class _Config:
+        storage = _Storage()
+
+    # pool_min must be at least 1 — the pool would reject 0.
+    assert mod.resolve_pool_sizing(_Config()) == (1, 5)
+
+
+def test_resolve_pool_sizing_clamps_max_below_min():
+    mod = _reload_pool_module()
+
+    class _PgSection:
+        pool_min = 4
+        pool_max = 2  # nonsensical; clamped up
+
+    class _Storage:
+        pg = _PgSection()
+
+    class _Config:
+        storage = _Storage()
+
+    min_size, max_size = mod.resolve_pool_sizing(_Config())
+    assert min_size == 4
+    assert max_size >= min_size
+
+
+def test_safe_dsn_redacts_password():
+    mod = _reload_pool_module()
+    masked = mod._safe_dsn("postgresql://alice:secretpw@host:5432/db")
+    assert "secretpw" not in masked
+    assert "alice" in masked
+
+
+def test_safe_dsn_preserves_passwordless():
+    mod = _reload_pool_module()
+    assert mod._safe_dsn("postgresql://host/db") == "postgresql://host/db"
+
+
+# --------------------------------------------------------------------- #
+# Live-pool lifecycle — needs a real pg.
+# --------------------------------------------------------------------- #
+
+
+def _live_pg_dsn() -> str | None:
+    """Return a working pg DSN for the live pool tests, or None.
+
+    Honours ``POLLYPM_PG_DSN`` when it points at a reachable instance
+    and falls back to the local-default DSN otherwise. Returns None
+    (and the live tests skip) on any connection failure or missing
+    driver.
+    """
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    candidates: list[str] = []
+    env = os.environ.get("POLLYPM_PG_DSN", "").strip()
+    if env:
+        candidates.append(env)
+    candidates.append("postgresql://localhost:5432/pollypm_test")
+    candidates.append("postgresql://localhost:5432/pollypm")
+    for dsn in candidates:
+        try:
+            conn = psycopg.connect(dsn, connect_timeout=2)
+        except Exception:  # noqa: BLE001
+            continue
+        conn.close()
+        return dsn
+    return None
+
+
+_LIVE_DSN = _live_pg_dsn()
+
+live_pg = pytest.mark.skipif(
+    _LIVE_DSN is None,
+    reason="local pg not reachable; set POLLYPM_PG_DSN or start postgres",
+)
+
+
+@live_pg
+def test_get_rw_pool_returns_singleton(monkeypatch):
+    monkeypatch.setenv("POLLYPM_PG_DSN", _LIVE_DSN)
+    mod = _reload_pool_module()
+    try:
+        p1 = mod.get_rw_pool(None)
+        p2 = mod.get_rw_pool(None)
+        assert p1 is p2
+        with p1.connection() as conn, conn.cursor() as cur:
+            cur.execute("SELECT 1")
+            assert cur.fetchone()[0] == 1
+    finally:
+        mod.pg_pool_shutdown()
+
+
+@live_pg
+def test_ro_pool_blocks_writes(monkeypatch):
+    monkeypatch.setenv("POLLYPM_PG_DSN", _LIVE_DSN)
+    mod = _reload_pool_module()
+    try:
+        import psycopg  # type: ignore[import-not-found]
+
+        rw = mod.get_rw_pool(None)
+        with rw.connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                "CREATE TABLE IF NOT EXISTS _pg_pool_test (id int PRIMARY KEY)"
+            )
+        ro = mod.get_ro_pool(None)
+        with ro.connection() as conn, conn.cursor() as cur:
+            with pytest.raises(psycopg.errors.ReadOnlySqlTransaction):
+                cur.execute("INSERT INTO _pg_pool_test VALUES (1)")
+        # Cleanup — RW pool drops the helper table.
+        with rw.connection() as conn, conn.cursor() as cur:
+            cur.execute("DROP TABLE IF EXISTS _pg_pool_test")
+    finally:
+        mod.pg_pool_shutdown()
+
+
+@live_pg
+def test_pg_pool_shutdown_is_idempotent(monkeypatch):
+    monkeypatch.setenv("POLLYPM_PG_DSN", _LIVE_DSN)
+    mod = _reload_pool_module()
+    mod.get_rw_pool(None)
+    mod.pg_pool_shutdown()
+    mod.pg_pool_shutdown()  # second call must not raise
+
+
+def test_bad_dsn_raises_on_first_use(monkeypatch):
+    """A DSN that points nowhere must fail loudly when used.
+
+    psycopg_pool defers the actual connect until first ``.connection()``
+    when ``open=True`` is set (the pool backfills in a background
+    thread). The user-visible contract is: trying to USE a bad DSN
+    raises within a reasonable time. We assert that contract directly.
+    """
+    try:
+        import psycopg_pool  # noqa: F401  # type: ignore[import-not-found]
+    except ImportError:
+        pytest.skip("psycopg_pool not installed")
+    monkeypatch.setenv(
+        "POLLYPM_PG_DSN",
+        "postgresql://does-not-exist.invalid:65535/nope?connect_timeout=1",
+    )
+    mod = _reload_pool_module()
+    try:
+        with pytest.raises(Exception):
+            pool = mod.get_rw_pool(None)
+            # Force-acquire so a deferred-connect pool surfaces the
+            # bad-host error rather than hanging on the background
+            # warm-up loop.
+            with pool.connection(timeout=3) as conn:
+                conn.execute("SELECT 1")
+    finally:
+        mod.pg_pool_shutdown()

--- a/tests/test_pg_schema.py
+++ b/tests/test_pg_schema.py
@@ -1,0 +1,131 @@
+"""Tests for the canonical pg schema + migration applier (issue #1737).
+
+Strategy
+--------
+
+Fixtures (``_pg_container`` + ``pg_schema_pool``) live in
+``tests/conftest_pg.py`` so multiple ``test_pg_*.py`` modules share
+them. Each test runs against a fresh schema namespace inside one
+session-scoped pg container so cases don't collide and teardown is
+cheap.
+
+Skipped automatically when neither Docker nor a local pg with
+``vector`` is available.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# --------------------------------------------------------------------- #
+# Schema apply tests.
+# --------------------------------------------------------------------- #
+
+
+def test_initial_migration_applies_cleanly(pg_schema_pool):
+    from pollypm.storage.pg_migrations import apply_migrations
+    from pollypm.storage.pg_schema import all_table_names
+
+    result = apply_migrations(pg_schema_pool)
+    assert result.did_anything
+    assert [v for v, _ in result.applied] == [1]
+
+    expected = set(all_table_names())
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT tablename FROM pg_tables WHERE schemaname = current_schema()"
+        )
+        present = {row[0] for row in cur.fetchall()}
+    missing = expected - present
+    assert not missing, f"missing tables after migrate: {sorted(missing)}"
+
+
+def test_migration_is_idempotent(pg_schema_pool):
+    """Apply twice — the second pass must be a no-op."""
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    first = apply_migrations(pg_schema_pool)
+    assert first.did_anything
+    second = apply_migrations(pg_schema_pool)
+    assert not second.did_anything
+    assert [v for v, _ in second.already_applied] == [1]
+
+
+def test_schema_migrations_table_records_label(pg_schema_pool):
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT version, label FROM schema_migrations ORDER BY version"
+        )
+        rows = cur.fetchall()
+    assert rows == [(1, "0001_initial")]
+
+
+def test_vector_extension_installed(pg_schema_pool):
+    """The applier must install pgvector before any vector(N) DDL.
+
+    Without the extension the embeddings table DDL would fail and the
+    whole migration would roll back; the existence check here is the
+    direct positive assertion.
+    """
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM pg_extension WHERE extname = 'vector'")
+        assert cur.fetchone() is not None
+
+
+def test_embeddings_hnsw_index_present(pg_schema_pool):
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM pg_indexes "
+            "WHERE schemaname = current_schema() "
+            "AND tablename = 'embeddings' "
+            "AND indexname = 'embeddings_hnsw'"
+        )
+        assert cur.fetchone() is not None
+
+
+def test_messages_tsvector_column_generated(pg_schema_pool):
+    """The generated tsvector column on messages must be queryable."""
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO messages (scope, type, recipient, sender, subject, body) "
+            "VALUES ('s', 'event', 'r', 'me', 'hello world', 'goodbye moon')"
+        )
+        cur.execute(
+            "SELECT (subject_body_tsv)::text FROM messages "
+            "WHERE subject = 'hello world'"
+        )
+        row = cur.fetchone()
+        assert row is not None
+        assert "hello" in row[0]
+
+
+def test_validate_migration_order_catches_gap(monkeypatch):
+    """Sanity: a missing version in MIGRATIONS must fail loud at validate-time."""
+    from pollypm.storage import pg_migrations
+
+    bad = [(1, "a", "select 1"), (3, "c", "select 1")]
+    monkeypatch.setattr(pg_migrations, "MIGRATIONS", bad)
+    with pytest.raises(RuntimeError, match="missing migration"):
+        pg_migrations._validate_migration_order()
+
+
+def test_validate_migration_order_catches_duplicate(monkeypatch):
+    from pollypm.storage import pg_migrations
+
+    bad = [(1, "a", "select 1"), (1, "b", "select 1")]
+    monkeypatch.setattr(pg_migrations, "MIGRATIONS", bad)
+    with pytest.raises(RuntimeError, match="duplicate migration"):
+        pg_migrations._validate_migration_order()

--- a/tests/test_pg_work_service.py
+++ b/tests/test_pg_work_service.py
@@ -1,0 +1,268 @@
+"""Tests for the Slice A subset of :class:`PgWorkService` (issue #1737).
+
+Covers the read + minimal-CRUD surface shipped in Slice A:
+
+* ``__init__`` opens a pool and runs the schema migration applier.
+* ``create`` allocates a new task_number atomically per project.
+* ``get`` round-trips every column in the schema port.
+* ``list_tasks`` honours the supported filter subset.
+* ``queue`` / ``mark_done`` / ``cancel`` write through the
+  ``work_transitions`` audit trail.
+* ``state_counts`` aggregates by status.
+
+The ``pg_schema_pool`` fixture comes from ``tests/conftest_pg.py``; if
+Docker / local pg isn't available the whole module skips.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def pg_service(pg_schema_pool):
+    from pollypm.work.pg_service import PgWorkService
+
+    return PgWorkService(pool=pg_schema_pool, ro_pool=None)
+
+
+def test_init_applies_schema(pg_schema_pool):
+    """Constructor must apply the schema migration on first open."""
+    from pollypm.work.pg_service import PgWorkService
+
+    PgWorkService(pool=pg_schema_pool, ro_pool=None)
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT 1 FROM pg_tables "
+            "WHERE schemaname = current_schema() "
+            "AND tablename = 'work_tasks'"
+        )
+        assert cur.fetchone() is not None
+
+
+def test_create_assigns_sequential_task_numbers(pg_service):
+    t1 = pg_service.create(
+        title="first",
+        type="task",
+        project="demo",
+        flow_template="default",
+        roles={"worker": "alice"},
+    )
+    t2 = pg_service.create(
+        title="second",
+        type="task",
+        project="demo",
+        flow_template="default",
+        roles={"worker": "alice"},
+    )
+    assert t1.task_number == 1
+    assert t2.task_number == 2
+    assert t1.project == "demo"
+
+
+def test_create_per_project_isolation(pg_service):
+    """Task numbers must increment per project, not globally."""
+    a = pg_service.create(
+        title="a",
+        type="task",
+        project="proj-a",
+        flow_template="default",
+        roles={"worker": "alice"},
+    )
+    b = pg_service.create(
+        title="b",
+        type="task",
+        project="proj-b",
+        flow_template="default",
+        roles={"worker": "alice"},
+    )
+    assert a.task_number == 1
+    assert b.task_number == 1
+
+
+def test_get_round_trips_fields(pg_service):
+    from pollypm.inbox.kind import InboxItemKind
+    from pollypm.work.models import Priority, TaskType, WorkStatus
+
+    created = pg_service.create(
+        title="round trip",
+        description="full payload",
+        type="bug",
+        project="demo",
+        flow_template="custom",
+        roles={"worker": "alice", "reviewer": "bob"},
+        priority="high",
+        labels=["urgent", "backend"],
+        relevant_files=["a.py", "b.py"],
+        kind="approval_request",
+    )
+
+    task = pg_service.get(f"demo/{created.task_number}")
+    assert task.title == "round trip"
+    assert task.description == "full payload"
+    assert task.type is TaskType.BUG
+    assert task.priority is Priority.HIGH
+    assert task.work_status is WorkStatus.DRAFT
+    assert task.labels == ["urgent", "backend"]
+    assert task.relevant_files == ["a.py", "b.py"]
+    assert task.roles == {"worker": "alice", "reviewer": "bob"}
+    assert task.kind is InboxItemKind.APPROVAL_REQUEST
+
+
+def test_get_missing_raises(pg_service):
+    from pollypm.work.service_support import TaskNotFoundError
+
+    with pytest.raises(TaskNotFoundError):
+        pg_service.get("nope/999")
+
+
+def test_list_tasks_filters_by_project(pg_service):
+    pg_service.create(
+        title="a", type="task", project="alpha",
+        flow_template="default", roles={"worker": "a"},
+    )
+    pg_service.create(
+        title="b", type="task", project="beta",
+        flow_template="default", roles={"worker": "a"},
+    )
+    pg_service.create(
+        title="c", type="task", project="alpha",
+        flow_template="default", roles={"worker": "a"},
+    )
+    alpha = pg_service.list_tasks(project="alpha")
+    beta = pg_service.list_tasks(project="beta")
+    assert {t.title for t in alpha} == {"a", "c"}
+    assert {t.title for t in beta} == {"b"}
+
+
+def test_list_tasks_filter_by_status(pg_service):
+    a = pg_service.create(
+        title="a", type="task", project="demo",
+        flow_template="default", roles={"worker": "x"},
+    )
+    pg_service.create(
+        title="b", type="task", project="demo",
+        flow_template="default", roles={"worker": "x"},
+    )
+    pg_service.queue(f"demo/{a.task_number}", actor="user")
+    queued = pg_service.list_tasks(project="demo", work_status="queued")
+    assert {t.title for t in queued} == {"a"}
+
+
+def test_queue_transitions_draft_to_queued(pg_service):
+    from pollypm.work.models import WorkStatus
+
+    task = pg_service.create(
+        title="x", type="task", project="demo",
+        flow_template="default", roles={"worker": "a"},
+    )
+    queued = pg_service.queue(f"demo/{task.task_number}", actor="user")
+    assert queued.work_status is WorkStatus.QUEUED
+
+
+def test_queue_writes_transition_row(pg_service, pg_schema_pool):
+    task = pg_service.create(
+        title="x", type="task", project="demo",
+        flow_template="default", roles={"worker": "a"},
+    )
+    pg_service.queue(f"demo/{task.task_number}", actor="user")
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT from_state, to_state, actor FROM work_transitions "
+            "WHERE task_project = 'demo' AND task_number = %s",
+            (task.task_number,),
+        )
+        rows = cur.fetchall()
+    assert ("draft", "queued", "user") in [(r[0], r[1], r[2]) for r in rows]
+
+
+def test_queue_is_idempotent(pg_service):
+    from pollypm.work.models import WorkStatus
+
+    task = pg_service.create(
+        title="x", type="task", project="demo",
+        flow_template="default", roles={"worker": "a"},
+    )
+    pg_service.queue(f"demo/{task.task_number}", actor="user")
+    second = pg_service.queue(f"demo/{task.task_number}", actor="user")
+    assert second.work_status is WorkStatus.QUEUED
+
+
+def test_cancel_transitions_to_cancelled(pg_service):
+    from pollypm.work.models import WorkStatus
+
+    task = pg_service.create(
+        title="x", type="task", project="demo",
+        flow_template="default", roles={"worker": "a"},
+    )
+    cancelled = pg_service.cancel(
+        f"demo/{task.task_number}", actor="user", reason="moot"
+    )
+    assert cancelled.work_status is WorkStatus.CANCELLED
+
+
+def test_cancel_rejects_terminal_task(pg_service):
+    from pollypm.work.service_support import InvalidTransitionError
+
+    task = pg_service.create(
+        title="x", type="task", project="demo",
+        flow_template="default", roles={"worker": "a"},
+    )
+    pg_service.mark_done(f"demo/{task.task_number}", actor="user")
+    with pytest.raises(InvalidTransitionError):
+        pg_service.cancel(
+            f"demo/{task.task_number}", actor="user", reason="nope"
+        )
+
+
+def test_mark_done_transitions_to_done(pg_service):
+    from pollypm.work.models import WorkStatus
+
+    task = pg_service.create(
+        title="x", type="task", project="demo",
+        flow_template="default", roles={"worker": "a"},
+    )
+    done = pg_service.mark_done(f"demo/{task.task_number}", actor="user")
+    assert done.work_status is WorkStatus.DONE
+
+
+def test_state_counts_aggregates(pg_service):
+    a = pg_service.create(
+        title="a", type="task", project="demo",
+        flow_template="default", roles={"worker": "a"},
+    )
+    pg_service.create(
+        title="b", type="task", project="demo",
+        flow_template="default", roles={"worker": "a"},
+    )
+    pg_service.queue(f"demo/{a.task_number}", actor="user")
+    counts = pg_service.state_counts(project="demo")
+    assert counts.get("draft", 0) == 1
+    assert counts.get("queued", 0) == 1
+
+
+def test_list_nonterminal_excludes_done_and_cancelled(pg_service):
+    a = pg_service.create(
+        title="a", type="task", project="demo",
+        flow_template="default", roles={"worker": "x"},
+    )
+    b = pg_service.create(
+        title="b", type="task", project="demo",
+        flow_template="default", roles={"worker": "x"},
+    )
+    c = pg_service.create(
+        title="c", type="task", project="demo",
+        flow_template="default", roles={"worker": "x"},
+    )
+    pg_service.mark_done(f"demo/{a.task_number}", actor="u")
+    pg_service.cancel(f"demo/{b.task_number}", actor="u", reason="r")
+    rows = pg_service.list_nonterminal_tasks(project="demo")
+    assert [t.task_number for t in rows] == [c.task_number]
+
+
+def test_protocol_stubs_raise_not_implemented(pg_service):
+    """Slice A stubs must crash loud, not return None."""
+    with pytest.raises(NotImplementedError, match="Slice"):
+        pg_service.claim("demo/1", actor="u")
+    with pytest.raises(NotImplementedError, match="Slice"):
+        pg_service.approve("demo/1", actor="u")


### PR DESCRIPTION
## Summary

Slice A of the Postgres + pgvector migration scoped at #1737. Foundation work — the primitives Slices B–H sit on top of. Everything is behind the existing `[storage] backend` feature flag; default stays `"sqlite"` and the new code paths are unreachable until the cutover PR.

## What ships (per the slice spec)

- [x] **1. pg connection pool primitive** — `src/pollypm/storage/pg_pool.py`. Dual RW/RO `psycopg_pool.ConnectionPool` singletons. RO sessions run `SET default_transaction_read_only = on` so stray writes crash loud. DSN resolution: `POLLYPM_PG_DSN` env > `[storage] url` (only when it smells like pg) > `postgresql://localhost:5432/pollypm` default. `get_rw_pool()` / `get_ro_pool()` / `pg_pool_shutdown()`.
- [x] **2. Schema DDL + migrations applier** — `pg_schema.py` (full table port, jsonb where sqlite stored JSON-as-text, `timestamptz` for ISO-8601, real `ON DELETE CASCADE` FKs, GIN on queried jsonb cols, generated-column tsvector for messages + memory_entries) + `pg_migrations.py` (forward-only, `schema_migrations` audit table, gap/duplicate detection).
- [x] **3. pgvector extension setup** — `CREATE EXTENSION IF NOT EXISTS vector` bootstrapped before any version DDL; `embeddings(source_table, source_id, embedding vector(1536), model, generated_at)` table + HNSW cosine index live in migration 0001.
- [x] **4. `PgWorkService` skeleton** — `src/pollypm/work/pg_service.py`. Slice A subset: constructor (applies migrations on first open), `get`, `list_tasks`, `list_nonterminal_tasks`, `state_counts`, minimal `create`, `queue`, `cancel`, `mark_done` (all writing through `work_transitions` for audit parity). The remaining Protocol methods raise `NotImplementedError` with a "Slice B" pointer.
- [x] **5. Backend factory wiring** — `work/factory.py` dispatches on `config.storage.backend`. `"sqlite"` returns `SQLiteWorkService` unchanged; `"postgres"` returns `PgWorkService`.
- [x] **6. Config knobs** — `[storage.pg]` (`pool_min`, `pool_max`, `min_version`, `dsn`) + `[storage.embedding]` (`model`, `provider`, `api_key_env`). Parsed defensively — a fat-fingered knob falls back to the dataclass default.
- [x] **7. `pm doctor` pg-connection check** — registers as a category-`install` check that's `skipped` on sqlite installs. Probes `SELECT 1`, parses `server_version_num`, verifies `vector` extension. Standalone CLI `pm doctor-pg-connection` runs only this probe.
- [x] **8. Tests** — `test_pg_pool` (14 tests), `test_pg_schema` (8 tests), `test_pg_work_service` (16 tests). Live tests use `pgvector/pgvector:pg16` testcontainer when Docker is up; fall back to local pg via `POLLYPM_PG_DSN`; skip cleanly when neither is available.
- [x] **9. Operator runbook** — "Setting up Postgres" section in `operator-runbook.md` covering macOS + Linux install, `CREATE EXTENSION`, config snippet, doctor smoke, and the safe-rollback contract.

## Scope guardrails honoured

- `SQLiteWorkService` + `storage/*` read-side facades untouched (Slices B / C).
- `pm storage migrate-to-pg` not shipped (Slice E).
- Default backend stays `"sqlite"`; cutover PR flips it.
- `notification_staging` ported 1:1 to pg; retirement is a separate follow-up.
- Audit JSONL files untouched.

## Verification

- 38/38 new pg tests pass against a local pg 16 + pgvector instance (`POLLYPM_PG_DSN=postgresql://localhost:5432/pollypm_test`).
- 70/70 existing `test_work_service.py` tests still green.
- 74/74 doctor tests still green (deselected only the env-flaky `test_doctor_performance_budget`).
- ruff clean on every touched src + tests file.
- `pm doctor-pg-connection` manually exercised against pg 16.12 — reports `pg 16.12 reachable at <dsn> (vector extension installed)`. Configured `min_version = "99.0"` correctly fails with the expected three-question message.

## Test plan

- [ ] CI runs the new test files against the testcontainers `pgvector:pg16` image.
- [ ] On a dev machine: `brew install postgresql@17 pgvector && createdb pollypm && psql pollypm -c "CREATE EXTENSION vector"`, then flip `[storage] backend = "postgres"` in `~/.pollypm/pollypm.toml`, run `pm doctor-pg-connection`, confirm pass.
- [ ] Verify on a sqlite install: `pm doctor` shows the `pg-connection` check as skipped (not failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)