### PR TITLE
fix(pg): port requires_human_review gate + review_summary_invocation hook to PgWorkService (closes #1767, #1768, #1737)

### DIFF
--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -42,7 +42,7 @@ import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from pollypm.inbox.kind import coerce_kind as _coerce_inbox_kind
+from pollypm.inbox.kind import InboxItemKind, coerce_kind as _coerce_inbox_kind
 from pollypm.work.models import (
     ActorType,
     ArtifactKind,
@@ -59,6 +59,7 @@ from pollypm.work.models import (
     Priority,
     Task,
     TaskType,
+    TERMINAL_STATUSES,
     WorkOutput,
     WorkStatus,
     WorkerSessionRecord,
@@ -483,19 +484,184 @@ class PgWorkService:
         self,
         task_id: str,
         actor: str,
-        skip_gates: bool = False,  # noqa: ARG002 — Slice B wires gates
+        skip_gates: bool = False,
     ) -> Task:
         """Move a ``draft`` task to ``queued``.
 
-        Slice A skips gate evaluation entirely. The transition row is
-        still written so the audit history is sane.
+        Mirrors the sqlite ``queue`` gate semantics (#1767): when the
+        task is flagged ``requires_human_review`` we refuse to transition
+        unless either (a) a ``human_review_approved`` context entry has
+        been recorded via :meth:`approve_human_review` or (b) the caller
+        passes ``skip_gates=True``, in which case we still record an
+        audit entry that the bypass happened. When the gate trips we
+        also materialise a user-owned inbox task so the operator has a
+        place to land the approval/reject decision.
         """
+        task = self.get(task_id)
+        if (
+            task.requires_human_review
+            and not skip_gates
+            and not self.has_human_review_approval(task_id)
+        ):
+            approval_task = self.ensure_human_review_request_task(
+                task_id, actor
+            )
+            raise InvalidTransitionError(
+                "Task requires human review before queueing.\n"
+                "\n"
+                "Why: this task is marked requires_human_review, so it "
+                "must be approved by the user or explicitly fast-tracked "
+                "by an authorized operator before workers can pick it up.\n"
+                "\n"
+                f"Created user inbox task: {approval_task.task_id}\n"
+                "\n"
+                "Fix: approve it with "
+                f"`pm task approve-human-review {task_id} --actor user`, "
+                "or have the operator use "
+                f"`pm task approve-human-review {task_id} --actor polly "
+                '--fast-track-authorized --reason "..."`.'
+            )
+        if (
+            task.requires_human_review
+            and skip_gates
+            and not self.has_human_review_approval(task_id)
+        ):
+            self.add_context(
+                task_id,
+                actor,
+                "fast-track queue bypass recorded via --skip-gates",
+                entry_type="human_review_approved",
+            )
         return self._simple_transition(
             task_id,
             from_state=WorkStatus.DRAFT,
             to_state=WorkStatus.QUEUED,
             actor=actor,
         )
+
+    def has_human_review_approval(self, task_id: str) -> bool:
+        """Return True when a pre-queue human review approval is recorded.
+
+        Mirrors :meth:`SQLiteWorkService.has_human_review_approval`. A
+        task that doesn't require human review is trivially "approved";
+        otherwise we look for at least one ``human_review_approved``
+        context entry.
+        """
+        task = self.get(task_id)
+        if not task.requires_human_review:
+            return True
+        rows = self.get_context(
+            task_id, entry_type="human_review_approved", limit=1
+        )
+        return bool(rows)
+
+    def ensure_human_review_request_task(
+        self,
+        task_id: str,
+        actor: str,
+    ) -> Task:
+        """Materialize a user-owned task requesting pre-queue approval.
+
+        Mirrors :meth:`SQLiteWorkService.ensure_human_review_request_task`.
+        Idempotent: if a non-terminal request task already exists for
+        ``task_id`` we return it instead of creating a duplicate.
+        """
+        target = self.get(task_id)
+        label = f"target_task:{target.task_id}"
+        for candidate in self.list_tasks(project=target.project):
+            labels = set(candidate.labels or [])
+            if (
+                "human_review_request" in labels
+                and label in labels
+                and candidate.work_status not in TERMINAL_STATUSES
+            ):
+                return candidate
+
+        description = "\n".join(
+            [
+                f"Review whether `{target.task_id}` should enter the worker queue.",
+                "",
+                f"Task: {target.title}",
+                target.description or "(no description)",
+                "",
+                "Approve if this work is authorized to proceed. Reject or reply "
+                "with clarification if it needs changes before delegation.",
+            ]
+        )
+        return self.create(
+            title=f"Human review required before queueing {target.task_id}",
+            description=description,
+            type="task",
+            project=target.project,
+            flow_template="chat",
+            roles={"requester": "user", "operator": actor or "polly"},
+            priority=target.priority.value,
+            created_by=actor or "system",
+            labels=[
+                "human_review_request",
+                f"project:{target.project}",
+                label,
+            ],
+            requires_human_review=False,
+            kind=InboxItemKind.APPROVAL_REQUEST.value,
+        )
+
+    def approve_human_review(
+        self,
+        task_id: str,
+        actor: str,
+        reason: str | None = None,
+        *,
+        fast_track_authorized: bool = False,
+    ) -> Task:
+        """Record pre-queue approval for a ``requires_human_review`` task.
+
+        Mirrors :meth:`SQLiteWorkService.approve_human_review`. Only the
+        human user can approve unless an authorised operator passes
+        ``fast_track_authorized=True``. On approval we close any open
+        approval-request inbox task so the operator's queue clears.
+        """
+        task = self.get(task_id)
+        actor_norm = (actor or "").strip().lower()
+        is_user = actor_norm in {"user", "sam", "human"}
+        if not is_user and not fast_track_authorized:
+            raise InvalidTransitionError(
+                "Only the user can approve this review unless the operator "
+                "explicitly records --fast-track-authorized."
+            )
+        detail = reason.strip() if reason else "approved"
+        if fast_track_authorized and not is_user:
+            detail = f"fast-track authorized by {actor}: {detail}"
+        self.add_context(
+            task_id,
+            actor or "user",
+            detail,
+            entry_type="human_review_approved",
+        )
+
+        label = f"target_task:{task.task_id}"
+        for candidate in self.list_tasks(project=task.project):
+            labels = set(candidate.labels or [])
+            if (
+                "human_review_request" in labels
+                and label in labels
+                and candidate.work_status not in TERMINAL_STATUSES
+            ):
+                try:
+                    self.add_context(
+                        candidate.task_id,
+                        actor or "user",
+                        f"approved target {task.task_id}",
+                        entry_type="reply",
+                    )
+                    self.mark_done(candidate.task_id, actor or "user")
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "failed to close human review request %s",
+                        candidate.task_id,
+                        exc_info=True,
+                    )
+        return self.get(task_id)
 
     def cancel(self, task_id: str, actor: str, reason: str) -> Task:
         """Move any non-terminal task to ``cancelled``."""
@@ -1031,7 +1197,70 @@ class PgWorkService:
                     cur, task, flow, node.next_node_id, actor, from_status
                 )
             conn.commit()
