### PR TITLE
fix(cockpit): distinguish offline workers from working in roster fallback

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -1650,7 +1650,7 @@ def _render_worker_roster_panel(config_path: Path) -> str:
     lines = ["Workers", ""]
     dot_for = {
         "working": "\u25cf", "idle": "\u25cb",
-        "stuck": "\u25b2", "offline": "\u25cf",
+        "stuck": "\u25b2", "offline": "\u25cb",
     }
     for row in rows:
         dot = dot_for.get(row.status, "\u25cb")


### PR DESCRIPTION
## Summary

Real cosmetic bug in the plain-text fallback of `_render_worker_roster_panel` (`src/pollypm/cockpit_inbox.py`): the `dot_for` glyph table mapped BOTH `"working"` and `"offline"` to ● (U+25CF, filled circle), so in the text fallback (reached via `cockpit.py:142` when `build_cockpit_detail` returns text-only output, e.g. before Textual mounts) live workers were visually indistinguishable from dead sessions.

One-character fix: change `"offline": "●"` → `"offline": "○"` (hollow circle). Matches the inert-state convention used elsewhere in the codebase.

## Grep evidence (no test snapshots tied to the glyph)

- `grep -nE "●|u25cf" src/pollypm/cockpit_inbox.py` → only the 2 colliding hits in the table; no other filled-circle refs in this file.
- `grep -rn "dot_for" src/ tests/` → 1 hit (the table + its lookup line); no external callers depend on the offline glyph.
- `grep -rn '"offline"' src/ tests/` → no test asserts on the specific glyph value in the worker-roster fallback path. Other `●` test assertions are in unrelated dashboard / operator / project paths.
- `grep -rn "_render_worker_roster_panel" src/ tests/` → 1 external caller (`cockpit.py:142`); no test exercises the fallback path directly.

## Scoped tests run

- `uv run python -c "import pollypm.cockpit_inbox"` → OK
- `uv run --extra dev pytest tests/test_worker_roster_ui.py` → 24 passed
- `uv run --extra dev pytest tests/test_cockpit_inbox_dual_open_removed.py tests/test_cockpit_inbox_threads.py tests/test_cockpit_inbox_ui.py tests/test_worker_roster_ui.py` → 100 passed, 16 failed. The 16 failures are pre-existing on baseline (verified via `git stash` round-trip — same 16 fail without this change) and stem from the in-flight pg-cutover work (#1737, SQLAlchemyStore-under-pg assertions). Orthogonal to this PR.

## Scope guard

Only `src/pollypm/cockpit_inbox.py` was staged. Did not bundle the defensive-getattr cleanup carried in earlier ticks — that would be a separate PR.

## Test plan

- [ ] Visually confirm `pm cockpit-pane workers` (text fallback path) shows ● for `working` rows and ○ for `offline` rows.
- [ ] No regression in worker_roster_ui tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)