### PR TITLE
feat(storage): pg dispatch for read-side facades — slice C of #1737

### DIFF
--- a/src/pollypm/storage/_backend_dispatch.py
+++ b/src/pollypm/storage/_backend_dispatch.py
@@ -1,0 +1,67 @@
+"""Backend dispatch helper for read-side storage facades (#1737, Slice C).
+
+The read-side ``storage/*`` facades historically open a sqlite file
+directly via ``sqlite3.connect(readonly_uri(db_path), uri=True)``. Slice C
+extends them so the same call dispatches to Postgres when the active
+backend is ``"postgres"`` (issue #1737).
+
+Most call sites already accept a ``db_path: Path`` plus a
+``project_key: str`` — that's exactly the per-project partition the pg
+schema port keys on. So the dispatch shape is:
+
+* If the active backend is sqlite, run the current path verbatim.
+* If the active backend is postgres, run the same query against the
+  process-wide RO pool with ``WHERE project_key = %s`` (or ``project = %s``
+  where the table uses the legacy column name).
+
+This module is the single shared resolver for that branch. Keeping it in
+one place means the dozen facades don't each grow their own copy of the
+"is the active backend pg?" probe — and a future config-key rename only
+needs to touch one spot.
+
+The resolver is intentionally tolerant: a missing config / unreadable
+config / fat-fingered backend value falls back to ``False`` (sqlite).
+Slice A's doctor check already surfaces real typos through its own
+error path, so the facades themselves stay quiet on bad config.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pollypm.models import PollyPMConfig
+
+logger = logging.getLogger(__name__)
+
+
+def is_pg_backend(config: "PollyPMConfig | None" = None) -> bool:
+    """Return ``True`` when the active storage backend is Postgres.
+
+    Reads ``config.storage.backend``; when ``config`` is ``None`` it
+    falls back to :func:`pollypm.config.load_config`. A failed load,
+    missing attribute, or non-string value is treated as "not pg" so
+    the facade defaults to its current sqlite path.
+
+    The lookup is intentionally cheap — the facades that use it run on
+    cockpit hot paths. The config load is memoised by ``load_config``
+    itself, so repeated calls inside one process don't reparse the TOML.
+    """
+    if config is None:
+        try:
+            from pollypm.config import load_config
+
+            config = load_config()
+        except Exception:  # noqa: BLE001 — never break a render on config
+            return False
+    storage = getattr(config, "storage", None)
+    if storage is None:
+        return False
+    backend = getattr(storage, "backend", "sqlite")
+    if not isinstance(backend, str):
+        return False
+    return backend.strip().lower() == "postgres"
+
+
+__all__ = ["is_pg_backend"]

--- a/src/pollypm/storage/doctor_state_probes.py
+++ b/src/pollypm/storage/doctor_state_probes.py
@@ -26,10 +26,49 @@ from __future__ import annotations
 import logging
 import sqlite3
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from pollypm.storage._backend_dispatch import is_pg_backend
 from pollypm.storage.sqlite_pragmas import apply_workspace_pragmas, readonly_uri
 
+if TYPE_CHECKING:
+    from pollypm.models import PollyPMConfig
+
 logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------- #
+# Postgres branch (#1737, Slice C)
+# --------------------------------------------------------------------- #
+#
+# All probes here key off ``state.db`` in the sqlite world. The pg port
+# has a single shared schema (no per-project DB), so the doctor probes
+# become straight SELECTs against the RO pool.
+#
+# The ``schema_version`` / ``work_schema_version`` table doesn't exist
+# on the pg side — the pg migration applier uses ``schema_migrations``
+# (version 1 = ``0001_initial`` which contains the merged schema).
+# ``applied_schema_version_ro`` returns the max version from that table
+# instead so the doctor check can still answer "schema is current".
+
+
+def _pg_ro_conn(config: "PollyPMConfig | None" = None):
+    """Open a pool-borrowed RO connection or return ``None``.
+
+    Mirrors :func:`_connect_readonly`'s contract: every probe must
+    degrade silently when the backend is unreachable so a doctor run
+    never throws on a transient pool / network blip.
+    """
+    try:
+        from pollypm.storage.pg_pool import get_ro_pool
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("doctor_state_probes: pg_pool import failed: %s", exc)
+        return None
+    try:
+        return get_ro_pool(config).connection()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("doctor_state_probes: get_ro_pool failed: %s", exc)
+        return None
 
 
 def _connect_readonly(db_path: Path) -> sqlite3.Connection | None:
@@ -55,7 +94,12 @@ def _connect_readonly(db_path: Path) -> sqlite3.Connection | None:
     return conn
 
 
-def applied_schema_version_ro(db_path: Path, table: str) -> int | None:
+def applied_schema_version_ro(
+    db_path: Path,
+    table: str,
+    *,
+    config: "PollyPMConfig | None" = None,
+) -> int | None:
     """Return ``MAX(version)`` from a schema-version table, or ``None``.
 
     ``table`` is interpolated into the SQL string because the schema
@@ -67,7 +111,30 @@ def applied_schema_version_ro(db_path: Path, table: str) -> int | None:
     Returns ``None`` when the DB file is missing, the connect fails, or
     the table does not exist. Returns ``0`` when the table is present
     but empty (no migrations applied yet).
+
+    On the pg backend both ``schema_version`` and ``work_schema_version``
+    map to the unified ``schema_migrations`` table — the pg port collapses
+    the two-version split into a single forward-only migration list
+    (Slice A). Callers passing either table name get back the same
+    ``MAX(version)`` so existing doctor checks keep working.
     """
+    if is_pg_backend(config):
+        ctx = _pg_ro_conn(config)
+        if ctx is None:
+            return None
+        try:
+            with ctx as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations"
+                    )
+                    row = cur.fetchone()
+                except Exception:  # noqa: BLE001
+                    return None
+                return int(row[0]) if row and row[0] is not None else 0
+        except Exception:  # noqa: BLE001
+            return None
+
     conn = _connect_readonly(db_path)
     if conn is None:
         return None
@@ -83,7 +150,11 @@ def applied_schema_version_ro(db_path: Path, table: str) -> int | None:
         conn.close()
 
 
-def count_work_tasks_ro(db_path: Path) -> int | None:
+def count_work_tasks_ro(
+    db_path: Path,
+    *,
+    config: "PollyPMConfig | None" = None,
+) -> int | None:
     """Return ``COUNT(*) FROM work_tasks`` on ``db_path``, or ``None``.
 
     Returns ``None`` when the file is missing OR when the ``work_tasks``
@@ -91,6 +162,28 @@ def count_work_tasks_ro(db_path: Path) -> int | None:
     is empty. Used by the dual-DB drift probe to tell "no work tables
     on this file" apart from "tables present but empty".
     """
+    if is_pg_backend(config):
+        ctx = _pg_ro_conn(config)
+        if ctx is None:
+            return None
+        try:
+            with ctx as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        "SELECT 1 FROM information_schema.tables "
+                        "WHERE table_schema = current_schema() "
+                        "AND table_name = 'work_tasks'"
+                    )
+                    if cur.fetchone() is None:
+                        return None
+                    cur.execute("SELECT COUNT(*) FROM work_tasks")
+                    row = cur.fetchone()
+                except Exception:  # noqa: BLE001
+                    return None
+                return int(row[0]) if row and row[0] is not None else 0
+        except Exception:  # noqa: BLE001
+            return None
+
     conn = _connect_readonly(db_path)
     if conn is None:
         return None
@@ -113,13 +206,35 @@ def count_work_tasks_ro(db_path: Path) -> int | None:
         conn.close()
 
 
-def has_messages_table_ro(db_path: Path) -> bool:
+def has_messages_table_ro(
+    db_path: Path,
+    *,
+    config: "PollyPMConfig | None" = None,
+) -> bool:
     """Return ``True`` when ``db_path`` carries a ``messages`` table.
 
     Read-only probe used by the dual-DB drift check to decide whether a
     given state.db is the messages-side DB. Returns ``False`` on any
     open / read failure.
     """
+    if is_pg_backend(config):
+        ctx = _pg_ro_conn(config)
+        if ctx is None:
+            return False
+        try:
+            with ctx as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        "SELECT 1 FROM information_schema.tables "
+                        "WHERE table_schema = current_schema() "
+                        "AND table_name = 'messages'"
+                    )
+                    return cur.fetchone() is not None
+                except Exception:  # noqa: BLE001
+                    return False
+        except Exception:  # noqa: BLE001
+            return False
+
     conn = _connect_readonly(db_path)
     if conn is None:
         return False
@@ -136,7 +251,11 @@ def has_messages_table_ro(db_path: Path) -> bool:
         conn.close()
 
 
-def sessions_row_count_ro(db_path: Path) -> int | None:
+def sessions_row_count_ro(
+    db_path: Path,
+    *,
+    config: "PollyPMConfig | None" = None,
+) -> int | None:
     """Return ``COUNT(*) FROM sessions`` on ``db_path``, or ``None``.
 
     Returns ``None`` when the DB file cannot be opened or the
@@ -147,6 +266,28 @@ def sessions_row_count_ro(db_path: Path) -> int | None:
     distinct fail signal so the operator gets a clear "repair didn't
     run" hint instead of a silent skip.
     """
+    if is_pg_backend(config):
+        ctx = _pg_ro_conn(config)
+        if ctx is None:
+            return None
+        try:
+            with ctx as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        "SELECT 1 FROM information_schema.tables "
+                        "WHERE table_schema = current_schema() "
+                        "AND table_name = 'sessions'"
+                    )
+                    if cur.fetchone() is None:
+                        return None
+                    cur.execute("SELECT COUNT(*) FROM sessions")
+                    row = cur.fetchone()
+                except Exception:  # noqa: BLE001
+                    return None
+                return int(row[0]) if row and row[0] is not None else 0
+        except Exception:  # noqa: BLE001
+            return None
+
     conn = _connect_readonly(db_path)
     if conn is None:
         return None
@@ -160,7 +301,11 @@ def sessions_row_count_ro(db_path: Path) -> int | None:
         conn.close()
 
 
-def session_window_names_ro(db_path: Path) -> set[str] | None:
+def session_window_names_ro(
+    db_path: Path,
+    *,
+    config: "PollyPMConfig | None" = None,
+) -> set[str] | None:
     """Return the set of ``window_name`` values in ``sessions``, or ``None``.
 
     Returns ``None`` when the DB cannot be opened or the ``sessions``
