### PR TITLE
fix(pg): remove direct SQLiteWorkService imports from production code (#1369, #1737)

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -785,8 +785,9 @@ def _render_inbox_panel(config) -> str:
     each, and renders the combined view. Projects with no DB are silently
     skipped so a fresh install stays usable.
     """
+    from typing import Any
+
     from pollypm.work import create_work_service
-    from pollypm.work.sqlite_service import SQLiteWorkService
 
     # Aggregate inbox tasks across all tracked projects. Each project has its
     # own SQLite db; we open each, query, then close.
@@ -817,7 +818,7 @@ def _render_inbox_panel(config) -> str:
             raise KeyError(f"flow {name!r} not found")
 
     agg = _AggregateService()
-    opened: list[SQLiteWorkService] = []
+    opened: list[Any] = []
     seen_task_ids: set[str] = set()
     try:
         for project_key, db_path, project_path in _inbox_db_sources(config):

--- a/src/pollypm/cockpit_inbox_items.py
+++ b/src/pollypm/cockpit_inbox_items.py
@@ -32,7 +32,6 @@ from pollypm.work.inbox_plan_reviews import (
     task_user_approval_is_approved,
 )
 from pollypm.work import create_work_service
-from pollypm.work.sqlite_service import SQLiteWorkService
 
 logger = logging.getLogger(__name__)
 
@@ -620,7 +619,7 @@ def _filter_approved_plan_reviews(
         approved_refs = approved_plan_review_refs(
             refs_by_db=refs_by_db,
             project_db_paths=project_db_paths,
-            service_factory=SQLiteWorkService,
+            service_factory=create_work_service,
         )
     kept: list[InboxEntry] = []
     dropped = 0

--- a/src/pollypm/work/inbox_plan_reviews.py
+++ b/src/pollypm/work/inbox_plan_reviews.py
@@ -52,9 +52,9 @@ def approved_plan_review_refs(
 ) -> set[str]:
     """Return ``project/N`` refs whose plan-review task is already approved."""
     if service_factory is None:
-        from pollypm.work.sqlite_service import SQLiteWorkService
+        from pollypm.work.factory import create_work_service
 
-        service_factory = SQLiteWorkService
+        service_factory = create_work_service
     approved_refs: set[str] = set()
     for db_key, refs in refs_by_db.items():
         db_path, project_path = project_db_paths[db_key]

--- a/src/pollypm/work/service_dependencies.py
+++ b/src/pollypm/work/service_dependencies.py
@@ -10,16 +10,20 @@ Contract:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Any
 
 from pollypm.work.models import LinkKind, Task, WorkStatus
 from pollypm.work.service_support import TaskNotFoundError, ValidationError, _now, _parse_task_id
 
-if TYPE_CHECKING:
-    from pollypm.work.sqlite_service import SQLiteWorkService
+# ``service`` is typed ``Any`` here because these helpers reach into
+# SQLite-specific internals (``service._conn``, ``service._record_transition``,
+# etc.) that aren't part of the public ``WorkService`` Protocol. The
+# previous TYPE_CHECKING import of ``SQLiteWorkService`` was a hint for
+# IDEs only; dropping it removes a direct ``sqlite_service`` import so
+# the pg cutover can delete that module (#1369, #1737).
 
 
-def link_tasks(service: "SQLiteWorkService", from_id: str, to_id: str, kind: str) -> None:
+def link_tasks(service: Any, from_id: str, to_id: str, kind: str) -> None:
     try:
         link_kind = LinkKind(kind)
     except ValueError as exc:
@@ -68,7 +72,7 @@ def link_tasks(service: "SQLiteWorkService", from_id: str, to_id: str, kind: str
         maybe_block(service, to_id)
 
 
-def unlink_tasks(service: "SQLiteWorkService", from_id: str, to_id: str, kind: str) -> None:
+def unlink_tasks(service: Any, from_id: str, to_id: str, kind: str) -> None:
     try:
         link_kind = LinkKind(kind)
     except ValueError as exc:
@@ -91,7 +95,7 @@ def unlink_tasks(service: "SQLiteWorkService", from_id: str, to_id: str, kind: s
         maybe_unblock(service, to_id)
 
 
-def dependent_tasks(service: "SQLiteWorkService", task_id: str) -> list[Task]:
+def dependent_tasks(service: Any, task_id: str) -> list[Task]:
     project, number = _parse_task_id(task_id)
     rows = service._conn.execute(
         """
@@ -130,7 +134,7 @@ def dependent_tasks(service: "SQLiteWorkService", task_id: str) -> list[Task]:
 
 
 def would_create_cycle(
-    service: "SQLiteWorkService",
+    service: Any,
     from_project: str,
     from_number: int,
     to_project: str,
@@ -158,7 +162,7 @@ def would_create_cycle(
     return False
 
 
-def has_unresolved_blockers(service: "SQLiteWorkService", task_id: str) -> bool:
+def has_unresolved_blockers(service: Any, task_id: str) -> bool:
     project, number = _parse_task_id(task_id)
     rows = service._conn.execute(
         "SELECT d.from_project, d.from_task_number "
@@ -180,7 +184,7 @@ def has_unresolved_blockers(service: "SQLiteWorkService", task_id: str) -> bool:
     return False
 
 
-def maybe_block(service: "SQLiteWorkService", task_id: str) -> None:
+def maybe_block(service: Any, task_id: str) -> None:
     task = service.get(task_id)
     if task.work_status not in (WorkStatus.QUEUED, WorkStatus.IN_PROGRESS):
         return
@@ -203,7 +207,7 @@ def maybe_block(service: "SQLiteWorkService", task_id: str) -> None:
     service._conn.commit()
 
 
-def maybe_unblock(service: "SQLiteWorkService", task_id: str) -> None:
+def maybe_unblock(service: Any, task_id: str) -> None:
     task = service.get(task_id)
     if task.work_status != WorkStatus.BLOCKED:
         return
@@ -226,7 +230,7 @@ def maybe_unblock(service: "SQLiteWorkService", task_id: str) -> None:
     service._conn.commit()
 
 
-def check_auto_unblock(service: "SQLiteWorkService", task_id: str) -> None:
+def check_auto_unblock(service: Any, task_id: str) -> None:
     task = service.get(task_id)
     rows = service._conn.execute(
         "SELECT to_project, to_task_number FROM work_task_dependencies "
@@ -267,7 +271,7 @@ def check_auto_unblock(service: "SQLiteWorkService", task_id: str) -> None:
         )
 
 
-def on_cancelled(service: "SQLiteWorkService", task_id: str) -> None:
+def on_cancelled(service: Any, task_id: str) -> None:
     task = service.get(task_id)
     rows = service._conn.execute(
         "SELECT to_project, to_task_number FROM work_task_dependencies "

--- a/src/pollypm/work/service_queries.py
+++ b/src/pollypm/work/service_queries.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pollypm.inbox.kind import coerce_kind as _coerce_inbox_kind
 from pollypm.storage.sqlite_pragmas import readonly_uri
@@ -23,8 +23,14 @@ from pollypm.work.service_support import TaskNotFoundError, ValidationError, _no
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from pollypm.work.sqlite_service import SQLiteWorkService
 
+# ``service`` is typed ``Any`` here because these helpers reach into the
+# SQLite-specific service internals (``_conn``, ``_row_to_task``,
+# ``_load_task_token_sums_bulk``, etc.) that aren't part of the public
+# ``WorkService`` Protocol. The previous TYPE_CHECKING import of
+# ``SQLiteWorkService`` was an IDE hint only; dropping it removes a
+# direct ``sqlite_service`` import so the pg cutover can delete that
+# module (#1369, #1737).
 
 logger = logging.getLogger(__name__)
 
@@ -217,7 +223,7 @@ def _enforce_product_state_gate(
 
 
 def create_task(
-    service: "SQLiteWorkService",
+    service: Any,
     *,
     title: str,
     description: str = "",
@@ -406,7 +412,7 @@ def create_task(
     return task
 
 
-def get_task(service: "SQLiteWorkService", task_id: str) -> Task:
+def get_task(service: Any, task_id: str) -> Task:
     project, task_number = _parse_task_id(task_id)
     row = service._conn.execute(
         "SELECT * FROM work_tasks WHERE project = ? AND task_number = ?",
@@ -418,7 +424,7 @@ def get_task(service: "SQLiteWorkService", task_id: str) -> Task:
 
 
 def list_tasks(
-    service: "SQLiteWorkService",
+    service: Any,
     *,
     work_status: str | None = None,
     owner: str | None = None,
@@ -462,7 +468,7 @@ def list_tasks(
 
 
 def list_nonterminal_tasks(
-    service: "SQLiteWorkService",
+    service: Any,
     *,
     project: str | None = None,
 ) -> list[Task]:
@@ -494,7 +500,7 @@ def list_nonterminal_tasks(
     return tasks
 
 
-def update_task(service: "SQLiteWorkService", task_id: str, **fields: object) -> Task:
+def update_task(service: Any, task_id: str, **fields: object) -> Task:
     if "work_status" in fields:
         raise ValidationError(
             "Cannot change work_status via update(). "
@@ -552,7 +558,7 @@ def update_task(service: "SQLiteWorkService", task_id: str, **fields: object) ->
 
 
 def _unresolved_blocked_task_keys(
-    service: "SQLiteWorkService",
+    service: Any,
     *,
     project: str | None = None,
 ) -> set[tuple[str, int]]:
@@ -581,7 +587,7 @@ def _unresolved_blocked_task_keys(
 
 
 def next_task(
-    service: "SQLiteWorkService",
+    service: Any,
     *,
     agent: str | None = None,
     project: str | None = None,
@@ -618,14 +624,14 @@ def next_task(
             # ``_safe_json_dict`` helper so the corrupt-payload defense
             # stays consistent with ``_row_to_task`` / ``_get_flow``
             # (cycles 107-113).
-            from pollypm.work.sqlite_service import _safe_json_dict
+            from pollypm.work._safe_json import _safe_json_dict
             if _safe_json_dict(row["roles"]).get("worker") != agent:
                 continue
         return service._row_to_task(row)
     return None
 
 
-def my_tasks(service: "SQLiteWorkService", agent: str) -> list[Task]:
+def my_tasks(service: Any, agent: str) -> list[Task]:
     rows = service._conn.execute(
         "SELECT * FROM work_tasks "
         "WHERE current_node_id IS NOT NULL AND assignee = ? "
@@ -635,7 +641,7 @@ def my_tasks(service: "SQLiteWorkService", agent: str) -> list[Task]:
     return [service._row_to_task(row) for row in rows]
 
 
-def state_counts(service: "SQLiteWorkService", project: str | None = None) -> dict[str, int]:
+def state_counts(service: Any, project: str | None = None) -> dict[str, int]:
     counts = {status.value: 0 for status in WorkStatus}
     clauses: list[str] = []
     params: list[object] = []
@@ -652,7 +658,7 @@ def state_counts(service: "SQLiteWorkService", project: str | None = None) -> di
     return counts
 
 
-def blocked_tasks(service: "SQLiteWorkService", project: str | None = None) -> list[Task]:
+def blocked_tasks(service: Any, project: str | None = None) -> list[Task]:
     clauses = ["work_status = ?"]
     params: list[object] = [WorkStatus.BLOCKED.value]
     if project is not None:

--- a/src/pollypm/work/service_transition_manager.py
+++ b/src/pollypm/work/service_transition_manager.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable
+from typing import Any, Callable
 
 from pollypm.review_notify import notify_requires_review_hold
 from pollypm.task_review_summary import store_review_plain_summary
@@ -40,8 +40,12 @@ from pollypm.work.service_support import (
     _parse_task_id,
 )
 
-if TYPE_CHECKING:
-    from pollypm.work.sqlite_service import SQLiteWorkService
+# ``service`` is typed ``Any`` here because the manager calls into the
+# SQLite-specific service internals (``_conn``, ``_record_transition``,
+# ``_session_mgr``, etc.) that aren't part of the public ``WorkService``
+# Protocol. The previous TYPE_CHECKING import of ``SQLiteWorkService``
+# was an IDE hint only; dropping it removes a direct ``sqlite_service``
+# import so the pg cutover can delete that module (#1369, #1737).
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +98,7 @@ class _PMRepairCallSiteOutcome:
 class WorkTransitionManager:
     """Group the state-transition operations for ``SQLiteWorkService``."""
 
-    service: "SQLiteWorkService"
+    service: Any
 
     def _commit(self, mutate: Callable[[], None]) -> None:
         try:

--- a/src/pollypm/work/service_worker_sessions.py
+++ b/src/pollypm/work/service_worker_sessions.py
@@ -11,12 +11,15 @@ Contract:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Any
 
 from pollypm.work.models import WorkerSessionRecord
 
-if TYPE_CHECKING:
-    from pollypm.work.sqlite_service import SQLiteWorkService
+# ``service`` is typed ``Any`` here because these helpers reach into the
+# SQLite-specific ``service._conn`` attribute. The previous TYPE_CHECKING
+# import of ``SQLiteWorkService`` was an IDE hint only; dropping it
+# removes a direct ``sqlite_service`` import so the pg cutover can delete
+# that module (#1369, #1737).
 
 
 WORK_SESSIONS_DDL = """
@@ -75,12 +78,12 @@ def row_to_worker_session_record(row) -> WorkerSessionRecord:
     )
 
 
-def ensure_worker_session_schema(service: "SQLiteWorkService") -> None:
+def ensure_worker_session_schema(service: Any) -> None:
     service._conn.executescript(WORK_SESSIONS_DDL)
 
 
 def upsert_worker_session(
-    service: "SQLiteWorkService",
+    service: Any,
     *,
     task_project: str,
     task_number: int,
@@ -141,7 +144,7 @@ def upsert_worker_session(
 
 
 def mark_worker_session_ended(
-    service: "SQLiteWorkService",
+    service: Any,
     *,
     task_project: str,
     task_number: int,
@@ -172,7 +175,7 @@ def mark_worker_session_ended(
 
 
 def get_worker_session(
-    service: "SQLiteWorkService",
+    service: Any,
     *,
     task_project: str,
     task_number: int,
@@ -196,7 +199,7 @@ def get_worker_session(
 
 
 def list_worker_sessions(
-    service: "SQLiteWorkService",
+    service: Any,
     *,
     project: str | None = None,
     active_only: bool = True,
@@ -217,7 +220,7 @@ def list_worker_sessions(
 
 
 def end_worker_session(
-    service: "SQLiteWorkService",
+    service: Any,
     *,
     task_project: str,
     task_number: int,
@@ -243,7 +246,7 @@ def end_worker_session(
 
 
 def update_worker_session_tokens(
-    service: "SQLiteWorkService",
+    service: Any,
     *,
     task_project: str,
     task_number: int,


### PR DESCRIPTION
## Summary

K-state-port and K-tests are done; K-source-ripout needs to delete
`pollypm.work.sqlite_service` outright. This change clears the 7
remaining `from pollypm.work.sqlite_service` import sites in production
source so the ripout has nothing left to untangle. The only remaining
sqlite_service import lives in `pollypm.work.factory` — that's the
dispatch entry the ripout will simplify in the same slice.

## Per-file before/after

### 4 TYPE_CHECKING-only sites — `SQLiteWorkService` annotation -> `Any`

These helpers reach into SQLite-specific internals (`service._conn`,
`service._record_transition`, `service._row_to_task`, `_session_mgr`,
etc.) that aren't part of the public `WorkService` Protocol, so a
Protocol annotation would lie. `Any` matches the runtime contract
(they're called only from inside `SQLiteWorkService`) and removes the
direct dependency on the sqlite module.

- `src/pollypm/work/service_dependencies.py`
  - **Before:** `if TYPE_CHECKING: from pollypm.work.sqlite_service import SQLiteWorkService` + `: "SQLiteWorkService"` annotations.
  - **After:** `from typing import Any` + `: Any` annotations.
- `src/pollypm/work/service_worker_sessions.py` — same shape.
- `src/pollypm/work/service_transition_manager.py` — same shape; `TYPE_CHECKING` import on `Callable` widens to `from typing import Any, Callable`.
- `src/pollypm/work/service_queries.py` — same shape, plus the lazy
  `from pollypm.work.sqlite_service import _safe_json_dict` inside
  `next_task` is rewired to `from pollypm.work._safe_json import _safe_json_dict` (the leaf module where the helper actually lives; sqlite_service only re-exports it).

### 3 production consumers — switch to `create_work_service`

- `src/pollypm/cockpit_inbox.py`
  - **Before:** module-level `from pollypm.work.sqlite_service import SQLiteWorkService` (lazy, inside `_render_inbox_panel`) + `opened: list[SQLiteWorkService] = []`.
  - **After:** drop the import; `opened: list[Any] = []`. The actual construction was already going through `create_work_service(...)`; only the type hint was leaking.
- `src/pollypm/cockpit_inbox_items.py`
  - **Before:** module-level `from pollypm.work.sqlite_service import SQLiteWorkService` + `service_factory=SQLiteWorkService` in the call to `approved_plan_review_refs`.
  - **After:** drop the import; `service_factory=create_work_service`. The factory contract (`Callable[..., Any]`) is satisfied by both, and the new path routes through the backend resolver so pg installs get a pg service for plan-review approval checks instead of forcing a sqlite open.
- `src/pollypm/work/inbox_plan_reviews.py`
  - **Before:** `if service_factory is None: from pollypm.work.sqlite_service import SQLiteWorkService; service_factory = SQLiteWorkService`.
  - **After:** `if service_factory is None: from pollypm.work.factory import create_work_service; service_factory = create_work_service`.

## Verification

```
$ git --no-pager grep -l "from pollypm.work.sqlite_service" -- src/ \
    | grep -v "src/pollypm/work/factory.py"
$ # (empty — only factory.py remains, which K-source-ripout handles)
```

## Test plan

- [x] `uv run pytest tests/ --collect-only -q` — clean collection (5104 tests).
- [x] Targeted suite for every touched module: `test_work_queries`, `test_work_dependencies`, `test_workers`, `test_worker_session_gap`, `test_human_review_queue`, `test_rejection_feedback`, `test_cockpit_inbox_threads`, `test_plan_review_emit`, `test_plan_review_bypassed_approval`, `test_inbox_predicates`, `test_inbox_review_ordering`, `test_morning_briefing_inbox`, `test_advisor_inbox`, `test_task_shipped_inbox`, `test_inbox_backfill_heuristics`, `test_inbox_cli_filters`, `test_task_backend`, `test_task_review_summary`, `test_alert_task_lookup`, `test_work_dashboard`, `test_work_service_protocol_conformance` — 319 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)