### PR TITLE
feat(pg): fill out PgWorkService — slice B of #1737

### DIFF
--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -44,10 +44,18 @@ from typing import TYPE_CHECKING, Any
 
 from pollypm.inbox.kind import coerce_kind as _coerce_inbox_kind
 from pollypm.work.models import (
+    ActorType,
+    ArtifactKind,
     ContextEntry,
+    Decision,
+    ExecutionStatus,
+    FlowNode,
     FlowNodeExecution,
     FlowTemplate,
     GateResult,
+    LinkKind,
+    NodeType,
+    OutputType,
     Priority,
     Task,
     TaskType,
@@ -605,142 +613,1039 @@ class PgWorkService:
             rows = cur.fetchall()
         return [self._row_to_task(row) for row in rows]
 
-    def update(self, task_id: str, **fields: object) -> Task:  # noqa: ARG002
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+    # ------------------------------------------------------------------
+    # Mutable field updates
+    # ------------------------------------------------------------------
+
+    _UPDATE_ALLOWED_COLUMNS = {
+        "title": "title",
+        "description": "description",
+        "priority": "priority",
+        "labels": "labels",
+        "roles": "roles",
+        "acceptance_criteria": "acceptance_criteria",
+        "constraints": "constraints",
+        "relevant_files": "relevant_files",
+    }
+    _UPDATE_JSON_COLUMNS = frozenset({"labels", "relevant_files", "roles"})
+
+    def update(self, task_id: str, **fields: object) -> Task:
+        """Update mutable fields on a task.
+
+        Slice B port of ``update_task`` (service_queries.py). Refuses
+        ``work_status`` and ``flow_template`` changes — those go through
+        the lifecycle methods.
+        """
+        if "work_status" in fields:
+            raise ValidationError(
+                "Cannot change work_status via update(). "
+                "Use lifecycle methods (queue, claim, cancel, etc.)."
+            )
+        if "flow_template" in fields or "flow_template_id" in fields:
+            raise ValidationError("Cannot change flow_template after creation.")
+
+        project, task_number = _parse_task_id(task_id)
+        set_clauses: list[str] = []
+        params: list[object] = []
+        for key, value in fields.items():
+            column = self._UPDATE_ALLOWED_COLUMNS.get(key)
+            if column is None:
+                raise ValidationError(f"Field '{key}' is not updatable.")
+            if key in self._UPDATE_JSON_COLUMNS:
+                params.append(json.dumps(value))
+                set_clauses.append(f"{column} = %s::jsonb")
+            else:
+                params.append(value)
+                set_clauses.append(f"{column} = %s")
+
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM work_tasks "
+                    "WHERE project = %s AND task_number = %s",
+                    (project, task_number),
+                )
+                if cur.fetchone() is None:
+                    raise TaskNotFoundError(f"Task '{task_id}' not found.")
+                if not set_clauses:
+                    return self.get(task_id)
+                set_clauses.append("updated_at = %s")
+                params.append(_now_iso())
+                params.extend([project, task_number])
+                cur.execute(
+                    f"UPDATE work_tasks SET {', '.join(set_clauses)} "
+                    "WHERE project = %s AND task_number = %s",
+                    params,
+                )
+            conn.commit()
+        return self.get(task_id)
 
     def increment_plan_version(
         self,
-        task_id: str,  # noqa: ARG002
+        task_id: str,
         *,
-        actor: str = "system",  # noqa: ARG002
-        reason: str | None = None,  # noqa: ARG002
+        actor: str = "system",  # noqa: ARG002 — audit emission is Slice C
+        reason: str | None = None,  # noqa: ARG002 — audit emission is Slice C
     ) -> Task:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        """Bump ``plan_version`` on a plan task (#1398).
 
-    def list_successors(
-        self, predecessor_task_id: str
-    ) -> list[Task]:  # noqa: ARG002
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        Slice B keeps the version bump itself; the audit emission
+        (``plan.version_incremented``) lands when Slice C ports the
+        audit log adapter. Behavior is otherwise 1:1 with the sqlite
+        path.
+        """
+        project, task_number = _parse_task_id(task_id)
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT plan_version FROM work_tasks "
+                    "WHERE project = %s AND task_number = %s",
+                    (project, task_number),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    raise TaskNotFoundError(f"Task '{task_id}' not found.")
+                old_version = int(row[0] or 1)
+                new_version = old_version + 1
+                cur.execute(
+                    "UPDATE work_tasks "
+                    "SET plan_version = %s, updated_at = %s "
+                    "WHERE project = %s AND task_number = %s",
+                    (new_version, _now_iso(), project, task_number),
+                )
+            conn.commit()
+        return self.get(task_id)
 
-    def claim(
-        self, task_id: str, actor: str, skip_gates: bool = False  # noqa: ARG002
-    ) -> Task:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+    def list_successors(self, predecessor_task_id: str) -> list[Task]:
+        """Tasks whose ``predecessor_task_id`` matches (#1398)."""
+        sql = (
+            "SELECT project, task_number, project_key, title, type, labels, "
+            "work_status, flow_template_id, flow_template_version, "
+            "current_node_id, assignee, priority, requires_human_review, "
+            "description, acceptance_criteria, constraints, relevant_files, "
+            "parent_project, parent_task_number, "
+            "supersedes_project, supersedes_task_number, "
+            "plan_version, predecessor_task_id, kind, roles, external_refs, "
+            "created_at, created_by, updated_at "
+            "FROM work_tasks WHERE predecessor_task_id = %s "
+            "ORDER BY project, task_number"
+        )
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, (predecessor_task_id,))
+            rows = cur.fetchall()
+        return [self._row_to_task(row) for row in rows]
+
+    # ------------------------------------------------------------------
+    # State transitions (Slice B port of the transition manager)
+    #
+    # These intentionally implement a simplified version of the sqlite
+    # transition manager: state checks + node advancement + audit row,
+    # without the post-commit side effects (session provisioning, auto-
+    # repair, sync adapters, plan-review emission). Those land in
+    # Slice C alongside the audit / sync adapter ports.
+    # ------------------------------------------------------------------
+
+    def claim(self, task_id: str, actor: str, skip_gates: bool = False) -> Task:  # noqa: ARG002
+        """Atomically claim a queued task.
+
+        Loads the flow template, resolves the start (or current) node,
+        moves the task to ``in_progress`` (or ``review`` for a review
+        start node), and writes the audit transition row.
+        """
+        task = self.get(task_id)
+        if task.work_status != WorkStatus.QUEUED:
+            raise InvalidTransitionError(
+                f"Cannot claim task in '{task.work_status.value}' state. "
+                f"Task must be in 'queued' state."
+            )
+        if task.blocked:
+            raise InvalidTransitionError(
+                f"Cannot claim task {task_id}: it is blocked by another task."
+            )
+
+        flow = self._load_flow(task)
+        node_id = task.current_node_id or flow.start_node
+        if not node_id:
+            raise InvalidTransitionError(
+                f"Task {task_id} has no claimable flow node."
+            )
+        node = flow.nodes.get(node_id)
+        if node is None:
+            raise InvalidTransitionError(
+                f"Current node '{node_id}' not found in flow '{flow.name}'."
+            )
+        if node.type == NodeType.TERMINAL:
+            raise InvalidTransitionError(
+                f"Current node '{node_id}' is terminal and cannot be claimed."
+            )
+
+        assignee = self._resolve_node_assignee(task, node) or actor
+        target_status = (
+            WorkStatus.REVIEW
+            if node.type == NodeType.REVIEW
+            else WorkStatus.IN_PROGRESS
+        )
+        now = _now_iso()
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE work_tasks SET work_status = %s, assignee = %s, "
+                    "current_node_id = %s, updated_at = %s "
+                    "WHERE project = %s AND task_number = %s",
+                    (
+                        target_status.value,
+                        assignee,
+                        node_id,
+                        now,
+                        task.project,
+                        task.task_number,
+                    ),
+                )
+                # If we're resuming a blocked execution, flip its status;
+                # otherwise insert a fresh visit row.
+                cur.execute(
+                    "SELECT id, status FROM work_node_executions "
+                    "WHERE task_project = %s AND task_number = %s "
+                    "AND node_id = %s "
+                    "ORDER BY visit DESC, id DESC LIMIT 1",
+                    (task.project, task.task_number, node_id),
+                )
+                latest = cur.fetchone()
+                if (
+                    task.current_node_id is not None
+                    and latest is not None
+                    and latest[1] == ExecutionStatus.BLOCKED.value
+                ):
+                    cur.execute(
+                        "UPDATE work_node_executions SET status = %s "
+                        "WHERE id = %s",
+                        (ExecutionStatus.ACTIVE.value, latest[0]),
+                    )
+                elif not (
+                    task.current_node_id is not None
+                    and latest is not None
+                    and latest[1] == ExecutionStatus.ACTIVE.value
+                ):
+                    visit = self._next_visit_locked(
+                        cur, task.project, task.task_number, node_id
+                    )
+                    cur.execute(
+                        "INSERT INTO work_node_executions "
+                        "(task_project, task_number, node_id, visit, "
+                        "status, started_at) VALUES "
+                        "(%s, %s, %s, %s, %s, %s)",
+                        (
+                            task.project,
+                            task.task_number,
+                            node_id,
+                            visit,
+                            ExecutionStatus.ACTIVE.value,
+                            now,
+                        ),
+                    )
+                self._insert_transition_locked(
+                    cur,
+                    task.project,
+                    task.task_number,
+                    WorkStatus.QUEUED.value,
+                    target_status.value,
+                    actor,
+                    None,
+                )
+            conn.commit()
+        return self.get(task_id)
 
     def next(  # noqa: A003
         self,
         *,
-        agent: str | None = None,  # noqa: ARG002
-        project: str | None = None,  # noqa: ARG002
+        agent: str | None = None,
+        project: str | None = None,
     ) -> Task | None:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        """Highest-priority queued+unblocked task; does NOT claim."""