@@ -168,11 +313,36 @@ def session_window_names_ro(db_path: Path) -> set[str] | None:
     no rows) so the session-drift doctor check can skip cleanly when
     the table itself has not been provisioned yet.
     """
+    if is_pg_backend(config):
+        ctx = _pg_ro_conn(config)
+        if ctx is None:
+            return None
+        try:
+            with ctx as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        "SELECT 1 FROM information_schema.tables "
+                        "WHERE table_schema = current_schema() "
+                        "AND table_name = 'sessions'"
+                    )
+                    if cur.fetchone() is None:
+                        return None
+                    cur.execute("SELECT window_name FROM sessions")
+                    windows: set[str] = set()
+                    for row in cur.fetchall():
+                        if row and row[0]:
+                            windows.add(str(row[0]))
+                    return windows
+                except Exception:  # noqa: BLE001
+                    return None
+        except Exception:  # noqa: BLE001
+            return None
+
     conn = _connect_readonly(db_path)
     if conn is None:
         return None
     try:
-        windows: set[str] = set()
+        windows = set()
         try:
             for row in conn.execute("SELECT window_name FROM sessions"):
                 if row and row[0]:

--- a/src/pollypm/storage/inbox_action_preview.py
+++ b/src/pollypm/storage/inbox_action_preview.py
@@ -15,9 +15,13 @@ from pathlib import Path
 import re
 import sqlite3
 import tomllib
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from pollypm.storage._backend_dispatch import is_pg_backend
 from pollypm.storage.sqlite_pragmas import readonly_uri
+
+if TYPE_CHECKING:
+    from pollypm.models import PollyPMConfig
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +104,7 @@ def load_fast_inbox_action_preview(
     *,
     project: str | None = None,
     limit: int = 12,
+    config: "PollyPMConfig | None" = None,
 ) -> tuple[list[FastInboxPreviewEntry], set[str], int] | None:
     """Return Store-backed action rows without importing the full inbox stack.
 
@@ -120,11 +125,39 @@ def load_fast_inbox_action_preview(
             exc_info=True,
         )
         return None
+
+    if is_pg_backend(config):
+        # Postgres branch: one unified ``messages`` table — collapse the
+        # per-state.db scan into a single query against the shared pool.
+        projects_raw = raw.get("projects")
+        projects = projects_raw if isinstance(projects_raw, dict) else {}
+        known_projects = {str(key) for key in projects}
+        rows_per_source = max(preview_limit * 4, 48)
+        pg_rows = _pg_query_message_rows(limit=rows_per_source, config=config)
+        items: list[FastInboxPreviewEntry] = []
+        for row in pg_rows:
+            item = _row_to_entry(
+                row,
+                source_key=WORKSPACE_DB_KEY,
+                known_projects=known_projects,
+            )
+            if item is None:
+                continue
+            if project and item.project != project:
+                continue
+            items.append(item)
+        if not items:
+            return None
+        items = _dedupe_replayed_plan_reviews(items)
+        items.sort(key=_entry_sort_value, reverse=True)
+        preview = items[:preview_limit]
+        return preview, {item.task_id for item in preview}, len(items)
+
     sources, known_projects = _message_sources(raw, config_path=config_path)
     if not sources:
         return None
 
-    items: list[FastInboxPreviewEntry] = []
+    items = []
     rows_per_source = max(preview_limit * 4, 48)
     for source_key, db_path in sources:
         if not db_path.exists():
@@ -148,6 +181,53 @@ def load_fast_inbox_action_preview(
     items.sort(key=_entry_sort_value, reverse=True)
     preview = items[:preview_limit]
     return preview, {item.task_id for item in preview}, len(items)
+
+
+def _pg_query_message_rows(
+    *,
+    limit: int,
+    config: "PollyPMConfig | None",
+) -> list[dict[str, object]]:
+    """Postgres branch for :func:`_query_message_rows`.
+
+    Returns one row per qualifying ``messages`` row; the dict shape
+    matches the sqlite branch (same column names) so ``_row_to_entry``
+    is backend-agnostic.
+    """
+    try:
+        from pollypm.storage.pg_pool import get_ro_pool
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("inbox_action_preview: pg_pool import failed: %s", exc)
+        return []
+    try:
+        pool = get_ro_pool(config)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("inbox_action_preview: get_ro_pool failed: %s", exc)
+        return []
+    sql = (
+        "SELECT id, scope, type, tier, recipient, sender, state, parent_id, "
+        "       subject, body, payload_json, labels, "
+        "       created_at, updated_at, closed_at "
+        "FROM messages "
+        "WHERE recipient = %s AND state = %s "
+        "  AND type IN (%s, %s, %s) "
+        "ORDER BY created_at DESC, id DESC "
+        "LIMIT %s"
+    )
+    try:
+        with pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                sql,
+                ("user", "open", "notify", "inbox_task", "alert", int(limit)),
+            )
+            cols = [d[0] for d in cur.description] if cur.description else []
+            rows = cur.fetchall()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "inbox_action_preview: pg query failed: %s", exc, exc_info=True,
+        )
+        return []
+    return [dict(zip(cols, row, strict=False)) for row in rows]
 
 
 def _message_sources(

--- a/src/pollypm/storage/legacy_per_project_db.py
+++ b/src/pollypm/storage/legacy_per_project_db.py
@@ -43,6 +43,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from pollypm.storage._backend_dispatch import is_pg_backend
 from pollypm.storage.sqlite_pragmas import readonly_uri
 
 if TYPE_CHECKING:
@@ -334,6 +335,14 @@ def migrate_legacy_per_project_dbs(
         except Exception as exc:  # noqa: BLE001
             logger.warning("legacy_per_project_db: load_config failed: %s", exc)
             return []
+
+    # #1737, Slice C: on the postgres backend there are no per-project
+    # state.db files — the unified ``messages`` + ``work_*`` tables live
+    # in the shared pg DB. Skip the migration entirely so an install with
+    # ``backend = "postgres"`` never tries to open sqlite shards that
+    # don't exist.
+    if is_pg_backend(config):
+        return []
 
     workspace_root_raw = getattr(config.project, "workspace_root", None)
     if workspace_root_raw is None:

--- a/src/pollypm/storage/morning_briefing_queries.py
+++ b/src/pollypm/storage/morning_briefing_queries.py
@@ -5,11 +5,31 @@ from __future__ import annotations
 import logging
 import sqlite3
 from pathlib import Path
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable
 
+from pollypm.storage._backend_dispatch import is_pg_backend
 from pollypm.storage.sqlite_pragmas import readonly_uri
 
+if TYPE_CHECKING:
+    from pollypm.models import PollyPMConfig
+
 logger = logging.getLogger(__name__)
+
+
+def _pg_pool(config: "PollyPMConfig | None"):
+    """Borrow the RO pool or return ``None`` on import / open failure."""
+    try:
+        from pollypm.storage.pg_pool import get_ro_pool
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("morning_briefing_queries: pg_pool import failed: %s", exc)
+        return None
+    try:
+        return get_ro_pool(config)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "morning_briefing_queries: get_ro_pool failed: %s", exc,
+        )
+        return None
 
 
 _TRANSITION_SQL = (
@@ -51,8 +71,38 @@ def transition_rows(
     project_key: str,
     since_iso: str,
     until_iso: str,
+    config: "PollyPMConfig | None" = None,
 ) -> list[dict[str, Any]]:
     """Return work transition rows for ``project_key`` in a time window."""
+    if is_pg_backend(config):
+        pool = _pg_pool(config)
+        if pool is None:
+            return []
+        sql = (
+            "SELECT t.task_project AS project, t.task_number AS task_number, "
+            "       COALESCE(w.title, '') AS title, "
+            "       t.from_state AS from_state, t.to_state AS to_state, "
+            "       t.actor AS actor, t.created_at AS created_at "
+            "FROM work_transitions t "
+            "LEFT JOIN work_tasks w "
+            "  ON w.project = t.task_project AND w.task_number = t.task_number "
+            "WHERE t.task_project = %s "
+            "  AND t.created_at::text >= %s AND t.created_at::text < %s "
+            "ORDER BY t.created_at ASC"
+        )
+        try:
+            with pool.connection() as conn, conn.cursor() as cur:
+                cur.execute(sql, (project_key, since_iso, until_iso))
+                cols = [d[0] for d in cur.description] if cur.description else []
+                rows = cur.fetchall()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "briefing: pg transitions SQL failed for %s: %s",
+                project_key, exc,
+            )
+            return []
+        return [dict(zip(cols, row, strict=False)) for row in rows]
+
     out: list[dict[str, Any]] = []
     seen_keys: set[tuple[str, int, str]] = set()
     for db_path in db_paths:
@@ -91,8 +141,46 @@ def downtime_artifact_rows(
     project_key: str,
     since_iso: str,
     until_iso: str,
+    config: "PollyPMConfig | None" = None,
 ) -> list[dict[str, Any]]:
     """Return downtime tasks that reached awaiting approval in a window."""
+    if is_pg_backend(config):
+        pool = _pg_pool(config)
+        if pool is None:
+            return []
+        sql = (
+            "SELECT t.task_project AS project, t.task_number AS task_number, "
+            "       COALESCE(w.title, '') AS title, "
+            "       t.created_at AS created_at, "
+            "       COALESCE(w.labels::text, '[]') AS labels "
+            "FROM work_transitions t "
+            "LEFT JOIN work_tasks w "
+            "  ON w.project = t.task_project AND w.task_number = t.task_number "
+            "WHERE t.task_project = %s "
+            "  AND t.to_state = 'awaiting_approval' "
+            "  AND t.created_at::text >= %s AND t.created_at::text < %s "
+            "ORDER BY t.created_at ASC"
+        )
+        try:
+            with pool.connection() as conn, conn.cursor() as cur:
+                cur.execute(sql, (project_key, since_iso, until_iso))
+                cols = [d[0] for d in cur.description] if cur.description else []
+                rows = cur.fetchall()
+        except Exception:  # noqa: BLE001
+            return []
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            rec = dict(zip(cols, row, strict=False))
+            labels_raw = str(rec.get("labels") or "[]")
+            if "downtime" not in labels_raw.lower():
+                continue
+            try:
+                int(rec.get("task_number"))
+            except (TypeError, ValueError):
+                continue
+            out.append(rec)
+        return out
+
     out: list[dict[str, Any]] = []
     seen_keys: set[tuple[str, int, str]] = set()
     for db_path in db_paths:
@@ -143,8 +231,53 @@ def priority_task_rows(
     project_key: str,
     open_statuses: tuple[str, ...],
     limit: int,
+    config: "PollyPMConfig | None" = None,
 ) -> list[dict[str, Any]]:
     """Return candidate priority task rows for one project."""
+    if is_pg_backend(config):
+        pool = _pg_pool(config)
+        if pool is None:
+            return []
+        placeholders = ", ".join("%s" for _ in open_statuses) or "%s"
+        sql = (
+            "SELECT project, task_number, title, priority, work_status, "
+            "       COALESCE(assignee, '') AS assignee, "
+            "       created_at, updated_at "
+            "FROM work_tasks "
+            f"WHERE project = %s AND work_status IN ({placeholders}) "
+            "ORDER BY "
+            "  CASE priority "
+            "    WHEN 'critical' THEN 0 "
+            "    WHEN 'high' THEN 1 "
+            "    WHEN 'normal' THEN 2 "
+            "    WHEN 'low' THEN 3 ELSE 4 END ASC, "
+            "  updated_at ASC "
+            "LIMIT %s"
+        )
+        try:
+            with pool.connection() as conn, conn.cursor() as cur:
+                cur.execute(
+                    sql,
+                    (project_key, *open_statuses, max(1, limit) * 4),
+                )
+                cols = [d[0] for d in cur.description] if cur.description else []
+                rows = cur.fetchall()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "briefing: pg top-tasks SQL failed for %s: %s",
+                project_key, exc,
+            )
+            return []
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            rec = dict(zip(cols, row, strict=False))
+            try:
+                int(rec.get("task_number"))
+            except (TypeError, ValueError):
+                continue
+            out.append(rec)
+        return out
+
     out: list[dict[str, Any]] = []
     seen_ids: set[tuple[str, int]] = set()
     for db_path in db_paths:
