### PR TITLE
refactor(operator_dashboard): collapse identical IDLE/PAUSED branches

### DIFF
--- a/src/pollypm/cockpit_apps/operator_dashboard.py
+++ b/src/pollypm/cockpit_apps/operator_dashboard.py
@@ -420,9 +420,7 @@ def _format_section(rows, *, empty: str) -> str:
         glyph_markup = f"[{color}]{glyph}[/{color}]" if color else glyph
         project = _escape(row.project_key)
         detail = _escape(row.detail)
-        if row.state is ProjectState.IDLE:
-            lines.append(f"{glyph_markup} [dim]{project}[/dim]  [dim]{detail}[/dim]")
-        elif row.state is ProjectState.PAUSED:
+        if row.state in (ProjectState.IDLE, ProjectState.PAUSED):
             lines.append(f"{glyph_markup} [dim]{project}[/dim]  [dim]{detail}[/dim]")
         else:
             lines.append(f"{glyph_markup} [b]{project}[/b]  {detail}")
@@ -434,8 +432,6 @@ def _color_for_state(state: ProjectState) -> str:
         return "#d29922"
     if state is ProjectState.WORKING:
         return "#3fb950"
-    if state is ProjectState.IDLE:
-        return "#484f58"
-    if state is ProjectState.PAUSED:
+    if state in (ProjectState.IDLE, ProjectState.PAUSED):
         return "#484f58"
     return ""


### PR DESCRIPTION
## Summary

Dead-branch duplication collapse in `src/pollypm/cockpit_apps/operator_dashboard.py`. Two private helpers each had byte-identical `IDLE` and `PAUSED` branches:

- `_format_section` row loop: both branches appended the same f-string `f"{glyph_markup} [dim]{project}[/dim]  [dim]{detail}[/dim]"`.
- `_color_for_state`: both branches returned the same color `"#484f58"`.

Each helper now uses a single `state in (ProjectState.IDLE, ProjectState.PAUSED)` branch.

## Grep evidence

- `grep -rn "_format_section\|_color_for_state" src/ tests/` -> only internal hits in `operator_dashboard.py`; both helpers are private with no external callers or test seam.
- The upstream logical distinction between idle and paused projects is preserved in `_render_view` (~lines 252-257), where `view.paused` has its own dedicated section. Only the cosmetic rendering for already-paused rows was duplicated.

## Diff stats

`1 file changed, 2 insertions(+), 6 deletions(-)` -- net -4 LOC.

## Test plan

- [x] `uv run python -c "import pollypm.cockpit_apps.operator_dashboard"` (smoke import: OK)
- [x] `uv run --extra dev pytest tests/test_operator_dashboard_pilot.py tests/test_dashboard_operator_view.py -x` -- 9 passed