-        return self.get(task_id)
+        result = self.get(task_id)
+        self._write_review_summary_after_transition(result)
+        return result
+
+    def _write_review_summary_after_transition(self, task: Task) -> None:
+        """Invoke the LLM review-summary hook after a transition (#1768).
+
+        Mirrors :meth:`_TransitionManager._write_review_summary_after_transition`
+        in the sqlite path: when a task lands in ``review`` or ``on_hold``
+        we ask :mod:`pollypm.task_review_summary` to generate and persist
+        a plain-language summary. Any failure is swallowed with a warning
+        so the transition itself remains durable.
+
+        Note: pg's :meth:`get` does not yet hydrate ``executions`` /
+        ``context`` (Slice B carryover), so the summary helper would see
+        an empty work-output history if called against the raw ``get``
+        result. We hydrate those fields locally before invoking the
+        generator so the prompt has the worker's submission to summarise.
+        """
+        if task.work_status not in {WorkStatus.REVIEW, WorkStatus.ON_HOLD}:
+            return
+        try:
+            from pollypm.task_review_summary import (
+                PLAIN_SUMMARY_ENTRY_TYPE,
+                REVIEW_SUMMARY_ACTOR,
+                generate_review_plain_summary,
+            )
+
+            hydrated = self._hydrate_task_for_review_summary(task)
+            if any(
+                entry.entry_type == PLAIN_SUMMARY_ENTRY_TYPE
+                for entry in hydrated.context
+            ):
+                return
+            summary = generate_review_plain_summary(hydrated)
+            if not summary:
+                return
+            self.add_context(
+                task.task_id,
+                REVIEW_SUMMARY_ACTOR,
+                summary,
+                entry_type=PLAIN_SUMMARY_ENTRY_TYPE,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "review plain summary generation skipped for %s: %s",
+                task.task_id,
+                exc,
+            )
+
+    def _hydrate_task_for_review_summary(self, task: Task) -> Task:
+        """Return ``task`` with ``executions`` and ``context`` populated.
+
+        The review-summary generator reads ``task.executions`` (for the
+        latest worker output) and ``task.context`` (to short-circuit
+        when a summary already exists). pg's :meth:`get` returns a thin
+        Task in Slice A; we attach the extra lists here so the generator
+        sees the same shape sqlite would have produced.
+        """
+        executions = self.get_execution(task.task_id)
+        context_entries = self.get_context(task.task_id)
+        task.executions = executions
+        task.context = context_entries
+        return task
 
     def approve(
         self,

--- a/tests/test_human_review_queue.py
+++ b/tests/test_human_review_queue.py
@@ -12,10 +12,6 @@ from pollypm.work.service_support import InvalidTransitionError
 runner = CliRunner()
 
 
-@pytest.mark.xfail(
-    reason="PgWorkService.queue() doesn't enforce requires_human_review gate yet (#1767)",
-    strict=False,
-)
 def test_requires_human_review_materializes_user_inbox_task(pg_work_service):
     svc = pg_work_service
     task = svc.create(
@@ -43,10 +39,6 @@ def test_requires_human_review_materializes_user_inbox_task(pg_work_service):
     assert [item.task_id for item in inbox_tasks(svc, project="demo")] == ["demo/2"]
 
 
-@pytest.mark.xfail(
-    reason="PgWorkService.queue() doesn't enforce requires_human_review gate yet (#1767)",
-    strict=False,
-)
 def test_human_review_approval_unlocks_queue_and_closes_request(pg_work_service):
     svc = pg_work_service
     task = svc.create(
@@ -72,10 +64,6 @@ def test_human_review_approval_unlocks_queue_and_closes_request(pg_work_service)
     assert context[-1].text == "looks safe"
 
 
-@pytest.mark.xfail(
-    reason="PgWorkService.queue() doesn't enforce requires_human_review gate yet (#1767)",
-    strict=False,
-)
 def test_operator_fast_track_requires_explicit_authorization(pg_work_service):
     svc = pg_work_service
     task = svc.create(

--- a/tests/test_task_review_summary.py
+++ b/tests/test_task_review_summary.py
@@ -45,10 +45,6 @@ def _move_to_review(svc, task_id: str, *, summary: str = "Implemented the work."
 import pytest
 
 
-@pytest.mark.xfail(
-    reason="PgWorkService.node_done() doesn't invoke review_summary generator yet (#1768)",
-    strict=False,
-)
 def test_node_done_writes_llm_generated_plain_summary(pg_work_service, monkeypatch) -> None:
     monkeypatch.delenv("POLLYPM_DISABLE_AGENTIC_REVIEW_SUMMARIES", raising=False)
     prompts: list[str] = []
@@ -76,10 +72,6 @@ def test_node_done_writes_llm_generated_plain_summary(pg_work_service, monkeypat
     assert "Do not tell the user to run pm commands" in prompts[0]
 
 
-@pytest.mark.xfail(
-    reason="PgWorkService.node_done() doesn't invoke review_summary generator yet (#1768)",
-    strict=False,
-)
 def test_rework_review_summary_prompt_includes_previous_rejection(
     pg_work_service, monkeypatch,
 ) -> None:


### PR DESCRIPTION
Two Slice B leftovers in `PgWorkService` diverged from `SQLiteWorkService`. This PR ports both to the pg path. SQLiteWorkService is left untouched (Slice K-source-ripout will delete it whole).

## #1767 — `queue()` didn't enforce `requires_human_review`

**sqlite reference** (`service_transition_manager.queue`): if `task.requires_human_review` and no `human_review_approved` context entry exists, `queue()` raises `InvalidTransitionError` and calls `ensure_human_review_request_task` to materialise a user-owned approval-request task (labelled `human_review_request` + `target_task:<id>`). The `skip_gates` branch records a fast-track bypass context entry rather than silently letting it through.

**pg port** (`pg_service.queue`): same gate. Also ports `has_human_review_approval`, `ensure_human_review_request_task`, and `approve_human_review` with identical sqlite semantics (user-only approval unless `--fast-track-authorized`; approved request task is closed via `mark_done` so the operator inbox clears).

## #1768 — `node_done()` didn't invoke `review_summary_invocation`

**sqlite reference** (`service_transition_manager._write_review_summary_after_transition`): after the transition lands in `REVIEW` or `ON_HOLD`, calls `task_review_summary.store_review_plain_summary`, which builds the prompt from the task's `executions` + `context`, runs the configured LLM, and writes a `PLAIN_SUMMARY_ENTRY_TYPE` context entry.

**pg port** (`pg_service.node_done` + `_write_review_summary_after_transition`): node_done now invokes the hook. Because pg's `get()` does not yet hydrate `executions`/`context` (Slice B carryover), the hook pre-fetches them via `get_execution` + `get_context` and attaches them to the Task before calling `generate_review_plain_summary` directly. This keeps the LLM contract identical to sqlite without papering over the hydration gap.

## Divergence noted (not papered over)

- sqlite's `store_review_plain_summary` is also wired from `hold` and `resume` via `_finish(after_reload=...)`. The pg port currently only fires from `node_done` because pg's hold/resume paths don't have the same `after_reload` hook structure. Adding it there is a separate follow-up — the bug surfaced in the K-tests is `node_done`-specific, and `test_hold_on_work_node_does_not_generate_review_summary` already passes (the hook is gated on `REVIEW`/`ON_HOLD`, and a hold on a work node lands in `ON_HOLD` only via sqlite's existing reviewish-task check).

## Test plan

- [x] `uv run pytest tests/test_human_review_queue.py tests/test_task_review_summary.py tests/test_work_service_protocol_conformance.py -q` — 29 passed, 1 xpassed
- [x] `uv run pytest tests/test_pg_*.py -q` — same 9 pre-existing failures as `main` (test_pg_backup_keep_prunes, test_pg_memory_recall x4, stale TestSliceBStubsRaiseLoudly x4); none introduced by this change
- [x] Flipped 3 xfails in `tests/test_human_review_queue.py` and 2 in `tests/test_task_review_summary.py` to expected-pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)