### PR TITLE
feat(storage): pg_dump/pg_restore backup branch — slice G of #1737

### DIFF
--- a/src/pollypm/backup.py
+++ b/src/pollypm/backup.py
@@ -1,40 +1,57 @@
 """Backup + restore of the PollyPM state database.
 
-This module is the implementation behind ``pm backup`` / ``pm restore``. The
-CLI layer in :mod:`pollypm.cli` is kept thin — all of the IO, sanity
-checks, and retention logic live here so they are testable without going
-through Typer.
+This module is the implementation behind ``pm backup`` / ``pm restore``
+and ``pm storage backup`` / ``pm storage restore``. The CLI layer in
+:mod:`pollypm.cli` is kept thin — all of the IO, sanity checks, and
+retention logic live here so they are testable without going through
+Typer.
 
 Design notes:
 
-* The DB snapshot uses SQLite's online backup API (``sqlite3.Connection.backup``),
-  NOT ``shutil.copy``. That is the only safe way to copy a live WAL-mode
-  database while the heartbeat / cockpit may be writing to it.
-* Snapshots are gzipped on disk. The backup API needs a plain sqlite
-  file to write into, so we back up to a temporary uncompressed file
-  first and then gzip it.
-* ``--full`` tar.gz archives include the snapshot DB plus config /
-  logs / snapshots / agent homes. They are not touched by retention —
-  operators use them for point-in-time rescue, not routine cleanup.
+* The SQLite DB snapshot uses SQLite's online backup API
+  (``sqlite3.Connection.backup``), NOT ``shutil.copy``. That is the
+  only safe way to copy a live WAL-mode database while the heartbeat
+  / cockpit may be writing to it.
+* SQLite snapshots are gzipped on disk. The backup API needs a plain
+  sqlite file to write into, so we back up to a temporary uncompressed
+  file first and then gzip it.
+* The Postgres branch (#1737, Slice G) shells out to ``pg_dump
+  --format=custom`` and ``pg_restore --clean --if-exists --no-owner``.
+  Custom format is already compressed; we do not gzip on top.
+* ``--full`` tar.gz archives include the SQLite snapshot DB plus
+  config / logs / snapshots / agent homes. They are not touched by
+  retention — operators use them for point-in-time rescue, not routine
+  cleanup.
 * Restores always write a ``.before-restore`` sibling copy of the live
   DB before replacing it. This is the safety net; it's non-negotiable
-  and the CLI layer cannot skip it.
+  and the CLI layer cannot skip it. For the pg branch the safety copy
+  is itself a ``pg_dump`` to ``<dsn>.before-restore-<ts>.pgdump``.
+* Backend dispatch reads ``config.storage.backend``: ``"sqlite"``
+  preserves the legacy path verbatim (the migration rollback safety
+  net), ``"postgres"`` runs the pg_dump / pg_restore branch added in
+  Slice G.
 """
 
 from __future__ import annotations
 
 import gzip
+import json
 import os
 import shutil
 import sqlite3
+import subprocess
 import tarfile
 import tempfile
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pollypm.storage.sqlite_pragmas import readonly_uri
+
+if TYPE_CHECKING:
+    from pollypm.models import PollyPMConfig
 
 # Retention only applies to plain DB snapshots (``state-db-*.db.gz``).
 # ``--full`` tar.gz archives are left alone because they are larger and
@@ -45,7 +62,16 @@ _DB_SNAPSHOT_SUFFIX = ".db.gz"
 _FULL_SNAPSHOT_PREFIX = "full-"
 _FULL_SNAPSHOT_SUFFIX = ".tar.gz"
 
-# Default retention for plain DB snapshots; keep the last N.
+# Postgres pg_dump custom-format snapshot naming. Filename shape mirrors
+# the sqlite path so an operator scanning ``~/.pollypm/backups/`` can
+# tell which backend a snapshot came from at a glance.
+_PG_SNAPSHOT_PREFIX = "pg-"
+_PG_SNAPSHOT_SUFFIX = ".pgdump"
+_PG_AUDIT_INDEX_FILENAME = "index.jsonl"
+
+# Default retention for plain DB snapshots; keep the last N. Applies to
+# both the sqlite ``.db.gz`` path and the pg ``.pgdump`` path so an
+# operator's mental model carries cleanly across the cutover.
 DEFAULT_KEEP = 7
 BACKUP_LOCK_RETRY_MAX_SECONDS = 3.0
 BACKUP_LOCK_RETRY_INITIAL_SECONDS = 0.1
@@ -83,6 +109,41 @@ class RestoreResult:
 
 class BackupLockedError(RuntimeError):
     """Raised when the live SQLite DB stays locked across backup retries."""
+
+
+class PgBackupError(RuntimeError):
+    """Raised when ``pg_dump`` / ``pg_restore`` fails or is missing."""
+
+
+@dataclass(slots=True)
+class PgBackupResult:
+    """Outcome of a successful ``pg_dump`` snapshot.
+
+    Mirrors :class:`BackupResult` for the sqlite path but is its own
+    type so the CLI layer can dispatch on backend without a ``full``
+    flag in the way.
+    """
+
+    path: Path
+    archive_size: int
+    pruned: list[Path]
+    dsn: str
+
+
+@dataclass(slots=True)
+class PgRestorePlan:
+    """Description of what ``pg_restore`` would do against ``dsn``."""
+
+    snapshot_path: Path
+    dsn: str
+    safety_path: Path
+
+
+@dataclass(slots=True)
+class PgRestoreResult:
+    snapshot_path: Path
+    dsn: str
+    safety_path: Path | None
 
 
 # --------------------------------------------------------------------- #
@@ -389,8 +450,445 @@ def _prune_db_snapshots(backup_dir: Path, keep: int) -> list[Path]:
 
 
 # --------------------------------------------------------------------- #
