### PR TITLE
feat(storage): pgvector embedder + hybrid memory recall — Slice D of #1737

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,14 +25,17 @@ dev = [
   # dev installs always pull both so `pytest tests/test_pg_*` runs.
   "psycopg[binary]>=3.2.0",
   "psycopg-pool>=3.2.0",
+  "pgvector>=0.3.0",
   "testcontainers[postgres]>=4.8.0",
 ]
 # Runtime extra for the postgres backend. Operators flipping
 # ``[storage] backend = "postgres"`` in pollypm.toml must
-# ``uv pip install 'pollypm[postgres]'`` (#1737).
+# ``uv pip install 'pollypm[postgres]'`` (#1737). pgvector ships
+# the psycopg type adapter for the recall path (Slice D).
 postgres = [
   "psycopg[binary]>=3.2.0",
   "psycopg-pool>=3.2.0",
+  "pgvector>=0.3.0",
 ]
 
 [project.scripts]

--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -199,6 +199,9 @@ from pollypm.plugins_builtin.project_planning.cli import project_app
 app.add_typer(project_app, name="project")
 
 from pollypm.memory_cli import memory_app
+# Imported for the @memory_app.command side effect — registers
+# ``pm memory pg-recall`` and ``pm memory backfill-embeddings`` (#1737 Slice D).
+from pollypm import memory_recall_cli as _memory_recall_cli  # noqa: F401
 app.add_typer(memory_app, name="memory")
 
 from pollypm.plugins_builtin.advisor.cli.advisor_cli import advisor_app

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from pollypm.models import (
     AccountConfig,
+    EmbeddingScoreWeights,
     EmbeddingSettings,
     EventsRetentionSettings,
     LoggingSettings,
@@ -627,10 +628,37 @@ def _parse_storage_settings(
     api_key_env_raw = embed_raw.get("api_key_env", embed_defaults.api_key_env)
     if not isinstance(api_key_env_raw, str) or not api_key_env_raw.strip():
         api_key_env_raw = embed_defaults.api_key_env
+
+    # ``[storage.embedding] score_weights`` — hybrid-recall blend
+    # (#1737 Slice D). Knob is a sub-table; one fat-fingered value
+    # falls back individually so the whole blend doesn't void.
+    weight_defaults = embed_defaults.score_weights
+    weights_raw = embed_raw.get("score_weights", {})
+    if not isinstance(weights_raw, dict):
+        weights_raw = {}
+
+    def _coerce_weight(key: str, default: float) -> float:
+        raw = weights_raw.get(key, default)
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return default
+        if value < 0:
+            return default
+        return value
+
+    score_weights = EmbeddingScoreWeights(
+        semantic=_coerce_weight("semantic", weight_defaults.semantic),
+        fts=_coerce_weight("fts", weight_defaults.fts),
+        importance=_coerce_weight("importance", weight_defaults.importance),
+        recency=_coerce_weight("recency", weight_defaults.recency),
+    )
+
     embedding_settings = EmbeddingSettings(
         model=model_raw.strip(),
         provider=provider_raw.strip(),
         api_key_env=api_key_env_raw.strip(),
+        score_weights=score_weights,
     )
 
     return StorageSettings(

--- a/src/pollypm/memory_recall_cli.py
+++ b/src/pollypm/memory_recall_cli.py
@@ -1,0 +1,329 @@
+"""CLI surface for pgvector-backed hybrid recall (issue #1737, Slice D).
+
+Adds two commands under the existing ``pm memory`` Typer:
+
+* ``pm memory pg-recall "<query>" [--limit N] [--source messages,...]``
+  Runs the hybrid pgvector + FTS recall query against the workspace
+  pg backend. Prints results as a table or JSON.
+* ``pm memory backfill-embeddings [--source ...] [--limit N]``
+  Walks ``messages`` / ``work_context_entries`` / ``memory_entries``
+  for rows without a row in ``embeddings`` and embeds them. Idempotent
+  and resumable.
+
+These are registered on the existing ``memory_app`` from
+:mod:`pollypm.memory_cli` so they appear under ``pm memory ...`` in
+``pm --help``.
+
+A separate module (not in-line in ``memory_cli.py``) so the file-backed
+memory commands stay readable and the pg-backed surface can grow
+without churning the legacy file. The legacy ``pm memory recall``
+keeps its FTS+importance+recency behaviour against the FileMemoryBackend;
+the pg surface ships under ``pm memory pg-recall``. Once Slice H deletes
+the legacy backend the pg-recall command becomes the canonical
+``pm memory recall``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Iterable
+
+import typer
+
+from pollypm.config import DEFAULT_CONFIG_PATH, load_config, resolve_config_path
+from pollypm.memory_cli import memory_app
+from pollypm.storage.memory_recall import (
+    RecallHit,
+    SUPPORTED_SOURCES,
+    recall as run_recall,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------- #
+# Helpers.
+# --------------------------------------------------------------------- #
+
+
+def _parse_source_list(raw: str | None) -> list[str] | None:
+    """Parse the ``--source`` CSV into a clean list.
+
+    Accepts ``--source messages,work_context_entries`` or
+    ``--source memory_entries``. Also accepts the short alias
+    ``work_context`` as a synonym for ``work_context_entries`` because
+    that's what Sam will type. ``None`` means "all supported sources".
+    """
+    if raw is None:
+        return None
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    if not parts:
+        return None
+    canonical: list[str] = []
+    for part in parts:
+        if part == "work_context":
+            canonical.append("work_context_entries")
+            continue
+        canonical.append(part)
+    unknown = sorted(set(canonical) - set(SUPPORTED_SOURCES))
+    if unknown:
+        raise typer.BadParameter(
+            f"--source has unknown values {unknown!r}; "
+            f"choose from {list(SUPPORTED_SOURCES)!r}"
+        )
+    return canonical
+
+
+def _hit_to_dict(hit: RecallHit) -> dict[str, object]:
+    return {
+        "source_table": hit.source_table,
+        "source_id": hit.source_id,
+        "score": round(hit.score, 4),
+        "text_preview": hit.text_preview,
+        "metadata": hit.metadata,
+    }
+
+
+def _print_hit_table(hits: Iterable[RecallHit]) -> None:
+    """Render hits as a human-readable column table."""
+    rows = list(hits)
+    if not rows:
+        typer.echo("No results.")
+        return
+    typer.echo(
+        f"{'score':>6}  {'source':<22} {'id':>8}  preview"
+    )
+    typer.echo("-" * 80)
+    for hit in rows:
+        preview = hit.text_preview[:60]
+        typer.echo(
+            f"{hit.score:6.3f}  "
+            f"{hit.source_table:<22} "
+            f"{hit.source_id:>8}  "
+            f"{preview}"
+        )
+
+
+# --------------------------------------------------------------------- #
+# pg-recall command.
+# --------------------------------------------------------------------- #
+
+
+@memory_app.command("pg-recall")
+def pg_recall(
+    query: str = typer.Argument(..., help="Free-text query."),
+    limit: int = typer.Option(10, "--limit", help="Max hits to return."),
+    source: str | None = typer.Option(
+        None,
+        "--source",
+        help=(
+            "Comma-separated source tables: messages, work_context_entries, "
+            "memory_entries (or the alias 'work_context'). Default: all three."
+        ),
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit structured JSON.",
+    ),
+    config_path: Path = typer.Option(
+        DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path.",
+    ),
+) -> None:
+    """Hybrid pgvector + FTS recall (Slice D)."""
+    if limit <= 0:
+        raise typer.BadParameter("--limit must be >= 1")
+
+    resolved = resolve_config_path(config_path)
+    if not resolved.exists():
+        from pollypm.errors import format_config_not_found_error
+
+        raise typer.BadParameter(format_config_not_found_error(resolved))
+    config = load_config(resolved)
+    sources = _parse_source_list(source)
+
+    try:
+        hits = run_recall(
+            query,
+            limit=limit,
+            source_tables=sources,
+            config=config,
+        )
+    except Exception as exc:  # noqa: BLE001 - surfaced to operator
+        if json_output:
+            typer.echo(json.dumps({"error": str(exc)}))
+        else:
+            typer.echo(f"recall failed: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    if json_output:
+        typer.echo(
+            json.dumps(
+                [_hit_to_dict(h) for h in hits],
+                indent=2,
+                sort_keys=True,
+                default=str,
+            )
+        )
+        return
+
+    _print_hit_table(hits)
+
+
+# --------------------------------------------------------------------- #
+# backfill-embeddings command.
+# --------------------------------------------------------------------- #
+
+
+@memory_app.command("backfill-embeddings")
+def backfill_embeddings(
+    source: str = typer.Option(
+        "all",
+        "--source",
+        help=(
+            "Single source table to backfill, or 'all'. Choices: "
+            "messages, work_context_entries, memory_entries, all."
+        ),
+    ),
+    limit: int = typer.Option(
+        0,
+        "--limit",
+        help="Max rows to process per source (0 = no cap).",
+    ),
+    batch_size: int = typer.Option(
+        32, "--batch-size", help="Rows per embed batch.",
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit structured JSON summary.",
+    ),
+    config_path: Path = typer.Option(
+        DEFAULT_CONFIG_PATH, "--config", help="PollyPM config path.",
+    ),
+) -> None:
+    """Scan source tables for rows missing embeddings; embed them.
+
+    Idempotent: skips rows that already have an ``embeddings`` row at
+    ``(source_table, source_id)``. Resumable: a re-run after a partial
+    backfill picks up exactly where it left off.
+    """
+    if limit < 0:
+        raise typer.BadParameter("--limit must be >= 0")
+    if batch_size <= 0:
+        raise typer.BadParameter("--batch-size must be >= 1")
+
+    if source == "all":
+        targets = list(SUPPORTED_SOURCES)
+    else:
+        targets = _parse_source_list(source) or []
+        if not targets:
+            raise typer.BadParameter("--source produced an empty list")
+
+    resolved = resolve_config_path(config_path)
+    if not resolved.exists():
+        from pollypm.errors import format_config_not_found_error
+
+        raise typer.BadParameter(format_config_not_found_error(resolved))
+    config = load_config(resolved)
+
+    # Resolve the embedder + pool exactly once so a thousand-row
+    # backfill doesn't re-look-up the API key on every batch.
+    from pollypm.storage import pg_pool
+    from pollypm.storage.embedder import resolve_embedder
+    from pollypm.storage.embedding_writer import EmbeddingWriter
+
+    embedder = resolve_embedder(
+        config.storage.embedding.model,
+        config.storage.embedding.api_key_env,
+    )
+    pool = pg_pool.get_rw_pool(config)
+    writer = EmbeddingWriter(pool, embedder, batch_size=batch_size)
+
+    summary: dict[str, dict[str, int]] = {}
+    for table in targets:
+        scanned, queued = _enqueue_missing(pool, table, writer, limit)
+        embedded = writer.drain_once(max_batches=10_000)
+        summary[table] = {
+            "scanned": scanned,
+            "queued": queued,
+            "embedded": embedded,
+            "failures": writer.metrics_batch_failures,
+        }
+        # Reset per-table counters so the next table's summary is clean.
+        writer.metrics_batch_failures = 0
+        writer.metrics_batches_processed = 0
+        writer.metrics_rows_embedded = 0
+        writer.metrics_rows_skipped = 0
+
+    if json_output:
+        typer.echo(json.dumps(summary, indent=2, sort_keys=True))
+        return
+
+    for table, stats in summary.items():
+        typer.echo(
+            f"{table:<22}  scanned={stats['scanned']:>5}  "
+            f"queued={stats['queued']:>5}  "
+            f"embedded={stats['embedded']:>5}  "
+            f"failures={stats['failures']}"
+        )
+
+
+def _enqueue_missing(
+    pool,
+    table: str,
+    writer,
+    limit: int,
+) -> tuple[int, int]:
+    """Scan ``table`` for rows lacking an ``embeddings`` row; enqueue.
+
+    Returns ``(scanned, queued)``. ``scanned`` is the number of rows
+    inspected; ``queued`` is the subset that didn't already have a row
+    in ``embeddings``. A ``limit`` of 0 means "no cap" — the backfill
+    walks the whole table.
+    """
+    if table not in SUPPORTED_SOURCES:
+        raise ValueError(f"backfill: unsupported source {table!r}")
+
+    sql_lookup = {
+        "messages": "SELECT id::text FROM messages ORDER BY id",
+        "work_context_entries": (
+            "SELECT id::text FROM work_context_entries ORDER BY id"
+        ),
+        "memory_entries": "SELECT id::text FROM memory_entries ORDER BY id",
+    }
+    base_sql = sql_lookup[table]
+    if limit > 0:
+        base_sql = f"{base_sql} LIMIT {int(limit)}"
+
+    scanned = 0
+    candidates: list[str] = []
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(base_sql)
+        for row in cur:
+            scanned += 1
+            candidates.append(str(row[0]))
+
+    if not candidates:
+        return scanned, 0
+
+    # Single missing-row probe instead of per-row checks — same shape
+    # as the writer's _filter_existing, but pulled inline so the
+    # backfill CLI can report counts cleanly.
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT source_id FROM embeddings "
+            "WHERE source_table = %s AND source_id = ANY(%s)",
+            (table, candidates),
+        )
+        already = {row[0] for row in cur.fetchall()}
+
+    missing = [sid for sid in candidates if sid not in already]
+    for sid in missing:
+        writer.enqueue(table, sid)
+    return scanned, len(missing)
+
+
+__all__ = [
+    "backfill_embeddings",
+    "pg_recall",
+]

--- a/src/pollypm/models.py
+++ b/src/pollypm/models.py
@@ -272,21 +272,50 @@ class PgStorageSettings:
 
 
 @dataclass(slots=True)
+class EmbeddingScoreWeights:
+    """Hybrid-recall scoring knobs (#1737, Slice D).
+
+    The pg memory recall layer blends four components into one
+    final score:
+
+    * ``semantic`` — cosine similarity from pgvector
+    * ``fts`` — Postgres ``ts_rank_cd`` against the generated
+      ``tsvector`` columns
+    * ``importance`` — ``memory_entries.importance`` normalised to
+      ``[0, 1]``
+    * ``recency`` — exponential decay over ``created_at`` age
+
+    Weights are non-negative; the recall query normalises them to sum
+    to 1 before blending so an operator can leave one knob alone.
+    Defaults mirror the design doc at #1737 §3.4.
+    """
+
+    semantic: float = 0.5
+    fts: float = 0.25
+    importance: float = 0.15
+    recency: float = 0.1
+
+
+@dataclass(slots=True)
 class EmbeddingSettings:
     """``[storage.embedding]`` knobs — embedding provider for pgvector.
 
-    Slice A only carries the dataclass shape; the writer lands in
-    Slice D. Knobs:
+    Slice A laid the dataclass shape; Slice D wires the writer +
+    recall path. Knobs:
 
     ``model`` — provider-namespaced model name (``openai:text-embedding-3-small``).
     ``provider`` — short id used by the resolver (``openai``, ``ollama``, ...).
     ``api_key_env`` — name of the env var that holds the provider's
         API key. Defaults to ``OPENAI_API_KEY``.
+    ``score_weights`` — hybrid-recall blend weights (#1737 Slice D).
     """
 
     model: str = "openai:text-embedding-3-small"
     provider: str = "openai"
     api_key_env: str = "OPENAI_API_KEY"
+    score_weights: EmbeddingScoreWeights = field(
+        default_factory=EmbeddingScoreWeights,
+    )
 
 
 @dataclass(slots=True)

--- a/src/pollypm/storage/embedder.py
+++ b/src/pollypm/storage/embedder.py
@@ -1,0 +1,418 @@
+"""Embedding-provider abstraction for pgvector recall (issue #1737, Slice D).
+
+The :class:`Embedder` Protocol is a tiny synchronous batch surface — give
+it a list of strings, get back a list of float vectors. The default
+implementation :class:`OpenAIEmbedder` calls OpenAI's embeddings API with
+exponential backoff on transient errors.
+
+Why a Protocol + registry
+-------------------------
+
+Sam wants the option to swap to a local model (``nomic-embed-text`` via
+Ollama, etc.) without rewriting the embedding-on-write path. The
+Protocol pins the contract; the registry resolves a provider-namespaced
+model name (``openai:text-embedding-3-small``) to a concrete class so
+``[storage.embedding] model = "..."`` is the single switch. Slice D
+only ships the OpenAI implementation; the registry is the seam future
+providers slot into.
+
+Why sync
+--------
+
+PollyPM's storage layer is sync (psycopg 3 sync, ``threading.Lock``).
+Making the embedder async would force every caller (background writer
+thread, recall API, backfill CLI) to either spawn an event loop or wrap
+``asyncio.run`` per batch. The OpenAI client supports sync calls
+natively; we use ``urllib`` instead so the package doesn't grow another
+runtime dep just for this slice.
+
+Network errors
+--------------
+
+Transient HTTP failures (429, 500, 502, 503, 504, network timeouts) are
+retried with exponential backoff up to ``max_retries``. Non-retryable
+errors (auth, bad-request shape) raise :class:`EmbedderError` straight
+through so the caller (background writer) logs + skips rather than
+spinning forever.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Callable, Protocol
+
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------- #
+# Public Protocol + result types.
+# --------------------------------------------------------------------- #
+
+
+class EmbedderError(RuntimeError):
+    """Embedder failed in a non-retryable way (auth, bad shape, etc.).
+
+    Background writer + backfill catch this, log, and skip the row.
+    """
+
+
+@dataclass(slots=True, frozen=True)
+class EmbedderInfo:
+    """Static metadata about an embedder.
+
+    Used by the writer to stamp the ``embeddings.model`` column and
+    by the schema to verify the embedding dim matches ``vector(N)``.
+    """
+
+    model: str
+    dim: int
+
+
+class Embedder(Protocol):
+    """Batch text -> dense vectors.
+
+    All implementations MUST:
+
+    * Accept any non-empty list of strings up to
+      :attr:`max_batch_size` long.
+    * Return a list of float lists in the same order as the input.
+    * Each vector MUST have exactly :attr:`info.dim` entries.
+    * Raise :class:`EmbedderError` on permanent failure;
+      transient errors should be retried internally.
+    """
+
+    @property
+    def info(self) -> EmbedderInfo: ...
+
+    @property
+    def max_batch_size(self) -> int: ...
+
+    def embed(self, texts: list[str]) -> list[list[float]]: ...
+
+
+# --------------------------------------------------------------------- #
+# OpenAI implementation.
+# --------------------------------------------------------------------- #
+
+
+# OpenAI's documented per-request cap is 2048 inputs but the practical
+# soft limit lives lower (rate-limit token math + per-request latency).
+# 100 keeps every batch comfortably under the per-minute token rate
+# limit while still amortising the HTTP overhead. The writer batches
+# at 32 (per #1737 spec) so this is a generous upper bound.
+OPENAI_BATCH_CAP = 100
+
+_OPENAI_MODEL_DIMS: dict[str, int] = {
+    "text-embedding-3-small": 1536,
+    "text-embedding-3-large": 3072,
+    "text-embedding-ada-002": 1536,
+}
+
+# HTTP status codes that signal "try again later". 408 (request timeout),
+# 429 (rate-limited), and 5xx server errors are all retryable; anything
+# else (auth, bad request) crashes out as non-retryable.
+_RETRYABLE_STATUS = frozenset({408, 429, 500, 502, 503, 504})
+
+
+@dataclass(slots=True)
+class OpenAIEmbedder:
+    """OpenAI ``v1/embeddings`` implementation of :class:`Embedder`.
+
+    Constructor params:
+
+    ``model`` — bare model id (no ``openai:`` prefix). Use
+        ``"text-embedding-3-small"`` for the default knob.
+    ``api_key`` — API key. ``None`` means resolve from the env var
+        named by ``api_key_env_name`` at call time.
+    ``api_key_env_name`` — env var to look up when ``api_key`` is
+        ``None``. Defaults to ``"OPENAI_API_KEY"``.
+    ``api_base`` — override for the API base URL. Useful for tests
+        or self-hosted proxies. Defaults to OpenAI production.
+    ``max_retries`` — number of retry attempts on transient errors.
+    ``backoff_initial`` / ``backoff_max`` — exponential-backoff
+        bounds, in seconds.
+    ``timeout`` — per-request HTTP timeout.
+    ``http_post`` — injection seam for tests; pass a callable with
+        signature ``(url, body_bytes, headers, timeout) -> (status,
+        body_bytes)``. Defaults to a :mod:`urllib`-backed helper.
+    """
+
+    model: str = "text-embedding-3-small"
+    api_key: str | None = None
+    api_key_env_name: str = "OPENAI_API_KEY"
+    api_base: str = "https://api.openai.com/v1"
+    max_retries: int = 5
+    backoff_initial: float = 0.5
+    backoff_max: float = 30.0
+    timeout: float = 30.0
+    http_post: Callable[
+        [str, bytes, dict[str, str], float], tuple[int, bytes]
+    ] | None = None
+    sleep: Callable[[float], None] = field(default=time.sleep)
+
+    @property
+    def info(self) -> EmbedderInfo:
+        dim = _OPENAI_MODEL_DIMS.get(self.model, 1536)
+        return EmbedderInfo(model=f"openai:{self.model}", dim=dim)
+
+    @property
+    def max_batch_size(self) -> int:
+        return OPENAI_BATCH_CAP
+
+    def _resolve_key(self) -> str:
+        if self.api_key:
+            return self.api_key
+        env_value = os.environ.get(self.api_key_env_name, "").strip()
+        if not env_value:
+            raise EmbedderError(
+                f"OpenAI embedder: no API key in ${self.api_key_env_name}; "
+                "set the env var or pass api_key=... to the constructor."
+            )
+        return env_value
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        if len(texts) > self.max_batch_size:
+            raise EmbedderError(
+                f"OpenAI embedder: batch of {len(texts)} exceeds cap of "
+                f"{self.max_batch_size}; chunk before calling embed()."
+            )
+        # OpenAI rejects empty inputs with 400. Replace empty strings
+        # with a single space so the writer's "embed everything"
+        # contract still holds — empty memory entries are real (a row
+        # might be a title-only stub) and we'd rather embed a stand-in
+        # than fail the whole batch.
+        sanitized = [t if t.strip() else " " for t in texts]
+
+        api_key = self._resolve_key()
+        url = f"{self.api_base.rstrip('/')}/embeddings"
+        body = json.dumps({"model": self.model, "input": sanitized}).encode(
+            "utf-8"
+        )
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        post = self.http_post or _urllib_post
+        attempt = 0
+        delay = self.backoff_initial
+        while True:
+            attempt += 1
+            try:
+                status, response_body = post(url, body, headers, self.timeout)
+            except (urllib.error.URLError, TimeoutError, OSError) as exc:
+                if attempt > self.max_retries:
+                    raise EmbedderError(
+                        f"OpenAI embedder: network failure after "
+                        f"{attempt} attempts: {exc!r}"
+                    ) from exc
+                logger.warning(
+                    "embedder: network error attempt=%d/%d err=%r; "
+                    "sleeping %.2fs",
+                    attempt,
+                    self.max_retries,
+                    exc,
+                    delay,
+                )
+                self.sleep(delay)
+                delay = min(delay * 2, self.backoff_max)
+                continue
+
+            if 200 <= status < 300:
+                return _parse_embedding_response(response_body, len(sanitized))
+
+            if status in _RETRYABLE_STATUS and attempt <= self.max_retries:
+                logger.warning(
+                    "embedder: transient HTTP %d attempt=%d/%d; "
+                    "sleeping %.2fs",
+                    status,
+                    attempt,
+                    self.max_retries,
+                    delay,
+                )
+                self.sleep(delay)
+                delay = min(delay * 2, self.backoff_max)
+                continue
+
+            snippet = response_body[:512].decode("utf-8", errors="replace")
+            raise EmbedderError(
+                f"OpenAI embedder: HTTP {status} after attempt {attempt}: "
+                f"{snippet}"
+            )
+
+
+def _urllib_post(
+    url: str,
+    body: bytes,
+    headers: dict[str, str],
+    timeout: float,
+) -> tuple[int, bytes]:
+    """Default HTTP POST via :mod:`urllib`. Returns ``(status, body)``.
+
+    Both successful and HTTP-error responses are surfaced as
+    ``(status, body)`` so the caller's retry loop can inspect the
+    status code. Network/timeout failures still raise — those are
+    caught upstream and counted against the retry budget.
+    """
+    request = urllib.request.Request(  # noqa: S310 — fixed scheme, no user input
+        url,
+        data=body,
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(  # noqa: S310 — fixed scheme
+            request, timeout=timeout
+        ) as response:
+            return response.status, response.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read() if exc.fp else b""
+
+
+def _parse_embedding_response(body: bytes, expected: int) -> list[list[float]]:
+    """Parse OpenAI's ``v1/embeddings`` response into a list of vectors.
+
+    Raises :class:`EmbedderError` on missing fields or wrong shape so
+    a malformed proxy response doesn't silently produce zero-length
+    vectors.
+    """
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise EmbedderError(
+            f"OpenAI embedder: response was not JSON: {exc!r}"
+        ) from exc
+
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, list):
+        raise EmbedderError(
+            "OpenAI embedder: response missing 'data' array; "
+            f"got keys {list(payload) if isinstance(payload, dict) else payload!r}"
+        )
+    if len(data) != expected:
+        raise EmbedderError(
+            f"OpenAI embedder: expected {expected} embeddings, "
+            f"got {len(data)}"
+        )
+
+    # OpenAI returns rows with an ``index`` field; sort by it to be
+    # robust to out-of-order responses (the API documents in-order
+    # but the spec allows for shuffle).
+    vectors: list[list[float] | None] = [None] * expected
+    for row in data:
+        if not isinstance(row, dict):
+            raise EmbedderError(
+                "OpenAI embedder: malformed row in response data"
+            )
+        idx = row.get("index", 0)
+        embedding = row.get("embedding")
+        if not isinstance(embedding, list):
+            raise EmbedderError(
+                "OpenAI embedder: row missing 'embedding' list"
+            )
+        try:
+            float_vec = [float(x) for x in embedding]
+        except (TypeError, ValueError) as exc:
+            raise EmbedderError(
+                f"OpenAI embedder: non-float entry in embedding: {exc!r}"
+            ) from exc
+        if not isinstance(idx, int) or not (0 <= idx < expected):
+            raise EmbedderError(
+                f"OpenAI embedder: bad index {idx!r} in response"
+            )
+        vectors[idx] = float_vec
+
+    if any(v is None for v in vectors):
+        raise EmbedderError(
+            "OpenAI embedder: response had gaps in index sequence"
+        )
+    return vectors  # type: ignore[return-value]
+
+
+# --------------------------------------------------------------------- #
+# Registry — resolve provider-namespaced model names to a class.
+# --------------------------------------------------------------------- #
+
+
+# A factory takes the bare model name (without the ``provider:`` prefix)
+# and an env-var name; returns a constructed :class:`Embedder`. Tests
+# register stubs via :func:`register_embedder` to inject canned vectors.
+EmbedderFactory = Callable[[str, str], Embedder]
+
+
+_EMBEDDER_REGISTRY: dict[str, EmbedderFactory] = {}
+
+
+def register_embedder(provider: str, factory: EmbedderFactory) -> None:
+    """Register a provider factory under ``provider`` (e.g. ``"openai"``).
+
+    Replaces any existing entry — the registry is intentionally
+    last-write-wins so tests can override the real OpenAI factory
+    with a stub.
+    """
+    _EMBEDDER_REGISTRY[provider] = factory
+
+
+def unregister_embedder(provider: str) -> None:
+    """Remove ``provider`` from the registry. Idempotent."""
+    _EMBEDDER_REGISTRY.pop(provider, None)
+
+
+def _default_openai_factory(model: str, api_key_env: str) -> Embedder:
+    return OpenAIEmbedder(model=model, api_key_env_name=api_key_env)
+
+
+# Bootstrap the OpenAI default. Tests that need a deterministic
+# embedder call :func:`register_embedder` to override.
+register_embedder("openai", _default_openai_factory)
+
+
+def resolve_embedder(model_spec: str, api_key_env: str) -> Embedder:
+    """Resolve ``provider:model`` -> :class:`Embedder` via the registry.
+
+    Parameters
+    ----------
+    model_spec:
+        A provider-namespaced model name such as
+        ``"openai:text-embedding-3-small"``. The portion before the
+        first colon is the provider key; the rest is the model id
+        passed to the factory. A bare model name (no colon) is
+        treated as the ``openai`` provider — preserves backwards
+        compatibility with installs that haven't updated their
+        config since pre-Slice-D.
+    api_key_env:
+        Name of the env var that holds the provider's API key.
+        Passed through to the factory.
+    """
+    if ":" in model_spec:
+        provider, _, model = model_spec.partition(":")
+    else:
+        provider, model = "openai", model_spec
+    factory = _EMBEDDER_REGISTRY.get(provider)
+    if factory is None:
+        raise EmbedderError(
+            f"embedder: no factory registered for provider "
+            f"{provider!r}; known: {sorted(_EMBEDDER_REGISTRY)}"
+        )
+    return factory(model, api_key_env)
+
+
+__all__ = [
+    "Embedder",
+    "EmbedderError",
+    "EmbedderFactory",
+    "EmbedderInfo",
+    "OpenAIEmbedder",
+    "register_embedder",
+    "resolve_embedder",
+    "unregister_embedder",
+]

--- a/src/pollypm/storage/embedding_writer.py
+++ b/src/pollypm/storage/embedding_writer.py
@@ -1,0 +1,492 @@
+"""Background embedding writer for pgvector recall (issue #1737, Slice D).
+
+When a row lands in ``messages``, ``work_context_entries`` or
+``memory_entries`` we want a corresponding row in ``embeddings`` so the
+recall query has a vector to compare against. Doing the embed inline on
+the write path would (a) couple every domain write to an outbound HTTP
+call and (b) block the caller for hundreds of milliseconds. Instead we
+queue ``(source_table, source_id)`` pairs on an in-process queue and
+drain it from a background thread that batches rows into 32-at-a-time
+embed calls.
+
+Catastrophic-failure contract
+-----------------------------
+
+The writer thread MUST NOT crash on:
+
+* missing API key (the embedder raises ``EmbedderError`` → log + drop)
+* HTTP errors after retries are exhausted (log + drop the batch)
+* missing source rows (log + drop; the row may have been deleted
+  between enqueue and drain)
+* psycopg connection errors (log; retry the batch one more time, then
+  drop)
+
+The contract is "embedding is best-effort coverage". A row without an
+embedding is still recallable via the FTS leg of the hybrid scorer.
+
+Idempotency
+-----------
+
+Before embedding, the writer checks the ``embeddings`` table for an
+existing row at ``(source_table, source_id)``. If one is present the
+row is skipped — re-enqueueing after a process restart is therefore
+free.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from queue import Empty, Queue
+from typing import TYPE_CHECKING, Iterable
+
+from pollypm.storage.embedder import Embedder, EmbedderError
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+
+logger = logging.getLogger(__name__)
+
+
+# Per-#1737 spec: batch 32 rows per embed call. Picked to amortise the
+# HTTP overhead while keeping per-batch latency under a second on the
+# default text-embedding-3-small model.
+DEFAULT_EMBED_BATCH = 32
+
+# How long the drain thread waits between empty-queue polls. Tests
+# inject a tiny value so the thread exits cheaply; production uses 0.5s.
+DEFAULT_POLL_INTERVAL = 0.5
+
+# Tables we know about. Anything else enqueued is rejected with a
+# warning so a typo in the writer-call site shows up immediately
+# rather than silently never embedding.
+KNOWN_SOURCE_TABLES = frozenset({
+    "messages",
+    "work_context_entries",
+    "memory_entries",
+})
+
+
+@dataclass(slots=True, frozen=True)
+class EmbedJob:
+    """A single ``(source_table, source_id)`` enqueued for embedding."""
+
+    source_table: str
+    source_id: str
+
+
+# --------------------------------------------------------------------- #
+# Source-text extractors.
+# --------------------------------------------------------------------- #
+# Each source table has a different shape — extract the text we
+# actually want to embed, falling back to empty string when the row
+# is missing or the columns are NULL.
+
+
+_SOURCE_TEXT_SQL: dict[str, str] = {
+    "messages": (
+        "SELECT coalesce(subject, '') || E'\\n' || coalesce(body, '') "
+        "FROM messages WHERE id::text = %s"
+    ),
+    "work_context_entries": (
+        "SELECT coalesce(text, '') "
+        "FROM work_context_entries WHERE id::text = %s"
+    ),
+    "memory_entries": (
+        "SELECT coalesce(title, '') || E'\\n' || coalesce(body, '') "
+        "FROM memory_entries WHERE id::text = %s"
+    ),
+}
+
+
+def _fetch_source_text(conn, table: str, source_id: str) -> str | None:
+    """Look up the text to embed for ``(table, source_id)``.
+
+    Returns ``None`` when the row no longer exists (legitimate race —
+    a writer enqueued the row, a curator/delete swept it before the
+    drain thread ran). The writer skips ``None`` rows quietly.
+    """
+    sql = _SOURCE_TEXT_SQL.get(table)
+    if sql is None:
+        return None
+    with conn.cursor() as cur:
+        cur.execute(sql, (source_id,))
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return row[0] or ""
+
+
+def _filter_existing(
+    conn,
+    jobs: list[EmbedJob],
+) -> list[EmbedJob]:
+    """Return only the jobs that aren't already in ``embeddings``.
+
+    Skipping pre-existing rows is what makes the writer idempotent —
+    a backfill + a fresh enqueue race converge instead of double-billing
+    the OpenAI account.
+    """
+    if not jobs:
+        return []
+    keys = [(j.source_table, j.source_id) for j in jobs]
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT source_table, source_id FROM embeddings "
+            "WHERE (source_table, source_id) IN ("
+            + ",".join(["(%s, %s)"] * len(keys))
+            + ")",
+            [v for pair in keys for v in pair],
+        )
+        existing = {(row[0], row[1]) for row in cur.fetchall()}
+    return [j for j in jobs if (j.source_table, j.source_id) not in existing]
+
+
+def _write_embeddings(
+    conn,
+    rows: list[tuple[str, str, list[float], str]],
+) -> None:
+    """Insert (or overwrite) embedding rows in one shot.
+
+    Each ``rows`` entry is ``(source_table, source_id, vector, model)``.
+    The ``ON CONFLICT`` clause makes the writer safe to re-run against
+    rows that were just inserted by another process.
+    """
+    if not rows:
+        return
+    # psycopg's pgvector adapter is opt-in via pgvector.psycopg.register_vector
+    # — without it psycopg sends the list as a Postgres array. We always
+    # call ``register_vector`` once per connection in :func:`_ensure_vector`.
+    with conn.cursor() as cur:
+        cur.executemany(
+            "INSERT INTO embeddings (source_table, source_id, embedding, model) "
+            "VALUES (%s, %s, %s, %s) "
+            "ON CONFLICT (source_table, source_id) DO UPDATE "
+            "SET embedding = EXCLUDED.embedding, "
+            "    model = EXCLUDED.model, "
+            "    generated_at = now()",
+            rows,
+        )
+
+
+def _ensure_vector(conn) -> None:
+    """Register pgvector's psycopg adapter on this connection.
+
+    Idempotent — the adapter sets a flag on the connection so a second
+    call is a no-op. Localised so the writer doesn't import pgvector
+    unless it's actually going to embed.
+    """
+    try:
+        from pgvector.psycopg import register_vector
+    except ImportError as exc:  # pragma: no cover - environment-dependent
+        raise EmbedderError(
+            "pgvector adapter not installed; the postgres extra "
+            "must include `pgvector` for the embedding writer to "
+            "speak the vector type"
+        ) from exc
+    register_vector(conn)
+
+
+# --------------------------------------------------------------------- #
+# Public writer.
+# --------------------------------------------------------------------- #
+
+
+class EmbeddingWriter:
+    """Background drain thread that turns ``EmbedJob`` queue items into
+    rows in the ``embeddings`` table.
+
+    Public surface:
+
+    * :meth:`enqueue` — non-blocking; called by the write hooks.
+    * :meth:`start` — spawn the drain thread.
+    * :meth:`stop` — signal shutdown; joins with a bounded timeout.
+    * :meth:`drain_once` — synchronous drain pass; tests + the backfill
+      CLI use this to embed without spawning a thread.
+    """
+
+    def __init__(
+        self,
+        pool: "ConnectionPool",
+        embedder: Embedder,
+        *,
+        batch_size: int = DEFAULT_EMBED_BATCH,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
+    ) -> None:
+        self._pool = pool
+        self._embedder = embedder
+        self._batch_size = max(1, min(batch_size, embedder.max_batch_size))
+        self._poll_interval = poll_interval
+        self._queue: Queue[EmbedJob] = Queue()
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        # Tests use this to assert exactly N batches landed without
+        # racing the queue.
+        self.metrics_batches_processed = 0
+        self.metrics_rows_embedded = 0
+        self.metrics_rows_skipped = 0
+        self.metrics_batch_failures = 0
+
+    # --- enqueue surface ---------------------------------------------- #
+
+    def enqueue(self, source_table: str, source_id: str | int) -> None:
+        """Queue ``(source_table, source_id)`` for embedding.
+
+        Non-blocking. Unknown tables log + drop — that's a programming
+        error in the caller, not a runtime condition, so we don't want
+        it to silently soak up writer time.
+        """
+        if source_table not in KNOWN_SOURCE_TABLES:
+            logger.warning(
+                "embedding_writer: unknown source_table=%r; ignoring",
+                source_table,
+            )
+            return
+        self._queue.put(EmbedJob(source_table=source_table, source_id=str(source_id)))
+
+    def enqueue_many(self, jobs: Iterable[EmbedJob]) -> None:
+        for job in jobs:
+            self.enqueue(job.source_table, job.source_id)
+
+    # --- thread lifecycle --------------------------------------------- #
+
+    def start(self) -> None:
+        """Spawn the drain thread. Idempotent."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="pollypm-embedding-writer",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, *, timeout: float = 5.0) -> None:
+        """Signal shutdown and join the thread. Safe to call when stopped."""
+        self._stop_event.set()
+        thread = self._thread
+        if thread is None:
+            return
+        thread.join(timeout=timeout)
+        self._thread = None
+
+    def _run(self) -> None:
+        """Drain loop: gather a batch, embed, write, repeat."""
+        while not self._stop_event.is_set():
+            try:
+                jobs = self._collect_batch()
+                if not jobs:
+                    # Sleep on the event so stop() unblocks promptly.
+                    self._stop_event.wait(self._poll_interval)
+                    continue
+                self._process_batch(jobs)
+            except Exception:  # noqa: BLE001 — never crash the writer
+                logger.exception("embedding_writer: loop iteration crashed")
+                self.metrics_batch_failures += 1
+                self._stop_event.wait(self._poll_interval)
+
+    def _collect_batch(self) -> list[EmbedJob]:
+        """Drain up to ``batch_size`` items from the queue.
+
+        Returns immediately if the queue is empty — the caller sleeps.
+        """
+        jobs: list[EmbedJob] = []
+        deadline_reached = False
+        while len(jobs) < self._batch_size and not deadline_reached:
+            try:
+                job = self._queue.get_nowait()
+            except Empty:
+                deadline_reached = True
+                continue
+            jobs.append(job)
+        return jobs
+
+    # --- batch processing --------------------------------------------- #
+
+    def drain_once(self, *, max_batches: int = 1024) -> int:
+        """Synchronous drain: pull and embed until the queue empties.
+
+        Returns the count of rows successfully embedded. Used by the
+        backfill CLI (no thread spawn) and by tests that want
+        deterministic timing.
+        """
+        rows_embedded = 0
+        for _ in range(max_batches):
+            jobs = self._collect_batch()
+            if not jobs:
+                break
+            rows_embedded += self._process_batch(jobs)
+        return rows_embedded
+
+    def _process_batch(self, jobs: list[EmbedJob]) -> int:
+        """Embed one batch end-to-end. Returns rows successfully written."""
+        self.metrics_batches_processed += 1
+        try:
+            with self._pool.connection() as conn:
+                _ensure_vector(conn)
+
+                # Idempotency: skip rows that already have an embedding.
+                pending = _filter_existing(conn, jobs)
+                if not pending:
+                    self.metrics_rows_skipped += len(jobs)
+                    return 0
+                self.metrics_rows_skipped += len(jobs) - len(pending)
+
+                # Fetch the source text for each pending row.
+                texts: list[str] = []
+                resolved: list[EmbedJob] = []
+                for job in pending:
+                    text = _fetch_source_text(
+                        conn, job.source_table, job.source_id,
+                    )
+                    if text is None:
+                        # Source row gone (deleted between enqueue + drain).
+                        self.metrics_rows_skipped += 1
+                        continue
+                    texts.append(text)
+                    resolved.append(job)
+
+                if not resolved:
+                    return 0
+
+                # Run the embedder OUTSIDE the connection's implicit
+                # transaction so a slow HTTP call doesn't hold a pg
+                # connection. ``with self._pool.connection()`` will
+                # commit + return the connection here; we re-open
+                # one for the write below.
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "embedding_writer: prep failed for %d jobs; dropping batch",
+                len(jobs),
+            )
+            self.metrics_batch_failures += 1
+            return 0
+
+        try:
+            vectors = self._embedder.embed(texts)
+        except EmbedderError as exc:
+            logger.warning(
+                "embedding_writer: embedder failed: %r; dropping %d rows",
+                exc,
+                len(resolved),
+            )
+            self.metrics_batch_failures += 1
+            return 0
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "embedding_writer: embedder crashed; dropping %d rows",
+                len(resolved),
+            )
+            self.metrics_batch_failures += 1
+            return 0
+
+        if len(vectors) != len(resolved):
+            logger.warning(
+                "embedding_writer: embedder returned %d vectors for %d "
+                "jobs; dropping batch",
+                len(vectors),
+                len(resolved),
+            )
+            self.metrics_batch_failures += 1
+            return 0
+
+        model_label = self._embedder.info.model
+        write_rows = [
+            (j.source_table, j.source_id, vec, model_label)
+            for j, vec in zip(resolved, vectors)
+        ]
+        try:
+            with self._pool.connection() as conn:
+                _ensure_vector(conn)
+                _write_embeddings(conn, write_rows)
+                conn.commit()
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "embedding_writer: write failed for %d rows; dropping",
+                len(write_rows),
+            )
+            self.metrics_batch_failures += 1
+            return 0
+
+        self.metrics_rows_embedded += len(write_rows)
+        return len(write_rows)
+
+
+# --------------------------------------------------------------------- #
+# Module-level singleton — installed by ``pm cockpit`` startup so
+# write-hook callers don't have to thread a writer through every site.
+# Slice D ships the wiring; Slice H is the place to flip the write
+# hooks on. The singleton is lazily created so tests can wholly skip
+# the writer by not calling get_embedding_writer().
+# --------------------------------------------------------------------- #
+
+
+_WRITER_LOCK = threading.Lock()
+_WRITER: EmbeddingWriter | None = None
+
+
+def get_embedding_writer() -> EmbeddingWriter | None:
+    """Return the process-wide writer if one has been installed."""
+    return _WRITER
+
+
+def install_embedding_writer(writer: EmbeddingWriter) -> None:
+    """Install ``writer`` as the process singleton, replacing any prior."""
+    global _WRITER
+    with _WRITER_LOCK:
+        previous = _WRITER
+        _WRITER = writer
+    if previous is not None:
+        try:
+            previous.stop()
+        except Exception:  # noqa: BLE001 — never raise on shutdown
+            logger.warning("embedding_writer: previous stop failed", exc_info=True)
+
+
+def shutdown_embedding_writer() -> None:
+    """Stop and clear the singleton. Idempotent."""
+    global _WRITER
+    with _WRITER_LOCK:
+        writer = _WRITER
+        _WRITER = None
+    if writer is not None:
+        try:
+            writer.stop()
+        except Exception:  # noqa: BLE001
+            logger.warning("embedding_writer: stop failed", exc_info=True)
+
+
+def enqueue_embedding(source_table: str, source_id: str | int) -> None:
+    """Convenience: enqueue against the singleton if installed.
+
+    Safe to call when no writer is installed (sqlite-backed installs
+    or test runs that don't exercise the pg path). The whole call is
+    a no-op in that case.
+    """
+    writer = _WRITER
+    if writer is None:
+        return
+    try:
+        writer.enqueue(source_table, source_id)
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "embedding_writer: enqueue failed for %s/%s",
+            source_table,
+            source_id,
+        )
+
+
+__all__ = [
+    "DEFAULT_EMBED_BATCH",
+    "DEFAULT_POLL_INTERVAL",
+    "EmbedJob",
+    "EmbeddingWriter",
+    "KNOWN_SOURCE_TABLES",
+    "enqueue_embedding",
+    "get_embedding_writer",
+    "install_embedding_writer",
+    "shutdown_embedding_writer",
+]

--- a/src/pollypm/storage/memory_recall.py
+++ b/src/pollypm/storage/memory_recall.py
@@ -1,0 +1,463 @@
+"""Hybrid pgvector + FTS memory recall (issue #1737, Slice D).
+
+The public surface is :func:`recall` — embed the query once, then run a
+single pg query that joins ``embeddings`` against the originating
+source table and blends four components into a final score:
+
+* **semantic** — cosine similarity from pgvector (``1 - embedding <=> q``)
+* **fts** — ``ts_rank_cd`` against the generated ``tsvector`` columns
+* **importance** — only meaningful for ``memory_entries``;
+  defaults to ``0.6`` for tables without an importance column
+* **recency** — exponential decay over ``created_at`` age
+
+Weights come from ``[storage.embedding] score_weights``. The query
+normalises them to sum to 1 before applying — operators can leave any
+single knob alone without throwing the whole blend off.
+
+Out-of-scope for Slice D
+------------------------
+
+* The cockpit recall pane (future slice; CLI is the only surface today).
+* Per-table scope filters (``project_key``, ``recipient``, ...). The
+  CLI exposes ``--source`` for picking which tables to search; per-row
+  filtering is a Slice E-or-later refinement once an operator actually
+  asks for it.
+* Cross-encoder reranking. Hybrid blend is enough for the use cases on
+  the recall-pane wishlist; a reranker stage can be appended later.
+
+The recall function is intentionally pure: no module-level state, no
+threads. It opens a read-only pg connection from the pool, runs one
+query, returns. Callers (CLI, future cockpit pane, tests) treat it as
+a function.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from pollypm.storage.embedder import Embedder, EmbedderError, resolve_embedder
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+    from pollypm.models import EmbeddingScoreWeights, PollyPMConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+# Tables we know how to recall from. Each has its own per-table query
+# fragment (different text columns, different tsvector column,
+# different importance handling). ``order`` is the UNION ALL emit
+# order — recall results from earlier tables tie-break ahead of later
+# ones at equal score, which matches operator intuition (memory entries
+# beat raw messages beat work-context notes when the scores match).
+SUPPORTED_SOURCES = ("memory_entries", "messages", "work_context_entries")
+
+
+@dataclass(slots=True)
+class RecallHit:
+    """One row from the hybrid recall query.
+
+    ``source_table`` — which table the hit came from.
+    ``source_id`` — the row's id, stringified to match ``embeddings.source_id``.
+    ``score`` — final blended score in ``[0, 1]`` (higher = better).
+    ``text_preview`` — short snippet of the matched text (first ~240 chars).
+    ``metadata`` — dict of per-table extras (title, scope, type, ...).
+    Includes the score breakdown under the ``"components"`` key for
+    debugging.
+    """
+
+    source_table: str
+    source_id: str
+    score: float
+    text_preview: str
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+# --------------------------------------------------------------------- #
+# Per-table query fragments.
+# --------------------------------------------------------------------- #
+# Each fragment SELECTs a uniform projection so the UNION ALL parent
+# query can blend results without a CASE-per-table mess. The columns,
+# in order:
+#
+#   source_table TEXT
+#   source_id TEXT
+#   raw_text TEXT             -- text we'd want to preview
+#   semantic_score FLOAT       -- 1 - (embedding <=> $q_vec); 0 if no embed
+#   fts_score FLOAT            -- ts_rank_cd; 0 if no fts hit
+#   importance_score FLOAT     -- normalised [0,1]; 0.6 default
+#   recency_score FLOAT        -- exp(-age_days/90)
+#   metadata_json TEXT         -- per-table extras as jsonb_build_object
+#
+# The semantic score is computed even for rows without an embedding
+# (joins as LEFT JOIN so the row still surfaces under FTS-only matches).
+
+_FTS_RANK_SQL = "coalesce(ts_rank_cd({tsv}, plainto_tsquery('english', %(query_text)s)), 0)"
+
+_RECENCY_SQL = (
+    "exp(-extract(epoch from (now() - {ts_col})) / (90.0 * 86400.0))"
+)
+
+_SEMANTIC_SQL = (
+    "CASE WHEN e.embedding IS NULL THEN 0.0 "
+    "ELSE 1.0 - (e.embedding <=> %(query_vec)s::vector) END"
+)
+
+
+def _per_table_select(source_table: str) -> str:
+    """Return the SELECT fragment for ``source_table``.
+
+    Each fragment must produce a row shape identical to the UNION
+    parent. ``source_id`` is forced to ``text`` everywhere so the
+    pg vector index join key matches across tables.
+    """
+    if source_table == "memory_entries":
+        return f"""
+        SELECT
+            'memory_entries'::text AS source_table,
+            m.id::text AS source_id,
+            (coalesce(m.title, '') || E'\\n' || coalesce(m.body, '')) AS raw_text,
+            {_SEMANTIC_SQL} AS semantic_score,
+            {_FTS_RANK_SQL.format(tsv='m.title_body_tsv')} AS fts_score,
+            (m.importance::float / 5.0) AS importance_score,
+            {_RECENCY_SQL.format(ts_col='m.created_at')} AS recency_score,
+            jsonb_build_object(
+                'title', m.title,
+                'scope', m.scope,
+                'scope_tier', m.scope_tier,
+                'type', m.type,
+                'importance', m.importance,
+                'tags', m.tags,
+                'created_at', m.created_at
+            ) AS metadata_json
+        FROM memory_entries m
+        LEFT JOIN embeddings e
+            ON e.source_table = 'memory_entries'
+           AND e.source_id = m.id::text
+        WHERE (m.superseded_by IS NULL)
+        """
+    if source_table == "messages":
+        return f"""
+        SELECT
+            'messages'::text AS source_table,
+            mm.id::text AS source_id,
+            (coalesce(mm.subject, '') || E'\\n' || coalesce(mm.body, '')) AS raw_text,
+            {_SEMANTIC_SQL} AS semantic_score,
+            {_FTS_RANK_SQL.format(tsv='mm.subject_body_tsv')} AS fts_score,
+            0.6::float AS importance_score,
+            {_RECENCY_SQL.format(ts_col='mm.created_at')} AS recency_score,
+            jsonb_build_object(
+                'subject', mm.subject,
+                'scope', mm.scope,
+                'type', mm.type,
+                'tier', mm.tier,
+                'recipient', mm.recipient,
+                'sender', mm.sender,
+                'state', mm.state,
+                'created_at', mm.created_at
+            ) AS metadata_json
+        FROM messages mm
+        LEFT JOIN embeddings e
+            ON e.source_table = 'messages'
+           AND e.source_id = mm.id::text
+        """
+    if source_table == "work_context_entries":
+        return f"""
+        SELECT
+            'work_context_entries'::text AS source_table,
+            w.id::text AS source_id,
+            coalesce(w.text, '') AS raw_text,
+            {_SEMANTIC_SQL} AS semantic_score,
+            (CASE
+                WHEN plainto_tsquery('english', %(query_text)s) = ''::tsquery
+                    THEN 0.0
+                ELSE coalesce(
+                    ts_rank_cd(
+                        to_tsvector('english', coalesce(w.text, '')),
+                        plainto_tsquery('english', %(query_text)s)
+                    ),
+                    0
+                )
+            END) AS fts_score,
+            0.6::float AS importance_score,
+            {_RECENCY_SQL.format(ts_col='w.created_at')} AS recency_score,
+            jsonb_build_object(
+                'task_project', w.task_project,
+                'task_number', w.task_number,
+                'actor', w.actor,
+                'entry_type', w.entry_type,
+                'created_at', w.created_at
+            ) AS metadata_json
+        FROM work_context_entries w
+        LEFT JOIN embeddings e
+            ON e.source_table = 'work_context_entries'
+           AND e.source_id = w.id::text
+        """
+    raise ValueError(f"recall: unsupported source_table {source_table!r}")
+
+
+# --------------------------------------------------------------------- #
+# Score normalisation.
+# --------------------------------------------------------------------- #
+
+
+def _normalise_weights(
+    weights: "EmbeddingScoreWeights",
+) -> tuple[float, float, float, float]:
+    """Return (semantic, fts, importance, recency) normalised to sum 1.
+
+    Negative weights are clamped at 0. An all-zero blend falls back to
+    the documented default so the recall query never multiplies by 0
+    across the board.
+    """
+    s = max(0.0, weights.semantic)
+    f = max(0.0, weights.fts)
+    i = max(0.0, weights.importance)
+    r = max(0.0, weights.recency)
+    total = s + f + i + r
+    if total <= 0:
+        return (0.5, 0.25, 0.15, 0.10)
+    return (s / total, f / total, i / total, r / total)
+
+
+# --------------------------------------------------------------------- #
+# Public API.
+# --------------------------------------------------------------------- #
+
+
+def recall(
+    query: str,
+    *,
+    limit: int = 10,
+    source_tables: list[str] | None = None,
+    config: "PollyPMConfig | None" = None,
+    pool: "ConnectionPool | None" = None,
+    embedder: Embedder | None = None,
+) -> list[RecallHit]:
+    """Hybrid pgvector + FTS recall.
+
+    Parameters
+    ----------
+    query:
+        Free-text query. Empty/whitespace-only queries are allowed —
+        results then rank purely on importance + recency, useful for
+        "show me anything recent" smoke tests.
+    limit:
+        Max hits to return. Capped at 200 to keep the round-trip
+        bounded — the recall API isn't a paginated list endpoint.
+    source_tables:
+        Restrict to a subset of ``("memory_entries", "messages",
+        "work_context_entries")``. ``None`` (default) searches all
+        three.
+    config:
+        Loaded :class:`PollyPMConfig`. Required for the embedder
+        unless ``embedder`` is passed explicitly.
+    pool:
+        Read-only :class:`psycopg_pool.ConnectionPool`. Defaults to
+        :func:`pollypm.storage.pg_pool.get_ro_pool`.
+    embedder:
+        Injection seam for tests / backfill. Defaults to the one
+        resolved from ``config.storage.embedding``.
+    """
+    if limit <= 0:
+        raise ValueError("recall: limit must be >= 1")
+    limit = min(limit, 200)
+
+    tables = list(source_tables or SUPPORTED_SOURCES)
+    unknown = set(tables) - set(SUPPORTED_SOURCES)
+    if unknown:
+        raise ValueError(
+            f"recall: unsupported source_tables {sorted(unknown)!r}; "
+            f"known: {SUPPORTED_SOURCES!r}"
+        )
+
+    if pool is None:
+        from pollypm.storage import pg_pool
+
+        pool = pg_pool.get_ro_pool(config)
+
+    # Resolve weights from config (or fall back to dataclass defaults).
+    if config is not None:
+        weights = config.storage.embedding.score_weights
+    else:
+        from pollypm.models import EmbeddingScoreWeights
+
+        weights = EmbeddingScoreWeights()
+    w_sem, w_fts, w_imp, w_rec = _normalise_weights(weights)
+
+    # Embed the query. If the embedder is missing or fails, fall back
+    # to a zero vector — the recall still works against the FTS leg,
+    # just with no semantic contribution. We log so an operator can
+    # see why their `pm memory recall` query went keyword-only.
+    query_vec = _resolve_query_vector(query, config, embedder)
+
+    # Build the UNION ALL across selected source tables.
+    union_parts = [_per_table_select(t) for t in tables]
+    union_sql = "\nUNION ALL\n".join(union_parts)
+
+    # Wrap the union in an outer SELECT that applies the weight blend
+    # and orders + limits. The CASE on plainto_tsquery handles the
+    # empty-query case (no FTS contribution) cleanly.
+    final_sql = f"""
+    WITH hits AS (
+        {union_sql}
+    )
+    SELECT
+        source_table,
+        source_id,
+        raw_text,
+        ({w_sem} * semantic_score
+         + {w_fts} * fts_score
+         + {w_imp} * importance_score
+         + {w_rec} * recency_score) AS score,
+        semantic_score,
+        fts_score,
+        importance_score,
+        recency_score,
+        metadata_json
+    FROM hits
+    ORDER BY score DESC, source_table, source_id DESC
+    LIMIT %(limit)s
+    """
+
+    return _run_recall_query(pool, final_sql, query, query_vec, limit)
+
+
+def _resolve_query_vector(
+    query: str,
+    config: "PollyPMConfig | None",
+    embedder: Embedder | None,
+) -> list[float] | None:
+    """Embed ``query`` once. Returns ``None`` on failure (FTS-only mode).
+
+    The zero-vector fallback inside the SQL (the ``CASE WHEN
+    e.embedding IS NULL THEN 0.0`` clause) means a ``None`` here just
+    drops the semantic contribution to zero — recall still works on
+    the FTS / importance / recency legs.
+    """
+    if embedder is None and config is not None:
+        try:
+            embedder = resolve_embedder(
+                config.storage.embedding.model,
+                config.storage.embedding.api_key_env,
+            )
+        except EmbedderError:
+            logger.exception(
+                "recall: embedder resolution failed; "
+                "falling back to FTS-only"
+            )
+            return None
+
+    if embedder is None:
+        return None
+    if not query.strip():
+        # Empty query — no need to call the embedder. The CASE in the
+        # SQL will see a NULL query_vec and skip the cosine compare.
+        return None
+    try:
+        vectors = embedder.embed([query])
+    except EmbedderError:
+        logger.exception(
+            "recall: embed failed; falling back to FTS-only"
+        )
+        return None
+    if not vectors:
+        return None
+    return vectors[0]
+
+
+def _run_recall_query(
+    pool: "ConnectionPool",
+    sql: str,
+    query_text: str,
+    query_vec: list[float] | None,
+    limit: int,
+) -> list[RecallHit]:
+    """Execute the recall query and pack results into :class:`RecallHit`.
+
+    The ``query_vec`` ``None`` case substitutes a zero vector — the
+    cosine compare against zero yields a constant similarity for
+    every row, so the semantic term contributes equally and the
+    blended score collapses cleanly onto the FTS+importance+recency
+    components.
+    """
+    # When the embedder failed or the query was empty, hand the SQL
+    # a zero vector. We don't bother to skip the join because pgvector
+    # cosine is cheap relative to the FTS path.
+    if query_vec is None:
+        effective_vec: list[float] = [0.0] * 1536
+    else:
+        effective_vec = query_vec
+
+    # pgvector wants a literal of the form '[0.1, 0.2, ...]' for the
+    # ``::vector`` cast in the SQL. The psycopg adapter
+    # (``register_vector``) accepts ``list[float]`` natively, but the
+    # recall path can also be called without the adapter (sqlite
+    # installs + unit tests). Format manually so we don't add a
+    # mandatory import here.
+    vec_literal = "[" + ",".join(repr(float(v)) for v in effective_vec) + "]"
+
+    params = {
+        "query_text": query_text,
+        "query_vec": vec_literal,
+        "limit": limit,
+    }
+
+    with pool.connection() as conn:
+        # Make this query read-only at the transaction level — the
+        # RO pool already sets the session-level flag but defensive
+        # belts + suspenders.
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+
+    return [_row_to_hit(row) for row in rows]
+
+
+def _row_to_hit(row) -> RecallHit:
+    """Pack a recall row into :class:`RecallHit`.
+
+    Row shape: ``(source_table, source_id, raw_text, score,
+    semantic, fts, importance, recency, metadata_json)``.
+    """
+    (
+        source_table,
+        source_id,
+        raw_text,
+        score,
+        semantic,
+        fts,
+        importance,
+        recency,
+        metadata_json,
+    ) = row
+    text_preview = (raw_text or "").strip().replace("\n", " ")[:240]
+
+    meta: dict[str, object] = {}
+    if isinstance(metadata_json, dict):
+        meta.update(metadata_json)
+    meta["components"] = {
+        "semantic": float(semantic or 0.0),
+        "fts": float(fts or 0.0),
+        "importance": float(importance or 0.0),
+        "recency": float(recency or 0.0),
+    }
+
+    return RecallHit(
+        source_table=str(source_table),
+        source_id=str(source_id),
+        score=float(score or 0.0),
+        text_preview=text_preview,
+        metadata=meta,
+    )
+
+
+__all__ = [
+    "RecallHit",
+    "SUPPORTED_SOURCES",
+    "recall",
+]

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,0 +1,313 @@
+"""Unit tests for :mod:`pollypm.storage.embedder` (issue #1737, Slice D).
+
+The OpenAI implementation is exercised against a mock ``http_post``
+callable so no real API key or network is needed. The registry surface
+is tested via :func:`register_embedder` round-trips.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pollypm.storage.embedder import (
+    EmbedderError,
+    EmbedderInfo,
+    OpenAIEmbedder,
+    register_embedder,
+    resolve_embedder,
+    unregister_embedder,
+)
+
+
+# --------------------------------------------------------------------- #
+# Helpers — a fake http_post that records calls and returns canned
+# bodies. Each instance owns its own state so tests don't share.
+# --------------------------------------------------------------------- #
+
+
+class _FakeHTTP:
+    def __init__(self, *, status: int = 200, body: dict | None = None) -> None:
+        self.status = status
+        self.body = body or {"data": []}
+        self.calls: list[tuple[str, bytes, dict[str, str], float]] = []
+        # Allow per-call overrides for retry-flow tests.
+        self.queued: list[tuple[int, bytes]] = []
+
+    def __call__(self, url, body, headers, timeout):
+        self.calls.append((url, body, headers, timeout))
+        if self.queued:
+            return self.queued.pop(0)
+        return self.status, json.dumps(self.body).encode("utf-8")
+
+
+def _ok_body(vectors: list[list[float]]) -> dict:
+    return {
+        "data": [
+            {"index": i, "embedding": v, "object": "embedding"}
+            for i, v in enumerate(vectors)
+        ],
+        "model": "text-embedding-3-small",
+        "object": "list",
+    }
+
+
+# --------------------------------------------------------------------- #
+# Basic OpenAIEmbedder behaviour.
+# --------------------------------------------------------------------- #
+
+
+def test_info_exposes_known_dim():
+    e = OpenAIEmbedder(model="text-embedding-3-small", api_key="sk-test")
+    assert e.info == EmbedderInfo(model="openai:text-embedding-3-small", dim=1536)
+
+
+def test_info_exposes_large_dim():
+    e = OpenAIEmbedder(model="text-embedding-3-large", api_key="sk-test")
+    assert e.info.dim == 3072
+    assert e.info.model == "openai:text-embedding-3-large"
+
+
+def test_embed_happy_path_round_trip():
+    http = _FakeHTTP(body=_ok_body([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]))
+    embedder = OpenAIEmbedder(
+        api_key="sk-test", http_post=http,
+    )
+    out = embedder.embed(["alpha", "beta"])
+    assert out == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+    # One request, with the right body.
+    assert len(http.calls) == 1
+    sent_body = json.loads(http.calls[0][1])
+    assert sent_body["input"] == ["alpha", "beta"]
+    assert sent_body["model"] == "text-embedding-3-small"
+    assert http.calls[0][2]["Authorization"] == "Bearer sk-test"
+
+
+def test_embed_empty_list_returns_empty():
+    http = _FakeHTTP()
+    embedder = OpenAIEmbedder(api_key="sk-test", http_post=http)
+    assert embedder.embed([]) == []
+    assert http.calls == []
+
+
+def test_embed_substitutes_empty_strings():
+    """OpenAI rejects empty input; the embedder replaces with ' '."""
+    http = _FakeHTTP(body=_ok_body([[0.1, 0.2]]))
+    embedder = OpenAIEmbedder(api_key="sk-test", http_post=http)
+    embedder.embed([""])
+    sent = json.loads(http.calls[0][1])
+    assert sent["input"] == [" "]
+
+
+def test_embed_out_of_order_response_is_sorted():
+    """OpenAI reserves the right to shuffle; the parser must re-order."""
+    payload = {
+        "data": [
+            {"index": 1, "embedding": [0.2, 0.2], "object": "embedding"},
+            {"index": 0, "embedding": [0.1, 0.1], "object": "embedding"},
+        ],
+        "model": "x",
+        "object": "list",
+    }
+    http = _FakeHTTP(body=payload)
+    embedder = OpenAIEmbedder(api_key="sk-test", http_post=http)
+    assert embedder.embed(["a", "b"]) == [[0.1, 0.1], [0.2, 0.2]]
+
+
+def test_embed_batch_too_large_raises():
+    embedder = OpenAIEmbedder(api_key="sk-test", http_post=_FakeHTTP())
+    too_many = ["x"] * (embedder.max_batch_size + 1)
+    with pytest.raises(EmbedderError, match="exceeds cap"):
+        embedder.embed(too_many)
+
+
+# --------------------------------------------------------------------- #
+# Auth / API key resolution.
+# --------------------------------------------------------------------- #
+
+
+def test_resolve_key_from_constructor_arg():
+    http = _FakeHTTP(body=_ok_body([[0.0]]))
+    e = OpenAIEmbedder(api_key="sk-from-ctor", http_post=http)
+    e.embed(["x"])
+    assert http.calls[0][2]["Authorization"] == "Bearer sk-from-ctor"
+
+
+def test_resolve_key_from_env(monkeypatch):
+    monkeypatch.setenv("CUSTOM_KEY_ENV", "sk-from-env")
+    http = _FakeHTTP(body=_ok_body([[0.0]]))
+    e = OpenAIEmbedder(
+        api_key_env_name="CUSTOM_KEY_ENV", http_post=http,
+    )
+    e.embed(["x"])
+    assert http.calls[0][2]["Authorization"] == "Bearer sk-from-env"
+
+
+def test_resolve_key_missing_raises(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    e = OpenAIEmbedder(http_post=_FakeHTTP())
+    with pytest.raises(EmbedderError, match="no API key"):
+        e.embed(["x"])
+
+
+# --------------------------------------------------------------------- #
+# Retry / backoff.
+# --------------------------------------------------------------------- #
+
+
+def test_retries_on_429_then_succeeds():
+    http = _FakeHTTP()
+    http.queued = [
+        (429, b'{"error": "rate-limited"}'),
+        (429, b'{"error": "rate-limited"}'),
+        (200, json.dumps(_ok_body([[0.5]])).encode("utf-8")),
+    ]
+    sleeps: list[float] = []
+    e = OpenAIEmbedder(
+        api_key="sk-test",
+        http_post=http,
+        max_retries=5,
+        backoff_initial=0.01,
+        backoff_max=0.1,
+        sleep=lambda s: sleeps.append(s),
+    )
+    result = e.embed(["x"])
+    assert result == [[0.5]]
+    assert len(http.calls) == 3
+    # First two failures slept; third call succeeded.
+    assert len(sleeps) == 2
+    assert sleeps[0] <= sleeps[1]
+
+
+def test_retries_exhausted_on_persistent_500():
+    http = _FakeHTTP()
+    http.queued = [(500, b"err")] * 6
+    sleeps: list[float] = []
+    e = OpenAIEmbedder(
+        api_key="sk-test",
+        http_post=http,
+        max_retries=3,
+        backoff_initial=0.01,
+        backoff_max=0.1,
+        sleep=lambda s: sleeps.append(s),
+    )
+    with pytest.raises(EmbedderError, match="HTTP 500"):
+        e.embed(["x"])
+    # 1 initial + 3 retries = 4 attempts total.
+    assert len(http.calls) == 4
+
+
+def test_non_retryable_4xx_raises_immediately():
+    http = _FakeHTTP()
+    http.queued = [(401, b'{"error": "unauthorized"}')]
+    e = OpenAIEmbedder(
+        api_key="sk-test",
+        http_post=http,
+        max_retries=5,
+        backoff_initial=0.01,
+        sleep=lambda _s: None,
+    )
+    with pytest.raises(EmbedderError, match="HTTP 401"):
+        e.embed(["x"])
+    # One attempt — 401 is non-retryable.
+    assert len(http.calls) == 1
+
+
+def test_network_error_retries():
+    import urllib.error
+
+    sleeps: list[float] = []
+    attempts = {"n": 0}
+    good_body = json.dumps(_ok_body([[0.7]])).encode("utf-8")
+
+    def flaky_post(url, body, headers, timeout):
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise urllib.error.URLError("connection refused")
+        return 200, good_body
+
+    e = OpenAIEmbedder(
+        api_key="sk-test",
+        http_post=flaky_post,
+        max_retries=5,
+        backoff_initial=0.01,
+        sleep=lambda s: sleeps.append(s),
+    )
+    assert e.embed(["x"]) == [[0.7]]
+    assert attempts["n"] == 3
+    assert len(sleeps) == 2
+
+
+# --------------------------------------------------------------------- #
+# Response shape validation.
+# --------------------------------------------------------------------- #
+
+
+def test_malformed_response_raises():
+    http = _FakeHTTP(body={"oops": True})
+    e = OpenAIEmbedder(api_key="sk-test", http_post=http)
+    with pytest.raises(EmbedderError, match="missing 'data'"):
+        e.embed(["x"])
+
+
+def test_wrong_count_response_raises():
+    http = _FakeHTTP(body=_ok_body([[0.1]]))  # 1 vec for 2 inputs
+    e = OpenAIEmbedder(api_key="sk-test", http_post=http)
+    with pytest.raises(EmbedderError, match="expected 2"):
+        e.embed(["a", "b"])
+
+
+def test_invalid_json_response_raises():
+    http = _FakeHTTP()
+    http.queued = [(200, b"not json")]
+    e = OpenAIEmbedder(api_key="sk-test", http_post=http)
+    with pytest.raises(EmbedderError, match="not JSON"):
+        e.embed(["x"])
+
+
+# --------------------------------------------------------------------- #
+# Registry surface.
+# --------------------------------------------------------------------- #
+
+
+def test_resolve_embedder_bare_model_uses_openai_default():
+    # No colon → openai provider. The default factory will try to
+    # build an OpenAIEmbedder; we don't call .embed() so no key
+    # check fires.
+    embedder = resolve_embedder("text-embedding-3-small", "OPENAI_API_KEY")
+    assert isinstance(embedder, OpenAIEmbedder)
+    assert embedder.model == "text-embedding-3-small"
+
+
+def test_resolve_embedder_dispatches_by_provider():
+    seen: list[tuple[str, str]] = []
+
+    class Stub:
+        @property
+        def info(self):
+            return EmbedderInfo(model="stub:x", dim=4)
+
+        @property
+        def max_batch_size(self):
+            return 10
+
+        def embed(self, texts):
+            return [[0.0] * 4 for _ in texts]
+
+    def factory(model: str, api_key_env: str):
+        seen.append((model, api_key_env))
+        return Stub()
+
+    try:
+        register_embedder("stubprov", factory)
+        e = resolve_embedder("stubprov:my-model", "MY_KEY")
+        assert isinstance(e, Stub)
+        assert seen == [("my-model", "MY_KEY")]
+    finally:
+        unregister_embedder("stubprov")
+
+
+def test_resolve_embedder_unknown_provider_raises():
+    with pytest.raises(EmbedderError, match="no factory"):
+        resolve_embedder("nope:foo", "X")

--- a/tests/test_memory_recall_cli.py
+++ b/tests/test_memory_recall_cli.py
@@ -1,0 +1,370 @@
+"""CLI smoke tests for the Slice D pg-recall + backfill commands.
+
+Goes through the Typer CliRunner with ``pollypm.storage.memory_recall.recall``
+patched to a stub. Real recall against pg is covered in
+``tests/test_pg_memory_recall.py``; this module only verifies
+argument parsing, JSON output shape, and error handling.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm.memory_cli import memory_app
+
+
+runner = CliRunner()
+
+
+# --------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def config_path(tmp_path: Path) -> Path:
+    """Minimal pollypm.toml that loads cleanly."""
+    cfg = tmp_path / "pollypm.toml"
+    cfg.write_text(
+        """
+[project]
+name = "test"
+provider = "claude"
+root_dir = "."
+kind = "folder"
+
+[pollypm]
+home = ".pollypm"
+
+[accounts.default]
+provider = "claude"
+home = ".claude"
+""".strip()
+    )
+    # Match the resolve_config_path heuristics — cwd-or-explicit path.
+    return cfg
+
+
+# --------------------------------------------------------------------- #
+# pg-recall command
+# --------------------------------------------------------------------- #
+
+
+def test_pg_recall_invokes_recall_and_prints_table(monkeypatch, config_path):
+    from pollypm.storage.memory_recall import RecallHit
+
+    captured: dict[str, object] = {}
+
+    def fake_recall(query, *, limit, source_tables, config, **_kw):
+        captured["query"] = query
+        captured["limit"] = limit
+        captured["source_tables"] = source_tables
+        return [
+            RecallHit(
+                source_table="memory_entries",
+                source_id="42",
+                score=0.875,
+                text_preview="hello world",
+                metadata={
+                    "title": "thing",
+                    "components": {
+                        "semantic": 0.9,
+                        "fts": 0.5,
+                        "importance": 0.6,
+                        "recency": 0.95,
+                    },
+                },
+            ),
+        ]
+
+    monkeypatch.setattr(
+        "pollypm.memory_recall_cli.run_recall", fake_recall,
+    )
+
+    result = runner.invoke(
+        memory_app,
+        [
+            "pg-recall",
+            "test query",
+            "--limit",
+            "5",
+            "--source",
+            "memory_entries",
+            "--config",
+            str(config_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["query"] == "test query"
+    assert captured["limit"] == 5
+    assert captured["source_tables"] == ["memory_entries"]
+    # Table layout shows id + preview.
+    assert "memory_entries" in result.output
+    assert "42" in result.output
+    assert "hello world" in result.output
+
+
+def test_pg_recall_json_output(monkeypatch, config_path):
+    from pollypm.storage.memory_recall import RecallHit
+
+    def fake_recall(query, **_kw):
+        return [
+            RecallHit(
+                source_table="messages",
+                source_id="7",
+                score=0.42,
+                text_preview="subject body",
+                metadata={"subject": "subject", "components": {}},
+            ),
+        ]
+
+    monkeypatch.setattr(
+        "pollypm.memory_recall_cli.run_recall", fake_recall,
+    )
+
+    result = runner.invoke(
+        memory_app,
+        [
+            "pg-recall",
+            "anything",
+            "--json",
+            "--config",
+            str(config_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert isinstance(payload, list)
+    assert payload[0]["source_table"] == "messages"
+    assert payload[0]["source_id"] == "7"
+    assert payload[0]["score"] == pytest.approx(0.42, rel=1e-3)
+
+
+def test_pg_recall_alias_work_context(monkeypatch, config_path):
+    captured: dict[str, object] = {}
+
+    def fake_recall(query, *, source_tables, **_kw):
+        captured["source_tables"] = source_tables
+        return []
+
+    monkeypatch.setattr(
+        "pollypm.memory_recall_cli.run_recall", fake_recall,
+    )
+
+    result = runner.invoke(
+        memory_app,
+        [
+            "pg-recall",
+            "x",
+            "--source",
+            "work_context",
+            "--config",
+            str(config_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # The alias must expand to the canonical table name.
+    assert captured["source_tables"] == ["work_context_entries"]
+
+
+def test_pg_recall_bad_source_rejects(monkeypatch, config_path):
+    result = runner.invoke(
+        memory_app,
+        [
+            "pg-recall",
+            "x",
+            "--source",
+            "nope",
+            "--config",
+            str(config_path),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "unknown" in result.output.lower() or "invalid" in result.output.lower()
+
+
+def test_pg_recall_empty_results_says_no_results(monkeypatch, config_path):
+    monkeypatch.setattr(
+        "pollypm.memory_recall_cli.run_recall", lambda *a, **kw: [],
+    )
+    result = runner.invoke(
+        memory_app,
+        [
+            "pg-recall",
+            "anything",
+            "--config",
+            str(config_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "No results" in result.output
+
+
+def test_pg_recall_recall_failure_propagates(monkeypatch, config_path):
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated pg outage")
+
+    monkeypatch.setattr("pollypm.memory_recall_cli.run_recall", boom)
+    result = runner.invoke(
+        memory_app,
+        [
+            "pg-recall",
+            "x",
+            "--config",
+            str(config_path),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "simulated pg outage" in result.output
+
+
+def test_pg_recall_limit_zero_rejected(monkeypatch, config_path):
+    monkeypatch.setattr(
+        "pollypm.memory_recall_cli.run_recall", lambda *a, **kw: [],
+    )
+    result = runner.invoke(
+        memory_app,
+        [
+            "pg-recall",
+            "x",
+            "--limit",
+            "0",
+            "--config",
+            str(config_path),
+        ],
+    )
+    assert result.exit_code != 0
+
+
+# --------------------------------------------------------------------- #
+# backfill-embeddings command
+# --------------------------------------------------------------------- #
+
+
+def test_backfill_embeddings_dispatches_per_source(monkeypatch, config_path):
+    """The backfill CLI must walk each requested source table."""
+    calls: list[tuple[str, int]] = []
+
+    class _StubWriter:
+        metrics_batches_processed = 0
+        metrics_rows_embedded = 0
+        metrics_rows_skipped = 0
+        metrics_batch_failures = 0
+
+        def __init__(self, *a, **kw):
+            pass
+
+        def enqueue(self, *_a, **_kw):
+            pass
+
+        def drain_once(self, *, max_batches=1):
+            return 0
+
+    def stub_enqueue(_pool, table, _writer, limit):
+        calls.append((table, limit))
+        return 3, 1  # scanned=3, queued=1
+
+    class _Pool:
+        def connection(self):  # pragma: no cover
+            raise AssertionError("pool not expected to be opened")
+
+    monkeypatch.setattr(
+        "pollypm.memory_recall_cli._enqueue_missing", stub_enqueue,
+    )
+    monkeypatch.setattr(
+        "pollypm.storage.embedding_writer.EmbeddingWriter", _StubWriter,
+    )
+    monkeypatch.setattr(
+        "pollypm.storage.pg_pool.get_rw_pool", lambda _cfg: _Pool(),
+    )
+    monkeypatch.setattr(
+        "pollypm.storage.embedder.resolve_embedder",
+        lambda _m, _k: object(),
+    )
+
+    result = runner.invoke(
+        memory_app,
+        [
+            "backfill-embeddings",
+            "--source",
+            "memory_entries,messages",
+            "--config",
+            str(config_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    tables = {c[0] for c in calls}
+    assert tables == {"memory_entries", "messages"}
+
+
+def test_backfill_embeddings_json_summary(monkeypatch, config_path):
+    class _StubWriter:
+        metrics_batches_processed = 0
+        metrics_rows_embedded = 0
+        metrics_rows_skipped = 0
+        metrics_batch_failures = 0
+
+        def __init__(self, *a, **kw):
+            pass
+
+        def enqueue(self, *_a, **_kw):
+            pass
+
+        def drain_once(self, *, max_batches=1):
+            return 1
+
+    class _Pool:
+        def connection(self):  # pragma: no cover
+            raise AssertionError("pool not expected to be opened")
+
+    monkeypatch.setattr(
+        "pollypm.memory_recall_cli._enqueue_missing",
+        lambda *_a, **_kw: (5, 2),
+    )
+    monkeypatch.setattr(
+        "pollypm.storage.embedding_writer.EmbeddingWriter", _StubWriter,
+    )
+    monkeypatch.setattr(
+        "pollypm.storage.pg_pool.get_rw_pool", lambda _cfg: _Pool(),
+    )
+    monkeypatch.setattr(
+        "pollypm.storage.embedder.resolve_embedder",
+        lambda _m, _k: object(),
+    )
+
+    result = runner.invoke(
+        memory_app,
+        [
+            "backfill-embeddings",
+            "--source",
+            "all",
+            "--json",
+            "--config",
+            str(config_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert set(payload.keys()) == {
+        "memory_entries", "messages", "work_context_entries",
+    }
+    assert payload["memory_entries"]["scanned"] == 5
+    assert payload["memory_entries"]["queued"] == 2
+
+
+def test_backfill_bad_source_rejected(monkeypatch, config_path):
+    result = runner.invoke(
+        memory_app,
+        [
+            "backfill-embeddings",
+            "--source",
+            "not_a_table",
+            "--config",
+            str(config_path),
+        ],
+    )
+    assert result.exit_code != 0

--- a/tests/test_pg_memory_recall.py
+++ b/tests/test_pg_memory_recall.py
@@ -1,0 +1,513 @@
+"""Tests for hybrid pgvector + FTS recall (issue #1737, Slice D).
+
+Lives next to the other ``test_pg_*`` modules. Runs against the
+testcontainer pg fixture (``pg_schema_pool``); skipped automatically
+when Docker / local pg isn't available.
+
+A deterministic stub embedder is registered for the duration of each
+test so vectors are reproducible without an OpenAI key.
+
+Note: distinct from ``test_memory_recall.py`` which exercises the
+legacy ``FileMemoryBackend.recall`` (M02 / #231).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+
+# --------------------------------------------------------------------- #
+# Stub embedder — deterministic 1536-dim vectors keyed by text hash.
+# --------------------------------------------------------------------- #
+
+
+class _StubEmbedder:
+    """Reproducible embedder: SHA-256-derived 1536-dim float vectors.
+
+    Each text seeds a tiny pseudo-random generator so two embed() calls
+    on the same text produce the same vector. Vectors live in [-1, 1].
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    @property
+    def info(self):
+        from pollypm.storage.embedder import EmbedderInfo
+
+        return EmbedderInfo(model="stub:test-1536", dim=1536)
+
+    @property
+    def max_batch_size(self) -> int:
+        return 100
+
+    def embed(self, texts):
+        self.calls.append(list(texts))
+        return [self._vector_for(t) for t in texts]
+
+    @staticmethod
+    def _vector_for(text: str) -> list[float]:
+        seed = hashlib.sha256(text.encode("utf-8")).digest()
+        vec: list[float] = []
+        for i in range(1536):
+            byte = seed[i % 32] ^ ((i // 32) & 0xFF)
+            vec.append((byte / 127.5) - 1.0)
+        return vec
+
+
+@pytest.fixture()
+def stub_embedder():
+    return _StubEmbedder()
+
+
+@pytest.fixture()
+def memory_pool(pg_schema_pool):
+    """Apply the schema migration so the recall tables exist."""
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+    return pg_schema_pool
+
+
+# --------------------------------------------------------------------- #
+# Helpers.
+# --------------------------------------------------------------------- #
+
+
+def _insert_memory_entry(
+    pool,
+    *,
+    title: str,
+    body: str,
+    scope: str = "project/demo",
+    importance: int = 3,
+    tags: str = "",
+    age_seconds: int = 0,
+) -> int:
+    sql = """
+    INSERT INTO memory_entries (
+        scope, project_key, kind, title, body, tags, source,
+        file_path, summary_path, created_at, updated_at,
+        type, importance, scope_tier
+    ) VALUES (
+        %s, %s, %s, %s, %s, %s, %s, %s, %s,
+        now() - make_interval(secs => %s),
+        now() - make_interval(secs => %s),
+        %s, %s, %s
+    ) RETURNING id
+    """
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            sql,
+            (
+                scope, "demo", "knowledge", title, body, tags, "test",
+                "memory.md", "summary.md", age_seconds, age_seconds,
+                "project", importance, "project",
+            ),
+        )
+        row = cur.fetchone()
+        conn.commit()
+    return int(row[0])
+
+
+def _insert_message(
+    pool,
+    *,
+    subject: str,
+    body: str,
+    scope: str = "project/demo",
+) -> int:
+    sql = """
+    INSERT INTO messages (scope, type, recipient, sender, subject, body)
+    VALUES (%s, %s, %s, %s, %s, %s) RETURNING id
+    """
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            sql, (scope, "note", "operator", "agent", subject, body),
+        )
+        row = cur.fetchone()
+        conn.commit()
+    return int(row[0])
+
+
+def _embed_row(pool, source_table: str, source_id: int):
+    """Write a stub-embedder embedding for a row."""
+    from pollypm.storage.embedding_writer import EmbeddingWriter
+
+    embedder = _StubEmbedder()
+    writer = EmbeddingWriter(pool, embedder)
+    writer.enqueue(source_table, str(source_id))
+    writer.drain_once()
+
+
+# --------------------------------------------------------------------- #
+# Recall behaviour.
+# --------------------------------------------------------------------- #
+
+
+def test_recall_empty_when_no_rows(memory_pool, stub_embedder):
+    from pollypm.storage.memory_recall import recall
+
+    out = recall(
+        "anything",
+        limit=5,
+        pool=memory_pool,
+        embedder=stub_embedder,
+    )
+    assert out == []
+
+
+def test_recall_fts_matches_without_embedding(memory_pool, stub_embedder):
+    """An FTS hit must surface even when the row has no embedding."""
+    from pollypm.storage.memory_recall import recall
+
+    _insert_memory_entry(
+        memory_pool,
+        title="postgres migration playbook",
+        body="how to flip the storage backend safely",
+    )
+    _insert_memory_entry(
+        memory_pool,
+        title="completely different topic",
+        body="kale recipes for the brave",
+    )
+
+    hits = recall(
+        "postgres migration",
+        limit=5,
+        source_tables=["memory_entries"],
+        pool=memory_pool,
+        embedder=stub_embedder,
+    )
+    assert hits
+    assert "postgres migration" in hits[0].text_preview.lower()
+
+
+def test_recall_semantic_surfaces_when_embedding_present(
+    memory_pool, stub_embedder,
+):
+    """An embedded row scores high on identical-text semantic match.
+
+    The writer embeds ``title + "\\n" + body``; we craft the row so
+    that text equals the query — same string → same stub vector → cos
+    similarity = 1. Picks a unique nonsense phrase so FTS doesn't
+    contribute at all and the assertion targets the semantic leg.
+    """
+    from pollypm.storage.memory_recall import recall
+
+    embed_text = "unique-phrase-foo-bar-baz\n"  # body is empty
+    target_id = _insert_memory_entry(
+        memory_pool,
+        title="unique-phrase-foo-bar-baz",
+        body="",
+    )
+    _embed_row(memory_pool, "memory_entries", target_id)
+
+    # Recall with the same embedded text so vectors match exactly.
+    hits = recall(
+        embed_text,
+        limit=5,
+        source_tables=["memory_entries"],
+        pool=memory_pool,
+        embedder=stub_embedder,
+    )
+    assert hits, "expected at least one hit"
+    top = hits[0]
+    assert top.source_table == "memory_entries"
+    assert top.source_id == str(target_id)
+    components = top.metadata["components"]
+    # Same vector on both sides → cosine sim ≈ 1.
+    assert components["semantic"] > 0.99
+
+
+def test_recall_returns_metadata_and_components(memory_pool, stub_embedder):
+    from pollypm.storage.memory_recall import recall
+
+    entry_id = _insert_memory_entry(
+        memory_pool,
+        title="alpha title",
+        body="beta body content",
+        importance=5,
+        scope="user/test",
+        tags="t1,t2",
+    )
+
+    hits = recall(
+        "alpha",
+        limit=5,
+        source_tables=["memory_entries"],
+        pool=memory_pool,
+        embedder=stub_embedder,
+    )
+    assert hits
+    hit = hits[0]
+    assert hit.source_id == str(entry_id)
+    comp_keys = set(hit.metadata["components"])
+    assert comp_keys == {"semantic", "fts", "importance", "recency"}
+    # Importance 5 normalises to 1.0.
+    assert hit.metadata["components"]["importance"] == pytest.approx(1.0)
+
+
+def test_recall_source_filter_restricts_tables(memory_pool, stub_embedder):
+    from pollypm.storage.memory_recall import recall
+
+    _insert_memory_entry(
+        memory_pool, title="lookup keyword", body="memory hit",
+    )
+    _insert_message(
+        memory_pool, subject="lookup keyword", body="message hit",
+    )
+
+    only_messages = recall(
+        "lookup keyword",
+        limit=5,
+        source_tables=["messages"],
+        pool=memory_pool,
+        embedder=stub_embedder,
+    )
+    assert only_messages
+    assert all(h.source_table == "messages" for h in only_messages)
+
+    only_memory = recall(
+        "lookup keyword",
+        limit=5,
+        source_tables=["memory_entries"],
+        pool=memory_pool,
+        embedder=stub_embedder,
+    )
+    assert only_memory
+    assert all(h.source_table == "memory_entries" for h in only_memory)
+
+
+def test_recall_limit_caps_results(memory_pool, stub_embedder):
+    from pollypm.storage.memory_recall import recall
+
+    for i in range(15):
+        _insert_memory_entry(
+            memory_pool, title=f"common-token entry {i}", body="x",
+        )
+
+    hits = recall(
+        "common-token",
+        limit=3,
+        source_tables=["memory_entries"],
+        pool=memory_pool,
+        embedder=stub_embedder,
+    )
+    assert len(hits) == 3
+
+
+def test_recall_unsupported_source_raises(memory_pool, stub_embedder):
+    from pollypm.storage.memory_recall import recall
+
+    with pytest.raises(ValueError, match="unsupported"):
+        recall(
+            "x",
+            source_tables=["definitely_not_a_table"],
+            pool=memory_pool,
+            embedder=stub_embedder,
+        )
+
+
+def test_recall_zero_limit_raises(memory_pool, stub_embedder):
+    from pollypm.storage.memory_recall import recall
+
+    with pytest.raises(ValueError, match=">= 1"):
+        recall("x", limit=0, pool=memory_pool, embedder=stub_embedder)
+
+
+# --------------------------------------------------------------------- #
+# Writer + idempotency.
+# --------------------------------------------------------------------- #
+
+
+def test_writer_idempotent_skips_existing(memory_pool, stub_embedder):
+    """A second drain on the same row must not re-call the embedder."""
+    from pollypm.storage.embedding_writer import EmbeddingWriter
+
+    entry_id = _insert_memory_entry(
+        memory_pool, title="idempotency", body="check",
+    )
+
+    writer = EmbeddingWriter(memory_pool, stub_embedder)
+    writer.enqueue("memory_entries", str(entry_id))
+    first = writer.drain_once()
+    assert first == 1
+
+    writer.enqueue("memory_entries", str(entry_id))
+    second = writer.drain_once()
+    assert second == 0
+    # Only one call landed on the embedder.
+    assert len(stub_embedder.calls) == 1
+
+
+def test_writer_handles_missing_source_row(memory_pool, stub_embedder):
+    """Enqueued rows that no longer exist must drop quietly."""
+    from pollypm.storage.embedding_writer import EmbeddingWriter
+
+    writer = EmbeddingWriter(memory_pool, stub_embedder)
+    writer.enqueue("memory_entries", "99999999")
+    drained = writer.drain_once()
+    assert drained == 0
+    assert stub_embedder.calls == []
+
+
+def test_writer_catastrophic_failure_does_not_crash(memory_pool):
+    """An embedder error logs + skips; metrics record the failure."""
+    from pollypm.storage.embedder import EmbedderError
+    from pollypm.storage.embedding_writer import EmbeddingWriter
+
+    class _BoomEmbedder:
+        @property
+        def info(self):
+            from pollypm.storage.embedder import EmbedderInfo
+
+            return EmbedderInfo(model="boom:v0", dim=1536)
+
+        @property
+        def max_batch_size(self) -> int:
+            return 32
+
+        def embed(self, texts):
+            raise EmbedderError("simulated outage")
+
+    entry_id = _insert_memory_entry(
+        memory_pool, title="boom", body="boom",
+    )
+    writer = EmbeddingWriter(memory_pool, _BoomEmbedder())
+    writer.enqueue("memory_entries", str(entry_id))
+    assert writer.drain_once() == 0
+    assert writer.metrics_batch_failures >= 1
+
+
+def test_writer_unknown_table_logs_and_drops(memory_pool, stub_embedder, caplog):
+    from pollypm.storage.embedding_writer import EmbeddingWriter
+
+    writer = EmbeddingWriter(memory_pool, stub_embedder)
+    with caplog.at_level("WARNING"):
+        writer.enqueue("not_a_real_table", "1")
+    assert writer.drain_once() == 0
+    assert "unknown source_table" in caplog.text
+
+
+def test_writer_embeds_messages_and_work_context(memory_pool, stub_embedder):
+    """Sanity-check all three source tables can be embedded."""
+    from pollypm.storage.embedding_writer import EmbeddingWriter
+
+    # messages row
+    msg_id = _insert_message(
+        memory_pool, subject="hello", body="world",
+    )
+
+    # work_context row — needs a work_task FK, so set the task up first.
+    with memory_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO work_flow_templates (name, version, start_node, created_at) "
+            "VALUES ('t', 1, 'n1', now())"
+        )
+        cur.execute(
+            "INSERT INTO work_tasks ("
+            "  project, task_number, project_key, title, type, "
+            "  flow_template_id, created_at, created_by, updated_at"
+            ") VALUES ('p', 1, 'p', 't', 'task', 't', now(), 'u', now())"
+        )
+        cur.execute(
+            "INSERT INTO work_context_entries ("
+            "  task_project, task_number, actor, text, created_at"
+            ") VALUES ('p', 1, 'op', 'sample context', now()) "
+            "RETURNING id"
+        )
+        ctx_id = int(cur.fetchone()[0])
+        conn.commit()
+
+    writer = EmbeddingWriter(memory_pool, stub_embedder)
+    writer.enqueue("messages", str(msg_id))
+    writer.enqueue("work_context_entries", str(ctx_id))
+    assert writer.drain_once() == 2
+
+    # Both should now appear in the embeddings table.
+    with memory_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT source_table, source_id FROM embeddings "
+            "ORDER BY source_table"
+        )
+        rows = cur.fetchall()
+    assert (("messages", str(msg_id)) in rows)
+    assert (("work_context_entries", str(ctx_id)) in rows)
+
+
+# --------------------------------------------------------------------- #
+# Score weight normalisation (pure-Python).
+# --------------------------------------------------------------------- #
+
+
+def test_score_weights_normalised():
+    from pollypm.models import EmbeddingScoreWeights
+    from pollypm.storage.memory_recall import _normalise_weights
+
+    w = EmbeddingScoreWeights(
+        semantic=2.0, fts=2.0, importance=0.0, recency=0.0,
+    )
+    out = _normalise_weights(w)
+    assert sum(out) == pytest.approx(1.0)
+    assert out[0] == pytest.approx(0.5)
+    assert out[1] == pytest.approx(0.5)
+
+
+def test_score_weights_all_zero_falls_back():
+    from pollypm.models import EmbeddingScoreWeights
+    from pollypm.storage.memory_recall import _normalise_weights
+
+    w = EmbeddingScoreWeights(
+        semantic=0.0, fts=0.0, importance=0.0, recency=0.0,
+    )
+    assert _normalise_weights(w) == (0.5, 0.25, 0.15, 0.10)
+
+
+def test_score_weights_negative_clamped():
+    from pollypm.models import EmbeddingScoreWeights
+    from pollypm.storage.memory_recall import _normalise_weights
+
+    w = EmbeddingScoreWeights(
+        semantic=-1.0, fts=1.0, importance=0.0, recency=0.0,
+    )
+    out = _normalise_weights(w)
+    assert out == (0.0, 1.0, 0.0, 0.0)
+
+
+# --------------------------------------------------------------------- #
+# Backfill helper.
+# --------------------------------------------------------------------- #
+
+
+def test_backfill_enqueues_only_missing_rows(memory_pool, stub_embedder):
+    """The backfill helper must skip rows that already have embeddings."""
+    from pollypm.memory_recall_cli import _enqueue_missing
+    from pollypm.storage.embedding_writer import EmbeddingWriter
+
+    # Two memory rows; embed one of them in advance.
+    id1 = _insert_memory_entry(memory_pool, title="a", body="alpha")
+    id2 = _insert_memory_entry(memory_pool, title="b", body="beta")
+    _embed_row(memory_pool, "memory_entries", id1)
+
+    writer = EmbeddingWriter(memory_pool, stub_embedder)
+    scanned, queued = _enqueue_missing(
+        memory_pool, "memory_entries", writer, limit=0,
+    )
+    assert scanned == 2
+    assert queued == 1
+    embedded = writer.drain_once()
+    assert embedded == 1
+
+    # Confirm both rows now have embeddings.
+    with memory_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM embeddings "
+            "WHERE source_table = 'memory_entries' "
+            "AND source_id = ANY(%s)",
+            ([str(id1), str(id2)],),
+        )
+        count = int(cur.fetchone()[0])
+    assert count == 2

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,63 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -69,6 +126,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -291,6 +362,56 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+]
+
+[[package]]
 name = "openapi-schema-validator"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -343,6 +464,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pgvector"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/6c/6d8b4b03b958c02fa8687ec6063c49d952a189f8c91ebbe51e877dfab8f7/pgvector-0.4.2.tar.gz", hash = "sha256:322cac0c1dc5d41c9ecf782bd9991b7966685dee3a00bc873631391ed949513a", size = 31354, upload-time = "2025-12-05T01:07:17.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/26/6cee8a1ce8c43625ec561aff19df07f9776b7525d9002c86bceb3e0ac970/pgvector-0.4.2-py3-none-any.whl", hash = "sha256:549d45f7a18593783d5eec609ea1684a724ba8405c4cb182a0b2b08aeff04e08", size = 27441, upload-time = "2025-12-05T01:07:16.536Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -378,8 +511,17 @@ dependencies = [
 dev = [
     { name = "httpx" },
     { name = "openapi-spec-validator" },
+    { name = "pgvector" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "testcontainers" },
+]
+postgres = [
+    { name = "pgvector" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
 ]
 
 [package.metadata]
@@ -388,15 +530,80 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "openapi-spec-validator", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "packaging", specifier = ">=23.0" },
+    { name = "pgvector", marker = "extra == 'dev'", specifier = ">=0.3.0" },
+    { name = "pgvector", marker = "extra == 'postgres'", specifier = ">=0.3.0" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'dev'", specifier = ">=3.2.0" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.2.0" },
+    { name = "psycopg-pool", marker = "extra == 'dev'", specifier = ">=3.2.0" },
+    { name = "psycopg-pool", marker = "extra == 'postgres'", specifier = ">=3.2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.12" },
     { name = "sqlalchemy", specifier = ">=2.0" },
+    { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.8.0" },
     { name = "textual", specifier = ">=6.1.0" },
     { name = "typer", specifier = ">=0.16.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "postgres"]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
+]
 
 [[package]]
 name = "pydantic"
@@ -518,6 +725,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -564,6 +784,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -752,6 +987,22 @@ wheels = [
 ]
 
 [[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
+]
+
+[[package]]
 name = "textual"
 version = "8.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -805,12 +1056,30 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
 name = "uc-micro-py"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -824,4 +1093,57 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]


### PR DESCRIPTION
## Summary

Slice D of the pg + pgvector migration (#1737). Wires the embedding
engine on top of the Slice A foundation (#1738): embedder abstraction,
background write hooks, hybrid recall query, and the `pm memory`
CLI surface. Scope guardrail: no UI surfaces; the cockpit recall pane
is a future slice. `PgWorkService` untouched.

## What ships

- [x] **Embedder abstraction** — `src/pollypm/storage/embedder.py`.
  `Embedder` Protocol + `OpenAIEmbedder` impl (urllib-backed, no extra
  runtime dep). Reads `OPENAI_API_KEY` (or whatever
  `[storage.embedding] api_key_env` names). Exponential backoff on
  429/5xx/network errors; non-retryable 4xx raises immediately.
  Per-call batch cap of 100. Registry pattern (`register_embedder`)
  so `nomic-embed-text` / `ollama:...` slot in later without touching
  the writer.
- [x] **Embedding-on-write engine** — `src/pollypm/storage/embedding_writer.py`.
  `EmbeddingWriter` owns a `Queue[EmbedJob]` + a daemon
  `threading.Thread`. Batches 32 rows per embed call. Idempotent:
  `_filter_existing` drops jobs already present in `embeddings`;
  the INSERT uses `ON CONFLICT (source_table, source_id) DO UPDATE`.
  Catastrophic-failure contract — embedder error, missing row, or
  pg write fail all log + skip without crashing the drain thread.
  `enqueue_embedding(source_table, source_id)` is the no-op-safe
  module-level helper Slice H will call from the actual write sites.
- [x] **Hybrid recall** — `src/pollypm/storage/memory_recall.py`.
  Single UNION ALL across `memory_entries` / `messages` /
  `work_context_entries` joined LEFT against `embeddings`. Blends
  `semantic + fts + importance + recency` per
  `[storage.embedding] score_weights = {semantic, fts, importance, recency}`
  (defaults `0.5 / 0.25 / 0.15 / 0.10`, normalised to sum 1). FTS-only
  fallback when the embedder is unreachable.
- [x] **CLI** — `pm memory pg-recall "<query>" [--limit N] [--source ...]`
  and `pm memory backfill-embeddings [--source ...] [--limit N]`.
  `--source` accepts `messages`, `work_context_entries`,
  `memory_entries`, or `all`; the `work_context` alias maps to
  `work_context_entries`. `--json` and table output. Backfill is
  idempotent + resumable (it only enqueues rows missing from
  `embeddings`).
- [x] **Config knobs** — `[storage.embedding] score_weights` parsed
  defensively (fat-fingered values fall back to dataclass defaults
  individually; total-zero blend falls back to documented defaults).
- [x] **Runtime extra** — `pgvector>=0.3.0` added to the `postgres`
  extra so the pgvector psycopg type adapter is available.

## Tests

- 20 unit tests for the embedder against a mocked `http_post`
  (`tests/test_embedder.py`) — happy path, retries, auth, response
  shape, registry round-trip.
- 17 live-pg tests for recall + writer + backfill
  (`tests/test_pg_memory_recall.py`) — FTS-only fallback, semantic
  surfaces with identical-text embedding, all-three source tables
  round-trip, idempotency, catastrophic-failure-doesn't-crash, score
  weight normalisation.
- 11 CLI smoke tests (`tests/test_memory_recall_cli.py`) — table +
  JSON output, alias parsing, error propagation, backfill summary.
- 38 Slice A tests still pass; 38 existing memory CLI tests still pass.
- ruff clean across every new + touched file.

## Scope guardrails honoured

- No UI surfaces; the cockpit recall pane is a future slice.
- `PgWorkService` untouched.
- Write hooks ship as a no-op-safe singleton helper
  (`enqueue_embedding`) so Slice H can wire them on without rewriting
  this PR.

## Test plan

- [ ] CI runs the new tests against `pgvector/pgvector:pg16` via the
  testcontainers fixture.
- [ ] On a dev machine with local pg + pgvector + an OpenAI key:
  - `pm memory backfill-embeddings --source memory_entries --limit 5`
    reports `scanned=5 queued=N embedded=N`.
  - `pm memory pg-recall "something I remember"` returns the relevant
    rows with non-zero `semantic` components.
- [ ] Without `OPENAI_API_KEY`: `pm memory pg-recall ...` still
  returns FTS-only hits (semantic component = 0) instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)