### PR TITLE
feat(pg): port notification_staging + dashboard/categorization to postgres (Slice K-misc, #1737)

### DIFF
--- a/src/pollypm/dashboard/categorization.py
+++ b/src/pollypm/dashboard/categorization.py
@@ -25,8 +25,10 @@ Four categories, priority-ordered:
 The module is a leaf in the import graph: it depends only on the
 canonical inbox predicate, the ``InboxItemKind`` enum, and the
 structural shape of the work service. No cockpit, no Supervisor, no
-sqlite3. That keeps it importable from every surface (rail, dashboard
-app, CLI, tests).
+direct database driver (sqlite3 or psycopg) — the work service is
+consumed structurally via :class:`_WorkServiceLike` so either backend
+satisfies the contract. That keeps it importable from every surface
+(rail, dashboard app, CLI, tests).
 """
 
 from __future__ import annotations
@@ -106,7 +108,7 @@ class _WorkerSession(Protocol):
 class _WorkServiceLike(Protocol):
     """The narrow slice of ``WorkService`` the categorizer needs.
 
-    Both :class:`pollypm.work.sqlite_service.SQLiteWorkService` and
+    Both :class:`pollypm.work.pg_service.PgWorkService` and
     :class:`pollypm.work.mock_service.MockWorkService` satisfy this
     shape, so tests can pass either implementation. Method signatures
     mirror the public protocol — adding methods here would tighten the

--- a/src/pollypm/notification_staging.py
+++ b/src/pollypm/notification_staging.py
@@ -37,6 +37,15 @@ table. It exposes:
 * :func:`check_and_flush_on_done`  — transition hook: milestone-or-idle flush
 * :func:`check_regression_on_reopen` — transition hook: milestone regression ping
 * :func:`prune_old_staging`        — 30-day hygiene for the plugin handler
+
+Backend (issue #1737, Slice K-misc): every direct-DB helper here talks
+to Postgres via psycopg connections obtained from the process-wide
+:mod:`pollypm.storage.pg_pool` (or an explicit psycopg connection
+passed by the caller). The canonical DDL lives in
+:data:`pollypm.storage.pg_schema.INITIAL_SCHEMA_DDL` group D; the
+inline ``CREATE TABLE IF NOT EXISTS`` mirror below stays as a test-
+friendly fallback so a bare-empty pg schema can be lit up without
+first running the migration applier.
 """
 
 from __future__ import annotations
@@ -44,12 +53,14 @@ from __future__ import annotations
 import json
 import logging
 import re
-import sqlite3
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pollypm.inbox.kind import InboxItemKind
+
+if TYPE_CHECKING:
+    import psycopg
 
 logger = logging.getLogger(__name__)
 
@@ -64,43 +75,55 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _now_iso() -> str:
-    return datetime.now(UTC).isoformat()
+# Idempotent DDL kept inline so a freshly-created schema (e.g. the
+# per-test schema fixture) can host writes without the test having to
+# bootstrap the full migration set. The shape is a faithful port of
+# the sqlite original; ``bigserial`` replaces ``INTEGER PRIMARY KEY
+# AUTOINCREMENT`` and ``timestamptz`` replaces ``TEXT`` for the two
+# timestamp columns. Matches group D of
+# :data:`pollypm.storage.pg_schema.INITIAL_SCHEMA_DDL`.
+_STAGING_DDL = """
+CREATE TABLE IF NOT EXISTS notification_staging (
+    id              bigserial PRIMARY KEY,
+    project         text NOT NULL,
+    subject         text NOT NULL,
+    body            text NOT NULL,
+    actor           text NOT NULL,
+    priority        text NOT NULL,
+    payload_json    jsonb NOT NULL,
+    milestone_key   text,
+    created_at      timestamptz NOT NULL,
+    flushed_at      timestamptz,
+    rollup_task_id  text
+);
+CREATE INDEX IF NOT EXISTS idx_notification_staging_pending
+    ON notification_staging(project, milestone_key, flushed_at);
+CREATE INDEX IF NOT EXISTS idx_notification_staging_created
+    ON notification_staging(created_at);
+"""
 
 
-def _ensure_staging_table(conn: sqlite3.Connection) -> None:
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _ensure_staging_table(conn: "psycopg.Connection") -> None:
     """Create the staging table (and indexes) if missing.
 
-    The canonical migration lives in :mod:`pollypm.work.schema`; this
-    helper is a fallback for direct-connection callers (e.g. the
-    ``pm notify`` path which opens a bare ``StateStore`` before any
-    ``SQLiteWorkService`` ran migrations).
+    The canonical DDL lives in
+    :data:`pollypm.storage.pg_schema.INITIAL_SCHEMA_DDL` (applied via
+    :mod:`pollypm.storage.pg_migrations`); this helper is a fallback
+    for callers that hold a bare psycopg connection on a schema that
+    doesn't have the migration applied yet (test fixtures that mount
+    a per-test schema namespace, mostly).
     """
-    conn.executescript(
-        """
-        CREATE TABLE IF NOT EXISTS notification_staging (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            project TEXT NOT NULL,
-            subject TEXT NOT NULL,
-            body TEXT NOT NULL,
-            actor TEXT NOT NULL,
-            priority TEXT NOT NULL,
-            payload_json TEXT NOT NULL,
-            milestone_key TEXT,
-            created_at TEXT NOT NULL,
-            flushed_at TEXT,
-            rollup_task_id TEXT
-        );
-        CREATE INDEX IF NOT EXISTS idx_notification_staging_pending
-            ON notification_staging(project, milestone_key, flushed_at);
-        CREATE INDEX IF NOT EXISTS idx_notification_staging_created
-            ON notification_staging(created_at);
-        """
-    )
+    with conn.cursor() as cur:
+        cur.execute(_STAGING_DDL)
+    conn.commit()
 
 
 def stage_notification(
-    conn: sqlite3.Connection,
+    conn: "psycopg.Connection",
     *,
     project: str,
     subject: str,
@@ -125,56 +148,66 @@ def stage_notification(
     payload_dict.setdefault("body", body)
     payload_dict.setdefault("actor", actor)
     payload_dict.setdefault("project", project)
-    cur = conn.execute(
-        "INSERT INTO notification_staging "
-        "(project, subject, body, actor, priority, payload_json, "
-        "milestone_key, created_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-        (
-            project,
-            subject,
-            body,
-            actor,
-            priority,
-            json.dumps(payload_dict, separators=(",", ":"), default=str),
-            milestone_key,
-            _now_iso(),
-        ),
-    )
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO notification_staging "
+            "(project, subject, body, actor, priority, payload_json, "
+            "milestone_key, created_at) "
+            "VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s) RETURNING id",
+            (
+                project,
+                subject,
+                body,
+                actor,
+                priority,
+                json.dumps(payload_dict, separators=(",", ":"), default=str),
+                milestone_key,
+                _now(),
+            ),
+        )
+        row = cur.fetchone()
     conn.commit()
-    return int(cur.lastrowid or 0)
+    return int(row[0]) if row else 0
 
 
 def list_pending(
-    conn: sqlite3.Connection,
+    conn: "psycopg.Connection",
     *,
     project: str,
     milestone_key: str | None,
-) -> list[sqlite3.Row]:
+) -> list[dict[str, Any]]:
     """Return pending digest rows for (project, milestone_key), oldest first.
 
     "Pending" = ``flushed_at IS NULL`` AND ``priority = 'digest'``. Silent
     rows are skipped — they're audit-only and never show up in rollups.
     ``milestone_key IS NULL`` is matched when ``milestone_key`` is None.
+
+    Returns a list of dict rows (psycopg's ``dict_row`` factory) so
+    callers can access columns by name. The sqlite-era predecessor
+    returned ``list[sqlite3.Row]`` — semantically identical for the
+    mapping-access call sites the legacy ``list_pending`` had.
     """
+    from psycopg.rows import dict_row
+
     _ensure_staging_table(conn)
-    conn.row_factory = sqlite3.Row
-    if milestone_key is None:
-        rows = conn.execute(
-            "SELECT * FROM notification_staging "
-            "WHERE project = ? AND milestone_key IS NULL "
-            "AND flushed_at IS NULL AND priority = 'digest' "
-            "ORDER BY created_at, id",
-            (project,),
-        ).fetchall()
-    else:
-        rows = conn.execute(
-            "SELECT * FROM notification_staging "
-            "WHERE project = ? AND milestone_key = ? "
-            "AND flushed_at IS NULL AND priority = 'digest' "
-            "ORDER BY created_at, id",
-            (project, milestone_key),
-        ).fetchall()
+    with conn.cursor(row_factory=dict_row) as cur:
+        if milestone_key is None:
+            cur.execute(
+                "SELECT * FROM notification_staging "
+                "WHERE project = %s AND milestone_key IS NULL "
+                "AND flushed_at IS NULL AND priority = 'digest' "
+                "ORDER BY created_at, id",
+                (project,),
+            )
+        else:
+            cur.execute(
+                "SELECT * FROM notification_staging "
+                "WHERE project = %s AND milestone_key = %s "
+                "AND flushed_at IS NULL AND priority = 'digest' "
+                "ORDER BY created_at, id",
+                (project, milestone_key),
+            )
+        rows = cur.fetchall()
     return list(rows)
 
 
@@ -359,7 +392,7 @@ def flush_milestone_digest(
     svc.mark_rollup_candidates_flushed(
         merged,
         rollup_task_id=task.task_id,
-        flushed_at=_now_iso(),
+        flushed_at=_now().isoformat(),
     )
     return task.task_id
 
@@ -487,7 +520,7 @@ def detect_milestone_completion(
         return None
 
     # Late import to avoid a circular import at module load; the status
-    # enum lives alongside SQLiteWorkService.
+    # enum lives alongside the work service implementations.
     from pollypm.work.models import WorkStatus
 
     for milestone_key, spec in specs:
@@ -599,7 +632,7 @@ def check_regression_on_reopen(
 
 
 # ---------------------------------------------------------------------------
-# Transition hook — called from sqlite_service after a task moves to done.
+# Transition hook — called from the work service after a task moves to done.
 # ---------------------------------------------------------------------------
 
 
@@ -661,7 +694,7 @@ def check_and_flush_on_done(
 
 
 def prune_old_staging(
-    conn: sqlite3.Connection,
+    conn: "psycopg.Connection",
     *,
     retain_days: int = 30,
 ) -> dict[str, int]:
@@ -671,21 +704,22 @@ def prune_old_staging(
     that simply hasn't closed yet. Returns a summary for logging.
     """
     _ensure_staging_table(conn)
-    cutoff = (datetime.now(UTC) - timedelta(days=retain_days)).isoformat()
+    cutoff = _now() - timedelta(days=retain_days)
 
-    cur = conn.execute(
-        "DELETE FROM notification_staging "
-        "WHERE flushed_at IS NOT NULL AND flushed_at <= ?",
-        (cutoff,),
-    )
-    flushed_deleted = cur.rowcount or 0
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM notification_staging "
+            "WHERE flushed_at IS NOT NULL AND flushed_at <= %s",
+            (cutoff,),
+        )
+        flushed_deleted = cur.rowcount or 0
 
-    cur = conn.execute(
-        "DELETE FROM notification_staging "
-        "WHERE priority = 'silent' AND created_at <= ?",
-        (cutoff,),
-    )
-    silent_deleted = cur.rowcount or 0
+        cur.execute(
+            "DELETE FROM notification_staging "
+            "WHERE priority = 'silent' AND created_at <= %s",
+            (cutoff,),
+        )
+        silent_deleted = cur.rowcount or 0
 
     conn.commit()
     return {

--- a/tests/test_notification_staging.py
+++ b/tests/test_notification_staging.py
@@ -1,0 +1,334 @@
+"""Pg-backed tests for :mod:`pollypm.notification_staging` (Slice K-misc, #1737).
+
+These tests cover the public surface of the standalone module after the
+sqlite → psycopg port:
+
+* :func:`stage_notification` / :func:`list_pending` round-trip
+* :func:`prune_old_staging` retention semantics
+
+The work-service-facing helpers (``flush_milestone_digest``,
+``check_and_flush_on_done``, ``check_regression_on_reopen``) are
+covered by the in-memory mocks in
+:mod:`tests.test_inbox_kind_emit_sites` — they don't touch a DB
+directly, so they're backend-agnostic and don't need a pg fixture.
+
+The legacy ``tests/test_notification_tiering.py`` still exercises the
+sqlite path via :class:`SQLiteWorkService`; that file belongs to the
+K-deletion sweep (separate PR) which collapses the sqlite stack
+entirely.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+
+pytestmark = pytest.mark.usefixtures("pg_schema_pool")
+
+
+def _row_count(conn) -> int:
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM notification_staging")
+        return int(cur.fetchone()[0])
+
+
+def _all_rows(conn) -> list[dict]:
+    from psycopg.rows import dict_row
+
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute("SELECT * FROM notification_staging ORDER BY id")
+        return list(cur.fetchall())
+
+
+# ---------------------------------------------------------------------------
+# _ensure_staging_table — idempotent on pg
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_staging_table_creates_pg_shape(pg_schema_pool) -> None:
+    from pollypm.notification_staging import _ensure_staging_table
+
+    with pg_schema_pool.connection() as conn:
+        _ensure_staging_table(conn)
+        # Second call is a no-op — IF NOT EXISTS protects.
+        _ensure_staging_table(conn)
+        # Column types are pg-native (bigint id, jsonb payload, tz timestamps).
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT column_name, data_type FROM information_schema.columns "
+                "WHERE table_name = 'notification_staging' "
+                "ORDER BY ordinal_position"
+            )
+            cols = dict(cur.fetchall())
+    assert cols["id"] == "bigint"
+    assert cols["payload_json"] == "jsonb"
+    assert cols["created_at"] == "timestamp with time zone"
+    assert cols["flushed_at"] == "timestamp with time zone"
+
+
+# ---------------------------------------------------------------------------
+# stage_notification
+# ---------------------------------------------------------------------------
+
+
+def test_stage_notification_inserts_row_and_returns_id(pg_schema_pool) -> None:
+    from pollypm.notification_staging import stage_notification
+
+    with pg_schema_pool.connection() as conn:
+        row_id = stage_notification(
+            conn,
+            project="demo",
+            subject="Task A done",
+            body="merged PR #99",
+            actor="polly",
+            priority="digest",
+            milestone_key="milestones/01-init",
+            payload={"pr": "#99"},
+        )
+        assert row_id > 0
+
+        rows = _all_rows(conn)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["project"] == "demo"
+    assert row["subject"] == "Task A done"
+    assert row["priority"] == "digest"
+    assert row["milestone_key"] == "milestones/01-init"
+    # payload_json comes back as a python dict thanks to jsonb adaptation.
+    payload = row["payload_json"]
+    if isinstance(payload, str):  # belt-and-braces: psycopg returns dict
+        payload = json.loads(payload)
+    assert payload["pr"] == "#99"
+    # The producer fills in convenience fields on the payload dict.
+    assert payload["subject"] == "Task A done"
+    assert payload["actor"] == "polly"
+    assert payload["project"] == "demo"
+
+
+def test_stage_notification_rejects_immediate_priority(pg_schema_pool) -> None:
+    from pollypm.notification_staging import stage_notification
+
+    with pg_schema_pool.connection() as conn:
+        with pytest.raises(AssertionError):
+            stage_notification(
+                conn,
+                project="demo",
+                subject="urgent",
+                body="",
+                actor="polly",
+                priority="immediate",  # not stageable
+                milestone_key=None,
+            )
+
+
+def test_stage_notification_accepts_silent_priority(pg_schema_pool) -> None:
+    from pollypm.notification_staging import stage_notification
+
+    with pg_schema_pool.connection() as conn:
+        row_id = stage_notification(
+            conn,
+            project="demo",
+            subject="audit log",
+            body="",
+            actor="polly",
+            priority="silent",
+            milestone_key=None,
+        )
+        assert row_id > 0
+        rows = _all_rows(conn)
+    assert len(rows) == 1
+    assert rows[0]["priority"] == "silent"
+    assert rows[0]["milestone_key"] is None
+
+
+# ---------------------------------------------------------------------------
+# list_pending
+# ---------------------------------------------------------------------------
+
+
+def test_list_pending_returns_oldest_first(pg_schema_pool) -> None:
+    from pollypm.notification_staging import list_pending, stage_notification
+
+    with pg_schema_pool.connection() as conn:
+        for i in range(3):
+            stage_notification(
+                conn,
+                project="demo",
+                subject=f"subject-{i}",
+                body=f"body-{i}",
+                actor="polly",
+                priority="digest",
+                milestone_key="milestones/01-init",
+            )
+
+        rows = list_pending(
+            conn, project="demo", milestone_key="milestones/01-init",
+        )
+    assert [r["subject"] for r in rows] == ["subject-0", "subject-1", "subject-2"]
+
+
+def test_list_pending_filters_by_milestone_key(pg_schema_pool) -> None:
+    from pollypm.notification_staging import list_pending, stage_notification
+
+    with pg_schema_pool.connection() as conn:
+        stage_notification(
+            conn, project="demo", subject="a", body="", actor="polly",
+            priority="digest", milestone_key="milestones/01",
+        )
+        stage_notification(
+            conn, project="demo", subject="b", body="", actor="polly",
+            priority="digest", milestone_key="milestones/02",
+        )
+        stage_notification(
+            conn, project="demo", subject="c", body="", actor="polly",
+            priority="digest", milestone_key=None,
+        )
+
+        only_01 = list_pending(
+            conn, project="demo", milestone_key="milestones/01",
+        )
+        only_null = list_pending(conn, project="demo", milestone_key=None)
+    assert [r["subject"] for r in only_01] == ["a"]
+    assert [r["subject"] for r in only_null] == ["c"]
+
+
+def test_list_pending_skips_silent_and_flushed(pg_schema_pool) -> None:
+    from pollypm.notification_staging import list_pending, stage_notification
+
+    with pg_schema_pool.connection() as conn:
+        # Silent never surfaces.
+        stage_notification(
+            conn, project="demo", subject="audit", body="", actor="polly",
+            priority="silent", milestone_key="milestones/01",
+        )
+        # Digest pending → surfaces.
+        stage_notification(
+            conn, project="demo", subject="open", body="", actor="polly",
+            priority="digest", milestone_key="milestones/01",
+        )
+        # Digest already flushed → does not surface.
+        stage_notification(
+            conn, project="demo", subject="closed", body="", actor="polly",
+            priority="digest", milestone_key="milestones/01",
+        )
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE notification_staging SET flushed_at = now(), "
+                "rollup_task_id = 'demo/1' WHERE subject = 'closed'"
+            )
+        conn.commit()
+
+        rows = list_pending(
+            conn, project="demo", milestone_key="milestones/01",
+        )
+    assert [r["subject"] for r in rows] == ["open"]
+
+
+# ---------------------------------------------------------------------------
+# prune_old_staging
+# ---------------------------------------------------------------------------
+
+
+def _insert_row(
+    conn, *, subject, priority, created_at, flushed_at=None, milestone_key=None,
+):
+    """Direct INSERT used by the prune tests to fix timestamps in the past."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO notification_staging "
+            "(project, subject, body, actor, priority, payload_json, "
+            "milestone_key, created_at, flushed_at, rollup_task_id) "
+            "VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s)",
+            (
+                "demo", subject, "body", "polly", priority, "{}",
+                milestone_key, created_at, flushed_at,
+                "demo/99" if flushed_at else None,
+            ),
+        )
+    conn.commit()
+
+
+def test_prune_removes_old_flushed_and_silent_rows(pg_schema_pool) -> None:
+    from pollypm.notification_staging import (
+        _ensure_staging_table, prune_old_staging,
+    )
+
+    with pg_schema_pool.connection() as conn:
+        _ensure_staging_table(conn)
+        now = datetime.now(UTC)
+
+        # (a) Flushed 40 days ago — should be pruned.
+        _insert_row(
+            conn,
+            subject="old flushed",
+            priority="digest",
+            milestone_key="milestones/01",
+            created_at=now - timedelta(days=50),
+            flushed_at=now - timedelta(days=40),
+        )
+        # (b) Flushed 5 days ago — keep.
+        _insert_row(
+            conn,
+            subject="recent flushed",
+            priority="digest",
+            milestone_key="milestones/01",
+            created_at=now - timedelta(days=10),
+            flushed_at=now - timedelta(days=5),
+        )
+        # (c) Pending digest from 60 days ago — keep (never pruned).
+        _insert_row(
+            conn,
+            subject="old pending",
+            priority="digest",
+            milestone_key="milestones/02",
+            created_at=now - timedelta(days=60),
+        )
+        # (d) Silent row 40 days ago — prune.
+        _insert_row(
+            conn,
+            subject="old audit",
+            priority="silent",
+            created_at=now - timedelta(days=40),
+        )
+
+        summary = prune_old_staging(conn, retain_days=30)
+
+        rows = _all_rows(conn)
+    assert summary == {"flushed_pruned": 1, "silent_pruned": 1}
+    remaining = sorted(r["subject"] for r in rows)
+    assert remaining == ["old pending", "recent flushed"]
+
+
+def test_prune_is_noop_on_empty_table(pg_schema_pool) -> None:
+    from pollypm.notification_staging import prune_old_staging
+
+    with pg_schema_pool.connection() as conn:
+        summary = prune_old_staging(conn, retain_days=30)
+        assert _row_count(conn) == 0
+    assert summary == {"flushed_pruned": 0, "silent_pruned": 0}
+
+
+# ---------------------------------------------------------------------------
+# Backend-shape regression — sqlite type hints are gone.
+# ---------------------------------------------------------------------------
+
+
+def test_module_does_not_import_sqlite3() -> None:
+    """The K-misc port must leave no sqlite3 reference behind."""
+    import pollypm.notification_staging as ns
+
+    # sqlite3 was a top-level import on the legacy module; the port
+    # dropped it. Re-imports of the module shouldn't bring it back.
+    assert getattr(ns, "sqlite3", None) is None
+    # And the source file shouldn't carry any sqlite3 textual references.
+    from pathlib import Path
+
+    src = Path(ns.__file__).read_text(encoding="utf-8")
+    # Permit references inside docstring comparisons ("sqlite3.Row")
+    # only if they're explicitly noting the port — but the actual
+    # ``import sqlite3`` line must not appear.
+    assert "\nimport sqlite3" not in src
+    assert "from sqlite3" not in src


### PR DESCRIPTION
## Summary

Slice K-misc of #1737 — ports the two remaining sqlite-only modules in the
"misc pg-ports" partition before the K-deletion sweep can run.

### `src/pollypm/notification_staging.py`

The legacy module took raw `sqlite3.Connection` objects in four helpers
(`_ensure_staging_table`, `stage_notification`, `list_pending`,
`prune_old_staging`) and emitted sqlite-flavored DDL inline. Ported to
psycopg:

- Type hints flip to `psycopg.Connection` (TYPE_CHECKING-guarded).
- Parameter placeholders flip `?` → `%s` (with `%s::jsonb` for the
  payload column).
- The inline DDL becomes pg-native: `bigserial` PK, `timestamptz`
  columns, `jsonb` payload — matches Group D of
  `pollypm.storage.pg_schema.INITIAL_SCHEMA_DDL`. Kept inline as a
  test-friendly idempotent fallback (`CREATE TABLE IF NOT EXISTS`) so a
  bare-empty per-test schema can host writes without running the full
  migration applier.
- `list_pending` now uses psycopg's `dict_row` row factory.
- Timestamps move from ISO strings to `datetime` objects (psycopg adapts
  natively).
- `INSERT ... RETURNING id` replaces `lastrowid`.

The work-service-facing helpers (`flush_milestone_digest`,
`check_and_flush_on_done`, `check_regression_on_reopen`) were already
backend-agnostic — they call into `svc.list_digest_rollup_candidates(...)`
/ `svc.mark_rollup_candidates_flushed(...)` rather than touching the DB
directly. No behavior change.

Public API: function names, parameter order, and return semantics are
identical. `list_pending`'s return type widens from `list[sqlite3.Row]`
to `list[dict]`, but both are mapping-shaped so `row["subject"]`
callsites work either way.

### `src/pollypm/dashboard/categorization.py`

This module never imported `sqlite3` — the load-bearing docstring
claim ("No cockpit, no Supervisor, no sqlite3") was already true. The
only edits are updating the docstring to "no direct DB driver (sqlite3
or psycopg)" and flipping the `_WorkServiceLike` Protocol example from
`SQLiteWorkService` to `PgWorkService` so the post-cutover reader
doesn't get a stale reference. Functional behavior is unchanged.

