### PR TITLE
refactor(dashboard_data): drop redundant inline imports

### DIFF
--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 import logging
 import re
 import subprocess
+import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from pollypm.config import load_config
-from pollypm.config import PollyPMConfig
+from pollypm.config import PollyPMConfig, load_config
 from pollypm.storage.state import StateStore
 
 logger = logging.getLogger(__name__)
@@ -209,10 +209,7 @@ _COMMIT_CACHE_TTL_SECONDS = 60.0
 _COMMIT_PER_PROJECT_TIMEOUT_SECONDS = 2.0
 
 
-from dataclasses import dataclass as _dataclass
-
-
-@_dataclass(slots=True, frozen=True)
+@dataclass(slots=True, frozen=True)
 class _CachedCommitRow:
     """git-log row stored in the cache — converted to CommitInfo on read.
 
@@ -227,11 +224,9 @@ class _CachedCommitRow:
 
 def _git_log_rows_cached(project_path: Path, hours: int) -> list[_CachedCommitRow]:
     """Return cached git-log rows for ``project_path``, refreshing on TTL."""
-    import time as _time
-
     cache_key = (str(project_path), hours)
     cached = _COMMIT_CACHE.get(cache_key)
-    now_mono = _time.monotonic()
+    now_mono = time.monotonic()
     if cached is not None and (now_mono - cached[0]) < _COMMIT_CACHE_TTL_SECONDS:
         return cached[1]
 


### PR DESCRIPTION
## Summary

Three import-hygiene dedups in `src/pollypm/dashboard_data.py`. Mirrors the just-merged pattern from #1778. No behavior change.

- **Inline `import time as _time` (was line 230) hoisted to top-level `import time`** — single callsite (`_time.monotonic()` at line 234) renamed to `time.monotonic()`. Scope-verified the comment hit on line 454 ("Working indicator with time") is comment-only; no other `time.X` callsites in the module.
- **Redundant `from dataclasses import dataclass as _dataclass` (was line 212) dropped** — `dataclass` is already imported at line 7. Lone decorator `@_dataclass(slots=True, frozen=True)` rewritten to `@dataclass(slots=True, frozen=True)`.
- **Split `from pollypm.config import load_config` / `from pollypm.config import PollyPMConfig` (was lines 11-12) collapsed** to `from pollypm.config import PollyPMConfig, load_config`.

Scope-verified grep evidence (pre-edit):
- `grep -nE "\btime\b"` → 2 hits (inline import + comment); `_time.monotonic()` doesn't match `\btime\b` due to leading underscore
- `grep -nE "from dataclasses"` → 2 hits (top-level + the redundant inline)
- `grep -nE "^from pollypm.config import"` → 2 hits (the split pair)
- No `time` / `dataclass` rebinding shadows

Diff: **+4 / -9** lines, one file.

## Test plan

- [x] `uv run python -c "import pollypm.dashboard_data"` — passes
- [x] `uv run --extra dev pytest tests/test_dashboard_data_*.py tests/test_dashboard_*.py` (8 files, ~88 tests) — same pass/fail counts as `main` (4 pre-existing failures in `test_dashboard_data_alert_dedup` + `test_dashboard_data_pg`, verified pre-existing via `git stash` baseline; unrelated to import hygiene — sqlite/pg cutover artifacts)
- [x] Dashboard pg tests pass cleanly in isolation post-edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)