@@ -188,8 +321,71 @@ def priority_task_rows(
     return out
 
 
-def blocker_rows(db_paths: Iterable[Path], *, project_key: str) -> list[dict[str, Any]]:
+def blocker_rows(
+    db_paths: Iterable[Path],
+    *,
+    project_key: str,
+    config: "PollyPMConfig | None" = None,
+) -> list[dict[str, Any]]:
     """Return blocked tasks with their blocker references."""
+    if is_pg_backend(config):
+        pool = _pg_pool(config)
+        if pool is None:
+            return []
+        results: list[dict[str, Any]] = []
+        try:
+            with pool.connection() as conn, conn.cursor() as cur:
+                cur.execute(
+                    "SELECT project, task_number, title "
+                    "FROM work_tasks "
+                    "WHERE project = %s AND work_status = 'blocked' "
+                    "ORDER BY updated_at ASC",
+                    (project_key,),
+                )
+                cols = [d[0] for d in cur.description] if cur.description else []
+                rows = cur.fetchall()
+                for row in rows:
+                    rec = dict(zip(cols, row, strict=False))
+                    proj = str(rec.get("project") or "")
+                    try:
+                        num = int(rec.get("task_number"))
+                    except (TypeError, ValueError):
+                        continue
+                    cur.execute(
+                        "SELECT d.to_project AS to_project, "
+                        "       d.to_task_number AS to_task_number, "
+                        "       COALESCE(t.work_status, '') AS blocker_status "
+                        "FROM work_task_dependencies d "
+                        "LEFT JOIN work_tasks t "
+                        "  ON t.project = d.to_project "
+                        "  AND t.task_number = d.to_task_number "
+                        "WHERE d.from_project = %s AND d.from_task_number = %s "
+                        "  AND d.kind = 'blocks'",
+                        (proj, num),
+                    )
+                    dep_cols = [d[0] for d in cur.description] if cur.description else []
+                    dep_rows = cur.fetchall()
+                    blocked_by: list[str] = []
+                    unresolved: list[str] = []
+                    for dep in dep_rows:
+                        dep_rec = dict(zip(dep_cols, dep, strict=False))
+                        blocker_id = (
+                            f"{dep_rec.get('to_project')}/"
+                            f"{dep_rec.get('to_task_number')}"
+                        )
+                        blocked_by.append(blocker_id)
+                        status = str(dep_rec.get("blocker_status") or "").lower()
+                        if status and status not in ("done", "cancelled"):
+                            unresolved.append(blocker_id)
+                    rec["blocked_by"] = blocked_by
+                    rec["unresolved_blockers"] = unresolved
+                    results.append(rec)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "briefing: pg blocker SQL failed for %s: %s", project_key, exc,
+            )
+        return results
+
     results: list[dict[str, Any]] = []
     seen_ids: set[tuple[str, int]] = set()
     for db_path in db_paths:

--- a/src/pollypm/storage/project_state_purge.py
+++ b/src/pollypm/storage/project_state_purge.py
@@ -23,6 +23,12 @@ from __future__ import annotations
 import logging
 import sqlite3
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pollypm.storage._backend_dispatch import is_pg_backend
+
+if TYPE_CHECKING:
+    from pollypm.models import PollyPMConfig
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +89,8 @@ def _params_for(project_key: str, kind: str) -> tuple[str, ...]:
 def count_project_state_rows(
     db_path: Path | None,
     project_key: str,
+    *,
+    config: "PollyPMConfig | None" = None,
 ) -> dict[str, int]:
     """Return per-table row counts for ``project_key`` in ``db_path``.
 
@@ -93,6 +101,9 @@ def count_project_state_rows(
     onto the result.
     """
     counts: dict[str, int] = {table: 0 for table, _w, _p in _STATE_PURGE_TABLES}
+
+    if is_pg_backend(config):
+        return _pg_count_project_state_rows(project_key, counts, config=config)
 
     if db_path is None or not db_path.exists():
         return counts
@@ -136,6 +147,7 @@ def purge_project_state_rows(
     project_key: str,
     *,
     dry_run: bool = False,
+    config: "PollyPMConfig | None" = None,
 ) -> dict[str, int]:
     """Delete every project-scoped row from ``db_path``.
 
@@ -165,9 +177,12 @@ def purge_project_state_rows(
     silences the side-channels and matches the operator's mental
     model ("tear it all down, fast").
     """
-    counts = count_project_state_rows(db_path, project_key)
+    counts = count_project_state_rows(db_path, project_key, config=config)
     if dry_run:
         return counts
+
+    if is_pg_backend(config):
+        return _pg_purge_project_state_rows(project_key, counts, config=config)
 
     if db_path is None or not db_path.exists():
         return counts