+        clauses = ["t.work_status = %s"]
+        params: list[object] = [WorkStatus.QUEUED.value]
+        if project is not None:
+            clauses.append("t.project = %s")
+            params.append(project)
+        where = " AND ".join(clauses)
+        sql = (
+            "SELECT t.project, t.task_number, t.project_key, t.title, t.type, "
+            "t.labels, t.work_status, t.flow_template_id, "
+            "t.flow_template_version, t.current_node_id, t.assignee, "
+            "t.priority, t.requires_human_review, t.description, "
+            "t.acceptance_criteria, t.constraints, t.relevant_files, "
+            "t.parent_project, t.parent_task_number, "
+            "t.supersedes_project, t.supersedes_task_number, "
+            "t.plan_version, t.predecessor_task_id, t.kind, t.roles, "
+            "t.external_refs, t.created_at, t.created_by, t.updated_at "
+            "FROM work_tasks t "
+            f"WHERE {where} "
+            "ORDER BY CASE t.priority "
+            "  WHEN 'critical' THEN 0 "
+            "  WHEN 'high' THEN 1 "
+            "  WHEN 'normal' THEN 2 "
+            "  WHEN 'low' THEN 3 "
+            "  ELSE 4 END, t.created_at ASC"
+        )
+        blocked_keys = self._unresolved_blocked_keys(project)
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        for row in rows:
+            task_key = (str(row[0]), int(row[1]))
+            if task_key in blocked_keys:
+                continue
+            task = self._row_to_task(row)
+            if agent is not None and task.roles.get("worker") != agent:
+                continue
+            return task
+        return None
 
     def hold(
-        self, task_id: str, actor: str, reason: str | None = None  # noqa: ARG002
+        self, task_id: str, actor: str, reason: str | None = None
     ) -> Task:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        """Move in_progress / rework / review / queued → on_hold."""
+        task = self.get(task_id)
+        if task.work_status not in (
+            WorkStatus.IN_PROGRESS,
+            WorkStatus.REWORK,
+            WorkStatus.QUEUED,
+            WorkStatus.REVIEW,
+        ):
+            raise InvalidTransitionError(
+                f"Cannot hold task in '{task.work_status.value}' state. "
+                f"Task must be in 'in_progress', 'rework', 'review', "
+                f"or 'queued' state."
+            )
+        return self._simple_transition(
+            task_id,
+            from_state=task.work_status,
+            to_state=WorkStatus.ON_HOLD,
+            actor=actor,
+            reason=reason,
+        )
 
-    def resume(self, task_id: str, actor: str) -> Task:  # noqa: ARG002
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+    def resume(self, task_id: str, actor: str) -> Task:
+        """Move on_hold → queued (or in_progress if a node is active)."""
+        task = self.get(task_id)
+        if task.work_status != WorkStatus.ON_HOLD:
+            raise InvalidTransitionError(
+                f"Cannot resume task in '{task.work_status.value}' state. "
+                f"Task must be in 'on_hold' state."
+            )
+        target_status = WorkStatus.QUEUED
+        if task.current_node_id:
+            # If an execution is still ACTIVE for the current node, the
+            # task was held mid-work and resumes in-progress/review.
+            with self._pool.connection() as conn, conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM work_node_executions "
+                    "WHERE task_project = %s AND task_number = %s "
+                    "AND node_id = %s AND status = %s",
+                    (
+                        task.project,
+                        task.task_number,
+                        task.current_node_id,
+                        ExecutionStatus.ACTIVE.value,
+                    ),
+                )
+                if cur.fetchone() is not None:
+                    flow = self._load_flow(task)
+                    node = flow.nodes.get(task.current_node_id)
+                    if node is not None:
+                        target_status = (
+                            WorkStatus.REVIEW
+                            if node.type == NodeType.REVIEW
+                            else WorkStatus.IN_PROGRESS
+                        )
+        return self._simple_transition(
+            task_id,
+            from_state=WorkStatus.ON_HOLD,
+            to_state=target_status,
+            actor=actor,
+        )
 
     def node_done(
         self,
-        task_id: str,  # noqa: ARG002
-        actor: str,  # noqa: ARG002
-        work_output: WorkOutput | dict | None = None,  # noqa: ARG002
-        skip_gates: bool = False,  # noqa: ARG002
+        task_id: str,
+        actor: str,
+        work_output: WorkOutput | dict | None = None,
+        skip_gates: bool = False,  # noqa: ARG002 — gate eval is Slice C
     ) -> Task:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        """Complete a work node and advance to the next flow node."""
+        task = self.get(task_id)
+        if task.work_status not in (WorkStatus.IN_PROGRESS, WorkStatus.REWORK):
+            raise InvalidTransitionError(
+                f"Cannot complete node on task in "
+                f"'{task.work_status.value}' state. "
+                f"Task must be in 'in_progress' or 'rework' state."
+            )
+        flow = self._load_flow(task)
+        if task.current_node_id is None:
+            raise InvalidTransitionError("Task has no current flow node.")
+        node = flow.nodes.get(task.current_node_id)
+        if node is None:
+            raise InvalidTransitionError(
+                f"Current node '{task.current_node_id}' not found in flow "
+                f"'{task.flow_template_id}'."
+            )
+        if node.type != NodeType.WORK:
+            raise InvalidTransitionError(
+                f"Current node '{task.current_node_id}' is not a work node "
+                f"(type: {node.type.value})."
+            )
+
+        coerced = self._coerce_work_output(work_output)
+        if coerced is None:
+            raise ValidationError(
+                "pm task done requires a --output payload describing "
+                "what you built."
+            )
+        self._validate_work_output(coerced)
+
+        now = _now_iso()
+        wo_jsonb = self._serialize_work_output_for_pg(coerced)
+        from_status = task.work_status
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE work_node_executions SET status = %s, "
+                    "work_output = %s::jsonb, completed_at = %s "
+                    "WHERE task_project = %s AND task_number = %s "
+                    "AND node_id = %s AND status = %s",
+                    (
+                        ExecutionStatus.COMPLETED.value,
+                        wo_jsonb,
+                        now,
+                        task.project,
+                        task.task_number,
+                        task.current_node_id,
+                        ExecutionStatus.ACTIVE.value,
+                    ),
+                )
+                self._advance_to_node_locked(
+                    cur, task, flow, node.next_node_id, actor, from_status
+                )
+            conn.commit()
+        return self.get(task_id)
 
     def approve(
         self,
-        task_id: str,  # noqa: ARG002
-        actor: str,  # noqa: ARG002
-        reason: str | None = None,  # noqa: ARG002
-        skip_gates: bool = False,  # noqa: ARG002
-        resume_merge: bool = False,  # noqa: ARG002
+        task_id: str,
+        actor: str,
+        reason: str | None = None,
+        skip_gates: bool = False,  # noqa: ARG002 — gate eval is Slice C
+        resume_merge: bool = False,  # noqa: ARG002 — git auto-merge is Slice C
     ) -> Task:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        """Approve a review node and advance the flow."""
+        task = self.get(task_id)
+        if task.work_status != WorkStatus.REVIEW:
+            raise InvalidTransitionError(
+                f"Cannot approve task in '{task.work_status.value}' state. "
+                f"Only tasks in 'review' can be approved."
+            )
+        flow = self._load_flow(task)
+        if task.current_node_id is None:
+            raise InvalidTransitionError("Task has no current flow node.")
+        node = flow.nodes.get(task.current_node_id)
+        if node is None or node.type != NodeType.REVIEW:
+            raise InvalidTransitionError(
+                f"Current node '{task.current_node_id}' is not a review node."
+            )
 
-    def reject(
-        self, task_id: str, actor: str, reason: str  # noqa: ARG002
-    ) -> Task:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        now = _now_iso()
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE work_node_executions SET status = %s, "
+                    "decision = %s, decision_reason = %s, completed_at = %s "
+                    "WHERE task_project = %s AND task_number = %s "
+                    "AND node_id = %s AND status = %s",
+                    (
+                        ExecutionStatus.COMPLETED.value,
+                        Decision.APPROVED.value,
+                        reason,
+                        now,
+                        task.project,
+                        task.task_number,
+                        task.current_node_id,
+                        ExecutionStatus.ACTIVE.value,
+                    ),
+                )
+                self._advance_to_node_locked(
+                    cur, task, flow, node.next_node_id, actor, WorkStatus.REVIEW
+                )
+            conn.commit()
+        return self.get(task_id)
 
-    def block(
-        self, task_id: str, actor: str, blocker_task_id: str  # noqa: ARG002
-    ) -> Task:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+    def reject(self, task_id: str, actor: str, reason: str) -> Task:
+        """Reject a review node and bounce the task to ``rework``."""
+        task = self.get(task_id)
+        if task.work_status != WorkStatus.REVIEW:
+            raise InvalidTransitionError(
+                f"Cannot reject task in '{task.work_status.value}' state. "
+                f"Task must be in 'review' state."
+            )
+        if not reason or not reason.strip():
+            raise ValidationError("Reason is required for rejection.")
+        flow = self._load_flow(task)
+        if task.current_node_id is None:
+            raise InvalidTransitionError("Task has no current flow node.")
+        node = flow.nodes.get(task.current_node_id)
+        if node is None or node.type != NodeType.REVIEW:
+            raise InvalidTransitionError(
+                f"Current node '{task.current_node_id}' is not a review node."
+            )
+        if node.reject_node_id is None:
+            raise InvalidTransitionError(
+                f"Review node '{task.current_node_id}' has no reject_node defined."
+            )
+        reject_target = flow.nodes.get(node.reject_node_id)
+        if reject_target is None:
+            raise InvalidTransitionError(
+                f"Reject node '{node.reject_node_id}' not found in flow."
+            )
+
+        now = _now_iso()
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE work_node_executions SET status = %s, "
+                    "decision = %s, decision_reason = %s, completed_at = %s "
+                    "WHERE task_project = %s AND task_number = %s "
+                    "AND node_id = %s AND status = %s",
+                    (
+                        ExecutionStatus.COMPLETED.value,
+                        Decision.REJECTED.value,
+                        reason,
+                        now,
+                        task.project,
+                        task.task_number,
+                        task.current_node_id,
+                        ExecutionStatus.ACTIVE.value,
+                    ),
+                )
+                reject_assignee = self._resolve_node_assignee(task, reject_target)
+                cur.execute(
+                    "UPDATE work_tasks SET work_status = %s, assignee = %s, "
+                    "current_node_id = %s, updated_at = %s "
+                    "WHERE project = %s AND task_number = %s",
+                    (
+                        WorkStatus.REWORK.value,
+                        reject_assignee,
+                        node.reject_node_id,
+                        now,
+                        task.project,
+                        task.task_number,
+                    ),
+                )
+                visit = self._next_visit_locked(
+                    cur, task.project, task.task_number, node.reject_node_id
+                )
+                cur.execute(
+                    "INSERT INTO work_node_executions "
+                    "(task_project, task_number, node_id, visit, status, "
+                    "started_at) VALUES (%s, %s, %s, %s, %s, %s)",
+                    (
+                        task.project,
+                        task.task_number,
+                        node.reject_node_id,
+                        visit,
+                        ExecutionStatus.ACTIVE.value,
+                        now,
+                    ),
+                )
+                self._insert_transition_locked(
+                    cur,
+                    task.project,
+                    task.task_number,
+                    WorkStatus.REVIEW.value,
+                    WorkStatus.REWORK.value,
+                    actor,
+                    reason,
+                )
+            conn.commit()
+        return self.get(task_id)
+
+    def block(self, task_id: str, actor: str, blocker_task_id: str) -> Task:
+        """Mark a task blocked by ``blocker_task_id``."""
+        task = self.get(task_id)
+        if task.work_status not in (WorkStatus.IN_PROGRESS, WorkStatus.REVIEW):
+            raise InvalidTransitionError(
+                f"Cannot block task in '{task.work_status.value}' state. "
+                f"Task must be in 'in_progress' or 'review' state."
+            )
+        # Validate blocker exists.
+        self.get(blocker_task_id)
+        blocker_project, blocker_number = _parse_task_id(blocker_task_id)
+        if self._would_create_cycle(
+            blocker_project,
+            blocker_number,
+            task.project,
+            task.task_number,
+        ):
+            raise ValidationError("circular dependency detected")
+
+        now = _now_iso()
+        old_status = task.work_status
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO work_task_dependencies "
+                    "(from_project, from_task_number, to_project, "
+                    "to_task_number, kind, created_at) "
+                    "VALUES (%s, %s, %s, %s, %s, %s) "
+                    "ON CONFLICT DO NOTHING",
+                    (
+                        blocker_project,
+                        blocker_number,
+                        task.project,
+                        task.task_number,
+                        LinkKind.BLOCKS.value,
+                        now,
+                    ),
+                )
+                cur.execute(
+                    "UPDATE work_tasks SET work_status = %s, updated_at = %s "
+                    "WHERE project = %s AND task_number = %s",
+                    (
+                        WorkStatus.BLOCKED.value,
+                        now,
+                        task.project,
+                        task.task_number,
+                    ),
+                )
+                if task.current_node_id:
+                    cur.execute(
+                        "UPDATE work_node_executions SET status = %s "
+                        "WHERE task_project = %s AND task_number = %s "
+                        "AND node_id = %s AND status = %s",
+                        (
+                            ExecutionStatus.BLOCKED.value,
+                            task.project,
+                            task.task_number,
+                            task.current_node_id,
+                            ExecutionStatus.ACTIVE.value,
+                        ),
+                    )
+                self._insert_transition_locked(
+                    cur,
+                    task.project,
+                    task.task_number,
+                    old_status.value,
+                    WorkStatus.BLOCKED.value,
+                    actor,
+                    f"Blocked by {blocker_task_id}",
+                )
+            conn.commit()
+        return self.get(task_id)
+
+    # ------------------------------------------------------------------
+    # Execution query
+    # ------------------------------------------------------------------
 
     def get_execution(
         self,
-        task_id: str,  # noqa: ARG002
-        node_id: str | None = None,  # noqa: ARG002
-        visit: int | None = None,  # noqa: ARG002
+        task_id: str,
+        node_id: str | None = None,
+        visit: int | None = None,
     ) -> list[FlowNodeExecution]:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        """Read execution records for a task with optional filters."""
