### PR TITLE
docs(pg): scrub sqlite/state.db references for the pg cutover (Slice K-docs, #1737)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Load-bearing surfaces:
 - Worker protocol injection: `src/pollypm/memory_prompts.py`
 - Per-task worker bootstrap: `src/pollypm/work/session_manager.py`
 - Session orchestration: `src/pollypm/supervisor.py`
-- Work state machine: `src/pollypm/work/sqlite_service.py`
+- Work state machine: `src/pollypm/work/pg_service.py` (Postgres-backed `WorkService` impl)
 - Cockpit shell: `src/pollypm/cockpit_ui.py`
 
 Contributor rules of thumb:

--- a/docs/agent-handbook.md
+++ b/docs/agent-handbook.md
@@ -8,8 +8,8 @@ trial-and-error, you are in the right place.
 
 This page is the discoverable reference for the agent-facing surface. It
 exists because earlier agents trial-and-errored through `--help` and fell
-through to raw `sqlite3 state.db` to inspect tables (see issue #1629). The
-fix is: every common verb has a CLI; this page lists them.
+through to raw SQL on the workspace DB to inspect tables (see issue
+#1629). The fix is: every common verb has a CLI; this page lists them.
 
 The full Typer command tree is also machine-readable — grep
 `pm cli-reference --json` into your working context if you need flags this
@@ -132,7 +132,7 @@ authoritative reality.
 | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Error: Required task roles are missing. The 'standard' requires worker, reviewer.`      | Pre-#1637 behavior. The `standard` flow now auto-adds `worker`+`reviewer` when no `--role` is passed.             | Just rerun without the role flags: `pm task create "<title>" -p <project>`. Or explicitly: `--role worker=worker --role reviewer=reviewer`.       |
 | `Error: No such option: '--reason'. Did you mean '--json'?` on `pm task queue`           | `task queue` does **not** accept `--reason`. The `--json` suggestion is wrong (distance match, not semantic).      | Queue first, then record context as a separate call: `pm task queue <id>` followed by `pm task context <id> "<reason text>" --actor <your-role>`. |
-| `Error: in prepare, no such column: source` (from a raw sqlite3 query on `work_context_entries`) | The schema doesn't have a `source` column — the columns are `entry_type`, `actor`, `text`, `task_id`, `timestamp`, etc. | Don't shell into sqlite. Use `pm task context <id>` (lists entries) and `pm task transitions <id>` (lists state changes).                          |
+| `ERROR: column "source" does not exist` (from a raw psql query on `work_context_entries`) | The schema doesn't have a `source` column — the columns are `entry_type`, `actor`, `text`, `task_id`, `timestamp`, etc. | Don't shell into the workspace DB. Use `pm task context <id>` (lists entries) and `pm task transitions <id>` (lists state changes).                          |
 | `Required: --role`                                                                       | The non-`standard` flow you picked has required role keys you didn't pass.                                         | Either switch back to `--flow standard` (auto-fills) or pass `--role <key>=<agent>` for each required role. See `pm flow list`.                    |
 | `worker-start --role worker` prints DEPRECATED                                           | The managed-worker pattern is gone (memory-leak hazard). Per-task workers are spawned by `pm task claim`.          | Use `pm task next -p <project>` then `pm task claim <id>`. For a long-running planner, use `--role architect`.                                     |
 | `WARNING: task claim recorded, but worker session provisioning failed`                   | The DB row claim succeeded; the tmux session did not.                                                              | Either continue inside an existing session, or `pm task hold <id> --reason "provision failed"` and `pm task resume <id>` after fixing.             |
@@ -143,10 +143,10 @@ authoritative reality.
 These are things autonomous agents have repeatedly tried that are wrong.
 Avoid them.
 
-- **Don't shell out to `sqlite3 state.db`.** The schema is internal and
-  has shifted (column renames, table splits) several times. The CLI is
-  the contract; `pm task context`, `pm task transitions`, `pm task get
-  --json`, and `pm cli-reference --json` cover the read paths.
+- **Don't shell out to `psql` against the workspace DB.** The schema is
+  internal and has shifted (column renames, table splits) several times.
+  The CLI is the contract; `pm task context`, `pm task transitions`,
+  `pm task get --json`, and `pm cli-reference --json` cover the read paths.
 - **Don't `pm task approve` from a hot loop.** Reviewer approval is a
   one-shot decision per `review` node. Repeated calls either no-op or
   raise; if you're polling for "is this done yet," read `pm task status`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ System design, components, boundaries, data flow, and dependencies.
 - Multi-session orchestration layer for parallel AI coding sessions
 - Heartbeat supervision and monitoring with idle detection (5+ cycle threshold)
 - Heartbeat status classification based on tmux pane content snapshots
-- SQLite storage layer for state management
+- Postgres storage layer for state management (pgvector for semantic recall)
 - tmux integration for terminal-based control and visibility
 - Role-based permission enforcement system (Heartbeat vs Operator)
 - Issue state machine with review gates (states 03-needs-review, 04-in-review)

--- a/docs/archive/snapshots/system-state-2026-04-11.md
+++ b/docs/archive/snapshots/system-state-2026-04-11.md
@@ -1,3 +1,9 @@
+> ⚠️ **Archived.** This document predates the Postgres cutover (#1737)
+> and references SQLite / per-project `state.db` / dual-backend mode that no
+> longer exist. Kept for historical context only; consult
+> `docs/architecture.md` and `src/pollypm/defaults/docs/reference/operator-runbook.md`
+> for the current storage model.
+
 # PollyPM System State — April 11, 2026
 
 ## What PollyPM Is

--- a/docs/archive/testing/cockpit-qa-prompt.md
+++ b/docs/archive/testing/cockpit-qa-prompt.md
@@ -1,3 +1,9 @@
+> ⚠️ **Archived.** This document predates the Postgres cutover (#1737)
+> and references SQLite / per-project `state.db` / dual-backend mode that no
+> longer exist. Kept for historical context only; consult
+> `docs/architecture.md` and `src/pollypm/defaults/docs/reference/operator-runbook.md`
+> for the current storage model.
+
 # Cockpit QA — Automated Testing Prompt
 
 **Goal**: Systematically test every clickable element in the PollyPM cockpit, fix every bug found, and make the dashboard and task views genuinely useful. When Sam tests tonight, nothing should be broken.

--- a/docs/archive/testing/live-integration-test-spec.md
+++ b/docs/archive/testing/live-integration-test-spec.md
@@ -1,3 +1,9 @@
+> ⚠️ **Archived.** This document predates the Postgres cutover (#1737)
+> and references SQLite / per-project `state.db` / dual-backend mode that no
+> longer exist. Kept for historical context only; consult
+> `docs/architecture.md` and `src/pollypm/defaults/docs/reference/operator-runbook.md`
+> for the current storage model.
+
 # Live Integration Test Spec — WeatherCLI Project
 
 **Goal**: Build a real project end-to-end through Polly, verifying every step

--- a/docs/archive/testing/stability-test-spec.md
+++ b/docs/archive/testing/stability-test-spec.md
@@ -1,3 +1,9 @@
+> ⚠️ **Archived.** This document predates the Postgres cutover (#1737)
+> and references SQLite / per-project `state.db` / dual-backend mode that no
+> longer exist. Kept for historical context only; consult
+> `docs/architecture.md` and `src/pollypm/defaults/docs/reference/operator-runbook.md`
+> for the current storage model.
+
 # Stability Test Spec — Pre-Demo Fix
 
 Sam presents to investors tomorrow. Everything must work: cockpit, sessions,

--- a/docs/archive/testing/work-service-test-plan.md
+++ b/docs/archive/testing/work-service-test-plan.md
@@ -1,3 +1,9 @@
+> ⚠️ **Archived.** This document predates the Postgres cutover (#1737)
+> and references SQLite / per-project `state.db` / dual-backend mode that no
+> longer exist. Kept for historical context only; consult
+> `docs/architecture.md` and `src/pollypm/defaults/docs/reference/operator-runbook.md`
+> for the current storage model.
+
 # Work Service Integration Test Plan
 
 **Goal**: Validate the work service end-to-end as a real user would experience it. The user ONLY interacts through conversation with PollyPM agents via tmux. The user never runs CLI commands directly — that's the agents' job. CLI commands may be used by the tester ONLY for troubleshooting when a bug is detected, and the bug must then be fixed.

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -89,7 +89,7 @@ Common lifecycle examples:
 ```
 
 ```json
-{"schema":1,"ts":"2026-05-06T17:27:10.000000+00:00","project":"_workspace","event":"work_db.opened","subject":"/workspace/.pollypm/state.db","actor":"system","status":"ok","metadata":{"had_messages_table_pre_open":false,"tables_created":false,"project_path":"/path/to/demo"}}
+{"schema":1,"ts":"2026-05-06T17:27:10.000000+00:00","project":"_workspace","event":"work_db.opened","subject":"postgresql://localhost:5432/pollypm","actor":"system","status":"ok","metadata":{"had_messages_table_pre_open":false,"tables_created":false,"project_path":"/path/to/demo"}}
 ```
 
 ## Core Events
@@ -98,14 +98,14 @@ The current event families are:
 
 | Event | Emitted by | Key metadata |
 |---|---|---|
-| `task.created` | `SQLiteWorkService.create_task` helper | `title`, `type`, `flow_template`, `priority`, `requires_human_review` |
+| `task.created` | `PgWorkService.create_task` helper | `title`, `type`, `flow_template`, `priority`, `requires_human_review` |
 | `task.status_changed` | work-service transition writer | `from`, `to`, `reason` |
 | `task.deleted` | work-service prune path | `reason`, `flow_template`, `title` |
 | `marker.created` | worker provisioning | `window_name`, `marker_kind`, `error` |
 | `marker.create_failed` | worker provisioning failure path | `window_name`, `marker_kind`, `error` |
 | `marker.released` | tmux session service after kickoff delivery | `window_name`, `session_role`, `error` |
 | `marker.leaked` | tmux identity/persona guard branches | `window_name`, `session_role`, `error` |
-| `work_db.opened` | `SQLiteWorkService.__init__` | `had_messages_table_pre_open`, `tables_created`, `project_path` |
+| `work_db.opened` | `PgWorkService.__init__` | `had_messages_table_pre_open`, `tables_created`, `project_path` |
 | `work_table.cleared` | Reserved for future wholesale work-table reset paths | reset reason and affected scope |
 | `heartbeat.tick` | audit watchdog cadence | cadence metadata |
 | `audit.finding` | audit watchdog findings | `rule`, `message`, `recommendation`, plus rule-specific data |

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -62,9 +62,9 @@ guardrails left by the Supervisor decomposition (#179, #182, #186, #187):
 2. **No ``supervisor._<anything>`` reach-through.** Every private helper
    that had callers was promoted to public during the decomposition; if
    you need one that isn't public, promote it first.
-3. **No direct SQL on ``StateStore._conn`` / ``SQLiteWorkService._conn``.**
-   Use the typed accessor methods the store exposes. The connection's
-   lifecycle is owned by one module only.
+3. **No direct SQL on ``StateStore._conn`` / the work service's pool.**
+   Use the typed accessor methods the store and ``WorkService`` expose.
+   The connection / pool lifecycle is owned by one module only.
 
 If you hit one of these failures and the violation is genuinely
 unavoidable (usually: a core-decomposition step that's still mid-flight),

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2,14 +2,14 @@
 
 ## Summary
 - PollyPM is a tmux-first modular monolith: one local system with explicit internal boundaries instead of microservices.
-- SQLite-backed state and the work service are the operational source of truth; the cockpit and CLI are views and control surfaces over that state.
+- Postgres-backed state and the work service are the operational source of truth; the cockpit and CLI are views and control surfaces over that state.
 - Providers, runtimes, schedulers, heartbeat strategies, and agent profiles stay replaceable through plugin contracts.
 - Raw extracted knowledge now belongs under `.pollypm/knowledge/`; this document stays intentionally short and human-readable.
 
 ## Decisions
 - Use `tmux` as the native execution surface so operators can watch, take over, and recover real sessions instead of opaque background jobs.
 - Keep the system as a modular monolith rather than splitting into microservices. Core modules stay in one process, but provider/runtime/storage/session boundaries are explicit and replaceable.
-- Treat SQLite-backed state as the shared authority for session health, task flow, inbox/messages, and cached account usage.
+- Treat the Postgres workspace database as the shared authority for session health, task flow, inbox/messages, and cached account usage.
 - Route implementation through the work service and per-task worker sessions instead of long-lived generic worker shells.
 - Keep provider integrations behind adapter contracts so Claude Code, Codex CLI, and future providers can ship independently.
 - Keep runtime execution behind runtime adapters so local shell and containerized execution can evolve independently.

--- a/docs/internals/memory-system-review.md
+++ b/docs/internals/memory-system-review.md
@@ -8,7 +8,7 @@ The current memory system (`src/pollypm/memory_backends/`, ~300 LOC across `base
 
 - **Protocol:** `MemoryBackend` with `write_entry`, `list_entries`, `read_entry`, `summarize`, `compact`.
 - **Entry shape:** `MemoryEntry(entry_id, scope, kind, title, body, tags, source, file_path, summary_path, created_at, updated_at)`.
-- **Storage:** files at `.pollypm/memory/<scope>/<timestamp>-<slug>.md` + SQLite index (`record_memory_entry` in `storage/state.py`).
+- **Storage:** files at `.pollypm/memory/<scope>/<timestamp>-<slug>.md` + Postgres index (`record_memory_entry` in `storage/state.py`).
 - **Writers:** `knowledge_extract.py` (post-session knowledge deltas), `checkpoints.py` (session checkpoint summaries).
 - **Readers:** Almost nothing reads it back. `summarize` exists; no agent automatically pulls memory into its context at session start.
 
@@ -134,7 +134,7 @@ When a new memory contradicts an existing one, the writer flags it. The old memo
 ### 3.9 Plugin surface
 
 `MemoryBackend` stays a plugin kind. Existing `FileMemoryBackend` evolves. Future backends:
-- `SQLiteMemoryBackend` — one-file store, no separate markdown (simpler for some users).
+- `PgMemoryBackend` — DB-only store, no separate markdown (simpler for some users).
 - `VectorMemoryBackend` — v1.1, uses a vector store for semantic retrieval.
 
 Write paths go through an `observer` chain so plugins can intercept (e.g. a "team sync" plugin mirrors memories to a shared store).
@@ -160,7 +160,7 @@ Write paths go through an `observer` chain so plugins can intercept (e.g. a "tea
 
 **Phase 4 — Semantic retrieval (v1.2+)**
 
-- **#M09** Vector-embedding support — new `VectorMemoryBackend` plugin using a lightweight local store (e.g., chromadb or sqlite-vec).
+- **#M09** Vector-embedding support — already covered by the `pgvector`-backed `PgEmbeddingMemoryBackend` (Slice D of #1737).
 - **#M10** Cross-project memory for operator — user-tier memories surface across all projects the operator works in.
 
 ## 5. What this buys us

--- a/docs/plugin-boundaries.md
+++ b/docs/plugin-boundaries.md
@@ -28,10 +28,10 @@ Defined in `src/pollypm/work/service.py`. The central protocol covering:
 - Queries: state_counts, my_tasks, blocked_tasks
 
 Two implementations exist:
-- `SQLiteWorkService` (production, backed by SQLite)
+- `PgWorkService` (production, backed by Postgres)
 - `MockWorkService` (testing, in-memory dicts)
 
-Current status: the Protocol, `SQLiteWorkService`, and `MockWorkService` share
+Current status: the Protocol, `PgWorkService`, and `MockWorkService` share
 the same public signatures for the task lifecycle, flow progression, context,
 and worker-session methods. The conformance test in
 `tests/test_work_service_protocol_conformance.py` guards the parameters that
@@ -97,7 +97,7 @@ The `configure_work_plugins()` function reads this config and instantiates the a
 
 ## Interop Guarantees
 
-1. Code should accept `WorkService` and work identically with `MockWorkService` or `SQLiteWorkService`.
+1. Code should accept `WorkService` and work identically with `MockWorkService` or `PgWorkService`.
 2. Custom gates implementing the `Gate` protocol integrate into the gate registry without modification
 3. Custom sync adapters implementing `SyncAdapter` receive events via the `SyncManager`
 4. The `PluginRegistry` enforces that all required plugins are registered before use

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -7,7 +7,7 @@
 - This document stays deliberately short; raw extracted knowledge lives under `.pollypm/knowledge/`, and deeper references live in the docs listed below.
 
 ## What PollyPM Is
-PollyPM manages real terminal-native coding sessions. It launches operator and worker sessions in `tmux`, tracks them through a shared SQLite-backed state layer, and gives the operator a CLI and Textual cockpit for visibility, approval, and intervention.
+PollyPM manages real terminal-native coding sessions. It launches operator and worker sessions in `tmux`, tracks them through a shared Postgres-backed state layer, and gives the operator a CLI and Textual cockpit for visibility, approval, and intervention.
 
 The project is optimized for replaceability inside one local system:
 

--- a/docs/storage-source-of-truth.md
+++ b/docs/storage-source-of-truth.md
@@ -39,8 +39,8 @@ entry at import time.
 | `INBOX_ITEM`        | `pollypm.signal_routing:shared_inbox_count`              |
 | `ACTIVITY_EVENT`    | `pollypm.store.sqlalchemy_store:SQLAlchemyStore.query_messages` |
 | `ALERT`             | `pollypm.signal_routing:shared_alert_count`              |
-| `TASK`              | `pollypm.work.sqlite_service:SQLiteWorkService.list_tasks` |
-| `EXECUTION`         | `pollypm.work.sqlite_service:SQLiteWorkService.get_execution` |
+| `TASK`              | `pollypm.work.pg_service:PgWorkService.list_tasks` |
+| `EXECUTION`         | `pollypm.work.pg_service:PgWorkService.get_execution` |
 | `TRANSCRIPT`        | `pollypm.transcript_ingest:TranscriptIngestor`           |
 | `TOKEN_USAGE`       | `pollypm.storage.state:StateStore.get_token_sample`      |
 | `PROVIDER_ACCOUNT`  | `pollypm.config:load_config` (`.accounts`)               |
@@ -87,9 +87,9 @@ Currently active:
 Currently isolated (audit-passing):
 
 * **per-task workspace DB writes** — shadows `TASK`. Already
-  routed through `SQLiteWorkService` with the resolved per-
-  project DB path. Workspace-root writes are reserved for
-  messages-only concerns.
+  routed through `PgWorkService` against the single workspace
+  Postgres database. Per-project tables are namespaced by
+  `project_key` rather than separate DBs.
 
 ## Adding a new concept
 

--- a/docs/v1/01-architecture-and-domain.md
+++ b/docs/v1/01-architecture-and-domain.md
@@ -75,7 +75,7 @@ The central orchestration layer. Responsibilities:
 - **Transcript and pane access**: Provide transcript ingestion and pane capture to all callers
 - **LLM account/session plumbing**: Manage credentials, session routing, and provider connections
 - **Scheduling/cron trigger**: Drive recurring and one-shot orchestration jobs
-- **State store**: Record all events, heartbeats, launches, and alerts to SQLite (durable state store)
+- **State store**: Record all events, heartbeats, launches, and alerts to Postgres (durable state store)
 - **Stable internal API**: Expose a defined API surface that plugins call; plugins never reach into core internals
 - **CLI and TUI**: Expose `pm` commands via Typer and a Textual-based dashboard
 
@@ -120,7 +120,7 @@ The tmux layer manages the execution surface:
 
 ### State Store
 
-SQLite database at `<project>/.pollypm/state/pollypm.db` (project-scoped) with these core tables:
+Postgres workspace database (DSN from `[storage] url` in `pollypm.toml`) with these core tables:
 
 | Table | Purpose |
 |-------|---------|
@@ -178,7 +178,7 @@ The recovery prompt is the bridge between the old session and the new one. It mu
 | Language | Python 3.13+ | Ecosystem support, rapid iteration, Textual/Typer compatibility |
 | TUI | Textual | Rich terminal UI, async-native, good tmux coexistence |
 | CLI | Typer | Clean CLI framework, integrates with Textual |
-| State store | SQLite | Zero-config, single-file, sufficient for local supervisor workloads |
+| State store | Postgres + pgvector | Single DB across projects, pgvector for semantic recall (#1737) |
 | Execution surface | tmux | Universal, scriptable, human-attachable terminal multiplexer |
 | Package management | uv | Fast Python package installer, lockfile support |
 | Config format | TOML | Python-native, readable, hierarchical |
@@ -206,7 +206,7 @@ PollyPM does not:
 
 1. **Tmux as execution surface.** Every agent session is a real tmux window. This gives humans direct access, enables pane logging and capture, and avoids reinventing terminal multiplexing. The alternative (pty management in Python) was rejected for complexity and fragility.
 
-2. **SQLite, not Postgres.** PollyPM is a single-host local supervisor. SQLite is zero-config, embedded, and more than sufficient. Postgres adds deployment complexity with no benefit for this workload.
+2. **Postgres + pgvector, single DB.** PollyPM standardized on Postgres (#1737) so semantic recall can use `pgvector` and cross-project reads no longer fan out across per-project SQLite files. Operators install Postgres locally before first run (see operator-runbook).
 
 3. **Python, not Go.** The ecosystem (Textual, Typer, rich async support, rapid prototyping) outweighs Go's performance advantages. PollyPM is I/O-bound, not CPU-bound.
 

--- a/docs/v1/02-configuration-accounts-and-isolation.md
+++ b/docs/v1/02-configuration-accounts-and-isolation.md
@@ -171,14 +171,14 @@ system_prompt = "prompts/worker.md"
 ```toml
 [plugins]
 issue_backend = "github-issues"
-memory_backend = "sqlite"
+memory_backend = "postgres"
 doc_backend = "filesystem"
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `issue_backend` | string | no | Issue tracker plugin. Default: `folder-tracker` |
-| `memory_backend` | string | no | Memory storage plugin. Default: `sqlite` |
+| `memory_backend` | string | no | Memory storage plugin. Default: `postgres` |
 | `doc_backend` | string | no | Documentation plugin. Default: `filesystem` |
 
 
@@ -238,7 +238,7 @@ The following are isolated per account:
 The following are shared across accounts:
 
 - **Project source code**: Workers access the same project directories (or worktrees)
-- **PollyPM state store**: SQLite database per project at `<project>/.pollypm/state/pollypm.db`
+- **PollyPM state store**: Shared Postgres workspace database (DSN from `[storage] url`). Per-project rows are namespaced by `project_key`.
 - **PollyPM logs**: Project-scoped under `<project>/.pollypm/logs/`
 - **Git configuration**: System-level git config is inherited (user-level is isolated via HOME)
 
@@ -263,7 +263,7 @@ Each managed project has a single `.pollypm/` directory at its root containing a
   .pollypm/              # Operational state (gitignored)
     config/              # Project-specific config (plugin selections, overrides, project.toml)
     logs/                # Pane output logs, supervisor logs, snapshots
-    state/               # SQLite database, lock files, session-scoped state
+    state/               # session-scoped state and lock files (workspace rows live in the shared Postgres DB)
     transcripts/         # PollyPM-owned transcript archive (standardized JSONL)
     artifacts/           # Build artifacts, reports, generated outputs
     plugins/             # Project-local plugins (highest discovery precedence)
@@ -369,7 +369,7 @@ When multiple sessions need recovery simultaneously, PollyPM prioritizes:
 
 ## Capacity Registry
 
-Account capacity state is persisted in the SQLite state store in the `account_capacity` table.
+Account capacity state is persisted in the Postgres state store in the `account_capacity` table.
 
 | Column | Type | Description |
 |--------|------|-------------|
@@ -395,7 +395,7 @@ The capacity registry is the source of truth for failover decisions. Config defi
 
 4. **Controller accounts eligible last.** Controller accounts (used for heartbeat and operator) are eligible for worker failover, but only as a last resort. This prevents a cascade where worker failover starves the control plane.
 
-5. **File-based capacity registry.** Capacity state is stored in SQLite alongside other operational state. No external service or file-watching needed. The registry is updated on every probe and consulted on every account selection.
+5. **Centralized capacity registry.** Capacity state is stored in Postgres alongside other operational state. No external service or file-watching needed. The registry is updated on every probe and consulted on every account selection.
 
 
 ## Cross-Doc References

--- a/docs/v1/04-extensibility-and-plugin-system.md
+++ b/docs/v1/04-extensibility-and-plugin-system.md
@@ -28,7 +28,7 @@ The core is the runtime/API substrate. It owns all durable domain behavior and r
 - **Transcript and pane access**: ingestion, normalization, and access to pane output and transcript archives
 - **LLM account/session plumbing**: auth, credentials, session routing, provider connections
 - **Scheduling/cron trigger**: recurring, delayed, and one-shot orchestration jobs
-- **Durable state store**: SQLite-backed event log, heartbeats, launches, alerts, checkpoints
+- **Durable state store**: Postgres-backed event log, heartbeats, launches, alerts, checkpoints
 - **Stable internal API**: defined surface that plugins call — plugins never reach into core internals
 - **Projects**: declarations, bindings, directory mappings
 - **Sessions**: lifecycle state machine, role assignment, provider binding
@@ -230,7 +230,7 @@ Memory scopes:
 - **Session**: scoped to a single agent session
 - **Inbox thread**: scoped to a single conversation thread
 
-Default backend: local file + SQLite. Possible alternates: vector store, Postgres, remote hosted service.
+Default backend: local file + Postgres (with `pgvector` for embeddings). Possible alternates: remote hosted Postgres, external vector store.
 
 ### Task
 

--- a/docs/v1/06-issue-management.md
+++ b/docs/v1/06-issue-management.md
@@ -145,7 +145,7 @@ Users can write their own issue management plugins by implementing this interfac
 - Linear issue tracker integration
 - Jira adapter
 - Notion database backend
-- Plain SQLite tracker
+- Plain DB-backed tracker
 - Trello board adapter
 
 The plugin system handles discovery and registration — the issue management interface handles the contract.

--- a/docs/v1/08-project-state-memory-and-documentation.md
+++ b/docs/v1/08-project-state-memory-and-documentation.md
@@ -172,10 +172,10 @@ The memory system exposes a standardized interface (from doc 04) that any storag
 
 ### Default Backend
 
-The default memory backend is a file + SQLite hybrid:
+The default memory backend is a file + Postgres hybrid:
 
 - **File storage** for `docs/` documents and large text content
-- **SQLite** for indexed metadata, scope tracking, timestamps, and queries
+- **Postgres** for indexed metadata, scope tracking, timestamps, and queries (with `pgvector` for embeddings)
 - This requires no external services and works immediately on any system
 
 ### Future Backends

--- a/docs/v1/12-checkpoints-and-recovery.md
+++ b/docs/v1/12-checkpoints-and-recovery.md
@@ -223,13 +223,13 @@ In multi-session scenarios, checkpoint paths are scoped per-session via the `<se
 
 ### State Store Integration
 
-Checkpoint metadata is also recorded in the SQLite state store's `checkpoints` table. This enables:
+Checkpoint metadata is also recorded in the Postgres state store's `checkpoints` table. This enables:
 
 - Fast lookup of the canonical checkpoint for any session
 - Querying checkpoint history without scanning the filesystem
 - Cross-session checkpoint queries (e.g., "what is the latest checkpoint for each session in project X")
 
-The JSON files on disk are the source of truth. The SQLite records are an index.
+The JSON files on disk are the source of truth. The Postgres records are an index.
 
 
 ## Recovery Flow

--- a/docs/v1/13-security-observability-and-cost.md
+++ b/docs/v1/13-security-observability-and-cost.md
@@ -119,7 +119,7 @@ Per-session tmux pane logs capture everything an agent session outputs.
 
 ### Event Log
 
-All operational events are recorded in the SQLite state store.
+All operational events are recorded in the Postgres state store.
 
 Event types:
 
@@ -158,7 +158,7 @@ Structured recovery data created at meaningful boundaries (doc 12):
 
 - Machine-readable JSON files in `<project>/.pollypm/artifacts/checkpoints/`
 - Human-readable markdown summaries for Level 1 and Level 2 checkpoints
-- Indexed in the SQLite checkpoints table
+- Indexed in the `checkpoints` table
 
 ### TUI Dashboard
 
@@ -218,7 +218,7 @@ Every alert record contains:
 
 ### Alert Durability
 
-Alerts are durable. They are stored in the SQLite state store, not just displayed in the TUI.
+Alerts are durable. They are stored in the Postgres state store, not just displayed in the TUI.
 
 - Alerts persist across TUI restarts
 - Unresolved alerts are displayed immediately when the TUI starts
@@ -348,7 +348,7 @@ Mitigation:
 | Log Type | Default Retention | Configurable |
 |----------|------------------|--------------|
 | Pane logs | Indefinite | Yes |
-| Event log (SQLite) | Indefinite | Yes |
+| Event log (Postgres) | Indefinite | Yes |
 | Heartbeat snapshots | 24 hours | Yes |
 | Level 0 checkpoints | 24 hours | Yes |
 | Level 1+ checkpoints | Indefinite | Yes |
@@ -375,7 +375,7 @@ This pattern — strong defaults that are fully replaceable — applies througho
 
 2. **Account homes are the isolation boundary.** Setting `HOME` per-session is the primary isolation mechanism. It is simple, works with all provider CLIs, and leverages each provider's existing config/auth conventions. Container-level isolation is a future enhancement, not a requirement.
 
-3. **Alerts are durable, not ephemeral.** Alerts are stored in SQLite and persist across TUI restarts. This ensures no alert is lost due to a TUI crash or operator absence. Alert history is queryable and available to automated systems.
+3. **Alerts are durable, not ephemeral.** Alerts are stored in Postgres and persist across TUI restarts. This ensures no alert is lost due to a TUI crash or operator absence. Alert history is queryable and available to automated systems.
 
 4. **Token tracking via JSONL, not API polling.** Token usage is extracted from provider transcript files after the fact, not by intercepting or polling provider APIs. This is non-intrusive, works offline, and does not require provider API access beyond what the CLI already has.
 

--- a/docs/v1/14-testing-and-verification.md
+++ b/docs/v1/14-testing-and-verification.md
@@ -31,7 +31,7 @@ Unit tests verify individual functions, classes, and modules in isolation.
 Scope:
 
 - Config parsing: `pollypm.toml` loading, validation, default handling
-- State management: SQLite operations, event recording, query correctness
+- State management: Postgres operations, event recording, query correctness
 - Plugin loading: Discovery, registration, lifecycle hooks
 - Health classification: State machine transitions, classification logic
 - Checkpoint creation: Schema validation, delta computation, serialization
@@ -45,7 +45,7 @@ Properties:
 - Deterministic: same inputs always produce same outputs
 - Located in: `tests/unit/` within the pollypm repository
 
-Unit tests use standard Python testing tools (pytest) and may use lightweight test doubles for external interfaces (e.g., a fake SQLite database, mock filesystem). Heavy mocking of internal components is discouraged — if a unit test requires extensive mocking, the code under test may need better interfaces.
+Unit tests use standard Python testing tools (pytest) and may use lightweight test doubles for external interfaces (e.g., a fake DB pool, mock filesystem). Heavy mocking of internal components is discouraged — if a unit test requires extensive mocking, the code under test may need better interfaces.
 
 ### Layer 2: Integration Tests
 
@@ -63,7 +63,7 @@ Scope:
 Properties:
 
 - Slower than unit tests but still automated
-- Hit real systems where feasible: real SQLite databases, real filesystem operations, real tmux sessions
+- Hit real systems where feasible: a real Postgres database, real filesystem operations, real tmux sessions
 - May use real provider CLIs in test mode or with test accounts
 - Located in: `tests/integration/` within the pollypm repository
 
@@ -286,7 +286,7 @@ PollyPM is a live system in daily use. The testing requirements exist to protect
 
 Tests use a separate configuration that does not interfere with production PollyPM state:
 
-- Test SQLite database in a temporary directory
+- Test Postgres database (or a temp schema in the workspace DB) for the test session
 - Test tmux session with a unique name (avoids collision with production sessions)
 - Test account homes in temporary directories
 - Test configs that reference test accounts and test projects
@@ -394,7 +394,7 @@ This pattern — strong defaults that are fully replaceable — applies througho
 
 3. **Agents must use tmux for verification.** PollyPM agents have the ability to launch and interact with running systems. They are expected to use this ability for every feature and bug fix, not just rely on test output.
 
-4. **Integration tests use real systems, not mocks.** Where feasible, integration tests hit real SQLite databases, real filesystems, and real tmux sessions. Mocking is reserved for external services that cannot be used in tests.
+4. **Integration tests use real systems, not mocks.** Where feasible, integration tests hit a real Postgres database, real filesystems, and real tmux sessions. Mocking is reserved for external services that cannot be used in tests.
 
 5. **PM review is the final gate.** Automated tests and agent verification are necessary but the work is not done until a human or PM agent reviews it. This catches design issues, UX problems, and strategic misalignment that automated testing cannot.
 

--- a/docs/v1/15-migration-and-stability.md
+++ b/docs/v1/15-migration-and-stability.md
@@ -18,7 +18,7 @@ PollyPM's current functionality is the baseline. Any change that causes a regres
 This means:
 
 - Existing `pollypm.toml` configurations must continue to work after updates
-- Existing SQLite state stores must continue to be readable after schema changes
+- Existing Postgres state databases must continue to be readable after schema changes
 - Existing CLI commands must retain their current behavior (new flags and commands are fine; changing existing ones requires a deprecation cycle)
 - Existing plugins must continue to load and function after core changes
 - Existing tmux session structures must be compatible with updated PollyPM versions
@@ -57,7 +57,7 @@ Core changes are reserved for:
 
 Every change to shared state (database, config, file formats) must be forward-compatible:
 
-- New columns in SQLite tables must have defaults
+- New columns in Postgres tables must have defaults
 - New tables are fine — they do not affect existing queries
 - Existing columns are never dropped or renamed without a migration
 - New config keys must have defaults that preserve existing behavior
@@ -147,7 +147,7 @@ Plugins are the primary mechanism for adding capabilities without modifying core
 |------------|-----------|
 | Session lifecycle management | Fundamental orchestration — all plugins depend on it |
 | Tmux layer | Shared infrastructure — not provider-specific |
-| State store (SQLite) | Shared data layer — plugins read/write through defined APIs |
+| State store (Postgres) | Shared data layer — plugins read/write through defined APIs |
 | Config loading | Must work before plugins are loaded |
 | Plugin loader itself | Bootstrap dependency — cannot be a plugin |
 | CLI and TUI framework | Shared UI infrastructure |
@@ -166,7 +166,7 @@ Plugins depend on core interfaces. Those interfaces have a stability guarantee:
 
 ## State Store Migration
 
-The SQLite state store evolves as features are added. Migrations keep existing data accessible while enabling new functionality.
+The Postgres state store evolves as features are added. Migrations keep existing data accessible while enabling new functionality.
 
 ### Schema Versioning
 
@@ -215,7 +215,7 @@ Each migration script contains:
 
 On startup:
 
-1. Open the SQLite database
+1. Open the Postgres state database
 2. Read the current schema version from `schema_version`
 3. Find all migration scripts with version numbers higher than current
 4. Apply each migration in order, within a transaction
@@ -233,7 +233,7 @@ On startup:
 | Drop column | No | Breaks existing queries. Use deprecation. |
 | Rename column | No | Breaks existing queries. Add new column, migrate data, deprecate old. |
 | Drop table | No | Breaks existing queries. Only after all references are removed. |
-| Change column type | No | SQLite is flexible here but it can break application assumptions. |
+| Change column type | No | Even when Postgres permits the cast, it can break application assumptions. |
 
 ### Backup Before Migration
 

--- a/docs/visuals/architecture-overview.md
+++ b/docs/visuals/architecture-overview.md
@@ -21,7 +21,7 @@ graph TB
     end
 
     subgraph data["Shared State"]
-        DB[("SQLite state.db<br/>16,569 heartbeats<br/>16,528 checkpoints<br/>13,063 events")]
+        DB[("Postgres workspace DB<br/>heartbeats<br/>checkpoints<br/>events")]
         Issues["File-based Issues<br/>23 issues / 6 states"]
         Jobs["jobs.json<br/>Scheduler config"]
     end

--- a/docs/visuals/heartbeat-sweep-flow.md
+++ b/docs/visuals/heartbeat-sweep-flow.md
@@ -21,7 +21,7 @@ flowchart TD
     H -->|"error message / auth fail"| K["BLOCKED"]
     H -->|"task complete signal"| L["DONE"]
 
-    I --> M["Record heartbeat +<br/>level0 checkpoint<br/>in SQLite"]
+    I --> M["Record heartbeat +<br/>level0 checkpoint<br/>in Postgres"]
     J --> M
     K --> M
     L --> M

--- a/docs/visuals/index.html
+++ b/docs/visuals/index.html
@@ -41,7 +41,7 @@ graph TB
     end
 
     subgraph data["Shared State"]
-        DB[("SQLite state.db<br/>16,569 heartbeats<br/>16,528 checkpoints<br/>13,063 events")]
+        DB[("Postgres workspace DB<br/>heartbeats<br/>checkpoints<br/>events")]
         Issues["File-based Issues<br/>23 issues / 6 states"]
         Jobs["jobs.json<br/>Scheduler config"]
     end
@@ -94,7 +94,7 @@ flowchart TD
     H -->|"error message / auth fail"| K["BLOCKED"]
     H -->|"task complete signal"| L["DONE"]
 
-    I --> M["Record heartbeat +<br/>level0 checkpoint<br/>in SQLite"]
+    I --> M["Record heartbeat +<br/>level0 checkpoint<br/>in Postgres"]
     J --> M
     K --> M
     L --> M

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -49,7 +49,7 @@ worker-process control, multi-tenant authentication.
 ### Process model
 
 `pm serve --port N` is a **separate process** from the cockpit. It is a
-peer that reads and writes the same `state.db` and `audit.jsonl` via the
+peer that reads and writes the same Postgres workspace database and `audit.jsonl` via the
 existing `create_work_service` factory (see #1389) and the existing
 `pollypm.service_api.v1.PollyPMService` facade. The cockpit and the API
 server are independent — the frontend keeps working when the cockpit
@@ -67,9 +67,9 @@ is down, and vice versa.
                 └────────┬────────┘
                          │ SDK (PollyPMService, create_work_service)
                          ▼
-              ┌──────────────────────┐
-              │ state.db, audit.jsonl│  ← shared with cockpit
-              └──────────────────────┘
+              ┌──────────────────────────────┐
+              │ Postgres + audit.jsonl files │  ← shared with cockpit
+              └──────────────────────────────┘
 ```
 
 ### Why a separate process?
@@ -106,11 +106,11 @@ resistance.
 
 ### Concurrency model
 
-`pm serve` is a single-process, single-worker server in v1. SQLite
-WAL handles multi-reader / single-writer fine for personal-use
-volumes; the audit log is append-only JSONL. If we need to scale,
-the upgrade path is documented separately (process-per-request or
-SQLite → Postgres).
+`pm serve` is a single-process, single-worker server in v1. The
+Postgres pool handles multi-reader / single-writer fine for
+personal-use volumes; the audit log is append-only JSONL. If we need
+to scale, the upgrade path is documented separately (process-per-request
+or hosted Postgres).
 
 ---
 
@@ -276,7 +276,7 @@ Every 4xx and 5xx response body is:
 | 422 | `validation_error` | Body shape valid, but values failed validation (e.g. empty `reason`) |
 | 429 | `rate_limited` | Burst protection (future) |
 | 500 | `internal_error` | Unhandled server exception |
-| 503 | `service_unavailable` | Backing store unreachable (`state.db` lock contention beyond retry) |
+| 503 | `service_unavailable` | Backing store unreachable (Postgres pool exhausted or DSN unreachable beyond retry) |
 
 Validation errors carry an extra `details` field shaped like
 `[{"field": "reason", "message": "must be non-empty"}]`.

--- a/docs/work-service-spec.md
+++ b/docs/work-service-spec.md
@@ -92,9 +92,10 @@ The work service exposes its operations through the Layer 3 Service API, meaning
 ### Process Boundary
 
 V1 ships the work service as an in-process library. The `pm` CLI and other
-local callers obtain a `SQLiteWorkService` against the shared `state.db`
-through the `pollypm.work.create_work_service` factory; there is no
-separate daemon or Unix socket in the current build.
+local callers obtain a `PgWorkService` against the workspace Postgres
+database (DSN from `[storage] url` in `pollypm.toml`) through the
+`pollypm.work.create_work_service` factory; there is no separate daemon
+or Unix socket in the current build.
 
 ```python
 from pollypm.work import create_work_service
@@ -103,13 +104,13 @@ with create_work_service(project_path=project.path) as svc:
     ...
 ```
 
-Direct construction of `SQLiteWorkService` from outside the `pollypm.work`
-package is discouraged: it forces every callsite to know the on-disk
-layout (workspace vs. per-project paths, dual-DB confusion, etc.) and
-bypasses future resolver enhancements (env overrides, fallbacks,
-telemetry). The factory resolves the canonical DB path via
-`pollypm.work.db_resolver.resolve_work_db_path` and yields a
-context-managed service so the SQLite handle closes deterministically.
+Direct construction of `PgWorkService` from outside the `pollypm.work`
+package is discouraged: it forces every callsite to know the DSN
+resolution rules (env override, `[storage] url`, default) and bypasses
+future resolver enhancements (telemetry, pool tuning). The factory
+resolves the canonical DSN via `pollypm.work.db_resolver` and yields a
+context-managed service so the Postgres connection returns to the pool
+deterministically.
 
 Callers that genuinely need a non-canonical path (legacy migration,
 tests, explicit `--db` overrides) may pass `db_path=...` explicitly so the
@@ -118,10 +119,10 @@ deviation is visible at the callsite.
 ### Audit Hooks
 
 The current work-service implementation emits audit-log events for task
-creation, status transitions, task deletion/pruning, and every SQLite work DB
-open. The `work_db.opened` event is the forensic breadcrumb for the workspace
-vs. messages-side DB confusion: its metadata records whether the opened file
-already had a `messages` table and whether work tables had to be created.
+creation, status transitions, task deletion/pruning, and every work-DB
+open. The `work_db.opened` event is the forensic breadcrumb for schema
+state: its metadata records whether the opened DB already had a
+`messages` table and whether work tables had to be created.
 
 See [Audit Log](audit-log.md) for the JSONL schema, on-disk paths, watchdog
 rules that consume these events, and the contributor contract for adding new
@@ -135,8 +136,8 @@ event types.
   so a Unix-socket daemon can still be introduced later without redesigning
   flows, gates, or storage.
 
-SQLite WAL mode handles concurrent reads while writes stay serialized through
-the work-service boundary.
+Postgres handles concurrent reads through its MVCC model while writes
+stay serialized through the work-service boundary.
 
 ## 4. Task Schema
 
@@ -302,11 +303,11 @@ A `Transition`:
 ## 5. API Surface
 
 The work service exposes these operations. In the current build, all mutations
-are intended to flow through the in-process `SQLiteWorkService` boundary. All
+are intended to flow through the in-process `PgWorkService` boundary. All
 operations return structured results (not raw file contents).
 
-**Current implementation note (2026-04-26):** `WorkService`,
-`SQLiteWorkService`, and `MockWorkService` all expose the shared parameters
+**Current implementation note:** `WorkService`,
+`PgWorkService`, and `MockWorkService` all expose the shared parameters
 callers rely on, including `created_by`, `skip_gates`, and `entry_type`.
 
 ### Task Lifecycle
@@ -742,7 +743,7 @@ session.
 | Work status state machine | Eight states (`draft` through `cancelled`) derived from OtterCamp v2. `work_status` is a projection of flow node state, not an independent controller. |
 | File-first philosophy | The file sync adapter maintains `issues/` as a human-inspectable projection. `ls issues/01-ready/` still works. |
 | Override chain | Built-in < user-global < project-local. Same precedence model as rules, magic, and agent profiles. |
-| Heartbeat supervision | Still monitors agent health. Work-state mutations remain safe because the service is in-process and SQLite-backed. |
+| Heartbeat supervision | Still monitors agent health. Work-state mutations remain safe because the service is in-process and Postgres-backed. |
 
 ## 12. Open Questions
 
@@ -760,13 +761,13 @@ Future work tracker: see GitHub issue #141.
 
 Not a v1 concern. Tasks should be well-scoped enough that context logs stay manageable. If a task is accumulating a massive context log, it's too big and should be split. For v1, `get_context` with `limit` and `since` parameters is sufficient. Revisit if real-world usage reveals a problem.
 
-### ~~OQ-3: Storage Backend for v1~~ — RESOLVED
+### ~~OQ-3: Storage Backend for v1~~ — RESOLVED (revised post-#1737)
 
-SQLite, using the existing PollyPM state database (`state.db`). Work service tables use a `work_` prefix (`work_tasks`, `work_flow_templates`, `work_node_executions`, etc.) so they coexist cleanly with existing tables (`sessions`, `heartbeats`, `alerts`, etc.). This lets work service tables reference existing tables via foreign keys (e.g., project references) without cross-database joins or sync. Plugins follow the same pattern — prefixed tables in the shared database.
+Postgres, using the workspace database (DSN from `[storage] url`). Work service tables use a `work_` prefix (`work_tasks`, `work_flow_templates`, `work_node_executions`, etc.) so they coexist cleanly with existing tables (`sessions`, `heartbeats`, `alerts`, etc.). This lets work service tables reference existing tables via foreign keys (e.g., project references) without cross-database joins or sync. Plugins follow the same pattern — prefixed tables in the shared database. (The original v1 RFC picked SQLite; #1737 moved everything to Postgres + pgvector so semantic recall and cross-project reads stop fanning out across per-project DBs.)
 
 ### ~~OQ-4: Daemon vs. In-Process Service~~ — RESOLVED
 
-In-process for v1. The `pm` CLI calls the work service library directly. SQLite WAL mode handles concurrent reads. Graduate to a Unix socket daemon in Phase 3 once the API surface is stable. The API boundary is designed to be transport-agnostic, so the upgrade is a wiring change, not a redesign.
+In-process for v1. The `pm` CLI calls the work service library directly. The Postgres pool handles concurrent reads. Graduate to a Unix socket daemon in Phase 3 once the API surface is stable. The API boundary is designed to be transport-agnostic, so the upgrade is a wiring change, not a redesign.
 
 ### ~~OQ-5: Two-Way GitHub Sync Conflict Policy~~ — DEFERRED
 
@@ -796,7 +797,7 @@ Yes, cross-project dependencies are allowed. A task in project A can be blocked 
 Because v1 is in-process, callers could be tempted to reach around the service
 and mutate tables directly. That would bypass flows, gates, sync hooks, and
 transition logging. Mitigations:
-- Keep CLI and supervisor mutations routed through `SQLiteWorkService`
+- Keep CLI and supervisor mutations routed through `PgWorkService`
 - Maintain import-boundary tests around service helpers and storage access
 - Reserve a future transport boundary for the point where stronger process
   isolation is actually needed
@@ -1225,7 +1226,7 @@ test_migrate_idempotent
 
 ```
 test_e2e_worker_claims_and_completes
-  Build a real SQLiteWorkService against a temp DB
+  Build a real PgWorkService against a temp database / schema
   Polly calls: create → queue
   Worker calls: next → claim → add_context → node_done with work output
   Polly calls: approve
@@ -1242,13 +1243,13 @@ test_e2e_gate_blocks_advance
   Verify advance is rejected with gate failure message
 
 test_e2e_supervisor_assigns_work
-  Build a real SQLiteWorkService
+  Build a real PgWorkService
   Polly creates and assigns a task
   Verify the task shows up in my_tasks for the assigned worker
 
 test_e2e_service_reopen_recovery
-  Build a SQLiteWorkService, create some tasks, then drop it
-  Re-open a fresh SQLiteWorkService against the same DB
+  Build a PgWorkService, create some tasks, then drop it
+  Re-open a fresh PgWorkService against the same DB
   Verify all state is preserved and operations resume
 ```
 
@@ -1378,7 +1379,7 @@ Build the work service as an in-process library. This gets the API surface, flow
 
 Deliverables:
 - `WorkService` protocol definition
-- Default implementation with SQLite backend
+- Default implementation with Postgres backend (`PgWorkService`)
 - Flow engine with YAML loading and override resolution
 - Built-in gates
 - Full unit and integration test suite

--- a/src/pollypm/defaults/docs/reference/operator-runbook.md
+++ b/src/pollypm/defaults/docs/reference/operator-runbook.md
@@ -148,8 +148,8 @@ what will be deleted before you commit:
 
 - `sessions to purge:` — `[sessions.*]` blocks tied to this project,
   with a `(live)` or `(stale)` marker per tmux session.
-- `state.db rows to purge:` — per-table counts in the workspace
-  `state.db` (work_tasks, messages, worktrees, audit history, …).
+- `rows to purge:` — per-table counts in the workspace Postgres
+  database (work_tasks, messages, worktrees, audit history, …).
 - `worktree directories to purge:` — `<project>/.pollypm/worktrees/`
   subdirs, with a `[dirty]` marker on any worktree with uncommitted
   changes.
@@ -167,9 +167,9 @@ pm project remove russell --yes \
 
 | Flag | Effect |
 |------|--------|
-| (no flags) | Only removes the `[projects.<key>]` config entry. Refuses while `[sessions.*]` blocks reference the project. State.db rows, audit history, and worktree dirs are left in place. |
+| (no flags) | Only removes the `[projects.<key>]` config entry. Refuses while `[sessions.*]` blocks reference the project. Workspace-DB rows, audit history, and worktree dirs are left in place. |
 | `--purge-sessions` | Kills every tmux session tied to the project and drops the matching `[sessions.*]` entries. Required when sessions reference the project — otherwise `remove_project` refuses. |
-| `--purge-state` | Deletes every state.db row tied to the project (work_tasks, messages, audit_outbox, notification_staging, worktrees, architect_resume_tokens, token_usage, …) and removes the central audit-tail JSONL at `~/.pollypm/audit/<key>.jsonl`. |
+| `--purge-state` | Deletes every workspace-DB row tied to the project (work_tasks, messages, audit_outbox, notification_staging, worktrees, architect_resume_tokens, token_usage, …) and removes the central audit-tail JSONL at `~/.pollypm/audit/<key>.jsonl`. |
 | `--purge-worktrees` | Removes every git worktree under `<project>/.pollypm/worktrees/`. Uses `git worktree remove` for registered worktrees, `shutil.rmtree` for stale dirs. Refuses dirty worktrees unless `--force-discard-worktree-changes` is also set. |
 | `--force-discard-worktree-changes` | Pairs with `--purge-worktrees`. Runs `git worktree remove --force` so dirty worktrees are removed and the local branch ref is dropped. |
 | `--force` | Skips the active-task confirmation prompt (queued or in-flight work-service tasks). Does NOT auto-accept the `--purge-state` or `--purge-worktrees` destructive prompts — use `--yes` for those. |
@@ -184,9 +184,9 @@ The cascade always runs in this order, with each step gating the next:
 2. **Sessions.** With `--purge-sessions`, tmux sessions are killed first
    so workers don't keep writing to a project that's about to disappear.
    `[sessions.*]` entries drop next.
-3. **State.db rows.** With `--purge-state`, the SQLite sweep runs BEFORE
-   the TOML edit. A failure here aborts without touching the config so
-   the rows-vs-config asymmetry can only point one way (issue #1673).
+3. **Workspace-DB rows.** With `--purge-state`, the Postgres sweep runs
+   BEFORE the TOML edit. A failure here aborts without touching the config
+   so the rows-vs-config asymmetry can only point one way (issue #1673).
 4. **Worktree directories.** With `--purge-worktrees`, dirs under
    `.pollypm/worktrees/` are removed. Dirty worktrees are skipped unless
    `--force-discard-worktree-changes` is set.
@@ -228,7 +228,7 @@ pm project new <path-from-the-removed-entry> \
     --slug russell --skip-planner
 ```
 
-The full cascade — sessions, state.db rows, worktrees, config entry —
+The full cascade — sessions, workspace-DB rows, worktrees, config entry —
 runs in the same order documented in **Destructive-action ordering**
 above. Step 5 (re-register) re-runs `ensure_project_scaffold` on the
 path so the standard `.pollypm/` directory layout reappears.
@@ -471,15 +471,11 @@ What an operator sees:
   watchdog's dead-loop rule and route an escalation to the project
   architect.
 
-## Setting up Postgres (issue #1737, Slice A foundation)
+## Setting up Postgres (issue #1737)
 
-PollyPM is migrating from per-project SQLite to a single Postgres
-instance with `pgvector` for semantic recall. Slice A ships the
-foundation — the pool, the schema, and the doctor probe — behind a
-feature flag. The sqlite backend remains the default until the cutover
-PR; the steps below are required only for operators opting into the
-new backend ahead of cutover, or for the test suite that exercises the
-`PgWorkService` skeleton.
+PollyPM uses a single Postgres instance with `pgvector` for semantic
+recall as its only storage backend. The steps below are required on
+every host before `pm` will start.
 
 ### Prerequisites
 
@@ -510,7 +506,6 @@ Add to `~/.pollypm/pollypm.toml`:
 
 ```toml
 [storage]
-backend = "postgres"
 # Optional — leaving this empty falls through to POLLYPM_PG_DSN, then
 # the default postgresql://localhost:5432/pollypm.
 url = "postgresql://localhost:5432/pollypm"
@@ -536,8 +531,8 @@ export POLLYPM_PG_DSN="postgresql://user:pw@host:5432/pollypm"
 
 ### Smoke test
 
-Run the pg-only doctor probe — fast feedback whether the cockpit will
-boot against the configured backend:
+Run the pg doctor probe — fast feedback whether the cockpit will boot
+against the configured DSN:
 
 ```
 pm doctor-pg-connection
@@ -547,12 +542,3 @@ The check returns `ok` when pg is reachable, the server version is at
 least the configured `min_version`, and the `vector` extension is
 installed. Failures emit the standard three-question doctor message
 with an actionable fix command.
-
-### Flipping the backend back to sqlite
-
-Until the cutover PR lands, the safe rollback is to set `[storage]
-backend = "sqlite"` and restart. Slice A intentionally leaves the
-sqlite implementation in place — no data migration is required when
-the flag is flipped before any pg writes happen. After Slices B–H land
-and the cutover is complete the rollback path runs through the
-pre-cutover snapshot documented in the migration PR notes.


### PR DESCRIPTION
## Summary

Documentation partition of Slice K of #1737 — the SQLite-to-Postgres
cutover. Replaces SQLite / per-project `state.db` / dual-backend
language across PollyPM's markdown docs with the Postgres reality.
The K-deletion agent owns `src/`, `tests/`, and `pyproject.toml` once
Slice J merges; this PR is **markdown-only** by design.

## What each file lost

### Top-level / hot docs
- **README.md** — "Work state machine" load-bearing-surface link now points at `pg_service.py` (sqlite_service.py is going away).
- **docs/architecture.md** — bullet "SQLite storage layer for state management" → "Postgres storage layer for state management (pgvector for semantic recall)".
- **docs/agent-handbook.md** — three references to shelling out via `sqlite3 state.db` rewritten as workspace-DB / `psql` guidance.
- **docs/conventions.md** — boundary-test guard for `SQLiteWorkService._conn` retargeted at the work service's pool.
- **docs/decisions.md** — two "SQLite-backed state" bullets retargeted at the Postgres workspace database.
- **docs/audit-log.md** — example event subject now shows a Postgres DSN; `SQLiteWorkService` rows in the events table → `PgWorkService`.
- **docs/plugin-boundaries.md** — `SQLiteWorkService` → `PgWorkService` (three mentions).
- **docs/project-overview.md** — "shared SQLite-backed state layer" → "shared Postgres-backed state layer".
- **docs/storage-source-of-truth.md** — canonical reader registry rows for `TASK`/`EXECUTION` now point at `pollypm.work.pg_service:PgWorkService`; legacy-writers entry updated to describe per-key namespacing in the shared pg DB.
- **docs/web-api-spec.md** — process-model description, ASCII diagram, concurrency-model paragraph, and the 503 error row now describe Postgres + the connection pool instead of `state.db` + SQLite WAL.
- **docs/work-service-spec.md** — 13 hits across Process Boundary, Audit Hooks, API Surface implementation note, P-1 mitigation, OQ-3 (storage backend), OQ-4 (daemon decision), end-to-end + performance test templates, and Phase 1 deliverable list. OQ-3 retains a one-line note crediting the original SQLite decision and #1737's reason for moving to pg.

### v1 spec docs
- **docs/v1/01-architecture-and-domain.md** — state-store bullet, schema-location paragraph, choices table row, and rationale list item 2 (now "Postgres + pgvector, single DB" instead of "SQLite, not Postgres").
- **docs/v1/02-configuration-accounts-and-isolation.md** — `memory_backend = "sqlite"` → `"postgres"`; default doc updated; state-store description in the isolation section now describes the shared workspace pg DB; capacity-registry rationale.
- **docs/v1/04-extensibility-and-plugin-system.md** — durable-state-store bullet and memory-backend alternatives list.
- **docs/v1/06-issue-management.md** — "Plain SQLite tracker" → "Plain DB-backed tracker".
- **docs/v1/08-project-state-memory-and-documentation.md** — memory-backend description (file + Postgres hybrid; pgvector mention).
- **docs/v1/12-checkpoints-and-recovery.md** — checkpoint-metadata storage description.
- **docs/v1/13-security-observability-and-cost.md** — five "SQLite state store" references retargeted; durable-alerts rationale.
- **docs/v1/14-testing-and-verification.md** — unit/integration test guidance now talks about Postgres / a DB pool instead of fake SQLite databases.
- **docs/v1/15-migration-and-stability.md** — migration guarantees, schema-evolution paragraph, and the "Change column type" table row.

### Visuals
- **docs/visuals/heartbeat-sweep-flow.md** — mermaid label now says "in Postgres".
- **docs/visuals/architecture-overview.md** — mermaid DB node now says "Postgres workspace DB" (dropped the stale row counts).
- **docs/visuals/index.html** — both mermaid diagrams updated to match.

### Internals
- **docs/internals/memory-system-review.md** — `SQLiteMemoryBackend` → `PgMemoryBackend`; `#M09` note now points at `PgEmbeddingMemoryBackend` (Slice D).

### Defaults (markdown shipped with the package)
- **src/pollypm/defaults/docs/reference/operator-runbook.md** — `state.db` purge language rewritten as "workspace-DB rows"; Postgres setup section dropped the Slice-A feature-flag framing (pg is now mandatory); deleted the "Flipping the backend back to sqlite" subsection; dropped `backend = "postgres"` from the example `[storage]` block (the field no longer exists post-cutover).

### Archive (banner only, no content rewritten)
Per the brief, archived docs predating the pg cutover get a banner instead of a rewrite:
- docs/archive/testing/live-integration-test-spec.md
- docs/archive/testing/stability-test-spec.md
- docs/archive/testing/cockpit-qa-prompt.md
- docs/archive/testing/work-service-test-plan.md
- docs/archive/snapshots/system-state-2026-04-11.md

Each gets a one-block notice: "Archived. This document predates the Postgres cutover (#1737)..."

### Intentionally left alone
- `docs/project-specs/*.md` — these are user-app demo specs (FastAPI + SQLite recipe site, etc.). They describe stack choices for fictional user projects, not PollyPM's storage.
- `docs/worker-guide.md` line 135 / `src/pollypm/defaults/docs/worker-guide.md` line 160 — inside a worked-example JSON payload from a fictional `shortlink_gen` demo task.

## Test plan
- [ ] grep -rn 'state\.db' docs/ src/pollypm/defaults/docs/ README.md returns only intentional historical / archived hits.
- [ ] git diff --name-only origin/main..HEAD is markdown / HTML only — no src/*.py, no tests/, no pyproject.toml, no issues/**.
- [ ] Operator-runbook 'pm doctor-pg-connection' smoke-test instructions are still accurate against src/pollypm/doctor/install_state.py.

Refs #1737