### PR TITLE
feat(pg): port StateStore clusters F+G+H+I to pg facades (Slice K-state-port phase 2b, #1737)

### DIFF
--- a/src/pollypm/plugins_builtin/default_launch_planner/planner.py
+++ b/src/pollypm/plugins_builtin/default_launch_planner/planner.py
@@ -34,7 +34,6 @@ from pollypm.runtimes import get_runtime
 
 if TYPE_CHECKING:
     from pollypm.config import PollyPMConfig
-    from pollypm.storage.state import StateStore
 from pollypm.models import CONTROL_ROLES as _CONTROL_ROLES
 
 _ROUTED_ROLES = frozenset({"operator-pm", "architect", "worker", "reviewer"})

--- a/src/pollypm/storage/pg_architect_resume.py
+++ b/src/pollypm/storage/pg_architect_resume.py
@@ -1,0 +1,175 @@
+"""Postgres facade for the ``architect_resume_tokens`` table (#1737).
+
+This module owns the read/write path for the per-project resume
+tokens that :mod:`pollypm.architect_lifecycle` persists when an idle
+architect-session is closed. Mirrors the four StateStore methods that
+used to back the same table on the sqlite path:
+
+* :func:`upsert_architect_resume_token`
+* :func:`get_architect_resume_token`
+* :func:`clear_architect_resume_token`
+* :func:`list_architect_resume_tokens`
+
+All four functions are module-level (no class) and accept an optional
+``pool`` kwarg defaulting to :func:`~pollypm.storage.pg_pool.get_rw_pool`
+for mutators or :func:`~pollypm.storage.pg_pool.get_ro_pool` for
+readers. Passing a custom pool is the test-harness seam.
+
+Slice K-state-port phase 2b — port of StateStore cluster F.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from pollypm.storage.records import ArchitectResumeRecord
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string.
+
+    Matches the value StateStore stamps on the sqlite ``captured_at``
+    column so dual-write callers (during the cutover) produce
+    indistinguishable rows.
+    """
+    return datetime.now(UTC).isoformat()
+
+
+def _stamp_str(value: object) -> str:
+    """Return ``value`` as an ISO-8601 string.
+
+    pg returns ``timestamptz`` columns as ``datetime`` objects;
+    StateStore returns them as strings. This helper normalises the
+    pg shape to the sqlite shape so the
+    :class:`~pollypm.storage.records.ArchitectResumeRecord` dataclass
+    sees the same value either way.
+    """
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def upsert_architect_resume_token(
+    *,
+    project_key: str,
+    provider: str,
+    session_id: str,
+    last_active_at: str,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Insert-or-replace the resume token row for ``project_key``.
+
+    The sqlite contract uses ISO-8601 strings for ``captured_at`` and
+    ``last_active_at``; pg's ``timestamptz`` column accepts the same
+    ISO-8601 input directly so callers don't need to convert.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    captured_at = _now_iso()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO architect_resume_tokens (
+                project_key, provider, session_id, captured_at, last_active_at
+            ) VALUES (%s, %s, %s, %s, %s)
+            ON CONFLICT (project_key) DO UPDATE SET
+                provider = EXCLUDED.provider,
+                session_id = EXCLUDED.session_id,
+                captured_at = EXCLUDED.captured_at,
+                last_active_at = EXCLUDED.last_active_at
+            """,
+            (project_key, provider, session_id, captured_at, last_active_at),
+        )
+
+
+def get_architect_resume_token(
+    project_key: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> ArchitectResumeRecord | None:
+    """Return the resume token for ``project_key``, or ``None``."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT project_key, provider, session_id, captured_at, last_active_at
+            FROM architect_resume_tokens WHERE project_key = %s
+            """,
+            (project_key,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return ArchitectResumeRecord(
+        project_key=row[0],
+        provider=row[1],
+        session_id=row[2],
+        captured_at=_stamp_str(row[3]),
+        last_active_at=_stamp_str(row[4]),
+    )
+
+
+def clear_architect_resume_token(
+    project_key: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Delete the resume token row for ``project_key`` (no-op if missing)."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM architect_resume_tokens WHERE project_key = %s",
+            (project_key,),
+        )
+
+
+def list_architect_resume_tokens(
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> list[ArchitectResumeRecord]:
+    """Return every stored resume token (unordered)."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT project_key, provider, session_id, captured_at, last_active_at
+            FROM architect_resume_tokens
+            """
+        )
+        rows = cur.fetchall()
+    return [
+        ArchitectResumeRecord(
+            project_key=row[0],
+            provider=row[1],
+            session_id=row[2],
+            captured_at=_stamp_str(row[3]),
+            last_active_at=_stamp_str(row[4]),
+        )
+        for row in rows
+    ]
+
+
+__all__ = [
+    "clear_architect_resume_token",
+    "get_architect_resume_token",
+    "list_architect_resume_tokens",
+    "upsert_architect_resume_token",
+]

--- a/src/pollypm/storage/pg_checkpoints.py
+++ b/src/pollypm/storage/pg_checkpoints.py
@@ -1,0 +1,142 @@
+"""Postgres facade for the ``checkpoints`` table (#1737).
+
+This module owns the read/write path for the per-session checkpoint
+rows that :mod:`pollypm.checkpoints` records during the heartbeat
+cascade and the cockpit's manual-checkpoint flow. Mirrors the two
+StateStore methods that used to back the same table on the sqlite
+path:
+
+* :func:`record_checkpoint`
+* :func:`latest_checkpoint`
+
+Both functions are module-level (no class) and accept an optional
+``pool`` kwarg defaulting to :func:`~pollypm.storage.pg_pool.get_rw_pool`
+for the writer or :func:`~pollypm.storage.pg_pool.get_ro_pool` for the
+reader. Passing a custom pool is the test-harness seam.
+
+Slice K-state-port phase 2b — port of StateStore cluster G.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from pollypm.storage.records import CheckpointRecord
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string.
+
+    Matches the value StateStore stamps on the sqlite ``created_at``
+    column so dual-write callers (during the cutover) produce
+    indistinguishable rows.
+    """
+    return datetime.now(UTC).isoformat()
+
+
+def _stamp_str(value: object) -> str:
+    """Return ``value`` as an ISO-8601 string.
+
+    pg returns ``timestamptz`` columns as ``datetime`` objects;
+    StateStore returns them as strings. This helper normalises the
+    pg shape to the sqlite shape so the
+    :class:`~pollypm.storage.records.CheckpointRecord` dataclass sees
+    the same value either way.
+    """
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def record_checkpoint(
+    *,
+    session_name: str,
+    project_key: str,
+    level: str,
+    json_path: str,
+    summary_path: str,
+    snapshot_path: str,
+    summary_text: str,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Append a checkpoint row.
+
+    Mirrors :meth:`StateStore.record_checkpoint`: each call inserts a
+    new row (no upsert — the ``id`` serial gives us a monotonic
+    ordering that :func:`latest_checkpoint` uses to find the most
+    recent entry).
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    created_at = _now_iso()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO checkpoints (
+                session_name, project_key, level, json_path, summary_path,
+                snapshot_path, summary_text, created_at
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                session_name,
+                project_key,
+                level,
+                json_path,
+                summary_path,
+                snapshot_path,
+                summary_text,
+                created_at,
+            ),
+        )
+
+
+def latest_checkpoint(
+    session_name: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> CheckpointRecord | None:
+    """Return the most recently inserted checkpoint for ``session_name``."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT session_name, project_key, level, json_path, summary_path,
+                   snapshot_path, summary_text, created_at
+            FROM checkpoints
+            WHERE session_name = %s
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (session_name,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return CheckpointRecord(
+        session_name=row[0],
+        project_key=row[1],
+        level=row[2],
+        json_path=row[3],
+        summary_path=row[4],
+        snapshot_path=row[5],
+        summary_text=row[6],
+        created_at=_stamp_str(row[7]),
+    )
+
+
+__all__ = [
+    "latest_checkpoint",
+    "record_checkpoint",
+]

--- a/src/pollypm/storage/pg_token_usage.py
+++ b/src/pollypm/storage/pg_token_usage.py
@@ -1,0 +1,383 @@
+"""Postgres facade for the ``token_samples`` + ``token_usage_hourly`` tables (#1737).
+
+This module owns the read/write path for the per-session token
+cumulative samples and the hourly aggregate that the cockpit's token
+strip / dashboard reads. Mirrors the six StateStore methods that
+used to back the same tables on the sqlite path:
+
+* :func:`get_token_sample` — latest sample for a session
+* :func:`record_token_sample` — observe + roll forward (delta into hourly bucket)
+* :func:`upsert_token_sample` — raw sample upsert (no delta tracking)
+* :func:`replace_token_usage_hourly` — atomic delete-and-reinsert
+* :func:`recent_token_usage` — hourly slice, newest first
+* :func:`daily_token_usage` — per-day rollup over N days
+
+All six functions are module-level (no class) and accept an optional
+``pool`` kwarg defaulting to :func:`~pollypm.storage.pg_pool.get_rw_pool`
+for mutators or :func:`~pollypm.storage.pg_pool.get_ro_pool` for readers.
+Passing a custom pool is the test-harness seam.
+
+Slice K-state-port phase 2b — port of StateStore cluster I.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from pollypm.storage.records import TokenSampleRecord, TokenUsageHourlyRecord
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string.
+
+    Matches the value StateStore stamps on the sqlite ``observed_at``
+    column so dual-write callers (during the cutover) produce
+    indistinguishable rows.
+    """
+    return datetime.now(UTC).isoformat()
+
+
+def _stamp_str(value: object) -> str:
+    """Return ``value`` as an ISO-8601 string.
+
+    pg returns ``timestamptz`` columns as ``datetime`` objects;
+    StateStore returns them as strings.
+    """
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _hour_bucket(observed_at: str) -> str:
+    """Truncate an ISO-8601 timestamp to its hour bucket.
+
+    Mirrors the StateStore convention of ``YYYY-MM-DDTHH:00:00+00:00``.
+    The hourly aggregate is keyed on this string so a sample observed
+    at 14:37 lands in the 14:00 bucket alongside every other 14:xx
+    sample from the same account/provider/model/project.
+    """
+    return observed_at[:13] + ":00:00+00:00"
+
+
+def get_token_sample(
+    session_name: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> TokenSampleRecord | None:
+    """Return the latest cumulative-token sample for ``session_name``."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT session_name, account_name, provider, model_name,
+                   project_key, cumulative_tokens, observed_at
+            FROM token_samples
+            WHERE session_name = %s
+            """,
+            (session_name,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return TokenSampleRecord(
+        session_name=row[0],
+        account_name=row[1],
+        provider=row[2],
+        model_name=row[3],
+        project_key=row[4],
+        cumulative_tokens=int(row[5]),
+        observed_at=_stamp_str(row[6]),
+    )
+
+
+def record_token_sample(
+    *,
+    session_name: str,
+    account_name: str,
+    provider: str,
+    model_name: str,
+    project_key: str,
+    cumulative_tokens: int,
+    observed_at: str | None = None,
+    pool: "ConnectionPool | None" = None,
+) -> int:
+    """Observe a cumulative-token reading and roll forward the hourly bucket.
+
+    Mirrors :meth:`StateStore.record_token_sample`:
+
+    1. Read the previous sample for the session.
+    2. If the previous sample is for the same account/provider/model/
+       project tuple AND ``cumulative_tokens`` is non-decreasing,
+       compute ``delta = cumulative - previous``. Otherwise the
+       delta is zero (session swapped accounts / counter reset).
+    3. Upsert the new sample.
+    4. If ``delta > 0``, increment the corresponding hourly bucket
+       row in ``token_usage_hourly``.
+
+    Returns the computed ``delta`` so callers (the supervisor) can
+    log per-tick usage. The whole flow runs inside one psycopg
+    transaction so a concurrent sample for the same session can't see
+    a half-applied state.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    now = observed_at or _now_iso()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT account_name, provider, model_name, project_key,
+                   cumulative_tokens
+            FROM token_samples
+            WHERE session_name = %s
+            FOR UPDATE
+            """,
+            (session_name,),
+        )
+        previous = cur.fetchone()
+        delta = 0
+        if previous is not None:
+            if (
+                previous[0] == account_name
+                and previous[1] == provider
+                and previous[2] == model_name
+                and previous[3] == project_key
+                and int(cumulative_tokens) >= int(previous[4])
+            ):
+                delta = int(cumulative_tokens) - int(previous[4])
+        cur.execute(
+            """
+            INSERT INTO token_samples (
+                session_name, account_name, provider, model_name,
+                project_key, cumulative_tokens, observed_at
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (session_name) DO UPDATE SET
+                account_name = EXCLUDED.account_name,
+                provider = EXCLUDED.provider,
+                model_name = EXCLUDED.model_name,
+                project_key = EXCLUDED.project_key,
+                cumulative_tokens = EXCLUDED.cumulative_tokens,
+                observed_at = EXCLUDED.observed_at
+            """,
+            (
+                session_name,
+                account_name,
+                provider,
+                model_name,
+                project_key,
+                int(cumulative_tokens),
+                now,
+            ),
+        )
+        if delta > 0:
+            bucket = _hour_bucket(now)
+            cur.execute(
+                """
+                INSERT INTO token_usage_hourly (
+                    hour_bucket, account_name, provider, model_name,
+                    project_key, tokens_used, updated_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (hour_bucket, account_name, provider, model_name, project_key)
+                DO UPDATE SET
+                    tokens_used = token_usage_hourly.tokens_used + EXCLUDED.tokens_used,
+                    updated_at = EXCLUDED.updated_at
+                """,
+                (
+                    bucket,
+                    account_name,
+                    provider,
+                    model_name,
+                    project_key,
+                    int(delta),
+                    now,
+                ),
+            )
+    return delta
+
+
+def upsert_token_sample(
+    *,
+    session_name: str,
+    account_name: str,
+    provider: str,
+    model_name: str,
+    project_key: str,
+    cumulative_tokens: int,
+    observed_at: str,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Raw upsert of a cumulative-token sample (no delta tracking).
+
+    Used by the transcript-ledger backfill where the hourly aggregate
+    is rebuilt wholesale from the transcript JSONL — there's no
+    per-tick delta to track, the sample is just bookkeeping for
+    ``record_token_sample``'s next call.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO token_samples (
+                session_name, account_name, provider, model_name,
+                project_key, cumulative_tokens, observed_at
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (session_name) DO UPDATE SET
+                account_name = EXCLUDED.account_name,
+                provider = EXCLUDED.provider,
+                model_name = EXCLUDED.model_name,
+                project_key = EXCLUDED.project_key,
+                cumulative_tokens = EXCLUDED.cumulative_tokens,
+                observed_at = EXCLUDED.observed_at
+            """,
+            (
+                session_name,
+                account_name,
+                provider,
+                model_name,
+                project_key,
+                int(cumulative_tokens),
+                observed_at,
+            ),
+        )
+
+
+def replace_token_usage_hourly(
+    rows: list[TokenUsageHourlyRecord],
+    *,
+    account_names: list[str] | None = None,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Atomically delete-and-reinsert the hourly aggregate.
+
+    When ``account_names`` is supplied only those accounts' rows are
+    cleared (the transcript backfill processes one account at a time);
+    otherwise the whole table is replaced. Runs inside one psycopg
+    transaction so a concurrent reader sees either the pre- or
+    post-replace state, never a partial wipe.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        if account_names:
+            cur.execute(
+                "DELETE FROM token_usage_hourly WHERE account_name = ANY(%s)",
+                (list(account_names),),
+            )
+        else:
+            cur.execute("DELETE FROM token_usage_hourly")
+        for row in rows:
+            cur.execute(
+                """
+                INSERT INTO token_usage_hourly (
+                    hour_bucket, account_name, provider, model_name,
+                    project_key, tokens_used, updated_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    row.hour_bucket,
+                    row.account_name,
+                    row.provider,
+                    row.model_name,
+                    row.project_key,
+                    int(row.tokens_used),
+                    row.updated_at,
+                ),
+            )
+
+
+def recent_token_usage(
+    limit: int = 24,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> list[TokenUsageHourlyRecord]:
+    """Return the most recent hourly aggregate rows (newest hour first).
+
+    Sort order matches StateStore: primary key is ``hour_bucket`` DESC,
+    secondary is ``tokens_used`` DESC so a tied bucket prefers the
+    heavier consumer.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT hour_bucket, account_name, provider, model_name,
+                   project_key, tokens_used, updated_at
+            FROM token_usage_hourly
+            ORDER BY hour_bucket DESC, tokens_used DESC
+            LIMIT %s
+            """,
+            (int(limit),),
+        )
+        rows = cur.fetchall()
+    return [
+        TokenUsageHourlyRecord(
+            hour_bucket=row[0],
+            account_name=row[1],
+            provider=row[2],
+            model_name=row[3],
+            project_key=row[4],
+            tokens_used=int(row[5]),
+            updated_at=_stamp_str(row[6]),
+        )
+        for row in rows
+    ]
+
+
+def daily_token_usage(
+    days: int = 30,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> list[tuple[str, int]]:
+    """Return the last ``days`` days as ``(YYYY-MM-DD, total_tokens)`` pairs.
+
+    The list is oldest-first to match the StateStore contract (the
+    sqlite branch ``reverse()``\\s the DESC-ordered SELECT). Empty
+    buckets are omitted — the caller is expected to fill gaps.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT substr(hour_bucket, 1, 10) AS day,
+                   SUM(tokens_used) AS total
+            FROM token_usage_hourly
+            GROUP BY day
+            ORDER BY day DESC
+            LIMIT %s
+            """,
+            (int(days),),
+        )
+        rows = cur.fetchall()
+    return [(row[0], int(row[1])) for row in reversed(rows)]
+
+
+__all__ = [
+    "daily_token_usage",
+    "get_token_sample",
+    "recent_token_usage",
+    "record_token_sample",
+    "replace_token_usage_hourly",
+    "upsert_token_sample",
+]

--- a/src/pollypm/storage/pg_worktrees.py
+++ b/src/pollypm/storage/pg_worktrees.py
@@ -1,0 +1,223 @@
+"""Postgres facade for the ``worktrees`` table (#1737).
+
+This module owns the read/write path for the per-project worktree
+inventory that :mod:`pollypm.worktrees` records. Each row tracks a
+provisioned worktree directory (path + branch) by project key, lane
+(``main`` / ``issue`` / ``task``), and lane-key. Mirrors the three
+StateStore methods that used to back the same table on the sqlite
+path:
+
+* :func:`upsert_worktree`
+* :func:`update_worktree_status`
+* :func:`list_worktrees`
+
+All three functions are module-level (no class) and accept an optional
+``pool`` kwarg defaulting to :func:`~pollypm.storage.pg_pool.get_rw_pool`
+for mutators or :func:`~pollypm.storage.pg_pool.get_ro_pool` for the
+reader. Passing a custom pool is the test-harness seam.
+
+Slice K-state-port phase 2b — port of StateStore cluster H.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from pollypm.storage.records import WorktreeRecord
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string.
+
+    Matches the value StateStore stamps on the sqlite ``created_at`` /
+    ``updated_at`` columns so dual-write callers (during the cutover)
+    produce indistinguishable rows.
+    """
+    return datetime.now(UTC).isoformat()
+
+
+def _stamp_str(value: object) -> str:
+    """Return ``value`` as an ISO-8601 string.
+
+    pg returns ``timestamptz`` columns as ``datetime`` objects;
+    StateStore returns them as strings. This helper normalises the
+    pg shape to the sqlite shape so the
+    :class:`~pollypm.storage.records.WorktreeRecord` dataclass sees
+    the same value either way.
+    """
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def upsert_worktree(
+    *,
+    project_key: str,
+    lane_kind: str,
+    lane_key: str,
+    session_name: str | None,
+    issue_key: str | None,
+    path: str,
+    branch: str,
+    status: str,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Insert-or-update the worktree row for ``(project, lane, status)``.
+
+    Mirrors the StateStore semantics: rows are deduplicated on
+    ``(project_key, lane_kind, lane_key, status)`` so a fresh
+    provisioning that lands on an existing active worktree updates
+    the existing row in place (path/branch/session_name/issue_key) and
+    bumps ``updated_at``. A different ``status`` produces a new row.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    now = _now_iso()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id FROM worktrees
+            WHERE project_key = %s
+              AND lane_kind = %s
+              AND lane_key = %s
+              AND status = %s
+            """,
+            (project_key, lane_kind, lane_key, status),
+        )
+        row = cur.fetchone()
+        if row is None:
+            cur.execute(
+                """
+                INSERT INTO worktrees (
+                    project_key, lane_kind, lane_key, session_name, issue_key,
+                    path, branch, status, created_at, updated_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    project_key,
+                    lane_kind,
+                    lane_key,
+                    session_name,
+                    issue_key,
+                    path,
+                    branch,
+                    status,
+                    now,
+                    now,
+                ),
+            )
+        else:
+            cur.execute(
+                """
+                UPDATE worktrees
+                SET session_name = %s,
+                    issue_key = %s,
+                    path = %s,
+                    branch = %s,
+                    updated_at = %s
+                WHERE id = %s
+                """,
+                (session_name, issue_key, path, branch, now, row[0]),
+            )
+
+
+def update_worktree_status(
+    project_key: str,
+    lane_kind: str,
+    lane_key: str,
+    status: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Promote the ``active`` row for ``(project, lane)`` to ``status``.
+
+    The sqlite contract: only the currently-active row is affected;
+    rows that are already in a terminal status (``closed``, etc) are
+    left alone so the historical record is preserved.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    now = _now_iso()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE worktrees
+            SET status = %s, updated_at = %s
+            WHERE project_key = %s
+              AND lane_kind = %s
+              AND lane_key = %s
+              AND status = 'active'
+            """,
+            (status, now, project_key, lane_kind, lane_key),
+        )
+
+
+def list_worktrees(
+    project_key: str | None = None,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> list[WorktreeRecord]:
+    """Return every worktree row, ordered most-recently-updated first.
+
+    Pass ``project_key`` to scope the result to a single project; pass
+    ``None`` to return the full inventory.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        if project_key is None:
+            cur.execute(
+                """
+                SELECT project_key, lane_kind, lane_key, session_name, issue_key,
+                       path, branch, status, created_at, updated_at
+                FROM worktrees
+                ORDER BY updated_at DESC
+                """
+            )
+        else:
+            cur.execute(
+                """
+                SELECT project_key, lane_kind, lane_key, session_name, issue_key,
+                       path, branch, status, created_at, updated_at
+                FROM worktrees
+                WHERE project_key = %s
+                ORDER BY updated_at DESC
+                """,
+                (project_key,),
+            )
+        rows = cur.fetchall()
+    return [
+        WorktreeRecord(
+            project_key=row[0],
+            lane_kind=row[1],
+            lane_key=row[2],
+            session_name=row[3],
+            issue_key=row[4],
+            path=row[5],
+            branch=row[6],
+            status=row[7],
+            created_at=_stamp_str(row[8]),
+            updated_at=_stamp_str(row[9]),
+        )
+        for row in rows
+    ]
+
+
+__all__ = [
+    "list_worktrees",
+    "update_worktree_status",
+    "upsert_worktree",
+]

--- a/src/pollypm/worktrees.py
+++ b/src/pollypm/worktrees.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import subprocess
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import typer
 
@@ -14,10 +15,105 @@ from pollypm.projects import (
     release_session_lock,
     session_scoped_dir,
 )
+from pollypm.storage._backend_dispatch import is_pg_backend
 from pollypm.storage.records import WorktreeRecord
-from pollypm.storage.state import StateStore
+
+if TYPE_CHECKING:
+    from pollypm.models import PollyPMConfig
 
 _SAFE_WORKTREE_KEY_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def _list_worktrees_for_backend(
+    config: "PollyPMConfig", project_key: str | None
+) -> list[WorktreeRecord]:
+    """Backend-aware list helper.
+
+    On the pg path we go straight through the new pg_worktrees facade
+    (no per-process StateStore lifecycle); on the sqlite path we open
+    a short-lived StateStore for back-compat. Both branches return the
+    same :class:`WorktreeRecord` shape so callers don't have to care.
+    """
+    if is_pg_backend(config):
+        from pollypm.storage.pg_worktrees import list_worktrees as pg_list
+
+        return pg_list(project_key)
+    from pollypm.storage.state import StateStore
+
+    store = StateStore(config.project.state_db)
+    try:
+        return store.list_worktrees(project_key)
+    finally:
+        store.close()
+
+
+def _upsert_worktree_for_backend(
+    config: "PollyPMConfig",
+    *,
+    project_key: str,
+    lane_kind: str,
+    lane_key: str,
+    session_name: str | None,
+    issue_key: str | None,
+    path: str,
+    branch: str,
+    status: str,
+) -> None:
+    """Backend-aware upsert wrapper. See :func:`_list_worktrees_for_backend`."""
+    if is_pg_backend(config):
+        from pollypm.storage.pg_worktrees import upsert_worktree as pg_upsert
+
+        pg_upsert(
+            project_key=project_key,
+            lane_kind=lane_kind,
+            lane_key=lane_key,
+            session_name=session_name,
+            issue_key=issue_key,
+            path=path,
+            branch=branch,
+            status=status,
+        )
+        return
+    from pollypm.storage.state import StateStore
+
+    store = StateStore(config.project.state_db)
+    try:
+        store.upsert_worktree(
+            project_key=project_key,
+            lane_kind=lane_kind,
+            lane_key=lane_key,
+            session_name=session_name,
+            issue_key=issue_key,
+            path=path,
+            branch=branch,
+            status=status,
+        )
+    finally:
+        store.close()
+
+
+def _update_worktree_status_for_backend(
+    config: "PollyPMConfig",
+    project_key: str,
+    lane_kind: str,
+    lane_key: str,
+    status: str,
+) -> None:
+    """Backend-aware status-promotion wrapper."""
+    if is_pg_backend(config):
+        from pollypm.storage.pg_worktrees import (
+            update_worktree_status as pg_update,
+        )
+
+        pg_update(project_key, lane_kind, lane_key, status)
+        return
+    from pollypm.storage.state import StateStore
+
+    store = StateStore(config.project.state_db)
+    try:
+        store.update_worktree_status(project_key, lane_kind, lane_key, status)
+    finally:
+        store.close()
 
 
 def _validate_worktree_key(param_name: str, param_value: str) -> None:
@@ -54,8 +150,7 @@ def ensure_worktree(
     if not (project.path / ".git").exists():
         return None
 
-    store = StateStore(config.project.state_db)
-    existing = _active_worktree(store, project_key, lane_kind, lane_key)
+    existing = _active_worktree(config, project_key, lane_kind, lane_key)
     if existing is not None and Path(existing.path).exists():
         return existing
 
@@ -74,7 +169,8 @@ def ensure_worktree(
             release_session_lock(worktree_root, session_id)
             raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git worktree add failed")
 
-    store.upsert_worktree(
+    _upsert_worktree_for_backend(
+        config,
         project_key=project_key,
         lane_kind=lane_kind,
         lane_key=lane_key,
@@ -84,7 +180,7 @@ def ensure_worktree(
         branch=branch,
         status="active",
     )
-    return _active_worktree(store, project_key, lane_kind, lane_key)
+    return _active_worktree(config, project_key, lane_kind, lane_key)
 
 
 def cleanup_worktree(
@@ -106,8 +202,7 @@ def cleanup_worktree(
     project = config.projects.get(project_key)
     if project is None:
         raise typer.BadParameter(f"Unknown project: {project_key}")
-    store = StateStore(config.project.state_db)
-    record = _active_worktree(store, project_key, lane_kind, lane_key)
+    record = _active_worktree(config, project_key, lane_kind, lane_key)
     if record is None:
         raise typer.BadParameter(f"No active worktree for {project_key}:{lane_kind}:{lane_key}")
     path = Path(record.path)
@@ -134,18 +229,19 @@ def cleanup_worktree(
         timeout=60,
     )
     release_session_lock(path.parent, record.session_name)
-    store.update_worktree_status(project_key, lane_kind, lane_key, "closed")
+    _update_worktree_status_for_backend(config, project_key, lane_kind, lane_key, "closed")
     return path
 
 
 def list_worktrees(config_path: Path, project_key: str | None = None) -> list[WorktreeRecord]:
     config = load_config(config_path)
-    store = StateStore(config.project.state_db)
-    return store.list_worktrees(project_key)
+    return _list_worktrees_for_backend(config, project_key)
 
 
-def _active_worktree(store: StateStore, project_key: str, lane_kind: str, lane_key: str) -> WorktreeRecord | None:
-    for item in store.list_worktrees(project_key):
+def _active_worktree(
+    config: "PollyPMConfig", project_key: str, lane_kind: str, lane_key: str
+) -> WorktreeRecord | None:
+    for item in _list_worktrees_for_backend(config, project_key):
         if item.lane_kind == lane_kind and item.lane_key == lane_key and item.status == "active":
             return item
     return None

--- a/tests/test_pg_storage_facades.py
+++ b/tests/test_pg_storage_facades.py
@@ -869,3 +869,360 @@ def test_pg_notifications_recent_notifications_shape(pg_schema_pool, pg_config):
         project="gamma", limit=10, pool=pg_schema_pool,
     )
     assert [r["task_id"] for r in only_gamma] == ["gamma:5"]
+
+
+# --------------------------------------------------------------------- #
+# pg_architect_resume — resume tokens (Slice K-state-port phase 2b)
+# --------------------------------------------------------------------- #
+
+
+def test_pg_architect_resume_upsert_get_clear_roundtrip(pg_schema_pool, pg_config):
+    """The pg facade must mirror StateStore's upsert / get / clear contract."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_architect_resume import (
+        clear_architect_resume_token,
+        get_architect_resume_token,
+        list_architect_resume_tokens,
+        upsert_architect_resume_token,
+    )
+
+    assert get_architect_resume_token("alpha", pool=pg_schema_pool) is None
+
+    upsert_architect_resume_token(
+        project_key="alpha",
+        provider="claude",
+        session_id="sess-uuid-1",
+        last_active_at="2025-01-01T12:00:00+00:00",
+        pool=pg_schema_pool,
+    )
+    record = get_architect_resume_token("alpha", pool=pg_schema_pool)
+    assert record is not None
+    assert record.project_key == "alpha"
+    assert record.provider == "claude"
+    assert record.session_id == "sess-uuid-1"
+    # captured_at is stamped server-side; just confirm it's a non-empty string.
+    assert isinstance(record.captured_at, str) and record.captured_at
+    # last_active_at round-trips as the iso-8601 datetime we passed in.
+    assert record.last_active_at.startswith("2025-01-01")
+
+    # Re-upsert replaces the row (same project_key — primary key).
+    upsert_architect_resume_token(
+        project_key="alpha",
+        provider="codex",
+        session_id="sess-uuid-2",
+        last_active_at="2025-01-02T12:00:00+00:00",
+        pool=pg_schema_pool,
+    )
+    record2 = get_architect_resume_token("alpha", pool=pg_schema_pool)
+    assert record2 is not None
+    assert record2.provider == "codex"
+    assert record2.session_id == "sess-uuid-2"
+
+    # list returns every row.
+    upsert_architect_resume_token(
+        project_key="beta",
+        provider="claude",
+        session_id="sess-uuid-3",
+        last_active_at="2025-01-03T12:00:00+00:00",
+        pool=pg_schema_pool,
+    )
+    rows = list_architect_resume_tokens(pool=pg_schema_pool)
+    keys = {r.project_key for r in rows}
+    assert keys == {"alpha", "beta"}
+
+    # clear is a no-op on miss, removes on hit.
+    clear_architect_resume_token("alpha", pool=pg_schema_pool)
+    assert get_architect_resume_token("alpha", pool=pg_schema_pool) is None
+    clear_architect_resume_token("missing", pool=pg_schema_pool)  # no raise
+
+
+# --------------------------------------------------------------------- #
+# pg_checkpoints — checkpoint ring (Slice K-state-port phase 2b)
+# --------------------------------------------------------------------- #
+
+
+def test_pg_checkpoints_record_and_latest(pg_schema_pool, pg_config):
+    """Each record_checkpoint inserts a new row; latest_checkpoint returns newest."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_checkpoints import (
+        latest_checkpoint,
+        record_checkpoint,
+    )
+
+    assert latest_checkpoint("worker-alpha", pool=pg_schema_pool) is None
+
+    record_checkpoint(
+        session_name="worker-alpha",
+        project_key="alpha",
+        level="L0",
+        json_path="/tmp/cp1.json",
+        summary_path="/tmp/cp1.md",
+        snapshot_path="/tmp/cp1.snap",
+        summary_text="first checkpoint",
+        pool=pg_schema_pool,
+    )
+    record_checkpoint(
+        session_name="worker-alpha",
+        project_key="alpha",
+        level="L1",
+        json_path="/tmp/cp2.json",
+        summary_path="/tmp/cp2.md",
+        snapshot_path="/tmp/cp2.snap",
+        summary_text="second checkpoint",
+        pool=pg_schema_pool,
+    )
+    # A different session must not bleed into the lookup.
+    record_checkpoint(
+        session_name="worker-beta",
+        project_key="beta",
+        level="L0",
+        json_path="/tmp/other.json",
+        summary_path="/tmp/other.md",
+        snapshot_path="/tmp/other.snap",
+        summary_text="unrelated",
+        pool=pg_schema_pool,
+    )
+
+    latest = latest_checkpoint("worker-alpha", pool=pg_schema_pool)
+    assert latest is not None
+    assert latest.level == "L1"
+    assert latest.summary_text == "second checkpoint"
+    assert latest.session_name == "worker-alpha"
+    assert isinstance(latest.created_at, str) and latest.created_at
+
+
+# --------------------------------------------------------------------- #
+# pg_worktrees — worktree inventory (Slice K-state-port phase 2b)
+# --------------------------------------------------------------------- #
+
+
+def test_pg_worktrees_upsert_status_list(pg_schema_pool, pg_config):
+    """upsert dedupes on (project, lane, status); list returns newest first."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_worktrees import (
+        list_worktrees,
+        update_worktree_status,
+        upsert_worktree,
+    )
+
+    assert list_worktrees(pool=pg_schema_pool) == []
+
+    upsert_worktree(
+        project_key="alpha",
+        lane_kind="main",
+        lane_key="alpha",
+        session_name="sess-1",
+        issue_key=None,
+        path="/tmp/wt-alpha",
+        branch="main",
+        status="active",
+        pool=pg_schema_pool,
+    )
+    # Re-upserting the same (project, lane, status) updates in place.
+    upsert_worktree(
+        project_key="alpha",
+        lane_kind="main",
+        lane_key="alpha",
+        session_name="sess-1b",
+        issue_key="alpha#42",
+        path="/tmp/wt-alpha",
+        branch="main",
+        status="active",
+        pool=pg_schema_pool,
+    )
+    rows = list_worktrees("alpha", pool=pg_schema_pool)
+    assert len(rows) == 1
+    assert rows[0].session_name == "sess-1b"
+    assert rows[0].issue_key == "alpha#42"
+
+    # Promoting active → closed leaves a single row in the closed state.
+    update_worktree_status("alpha", "main", "alpha", "closed", pool=pg_schema_pool)
+    rows = list_worktrees("alpha", pool=pg_schema_pool)
+    assert len(rows) == 1
+    assert rows[0].status == "closed"
+
+    # A fresh active row coexists with the historical closed row.
+    upsert_worktree(
+        project_key="alpha",
+        lane_kind="main",
+        lane_key="alpha",
+        session_name="sess-2",
+        issue_key=None,
+        path="/tmp/wt-alpha-2",
+        branch="main",
+        status="active",
+        pool=pg_schema_pool,
+    )
+    rows = list_worktrees("alpha", pool=pg_schema_pool)
+    assert len(rows) == 2
+    statuses = {r.status for r in rows}
+    assert statuses == {"active", "closed"}
+
+    # Scoped list filters by project.
+    upsert_worktree(
+        project_key="beta",
+        lane_kind="issue",
+        lane_key="beta#1",
+        session_name=None,
+        issue_key="beta#1",
+        path="/tmp/wt-beta",
+        branch="issue/beta-1",
+        status="active",
+        pool=pg_schema_pool,
+    )
+    all_rows = list_worktrees(pool=pg_schema_pool)
+    alpha_rows = list_worktrees("alpha", pool=pg_schema_pool)
+    assert len(all_rows) == 3
+    assert len(alpha_rows) == 2
+
+
+# --------------------------------------------------------------------- #
+# pg_token_usage — token samples + hourly aggregate (Slice K-state-port phase 2b)
+# --------------------------------------------------------------------- #
+
+
+def test_pg_token_usage_record_sample_rolls_hourly(pg_schema_pool, pg_config):
+    """record_token_sample computes delta + rolls forward the hourly bucket."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_token_usage import (
+        get_token_sample,
+        record_token_sample,
+        recent_token_usage,
+    )
+
+    assert get_token_sample("worker-alpha", pool=pg_schema_pool) is None
+
+    # First sample: no previous row, so delta is zero and the hourly
+    # aggregate stays empty.
+    delta1 = record_token_sample(
+        session_name="worker-alpha",
+        account_name="acct-1",
+        provider="claude",
+        model_name="sonnet",
+        project_key="alpha",
+        cumulative_tokens=100,
+        observed_at="2025-01-01T12:30:00+00:00",
+        pool=pg_schema_pool,
+    )
+    assert delta1 == 0
+    assert recent_token_usage(pool=pg_schema_pool) == []
+
+    sample = get_token_sample("worker-alpha", pool=pg_schema_pool)
+    assert sample is not None
+    assert sample.cumulative_tokens == 100
+
+    # Second sample (same tuple, higher cumulative): delta = 150,
+    # lands in the 12:00 hour bucket.
+    delta2 = record_token_sample(
+        session_name="worker-alpha",
+        account_name="acct-1",
+        provider="claude",
+        model_name="sonnet",
+        project_key="alpha",
+        cumulative_tokens=250,
+        observed_at="2025-01-01T12:45:00+00:00",
+        pool=pg_schema_pool,
+    )
+    assert delta2 == 150
+    rows = recent_token_usage(pool=pg_schema_pool)
+    assert len(rows) == 1
+    assert rows[0].tokens_used == 150
+    assert rows[0].hour_bucket.startswith("2025-01-01T12")
+
+    # Third sample (switched accounts): delta resets to zero, no
+    # hourly write.
+    delta3 = record_token_sample(
+        session_name="worker-alpha",
+        account_name="acct-2",
+        provider="claude",
+        model_name="sonnet",
+        project_key="alpha",
+        cumulative_tokens=400,
+        observed_at="2025-01-01T13:15:00+00:00",
+        pool=pg_schema_pool,
+    )
+    assert delta3 == 0
+    rows = recent_token_usage(pool=pg_schema_pool)
+    # Still one row — the acct-1 12:00 bucket; acct-2 never wrote.
+    assert len(rows) == 1
+
+
+def test_pg_token_usage_replace_hourly_and_daily(pg_schema_pool, pg_config):
+    """replace_token_usage_hourly + daily_token_usage parity shape."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_token_usage import (
+        daily_token_usage,
+        recent_token_usage,
+        replace_token_usage_hourly,
+    )
+    from pollypm.storage.records import TokenUsageHourlyRecord
+
+    seed = [
+        TokenUsageHourlyRecord(
+            hour_bucket="2025-01-01T12:00:00+00:00",
+            account_name="acct-1",
+            provider="claude",
+            model_name="sonnet",
+            project_key="alpha",
+            tokens_used=100,
+            updated_at="2025-01-01T12:45:00+00:00",
+        ),
+        TokenUsageHourlyRecord(
+            hour_bucket="2025-01-02T08:00:00+00:00",
+            account_name="acct-1",
+            provider="claude",
+            model_name="sonnet",
+            project_key="alpha",
+            tokens_used=250,
+            updated_at="2025-01-02T08:30:00+00:00",
+        ),
+        TokenUsageHourlyRecord(
+            hour_bucket="2025-01-02T09:00:00+00:00",
+            account_name="acct-2",
+            provider="codex",
+            model_name="gpt-5",
+            project_key="beta",
+            tokens_used=50,
+            updated_at="2025-01-02T09:15:00+00:00",
+        ),
+    ]
+    replace_token_usage_hourly(seed, pool=pg_schema_pool)
+
+    rows = recent_token_usage(limit=10, pool=pg_schema_pool)
+    assert len(rows) == 3
+    # ORDER BY hour_bucket DESC, tokens_used DESC.
+    assert rows[0].hour_bucket.startswith("2025-01-02T09")
+    assert rows[1].hour_bucket.startswith("2025-01-02T08")
+    assert rows[2].hour_bucket.startswith("2025-01-01T12")
+
+    days = daily_token_usage(days=10, pool=pg_schema_pool)
+    # oldest-first per the StateStore contract.
+    by_day = dict(days)
+    assert by_day["2025-01-01"] == 100
+    assert by_day["2025-01-02"] == 300
+    assert days[0][0] == "2025-01-01"
+    assert days[-1][0] == "2025-01-02"
+
+    # Scoped replace only clears the named accounts.
+    replace_token_usage_hourly(
+        [
+            TokenUsageHourlyRecord(
+                hour_bucket="2025-01-03T10:00:00+00:00",
+                account_name="acct-1",
+                provider="claude",
+                model_name="sonnet",
+                project_key="alpha",
+                tokens_used=999,
+                updated_at="2025-01-03T10:15:00+00:00",
+            ),
+        ],
+        account_names=["acct-1"],
+        pool=pg_schema_pool,
+    )
+    rows = recent_token_usage(limit=10, pool=pg_schema_pool)
+    # acct-1 rows are gone except the new one; acct-2 row is preserved.
+    by_acct = sorted({(r.account_name, r.hour_bucket[:10]) for r in rows})
+    assert by_acct == [
+        ("acct-1", "2025-01-03"),
+        ("acct-2", "2025-01-02"),
+    ]


### PR DESCRIPTION
## Summary

Phase 2b of the K-state-port (#1737) — port four medium-small StateStore
clusters to dedicated pg facade modules under `pollypm/storage/pg_*.py`,
matching the pattern established in #1804 (phase 2a).

### Cluster F — architect_resume_tokens (`pg_architect_resume.py`)
4 methods: `upsert_architect_resume_token`, `get_architect_resume_token`,
`clear_architect_resume_token`, `list_architect_resume_tokens`.
Also drops the dead `TYPE_CHECKING` StateStore import from
`plugins_builtin/default_launch_planner/planner.py` — the symbol was
unreferenced after phase 2a's `store: Any` retype.

### Cluster G — checkpoints (`pg_checkpoints.py`)
2 methods: `record_checkpoint`, `latest_checkpoint`. The in-tree
caller (`pollypm.checkpoints.record_checkpoint`) keeps its StateStore
parameter because the same function also touches cluster A's
session_runtime; the call site will swap over when the supervisor's
cluster A port lands.

### Cluster H — worktrees (`pg_worktrees.py` + dispatch in `worktrees.py`)
3 methods: `upsert_worktree`, `update_worktree_status`, `list_worktrees`.
`worktrees.py` gains three `_*_for_backend` helpers that branch on
`is_pg_backend(config)` — sqlite path keeps the short-lived StateStore
lifecycle; pg path dispatches straight to the new facade. The config
is threaded through (rather than re-loaded inside `is_pg_backend`) so
the existing `tests/test_worktrees.py` monkeypatch of `load_config` is
honoured.

### Cluster I — token_samples + token_usage_hourly (`pg_token_usage.py`)
6 methods: `get_token_sample`, `record_token_sample`,
`upsert_token_sample`, `replace_token_usage_hourly`,
`recent_token_usage`, `daily_token_usage`. `record_token_sample`
reproduces the sqlite atomic sample + delta + hourly-bucket rollup
inside one psycopg transaction with `SELECT ... FOR UPDATE` on the
previous sample. In-tree call sites (`transcript_ledger.py`,
`dashboard_data.py`, `capacity.py`, supervisor) still go through
StateStore — `transcript_ledger.py` also issues a raw `store.execute()`
against `cache_read_tokens` (sqlite-only column from legacy
migration 4) so the file retains its StateStore import regardless.

### Tests
`tests/test_pg_storage_facades.py` gains four round-trip parity tests
covering each new facade against the pg schema fixture (32 -> 36 tests
in that file). Skips cleanly when neither Docker nor a local pg is
available.

### Importer count
- Before this PR: 29 StateStore importers in `src/`
- After this PR: 28 (planner.py dropped; worktrees.py still text-grep
  matches via lazy sqlite-fallback imports inside the dispatch
  helpers)

## TODOs for next batch
Remaining clusters per `/tmp/k-state-port-plan.md`:
- Cluster A — sessions / session_runtime / events (the giant cluster,
  ~6 consumers including supervisor.py with 89 store calls — deserves
  its own dedicated agent day)
- Cluster B — alerts
- Cluster C — heartbeats
- Cluster D — leases
- Cluster E — account usage / account runtime
- Cluster J — memory entries / summaries (extend existing
  `memory_recall.py`)

After clusters A-E + J land, `state.py` is reduced to housekeeping
(`_migrate`, `incremental_vacuum`, `prune_old_data`, `close`) and
the schema-history table that `store/migrations.py` introspects.

## Test plan
- [x] `uv run pytest tests/test_pg_storage_facades.py` — 32 passed
  (all 4 new tests included)
- [x] `uv run pytest tests/test_worktrees.py` — 4 passed (after
  threading config through the dispatch to honour the test stub)
- [x] `uv run pytest tests/test_architect_lifecycle.py tests/test_checkpoints.py tests/test_checkpoint_levels.py tests/test_transcript_ledger.py tests/test_transcript_ingest.py` — 73 passed
- [x] `uv run python -c "import pollypm; from pollypm.config import load_config; load_config()"` — config loads
- [x] `uv run pytest tests/ --collect-only -q` — 5074 collected
- [x] PR diff carries 0 `issues/**` files