+        project, task_number = _parse_task_id(task_id)
+        clauses = ["task_project = %s", "task_number = %s"]
+        params: list[object] = [project, task_number]
+        if node_id is not None:
+            clauses.append("node_id = %s")
+            params.append(node_id)
+        if visit is not None:
+            clauses.append("visit = %s")
+            params.append(visit)
+        where = " AND ".join(clauses)
+        sql = (
+            "SELECT task_project, task_number, node_id, visit, status, "
+            "work_output, decision, decision_reason, started_at, "
+            "completed_at FROM work_node_executions "
+            f"WHERE {where} ORDER BY id"
+        )
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        result: list[FlowNodeExecution] = []
+        for row in rows:
+            (
+                tp,
+                tn,
+                nid,
+                visit_v,
+                status_raw,
+                work_output_raw,
+                decision_raw,
+                decision_reason,
+                started_at,
+                completed_at,
+            ) = row
+            wo = self._decode_work_output(work_output_raw)
+            try:
+                status = ExecutionStatus(status_raw)
+            except ValueError:
+                status = ExecutionStatus.PENDING
+            decision: Decision | None = None
+            if decision_raw:
+                try:
+                    decision = Decision(decision_raw)
+                except ValueError:
+                    decision = None
+            result.append(
+                FlowNodeExecution(
+                    task_id=f"{tp}/{tn}",
+                    node_id=str(nid),
+                    visit=int(visit_v),
+                    status=status,
+                    work_output=wo,
+                    decision=decision,
+                    decision_reason=decision_reason,
+                    started_at=started_at,
+                    completed_at=completed_at,
+                )
+            )
+        return result
+
+    # ------------------------------------------------------------------
+    # Context log
+    # ------------------------------------------------------------------
 
     def add_context(
         self,
-        task_id: str,  # noqa: ARG002
-        actor: str,  # noqa: ARG002
-        text: str,  # noqa: ARG002
+        task_id: str,
+        actor: str,
+        text: str,
         *,
-        entry_type: str = "note",  # noqa: ARG002
+        entry_type: str = "note",
     ) -> ContextEntry:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        """Append a context entry to a task's log."""
+        project, task_number = _parse_task_id(task_id)
+        now = _now_iso()
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM work_tasks "
+                    "WHERE project = %s AND task_number = %s",
+                    (project, task_number),
+                )
+                if cur.fetchone() is None:
+                    raise TaskNotFoundError(f"Task '{task_id}' not found.")
+                cur.execute(
+                    "INSERT INTO work_context_entries "
+                    "(task_project, task_number, actor, text, created_at, "
+                    "entry_type) VALUES (%s, %s, %s, %s, %s, %s)",
+                    (project, task_number, actor, text, now, entry_type),
+                )
+            conn.commit()
+        return ContextEntry(
+            actor=actor,
+            timestamp=now,
+            text=text,
+            entry_type=entry_type,
+        )
 
     def get_context(
         self,
-        task_id: str,  # noqa: ARG002
-        limit: int | None = None,  # noqa: ARG002
-        since: str | None = None,  # noqa: ARG002
-        entry_type: str | None = None,  # noqa: ARG002
+        task_id: str,
+        limit: int | None = None,
+        since: datetime | None = None,
+        entry_type: str | None = None,
     ) -> list[ContextEntry]:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        """Query context entries for a task, most recent first."""
+        project, task_number = _parse_task_id(task_id)
+        clauses = ["task_project = %s", "task_number = %s"]
+        params: list[object] = [project, task_number]
+        if since is not None:
+            clauses.append("created_at > %s")
+            params.append(since)
+        if entry_type is not None:
+            clauses.append("entry_type = %s")
+            params.append(entry_type)
+        where = " AND ".join(clauses)
+        sql = (
+            "SELECT actor, created_at, text, entry_type "
+            "FROM work_context_entries "
+            f"WHERE {where} ORDER BY id DESC"
+        )
+        if limit is not None:
+            sql += f" LIMIT {int(limit)}"
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        return [
+            ContextEntry(
+                actor=str(r[0]),
+                timestamp=r[1],
+                text=str(r[2]),
+                entry_type=str(r[3] or "note"),
+            )
+            for r in rows
+        ]
 
-    def link(
-        self, from_id: str, to_id: str, kind: str  # noqa: ARG002
-    ) -> None:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+    # ------------------------------------------------------------------
+    # Dependencies
+    # ------------------------------------------------------------------
 
-    def unlink(
-        self, from_id: str, to_id: str, kind: str  # noqa: ARG002
-    ) -> None:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+    def link(self, from_id: str, to_id: str, kind: str) -> None:
+        """Create a relationship between two tasks."""
+        try:
+            link_kind = LinkKind(kind)
+        except ValueError as exc:
+            raise ValidationError(
+                f"Invalid link kind '{kind}'. "
+                f"Must be one of: {[item.value for item in LinkKind]}."
+            ) from exc
 
-    def dependents(self, task_id: str) -> list[Task]:  # noqa: ARG002
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        from_project, from_number = _parse_task_id(from_id)
+        to_project, to_number = _parse_task_id(to_id)
 
-    def available_flows(
-        self, project: str | None = None  # noqa: ARG002
-    ) -> list[FlowTemplate]:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                for project, number, tid in (
+                    (from_project, from_number, from_id),
+                    (to_project, to_number, to_id),
+                ):
+                    cur.execute(
+                        "SELECT 1 FROM work_tasks "
+                        "WHERE project = %s AND task_number = %s",
+                        (project, number),
+                    )
+                    if cur.fetchone() is None:
+                        raise TaskNotFoundError(f"Task '{tid}' not found.")
+                if link_kind is LinkKind.BLOCKS and self._would_create_cycle(
+                    from_project, from_number, to_project, to_number
+                ):
+                    raise ValidationError("circular dependency detected")
+                cur.execute(
+                    "INSERT INTO work_task_dependencies "
+                    "(from_project, from_task_number, to_project, "
+                    "to_task_number, kind, created_at) "
+                    "VALUES (%s, %s, %s, %s, %s, %s) "
+                    "ON CONFLICT DO NOTHING",
+                    (
+                        from_project,
+                        from_number,
+                        to_project,
+                        to_number,
+                        link_kind.value,
+                        _now_iso(),
+                    ),
+                )
+            conn.commit()
+        if link_kind is LinkKind.BLOCKS:
+            self._maybe_block(to_id)
+
+    def unlink(self, from_id: str, to_id: str, kind: str) -> None:
+        """Remove a relationship between two tasks."""
+        try:
+            link_kind = LinkKind(kind)
+        except ValueError as exc:
+            raise ValidationError(
+                f"Invalid link kind '{kind}'. "
+                f"Must be one of: {[item.value for item in LinkKind]}."
+            ) from exc
+        from_project, from_number = _parse_task_id(from_id)
+        to_project, to_number = _parse_task_id(to_id)
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM work_task_dependencies "
+                    "WHERE from_project = %s AND from_task_number = %s "
+                    "AND to_project = %s AND to_task_number = %s "
+                    "AND kind = %s",
+                    (
+                        from_project,
+                        from_number,
+                        to_project,
+                        to_number,
+                        link_kind.value,
+                    ),
+                )
+            conn.commit()
+        if link_kind is LinkKind.BLOCKS:
+            self._maybe_unblock(to_id)
+
+    def dependents(self, task_id: str) -> list[Task]:
+        """All tasks blocked by this task, transitively."""
+        project, number = _parse_task_id(task_id)
+        sql = """
+            WITH RECURSIVE deps(project, task_number) AS (
+                SELECT to_project, to_task_number
+                FROM work_task_dependencies
+                WHERE from_project = %s AND from_task_number = %s
+                  AND kind = %s
+                UNION
+                SELECT d.to_project, d.to_task_number
+                FROM work_task_dependencies d
+                JOIN deps
+                  ON d.from_project = deps.project
+                 AND d.from_task_number = deps.task_number
+                WHERE d.kind = %s
+            )
+            SELECT DISTINCT project, task_number
+            FROM deps
+            ORDER BY project, task_number
+        """
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                sql,
+                (project, number, LinkKind.BLOCKS.value, LinkKind.BLOCKS.value),
+            )
+            task_keys = [(row[0], int(row[1])) for row in cur.fetchall()]
+        return [self.get(f"{p}/{n}") for p, n in task_keys]
+
+    # ------------------------------------------------------------------
+    # Flow templates
+    # ------------------------------------------------------------------
+
+    def available_flows(self, project: str | None = None) -> list[FlowTemplate]:
+        """List available flows (file-based — pg backend reuses resolver)."""
+        from pollypm.work.flow_engine import (
+            available_flows as _available_flows,
+            resolve_flow,
+        )
+
+        project_path = self._resolve_project_path(project)
+        flow_map = _available_flows(project_path)
+        templates: list[FlowTemplate] = []
+        for name in flow_map:
+            try:
+                templates.append(resolve_flow(name, project_path))
+            except Exception:  # noqa: BLE001 — skip unresolvable templates
+                logger.debug(
+                    "skipping unavailable flow template %s", name, exc_info=True
+                )
+        return templates
 
     def get_flow(
-        self, name: str, project: str | None = None  # noqa: ARG002
+        self, name: str, project: str | None = None
     ) -> FlowTemplate:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        """Resolve a flow by name."""
