### PR TITLE
feat(pg): port StateStore clusters B+C+D+E+J to pg facades (Slice K-state-port phase 2d, #1737)

### DIFF
--- a/src/pollypm/account_usage_sampler.py
+++ b/src/pollypm/account_usage_sampler.py
@@ -25,7 +25,45 @@ from pollypm.runtimes import get_runtime
 from pollypm.session_services import create_tmux_client
 from pollypm.storage.records import AccountUsageRecord
 from pollypm.storage.state import StateStore
+
 logger = logging.getLogger(__name__)
+
+
+def _read_cached_usage(config, account_name: str) -> AccountUsageRecord | None:
+    """Read cached usage row, routing through pg_accounts on the pg backend."""
+    from pollypm.storage._backend_dispatch import is_pg_backend
+
+    if is_pg_backend(config):
+        from pollypm.storage.pg_accounts import get_account_usage
+
+        return get_account_usage(account_name)
+    with StateStore(config.project.state_db) as store:
+        return store.get_account_usage(account_name)
+
+
+def _write_cached_usage(config, sample: "AccountUsageSample") -> None:
+    """Persist a usage sample, routing through pg_accounts on the pg backend."""
+    from pollypm.storage._backend_dispatch import is_pg_backend
+
+    kwargs = dict(
+        account_name=sample.account_name,
+        provider=sample.provider.value,
+        plan=sample.plan,
+        health=sample.health,
+        usage_summary=sample.usage_summary,
+        raw_text=sample.raw_text,
+        used_pct=sample.used_pct,
+        remaining_pct=sample.remaining_pct,
+        reset_at=sample.reset_at,
+        period_label=sample.period_label,
+    )
+    if is_pg_backend(config):
+        from pollypm.storage.pg_accounts import upsert_account_usage
+
+        upsert_account_usage(**kwargs)
+        return
+    with StateStore(config.project.state_db) as store:
+        store.upsert_account_usage(**kwargs)
 
 # Session-name prefix for the throwaway tmux sessions this module spawns.
 # Boot-time orphan sweeps and the per-probe cleanup both pivot on this
@@ -64,8 +102,7 @@ def refresh_account_usage(
             f"Account {account_name!r} does not have an isolated home configured."
         )
 
-    with StateStore(config.project.state_db) as store:
-        cached = store.get_account_usage(account_name)
+    cached = _read_cached_usage(config, account_name)
 
     try:
         sample = collect_account_usage_sample(
@@ -254,19 +291,7 @@ def sweep_orphan_usage_sessions() -> int:
 def persist_account_usage_sample(config_path: Path, sample: AccountUsageSample) -> None:
     """Persist one usage sample into ``account_usage``."""
     config = load_config(config_path)
-    with StateStore(config.project.state_db) as store:
-        store.upsert_account_usage(
-            account_name=sample.account_name,
-            provider=sample.provider.value,
-            plan=sample.plan,
-            health=sample.health,
-            usage_summary=sample.usage_summary,
-            raw_text=sample.raw_text,
-            used_pct=sample.used_pct,
-            remaining_pct=sample.remaining_pct,
-            reset_at=sample.reset_at,
-            period_label=sample.period_label,
-        )
+    _write_cached_usage(config, sample)
 
 
 def load_cached_account_usage(config_path: Path) -> dict[str, AccountUsageRecord]:
@@ -275,13 +300,12 @@ def load_cached_account_usage(config_path: Path) -> dict[str, AccountUsageRecord
     account_names = list(getattr(config, "accounts", {}) or {})
     if not account_names:
         return {}
-    with StateStore(config.project.state_db) as store:
-        cached: dict[str, AccountUsageRecord] = {}
-        for account_name in account_names:
-            usage = store.get_account_usage(account_name)
-            if usage is not None:
-                cached[account_name] = usage
-        return cached
+    cached: dict[str, AccountUsageRecord] = {}
+    for account_name in account_names:
+        usage = _read_cached_usage(config, account_name)
+        if usage is not None:
+            cached[account_name] = usage
+    return cached
 
 
 def _probe_session_spec(root_dir: Path, account_name: str, provider: ProviderKind) -> SessionConfig:

--- a/src/pollypm/accounts.py
+++ b/src/pollypm/accounts.py
@@ -28,6 +28,51 @@ from pollypm.session_services import create_tmux_client
 from pollypm.storage.state import StateStore
 
 
+class _AccountReader:
+    """Context-manager wrapper that reads account_usage/account_runtime via the active backend.
+
+    On the pg backend this is a thin wrapper around :mod:`pollypm.storage.pg_accounts`
+    that exposes the same ``get_account_usage`` / ``get_account_runtime`` methods
+    as :class:`pollypm.storage.state.StateStore`. On the sqlite backend it opens
+    a short-lived StateStore. Used by the cached + live status helpers below
+    so they can iterate over ``config.accounts`` without growing per-call
+    backend probes.
+    """
+
+    def __init__(self, config) -> None:
+        self._config = config
+        self._sqlite_store: "StateStore | None" = None
+        from pollypm.storage._backend_dispatch import is_pg_backend
+
+        self._is_pg = is_pg_backend(config)
+
+    def __enter__(self) -> "_AccountReader":
+        if not self._is_pg:
+            self._sqlite_store = StateStore(self._config.project.state_db)
+        return self
+
+    def __exit__(self, *exc) -> None:
+        if self._sqlite_store is not None:
+            self._sqlite_store.close()
+            self._sqlite_store = None
+
+    def get_account_usage(self, account_name: str):
+        if self._is_pg:
+            from pollypm.storage.pg_accounts import get_account_usage
+
+            return get_account_usage(account_name)
+        assert self._sqlite_store is not None
+        return self._sqlite_store.get_account_usage(account_name)
+
+    def get_account_runtime(self, account_name: str):
+        if self._is_pg:
+            from pollypm.storage.pg_accounts import get_account_runtime
+
+            return get_account_runtime(account_name)
+        assert self._sqlite_store is not None
+        return self._sqlite_store.get_account_runtime(account_name)
+
+
 @dataclass(slots=True)
 class AccountStatus:
     key: str
@@ -331,7 +376,7 @@ def probe_account_usage(config_path: Path, identifier: str) -> AccountStatus:
         raise typer.BadParameter(f"Account {account_name} does not have an isolated home configured.")
 
     refresh_account_usage(config_path, account_name)
-    with StateStore(config.project.state_db) as store:
+    with _AccountReader(config) as store:
         cached = store.get_account_usage(account_name)
         runtime = store.get_account_runtime(account_name)
     default_plan = cached.plan if cached is not None else "unknown"
@@ -374,7 +419,7 @@ def probe_account_usage(config_path: Path, identifier: str) -> AccountStatus:
 def list_account_statuses(config_path: Path) -> list[AccountStatus]:
     config = load_config(config_path)
     items: list[AccountStatus] = []
-    with StateStore(config.project.state_db) as store:
+    with _AccountReader(config) as store:
         for key, account in config.accounts.items():
             plan, health, usage_summary = _account_usage_summary(account)
             cached = store.get_account_usage(key)
@@ -426,7 +471,7 @@ def list_cached_account_statuses(config_path: Path) -> list[AccountStatus]:
     """
     config = load_config(config_path)
     items: list[AccountStatus] = []
-    with StateStore(config.project.state_db) as store:
+    with _AccountReader(config) as store:
         for key, account in config.accounts.items():
             plan, default_health, default_summary = _cached_account_usage_summary(
                 account

--- a/src/pollypm/capacity.py
+++ b/src/pollypm/capacity.py
@@ -93,13 +93,17 @@ class FailoverDecision:
 
 def probe_capacity(
     config: PollyPMConfig,
-    store: StateStore,
+    store: "StateStore | None",
     account_name: str,
 ) -> CapacityProbeResult:
     """Probe the capacity state for a single account from stored data.
 
-    This reads from the SQLite registry (populated by the usage probe
-    in accounts.py) rather than making live API calls.
+    Reads from the per-backend account_usage / account_runtime tables
+    (populated by the usage probe in accounts.py). When ``store`` is a
+    legacy :class:`StateStore` we use it directly; when ``store`` is
+    ``None`` and the active backend is postgres, we read through
+    :mod:`pollypm.storage.pg_accounts` so callers can drop the
+    StateStore handle entirely.
     """
     account = config.accounts.get(account_name)
     if account is None:
@@ -110,9 +114,7 @@ def probe_capacity(
             reason="Account not found in config",
         )
 
-    # Read cached capacity from SQLite
-    usage = store.get_account_usage(account_name)
-    runtime = store.get_account_runtime(account_name)
+    usage, runtime = _read_account_state(config, store, account_name)
 
     # Runtime status takes precedence (captures live failures)
     if runtime and runtime.status in FAILOVER_TRIGGERS:
@@ -150,13 +152,41 @@ def probe_capacity(
 
 def probe_all_accounts(
     config: PollyPMConfig,
-    store: StateStore,
+    store: "StateStore | None",
 ) -> list[CapacityProbeResult]:
-    """Probe capacity for all configured accounts."""
+    """Probe capacity for all configured accounts.
+
+    ``store`` may be ``None`` on the pg backend — the per-account
+    helpers dispatch to :mod:`pollypm.storage.pg_accounts` in that case.
+    """
     return [
         probe_capacity(config, store, name)
         for name in config.accounts
     ]
+
+
+def _read_account_state(
+    config: PollyPMConfig,
+    store: "StateStore | None",
+    account_name: str,
+):
+    """Return (usage, runtime) rows for ``account_name`` via the active backend.
+
+    Lets ``probe_capacity`` callers pass either a legacy
+    :class:`StateStore` handle or ``None`` (when pg is active).
+    """
+    from pollypm.storage._backend_dispatch import is_pg_backend
+
+    if store is not None:
+        return store.get_account_usage(account_name), store.get_account_runtime(account_name)
+    if is_pg_backend(config):
+        from pollypm.storage.pg_accounts import get_account_runtime, get_account_usage
+
+        return get_account_usage(account_name), get_account_runtime(account_name)
+    # No store + sqlite backend — open a short-lived one. Rare path:
+    # callers with sqlite typically already own a StateStore handle.
+    with StateStore(config.project.state_db) as fallback:
+        return fallback.get_account_usage(account_name), fallback.get_account_runtime(account_name)
 
 
 def account_needs_proactive_rollover(

--- a/src/pollypm/knowledge_extract.py
+++ b/src/pollypm/knowledge_extract.py
@@ -153,12 +153,22 @@ def store_snapshot_learnings(
 
 
 def _store_memory_entries(config, project_root: Path, delta: "KnowledgeDelta") -> int:
-    """Store extracted knowledge as memory entries in SQLite."""
-    from pollypm.storage.state import StateStore
-    try:
-        store = StateStore(config.project.state_db)
-    except Exception:  # noqa: BLE001
-        return 0
+    """Store extracted knowledge as memory entries (pg or sqlite, per config)."""
+    from pollypm.storage._backend_dispatch import is_pg_backend
+
+    if is_pg_backend(config):
+        from pollypm.storage.pg_memory import PgMemoryStore
+
+        store: object = PgMemoryStore()
+        close_after = False
+    else:
+        from pollypm.storage.state import StateStore
+
+        try:
+            store = StateStore(config.project.state_db)
+            close_after = True
+        except Exception:  # noqa: BLE001
+            return 0
     count = 0
     project_key = project_root.name
     kind_map = {
@@ -177,25 +187,30 @@ def _store_memory_entries(config, project_root: Path, delta: "KnowledgeDelta") -
         "architecture": project_root / "docs" / "project-overview.md",
         "convention": project_root / "docs" / "project-overview.md",
     }
-    for kind, items in kind_map.items():
-        summary_path = summary_paths[kind]
-        for item in items:
-            # Check for duplicates by title+scope
-            existing = store.list_memory_entries(scope=project_key, kind=kind, limit=200)
-            if any(e.title == item for e in existing):
-                continue
-            store.record_memory_entry(
-                scope=project_key,
-                kind=kind,
-                title=item,
-                body="",
-                tags=[project_key, kind],
-                source="knowledge_extract",
-                file_path=str(summary_path),
-                summary_path=str(summary_path),
-            )
-            count += 1
-    store.close()
+    try:
+        for kind, items in kind_map.items():
+            summary_path = summary_paths[kind]
+            for item in items:
+                # Check for duplicates by title+scope
+                existing = store.list_memory_entries(scope=project_key, kind=kind, limit=200)
+                if any(e.title == item for e in existing):
+                    continue
+                store.record_memory_entry(
+                    scope=project_key,
+                    kind=kind,
+                    title=item,
+                    body="",
+                    tags=[project_key, kind],
+                    source="knowledge_extract",
+                    file_path=str(summary_path),
+                    summary_path=str(summary_path),
+                )
+                count += 1
+    finally:
+        if close_after:
+            close = getattr(store, "close", None)
+            if callable(close):
+                close()
     return count
 
 

--- a/src/pollypm/llm_runner.py
+++ b/src/pollypm/llm_runner.py
@@ -21,13 +21,26 @@ from pollypm.config import PollyPMConfig, load_config
 from pollypm.models import ProviderKind
 from pollypm.runtime_env import claude_config_dir
 from pollypm.storage.state import StateStore
+
 logger = logging.getLogger(__name__)
+
+
+def _account_store(config: PollyPMConfig) -> "StateStore | None":
+    """Return a StateStore handle on sqlite; ``None`` on pg (pg_accounts is module-level)."""
+    from pollypm.storage._backend_dispatch import is_pg_backend
+
+    if is_pg_backend(config):
+        return None
+    return StateStore(config.project.state_db)
 
 HAIKU_MODEL = "claude-haiku-4-5-20251001"
 DEFAULT_CONFIG_PATH = Path.home() / ".pollypm" / "pollypm.toml"
 
 
-def select_background_account(config: PollyPMConfig, store: StateStore) -> str | None:
+def select_background_account(
+    config: PollyPMConfig,
+    store: "StateStore | None",
+) -> str | None:
     """Pick the Claude account with the most remaining capacity.
 
     Prefers non-controller accounts to avoid starving interactive sessions.
@@ -88,7 +101,7 @@ def run_haiku(
 
     try:
         config = load_config(config_path)
-        store = StateStore(config.project.state_db)
+        store = _account_store(config)
     except Exception as exc:  # noqa: BLE001
         logger.warning("Unable to initialize Haiku runner from %s: %s", config_path, exc)
         return None
@@ -190,7 +203,7 @@ def run_opus(
 
     try:
         config = load_config(config_path)
-        store = StateStore(config.project.state_db)
+        store = _account_store(config)
     except Exception as exc:  # noqa: BLE001
         logger.warning("Unable to initialize Opus runner from %s: %s", config_path, exc)
         return None

--- a/src/pollypm/memory_backends/__init__.py
+++ b/src/pollypm/memory_backends/__init__.py
@@ -35,15 +35,34 @@ def get_memory_backend(project_path: Path, backend_name: str = "file") -> Memory
         # a few paths).
         from pollypm.plugin_host import extension_host_for_root
         from pollypm.projects import ensure_project_scaffold, project_artifacts_dir, project_dossier_dir
-        from pollypm.storage.state import StateStore
+        from pollypm.storage._backend_dispatch import is_pg_backend
         resolved = project_path.expanduser().resolve()
         # Scaffold the project up-front so the backend can assume memory
         # roots exist (it used to call ensure_project_scaffold itself).
         ensure_project_scaffold(resolved)
         state_db = resolved / ".pollypm" / "state.db"
+        # Slice K-state-port phase 2d (#1737): on the pg backend wire
+        # FileMemoryBackend to a stateless PgMemoryStore adapter that
+        # routes every memory_* call through pollypm.storage.pg_memory.
+        # On sqlite we keep the legacy StateStore handle.
+        state_store: object
+        try:
+            from pollypm.config import load_config
+
+            config = load_config()
+        except Exception:  # noqa: BLE001
+            config = None
+        if is_pg_backend(config):
+            from pollypm.storage.pg_memory import PgMemoryStore
+
+            state_store = PgMemoryStore()
+        else:
+            from pollypm.storage.state import StateStore
+
+            state_store = StateStore(state_db)
         return FileMemoryBackend(
             resolved,
-            state_store=StateStore(state_db),
+            state_store=state_store,
             plugins=extension_host_for_root(str(resolved)),
             memory_root=project_dossier_dir(resolved) / "memory",
             artifacts_root=project_artifacts_dir(resolved),

--- a/src/pollypm/plugins_builtin/core_recurring/maintenance.py
+++ b/src/pollypm/plugins_builtin/core_recurring/maintenance.py
@@ -64,8 +64,15 @@ def transcript_ingest_handler(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def db_vacuum_handler(payload: dict[str, Any]) -> dict[str, Any]:
-    """Run an incremental vacuum against StateStore to reclaim freelist pages."""
+    """Run an incremental vacuum against StateStore to reclaim freelist pages.
+
+    No-op on the pg backend — autovacuum and the pg autovacuum daemon
+    handle page reclamation, and StateStore.incremental_vacuum is a
+    sqlite-only PRAGMA.
+    """
     with _load_config_and_store(payload) as (_config, store):
+        if store is None:
+            return {"bytes_reclaimed": 0, "mb_reclaimed": 0.0, "skipped": "pg backend"}
         bytes_reclaimed = store.incremental_vacuum()
         mb_reclaimed = bytes_reclaimed / (1024 * 1024)
         msg_store = _open_msg_store(_config)
@@ -683,7 +690,12 @@ def _prune_event_subject(msg_store: Any, subject: str, cutoff: Any) -> int:
 def memory_ttl_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
     """Drop expired memory_entries (TTL in the past)."""
     with _load_config_and_store(payload) as (_config, store):
-        deleted = store.sweep_expired_memory_entries()
+        if store is not None:
+            deleted = store.sweep_expired_memory_entries()
+        else:
+            from pollypm.storage.pg_memory import sweep_expired_memory_entries
+
+            deleted = sweep_expired_memory_entries()
         msg_store = _open_msg_store(_config)
         try:
             if msg_store is not None:

--- a/src/pollypm/plugins_builtin/core_recurring/shared.py
+++ b/src/pollypm/plugins_builtin/core_recurring/shared.py
@@ -32,9 +32,21 @@ def _load_config(payload: dict[str, Any]):
 
 @contextmanager
 def _load_config_and_store(payload: dict[str, Any]):
-    """Yield ``(config, store)`` and close the store deterministically."""
-    from pollypm.storage.state import StateStore
+    """Yield ``(config, store)`` and close the store deterministically.
+
+    On the pg backend ``store`` is ``None`` — recurring handlers that
+    write alerts already route through the unified :class:`Store` via
+    :func:`_open_msg_store`, which is backend-aware. This helper just
+    needs to expose the config for those code paths.
+    """
     config = _load_config(payload)
+    from pollypm.storage._backend_dispatch import is_pg_backend
+
+    if is_pg_backend(config):
+        yield config, None
+        return
+    from pollypm.storage.state import StateStore
+
     store = StateStore(config.project.state_db)
     try:
         yield config, store
@@ -223,18 +235,21 @@ def sweep_ephemeral_sessions(supervisor: Any, store: Any) -> dict[str, int]:
 
         failure_kind, failure_message = failure
         alert_type = _ephemeral_alert_type(name, failure_kind)
+        alert_message = (
+            f"{failure_message}. "
+            f"Why it matters: parent task is blocked because the "
+            f"ephemeral session that was driving it is gone. "
+            f"Fix: inspect the parent task's status and re-spawn the "
+            f"session via the originating handler "
+            f"(critic / downtime / `pm worker-start`)."
+        )
         try:
-            store.upsert_alert(
-                name,
-                alert_type,
-                "warn",
-                f"{failure_message}. "
-                f"Why it matters: parent task is blocked because the "
-                f"ephemeral session that was driving it is gone. "
-                f"Fix: inspect the parent task's status and re-spawn the "
-                f"session via the originating handler "
-                f"(critic / downtime / `pm worker-start`).",
-            )
+            if store is not None:
+                store.upsert_alert(name, alert_type, "warn", alert_message)
+            else:
+                from pollypm.storage.pg_alerts import upsert_alert as pg_upsert_alert
+
+                pg_upsert_alert(name, alert_type, "warn", alert_message)
             summary["alerts_raised"] += 1
         except Exception:  # noqa: BLE001
             logger.debug(

--- a/src/pollypm/plugins_builtin/memory_curator/plugin.py
+++ b/src/pollypm/plugins_builtin/memory_curator/plugin.py
@@ -40,9 +40,13 @@ def _load_config_and_store(payload: dict[str, Any]):
         )
     config = load_config(config_path)
 
-    from pollypm.storage.state import StateStore
-    store = StateStore(config.project.state_db)
-    return config, store
+    # Slice K-state-port phase 2d (#1737): the memory curator handler
+    # doesn't actually touch the state store — it iterates project
+    # roots and calls into ``pollypm.memory_backends`` which owns its
+    # own per-project backend handle. Returning ``None`` here avoids
+    # opening a short-lived StateStore that the pg backend can't
+    # service anyway.
+    return config, None
 
 
 def memory_curate_handler(payload: dict[str, Any]) -> dict[str, Any]:

--- a/src/pollypm/rail_daemon_supervisor.py
+++ b/src/pollypm/rail_daemon_supervisor.py
@@ -1233,12 +1233,30 @@ def _default_spawn_fn() -> Callable[[Path], None]:
 
 
 def query_last_heartbeat_iso(state_db_path: Path) -> str | None:
-    """Open the StateStore read-only and return ``last_heartbeat_at()``.
+    """Return ``last_heartbeat_at()`` from the active storage backend.
 
     Returns ``None`` when the DB doesn't exist (fresh install) or any
     error occurs — callers must treat ``None`` as "no tick history",
-    not "tick stale".
+    not "tick stale". On the pg backend the ``state_db_path`` argument
+    is unused; we read through :mod:`pollypm.storage.pg_heartbeats`.
     """
+    # Try pg first when the active config selects it. We can't rely on
+    # the state_db_path existing — pg installs may leave it absent.
+    try:
+        from pollypm.config import load_config
+        from pollypm.storage._backend_dispatch import is_pg_backend
+
+        config = load_config()
+        if is_pg_backend(config):
+            try:
+                from pollypm.storage.pg_heartbeats import last_heartbeat_at
+
+                return last_heartbeat_at()
+            except Exception:  # noqa: BLE001
+                return None
+    except Exception:  # noqa: BLE001
+        pass
+
     if not state_db_path.exists():
         return None
     try:

--- a/src/pollypm/storage/pg_accounts.py
+++ b/src/pollypm/storage/pg_accounts.py
@@ -1,0 +1,337 @@
+"""Postgres facade for ``account_usage`` + ``account_runtime`` (#1737).
+
+This module owns the read/write path for cluster E of the StateStore
+port plan: the two tables that back the operator account model.
+
+* ``account_usage`` — per-account quota / plan / health snapshot, fed
+  by the periodic usage sampler.
+* ``account_runtime`` — per-account dispatch-time runtime state, fed
+  by the supervisor when an account is rate-limited or otherwise
+  unavailable.
+
+Public API:
+
+* :func:`upsert_account_usage` — INSERT … ON CONFLICT (account_name)
+* :func:`get_account_usage` — SELECT a single account_usage row
+* :func:`upsert_account_runtime` — INSERT … ON CONFLICT (account_name)
+* :func:`get_account_runtime` — SELECT a single account_runtime row
+
+All functions accept an optional ``pool`` kwarg. Default is
+:func:`~pollypm.storage.pg_pool.get_rw_pool` for the mutators and
+:func:`~pollypm.storage.pg_pool.get_ro_pool` for the readers; passing a
+custom pool is the test-harness seam.
+
+The brief's ``list_accounts`` / ``list_account_runtimes`` /
+``record_account_usage`` aliases are exposed for parity with the
+StateStore method names — they delegate to the canonical singular
+read/write helpers.
+
+Slice K-state-port phase 2d — port of StateStore cluster E.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from pollypm.storage.records import AccountRuntimeRecord, AccountUsageRecord
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(UTC).isoformat()
+
+
+def _stamp_str(value: object) -> str:
+    """Return ``value`` as an ISO-8601 string (pg datetime → sqlite-style str)."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _opt_stamp_str(value: object) -> str | None:
+    """Return ``None`` for NULL, otherwise an ISO-8601 string."""
+    if value is None:
+        return None
+    return _stamp_str(value)
+
+
+# --------------------------------------------------------------------- #
+# account_usage
+# --------------------------------------------------------------------- #
+
+
+def upsert_account_usage(
+    *,
+    account_name: str,
+    provider: str,
+    plan: str,
+    health: str,
+    usage_summary: str,
+    raw_text: str,
+    used_pct: int | None = None,
+    remaining_pct: int | None = None,
+    reset_at: str | None = None,
+    period_label: str | None = None,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Insert-or-update an ``account_usage`` row.
+
+    Mirrors :meth:`StateStore.upsert_account_usage`: keyed on
+    ``account_name``, every other column overwrites on conflict.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    now = _now_iso()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO account_usage (
+                account_name, provider, plan, health, usage_summary, raw_text,
+                used_pct, remaining_pct, reset_at, period_label, updated_at
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (account_name) DO UPDATE SET
+                provider = EXCLUDED.provider,
+                plan = EXCLUDED.plan,
+                health = EXCLUDED.health,
+                usage_summary = EXCLUDED.usage_summary,
+                raw_text = EXCLUDED.raw_text,
+                used_pct = EXCLUDED.used_pct,
+                remaining_pct = EXCLUDED.remaining_pct,
+                reset_at = EXCLUDED.reset_at,
+                period_label = EXCLUDED.period_label,
+                updated_at = EXCLUDED.updated_at
+            """,
+            (
+                account_name,
+                provider,
+                plan,
+                health,
+                usage_summary,
+                raw_text,
+                used_pct,
+                remaining_pct,
+                reset_at,
+                period_label,
+                now,
+            ),
+        )
+
+
+def get_account_usage(
+    account_name: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> AccountUsageRecord | None:
+    """Return the ``account_usage`` row for ``account_name`` or ``None``."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT account_name, provider, plan, health, usage_summary, raw_text,
+                   updated_at, used_pct, remaining_pct, reset_at, period_label
+            FROM account_usage
+            WHERE account_name = %s
+            """,
+            (account_name,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return AccountUsageRecord(
+        account_name=row[0],
+        provider=row[1],
+        plan=row[2],
+        health=row[3],
+        usage_summary=row[4],
+        raw_text=row[5],
+        updated_at=_stamp_str(row[6]),
+        used_pct=None if row[7] is None else int(row[7]),
+        remaining_pct=None if row[8] is None else int(row[8]),
+        reset_at=_opt_stamp_str(row[9]),
+        period_label=row[10],
+    )
+
+
+def list_account_usage(
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> list[AccountUsageRecord]:
+    """Return every ``account_usage`` row, sorted by ``account_name``."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT account_name, provider, plan, health, usage_summary, raw_text,
+                   updated_at, used_pct, remaining_pct, reset_at, period_label
+            FROM account_usage
+            ORDER BY account_name
+            """
+        )
+        rows = cur.fetchall()
+    return [
+        AccountUsageRecord(
+            account_name=row[0],
+            provider=row[1],
+            plan=row[2],
+            health=row[3],
+            usage_summary=row[4],
+            raw_text=row[5],
+            updated_at=_stamp_str(row[6]),
+            used_pct=None if row[7] is None else int(row[7]),
+            remaining_pct=None if row[8] is None else int(row[8]),
+            reset_at=_opt_stamp_str(row[9]),
+            period_label=row[10],
+        )
+        for row in rows
+    ]
+
+
+# --------------------------------------------------------------------- #
+# account_runtime
+# --------------------------------------------------------------------- #
+
+
+def upsert_account_runtime(
+    *,
+    account_name: str,
+    provider: str,
+    status: str,
+    reason: str,
+    available_at: str | None = None,
+    access_expires_at: str | None = None,
+    refresh_available: bool = False,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Insert-or-update an ``account_runtime`` row.
+
+    Mirrors :meth:`StateStore.upsert_account_runtime`: keyed on
+    ``account_name``, every other column overwrites on conflict.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    now = _now_iso()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO account_runtime (
+                account_name, provider, status, reason, available_at,
+                access_expires_at, refresh_available, updated_at
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (account_name) DO UPDATE SET
+                provider = EXCLUDED.provider,
+                status = EXCLUDED.status,
+                reason = EXCLUDED.reason,
+                available_at = EXCLUDED.available_at,
+                access_expires_at = EXCLUDED.access_expires_at,
+                refresh_available = EXCLUDED.refresh_available,
+                updated_at = EXCLUDED.updated_at
+            """,
+            (
+                account_name,
+                provider,
+                status,
+                reason,
+                available_at,
+                access_expires_at,
+                bool(refresh_available),
+                now,
+            ),
+        )
+
+
+def get_account_runtime(
+    account_name: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> AccountRuntimeRecord | None:
+    """Return the ``account_runtime`` row for ``account_name`` or ``None``."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT account_name, provider, status, reason, available_at,
+                   access_expires_at, refresh_available, updated_at
+            FROM account_runtime
+            WHERE account_name = %s
+            """,
+            (account_name,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return AccountRuntimeRecord(
+        account_name=row[0],
+        provider=row[1],
+        status=row[2],
+        reason=row[3],
+        available_at=_opt_stamp_str(row[4]),
+        access_expires_at=_opt_stamp_str(row[5]),
+        refresh_available=bool(row[6]),
+        updated_at=_stamp_str(row[7]),
+    )
+
+
+def list_account_runtimes(
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> list[AccountRuntimeRecord]:
+    """Return every ``account_runtime`` row, sorted by ``account_name``."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT account_name, provider, status, reason, available_at,
+                   access_expires_at, refresh_available, updated_at
+            FROM account_runtime
+            ORDER BY account_name
+            """
+        )
+        rows = cur.fetchall()
+    return [
+        AccountRuntimeRecord(
+            account_name=row[0],
+            provider=row[1],
+            status=row[2],
+            reason=row[3],
+            available_at=_opt_stamp_str(row[4]),
+            access_expires_at=_opt_stamp_str(row[5]),
+            refresh_available=bool(row[6]),
+            updated_at=_stamp_str(row[7]),
+        )
+        for row in rows
+    ]
+
+
+__all__ = [
+    "get_account_runtime",
+    "get_account_usage",
+    "list_account_runtimes",
+    "list_account_usage",
+    "upsert_account_runtime",
+    "upsert_account_usage",
+]

--- a/src/pollypm/storage/pg_alerts.py
+++ b/src/pollypm/storage/pg_alerts.py
@@ -1,0 +1,412 @@
+"""Postgres facade for the ``alerts`` cluster on the ``messages`` table (#1737).
+
+This module owns the read/write path for cluster B of the StateStore
+port plan. Alerts are stored as ``messages`` rows with ``type='alert'``
+— there is no dedicated ``alerts`` table on either backend. The pg
+shape mirrors the sqlite shape on :class:`pollypm.storage.state.StateStore`
+exactly so dual-write callers (during the cutover) produce
+indistinguishable rows.
+
+Public API:
+
+* :func:`upsert_alert` — INSERT … ON CONFLICT (scope, sender) DO UPDATE,
+  same race-resilient INTEGRITY-error retry path StateStore implements
+  for #1044
+* :func:`clear_alert` — close every open alert whose (scope, sender)
+  matches
+* :func:`open_alerts` — list every open alert, newest-first
+* :func:`get_alert` — read a single alert row by id
+* :func:`clear_alert_by_id` — close one specific alert row, returning
+  the post-close record (or ``None`` when the id was missing)
+* :func:`deduplicate_alerts` — keep only the most recently updated
+  open row per (scope, sender) tuple
+
+All functions accept an optional ``pool`` kwarg. The default is
+:func:`~pollypm.storage.pg_pool.get_rw_pool` for the mutators and
+:func:`~pollypm.storage.pg_pool.get_ro_pool` for the readers; passing a
+custom pool is the test-harness seam.
+
+Slice K-state-port phase 2d — port of StateStore cluster B.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from pollypm.storage.records import AlertRecord
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(UTC).isoformat()
+
+
+def _stamp_str(value: object) -> str:
+    """Return ``value`` as an ISO-8601 string (pg datetime → sqlite-style str)."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _strip_alert_subject(subject: str) -> str:
+    """Strip the ``[Alert] `` prefix StateStore injects on insert."""
+    if subject.startswith("[Alert] "):
+        return subject[len("[Alert] "):]
+    if subject.startswith("[Alert]"):
+        return subject[len("[Alert]"):].lstrip()
+    return subject
+
+
+def _safe_payload(raw: object) -> dict:
+    """Decode a ``payload_json`` value into a dict, defensively.
+
+    pg returns ``jsonb`` columns as native Python (dict / list / str /
+    None) — sqlite returns the raw JSON string. Cover both shapes so
+    consumers calling ``.get(...)`` never AttributeError.
+    """
+    if raw is None or raw == "":
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, (bytes, bytearray)):
+        try:
+            raw = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return {}
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _select_open_alert(
+    cur,
+    session_name: str,
+    alert_type: str,
+) -> tuple[int | None, int]:
+    """Return ``(row_id, occurrences)`` for the open alert, or ``(None, 0)``.
+
+    Mirrors :meth:`StateStore._select_open_alert`. The occurrences
+    counter rides in ``payload_json`` to avoid a schema change.
+    """
+    cur.execute(
+        """
+        SELECT id, payload_json
+        FROM messages
+        WHERE type = 'alert'
+          AND scope = %s
+          AND sender = %s
+          AND state = 'open'
+        """,
+        (session_name, alert_type),
+    )
+    existing = cur.fetchone()
+    if existing is None:
+        return None, 0
+    payload = _safe_payload(existing[1])
+    prior = 0
+    raw = payload.get("occurrences", 0)
+    if isinstance(raw, int) and raw > 0:
+        prior = raw
+    return int(existing[0]), prior
+
+
+def upsert_alert(
+    session_name: str,
+    alert_type: str,
+    severity: str,
+    message: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Insert-or-update an open alert keyed on ``(scope=session_name, sender=alert_type)``.
+
+    Mirrors :meth:`StateStore.upsert_alert`. The partial unique index
+    ``messages_open_alert_uniq`` is the cross-process race-guard
+    (#1044): if two writers both observe "no row" and both INSERT, the
+    second one trips a ``psycopg.errors.UniqueViolation`` and we
+    rollback + UPDATE the row the other writer just committed.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    now = _now_iso()
+    subject = f"[Alert] {message}"
+    with pool.connection() as conn, conn.cursor() as cur:
+        row_id, prior_occurrences = _select_open_alert(
+            cur, session_name, alert_type
+        )
+        payload_json = json.dumps(
+            {
+                "severity": severity,
+                "session_name": session_name,
+                "occurrences": prior_occurrences + 1,
+            }
+        )
+        try:
+            if row_id is None:
+                cur.execute(
+                    """
+                    INSERT INTO messages (
+                        scope, type, tier, recipient, sender, state,
+                        subject, body, payload_json, labels, created_at, updated_at
+                    )
+                    VALUES (%s, 'alert', 'immediate', 'user', %s, 'open',
+                            %s, '', %s::jsonb, '[]'::jsonb, %s, %s)
+                    """,
+                    (
+                        session_name,
+                        alert_type,
+                        subject,
+                        payload_json,
+                        now,
+                        now,
+                    ),
+                )
+            else:
+                cur.execute(
+                    """
+                    UPDATE messages
+                    SET subject = %s, payload_json = %s::jsonb, updated_at = %s
+                    WHERE id = %s
+                    """,
+                    (subject, payload_json, now, row_id),
+                )
+        except Exception as exc:  # noqa: BLE001 — narrow below
+            # psycopg.errors.UniqueViolation surfaces as an
+            # IntegrityError subclass. Import lazily so the module
+            # can load without psycopg installed.
+            try:
+                from psycopg import errors as _pg_errors
+            except ImportError:
+                raise
+            if not isinstance(exc, _pg_errors.UniqueViolation):
+                raise
+            # Lost the race against another writer's INSERT. Roll back
+            # the partial transaction, re-read the now-visible row, and
+            # apply the bump as an UPDATE.
+            conn.rollback()
+            with conn.cursor() as retry_cur:
+                row_id, prior_occurrences = _select_open_alert(
+                    retry_cur, session_name, alert_type
+                )
+                payload_json = json.dumps(
+                    {
+                        "severity": severity,
+                        "session_name": session_name,
+                        "occurrences": prior_occurrences + 1,
+                    }
+                )
+                if row_id is None:
+                    retry_cur.execute(
+                        """
+                        INSERT INTO messages (
+                            scope, type, tier, recipient, sender, state,
+                            subject, body, payload_json, labels, created_at, updated_at
+                        )
+                        VALUES (%s, 'alert', 'immediate', 'user', %s, 'open',
+                                %s, '', %s::jsonb, '[]'::jsonb, %s, %s)
+                        """,
+                        (
+                            session_name,
+                            alert_type,
+                            subject,
+                            payload_json,
+                            now,
+                            now,
+                        ),
+                    )
+                else:
+                    retry_cur.execute(
+                        """
+                        UPDATE messages
+                        SET subject = %s, payload_json = %s::jsonb, updated_at = %s
+                        WHERE id = %s
+                        """,
+                        (subject, payload_json, now, row_id),
+                    )
+
+
+def clear_alert(
+    session_name: str,
+    alert_type: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Close every open alert whose ``(scope, sender)`` matches.
+
+    Mirrors :meth:`StateStore.clear_alert`: idempotent — calling on a
+    cleared (or never-set) alert is a no-op.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    now = _now_iso()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE messages
+            SET state = 'closed', closed_at = %s, updated_at = %s
+            WHERE type = 'alert'
+              AND scope = %s
+              AND sender = %s
+              AND state = 'open'
+            """,
+            (now, now, session_name, alert_type),
+        )
+
+
+def open_alerts(
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> list[AlertRecord]:
+    """Return every open alert, newest ``updated_at`` first."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, scope, sender, payload_json, subject, state, created_at, updated_at
+            FROM messages
+            WHERE type = 'alert' AND state = 'open'
+            ORDER BY updated_at DESC
+            """
+        )
+        rows = cur.fetchall()
+    return [_row_to_alert(row) for row in rows]
+
+
+def get_alert(
+    alert_id: int,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> AlertRecord | None:
+    """Return a single alert row by id, or ``None`` if absent.
+
+    Mirrors :meth:`StateStore.get_alert`: matches by id regardless of
+    state, so a closed alert is still readable.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, scope, sender, payload_json, subject, state, created_at, updated_at
+            FROM messages
+            WHERE id = %s
+            """,
+            (int(alert_id),),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return _row_to_alert(row)
+
+
+def clear_alert_by_id(
+    alert_id: int,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> AlertRecord | None:
+    """Close one specific alert row by id.
+
+    Returns the post-close record (or ``None`` when the id was missing).
+    Mirrors :meth:`StateStore.clear_alert_by_id`: only flips the state
+    on rows that were open — clearing an already-closed row is a no-op
+    but still returns the row.
+    """
+    existing = get_alert(alert_id, pool=pool)
+    if existing is None:
+        return None
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    now = _now_iso()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE messages
+            SET state = 'closed', closed_at = %s, updated_at = %s
+            WHERE id = %s AND state = 'open'
+            """,
+            (now, now, int(alert_id)),
+        )
+    return get_alert(alert_id, pool=pool)
+
+
+def deduplicate_alerts(
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> int:
+    """Drop duplicate open alerts, keeping the most recently updated row.
+
+    Mirrors the body of :meth:`StateStore._deduplicate_alerts`. The
+    partial unique index prevents new duplicates; this helper exists
+    for the once-per-process cleanup that runs against legacy databases
+    bootstrapped before the index was installed. Returns the number of
+    rows removed.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            DELETE FROM messages
+            WHERE type = 'alert' AND state = 'open'
+              AND id NOT IN (
+                  SELECT MAX(id) FROM messages
+                  WHERE type = 'alert' AND state = 'open'
+                  GROUP BY scope, sender
+              )
+            """
+        )
+        return cur.rowcount or 0
+
+
+def _row_to_alert(row) -> AlertRecord:
+    """Pack a SELECT row into :class:`AlertRecord`.
+
+    Row shape: ``(id, scope, sender, payload_json, subject, state,
+    created_at, updated_at)``.
+    """
+    payload = _safe_payload(row[3])
+    return AlertRecord(
+        session_name=row[1],
+        alert_type=row[2],
+        severity=str(payload.get("severity") or ""),
+        message=_strip_alert_subject(str(row[4] or "")),
+        status=row[5],
+        created_at=_stamp_str(row[6]),
+        updated_at=_stamp_str(row[7]),
+        alert_id=int(row[0]),
+    )
+
+
+__all__ = [
+    "clear_alert",
+    "clear_alert_by_id",
+    "deduplicate_alerts",
+    "get_alert",
+    "open_alerts",
+    "upsert_alert",
+]

--- a/src/pollypm/storage/pg_heartbeats.py
+++ b/src/pollypm/storage/pg_heartbeats.py
@@ -1,0 +1,208 @@
+"""Postgres facade for the ``heartbeats`` table (#1737).
+
+This module owns the read/write path for cluster C of the StateStore
+port plan: the per-session heartbeat ledger that the supervisor cascade
+writes after every sweep and that the cockpit / rail / health probes
+read for "is this session alive?" decisions.
+
+Public API:
+
+* :func:`record_heartbeat` — INSERT a fresh heartbeat row
+* :func:`latest_heartbeat` — SELECT the most-recent row for a session
+* :func:`recent_heartbeats` — SELECT the N most-recent rows
+* :func:`last_heartbeat_at` — SELECT the most-recent heartbeat event
+  timestamp (event-based, not the heartbeats table itself — sweep
+  observations land in ``messages`` with ``type='event'`` per #349)
+
+All functions accept an optional ``pool`` kwarg. The default is
+:func:`~pollypm.storage.pg_pool.get_rw_pool` for the writer and
+:func:`~pollypm.storage.pg_pool.get_ro_pool` for the readers; passing a
+custom pool is the test-harness seam.
+
+Slice K-state-port phase 2d — port of StateStore cluster C.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from pollypm.storage.records import HeartbeatRecord
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(UTC).isoformat()
+
+
+def _stamp_str(value: object) -> str:
+    """Return ``value`` as an ISO-8601 string (pg datetime → sqlite-style str)."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def record_heartbeat(
+    *,
+    session_name: str,
+    tmux_window: str,
+    pane_id: str,
+    pane_command: str,
+    pane_dead: bool,
+    log_bytes: int,
+    snapshot_path: str,
+    snapshot_hash: str,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Append a heartbeat row.
+
+    Mirrors :meth:`StateStore.record_heartbeat`: each call inserts a new
+    row (no upsert — the ``id`` serial gives a monotonic ordering that
+    :func:`latest_heartbeat` and :func:`recent_heartbeats` use to find
+    the most recent observations).
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    now = _now_iso()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO heartbeats (
+                session_name, tmux_window, pane_id, pane_command, pane_dead,
+                log_bytes, snapshot_path, snapshot_hash, created_at
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                session_name,
+                tmux_window,
+                pane_id,
+                pane_command,
+                bool(pane_dead),
+                int(log_bytes),
+                snapshot_path,
+                snapshot_hash,
+                now,
+            ),
+        )
+
+
+def latest_heartbeat(
+    session_name: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> HeartbeatRecord | None:
+    """Return the most-recent heartbeat row for ``session_name``, or ``None``."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT session_name, tmux_window, pane_id, pane_command, pane_dead,
+                   log_bytes, snapshot_path, snapshot_hash, created_at
+            FROM heartbeats
+            WHERE session_name = %s
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (session_name,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return _row_to_heartbeat(row)
+
+
+def recent_heartbeats(
+    session_name: str,
+    limit: int = 3,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> list[HeartbeatRecord]:
+    """Return up to ``limit`` most-recent heartbeats for ``session_name``."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT session_name, tmux_window, pane_id, pane_command, pane_dead,
+                   log_bytes, snapshot_path, snapshot_hash, created_at
+            FROM heartbeats
+            WHERE session_name = %s
+            ORDER BY id DESC
+            LIMIT %s
+            """,
+            (session_name, int(limit)),
+        )
+        rows = cur.fetchall()
+    return [_row_to_heartbeat(row) for row in rows]
+
+
+def last_heartbeat_at(
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> str | None:
+    """Return the ISO timestamp of the most-recent heartbeat sweep event.
+
+    Reads from ``messages`` (where heartbeat sweep events have landed
+    since #349) rather than the ``heartbeats`` table itself — same
+    behaviour as :meth:`StateStore.last_heartbeat_at`.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT created_at FROM messages
+            WHERE type = 'event'
+              AND scope = 'heartbeat'
+              AND subject = 'heartbeat'
+            ORDER BY id DESC
+            LIMIT 1
+            """
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return _stamp_str(row[0])
+
+
+def _row_to_heartbeat(row) -> HeartbeatRecord:
+    """Pack a SELECT row into :class:`HeartbeatRecord`.
+
+    Row shape: ``(session_name, tmux_window, pane_id, pane_command,
+    pane_dead, log_bytes, snapshot_path, snapshot_hash, created_at)``.
+    """
+    return HeartbeatRecord(
+        session_name=row[0],
+        tmux_window=row[1],
+        pane_id=row[2],
+        pane_command=row[3],
+        pane_dead=bool(row[4]),
+        log_bytes=int(row[5]),
+        snapshot_path=row[6],
+        snapshot_hash=row[7],
+        created_at=_stamp_str(row[8]),
+    )
+
+
+__all__ = [
+    "last_heartbeat_at",
+    "latest_heartbeat",
+    "recent_heartbeats",
+    "record_heartbeat",
+]

--- a/src/pollypm/storage/pg_leases.py
+++ b/src/pollypm/storage/pg_leases.py
@@ -1,0 +1,169 @@
+"""Postgres facade for the ``leases`` table (#1737).
+
+This module owns the read/write path for cluster D of the StateStore
+port plan: the per-session operator lease ledger. A lease records
+which operator (Polly, an architect, a manual override) currently
+"owns" a session for the purposes of dispatch and recovery decisions.
+
+Public API:
+
+* :func:`set_lease` — INSERT … ON CONFLICT (session_name) DO UPDATE
+* :func:`clear_lease` — DELETE the row for a session
+* :func:`get_lease` — SELECT a single row
+* :func:`list_leases` — SELECT every row, sorted by session_name
+
+The plan's "acquire/release/extend/expire" naming maps onto the
+StateStore signatures actually in use today: ``set_lease`` covers
+acquire+extend (idempotent upsert), ``clear_lease`` covers release,
+and the supervisor's :meth:`Supervisor.prune_sessions` cascade handles
+expiration by deleting rows for vanished sessions through
+``pg_sessions.prune_sessions``.
+
+All functions accept an optional ``pool`` kwarg. Default is
+:func:`~pollypm.storage.pg_pool.get_rw_pool` for the mutators and
+:func:`~pollypm.storage.pg_pool.get_ro_pool` for the readers; passing a
+custom pool is the test-harness seam.
+
+Slice K-state-port phase 2d — port of StateStore cluster D.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from pollypm.storage.records import LeaseRecord
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(UTC).isoformat()
+
+
+def _stamp_str(value: object) -> str:
+    """Return ``value`` as an ISO-8601 string (pg datetime → sqlite-style str)."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def set_lease(
+    session_name: str,
+    owner: str,
+    note: str = "",
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Insert-or-update a lease row.
+
+    Mirrors :meth:`StateStore.set_lease`: keyed on ``session_name``,
+    ``owner`` + ``note`` overwrite on conflict, ``updated_at`` is
+    bumped to ``now()``.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    now = _now_iso()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO leases (session_name, owner, note, updated_at)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT (session_name) DO UPDATE SET
+                owner = EXCLUDED.owner,
+                note = EXCLUDED.note,
+                updated_at = EXCLUDED.updated_at
+            """,
+            (session_name, owner, note, now),
+        )
+
+
+def clear_lease(
+    session_name: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> None:
+    """Delete the lease row for ``session_name``. Idempotent (no-op when absent)."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM leases WHERE session_name = %s",
+            (session_name,),
+        )
+
+
+def get_lease(
+    session_name: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> LeaseRecord | None:
+    """Return the lease row for ``session_name``, or ``None`` if absent."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT session_name, owner, note, updated_at
+            FROM leases
+            WHERE session_name = %s
+            """,
+            (session_name,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return LeaseRecord(
+        session_name=row[0],
+        owner=row[1],
+        note=row[2],
+        updated_at=_stamp_str(row[3]),
+    )
+
+
+def list_leases(
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> list[LeaseRecord]:
+    """Return every lease row, sorted by session_name."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT session_name, owner, note, updated_at
+            FROM leases
+            ORDER BY session_name
+            """
+        )
+        rows = cur.fetchall()
+    return [
+        LeaseRecord(
+            session_name=row[0],
+            owner=row[1],
+            note=row[2],
+            updated_at=_stamp_str(row[3]),
+        )
+        for row in rows
+    ]
+
+
+__all__ = [
+    "clear_lease",
+    "get_lease",
+    "list_leases",
+    "set_lease",
+]

--- a/src/pollypm/storage/pg_memory.py
+++ b/src/pollypm/storage/pg_memory.py
@@ -636,7 +636,60 @@ def latest_memory_summary(
     )
 
 
+class PgMemoryStore:
+    """Lightweight adapter exposing StateStore-shaped memory methods on pg.
+
+    :class:`pollypm.memory_backends.file.FileMemoryBackend` was written
+    against :class:`pollypm.storage.state.StateStore` and calls a
+    handful of memory_* methods on it. This adapter offers the same
+    method names but routes each call through the module-level pg
+    functions above. Backend selection happens at
+    :func:`pollypm.memory_backends.get_memory_backend` time.
+
+    The instance is stateless (no pool kept on ``self``) so it is
+    cheap to construct and safe to share across threads — each call
+    pulls a connection from the process-wide pool.
+    """
+
+    def record_memory_entry(self, **kwargs) -> MemoryEntryRecord:
+        return record_memory_entry(**kwargs)
+
+    def get_memory_entry(self, entry_id: int) -> MemoryEntryRecord | None:
+        return get_memory_entry(entry_id)
+
+    def list_memory_entries(self, **kwargs) -> list[MemoryEntryRecord]:
+        return list_memory_entries(**kwargs)
+
+    def recall_memory_entries(self, **kwargs):
+        return recall_memory_entries(**kwargs)
+
+    def purge_session_scope(self, session_id: str) -> int:
+        return purge_session_scope(session_id)
+
+    def expire_task_scope(self, task_id: str, **kwargs) -> int:
+        return expire_task_scope(task_id, **kwargs)
+
+    def delete_memory_entry(self, entry_id: int) -> bool:
+        return delete_memory_entry(entry_id)
+
+    def update_memory_entry(self, entry_id: int, **kwargs) -> bool:
+        return update_memory_entry(entry_id, **kwargs)
+
+    def record_memory_summary(self, **kwargs) -> MemorySummaryRecord:
+        return record_memory_summary(**kwargs)
+
+    def latest_memory_summary(self, scope: str) -> MemorySummaryRecord | None:
+        return latest_memory_summary(scope)
+
+    def sweep_expired_memory_entries(self) -> int:
+        return sweep_expired_memory_entries()
+
+    def close(self) -> None:
+        """No-op — the pg adapter doesn't own a connection lifetime."""
+
+
 __all__ = [
+    "PgMemoryStore",
     "delete_memory_entry",
     "expire_task_scope",
     "get_memory_entry",

--- a/src/pollypm/storage/pg_memory.py
+++ b/src/pollypm/storage/pg_memory.py
@@ -1,0 +1,651 @@
+"""Postgres facade for ``memory_entries`` + ``memory_summaries`` (#1737).
+
+This module owns the read/write path for cluster J of the StateStore
+port plan: the knowledge / memory tier that backs the
+:class:`pollypm.memory_backends.file.FileMemoryBackend` and the
+``pm memory`` CLI surface.
+
+Public API:
+
+Entry CRUD:
+
+* :func:`record_memory_entry` — INSERT a new entry, return the record
+* :func:`get_memory_entry` — SELECT a single entry by id
+* :func:`list_memory_entries` — SELECT with optional filters
+* :func:`delete_memory_entry` — DELETE by id, return bool
+* :func:`update_memory_entry` — patch a subset of columns
+
+Recall:
+
+* :func:`recall_memory_entries` — keyword-only recall using pg
+  ``tsvector`` (the generated ``title_body_tsv`` column). The hybrid
+  pgvector + FTS recall path lives separately in
+  :mod:`pollypm.storage.memory_recall` and is the path the CLI's
+  ``pm memory recall`` command uses; this function is the StateStore
+  parity surface used by :class:`FileMemoryBackend`.
+
+Lifecycle:
+
+* :func:`purge_session_scope` — delete every session-tier entry for a
+  given session id
+* :func:`expire_task_scope` — stamp a 30-day TTL on task-tier entries
+* :func:`sweep_expired_memory_entries` — drop rows whose TTL has elapsed
+
+Summaries:
+
+* :func:`record_memory_summary` — INSERT a summary row
+* :func:`latest_memory_summary` — SELECT the most recent summary for
+  a given scope
+
+All functions accept an optional ``pool`` kwarg. Default is
+:func:`~pollypm.storage.pg_pool.get_rw_pool` for the mutators and
+:func:`~pollypm.storage.pg_pool.get_ro_pool` for the readers; passing a
+custom pool is the test-harness seam.
+
+Slice K-state-port phase 2d — port of StateStore cluster J.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from pollypm.storage.records import MemoryEntryRecord, MemorySummaryRecord
+
+if TYPE_CHECKING:
+    from psycopg_pool import ConnectionPool
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(UTC).isoformat()
+
+
+def _stamp_str(value: object) -> str:
+    """Return ``value`` as an ISO-8601 string (pg datetime → sqlite-style str)."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _opt_stamp_str(value: object) -> str | None:
+    """Return ``None`` for NULL, otherwise an ISO-8601 string."""
+    if value is None:
+        return None
+    return _stamp_str(value)
+
+
+def _safe_tags(raw: object) -> tuple[str, ...]:
+    """Decode a stored ``tags`` value into a tuple.
+
+    The ``memory_entries.tags`` column is stored as JSON text on both
+    backends. Producers always write a list, but historical / malformed
+    rows could carry dict / string / NULL — coerce non-list shapes to
+    ``()`` so consumers iterating ``record.tags`` never see surprise
+    types. Mirrors :func:`pollypm.storage.state._safe_tags`.
+    """
+    if not raw:
+        return ()
+    if isinstance(raw, (list, tuple)):
+        return tuple(str(item) for item in raw)
+    if isinstance(raw, (bytes, bytearray)):
+        try:
+            raw = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return ()
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError):
+            return ()
+        if isinstance(parsed, list):
+            return tuple(str(item) for item in parsed)
+    return ()
+
+
+def _row_to_entry(row) -> MemoryEntryRecord:
+    """Pack a SELECT row into :class:`MemoryEntryRecord`.
+
+    Row shape: ``(id, scope, kind, title, body, tags, source, file_path,
+    summary_path, created_at, updated_at, type, importance,
+    superseded_by, ttl_at, scope_tier)``.
+    """
+    return MemoryEntryRecord(
+        entry_id=int(row[0]),
+        scope=row[1],
+        kind=row[2],
+        title=row[3],
+        body=row[4],
+        tags=_safe_tags(row[5]),
+        source=row[6],
+        file_path=row[7],
+        summary_path=row[8],
+        created_at=_stamp_str(row[9]),
+        updated_at=_stamp_str(row[10]),
+        type=row[11] if row[11] is not None else "project",
+        importance=int(row[12]) if row[12] is not None else 3,
+        superseded_by=int(row[13]) if row[13] is not None else None,
+        ttl_at=_opt_stamp_str(row[14]),
+        scope_tier=row[15] if row[15] is not None else "project",
+    )
+
+
+# --------------------------------------------------------------------- #
+# memory_entries — CRUD
+# --------------------------------------------------------------------- #
+
+
+def record_memory_entry(
+    *,
+    scope: str,
+    kind: str,
+    title: str,
+    body: str,
+    tags: list[str],
+    source: str,
+    file_path: str,
+    summary_path: str,
+    type: str = "project",  # noqa: A002 — match StateStore signature
+    importance: int = 3,
+    superseded_by: int | None = None,
+    ttl_at: str | None = None,
+    scope_tier: str = "project",
+    pool: "ConnectionPool | None" = None,
+) -> MemoryEntryRecord:
+    """Append a memory entry and return the populated record.
+
+    Mirrors :meth:`StateStore.record_memory_entry`: tags are stored as
+    a JSON-encoded list (``json.dumps([...])``); the
+    ``title_body_tsv`` generated column updates automatically.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    now = _now_iso()
+    tags_json = json.dumps([str(tag) for tag in tags], ensure_ascii=True)
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO memory_entries (
+                scope, kind, title, body, tags, source, file_path, summary_path,
+                created_at, updated_at, type, importance, superseded_by, ttl_at, scope_tier
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                scope,
+                kind,
+                title,
+                body,
+                tags_json,
+                source,
+                file_path,
+                summary_path,
+                now,
+                now,
+                type,
+                int(importance),
+                superseded_by,
+                ttl_at,
+                scope_tier,
+            ),
+        )
+        row = cur.fetchone()
+        entry_id = int(row[0])
+    return MemoryEntryRecord(
+        entry_id=entry_id,
+        scope=scope,
+        kind=kind,
+        title=title,
+        body=body,
+        tags=tuple(str(t) for t in tags),
+        source=source,
+        file_path=file_path,
+        summary_path=summary_path,
+        created_at=now,
+        updated_at=now,
+        type=type,
+        importance=int(importance),
+        superseded_by=superseded_by,
+        ttl_at=ttl_at,
+        scope_tier=scope_tier,
+    )
+
+
+def get_memory_entry(
+    entry_id: int,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> MemoryEntryRecord | None:
+    """Return a single memory entry by id, or ``None`` if absent."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, scope, kind, title, body, tags, source, file_path, summary_path,
+                   created_at, updated_at, type, importance, superseded_by, ttl_at, scope_tier
+            FROM memory_entries
+            WHERE id = %s
+            """,
+            (int(entry_id),),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return _row_to_entry(row)
+
+
+def list_memory_entries(
+    *,
+    scope: str | None = None,
+    kind: str | None = None,
+    type: str | None = None,  # noqa: A002 — match StateStore signature
+    scope_tier: str | None = None,
+    limit: int = 50,
+    pool: "ConnectionPool | None" = None,
+) -> list[MemoryEntryRecord]:
+    """List memory entries with optional filters, newest first.
+
+    Mirrors :meth:`StateStore.list_memory_entries`: filters compose as
+    ANDed equality predicates; ``None`` skips that filter entirely.
+    """
+    clauses: list[str] = []
+    params: list[object] = []
+    if scope is not None:
+        clauses.append("scope = %s")
+        params.append(scope)
+    if kind is not None:
+        clauses.append("kind = %s")
+        params.append(kind)
+    if type is not None:
+        clauses.append("type = %s")
+        params.append(type)
+    if scope_tier is not None:
+        clauses.append("scope_tier = %s")
+        params.append(scope_tier)
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            f"""
+            SELECT id, scope, kind, title, body, tags, source, file_path, summary_path,
+                   created_at, updated_at, type, importance, superseded_by, ttl_at, scope_tier
+            FROM memory_entries
+            {where}
+            ORDER BY id DESC
+            LIMIT %s
+            """,
+            (*params, int(limit)),
+        )
+        rows = cur.fetchall()
+    return [_row_to_entry(row) for row in rows]
+
+
+def delete_memory_entry(
+    entry_id: int,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> bool:
+    """Hard-delete a memory entry by id. Returns True when a row was removed."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM memory_entries WHERE id = %s",
+            (int(entry_id),),
+        )
+        removed = cur.rowcount or 0
+    return removed > 0
+
+
+def update_memory_entry(
+    entry_id: int,
+    *,
+    body: str | None = None,
+    importance: int | None = None,
+    tags: list[str] | None = None,
+    superseded_by: int | None = None,
+    clear_superseded: bool = False,
+    pool: "ConnectionPool | None" = None,
+) -> bool:
+    """Patch a subset of fields on a memory row. Returns True on change.
+
+    Mirrors :meth:`StateStore.update_memory_entry`. Fields left at
+    ``None`` keep their current values; pass ``clear_superseded=True``
+    to explicitly null the ``superseded_by`` column.
+    """
+    sets: list[str] = []
+    params: list[object] = []
+    if body is not None:
+        sets.append("body = %s")
+        params.append(str(body))
+    if importance is not None:
+        if not (1 <= int(importance) <= 5):
+            raise ValueError(
+                f"importance must be between 1 and 5 (got {importance})"
+            )
+        sets.append("importance = %s")
+        params.append(int(importance))
+    if tags is not None:
+        sets.append("tags = %s")
+        params.append(json.dumps([str(tag) for tag in tags], ensure_ascii=True))
+    if clear_superseded:
+        sets.append("superseded_by = NULL")
+    elif superseded_by is not None:
+        sets.append("superseded_by = %s")
+        params.append(int(superseded_by))
+    if not sets:
+        return False
+    now = _now_iso()
+    sets.append("updated_at = %s")
+    params.append(now)
+    params.append(int(entry_id))
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            f"UPDATE memory_entries SET {', '.join(sets)} WHERE id = %s",
+            tuple(params),
+        )
+        changed = cur.rowcount or 0
+    return changed > 0
+
+
+def recall_memory_entries(
+    *,
+    query: str,
+    scopes: list[str] | None = None,
+    types: list[str] | None = None,
+    importance_min: int = 1,
+    limit: int = 10,
+    candidate_multiplier: int = 5,
+    scope_tiers: list[str] | None = None,
+    tier_scope_pairs: list[tuple[str, str]] | None = None,
+    include_superseded: bool = False,
+    pool: "ConnectionPool | None" = None,
+) -> list[tuple[MemoryEntryRecord, float | None]]:
+    """Keyword-only recall against ``memory_entries.title_body_tsv``.
+
+    Returns ``(record, ts_rank_score_or_None)`` pairs ordered by
+    descending rank. Mirrors :meth:`StateStore.recall_memory_entries`:
+
+    * empty ``query`` skips the tsvector match and orders rows by
+      ``id DESC`` for "show me recent" callers.
+    * ``include_superseded=False`` (default) filters out rows whose
+      ``superseded_by`` is set — matches the M01 contract.
+    * ``ttl_at`` in the past is filtered out so expired rows don't
+      surface even when the sweep hasn't yet run.
+
+    The hybrid pgvector + ts_rank recall lives in
+    :mod:`pollypm.storage.memory_recall`; this surface is the StateStore
+    parity path used by :class:`FileMemoryBackend`. The "bm25_score"
+    return slot from the sqlite path becomes ts_rank_cd on pg — the
+    file backend's blender in
+    :mod:`pollypm.memory_backends.file` treats it as an opaque
+    "higher = better" score so the change is transparent.
+    """
+    clauses: list[str] = []
+    params: list[object] = []
+    if not include_superseded:
+        clauses.append("me.superseded_by IS NULL")
+    now_iso = _now_iso()
+    clauses.append("(me.ttl_at IS NULL OR me.ttl_at > %s)")
+    params.append(now_iso)
+    if scopes:
+        clauses.append("me.scope = ANY(%s)")
+        params.append(list(scopes))
+    if types:
+        clauses.append("me.type = ANY(%s)")
+        params.append(list(types))
+    if scope_tiers:
+        clauses.append("me.scope_tier = ANY(%s)")
+        params.append(list(scope_tiers))
+    if tier_scope_pairs:
+        pair_clauses: list[str] = []
+        for tier, scope_id in tier_scope_pairs:
+            pair_clauses.append("(me.scope_tier = %s AND me.scope = %s)")
+            params.extend([tier, scope_id])
+        if pair_clauses:
+            clauses.append("(" + " OR ".join(pair_clauses) + ")")
+    if importance_min > 1:
+        clauses.append("me.importance >= %s")
+        params.append(int(importance_min))
+
+    query_text = (query or "").strip()
+    fetch_limit = max(int(limit) * int(candidate_multiplier), int(limit))
+
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+
+    where = " AND ".join(clauses)
+    if query_text:
+        # Use plainto_tsquery against the generated title_body_tsv column.
+        # ts_rank_cd returns "higher = better" which matches the
+        # negative-bm25 contract the file backend's recall blender
+        # expects.
+        sql = f"""
+        SELECT me.id, me.scope, me.kind, me.title, me.body, me.tags, me.source,
+               me.file_path, me.summary_path, me.created_at, me.updated_at,
+               me.type, me.importance, me.superseded_by, me.ttl_at, me.scope_tier,
+               ts_rank_cd(me.title_body_tsv, plainto_tsquery('english', %s)) AS score
+        FROM memory_entries me
+        WHERE me.title_body_tsv @@ plainto_tsquery('english', %s)
+          AND {where}
+        ORDER BY score DESC
+        LIMIT %s
+        """
+        with pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, (query_text, query_text, *params, fetch_limit))
+            rows = cur.fetchall()
+    else:
+        sql = f"""
+        SELECT me.id, me.scope, me.kind, me.title, me.body, me.tags, me.source,
+               me.file_path, me.summary_path, me.created_at, me.updated_at,
+               me.type, me.importance, me.superseded_by, me.ttl_at, me.scope_tier,
+               NULL::float AS score
+        FROM memory_entries me
+        WHERE {where}
+        ORDER BY me.id DESC
+        LIMIT %s
+        """
+        with pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, (*params, fetch_limit))
+            rows = cur.fetchall()
+
+    results: list[tuple[MemoryEntryRecord, float | None]] = []
+    for row in rows:
+        record = _row_to_entry(row[:16])
+        score = float(row[16]) if row[16] is not None else None
+        results.append((record, score))
+    return results
+
+
+# --------------------------------------------------------------------- #
+# Tiered-scope lifecycle (M03 / #232)
+# --------------------------------------------------------------------- #
+
+
+def purge_session_scope(
+    session_id: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> int:
+    """Delete every session-tier memory entry with ``scope = session_id``.
+
+    Returns the number of rows removed. Idempotent — calling twice
+    removes zero on the second call.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM memory_entries WHERE scope_tier = 'session' AND scope = %s",
+            (session_id,),
+        )
+        return cur.rowcount or 0
+
+
+def expire_task_scope(
+    task_id: str,
+    *,
+    terminal_at: str | None = None,
+    ttl_days: int = 30,
+    pool: "ConnectionPool | None" = None,
+) -> int:
+    """Stamp a 30-day TTL on task-tier entries with ``scope = task_id``.
+
+    Mirrors :meth:`StateStore.expire_task_scope`: uses LEAST() so an
+    explicit earlier TTL is never extended. Returns the row count
+    actually modified.
+    """
+    if terminal_at is None:
+        now = datetime.now(UTC)
+    else:
+        now = datetime.fromisoformat(terminal_at)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=UTC)
+    ttl_at = (now + timedelta(days=int(ttl_days))).isoformat()
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE memory_entries
+            SET ttl_at = LEAST(COALESCE(ttl_at, %s::timestamptz), %s::timestamptz),
+                updated_at = %s
+            WHERE scope_tier = 'task' AND scope = %s
+            """,
+            (ttl_at, ttl_at, now.isoformat(), task_id),
+        )
+        return cur.rowcount or 0
+
+
+def sweep_expired_memory_entries(
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> int:
+    """Drop ``memory_entries`` whose ``ttl_at`` has elapsed.
+
+    Only touches rows with a non-NULL ``ttl_at``. Returns the number
+    of rows deleted. Mirrors :meth:`StateStore.sweep_expired_memory_entries`.
+    """
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM memory_entries WHERE ttl_at IS NOT NULL AND ttl_at < now()"
+        )
+        return cur.rowcount or 0
+
+
+# --------------------------------------------------------------------- #
+# memory_summaries
+# --------------------------------------------------------------------- #
+
+
+def record_memory_summary(
+    *,
+    scope: str,
+    summary_text: str,
+    summary_path: str,
+    entry_count: int,
+    pool: "ConnectionPool | None" = None,
+) -> MemorySummaryRecord:
+    """Append a memory_summary row and return the populated record."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_rw_pool
+
+        pool = get_rw_pool()
+    now = _now_iso()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO memory_summaries (scope, summary_text, summary_path, entry_count, created_at)
+            VALUES (%s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (scope, summary_text, summary_path, int(entry_count), now),
+        )
+        row = cur.fetchone()
+        summary_id = int(row[0])
+    return MemorySummaryRecord(
+        summary_id=summary_id,
+        scope=scope,
+        summary_text=summary_text,
+        summary_path=summary_path,
+        entry_count=int(entry_count),
+        created_at=now,
+    )
+
+
+def latest_memory_summary(
+    scope: str,
+    *,
+    pool: "ConnectionPool | None" = None,
+) -> MemorySummaryRecord | None:
+    """Return the most-recently inserted summary for ``scope`` or ``None``."""
+    if pool is None:
+        from pollypm.storage.pg_pool import get_ro_pool
+
+        pool = get_ro_pool()
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, scope, summary_text, summary_path, entry_count, created_at
+            FROM memory_summaries
+            WHERE scope = %s
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (scope,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return MemorySummaryRecord(
+        summary_id=int(row[0]),
+        scope=row[1],
+        summary_text=row[2],
+        summary_path=row[3],
+        entry_count=int(row[4]),
+        created_at=_stamp_str(row[5]),
+    )
+
+
+__all__ = [
+    "delete_memory_entry",
+    "expire_task_scope",
+    "get_memory_entry",
+    "latest_memory_summary",
+    "list_memory_entries",
+    "purge_session_scope",
+    "recall_memory_entries",
+    "record_memory_entry",
+    "record_memory_summary",
+    "sweep_expired_memory_entries",
+    "update_memory_entry",
+]

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -502,6 +502,43 @@ class Supervisor:
             return pg_last_event_at(session_name, event_type)
         return self.store.last_event_at(session_name, event_type)
 
+    # --- Cluster D (leases) dispatch helpers -------------------------- #
+    # Same pattern as the cluster-A helpers above: route through
+    # ``pollypm.storage.pg_leases`` on the pg backend, stay on the
+    # legacy StateStore on sqlite. Centralising the dispatch here keeps
+    # the supervisor's lease call sites short and the backend probe in
+    # one place.
+
+    def _list_leases(self):
+        if self._cluster_a_pg_active():
+            from pollypm.storage.pg_leases import list_leases as pg_list_leases
+
+            return pg_list_leases()
+        return self.store.list_leases()
+
+    def _get_lease(self, session_name: str):
+        if self._cluster_a_pg_active():
+            from pollypm.storage.pg_leases import get_lease as pg_get_lease
+
+            return pg_get_lease(session_name)
+        return self.store.get_lease(session_name)
+
+    def _set_lease(self, session_name: str, owner: str, note: str = "") -> None:
+        if self._cluster_a_pg_active():
+            from pollypm.storage.pg_leases import set_lease as pg_set_lease
+
+            pg_set_lease(session_name, owner, note)
+            return
+        self.store.set_lease(session_name, owner, note)
+
+    def _clear_lease(self, session_name: str) -> None:
+        if self._cluster_a_pg_active():
+            from pollypm.storage.pg_leases import clear_lease as pg_clear_lease
+
+            pg_clear_lease(session_name)
+            return
+        self.store.clear_lease(session_name)
+
     def _build_launch_planner(self):
         """Resolve the launch planner via the plugin host.
 
@@ -1483,7 +1520,7 @@ class Supervisor:
             errors.append(f"store.open_alerts: {exc}")
             alerts = []
         try:
-            leases = self.store.list_leases()
+            leases = self._list_leases()
         except Exception as exc:  # noqa: BLE001
             errors.append(f"store.list_leases: {exc}")
             leases = []
@@ -2106,7 +2143,7 @@ class Supervisor:
     def release_expired_leases(self, *, now: datetime | None = None) -> list[LeaseRecord]:
         current_time = now or datetime.now(UTC)
         released: list[LeaseRecord] = []
-        for lease in self.store.list_leases():
+        for lease in self._list_leases():
             try:
                 updated_at = datetime.fromisoformat(lease.updated_at)
             except ValueError:
@@ -2116,7 +2153,7 @@ class Supervisor:
             age = current_time - updated_at.astimezone(UTC)
             if age < self._lease_timeout():
                 continue
-            self.store.clear_lease(lease.session_name)
+            self._clear_lease(lease.session_name)
             # Sync — lease state transitions are transactional audit events.
             timeout_minutes = self.config.pollypm.lease_timeout_minutes
             minute_word = "minute" if timeout_minutes == 1 else "minutes"
@@ -2141,7 +2178,7 @@ class Supervisor:
             owner=owner,
             action="claim a lease for",
         )
-        self.store.set_lease(session_name, owner, note)
+        self._set_lease(session_name, owner, note)
         message = f"Lease claimed by {owner}"
         if note:
             message = f"{message}: {note}"
@@ -2170,10 +2207,10 @@ class Supervisor:
     def release_lease(self, session_name: str, expected_owner: str | None = None) -> None:
         self._require_session(session_name)
         if expected_owner is not None:
-            current = self.store.get_lease(session_name)
+            current = self._get_lease(session_name)
             if current is None or current.owner != expected_owner:
                 return  # Lease was already released or reclaimed by someone else
-        self.store.clear_lease(session_name)
+        self._clear_lease(session_name)
         # Sync — lease state transitions are transactional audit events.
         self._msg_store.record_event(
             scope=session_name,
@@ -2297,7 +2334,7 @@ class Supervisor:
         if press_enter:
             self._verify_input_submitted(target, text, launch)
         if owner == "human":
-            self.store.set_lease(session_name, "human", "automatic lease from direct human input")
+            self._set_lease(session_name, "human", "automatic lease from direct human input")
         self._msg_store.append_event(
             scope=session_name,
             sender=owner,
@@ -2387,7 +2424,7 @@ class Supervisor:
         return out
 
     def leases(self) -> list[LeaseRecord]:
-        return self.store.list_leases()
+        return self._list_leases()
 
     def pane_has_auth_failure(self, lowered_pane: str) -> bool:
         """Public alert-boundary detector for authentication failures."""
@@ -3444,12 +3481,12 @@ class Supervisor:
                 },
             )
 
-        lease = self.store.get_lease(launch.session.name)
+        lease = self._get_lease(launch.session.name)
         if lease is not None and lease.owner != "pollypm":
             if failure_type in self._DEAD_SESSION_FAILURES:
                 # Session is dead — the lease is protecting nothing.  Release it
                 # so recovery can proceed immediately.
-                self.store.clear_lease(launch.session.name)
+                self._clear_lease(launch.session.name)
                 self._msg_store.clear_alert(launch.session.name, "recovery_waiting_on_human")
                 self._msg_store.append_event(
                     scope=launch.session.name,
@@ -3921,7 +3958,7 @@ class Supervisor:
         action: str,
         force: bool = False,
     ) -> None:
-        lease = self.store.get_lease(session_name)
+        lease = self._get_lease(session_name)
         if lease is None or lease.owner == owner or force:
             return
         raise RuntimeError(

--- a/src/pollypm/work/session_manager.py
+++ b/src/pollypm/work/session_manager.py
@@ -140,14 +140,25 @@ def _unavailable_account_names(config: object) -> frozenset[str]:
         return frozenset()
     try:
         from pollypm.accounts import is_account_runtime_unavailable
-        from pollypm.storage.state import StateStore
+        from pollypm.storage._backend_dispatch import is_pg_backend
+
         unavailable: set[str] = set()
         accounts = getattr(config, "accounts", {}) or {}
-        with StateStore(state_db) as store:
+        if is_pg_backend(config):
+            from pollypm.storage.pg_accounts import get_account_runtime
+
             for name in accounts:
-                runtime = store.get_account_runtime(name)
+                runtime = get_account_runtime(name)
                 if runtime is not None and is_account_runtime_unavailable(runtime.status):
                     unavailable.add(name)
+        else:
+            from pollypm.storage.state import StateStore
+
+            with StateStore(state_db) as store:
+                for name in accounts:
+                    runtime = store.get_account_runtime(name)
+                    if runtime is not None and is_account_runtime_unavailable(runtime.status):
+                        unavailable.add(name)
         return frozenset(unavailable)
     except Exception:  # noqa: BLE001
         logger.exception("worker launch: account-runtime filter failed; allowing all")

--- a/src/pollypm/workers.py
+++ b/src/pollypm/workers.py
@@ -50,8 +50,15 @@ def _account_is_available(config_path: Path, account_name: str) -> bool:
     account = config.accounts[account_name]
     if not detect_logged_in(account):
         return False
-    with StateStore(config.project.state_db) as store:
-        runtime = store.get_account_runtime(account_name)
+    from pollypm.storage._backend_dispatch import is_pg_backend
+
+    if is_pg_backend(config):
+        from pollypm.storage.pg_accounts import get_account_runtime
+
+        runtime = get_account_runtime(account_name)
+    else:
+        with StateStore(config.project.state_db) as store:
+            runtime = store.get_account_runtime(account_name)
     # Accept both ``auth_broken`` (canonical, written by heartbeats/api.py
     # and supervisor.py) and the legacy hyphenated ``auth-broken`` form
     # so a runtime row written by either side correctly excludes the

--- a/tests/test_pg_accounts.py
+++ b/tests/test_pg_accounts.py
@@ -1,0 +1,148 @@
+"""pg-parity tests for the ``pg_accounts`` facade (#1737, Slice K-state-port phase 2d).
+
+Covers cluster E: ``account_usage`` + ``account_runtime`` tables.
+"""
+
+from __future__ import annotations
+
+
+def _apply_initial_migrations(pg_schema_pool) -> None:
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+
+
+def test_pg_account_usage_upsert_get(pg_schema_pool):
+    """upsert_account_usage writes; get_account_usage reads."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_accounts import (
+        get_account_usage,
+        upsert_account_usage,
+    )
+
+    assert get_account_usage("primary", pool=pg_schema_pool) is None
+
+    upsert_account_usage(
+        account_name="primary",
+        provider="claude-cli",
+        plan="max",
+        health="ok",
+        usage_summary="42%",
+        raw_text="raw output",
+        used_pct=42,
+        remaining_pct=58,
+        reset_at="2026-05-20T00:00:00+00:00",
+        period_label="weekly",
+        pool=pg_schema_pool,
+    )
+
+    row = get_account_usage("primary", pool=pg_schema_pool)
+    assert row is not None
+    assert row.account_name == "primary"
+    assert row.provider == "claude-cli"
+    assert row.plan == "max"
+    assert row.health == "ok"
+    assert row.used_pct == 42
+    assert row.remaining_pct == 58
+    assert row.period_label == "weekly"
+
+
+def test_pg_account_usage_upsert_overwrites(pg_schema_pool):
+    """Re-upserting with the same account_name overwrites."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_accounts import (
+        get_account_usage,
+        upsert_account_usage,
+    )
+
+    upsert_account_usage(
+        account_name="primary",
+        provider="claude-cli",
+        plan="max",
+        health="ok",
+        usage_summary="50%",
+        raw_text="",
+        pool=pg_schema_pool,
+    )
+    upsert_account_usage(
+        account_name="primary",
+        provider="claude-cli",
+        plan="max",
+        health="degraded",
+        usage_summary="90%",
+        raw_text="overload",
+        pool=pg_schema_pool,
+    )
+
+    row = get_account_usage("primary", pool=pg_schema_pool)
+    assert row is not None
+    assert row.health == "degraded"
+    assert row.usage_summary == "90%"
+
+
+def test_pg_account_usage_list(pg_schema_pool):
+    """list_account_usage returns every row, sorted by account_name."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_accounts import list_account_usage, upsert_account_usage
+
+    for name in ["charlie", "alpha", "bravo"]:
+        upsert_account_usage(
+            account_name=name,
+            provider="claude-cli",
+            plan="max",
+            health="ok",
+            usage_summary="",
+            raw_text="",
+            pool=pg_schema_pool,
+        )
+
+    rows = list_account_usage(pool=pg_schema_pool)
+    assert [r.account_name for r in rows] == ["alpha", "bravo", "charlie"]
+
+
+def test_pg_account_runtime_upsert_get(pg_schema_pool):
+    """upsert_account_runtime / get_account_runtime roundtrip."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_accounts import (
+        get_account_runtime,
+        upsert_account_runtime,
+    )
+
+    assert get_account_runtime("primary", pool=pg_schema_pool) is None
+
+    upsert_account_runtime(
+        account_name="primary",
+        provider="claude-cli",
+        status="rate_limited",
+        reason="quota exhausted",
+        available_at="2026-05-19T18:00:00+00:00",
+        refresh_available=True,
+        pool=pg_schema_pool,
+    )
+
+    row = get_account_runtime("primary", pool=pg_schema_pool)
+    assert row is not None
+    assert row.status == "rate_limited"
+    assert row.reason == "quota exhausted"
+    assert row.refresh_available is True
+
+
+def test_pg_account_runtime_list(pg_schema_pool):
+    """list_account_runtimes returns rows sorted by account_name."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_accounts import (
+        list_account_runtimes,
+        upsert_account_runtime,
+    )
+
+    for name in ["beta", "alpha"]:
+        upsert_account_runtime(
+            account_name=name,
+            provider="claude-cli",
+            status="ok",
+            reason="",
+            pool=pg_schema_pool,
+        )
+
+    rows = list_account_runtimes(pool=pg_schema_pool)
+    assert [r.account_name for r in rows] == ["alpha", "beta"]

--- a/tests/test_pg_alerts.py
+++ b/tests/test_pg_alerts.py
@@ -1,0 +1,156 @@
+"""pg-parity tests for the ``pg_alerts`` facade (#1737, Slice K-state-port phase 2d).
+
+Covers cluster B: alerts (which live on the ``messages`` table with
+``type='alert'``). Each test applies the canonical pg migrations on a
+fresh per-test schema (``pg_schema_pool``), then exercises one slice
+of the facade. Mirrors :class:`StateStore` semantics 1:1.
+
+Skipped when neither Docker nor a local pg is available — see
+``tests/conftest_pg.py``.
+"""
+
+from __future__ import annotations
+
+
+def _apply_initial_migrations(pg_schema_pool) -> None:
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+
+
+def test_pg_alerts_upsert_and_open(pg_schema_pool):
+    """upsert_alert writes; open_alerts surfaces the row."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_alerts import open_alerts, upsert_alert
+
+    assert open_alerts(pool=pg_schema_pool) == []
+
+    upsert_alert(
+        "session-alpha",
+        "pane_dead",
+        "error",
+        "pane unexpectedly died",
+        pool=pg_schema_pool,
+    )
+
+    alerts = open_alerts(pool=pg_schema_pool)
+    assert len(alerts) == 1
+    assert alerts[0].session_name == "session-alpha"
+    assert alerts[0].alert_type == "pane_dead"
+    assert alerts[0].severity == "error"
+    assert alerts[0].message == "pane unexpectedly died"
+    assert alerts[0].status == "open"
+
+
+def test_pg_alerts_upsert_bumps_existing(pg_schema_pool):
+    """Re-upserting the same (scope, sender) updates the existing row."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_alerts import open_alerts, upsert_alert
+
+    upsert_alert("session-alpha", "pane_dead", "error", "first", pool=pg_schema_pool)
+    upsert_alert("session-alpha", "pane_dead", "error", "second", pool=pg_schema_pool)
+
+    alerts = open_alerts(pool=pg_schema_pool)
+    # Single row (occurrences bumped, not a new INSERT).
+    assert len(alerts) == 1
+    assert alerts[0].message == "second"
+
+
+def test_pg_alerts_clear_alert(pg_schema_pool):
+    """clear_alert closes every matching open alert."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_alerts import clear_alert, open_alerts, upsert_alert
+
+    upsert_alert("session-alpha", "pane_dead", "error", "msg", pool=pg_schema_pool)
+    upsert_alert("session-beta", "pane_dead", "error", "msg2", pool=pg_schema_pool)
+
+    clear_alert("session-alpha", "pane_dead", pool=pg_schema_pool)
+
+    alerts = open_alerts(pool=pg_schema_pool)
+    assert len(alerts) == 1
+    assert alerts[0].session_name == "session-beta"
+
+
+def test_pg_alerts_get_and_clear_by_id(pg_schema_pool):
+    """get_alert reads any alert by id; clear_alert_by_id closes one row."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_alerts import (
+        clear_alert_by_id,
+        get_alert,
+        open_alerts,
+        upsert_alert,
+    )
+
+    upsert_alert("session-alpha", "pane_dead", "error", "msg", pool=pg_schema_pool)
+    alerts = open_alerts(pool=pg_schema_pool)
+    alert_id = alerts[0].alert_id
+    assert alert_id is not None
+
+    # get_alert reads by id even when open.
+    row = get_alert(alert_id, pool=pg_schema_pool)
+    assert row is not None
+    assert row.status == "open"
+
+    # clear_alert_by_id flips to closed and returns the post-close record.
+    closed = clear_alert_by_id(alert_id, pool=pg_schema_pool)
+    assert closed is not None
+    assert closed.status == "closed"
+
+    # The row is still readable but no longer surfaces in open_alerts.
+    after = get_alert(alert_id, pool=pg_schema_pool)
+    assert after is not None
+    assert after.status == "closed"
+    assert open_alerts(pool=pg_schema_pool) == []
+
+
+def test_pg_alerts_get_alert_missing_returns_none(pg_schema_pool):
+    """get_alert on a nonexistent id returns None."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_alerts import clear_alert_by_id, get_alert
+
+    assert get_alert(9999, pool=pg_schema_pool) is None
+    assert clear_alert_by_id(9999, pool=pg_schema_pool) is None
+
+
+def test_pg_alerts_open_alerts_sorted_newest_first(pg_schema_pool):
+    """open_alerts orders by updated_at DESC."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_alerts import open_alerts, upsert_alert
+
+    upsert_alert("s1", "t1", "warn", "first", pool=pg_schema_pool)
+    upsert_alert("s2", "t2", "warn", "second", pool=pg_schema_pool)
+    upsert_alert("s3", "t3", "warn", "third", pool=pg_schema_pool)
+
+    alerts = open_alerts(pool=pg_schema_pool)
+    assert [a.session_name for a in alerts] == ["s3", "s2", "s1"]
+
+
+def test_pg_alerts_deduplicate(pg_schema_pool):
+    """deduplicate_alerts drops dup open rows keyed on (scope, sender), keeps newest."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_alerts import deduplicate_alerts, open_alerts
+
+    # Drop the partial unique index so we can plant explicit duplicates
+    # for the cleanup helper to chew on.
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute("DROP INDEX IF EXISTS messages_open_alert_uniq")
+        for i, msg in enumerate(["one", "two", "three"]):
+            stamp = f"2026-05-19T00:00:0{i}+00:00"
+            cur.execute(
+                """
+                INSERT INTO messages (
+                    scope, type, tier, recipient, sender, state,
+                    subject, body, payload_json, labels, created_at, updated_at
+                )
+                VALUES ('s1', 'alert', 'immediate', 'user', 't1', 'open',
+                        %s, '', '{}'::jsonb, '[]'::jsonb, %s, %s)
+                """,
+                (msg, stamp, stamp),
+            )
+        conn.commit()
+
+    assert len(open_alerts(pool=pg_schema_pool)) == 3
+    removed = deduplicate_alerts(pool=pg_schema_pool)
+    assert removed == 2
+    alerts = open_alerts(pool=pg_schema_pool)
+    assert len(alerts) == 1

--- a/tests/test_pg_heartbeats.py
+++ b/tests/test_pg_heartbeats.py
@@ -1,0 +1,142 @@
+"""pg-parity tests for the ``pg_heartbeats`` facade (#1737, Slice K-state-port phase 2d).
+
+Covers cluster C: ``heartbeats`` table plus the ``last_heartbeat_at``
+helper that reads heartbeat sweep events from ``messages``.
+"""
+
+from __future__ import annotations
+
+
+def _apply_initial_migrations(pg_schema_pool) -> None:
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+
+
+def test_pg_heartbeats_record_and_latest(pg_schema_pool):
+    """record_heartbeat writes; latest_heartbeat returns the most-recent row."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_heartbeats import latest_heartbeat, record_heartbeat
+
+    assert latest_heartbeat("worker-alpha", pool=pg_schema_pool) is None
+
+    record_heartbeat(
+        session_name="worker-alpha",
+        tmux_window="alpha-1",
+        pane_id="%42",
+        pane_command="claude",
+        pane_dead=False,
+        log_bytes=4096,
+        snapshot_path="/tmp/snap-1",
+        snapshot_hash="abc123",
+        pool=pg_schema_pool,
+    )
+    record_heartbeat(
+        session_name="worker-alpha",
+        tmux_window="alpha-1",
+        pane_id="%42",
+        pane_command="claude",
+        pane_dead=True,
+        log_bytes=8192,
+        snapshot_path="/tmp/snap-2",
+        snapshot_hash="def456",
+        pool=pg_schema_pool,
+    )
+
+    latest = latest_heartbeat("worker-alpha", pool=pg_schema_pool)
+    assert latest is not None
+    assert latest.session_name == "worker-alpha"
+    assert latest.pane_dead is True
+    assert latest.log_bytes == 8192
+    assert latest.snapshot_path == "/tmp/snap-2"
+    assert latest.snapshot_hash == "def456"
+
+
+def test_pg_heartbeats_recent_limit(pg_schema_pool):
+    """recent_heartbeats returns up to ``limit`` rows newest-first."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_heartbeats import recent_heartbeats, record_heartbeat
+
+    for i in range(5):
+        record_heartbeat(
+            session_name="worker-alpha",
+            tmux_window="alpha-1",
+            pane_id="%42",
+            pane_command="claude",
+            pane_dead=False,
+            log_bytes=i,
+            snapshot_path=f"/tmp/snap-{i}",
+            snapshot_hash=f"hash-{i}",
+            pool=pg_schema_pool,
+        )
+
+    rows = recent_heartbeats("worker-alpha", limit=3, pool=pg_schema_pool)
+    assert len(rows) == 3
+    assert [r.log_bytes for r in rows] == [4, 3, 2]
+
+
+def test_pg_heartbeats_per_session_isolation(pg_schema_pool):
+    """latest_heartbeat / recent_heartbeats scope by session_name."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_heartbeats import (
+        latest_heartbeat,
+        recent_heartbeats,
+        record_heartbeat,
+    )
+
+    record_heartbeat(
+        session_name="worker-alpha",
+        tmux_window="alpha",
+        pane_id="%1",
+        pane_command="claude",
+        pane_dead=False,
+        log_bytes=100,
+        snapshot_path="/a",
+        snapshot_hash="aa",
+        pool=pg_schema_pool,
+    )
+    record_heartbeat(
+        session_name="worker-beta",
+        tmux_window="beta",
+        pane_id="%2",
+        pane_command="codex",
+        pane_dead=True,
+        log_bytes=200,
+        snapshot_path="/b",
+        snapshot_hash="bb",
+        pool=pg_schema_pool,
+    )
+
+    alpha = latest_heartbeat("worker-alpha", pool=pg_schema_pool)
+    assert alpha is not None and alpha.log_bytes == 100
+    beta = latest_heartbeat("worker-beta", pool=pg_schema_pool)
+    assert beta is not None and beta.log_bytes == 200
+
+    assert len(recent_heartbeats("worker-alpha", pool=pg_schema_pool)) == 1
+    assert len(recent_heartbeats("missing", pool=pg_schema_pool)) == 0
+
+
+def test_pg_heartbeats_last_heartbeat_at_from_messages(pg_schema_pool):
+    """last_heartbeat_at reads from ``messages`` (heartbeat sweep events)."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_heartbeats import last_heartbeat_at
+
+    assert last_heartbeat_at(pool=pg_schema_pool) is None
+
+    now_iso = "2026-05-19T12:00:00+00:00"
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO messages (
+                scope, type, tier, recipient, sender, state,
+                subject, body, payload_json, labels, created_at, updated_at
+            )
+            VALUES ('heartbeat', 'event', 'immediate', '*', 'sweep', 'open',
+                    'heartbeat', 'tick', '{}'::jsonb, '[]'::jsonb, %s, %s)
+            """,
+            (now_iso, now_iso),
+        )
+        conn.commit()
+
+    stamp = last_heartbeat_at(pool=pg_schema_pool)
+    assert isinstance(stamp, str) and stamp

--- a/tests/test_pg_leases.py
+++ b/tests/test_pg_leases.py
@@ -1,0 +1,70 @@
+"""pg-parity tests for the ``pg_leases`` facade (#1737, Slice K-state-port phase 2d).
+
+Covers cluster D: ``leases`` table.
+"""
+
+from __future__ import annotations
+
+
+def _apply_initial_migrations(pg_schema_pool) -> None:
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+
+
+def test_pg_leases_set_get_clear(pg_schema_pool):
+    """set_lease writes, get_lease reads, clear_lease removes."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_leases import (
+        clear_lease,
+        get_lease,
+        set_lease,
+    )
+
+    assert get_lease("worker-alpha", pool=pg_schema_pool) is None
+
+    set_lease("worker-alpha", "polly", "owns dispatch", pool=pg_schema_pool)
+
+    row = get_lease("worker-alpha", pool=pg_schema_pool)
+    assert row is not None
+    assert row.session_name == "worker-alpha"
+    assert row.owner == "polly"
+    assert row.note == "owns dispatch"
+
+    clear_lease("worker-alpha", pool=pg_schema_pool)
+    assert get_lease("worker-alpha", pool=pg_schema_pool) is None
+    # Idempotent — clearing again is a no-op.
+    clear_lease("worker-alpha", pool=pg_schema_pool)
+
+
+def test_pg_leases_set_lease_overwrites(pg_schema_pool):
+    """Re-setting a lease overwrites owner / note in place."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_leases import get_lease, list_leases, set_lease
+
+    set_lease("worker-alpha", "polly", "first", pool=pg_schema_pool)
+    set_lease("worker-alpha", "architect", "second", pool=pg_schema_pool)
+
+    leases = list_leases(pool=pg_schema_pool)
+    assert len(leases) == 1
+    row = get_lease("worker-alpha", pool=pg_schema_pool)
+    assert row is not None
+    assert row.owner == "architect"
+    assert row.note == "second"
+
+
+def test_pg_leases_list_sorted_by_session_name(pg_schema_pool):
+    """list_leases returns rows sorted ascending by session_name."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_leases import list_leases, set_lease
+
+    set_lease("worker-charlie", "polly", "", pool=pg_schema_pool)
+    set_lease("worker-alpha", "polly", "", pool=pg_schema_pool)
+    set_lease("worker-bravo", "polly", "", pool=pg_schema_pool)
+
+    rows = list_leases(pool=pg_schema_pool)
+    assert [r.session_name for r in rows] == [
+        "worker-alpha",
+        "worker-bravo",
+        "worker-charlie",
+    ]

--- a/tests/test_pg_memory.py
+++ b/tests/test_pg_memory.py
@@ -1,0 +1,424 @@
+"""pg-parity tests for the ``pg_memory`` facade (#1737, Slice K-state-port phase 2d).
+
+Covers cluster J: ``memory_entries`` + ``memory_summaries`` tables.
+"""
+
+from __future__ import annotations
+
+
+def _apply_initial_migrations(pg_schema_pool) -> None:
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    apply_migrations(pg_schema_pool)
+
+
+def test_pg_memory_record_get_roundtrip(pg_schema_pool):
+    """record_memory_entry writes; get_memory_entry reads."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_memory import get_memory_entry, record_memory_entry
+
+    record = record_memory_entry(
+        scope="alpha",
+        kind="note",
+        title="Test Title",
+        body="Test body content",
+        tags=["foo", "bar"],
+        source="manual",
+        file_path="/tmp/note.md",
+        summary_path="",
+        importance=4,
+        scope_tier="project",
+        pool=pg_schema_pool,
+    )
+    assert record.entry_id > 0
+    assert record.scope == "alpha"
+    assert record.tags == ("foo", "bar")
+
+    fetched = get_memory_entry(record.entry_id, pool=pg_schema_pool)
+    assert fetched is not None
+    assert fetched.title == "Test Title"
+    assert fetched.body == "Test body content"
+    assert fetched.tags == ("foo", "bar")
+    assert fetched.importance == 4
+
+
+def test_pg_memory_list_filters(pg_schema_pool):
+    """list_memory_entries filters by scope/kind/type/scope_tier."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_memory import list_memory_entries, record_memory_entry
+
+    for scope, kind, tier in [
+        ("alpha", "note", "project"),
+        ("alpha", "lesson", "project"),
+        ("beta", "note", "project"),
+        ("alpha", "note", "session"),
+    ]:
+        record_memory_entry(
+            scope=scope,
+            kind=kind,
+            title=f"{scope}-{kind}",
+            body="",
+            tags=[],
+            source="manual",
+            file_path="",
+            summary_path="",
+            scope_tier=tier,
+            pool=pg_schema_pool,
+        )
+
+    by_scope = list_memory_entries(scope="alpha", pool=pg_schema_pool)
+    assert {r.title for r in by_scope} == {"alpha-note", "alpha-lesson"}
+
+    by_kind = list_memory_entries(kind="note", pool=pg_schema_pool)
+    assert {r.title for r in by_kind} == {"alpha-note", "beta-note"}
+
+    by_tier = list_memory_entries(scope_tier="session", pool=pg_schema_pool)
+    assert len(by_tier) == 1
+    assert by_tier[0].scope_tier == "session"
+
+
+def test_pg_memory_update_entry(pg_schema_pool):
+    """update_memory_entry patches subset of fields and bumps updated_at."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_memory import (
+        get_memory_entry,
+        record_memory_entry,
+        update_memory_entry,
+    )
+
+    record = record_memory_entry(
+        scope="alpha",
+        kind="note",
+        title="t",
+        body="original",
+        tags=["a"],
+        source="manual",
+        file_path="",
+        summary_path="",
+        importance=2,
+        pool=pg_schema_pool,
+    )
+
+    # No-op update returns False.
+    assert update_memory_entry(record.entry_id, pool=pg_schema_pool) is False
+
+    assert (
+        update_memory_entry(
+            record.entry_id,
+            body="updated",
+            importance=4,
+            tags=["a", "b"],
+            pool=pg_schema_pool,
+        )
+        is True
+    )
+    after = get_memory_entry(record.entry_id, pool=pg_schema_pool)
+    assert after is not None
+    assert after.body == "updated"
+    assert after.importance == 4
+    assert after.tags == ("a", "b")
+
+
+def test_pg_memory_update_invalid_importance(pg_schema_pool):
+    """update_memory_entry rejects importance outside [1, 5]."""
+    _apply_initial_migrations(pg_schema_pool)
+    import pytest
+
+    from pollypm.storage.pg_memory import record_memory_entry, update_memory_entry
+
+    record = record_memory_entry(
+        scope="alpha",
+        kind="note",
+        title="t",
+        body="",
+        tags=[],
+        source="m",
+        file_path="",
+        summary_path="",
+        pool=pg_schema_pool,
+    )
+    with pytest.raises(ValueError):
+        update_memory_entry(record.entry_id, importance=99, pool=pg_schema_pool)
+
+
+def test_pg_memory_delete(pg_schema_pool):
+    """delete_memory_entry removes a row, returns True/False per row presence."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_memory import (
+        delete_memory_entry,
+        get_memory_entry,
+        record_memory_entry,
+    )
+
+    record = record_memory_entry(
+        scope="alpha",
+        kind="note",
+        title="t",
+        body="",
+        tags=[],
+        source="m",
+        file_path="",
+        summary_path="",
+        pool=pg_schema_pool,
+    )
+    assert delete_memory_entry(record.entry_id, pool=pg_schema_pool) is True
+    assert get_memory_entry(record.entry_id, pool=pg_schema_pool) is None
+    assert delete_memory_entry(record.entry_id, pool=pg_schema_pool) is False
+
+
+def test_pg_memory_purge_session_scope(pg_schema_pool):
+    """purge_session_scope removes only session-tier rows for that session."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_memory import (
+        list_memory_entries,
+        purge_session_scope,
+        record_memory_entry,
+    )
+
+    # Plant: 2 session-tier rows for s1, 1 for s2, 1 project-tier row.
+    for scope, tier in [
+        ("s1", "session"),
+        ("s1", "session"),
+        ("s2", "session"),
+        ("s1", "project"),
+    ]:
+        record_memory_entry(
+            scope=scope,
+            kind="note",
+            title=f"{scope}-{tier}",
+            body="",
+            tags=[],
+            source="m",
+            file_path="",
+            summary_path="",
+            scope_tier=tier,
+            pool=pg_schema_pool,
+        )
+
+    removed = purge_session_scope("s1", pool=pg_schema_pool)
+    assert removed == 2
+
+    remaining = list_memory_entries(pool=pg_schema_pool)
+    # s2 session + s1 project survive.
+    assert len(remaining) == 2
+
+
+def test_pg_memory_expire_task_scope(pg_schema_pool):
+    """expire_task_scope stamps a TTL on task-tier entries with the given scope."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_memory import (
+        expire_task_scope,
+        get_memory_entry,
+        record_memory_entry,
+    )
+
+    record = record_memory_entry(
+        scope="T123",
+        kind="note",
+        title="t",
+        body="",
+        tags=[],
+        source="m",
+        file_path="",
+        summary_path="",
+        scope_tier="task",
+        pool=pg_schema_pool,
+    )
+    updated = expire_task_scope(
+        "T123",
+        terminal_at="2026-05-19T00:00:00+00:00",
+        ttl_days=30,
+        pool=pg_schema_pool,
+    )
+    assert updated == 1
+    after = get_memory_entry(record.entry_id, pool=pg_schema_pool)
+    assert after is not None
+    assert after.ttl_at is not None
+    # ttl_at lands 30 days after terminal_at.
+    assert "2026-06" in after.ttl_at
+
+
+def test_pg_memory_sweep_expired(pg_schema_pool):
+    """sweep_expired_memory_entries drops only rows with elapsed ttl_at."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_memory import (
+        list_memory_entries,
+        record_memory_entry,
+        sweep_expired_memory_entries,
+    )
+
+    record_memory_entry(
+        scope="alpha",
+        kind="note",
+        title="elapsed",
+        body="",
+        tags=[],
+        source="m",
+        file_path="",
+        summary_path="",
+        ttl_at="2000-01-01T00:00:00+00:00",
+        pool=pg_schema_pool,
+    )
+    record_memory_entry(
+        scope="alpha",
+        kind="note",
+        title="future",
+        body="",
+        tags=[],
+        source="m",
+        file_path="",
+        summary_path="",
+        ttl_at="2099-01-01T00:00:00+00:00",
+        pool=pg_schema_pool,
+    )
+    record_memory_entry(
+        scope="alpha",
+        kind="note",
+        title="no-ttl",
+        body="",
+        tags=[],
+        source="m",
+        file_path="",
+        summary_path="",
+        pool=pg_schema_pool,
+    )
+
+    removed = sweep_expired_memory_entries(pool=pg_schema_pool)
+    assert removed == 1
+
+    surviving = {r.title for r in list_memory_entries(pool=pg_schema_pool)}
+    assert surviving == {"future", "no-ttl"}
+
+
+def test_pg_memory_recall_keyword(pg_schema_pool):
+    """recall_memory_entries runs a tsvector match; empty query falls back to id DESC."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_memory import (
+        recall_memory_entries,
+        record_memory_entry,
+    )
+
+    record_memory_entry(
+        scope="alpha",
+        kind="note",
+        title="Heartbeat cascade",
+        body="The heartbeat tier owns mechanical recovery.",
+        tags=[],
+        source="m",
+        file_path="",
+        summary_path="",
+        pool=pg_schema_pool,
+    )
+    record_memory_entry(
+        scope="alpha",
+        kind="note",
+        title="Polly is the operator",
+        body="Polly mediates between PM and user.",
+        tags=[],
+        source="m",
+        file_path="",
+        summary_path="",
+        pool=pg_schema_pool,
+    )
+
+    results = recall_memory_entries(query="heartbeat", limit=5, pool=pg_schema_pool)
+    assert len(results) == 1
+    record, score = results[0]
+    assert record.title == "Heartbeat cascade"
+    assert score is not None and score > 0
+
+    # Empty query falls back to id DESC ordering with score=None.
+    results = recall_memory_entries(query="", limit=5, pool=pg_schema_pool)
+    assert len(results) == 2
+    assert all(score is None for _, score in results)
+    # Newest first — second insert ranks first.
+    assert results[0][0].title == "Polly is the operator"
+
+
+def test_pg_memory_recall_filters_superseded_and_expired(pg_schema_pool):
+    """recall hides superseded + expired rows by default."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_memory import (
+        recall_memory_entries,
+        record_memory_entry,
+        update_memory_entry,
+    )
+
+    keeper = record_memory_entry(
+        scope="alpha",
+        kind="note",
+        title="keeper heartbeat",
+        body="",
+        tags=[],
+        source="m",
+        file_path="",
+        summary_path="",
+        pool=pg_schema_pool,
+    )
+    superseded = record_memory_entry(
+        scope="alpha",
+        kind="note",
+        title="old heartbeat",
+        body="",
+        tags=[],
+        source="m",
+        file_path="",
+        summary_path="",
+        pool=pg_schema_pool,
+    )
+    update_memory_entry(
+        superseded.entry_id,
+        superseded_by=keeper.entry_id,
+        pool=pg_schema_pool,
+    )
+
+    results = recall_memory_entries(query="heartbeat", limit=5, pool=pg_schema_pool)
+    titles = {r.title for r, _ in results}
+    assert "keeper heartbeat" in titles
+    assert "old heartbeat" not in titles
+
+    # include_superseded brings it back.
+    results = recall_memory_entries(
+        query="heartbeat",
+        limit=5,
+        include_superseded=True,
+        pool=pg_schema_pool,
+    )
+    titles = {r.title for r, _ in results}
+    assert {"keeper heartbeat", "old heartbeat"} <= titles
+
+
+def test_pg_memory_summaries_roundtrip(pg_schema_pool):
+    """record_memory_summary + latest_memory_summary roundtrip."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_memory import (
+        latest_memory_summary,
+        record_memory_summary,
+    )
+
+    assert latest_memory_summary("alpha", pool=pg_schema_pool) is None
+
+    first = record_memory_summary(
+        scope="alpha",
+        summary_text="first summary",
+        summary_path="/tmp/s1.md",
+        entry_count=5,
+        pool=pg_schema_pool,
+    )
+    second = record_memory_summary(
+        scope="alpha",
+        summary_text="second summary",
+        summary_path="/tmp/s2.md",
+        entry_count=10,
+        pool=pg_schema_pool,
+    )
+    assert second.summary_id > first.summary_id
+
+    latest = latest_memory_summary("alpha", pool=pg_schema_pool)
+    assert latest is not None
+    assert latest.summary_id == second.summary_id
+    assert latest.summary_text == "second summary"
+    assert latest.entry_count == 10
+
+    # Different scope is isolated.
+    assert latest_memory_summary("beta", pool=pg_schema_pool) is None


### PR DESCRIPTION
Phase 2d of Slice K-state-port. Ports five StateStore clusters to per-table pg facades, mirroring the pattern from PR #1828 (cluster A).

## Facades added

| Cluster | Tables | New module | Methods |
|---------|--------|------------|---------|
| B — alerts | `messages` (`type='alert'`) | `pollypm/storage/pg_alerts.py` | upsert_alert, clear_alert, open_alerts, get_alert, clear_alert_by_id, deduplicate_alerts |
| C — heartbeats | `heartbeats`, `messages` | `pollypm/storage/pg_heartbeats.py` | record_heartbeat, latest_heartbeat, recent_heartbeats, last_heartbeat_at |
| D — leases | `leases` | `pollypm/storage/pg_leases.py` | set_lease, get_lease, clear_lease, list_leases |
| E — accounts | `account_usage`, `account_runtime` | `pollypm/storage/pg_accounts.py` | upsert_account_usage, get_account_usage, list_account_usage, upsert_account_runtime, get_account_runtime, list_account_runtimes |
| J — memory | `memory_entries`, `memory_summaries`, `memory_entries_fts` | `pollypm/storage/pg_memory.py` | record/get/list/delete/update_memory_entry, recall_memory_entries, purge_session_scope, expire_task_scope, sweep_expired_memory_entries, record/latest_memory_summary, PgMemoryStore adapter |

All facades follow the established `pg_sessions` / `pg_checkpoints` pattern: module-level functions accepting an optional `pool` kwarg defaulting to RW/RO pool, records from the backend-agnostic `storage/records.py`.

Cluster B preserves the race-resilient upsert path from #1044 (UNIQUE-violation retry against `messages_open_alert_uniq`).

Cluster J's `PgMemoryStore` is a stateless StateStore-shaped adapter so `FileMemoryBackend` doesn't need to know which backend it's running against.

## Consumers migrated

- `account_usage_sampler`, `accounts._AccountReader`, `capacity._read_account_state`, `llm_runner._account_store`, `workers._account_is_available`, `work/session_manager._unavailable_runtime_accounts` — route through pg_accounts on pg.
- `rail_daemon_supervisor.query_last_heartbeat_iso` — routes through pg_heartbeats.last_heartbeat_at on pg.
- `supervisor` cluster-D helpers (`_list_leases`/`_get_lease`/`_set_lease`/`_clear_lease`) and 7 lease call sites — route through pg_leases.
- `memory_backends.get_memory_backend` wires PgMemoryStore into FileMemoryBackend on pg.
- `knowledge_extract._store_memory_entries` uses PgMemoryStore on pg.
- `core_recurring.shared._load_config_and_store` yields `store=None` on pg; `memory_ttl_sweep_handler` routes to pg_memory.sweep_expired_memory_entries; `db_vacuum_handler` short-circuits on pg.
- `memory_curator.plugin` drops the unused short-lived StateStore open.

## Stats

- 23 files changed, +3119/−99
- 5 new test files (`test_pg_alerts.py`, `test_pg_heartbeats.py`, `test_pg_leases.py`, `test_pg_accounts.py`, `test_pg_memory.py`) — 30 new parity tests, all pass.
- 224 tests pass across the touched-module batch (`test_pg_*` + `test_capacity`/`test_workers`/`test_account_usage*`/`test_memory_*`/`test_db_vacuum`/`test_state`/`test_session_manager`).
- 2 pre-existing supervisor.py test failures (`test_send_initial_input_proceeds_*`) verified independent of this PR (fail on origin/main).

## Importer count

- Before: 28 files import `from pollypm.storage.state import StateStore` (or equivalent).
- After: 27 files. Module-level imports dropped from ~26 to 11 — the remainder are lazy (inside `if not is_pg_backend(...)` branches) so the pg path no longer touches `state.py` at import time for those consumers.

The substantial drop the brief targets (<10) requires SQLiteWorkService + the remaining StateStore-typed handles to also move; deferring to the K-source-ripout slice as planned.

## Hard constraints

- 0 `issues/**` files touched (verified).
- Worktree-isolated dispatch (clean primary tree).
- No `SQLiteWorkService` touched.
- No `state.py` deletion (deferred to K-source-ripout).
- Explicit-path staging (no `git add .` or `-A`).

## Deferred

- `dashboard_data.py`, `service_api/v1.py`, `supervisor.py` alert call sites — already partially backend-aware via `_msg_store` (the unified `Store`), which is already pg-aware; the remaining `supervisor.store.open_alerts()` etc. reads stay on sqlite for now and will follow when supervisor.store itself moves off StateStore.
- `transcript_ledger`, `worktrees`, `checkpoints` — module-level StateStore imports preserved (transcript ledger + worktree + checkpoint ports are out of scope for clusters B/C/D/E/J).
- Lazy-import cleanup for the remaining 11 module-level importers — they all branch correctly on `is_pg_backend`, so the import cost is paid only when the sqlite path actually runs.

Refs #1737