## Forward migration

No new forward migration is required — the `notification_staging` table
already exists in `pg_schema.INITIAL_SCHEMA_DDL` Group D as of Slice A.
The inline DDL in `notification_staging._ensure_staging_table` mirrors
the canonical schema and stays as a test-friendly bootstrap fallback:

```sql
CREATE TABLE IF NOT EXISTS notification_staging (
    id              bigserial PRIMARY KEY,
    project         text NOT NULL,
    subject         text NOT NULL,
    body            text NOT NULL,
    actor           text NOT NULL,
    priority        text NOT NULL,
    payload_json    jsonb NOT NULL,
    milestone_key   text,
    created_at      timestamptz NOT NULL,
    flushed_at      timestamptz,
    rollup_task_id  text
);
CREATE INDEX IF NOT EXISTS idx_notification_staging_pending
    ON notification_staging(project, milestone_key, flushed_at);
CREATE INDEX IF NOT EXISTS idx_notification_staging_created
    ON notification_staging(created_at);
```

## Test plan

```
uv run pytest tests/test_notification_staging.py tests/test_dashboard_categorization.py -x -q
```

Result: `42 passed in 1.54s` (10 new pg-backed staging tests + 32
unchanged categorization tests).

New `tests/test_notification_staging.py` covers:

- [x] `_ensure_staging_table` idempotency + pg column shape
- [x] `stage_notification` insert + assertion on non-stageable priority
- [x] `list_pending` ordering, milestone filter (including `IS NULL`), and
      skip-flushed/skip-silent semantics
- [x] `prune_old_staging` retention rules (flushed+silent prune, pending
      preserved)
- [x] Regression: the module no longer imports `sqlite3`

The legacy `tests/test_notification_tiering.py` (sqlite-keyed via
`SQLiteWorkService`) is untouched — it belongs to the K-deletion sweep.

## Notes on translation

- **Optimistic locks**: nothing in scope used `WHERE updated_at = ?`
  patterns — clean port.
- **NULL-aware uniqueness**: the staging table has no UNIQUE indexes, so
  pg's NULL-distinct default vs sqlite's NULL-equal default doesn't bite
  this surface.
- **Timestamp comparison**: pg compares `timestamptz` arithmetically;
  the sqlite path compared ISO strings lexicographically. Same total
  order for valid ISO-8601 / RFC-3339 inputs, so the `WHERE created_at
  <= cutoff` prune predicate behaves identically.
- **`INSERT ... RETURNING id`** replaces the sqlite `cur.lastrowid`
  idiom — no semantic drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)