### PR TITLE
refactor(pg_service): drop dead _NOT_IMPLEMENTED_SLICE_B constant

### DIFF
--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -82,14 +82,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-_NOT_IMPLEMENTED_SLICE_B = (
-    "PgWorkService method not implemented in Slice A. "
-    "The full work-service port lands in Slice B (#1737). "
-    "Fix: keep ``[storage] backend = 'sqlite'`` until Slice B merges, "
-    "or implement the method here if you are wiring Slice B."
-)
-
-
 def _parse_task_id(task_id: str) -> tuple[str, int]:
     """Split ``project/number`` into ``(project, int(number))``.
 


### PR DESCRIPTION
## Summary
- Deletes the `_NOT_IMPLEMENTED_SLICE_B` module-level constant in `src/pollypm/work/pg_service.py` (8 lines including trailing blank).
- Constant was the message for `raise NotImplementedError(_NOT_IMPLEMENTED_SLICE_B)` stubs in Slice A; every method that referenced it has been implemented across Slices B-J. No remaining callers.

## Context
- 6-tick carry-forward from the overnight smoketest orchestrator (tick #1 surfaced it).
- All 4 grep checks re-verified in the worktree before editing:
  - `grep -rn "_NOT_IMPLEMENTED_SLICE_B" src/ tests/` -> 1 hit (def site only)
  - `grep -rn "NotImplementedError(_NOT_IMPLEMENTED_SLICE_B" src/ tests/` -> 0 hits
  - `grep -rn "SLICE_B" src/ tests/` -> 1 hit (def site only; not a substring of any live identifier)
  - `grep -rn "_NOT_IMPLEMENTED_SLICE_B" tests/` -> 0 hits

## Test plan
- [x] `uv run python -c "import pollypm.work.pg_service"` (smoke import) -> ok
- [x] `uv run --extra dev pytest tests/test_pg_work_service.py tests/test_pg_work_service_full.py tests/test_pg_work_service_parity.py -x` -> 83 passed, 4 skipped
- [ ] CI green on PR

Note: the spec-listed globs `tests/test_pg_service*.py` and `tests/test_work_pg*.py` don't match any files in the tree; the closest matches (`tests/test_pg_work_service*.py`) were run instead.

Generated with [Claude Code](https://claude.com/claude-code)