### PR TITLE
feat(storage): pm storage migrate-to-pg — slice E of #1737

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -59,6 +59,7 @@ from pollypm.cli_features.migrate import register_migrate_commands
 from pollypm.cli_features.projects import register_project_commands
 from pollypm.cli_features.send_up import register_send_up_commands
 from pollypm.cli_features.session_runtime import register_session_runtime_commands
+from pollypm.cli_features.storage import register_storage_commands
 from pollypm.cli_features.ui import register_ui_commands
 from pollypm.cli_features.update import register_update_commands
 from pollypm.cli_features.upgrade import register_upgrade_commands
@@ -213,6 +214,7 @@ register_maintenance_commands(app)
 register_update_commands(app)
 register_upgrade_commands(app)
 register_migrate_commands(app)
+register_storage_commands(app)
 register_worker_commands(app)
 register_tier4_commands(app)
 register_session_runtime_commands(app, helpers=sys.modules[__name__])

--- a/src/pollypm/cli_features/storage.py
+++ b/src/pollypm/cli_features/storage.py
@@ -1,0 +1,273 @@
+"""``pm storage`` CLI — Postgres migration tooling (issue #1737, Slice E).
+
+Slice E ships the operator-facing ``pm storage migrate-to-pg`` command
+that moves data from the existing sqlite workspace into the pg schema
+installed by Slice A. The implementation lives in
+:mod:`pollypm.storage.pg_migration_tool`; this module is the typer-level
+glue: flag parsing, confirmation prompt, structured failure messages.
+
+Contract
+--------
+
+- Inputs: ``--dsn``, ``--from-sqlite``, ``--include-legacy-per-project``,
+  ``--reembed``, ``--dry-run`` (default), ``--commit`` (kill switch),
+  ``--yes`` (skip confirmation), plus the standard ``--config``.
+- Outputs: human-readable progress + per-source summary on stdout,
+  structured failure messages on stderr.
+- Exit codes:
+    0 — success (every source either copied or already imported)
+    1 — partial / total failure (at least one source failed)
+    2 — bad flags / config not found
+    3 — pre-flight check failed (pg unreachable, schema missing, etc.)
+- Side effects: mutates pg only when ``--commit`` is set. Renames each
+  source ``state.db`` to ``state.db.pre-pg-<ts>`` on success. The audit
+  table ``_pg_migration_audit`` is created on first run and consulted
+  for idempotency.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from pollypm.cli_help import help_with_examples
+from pollypm.config import DEFAULT_CONFIG_PATH, load_config, resolve_config_path
+
+
+__all__ = ["storage_app", "register_storage_commands"]
+
+
+storage_app = typer.Typer(
+    help=help_with_examples(
+        "Storage backend tooling (sqlite ↔ postgres migration).",
+        [
+            (
+                "pm storage migrate-to-pg",
+                "preview the sqlite → postgres data migration (dry-run)",
+            ),
+            (
+                "pm storage migrate-to-pg --commit --yes",
+                "move data from sqlite to postgres and rename source files",
+            ),
+        ],
+    ),
+    no_args_is_help=True,
+)
+
+
+_MIGRATE_HELP = help_with_examples(
+    (
+        "Migrate the sqlite workspace state (and any per-project legacy "
+        "DBs) into the Postgres backend installed by `pm doctor-pg-"
+        "connection`.\n\n"
+        "DEFAULT IS DRY-RUN. Pass --commit to actually mutate pg. The "
+        "tool is idempotent: a re-run against an unchanged sqlite "
+        "file is a no-op."
+    ),
+    [
+        ("pm storage migrate-to-pg", "preview what would happen"),
+        (
+            "pm storage migrate-to-pg --commit --yes",
+            "do the migration and rename source files",
+        ),
+        (
+            "pm storage migrate-to-pg --from-sqlite ~/old.db --commit",
+            "migrate a specific sqlite file (skips auto-discovery)",
+        ),
+    ],
+    trailing=(
+        "On --commit success each source state.db is renamed to "
+        "state.db.pre-pg-<timestamp>. To roll back, flip the "
+        "storage backend back to sqlite and rename the snapshot."
+    ),
+)
+
+
+def register_storage_commands(app: typer.Typer) -> None:
+    """Attach the ``storage`` sub-app to the root CLI."""
+    app.add_typer(storage_app, name="storage")
+
+
+@storage_app.command("migrate-to-pg", help=_MIGRATE_HELP)
+def migrate_to_pg(
+    dsn: str = typer.Option(
+        "",
+        "--dsn",
+        help=(
+            "Override the Postgres DSN. Default: resolve from "
+            "[storage] url / POLLYPM_PG_DSN env / built-in default."
+        ),
+    ),
+    from_sqlite: str = typer.Option(
+        "auto",
+        "--from-sqlite",
+        help=(
+            "Sqlite source. 'auto' = workspace state.db + every "
+            "per-project state.db registered in pollypm.toml. Pass a "
+            "file path to migrate exactly that DB and skip discovery."
+        ),
+    ),
+    include_legacy_per_project: bool = typer.Option(
+        True,
+        "--include-legacy-per-project/--no-legacy-per-project",
+        help=(
+            "Include per-project <project>/.pollypm/state.db files in "
+            "auto-discovery. Off only for testing."
+        ),
+    ),
+    reembed: bool = typer.Option(
+        False,
+        "--reembed",
+        help=(
+            "After copy, re-run `pm memory backfill-embeddings` so the "
+            "new pgvector embeddings column is populated. Slice E "
+            "wires the flag; the actual re-embed pass lands once "
+            "Slice D's embedding writer is in (TODO)."
+        ),
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help=(
+            "Force dry-run mode even when --commit is set. The default "
+            "is already a dry-run; this flag is kept for clarity in "
+            "scripts."
+        ),
+    ),
+    commit: bool = typer.Option(
+        False,
+        "--commit",
+        help=(
+            "Kill switch — only mutates pg when set. Without --commit "
+            "the tool runs the entire pipeline against a rolled-back "
+            "transaction so pre-flight + parity checks surface."
+        ),
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip the confirmation prompt before --commit.",
+    ),
+    config_path: Path = typer.Option(
+        DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."
+    ),
+) -> None:
+    """``pm storage migrate-to-pg`` entry point."""
+    # The two flags can disagree: --dry-run overrides --commit so a
+    # script that always passes --commit can opt back into preview mode
+    # with --dry-run for a CI smoke pass.
+    do_commit = commit and not dry_run
+
+    # Load config — needed for auto-discovery + default DSN resolution.
+    config = None
+    resolved_config = resolve_config_path(config_path)
+    if resolved_config.exists():
+        try:
+            config = load_config(resolved_config)
+        except Exception as exc:  # noqa: BLE001
+            typer.echo(
+                f"Could not load config from {resolved_config}: {exc}",
+                err=True,
+            )
+            raise typer.Exit(code=2) from exc
+    # Note: config missing is OK if --from-sqlite is a specific path
+    # AND --dsn is set. The pool factory will fall through to the env
+    # var / default DSN; discovery will see exactly the one source.
+
+    # Apply DSN override before opening the pool.
+    if dsn:
+        import os
+
+        os.environ["POLLYPM_PG_DSN"] = dsn
+
+    # Lazy import — these pull psycopg, which we don't want at module
+    # import time so sqlite-only installs aren't paying the cost.
+    from pollypm.storage import pg_migration_tool, pg_pool
+
+    sources = pg_migration_tool.discover_sources(
+        config=config,
+        include_legacy_per_project=include_legacy_per_project,
+        from_sqlite_override=from_sqlite,
+    )
+
+    if not sources:
+        typer.echo(
+            "No sqlite sources discovered. Either pass --from-sqlite "
+            "<path> or check that workspace_root + projects in "
+            "pollypm.toml point at directories containing .pollypm/state.db."
+        )
+        raise typer.Exit(code=0)
+
+    typer.echo(f"Discovered {len(sources)} sqlite source(s):")
+    for src in sources:
+        suffix = (
+            f" [project_key={src.project_key}]"
+            if src.project_key
+            else ""
+        )
+        typer.echo(f"  - {src.path} ({src.kind}){suffix}")
+    typer.echo("")
+
+    # Open the pool + run preflight before doing any per-source work.
+    try:
+        pool = pg_pool.get_rw_pool(config)
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(
+            f"Could not open pg pool: {exc}\n"
+            "Fix: confirm Postgres is running and POLLYPM_PG_DSN / "
+            "[storage] url points at a reachable instance, then re-run.",
+            err=True,
+        )
+        raise typer.Exit(code=3) from exc
+
+    preflight = pg_migration_tool.preflight(pool)
+    if not preflight.ok:
+        typer.echo(f"Pre-flight failed: {preflight.message}", err=True)
+        typer.echo(
+            "Fix: run `pm doctor-pg-connection` to diagnose, ensure pg "
+            ">= 16 is reachable, vector extension is installed, and "
+            "open a PgWorkService once so schema migrations apply.",
+            err=True,
+        )
+        raise typer.Exit(code=3)
+    typer.echo(f"Pre-flight: {preflight.message}")
+    typer.echo("")
+
+    # Confirmation gate. We ONLY prompt when we're about to commit and
+    # the user didn't pre-confirm with --yes. Dry-run never prompts.
+    if do_commit and not yes:
+        confirm = typer.confirm(
+            f"About to copy {len(sources)} sqlite source(s) into pg and "
+            "rename each state.db to state.db.pre-pg-<ts>. Continue?"
+        )
+        if not confirm:
+            typer.echo("Aborted.")
+            raise typer.Exit(code=0)
+
+    run = pg_migration_tool.migrate_sources(
+        sources,
+        pool=pool,
+        commit=do_commit,
+    )
+
+    summary = pg_migration_tool.format_run_summary(run)
+    typer.echo(summary)
+
+    if reembed and do_commit and run.succeeded:
+        # TODO(slice-D): wire `pm memory backfill-embeddings` once the
+        # embedding writer (Slice D) is in. For now, surface a clear
+        # follow-up rather than silently ignoring the flag.
+        typer.echo("")
+        typer.echo(
+            "--reembed: deferred — the embedding writer lands in Slice "
+            "D. Re-run `pm memory backfill-embeddings` manually once "
+            "that PR ships."
+        )
+
+    if run.preflight_error:
+        raise typer.Exit(code=3)
+    if not run.succeeded:
+        raise typer.Exit(code=1)
+    raise typer.Exit(code=0)

--- a/src/pollypm/storage/pg_migration_tool.py
+++ b/src/pollypm/storage/pg_migration_tool.py
@@ -1,0 +1,1226 @@
+"""SQLite → Postgres bulk data migration tool (issue #1737, Slice E).
+
+Slice E ships the operator-facing one-shot ``pm storage migrate-to-pg``
+that moves data from PollyPM's existing sqlite workspace (and any
+leftover per-project ``state.db`` files) into the pg schema installed
+by Slice A's :mod:`pollypm.storage.pg_migrations` applier.
+
+Design (per the slice spec)
+---------------------------
+
+* **Sources**: enumerate the workspace ``~/.pollypm/state.db`` plus every
+  ``<project>/.pollypm/state.db`` registered in the loaded config. The
+  per-project DBs (#1004 legacy) carry the same shape but the
+  ``project_key`` column derives from the filename instead of a row
+  column.
+* **Idempotency**: SHA-256 of each source file is recorded in
+  ``_pg_migration_audit``. A second run against an unchanged sqlite file
+  is a no-op with a clear "already imported" message.
+* **Atomicity**: every source is copied inside one pg transaction. A
+  failure rolls back the whole source — the sqlite file is **not**
+  renamed and the tool exits non-zero. Other already-finished sources
+  stay committed (each has its own audit row).
+* **Performance**: bounded-batch INSERTs (5000 rows / batch) via
+  ``psycopg.cursor.executemany``. ``COPY FROM STDIN`` was considered
+  but the spec is fine with a plain bulk insert for the time budget;
+  the audit table records throughput so a follow-up can swap in COPY
+  if real installs are slow.
+* **Safety**: ``--commit`` is the kill switch. Without it the tool runs
+  the whole pipeline against a transaction it always rolls back, so
+  pre-flight + parity checks still surface but the pg state is
+  untouched.
+* **Rollback**: on success the source sqlite files are renamed to
+  ``state.db.pre-pg-<timestamp>`` (not deleted). Operators flip
+  ``[storage] backend`` back to ``sqlite`` and rename the file back to
+  recover.
+
+Out of scope (per the spec)
+---------------------------
+
+* The actual cutover (flipping ``[storage] backend = "postgres"``) is
+  Slice J.
+* ``notification_staging`` retirement (#704) is **not** bundled — the
+  table is copied 1:1.
+* ``--reembed`` is wired as a flag but the actual re-embed call is a
+  TODO pointer; the writer that would re-fire ``pm memory
+  backfill-embeddings`` lands when Slice D's embedding writer is in.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pollypm.storage.sqlite_pragmas import readonly_uri
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+    from pollypm.models import PollyPMConfig
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------- #
+
+
+# Audit-table DDL. Created on first run; not part of the canonical
+# schema in ``pg_schema.py`` because it's a migration-tool artefact
+# rather than a domain table. The schema mirrors what an operator
+# would actually want to see: source path, content hash, when it
+# completed, what got moved.
+AUDIT_TABLE_DDL = """
+CREATE TABLE IF NOT EXISTS _pg_migration_audit (
+    id              bigserial PRIMARY KEY,
+    source_path     text NOT NULL,
+    source_sha256   text NOT NULL,
+    source_kind     text NOT NULL,
+    project_key     text NOT NULL DEFAULT '',
+    rows_per_table  jsonb NOT NULL DEFAULT '{}'::jsonb,
+    started_at      timestamptz NOT NULL,
+    completed_at    timestamptz NOT NULL,
+    tool_version    text NOT NULL DEFAULT 'slice-e-1737',
+    UNIQUE (source_sha256)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pg_migration_audit_path
+    ON _pg_migration_audit(source_path);
+"""
+
+
+# Batch size for bulk inserts. 5000 is a sweet spot per the spec — large
+# enough to amortise per-statement round-trips, small enough that one
+# batch fits comfortably in pg's WAL buffer on default tunings.
+COPY_BATCH_SIZE = 5000
+
+
+# Suffix appended to source sqlite files after a successful copy. The
+# timestamp is YYYYMMDDTHHMMSSZ so the suffix sorts naturally.
+RENAME_SUFFIX_PREFIX = ".pre-pg-"
+
+
+# Tables copied per source. Order matters for FK validity in pg:
+# parents (work_tasks, work_flow_templates) must land before children.
+# Each entry is ``(sqlite_table, pg_table, json_cols, ts_cols, bool_cols,
+# add_project_key_from_source: bool)``.
+#
+# ``json_cols`` — sqlite columns that store TEXT-encoded JSON; the
+# migrator parses and re-encodes to pg's jsonb adapter.
+# ``ts_cols`` — sqlite columns that store ISO-8601 TEXT; coerced to
+# datetime for pg's timestamptz adapter.
+# ``bool_cols`` — sqlite columns that store 0/1 INTEGER; coerced to
+# Python bool for pg's boolean adapter.
+# ``inject_project_key`` — when True, the migrator adds a synthetic
+# ``project_key`` column to the inserted row using the source DB's
+# derived project key (per-project DB filename) when the source row
+# doesn't carry one.
+@dataclass(frozen=True)
+class TableSpec:
+    sqlite_table: str
+    pg_table: str
+    json_cols: tuple[str, ...] = ()
+    ts_cols: tuple[str, ...] = ()
+    bool_cols: tuple[str, ...] = ()
+    inject_project_key: bool = False
+
+
+# Order: schema_version / FK-parents first, children after.
+TABLE_SPECS: tuple[TableSpec, ...] = (
+    # Operator / runtime tables — no inter-table FKs to worry about.
+    TableSpec(
+        sqlite_table="sessions",
+        pg_table="sessions",
+    ),
+    TableSpec(
+        sqlite_table="heartbeats",
+        pg_table="heartbeats",
+        ts_cols=("created_at",),
+        bool_cols=("pane_dead",),
+    ),
+    TableSpec(
+        sqlite_table="leases",
+        pg_table="leases",
+        ts_cols=("updated_at",),
+    ),
+    TableSpec(
+        sqlite_table="account_usage",
+        pg_table="account_usage",
+        ts_cols=("reset_at", "updated_at"),
+    ),
+    TableSpec(
+        sqlite_table="account_runtime",
+        pg_table="account_runtime",
+        ts_cols=("available_at", "access_expires_at", "updated_at"),
+        bool_cols=("refresh_available",),
+    ),
+    TableSpec(
+        sqlite_table="session_runtime",
+        pg_table="session_runtime",
+        ts_cols=(
+            "recovery_window_started_at",
+            "retry_at",
+            "last_recovered_at",
+            "updated_at",
+        ),
+    ),
+    TableSpec(
+        sqlite_table="checkpoints",
+        pg_table="checkpoints",
+        ts_cols=("created_at",),
+    ),
+    TableSpec(
+        sqlite_table="worktrees",
+        pg_table="worktrees",
+        ts_cols=("created_at", "updated_at"),
+    ),
+    TableSpec(
+        sqlite_table="token_samples",
+        pg_table="token_samples",
+        ts_cols=("observed_at",),
+    ),
+    TableSpec(
+        sqlite_table="token_usage_hourly",
+        pg_table="token_usage_hourly",
+        ts_cols=("updated_at",),
+    ),
+    # Messages — the unified inbox surface.
+    TableSpec(
+        sqlite_table="messages",
+        pg_table="messages",
+        json_cols=("payload_json", "labels"),
+        ts_cols=("created_at", "updated_at", "closed_at"),
+        inject_project_key=True,
+    ),
+    # Work flow templates land before tasks/nodes (FK parent).
+    TableSpec(
+        sqlite_table="work_flow_templates",
+        pg_table="work_flow_templates",
+        json_cols=("roles",),
+        ts_cols=("created_at",),
+        bool_cols=("is_current",),
+    ),
+    TableSpec(
+        sqlite_table="work_flow_nodes",
+        pg_table="work_flow_nodes",
+        json_cols=("gates",),
+    ),
+    # Work tasks — the FK parent for the rest of the work-* tables.
+    TableSpec(
+        sqlite_table="work_tasks",
+        pg_table="work_tasks",
+        json_cols=("labels", "relevant_files", "roles", "external_refs"),
+        ts_cols=("created_at", "updated_at"),
+        bool_cols=("requires_human_review",),
+        inject_project_key=True,
+    ),
+    TableSpec(
+        sqlite_table="work_task_delete_audit_outbox",
+        pg_table="work_task_delete_audit_outbox",
+        ts_cols=("deleted_at",),
+    ),
+    TableSpec(
+        sqlite_table="work_task_dependencies",
+        pg_table="work_task_dependencies",
+        ts_cols=("created_at",),
+    ),
+    TableSpec(
+        sqlite_table="work_node_executions",
+        pg_table="work_node_executions",
+        json_cols=("work_output",),
+        ts_cols=("started_at", "completed_at", "kickoff_sent_at"),
+    ),
+    TableSpec(
+        sqlite_table="work_context_entries",
+        pg_table="work_context_entries",
+        ts_cols=("created_at",),
+    ),
+    TableSpec(
+        sqlite_table="work_transitions",
+        pg_table="work_transitions",
+        ts_cols=("created_at",),
+    ),
+    TableSpec(
+        sqlite_table="work_sessions",
+        pg_table="work_sessions",
+        ts_cols=("started_at", "ended_at"),
+    ),
+    TableSpec(
+        sqlite_table="work_sync_state",
+        pg_table="work_sync_state",
+        ts_cols=("last_synced_at",),
+    ),
+    # Memory / ops.
+    TableSpec(
+        sqlite_table="memory_entries",
+        pg_table="memory_entries",
+        ts_cols=("created_at", "updated_at", "ttl_at"),
+        inject_project_key=True,
+    ),
+    TableSpec(
+        sqlite_table="memory_summaries",
+        pg_table="memory_summaries",
+        ts_cols=("created_at",),
+    ),
+    TableSpec(
+        sqlite_table="work_jobs",
+        pg_table="work_jobs",
+        json_cols=("payload_json",),
+        ts_cols=("enqueued_at", "run_after", "claimed_at", "finished_at"),
+    ),
+    TableSpec(
+        sqlite_table="architect_resume_tokens",
+        pg_table="architect_resume_tokens",
+        ts_cols=("captured_at", "last_active_at"),
+    ),
+    TableSpec(
+        sqlite_table="workspace_state",
+        pg_table="workspace_state",
+        json_cols=("value_json",),
+        ts_cols=("set_at",),
+    ),
+    TableSpec(
+        sqlite_table="tier4_promotion_state",
+        pg_table="tier4_promotion_state",
+        json_cols=("dispatch_history_json",),
+        ts_cols=("last_promotion_at", "tier4_entered_at", "updated_at"),
+        bool_cols=("tier4_active",),
+    ),
+    TableSpec(
+        sqlite_table="notification_staging",
+        pg_table="notification_staging",
+        json_cols=("payload_json",),
+        ts_cols=("created_at", "flushed_at"),
+    ),
+)
+
+
+# --------------------------------------------------------------------- #
+# Data model
+# --------------------------------------------------------------------- #
+
+
+@dataclass
+class SourceDescriptor:
+    """One sqlite source to migrate.
+
+    ``project_key`` is the value injected into rows of tables flagged
+    with ``inject_project_key=True`` when the source row does not
+    already carry a ``project_key`` column. For the workspace DB this
+    is empty (the row's existing ``project`` / ``scope`` columns carry
+    the binding); for a per-project DB it's the project key derived
+    from the parent directory name.
+    """
+
+    path: Path
+    kind: str  # "workspace" | "per_project"
+    project_key: str = ""
+
+    @property
+    def display(self) -> str:
+        return str(self.path)
+
+
+@dataclass
+class TableCopyReport:
+    """Per-table outcome for one source DB."""
+
+    table: str
+    sqlite_rows: int = 0
+    pg_rows_copied: int = 0
+    skipped_reason: str | None = None
+
+
+@dataclass
+class SourceMigrationReport:
+    """End-to-end outcome for one source DB."""
+
+    source: SourceDescriptor
+    source_sha256: str
+    started_at: datetime
+    completed_at: datetime | None = None
+    per_table: list[TableCopyReport] = field(default_factory=list)
+    skipped_already_imported_at: datetime | None = None
+    renamed_to: Path | None = None
+    failure: str | None = None
+    failed_table: str | None = None
+    parity_ok: bool = True
+    parity_mismatches: list[tuple[str, int, int]] = field(default_factory=list)
+
+    @property
+    def total_rows_copied(self) -> int:
+        return sum(t.pg_rows_copied for t in self.per_table)
+
+    @property
+    def succeeded(self) -> bool:
+        return self.failure is None and self.skipped_already_imported_at is None
+
+    def rows_per_table_map(self) -> dict[str, int]:
+        return {t.table: t.pg_rows_copied for t in self.per_table if t.pg_rows_copied}
+
+
+@dataclass
+class MigrationRunReport:
+    """Top-level report — list of per-source reports + flags."""
+
+    sources: list[SourceMigrationReport] = field(default_factory=list)
+    dry_run: bool = True
+    committed: bool = False
+    preflight_error: str | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        if self.preflight_error is not None:
+            return False
+        return all(s.succeeded or s.skipped_already_imported_at is not None
+                   for s in self.sources)
+
+
+# --------------------------------------------------------------------- #
+# Source enumeration
+# --------------------------------------------------------------------- #
+
+
+def _workspace_db_path(config: "PollyPMConfig | None") -> Path | None:
+    """Resolve the workspace ``state.db`` path from the loaded config.
+
+    Returns ``None`` when the config can't be loaded (the caller treats
+    that as "no auto-discovery; rely on operator override").
+    """
+    if config is None:
+        return None
+    workspace_root_raw = getattr(config.project, "workspace_root", None)
+    if workspace_root_raw is None:
+        return None
+    return Path(workspace_root_raw) / ".pollypm" / "state.db"
+
+
+def _project_db_path(project_path: Path) -> Path:
+    return project_path / ".pollypm" / "state.db"
+
+
+def discover_sources(
+    *,
+    config: "PollyPMConfig | None" = None,
+    include_legacy_per_project: bool = True,
+    from_sqlite_override: str | None = None,
+) -> list[SourceDescriptor]:
+    """Enumerate the sqlite sources to migrate.
+
+    ``from_sqlite_override`` (the CLI's ``--from-sqlite``) takes priority
+    when set to anything other than ``"auto"``. When ``"auto"`` (or
+    ``None``), the workspace DB and every per-project DB registered in
+    the config are returned (in that order — workspace first so its
+    rows land before any legacy per-project overlay).
+    """
+    sources: list[SourceDescriptor] = []
+
+    if from_sqlite_override and from_sqlite_override != "auto":
+        # Operator-pinned source. Treat as workspace-kind so no
+        # project_key injection happens — the rows are taken at face
+        # value.
+        path = Path(from_sqlite_override).expanduser().resolve()
+        if path.exists():
+            sources.append(
+                SourceDescriptor(path=path, kind="workspace", project_key="")
+            )
+        return sources
+
+    workspace_db = _workspace_db_path(config)
+    if workspace_db is not None and workspace_db.exists():
+        sources.append(
+            SourceDescriptor(
+                path=workspace_db.resolve(),
+                kind="workspace",
+                project_key="",
+            )
+        )
+
+    if include_legacy_per_project and config is not None:
+        known = getattr(config, "projects", {}) or {}
+        for project_key, project_cfg in known.items():
+            project_path_raw = getattr(project_cfg, "path", None)
+            if project_path_raw is None:
+                continue
+            per_project_db = _project_db_path(Path(project_path_raw))
+            if not per_project_db.exists():
+                continue
+            try:
+                resolved = per_project_db.resolve()
+            except OSError:
+                continue
+            # Skip if same inode as the workspace DB (project at
+            # workspace root case).
+            if any(s.path == resolved for s in sources):
+                continue
+            sources.append(
+                SourceDescriptor(
+                    path=resolved,
+                    kind="per_project",
+                    project_key=project_key,
+                )
+            )
+    return sources
+
+
+# --------------------------------------------------------------------- #
+# Hashing + audit
+# --------------------------------------------------------------------- #
+
+
+def compute_sha256(path: Path) -> str:
+    """Stream-hash a sqlite file. The .db is the canonical content; we
+    deliberately exclude any -wal/-shm sidecars because their contents
+    are merged into the .db on a clean close, and including them would
+    make the hash non-deterministic across runs.
+    """
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _ensure_audit_table(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(AUDIT_TABLE_DDL)
+    conn.commit()
+
+
+def _audit_lookup(conn, sha256: str) -> datetime | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT completed_at FROM _pg_migration_audit WHERE source_sha256 = %s",
+            (sha256,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return row[0]
+
+
+def _audit_record(
+    conn,
+    *,
+    report: SourceMigrationReport,
+) -> None:
+    """Insert one audit row inside the caller's open transaction.
+
+    Caller controls commit/rollback — dry-run callers always roll back
+    so the audit row never persists.
+    """
+    from psycopg.types.json import Jsonb
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO _pg_migration_audit
+                (source_path, source_sha256, source_kind, project_key,
+                 rows_per_table, started_at, completed_at)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (source_sha256) DO NOTHING
+            """,
+            (
+                str(report.source.path),
+                report.source_sha256,
+                report.source.kind,
+                report.source.project_key,
+                Jsonb(report.rows_per_table_map()),
+                report.started_at,
+                report.completed_at or datetime.now(UTC),
+            ),
+        )
+
+
+# --------------------------------------------------------------------- #
+# Pre-flight
+# --------------------------------------------------------------------- #
+
+
+@dataclass
+class PreflightResult:
+    ok: bool
+    server_version_num: int | None = None
+    vector_installed: bool = False
+    migration_version: int | None = None
+    message: str = ""
+
+
+def preflight(pool: "ConnectionPool", *, min_version: int = 16) -> PreflightResult:
+    """Verify pg is reachable, modern enough, and schema migration 0001 is applied.
+
+    Parameters
+    ----------
+    pool:
+        RW pool — the audit table + bulk inserts both need write access.
+    min_version:
+        Major-version gate (default 16). The schema relies on generated
+        tsvector columns + pgvector hnsw which is best on pg 16+.
+    """
+    try:
+        with pool.connection() as conn, conn.cursor() as cur:
+            cur.execute("SELECT current_setting('server_version_num')")
+            version_num = int(cur.fetchone()[0])
+            major = version_num // 10000
+            cur.execute(
+                "SELECT 1 FROM pg_extension WHERE extname = 'vector'"
+            )
+            vector = cur.fetchone() is not None
+            cur.execute(
+                "SELECT max(version) FROM schema_migrations"
+            )
+            row = cur.fetchone()
+            migration_version = int(row[0]) if row and row[0] is not None else None
+    except Exception as exc:  # noqa: BLE001
+        return PreflightResult(
+            ok=False,
+            message=f"pg unreachable or schema_migrations missing: {exc}",
+        )
+
+    if major < min_version:
+        return PreflightResult(
+            ok=False,
+            server_version_num=version_num,
+            vector_installed=vector,
+            migration_version=migration_version,
+            message=(
+                f"pg server version {major} < required {min_version}. "
+                "Upgrade pg before running the migration."
+            ),
+        )
+    if not vector:
+        return PreflightResult(
+            ok=False,
+            server_version_num=version_num,
+            vector_installed=False,
+            migration_version=migration_version,
+            message=(
+                "vector extension not installed. Run "
+                "`CREATE EXTENSION vector` in the target database."
+            ),
+        )
+    if migration_version is None or migration_version < 1:
+        return PreflightResult(
+            ok=False,
+            server_version_num=version_num,
+            vector_installed=vector,
+            migration_version=migration_version,
+            message=(
+                "schema_migrations does not record 0001. Run "
+                "`apply_migrations()` (or open a PgWorkService) once "
+                "before migrating data."
+            ),
+        )
+    return PreflightResult(
+        ok=True,
+        server_version_num=version_num,
+        vector_installed=vector,
+        migration_version=migration_version,
+        message=(
+            f"pg {major} reachable; vector ext present; "
+            f"schema_migrations at version {migration_version}."
+        ),
+    )
+
+
+# --------------------------------------------------------------------- #
+# sqlite helpers
+# --------------------------------------------------------------------- #
+
+
+def _sqlite_open_ro(path: Path) -> sqlite3.Connection:
+    """Open a sqlite file read-only. Uses :func:`readonly_uri` so the
+    pragma machinery is consistent with the rest of the codebase."""
+    conn = sqlite3.connect(readonly_uri(path), uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _sqlite_table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    )
+    return cur.fetchone() is not None
+
+
+def _sqlite_columns(conn: sqlite3.Connection, table: str) -> list[str]:
+    cur = conn.execute(f"PRAGMA table_info({table})")
+    return [row[1] for row in cur.fetchall()]
+
+
+def _sqlite_count(conn: sqlite3.Connection, table: str) -> int:
+    cur = conn.execute(f"SELECT count(*) FROM {table}")
+    return int(cur.fetchone()[0])
+
+
+# --------------------------------------------------------------------- #
+# Row conversion
+# --------------------------------------------------------------------- #
+
+
+def _parse_iso_timestamp(value: Any) -> datetime | None:
+    """Best-effort parse of a sqlite-stored ISO-8601 string.
+
+    sqlite stores timestamps as TEXT in a variety of shapes:
+    ``YYYY-MM-DD HH:MM:SS`` (the ``CURRENT_TIMESTAMP`` default),
+    ``YYYY-MM-DDTHH:MM:SS+00:00`` (Python ``datetime.isoformat()``),
+    sometimes with microseconds. ``datetime.fromisoformat`` (py>=3.11)
+    handles both forms; we patch the legacy ``YYYY-MM-DD HH:MM:SS`` form
+    by swapping the space for ``T`` so older formats still parse.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    candidate = text
+    if " " in candidate and "T" not in candidate:
+        candidate = candidate.replace(" ", "T", 1)
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(candidate)
+    except ValueError:
+        logger.debug("pg_migration_tool: cannot parse timestamp %r", value)
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _parse_json_text(value: Any, default: Any) -> Any:
+    """Decode a sqlite TEXT-as-JSON column to a Python object.
+
+    sqlite stores these as text; pg expects jsonb. Empty / NULL coalesce
+    to ``default`` so an INSERT with a NOT NULL DEFAULT still satisfies
+    the column.
+    """
+    if value is None:
+        return default
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            return json.loads(value.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return default
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return default
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return default
+    return default
+
+
+def _coerce_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "t", "yes")
+    return bool(value)
+
+
+def _convert_row(
+    row: sqlite3.Row,
+    *,
+    source_columns: list[str],
+    spec: TableSpec,
+    project_key: str,
+    target_columns: set[str],
+) -> tuple[tuple[str, ...], tuple[Any, ...]]:
+    """Convert one sqlite Row into ``(columns_tuple, values_tuple)``
+    aligned with the pg schema.
+
+    Behaviour:
+
+    * Source columns not present in pg are dropped silently (sqlite
+      might carry a column the pg schema collapsed away; the migrator
+      doesn't lose data because the FK-related columns are guaranteed
+      to be in both).
+    * jsonb columns parse the sqlite TEXT to a Python object and wrap
+      in ``psycopg.types.json.Jsonb`` so the adapter inserts them as
+      real jsonb.
+    * timestamptz columns parse the ISO-8601 TEXT to a ``datetime``.
+    * boolean columns coerce 0/1 to bool.
+    * ``project_key`` is appended (or substituted) when the spec
+      requires it and the source row doesn't already carry one.
+    """
+    from psycopg.types.json import Jsonb
+
+    json_cols = set(spec.json_cols)
+    ts_cols = set(spec.ts_cols)
+    bool_cols = set(spec.bool_cols)
+
+    cols_out: list[str] = []
+    vals_out: list[Any] = []
+
+    for col in source_columns:
+        if col not in target_columns:
+            continue
+        raw = row[col]
+        if col in json_cols:
+            default = {} if col in {"payload_json", "value_json", "roles",
+                                     "external_refs", "work_output"} else []
+            parsed = _parse_json_text(raw, default)
+            cols_out.append(col)
+            vals_out.append(Jsonb(parsed))
+            continue
+        if col in ts_cols:
+            cols_out.append(col)
+            vals_out.append(_parse_iso_timestamp(raw))
+            continue
+        if col in bool_cols:
+            cols_out.append(col)
+            vals_out.append(_coerce_bool(raw))
+            continue
+        cols_out.append(col)
+        vals_out.append(raw)
+
+    if spec.inject_project_key and "project_key" in target_columns:
+        # Only inject when the source row didn't supply one. For
+        # workspace-DB tables that already carry project_key (e.g.
+        # checkpoints/worktrees) this branch is skipped.
+        if "project_key" not in source_columns:
+            cols_out.append("project_key")
+            vals_out.append(project_key)
+
+    return tuple(cols_out), tuple(vals_out)
+
+
+def _pg_table_columns(conn, pg_table: str) -> set[str]:
+    """Introspect pg for the destination column set. Used to drop any
+    sqlite-only columns from the inserted row."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT column_name
+              FROM information_schema.columns
+             WHERE table_schema = current_schema()
+               AND table_name = %s
+            """,
+            (pg_table,),
+        )
+        return {row[0] for row in cur.fetchall()}
+
+
+# --------------------------------------------------------------------- #
+# Per-table copy
+# --------------------------------------------------------------------- #
+
+
+def _copy_table(
+    *,
+    conn,
+    sqlite_conn: sqlite3.Connection,
+    spec: TableSpec,
+    project_key: str,
+    batch_size: int = COPY_BATCH_SIZE,
+) -> TableCopyReport:
+    """Bulk-copy one table from sqlite to pg.
+
+    Inserts go through :class:`psycopg.Cursor.executemany` in batches
+    of ``batch_size``. The caller owns the surrounding transaction; a
+    failure inside this function lets the exception propagate so the
+    caller's rollback covers every prior table.
+    """
+    report = TableCopyReport(table=spec.sqlite_table)
+
+    if not _sqlite_table_exists(sqlite_conn, spec.sqlite_table):
+        report.skipped_reason = "sqlite_table_missing"
+        return report
+
+    source_columns = _sqlite_columns(sqlite_conn, spec.sqlite_table)
+    target_columns = _pg_table_columns(conn, spec.pg_table)
+    if not source_columns or not target_columns:
+        report.skipped_reason = "no_columns"
+        return report
+
+    report.sqlite_rows = _sqlite_count(sqlite_conn, spec.sqlite_table)
+    if report.sqlite_rows == 0:
+        return report
+
+    # Stream sqlite rows; psycopg executemany handles batching but
+    # we still chunk to bound memory.
+    cursor = sqlite_conn.execute(
+        f"SELECT * FROM {spec.sqlite_table}"
+    )
+
+    batch: list[tuple[Any, ...]] = []
+    columns_for_insert: tuple[str, ...] | None = None
+    inserted = 0
+
+    with conn.cursor() as pg_cur:
+        for row in cursor:
+            cols, vals = _convert_row(
+                row,
+                source_columns=source_columns,
+                spec=spec,
+                project_key=project_key,
+                target_columns=target_columns,
+            )
+            if columns_for_insert is None:
+                columns_for_insert = cols
+                col_list = ", ".join(columns_for_insert)
+                placeholders = ", ".join("%s" for _ in columns_for_insert)
+                insert_sql = (
+                    f"INSERT INTO {spec.pg_table} ({col_list}) "
+                    f"VALUES ({placeholders}) "
+                    "ON CONFLICT DO NOTHING"
+                )
+            elif cols != columns_for_insert:
+                # Schema shape drifted mid-table (shouldn't happen —
+                # all rows of one sqlite table share the same columns)
+                # but defend by flushing what we have and re-deriving.
+                if batch:
+                    pg_cur.executemany(insert_sql, batch)
+                    inserted += len(batch)
+                    batch = []
+                columns_for_insert = cols
+                col_list = ", ".join(columns_for_insert)
+                placeholders = ", ".join("%s" for _ in columns_for_insert)
+                insert_sql = (
+                    f"INSERT INTO {spec.pg_table} ({col_list}) "
+                    f"VALUES ({placeholders}) "
+                    "ON CONFLICT DO NOTHING"
+                )
+
+            batch.append(vals)
+            if len(batch) >= batch_size:
+                pg_cur.executemany(insert_sql, batch)
+                inserted += len(batch)
+                batch = []
+
+        if batch:
+            pg_cur.executemany(insert_sql, batch)
+            inserted += len(batch)
+
+    report.pg_rows_copied = inserted
+    return report
+
+
+# --------------------------------------------------------------------- #
+# Parity check
+# --------------------------------------------------------------------- #
+
+
+def _parity_check(
+    *,
+    conn,
+    sqlite_conn: sqlite3.Connection,
+    source: SourceDescriptor,
+) -> list[tuple[str, int, int]]:
+    """Return the list of (table, sqlite_count, pg_count) mismatches.
+
+    Only checks tables we copied. Per-project sources count only rows
+    where ``project = <source.project_key>`` on the pg side, since
+    other projects may have already been imported from other sources.
+    The workspace source compares total counts.
+    """
+    mismatches: list[tuple[str, int, int]] = []
+    with conn.cursor() as cur:
+        for spec in TABLE_SPECS:
+            if not _sqlite_table_exists(sqlite_conn, spec.sqlite_table):
+                continue
+            sqlite_n = _sqlite_count(sqlite_conn, spec.sqlite_table)
+            target_columns = _pg_table_columns(conn, spec.pg_table)
+            if source.kind == "per_project" and "project" in target_columns:
+                cur.execute(
+                    f"SELECT count(*) FROM {spec.pg_table} "
+                    "WHERE project = %s",
+                    (source.project_key,),
+                )
+            elif (
+                source.kind == "per_project"
+                and "project_key" in target_columns
+            ):
+                cur.execute(
+                    f"SELECT count(*) FROM {spec.pg_table} "
+                    "WHERE project_key = %s",
+                    (source.project_key,),
+                )
+            else:
+                cur.execute(f"SELECT count(*) FROM {spec.pg_table}")
+            pg_n = int(cur.fetchone()[0])
+            # For workspace source, the workspace might be the union
+            # of every project — pg can legitimately have MORE rows
+            # than sqlite after we also import per-project DBs in the
+            # same run. So we only flag "pg < sqlite" as a mismatch.
+            if pg_n < sqlite_n:
+                mismatches.append((spec.sqlite_table, sqlite_n, pg_n))
+    return mismatches
+
+
+# --------------------------------------------------------------------- #
+# Top-level entry point
+# --------------------------------------------------------------------- #
+
+
+def _rename_source(source_path: Path) -> Path:
+    """Rename ``state.db`` (+ sidecars) to ``state.db.pre-pg-<ts>``."""
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    suffix = f"{RENAME_SUFFIX_PREFIX}{ts}"
+    target = source_path.with_name(source_path.name + suffix)
+    # Avoid collision if two runs land in the same second.
+    i = 0
+    while target.exists():
+        i += 1
+        target = source_path.with_name(source_path.name + suffix + f".{i}")
+    # Rename the .db and any -wal/-shm sidecars alongside.
+    source_path.rename(target)
+    for sidecar_suffix in ("-wal", "-shm"):
+        sidecar = source_path.with_name(source_path.name + sidecar_suffix)
+        if sidecar.exists():
+            sidecar.rename(
+                target.with_name(target.name + sidecar_suffix)
+            )
+    return target
+
+
+def migrate_sources(
+    sources: list[SourceDescriptor],
+    *,
+    pool: "ConnectionPool",
+    commit: bool,
+    rename_on_success: bool = True,
+) -> MigrationRunReport:
+    """Run the migration pipeline against every source.
+
+    Parameters
+    ----------
+    sources:
+        Output of :func:`discover_sources`.
+    pool:
+        RW pool to mutate.
+    commit:
+        When False, every per-source transaction is rolled back at the
+        end — the dry-run safety net. When True, transactions commit
+        on success and the source sqlite file is renamed.
+    rename_on_success:
+        Pass False when called from a smoke-test that wants the source
+        preserved; defaults to True so the real CLI gets the rollback
+        snapshot the spec promised.
+    """
+    run = MigrationRunReport(dry_run=not commit, committed=False)
+
+    # Bootstrap audit table once at the top of the run. Always commits
+    # — dry-run still needs to read the table even though it never
+    # writes a row.
+    with pool.connection() as bootstrap:
+        bootstrap.autocommit = False
+        try:
+            _ensure_audit_table(bootstrap)
+        except Exception as exc:  # noqa: BLE001
+            run.preflight_error = f"audit table bootstrap failed: {exc}"
+            return run
+
+    for source in sources:
+        started_at = datetime.now(UTC)
+        try:
+            sha = compute_sha256(source.path)
+        except OSError as exc:
+            report = SourceMigrationReport(
+                source=source,
+                source_sha256="",
+                started_at=started_at,
+                failure=f"hash failed: {exc}",
+            )
+            run.sources.append(report)
+            continue
+
+        report = SourceMigrationReport(
+            source=source,
+            source_sha256=sha,
+            started_at=started_at,
+        )
+
+        # Idempotency: if this exact file has been imported, skip.
+        with pool.connection() as audit_conn:
+            audit_conn.autocommit = False
+            prior = _audit_lookup(audit_conn, sha)
+        if prior is not None:
+            report.skipped_already_imported_at = prior
+            report.completed_at = datetime.now(UTC)
+            run.sources.append(report)
+            continue
+
+        try:
+            sqlite_conn = _sqlite_open_ro(source.path)
+        except sqlite3.Error as exc:
+            report.failure = f"sqlite open failed: {exc}"
+            run.sources.append(report)
+            continue
+
+        try:
+            with pool.connection() as conn:
+                conn.autocommit = False
+                try:
+                    for spec in TABLE_SPECS:
+                        try:
+                            table_report = _copy_table(
+                                conn=conn,
+                                sqlite_conn=sqlite_conn,
+                                spec=spec,
+                                project_key=source.project_key,
+                            )
+                        except Exception as exc:  # noqa: BLE001
+                            report.failure = (
+                                f"copy of {spec.sqlite_table} failed: {exc}"
+                            )
+                            report.failed_table = spec.sqlite_table
+                            raise
+                        report.per_table.append(table_report)
+
+                    # Parity check inside the same txn so a failure
+                    # rolls back the copy.
+                    mismatches = _parity_check(
+                        conn=conn,
+                        sqlite_conn=sqlite_conn,
+                        source=source,
+                    )
+                    if mismatches:
+                        report.parity_ok = False
+                        report.parity_mismatches = mismatches
+
+                    report.completed_at = datetime.now(UTC)
+
+                    if commit:
+                        _audit_record(conn, report=report)
+                        conn.commit()
+                        run.committed = True
+                    else:
+                        # Dry-run — never persist.
+                        conn.rollback()
+                except Exception:
+                    conn.rollback()
+                    if report.failure is None:
+                        report.failure = "transaction rolled back"
+        finally:
+            sqlite_conn.close()
+
+        if commit and report.succeeded and rename_on_success:
+            try:
+                report.renamed_to = _rename_source(source.path)
+            except OSError as exc:
+                # The pg copy is already committed; surface the rename
+                # failure as a soft warning rather than failing the
+                # whole run. Operator can rename manually.
+                report.failure = (
+                    f"copy committed but rename failed: {exc}; "
+                    "rename the source manually to avoid re-import"
+                )
+
+        run.sources.append(report)
+
+    return run
+
+
+# --------------------------------------------------------------------- #
+# Reporting helpers used by the CLI
+# --------------------------------------------------------------------- #
+
+
+def format_run_summary(run: MigrationRunReport) -> str:
+    """Render a human-friendly summary the CLI dumps to stdout."""
+    lines: list[str] = []
+    if run.preflight_error:
+        lines.append(f"Pre-flight failed: {run.preflight_error}")
+        return "\n".join(lines)
+
+    mode = "DRY RUN" if run.dry_run else "COMMIT"
+    lines.append(f"pm storage migrate-to-pg — {mode}")
+    lines.append("")
+
+    if not run.sources:
+        lines.append("No sqlite sources discovered. Nothing to do.")
+        return "\n".join(lines)
+
+    for report in run.sources:
+        lines.append(f"source: {report.source.display}")
+        lines.append(f"  kind: {report.source.kind}")
+        if report.source.project_key:
+            lines.append(f"  project_key: {report.source.project_key}")
+        lines.append(f"  sha256: {report.source_sha256[:16]}…")
+
+        if report.skipped_already_imported_at is not None:
+            lines.append(
+                "  status: SKIPPED — already imported on "
+                f"{report.skipped_already_imported_at.isoformat()}"
+            )
+            lines.append("")
+            continue
+
+        if report.failure:
+            lines.append(f"  status: FAILED — {report.failure}")
+            if report.failed_table:
+                lines.append(f"  failed_table: {report.failed_table}")
+            lines.append("")
+            continue
+
+        total = report.total_rows_copied
+        lines.append(f"  status: OK — {total} rows copied")
+        # Only surface tables that actually moved data. The full skip
+        # roster is in the structured report for programmatic callers;
+        # the operator summary stays scannable.
+        for t in report.per_table:
+            if t.pg_rows_copied:
+                lines.append(
+                    f"    {t.table}: {t.pg_rows_copied}/{t.sqlite_rows}"
+                )
+        if report.parity_mismatches:
+            lines.append("  parity mismatches (pg < sqlite):")
+            for tbl, sn, pn in report.parity_mismatches:
+                lines.append(f"    {tbl}: sqlite={sn} pg={pn}")
+        if report.renamed_to:
+            lines.append(f"  renamed to: {report.renamed_to}")
+        elif run.dry_run:
+            lines.append("  (dry-run — source file untouched)")
+        lines.append("")
+
+    if run.dry_run:
+        lines.append(
+            "Dry-run complete. Re-run with --commit to actually move "
+            "data into pg."
+        )
+    elif run.succeeded:
+        lines.append("All sources migrated successfully.")
+    else:
+        lines.append(
+            "At least one source failed; see per-source status above."
+        )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "AUDIT_TABLE_DDL",
+    "COPY_BATCH_SIZE",
+    "MigrationRunReport",
+    "PreflightResult",
+    "SourceDescriptor",
+    "SourceMigrationReport",
+    "TableCopyReport",
+    "TABLE_SPECS",
+    "compute_sha256",
+    "discover_sources",
+    "format_run_summary",
+    "migrate_sources",
+    "preflight",
+]

--- a/tests/test_pg_migration_tool.py
+++ b/tests/test_pg_migration_tool.py
@@ -1,0 +1,575 @@
+"""Tests for ``pm storage migrate-to-pg`` (issue #1737, Slice E).
+
+Strategy
+--------
+
+The migrator is exercised end-to-end against a real testcontainer pg
+(or a local pg with pgvector if Docker isn't available) so the COPY
+pipeline, idempotency table, and parity checks run against the actual
+dialect. A pure-Python in-memory sqlite fixture stands in for the
+workspace state.db — sqlite's behaviour is consistent enough across
+platforms that an on-disk file isn't required for these cases.
+
+Coverage checklist (per the slice spec):
+
+* row-count parity post-copy ✅
+* idempotency: second run is a no-op ✅
+* dry-run prints summary but doesn't mutate pg ✅
+* source files survive on failure ✅
+* per-project DB project_key injection ✅
+* legacy timestamp parsing (sqlite TEXT → pg timestamptz) ✅
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+
+# --------------------------------------------------------------------- #
+# Sqlite fixture helpers
+# --------------------------------------------------------------------- #
+
+
+_WORK_TASKS_DDL = """
+CREATE TABLE work_tasks (
+    project TEXT NOT NULL,
+    task_number INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    type TEXT NOT NULL,
+    labels TEXT NOT NULL DEFAULT '[]',
+    work_status TEXT NOT NULL DEFAULT 'draft',
+    flow_template_id TEXT NOT NULL,
+    flow_template_version INTEGER NOT NULL DEFAULT 1,
+    current_node_id TEXT,
+    assignee TEXT,
+    priority TEXT NOT NULL DEFAULT 'normal',
+    requires_human_review INTEGER NOT NULL DEFAULT 0,
+    description TEXT NOT NULL DEFAULT '',
+    acceptance_criteria TEXT,
+    constraints TEXT,
+    relevant_files TEXT NOT NULL DEFAULT '[]',
+    parent_project TEXT,
+    parent_task_number INTEGER,
+    supersedes_project TEXT,
+    supersedes_task_number INTEGER,
+    plan_version INTEGER NOT NULL DEFAULT 1,
+    predecessor_task_id TEXT,
+    kind TEXT NOT NULL DEFAULT 'legacy',
+    roles TEXT NOT NULL DEFAULT '{}',
+    external_refs TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    created_by TEXT NOT NULL DEFAULT 'test',
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (project, task_number)
+);
+"""
+
+
+_MESSAGES_DDL = """
+CREATE TABLE messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    scope TEXT NOT NULL,
+    type TEXT NOT NULL,
+    tier TEXT NOT NULL DEFAULT 'immediate',
+    recipient TEXT NOT NULL,
+    sender TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'open',
+    parent_id INTEGER,
+    subject TEXT NOT NULL,
+    body TEXT NOT NULL DEFAULT '',
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    labels TEXT NOT NULL DEFAULT '[]',
+    kind TEXT NOT NULL DEFAULT 'legacy',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    closed_at TEXT
+);
+"""
+
+
+_HEARTBEATS_DDL = """
+CREATE TABLE heartbeats (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_name TEXT NOT NULL,
+    tmux_window TEXT NOT NULL,
+    pane_id TEXT NOT NULL,
+    pane_command TEXT NOT NULL,
+    pane_dead INTEGER NOT NULL,
+    log_bytes INTEGER NOT NULL,
+    snapshot_path TEXT NOT NULL,
+    snapshot_hash TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL
+);
+"""
+
+
+def _build_sqlite_workspace(path: Path) -> None:
+    """Seed a sqlite file with the minimal table shape the migrator
+    needs to verify a non-trivial copy."""
+    conn = sqlite3.connect(path)
+    conn.executescript(_WORK_TASKS_DDL + _MESSAGES_DDL + _HEARTBEATS_DDL)
+    now = datetime.now(UTC).isoformat()
+    conn.executemany(
+        """
+        INSERT INTO work_tasks (
+            project, task_number, title, type, labels, work_status,
+            flow_template_id, roles, external_refs,
+            created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                "demo", 1, "First task", "task",
+                '["a", "b"]', "queued",
+                "default",
+                '{"worker": "alice"}',
+                '{}',
+                now, now,
+            ),
+            (
+                "demo", 2, "Second task", "task",
+                "[]", "in_progress",
+                "default",
+                '{"worker": "bob"}',
+                '{"github": "#42"}',
+                now, now,
+            ),
+            (
+                "other", 1, "Other task", "task",
+                "[]", "draft",
+                "default",
+                "{}", "{}",
+                now, now,
+            ),
+        ],
+    )
+    conn.executemany(
+        """
+        INSERT INTO messages (
+            scope, type, recipient, sender, subject, body,
+            payload_json, labels, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (
+                "demo", "notify", "user", "system",
+                "Hello", "World", '{"k": "v"}', '["x"]',
+                now, now,
+            ),
+            (
+                "demo", "alert", "user", "system",
+                "Alert!", "body", "{}", "[]", now, now,
+            ),
+        ],
+    )
+    conn.executemany(
+        """
+        INSERT INTO heartbeats (
+            session_name, tmux_window, pane_id, pane_command,
+            pane_dead, log_bytes, snapshot_path, snapshot_hash,
+            created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            ("operator", "main", "%1", "claude", 0, 1024, "/tmp/snap1", "h1", now),
+            ("operator", "main", "%2", "claude", 1, 0, "/tmp/snap2", "", now),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture()
+def sqlite_workspace(tmp_path: Path) -> Path:
+    """Seeded sqlite workspace file at ``<tmp>/state.db``."""
+    db = tmp_path / "state.db"
+    _build_sqlite_workspace(db)
+    return db
+
+
+@pytest.fixture()
+def per_project_sqlite(tmp_path: Path) -> Path:
+    """A small per-project sqlite — only work_tasks under one project."""
+    project_dir = tmp_path / "myproject" / ".pollypm"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    db = project_dir / "state.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(_WORK_TASKS_DDL)
+    now = datetime.now(UTC).isoformat()
+    conn.execute(
+        """
+        INSERT INTO work_tasks (
+            project, task_number, title, type, work_status,
+            flow_template_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "myproject", 1, "Per-project legacy task", "task",
+            "queued", "default", now, now,
+        ),
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+# --------------------------------------------------------------------- #
+# Pure-Python tests (no pg required)
+# --------------------------------------------------------------------- #
+
+
+def test_compute_sha256_is_stable(sqlite_workspace):
+    from pollypm.storage.pg_migration_tool import compute_sha256
+
+    h1 = compute_sha256(sqlite_workspace)
+    h2 = compute_sha256(sqlite_workspace)
+    assert h1 == h2
+    assert len(h1) == 64
+
+
+def test_discover_sources_returns_explicit_override(tmp_path, sqlite_workspace):
+    from pollypm.storage.pg_migration_tool import discover_sources
+
+    sources = discover_sources(
+        config=None,
+        include_legacy_per_project=False,
+        from_sqlite_override=str(sqlite_workspace),
+    )
+    assert len(sources) == 1
+    assert sources[0].path == sqlite_workspace.resolve()
+    assert sources[0].kind == "workspace"
+
+
+def test_discover_sources_skips_nonexistent_override(tmp_path):
+    from pollypm.storage.pg_migration_tool import discover_sources
+
+    sources = discover_sources(
+        config=None,
+        include_legacy_per_project=False,
+        from_sqlite_override=str(tmp_path / "does-not-exist.db"),
+    )
+    assert sources == []
+
+
+def test_discover_sources_auto_from_config(tmp_path, sqlite_workspace):
+    """``auto`` mode must pick up the workspace DB and per-project DBs."""
+    from pollypm.storage.pg_migration_tool import discover_sources
+
+    # Build a minimal config shape that matches what ``load_config``
+    # would return for the relevant attributes.
+    class _Project:
+        workspace_root = sqlite_workspace.parent
+
+    proj_dir = sqlite_workspace.parent / "demo"
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    (proj_dir / ".pollypm").mkdir(parents=True, exist_ok=True)
+    per_project_db = proj_dir / ".pollypm" / "state.db"
+    # Reuse the workspace DDL — content doesn't matter for discovery.
+    sqlite3.connect(per_project_db).close()
+
+    class _Known:
+        path = proj_dir
+
+    class _Config:
+        project = _Project()
+        projects = {"demo": _Known()}
+
+    # Workspace DB is at <tmp>/state.db; auto-discovery looks for
+    # <workspace_root>/.pollypm/state.db. Re-shape: put the seeded DB
+    # inside a .pollypm subdir.
+    workspace_pollypm = sqlite_workspace.parent / ".pollypm"
+    workspace_pollypm.mkdir(parents=True, exist_ok=True)
+    target = workspace_pollypm / "state.db"
+    sqlite_workspace.rename(target)
+
+    sources = discover_sources(
+        config=_Config(),
+        include_legacy_per_project=True,
+        from_sqlite_override="auto",
+    )
+    paths = {s.path for s in sources}
+    assert target.resolve() in paths
+    assert per_project_db.resolve() in paths
+
+
+def test_parse_iso_timestamp_handles_legacy_format():
+    from pollypm.storage.pg_migration_tool import _parse_iso_timestamp
+
+    # sqlite CURRENT_TIMESTAMP default form
+    dt = _parse_iso_timestamp("2025-01-15 10:30:00")
+    assert dt is not None
+    assert dt.year == 2025 and dt.tzinfo is not None
+
+    # Python isoformat with tz
+    dt = _parse_iso_timestamp("2025-01-15T10:30:00+00:00")
+    assert dt is not None and dt.year == 2025
+
+    # Trailing Z
+    dt = _parse_iso_timestamp("2025-01-15T10:30:00Z")
+    assert dt is not None and dt.year == 2025
+
+    assert _parse_iso_timestamp(None) is None
+    assert _parse_iso_timestamp("") is None
+    assert _parse_iso_timestamp("not a date") is None
+
+
+def test_parse_json_text_handles_text_and_objects():
+    from pollypm.storage.pg_migration_tool import _parse_json_text
+
+    assert _parse_json_text('{"a": 1}', {}) == {"a": 1}
+    assert _parse_json_text("[]", []) == []
+    assert _parse_json_text("", {}) == {}
+    assert _parse_json_text(None, []) == []
+    assert _parse_json_text("not json", {"d": 1}) == {"d": 1}
+    assert _parse_json_text({"already": "parsed"}, {}) == {"already": "parsed"}
+
+
+# --------------------------------------------------------------------- #
+# Pg-backed tests
+# --------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def applied_pg_pool(pg_schema_pool):
+    """Apply the canonical pg schema to the test pool so the migrator's
+    pre-flight check passes and the destination tables exist."""
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+    return pg_schema_pool
+
+
+def test_preflight_ok_after_schema_applied(applied_pg_pool):
+    from pollypm.storage.pg_migration_tool import preflight
+
+    result = preflight(applied_pg_pool)
+    assert result.ok, result.message
+    assert result.vector_installed
+    assert result.migration_version == 1
+
+
+def test_dry_run_does_not_mutate_pg(applied_pg_pool, sqlite_workspace):
+    """Dry-run must surface a full report but leave pg untouched."""
+    from pollypm.storage.pg_migration_tool import (
+        SourceDescriptor,
+        migrate_sources,
+    )
+
+    sources = [
+        SourceDescriptor(
+            path=sqlite_workspace, kind="workspace", project_key=""
+        )
+    ]
+    run = migrate_sources(sources, pool=applied_pg_pool, commit=False)
+    assert run.dry_run is True
+    assert run.committed is False
+    assert len(run.sources) == 1
+    report = run.sources[0]
+    assert report.failure is None
+    # The copy ran but was rolled back — pg side must be empty.
+    with applied_pg_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM work_tasks")
+        assert cur.fetchone()[0] == 0
+        cur.execute("SELECT count(*) FROM messages")
+        assert cur.fetchone()[0] == 0
+        cur.execute("SELECT count(*) FROM _pg_migration_audit")
+        assert cur.fetchone()[0] == 0
+    # Source file must survive a dry-run.
+    assert sqlite_workspace.exists()
+
+
+def test_commit_copies_rows_and_renames_source(
+    applied_pg_pool, sqlite_workspace
+):
+    """Happy-path commit: rows land, parity holds, source is renamed."""
+    from pollypm.storage.pg_migration_tool import (
+        SourceDescriptor,
+        migrate_sources,
+    )
+
+    sources = [
+        SourceDescriptor(
+            path=sqlite_workspace, kind="workspace", project_key=""
+        )
+    ]
+    run = migrate_sources(sources, pool=applied_pg_pool, commit=True)
+    assert run.committed is True
+    assert len(run.sources) == 1
+    report = run.sources[0]
+    assert report.failure is None, report.failure
+    assert report.completed_at is not None
+    assert report.renamed_to is not None
+    assert report.renamed_to.exists()
+    assert not sqlite_workspace.exists()
+
+    # Verify the rows actually landed.
+    with applied_pg_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM work_tasks")
+        assert cur.fetchone()[0] == 3
+        cur.execute("SELECT count(*) FROM messages")
+        assert cur.fetchone()[0] == 2
+        cur.execute("SELECT count(*) FROM heartbeats")
+        assert cur.fetchone()[0] == 2
+        # jsonb round-trip
+        cur.execute(
+            "SELECT labels FROM work_tasks "
+            "WHERE project = 'demo' AND task_number = 1"
+        )
+        labels = cur.fetchone()[0]
+        assert labels == ["a", "b"]
+        # boolean round-trip (pane_dead 0/1 → bool)
+        cur.execute("SELECT pane_dead FROM heartbeats ORDER BY pane_id")
+        rows = [r[0] for r in cur.fetchall()]
+        assert rows == [False, True]
+        # audit row exists
+        cur.execute(
+            "SELECT count(*) FROM _pg_migration_audit "
+            "WHERE source_sha256 = %s",
+            (report.source_sha256,),
+        )
+        assert cur.fetchone()[0] == 1
+
+
+def test_idempotency_second_run_is_noop(applied_pg_pool, sqlite_workspace):
+    """Running the migration twice on the same SHA must skip cleanly."""
+    from pollypm.storage.pg_migration_tool import (
+        SourceDescriptor,
+        compute_sha256,
+        migrate_sources,
+    )
+
+    # SHA must be stable across the rename — the audit table keys on
+    # content hash, not path, so renaming the source DB must not break
+    # idempotency. Capture both before/after and assert equality.
+    sha_before = compute_sha256(sqlite_workspace)
+    sources = [
+        SourceDescriptor(
+            path=sqlite_workspace, kind="workspace", project_key=""
+        )
+    ]
+    # First run commits + renames.
+    run1 = migrate_sources(sources, pool=applied_pg_pool, commit=True)
+    assert run1.sources[0].failure is None
+    renamed = run1.sources[0].renamed_to
+    assert renamed is not None and renamed.exists()
+    assert compute_sha256(renamed) == sha_before
+
+    # Build a "fresh" source descriptor pointing at the renamed file —
+    # the SHA is identical so the audit table should short-circuit.
+    sources2 = [
+        SourceDescriptor(path=renamed, kind="workspace", project_key="")
+    ]
+    run2 = migrate_sources(sources2, pool=applied_pg_pool, commit=True)
+    assert len(run2.sources) == 1
+    skip = run2.sources[0]
+    assert skip.skipped_already_imported_at is not None
+    assert skip.failure is None
+    # And pg row counts didn't double.
+    with applied_pg_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM work_tasks")
+        assert cur.fetchone()[0] == 3
+
+
+def test_per_project_db_injects_project_key(
+    applied_pg_pool, per_project_sqlite
+):
+    """A per-project source must surface the derived project_key on rows
+    that don't carry it natively."""
+    from pollypm.storage.pg_migration_tool import (
+        SourceDescriptor,
+        migrate_sources,
+    )
+
+    sources = [
+        SourceDescriptor(
+            path=per_project_sqlite,
+            kind="per_project",
+            project_key="myproject",
+        )
+    ]
+    run = migrate_sources(sources, pool=applied_pg_pool, commit=True)
+    report = run.sources[0]
+    assert report.failure is None, report.failure
+    with applied_pg_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT project, project_key FROM work_tasks "
+            "WHERE project = 'myproject'"
+        )
+        row = cur.fetchone()
+        assert row is not None
+        assert row[0] == "myproject"
+        assert row[1] == "myproject"
+
+
+def test_failure_preserves_source_and_does_not_audit(
+    applied_pg_pool, sqlite_workspace, monkeypatch
+):
+    """If any single table copy raises, the whole txn rolls back and
+    the source sqlite file is NOT renamed."""
+    from pollypm.storage import pg_migration_tool
+    from pollypm.storage.pg_migration_tool import (
+        SourceDescriptor,
+        migrate_sources,
+    )
+
+    original = pg_migration_tool._copy_table
+
+    def _boom(*, conn, sqlite_conn, spec, project_key, batch_size=5000):
+        if spec.sqlite_table == "messages":
+            raise RuntimeError("simulated failure on messages")
+        return original(
+            conn=conn,
+            sqlite_conn=sqlite_conn,
+            spec=spec,
+            project_key=project_key,
+            batch_size=batch_size,
+        )
+
+    monkeypatch.setattr(pg_migration_tool, "_copy_table", _boom)
+
+    sources = [
+        SourceDescriptor(
+            path=sqlite_workspace, kind="workspace", project_key=""
+        )
+    ]
+    run = migrate_sources(sources, pool=applied_pg_pool, commit=True)
+    report = run.sources[0]
+    assert report.failure is not None
+    assert "messages" in (report.failed_table or "")
+    # Source still on disk — caller can retry after fixing the cause.
+    assert sqlite_workspace.exists()
+    assert report.renamed_to is None
+
+    # Verify rollback: no rows in pg, no audit row.
+    with applied_pg_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM work_tasks")
+        assert cur.fetchone()[0] == 0
+        cur.execute("SELECT count(*) FROM _pg_migration_audit")
+        assert cur.fetchone()[0] == 0
+
+
+def test_format_run_summary_includes_per_source_status(
+    applied_pg_pool, sqlite_workspace
+):
+    """The CLI-facing summary string must mention each source's status."""
+    from pollypm.storage.pg_migration_tool import (
+        SourceDescriptor,
+        format_run_summary,
+        migrate_sources,
+    )
+
+    sources = [
+        SourceDescriptor(
+            path=sqlite_workspace, kind="workspace", project_key=""
+        )
+    ]
+    run = migrate_sources(sources, pool=applied_pg_pool, commit=False)
+    summary = format_run_summary(run)
+    assert "DRY RUN" in summary
+    assert str(sqlite_workspace) in summary
+    # Dry-run mentions the rolled-back state.
+    assert "untouched" in summary or "dry-run" in summary.lower()


### PR DESCRIPTION
## Summary

Slice E of the Postgres + pgvector migration scoped at #1737 — the operator-facing one-shot `pm storage migrate-to-pg` that moves sqlite workspace state (and any leftover per-project legacy `state.db` files) into the pg schema installed by Slice A (#1738).

Default backend stays sqlite. The new command is unreachable until an operator explicitly runs it, and even then `--commit` is the kill switch — without it the entire pipeline runs against a rolled-back transaction so pre-flight + parity checks surface without touching pg.

## Flags shipped (every one in the slice spec)

- `--dsn` — DSN override (else `POLLYPM_PG_DSN` / `[storage] url` / default)
- `--from-sqlite` — `auto` (workspace + per-project) or a pinned path
- `--include-legacy-per-project` / `--no-legacy-per-project`
- `--reembed` — flag wired with a clear TODO pointer; the actual `pm memory backfill-embeddings` re-fire lands with Slice D's embedding writer (per the time-box)
- `--dry-run` — defaults already to dry-run; flag retained for scripts
- `--commit` — kill switch; mutates pg only when set
- `--yes` / `-y` — skip confirmation
- `--config` — standard config-path option

## Pipeline

1. **Pre-flight** — pg reachable, version >= 16, `vector` extension present, `schema_migrations` applied through 0001.
2. **Enumerate sources** — workspace `<workspace>/.pollypm/state.db` + every per-project `<project>/.pollypm/state.db` registered in `pollypm.toml`. `--from-sqlite <path>` skips discovery.
3. **SHA-256 + audit** — each source's content hash is recorded in `_pg_migration_audit` (`UNIQUE (source_sha256)`). A re-run on an unchanged file is a no-op with a clear "already imported on YYYY-MM-DD" message.
4. **Bounded-batch COPY** — for each table in FK dependency order, bulk INSERT via `cursor.executemany` in 5000-row batches. jsonb / timestamptz / boolean adapters wrap the sqlite TEXT/INTEGER source columns. `project_key` is injected from the filename for per-project sources.
5. **Parity check** — `SELECT count(*)` mismatches (pg < sqlite) inside the same txn surface as `parity_mismatches` on the report.
6. **Atomicity** — one pg transaction per source. Any failure rolls back the whole source; the sqlite file is **not** renamed and the tool exits non-zero.
7. **Rollback safety** — on success the source `state.db` (plus `-wal`/`-shm` sidecars) is renamed to `state.db.pre-pg-<UTC timestamp>`. Operators rename back to roll back.

## Audit table

`_pg_migration_audit` records source path, content sha, source kind, project key, per-table row counts (jsonb), started_at, completed_at, tool_version. UNIQUE-on-sha makes idempotency a single index probe.

## Out of scope (per the spec)

- The actual cutover — flipping `[storage] backend = "postgres"` — is Slice J.
- The `notification_staging` retirement (#704) — table is ported 1:1.

## Verification

- 13/13 new tests pass against pg 18 local + pgvector (`POLLYPM_PG_DSN=postgresql://localhost:5432/pollypm_test`).
- All 38 existing pg-related tests (`test_pg_pool.py`, `test_pg_schema.py`, `test_pg_work_service.py`) still green.
- 41 CLI help / reference tests still green.
- `ruff check` clean on every touched src + test file.
- Manual smoke: built a 5-row sqlite, ran `--dry-run` (no mutation, no audit row), then `--commit` (rows landed, source renamed to `.pre-pg-<ts>`, audit row written, second run skipped via "already imported").

## Test plan

- [ ] CI runs `tests/test_pg_migration_tool.py` against the `pgvector/pgvector:pg16` testcontainer (fixture from `conftest_pg.py`).
- [ ] On a dev box with pg 16+ and pgvector: `pm storage migrate-to-pg` (dry-run) → `pm storage migrate-to-pg --commit --yes`.
- [ ] Confirm `_pg_migration_audit` has one row per migrated source, with `source_sha256` matching `sha256sum state.db.pre-pg-<ts>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)