@@ -214,6 +229,121 @@ def purge_project_state_rows(
     finally:
         conn.close()
 
+    return counts
+
+
+def _pg_count_project_state_rows(
+    project_key: str,
+    counts: dict[str, int],
+    *,
+    config: "PollyPMConfig | None",
+) -> dict[str, int]:
+    """Postgres branch for :func:`count_project_state_rows`.
+
+    Runs each per-table COUNT through the RO pool. Best-effort per
+    table: a missing table (slate-clean pg DB before migrations) yields
+    zero so the caller's summary stays accurate.
+    """
+    try:
+        from pollypm.storage.pg_pool import get_ro_pool
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("project_state_purge: pg_pool import failed: %s", exc)
+        return counts
+    try:
+        pool = get_ro_pool(config)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("project_state_purge: get_ro_pool failed: %s", exc)
+        return counts
+    try:
+        with pool.connection() as conn, conn.cursor() as cur:
+            for table, where, ptype in _STATE_PURGE_TABLES:
+                params = _params_for(project_key, ptype)
+                # ``?`` placeholders in the sqlite WHERE clause have to
+                # become ``%s`` for psycopg. Replace each ``?`` one at a
+                # time so the count of placeholders stays right for both
+                # the ``single`` and ``pair`` shapes.
+                where_pg = where.replace("?", "%s")
+                try:
+                    cur.execute(
+                        f"SELECT COUNT(*) FROM {table} WHERE {where_pg}",
+                        params,
+                    )
+                    row = cur.fetchone()
+                    counts[table] = int(row[0]) if row else 0
+                except Exception:  # noqa: BLE001
+                    # Rollback the per-statement error so the next loop
+                    # iteration's execute succeeds; psycopg aborts the
+                    # whole transaction on any error otherwise.
+                    try:
+                        conn.rollback()
+                    except Exception:  # noqa: BLE001
+                        pass
+                    counts[table] = 0
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("project_state_purge: pg count failed: %s", exc)
+    return counts
+
+
+def _pg_purge_project_state_rows(
+    project_key: str,
+    counts: dict[str, int],
+    *,
+    config: "PollyPMConfig | None",
+) -> dict[str, int]:
+    """Postgres branch for :func:`purge_project_state_rows`.
+
+    Wraps every per-table DELETE in a single transaction against the
+    RW pool. Matches the sqlite shape: any pg-level error rolls back
+    and raises :class:`ProjectStatePurgeError` so the caller can abort
+    before mutating ``pollypm.toml``.
+    """
+    try:
+        from pollypm.storage.pg_pool import get_rw_pool
+    except Exception as exc:  # noqa: BLE001
+        raise ProjectStatePurgeError(
+            f"pg_pool import failed during purge of '{project_key}': {exc}"
+        ) from exc
+    try:
+        pool = get_rw_pool(config)
+    except Exception as exc:  # noqa: BLE001
+        raise ProjectStatePurgeError(
+            f"could not open pg pool during purge of '{project_key}': {exc}"
+        ) from exc
+    try:
+        with pool.connection() as conn:
+            conn.autocommit = False
+            try:
+                with conn.cursor() as cur:
+                    for table, where, ptype in _STATE_PURGE_TABLES:
+                        params = _params_for(project_key, ptype)
+                        where_pg = where.replace("?", "%s")
+                        try:
+                            cur.execute(
+                                f"DELETE FROM {table} WHERE {where_pg}",
+                                params,
+                            )
+                            counts[table] = int(cur.rowcount or 0)
+                        except Exception:  # noqa: BLE001
+                            # Missing-table case in pg aborts the
+                            # transaction; surface so the caller sees a
+                            # consistent partial-rollback signal rather
+                            # than a silent skip.
+                            raise
+                conn.commit()
+            except Exception as exc:  # noqa: BLE001
+                try:
+                    conn.rollback()
+                except Exception:  # noqa: BLE001
+                    pass
+                raise ProjectStatePurgeError(
+                    f"pg state purge failed for '{project_key}': {exc}"
+                ) from exc
+    except ProjectStatePurgeError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise ProjectStatePurgeError(
+            f"pg state purge failed for '{project_key}': {exc}"
+        ) from exc
     return counts
 
 

--- a/src/pollypm/storage/work_session_queries.py
+++ b/src/pollypm/storage/work_session_queries.py
@@ -7,6 +7,17 @@ projection reads against ``work_sessions``.
 The aggregate used by the per-project dashboard's Tokens line lives
 here so the rendering layer (``cockpit_sections``) no longer has to
 ``import sqlite3`` or know the table name.
+
+Backend dispatch (#1737, Slice C)
+---------------------------------
+
+When ``[storage] backend = "postgres"`` is active, the same aggregate
+runs against the process-wide read-only pool keyed on the
+``task_project`` column (the pg schema uses the same column name as the
+sqlite shape — see :mod:`pollypm.storage.pg_schema`). The sqlite branch
+is preserved verbatim so first-run installs keep their existing
+``file:<path>?mode=ro`` semantics, including the ``apply_workspace_pragmas``
+busy-timeout setup that #1018 introduced.
 """
 
 from __future__ import annotations
@@ -14,8 +25,13 @@ from __future__ import annotations
 import logging
 import sqlite3
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from pollypm.storage._backend_dispatch import is_pg_backend
 from pollypm.storage.sqlite_pragmas import apply_workspace_pragmas, readonly_uri
+
+if TYPE_CHECKING:
+    from pollypm.models import PollyPMConfig
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +40,7 @@ def aggregate_project_session_tokens(
     db_path: Path,
     *,
     project_key: str,
+    config: "PollyPMConfig | None" = None,
 ) -> tuple[int, int] | None:
     """Return ``(SUM(total_input_tokens), SUM(total_output_tokens))`` for ``project_key``.
 
@@ -36,6 +53,9 @@ def aggregate_project_session_tokens(
     pragmas because the cockpit reader runs alongside JobWorkerPool +
     heartbeat writers on the same DB (#1018).
     """
+    if is_pg_backend(config):
+        return _aggregate_pg(project_key=project_key, config=config)
+
     try:
         if not db_path.exists():
             return None
@@ -70,6 +90,46 @@ def aggregate_project_session_tokens(
             return None
     finally:
         conn.close()
+    if row is None:
+        return 0, 0
+    return int(row[0] or 0), int(row[1] or 0)
+
+
+def _aggregate_pg(
+    *,
+    project_key: str,
+    config: "PollyPMConfig | None",
+) -> tuple[int, int] | None:
+    """Postgres branch for :func:`aggregate_project_session_tokens`.
+
+    Same shape as the sqlite branch: returns ``(in, out)`` tuple
+    (zero-filled on empty rows) or ``None`` when the pool / query
+    can't be reached. The ``COALESCE(SUM(...), 0)`` form mirrors the
+    sqlite query so the empty-table case yields ``(0, 0)`` consistently
+    across both backends.
+    """
+    try:
+        from pollypm.storage.pg_pool import get_ro_pool
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("work_session_queries: pg_pool import failed: %s", exc)
+        return None
+    try:
+        pool = get_ro_pool(config)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("work_session_queries: get_ro_pool failed: %s", exc)
+        return None
+    try:
+        with pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT COALESCE(SUM(total_input_tokens), 0), "
+                "       COALESCE(SUM(total_output_tokens), 0) "
+                "FROM work_sessions WHERE task_project = %s",
+                (project_key,),
+            )
+            row = cur.fetchone()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("work_session_queries: pg query failed: %s", exc)
+        return None
     if row is None:
         return 0, 0
     return int(row[0] or 0), int(row[1] or 0)

--- a/src/pollypm/storage/work_task_state.py
+++ b/src/pollypm/storage/work_task_state.py
@@ -11,11 +11,39 @@ from __future__ import annotations
 import logging
 import sqlite3
 from pathlib import Path
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
+from pollypm.storage._backend_dispatch import is_pg_backend
 from pollypm.storage.sqlite_pragmas import apply_workspace_pragmas, readonly_uri
 
+if TYPE_CHECKING:
+    from pollypm.models import PollyPMConfig
+
 logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------- #
+# Postgres branch (#1737, Slice C)
+# --------------------------------------------------------------------- #
+#
+# Sqlite probes walk a list of candidate per-project DB paths. Postgres
+# has one shared DB so the candidate list collapses to a single pool
+# borrow. The probes preserve the same return shape — callers above
+# storage stay unchanged.
+
+
+def _pg_ro_conn(config: "PollyPMConfig | None" = None):
+    """Borrow an RO connection from the pool or return ``None``."""
+    try:
+        from pollypm.storage.pg_pool import get_ro_pool
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("work_task_state: pg_pool import failed: %s", exc)
+        return None
+    try:
+        return get_ro_pool(config).connection()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("work_task_state: get_ro_pool failed: %s", exc)
+        return None
 
 
 def _candidate_paths(
@@ -58,6 +86,7 @@ def task_status_probe(
     task_number: int,
     project_path: Path,
     workspace_root: Path | None = None,
+    config: "PollyPMConfig | None" = None,
 ) -> tuple[bool, str | None]:
     """Return ``(found_any_db, status)`` for a task lookup.
 
@@ -65,6 +94,28 @@ def task_status_probe(
     Transient SQLite errors are treated as misses for that DB so callers
     can keep their existing best-effort behavior.
     """
+    if is_pg_backend(config):
+        ctx = _pg_ro_conn(config)
+        if ctx is None:
+            return False, None
+        try:
+            with ctx as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        "SELECT work_status FROM work_tasks "
+                        "WHERE project = %s AND task_number = %s",
+                        (project_key, int(task_number)),
+                    )
+                    row = cur.fetchone()
+                except Exception:  # noqa: BLE001
+                    return True, None
+                if row is None:
+                    return True, None
+                status = row[0]
+                return True, status if isinstance(status, str) else None
+        except Exception:  # noqa: BLE001
+            return False, None
+
     found_any_db = False
     for db_path in _candidate_paths(project_path, workspace_root=workspace_root):
         try:
@@ -100,11 +151,40 @@ def task_numbers_with_statuses(
     project_path: Path,
     statuses: Iterable[str],
     workspace_root: Path | None = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[int]:
     """Return sorted task numbers whose ``work_status`` is in ``statuses``."""
     status_values = tuple(str(status) for status in statuses)
     if not status_values:
         return []
+    if is_pg_backend(config):
+        ctx = _pg_ro_conn(config)
+        if ctx is None:
+            return []
+        placeholders_pg = ", ".join("%s" for _ in status_values)
+        try:
+            with ctx as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        "SELECT task_number FROM work_tasks "
+                        "WHERE project = %s "
+                        f"AND work_status IN ({placeholders_pg}) "
+                        "ORDER BY task_number ASC",
+                        (project_key, *status_values),
+                    )
+                    rows = cur.fetchall()
+                except Exception:  # noqa: BLE001
+                    return []
+        except Exception:  # noqa: BLE001
+            return []
+        out: list[int] = []
+        for row in rows:
+            try:
+                out.append(int(row[0]))
+            except (TypeError, ValueError):
+                continue
+        return out
+
     placeholders = ", ".join("?" for _ in status_values)
     for db_path in _candidate_paths(project_path, workspace_root=workspace_root):
         conn = _connect_readonly(db_path)
@@ -141,6 +221,7 @@ def project_task_total_fast(
     project_key: str,
     connect_timeout: float = 0.05,
     busy_timeout_ms: int = 50,
+    config: "PollyPMConfig | None" = None,
 ) -> int | None:
     """Return the work-task count for ``project_key`` quickly.
 
@@ -148,7 +229,35 @@ def project_task_total_fast(
     DB is locked/busy and the caller should surface a ``busy`` indicator
     rather than wait. Any other SQLite error is treated as ``0`` to
     preserve the previous best-effort UI behavior.
+
+    Postgres branch (#1737, Slice C): the pg pool has its own
+    busy-handling semantics, so we just run the COUNT and return 0 on
+    failure. The "busy" sentinel (``None``) only fires when the pool
+    isn't reachable at all.
     """
+    if is_pg_backend(config):
+        ctx = _pg_ro_conn(config)
+        if ctx is None:
+            return None
+        try:
+            with ctx as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        "SELECT COUNT(*) FROM work_tasks WHERE project = %s",
+                        (project_key,),
+                    )
+                    row = cur.fetchone()
+                except Exception:  # noqa: BLE001
+                    return 0
+                if row is None:
+                    return 0
+                try:
+                    return int(row[0] or 0)
+                except (TypeError, ValueError):
+                    return 0
+        except Exception:  # noqa: BLE001
+            return 0
+
     try:
         if not db_path.exists():
             return 0
@@ -200,8 +309,36 @@ def has_work_task_rows(
     db_path: Path,
     *,
     project_key: str | None = None,
+    config: "PollyPMConfig | None" = None,
 ) -> bool:
     """Return whether ``work_tasks`` has rows, optionally scoped by project."""
+    if is_pg_backend(config):
+        ctx = _pg_ro_conn(config)
+        if ctx is None:
+            return False
+        try:
+            with ctx as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        "SELECT 1 FROM information_schema.tables "
+                        "WHERE table_schema = current_schema() "
+                        "AND table_name = 'work_tasks'"
+                    )
+                    if cur.fetchone() is None:
+                        return False
+                    if project_key:
+                        cur.execute(
+                            "SELECT 1 FROM work_tasks WHERE project = %s LIMIT 1",
+                            (project_key,),
+                        )
+                    else:
+                        cur.execute("SELECT 1 FROM work_tasks LIMIT 1")
+                    return cur.fetchone() is not None
+                except Exception:  # noqa: BLE001
+                    return False
+        except Exception:  # noqa: BLE001
+            return False
+
     conn = _connect_readonly(db_path)
     if conn is None:
         return False
@@ -233,8 +370,40 @@ def project_activity_probe(
     project_path: Path,
     cutoff_iso: str,
     workspace_root: Path | None = None,
+    config: "PollyPMConfig | None" = None,
 ) -> tuple[bool, bool]:
     """Return ``(is_active, has_working_task)`` from work-task rows."""
+    if is_pg_backend(config):
+        ctx = _pg_ro_conn(config)
+        if ctx is None:
+            return False, False
+        try:
+            with ctx as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        "SELECT "
+                        "  SUM(CASE WHEN work_status = 'in_progress' "
+                        "           THEN 1 ELSE 0 END) AS working_count, "
+                        "  MAX(updated_at::text) AS max_updated "
+                        "FROM work_tasks WHERE project = %s",
+                        (project_key,),
+                    )
+                    row = cur.fetchone()
+                except Exception:  # noqa: BLE001
+                    return False, False
+                if row is None:
+                    return False, False
+                working_count = int(row[0] or 0)
+                max_updated = str(row[1] or "")
+                has_working_task = working_count > 0
+                is_active = bool(
+                    has_working_task
+                    or (max_updated and max_updated >= cutoff_iso)
+                )
+                return is_active, has_working_task
+        except Exception:  # noqa: BLE001
+            return False, False
+
     for db_path in _candidate_paths(project_path, workspace_root=workspace_root):
         conn = _connect_readonly(db_path)
         if conn is None:

--- a/src/pollypm/storage/work_transition_queries.py
+++ b/src/pollypm/storage/work_transition_queries.py
@@ -11,9 +11,13 @@ from __future__ import annotations
 import logging
 import sqlite3
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from pollypm.storage._backend_dispatch import is_pg_backend
 from pollypm.storage.sqlite_pragmas import apply_workspace_pragmas, readonly_uri
+
+if TYPE_CHECKING:
+    from pollypm.models import PollyPMConfig
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +31,18 @@ _ADVISOR_TRANSITION_SQL = (
     "LEFT JOIN work_tasks w "
     "  ON w.project = t.task_project AND w.task_number = t.task_number "
     "WHERE t.task_project = ? AND t.created_at >= ? "
+    "ORDER BY t.created_at ASC"
+)
+
+_ADVISOR_TRANSITION_PG_SQL = (
+    "SELECT t.task_project AS project, t.task_number AS task_number, "
+    "       COALESCE(w.title, '') AS title, "
+    "       t.from_state AS from_state, t.to_state AS to_state, "
+    "       t.actor AS actor, t.created_at AS created_at "
+    "FROM work_transitions t "
+    "LEFT JOIN work_tasks w "
+    "  ON w.project = t.task_project AND w.task_number = t.task_number "
+    "WHERE t.task_project = %s AND t.created_at::text >= %s "
     "ORDER BY t.created_at ASC"
 )
 
@@ -64,8 +80,14 @@ def advisor_transition_rows(
     *,
     project_key: str,
     since_iso: str,
+    config: "PollyPMConfig | None" = None,
 ) -> list[dict[str, Any]]:
     """Return transition rows for advisor change detection."""
+    if is_pg_backend(config):
+        return _pg_advisor_transition_rows(
+            project_key=project_key, since_iso=since_iso, config=config,
+        )
+
     conn = _open_readonly(db_path)
     if conn is None:
         return []
@@ -92,8 +114,14 @@ def activity_feed_transition_rows(
     *,
     since_ts: str | None,
     limit: int,
+    config: "PollyPMConfig | None" = None,
 ) -> list[dict[str, Any]]:
     """Return recent work-transition rows for activity-feed projection."""
+    if is_pg_backend(config):
+        return _pg_activity_feed_transition_rows(
+            since_ts=since_ts, limit=limit, config=config,
+        )
+
     conn = _open_readonly(db_path)
     if conn is None:
         return []
@@ -127,6 +155,84 @@ def activity_feed_transition_rows(
     finally:
         conn.close()
     return [_row_dict(row) for row in rows]
+
+
+def _pg_advisor_transition_rows(
+    *,
+    project_key: str,
+    since_iso: str,
+    config: "PollyPMConfig | None",
+) -> list[dict[str, Any]]:
+    """Postgres branch for :func:`advisor_transition_rows`.
+
+    Same column shape as the sqlite query. The pg ``created_at`` is a
+    ``timestamptz``; psycopg returns it as a ``datetime`` — callers that
+    compared the value as a string still work because the advisor wraps
+    every read in its own ``str(..)`` coerce. The dict keys land in the
+    same lower-case form as the sqlite Row factory.
+    """
+    try:
+        from pollypm.storage.pg_pool import get_ro_pool
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("work_transition_queries: pg_pool import failed: %s", exc)
+        return []
+    try:
+        pool = get_ro_pool(config)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("work_transition_queries: get_ro_pool failed: %s", exc)
+        return []
+    try:
+        with pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(_ADVISOR_TRANSITION_PG_SQL, (project_key, since_iso))
+            cols = [d[0] for d in cur.description] if cur.description else []
+            rows = cur.fetchall()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "work_transition_queries: pg advisor query failed for %s: %s",
+            project_key, exc,
+        )
+        return []
+    return [dict(zip(cols, row, strict=False)) for row in rows]
+
+
+def _pg_activity_feed_transition_rows(
+    *,
+    since_ts: str | None,
+    limit: int,
+    config: "PollyPMConfig | None",
+) -> list[dict[str, Any]]:
+    """Postgres branch for :func:`activity_feed_transition_rows`."""
+    try:
+        from pollypm.storage.pg_pool import get_ro_pool
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("work_transition_queries: pg_pool import failed: %s", exc)
+        return []
+    try:
+        pool = get_ro_pool(config)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("work_transition_queries: get_ro_pool failed: %s", exc)
+        return []
+    params: list[Any] = []
+    where = ""
+    if since_ts is not None:
+        where = "WHERE created_at::text >= %s"
+        params.append(since_ts)
+    sql = (
+        "SELECT id, task_project, task_number, from_state, to_state, "
+        f"actor, reason, created_at FROM work_transitions {where} "
+        "ORDER BY id DESC LIMIT %s"
+    )
+    try:
+        with pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, (*params, int(limit)))
+            cols = [d[0] for d in cur.description] if cur.description else []
+            rows = cur.fetchall()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "work_transition_queries: pg activity-feed query failed: %s", exc,
+        )
+        return []
+    return [dict(zip(cols, row, strict=False)) for row in rows]
 
 
 __all__ = [

--- a/tests/test_pg_storage_facades.py
+++ b/tests/test_pg_storage_facades.py
@@ -1,0 +1,668 @@
+"""pg-parity tests for the read-side ``storage/*`` facades (#1737, Slice C).
+
+For each facade we seed the pg test schema with the same shape its
+sqlite counterpart would carry, then call the facade with
+``config.storage.backend = "postgres"`` and assert the same return
+shape as the sqlite branch. The ``pg_schema_pool`` fixture (from
+``tests/conftest_pg.py``) creates a fresh schema namespace per test.
+
+Skipped when neither Docker nor a local pg with the ``vector``
+extension is available — see the conftest_pg docstring.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+
+# --------------------------------------------------------------------- #
+# Shared helpers
+# --------------------------------------------------------------------- #
+
+
+@dataclass(slots=True)
+class _StubStorage:
+    backend: str = "postgres"
+
+
+@dataclass(slots=True)
+class _StubConfig:
+    """Minimal config stub the facades treat as a real PollyPMConfig."""
+
+    storage: _StubStorage = field(default_factory=_StubStorage)
+
+
+@pytest.fixture()
+def pg_config(pg_schema_pool):  # noqa: ARG001 — fixture just needs to run first
+    """Return a stub config that signals the pg backend is active."""
+    return _StubConfig()
+
+
+def _seed_work_tasks(pg_schema_pool, rows: list[dict]) -> None:
+    """Insert minimal ``work_tasks`` rows for a facade test."""
+    defaults = {
+        "title": "",
+        "type": "task",
+        "labels": "[]",
+        "work_status": "draft",
+        "flow_template_id": "default",
+        "flow_template_version": 1,
+        "current_node_id": None,
+        "assignee": None,
+        "priority": "normal",
+        "requires_human_review": False,
+        "description": "",
+        "acceptance_criteria": None,
+        "constraints": None,
+        "relevant_files": "[]",
+        "parent_project": None,
+        "parent_task_number": None,
+        "supersedes_project": None,
+        "supersedes_task_number": None,
+        "plan_version": 1,
+        "predecessor_task_id": None,
+        "kind": "legacy",
+        "roles": "{}",
+        "external_refs": "{}",
+        "created_by": "test",
+    }
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        for row in rows:
+            payload = {**defaults, **row}
+            payload.setdefault("project_key", payload["project"])
+            cur.execute(
+                "INSERT INTO work_tasks ("
+                "project, task_number, project_key, title, type, labels, "
+                "work_status, flow_template_id, flow_template_version, "
+                "current_node_id, assignee, priority, requires_human_review, "
+                "description, acceptance_criteria, constraints, relevant_files, "
+                "parent_project, parent_task_number, "
+                "supersedes_project, supersedes_task_number, "
+                "plan_version, predecessor_task_id, kind, "
+                "roles, external_refs, created_at, created_by, updated_at"
+                ") VALUES ("
+                " %s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s, %s, %s, %s, "
+                " %s, %s, %s, %s::jsonb, %s, %s, %s, %s, %s, %s, %s, "
+                " %s::jsonb, %s::jsonb, now(), %s, now()"
+                ")",
+                (
+                    payload["project"],
+                    payload["task_number"],
+                    payload["project_key"],
+                    payload["title"],
+                    payload["type"],
+                    payload["labels"],
+                    payload["work_status"],
+                    payload["flow_template_id"],
+                    payload["flow_template_version"],
+                    payload["current_node_id"],
+                    payload["assignee"],
+                    payload["priority"],
+                    payload["requires_human_review"],
+                    payload["description"],
+                    payload["acceptance_criteria"],
+                    payload["constraints"],
+                    payload["relevant_files"],
+                    payload["parent_project"],
+                    payload["parent_task_number"],
+                    payload["supersedes_project"],
+                    payload["supersedes_task_number"],
+                    payload["plan_version"],
+                    payload["predecessor_task_id"],
+                    payload["kind"],
+                    payload["roles"],
+                    payload["external_refs"],
+                    payload["created_by"],
+                ),
+            )
+        conn.commit()
+
+
+def _apply_initial_migrations(pg_schema_pool) -> None:
+    """Apply the canonical migration so the schema port lands on the pool."""
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+
+
+# --------------------------------------------------------------------- #
+# work_session_queries — aggregate Tokens line for the project dashboard
+# --------------------------------------------------------------------- #
+
+
+def test_pg_aggregate_project_session_tokens(pg_schema_pool, pg_config, tmp_path):
+    """The pg branch must return the same (sum_in, sum_out) tuple shape."""
+    _apply_initial_migrations(pg_schema_pool)
+    _seed_work_tasks(pg_schema_pool, [
+        {"project": "alpha", "task_number": 1},
+        {"project": "alpha", "task_number": 2},
+        {"project": "beta", "task_number": 1},
+    ])
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        for project, num, tin, tout in [
+            ("alpha", 1, 100, 50),
+            ("alpha", 2, 200, 25),
+            ("beta", 1, 999, 999),
+        ]:
+            cur.execute(
+                "INSERT INTO work_sessions ("
+                "task_project, task_number, agent_name, started_at, "
+                "total_input_tokens, total_output_tokens"
+                ") VALUES (%s, %s, %s, now(), %s, %s)",
+                (project, num, "worker", tin, tout),
+            )
+        conn.commit()
+
+    from pollypm.storage.work_session_queries import (
+        aggregate_project_session_tokens,
+    )
+
+    # db_path is ignored on the pg branch — pass a bogus path to prove it.
+    result = aggregate_project_session_tokens(
+        tmp_path / "ignored.db",
+        project_key="alpha",
+        config=pg_config,
+    )
+    assert result == (300, 75)
+
+
+def test_pg_aggregate_empty_returns_zero_tuple(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.work_session_queries import (
+        aggregate_project_session_tokens,
+    )
+
+    result = aggregate_project_session_tokens(
+        tmp_path / "missing.db",
+        project_key="alpha",
+        config=pg_config,
+    )
+    # Empty table → (0, 0), not None (matches sqlite empty-table parity).
+    assert result == (0, 0)
+
+
+# --------------------------------------------------------------------- #
+# doctor_state_probes
+# --------------------------------------------------------------------- #
+
+
+def test_pg_applied_schema_version_returns_max(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.doctor_state_probes import applied_schema_version_ro
+
+    # Both the sqlite ``schema_version`` and ``work_schema_version`` map
+    # to the unified ``schema_migrations`` table on pg.
+    assert applied_schema_version_ro(
+        tmp_path / "x.db", "schema_version", config=pg_config,
+    ) == 1
+    assert applied_schema_version_ro(
+        tmp_path / "x.db", "work_schema_version", config=pg_config,
+    ) == 1
+
+
+def test_pg_count_work_tasks(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    _seed_work_tasks(pg_schema_pool, [
+        {"project": "alpha", "task_number": 1},
+        {"project": "alpha", "task_number": 2},
+    ])
+    from pollypm.storage.doctor_state_probes import count_work_tasks_ro
+
+    assert count_work_tasks_ro(tmp_path / "x.db", config=pg_config) == 2
+
+
+def test_pg_has_messages_table(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.doctor_state_probes import has_messages_table_ro
+
+    assert has_messages_table_ro(tmp_path / "x.db", config=pg_config) is True
+
+
+def test_pg_sessions_row_count(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO sessions ("
+            "name, role, project, provider, account, cwd, window_name"
+            ") VALUES (%s, %s, %s, %s, %s, %s, %s)",
+            ("sess-1", "worker", "alpha", "claude", "default", "/tmp", "win"),
+        )
+        conn.commit()
+    from pollypm.storage.doctor_state_probes import sessions_row_count_ro
+
+    assert sessions_row_count_ro(tmp_path / "x.db", config=pg_config) == 1
+
+
+def test_pg_session_window_names(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO sessions ("
+            "name, role, project, provider, account, cwd, window_name"
+            ") VALUES (%s, %s, %s, %s, %s, %s, %s)",
+            ("sess-1", "worker", "alpha", "claude", "default", "/tmp", "win-a"),
+        )
+        cur.execute(
+            "INSERT INTO sessions ("
+            "name, role, project, provider, account, cwd, window_name"
+            ") VALUES (%s, %s, %s, %s, %s, %s, %s)",
+            ("sess-2", "worker", "alpha", "claude", "default", "/tmp", "win-b"),
+        )
+        conn.commit()
+    from pollypm.storage.doctor_state_probes import session_window_names_ro
+
+    windows = session_window_names_ro(tmp_path / "x.db", config=pg_config)
+    assert windows == {"win-a", "win-b"}
+
+
+# --------------------------------------------------------------------- #
+# work_task_state
+# --------------------------------------------------------------------- #
+
+
+def test_pg_task_status_probe_found(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    _seed_work_tasks(pg_schema_pool, [
+        {"project": "alpha", "task_number": 7, "work_status": "in_progress"},
+    ])
+    from pollypm.storage.work_task_state import task_status_probe
+
+    found, status = task_status_probe(
+        project_key="alpha",
+        task_number=7,
+        project_path=tmp_path,
+        config=pg_config,
+    )
+    assert found is True
+    assert status == "in_progress"
+
+
+def test_pg_task_status_probe_missing(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.work_task_state import task_status_probe
+
+    found, status = task_status_probe(
+        project_key="alpha",
+        task_number=999,
+        project_path=tmp_path,
+        config=pg_config,
+    )
+    # The pg branch reports the DB is reachable even when the row is
+    # missing — same shape as the sqlite branch when it found a candidate
+    # state.db but no matching row.
+    assert found is True
+    assert status is None
+
+
+def test_pg_task_numbers_with_statuses(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    _seed_work_tasks(pg_schema_pool, [
+        {"project": "alpha", "task_number": 1, "work_status": "queued"},
+        {"project": "alpha", "task_number": 2, "work_status": "in_progress"},
+        {"project": "alpha", "task_number": 3, "work_status": "done"},
+        {"project": "beta", "task_number": 1, "work_status": "queued"},
+    ])
+    from pollypm.storage.work_task_state import task_numbers_with_statuses
+
+    result = task_numbers_with_statuses(
+        project_key="alpha",
+        project_path=tmp_path,
+        statuses=("queued", "in_progress"),
+        config=pg_config,
+    )
+    assert result == [1, 2]
+
+
+def test_pg_project_task_total_fast(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    _seed_work_tasks(pg_schema_pool, [
+        {"project": "alpha", "task_number": 1},
+        {"project": "alpha", "task_number": 2},
+        {"project": "beta", "task_number": 1},
+    ])
+    from pollypm.storage.work_task_state import project_task_total_fast
+
+    assert project_task_total_fast(
+        tmp_path / "x.db",
+        project_key="alpha",
+        config=pg_config,
+    ) == 2
+
+
+def test_pg_has_work_task_rows(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.work_task_state import has_work_task_rows
+
+    assert has_work_task_rows(
+        tmp_path / "x.db", project_key="alpha", config=pg_config,
+    ) is False
+    _seed_work_tasks(pg_schema_pool, [
+        {"project": "alpha", "task_number": 1},
+    ])
+    assert has_work_task_rows(
+        tmp_path / "x.db", project_key="alpha", config=pg_config,
+    ) is True
+    assert has_work_task_rows(
+        tmp_path / "x.db", project_key="beta", config=pg_config,
+    ) is False
+
+
+def test_pg_project_activity_probe(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    _seed_work_tasks(pg_schema_pool, [
+        {"project": "alpha", "task_number": 1, "work_status": "in_progress"},
+    ])
+    from pollypm.storage.work_task_state import project_activity_probe
+
+    is_active, has_working = project_activity_probe(
+        project_key="alpha",
+        project_path=tmp_path,
+        cutoff_iso="2000-01-01T00:00:00",
+        config=pg_config,
+    )
+    assert has_working is True
+    assert is_active is True
+
+
+# --------------------------------------------------------------------- #
+# work_transition_queries
+# --------------------------------------------------------------------- #
+
+
+def _insert_transition(
+    pool,
+    *,
+    project: str,
+    task_number: int,
+    from_state: str,
+    to_state: str,
+    actor: str = "test",
+    created_at: str | None = None,
+) -> None:
+    with pool.connection() as conn, conn.cursor() as cur:
+        if created_at is None:
+            cur.execute(
+                "INSERT INTO work_transitions ("
+                "task_project, task_number, from_state, to_state, "
+                "actor, reason, created_at"
+                ") VALUES (%s, %s, %s, %s, %s, %s, now())",
+                (project, task_number, from_state, to_state, actor, None),
+            )
+        else:
+            cur.execute(
+                "INSERT INTO work_transitions ("
+                "task_project, task_number, from_state, to_state, "
+                "actor, reason, created_at"
+                ") VALUES (%s, %s, %s, %s, %s, %s, %s::timestamptz)",
+                (project, task_number, from_state, to_state, actor, None, created_at),
+            )
+        conn.commit()
+
+
+def test_pg_advisor_transition_rows(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    _seed_work_tasks(pg_schema_pool, [
+        {"project": "alpha", "task_number": 1, "title": "T1"},
+    ])
+    _insert_transition(
+        pg_schema_pool,
+        project="alpha", task_number=1,
+        from_state="draft", to_state="queued",
+        created_at="2025-01-01T12:00:00+00:00",
+    )
+    from pollypm.storage.work_transition_queries import advisor_transition_rows
+
+    rows = advisor_transition_rows(
+        tmp_path / "x.db",
+        project_key="alpha",
+        since_iso="2024-01-01",
+        config=pg_config,
+    )
+    assert len(rows) == 1
+    assert rows[0]["project"] == "alpha"
+    assert rows[0]["task_number"] == 1
+    assert rows[0]["from_state"] == "draft"
+    assert rows[0]["to_state"] == "queued"
+    assert rows[0]["title"] == "T1"
+
+
+def test_pg_activity_feed_transition_rows(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    _seed_work_tasks(pg_schema_pool, [
+        {"project": "alpha", "task_number": 1},
+    ])
+    _insert_transition(
+        pg_schema_pool,
+        project="alpha", task_number=1,
+        from_state="draft", to_state="queued",
+    )
+    from pollypm.storage.work_transition_queries import (
+        activity_feed_transition_rows,
+    )
+
+    rows = activity_feed_transition_rows(
+        tmp_path / "x.db",
+        since_ts=None,
+        limit=10,
+        config=pg_config,
+    )
+    assert len(rows) == 1
+    assert rows[0]["task_project"] == "alpha"
+    assert rows[0]["task_number"] == 1
+
+
+# --------------------------------------------------------------------- #
+# morning_briefing_queries
+# --------------------------------------------------------------------- #
+
+
+def test_pg_briefing_transition_rows(pg_schema_pool, pg_config):
+    _apply_initial_migrations(pg_schema_pool)
+    _seed_work_tasks(pg_schema_pool, [
+        {"project": "alpha", "task_number": 1, "title": "T1"},
+    ])
+    _insert_transition(
+        pg_schema_pool,
+        project="alpha", task_number=1,
+        from_state="draft", to_state="queued",
+        created_at="2025-01-02T12:00:00+00:00",
+    )
+    _insert_transition(
+        pg_schema_pool,
+        project="alpha", task_number=1,
+        from_state="queued", to_state="done",
+        created_at="2025-01-05T12:00:00+00:00",
+    )
+    from pollypm.storage.morning_briefing_queries import transition_rows
+
+    rows = transition_rows(
+        [],
+        project_key="alpha",
+        since_iso="2025-01-01",
+        until_iso="2025-01-03",
+        config=pg_config,
+    )
+    # Window is half-open [since, until) — only the Jan 2 transition.
+    assert len(rows) == 1
+    assert rows[0]["to_state"] == "queued"
+
+
+def test_pg_briefing_priority_task_rows(pg_schema_pool, pg_config):
+    _apply_initial_migrations(pg_schema_pool)
+    _seed_work_tasks(pg_schema_pool, [
+        {"project": "alpha", "task_number": 1, "title": "low", "priority": "low",
+         "work_status": "queued"},
+        {"project": "alpha", "task_number": 2, "title": "crit",
+         "priority": "critical", "work_status": "queued"},
+        {"project": "alpha", "task_number": 3, "title": "done",
+         "priority": "high", "work_status": "done"},
+    ])
+    from pollypm.storage.morning_briefing_queries import priority_task_rows
+
+    rows = priority_task_rows(
+        [],
+        project_key="alpha",
+        open_statuses=("queued", "in_progress", "blocked", "awaiting_approval"),
+        limit=10,
+        config=pg_config,
+    )
+    titles = [r["title"] for r in rows]
+    assert "crit" in titles
+    assert "low" in titles
+    assert "done" not in titles
+    # Critical sorts before low.
+    assert titles.index("crit") < titles.index("low")
+
+
+def test_pg_briefing_blocker_rows(pg_schema_pool, pg_config):
+    _apply_initial_migrations(pg_schema_pool)
+    _seed_work_tasks(pg_schema_pool, [
+        {"project": "alpha", "task_number": 1, "title": "blocker",
+         "work_status": "queued"},
+        {"project": "alpha", "task_number": 2, "title": "blocked",
+         "work_status": "blocked"},
+    ])
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO work_task_dependencies ("
+            "from_project, from_task_number, to_project, to_task_number, "
+            "kind, created_at"
+            ") VALUES (%s, %s, %s, %s, %s, now())",
+            ("alpha", 2, "alpha", 1, "blocks"),
+        )
+        conn.commit()
+    from pollypm.storage.morning_briefing_queries import blocker_rows
+
+    rows = blocker_rows([], project_key="alpha", config=pg_config)
+    assert len(rows) == 1
+    assert rows[0]["task_number"] == 2
+    assert rows[0]["blocked_by"] == ["alpha/1"]
+    assert rows[0]["unresolved_blockers"] == ["alpha/1"]
+
+
+# --------------------------------------------------------------------- #
+# inbox_action_preview
+# --------------------------------------------------------------------- #
+
+
+def test_pg_inbox_action_preview(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO messages ("
+            "scope, project_key, type, tier, recipient, sender, state, "
+            "subject, body, payload_json, labels, kind"
+            ") VALUES ("
+            " %s, %s, %s, %s, %s, %s, %s, "
+            " %s, %s, %s::jsonb, %s::jsonb, %s)",
+            (
+                "alpha", "alpha", "notify", "immediate", "user", "system",
+                "open", "Action required: review my plan",
+                "Plan needs your approval",
+                json.dumps({"project": "alpha"}),
+                json.dumps(["plan_review"]),
+                "legacy",
+            ),
+        )
+        conn.commit()
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        '[projects.alpha]\npath = "."\n',
+        encoding="utf-8",
+    )
+    from pollypm.storage.inbox_action_preview import (
+        load_fast_inbox_action_preview,
+    )
+
+    result = load_fast_inbox_action_preview(
+        config_path, project=None, limit=5, config=pg_config,
+    )
+    assert result is not None
+    preview, ids, total = result
+    assert total == 1
+    assert preview[0].title.startswith("Action required")
+    assert preview[0].triage_label == "plan review"
+
+
+# --------------------------------------------------------------------- #
+# project_state_purge
+# --------------------------------------------------------------------- #
+
+
+def test_pg_count_and_purge_project_state_rows(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    _seed_work_tasks(pg_schema_pool, [
+        {"project": "alpha", "task_number": 1},
+        {"project": "alpha", "task_number": 2},
+        {"project": "beta", "task_number": 1},
+    ])
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO worktrees ("
+            "project_key, lane_kind, lane_key, path, branch, status, "
+            "created_at, updated_at"
+            ") VALUES (%s, %s, %s, %s, %s, %s, now(), now())",
+            ("alpha", "main", "alpha", "/tmp/a", "main", "active"),
+        )
+        conn.commit()
+    from pollypm.storage.project_state_purge import (
+        count_project_state_rows,
+        purge_project_state_rows,
+    )
+
+    counts = count_project_state_rows(
+        tmp_path / "x.db", "alpha", config=pg_config,
+    )
+    assert counts["work_tasks"] == 2
+    assert counts["worktrees"] == 1
+
+    purged = purge_project_state_rows(
+        tmp_path / "x.db", "alpha", config=pg_config,
+    )
+    assert purged["work_tasks"] == 2
+    assert purged["worktrees"] == 1
+
+    # The other project is untouched.
+    other = count_project_state_rows(
+        tmp_path / "x.db", "beta", config=pg_config,
+    )
+    assert other["work_tasks"] == 1
+
+
+def test_pg_purge_dry_run_does_not_delete(pg_schema_pool, pg_config, tmp_path):
+    _apply_initial_migrations(pg_schema_pool)
+    _seed_work_tasks(pg_schema_pool, [
+        {"project": "alpha", "task_number": 1},
+    ])
+    from pollypm.storage.project_state_purge import (
+        count_project_state_rows,
+        purge_project_state_rows,
+    )
+
+    counts = purge_project_state_rows(
+        tmp_path / "x.db", "alpha", dry_run=True, config=pg_config,
+    )
+    assert counts["work_tasks"] == 1
+    # No mutation happened.
+    after = count_project_state_rows(
+        tmp_path / "x.db", "alpha", config=pg_config,
+    )
+    assert after["work_tasks"] == 1
+
+
+# --------------------------------------------------------------------- #
+# legacy_per_project_db — pg branch is a no-op
+# --------------------------------------------------------------------- #
+
+
+def test_pg_legacy_per_project_db_migration_skipped(pg_config):
+    from pollypm.storage.legacy_per_project_db import (
+        migrate_legacy_per_project_dbs,
+    )
+
+    reports = migrate_legacy_per_project_dbs(config=pg_config)
+    assert reports == []

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,63 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -69,6 +126,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -378,8 +449,15 @@ dependencies = [
 dev = [
     { name = "httpx" },
     { name = "openapi-spec-validator" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "testcontainers" },
+]
+postgres = [
+    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
 ]
 
 [package.metadata]
@@ -388,15 +466,78 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "openapi-spec-validator", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "packaging", specifier = ">=23.0" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'dev'", specifier = ">=3.2.0" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.2.0" },
+    { name = "psycopg-pool", marker = "extra == 'dev'", specifier = ">=3.2.0" },
+    { name = "psycopg-pool", marker = "extra == 'postgres'", specifier = ">=3.2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.12" },
     { name = "sqlalchemy", specifier = ">=2.0" },
+    { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.8.0" },
     { name = "textual", specifier = ">=6.1.0" },
     { name = "typer", specifier = ">=0.16.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "postgres"]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/43/13e9c406fbbf354580476e248a16b64802a376873ebe6339e30bb655572d/psycopg_binary-3.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fbd1d4ed566895ad2d3bf4ddfd8bae90026930ddf29df3b9d91d32c8c47866a7", size = 4590377, upload-time = "2026-05-01T23:29:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/22/be/2923cd7c3683e7afdecf4f10796a18de02f5c5ddc0969aa2ad0a8cdd3bbd/psycopg_binary-3.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:75a9067e236f9b9ae3535b66fe99bddb33d39c0de10112e49b9ab11eee53dc31", size = 4669023, upload-time = "2026-05-01T23:29:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a0/2c913d6fe13d6a8bd13597d36739bf47af063ad9399e402cfecab16f3c1e/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b56b603ebcea8aa10b46228b8410ba7f13e7c2ee54389d4d9be0927fd8ce2a70", size = 5467423, upload-time = "2026-05-01T23:29:33.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/38/205d10bc1ad0df4a21c5c51659126bd3ea0ef98fcad1e852f78c249bb9c3/psycopg_binary-3.3.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c677c4ad433cb7150c8cd304a0769ae3bcfbe5ea0676eb53faa7b1443b16d0d3", size = 5151137, upload-time = "2026-05-01T23:29:42.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fc/f0381ddcd45eff3bb70dbca6823a996048d7f507b2ec3fc92c6fabc0fe87/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:26df2717e59c0473e4465a97dfb1b7afebaa479277870fd5784d1436470db47c", size = 6736671, upload-time = "2026-05-01T23:29:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/95/40/fa545ae152c24327651e5624e4902121e808270be36c10b12e9939be09bc/psycopg_binary-3.3.4-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dc1f79fd16bb1f3f4421417a514607539f17804d95c7ed617265369d1981cae", size = 4979601, upload-time = "2026-05-01T23:29:56.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e4/2f8a47ee97f90cd2b933d0463081d35631ff419de2b8c984a5f369857de0/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:136f199a407b5348b9b857c504aff60c77622a28482e7195839ce1b51238c4cc", size = 4510513, upload-time = "2026-05-01T23:30:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/94e842ff4a7f98ed162580ca2e8b8864b28c1e0350f2443f8ee47f821167/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b6f5a29e9c775b9f12a1a717aa7a2c80f9e1db6f27ba44a5b59c80ac61d2ffcf", size = 4187243, upload-time = "2026-05-01T23:30:15.352Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/83/fc6c174b672e29b7de996ea77b6cbddf46c891751c3355f6974292baa6b4/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ee17a2cf4943cde261adfad1bbc5bf38d6b3776d7afff74c7cabcbeaeb08c260", size = 3927347, upload-time = "2026-05-01T23:30:21.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/65/768364d4a97a15b1a7f47ba52688c1686f22941d8332a8398cefc468e25f/psycopg_binary-3.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c4ab71be17bdca30cb34c34c4e1496e2f5d6f20c199c12bad226070b22ef9bf", size = 4236393, upload-time = "2026-05-01T23:30:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/218efbc9e645becd80cdf651acda05f85cfe546b7a9c0458c7cbc8fe1f74/psycopg_binary-3.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:dbfdb9b6cc79f31104a7b162a2b921b765fcc62af6c00540a167a8de47e4ed38", size = 3564592, upload-time = "2026-05-01T23:30:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a6/828c9185701dab71b234c2a76c38a08b098ebfec5020716b4e93807492b5/psycopg_binary-3.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:28b7398fdd19db3232c884fb24550bdfe951221f510e195e233299e4c9b78f97", size = 4607292, upload-time = "2026-05-01T23:30:38.962Z" },
+    { url = "https://files.pythonhosted.org/packages/92/58/5b40dbc9d839045c9dae956960e4fb6d20bcabe6c59a2aa34fc3a371913f/psycopg_binary-3.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1fbaa292a3c8bb61b45df1ad3da1908ccee7cb889db9425e3557d9e34e2a4829", size = 4687023, upload-time = "2026-05-01T23:30:47.227Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a9/793f0ac107a9003b48441d0d1f9f616d96e0f37458dd8dc12528ceff55fb/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94596f9e7633ee3f6440711d43bb70aa31cc0a46a900ab8b4201a366ace5c9e7", size = 5486985, upload-time = "2026-05-01T23:30:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/42e8533497e2592334f68ec529cf5f840f7fa4e99575a4bb61aa184dbfbf/psycopg_binary-3.3.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c0056529e68dbe9184cd4019a1f3d8f3a4ead2f6fc7a5afcf27d3314edd1277", size = 5168745, upload-time = "2026-05-01T23:31:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/b7151776cc08d5935d45c833ec818a9beb417cf7c08239af1aafbdae78ee/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c09aad7051326e7603c14e50636db9c01f78272dc54b3accff03d46370461e6", size = 6761486, upload-time = "2026-05-01T23:31:14.511Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ed/c92533b9124712d592cbf1cd6c76da933a2e0acea81dfe1fbe7e735f0cff/psycopg_binary-3.3.4-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:514404ed543efd620c85602b747df2a23cf1241b4067199e1a66f2d2757aaa41", size = 4997427, upload-time = "2026-05-01T23:31:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/ccadfd0de416aa188356daa199453af24087b042e296088706d190ae0295/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:46893c26858be12cc49ca4226ed6a60b4bfccadd946b3bebb783a60b38788228", size = 4533549, upload-time = "2026-05-01T23:31:26.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a0/c8f43cee36386f7bc891ab41a9d31ea07cf9826038e732da79f26b1e5f34/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:df1d567fc430f6df15c9fcf67d87685fc49bdb325adc0db5af1adfb2f44eb5c9", size = 4210256, upload-time = "2026-05-01T23:31:33.884Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
+]
 
 [[package]]
 name = "pydantic"
@@ -518,6 +659,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -564,6 +718,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -752,6 +921,22 @@ wheels = [
 ]
 
 [[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
+]
+
+[[package]]
 name = "textual"
 version = "8.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -805,12 +990,30 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
 name = "uc-micro-py"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -824,4 +1027,57 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]


### PR DESCRIPTION
## Summary

Slice C of the pg migration (#1737). Threads `config.storage.backend` checks through eight read-side `storage/*` facades so they query Postgres when `backend = "postgres"` is active, or fall through to the current sqlite path otherwise. Foundation (pg pool + schema + factory) shipped in Slice A (#1738).

- Sqlite branches keep their existing `readonly_uri()` + workspace-pragmas semantics verbatim — first-run installs don't change shape.
- Read paths borrow the RO pool from Slice A so a stray write fails fast.
- `project_state_purge` is the only facade with a write path — it borrows the RW pool and rolls back on failure.

## Facades shipped

- `work_session_queries` — per-project dashboard Tokens line.
- `doctor_state_probes` — pm doctor schema / sessions / messages probes.
- `work_task_state` — rail glyph + task-status / count probes.
- `work_transition_queries` — advisor change detection + activity feed.
- `morning_briefing_queries` — transitions, blockers, priority tasks.
- `inbox_action_preview` — cockpit inbox first-paint hot path.
- `project_state_purge` — count + bulk purge (RW pool).
- `legacy_per_project_db` — no-op on pg (no per-project DBs to migrate).

New `storage/_backend_dispatch.py` owns the shared `is_pg_backend()` probe so every facade has one place to look for the active backend.

## Out of scope

- `storage/state.py` (the `StateStore` RO path is a 3200-line module with deep migration logic; flagged for a follow-up slice).
- Cockpit write paths (Slice B / `PgWorkService`).
- `cockpit_*.py` / `dashboard_data.py` per-project fallback walks (Slice H).

## Test plan

- [x] `pytest tests/test_pg_storage_facades.py` — 22 pg-parity tests pass against the testcontainer fixture from `tests/conftest_pg.py` (skips automatically without Docker / local pg w/ pgvector).
- [x] `pytest tests/test_pg_pool.py tests/test_pg_schema.py tests/test_pg_work_service.py tests/test_pg_storage_facades.py tests/test_work_session_queries_readonly.py tests/test_legacy_per_project_db_migration.py tests/test_readonly_uri.py` — 87 pass (pg + sqlite parity for the touched facades).
- [x] `pytest tests/test_cockpit_right_pane_command.py` — 6 pass (verifies the inbox_action_preview import shape stays intact).
- [x] `pytest tests/test_doctor.py` — 74/75 pass; the single failure (`test_doctor_performance_budget`) is an unrelated live-environment wall-time benchmark that flaked at 99.72s under CPU contention from a parallel pytest run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)