### PR TITLE
test(pg): migrate sqlite-importing tests to pg fixtures (Slice K-tests part 2, #1737)

### DIFF
--- a/tests/test_dashboard_inbox_cache.py
+++ b/tests/test_dashboard_inbox_cache.py
@@ -1,7 +1,7 @@
 """Cycle 138 — perf: content-addressed cache on _dashboard_inbox.
 
 The per-project dashboard refresh tick (every 10s) used to call
-``_dashboard_inbox`` which opens SQLAlchemyStore + SQLiteWorkService
+``_dashboard_inbox`` which opens SQLAlchemyStore + PgWorkService
 and runs queries against both. On 9 projects = 18 DB opens per tick
 even when no inbox change has landed.
 

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -14,17 +14,28 @@ from __future__ import annotations
 import pytest
 
 from pollypm.work.models import WorkStatus
-from pollypm.work.sqlite_service import (
+from pollypm.work.service_support import (
     InvalidTransitionError,
-    SQLiteWorkService,
     ValidationError,
 )
 
 
+# This module pins the three-question error message copy (#240). The
+# wording lives in the sqlite path's transition helpers; ``PgWorkService``
+# raises the same exception types but with terse generic messages, so
+# the guidance copy assertions fail until the pg port catches up (#1771).
+pytestmark = pytest.mark.xfail(
+    reason=(
+        "PgWorkService error messages don't carry the three-question "
+        "guidance text yet (#1771)"
+    ),
+    strict=False,
+)
+
+
 @pytest.fixture
-def svc(tmp_path):
-    db_path = tmp_path / "work.db"
-    return SQLiteWorkService(db_path=db_path)
+def svc(pg_work_service):
+    return pg_work_service
 
 
 def _queued_task(svc, title="x", description="y"):

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -29,10 +29,8 @@ from pollypm.work.models import (
     WorkOutput,
     WorkStatus,
 )
-from pollypm.work.sqlite_service import (
-    SQLiteWorkService,
-    ValidationError,
-)
+from pollypm.work.pg_service import PgWorkService
+from pollypm.work.service_support import ValidationError
 
 
 # ---------------------------------------------------------------------------
@@ -365,9 +363,8 @@ class TestGateRegistry:
 
 
 @pytest.fixture
-def svc(tmp_path):
-    db_path = tmp_path / "work.db"
-    return SQLiteWorkService(db_path=db_path)
+def svc(pg_work_service):
+    return pg_work_service
 
 
 def _create_standard_task(svc, project="proj", title="My task", description="Do the thing", **kwargs):
@@ -386,6 +383,13 @@ def _create_standard_task(svc, project="proj", title="My task", description="Do 
 
 
 class TestSkipGates:
+    @pytest.mark.xfail(
+        reason=(
+            "PgWorkService.queue() doesn't enforce description/readiness "
+            "gates yet (#1767, same gap as requires_human_review)"
+        ),
+        strict=False,
+    )
     def test_skip_gates_allows_queue_without_description(self, svc):
         """queue a task with no description but skip_gates=True succeeds."""
         task = _create_standard_task(svc, description="")
@@ -404,6 +408,13 @@ class TestSkipGates:
 
 
 class TestValidateAdvance:
+    @pytest.mark.xfail(
+        reason=(
+            "PgWorkService.validate_advance() returns empty list "
+            "instead of evaluating gates (#1774)"
+        ),
+        strict=False,
+    )
     def test_dry_run(self, svc):
         """Create and claim a task. validate_advance shows gate results."""
         task = _create_standard_task(svc)
@@ -457,6 +468,14 @@ class TestValidateAdvance:
 
 
 class TestProjectRootGateResolution:
+    @pytest.mark.xfail(
+        reason=(
+            "PgWorkService is pool-based and doesn't carry a "
+            "filesystem ``project_path``; receipt-lookup gate "
+            "resolution belongs to part 4 (complex)."
+        ),
+        strict=False,
+    )
     def test_approve_uses_service_project_root_for_receipt_lookup(
         self,
         tmp_path,
@@ -469,7 +488,7 @@ class TestProjectRootGateResolution:
         outside_cwd = tmp_path / "elsewhere"
         outside_cwd.mkdir()
 
-        svc = SQLiteWorkService(db_path=db_path, project_path=project_root)
+        svc = PgWorkService(db_path=db_path, project_path=project_root)
         try:
             task = svc.create(
                 title="Module task",

--- a/tests/test_inbox_actions.py
+++ b/tests/test_inbox_actions.py
@@ -13,17 +13,27 @@ from types import SimpleNamespace
 import pytest
 
 from pollypm.work.models import WorkStatus
-from pollypm.work.sqlite_service import (
-    SQLiteWorkService,
+from pollypm.work.service_support import (
     TaskNotFoundError,
     ValidationError,
 )
 
 
+# PgWorkService is missing the four inbox interaction methods
+# (add_reply/list_replies/mark_read/archive_task) — see #1776. Module-
+# level xfail; tests will xpass automatically once #1776 lands.
+pytestmark = pytest.mark.xfail(
+    reason=(
+        "PgWorkService inbox interaction methods "
+        "(add_reply/list_replies/mark_read/archive_task) not implemented (#1776)"
+    ),
+    strict=False,
+)
+
+
 @pytest.fixture
-def svc(tmp_path):
-    db_path = tmp_path / "inbox.db"
-    return SQLiteWorkService(db_path=db_path)
+def svc(pg_work_service):
+    return pg_work_service
 
 
 def _inbox_task(svc, *, title: str = "Hello Sam", body: str = "Read me.") -> str:
@@ -199,6 +209,10 @@ class TestResolveInboxWorkService:
         self, tmp_path,
     ):
         """Workspace-root task rows must render even if a project DB exists."""
+        # Test exercises dual-DB resolution that K-source-ripout removes;
+        # keep the sqlite import local so the module load doesn't depend on it.
+        from pollypm.work.sqlite_service import SQLiteWorkService
+
         project_path = tmp_path / "pollypm"
         project_path.mkdir()
         project_db = project_path / ".pollypm" / "state.db"

--- a/tests/test_pane_patterns.py
+++ b/tests/test_pane_patterns.py
@@ -43,7 +43,7 @@ from pollypm.recovery.pane_patterns import (
     rule_by_name,
 )
 from pollypm.storage.state import StateStore
-from pollypm.work.sqlite_service import SQLiteWorkService
+from pollypm.work.pg_service import PgWorkService
 
 
 # ---------------------------------------------------------------------------
@@ -440,7 +440,7 @@ class TestPaneClassifyHandler:
     """Handler raises + clears + emits inbox tasks correctly."""
 
     def test_handler_raises_alert_for_matched_rule(
-        self, tmp_path, monkeypatch,
+        self, tmp_path, monkeypatch, pg_work_service,
     ) -> None:
         store = StateStore(tmp_path / "state.db")
         svc = FakeSessionService(
@@ -462,7 +462,7 @@ class TestPaneClassifyHandler:
         assert svc.sent == []
 
     def test_alert_clears_when_text_no_longer_matches(
-        self, tmp_path, monkeypatch,
+        self, tmp_path, monkeypatch, pg_work_service,
     ) -> None:
         store = StateStore(tmp_path / "state.db")
         svc = FakeSessionService(
@@ -484,10 +484,10 @@ class TestPaneClassifyHandler:
         assert svc.sent == []
 
     def test_user_visible_rule_emits_inbox_task(
-        self, tmp_path, monkeypatch,
+        self, tmp_path, monkeypatch, pg_work_service,
     ) -> None:
         store = StateStore(tmp_path / "state.db")
-        work = SQLiteWorkService(db_path=tmp_path / "work.db")
+        work = pg_work_service
         svc = FakeSessionService(
             handles=[FakeHandle("worker-demo")],
             captures={"worker-demo": CONTEXT_FULL_POSITIVE},
@@ -508,10 +508,10 @@ class TestPaneClassifyHandler:
         assert svc.sent == []
 
     def test_non_user_visible_rule_does_not_emit_inbox(
-        self, tmp_path, monkeypatch,
+        self, tmp_path, monkeypatch, pg_work_service,
     ) -> None:
         store = StateStore(tmp_path / "state.db")
-        work = SQLiteWorkService(db_path=tmp_path / "work.db")
+        work = pg_work_service
         svc = FakeSessionService(
             handles=[FakeHandle("worker-demo")],
             captures={"worker-demo": STUCK_ON_ERROR_POSITIVE},
@@ -525,7 +525,7 @@ class TestPaneClassifyHandler:
         assert svc.sent == []
 
     def test_handler_skips_when_session_service_missing(
-        self, tmp_path, monkeypatch,
+        self, tmp_path, monkeypatch, pg_work_service,
     ) -> None:
         # Resolver returns None services — handler short-circuits.
         def _fake_loader(*, config_path=None):
@@ -544,10 +544,10 @@ class TestPaneClassifyHandler:
         assert result == {"outcome": "skipped", "reason": "services_unavailable"}
 
     def test_no_match_yields_no_alerts_no_inbox(
-        self, tmp_path, monkeypatch,
+        self, tmp_path, monkeypatch, pg_work_service,
     ) -> None:
         store = StateStore(tmp_path / "state.db")
-        work = SQLiteWorkService(db_path=tmp_path / "work.db")
+        work = pg_work_service
         svc = FakeSessionService(
             handles=[FakeHandle("worker-clean")],
             captures={"worker-clean": "Working normally. All good."},

--- a/tests/test_plan_refinement.py
+++ b/tests/test_plan_refinement.py
@@ -25,9 +25,6 @@ from pollypm.plan_refinement import (
     is_refinement_signal,
     select_chat_primer_for_project_dashboard,
 )
-from pollypm.work.sqlite_service import SQLiteWorkService
-
-
 # ---------------------------------------------------------------------------
 # Fixtures + helpers
 # ---------------------------------------------------------------------------
@@ -47,8 +44,8 @@ def _create_plan_task(svc, project="demo"):
 
 
 @pytest.fixture
-def svc(tmp_path):
-    return SQLiteWorkService(db_path=tmp_path / "work.db")
+def svc(pg_work_service):
+    return pg_work_service
 
 
 class _FakeDashboardData:
@@ -356,6 +353,13 @@ class TestApplyPlanRefinement:
             "updated"
         )
 
+    @pytest.mark.xfail(
+        reason=(
+            "PgWorkService.refine_plan() doesn't emit "
+            "plan_version_incremented audit event (#1773)"
+        ),
+        strict=False,
+    )
     def test_emits_plan_version_incremented_audit(
         self, svc, tmp_path, monkeypatch
     ):
@@ -423,6 +427,13 @@ class TestChatToRefineFullCycle:
     new version.
     """
 
+    @pytest.mark.xfail(
+        reason=(
+            "PgWorkService.refine_plan() doesn't emit "
+            "plan_version_incremented audit event (#1773)"
+        ),
+        strict=False,
+    )
     def test_full_refinement_cycle(self, svc, tmp_path, monkeypatch):
         from pollypm.audit import read_events
         from pollypm.audit.log import EVENT_PLAN_VERSION_INCREMENTED

--- a/tests/test_plan_review_bypassed_approval.py
+++ b/tests/test_plan_review_bypassed_approval.py
@@ -271,7 +271,7 @@ class _FakeCreatedTask:
 
 
 class _FakeSvc:
-    """Minimal stand-in for SQLiteWorkService used by emit_plan_review_for_task."""
+    """Minimal stand-in for PgWorkService used by emit_plan_review_for_task."""
 
     def __init__(self, *, db_path: Path, task: _FakeTask) -> None:
         self._db_path = db_path

--- a/tests/test_plan_review_emit.py
+++ b/tests/test_plan_review_emit.py
@@ -79,7 +79,7 @@ class _FakeCreatedTask:
 
 
 class _FakeSvc:
-    """Minimal stand-in for :class:`SQLiteWorkService`.
+    """Minimal stand-in for :class:`PgWorkService`.
 
     Records ``svc.create`` calls so tests can assert on the inbox task
     that the emit path produces. ``_db_path`` is used by the emit

--- a/tests/test_plugin_boundary_conformance.py
+++ b/tests/test_plugin_boundary_conformance.py
@@ -271,7 +271,7 @@ def test_protocol_mismatch_summary_is_human_readable() -> None:
 
 def test_work_service_protocol_real_implementations_conform() -> None:
     """Both built-in WorkService implementations
-    (SQLiteWorkService, MockWorkService) must conform to the
+    (PgWorkService, MockWorkService) must conform to the
     WorkService protocol on the methods the cockpit relies on.
 
     A failing test means the audit's #802 / #803 / #804 / #805
@@ -279,13 +279,13 @@ def test_work_service_protocol_real_implementations_conform() -> None:
     recurred."""
     try:
         from pollypm.work.service import WorkService
-        from pollypm.work.sqlite_service import SQLiteWorkService
+        from pollypm.work.pg_service import PgWorkService
         from pollypm.work.mock_service import MockWorkService
     except ImportError:
         pytest.skip("work-service modules not importable")
 
-    sqlite_mismatches = assert_implements_protocol(
-        protocol=WorkService, impl=SQLiteWorkService
+    pg_mismatches = assert_implements_protocol(
+        protocol=WorkService, impl=PgWorkService
     )
     mock_mismatches = assert_implements_protocol(
         protocol=WorkService, impl=MockWorkService
@@ -302,11 +302,11 @@ def test_work_service_protocol_real_implementations_conform() -> None:
     # Filter to *missing methods*; parameter checks are the deeper
     # test_work_service_protocol_conformance suite's job.
     missing_methods = [
-        m for m in sqlite_mismatches
+        m for m in pg_mismatches
         if m.method != "_unused" and "does not declare" in m.detail
     ]
     assert missing_methods == [], (
-        "SQLiteWorkService missing protocol methods: "
+        "PgWorkService missing protocol methods: "
         + ", ".join(m.method for m in missing_methods)
     )
     missing_methods_mock = [

--- a/tests/test_task_assignment_handlers_fd_leak.py
+++ b/tests/test_task_assignment_handlers_fd_leak.py
@@ -9,7 +9,7 @@ transitions) the post-#1067 daemon still grew the user-scope
 
 Root cause: ``task_assignment_notify.resolver.load_runtime_services``
 opens a fresh ``StateStore`` on every call and a fresh
-``SQLiteWorkService``. The cadence handlers
+``PgWorkService``. The cadence handlers
 (``task_assignment.sweep`` @every 30s, ``task_assignment.notify``
 on every state transition incl. rework/notify_rejection,
 ``pane.classify`` @every 30s) used to close only the work service

--- a/tests/test_task_shipped_inbox.py
+++ b/tests/test_task_shipped_inbox.py
@@ -51,7 +51,7 @@ class _FakeCard:
 
 
 class _FakeSvc:
-    """Minimal stand-in for SQLiteWorkService that records create() calls."""
+    """Minimal stand-in for PgWorkService that records create() calls."""
 
     def __init__(
         self,

--- a/tests/test_work_dependencies.py
+++ b/tests/test_work_dependencies.py
@@ -8,10 +8,22 @@ from datetime import datetime, timezone, timedelta
 import pytest
 
 from pollypm.work.models import ExecutionStatus, WorkStatus
-from pollypm.work.sqlite_service import (
-    SQLiteWorkService,
+from pollypm.work.service_support import (
     TaskNotFoundError,
     ValidationError,
+)
+
+
+# Most of this module exercises the dependency surface
+# (link/blocks/blocked_by/auto-unblock) that ``PgWorkService`` doesn't
+# implement yet (#1770). Mark the module-level xfail so the migration
+# lands without blocking on the production fix, per the K-tests rules.
+pytestmark = pytest.mark.xfail(
+    reason=(
+        "PgWorkService dependency surface (blocks/blocked/dependents) "
+        "is not yet implemented (#1770)"
+    ),
+    strict=False,
 )
 
 
@@ -21,9 +33,8 @@ from pollypm.work.sqlite_service import (
 
 
 @pytest.fixture
-def svc(tmp_path):
-    db_path = tmp_path / "work.db"
-    return SQLiteWorkService(db_path=db_path)
+def svc(pg_work_service):
+    return pg_work_service
 
 
 def _mk(svc, project="proj", title="Task", description="Do it", **kw):

--- a/tests/web_api/test_endpoints.py
+++ b/tests/web_api/test_endpoints.py
@@ -1,7 +1,7 @@
 """Per-endpoint integration tests for Phase 1 read endpoints.
 
 Each test exercises the FastAPI app against a real
-:class:`SQLiteWorkService` + tmp config. The work-service is opened
+:class:`PgWorkService` + tmp config. The work-service is opened
 through the canonical :func:`pollypm.work.factory.create_work_service`
 so the test path matches what the cockpit uses.
 """
@@ -154,7 +154,7 @@ def test_get_task_detail_passes_through_production_entry_types(
     with create_work_service(db_path=db_path, project_path=project_root) as svc:
         task = make_task(svc, project="myproj", title="Review me")
         # ``human_review_approved`` is a real production entry_type
-        # written by SQLiteWorkService.transition() on approve.
+        # written by PgWorkService.transition() on approve.
         svc.add_context(
             task.task_id,
             actor="pm",


### PR DESCRIPTION
## Summary

Slice K-tests part 2: continues #1769's sqlite → pg test migration. Targets the simple-pattern subset that constructs `SQLiteWorkService(db_path=tmp_path / ...)` without filesystem `project_path` integration.

## Counts

- **Migrated to `pg_work_service` fixture:** 6 files
  - `test_work_dependencies.py` — module-level xfail (#1770)
  - `test_error_messages.py` — module-level xfail (#1771)
  - `test_plan_refinement.py` — 2 tests xfailed (#1773), 30 pass
  - `test_gates.py` — 26 pass, 3 xfailed (#1767, #1774, project_path-deferred)
  - `test_inbox_actions.py` — module-level xfail (#1776)
  - `test_pane_patterns.py` — 31 pass
- **Updated protocol/docstring references:** 7 files
  - `test_plan_review_emit.py`, `test_plugin_boundary_conformance.py`, `test_plan_review_bypassed_approval.py`, `test_dashboard_inbox_cache.py`, `test_task_assignment_handlers_fd_leak.py`, `test_task_shipped_inbox.py`, `tests/web_api/test_endpoints.py`

## New pg-gap issues filed

- **#1770** — `PgWorkService` dependency surface (blocks/blocked/dependents) not implemented
- **#1771** — `PgWorkService` error messages lack three-question guidance (#240)
- **#1773** — `PgWorkService.refine_plan()` doesn't emit plan_version_incremented audit
- **#1774** — `PgWorkService.validate_advance()` returns empty results
- **#1776** — `PgWorkService` missing inbox interaction methods (add_reply / list_replies / mark_read / archive_task)

(#1775 — sync_manager kwarg — was filed but the migration of `test_sync_adapters.py` was deferred to part 3 due to Codex parallel-branch race conditions during this session. The issue is still useful as a forward-looking gap doc.)

## Files NOT touched (deferred to part 3 / 4)

The audit found ~58 truly "simple" candidates; this PR ships 13. The remaining ~45 fall into these buckets, all deferred:

- **`project_path=` filesystem integration** — most cockpit / UI tests use `SQLiteWorkService(db_path=..., project_path=project_path)` so the on-disk gates (`receipt-lookup`, plan files, audit log per-project paths) resolve. The pg port is pool-based with no equivalent attribute yet; these need either a `project_root` arg on `PgWorkService` or test rewires to skip the filesystem hook. Examples: `test_cockpit_*.py`, `test_inbox_filter.py`, `test_inbox_actions.py`'s dual-DB test, `test_keyboard_help.py`, `test_command_palette.py`, `test_morning_briefing_gather.py`, `test_review_pending_alerts.py`, `test_improvement_proposals.py`, `test_task_assignment_fanout.py`.
- **`monkeypatch.setattr("pollypm.work.sqlite_service.SQLiteWorkService", ...)`** — production code change required to update the patch path. Examples: `test_recovery_prompt.py`, `test_dashboard_data_alert_dedup.py`, `test_heartbeat_plugin_api.py`, `test_worktree_state_audit.py`.
- **Sqlite-specific lifecycle behaviour** — tests that simulate restart by constructing a second `SQLiteWorkService(db_path=...)` on the same DB; with pg the per-test schema makes this a no-op. Examples: `test_kickoff_sweep_force_push.py`, `test_work_progress_sweep.py`, `test_state_drift_reconciliation.py`, `test_worker_turn_end_reprompt.py`.
- **`sync_manager=` constructor kwarg** — `test_sync_adapters.py` (#1775).
- **CLI `--db <path>` flag** — `test_supervisor.py`, etc. — part 3 scope per #1769's audit.
- **`tests/conftest.py` + `tests/test_pg_fixtures.py`** — intentional backend-dispatch infrastructure; leave alone.

Estimated remaining for part 3 (simple-pattern, project_path-aware migration): ~35 files. Part 4 (`monkeypatch.setattr` + lifecycle simulation): ~10.

## Test plan

- [x] `uv run pytest <13 files> -q` → 193 passed, 44 xfailed, 12 xpassed.
- [x] No `issues/**` files in the diff (`git diff --stat origin/main..HEAD | grep -c '^issues/' → 0`).
- [x] Branched off `origin/main` (rebased onto today's `main` which includes #1772, #1777).
- [x] Each test file staged explicitly; no `git add .` or `-A`.
- [ ] Reviewer: verify each filed pg-gap issue (#1770/#1771/#1773/#1774/#1776) matches the xfail reason copy in the diff before approving.

## Session caveat — parallel-branch race

The user's Codex agent was running in parallel during this session, periodically toggling the working-tree branch (between `pg-tests-migrate-part2` and `fix/pg-human-review-and-summary`). I worked around this by committing+pushing frequently and re-applying lost edits, but it limited the depth of the batch. The remaining simple-pattern files are mechanically clean and can be picked up in part 3 without surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)