### PR TITLE
fix(install): promote postgres deps from optional extras to base dependencies (closes #1813, #1746, #1737)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,15 @@ dependencies = [
   "textual>=6.1.0",
   "typer>=0.16.0",
   "uvicorn>=0.30.0",
+  # Postgres is the only supported storage backend (#1737). Keeping
+  # these as base ``dependencies`` (rather than an opt-in extra)
+  # closes the "reinstall trap" (#1813, #1746) where
+  # ``uv tool install --reinstall pollypm`` silently dropped the pg
+  # driver and the cockpit crashed at first connection. pgvector
+  # ships the psycopg type adapter for the recall path (Slice D).
+  "psycopg[binary]>=3.2.0",
+  "psycopg-pool>=3.2.0",
+  "pgvector>=0.3.0",
 ]
 
 [project.optional-dependencies]
@@ -20,22 +29,7 @@ dev = [
   "openapi-spec-validator>=0.7.0",
   "pytest>=8.4.0",
   "ruff>=0.15.12",
-  # Postgres + pgvector migration tests (#1737, Slice A). The pg
-  # driver itself is a runtime extra so sqlite installs stay slim;
-  # dev installs always pull both so `pytest tests/test_pg_*` runs.
-  "psycopg[binary]>=3.2.0",
-  "psycopg-pool>=3.2.0",
-  "pgvector>=0.3.0",
   "testcontainers[postgres]>=4.8.0",
-]
-# Runtime extra for the postgres backend. Operators flipping
-# ``[storage] backend = "postgres"`` in pollypm.toml must
-# ``uv pip install 'pollypm[postgres]'`` (#1737). pgvector ships
-# the psycopg type adapter for the recall path (Slice D).
-postgres = [
-  "psycopg[binary]>=3.2.0",
-  "psycopg-pool>=3.2.0",
-  "pgvector>=0.3.0",
 ]
 
 [project.scripts]

--- a/src/pollypm/doctor/install_state.py
+++ b/src/pollypm/doctor/install_state.py
@@ -321,14 +321,14 @@ def check_pg_connection() -> doctor.CheckResult:
         return doctor._fail(
             "pg pool module unavailable",
             why=(
-                "The Postgres backend is selected but the pollypm pg "
-                "pool module failed to import — psycopg/psycopg_pool "
-                "are likely missing."
+                "The pollypm pg pool module failed to import — "
+                "psycopg/psycopg_pool are missing from this install. "
+                "They are required base dependencies (#1813); something "
+                "stripped them out of the environment."
             ),
             fix=(
-                "Install the runtime extras —\n"
-                "  uv pip install 'pollypm[postgres]'\n"
-                "Or switch `[storage] backend` back to `sqlite`.\n"
+                "Reinstall pollypm so the pg base deps are restored —\n"
+                "  uv tool install --reinstall --force pollypm\n"
                 "Recheck: pm doctor"
             ),
             data={"error": str(exc)},

--- a/uv.lock
+++ b/uv.lock
@@ -500,6 +500,9 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "packaging" },
+    { name = "pgvector" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
     { name = "pyyaml" },
     { name = "sqlalchemy" },
     { name = "textual" },
@@ -511,17 +514,9 @@ dependencies = [
 dev = [
     { name = "httpx" },
     { name = "openapi-spec-validator" },
-    { name = "pgvector" },
-    { name = "psycopg", extra = ["binary"] },
-    { name = "psycopg-pool" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "testcontainers" },
-]
-postgres = [
-    { name = "pgvector" },
-    { name = "psycopg", extra = ["binary"] },
-    { name = "psycopg-pool" },
 ]
 
 [package.metadata]
@@ -530,12 +525,9 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "openapi-spec-validator", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "packaging", specifier = ">=23.0" },
-    { name = "pgvector", marker = "extra == 'dev'", specifier = ">=0.3.0" },
-    { name = "pgvector", marker = "extra == 'postgres'", specifier = ">=0.3.0" },
-    { name = "psycopg", extras = ["binary"], marker = "extra == 'dev'", specifier = ">=3.2.0" },
-    { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.2.0" },
-    { name = "psycopg-pool", marker = "extra == 'dev'", specifier = ">=3.2.0" },
-    { name = "psycopg-pool", marker = "extra == 'postgres'", specifier = ">=3.2.0" },
+    { name = "pgvector", specifier = ">=0.3.0" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
+    { name = "psycopg-pool", specifier = ">=3.2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.12" },
@@ -545,7 +537,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.16.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },
 ]
-provides-extras = ["dev", "postgres"]
+provides-extras = ["dev"]
 
 [[package]]
 name = "psycopg"


### PR DESCRIPTION
## The reinstall trap

When operators run the natural \`uv tool install --reinstall pollypm\`,
two things broke:

1. **Picks the wrong artifact** — bare \`--reinstall\` without a
   path/ref defaults to PyPI or a stale ref instead of the local
   checkout.
2. **Drops the pg deps** — \`psycopg[binary]\`, \`psycopg-pool\`,
   \`pgvector\` lived in \`[project.optional-dependencies].postgres\`,
   so reinstall without explicit \`--with\` flags stripped them and
   the cockpit crashed at first connection (#1813).

Postgres is the only supported storage backend after #1737, so the
extras shouldn't be optional anymore. This structurally closes #1746
as well — pg is mandatory, not opt-in.

## The fix

\`\`\`diff
 dependencies = [
   "fastapi>=0.115.0",
   ...
   "uvicorn>=0.30.0",
+  "psycopg[binary]>=3.2.0",
+  "psycopg-pool>=3.2.0",
+  "pgvector>=0.3.0",
 ]

 [project.optional-dependencies]
-postgres = [ ... ]   # dropped
 dev = [
   ...
-  "psycopg[binary]>=3.2.0",   # now base
-  "psycopg-pool>=3.2.0",      # now base
-  "pgvector>=0.3.0",          # now base
   "testcontainers[postgres]>=4.8.0",
 ]
\`\`\`

Also tightened the doctor remediation in \`install_state.py\` —
operators no longer need \`pollypm[postgres]\`; the fix is just
\`uv tool install --reinstall --force pollypm\`.

## Verification

\`\`\`
$ uv tool install --reinstall --force /tmp/pollypm-fix-1813
 + pgvector==0.4.2
 + psycopg==3.3.4
 + psycopg-binary==3.3.4
 + psycopg-pool==3.3.1
 ...
Installed 2 executables: pm, pollypm
\`\`\`

All four pg packages land without any \`--with\` flags. The
\`pollypm.storage.pg_pool\` import the doctor checks now succeeds
straight out of \`uv tool install --reinstall\`.

## Diff stats

\`\`\`
 pyproject.toml                      | 24 +++++++++---------------
 src/pollypm/doctor/install_state.py | 12 ++++++------
 uv.lock                             | 22 +++++++---------------
 3 files changed, 22 insertions(+), 36 deletions(-)
\`\`\`

0 \`issues/**\` files touched.

## Test plan

- [ ] \`uv tool install --reinstall --force pollypm\` produces a working install
- [ ] \`pm doctor\` pg-connection check passes (or skips cleanly on sqlite configs)
- [ ] No fresh-install operator hits the trap on the next RC

Closes #1813
Closes #1746
Closes #1737

Generated with Claude Code