### PR TITLE
fix(pg): orphaned-claim recovery + notification slot atomicity + config-aware pool resolution (closes #1822, #1821, #1819, #1796, #1754, #1737)

### DIFF
--- a/src/pollypm/heartbeat/boot.py
+++ b/src/pollypm/heartbeat/boot.py
@@ -156,6 +156,7 @@ class HeartbeatRail:
         state_db: Path,
         plugin_host: Any,
         config_path: Path | None = None,
+        config: Any = None,
         concurrency: int | None = None,
         tick_interval_seconds: float = DEFAULT_TICK_INTERVAL_SECONDS,
     ) -> "HeartbeatRail":
@@ -163,6 +164,12 @@ class HeartbeatRail:
 
         The plugin host must expose ``build_roster()`` and
         ``job_handler_registry()`` (see :class:`pollypm.plugin_host.ExtensionHost`).
+
+        ``config`` is the already-loaded :class:`PollyPMConfig`. When
+        provided, it's threaded into the pg pool resolution and into
+        the ``JobQueue`` so the configured ``[storage.pg] dsn`` /
+        ``[storage] url`` is honoured rather than silently falling
+        back to the localhost default (#1819).
         """
         worker_settings = (
             load_worker_settings(config_path) if config_path else WorkerSettings()
@@ -195,18 +202,22 @@ class HeartbeatRail:
         # contract. ``state_db`` is retained in the signature for
         # source-compat with the legacy caller (``from_config``);
         # the queue itself reads its DSN from the process-wide pool.
+        # ``config`` is threaded into ``get_rw_pool`` so the migration
+        # applier opens the pool against the configured DSN (#1819)
+        # — passing ``None`` here was the regression where a non-
+        # default ``[storage.pg] dsn`` silently hit localhost.
         try:
             from pollypm.storage.pg_migrations import apply_migrations
             from pollypm.storage.pg_pool import get_rw_pool
 
-            apply_migrations(get_rw_pool())
+            apply_migrations(get_rw_pool(config))
         except Exception:  # noqa: BLE001 — schema is a best-effort here
             logger.exception(
                 "HeartbeatRail.from_plugin_host: pg migration applier "
                 "raised; continuing — the queue will surface "
                 "UndefinedTable on first use if schema is genuinely missing",
             )
-        queue = JobQueue(db_path=state_db)
+        queue = JobQueue(db_path=state_db, config=config)
         pool = JobWorkerPool(
             queue, registry=registry, poll_interval=worker_settings.poll_interval,
         )
@@ -227,6 +238,7 @@ class HeartbeatRail:
             state_db=config.project.state_db,
             plugin_host=plugin_host,
             config_path=config_path,
+            config=config,
         )
 
     # ------------------------------------------------------------------

--- a/src/pollypm/jobs/cli.py
+++ b/src/pollypm/jobs/cli.py
@@ -65,7 +65,13 @@ def set_queue_factory(factory: _QueueFactory | None) -> None:
 
 
 def build_queue_for_config(config_path: Path) -> JobQueue:
-    """Default factory: open a ``JobQueue`` against the project's state DB."""
+    """Default factory: open a ``JobQueue`` against the loaded config.
+
+    Threads the loaded ``PollyPMConfig`` into the queue constructor so
+    the pg pool resolves ``[storage.pg] dsn`` / ``[storage] url``
+    rather than silently falling back to the localhost default (the
+    #1819 regression).
+    """
     resolved = resolve_config_path(config_path)
     if not resolved.exists():
         from pollypm.errors import format_config_not_found_error
@@ -74,7 +80,7 @@ def build_queue_for_config(config_path: Path) -> JobQueue:
     config = load_config(resolved)
     db_path = config.project.state_db
     db_path.parent.mkdir(parents=True, exist_ok=True)
-    return JobQueue(db_path=db_path)
+    return JobQueue(db_path=db_path, config=config)
 
 
 def _open_queue(config_path: Path) -> JobQueue:

--- a/src/pollypm/jobs/queue.py
+++ b/src/pollypm/jobs/queue.py
@@ -587,13 +587,22 @@ class JobQueue:
           1. UPDATE every ``claimed`` row back to ``queued`` with
              ``run_after = now()`` and rewind attempt by 1 since no
              handler body ever ran.
-          2. DELETE duplicate queued rows per ``handler_name``, keeping
-             only the newest. Pre-#1052 rows had no dedupe_key so the
+          2. Collapse the *legacy* cadence backlog only: rows with
+             ``dedupe_key IS NULL`` whose ``handler_name`` was just
+             requeued in step 1 *and* has more than one queued row
+             remaining. Pre-#1052 rows had no dedupe_key so the
              previous daemon's cadence ticks accumulated thousands of
              identical session.health_sweep / task_assignment.sweep
-             rows in ``claimed``; without this dedupe pass the worker
-             pool would spend hours grinding through the legacy pile
-             before it could fire freshly-scheduled handlers.
+             rows in ``claimed``; collapsing those keeps the worker
+             pool from grinding through the legacy pile before it can
+             fire freshly-scheduled handlers.
+
+             Critically, this prune is scoped to:
+               * the handlers actually recovered by *this* invocation,
+                 so a stale queued backlog from a healthy queue is left
+                 alone (#1822); and
+               * NULL-``dedupe_key`` rows only, so legitimate distinct
+                 payload/dedupe-keyed jobs are never collapsed (#1822).
 
         Returns ``(recovered, pruned)`` — the count of orphaned-claim
         rows we requeued, and the count of duplicate queued rows we
@@ -603,6 +612,22 @@ class JobQueue:
         with self._pool.connection() as conn:
             conn.autocommit = False
             with conn.cursor() as cur:
+                # Step 1 — capture the handler set we're recovering
+                # *before* we mutate ``status`` so the prune in step 2
+                # can scope to "handlers this boot just recovered".
+                # Without the capture-then-update split, the prune
+                # would see every queued handler (including untouched
+                # ones) and drop legitimate work — the #1822
+                # regression.
+                cur.execute(
+                    """
+                    SELECT DISTINCT handler_name
+                    FROM work_jobs
+                    WHERE status = 'claimed'
+                    """,
+                )
+                recovered_handlers = [row[0] for row in cur.fetchall()]
+
                 cur.execute(
                     """
                     UPDATE work_jobs
@@ -620,18 +645,32 @@ class JobQueue:
                 )
                 recovered = int(cur.rowcount or 0)
 
-                cur.execute(
-                    """
-                    DELETE FROM work_jobs
-                    WHERE status = 'queued'
-                      AND id NOT IN (
-                        SELECT MAX(id) FROM work_jobs
+                pruned = 0
+                if recovered_handlers:
+                    # Step 2 — collapse the legacy NULL-dedupe-key
+                    # backlog for the handlers we just recovered. We
+                    # keep the newest row per handler (so the cadence
+                    # can still fire) and drop the older duplicates.
+                    # Distinct dedupe_keyed rows are filtered out by
+                    # the ``dedupe_key IS NULL`` clause, so payload-
+                    # differentiated work survives untouched.
+                    cur.execute(
+                        """
+                        DELETE FROM work_jobs
                         WHERE status = 'queued'
-                        GROUP BY handler_name
-                      )
-                    """,
-                )
-                pruned = int(cur.rowcount or 0)
+                          AND dedupe_key IS NULL
+                          AND handler_name = ANY(%s)
+                          AND id NOT IN (
+                            SELECT MAX(id) FROM work_jobs
+                            WHERE status = 'queued'
+                              AND dedupe_key IS NULL
+                              AND handler_name = ANY(%s)
+                            GROUP BY handler_name
+                          )
+                        """,
+                        (recovered_handlers, recovered_handlers),
+                    )
+                    pruned = int(cur.rowcount or 0)
             conn.commit()
         return recovered, pruned
 

--- a/src/pollypm/storage/pg_notifications.py
+++ b/src/pollypm/storage/pg_notifications.py
@@ -118,6 +118,35 @@ def record_notification(
         )
 
 
+def _advisory_lock_keys(
+    session_name: str, task_id: str, execution_version: int, scope: str
+) -> tuple[int, int]:
+    """Hash the claim tuple into a two-int key for ``pg_advisory_xact_lock``.
+
+    Postgres's two-int advisory-lock variant takes ``(int4, int4)``;
+    we derive both halves from a stable SHA-1 of the dedupe tuple so
+    two concurrent callers with the same ``(session, task, version,
+    scope)`` always collide on the same lock, while distinct tuples
+    are virtually guaranteed not to. Collisions across distinct
+    tuples are harmless (one waits a few ms on a key that doesn't
+    apply to it); the safety property we need is that the *same*
+    tuple always serialises.
+    """
+    import hashlib
+
+    blob = (
+        f"pollypm:notif:{session_name}\x00{task_id}\x00"
+        f"{int(execution_version)}\x00{scope}"
+    ).encode("utf-8")
+    digest = hashlib.sha1(blob).digest()
+    # Two signed 32-bit ints — that's what pg_advisory_xact_lock(int4, int4)
+    # wants. ``int.from_bytes(..., signed=True)`` keeps us inside the
+    # accepted range without an extra modulo.
+    a = int.from_bytes(digest[0:4], "big", signed=True)
+    b = int.from_bytes(digest[4:8], "big", signed=True)
+    return a, b
+
+
 def claim_notification_slot(
     *,
     session_name: str,
@@ -132,8 +161,10 @@ def claim_notification_slot(
     """Atomically claim a dedupe slot for a ``(session, task, version)`` ping.
 
     Mirrors the sqlite implementation's TOCTOU-safe check-and-insert
-    (#952). The check + insert run inside one transaction so a
-    concurrent caller sees the pending row and returns ``None``.
+    (#952). The check + insert run inside one transaction, gated by a
+    transaction-scoped advisory lock keyed on the dedupe tuple so a
+    concurrent caller blocks until we commit instead of racing past
+    the empty SELECT.
 
     * Returns ``None`` when a row already exists for
       ``(session, task, execution_version, dedupe_scope)`` inside the
@@ -147,6 +178,19 @@ def claim_notification_slot(
     also throttles ordinary follow-up sweeps; scoped claims only
     match the same scope so a stale normal row can't suppress the
     forced kickoff.
+
+    Why an advisory lock (#1821)
+    ----------------------------
+    The previous implementation relied on ``SELECT ... FOR UPDATE`` to
+    serialise the check + insert. That only locks rows that already
+    exist — when no row matches (the common cold-path on the first
+    ping for a task), two concurrent callers both see an empty result
+    and both insert a ``pending`` row, defeating the #952 dedupe
+    guarantee. ``pg_advisory_xact_lock`` blocks the second caller
+    until the first commits, so the second one's SELECT then sees the
+    just-inserted row and returns ``None``. The lock is released
+    automatically on COMMIT/ROLLBACK (the ``_xact`` variant), so we
+    never leak a held lock across connection reuse.
     """
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
@@ -163,13 +207,25 @@ def claim_notification_slot(
             "dedupe_scope": scope,
         }
     )
+    # For ``normal`` claims, the dedupe predicate matches any scope, so
+    # the lock must collapse on a single ``normal`` key per tuple —
+    # otherwise two normal-scope callers could pick different ``scope``
+    # values (they can't here, both pass ``"normal"``, but a future
+    # caller wrapping this fn must not be able to bypass dedupe by
+    # varying scope). For non-normal claims we key on the scope so a
+    # forced kickoff and a normal sweep don't block each other.
+    lock_scope = scope if scope != "normal" else "normal"
+    key_a, key_b = _advisory_lock_keys(
+        session_name, task_id, int(execution_version), lock_scope
+    )
     with pool.connection() as conn, conn.cursor() as cur:
-        # The check + insert run inside the same psycopg transaction
-        # (one ``with conn`` block, no explicit COMMIT until exit) so a
-        # concurrent claim either sees our row and returns None, or
-        # gets blocked on the pg row lock until we commit. The unique
-        # constraint is enforced logically by the dedupe-scope match
-        # rather than a partial index because the window is dynamic.
+        # Acquire a transaction-scoped advisory lock keyed on the
+        # dedupe tuple. The lock is released at COMMIT/ROLLBACK; no
+        # explicit unlock needed. This is the load-bearing line that
+        # fixes the #1821 race — without it, two concurrent callers
+        # with no existing row would both pass the SELECT and both
+        # INSERT.
+        cur.execute("SELECT pg_advisory_xact_lock(%s, %s)", (key_a, key_b))
         cur.execute(
             """
             SELECT 1 FROM messages
@@ -186,7 +242,6 @@ def claim_notification_slot(
               )
               AND created_at >= %s
             LIMIT 1
-            FOR UPDATE
             """,
             (
                 session_name,

--- a/src/pollypm/storage/pg_pool.py
+++ b/src/pollypm/storage/pg_pool.py
@@ -15,16 +15,17 @@ kept side-by-side so accidental writes from read-side facades crash loudly:
 DSN resolution order (highest priority wins):
 
 1. ``POLLYPM_PG_DSN`` env var — operator override / one-shot test runs.
-2. ``[storage] url`` in ``pollypm.toml`` — only when it looks like a pg DSN
-   (``postgresql://...`` / ``postgres://...``); otherwise treated as a
-   sqlite URL and ignored here.
-3. The built-in default ``postgresql://localhost:5432/pollypm``.
+2. ``[storage.pg] dsn`` in ``pollypm.toml`` — the canonical pg DSN knob
+   when ``[storage] backend = "postgres"``. Only consulted when it
+   looks like a pg DSN (``postgresql://...`` / ``postgres://...``).
+3. ``[storage] url`` in ``pollypm.toml`` — only when it looks like a pg
+   DSN; otherwise treated as a sqlite URL and ignored here.
+4. The built-in default ``postgresql://localhost:5432/pollypm``.
 
-Note: :class:`~pollypm.models.PgStorageSettings` exposes a ``dsn`` field
-that :mod:`pollypm.config` parses from ``[storage.pg] dsn``, but
-:func:`resolve_dsn` does **not** read it yet — operators who want to
-override the DSN should use ``POLLYPM_PG_DSN`` or ``[storage] url``.
-Wiring ``[storage.pg].dsn`` is tracked as a post-RC follow-up.
+Both ``[storage.pg] dsn`` and ``[storage] url`` are honoured so an
+operator who already migrated to the nested section (#1754) and one
+who carries the legacy shared URL both see their config respected
+(#1819).
 
 The pools are lazy module-level singletons. :func:`pg_pool_shutdown` is the
 graceful close used by ``pm reset`` / test teardown — calling it is safe
@@ -107,22 +108,26 @@ def resolve_dsn(config: "PollyPMConfig | None" = None) -> str:
     Priority (highest wins):
 
     1. ``POLLYPM_PG_DSN`` env var.
-    2. ``config.storage.url`` — only when it parses as a pg DSN.
-    3. The built-in :data:`DEFAULT_DSN`.
+    2. ``config.storage.pg.dsn`` — the canonical pg DSN knob from
+       ``[storage.pg] dsn``. Only consulted when it parses as a pg DSN.
+    3. ``config.storage.url`` — the legacy shared URL knob. Only
+       consulted when it parses as a pg DSN.
+    4. The built-in :data:`DEFAULT_DSN`.
 
-    Note: ``config.storage.pg.dsn`` is parsed by :mod:`pollypm.config`
-    but **not** read here. Operators who set ``[storage.pg] dsn`` in
-    ``pollypm.toml`` are currently silently ignored; wiring that
-    source is tracked as a post-RC follow-up.
+    Both ``[storage.pg] dsn`` (#1754) and ``[storage] url`` are read
+    here so the production entry points (``PgStore``, ``JobQueue``,
+    the boot migration applier) honour whichever knob the operator
+    set — silently falling back to the localhost default when the
+    config carries a non-default DSN was the #1819 regression.
 
     Parameters
     ----------
     config:
         Optional :class:`pollypm.models.PollyPMConfig`. When provided,
-        ``config.storage.url`` is consulted as the second-priority
-        source. Pass ``None`` to resolve purely from env + the built-in
-        default (used by ``pm doctor`` before a config is loaded, and
-        by the tests).
+        ``config.storage.pg.dsn`` and ``config.storage.url`` are
+        consulted as the second/third priority sources. Pass ``None``
+        to resolve purely from env + the built-in default (used by
+        ``pm doctor`` before a config is loaded, and by the tests).
 
     Returns
     -------
@@ -135,6 +140,15 @@ def resolve_dsn(config: "PollyPMConfig | None" = None) -> str:
         return env_dsn
 
     if config is not None:
+        # ``[storage.pg] dsn`` first — it's the dedicated pg knob and
+        # was the one operators reach for when the legacy shared
+        # ``[storage] url`` already holds a sqlite URL.
+        pg_section = getattr(config.storage, "pg", None)
+        if pg_section is not None:
+            pg_dsn = getattr(pg_section, "dsn", "") or ""
+            if _looks_like_pg_dsn(pg_dsn):
+                return pg_dsn.strip()
+
         url = getattr(config.storage, "url", "") or ""
         if _looks_like_pg_dsn(url):
             return url.strip()

--- a/src/pollypm/store/backends/pg_store.py
+++ b/src/pollypm/store/backends/pg_store.py
@@ -74,13 +74,15 @@ class PgStore:
     Parameters
     ----------
     url:
-        The pg DSN. Accepted for protocol parity with
-        :class:`SQLAlchemyStore`; the value is stored for ``self.url``
-        but ignored when resolving the pool — the process-wide pg pool
-        already resolves its DSN via :func:`pollypm.storage.pg_pool.resolve_dsn`
-        (env > config > built-in default). Passing a DSN here that
-        disagrees with what the pool already opened is a no-op; the
-        pool wins.
+        The pg DSN. The entry-point registry passes the resolved
+        ``config.storage.url`` here. The store builds a thin config
+        shim from ``url`` (when it looks like a pg DSN) and passes it
+        to :func:`pollypm.storage.pg_pool.get_rw_pool` so the
+        process-wide pool opens against the operator-configured DSN
+        rather than silently falling back to localhost (#1819). When
+        the pool is already open against a different DSN, that pool
+        wins — the call site that opens the pool first sets the DSN
+        for the lifetime of the process.
     """
 
     def __init__(self, url: str) -> None:
@@ -96,6 +98,49 @@ class PgStore:
         # database. Slice A's migration applier is idempotent on a
         # fully-applied schema, so the cost amortizes to one pg round-trip.
         self._ensure_schema()
+
+    def _pool_config(self):
+        """Build a minimal config-shaped object carrying ``self._url``.
+
+        The pg pool's :func:`resolve_dsn` reads
+        ``config.storage.pg.dsn`` and ``config.storage.url`` — passing
+        the store's constructor URL through both fields covers the
+        case where the registry handed us either the legacy
+        ``[storage] url`` or the canonical ``[storage.pg] dsn`` (the
+        registry resolves them into one ``url`` string before
+        construction, and we can't tell which knob it came from).
+        """
+        url = (self._url or "").strip()
+        if not url:
+            return None
+        # Only proxy a pg-shaped URL; sqlite URLs would be filtered
+        # out by ``_looks_like_pg_dsn`` anyway, but skipping the build
+        # avoids a useless shim object on sqlite-backed installs.
+        from pollypm.storage.pg_pool import _looks_like_pg_dsn
+
+        if not _looks_like_pg_dsn(url):
+            return None
+
+        class _PgSection:
+            __slots__ = ("dsn",)
+
+            def __init__(self, dsn: str) -> None:
+                self.dsn = dsn
+
+        class _Storage:
+            __slots__ = ("url", "pg")
+
+            def __init__(self, url: str) -> None:
+                self.url = url
+                self.pg = _PgSection(url)
+
+        class _Config:
+            __slots__ = ("storage",)
+
+            def __init__(self, url: str) -> None:
+                self.storage = _Storage(url)
+
+        return _Config(url)
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -129,7 +174,7 @@ class PgStore:
     def _rw_pool(self) -> "ConnectionPool":
         from pollypm.storage.pg_pool import get_rw_pool
 
-        return get_rw_pool(None)
+        return get_rw_pool(self._pool_config())
 
     def _ro_pool(self) -> "ConnectionPool":
         # Read-side queries can run on the rw pool if the ro pool is
@@ -138,10 +183,11 @@ class PgStore:
         # write fails fast, which is the only reason to prefer it.
         from pollypm.storage.pg_pool import get_ro_pool, get_rw_pool
 
+        cfg = self._pool_config()
         try:
-            return get_ro_pool(None)
+            return get_ro_pool(cfg)
         except Exception:  # noqa: BLE001 - degrade to rw on ro errors
-            return get_rw_pool(None)
+            return get_rw_pool(cfg)
 
     def _ensure_schema(self) -> None:
         """Apply the canonical pg migration pack on first use.

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -362,6 +362,81 @@ def test_recover_orphaned_claims_collapses_legacy_duplicates(
     assert q.get(other).status is JobStatus.QUEUED
 
 
+def test_recover_orphaned_claims_preserves_queued_rows_when_nothing_claimed(
+    pg_job_queue: JobQueue,
+) -> None:
+    """#1822 — a boot with NO orphaned claims must not prune queued rows.
+
+    Two queued jobs share a handler. ``recover_orphaned_claims`` runs
+    when no row is in the ``claimed`` state. The old pg port deleted
+    the older queued row unconditionally; the fixed implementation
+    leaves both untouched because no recovery happened.
+    """
+    q = pg_job_queue
+    a = q.enqueue("sweep", {"p": "a"})
+    b = q.enqueue("sweep", {"p": "b"})
+
+    recovered, pruned = q.recover_orphaned_claims()
+    assert recovered == 0
+    assert pruned == 0
+
+    # Both rows must still exist and be queued.
+    job_a = q.get(a)
+    job_b = q.get(b)
+    assert job_a is not None and job_a.status is JobStatus.QUEUED
+    assert job_b is not None and job_b.status is JobStatus.QUEUED
+
+
+def test_recover_orphaned_claims_preserves_distinct_dedupe_keys(
+    pg_job_queue: JobQueue,
+) -> None:
+    """#1822 — distinct-dedupe-key rows survive recovery even when claimed.
+
+    Three rows for handler ``h`` with distinct dedupe_keys all wind up
+    in the ``claimed`` state (a crashed worker that claimed three rows
+    in one boot). Recovery requeues all three; the prune step must
+    NOT collapse them because they carry distinct dedupe keys — the
+    fix scopes the prune to ``dedupe_key IS NULL`` only.
+    """
+    q = pg_job_queue
+    a = q.enqueue("h", {"p": "a"}, dedupe_key="h:a")
+    b = q.enqueue("h", {"p": "b"}, dedupe_key="h:b")
+    c = q.enqueue("h", {"p": "c"}, dedupe_key="h:c")
+    # Crashed worker claimed all three rows before dying.
+    q.claim("crashed-worker", limit=3)
+
+    recovered, pruned = q.recover_orphaned_claims()
+    assert recovered == 3
+    # All three have distinct (non-NULL) dedupe_keys, so the prune
+    # leaves them alone.
+    assert pruned == 0
+
+    assert q.get(a) is not None and q.get(a).status is JobStatus.QUEUED
+    assert q.get(b) is not None and q.get(b).status is JobStatus.QUEUED
+    assert q.get(c) is not None and q.get(c).status is JobStatus.QUEUED
+
+
+def test_recover_orphaned_claims_preserves_distinct_payloads_same_handler(
+    pg_job_queue: JobQueue,
+) -> None:
+    """#1822 — two queued rows with the same handler + different payloads.
+
+    Both rows have ``dedupe_key=None`` (the legacy shape), but no
+    ``claimed`` row exists — there's nothing to recover, so the prune
+    step must NOT collapse them. The pre-fix code dropped the older
+    one unconditionally.
+    """
+    q = pg_job_queue
+    a = q.enqueue("user.handler", {"p": "first"})
+    b = q.enqueue("user.handler", {"p": "second"})
+
+    recovered, pruned = q.recover_orphaned_claims()
+    assert recovered == 0
+    assert pruned == 0
+    assert q.get(a) is not None and q.get(a).status is JobStatus.QUEUED
+    assert q.get(b) is not None and q.get(b).status is JobStatus.QUEUED
+
+
 def test_null_dedupe_key_does_not_deduplicate(pg_job_queue: JobQueue) -> None:
     q = pg_job_queue
     jid1 = q.enqueue("sweep", {"p": "a"})

--- a/tests/test_pg_notifications_race.py
+++ b/tests/test_pg_notifications_race.py
@@ -1,0 +1,130 @@
+"""Concurrency regression test for ``claim_notification_slot`` (#1821).
+
+The pg port of the task-notification dedupe API
+(:mod:`pollypm.storage.pg_notifications`) originally relied on
+``SELECT ... FOR UPDATE`` to serialise the check + insert. That only
+locks rows that *exist*; on the cold path (first ping for a task) two
+concurrent callers both see an empty result and both insert ``pending``
+rows, defeating the #952 dedupe contract.
+
+The fix gates the check + insert with a transaction-scoped advisory
+lock keyed on the dedupe tuple. These tests exercise the race by
+firing two ``claim_notification_slot`` calls from sibling threads
+against the same pg schema — the assertion is that exactly one of the
+two callers receives a row id and the other receives ``None``.
+
+The fixture uses the same per-test schema as the rest of the pg
+parity suite (``pg_schema_pool`` from ``tests/conftest_pg.py``), but
+because the schema is owned by ``search_path`` rather than a separate
+DB, both threads must run against the same pool — the advisory lock
+is keyed by ``(int4, int4)`` and is global to the pg cluster, so it
+serialises regardless of which connection holds it.
+"""
+
+from __future__ import annotations
+
+import threading
+
+
+def _apply_initial_migrations(pg_schema_pool) -> None:
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+
+
+def test_concurrent_claim_returns_one_winner(pg_schema_pool) -> None:
+    """Two concurrent claims on the same empty slot — exactly one wins.
+
+    Before the #1821 fix this test reliably saw both callers receive a
+    non-None id (both inserted a ``pending`` row because the
+    ``SELECT ... FOR UPDATE`` locked nothing). After the fix the
+    advisory lock serialises them: the loser's SELECT then sees the
+    winner's row and returns ``None``.
+    """
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_notifications import claim_notification_slot
+
+    barrier = threading.Barrier(2)
+    results: list[object] = [None, None]
+    errors: list[BaseException | None] = [None, None]
+
+    def _worker(slot: int) -> None:
+        try:
+            # Both threads line up on the barrier so the race window
+            # is real — without the barrier the first call wins the
+            # CPU and the second one trivially sees the row.
+            barrier.wait(timeout=10)
+            results[slot] = claim_notification_slot(
+                session_name="session-racey",
+                task_id="racey:1",
+                window_seconds=1800,
+                execution_version=0,
+                project="racey",
+                message="kickoff",
+                pool=pg_schema_pool,
+            )
+        except BaseException as exc:  # noqa: BLE001 — propagate to assertions
+            errors[slot] = exc
+
+    t1 = threading.Thread(target=_worker, args=(0,))
+    t2 = threading.Thread(target=_worker, args=(1,))
+    t1.start()
+    t2.start()
+    t1.join(timeout=15)
+    t2.join(timeout=15)
+
+    assert errors == [None, None], f"workers raised: {errors!r}"
+
+    winners = [r for r in results if r is not None]
+    losers = [r for r in results if r is None]
+    assert len(winners) == 1, (
+        f"expected exactly one claim to succeed, got results={results!r}. "
+        f"Two non-None ids means both callers inserted a pending row — "
+        f"the #1821 TOCTOU race."
+    )
+    assert len(losers) == 1
+    assert isinstance(winners[0], int) and winners[0] > 0
+
+
+def test_concurrent_distinct_tasks_both_succeed(pg_schema_pool) -> None:
+    """The advisory lock must not block claims for distinct tuples.
+
+    Two threads claim slots for different ``task_id`` values; both
+    should win because their advisory-lock keys differ. This guards
+    against an over-broad lock that would serialise unrelated
+    notifications and create a cross-task throughput cliff.
+    """
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_notifications import claim_notification_slot
+
+    barrier = threading.Barrier(2)
+    results: list[object] = [None, None]
+    errors: list[BaseException | None] = [None, None]
+
+    def _worker(slot: int, task_id: str) -> None:
+        try:
+            barrier.wait(timeout=10)
+            results[slot] = claim_notification_slot(
+                session_name="session-distinct",
+                task_id=task_id,
+                window_seconds=1800,
+                execution_version=0,
+                project="distinct",
+                message="kickoff",
+                pool=pg_schema_pool,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            errors[slot] = exc
+
+    t1 = threading.Thread(target=_worker, args=(0, "distinct:1"))
+    t2 = threading.Thread(target=_worker, args=(1, "distinct:2"))
+    t1.start()
+    t2.start()
+    t1.join(timeout=15)
+    t2.join(timeout=15)
+
+    assert errors == [None, None], f"workers raised: {errors!r}"
+    assert all(isinstance(r, int) and r > 0 for r in results), (
+        f"both distinct-task claims must succeed; got {results!r}"
+    )
+    assert results[0] != results[1]

--- a/tests/test_pg_pool_config.py
+++ b/tests/test_pg_pool_config.py
@@ -1,0 +1,410 @@
+"""Regression tests for config-threaded DSN resolution (#1819, #1754, #1796).
+
+The pg pool's :func:`resolve_dsn` is the load-bearing function that
+decides which DSN the process-wide pool opens against. Before the
+#1819 fix:
+
+* ``PgStore`` invoked ``get_rw_pool(None)`` / ``get_ro_pool(None)``,
+  so a configured ``[storage] url`` was stored on ``self._url`` but
+  silently ignored when opening pools.
+* ``JobQueue`` and the heartbeat boot migration applier hit the
+  pool with ``config=None``, falling back to the localhost default.
+* ``[storage.pg] dsn`` (parsed into :class:`PgStorageSettings`) was
+  documented in :class:`pollypm.models.PgStorageSettings` but never
+  consulted by :func:`resolve_dsn` (the #1754 / #1796 follow-up).
+
+These tests cover the pure-Python contract — they don't open a real
+pg pool. The fixes:
+
+1. :func:`resolve_dsn` reads ``config.storage.pg.dsn`` first, then
+   falls back to ``config.storage.url``, then to ``DEFAULT_DSN``.
+2. :class:`PgStore` threads its ``url`` through to the pool via a
+   minimal config shim.
+3. :func:`pollypm.jobs.cli.build_queue_for_config` passes the loaded
+   ``PollyPMConfig`` into the ``JobQueue`` constructor.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def _reload_pool_module():
+    import pollypm.storage.pg_pool as mod
+
+    importlib.reload(mod)
+    return mod
+
+
+# --------------------------------------------------------------------- #
+# resolve_dsn — reads ``[storage.pg].dsn`` (the #1754 / #1796 knob).
+# --------------------------------------------------------------------- #
+
+
+def test_resolve_dsn_reads_storage_pg_dsn(monkeypatch):
+    """``[storage.pg] dsn`` is honoured when ``[storage] url`` is empty."""
+    monkeypatch.delenv("POLLYPM_PG_DSN", raising=False)
+    mod = _reload_pool_module()
+
+    class _PgSection:
+        dsn = "postgresql://configured-host:5433/configured_db"
+
+    class _Storage:
+        url = ""
+        pg = _PgSection()
+
+    class _Config:
+        storage = _Storage()
+
+    assert (
+        mod.resolve_dsn(_Config())
+        == "postgresql://configured-host:5433/configured_db"
+    )
+
+
+def test_resolve_dsn_pg_section_wins_over_storage_url(monkeypatch):
+    """``[storage.pg] dsn`` takes priority over the legacy shared URL."""
+    monkeypatch.delenv("POLLYPM_PG_DSN", raising=False)
+    mod = _reload_pool_module()
+
+    class _PgSection:
+        dsn = "postgresql://pg-section-host:5432/db"
+
+    class _Storage:
+        url = "postgresql://legacy-url-host:5432/db"
+        pg = _PgSection()
+
+    class _Config:
+        storage = _Storage()
+
+    # The pg subsection is the dedicated knob — it wins so an operator
+    # who set both can rely on the more specific one.
+    assert mod.resolve_dsn(_Config()) == "postgresql://pg-section-host:5432/db"
+
+
+def test_resolve_dsn_falls_back_to_storage_url_when_pg_dsn_empty(monkeypatch):
+    """Empty ``[storage.pg] dsn`` does not block the legacy shared URL."""
+    monkeypatch.delenv("POLLYPM_PG_DSN", raising=False)
+    mod = _reload_pool_module()
+
+    class _PgSection:
+        dsn = ""
+
+    class _Storage:
+        url = "postgresql://legacy-host:5432/db"
+        pg = _PgSection()
+
+    class _Config:
+        storage = _Storage()
+
+    assert mod.resolve_dsn(_Config()) == "postgresql://legacy-host:5432/db"
+
+
+def test_resolve_dsn_env_still_wins_over_pg_section(monkeypatch):
+    """``POLLYPM_PG_DSN`` env override beats every config-level knob."""
+    monkeypatch.setenv("POLLYPM_PG_DSN", "postgresql://env-host:5432/envdb")
+    mod = _reload_pool_module()
+
+    class _PgSection:
+        dsn = "postgresql://pg-section-host:5432/db"
+
+    class _Storage:
+        url = "postgresql://legacy-url-host:5432/db"
+        pg = _PgSection()
+
+    class _Config:
+        storage = _Storage()
+
+    assert mod.resolve_dsn(_Config()) == "postgresql://env-host:5432/envdb"
+
+
+def test_resolve_dsn_ignores_sqlite_pg_section(monkeypatch):
+    """A non-pg DSN in ``[storage.pg] dsn`` is filtered out, not crashed."""
+    monkeypatch.delenv("POLLYPM_PG_DSN", raising=False)
+    mod = _reload_pool_module()
+
+    class _PgSection:
+        # Operator misconfiguration: sqlite path in the pg dsn slot.
+        dsn = "sqlite:///tmp/state.db"
+
+    class _Storage:
+        url = "postgresql://valid-pg-host:5432/db"
+        pg = _PgSection()
+
+    class _Config:
+        storage = _Storage()
+
+    # The sqlite-shaped value is dropped; the next-priority pg URL wins.
+    assert mod.resolve_dsn(_Config()) == "postgresql://valid-pg-host:5432/db"
+
+
+# --------------------------------------------------------------------- #
+# PgStore threads its url into the pool via the shim config.
+# --------------------------------------------------------------------- #
+
+
+def test_pg_store_threads_url_into_get_rw_pool(monkeypatch):
+    """``PgStore._rw_pool`` passes a config-shaped object carrying ``self._url``.
+
+    The shim's ``storage.pg.dsn`` matches the constructor URL so the
+    pool resolves to the configured DSN rather than localhost. The
+    test stubs out ``apply_migrations`` and ``get_rw_pool`` so no
+    real pg connection is made.
+    """
+    monkeypatch.delenv("POLLYPM_PG_DSN", raising=False)
+
+    captured: dict = {"configs": []}
+
+    def _fake_get_rw_pool(config):
+        captured["configs"].append(config)
+        return object()  # opaque pool; PgStore never uses it directly here
+
+    def _fake_apply_migrations(pool):
+        captured["migrations_applied"] = True
+
+    monkeypatch.setattr(
+        "pollypm.storage.pg_pool.get_rw_pool", _fake_get_rw_pool
+    )
+    monkeypatch.setattr(
+        "pollypm.storage.pg_migrations.apply_migrations",
+        _fake_apply_migrations,
+    )
+
+    from pollypm.store.backends.pg_store import PgStore
+
+    PgStore(url="postgresql://configured-host:5432/db")
+
+    assert captured["migrations_applied"] is True
+    assert captured["configs"], (
+        "PgStore did not call get_rw_pool — schema bootstrap path "
+        "diverged from expectations"
+    )
+    # The schema bootstrap call must have threaded a config carrying
+    # the constructor URL. Re-resolve through the real resolver to
+    # prove the threaded shim is wired correctly.
+    threaded_config = captured["configs"][0]
+    assert threaded_config is not None, (
+        "PgStore opened the pool with config=None — the #1819 regression "
+        "where the configured DSN was silently dropped"
+    )
+    # Confirm both fields are populated so resolve_dsn honours either.
+    assert (
+        threaded_config.storage.pg.dsn
+        == "postgresql://configured-host:5432/db"
+    )
+    assert (
+        threaded_config.storage.url
+        == "postgresql://configured-host:5432/db"
+    )
+
+    # And the resolver actually picks the threaded value:
+    mod = _reload_pool_module()
+    assert (
+        mod.resolve_dsn(threaded_config)
+        == "postgresql://configured-host:5432/db"
+    )
+
+
+def test_pg_store_skips_shim_for_sqlite_url(monkeypatch):
+    """A sqlite URL in PgStore constructor must not produce a pg shim.
+
+    PgStore against a sqlite URL is a misconfiguration; the registry
+    routes sqlite to ``SQLAlchemyStore``. If a test or third-party
+    caller does instantiate ``PgStore(url="sqlite:///...")``, the
+    shim must fall through to ``config=None`` so the env / default
+    path is honoured rather than handing the pool a sqlite DSN.
+    """
+    monkeypatch.delenv("POLLYPM_PG_DSN", raising=False)
+
+    captured: dict = {"configs": []}
+
+    def _fake_get_rw_pool(config):
+        captured["configs"].append(config)
+        return object()
+
+    def _fake_apply_migrations(pool):
+        return None
+
+    monkeypatch.setattr(
+        "pollypm.storage.pg_pool.get_rw_pool", _fake_get_rw_pool
+    )
+    monkeypatch.setattr(
+        "pollypm.storage.pg_migrations.apply_migrations",
+        _fake_apply_migrations,
+    )
+
+    from pollypm.store.backends.pg_store import PgStore
+
+    PgStore(url="sqlite:///tmp/state.db")
+
+    assert captured["configs"], "PgStore did not call get_rw_pool"
+    assert captured["configs"][0] is None, (
+        "PgStore should fall through to config=None for non-pg URLs"
+    )
+
+
+# --------------------------------------------------------------------- #
+# build_queue_for_config — threads config through to JobQueue.
+# --------------------------------------------------------------------- #
+
+
+def test_build_queue_for_config_threads_config_into_queue(tmp_path, monkeypatch):
+    """``build_queue_for_config`` must hand the loaded config to JobQueue.
+
+    The #1819 regression was that the CLI loaded the config, then
+    threw it away and built ``JobQueue(db_path=db_path)`` — silently
+    using the localhost default DSN regardless of the operator's
+    ``[storage.pg] dsn``.
+    """
+    monkeypatch.delenv("POLLYPM_PG_DSN", raising=False)
+
+    # Construct a real config file on disk so build_queue_for_config's
+    # ``load_config`` path runs untouched.
+    config_text = (
+        '[project]\n'
+        'name = "test-1819"\n'
+        'state_db = "state.db"\n'
+        '[storage]\n'
+        'backend = "postgres"\n'
+        '[storage.pg]\n'
+        'dsn = "postgresql://configured-host:5432/configured_db"\n'
+    )
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(config_text, encoding="utf-8")
+
+    captured: dict = {"queue_kwargs": []}
+
+    # Patch ``JobQueue`` at the cli import site to capture the kwargs
+    # without opening a real pg pool.
+    class _StubQueue:
+        def __init__(self, **kwargs):
+            captured["queue_kwargs"].append(kwargs)
+
+    import pollypm.jobs.cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "JobQueue", _StubQueue)
+
+    cli_mod.build_queue_for_config(config_path)
+
+    assert captured["queue_kwargs"], "JobQueue was never constructed"
+    kwargs = captured["queue_kwargs"][0]
+    assert "config" in kwargs and kwargs["config"] is not None, (
+        "build_queue_for_config did not pass config — the #1819 "
+        "regression where the loaded config was discarded"
+    )
+    cfg = kwargs["config"]
+    assert (
+        cfg.storage.pg.dsn
+        == "postgresql://configured-host:5432/configured_db"
+    )
+
+    # And the pool resolver picks up the threaded value end-to-end.
+    mod = _reload_pool_module()
+    assert (
+        mod.resolve_dsn(cfg)
+        == "postgresql://configured-host:5432/configured_db"
+    )
+
+
+# --------------------------------------------------------------------- #
+# HeartbeatRail.from_config threads config into the boot migration applier.
+# --------------------------------------------------------------------- #
+
+
+def test_heartbeat_rail_from_config_threads_config_to_get_rw_pool(
+    tmp_path, monkeypatch
+):
+    """The boot migration applier must use the loaded config, not None.
+
+    Before #1819, ``HeartbeatRail.from_plugin_host`` called
+    ``apply_migrations(get_rw_pool())`` with no config, so a
+    configured ``[storage.pg] dsn`` was silently ignored and the
+    migration ran against the localhost default. The fix threads
+    ``config`` through to both the pool resolution and the JobQueue
+    constructor.
+    """
+    monkeypatch.delenv("POLLYPM_PG_DSN", raising=False)
+
+    config_text = (
+        '[project]\n'
+        'name = "test-1819-boot"\n'
+        'state_db = "state.db"\n'
+        '[storage]\n'
+        'backend = "postgres"\n'
+        '[storage.pg]\n'
+        'dsn = "postgresql://boot-configured-host:5432/db"\n'
+    )
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(config_text, encoding="utf-8")
+
+    captured: dict = {
+        "pool_configs": [],
+        "queue_kwargs": [],
+    }
+
+    def _fake_get_rw_pool(config=None):
+        captured["pool_configs"].append(config)
+        return object()
+
+    def _fake_apply_migrations(pool):
+        return None
+
+    monkeypatch.setattr(
+        "pollypm.storage.pg_pool.get_rw_pool", _fake_get_rw_pool
+    )
+    monkeypatch.setattr(
+        "pollypm.storage.pg_migrations.apply_migrations",
+        _fake_apply_migrations,
+    )
+
+    import pollypm.heartbeat.boot as boot_mod
+
+    class _StubQueue:
+        def __init__(self, **kwargs):
+            captured["queue_kwargs"].append(kwargs)
+
+    class _StubPool:
+        def __init__(self, *args, **kwargs):
+            self.is_running = False
+
+    class _StubHeartbeat:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(boot_mod, "JobQueue", _StubQueue)
+    monkeypatch.setattr(boot_mod, "JobWorkerPool", _StubPool)
+
+    class _StubPluginHost:
+        def build_roster(self):
+            return object()
+
+        def job_handler_registry(self):
+            return object()
+
+        def initialize_plugins(self, **kwargs):
+            return None
+
+    # Avoid touching the real Heartbeat class — patch the import name
+    # used inside ``from_plugin_host``.
+    import pollypm.heartbeat as hb_pkg
+    monkeypatch.setattr(hb_pkg, "Heartbeat", _StubHeartbeat)
+
+    boot_mod.HeartbeatRail.from_config(config_path, _StubPluginHost())
+
+    assert captured["pool_configs"], "get_rw_pool was never called"
+    threaded_config = captured["pool_configs"][0]
+    assert threaded_config is not None, (
+        "HeartbeatRail.from_plugin_host opened the migration pool with "
+        "config=None — the #1819 regression"
+    )
+    assert (
+        threaded_config.storage.pg.dsn
+        == "postgresql://boot-configured-host:5432/db"
+    )
+
+    assert captured["queue_kwargs"], "JobQueue was never constructed"
+    queue_kwargs = captured["queue_kwargs"][0]
+    assert queue_kwargs.get("config") is not None, (
+        "JobQueue did not receive the threaded config — the #1819 "
+        "regression where the queue silently used localhost"
+    )


### PR DESCRIPTION
## Summary

Three correctness regressions in the recently-merged pg port, bundled into one PR.

### #1822 — orphaned-claim recovery deletes valid queued jobs

`JobQueue.recover_orphaned_claims()` was deleting queued rows unconditionally — two valid queued rows sharing a handler (different payload/dedupe_key) would lose all-but-the-newest on next rail boot, even when no orphaned claim existed.

**Fix:** scope the prune to (a) handlers actually recovered by *this* invocation (captured before the status UPDATE) AND (b) `dedupe_key IS NULL` rows only. Distinct payloads / dedupe keys are now preserved; the existing legacy-cadence collapse path still works for the original #1071 NULL-dedupe-key backlog shape.

### #1821 — claim_notification_slot is not atomic when no row exists

`SELECT ... FOR UPDATE` locks only rows that exist. On the cold path (first ping for a task) two concurrent sweepers both saw an empty result and both inserted `pending` rows, defeating the #952 dedupe contract.

**Fix:** gate the check+insert with a transaction-scoped `pg_advisory_xact_lock` keyed on a SHA-1 hash of `(session, task, execution_version, dedupe_scope)`. The second caller blocks until the first commits, then sees the just-inserted row and returns `None`. The `_xact` variant auto-releases on commit/rollback so no lock can leak across connection reuse.

### #1819 — PgStore / JobQueue / boot ignore loaded config when opening pools

`PgStore._rw_pool()` called `get_rw_pool(None)`. `build_queue_for_config` loaded config then discarded it. `HeartbeatRail.from_plugin_host` ran `apply_migrations(get_rw_pool())` with no config. Operators with `[storage.pg] dsn = "postgresql://..."` silently hit `postgresql://localhost:5432/pollypm` instead.

**Fix (closes #1754, #1796 as well):**
- `resolve_dsn` now reads `config.storage.pg.dsn` first, then falls back to `config.storage.url`, then to `DEFAULT_DSN`. `POLLYPM_PG_DSN` still wins.
- `PgStore` threads its constructor URL via a minimal config shim passed to `get_rw_pool` / `get_ro_pool`.
- `build_queue_for_config` and `HeartbeatRail.from_config` pass the loaded `PollyPMConfig` into `JobQueue(config=...)` and into the boot migration applier.

## Test plan

- [x] `tests/test_job_queue.py`: 3 new regression tests for #1822 (no-orphans-no-prune, distinct-dedupe-keys-preserved, distinct-payloads-preserved). 30/30 pass.
- [x] `tests/test_pg_notifications_race.py` (new): concurrent `claim_notification_slot` using `threading.Barrier` + sibling threads asserts exactly one winner; second test confirms distinct tuples don't block each other. 2/2 pass.
- [x] `tests/test_pg_pool_config.py` (new): 9 tests covering DSN-resolution priority for `[storage.pg].dsn`, env-override precedence, sqlite-DSN guard, plus config-threading through `PgStore`, `build_queue_for_config`, and `HeartbeatRail.from_config`. All pass.
- [x] Sanity: `test_pg_store`, `test_pg_storage_facades`, `test_pg_work_service*`, `test_jobs_cli`, `test_audit_watchdog_liveness_probe`, `test_rail_ticker` all pass — no behavioural change to existing callers.

Closes #1822, #1821, #1819, #1796, #1754, #1737.

Generated with [Claude Code](https://claude.com/claude-code)