### PR TITLE
feat(pg): migrate work CLI callsites to factory dispatch (Slice J-A, #1369, #1737)

### DIFF
--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -49,7 +49,7 @@ _TASK_APP_HELP = help_with_examples(
 )
 
 if TYPE_CHECKING:
-    from pollypm.work.sqlite_service import SQLiteWorkService
+    from pollypm.work.service import WorkService
 
 task_app = typer.Typer(help=_TASK_APP_HELP)
 flow_app = typer.Typer(
@@ -194,12 +194,36 @@ def _project_from_task_id(task_id: str) -> str | None:
     return None
 
 
-def _svc(db: str, project: str | None = None) -> SQLiteWorkService:
+def _svc(db: str, project: str | None = None) -> "WorkService":
     import atexit
 
+    from pollypm.work.db_resolver import WORKSPACE_DEFAULT_DB_PATH
+    from pollypm.work.factory import create_work_service
     from pollypm.work.sync import SyncManager
     from pollypm.work.sync_file import FileSyncAdapter
-    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    # Load config once per invocation so backend dispatch (#1737) sees
+    # the operator's ``[storage] backend = "postgres"`` setting. Hidden
+    # ``load_config()`` calls in callsites that omitted ``config=`` were
+    # the root cause of #1369 — the factory silently defaults to sqlite
+    # whenever ``config`` is None.
+    config_obj: object | None = None
+    try:
+        from pollypm.config import load_config
+
+        config_obj = load_config()
+    except Exception:  # noqa: BLE001
+        config_obj = None
+
+    # ``--db`` is the explicit test / CI escape hatch — a non-default
+    # value means the caller is pinning a specific sqlite file. The
+    # factory normally ignores ``db_path`` on the pg backend, so honour
+    # the override by routing through sqlite dispatch even when config
+    # selects postgres. ``config_obj`` is kept around for the
+    # SessionManager wiring below.
+    backend_config: object | None = config_obj
+    if db != WORKSPACE_DEFAULT_DB_PATH:
+        backend_config = None
 
     db_path = _resolve_db_path(db, project=project)
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -217,13 +241,10 @@ def _svc(db: str, project: str | None = None) -> SQLiteWorkService:
     # form (``blackjack_trainer``) while task IDs use the project's
     # display slug (``blackjack-trainer``); look up via both.
     project_root = db_derived_root
-    config_obj: object | None = None
-    if project:
+    if project and config_obj is not None:
         try:
-            from pollypm.config import load_config
             from pollypm.projects import slugify_project_key
 
-            config_obj = load_config()
             known = getattr(config_obj, "projects", {}) or {}
             project_cfg = known.get(project)
             if project_cfg is None:
@@ -242,13 +263,23 @@ def _svc(db: str, project: str | None = None) -> SQLiteWorkService:
                 if cfg_path is not None:
                     project_root = Path(cfg_path)
         except Exception:  # noqa: BLE001
-            config_obj = None
+            pass
 
     sync = SyncManager()
     sync.register(FileSyncAdapter(issues_root=project_root / "issues"))
 
-    svc = SQLiteWorkService(
-        db_path=db_path, sync_manager=sync, project_path=project_root,
+    # Route through the factory so ``[storage] backend`` is honoured
+    # (#1369, #1737). ``db_path`` / ``project_path`` / ``sync_manager``
+    # are sqlite-only; the pg backend ignores them per the factory
+    # docstring. An explicit ``--db`` override forces sqlite dispatch
+    # (see ``backend_config`` above) so the test / CI escape hatch
+    # keeps working on machines whose ``pollypm.toml`` selects postgres.
+    svc = create_work_service(
+        config=backend_config,
+        db_path=db_path,
+        project_path=project_root,
+        project_key=project,
+        sync_manager=sync,
     )
 
     # Wire up the session manager for per-task worker lifecycle
@@ -293,7 +324,7 @@ def _svc(db: str, project: str | None = None) -> SQLiteWorkService:
 
 
 def _resolve_actor_for_task(
-    svc: SQLiteWorkService,
+    svc: "WorkService",
     task_id: str,
     actor: str | None,
 ) -> str:

--- a/src/pollypm/work/inbox_actions.py
+++ b/src/pollypm/work/inbox_actions.py
@@ -19,9 +19,17 @@ def open_work_service_for_task(config: Any, task_id: str) -> Any | None:
     if not db_path.exists():
         return None
     try:
-        from pollypm.work.sqlite_service import SQLiteWorkService
+        from pollypm.work.factory import create_work_service
 
-        return SQLiteWorkService(db_path=db_path, project_path=project.path)
+        # Forward ``config`` so ``[storage] backend`` is honoured (#1369,
+        # #1737). ``db_path`` is ignored on the pg backend per the factory
+        # docstring; on sqlite the per-project file is used as before.
+        return create_work_service(
+            config=config,
+            db_path=db_path,
+            project_path=project.path,
+            project_key=project_key,
+        )
     except Exception:  # noqa: BLE001
         return None
 
@@ -66,9 +74,10 @@ def resolve_inbox_work_service(config: Any, item: Any, task_id: str) -> Any | No
             )
     if db_path is not None:
         try:
-            from pollypm.work.sqlite_service import SQLiteWorkService
+            from pollypm.work.factory import create_work_service
 
-            return SQLiteWorkService(
+            return create_work_service(
+                config=config,
                 db_path=db_path,
                 project_path=Path(db_path).parent.parent,
             )

--- a/src/pollypm/work/plugin_registry.py
+++ b/src/pollypm/work/plugin_registry.py
@@ -126,8 +126,8 @@ def configure_work_plugins(
     from pathlib import Path
     import tempfile
 
+    from pollypm.work.factory import create_work_service
     from pollypm.work.gates import GateRegistry
-    from pollypm.work.sqlite_service import SQLiteWorkService
     from pollypm.work.sync import SyncManager
 
     registry = PluginRegistry()
@@ -145,8 +145,14 @@ def configure_work_plugins(
     if project_path is not None:
         resolved_project = Path(str(project_path))
 
-    # WorkService
-    svc = SQLiteWorkService(db_path=resolved_db, project_path=resolved_project)
+    # WorkService — route through the factory so ``[storage] backend``
+    # decides sqlite vs postgres (#1369, #1737). ``db_path`` is ignored
+    # on the pg backend per the factory docstring.
+    svc = create_work_service(
+        config=config,
+        db_path=resolved_db,
+        project_path=resolved_project,
+    )
     registry.register_work_service(svc)
 
     # GateRegistry

--- a/src/pollypm/work/service_factory.py
+++ b/src/pollypm/work/service_factory.py
@@ -9,8 +9,16 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-def open_project_work_service(project: Any) -> Any | None:
-    """Open a per-project SQLite work service, returning None on failure."""
+def open_project_work_service(project: Any, *, config: Any = None) -> Any | None:
+    """Open a per-project work service, returning None on failure.
+
+    Routes through :func:`pollypm.work.factory.create_work_service` so the
+    operator's ``[storage] backend`` toml setting is honoured (#1369,
+    #1737). ``db_path`` is sqlite-specific and ignored on the pg backend.
+    ``config`` is optional; when omitted it is loaded on demand so the
+    pg dispatch path still fires for callers that haven't been threaded
+    yet (the canonical pattern is to pass the already-loaded config in).
+    """
     project_path = getattr(project, "path", None)
     if project_path is None:
         return None
@@ -20,10 +28,22 @@ def open_project_work_service(project: Any) -> Any | None:
             return None
     except OSError:
         return None
-    try:
-        from pollypm.work.sqlite_service import SQLiteWorkService
+    if config is None:
+        try:
+            from pollypm.config import load_config
 
-        return SQLiteWorkService(db_path=db_path, project_path=Path(project_path))
+            config = load_config()
+        except Exception:  # noqa: BLE001
+            config = None
+    try:
+        from pollypm.work.factory import create_work_service
+
+        return create_work_service(
+            config=config,
+            db_path=db_path,
+            project_path=Path(project_path),
+            project_key=getattr(project, "key", None),
+        )
     except Exception:  # noqa: BLE001
         logger.debug(
             "work.service_factory: open work service failed for %s",


### PR DESCRIPTION
## Summary

Routes every `pm task *` CLI command and three supporting work-service
helpers through `create_work_service(config=config, ...)` so the
operator's `[storage] backend` toml setting actually decides sqlite vs
postgres. Pre-this patch `_svc()` and three sibling helpers constructed
`SQLiteWorkService(...)` directly, silently bypassing the pg cutover
(Slices A-I of #1737).

Callsites migrated:
- `work/cli.py::_svc` — main `pm task` CLI service helper. All `pm task *` commands route through here.
- `work/inbox_actions.py::open_work_service_for_task` + the resolve_inbox_work_service fallback path.
- `work/plugin_registry.py::configure_work_plugins` — plugin host bootstrap.
- `work/service_factory.py::open_project_work_service` — non-CLI per-project opener used by sweeps + blocked-chain.

The `--db` CLI flag is preserved as the explicit test / CI escape
hatch: a non-default `--db` value now forces sqlite dispatch (passes
`config=None` to the factory) so the override actually works on
machines whose `pollypm.toml` selects postgres. Pre-patch the factory
would silently ignore `db_path` on the pg backend, defeating the test
escape hatch.

Refs #1369 (CLI callsite migration umbrella), #1737 (pg cutover).

## Manual verification

Config (`~/.pollypm/pollypm.toml`):

```toml
[storage]
backend = "postgres"
url = "postgresql://localhost:5432/pollypm"
```

### 1) `pm task list --project samblog`
Expected: ~28 rows from pg (pre-patch: 1 row from sqlite).

```
ID                   Status         Priority   Title
----------------------------------------------------------------------
samblog/1            done           high       Plan project samblog
samblog/2            cancelled      normal     samblog/1: claimed samblog/1; read brief; researching WordPress MCP auth ...
samblog/3            done           high       Verify Pressable and WordPress MCP readiness
samblog/4            queued         high       Rehearse technonymous Substack migration safely
samblog/5            blocked        high       Define SamBlog WordPress content model and IA
...                  (22 rows total, abridged)
samblog/21           queued         normal     Advisor review for samblog
samblog/25           cancelled      normal     ✓ samblog/3 SHIPPED — Produced docs/plan/phase-0-readiness.md ...
```

### 2) `pm task next --project samblog`

```
ID:       samblog/4
Title:    Rehearse technonymous Substack migration safely
Status:   queued
Priority: high
Project:  samblog
Type:     task
Roles:    {"worker": "worker", "reviewer": "russell"}
```

### 3) `pm task get samblog/21`

```
ID:       samblog/21
Title:    Advisor review for samblog
Status:   queued
Priority: normal
Project:  samblog
Type:     task
Roles:    {"advisor": "advisor"}
```

### 4) Pre-patch baseline (same machine, same config) — for comparison

`pm task list --project samblog` returned only `samblog/1   queued   normal  Advisor review for samblog` (sqlite, 1 row). That's the bug the patch fixes.

## Test plan

- [x] `uv run pytest tests/test_work_cli.py -x -q` — 70 passed
- [x] `uv run pytest tests/test_work_service_factory.py -x -q` — 10 passed
- [x] `uv run pytest tests/test_inbox_actions.py -x -q` — 18 passed
- [x] `uv run pytest tests/test_plugin_interop.py -x -q` — 10 passed
- [x] Manual pg verification of the four `pm task` commands (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)