### PR TITLE
fix(audit-watchdog): scheduler wedge + auto-heal probe (closes #1815, #1737)

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -60,7 +60,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
@@ -109,6 +109,7 @@ __all__ = [
     "scan_events",
     "scan_project",
     "emit_heartbeat_tick",
+    "freshest_heartbeat_tick_ts",
     "emit_finding",
     "emit_escalation_dispatched",
     "emit_operator_dispatched",
@@ -2792,6 +2793,94 @@ def scan_project(
 # ---------------------------------------------------------------------------
 
 
+def freshest_heartbeat_tick_ts(
+    *,
+    actor: str | None = "audit_watchdog",
+    central_root: Path | None = None,
+) -> datetime | None:
+    """Return the freshest ``heartbeat.tick`` ts across the central audit tail.
+
+    Scans every ``<central_root>/*.jsonl`` file (default: the audit
+    tail under ``~/.pollypm/audit/``) and returns the maximum ``ts``
+    of any line whose ``event == "heartbeat.tick"`` and (optionally)
+    whose ``actor`` matches. Returns ``None`` when no matching event
+    exists anywhere on disk — that's the "watchdog has never emitted"
+    state that #1815 Bug A was designed to detect.
+
+    Why a filesystem scan instead of a pg query: the audit log is
+    JSONL by design (see ``pollypm.audit.__init__`` docstring — it
+    survives DB rebuilds and travels with the project directory). The
+    central tail is the canonical liveness surface, and it's tens of
+    MB at most, so reading line-by-line is cheap enough for a
+    once-a-minute probe.
+
+    The scan reads each file from the tail (last 64 KiB) so it stays
+    O(num_files) rather than O(total_bytes); a stale event at the
+    head of a 1.7 GB file would otherwise dominate the cost.
+    """
+    import json
+
+    from pollypm.audit.log import _central_root  # type: ignore[attr-defined]
+
+    root = central_root if central_root is not None else _central_root()
+    if not root.exists():
+        return None
+
+    freshest: datetime | None = None
+    tail_window = 65536  # 64 KiB — large enough to cover ~hundreds of recent lines.
+
+    for path in root.glob("*.jsonl"):
+        try:
+            file_size = path.stat().st_size
+        except OSError:
+            continue
+        if file_size == 0:
+            continue
+        try:
+            with open(path, "rb") as fh:
+                if file_size > tail_window:
+                    fh.seek(file_size - tail_window)
+                    # Discard the partial first line so JSON parsing
+                    # doesn't trip on a mid-record boundary.
+                    fh.readline()
+                tail = fh.read()
+        except OSError:
+            continue
+
+        try:
+            decoded = tail.decode("utf-8", errors="replace")
+        except Exception:  # noqa: BLE001
+            continue
+
+        for line in decoded.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                obj = json.loads(stripped)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(obj, dict):
+                continue
+            if obj.get("event") != EVENT_HEARTBEAT_TICK:
+                continue
+            if actor is not None and obj.get("actor") != actor:
+                continue
+            ts_raw = obj.get("ts")
+            if not isinstance(ts_raw, str) or not ts_raw:
+                continue
+            try:
+                parsed = datetime.fromisoformat(ts_raw)
+            except ValueError:
+                continue
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=UTC)
+            if freshest is None or parsed > freshest:
+                freshest = parsed
+
+    return freshest
+
+
 def emit_heartbeat_tick(
     *,
     project: str = "",
@@ -2817,7 +2906,17 @@ def emit_heartbeat_tick(
             project_path=project_path,
         )
     except Exception:  # noqa: BLE001 — never fail the cadence on audit hiccups
-        logger.debug("emit_heartbeat_tick failed", exc_info=True)
+        # #1815 Bug A — was DEBUG. A silent emit-failure here directly
+        # defeats the liveness contract this function documents (the
+        # central tail's ``heartbeat.tick`` is the canonical "the
+        # scheduler is alive" signal). Raise to WARNING so a
+        # systematic failure surfaces in errors.log instead of
+        # disappearing into a never-enabled DEBUG channel.
+        logger.warning(
+            "audit.watchdog: emit_heartbeat_tick failed — "
+            "liveness contract is broken",
+            exc_info=True,
+        )
 
 
 def emit_finding(finding: Finding) -> None:

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -3045,6 +3045,17 @@ def audit_watchdog_handler(payload: dict[str, Any]) -> dict[str, Any]:
 
     Returns a dict with per-project + total counters for observability.
     """
+    # #1815 Bug A — liveness contract. The heartbeat tick MUST land in
+    # the central audit tail on every cadence fire so an operator (or
+    # ``audit_watchdog.liveness_probe``, below) can prove the
+    # scheduler is alive. Emit it BEFORE any pg / runtime-services
+    # call so that even if ``load_runtime_services`` hangs or the pg
+    # pool is wedged, the tick still lands. The prior call site
+    # (after ``load_runtime_services``) meant a load_runtime_services
+    # hang produced ZERO tick events anywhere on disk, defeating the
+    # whole liveness check.
+    emit_heartbeat_tick(metadata={"cadence": AUDIT_WATCHDOG_SCHEDULE})
+
     from pollypm.runtime_services import load_runtime_services
 
     config = _config_from_payload(payload or {})
@@ -3055,10 +3066,6 @@ def audit_watchdog_handler(payload: dict[str, Any]) -> dict[str, Any]:
 
     services = load_runtime_services(config_path=config_path)
     now = datetime.now(UTC)
-
-    # Liveness ping — emitted before scanning so that even if
-    # scanning blows up the heartbeat-tick still lands in the log.
-    emit_heartbeat_tick(metadata={"cadence": AUDIT_WATCHDOG_SCHEDULE})
 
     totals: dict[str, int] = {
         "projects_scanned": 0,

--- a/src/pollypm/plugins_builtin/core_recurring/maintenance.py
+++ b/src/pollypm/plugins_builtin/core_recurring/maintenance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
@@ -250,6 +251,277 @@ def stuck_claims_sweep_handler(
     state_db = config.project.state_db
     with JobQueue(db_path=state_db) as q:
         return _do_sweep(q)
+
+
+# ---------------------------------------------------------------------------
+# #1815 — audit_watchdog liveness auto-heal probe
+# ---------------------------------------------------------------------------
+
+# Cadence handlers must fire on their schedule for the system to be safe.
+# ``audit.watchdog`` is the most safety-critical of those — its 5 min sweep
+# is what catches stuck_draft / task_progress_stale / role_session_missing /
+# worker_session_dead_loop / cancellation_no_promotion / queue_without_motion /
+# advisor-priming-gaps. When it silently stops firing the operator-visible
+# surface (``pm alerts``, the rail badge) still looks healthy because
+# everything else is alive. #1815 documents the wedge symptom: last
+# ``heartbeat.tick`` 9+ hours stale while the heartbeat process itself is
+# alive and respawning.
+#
+# The probe runs once a minute and:
+#   1. Reads the freshest ``heartbeat.tick`` from the central audit tail.
+#   2. If the gap exceeds ``LIVENESS_STALE_THRESHOLD_SECONDS`` (default 3x
+#      the ``AUDIT_WATCHDOG_SCHEDULE``), force-recovers the queue
+#      (clears orphaned ``claimed`` rows that may be holding the
+#      ``audit.watchdog`` dedupe slot open) and re-enqueues the
+#      cadence job so the watchdog re-arms within ~60 s of detection.
+#   3. Emits an explicit ``audit_watchdog`` alert via the unified
+#      message store so ``pm alerts`` shows the heal action — an
+#      operator scanning the inbox sees "watchdog was wedged; auto-
+#      healed at <ts>" instead of silent recovery.
+#
+# This is the prong-2 self-heal rule called out by
+# ``project_heartbeat_cascade``: manual patches without a self-heal rule
+# are incomplete.
+
+# 3x the audit_watchdog schedule (5 min). A single missed fire is fine;
+# three in a row is the wedge.
+LIVENESS_STALE_THRESHOLD_SECONDS: float = 900.0
+# Floor on the heal cadence so the auto-heal can never spin: at most one
+# re-arm + alert per HEAL_THROTTLE_SECONDS. Keeps the probe idempotent
+# under contention if the watchdog handler is genuinely broken (in which
+# case the alert sticks around in ``pm alerts`` until the operator
+# acknowledges it).
+HEAL_THROTTLE_SECONDS: float = 300.0
+
+
+def audit_watchdog_liveness_probe_handler(
+    payload: dict[str, Any],
+    *,
+    queue: Any | None = None,
+    now: Any | None = None,
+    stale_threshold_seconds: float | None = None,
+) -> dict[str, Any]:
+    """Detect and auto-heal a wedged ``audit.watchdog`` scheduler (#1815).
+
+    The ``queue`` / ``now`` / ``stale_threshold_seconds`` keyword
+    arguments are test seams — production callers pass only ``payload``.
+
+    Returns a summary dict with:
+
+    * ``freshest_tick_ts``: ISO timestamp of the most recent
+      ``heartbeat.tick`` event found in the central tail, or ``None``.
+    * ``age_seconds``: how stale that event is relative to ``now``,
+      or ``None`` when no tick exists.
+    * ``stale``: bool — True iff age exceeds the threshold (or no
+      tick exists at all).
+    * ``action``: one of ``"none"``, ``"healed"``, ``"throttled"``.
+    """
+    from datetime import UTC, datetime
+
+    from pollypm.audit.watchdog import (
+        freshest_heartbeat_tick_ts,
+    )
+    from pollypm.jobs import JobQueue
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        AUDIT_WATCHDOG_HANDLER_NAME as _WATCHDOG_HANDLER_NAME,
+    )
+
+    resolved_now = now if isinstance(now, datetime) else datetime.now(UTC)
+    if resolved_now.tzinfo is None:
+        resolved_now = resolved_now.replace(tzinfo=UTC)
+
+    threshold = (
+        float(stale_threshold_seconds)
+        if stale_threshold_seconds is not None
+        else LIVENESS_STALE_THRESHOLD_SECONDS
+    )
+
+    freshest = freshest_heartbeat_tick_ts()
+    if freshest is None:
+        age_seconds: float | None = None
+        stale = True
+    else:
+        age_seconds = (resolved_now - freshest).total_seconds()
+        stale = age_seconds >= threshold
+
+    summary: dict[str, Any] = {
+        "freshest_tick_ts": freshest.isoformat() if freshest is not None else None,
+        "age_seconds": age_seconds,
+        "stale": stale,
+        "action": "none",
+        "threshold_seconds": threshold,
+    }
+
+    if not stale:
+        return summary
+
+    def _do_heal(q: Any) -> None:
+        # 1. Throttle: if we already healed inside the last
+        # HEAL_THROTTLE_SECONDS, leave the existing alert in place
+        # and bail. ``has_recent_or_active_dedupe`` is the cheapest
+        # observable proxy: re-enqueue uses dedupe_key="audit.watchdog",
+        # so a recent fire keeps that flag set.
+        recently = getattr(q, "has_recent_or_active_dedupe", None)
+        if callable(recently):
+            since = resolved_now - timedelta(seconds=HEAL_THROTTLE_SECONDS)
+            try:
+                if recently(_WATCHDOG_HANDLER_NAME, since=since):
+                    summary["action"] = "throttled"
+                    return
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "audit_watchdog.liveness_probe: "
+                    "has_recent_or_active_dedupe failed",
+                    exc_info=True,
+                )
+
+        # 2. Release any orphaned ``claimed`` rows. The most likely
+        # wedge under the new pg queue is that the previous
+        # ``audit.watchdog`` claim is still held by a dead /
+        # GC'd worker thread, and the dedupe-on-status='claimed'
+        # short-circuit at JobQueue.enqueue blocks every new fire.
+        try:
+            recovered, pruned = q.recover_orphaned_claims()
+            summary["recovered_claims"] = recovered
+            summary["pruned_claims"] = pruned
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "audit_watchdog.liveness_probe: "
+                "recover_orphaned_claims failed",
+                exc_info=True,
+            )
+            summary["recovered_claims"] = 0
+            summary["pruned_claims"] = 0
+
+        # 3. Re-enqueue the cadence job with the canonical dedupe
+        # key. If a prior row is queued / claimed at this point the
+        # enqueue is a no-op (returns the existing id), which is the
+        # correct behaviour — the heal already cleared the wedge,
+        # and a clean schedule on the cadence is enough.
+        try:
+            job_id = q.enqueue(
+                _WATCHDOG_HANDLER_NAME,
+                {},
+                dedupe_key=_WATCHDOG_HANDLER_NAME,
+            )
+            summary["enqueued_job_id"] = int(job_id)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "audit_watchdog.liveness_probe: re-enqueue failed",
+                exc_info=True,
+            )
+
+        summary["action"] = "healed"
+
+        # 4. Audit + alert so the heal action is observable. Audit
+        # emit is best-effort; the alert is the operator-visible
+        # surface.
+        try:
+            from pollypm.audit.log import emit as _audit_emit
+
+            _audit_emit(
+                event="audit_watchdog.liveness_probe.healed",
+                project="",
+                subject="audit_watchdog",
+                actor="audit_watchdog.liveness_probe",
+                status="warn",
+                metadata={
+                    "freshest_tick_ts": summary["freshest_tick_ts"],
+                    "age_seconds": age_seconds,
+                    "threshold_seconds": threshold,
+                    "recovered_claims": summary.get("recovered_claims", 0),
+                },
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "audit_watchdog.liveness_probe: audit emit failed",
+                exc_info=True,
+            )
+
+        _emit_liveness_probe_alert(
+            payload=payload,
+            age_seconds=age_seconds,
+            freshest_ts=summary["freshest_tick_ts"],
+            threshold_seconds=threshold,
+        )
+
+    if queue is not None:
+        _do_heal(queue)
+        return summary
+
+    try:
+        config = _load_config(payload)
+        state_db = config.project.state_db
+    except Exception:  # noqa: BLE001
+        # If config can't be resolved, we can't construct the queue
+        # without explicit injection. Still record the stale signal
+        # — the audit emit alone is useful for forensics.
+        logger.warning(
+            "audit_watchdog.liveness_probe: config resolution failed; "
+            "cannot heal",
+            exc_info=True,
+        )
+        summary["action"] = "config_unavailable"
+        return summary
+
+    with JobQueue(db_path=state_db) as q:
+        _do_heal(q)
+    return summary
+
+
+def _emit_liveness_probe_alert(
+    *,
+    payload: dict[str, Any],
+    age_seconds: float | None,
+    freshest_ts: str | None,
+    threshold_seconds: float,
+) -> None:
+    """Best-effort: upsert a ``watchdog_silent`` alert into ``pm alerts``.
+
+    The alert is keyed on a synthetic session name so repeat heals
+    fold into the same row instead of accumulating duplicates. We
+    use ``upsert_alert`` (the same channel the watchdog itself uses
+    for its findings) so ``pm alerts`` lists it under the same
+    actor surface.
+    """
+    try:
+        config = _load_config(payload)
+    except Exception:  # noqa: BLE001
+        return
+    msg_store = _open_msg_store(config)
+    if msg_store is None:
+        return
+    upsert = getattr(msg_store, "upsert_alert", None)
+    if not callable(upsert):
+        _close_msg_store(msg_store)
+        return
+    if age_seconds is None:
+        body = (
+            f"audit_watchdog liveness probe: no heartbeat.tick events "
+            f"found in central audit tail. Threshold {threshold_seconds:.0f}s. "
+            f"Auto-heal re-enqueued the cadence job."
+        )
+    else:
+        body = (
+            f"audit_watchdog wedged: last heartbeat.tick was "
+            f"{age_seconds:.0f}s ago ({freshest_ts}); threshold "
+            f"{threshold_seconds:.0f}s. Auto-heal recovered orphan claims "
+            f"and re-enqueued the cadence job."
+        )
+    try:
+        upsert(
+            "audit_watchdog/liveness",
+            "watchdog_silent",
+            "error",
+            body,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit_watchdog.liveness_probe: upsert_alert failed",
+            exc_info=True,
+        )
+    finally:
+        _close_msg_store(msg_store)
 
 
 AUDIT_EVENT_SUBJECTS: frozenset[str] = frozenset({

--- a/src/pollypm/plugins_builtin/core_recurring/plugin.py
+++ b/src/pollypm/plugins_builtin/core_recurring/plugin.py
@@ -30,6 +30,7 @@ from pollypm.plugins_builtin.core_recurring.maintenance import (
     OPERATIONAL_EVENT_SUBJECTS,
     account_usage_refresh_handler,
     agent_worktree_prune_handler,
+    audit_watchdog_liveness_probe_handler,
     capacity_probe_handler,
     cockpit_socket_reap_handler,
     db_vacuum_handler,
@@ -67,6 +68,13 @@ from pollypm.plugins_builtin.core_recurring.sweeps import (
 
 
 logger = logging.getLogger(__name__)
+
+
+# #1815 — auto-heal probe for the audit_watchdog scheduler. Runs every
+# minute; declared here so the handler-name string lives in exactly one
+# place across plugin.py + maintenance.py + tests.
+AUDIT_WATCHDOG_LIVENESS_PROBE_HANDLER_NAME = "audit_watchdog.liveness_probe"
+AUDIT_WATCHDOG_LIVENESS_PROBE_SCHEDULE = "@every 1m"
 
 
 # #1030 — cap concurrent ``session.health_sweep`` handler invocations.
@@ -491,6 +499,18 @@ def _register_handlers(api: JobHandlerAPI) -> None:
         AUDIT_WATCHDOG_HANDLER_NAME, audit_watchdog_handler,
         max_attempts=1, timeout_seconds=60.0,
     )
+    # #1815 — audit_watchdog self-heal probe. Runs every minute, scans
+    # the central audit tail for the freshest ``heartbeat.tick``, and
+    # force-re-enqueues the cadence job if the tick is older than
+    # 3× the audit_watchdog schedule. Cheap (filesystem tail scan +
+    # one indexed pg query); max_attempts=2 because if the probe
+    # itself wedges we want the next tick to retry rather than slot
+    # straight to terminal-failed.
+    api.register_handler(
+        AUDIT_WATCHDOG_LIVENESS_PROBE_HANDLER_NAME,
+        audit_watchdog_liveness_probe_handler,
+        max_attempts=2, timeout_seconds=30.0,
+    )
 
 
 def _register_roster(api: RosterAPI) -> None:
@@ -577,6 +597,15 @@ def _register_roster(api: RosterAPI) -> None:
         AUDIT_WATCHDOG_SCHEDULE, AUDIT_WATCHDOG_HANDLER_NAME, {},
         dedupe_key=AUDIT_WATCHDOG_HANDLER_NAME,
     )
+    # #1815 — auto-heal probe for the watchdog itself. 1 min cadence so
+    # a wedge (last ``heartbeat.tick`` older than 3× the watchdog
+    # schedule) auto-heals within ~60 s of detection.
+    api.register_recurring(
+        AUDIT_WATCHDOG_LIVENESS_PROBE_SCHEDULE,
+        AUDIT_WATCHDOG_LIVENESS_PROBE_HANDLER_NAME,
+        {},
+        dedupe_key=AUDIT_WATCHDOG_LIVENESS_PROBE_HANDLER_NAME,
+    )
 
 
 def _initialize(api: PluginAPI) -> None:
@@ -631,6 +660,10 @@ plugin = PollyPMPlugin(
         Capability(kind="job_handler", name="stuck_claims.sweep"),
         Capability(kind="job_handler", name="blocked_chain.sweep"),
         Capability(kind="job_handler", name="audit.watchdog"),
+        Capability(
+            kind="job_handler",
+            name="audit_watchdog.liveness_probe",
+        ),
         Capability(kind="roster_entry", name="core_recurring"),
     ),
     register_handlers=_register_handlers,

--- a/tests/test_audit_watchdog_liveness_probe.py
+++ b/tests/test_audit_watchdog_liveness_probe.py
@@ -1,0 +1,290 @@
+"""Tests for the audit_watchdog liveness auto-heal probe (#1815).
+
+The probe is registered as a 1-minute recurring handler. It:
+
+1. Scans the central audit tail for the freshest ``heartbeat.tick``.
+2. If the freshest tick is older than 3x the audit_watchdog schedule
+   (15 min default), force-clears any orphaned ``claimed`` rows
+   on the pg job queue and re-enqueues the ``audit.watchdog`` job
+   with its canonical dedupe key.
+3. Emits a ``watchdog_silent`` alert so the auto-heal is visible
+   in ``pm alerts``.
+
+These tests pin the wedge symptom from #1815 and prove the probe
+breaks it without manual intervention. They MUST run before the
+``pm rail-daemon`` ever boots in production — if the probe is dead,
+the V1 RC audit_watchdog liveness contract is dead with it.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pollypm.audit.watchdog import (
+    EVENT_HEARTBEAT_TICK,
+    freshest_heartbeat_tick_ts,
+)
+from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+    AUDIT_WATCHDOG_HANDLER_NAME,
+)
+from pollypm.plugins_builtin.core_recurring.maintenance import (
+    HEAL_THROTTLE_SECONDS,
+    LIVENESS_STALE_THRESHOLD_SECONDS,
+    audit_watchdog_liveness_probe_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_audit_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the central-tail root so tests never touch ~/.pollypm/."""
+    audit_home = tmp_path / "audit-home"
+    audit_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+    return audit_home
+
+
+@pytest.fixture
+def now() -> datetime:
+    return datetime(2026, 5, 19, 12, 0, 0, tzinfo=UTC)
+
+
+def _write_tick(
+    audit_home: Path, *, ts: datetime, project: str = "demo",
+    actor: str = "audit_watchdog",
+) -> None:
+    """Append a single ``heartbeat.tick`` line to ``<audit_home>/<project>.jsonl``."""
+    record = {
+        "schema": 1,
+        "ts": ts.isoformat(),
+        "project": project,
+        "event": EVENT_HEARTBEAT_TICK,
+        "subject": "audit_watchdog",
+        "actor": actor,
+        "status": "ok",
+        "metadata": {"cadence": "@every 5m"},
+    }
+    path = audit_home / f"{project}.jsonl"
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record))
+        fh.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# Fake job queue — captures every method the probe touches.
+# ---------------------------------------------------------------------------
+
+
+class _FakeQueue:
+    """In-memory queue stub that mirrors the parts of ``JobQueue`` the probe uses."""
+
+    def __init__(self, *, dedupe_active: bool = False) -> None:
+        self._dedupe_active = dedupe_active
+        self.recover_calls: int = 0
+        self.enqueued: list[tuple[str, str | None]] = []
+        self.dedupe_checks: list[tuple[str, datetime]] = []
+
+    def has_recent_or_active_dedupe(
+        self,
+        dedupe_key: str,
+        *,
+        since: datetime,
+    ) -> bool:
+        self.dedupe_checks.append((dedupe_key, since))
+        return self._dedupe_active
+
+    def recover_orphaned_claims(self) -> tuple[int, int]:
+        self.recover_calls += 1
+        # Simulate one orphaned claim being recovered — that's the
+        # observable signal the wedge described in #1815 leaves behind
+        # when ``audit.watchdog`` itself was the stuck handler.
+        return (1, 0)
+
+    def enqueue(
+        self,
+        handler_name: str,
+        payload: dict[str, Any] | None = None,
+        *,
+        dedupe_key: str | None = None,
+        run_after: datetime | None = None,
+        max_attempts: int | None = None,
+    ) -> int:
+        self.enqueued.append((handler_name, dedupe_key))
+        return 7
+
+
+# ---------------------------------------------------------------------------
+# freshest_heartbeat_tick_ts
+# ---------------------------------------------------------------------------
+
+
+def test_freshest_heartbeat_tick_returns_none_when_no_tail(
+    _isolate_audit_home: Path,
+) -> None:
+    """No central tail files → no fresh tick."""
+    assert freshest_heartbeat_tick_ts() is None
+
+
+def test_freshest_heartbeat_tick_returns_none_when_no_tick_events(
+    _isolate_audit_home: Path,
+    now: datetime,
+) -> None:
+    """Central tail exists but has no ``heartbeat.tick`` rows → None.
+
+    This is the #1815 Bug A symptom that was the gating clue:
+    audit files exist (with churn from work_db.opened etc.) but
+    ``heartbeat.tick`` has never landed.
+    """
+    other_record = {
+        "schema": 1,
+        "ts": now.isoformat(),
+        "project": "demo",
+        "event": "work_db.opened",
+        "subject": "demo",
+        "actor": "system",
+        "status": "ok",
+        "metadata": {},
+    }
+    path = _isolate_audit_home / "demo.jsonl"
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(json.dumps(other_record))
+        fh.write("\n")
+    assert freshest_heartbeat_tick_ts() is None
+
+
+def test_freshest_heartbeat_tick_picks_max_across_files(
+    _isolate_audit_home: Path,
+    now: datetime,
+) -> None:
+    """Returns the max ts across all *.jsonl files in the audit home."""
+    _write_tick(_isolate_audit_home, ts=now - timedelta(minutes=10), project="alpha")
+    _write_tick(_isolate_audit_home, ts=now - timedelta(minutes=3), project="bravo")
+    _write_tick(_isolate_audit_home, ts=now - timedelta(minutes=20), project="charlie")
+    fresh = freshest_heartbeat_tick_ts()
+    assert fresh is not None
+    assert abs((fresh - (now - timedelta(minutes=3))).total_seconds()) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Liveness probe — pinning #1815 behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_probe_noop_when_tail_is_fresh(
+    _isolate_audit_home: Path,
+    now: datetime,
+) -> None:
+    """A tick 2 minutes old leaves the queue untouched.
+
+    Pins the negative — we DON'T want the probe re-enqueueing the
+    cadence job on every minute, or it would defeat the dedupe.
+    """
+    _write_tick(_isolate_audit_home, ts=now - timedelta(minutes=2))
+    queue = _FakeQueue()
+    summary = audit_watchdog_liveness_probe_handler(
+        {}, queue=queue, now=now,
+    )
+    assert summary["stale"] is False
+    assert summary["action"] == "none"
+    assert queue.recover_calls == 0
+    assert queue.enqueued == []
+
+
+def test_probe_heals_when_tail_is_stale(
+    _isolate_audit_home: Path,
+    now: datetime,
+) -> None:
+    """Tail tick >15 minutes old triggers recover + re-enqueue.
+
+    This is the #1815 wedge symptom: the freshest ``heartbeat.tick``
+    in ``~/.pollypm/audit/*.jsonl`` is hours old. The probe must
+    recover orphaned claims (which may be holding the dedupe slot
+    open) and re-enqueue the cadence job.
+    """
+    _write_tick(_isolate_audit_home, ts=now - timedelta(hours=9))
+    queue = _FakeQueue(dedupe_active=False)
+    summary = audit_watchdog_liveness_probe_handler(
+        {}, queue=queue, now=now,
+    )
+    assert summary["stale"] is True
+    assert summary["action"] == "healed"
+    assert summary["age_seconds"] is not None
+    assert summary["age_seconds"] >= LIVENESS_STALE_THRESHOLD_SECONDS
+    assert queue.recover_calls == 1
+    assert queue.enqueued == [
+        (AUDIT_WATCHDOG_HANDLER_NAME, AUDIT_WATCHDOG_HANDLER_NAME),
+    ]
+
+
+def test_probe_heals_when_tail_has_no_ticks_at_all(
+    _isolate_audit_home: Path,
+    now: datetime,
+) -> None:
+    """Zero ``heartbeat.tick`` events anywhere → treated as the worst-case wedge.
+
+    This is the exact #1815 Bug A symptom: the watchdog has
+    NEVER successfully emitted a tick. The probe should not
+    require an existing tick to fire; the absence IS the alarm.
+    """
+    queue = _FakeQueue(dedupe_active=False)
+    summary = audit_watchdog_liveness_probe_handler(
+        {}, queue=queue, now=now,
+    )
+    assert summary["stale"] is True
+    assert summary["action"] == "healed"
+    assert summary["age_seconds"] is None
+    assert queue.recover_calls == 1
+    assert len(queue.enqueued) == 1
+
+
+def test_probe_throttles_when_recent_heal_already_landed(
+    _isolate_audit_home: Path,
+    now: datetime,
+) -> None:
+    """A recent ``audit.watchdog`` re-enqueue suppresses a second heal.
+
+    The probe checks ``has_recent_or_active_dedupe`` before
+    re-enqueueing. A True return there means a previous probe
+    (within HEAL_THROTTLE_SECONDS) already healed; the alert
+    that probe raised remains open, so this run is a no-op.
+    """
+    _write_tick(_isolate_audit_home, ts=now - timedelta(hours=9))
+    queue = _FakeQueue(dedupe_active=True)
+    summary = audit_watchdog_liveness_probe_handler(
+        {}, queue=queue, now=now,
+    )
+    assert summary["stale"] is True
+    assert summary["action"] == "throttled"
+    assert queue.recover_calls == 0
+    assert queue.enqueued == []
+    # The throttle window is HEAL_THROTTLE_SECONDS back from now.
+    assert len(queue.dedupe_checks) == 1
+    key, since = queue.dedupe_checks[0]
+    assert key == AUDIT_WATCHDOG_HANDLER_NAME
+    assert abs((now - since).total_seconds() - HEAL_THROTTLE_SECONDS) < 1.0
+
+
+def test_probe_respects_custom_stale_threshold(
+    _isolate_audit_home: Path,
+    now: datetime,
+) -> None:
+    """Test seam — tighter threshold lets the probe fire earlier."""
+    _write_tick(_isolate_audit_home, ts=now - timedelta(seconds=120))
+    queue = _FakeQueue()
+    summary = audit_watchdog_liveness_probe_handler(
+        {}, queue=queue, now=now, stale_threshold_seconds=60.0,
+    )
+    assert summary["stale"] is True
+    assert summary["action"] == "healed"
+    assert queue.enqueued == [
+        (AUDIT_WATCHDOG_HANDLER_NAME, AUDIT_WATCHDOG_HANDLER_NAME),
+    ]

--- a/tests/test_core_recurring_migration.py
+++ b/tests/test_core_recurring_migration.py
@@ -59,6 +59,8 @@ class TestCoreRecurringPlugin:
             # #savethenovel followup — audit-log watchdog (orphan
             # markers, stuck drafts, cancellation gaps).
             "audit.watchdog",
+            # #1815 — audit_watchdog liveness auto-heal probe.
+            "audit_watchdog.liveness_probe",
         }
         assert expected.issubset(set(registry.names()))
         # inbox.sweep was retired with the legacy inbox subsystem (iv04).
@@ -101,6 +103,10 @@ class TestCoreRecurringPlugin:
             "blocked_chain.sweep",
             # #savethenovel followup — audit-log watchdog, @every 5m.
             "audit.watchdog",
+            # #1592 — cockpit socket reap, @every 5m.
+            "cockpit_socket.reap",
+            # #1815 — audit_watchdog liveness auto-heal probe, @every 1m.
+            "audit_watchdog.liveness_probe",
         }
 
         # Cadences per issue #164 / #249.


### PR DESCRIPTION
## Summary

Two compounding bugs in the audit_watchdog liveness path documented in #1815. The first hid the second, leaving the watchdog tier dark for 9+ hours while the rest of the system looked healthy.

## Root cause

- **Bug A (masking bug).** `audit_watchdog_handler` called `emit_heartbeat_tick()` *after* `load_runtime_services()` and the emit-failure log was DEBUG-level. Any pg-pool or runtime-services hang produced **zero** `heartbeat.tick` events anywhere on disk (6.27M central-tail events, 0 ticks). The documented liveness contract was unreachable.
- **Bug B (the wedge).** After Slice K-jobs (PR #1772) pg-ported the jobs queue at 05:57 UTC, `audit.watchdog` stopped firing at 05:27 UTC across all 8 active per-project audit files. Scheduler tier looked alive (`pm heartbeat` running, `pm alerts` working); no automated way to detect the watchdog tier was dark — precisely because Bug A hid the gap.

## The fix

- Move `emit_heartbeat_tick()` to be the **first** line of `audit_watchdog_handler`, before `load_runtime_services()` and any pg call. Even a wedged pg pool now produces a tick whenever the handler runs.
- Raise the emit-failure log from DEBUG to WARNING so a systematic failure surfaces in `errors.log`.

## The auto-heal probe

New recurring handler `audit_watchdog.liveness_probe` (registered `@every 1m` in `core_recurring.plugin`, body in `maintenance.py`). Per `project_heartbeat_cascade.md`: manual patches without a self-heal rule are incomplete.

The probe:
1. Scans `~/.pollypm/audit/*.jsonl` for the freshest `heartbeat.tick` event (tail-reads last 64 KiB per file → O(num_files)).
2. If the freshest tick is older than `3 × AUDIT_WATCHDOG_SCHEDULE` (15 min default), or **no tick has ever landed** (Bug A worst case):
   - Calls `queue.recover_orphaned_claims()` — releases any stuck `audit.watchdog` claim that's pinning the dedupe slot open via the partial unique index.
   - Re-enqueues `audit.watchdog` with its canonical dedupe key, re-arming the cadence within ~60s.
   - Upserts a `watchdog_silent` alert so the heal action shows up in `pm alerts` — the operator sees the recovery instead of it being silent.
3. Throttles to one heal per `HEAL_THROTTLE_SECONDS` (300s) so a genuinely broken handler cannot spin the heal into a re-enqueue loop.

Helper exported: `pollypm.audit.watchdog.freshest_heartbeat_tick_ts()`.

## Test plan

- [x] `uv run pytest tests/test_audit_watchdog.py tests/test_jobs_cli.py tests/test_job_queue.py tests/test_job_workers.py tests/test_audit_watchdog_liveness_probe.py -x -q` → **163 passed**
- [x] New regression test `tests/test_audit_watchdog_liveness_probe.py` covers: fresh-tail no-op, stale-tail heals, zero-tick heals (Bug A worst case), throttle suppresses double-heal, custom threshold seam.
- [x] `tests/test_core_recurring_migration.py` updated for new roster entry + handler name.
- [x] 0 `issues/**` files in PR diff (verified).

Closes #1815, #1737.

🤖 Generated with [Claude Code](https://claude.com/claude-code)