### PR TITLE
refactor(work): drop dead session_manager kwarg from create_work_service

### DIFF
--- a/src/pollypm/work/factory.py
+++ b/src/pollypm/work/factory.py
@@ -70,7 +70,6 @@ def create_work_service(
     config: "PollyPMConfig | None" = None,
     project_key: str | None = None,
     sync_manager: "SyncManager | None" = None,
-    session_manager: object | None = None,
 ) -> Any:
     """Construct the configured work-service backend.
 
@@ -93,10 +92,10 @@ def create_work_service(
         Optional project key. Forwarded to the resolver so it can warn
         about stale per-project DB files (#1004), and to the pg service
         for the per-row ``project_key`` column.
-    sync_manager / session_manager:
+    sync_manager:
         Forwarded to the sqlite constructor for callers that need a
-        bespoke sync or session manager (the heartbeat does this).
-        Ignored on the pg backend until Slice B.
+        bespoke sync manager (the ``pm work`` CLI does this). Ignored
+        on the pg backend until Slice B.
 
     Returns
     -------
@@ -129,16 +128,14 @@ def create_work_service(
 
     # Forward only the args that callers explicitly opted into. The
     # underlying ``SQLiteWorkService.__init__`` accepts ``sync_manager``
-    # and ``session_manager`` as keyword args, but several test doubles
-    # in the tree implement a narrower constructor signature
-    # (``db_path``, ``project_path`` only). Passing ``None`` for the
-    # optional managers in the factory's default path would TypeError
-    # against those doubles, so we only forward when the caller asked.
-    extra: dict[str, object] = {}
-    if sync_manager is not None:
-        extra["sync_manager"] = sync_manager
-    if session_manager is not None:
-        extra["session_manager"] = session_manager
+    # as a keyword arg, but several test doubles in the tree implement
+    # a narrower constructor signature (``db_path``, ``project_path``
+    # only). Passing ``None`` for the optional manager in the factory's
+    # default path would TypeError against those doubles, so we only
+    # forward when the caller asked.
+    extra: dict[str, object] = (
+        {"sync_manager": sync_manager} if sync_manager is not None else {}
+    )
     return SQLiteWorkService(
         db_path=resolved_path,
         project_path=project_path_obj,


### PR DESCRIPTION
## Summary

Verified-safe subset of a tick-#2 cleanup dispatch that was correctly aborted when it targeted both `session_manager` and `sync_manager`. This PR removes ONLY the dead `session_manager` kwarg; `sync_manager` is deliberately preserved (used by `src/pollypm/work/cli.py:277-283`).

- Drops `session_manager: object | None = None` from `create_work_service` signature, docstring stanza, and forwarding block in `src/pollypm/work/factory.py`.
- Collapses the `extra = {}` accumulation to a single conditional dict literal since `sync_manager` is now the only caller-opt-in arg.
- `sync_manager` parameter, docstring, and forwarding logic untouched.

## Grep evidence

- `grep -rn "session_manager=" src/pollypm/ tests/ | grep -E "create_work_service|factory\.create"` -> **0 hits** (zero callers pass the kwarg to the factory).
- All other `session_manager` references in the tree are unrelated to the factory kwarg path: post-construction `svc.set_session_manager(...)` calls (`cli.py:318`, `task_assignment_notify.py:990`), direct service `__init__` kwargs (`sqlite_service.py:724`, `pg_service.py:238`), or imports of the `pollypm.work.session_manager` module.
- Docstring previously claimed "the heartbeat does this" -- it does not. Pure dead surface.

## Test plan

- [x] `uv run python -c "import pollypm.work.factory"` -> OK
- [x] `uv run --extra dev pytest tests/test_heartbeat_cascade_foundation.py tests/test_heartbeat_plugin_api.py tests/test_worktree_state_audit.py tests/test_onboarding.py tests/test_audit_watchdog.py tests/test_project_remove_cli.py -x` -> **236 passed** (factory-importing test files; pg-coupled test file skipped, no test_factory*.py exists)
- [ ] CI green on full suite