### PR TITLE
feat(pg): port StateStore cluster A (sessions/runtime/events) to pg facades (Slice K-state-port phase 2c, #1737)

### DIFF
--- a/src/pollypm/agent_profiles/defaults.py
+++ b/src/pollypm/agent_profiles/defaults.py
@@ -463,13 +463,30 @@ def reviewer_prompt() -> str:
 
 def _render_operator_state_brief(context: AgentProfileContext) -> str:
     """Return a compact JSON snapshot for operator-style prompts."""
-    from pollypm.storage.state import StateStore
+    # Slice K-state-port phase 2c (#1737): pg backend reads sessions /
+    # session_runtime through the cluster-A facade so we skip a sqlite
+    # open per render; sqlite backend uses the short-lived StateStore.
+    from pollypm.storage._backend_dispatch import is_pg_backend
+
     session_rows: dict[str, object] = {}
     runtime_rows: dict[str, object] = {}
     try:
-        with StateStore(context.config.project.state_db) as store:
-            session_rows = {row.name: row for row in store.list_sessions()}
-            runtime_rows = {row.session_name: row for row in store.list_session_runtimes()}
+        if is_pg_backend(context.config):
+            from pollypm.storage.pg_sessions import (
+                list_session_runtimes as _pg_list_runtimes,
+                list_sessions as _pg_list_sessions,
+            )
+
+            session_rows = {row.name: row for row in _pg_list_sessions()}
+            runtime_rows = {row.session_name: row for row in _pg_list_runtimes()}
+        else:
+            from pollypm.storage.state import StateStore
+
+            with StateStore(context.config.project.state_db) as store:
+                session_rows = {row.name: row for row in store.list_sessions()}
+                runtime_rows = {
+                    row.session_name: row for row in store.list_session_runtimes()
+                }
     except Exception:  # noqa: BLE001
         session_rows = {}
         runtime_rows = {}
@@ -661,9 +678,22 @@ def _read_active_issue(project_root: Path) -> str:
 
 
 def _read_latest_checkpoint(context: AgentProfileContext) -> str:
-    from pollypm.storage.state import StateStore
-    store = StateStore(context.config.project.state_db)
-    runtime = store.get_session_runtime(context.session.name)
+    # Slice K-state-port phase 2c (#1737): on the pg backend, the
+    # session_runtime row lives in postgres; the sqlite branch keeps a
+    # short-lived StateStore for back-compat.
+    from pollypm.storage._backend_dispatch import is_pg_backend
+
+    if is_pg_backend(context.config):
+        from pollypm.storage.pg_sessions import (
+            get_session_runtime as _pg_get_runtime,
+        )
+
+        runtime = _pg_get_runtime(context.session.name)
+    else:
+        from pollypm.storage.state import StateStore
+
+        store = StateStore(context.config.project.state_db)
+        runtime = store.get_session_runtime(context.session.name)
     if runtime is None or not runtime.last_checkpoint_path:
         return ""
     path = Path(runtime.last_checkpoint_path)

--- a/src/pollypm/capacity.py
+++ b/src/pollypm/capacity.py
@@ -317,10 +317,24 @@ def recovery_order(
     4. preempted - sessions that were preempted by failover
     5. new-work - sessions waiting for capacity
     """
+    # Slice K-state-port phase 2c (#1737): pg backend reads the cluster-A
+    # session_runtime row through the pg_sessions facade; sqlite path
+    # keeps the legacy StateStore reader.
+    from pollypm.storage._backend_dispatch import is_pg_backend
+
+    pg_active = is_pg_backend(config)
+    if pg_active:
+        from pollypm.storage.pg_sessions import (
+            get_session_runtime as _get_session_runtime,
+        )
+    else:
+        def _get_session_runtime(name: str):
+            return store.get_session_runtime(name)
+
     sessions: list[tuple[str, str, int]] = []
 
     for session_name, session_config in config.sessions.items():
-        runtime = store.get_session_runtime(session_name)
+        runtime = _get_session_runtime(session_name)
 
         if session_config.role == "heartbeat-supervisor":
             category = "heartbeat"

--- a/src/pollypm/checkpoints.py
+++ b/src/pollypm/checkpoints.py
@@ -650,6 +650,14 @@ def record_checkpoint(
         snapshot_path=str(snapshot_path),
         summary_text=artifact.summary_text,
     )
+    # NB: cluster-A pg dispatch for the runtime read/write is NOT
+    # threaded here yet — ``record_checkpoint`` is invoked with a live
+    # ``store`` (StateStore today; tests rely on it). Callers that have
+    # already chosen the pg backend obtain that store through
+    # ``Supervisor.store`` which still proxies sqlite. The follow-up
+    # phase will rewire ``record_checkpoint`` to take a config / route
+    # through the pg facade; for now we keep parity with the legacy
+    # behaviour. See Slice K-state-port (#1737).
     current = store.get_session_runtime(launch.session.name)
     store.upsert_session_runtime(
         session_name=launch.session.name,

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -862,11 +862,23 @@ def load_dashboard(config_path: Path) -> tuple[PollyPMConfig, DashboardData]:
 def gather(config: PollyPMConfig, store: StateStore) -> DashboardData:
     """Gather all dashboard data."""
     from pollypm.service_api import plan_launches_readonly
+    from pollypm.storage._backend_dispatch import is_pg_backend
 
     now = datetime.now(UTC)
+    pg_active = is_pg_backend(config)
 
-    # Active sessions
-    all_runtimes = store.list_session_runtimes()
+    # Active sessions — Slice K-state-port phase 2c (#1737): on the pg
+    # path go straight through pg_sessions; sqlite path uses the legacy
+    # StateStore reader. Both branches yield the same SessionRuntimeRecord
+    # shape, so the runtime_map build is unchanged.
+    if pg_active:
+        from pollypm.storage.pg_sessions import (
+            list_session_runtimes as pg_list_session_runtimes,
+        )
+
+        all_runtimes = pg_list_session_runtimes()
+    else:
+        all_runtimes = store.list_session_runtimes()
     runtime_map = {rt.session_name: rt for rt in all_runtimes}
     launches = plan_launches_readonly(config, store)
 
@@ -895,8 +907,15 @@ def gather(config: PollyPMConfig, store: StateStore) -> DashboardData:
             status=status, description=desc, age_seconds=age,
         ))
 
-    # Events summary
-    recent = store.recent_events(limit=300)
+    # Events summary — Slice K-state-port phase 2c (#1737).
+    if pg_active:
+        from pollypm.storage.pg_sessions import (
+            recent_events as pg_recent_events,
+        )
+
+        recent = pg_recent_events(limit=300)
+    else:
+        recent = store.recent_events(limit=300)
     cutoff = (now - timedelta(hours=24)).isoformat()
     day_events = [e for e in recent if e.created_at >= cutoff]
 

--- a/src/pollypm/plugins_builtin/default_launch_planner/planner.py
+++ b/src/pollypm/plugins_builtin/default_launch_planner/planner.py
@@ -260,8 +260,20 @@ class DefaultLaunchPlanner:
 
         effective = session
         routed_assignment = None
+        # Slice K-state-port phase 2c (#1737): when the pg backend is
+        # active, route the session_runtime read through the pg_sessions
+        # facade rather than the (sqlite-only) StateStore reader on ctx.
+        from pollypm.storage._backend_dispatch import is_pg_backend
+
         try:
-            runtime = ctx.store.get_session_runtime(session.name)
+            if is_pg_backend(ctx.config):
+                from pollypm.storage.pg_sessions import (
+                    get_session_runtime as _pg_get_runtime,
+                )
+
+                runtime = _pg_get_runtime(session.name)
+            else:
+                runtime = ctx.store.get_session_runtime(session.name)
         except Exception:  # noqa: BLE001
             runtime = None
         override_account: str | None = None

--- a/src/pollypm/storage/pg_sessions.py
+++ b/src/pollypm/storage/pg_sessions.py
@@ -1,0 +1,603 @@
+"""Postgres facade for the ``sessions`` / ``session_runtime`` / events cluster (#1737).
+
+This module owns the read/write path for cluster A of the StateStore
+port plan: the per-session tmux/runtime registry (``sessions`` table),
+the supervisor's per-session runtime state machine (``session_runtime``
+table), and the ``record_event`` / ``last_event_at`` / ``recent_events``
+trio that StateStore writes into the unified ``messages`` table with
+``type='event'``.
+
+The pg shape mirrors the sqlite shape on
+:class:`pollypm.storage.state.StateStore` exactly — same columns, same
+``ON CONFLICT`` upsert semantics, same ISO-8601 string stamping on
+``timestamptz`` columns so dual-write callers (during the cutover)
+produce indistinguishable rows.
+
+Public API:
+
+Sessions:
+
+* :func:`upsert_session` — INSERT … ON CONFLICT (name) DO UPDATE
+* :func:`list_sessions` — SELECT … FROM sessions
+* :func:`prune_sessions` — delete sessions/leases/session-tier memory
+  rows whose ``session_name`` is no longer in the valid set, mirroring
+  StateStore's compound prune (see #1528 + #232 for the alert/memory
+  carve-outs preserved here)
+* :func:`get_session_window` — SELECT window_name FROM sessions WHERE name=…
+
+Events (backed by ``messages`` with ``type='event'``):
+
+* :func:`record_event` — INSERT into ``messages`` with the same
+  json-encoded payload sqlite uses
+* :func:`last_event_at` — SELECT created_at … ORDER BY id DESC LIMIT 1
+* :func:`recent_events` — SELECT N most recent events with the same
+  fallback chain sqlite's ``json_extract`` + ``COALESCE`` ladder gave
+
+Session runtime:
+
+* :func:`upsert_session_runtime` — INSERT … ON CONFLICT (session_name)
+  DO UPDATE with the same _UNSET sentinel semantics StateStore exposes
+* :func:`get_session_runtime` — SELECT … FROM session_runtime WHERE …
+* :func:`list_session_runtimes` — SELECT … FROM session_runtime
+
+All functions accept an optional ``pool`` kwarg. The default is
+:func:`~pollypm.storage.pg_pool.get_rw_pool` for the mutators and
+:func:`~pollypm.storage.pg_pool.get_ro_pool` for the readers; passing a
+custom pool is the test-harness seam (the unit tests wire a disposable
+pool against a per-test schema).
+
+Slice K-state-port phase 2c — port of StateStore cluster A. The
+``sessions``, ``session_runtime``, and ``messages`` tables are migrated
+by :mod:`pollypm.storage.pg_schema` so they are always present before
+this module runs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from pollypm.storage.records import EventRecord, SessionRecord, SessionRuntimeRecord
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+logger = logging.getLogger(__name__)
+
+
+# Sentinel for "argument not provided" on ``upsert_session_runtime`` —
+# distinguishes "caller passed ``None``" (intentionally NULL the column)
+# from "caller didn't pass anything" (preserve the existing value). The
+# same sentinel pattern lives on StateStore as ``_UNSET``; both must
+# agree because callers pass either the sqlite path or the pg path and
+# the semantics need to match.
+_UNSET: object = object()
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string.
+
+    Matches the value StateStore stamps on the sqlite ``updated_at`` /
+    ``created_at`` columns so dual-write callers (during the cutover)
+    produce indistinguishable rows.
+    """
+    return datetime.now(UTC).isoformat()
+
+
+def _stamp_str(value: object) -> str:
+    """Return ``value`` as an ISO-8601 string.
+
+    pg returns ``timestamptz`` columns as ``datetime`` objects;
+    StateStore returns them as strings. Normalise to the sqlite shape so
+    the record dataclasses see the same value either way.
+    """
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _opt_stamp_str(value: object) -> str | None:
+    """Return ``None`` for NULL, otherwise an ISO-8601 string."""
+    if value is None:
+        return None
+    return _stamp_str(value)
+
+
+# --------------------------------------------------------------------- #
+# sessions table
+# --------------------------------------------------------------------- #
+
+
+def upsert_session(
+    *,
+    name: str,
+    role: str,
+    project: str,
+    provider: str,
+    account: str,
+    cwd: str,
+    window_name: str,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Insert-or-update a session row.
+
+    Mirrors :meth:`StateStore.upsert_session`: keyed on ``name``, all
+    other columns are overwritten on conflict.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO sessions (name, role, project, provider, account, cwd, window_name)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (name) DO UPDATE SET
+                role = EXCLUDED.role,
+                project = EXCLUDED.project,
+                provider = EXCLUDED.provider,
+                account = EXCLUDED.account,
+                cwd = EXCLUDED.cwd,
+                window_name = EXCLUDED.window_name
+            """,
+            (name, role, project, provider, account, cwd, window_name),
+        )
+
+
+def list_sessions(
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> list[SessionRecord]:
+    """Return every row in the ``sessions`` table as a SessionRecord."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT name, role, project, provider, account, cwd, window_name FROM sessions"
+        )
+        rows = cur.fetchall()
+    return [
+        SessionRecord(
+            name=row[0],
+            role=row[1],
+            project=row[2],
+            provider=row[3],
+            account=row[4],
+            cwd=row[5],
+            window_name=row[6],
+        )
+        for row in rows
+    ]
+
+
+def prune_sessions(
+    valid_session_names: set[str],
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Delete sessions / leases / session-tier memory not in ``valid_session_names``.
+
+    Compound operation that mirrors :meth:`StateStore.prune_sessions`:
+
+    * Delete rows from ``sessions`` whose name isn't in the set.
+    * Delete rows from ``leases`` whose session_name isn't in the set.
+    * Close every open ``type='alert'`` row in ``messages`` whose scope
+      isn't in the set — except the synthetic-scope alerts owned by the
+      task_assignment sweep (#1528: ``plan_missing``, ``no_session``,
+      ``no_session_for_assignment:*``).
+    * Delete ``memory_entries`` with ``scope_tier='session'`` whose
+      scope isn't in the set (#232 M03 session-tier auto-purge).
+
+    When ``valid_session_names`` is empty the same operations run with
+    no IN-list filter — everything not on the synthetic-scope allowlist
+    closes / purges.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    now = _now_iso()
+    with pool.connection() as conn, conn.cursor() as cur:
+        if valid_session_names:
+            params = tuple(sorted(valid_session_names))
+            cur.execute(
+                "DELETE FROM sessions WHERE name <> ALL(%s)",
+                (list(params),),
+            )
+            cur.execute(
+                "DELETE FROM leases WHERE session_name <> ALL(%s)",
+                (list(params),),
+            )
+            # #1528 — preserve task_assignment-sweep-owned synthetic
+            # alerts. See StateStore.prune_sessions for the full
+            # rationale.
+            cur.execute(
+                """
+                UPDATE messages
+                SET state = 'closed', closed_at = %s, updated_at = %s
+                WHERE type = 'alert'
+                  AND state = 'open'
+                  AND scope <> ALL(%s)
+                  AND sender NOT IN ('plan_missing', 'no_session')
+                  AND sender NOT LIKE 'no_session_for_assignment:%%'
+                """,
+                (now, now, list(params)),
+            )
+            # #232 M03 — session-tier memory auto-purges when its session ends.
+            cur.execute(
+                """
+                DELETE FROM memory_entries
+                WHERE scope_tier = 'session'
+                  AND scope <> ALL(%s)
+                """,
+                (list(params),),
+            )
+        else:
+            cur.execute("DELETE FROM sessions")
+            cur.execute("DELETE FROM leases")
+            cur.execute(
+                """
+                UPDATE messages
+                SET state = 'closed', closed_at = %s, updated_at = %s
+                WHERE type = 'alert' AND state = 'open'
+                  AND sender NOT IN ('plan_missing', 'no_session')
+                  AND sender NOT LIKE 'no_session_for_assignment:%%'
+                """,
+                (now, now),
+            )
+            cur.execute(
+                "DELETE FROM memory_entries WHERE scope_tier = 'session'"
+            )
+
+
+def get_session_window(
+    session_name: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> str | None:
+    """Return the tmux window_name for ``session_name``, or None if missing."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT window_name FROM sessions WHERE name = %s",
+            (session_name,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return str(row[0])
+
+
+# --------------------------------------------------------------------- #
+# events (backed by messages table with type='event')
+# --------------------------------------------------------------------- #
+
+
+def record_event(
+    session_name: str,
+    event_type: str,
+    message: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Append an event row into ``messages`` with type='event'.
+
+    Mirrors :meth:`StateStore.record_event`: same payload_json shape,
+    same fixed columns (scope=session_name, tier='immediate',
+    recipient='*', sender=session_name, state='open',
+    subject=event_type, body=message, labels='[]').
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    now = _now_iso()
+    payload = json.dumps(
+        {
+            "session_name": session_name,
+            "event_type": event_type,
+            "message": message,
+        }
+    )
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO messages (
+                scope, type, tier, recipient, sender, state,
+                subject, body, payload_json, labels, created_at, updated_at
+            )
+            VALUES (%s, 'event', 'immediate', '*', %s, 'open',
+                    %s, %s, %s::jsonb, '[]'::jsonb, %s, %s)
+            """,
+            (
+                session_name,
+                session_name,
+                event_type,
+                message,
+                payload,
+                now,
+                now,
+            ),
+        )
+
+
+def last_event_at(
+    session_name: str,
+    event_type: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> str | None:
+    """Return the ISO timestamp of the most recent matching event, or None."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT created_at FROM messages "
+            "WHERE type = 'event' AND scope = %s AND subject = %s "
+            "ORDER BY id DESC LIMIT 1",
+            (session_name, event_type),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return _stamp_str(row[0])
+
+
+def recent_events(
+    limit: int = 20,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> list[EventRecord]:
+    """Return the ``limit`` most recent event rows.
+
+    Mirrors :meth:`StateStore.recent_events`: the ``message`` field
+    falls back through body → payload_json.message → payload_json
+    string → subject so legacy rows that only set one of these surface
+    something sensible.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+                scope AS session_name,
+                COALESCE(payload_json->>'event_type', subject) AS event_type,
+                CASE
+                    WHEN body <> '' THEN body
+                    WHEN payload_json ? 'message'
+                        THEN payload_json->>'message'
+                    WHEN payload_json::text <> '{}' THEN payload_json::text
+                    ELSE subject
+                END AS message,
+                created_at
+            FROM messages
+            WHERE type = 'event'
+            ORDER BY id DESC
+            LIMIT %s
+            """,
+            (limit,),
+        )
+        rows = cur.fetchall()
+    return [
+        EventRecord(
+            session_name=row[0],
+            event_type=row[1],
+            message=row[2],
+            created_at=_stamp_str(row[3]),
+        )
+        for row in rows
+    ]
+
+
+# --------------------------------------------------------------------- #
+# session_runtime table
+# --------------------------------------------------------------------- #
+
+
+def upsert_session_runtime(
+    *,
+    session_name: str,
+    status: str,
+    effective_account: str | None | object = _UNSET,
+    effective_provider: str | None | object = _UNSET,
+    recovery_attempts: int | None | object = _UNSET,
+    recovery_window_started_at: str | None | object = _UNSET,
+    last_failure_type: str | None | object = _UNSET,
+    last_failure_message: str | None | object = _UNSET,
+    last_checkpoint_path: str | None | object = _UNSET,
+    retry_at: str | None | object = _UNSET,
+    last_recovered_at: str | None | object = _UNSET,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Insert-or-update a row in ``session_runtime``.
+
+    Mirrors :meth:`StateStore.upsert_session_runtime`: callers pass only
+    the columns they want to change; anything left at the ``_UNSET``
+    sentinel preserves the existing value (or its column default when
+    no row yet exists). Passing an explicit ``None`` writes SQL NULL.
+    """
+    current = get_session_runtime(session_name, pool=pool)
+
+    def _resolve(new: object, old_val: object, default: object = None) -> object:
+        if new is not _UNSET:
+            return new
+        return old_val if current else default
+
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    now = _now_iso()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO session_runtime (
+                session_name, status, effective_account, effective_provider,
+                recovery_attempts, recovery_window_started_at,
+                last_failure_type, last_failure_message, last_checkpoint_path,
+                retry_at, last_recovered_at, updated_at
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (session_name) DO UPDATE SET
+                status = EXCLUDED.status,
+                effective_account = EXCLUDED.effective_account,
+                effective_provider = EXCLUDED.effective_provider,
+                recovery_attempts = EXCLUDED.recovery_attempts,
+                recovery_window_started_at = EXCLUDED.recovery_window_started_at,
+                last_failure_type = EXCLUDED.last_failure_type,
+                last_failure_message = EXCLUDED.last_failure_message,
+                last_checkpoint_path = EXCLUDED.last_checkpoint_path,
+                retry_at = EXCLUDED.retry_at,
+                last_recovered_at = EXCLUDED.last_recovered_at,
+                updated_at = EXCLUDED.updated_at
+            """,
+            (
+                session_name,
+                status,
+                _resolve(
+                    effective_account,
+                    current.effective_account if current else None,
+                ),
+                _resolve(
+                    effective_provider,
+                    current.effective_provider if current else None,
+                ),
+                _resolve(
+                    recovery_attempts,
+                    current.recovery_attempts if current else 0,
+                    default=0,
+                ),
+                _resolve(
+                    recovery_window_started_at,
+                    current.recovery_window_started_at if current else None,
+                ),
+                _resolve(
+                    last_failure_type,
+                    current.last_failure_type if current else None,
+                ),
+                _resolve(
+                    last_failure_message,
+                    current.last_failure_message if current else None,
+                ),
+                _resolve(
+                    last_checkpoint_path,
+                    current.last_checkpoint_path if current else None,
+                ),
+                _resolve(
+                    retry_at,
+                    current.retry_at if current else None,
+                ),
+                _resolve(
+                    last_recovered_at,
+                    current.last_recovered_at if current else None,
+                ),
+                now,
+            ),
+        )
+
+
+def get_session_runtime(
+    session_name: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> SessionRuntimeRecord | None:
+    """Return the runtime row for ``session_name``, or None if absent."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT session_name, status, effective_account, effective_provider,
+                   recovery_attempts, recovery_window_started_at,
+                   last_failure_type, last_failure_message, last_checkpoint_path,
+                   retry_at, last_recovered_at, updated_at
+            FROM session_runtime
+            WHERE session_name = %s
+            """,
+            (session_name,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return SessionRuntimeRecord(
+        session_name=row[0],
+        status=row[1],
+        effective_account=row[2],
+        effective_provider=row[3],
+        recovery_attempts=int(row[4]),
+        recovery_window_started_at=_opt_stamp_str(row[5]),
+        last_failure_type=row[6],
+        last_failure_message=row[7],
+        last_checkpoint_path=row[8],
+        retry_at=_opt_stamp_str(row[9]),
+        last_recovered_at=_opt_stamp_str(row[10]),
+        updated_at=_stamp_str(row[11]),
+    )
+
+
+def list_session_runtimes(
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> list[SessionRuntimeRecord]:
+    """Return every row in the ``session_runtime`` table."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT session_name, status, effective_account, effective_provider,
+                   recovery_attempts, recovery_window_started_at,
+                   last_failure_type, last_failure_message, last_checkpoint_path,
+                   retry_at, last_recovered_at, updated_at
+            FROM session_runtime
+            """
+        )
+        rows = cur.fetchall()
+    return [
+        SessionRuntimeRecord(
+            session_name=row[0],
+            status=row[1],
+            effective_account=row[2],
+            effective_provider=row[3],
+            recovery_attempts=int(row[4]),
+            recovery_window_started_at=_opt_stamp_str(row[5]),
+            last_failure_type=row[6],
+            last_failure_message=row[7],
+            last_checkpoint_path=row[8],
+            retry_at=_opt_stamp_str(row[9]),
+            last_recovered_at=_opt_stamp_str(row[10]),
+            updated_at=_stamp_str(row[11]),
+        )
+        for row in rows
+    ]
+
+
+__all__ = [
+    "get_session_runtime",
+    "get_session_window",
+    "last_event_at",
+    "list_session_runtimes",
+    "list_sessions",
+    "prune_sessions",
+    "recent_events",
+    "record_event",
+    "upsert_session",
+    "upsert_session_runtime",
+]

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -484,6 +484,24 @@ class Supervisor:
             return
         self.store.upsert_session_runtime(**kwargs)
 
+    def _recent_events(self, limit: int = 20):
+        if self._cluster_a_pg_active():
+            from pollypm.storage.pg_sessions import (
+                recent_events as pg_recent_events,
+            )
+
+            return pg_recent_events(limit=limit)
+        return self.store.recent_events(limit=limit)
+
+    def _last_event_at(self, session_name: str, event_type: str):
+        if self._cluster_a_pg_active():
+            from pollypm.storage.pg_sessions import (
+                last_event_at as pg_last_event_at,
+            )
+
+            return pg_last_event_at(session_name, event_type)
+        return self.store.last_event_at(session_name, event_type)
+
     def _build_launch_planner(self):
         """Resolve the launch planner via the plugin host.
 

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -420,6 +420,70 @@ class Supervisor:
         if not readonly_state:
             self._core_rail.register_subsystem(self)
 
+    # --- Cluster A pg dispatch helpers (Slice K-state-port #1737) --- #
+    # The ``self.store.*`` session/runtime/event calls are dual-pathed: pg
+    # backend routes through ``pollypm.storage.pg_sessions`` (process-wide
+    # pool), sqlite backend stays on the legacy StateStore reader. The
+    # helpers below absorb the backend probe so the dozen-plus call sites
+    # in this file don't each grow an ``if is_pg_backend(...)`` branch.
+
+    def _cluster_a_pg_active(self) -> bool:
+        """Return True when cluster-A reads/writes should go through pg_sessions."""
+        from pollypm.storage._backend_dispatch import is_pg_backend
+
+        return is_pg_backend(self.config)
+
+    def _upsert_session(
+        self,
+        *,
+        name: str,
+        role: str,
+        project: str,
+        provider: str,
+        account: str,
+        cwd: str,
+        window_name: str,
+    ) -> None:
+        if self._cluster_a_pg_active():
+            from pollypm.storage.pg_sessions import upsert_session as pg_upsert
+
+            pg_upsert(
+                name=name, role=role, project=project, provider=provider,
+                account=account, cwd=cwd, window_name=window_name,
+            )
+            return
+        self.store.upsert_session(
+            name=name, role=role, project=project, provider=provider,
+            account=account, cwd=cwd, window_name=window_name,
+        )
+
+    def _prune_sessions(self, valid_session_names: set[str]) -> None:
+        if self._cluster_a_pg_active():
+            from pollypm.storage.pg_sessions import prune_sessions as pg_prune
+
+            pg_prune(valid_session_names)
+            return
+        self.store.prune_sessions(valid_session_names)
+
+    def _get_session_runtime(self, session_name: str):
+        if self._cluster_a_pg_active():
+            from pollypm.storage.pg_sessions import (
+                get_session_runtime as pg_get_runtime,
+            )
+
+            return pg_get_runtime(session_name)
+        return self.store.get_session_runtime(session_name)
+
+    def _upsert_session_runtime(self, **kwargs) -> None:
+        if self._cluster_a_pg_active():
+            from pollypm.storage.pg_sessions import (
+                upsert_session_runtime as pg_upsert_runtime,
+            )
+
+            pg_upsert_runtime(**kwargs)
+            return
+        self.store.upsert_session_runtime(**kwargs)
+
     def _build_launch_planner(self):
         """Resolve the launch planner via the plugin host.
 
@@ -998,7 +1062,7 @@ class Supervisor:
             if launch.window_name not in live_windows:
                 continue
             try:
-                self.store.upsert_session(
+                self._upsert_session(
                     name=launch.session.name,
                     role=launch.session.role,
                     project=launch.session.project,
@@ -1257,7 +1321,7 @@ class Supervisor:
         return None
 
     def _record_launch(self, launch: SessionLaunchSpec) -> None:
-        self.store.upsert_session(
+        self._upsert_session(
             name=launch.session.name,
             role=launch.session.role,
             project=launch.session.project,
@@ -1445,7 +1509,7 @@ class Supervisor:
             if base_account is None or base_account.home is None:
                 continue
             self._sync_control_home(base_account, session.name)
-        self.store.prune_sessions(
+        self._prune_sessions(
             {session.name for session in self.config.sessions.values() if session.enabled}
         )
         return project.base_dir
@@ -2399,7 +2463,7 @@ class Supervisor:
             return
         # Skip if we already rolled this session for low capacity in the
         # current recovery window — avoids oscillating between accounts.
-        runtime = self.store.get_session_runtime(launch.session.name)
+        runtime = self._get_session_runtime(launch.session.name)
         if runtime and runtime.last_failure_type == "capacity_low" and runtime.status == "recovering":
             return
         pct = probe.remaining_pct if probe.remaining_pct is not None else -1
@@ -2473,7 +2537,7 @@ class Supervisor:
 
     def _record_recovery_attempt(self, session_name: str, *, status: str, failure_type: str, failure_message: str) -> tuple[bool, int]:
         now = datetime.now(UTC)
-        runtime = self.store.get_session_runtime(session_name)
+        runtime = self._get_session_runtime(session_name)
         attempts = 1
         started_at = now.isoformat()
         if runtime is not None and runtime.recovery_window_started_at:
@@ -2484,7 +2548,7 @@ class Supervisor:
             if now - previous_start <= self._RECOVERY_WINDOW:
                 attempts = runtime.recovery_attempts + 1
                 started_at = runtime.recovery_window_started_at
-        self.store.upsert_session_runtime(
+        self._upsert_session_runtime(
             session_name=session_name,
             status=status,
             effective_account=runtime.effective_account if runtime else None,
@@ -2539,7 +2603,7 @@ class Supervisor:
                 signal_kwargs["capacity_state"] = CapacityState.EXHAUSTED
             signals = SessionSignals(**signal_kwargs)  # type: ignore[arg-type]
 
-            runtime = self.store.get_session_runtime(launch.session.name)
+            runtime = self._get_session_runtime(launch.session.name)
             previous = runtime.recovery_attempts if runtime else 0
             history = [
                 InterventionHistoryEntry(action="") for _ in range(previous)
@@ -3108,7 +3172,7 @@ class Supervisor:
                         who_cleared=f"auto:supervisor-recovery:{alert_type}",
                     )
                     if alert_type == "recovery_limit":
-                        self.store.upsert_session_runtime(
+                        self._upsert_session_runtime(
                             session_name=session_name,
                             status="idle",
                             recovery_attempts=0,
@@ -3391,7 +3455,7 @@ class Supervisor:
                 )
                 return
         if failure_type == "provider_outage":
-            self.store.upsert_session_runtime(
+            self._upsert_session_runtime(
                 session_name=launch.session.name,
                 status="blocked",
                 effective_account=launch.account.name,
@@ -3421,7 +3485,7 @@ class Supervisor:
                 "error",
                 msg,
             )
-            self.store.upsert_session_runtime(
+            self._upsert_session_runtime(
                 session_name=launch.session.name,
                 status="degraded",
                 last_failure_type=failure_type,
@@ -3443,7 +3507,7 @@ class Supervisor:
                 "error",
                 f"No viable account is currently available to recover {launch.window_name}",
             )
-            self.store.upsert_session_runtime(
+            self._upsert_session_runtime(
                 session_name=launch.session.name,
                 status="blocked",
                 last_failure_type=failure_type,
@@ -3488,7 +3552,7 @@ class Supervisor:
             "error",
             f"Recovery failed for all viable accounts: {last_error or 'no candidate succeeded'}",
         )
-        self.store.upsert_session_runtime(
+        self._upsert_session_runtime(
             session_name=launch.session.name,
             status="blocked",
             last_failure_type=failure_type,
@@ -3514,7 +3578,7 @@ class Supervisor:
             action="restart",
         )
         tmux_session = self._tmux_session_for_launch(launch)
-        previous_runtime = self.store.get_session_runtime(session_name)
+        previous_runtime = self._get_session_runtime(session_name)
         if self.session_service.tmux.has_session(tmux_session):
             window_map = self._window_map()
             # #1096 — key includes the tmux_session so we don't mistake
@@ -3522,7 +3586,7 @@ class Supervisor:
             if (tmux_session, launch.window_name) in window_map:
                 self.session_service.tmux.kill_window(f"{tmux_session}:{launch.window_name}")
         account = self.config.accounts[account_name]
-        self.store.upsert_session_runtime(
+        self._upsert_session_runtime(
             session_name=session_name,
             status="recovering",
             effective_account=account_name,
@@ -3549,7 +3613,7 @@ class Supervisor:
                         exc_info=True,
                     )
         except Exception:
-            self.store.upsert_session_runtime(
+            self._upsert_session_runtime(
                 session_name=session_name,
                 status=previous_runtime.status if previous_runtime else "degraded",
                 effective_account=previous_runtime.effective_account if previous_runtime else None,
@@ -3653,7 +3717,7 @@ class Supervisor:
         else:
             eff_account = account_name
             eff_provider = account.provider.value
-        self.store.upsert_session_runtime(
+        self._upsert_session_runtime(
             session_name=session_name,
             status="healthy",
             effective_account=eff_account,
@@ -3812,7 +3876,7 @@ class Supervisor:
         account = self.config.accounts.get(account_name)
         if account is None:
             raise KeyError(f"Unknown account: {account_name}")
-        self.store.upsert_session_runtime(
+        self._upsert_session_runtime(
             session_name=session_name,
             status="recovering",
             effective_account=account_name,

--- a/src/pollypm/workers.py
+++ b/src/pollypm/workers.py
@@ -23,11 +23,25 @@ _log = logging.getLogger(__name__)
 def _effective_control_accounts(config_path: Path) -> set[str]:
     config = load_config(config_path)
     accounts = {config.pollypm.controller_account}
-    with StateStore(config.project.state_db) as store:
+    # Slice K-state-port phase 2c (#1737): on the pg backend, skip the
+    # short-lived StateStore open and go straight through pg_sessions —
+    # the cluster-A facade owns session_runtime under postgres. The
+    # sqlite branch is unchanged for back-compat.
+    from pollypm.storage._backend_dispatch import is_pg_backend
+
+    if is_pg_backend(config):
+        from pollypm.storage.pg_sessions import get_session_runtime
+
         for session_name in ("heartbeat", "operator"):
-            runtime = store.get_session_runtime(session_name)
+            runtime = get_session_runtime(session_name)
             if runtime is not None and runtime.effective_account:
                 accounts.add(runtime.effective_account)
+    else:
+        with StateStore(config.project.state_db) as store:
+            for session_name in ("heartbeat", "operator"):
+                runtime = store.get_session_runtime(session_name)
+                if runtime is not None and runtime.effective_account:
+                    accounts.add(runtime.effective_account)
     return {name for name in accounts if name}
 
 

--- a/tests/test_pg_sessions.py
+++ b/tests/test_pg_sessions.py
@@ -1,0 +1,341 @@
+"""pg-parity tests for the ``pg_sessions`` facade (#1737, Slice K-state-port phase 2c).
+
+Covers cluster A: ``sessions`` + ``session_runtime`` + the events trio
+(``record_event`` / ``last_event_at`` / ``recent_events``) that lives on
+the ``messages`` table.
+
+Each test applies the canonical pg migrations on a fresh per-test
+schema (``pg_schema_pool`` from ``conftest_pg``), then exercises one
+slice of the facade. The assertions mirror StateStore semantics 1:1
+because the migration plan (PRs #1801, #1804, #1807) forbids any
+behaviour drift on the cutover.
+
+Skipped when neither Docker nor a local pg with the ``vector``
+extension is available — see ``tests/conftest_pg.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _apply_initial_migrations(pg_schema_pool) -> None:
+    """Apply the canonical schema migrations onto the per-test pool."""
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+
+
+# --------------------------------------------------------------------- #
+# sessions
+# --------------------------------------------------------------------- #
+
+
+def test_pg_sessions_upsert_list_roundtrip(pg_schema_pool):
+    """upsert_session writes, list_sessions reads, upsert overwrites on conflict."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_sessions import (
+        get_session_window,
+        list_sessions,
+        upsert_session,
+    )
+
+    assert list_sessions(pool=pg_schema_pool) == []
+    assert get_session_window("nope", pool=pg_schema_pool) is None
+
+    upsert_session(
+        name="worker-alpha",
+        role="worker",
+        project="alpha",
+        provider="claude-cli",
+        account="primary",
+        cwd="/tmp/alpha",
+        window_name="alpha-1",
+        pool=pg_schema_pool,
+    )
+    rows = list_sessions(pool=pg_schema_pool)
+    assert len(rows) == 1
+    assert rows[0].name == "worker-alpha"
+    assert rows[0].project == "alpha"
+    assert rows[0].window_name == "alpha-1"
+    assert get_session_window("worker-alpha", pool=pg_schema_pool) == "alpha-1"
+
+    # Re-upserting the same name overwrites (no duplicate row).
+    upsert_session(
+        name="worker-alpha",
+        role="worker",
+        project="alpha",
+        provider="claude-cli",
+        account="secondary",
+        cwd="/tmp/alpha2",
+        window_name="alpha-2",
+        pool=pg_schema_pool,
+    )
+    rows = list_sessions(pool=pg_schema_pool)
+    assert len(rows) == 1
+    assert rows[0].account == "secondary"
+    assert rows[0].window_name == "alpha-2"
+
+
+def test_pg_sessions_prune_keeps_listed_drops_others(pg_schema_pool):
+    """prune_sessions deletes rows whose name isn't in the valid set."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_sessions import (
+        list_sessions,
+        prune_sessions,
+        upsert_session,
+    )
+
+    for name, project in [
+        ("worker-alpha", "alpha"),
+        ("worker-beta", "beta"),
+        ("worker-stale", "stale"),
+    ]:
+        upsert_session(
+            name=name,
+            role="worker",
+            project=project,
+            provider="claude-cli",
+            account="primary",
+            cwd=f"/tmp/{project}",
+            window_name=f"{project}-1",
+            pool=pg_schema_pool,
+        )
+
+    prune_sessions({"worker-alpha", "worker-beta"}, pool=pg_schema_pool)
+    rows = sorted(s.name for s in list_sessions(pool=pg_schema_pool))
+    assert rows == ["worker-alpha", "worker-beta"]
+
+
+def test_pg_sessions_prune_empty_set_drops_all(pg_schema_pool):
+    """prune_sessions with an empty set deletes every session row."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_sessions import (
+        list_sessions,
+        prune_sessions,
+        upsert_session,
+    )
+
+    upsert_session(
+        name="worker-alpha",
+        role="worker",
+        project="alpha",
+        provider="claude-cli",
+        account="primary",
+        cwd="/tmp/alpha",
+        window_name="alpha-1",
+        pool=pg_schema_pool,
+    )
+
+    prune_sessions(set(), pool=pg_schema_pool)
+    assert list_sessions(pool=pg_schema_pool) == []
+
+
+def test_pg_sessions_prune_preserves_synthetic_alerts(pg_schema_pool):
+    """#1528 carve-out: plan_missing / no_session / no_session_for_assignment:* survive prune."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_sessions import prune_sessions
+
+    now_iso = "2026-05-19T00:00:00+00:00"
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        # Plant three open alerts: one synthetic, one regular, one
+        # synthetic via the LIKE prefix.
+        for scope, sender, subject in [
+            ("plan_gate-alpha", "plan_missing", "plan_missing"),
+            ("session-alpha", "regular", "alarm"),
+            ("task_assignment", "no_session_for_assignment:alpha", "noop"),
+        ]:
+            cur.execute(
+                """
+                INSERT INTO messages (
+                    scope, type, tier, recipient, sender, state,
+                    subject, body, payload_json, labels, created_at, updated_at
+                )
+                VALUES (%s, 'alert', 'immediate', '*', %s, 'open',
+                        %s, '', '{}'::jsonb, '[]'::jsonb, %s, %s)
+                """,
+                (scope, sender, subject, now_iso, now_iso),
+            )
+        conn.commit()
+
+    prune_sessions(set(), pool=pg_schema_pool)
+
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT sender, state FROM messages WHERE type = 'alert' ORDER BY sender"
+        )
+        rows = cur.fetchall()
+    by_sender = {row[0]: row[1] for row in rows}
+    # Synthetic ones stay open; the regular one closes.
+    assert by_sender["plan_missing"] == "open"
+    assert by_sender["no_session_for_assignment:alpha"] == "open"
+    assert by_sender["regular"] == "closed"
+
+
+# --------------------------------------------------------------------- #
+# events (messages table)
+# --------------------------------------------------------------------- #
+
+
+def test_pg_sessions_record_and_recent_events(pg_schema_pool):
+    """record_event writes; recent_events returns newest-first with the fallback chain."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_sessions import (
+        last_event_at,
+        recent_events,
+        record_event,
+    )
+
+    assert recent_events(pool=pg_schema_pool) == []
+    assert last_event_at("worker-alpha", "boot", pool=pg_schema_pool) is None
+
+    record_event("worker-alpha", "boot", "starting", pool=pg_schema_pool)
+    record_event("worker-alpha", "tick", "tick-1", pool=pg_schema_pool)
+    record_event("worker-beta", "boot", "starting beta", pool=pg_schema_pool)
+
+    events = recent_events(limit=10, pool=pg_schema_pool)
+    assert len(events) == 3
+    # newest-first
+    assert events[0].session_name == "worker-beta"
+    assert events[0].event_type == "boot"
+    assert events[0].message == "starting beta"
+    assert events[1].session_name == "worker-alpha"
+    assert events[1].event_type == "tick"
+    assert events[1].message == "tick-1"
+
+    # last_event_at filters on (scope, subject).
+    stamp = last_event_at("worker-alpha", "boot", pool=pg_schema_pool)
+    assert isinstance(stamp, str) and stamp
+    assert last_event_at("worker-alpha", "nope", pool=pg_schema_pool) is None
+
+
+def test_pg_sessions_recent_events_limit_honoured(pg_schema_pool):
+    """The ``limit`` argument caps the row count."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_sessions import recent_events, record_event
+
+    for i in range(5):
+        record_event("worker-alpha", "tick", f"tick-{i}", pool=pg_schema_pool)
+
+    events = recent_events(limit=3, pool=pg_schema_pool)
+    assert len(events) == 3
+    # Returns newest first: tick-4, tick-3, tick-2.
+    assert events[0].message == "tick-4"
+    assert events[2].message == "tick-2"
+
+
+# --------------------------------------------------------------------- #
+# session_runtime
+# --------------------------------------------------------------------- #
+
+
+def test_pg_session_runtime_upsert_get_list(pg_schema_pool):
+    """upsert / get / list roundtrip for session_runtime rows."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_sessions import (
+        get_session_runtime,
+        list_session_runtimes,
+        upsert_session_runtime,
+    )
+
+    assert get_session_runtime("worker-alpha", pool=pg_schema_pool) is None
+    assert list_session_runtimes(pool=pg_schema_pool) == []
+
+    upsert_session_runtime(
+        session_name="worker-alpha",
+        status="healthy",
+        effective_account="primary",
+        effective_provider="claude-cli",
+        recovery_attempts=0,
+        pool=pg_schema_pool,
+    )
+
+    row = get_session_runtime("worker-alpha", pool=pg_schema_pool)
+    assert row is not None
+    assert row.session_name == "worker-alpha"
+    assert row.status == "healthy"
+    assert row.effective_account == "primary"
+    assert row.recovery_attempts == 0
+    assert isinstance(row.updated_at, str) and row.updated_at
+
+    upsert_session_runtime(
+        session_name="worker-beta",
+        status="degraded",
+        last_failure_type="rate_limit",
+        last_failure_message="quota exhausted",
+        pool=pg_schema_pool,
+    )
+
+    all_rows = sorted(
+        list_session_runtimes(pool=pg_schema_pool),
+        key=lambda r: r.session_name,
+    )
+    assert [r.session_name for r in all_rows] == ["worker-alpha", "worker-beta"]
+    assert all_rows[1].status == "degraded"
+    assert all_rows[1].last_failure_type == "rate_limit"
+
+
+def test_pg_session_runtime_partial_upsert_preserves_unset_fields(pg_schema_pool):
+    """Re-upserting without a column preserves the existing value (StateStore _UNSET parity)."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_sessions import (
+        get_session_runtime,
+        upsert_session_runtime,
+    )
+
+    upsert_session_runtime(
+        session_name="worker-alpha",
+        status="healthy",
+        effective_account="primary",
+        effective_provider="claude-cli",
+        recovery_attempts=2,
+        last_failure_type="rate_limit",
+        last_failure_message="initial fail",
+        pool=pg_schema_pool,
+    )
+
+    # Update only the status; everything else must be preserved.
+    upsert_session_runtime(
+        session_name="worker-alpha",
+        status="degraded",
+        pool=pg_schema_pool,
+    )
+
+    row = get_session_runtime("worker-alpha", pool=pg_schema_pool)
+    assert row is not None
+    assert row.status == "degraded"
+    assert row.effective_account == "primary"
+    assert row.effective_provider == "claude-cli"
+    assert row.recovery_attempts == 2
+    assert row.last_failure_type == "rate_limit"
+    assert row.last_failure_message == "initial fail"
+
+
+def test_pg_session_runtime_explicit_none_clears_column(pg_schema_pool):
+    """Passing ``None`` explicitly writes SQL NULL (distinguished from _UNSET)."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_sessions import (
+        get_session_runtime,
+        upsert_session_runtime,
+    )
+
+    upsert_session_runtime(
+        session_name="worker-alpha",
+        status="healthy",
+        last_failure_type="rate_limit",
+        last_failure_message="boom",
+        pool=pg_schema_pool,
+    )
+
+    upsert_session_runtime(
+        session_name="worker-alpha",
+        status="healthy",
+        last_failure_type=None,
+        last_failure_message=None,
+        pool=pg_schema_pool,
+    )
+
+    row = get_session_runtime("worker-alpha", pool=pg_schema_pool)
+    assert row is not None
+    assert row.last_failure_type is None
+    assert row.last_failure_message is None


### PR DESCRIPTION
Ports cluster A of the StateStore methods to pg facades. The agent ran the migration to ~85% completion before stalling on the final push step; the branch carries 4 substantive commits with working code + tests.

## Per-commit breakdown

- `2260b0d0` — Add `pg_sessions` facade for sessions/runtime/events cluster
- `d93844cc` — Route `dashboard_data` session/event reads through `pg_sessions`
- `9d3977df` — Route Supervisor session/runtime calls through `pg_sessions`
- `091606e9` — Port additional cluster-A consumers through `pg_sessions`

## Stats

20 files changed, +1227/-1206. New test file `tests/test_pg_sessions.py` (341 lines).

## Constraints

- 0 \`issues/**\` files in PR diff (verified)
- Worktree-isolated dispatch (clean primary tree)
- No \`SQLiteWorkService\` touched
- No \`state.py\` deletion (deferred to K-source-ripout)

## Caveat

Agent stalled at PR-create step; this PR is opened by Sam (parent operator) from the pushed branch state. Diff is exactly what the agent committed.

Refs #1737