### PR TITLE
refactor(supervisor): drop redundant inline time imports

### DIFF
--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -2208,7 +2208,6 @@ class Supervisor:
         self.session_service.tmux.send_keys(target, prefixed, press_enter=press_enter)
         # Codex CLI buffers input and requires a second Enter to submit.
         if press_enter and launch.session.provider is ProviderKind.CODEX:
-            import time
             time.sleep(0.3)
             self.session_service.tmux.send_keys(target, "", press_enter=True)
         # Verify the message left the input bar.
@@ -2235,8 +2234,6 @@ class Supervisor:
         Captures the last few lines of the pane. If the text still appears
         on the final line (the input prompt), press Enter again.
         """
-        import time
-
         # Use a prefix of the message for matching (input may be truncated)
         check_text = text[:60].strip()
         if not check_text:
@@ -3537,8 +3534,7 @@ class Supervisor:
         except RuntimeError as exc:
             # Retry once if window name collision
             if "already exists" in str(exc).lower() or "duplicate" in str(exc).lower():
-                import time as _time
-                _time.sleep(0.5)
+                time.sleep(0.5)
                 try:
                     self.launch_session(session_name)
                 except Exception:


### PR DESCRIPTION
## Summary
- Module-level `import time` lives at `src/pollypm/supervisor.py:60`.
- Three function bodies redundantly re-imported it: `send_input` (line 2211), `_verify_input_submitted` (line 2238), and the `launch_session` retry block (line 3540, the latter as `import time as _time`).
- Grep evidence confirms zero `time` rebindings anywhere in the module — the inline imports and the `_time` alias were pure cruft, not disambiguation.

## Changes
- Deleted the three inline `import time` lines (2211, 2238) and the `import time as _time` (3540).
- Renamed the lone `_time.sleep(0.5)` call (former line 3541) to `time.sleep(0.5)`.
- Net diff: 1 insertion, 5 deletions.

## Evidence
```
$ grep -nE "^\s*time\s*=" src/pollypm/supervisor.py
(no matches — no local `time = ...` shadow anywhere in the module)

$ grep -nE "^\s+import time" src/pollypm/supervisor.py
(no matches after edit; was 3 matches before)
```

## Test plan
- [x] `uv run python -c "import pollypm.supervisor"` — OK
- [x] `uv run --extra dev pytest tests/test_supervisor.py tests/test_supervisor_alerts.py` — 97 passed; 2 failures pre-existing on clean main (verified via `git stash` round-trip), unrelated to imports:
  - `test_bootstrap_returns_before_provider_stabilization_finishes` (0.5s threading timeout — flaky on this hardware)
  - `test_supervisor_alert_helper_updates_and_nudges` (alert message-text mismatch)

## Notes
- Orthogonal to the #1737 pg cutover work.
- Other deferred supervisor.py cleanups (`_CONSOLE_WINDOW` alias, `pane_has_*` ladder, etc.) are intentionally not bundled here.