+        from pollypm.work.flow_engine import resolve_flow
+
+        return resolve_flow(name, self._resolve_project_path(project))
+
+    # ------------------------------------------------------------------
+    # Gate dry-run
+    # ------------------------------------------------------------------
 
     def validate_advance(
-        self, task_id: str, actor: str  # noqa: ARG002
+        self, task_id: str, actor: str
     ) -> list[GateResult]:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        """Dry-run preflight: would advancing the current node succeed?
 
-    def sync_status(self, task_id: str) -> dict[str, object]:  # noqa: ARG002
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        Slice B ships the actor-role check. Full gate evaluation lands
+        in Slice C alongside the gate registry / kwargs port.
+        """
+        task = self.get(task_id)
+        if task.current_node_id is None:
+            return []
+        try:
+            flow = self._load_flow(task)
+            node = flow.nodes.get(task.current_node_id)
+        except (TaskNotFoundError, InvalidTransitionError):
+            return []
+        if node is None:
+            return []
+        results: list[GateResult] = []
+        try:
+            self._validate_actor_role(task, node, actor)
+        except Exception as exc:  # noqa: BLE001
+            results.append(
+                GateResult(
+                    passed=False,
+                    reason=str(exc),
+                    gate_name="actor_role",
+                    gate_type="hard",
+                )
+            )
+        return results
+
+    # ------------------------------------------------------------------
+    # Sync
+    # ------------------------------------------------------------------
+
+    def sync_status(self, task_id: str) -> dict[str, object]:
+        """Current sync state per adapter for a task.
+
+        Slice B reads ``work_sync_state`` and returns the per-adapter
+        map. The actual adapter list (and force-sync) lands when Slice
+        C wires the sync manager. Without an adapter manager every task
+        returns an empty dict.
+        """
+        project, task_number = _parse_task_id(task_id)
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM work_tasks "
+                "WHERE project = %s AND task_number = %s",
+                (project, task_number),
+            )
+            if cur.fetchone() is None:
+                raise TaskNotFoundError(f"Task '{task_id}' not found.")
+            cur.execute(
+                "SELECT adapter_name, last_synced_at, last_error, attempts "
+                "FROM work_sync_state "
+                "WHERE task_project = %s AND task_number = %s",
+                (project, task_number),
+            )
+            rows = cur.fetchall()
+        return {
+            str(r[0]): {
+                "last_synced_at": r[1],
+                "last_error": r[2],
+                "attempts": int(r[3] or 0),
+            }
+            for r in rows
+        }
 
     def trigger_sync(
         self,
-        task_id: str | None = None,  # noqa: ARG002
-        adapter: str | None = None,  # noqa: ARG002
+        task_id: str | None = None,
+        adapter: str | None = None,  # noqa: ARG002 — adapter wiring is Slice C
     ) -> dict[str, object]:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        """Force a sync cycle.
+
+        Slice B returns ``{synced: 0, errors: {}}`` because the pg
+        service has no sync adapter manager yet — Slice C ports
+        ``service_sync.SyncManager`` to the pg pool. Callers can already
+        invoke this method; the sqlite path still goes through its own
+        adapters when they're registered there.
+        """
+        if task_id is not None:
+            project, task_number = _parse_task_id(task_id)
+            with self._pool.connection() as conn, conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM work_tasks "
+                    "WHERE project = %s AND task_number = %s",
+                    (project, task_number),
+                )
+                if cur.fetchone() is None:
+                    raise TaskNotFoundError(f"Task '{task_id}' not found.")
+        return {"synced": 0, "errors": {}}
+
+    # ------------------------------------------------------------------
+    # Aggregate queries
+    # ------------------------------------------------------------------
 
     def state_counts(
         self, project: str | None = None
     ) -> dict[str, int]:
-        """Task counts by state (Slice A: simple GROUP BY)."""
+        """Task counts by state, zero-filled across every WorkStatus."""
+        counts = {status.value: 0 for status in WorkStatus}
         sql = "SELECT work_status, COUNT(*) FROM work_tasks"
         params: list[object] = []
         if project is not None:
@@ -749,46 +1654,731 @@ class PgWorkService:
         sql += " GROUP BY work_status"
         with self._pool.connection() as conn, conn.cursor() as cur:
             cur.execute(sql, params)
-            return {str(row[0]): int(row[1]) for row in cur.fetchall()}
+            for row in cur.fetchall():
+                counts[str(row[0])] = int(row[1])
+        return counts
 
-    def my_tasks(self, agent: str) -> list[Task]:  # noqa: ARG002
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+    def my_tasks(self, agent: str) -> list[Task]:
+        """All tasks where ``agent`` is the live assignee."""
+        sql = (
+            "SELECT project, task_number, project_key, title, type, labels, "
+            "work_status, flow_template_id, flow_template_version, "
+            "current_node_id, assignee, priority, requires_human_review, "
+            "description, acceptance_criteria, constraints, relevant_files, "
+            "parent_project, parent_task_number, "
+            "supersedes_project, supersedes_task_number, "
+            "plan_version, predecessor_task_id, kind, roles, external_refs, "
+            "created_at, created_by, updated_at "
+            "FROM work_tasks "
+            "WHERE current_node_id IS NOT NULL AND assignee = %s "
+            "ORDER BY project, task_number"
+        )
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, (agent,))
+            rows = cur.fetchall()
+        return [self._row_to_task(row) for row in rows]
 
-    def blocked_tasks(
-        self, project: str | None = None  # noqa: ARG002
-    ) -> list[Task]:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+    def blocked_tasks(self, project: str | None = None) -> list[Task]:
+        """All tasks with ``work_status == blocked``."""
+        clauses = ["work_status = %s"]
+        params: list[object] = [WorkStatus.BLOCKED.value]
+        if project is not None:
+            clauses.append("project = %s")
+            params.append(project)
+        sql = (
+            "SELECT project, task_number, project_key, title, type, labels, "
+            "work_status, flow_template_id, flow_template_version, "
+            "current_node_id, assignee, priority, requires_human_review, "
+            "description, acceptance_criteria, constraints, relevant_files, "
+            "parent_project, parent_task_number, "
+            "supersedes_project, supersedes_task_number, "
+            "plan_version, predecessor_task_id, kind, roles, external_refs, "
+            "created_at, created_by, updated_at "
+            f"FROM work_tasks WHERE {' AND '.join(clauses)} "
+            "ORDER BY project, task_number"
+        )
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        return [self._row_to_task(row) for row in rows]
+
+    # ------------------------------------------------------------------
+    # Worker sessions
+    # ------------------------------------------------------------------
 
     def ensure_worker_session_schema(self) -> None:
         # Schema is installed by the migrations applier — no per-instance
         # bootstrap needed on the pg backend.
         return None
 
-    def upsert_worker_session(self, **kwargs: object) -> None:  # noqa: ARG002
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+    def upsert_worker_session(
+        self,
+        *,
+        task_project: str,
+        task_number: int,
+        agent_name: str,
+        pane_id: str,
+        worktree_path: str,
+        branch_name: str,
+        started_at: str | datetime,
+        provider: str | None = None,
+        provider_home: str | None = None,
+    ) -> None:
+        """Insert or refresh the work_sessions row for a task."""
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO work_sessions ("
+                    "task_project, task_number, agent_name, pane_id, "
+                    "worktree_path, branch_name, started_at, provider, "
+                    "provider_home) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) "
+                    "ON CONFLICT (task_project, task_number) DO UPDATE SET "
+                    "pane_id = EXCLUDED.pane_id, "
+                    "worktree_path = EXCLUDED.worktree_path, "
+                    "branch_name = EXCLUDED.branch_name, "
+                    "started_at = EXCLUDED.started_at, "
+                    "provider = EXCLUDED.provider, "
+                    "provider_home = EXCLUDED.provider_home, "
+                    "ended_at = NULL, archive_path = NULL",
+                    (
+                        task_project,
+                        task_number,
+                        agent_name,
+                        pane_id,
+                        worktree_path,
+                        branch_name,
+                        started_at,
+                        provider,
+                        provider_home,
+                    ),
+                )
+            conn.commit()
 
     def get_worker_session(
-        self, **kwargs: object  # noqa: ARG002
+        self,
+        *,
+        task_project: str,
+        task_number: int,
+        active_only: bool = False,
     ) -> WorkerSessionRecord | None:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        """Read one worker_session row."""
+        sql = (
+            "SELECT task_project, task_number, agent_name, pane_id, "
+            "worktree_path, branch_name, started_at, ended_at, "
+            "total_input_tokens, total_output_tokens, archive_path, "
+            "provider, provider_home FROM work_sessions "
+            "WHERE task_project = %s AND task_number = %s"
+        )
+        if active_only:
+            sql += " AND ended_at IS NULL"
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, (task_project, task_number))
+            row = cur.fetchone()
+        if row is None:
+            return None
+        return self._row_to_worker_session(row)
 
     def list_worker_sessions(
-        self, **kwargs: object  # noqa: ARG002
+        self,
+        *,
+        project: str | None = None,
+        active_only: bool = True,
     ) -> list[WorkerSessionRecord]:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        """List worker_session rows."""