+# Postgres branch — pg_dump / pg_restore (issue #1737, Slice G)
+# --------------------------------------------------------------------- #
+
+
+def _resolve_pg_binary(name: str) -> str:
+    """Return an absolute path to ``pg_dump``/``pg_restore`` or raise.
+
+    The pg client tools are usually on ``$PATH`` on a dev box but may
+    live under ``/opt/homebrew/opt/postgresql@17/bin`` on macOS. We
+    consult ``$PATH`` first (operators who put pg on PATH should keep
+    that override) and fall back to ``pg_config --bindir`` so the
+    Homebrew layout works without extra config.
+    """
+    found = shutil.which(name)
+    if found:
+        return found
+    pg_config = shutil.which("pg_config")
+    if pg_config:
+        try:
+            result = subprocess.run(
+                [pg_config, "--bindir"],
+                check=True,
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+        except (subprocess.SubprocessError, OSError):
+            result = None
+        if result is not None:
+            bindir = Path(result.stdout.strip())
+            candidate = bindir / name
+            if candidate.exists():
+                return str(candidate)
+    raise PgBackupError(
+        f"could not locate {name}. Install the Postgres client tools "
+        "(e.g. `brew install postgresql@17`) or put pg_dump on PATH."
+    )
+
+
+def _record_pg_backup_index(
+    backup_dir: Path,
+    *,
+    snapshot_path: Path,
+    dsn: str,
+    archive_size: int,
+    duration_seconds: float,
+) -> None:
+    """Append an audit row to ``~/.pollypm/backups/index.jsonl``.
+
+    The index gives operators a single ledger of every pg_dump that
+    ran without having to ``stat`` every file in the directory. Append-
+    only JSONL keeps the format trivial to grep and survives DB
+    rebuilds — the same reasoning behind the audit JSONL the migration
+    spec calls out as non-negotiable.
+
+    Errors writing the index are logged via stderr but do NOT fail the
+    backup — losing the audit row should not cost the operator a
+    snapshot they just paid for.
+    """
+    record = {
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "event": "pg_backup",
+        "path": str(snapshot_path),
+        "dsn": _redact_dsn(dsn),
+        "archive_size": archive_size,
+        "duration_seconds": round(duration_seconds, 3),
+    }
+    index_path = backup_dir / _PG_AUDIT_INDEX_FILENAME
+    try:
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        with index_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+    except OSError:
+        # Best-effort: the snapshot itself succeeded; losing the audit
+        # row would be embarrassing but not catastrophic.
+        return
+
+
+def _redact_dsn(dsn: str) -> str:
+    """Best-effort password redaction for log / audit output."""
+    try:
+        from urllib.parse import urlsplit, urlunsplit
+
+        parts = urlsplit(dsn)
+        if not parts.password:
+            return dsn
+        userinfo, _, hostinfo = parts.netloc.rpartition("@")
+        user = userinfo.partition(":")[0]
+        new_netloc = f"{user}:***@{hostinfo}" if user else f":***@{hostinfo}"
+        return urlunsplit(parts._replace(netloc=new_netloc))
+    except Exception:  # noqa: BLE001 — never break a log line
+        return "***"
+
+
+def _list_pg_snapshots(backup_dir: Path) -> list[Path]:
+    if not backup_dir.exists():
+        return []
+    out: list[Path] = []
+    for child in backup_dir.iterdir():
+        if not child.is_file():
+            continue
+        if child.name.startswith(_PG_SNAPSHOT_PREFIX) and child.name.endswith(
+            _PG_SNAPSHOT_SUFFIX
+        ):
+            out.append(child)
+    out.sort(key=lambda p: p.stat().st_mtime)
+    return out
+
+
+def _prune_pg_snapshots(backup_dir: Path, keep: int) -> list[Path]:
+    if keep < 0:
+        raise ValueError("keep must be >= 0")
+    snapshots = _list_pg_snapshots(backup_dir)
+    if len(snapshots) <= keep:
+        return []
+    to_delete = snapshots[: len(snapshots) - keep]
+    deleted: list[Path] = []
+    for path in to_delete:
+        try:
+            path.unlink()
+            deleted.append(path)
+        except OSError:
+            continue
+    return deleted
+
+
+def _run_pg_dump(
+    dsn: str,
+    dest: Path,
+    *,
+    pg_dump_binary: str | None = None,
+) -> None:
+    """Run ``pg_dump --format=custom`` against ``dsn`` into ``dest``.
+
+    Uses ``--no-owner`` and ``--no-privileges`` so the dump replays
+    cleanly into a fresh database owned by a different role (matches
+    the migration spec — operators can move PollyPM between machines
+    without dragging the original superuser ACL along).
+    """
+    binary = pg_dump_binary or _resolve_pg_binary("pg_dump")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        binary,
+        "--format=custom",
+        "--no-owner",
+        "--no-privileges",
+        f"--dbname={dsn}",
+        f"--file={dest}",
+    ]
+    try:
+        completed = subprocess.run(
+            cmd,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+    except OSError as exc:
+        raise PgBackupError(f"pg_dump invocation failed: {exc}") from exc
+    if completed.returncode != 0:
+        # Clean up partial output so retention math doesn't trip later.
+        try:
+            if dest.exists():
+                dest.unlink()
+        except OSError:
+            pass
+        raise PgBackupError(
+            f"pg_dump exited with code {completed.returncode}: "
+            f"{completed.stderr.strip() or completed.stdout.strip()}"
+        )
+
+
+def _run_pg_restore(
+    dsn: str,
+    source: Path,
+    *,
+    pg_restore_binary: str | None = None,
+) -> None:
+    """Run ``pg_restore --clean --if-exists --no-owner`` against ``dsn``.
+
+    ``--clean --if-exists`` drops + recreates objects so the restore is
+    idempotent against an already-populated database. ``--no-owner``
+    matches the dump-side flag so the restore doesn't try to chown
+    objects to the original role.
+    """
+    binary = pg_restore_binary or _resolve_pg_binary("pg_restore")
+    if not source.exists():
+        raise FileNotFoundError(f"snapshot not found: {source}")
+    cmd = [
+        binary,
+        "--clean",
+        "--if-exists",
+        "--no-owner",
+        f"--dbname={dsn}",
+        str(source),
+    ]
+    try:
+        completed = subprocess.run(
+            cmd,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+    except OSError as exc:
+        raise PgBackupError(f"pg_restore invocation failed: {exc}") from exc
+    # ``pg_restore`` exits non-zero even on benign "table did not exist
+    # to drop" warnings. The ``--exit-on-error`` flag would help but
+    # also rejects warnings we explicitly tolerate. We require returncode
+    # 0 OR 1 (1 = warnings only) and surface anything higher.
+    if completed.returncode not in (0, 1):
+        raise PgBackupError(
+            f"pg_restore exited with code {completed.returncode}: "
+            f"{completed.stderr.strip() or completed.stdout.strip()}"
+        )
+
+
+def _resolve_pg_dsn(config: "PollyPMConfig | None") -> str:
+    """Return the pg DSN to use for backup / restore.
+
+    Delegates to :mod:`pollypm.storage.pg_pool` so the priority order
+    (env override → ``[storage] url`` → default) stays in one place.
+    """
+    from pollypm.storage.pg_pool import resolve_dsn
+
+    return resolve_dsn(config)
+
+
+def backup_pg_dsn(
+    *,
+    base_dir: Path,
+    config: "PollyPMConfig | None" = None,
+    output: Path | None = None,
+    keep: int = DEFAULT_KEEP,
+    pg_dump_binary: str | None = None,
+) -> PgBackupResult:
+    """Snapshot the configured pg DSN to ``backup_dir`` via ``pg_dump``.
+
+    Parameters
+    ----------
+    base_dir:
+        ``config.project.base_dir`` — used to locate the default
+        ``backups/`` directory.
+    config:
+        Optional :class:`PollyPMConfig` so DSN resolution honours the
+        ``[storage] url`` knob. Pass ``None`` to fall back to the env
+        override + built-in default (matches the doctor probe).
+    output:
+        Optional custom destination path. Directories are created.
+    keep:
+        Retention count for pg snapshots.
+    pg_dump_binary:
+        Override the ``pg_dump`` binary path. Test seam only.
+    """
+    backup_dir = _default_backup_dir(base_dir)
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = _timestamp()
+    if output is not None:
+        snapshot_path = output
+    else:
+        snapshot_path = backup_dir / f"{_PG_SNAPSHOT_PREFIX}{timestamp}{_PG_SNAPSHOT_SUFFIX}"
+    snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+
+    dsn = _resolve_pg_dsn(config)
+    start = time.monotonic()
+    _run_pg_dump(dsn, snapshot_path, pg_dump_binary=pg_dump_binary)
+    duration = time.monotonic() - start
+
+    archive_size = _size_or_zero(snapshot_path)
+    _record_pg_backup_index(
+        backup_dir,
+        snapshot_path=snapshot_path,
+        dsn=dsn,
+        archive_size=archive_size,
+        duration_seconds=duration,
+    )
+
+    pruned: list[Path] = []
+    if output is None:
+        pruned = _prune_pg_snapshots(backup_dir, keep)
+
+    return PgBackupResult(
+        path=snapshot_path,
+        archive_size=archive_size,
+        pruned=pruned,
+        dsn=dsn,
+    )
+
+
+def plan_pg_restore(
+    snapshot_path: Path,
+    *,
+    config: "PollyPMConfig | None" = None,
+) -> PgRestorePlan:
+    """Validate ``snapshot_path`` and describe the planned restore.
+
+    Raises ``FileNotFoundError`` / ``ValueError`` on invalid input.
+    Does NOT touch the database.
+    """
+    if not snapshot_path.exists():
+        raise FileNotFoundError(f"snapshot not found: {snapshot_path}")
+    # The custom format starts with the 5-byte magic "PGDMP". We don't
+    # parse the header further — pg_restore itself is the canonical
+    # validator.
+    try:
+        with snapshot_path.open("rb") as fh:
+            magic = fh.read(5)
+    except OSError as exc:
+        raise ValueError(f"cannot read snapshot at {snapshot_path}: {exc}") from exc
+    if magic != b"PGDMP":
+        raise ValueError(
+            f"snapshot is not a pg_dump custom-format archive: {snapshot_path}"
+        )
+    dsn = _resolve_pg_dsn(config)
+    safety_path = snapshot_path.with_name(
+        f"{snapshot_path.stem}.before-restore-{_timestamp()}{_PG_SNAPSHOT_SUFFIX}"
+    )
+    return PgRestorePlan(snapshot_path=snapshot_path, dsn=dsn, safety_path=safety_path)
+
+
+def execute_pg_restore(
+    plan: PgRestorePlan,
+    *,
+    pg_dump_binary: str | None = None,
+    pg_restore_binary: str | None = None,
+) -> PgRestoreResult:
+    """Apply ``plan``: safety-snapshot the live pg, then run pg_restore.
+
+    The safety snapshot is best-effort — if the live pg is unreachable
+    (e.g. fresh install, never written to) we proceed without one so
+    operators can still bootstrap from a snapshot. That mirrors how the
+    sqlite branch tolerates a missing live DB.
+    """
+    safety_written: Path | None = None
+    try:
+        _run_pg_dump(
+            plan.dsn, plan.safety_path, pg_dump_binary=pg_dump_binary
+        )
+        safety_written = plan.safety_path
+    except PgBackupError:
+        # Best-effort safety dump. The restore is still useful — we
+        # surface the missing safety net to the operator via the
+        # returned result so the CLI can warn.
+        safety_written = None
+
+    _run_pg_restore(
+        plan.dsn, plan.snapshot_path, pg_restore_binary=pg_restore_binary
+    )
+
+    return PgRestoreResult(
+        snapshot_path=plan.snapshot_path,
+        dsn=plan.dsn,
+        safety_path=safety_written,
+    )
+
+
+def latest_pg_backup_age_seconds(base_dir: Path) -> float | None:
+    """Return the age in seconds of the most recent pg snapshot, or None.
+
+    Used by ``pm doctor`` (#1737, Slice G) to surface "last backup is
+    > N days old" as an actionable warning. Returns ``None`` when no
+    snapshot exists — the doctor renders that as a separate failure
+    mode ("no backups exist yet").
+    """
+    backup_dir = _default_backup_dir(base_dir)
+    snapshots = _list_pg_snapshots(backup_dir)
+    if not snapshots:
+        return None
+    newest = snapshots[-1]
+    try:
+        mtime = newest.stat().st_mtime
+    except OSError:
+        return None
+    return max(0.0, time.time() - mtime)
+
+
+# --------------------------------------------------------------------- #
 # Public API — backup
 # --------------------------------------------------------------------- #
+
+
+def backup_via_config(
+    config: "PollyPMConfig",
+    *,
+    output: Path | None = None,
+    full: bool = False,
+    keep: int = DEFAULT_KEEP,
+    extra_roots: list[Path] | None = None,
+) -> BackupResult | PgBackupResult:
+    """Dispatch to the sqlite or pg backup path based on ``config``.
+
+    Single entry point for the CLI layer so the dispatch lives in one
+    place and the tests can drive it without touching Typer. The
+    sqlite branch preserves :func:`backup_state_db` verbatim (still
+    the rollback safety net during the transition); the pg branch
+    delegates to :func:`backup_pg_dsn`.
+
+    ``full`` is sqlite-only — running ``--full`` against a pg backend
+    surfaces a clear error rather than silently dropping the flag.
+    """
+    backend = config.storage.backend
+    if backend == "postgres":
+        if full:
+            raise PgBackupError(
+                "--full archives are not supported on the postgres "
+                "backend. Run `pm storage backup` without --full, then "
+                "use your filesystem snapshot tool for ~/.pollypm/."
+            )
+        return backup_pg_dsn(
+            base_dir=config.project.base_dir,
+            config=config,
+            output=output,
+            keep=keep,
+        )
+    return backup_state_db(
+        config.project.state_db,
+        base_dir=config.project.base_dir,
+        output=output,
+        full=full,
+        keep=keep,
+        extra_roots=extra_roots,
+    )
+
+
+def restore_via_config(
+    config: "PollyPMConfig",
+    snapshot_path: Path,
+) -> tuple[RestorePlan | PgRestorePlan, str]:
+    """Build a restore plan dispatched on ``config.storage.backend``.
+
+    Returns ``(plan, backend)`` so the CLI can render the appropriate
+    confirmation banner before calling :func:`execute_restore` /
+    :func:`execute_pg_restore`. Raises the same ``FileNotFoundError``
+    / ``ValueError`` shapes the underlying planners do.
+    """
+    backend = config.storage.backend
+    if backend == "postgres":
+        plan = plan_pg_restore(snapshot_path, config=config)
+        return plan, "postgres"
+    plan = plan_restore(snapshot_path, config.project.state_db)
+    return plan, "sqlite"
 
 
 def backup_state_db(
@@ -646,9 +1144,19 @@ __all__ = [
     "BackupResult",
     "RestorePlan",
     "RestoreResult",
+    "PgBackupError",
+    "PgBackupResult",
+    "PgRestorePlan",
+    "PgRestoreResult",
     "DEFAULT_KEEP",
     "backup_state_db",
     "plan_restore",
     "execute_restore",
+    "backup_pg_dsn",
+    "plan_pg_restore",
+    "execute_pg_restore",
+    "backup_via_config",
+    "restore_via_config",
+    "latest_pg_backup_age_seconds",
     "humanize_bytes",
 ]

--- a/src/pollypm/cli_features/maintenance.py
+++ b/src/pollypm/cli_features/maintenance.py
@@ -15,6 +15,7 @@ import json
 import logging
 import shutil
 import subprocess
+import tempfile
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -910,12 +911,12 @@ def backup_cmd(
         None,
         "--output",
         "-o",
-        help="Custom destination path for the snapshot. Default: ~/.pollypm/backups/state-db-<ts>.db.gz",
+        help="Custom destination path for the snapshot. Default: ~/.pollypm/backups/state-db-<ts>.db.gz (sqlite) or pg-<ts>.pgdump (postgres).",
     ),
     full: bool = typer.Option(
         False,
         "--full",
-        help="Bundle state.db + ~/.pollypm/ tree into a single .tar.gz. Not subject to retention.",
+        help="Bundle state.db + ~/.pollypm/ tree into a single .tar.gz. sqlite backend only; ignored on postgres.",
     ),
     keep: int = typer.Option(
         None,
@@ -924,7 +925,13 @@ def backup_cmd(
     ),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    """Snapshot ~/.pollypm/state.db using SQLite's online backup API."""
+    """Snapshot the configured state backend.
+
+    Dispatches on ``[storage] backend``: sqlite snapshots use SQLite's
+    online backup API; postgres snapshots shell out to ``pg_dump
+    --format=custom``. See ``pm storage backup`` for the explicit
+    storage-namespaced alias (#1737, Slice G).
+    """
     from pollypm import backup as backup_mod
 
     try:
@@ -936,14 +943,11 @@ def backup_cmd(
         )
         raise typer.Exit(code=1)
 
-    state_db = config.project.state_db
-    base_dir = config.project.base_dir
     keep_value = backup_mod.DEFAULT_KEEP if keep is None else keep
 
     try:
-        result = backup_mod.backup_state_db(
-            state_db,
-            base_dir=base_dir,
+        result = backup_mod.backup_via_config(
+            config,
             output=output,
             full=full,
             keep=keep_value,
@@ -951,16 +955,25 @@ def backup_cmd(
     except FileNotFoundError as exc:
         typer.echo(f"Backup failed: {exc}", err=True)
         raise typer.Exit(code=1)
+    except backup_mod.PgBackupError as exc:
+        typer.echo(f"Backup failed: {exc}", err=True)
+        raise typer.Exit(code=1)
     except Exception as exc:
         typer.echo(f"Backup failed: {exc}", err=True)
         raise typer.Exit(code=1)
 
-    before = backup_mod.humanize_bytes(result.db_size_before)
     after = backup_mod.humanize_bytes(result.archive_size)
-    typer.echo(
-        f"Backed up to {result.path}. DB size before: {before}. "
-        f"Archive size: {after}."
-    )
+    if isinstance(result, backup_mod.PgBackupResult):
+        typer.echo(
+            f"Backed up pg DSN {result.dsn!r} to {result.path}. "
+            f"Archive size: {after}."
+        )
+    else:
+        before = backup_mod.humanize_bytes(result.db_size_before)
+        typer.echo(
+            f"Backed up to {result.path}. DB size before: {before}. "
+            f"Archive size: {after}."
+        )
     if result.pruned:
         snap_word = "snapshot" if len(result.pruned) == 1 else "snapshots"
         typer.echo(
@@ -969,7 +982,7 @@ def backup_cmd(
         )
 
 def restore_cmd(
-    snapshot_path: Path = typer.Argument(..., help="Path to a .db.gz DB snapshot or --full .tar.gz archive."),
+    snapshot_path: Path = typer.Argument(..., help="Path to a .db.gz DB snapshot, --full .tar.gz archive, or pg-*.pgdump file."),
     confirm: bool = typer.Option(
         False,
         "--confirm",
@@ -982,7 +995,13 @@ def restore_cmd(
     ),
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."),
 ) -> None:
-    """Restore state.db from a snapshot produced by ``pm backup``."""
+    """Restore the configured state backend from a snapshot.
+
+    Dispatches on ``[storage] backend``: sqlite restores swap state.db
+    after writing a ``.before-restore`` safety copy; postgres restores
+    shell out to ``pg_restore --clean --if-exists --no-owner`` after a
+    best-effort ``pg_dump`` safety snapshot.
+    """
     from pollypm import backup as backup_mod
     from pollypm.session_services import probe_session
 
@@ -995,10 +1014,8 @@ def restore_cmd(
         )
         raise typer.Exit(code=1)
 
-    live_db = config.project.state_db
-
     try:
-        plan = backup_mod.plan_restore(snapshot_path, live_db)
+        plan, backend = backup_mod.restore_via_config(config, snapshot_path)
     except FileNotFoundError as exc:
         typer.echo(f"Restore failed: {exc}", err=True)
         raise typer.Exit(code=1)
@@ -1008,17 +1025,26 @@ def restore_cmd(
 
     if dry_run:
         typer.echo("Dry run — no files will be touched.")
-        typer.echo(f"  snapshot:      {plan.snapshot_path}")
-        typer.echo(f"  live DB:       {plan.live_db_path}")
-        typer.echo(f"  safety copy:   {plan.safety_path}")
-        typer.echo(
-            f"  snapshot kind: {'full tar.gz' if plan.is_tar else 'db snapshot'}"
-        )
+        if isinstance(plan, backup_mod.PgRestorePlan):
+            typer.echo(f"  snapshot:      {plan.snapshot_path}")
+            typer.echo(f"  pg DSN:        {plan.dsn}")
+            typer.echo(f"  safety dump:   {plan.safety_path}")
+            typer.echo("  snapshot kind: pg_dump custom archive")
+        else:
+            typer.echo(f"  snapshot:      {plan.snapshot_path}")
+            typer.echo(f"  live DB:       {plan.live_db_path}")
+            typer.echo(f"  safety copy:   {plan.safety_path}")
+            typer.echo(
+                f"  snapshot kind: {'full tar.gz' if plan.is_tar else 'db snapshot'}"
+            )
         return
 
     if not confirm:
         session_name = config.project.tmux_session
-        typer.echo("Restore refused — this replaces the live state.db.")
+        if isinstance(plan, backup_mod.PgRestorePlan):
+            typer.echo("Restore refused — this replaces the live Postgres database.")
+        else:
+            typer.echo("Restore refused — this replaces the live state.db.")
         typer.echo("")
         typer.echo("Before you proceed:")
         typer.echo(
@@ -1028,10 +1054,17 @@ def restore_cmd(
         typer.echo("  2. Re-run with `--confirm`:")
         typer.echo(f"       pm restore {snapshot_path} --confirm")
         typer.echo("")
-        typer.echo(
-            "A safety copy of the live DB will be written to "
-            f"{plan.safety_path} before anything is replaced."
-        )
+        if isinstance(plan, backup_mod.PgRestorePlan):
+            typer.echo(
+                "A pg_dump safety snapshot of the live DB will be "
+                f"written to {plan.safety_path} before anything is "
+                "replaced."
+            )
+        else:
+            typer.echo(
+                "A safety copy of the live DB will be written to "
+                f"{plan.safety_path} before anything is replaced."
+            )
         raise typer.Exit(code=1)
 
     try:
@@ -1048,13 +1081,29 @@ def restore_cmd(
         )
 
     try:
-        result = backup_mod.execute_restore(plan)
+        if isinstance(plan, backup_mod.PgRestorePlan):
+            pg_result = backup_mod.execute_pg_restore(plan)
+            typer.echo(
+                f"Restored pg DSN {pg_result.dsn!r} from {pg_result.snapshot_path}."
+            )
+            if pg_result.safety_path is None:
+                typer.echo(
+                    "WARNING: pre-restore safety dump skipped (live pg "
+                    "was unreachable or empty)."
+                )
+            else:
+                typer.echo(
+                    f"Safety dump of the previous live DB: {pg_result.safety_path}"
+                )
+        else:
+            result = backup_mod.execute_restore(plan)
+            typer.echo(f"Restored {result.live_db_path} from {result.snapshot_path}.")
+            typer.echo(f"Safety copy of the previous live DB: {result.safety_path}")
     except Exception as exc:
         typer.echo(f"Restore failed mid-flight: {exc}", err=True)
         raise typer.Exit(code=1)
 
-    typer.echo(f"Restored {result.live_db_path} from {result.snapshot_path}.")
-    typer.echo(f"Safety copy of the previous live DB: {result.safety_path}")
+    _ = backend  # currently informational; reserved for richer next-step hints
     typer.echo("")
     typer.echo("Next steps:")
     typer.echo("  pm up                  # relaunch the cockpit")
@@ -1089,6 +1138,184 @@ def doctor_pg_connection(
     else:
         typer.echo(render_human(report))
     raise typer.Exit(code=0 if report.ok else 1)
+
+
+# --------------------------------------------------------------------- #
+# ``pm storage`` subcommands (issue #1737, Slice G)
+# --------------------------------------------------------------------- #
+
+
+storage_app = typer.Typer(
+    help=(
+        "Manage the configured state backend (sqlite or postgres). "
+        "Backup / restore dispatch on the storage backend setting in "
+        "pollypm.toml."
+    ),
+    no_args_is_help=True,
+)
+
+
+def storage_backup_cmd(
+    output: Path | None = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Custom destination path for the snapshot.",
+    ),
+    keep: int = typer.Option(
+        None,
+        "--keep",
+        help="Keep N most recent snapshots; prune the rest.",
+    ),
+    verify: bool = typer.Option(
+        False,
+        "--verify",
+        help="After taking the snapshot, re-open it via pg_restore --list (postgres) or the SQLite header probe (sqlite) to confirm it's restorable. Slice J's cutover gates on this passing.",
+    ),
+    config_path: Path = typer.Option(
+        DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."
+    ),
+) -> None:
+    """Snapshot the configured state backend.
+
+    Equivalent to ``pm backup`` but namespaced under ``pm storage``
+    for the post-cutover ergonomic where storage-management commands
+    live together. Both routes dispatch on ``[storage] backend``.
+    """
+    from pollypm import backup as backup_mod
+
+    try:
+        config = load_config(config_path)
+    except FileNotFoundError:
+        typer.echo(
+            f"Config not found at {config_path}. Run `pm` to onboard first.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    keep_value = backup_mod.DEFAULT_KEEP if keep is None else keep
+
+    try:
+        result = backup_mod.backup_via_config(
+            config,
+            output=output,
+            full=False,
+            keep=keep_value,
+        )
+    except FileNotFoundError as exc:
+        typer.echo(f"Backup failed: {exc}", err=True)
+        raise typer.Exit(code=1)
+    except backup_mod.PgBackupError as exc:
+        typer.echo(f"Backup failed: {exc}", err=True)
+        raise typer.Exit(code=1)
+    except Exception as exc:
+        typer.echo(f"Backup failed: {exc}", err=True)
+        raise typer.Exit(code=1)
+
+    archive_size = backup_mod.humanize_bytes(result.archive_size)
+    if isinstance(result, backup_mod.PgBackupResult):
+        typer.echo(
+            f"Backed up pg DSN to {result.path}. Archive size: {archive_size}."
+        )
+    else:
+        before = backup_mod.humanize_bytes(result.db_size_before)
+        typer.echo(
+            f"Backed up to {result.path}. DB size before: {before}. "
+            f"Archive size: {archive_size}."
+        )
+    if result.pruned:
+        word = "snapshot" if len(result.pruned) == 1 else "snapshots"
+        typer.echo(
+            f"Pruned {len(result.pruned)} older {word} (keep={keep_value})."
+        )
+
+    if verify:
+        verify_ok = _verify_snapshot(result)
+        if not verify_ok:
+            typer.echo(
+                "Verification failed — the snapshot exists but could not "
+                "be re-opened. Investigate before relying on it.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        typer.echo("Verified: snapshot re-opens cleanly.")
+
+
+def storage_restore_cmd(
+    snapshot_path: Path = typer.Argument(
+        ..., help="Path to a snapshot produced by `pm storage backup` (or legacy `pm backup`)."
+    ),
+    confirm: bool = typer.Option(
+        False,
+        "--confirm",
+        help="Required to actually overwrite the live DB. Without this flag, restore refuses.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Describe what would happen without touching any data.",
+    ),
+    config_path: Path = typer.Option(
+        DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path."
+    ),
+) -> None:
+    """Restore the configured backend from ``snapshot_path``.
+
+    Dispatches on ``[storage] backend`` exactly like ``pm storage backup``.
+    """
+    # Delegate to the root-level ``pm restore`` implementation so the
+    # two surfaces stay in lockstep. ``pm storage restore`` is the
+    # storage-namespaced spelling promoted by the migration runbook.
+    restore_cmd(
+        snapshot_path=snapshot_path,
+        confirm=confirm,
+        dry_run=dry_run,
+        config_path=config_path,
+    )
+
+
+def _verify_snapshot(result: "object") -> bool:
+    """Re-open ``result`` to confirm it's restorable.
+
+    Returns True if verification passed, False on any failure. Stays
+    local to the storage CLI because the verification rules differ
+    between backends and the test suite drives it via the public
+    surface.
+    """
+    from pollypm import backup as backup_mod
+
+    if isinstance(result, backup_mod.PgBackupResult):
+        try:
+            binary = backup_mod._resolve_pg_binary("pg_restore")  # type: ignore[attr-defined]
+        except backup_mod.PgBackupError:
+            return False
+        try:
+            completed = subprocess.run(
+                [binary, "--list", str(result.path)],
+                check=False,
+                text=True,
+                capture_output=True,
+                timeout=60,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        return completed.returncode == 0
+    if isinstance(result, backup_mod.BackupResult):
+        # sqlite gzipped DB — re-decompress and run the header probe.
+        if result.full:
+            return result.path.exists() and result.archive_size > 0
+        try:
+            with tempfile.TemporaryDirectory() as staging:
+                staged = Path(staging) / "probe.db"
+                backup_mod._gunzip_file(result.path, staged)  # type: ignore[attr-defined]
+                return backup_mod._is_valid_sqlite_file(staged)  # type: ignore[attr-defined]
+        except Exception:  # noqa: BLE001
+            return False
+    return False
+
+
+storage_app.command("backup")(storage_backup_cmd)
+storage_app.command("restore")(storage_restore_cmd)
 
 
 def register_maintenance_commands(app: typer.Typer) -> None:
@@ -1184,6 +1411,8 @@ def register_maintenance_commands(app: typer.Typer) -> None:
     app.command("backup")(backup_cmd)
 
     app.command("restore")(restore_cmd)
+
+    app.add_typer(storage_app, name="storage")
 
 
 

--- a/src/pollypm/doctor.py
+++ b/src/pollypm/doctor.py
@@ -576,6 +576,7 @@ check_config_file = _doctor_install_state.check_config_file
 check_provider_account_configured = _doctor_install_state.check_provider_account_configured
 check_storage_backend = _doctor_install_state.check_storage_backend
 check_pg_connection = _doctor_install_state.check_pg_connection
+check_pg_backup_freshness = _doctor_install_state.check_pg_backup_freshness
 check_registered_providers = _doctor_install_state.check_registered_providers
 
 check_builtin_plugin_manifests = _doctor_plugins.check_builtin_plugin_manifests
@@ -3809,6 +3810,15 @@ def _registered_checks() -> list[Check]:
         # #1737 — pg-connection probe. Skipped on sqlite installs so the
         # check never falsely fails for users who haven't opted in.
         Check("pg-connection", check_pg_connection, "install"),
+        # #1737 Slice G — pg backup freshness. Warning-only; skipped on
+        # sqlite. Surfaces "last backup is > N days old" as part of the
+        # cutover-safety pre-flight in the migration runbook.
+        Check(
+            "pg-backup-freshness",
+            check_pg_backup_freshness,
+            "install",
+            severity="warning",
+        ),
         Check("registered-providers", check_registered_providers, "install"),
         # Plugins
         Check("builtin-plugin-manifests", check_builtin_plugin_manifests, "plugins"),

--- a/src/pollypm/doctor/install_state.py
+++ b/src/pollypm/doctor/install_state.py
@@ -476,3 +476,74 @@ def check_pg_connection() -> doctor.CheckResult:
             "vector_installed": True,
         },
     )
+
+
+# Default freshness threshold for the pg backup probe (issue #1737,
+# Slice G). 7 days is a balance: short enough to surface an operator
+# who's stopped running ``pm storage backup``; long enough to avoid
+# nagging an operator who skipped one weekly run.
+PG_BACKUP_STALE_DAYS = 7
+
+
+def check_pg_backup_freshness() -> doctor.CheckResult:
+    """Warn when the most recent pg snapshot is older than N days.
+
+    Skipped on sqlite installs (the sqlite snapshot path has its own
+    retention semantics and this check would be noise). Returns a
+    warning, not a failure, so a stale backup doesn't gate the cockpit
+    from starting — the cutover flow in #1737 §9 surfaces the same
+    information through ``pm storage backup --verify`` instead.
+    """
+    from pollypm.backup import latest_pg_backup_age_seconds
+    from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+
+    if not DEFAULT_CONFIG_PATH.exists():
+        return doctor._skip("pg-backup-freshness skipped (no config)")
+    try:
+        config = load_config(DEFAULT_CONFIG_PATH)
+    except Exception as exc:  # noqa: BLE001
+        return doctor._skip(f"pg-backup-freshness skipped (config parse: {exc})")
+
+    if config.storage.backend != "postgres":
+        return doctor._skip(
+            f"pg-backup-freshness skipped (backend={config.storage.backend!r})"
+        )
+
+    age = latest_pg_backup_age_seconds(config.project.base_dir)
+    if age is None:
+        return doctor._fail(
+            "no pg backups found",
+            why=(
+                "PollyPM is configured for postgres but no pg_dump "
+                "snapshot has been taken yet. The migration runbook "
+                "requires a verified backup before any cutover."
+            ),
+            fix=(
+                "Take a backup now —\n"
+                "  pm storage backup --verify\n"
+                "Recheck: pm doctor"
+            ),
+            severity="warning",
+            data={"backup_dir": str(config.project.base_dir / "backups")},
+        )
+    days = age / 86400.0
+    if days > PG_BACKUP_STALE_DAYS:
+        return doctor._fail(
+            f"latest pg backup is {days:.1f} days old (> {PG_BACKUP_STALE_DAYS}d)",
+            why=(
+                "Operator backups are the rollback path for the pg "
+                "migration. A stale backup means a longer RPO than the "
+                "runbook promises."
+            ),
+            fix=(
+                "Refresh the snapshot —\n"
+                "  pm storage backup --verify\n"
+                "Recheck: pm doctor"
+            ),
+            severity="warning",
+            data={"age_days": round(days, 1), "threshold_days": PG_BACKUP_STALE_DAYS},
+        )
+    return doctor._ok(
+        f"latest pg backup is {days:.1f} days old",
+        data={"age_days": round(days, 1), "threshold_days": PG_BACKUP_STALE_DAYS},
+    )

--- a/tests/test_backup_dispatch.py
+++ b/tests/test_backup_dispatch.py
@@ -1,0 +1,312 @@
+"""Tests for the backup-backend dispatch shim (issue #1737, Slice G).
+
+Coverage target:
+
+1. ``backup_via_config`` routes to the sqlite branch when
+   ``[storage] backend = "sqlite"`` and produces a ``BackupResult``.
+2. ``backup_via_config`` routes to the pg branch when
+   ``[storage] backend = "postgres"`` and produces a
+   ``PgBackupResult``. The pg_dump invocation itself is monkeypatched
+   so the test runs without a live pg instance.
+3. ``--full`` against a pg backend raises ``PgBackupError`` rather
+   than silently dropping the flag.
+4. ``restore_via_config`` returns the right plan type per backend.
+
+These tests run without Docker — they exercise the dispatch logic and
+the pg branch's filesystem side effects with the actual ``pg_dump``
+binary stubbed. The end-to-end round-trip lives in
+``tests/test_pg_backup.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pollypm import backup as backup_mod
+from pollypm.models import (
+    AccountConfig,
+    EmbeddingSettings,
+    PgStorageSettings,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectSettings,
+    ProviderKind,
+    StorageSettings,
+)
+
+
+# --------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------- #
+
+
+def _seed_sqlite(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("CREATE TABLE probe (k TEXT PRIMARY KEY, v TEXT)")
+        conn.execute("INSERT INTO probe(k, v) VALUES ('hello', 'world')")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _build_config(
+    *,
+    backend: str,
+    base_dir: Path,
+    state_db: Path,
+    storage_url: str = "",
+) -> PollyPMConfig:
+    project = ProjectSettings(
+        name="PollyPM-Test",
+        tmux_session="pollypm-backup-dispatch-test",
+        workspace_root=base_dir.parent,
+        base_dir=base_dir,
+        logs_dir=base_dir / "logs",
+        snapshots_dir=base_dir / "snapshots",
+        state_db=state_db,
+    )
+    pollypm = PollyPMSettings(controller_account="claude_test")
+    accounts = {
+        "claude_test": AccountConfig(
+            name="claude_test",
+            provider=ProviderKind("claude"),
+            email="test@example.com",
+        )
+    }
+    storage = StorageSettings(
+        backend=backend,
+        url=storage_url,
+        pg=PgStorageSettings(),
+        embedding=EmbeddingSettings(),
+    )
+    return PollyPMConfig(
+        project=project,
+        pollypm=pollypm,
+        accounts=accounts,
+        sessions={},
+        storage=storage,
+    )
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path) -> Path:
+    base = tmp_path / ".pollypm"
+    base.mkdir()
+    return base
+
+
+@pytest.fixture
+def state_db(fake_home: Path) -> Path:
+    db = fake_home / "state.db"
+    _seed_sqlite(db)
+    return db
+
+
+@pytest.fixture
+def sqlite_config(fake_home: Path, state_db: Path) -> PollyPMConfig:
+    return _build_config(backend="sqlite", base_dir=fake_home, state_db=state_db)
+
+
+@pytest.fixture
+def pg_config(fake_home: Path, state_db: Path) -> PollyPMConfig:
+    return _build_config(
+        backend="postgres",
+        base_dir=fake_home,
+        state_db=state_db,
+        storage_url="postgresql://localhost:5432/pollypm-dispatch-test",
+    )
+
+
+# --------------------------------------------------------------------- #
+# Backup dispatch
+# --------------------------------------------------------------------- #
+
+
+def test_backup_via_config_sqlite_returns_sqlite_result(
+    sqlite_config: PollyPMConfig, fake_home: Path
+) -> None:
+    result = backup_mod.backup_via_config(sqlite_config)
+    assert isinstance(result, backup_mod.BackupResult)
+    assert not result.full
+    assert result.path.exists()
+    assert result.path.name.startswith("state-db-")
+    assert result.path.name.endswith(".db.gz")
+    # The pg index file must NOT have been written for the sqlite path.
+    assert not (fake_home / "backups" / "index.jsonl").exists()
+
+
+def test_backup_via_config_postgres_returns_pg_result(
+    pg_config: PollyPMConfig, fake_home: Path, monkeypatch
+) -> None:
+    """The pg branch must hit pg_dump, write a .pgdump file, and audit."""
+
+    invocations: list[list[str]] = []
+
+    def fake_run_pg_dump(dsn: str, dest: Path, *, pg_dump_binary=None) -> None:
+        invocations.append([dsn, str(dest)])
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"PGDMP\x00fake-archive-payload")
+
+    monkeypatch.setattr(backup_mod, "_run_pg_dump", fake_run_pg_dump)
+
+    result = backup_mod.backup_via_config(pg_config)
+    assert isinstance(result, backup_mod.PgBackupResult)
+    assert result.path.exists()
+    assert result.path.name.startswith("pg-")
+    assert result.path.name.endswith(".pgdump")
+    assert result.dsn == "postgresql://localhost:5432/pollypm-dispatch-test"
+    assert invocations, "pg_dump shim must have been invoked"
+    dsn_used, dest_used = invocations[0]
+    assert dsn_used == result.dsn
+    assert dest_used == str(result.path)
+
+    index_path = fake_home / "backups" / "index.jsonl"
+    assert index_path.exists()
+    lines = index_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["event"] == "pg_backup"
+    assert record["path"] == str(result.path)
+    assert record["archive_size"] == result.archive_size
+    assert "duration_seconds" in record
+
+
+def test_backup_via_config_full_against_postgres_raises(
+    pg_config: PollyPMConfig,
+) -> None:
+    with pytest.raises(backup_mod.PgBackupError):
+        backup_mod.backup_via_config(pg_config, full=True)
+
+
+def test_backup_via_config_postgres_rotates_keep(
+    pg_config: PollyPMConfig, fake_home: Path, monkeypatch
+) -> None:
+    """pg snapshots beyond --keep N must be pruned just like sqlite."""
+
+    backups_dir = fake_home / "backups"
+    backups_dir.mkdir(parents=True, exist_ok=True)
+    # Seed three pre-existing snapshots with staggered mtimes so the
+    # ordering is deterministic. The next backup will be the 4th —
+    # with keep=2 we expect only the 2 newest to remain.
+    import time
+
+    now = time.time()
+    old_paths: list[Path] = []
+    for i in range(3):
+        p = backups_dir / f"pg-old-{i}.pgdump"
+        p.write_bytes(b"PGDMP\x00")
+        mtime = now - (3 - i) * 100
+        import os
+
+        os.utime(p, (mtime, mtime))
+        old_paths.append(p)
+
+    def fake_run_pg_dump(dsn: str, dest: Path, *, pg_dump_binary=None) -> None:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"PGDMP\x00fresh")
+
+    monkeypatch.setattr(backup_mod, "_run_pg_dump", fake_run_pg_dump)
+
+    result = backup_mod.backup_via_config(pg_config, keep=2)
+    assert isinstance(result, backup_mod.PgBackupResult)
+    remaining = sorted(p.name for p in backups_dir.glob("pg-*.pgdump"))
+    # 2 kept: the newest seeded old (pg-old-2.pgdump) + the fresh one.
+    assert len(remaining) == 2
+    assert result.path.name in remaining
+    pruned_names = sorted(p.name for p in result.pruned)
+    # The two oldest must have been pruned.
+    assert "pg-old-0.pgdump" in pruned_names
+    assert "pg-old-1.pgdump" in pruned_names
+
+
+# --------------------------------------------------------------------- #
+# Restore dispatch
+# --------------------------------------------------------------------- #
+
+
+def test_restore_via_config_sqlite_returns_sqlite_plan(
+    sqlite_config: PollyPMConfig, fake_home: Path
+) -> None:
+    """The sqlite restore plan validates against a real gzipped snapshot."""
+    backup_result = backup_mod.backup_via_config(sqlite_config)
+    plan, backend = backup_mod.restore_via_config(
+        sqlite_config, backup_result.path
+    )
+    assert backend == "sqlite"
+    assert isinstance(plan, backup_mod.RestorePlan)
+    assert plan.snapshot_path == backup_result.path
+
+
+def test_restore_via_config_postgres_returns_pg_plan(
+    pg_config: PollyPMConfig, tmp_path: Path
+) -> None:
+    snapshot = tmp_path / "pg-fake.pgdump"
+    # The first 5 bytes must be "PGDMP" for the planner to accept it.
+    snapshot.write_bytes(b"PGDMP" + b"\x00" * 16)
+
+    plan, backend = backup_mod.restore_via_config(pg_config, snapshot)
+    assert backend == "postgres"
+    assert isinstance(plan, backup_mod.PgRestorePlan)
+    assert plan.snapshot_path == snapshot
+    assert plan.dsn == "postgresql://localhost:5432/pollypm-dispatch-test"
+
+
+def test_restore_via_config_postgres_rejects_non_pgdump(
+    pg_config: PollyPMConfig, tmp_path: Path
+) -> None:
+    snapshot = tmp_path / "not-a-pgdump.bin"
+    snapshot.write_bytes(b"NOT_PGDMP_HEADER")
+    with pytest.raises(ValueError):
+        backup_mod.restore_via_config(pg_config, snapshot)
+
+
+def test_restore_via_config_missing_snapshot(
+    pg_config: PollyPMConfig, tmp_path: Path
+) -> None:
+    snapshot = tmp_path / "does-not-exist.pgdump"
+    with pytest.raises(FileNotFoundError):
+        backup_mod.restore_via_config(pg_config, snapshot)
+
+
+# --------------------------------------------------------------------- #
+# latest_pg_backup_age_seconds — the doctor-check primitive
+# --------------------------------------------------------------------- #
+
+
+def test_latest_pg_backup_age_none_when_no_snapshots(fake_home: Path) -> None:
+    assert backup_mod.latest_pg_backup_age_seconds(fake_home) is None
+
+
+def test_latest_pg_backup_age_returns_seconds(fake_home: Path) -> None:
+    import os
+    import time
+
+    backups_dir = fake_home / "backups"
+    backups_dir.mkdir(parents=True, exist_ok=True)
+    snap = backups_dir / "pg-recent.pgdump"
+    snap.write_bytes(b"PGDMP\x00")
+    five_minutes_ago = time.time() - 300
+    os.utime(snap, (five_minutes_ago, five_minutes_ago))
+
+    age = backup_mod.latest_pg_backup_age_seconds(fake_home)
+    assert age is not None
+    assert 290 <= age <= 320
+
+
+# --------------------------------------------------------------------- #
+# _resolve_pg_binary — fallback to pg_config --bindir
+# --------------------------------------------------------------------- #
+
+
+def test_resolve_pg_binary_raises_when_missing(monkeypatch) -> None:
+    """If neither PATH nor pg_config can find pg_dump, raise PgBackupError."""
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    with pytest.raises(backup_mod.PgBackupError):
+        backup_mod._resolve_pg_binary("pg_dump")

--- a/tests/test_pg_backup.py
+++ b/tests/test_pg_backup.py
@@ -1,0 +1,261 @@
+"""End-to-end pg_dump → pg_restore round-trip (issue #1737, Slice G).
+
+Runs against the shared ``_pg_container`` fixture in
+``tests/conftest_pg.py``. Each test seeds a per-case database, takes a
+``pg_dump`` snapshot, restores it into a *fresh* database, and asserts
+row-count parity.
+
+Skipped automatically when neither Docker nor a local pg with
+``vector`` is available — same gating as the other ``test_pg_*.py``
+modules.
+"""
+
+from __future__ import annotations
+
+import shutil
+import uuid
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from pollypm import backup as backup_mod
+
+
+# --------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------- #
+
+
+def _require_pg_tools() -> tuple[str, str]:
+    """Return absolute paths to ``pg_dump`` and ``pg_restore`` or skip.
+
+    The container fixture guarantees a server side but the test
+    runner's host may not have the client binaries (e.g. CI image
+    without ``postgresql-client``). Skip rather than fail in that
+    case so the broader suite stays green.
+    """
+    try:
+        pg_dump = backup_mod._resolve_pg_binary("pg_dump")  # type: ignore[attr-defined]
+        pg_restore = backup_mod._resolve_pg_binary("pg_restore")  # type: ignore[attr-defined]
+    except backup_mod.PgBackupError:
+        pytest.skip("pg_dump / pg_restore client tools not installed")
+    return pg_dump, pg_restore
+
+
+def _base_dsn_parts(dsn: str) -> tuple[str, str]:
+    """Split ``postgresql://user:pw@host:port/dbname`` → (base, dbname)."""
+    from urllib.parse import urlsplit, urlunsplit
+
+    parts = urlsplit(dsn)
+    dbname = parts.path.lstrip("/") or "postgres"
+    base = urlunsplit(parts._replace(path="/postgres"))
+    return base, dbname
+
+
+@pytest.fixture
+def pg_dsn_pair(_pg_container) -> Iterator[tuple[str, str]]:
+    """Yield ``(source_dsn, target_dsn)`` — two fresh DBs on the same server.
+
+    Both are created before the test and dropped after. ``source_dsn``
+    is seeded with sample rows; ``target_dsn`` is left empty so the
+    restore has somewhere to land. Round-trip is then asserted at the
+    test level.
+    """
+    import psycopg  # type: ignore[import-not-found]
+
+    base_admin_dsn, _ = _base_dsn_parts(_pg_container)
+    src_name = f"pollypm_backup_src_{uuid.uuid4().hex[:10]}"
+    dst_name = f"pollypm_backup_dst_{uuid.uuid4().hex[:10]}"
+
+    # CREATE DATABASE cannot run inside a transaction — use autocommit.
+    with psycopg.connect(base_admin_dsn, autocommit=True) as admin:
+        with admin.cursor() as cur:
+            cur.execute(f'CREATE DATABASE "{src_name}"')
+            cur.execute(f'CREATE DATABASE "{dst_name}"')
+
+    src_base, _ = _base_dsn_parts(_pg_container)
+    src_dsn = src_base.replace("/postgres", f"/{src_name}")
+    dst_dsn = src_base.replace("/postgres", f"/{dst_name}")
+    try:
+        yield src_dsn, dst_dsn
+    finally:
+        with psycopg.connect(base_admin_dsn, autocommit=True) as admin:
+            with admin.cursor() as cur:
+                for name in (src_name, dst_name):
+                    # Force-disconnect any lingering sessions before drop.
+                    cur.execute(
+                        "SELECT pg_terminate_backend(pid) "
+                        "FROM pg_stat_activity WHERE datname = %s",
+                        (name,),
+                    )
+                    cur.execute(f'DROP DATABASE IF EXISTS "{name}"')
+
+
+def _seed_source(dsn: str) -> dict[str, int]:
+    """Seed the source DB with deterministic rows; return ``{table: count}``."""
+    import psycopg  # type: ignore[import-not-found]
+
+    counts = {"work_tasks": 5, "messages": 3}
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "CREATE TABLE work_tasks ("
+                " task_number int PRIMARY KEY,"
+                " project text NOT NULL,"
+                " title text NOT NULL"
+                ")"
+            )
+            for i in range(counts["work_tasks"]):
+                cur.execute(
+                    "INSERT INTO work_tasks (task_number, project, title) "
+                    "VALUES (%s, %s, %s)",
+                    (i + 1, "demo", f"task-{i + 1}"),
+                )
+            cur.execute(
+                "CREATE TABLE messages ("
+                " id bigserial PRIMARY KEY,"
+                " body text NOT NULL"
+                ")"
+            )
+            for i in range(counts["messages"]):
+                cur.execute(
+                    "INSERT INTO messages (body) VALUES (%s)",
+                    (f"msg-{i + 1}",),
+                )
+        conn.commit()
+    return counts
+
+
+def _row_counts(dsn: str, tables: list[str]) -> dict[str, int]:
+    import psycopg  # type: ignore[import-not-found]
+
+    out: dict[str, int] = {}
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            for table in tables:
+                cur.execute(f"SELECT COUNT(*) FROM {table}")
+                row = cur.fetchone()
+                out[table] = int(row[0]) if row else 0
+    return out
+
+
+# --------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------- #
+
+
+def test_pg_dump_then_pg_restore_round_trip(
+    pg_dsn_pair, tmp_path: Path, monkeypatch
+) -> None:
+    """pg_dump from source, pg_restore into target, verify row counts."""
+    _require_pg_tools()
+    src_dsn, dst_dsn = pg_dsn_pair
+    expected = _seed_source(src_dsn)
+
+    # Direct invocation — point ``resolve_dsn`` at the source for the
+    # backup, then at the target for the restore. The simplest way is
+    # via the env var override (highest priority in the resolver).
+    monkeypatch.setenv("POLLYPM_PG_DSN", src_dsn)
+
+    base_dir = tmp_path / ".pollypm"
+    backup_result = backup_mod.backup_pg_dsn(base_dir=base_dir)
+
+    assert backup_result.path.exists()
+    assert backup_result.path.read_bytes()[:5] == b"PGDMP"
+    assert backup_result.archive_size > 0
+
+    # The audit index must record this one snapshot.
+    index_path = base_dir / "backups" / "index.jsonl"
+    assert index_path.exists()
+    lines = index_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+
+    # Now restore into the *target* DSN.
+    monkeypatch.setenv("POLLYPM_PG_DSN", dst_dsn)
+    plan = backup_mod.plan_pg_restore(backup_result.path)
+    assert plan.dsn == dst_dsn
+
+    # The safety dump runs against the (empty) target. That's fine —
+    # pg_dump of an empty DB succeeds. We don't assert on the safety
+    # file existing because the integration-test target DB starts empty
+    # and the dump still has minimal content; either outcome is
+    # acceptable.
+    result = backup_mod.execute_pg_restore(plan)
+    assert result.dsn == dst_dsn
+
+    observed = _row_counts(dst_dsn, list(expected.keys()))
+    assert observed == expected
+
+
+def test_plan_pg_restore_rejects_non_pgdump(tmp_path: Path) -> None:
+    """Files that don't start with the ``PGDMP`` magic must be refused."""
+    junk = tmp_path / "junk.pgdump"
+    junk.write_bytes(b"NOT_A_PG_DUMP")
+    with pytest.raises(ValueError):
+        backup_mod.plan_pg_restore(junk)
+
+
+def test_plan_pg_restore_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        backup_mod.plan_pg_restore(tmp_path / "missing.pgdump")
+
+
+def test_pg_backup_records_audit_index(
+    pg_dsn_pair, tmp_path: Path, monkeypatch
+) -> None:
+    """A pg backup must append a JSONL audit row to ``backups/index.jsonl``."""
+    import json
+
+    _require_pg_tools()
+    src_dsn, _ = pg_dsn_pair
+    _seed_source(src_dsn)
+
+    monkeypatch.setenv("POLLYPM_PG_DSN", src_dsn)
+    base_dir = tmp_path / ".pollypm"
+
+    backup_mod.backup_pg_dsn(base_dir=base_dir)
+    backup_mod.backup_pg_dsn(base_dir=base_dir)
+
+    index_path = base_dir / "backups" / "index.jsonl"
+    lines = index_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    for line in lines:
+        record = json.loads(line)
+        assert record["event"] == "pg_backup"
+        assert record["archive_size"] > 0
+        assert record["path"].endswith(".pgdump")
+
+
+def test_pg_backup_keep_prunes_older_snapshots(
+    pg_dsn_pair, tmp_path: Path, monkeypatch
+) -> None:
+    """With ``keep=2`` and 4 snapshots, only the 2 newest survive."""
+    import os
+    import time
+
+    _require_pg_tools()
+    src_dsn, _ = pg_dsn_pair
+    _seed_source(src_dsn)
+
+    monkeypatch.setenv("POLLYPM_PG_DSN", src_dsn)
+    base_dir = tmp_path / ".pollypm"
+
+    # Take three snapshots up-front; bump the mtimes apart so the
+    # oldest are clearly the first two.
+    snaps: list[Path] = []
+    for i in range(3):
+        result = backup_mod.backup_pg_dsn(base_dir=base_dir, keep=99)
+        snaps.append(result.path)
+        os.utime(result.path, (time.time() - (3 - i) * 100,) * 2)
+
+    final = backup_mod.backup_pg_dsn(base_dir=base_dir, keep=2)
+    remaining = sorted(
+        (base_dir / "backups").glob("pg-*.pgdump"),
+        key=lambda p: p.stat().st_mtime,
+    )
+    assert len(remaining) == 2
+    # The final snapshot must always survive.
+    assert final.path in remaining
+    # Two of the three earlier snapshots were pruned.
+    assert len(final.pruned) == 2


### PR DESCRIPTION
## Summary

- Adds a pg-aware backend dispatch to `pollypm.backup`: sqlite installs keep the existing online-backup API path (the rollback safety net during the transition); `[storage] backend = \"postgres\"` shells out to `pg_dump --format=custom --no-owner --no-privileges` and `pg_restore --clean --if-exists --no-owner`.
- pg snapshots land at `~/.pollypm/backups/pg-<ts>.pgdump`, rotate with the same `--keep N` policy as the sqlite path, and append an audit row to `~/.pollypm/backups/index.jsonl`.
- Adds `pm storage backup` / `pm storage restore` — the storage-namespaced surfaces promoted by the migration runbook. `pm backup` / `pm restore` keep working and now dispatch through the same shim. `pm storage backup --verify` re-opens the snapshot via `pg_restore --list` (or the SQLite header probe) — Slice J's cutover gates on this passing.
- Adds `pm doctor`'s `pg-backup-freshness` check (warning severity, skipped on sqlite installs).

## Files

- `src/pollypm/backup.py` — new pg branch + dispatch shim (`backup_via_config`, `restore_via_config`, `backup_pg_dsn`, `plan_pg_restore`, `execute_pg_restore`, `latest_pg_backup_age_seconds`).
- `src/pollypm/cli_features/maintenance.py` — refactored `backup_cmd` / `restore_cmd` to dispatch on `config.storage.backend`; new `pm storage` Typer sub-app with `--verify`.
- `src/pollypm/doctor/install_state.py` + `src/pollypm/doctor.py` — `check_pg_backup_freshness` doctor check (threshold 7d).
- `tests/test_backup_dispatch.py` — 11 tests for the dispatch logic + pg branch filesystem side effects (no live pg required; pg_dump invocation is monkeypatched).
- `tests/test_pg_backup.py` — round-trip pg_dump → pg_restore against the shared testcontainer fixture. 2 always-on validation tests + 3 testcontainer-gated tests.

## Out of scope (per the slice spec)

- `pm project archive` per-project snapshot path is untouched.
- The sqlite backup branch is NOT deleted — Slice K does that after cutover.

## Test plan

- [x] `pytest tests/test_backup_dispatch.py` — 11 pass
- [x] `pytest tests/test_backup_restore.py` — 18 pass (no regression on the legacy sqlite path)
- [x] `pytest tests/test_pg_backup.py` — 2 pass, 3 skipped without Docker (round-trip lights up when the testcontainer fixture is available)
- [x] `pytest tests/test_pg_pool.py tests/test_pg_schema.py` — 12 pass (no regression on Slice A foundation)
- [x] `pytest tests/test_doctor.py` — 74 pass; one pre-existing flaky `test_doctor_performance_budget` failure on a heavily loaded test machine (live-env smoke test; my added check takes ~27ms and skips on sqlite — cannot have moved the budget)
- [x] `pm storage --help` renders `backup` / `restore` subcommands

Refs #1737.

🤖 Generated with [Claude Code](https://claude.com/claude-code)