### PR TITLE
refactor(cockpit_rail): drop redundant inline logging imports

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -444,8 +444,6 @@ def _visibility_passes(reg, ctx) -> bool:
       ``reg.feature_name`` (or ``reg.item_key`` as fallback).
     * ``Callable`` — invoked; exceptions treat as hidden-and-logged.
     """
-    import logging
-
     visibility = reg.visibility
     if visibility == "always":
         return True
@@ -462,7 +460,7 @@ def _visibility_passes(reg, ctx) -> bool:
         try:
             return bool(visibility(ctx))
         except Exception:  # noqa: BLE001
-            logging.getLogger(__name__).exception(
+            logger.exception(
                 "Rail item %s visibility predicate raised — hiding item",
                 reg.item_key,
             )
@@ -815,10 +813,7 @@ def _rows_for_registration(reg, ctx) -> list:
     handy for sections like ``projects`` where one registration fans
     out into N rows.
     """
-    import logging
     from pollypm.plugin_api.v1 import RailRow
-
-    logger = logging.getLogger(__name__)
 
     if reg.rows_provider is not None:
         try:
@@ -4335,8 +4330,7 @@ class CockpitRouter:
             f"window_name={getattr(launch, 'window_name', None)!r}"
         )
         try:
-            import logging as _logging
-            _logging.getLogger("pollypm.cockpit_rail").error(
+            logger.error(
                 "persona_swap_detected (rail-mount): %s — refusing to "
                 "join a pane whose content shows a different role's banner",
                 details,


### PR DESCRIPTION
## Summary

- Remove 3 inline `import logging` statements in `src/pollypm/cockpit_rail.py` (previously at lines 447, 818, 4338)
- Remove 1 local `logger = logging.getLogger(__name__)` rebind (previously at line 821) that was a pure shadow of the module-level binding at line 73 (identical value)
- Rewrite 3 `logging.getLogger(__name__).exception/error(...)` callsites to use the module-level `logger.exception/error(...)` directly
- Net: +2 / -8 lines, single file

Mirrors the import-hygiene cleanup pattern from PR #1778 (supervisor.py) and PR #1783 (dashboard_data.py).

## Scope-verification grep evidence

- `grep -nE "^\s+import logging" src/pollypm/cockpit_rail.py` -> 3 hits (447/818/4338); now 0
- `grep -nE "^\s*logger\s*=" src/pollypm/cockpit_rail.py` -> 2 hits (:73 module-level, :821 local shadow); now 1 (only :73)
- `grep -nE "^\s*logging\s*=" src/pollypm/cockpit_rail.py` -> 0 (no local `logging` rebindings that would shadow the module import)
- `grep -rn "from pollypm.cockpit_rail import logger" src/ tests/` -> 0 (logger is module-private, no external dependency to preserve)
- The line-4338 callsite was `_logging.getLogger("pollypm.cockpit_rail")` — that's the same logger as `logging.getLogger(__name__)` for this module, so collapsing to `logger` is semantically identical.

## Test plan

- [x] `uv run python -c "import pollypm.cockpit_rail"` smoke import: ok
- [x] `uv run --extra dev pytest tests/test_cockpit_rail*.py tests/test_rail*.py -x` -> 261 passed, 38 warnings (psycopg/sqlalchemy finalization noise unrelated to the diff)
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)