+        clauses: list[str] = []
+        params: list[object] = []
+        if active_only:
+            clauses.append("ended_at IS NULL")
+        if project is not None:
+            clauses.append("task_project = %s")
+            params.append(project)
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = (
+            "SELECT task_project, task_number, agent_name, pane_id, "
+            "worktree_path, branch_name, started_at, ended_at, "
+            "total_input_tokens, total_output_tokens, archive_path, "
+            "provider, provider_home FROM work_sessions" + where
+        )
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        return [self._row_to_worker_session(row) for row in rows]
 
-    def end_worker_session(self, **kwargs: object) -> None:  # noqa: ARG002
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+    def end_worker_session(
+        self,
+        *,
+        task_project: str,
+        task_number: int,
+        ended_at: str | datetime,
+        total_input_tokens: int,
+        total_output_tokens: int,
+        archive_path: str | None,
+    ) -> None:
+        """Mark a worker_session as ended and record final token counts."""
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE work_sessions SET ended_at = %s, "
+                    "total_input_tokens = %s, total_output_tokens = %s, "
+                    "archive_path = %s "
+                    "WHERE task_project = %s AND task_number = %s",
+                    (
+                        ended_at,
+                        total_input_tokens,
+                        total_output_tokens,
+                        archive_path,
+                        task_project,
+                        task_number,
+                    ),
+                )
+            conn.commit()
 
     def mark_worker_session_ended(
-        self, **kwargs: object  # noqa: ARG002
+        self,
+        *,
+        task_project: str,
+        task_number: int,
+        ended_at: str | datetime,
     ) -> None:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        """Stamp ``ended_at`` without zeroing tokens (#1014)."""
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE work_sessions SET ended_at = %s "
+                    "WHERE task_project = %s AND task_number = %s",
+                    (ended_at, task_project, task_number),
+                )
+            conn.commit()
 
     def update_worker_session_tokens(
-        self, **kwargs: object  # noqa: ARG002
+        self,
+        *,
+        task_project: str,
+        task_number: int,
+        total_input_tokens: int,
+        total_output_tokens: int,
+        archive_path: str | None,
     ) -> None:
-        raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)
+        """Refresh token totals on an open or completed session row."""
+        with self._pool.connection() as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE work_sessions SET total_input_tokens = %s, "
+                    "total_output_tokens = %s, archive_path = %s "
+                    "WHERE task_project = %s AND task_number = %s",
+                    (
+                        total_input_tokens,
+                        total_output_tokens,
+                        archive_path,
+                        task_project,
+                        task_number,
+                    ),
+                )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # Internal helpers (private)
+    # ------------------------------------------------------------------
+
+    def _row_to_worker_session(self, row: tuple) -> WorkerSessionRecord:
+        (
+            tp,
+            tn,
+            agent,
+            pane,
+            worktree,
+            branch,
+            started,
+            ended,
+            tot_in,
+            tot_out,
+            archive,
+            provider,
+            provider_home,
+        ) = row
+        return WorkerSessionRecord(
+            task_project=str(tp),
+            task_number=int(tn),
+            agent_name=str(agent),
+            pane_id=pane,
+            worktree_path=worktree,
+            branch_name=branch,
+            started_at=started.isoformat() if hasattr(started, "isoformat") else started,
+            ended_at=(
+                ended.isoformat() if ended is not None and hasattr(ended, "isoformat") else ended
+            ),
+            total_input_tokens=int(tot_in or 0),
+            total_output_tokens=int(tot_out or 0),
+            archive_path=archive,
+            provider=provider,
+            provider_home=provider_home,
+        )
+
+    def _load_flow(self, task: Task) -> FlowTemplate:
+        """Resolve the task's flow template from the file system.
+
+        Slice B uses the file-based resolver (same as sqlite's
+        ``available_flows`` fallback) because the pg ``work_flow_*``
+        tables are populated on demand by the sqlite path and the
+        Slice B port does not yet write to them. Slice C adds a DB
+        cache layer.
+        """
+        from pollypm.work.flow_engine import resolve_flow
+
+        try:
+            return resolve_flow(
+                task.flow_template_id, self._resolve_project_path(task.project)
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise InvalidTransitionError(
+                f"Flow template '{task.flow_template_id}' not found: {exc}"
+            ) from exc
+
+    def _resolve_project_path(self, project: str | None):
+        """Resolve a project name to a filesystem path via config.
+
+        Returns ``None`` when no path is registered; the file-based
+        flow resolver tolerates ``None`` and falls back to the bundled
+        flow set.
+        """
+        if project is None:
+            return None
+        try:
+            from pollypm.config import load_config
+
+            config = load_config()
+            normalized = project.replace("-", "_")
+            key = (
+                project
+                if project in config.projects
+                else (normalized if normalized in config.projects else None)
+            )
+            if key is not None:
+                return config.projects[key].path
+        except Exception:  # noqa: BLE001 — config lookup is best-effort
+            logger.debug(
+                "project path config lookup failed for %s", project, exc_info=True
+            )
+        return None
+
+    def _resolve_node_assignee(
+        self, task: Task, node: FlowNode
+    ) -> str | None:
+        if node.actor_type == ActorType.ROLE:
+            return task.roles.get(node.actor_role or "", task.assignee)
+        if node.actor_type == ActorType.HUMAN:
+            return "human"
+        if node.actor_type == ActorType.PROJECT_MANAGER:
+            return "project_manager"
+        if node.actor_type == ActorType.AGENT:
+            return node.agent_name or task.assignee
+        return task.assignee
+
+    _HUMAN_ACTOR_NAMES = frozenset({"human", "user", "sam"})
+
+    def _validate_actor_role(
+        self, task: Task, node: FlowNode, actor: str
+    ) -> None:
+        if node.actor_type == ActorType.HUMAN:
+            reviewer = None
+            if node.actor_role:
+                reviewer = task.roles.get(node.actor_role)
+            allowed = []
+            seen = set()
+            for name in (reviewer, *sorted(self._HUMAN_ACTOR_NAMES)):
+                if name and name not in seen:
+                    allowed.append(name)
+                    seen.add(name)
+            if actor not in allowed:
+                raise ValidationError(
+                    f"Node '{node.name}' requires human review. "
+                    f"Actor '{actor}' is not authorized."
+                )
+        elif node.actor_type == ActorType.ROLE and node.actor_role:
+            expected = task.roles.get(node.actor_role)
+            if expected and actor != expected:
+                if actor != node.actor_role:
+                    raise ValidationError(
+                        f"Actor '{actor}' does not match role "
+                        f"'{node.actor_role}' (expected '{expected}')."
+                    )
+            elif expected is None and actor != node.actor_role:
+                raise ValidationError(
+                    f"Actor '{actor}' does not match role '{node.actor_role}'."
+                )
+        elif node.actor_type == ActorType.AGENT and node.agent_name:
+            if actor != node.agent_name:
+                raise ValidationError(
+                    f"Node '{node.name}' is pinned to agent "
+                    f"'{node.agent_name}'. Actor '{actor}' is not authorized."
+                )
+
+    def _advance_to_node_locked(
+        self,
+        cur,
+        task: Task,
+        flow: FlowTemplate,
+        next_node_id: str | None,
+        actor: str,
+        from_status: WorkStatus,
+    ) -> None:
+        """Advance task to ``next_node_id`` (or terminal). Mutates inside an open tx."""
+        now = _now_iso()
+        if next_node_id is None:
+            raise InvalidTransitionError("No next node defined.")
+        next_node = flow.nodes.get(next_node_id)
+        if next_node is None:
+            raise InvalidTransitionError(
+                f"Next node '{next_node_id}' not found in flow."
+            )
+        if next_node.type == NodeType.TERMINAL:
+            cur.execute(
+                "UPDATE work_tasks SET work_status = %s, "
+                "current_node_id = NULL, updated_at = %s "
+                "WHERE project = %s AND task_number = %s",
+                (WorkStatus.DONE.value, now, task.project, task.task_number),
+            )
+            self._insert_transition_locked(
+                cur,
+                task.project,
+                task.task_number,
+                from_status.value,
+                WorkStatus.DONE.value,
+                actor,
+                None,
+            )
+            return
+        new_status = (
+            WorkStatus.REVIEW
+            if next_node.type == NodeType.REVIEW
+            else WorkStatus.IN_PROGRESS
+        )
+        next_assignee = self._resolve_node_assignee(task, next_node)
+        visit = self._next_visit_locked(
+            cur, task.project, task.task_number, next_node_id
+        )
+        cur.execute(
+            "UPDATE work_tasks SET work_status = %s, assignee = %s, "
+            "current_node_id = %s, updated_at = %s "
+            "WHERE project = %s AND task_number = %s",
+            (
+                new_status.value,
+                next_assignee,
+                next_node_id,
+                now,
+                task.project,
+                task.task_number,
+            ),
+        )
+        cur.execute(
+            "INSERT INTO work_node_executions "
+            "(task_project, task_number, node_id, visit, status, started_at) "
+            "VALUES (%s, %s, %s, %s, %s, %s)",
+            (
+                task.project,
+                task.task_number,
+                next_node_id,
+                visit,
+                ExecutionStatus.ACTIVE.value,
+                now,
+            ),
+        )
+        self._insert_transition_locked(
+            cur,
+            task.project,
+            task.task_number,
+            from_status.value,
+            new_status.value,
+            actor,
+            None,
+        )
+
+    def _next_visit_locked(
+        self, cur, project: str, task_number: int, node_id: str
+    ) -> int:
+        cur.execute(
+            "SELECT COALESCE(MAX(visit), 0) + 1 "
+            "FROM work_node_executions "
+            "WHERE task_project = %s AND task_number = %s AND node_id = %s",
+            (project, task_number, node_id),
+        )
+        return int(cur.fetchone()[0])
+
+    def _insert_transition_locked(
+        self,
+        cur,
+        project: str,
+        task_number: int,
+        from_state: str,
+        to_state: str,
+        actor: str,
+        reason: str | None,
+    ) -> None:
+        cur.execute(
+            "INSERT INTO work_transitions ("
+            "task_project, task_number, from_state, to_state, "
+            "actor, reason, created_at) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s)",
+            (
+                project,
+                task_number,
+                from_state,
+                to_state,
+                actor,
+                reason,
+                _now_iso(),
+            ),
+        )
+
+    def _unresolved_blocked_keys(
+        self, project: str | None
+    ) -> set[tuple[str, int]]:
+        clauses = [
+            "d.kind = %s",
+            "t.work_status NOT IN (%s, %s)",
+        ]
+        params: list[object] = [
+            LinkKind.BLOCKS.value,
+            WorkStatus.DONE.value,
+            WorkStatus.CANCELLED.value,
+        ]
+        if project is not None:
+            clauses.append("d.to_project = %s")
+            params.append(project)
+        sql = (
+            "SELECT DISTINCT d.to_project, d.to_task_number "
+            "FROM work_task_dependencies d "
+            "JOIN work_tasks t "
+            "  ON t.project = d.from_project "
+            " AND t.task_number = d.from_task_number "
+            f"WHERE {' AND '.join(clauses)}"
+        )
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            return {(str(r[0]), int(r[1])) for r in cur.fetchall()}
+
+    def _would_create_cycle(
+        self,
+        from_project: str,
+        from_number: int,
+        to_project: str,
+        to_number: int,
+    ) -> bool:
+        target = (from_project, from_number)
+        visited: set[tuple[str, int]] = set()
+        stack: list[tuple[str, int]] = [(to_project, to_number)]
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            while stack:
+                current = stack.pop()
+                if current == target:
+                    return True
+                if current in visited:
+                    continue
+                visited.add(current)
+                cur.execute(
+                    "SELECT to_project, to_task_number "
+                    "FROM work_task_dependencies "
+                    "WHERE from_project = %s AND from_task_number = %s "
+                    "AND kind = %s",
+                    (current[0], current[1], LinkKind.BLOCKS.value),
+                )
+                for row in cur.fetchall():
+                    stack.append((str(row[0]), int(row[1])))
+        return False
+
+    def _has_unresolved_blockers(self, task_id: str) -> bool:
+        project, number = _parse_task_id(task_id)
+        with self._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT t.work_status FROM work_task_dependencies d "
+                "JOIN work_tasks t "
+                "  ON t.project = d.from_project "
+                " AND t.task_number = d.from_task_number "
+                "WHERE d.to_project = %s AND d.to_task_number = %s "
+                "AND d.kind = %s",
+                (project, number, LinkKind.BLOCKS.value),
+            )
+            for row in cur.fetchall():
+                if row[0] not in (
+                    WorkStatus.DONE.value,
+                    WorkStatus.CANCELLED.value,
+                ):
+                    return True
+        return False
+
+    def _maybe_block(self, task_id: str) -> None:
+        task = self.get(task_id)
+        if task.work_status not in (WorkStatus.QUEUED, WorkStatus.IN_PROGRESS):
+            return
+        if not self._has_unresolved_blockers(task_id):
+            return
+        self._simple_transition(
+            task_id,
+            from_state=task.work_status,
+            to_state=WorkStatus.BLOCKED,
+            actor="system",
+            reason="blocked by dependency",
+        )
+
+    def _maybe_unblock(self, task_id: str) -> None:
+        task = self.get(task_id)
+        if task.work_status != WorkStatus.BLOCKED:
+            return
+        if self._has_unresolved_blockers(task_id):
+            return
+        self._simple_transition(
+            task_id,
+            from_state=WorkStatus.BLOCKED,
+            to_state=WorkStatus.QUEUED,
+            actor="system",
+            reason="all blockers resolved",
+        )
+
+    # ------------------------------------------------------------------
+    # Work-output coercion / serialization
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_work_output(output: WorkOutput) -> None:
+        if not isinstance(output.type, OutputType):
+            try:
+                OutputType(output.type)
+            except (ValueError, KeyError):
+                raise ValidationError(
+                    f"Invalid output type '{output.type}'."
+                )
+        if not output.summary or not output.summary.strip():
+            raise ValidationError("Work output has an empty summary.")
+        if not output.artifacts:
+            raise ValidationError(
+                "Work output must have at least one artifact."
+            )
+        for art in output.artifacts:
+            if not isinstance(art.kind, ArtifactKind):
+                try:
+                    ArtifactKind(art.kind)
+                except (ValueError, KeyError):
+                    raise ValidationError(
+                        f"Invalid artifact kind '{art.kind}'."
+                    )
+
+    @staticmethod
+    def _coerce_work_output(
+        output: WorkOutput | dict | None,
+    ) -> WorkOutput | None:
+        if output is None:
+            return None
+        if isinstance(output, WorkOutput):
+            return output
+        if not isinstance(output, dict):
+            raise ValidationError(
+                "Work output must be a WorkOutput or dict."
+            )
+        from pollypm.work.models import Artifact
+
+        try:
+            otype = OutputType(output.get("type", ""))
+        except (ValueError, KeyError):
+            raise ValidationError(
+                f"Invalid output type '{output.get('type')!r}'."
+            )
+        artifacts_raw = output.get("artifacts") or []
+        artifacts: list[Artifact] = []
+        for art in artifacts_raw:
+            if isinstance(art, Artifact):
+                artifacts.append(art)
+                continue
+            if not isinstance(art, dict):
+                raise ValidationError("Artifact entries must be objects.")
+            try:
+                kind = ArtifactKind(art.get("kind", ""))
+            except (ValueError, KeyError):
+                raise ValidationError(
+                    f"Invalid artifact kind '{art.get('kind')!r}'."
+                )
+            artifacts.append(
+                Artifact(
+                    kind=kind,
+                    description=str(art.get("description", "")),
+                    ref=art.get("ref"),
+                    path=art.get("path"),
+                    external_ref=art.get("external_ref"),
+                )
+            )
+        return WorkOutput(
+            type=otype,
+            summary=str(output.get("summary", "")),
+            artifacts=artifacts,
+        )
+
+    @staticmethod
+    def _serialize_work_output_for_pg(output: WorkOutput) -> str:
+        return json.dumps(
+            {
+                "type": output.type.value
+                if isinstance(output.type, OutputType)
+                else str(output.type),
+                "summary": output.summary,
+                "artifacts": [
+                    {
+                        "kind": (
+                            a.kind.value
+                            if isinstance(a.kind, ArtifactKind)
+                            else str(a.kind)
+                        ),
+                        "description": a.description,
+                        "ref": a.ref,
+                        "path": a.path,
+                        "external_ref": a.external_ref,
+                    }
+                    for a in output.artifacts
+                ],
+            }
+        )
+
+    @staticmethod
+    def _decode_work_output(raw: Any) -> WorkOutput | None:
+        if raw is None:
+            return None
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return None
+        if not isinstance(raw, dict):
+            return None
+        from pollypm.work.models import Artifact
+
+        try:
+            otype = OutputType(raw.get("type", ""))
+        except (ValueError, KeyError):
+            return None
+        artifacts: list[Artifact] = []
+        for art in raw.get("artifacts") or []:
+            if not isinstance(art, dict):
+                continue
+            try:
+                kind = ArtifactKind(art.get("kind", ""))
+            except (ValueError, KeyError):
+                continue
+            artifacts.append(
+                Artifact(
+                    kind=kind,
+                    description=str(art.get("description", "")),
+                    ref=art.get("ref"),
+                    path=art.get("path"),
+                    external_ref=art.get("external_ref"),
+                )
+            )
+        return WorkOutput(
+            type=otype,
+            summary=str(raw.get("summary", "")),
+            artifacts=artifacts,
+        )
 
 
 __all__ = ["PgWorkService"]

--- a/tests/test_pg_work_service.py
+++ b/tests/test_pg_work_service.py
@@ -260,9 +260,14 @@ def test_list_nonterminal_excludes_done_and_cancelled(pg_service):
     assert [t.task_number for t in rows] == [c.task_number]
 
 
-def test_protocol_stubs_raise_not_implemented(pg_service):
-    """Slice A stubs must crash loud, not return None."""
-    with pytest.raises(NotImplementedError, match="Slice"):
-        pg_service.claim("demo/1", actor="u")
-    with pytest.raises(NotImplementedError, match="Slice"):
-        pg_service.approve("demo/1", actor="u")
+def test_slice_b_methods_are_implemented(pg_service):
+    """Slice B (#1737) ships claim / approve / etc. — no NotImplementedError."""
+    from pollypm.work.service_support import TaskNotFoundError
+
+    # Methods now reach the DB and surface domain errors instead of
+    # NotImplementedError. The missing-task lookup is the cheapest way
+    # to prove "code ran past the stub".
+    with pytest.raises(TaskNotFoundError):
+        pg_service.claim("demo/999", actor="u")
+    with pytest.raises(TaskNotFoundError):
+        pg_service.approve("demo/999", actor="u")

--- a/tests/test_pg_work_service_full.py
+++ b/tests/test_pg_work_service_full.py
@@ -1,0 +1,633 @@
+"""Slice B (#1737) full :class:`PgWorkService` coverage.
+
+Sister suite to :mod:`tests.test_pg_work_service` (which covers the
+Slice A read+CRUD subset). This module exercises the methods that
+landed in Slice B against the testcontainer pg from
+:mod:`tests.conftest_pg`:
+
+* mutable-field ``update`` + ``increment_plan_version`` + ``list_successors``
+* claim / hold / resume / next state transitions
+* node_done / approve / reject / block flow progression
+* add_context / get_context
+* link / unlink / dependents
+* my_tasks / blocked_tasks / state_counts zero-fill
+* validate_advance preflight
+* sync_status / trigger_sync (Slice B stub shape)
+* worker_session CRUD trio (upsert / get / list / end / mark_ended / update_tokens)
+* available_flows / get_flow (file-resolver delegation)
+
+The fixture skips when neither Docker nor a local pg+vector DSN is
+available — same gate as :mod:`tests.test_pg_work_service`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def pg_service(pg_schema_pool):
+    from pollypm.work.pg_service import PgWorkService
+
+    return PgWorkService(pool=pg_schema_pool, ro_pool=None)
+
+
+# ---------------------------------------------------------------------------
+# update / increment_plan_version / list_successors
+# ---------------------------------------------------------------------------
+
+
+def _make_draft(svc, project="demo", title="t", **kw):
+    return svc.create(
+        title=title,
+        type=kw.pop("type", "task"),
+        project=project,
+        flow_template=kw.pop("flow_template", "standard"),
+        roles=kw.pop("roles", {"worker": "alice", "reviewer": "bob"}),
+        description=kw.pop("description", "has body"),
+        **kw,
+    )
+
+
+def test_update_title_and_priority(pg_service):
+    task = _make_draft(pg_service)
+    updated = pg_service.update(
+        task.task_id, title="renamed", priority="high"
+    )
+    from pollypm.work.models import Priority
+
+    assert updated.title == "renamed"
+    assert updated.priority is Priority.HIGH
+
+
+def test_update_labels_round_trips(pg_service):
+    task = _make_draft(pg_service)
+    updated = pg_service.update(task.task_id, labels=["a", "b"])
+    assert updated.labels == ["a", "b"]
+
+
+def test_update_rejects_work_status_change(pg_service):
+    from pollypm.work.service_support import ValidationError
+
+    task = _make_draft(pg_service)
+    with pytest.raises(ValidationError):
+        pg_service.update(task.task_id, work_status="queued")
+
+
+def test_update_rejects_flow_template_change(pg_service):
+    from pollypm.work.service_support import ValidationError
+
+    task = _make_draft(pg_service)
+    with pytest.raises(ValidationError):
+        pg_service.update(task.task_id, flow_template="other")
+
+
+def test_update_rejects_unknown_field(pg_service):
+    from pollypm.work.service_support import ValidationError
+
+    task = _make_draft(pg_service)
+    with pytest.raises(ValidationError):
+        pg_service.update(task.task_id, bogus="x")
+
+
+def test_update_missing_task_raises(pg_service):
+    from pollypm.work.service_support import TaskNotFoundError
+
+    with pytest.raises(TaskNotFoundError):
+        pg_service.update("nope/999", title="x")
+
+
+def test_increment_plan_version_bumps_counter(pg_service):
+    task = _make_draft(pg_service)
+    assert task.plan_version == 1
+    bumped = pg_service.increment_plan_version(task.task_id, actor="user")
+    assert bumped.plan_version == 2
+
+
+def test_list_successors_walks_predecessor_chain(pg_service):
+    parent = _make_draft(pg_service)
+    child = pg_service.create(
+        title="successor",
+        type="task",
+        project="demo",
+        flow_template="default",
+        roles={"worker": "a"},
+        predecessor_task_id=parent.task_id,
+    )
+    successors = pg_service.list_successors(parent.task_id)
+    assert [t.task_id for t in successors] == [child.task_id]
+
+
+# ---------------------------------------------------------------------------
+# add_context / get_context
+# ---------------------------------------------------------------------------
+
+
+def test_add_context_returns_entry_and_roundtrips(pg_service):
+    task = _make_draft(pg_service)
+    entry = pg_service.add_context(task.task_id, "user", "hello world")
+    assert entry.actor == "user"
+    assert entry.text == "hello world"
+    assert entry.entry_type == "note"
+
+    rows = pg_service.get_context(task.task_id)
+    assert len(rows) == 1
+    assert rows[0].text == "hello world"
+
+
+def test_add_context_missing_task(pg_service):
+    from pollypm.work.service_support import TaskNotFoundError
+
+    with pytest.raises(TaskNotFoundError):
+        pg_service.add_context("nope/1", "user", "x")
+
+
+def test_get_context_filters_by_entry_type(pg_service):
+    task = _make_draft(pg_service)
+    pg_service.add_context(task.task_id, "user", "note 1")
+    pg_service.add_context(
+        task.task_id, "user", "a reply", entry_type="reply"
+    )
+    notes = pg_service.get_context(task.task_id, entry_type="note")
+    replies = pg_service.get_context(task.task_id, entry_type="reply")
+    assert [e.text for e in notes] == ["note 1"]
+    assert [e.text for e in replies] == ["a reply"]
+
+
+def test_get_context_limit_honored(pg_service):
+    task = _make_draft(pg_service)
+    for i in range(5):
+        pg_service.add_context(task.task_id, "user", f"n{i}")
+    rows = pg_service.get_context(task.task_id, limit=2)
+    assert len(rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# link / unlink / dependents / would_create_cycle (via block)
+# ---------------------------------------------------------------------------
+
+
+def test_link_blocks_creates_edge_and_dependents_walk(pg_service):
+    a = _make_draft(pg_service, title="a")
+    b = _make_draft(pg_service, title="b")
+    c = _make_draft(pg_service, title="c")
+    pg_service.link(a.task_id, b.task_id, "blocks")
+    pg_service.link(b.task_id, c.task_id, "blocks")
+    deps = pg_service.dependents(a.task_id)
+    assert {t.task_id for t in deps} == {b.task_id, c.task_id}
+
+
+def test_link_rejects_invalid_kind(pg_service):
+    from pollypm.work.service_support import ValidationError
+
+    a = _make_draft(pg_service)
+    b = _make_draft(pg_service, title="b")
+    with pytest.raises(ValidationError):
+        pg_service.link(a.task_id, b.task_id, "bogus")
+
+
+def test_link_rejects_cycle(pg_service):
+    from pollypm.work.service_support import ValidationError
+
+    a = _make_draft(pg_service, title="a")
+    b = _make_draft(pg_service, title="b")
+    pg_service.link(a.task_id, b.task_id, "blocks")
+    with pytest.raises(ValidationError, match="circular"):
+        pg_service.link(b.task_id, a.task_id, "blocks")
+
+
+def test_unlink_removes_edge(pg_service):
+    a = _make_draft(pg_service, title="a")
+    b = _make_draft(pg_service, title="b")
+    pg_service.link(a.task_id, b.task_id, "blocks")
+    pg_service.unlink(a.task_id, b.task_id, "blocks")
+    assert pg_service.dependents(a.task_id) == []
+
+
+def test_link_missing_task_raises(pg_service):
+    from pollypm.work.service_support import TaskNotFoundError
+
+    a = _make_draft(pg_service)
+    with pytest.raises(TaskNotFoundError):
+        pg_service.link(a.task_id, "ghost/1", "blocks")
+
+
+# ---------------------------------------------------------------------------
+# claim / hold / resume / next
+# ---------------------------------------------------------------------------
+
+
+def test_claim_advances_to_in_progress(pg_service):
+    from pollypm.work.models import WorkStatus
+
+    task = _make_draft(pg_service)
+    pg_service.queue(task.task_id, actor="user")
+    claimed = pg_service.claim(task.task_id, actor="alice")
+    assert claimed.work_status is WorkStatus.IN_PROGRESS
+    assert claimed.current_node_id is not None
+
+
+def test_claim_from_wrong_state_raises(pg_service):
+    from pollypm.work.service_support import InvalidTransitionError
+
+    task = _make_draft(pg_service)
+    with pytest.raises(InvalidTransitionError):
+        pg_service.claim(task.task_id, actor="alice")
+
+
+def test_hold_from_in_progress(pg_service):
+    from pollypm.work.models import WorkStatus
+
+    task = _make_draft(pg_service)
+    pg_service.queue(task.task_id, actor="user")
+    pg_service.claim(task.task_id, actor="alice")
+    held = pg_service.hold(task.task_id, actor="user", reason="pause")
+    assert held.work_status is WorkStatus.ON_HOLD
+
+
+def test_hold_from_wrong_state(pg_service):
+    from pollypm.work.service_support import InvalidTransitionError
+
+    task = _make_draft(pg_service)
+    with pytest.raises(InvalidTransitionError):
+        pg_service.hold(task.task_id, actor="user")
+
+
+def test_resume_from_on_hold(pg_service):
+    from pollypm.work.models import WorkStatus
+
+    task = _make_draft(pg_service)
+    pg_service.queue(task.task_id, actor="user")
+    pg_service.hold(task.task_id, actor="user", reason="x")
+    resumed = pg_service.resume(task.task_id, actor="user")
+    assert resumed.work_status is WorkStatus.QUEUED
+
+
+def test_next_returns_highest_priority_queued(pg_service):
+    a = _make_draft(pg_service, title="a")
+    b = _make_draft(pg_service, title="b", priority="critical")
+    pg_service.queue(a.task_id, actor="u")
+    pg_service.queue(b.task_id, actor="u")
+    nxt = pg_service.next()
+    assert nxt is not None
+    assert nxt.task_id == b.task_id
+
+
+def test_next_returns_none_for_empty(pg_service):
+    assert pg_service.next() is None
+
+
+def test_next_respects_project_filter(pg_service):
+    a = _make_draft(pg_service, project="alpha", title="a")
+    _make_draft(pg_service, project="beta", title="b")
+    pg_service.queue(a.task_id, actor="u")
+    nxt_alpha = pg_service.next(project="alpha")
+    assert nxt_alpha is not None
+    assert nxt_alpha.project == "alpha"
+    # beta has no queued tasks
+    assert pg_service.next(project="beta") is None
+
+
+# ---------------------------------------------------------------------------
+# node_done / approve / reject (use a "chat" flow that reaches done)
+# ---------------------------------------------------------------------------
+
+
+def _drive_to_review(svc, project="demo"):
+    """Create a task, queue+claim it, then run node_done to reach review."""
+    task = svc.create(
+        title="t",
+        type="task",
+        project=project,
+        flow_template="standard",
+        roles={"worker": "alice", "reviewer": "bob"},
+        description="body",
+    )
+    svc.queue(task.task_id, actor="user")
+    svc.claim(task.task_id, actor="alice")
+    return task
+
+
+def test_node_done_requires_output(pg_service):
+    from pollypm.work.service_support import ValidationError
+
+    task = _drive_to_review(pg_service)
+    with pytest.raises(ValidationError):
+        pg_service.node_done(task.task_id, actor="alice")
+
+
+def test_node_done_advances_to_review(pg_service):
+    from pollypm.work.models import WorkStatus
+
+    task = _drive_to_review(pg_service)
+    done = pg_service.node_done(
+        task.task_id,
+        actor="alice",
+        work_output={
+            "type": "code_change",
+            "summary": "implemented X",
+            "artifacts": [
+                {"kind": "commit", "description": "impl", "ref": "HEAD"}
+            ],
+        },
+    )
+    # standard flow: build -> review, so after node_done we should be in review
+    assert done.work_status is WorkStatus.REVIEW
+
+
+def test_approve_from_non_review_raises(pg_service):
+    from pollypm.work.service_support import InvalidTransitionError
+
+    task = _make_draft(pg_service)
+    with pytest.raises(InvalidTransitionError):
+        pg_service.approve(task.task_id, actor="user")
+
+
+def test_reject_requires_reason(pg_service):
+    from pollypm.work.service_support import ValidationError
+
+    task = _drive_to_review(pg_service)
+    pg_service.node_done(
+        task.task_id,
+        actor="alice",
+        work_output={
+            "type": "code_change",
+            "summary": "implemented X",
+            "artifacts": [
+                {"kind": "commit", "description": "impl", "ref": "HEAD"}
+            ],
+        },
+    )
+    with pytest.raises(ValidationError):
+        pg_service.reject(task.task_id, actor="bob", reason="")
+
+
+# ---------------------------------------------------------------------------
+# block / blocked_tasks
+# ---------------------------------------------------------------------------
+
+
+def test_block_marks_task_blocked(pg_service):
+    from pollypm.work.models import WorkStatus
+
+    task = _drive_to_review(pg_service)
+    pg_service.node_done(
+        task.task_id,
+        actor="alice",
+        work_output={
+            "type": "code_change",
+            "summary": "x",
+            "artifacts": [{"kind": "commit", "description": "x", "ref": "HEAD"}],
+        },
+    )
+    # task is now in REVIEW
+    blocker = _make_draft(pg_service, title="blocker")
+    blocked = pg_service.block(
+        task.task_id, actor="user", blocker_task_id=blocker.task_id
+    )
+    assert blocked.work_status is WorkStatus.BLOCKED
+
+
+def test_blocked_tasks_filter_by_project(pg_service):
+    task = _drive_to_review(pg_service)
+    pg_service.node_done(
+        task.task_id,
+        actor="alice",
+        work_output={
+            "type": "code_change",
+            "summary": "x",
+            "artifacts": [{"kind": "commit", "description": "x", "ref": "HEAD"}],
+        },
+    )
+    blocker = _make_draft(pg_service, title="b")
+    pg_service.block(task.task_id, actor="user", blocker_task_id=blocker.task_id)
+    rows = pg_service.blocked_tasks(project="demo")
+    assert {t.task_id for t in rows} == {task.task_id}
+
+
+# ---------------------------------------------------------------------------
+# get_execution
+# ---------------------------------------------------------------------------
+
+
+def test_get_execution_after_claim(pg_service):
+    task = _make_draft(pg_service)
+    pg_service.queue(task.task_id, actor="user")
+    pg_service.claim(task.task_id, actor="alice")
+    rows = pg_service.get_execution(task.task_id)
+    assert len(rows) >= 1
+    assert rows[0].node_id is not None
+
+
+def test_get_execution_node_filter(pg_service):
+    task = _make_draft(pg_service)
+    pg_service.queue(task.task_id, actor="user")
+    pg_service.claim(task.task_id, actor="alice")
+    rows = pg_service.get_execution(task.task_id, node_id="unknown_node")
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# my_tasks / state_counts / sync_status / trigger_sync
+# ---------------------------------------------------------------------------
+
+
+def test_my_tasks_returns_active_assignee_tasks(pg_service):
+    task = _make_draft(pg_service)
+    pg_service.queue(task.task_id, actor="user")
+    pg_service.claim(task.task_id, actor="alice")
+    rows = pg_service.my_tasks("alice")
+    assert {t.task_id for t in rows} == {task.task_id}
+
+
+def test_my_tasks_empty_when_no_match(pg_service):
+    assert pg_service.my_tasks("ghost") == []
+
+
+def test_state_counts_zero_fills_all_statuses(pg_service):
+    counts = pg_service.state_counts()
+    from pollypm.work.models import WorkStatus
+
+    # every WorkStatus value must appear (zero-filled if absent)
+    for status in WorkStatus:
+        assert status.value in counts
+
+
+def test_sync_status_empty_for_unsynced_task(pg_service):
+    task = _make_draft(pg_service)
+    assert pg_service.sync_status(task.task_id) == {}
+
+
+def test_sync_status_missing_task_raises(pg_service):
+    from pollypm.work.service_support import TaskNotFoundError
+
+    with pytest.raises(TaskNotFoundError):
+        pg_service.sync_status("nope/1")
+
+
+def test_trigger_sync_returns_summary_shape(pg_service):
+    summary = pg_service.trigger_sync()
+    assert summary == {"synced": 0, "errors": {}}
+
+
+def test_trigger_sync_missing_task_raises(pg_service):
+    from pollypm.work.service_support import TaskNotFoundError
+
+    with pytest.raises(TaskNotFoundError):
+        pg_service.trigger_sync(task_id="nope/1")
+
+
+# ---------------------------------------------------------------------------
+# validate_advance preflight
+# ---------------------------------------------------------------------------
+
+
+def test_validate_advance_empty_for_draft(pg_service):
+    task = _make_draft(pg_service)
+    # draft has no current_node_id → empty results
+    assert pg_service.validate_advance(task.task_id, actor="user") == []
+
+
+def test_validate_advance_surfaces_actor_mismatch(pg_service):
+    task = _make_draft(pg_service)
+    pg_service.queue(task.task_id, actor="user")
+    pg_service.claim(task.task_id, actor="alice")
+    # standard flow's review node expects the reviewer role
+    results = pg_service.validate_advance(task.task_id, actor="random_actor")
+    # may be empty (no role mismatch on the current work node) or list a
+    # failure — either way the method must not crash. Smoke-only.
+    assert isinstance(results, list)
+
+
+# ---------------------------------------------------------------------------
+# Worker sessions
+# ---------------------------------------------------------------------------
+
+
+def test_worker_session_round_trip(pg_service):
+    from datetime import UTC, datetime
+
+    task = _make_draft(pg_service)
+    pg_service.upsert_worker_session(
+        task_project=task.project,
+        task_number=task.task_number,
+        agent_name="alice",
+        pane_id="pane-1",
+        worktree_path="/tmp/wt",
+        branch_name="task/demo-1",
+        started_at=datetime.now(UTC),
+    )
+    rec = pg_service.get_worker_session(
+        task_project=task.project, task_number=task.task_number
+    )
+    assert rec is not None
+    assert rec.agent_name == "alice"
+    assert rec.pane_id == "pane-1"
+
+
+def test_worker_session_active_only_filter(pg_service):
+    from datetime import UTC, datetime
+
+    task = _make_draft(pg_service)
+    pg_service.upsert_worker_session(
+        task_project=task.project,
+        task_number=task.task_number,
+        agent_name="alice",
+        pane_id="p",
+        worktree_path="/tmp/wt",
+        branch_name="b",
+        started_at=datetime.now(UTC),
+    )
+    pg_service.end_worker_session(
+        task_project=task.project,
+        task_number=task.task_number,
+        ended_at=datetime.now(UTC),
+        total_input_tokens=100,
+        total_output_tokens=200,
+        archive_path="/tmp/archive",
+    )
+    rec_active = pg_service.get_worker_session(
+        task_project=task.project,
+        task_number=task.task_number,
+        active_only=True,
+    )
+    rec_any = pg_service.get_worker_session(
+        task_project=task.project, task_number=task.task_number
+    )
+    assert rec_active is None
+    assert rec_any is not None
+    assert rec_any.total_input_tokens == 100
+    assert rec_any.total_output_tokens == 200
+
+
+def test_list_worker_sessions_active_only(pg_service):
+    from datetime import UTC, datetime
+
+    task = _make_draft(pg_service)
+    pg_service.upsert_worker_session(
+        task_project=task.project,
+        task_number=task.task_number,
+        agent_name="alice",
+        pane_id="p",
+        worktree_path="/tmp/wt",
+        branch_name="b",
+        started_at=datetime.now(UTC),
+    )
+    active = pg_service.list_worker_sessions(active_only=True)
+    assert len(active) == 1
+    pg_service.mark_worker_session_ended(
+        task_project=task.project,
+        task_number=task.task_number,
+        ended_at=datetime.now(UTC),
+    )
+    after = pg_service.list_worker_sessions(active_only=True)
+    assert after == []
+
+
+def test_update_worker_session_tokens(pg_service):
+    from datetime import UTC, datetime
+
+    task = _make_draft(pg_service)
+    pg_service.upsert_worker_session(
+        task_project=task.project,
+        task_number=task.task_number,
+        agent_name="alice",
+        pane_id="p",
+        worktree_path="/tmp/wt",
+        branch_name="b",
+        started_at=datetime.now(UTC),
+    )
+    pg_service.update_worker_session_tokens(
+        task_project=task.project,
+        task_number=task.task_number,
+        total_input_tokens=42,
+        total_output_tokens=99,
+        archive_path=None,
+    )
+    rec = pg_service.get_worker_session(
+        task_project=task.project, task_number=task.task_number
+    )
+    assert rec is not None
+    assert rec.total_input_tokens == 42
+    assert rec.total_output_tokens == 99
+
+
+def test_ensure_worker_session_schema_is_noop(pg_service):
+    # No-op on pg — migration applier owns schema. Must not raise.
+    pg_service.ensure_worker_session_schema()
+
+
+# ---------------------------------------------------------------------------
+# available_flows / get_flow
+# ---------------------------------------------------------------------------
+
+
+def test_available_flows_returns_some_templates(pg_service):
+    # Without a project_path the file resolver loads bundled flows.
+    templates = pg_service.available_flows()
+    assert isinstance(templates, list)
+
+
+def test_get_flow_returns_template(pg_service):
+    tmpl = pg_service.get_flow("standard")
+    assert tmpl.name == "standard"


### PR DESCRIPTION
## Summary

Slice B of the pg storage migration (#1737). Fills out every
`NotImplementedError("…Slice B")` stub on `PgWorkService` so the full
work-service Protocol is satisfied against the pg pool.

Methods implemented (24):

- `update`, `increment_plan_version`, `list_successors`
- `claim`, `hold`, `resume`, `next`
- `node_done`, `approve`, `reject`, `block`
- `add_context`, `get_context`
- `link`, `unlink`, `dependents`
- `my_tasks`, `blocked_tasks`, `state_counts` (zero-filled across every `WorkStatus`)
- `validate_advance` (actor-role preflight)
- `sync_status`, `trigger_sync` (stub shape — adapter dispatch is Slice C)
- `available_flows`, `get_flow` (file-resolver delegation)
- `get_execution`
- Worker-session CRUD: `ensure_worker_session_schema`, `upsert_worker_session`, `get_worker_session`, `list_worker_sessions`, `end_worker_session`, `mark_worker_session_ended`, `update_worker_session_tokens`

Deferred to Slice C (long-tail, not on `WorkService` Protocol hot path):
audit JSONL emission, gate registry/evaluation, sync adapter dispatch, session-manager provisioning, plan-review backstop emit, git auto-merge, inbox helpers (`archive_task`, `add_reply`, `mark_read`, `list_replies`, `bulk_list_replies`, `task_numbers_with_context_entry`), notification staging (`stage_notification` + digest rollup), human-review approval (`has_human_review_approval`, `ensure_human_review_request_task`, `approve_human_review`), kickoff/visit query API (`current_node_visit`, `kickoff_sent_at`, `mark_kickoff_sent`), `derive_owner`, `release_stale_claim`, `set_external_ref`, `backfill_kind`.

Out of scope per the issue: the `service_*.py` helper modules stay sqlite-only — they type against `_conn: sqlite3.Connection`, so the pg path reimplements their semantics inline rather than coupling backends through a shared Protocol surface that would force a sqlite import on every pg call site.

## Test plan

- [x] `tests/test_pg_work_service_full.py` — 49 new cases against the testcontainer pg from `conftest_pg`, covering every implemented method
- [x] `tests/test_pg_work_service.py` — original Slice A test updated so the `NotImplementedError` assertion now confirms the methods reach `TaskNotFoundError` instead of crashing on the stub
- [x] All 38 existing pg tests still pass (`test_pg_work_service.py`, `test_pg_pool.py`, `test_pg_schema.py`)
- [x] All 70 sqlite work-service tests still pass — no changes to `sqlite_service.py` or the `service_*.py` helpers

Run against a local pg with pgvector:

```
pytest tests/test_pg_work_service_full.py tests/test_pg_work_service.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)