### PR TITLE
fix(pg): liveness probe throttle + cluster-A residual calls + unused pytest import (closes #1829, #1830, #1831, #1737)

### DIFF
--- a/src/pollypm/checkpoints.py
+++ b/src/pollypm/checkpoints.py
@@ -640,6 +640,7 @@ def record_checkpoint(
     artifact: CheckpointArtifact,
     snapshot_path: Path,
     memory_backend_name: str = "file",
+    config: PollyPMConfig | None = None,
 ) -> None:
     store.record_checkpoint(
         session_name=launch.session.name,
@@ -650,20 +651,40 @@ def record_checkpoint(
         snapshot_path=str(snapshot_path),
         summary_text=artifact.summary_text,
     )
-    # NB: cluster-A pg dispatch for the runtime read/write is NOT
-    # threaded here yet — ``record_checkpoint`` is invoked with a live
-    # ``store`` (StateStore today; tests rely on it). Callers that have
-    # already chosen the pg backend obtain that store through
-    # ``Supervisor.store`` which still proxies sqlite. The follow-up
-    # phase will rewire ``record_checkpoint`` to take a config / route
-    # through the pg facade; for now we keep parity with the legacy
-    # behaviour. See Slice K-state-port (#1737).
-    current = store.get_session_runtime(launch.session.name)
-    store.upsert_session_runtime(
-        session_name=launch.session.name,
-        status=current.status if current is not None else "healthy",
-        last_checkpoint_path=str(artifact.summary_path),
-    )
+    # #1830: route the session_runtime read/write through pg_sessions
+    # when running on the postgres backend. ``agent_profiles.defaults``
+    # already reads ``last_checkpoint_path`` from pg_sessions in pg
+    # mode (#1828); without this dispatch newly written checkpoints
+    # land on the legacy SQLite StateStore and are invisible to prompt/
+    # recovery readers. Fall back to ``store`` (StateStore) when no
+    # config is threaded or the sqlite backend is active.
+    use_pg = False
+    if config is not None:
+        try:
+            from pollypm.storage._backend_dispatch import is_pg_backend
+
+            use_pg = is_pg_backend(config)
+        except Exception:  # noqa: BLE001
+            use_pg = False
+    if use_pg:
+        from pollypm.storage.pg_sessions import (
+            get_session_runtime as _pg_get_runtime,
+            upsert_session_runtime as _pg_upsert_runtime,
+        )
+
+        current = _pg_get_runtime(launch.session.name)
+        _pg_upsert_runtime(
+            session_name=launch.session.name,
+            status=current.status if current is not None else "healthy",
+            last_checkpoint_path=str(artifact.summary_path),
+        )
+    else:
+        current = store.get_session_runtime(launch.session.name)
+        store.upsert_session_runtime(
+            session_name=launch.session.name,
+            status=current.status if current is not None else "healthy",
+            last_checkpoint_path=str(artifact.summary_path),
+        )
     try:
         memory_backend = get_memory_backend(launch.session.cwd, memory_backend_name)
         memory_backend.write_entry(

--- a/src/pollypm/cli_features/session_runtime.py
+++ b/src/pollypm/cli_features/session_runtime.py
@@ -534,7 +534,8 @@ def debug_command(
         )
 
     typer.echo("")
-    events_list = supervisor.store.recent_events(limit=5)
+    # #1830: route through supervisor facade for pg/sqlite parity.
+    events_list = supervisor.recent_events(limit=5)
     if session is not None:
         events_list = [event for event in events_list if event.session_name == session]
     typer.echo(f"Recent events: {len(events_list)}")
@@ -558,7 +559,8 @@ def events(
     # as the next-step diagnostic; that hint must work without
     # ``pm up``). ``recent_events`` is a pure DB read.
     supervisor = helpers._load_supervisor(config_path)
-    items = supervisor.store.recent_events(limit=limit)
+    # #1830: route through supervisor facade for pg/sqlite parity.
+    items = supervisor.recent_events(limit=limit)
     if not items:
         typer.echo("No events recorded.")
         return

--- a/src/pollypm/cli_features/workers.py
+++ b/src/pollypm/cli_features/workers.py
@@ -207,7 +207,8 @@ def register_worker_commands(app: typer.Typer) -> None:
                 )
                 local_path.write_text(local_content)
                 typer.echo(f"  Updated project-local config with new args: {new_args}")
-        supervisor.store.upsert_session_runtime(
+        # #1830: route through supervisor facade for pg/sqlite parity.
+        supervisor.upsert_session_runtime(
             session_name=session_name,
             status="switching",
             effective_account=account,
@@ -254,7 +255,8 @@ def register_worker_commands(app: typer.Typer) -> None:
         except Exception:  # noqa: BLE001
             typer.echo(f"Session {session_name} was not running")
 
-        supervisor.store.upsert_session_runtime(
+        # #1830: route through supervisor facade for pg/sqlite parity.
+        supervisor.upsert_session_runtime(
             session_name=session_name,
             status="disabled",
         )

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -1198,7 +1198,8 @@ def _supervisor_stuck_and_heartbeat(
     if supervisor is None:
         return False, None, None
     try:
-        drift_at = supervisor.store.last_event_at(session_name, "state_drift")
+        # #1830: route through supervisor facade for pg/sqlite parity.
+        drift_at = supervisor.last_event_at(session_name, "state_drift")
     except Exception:  # noqa: BLE001
         drift_at = None
     stuck = False

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -1434,7 +1434,8 @@ class CockpitRouter:
         launches, windows, alerts, _leases, _errors = supervisor.status()
         recent_events = []
         try:
-            recent_events = list(supervisor.store.recent_events(limit=300))
+            # #1830: route through supervisor facade for pg/sqlite parity.
+            recent_events = list(supervisor.recent_events(limit=300))
         except Exception:  # noqa: BLE001
             recent_events = []
 
@@ -5133,7 +5134,8 @@ class PollyCockpitRail:
             pass
         try:
             supervisor = self.router._load_supervisor()
-            raw_events = list(supervisor.store.recent_events(limit=48))
+            # #1830: route through supervisor facade for pg/sqlite parity.
+            raw_events = list(supervisor.recent_events(limit=48))
         except Exception:  # noqa: BLE001
             return ""
         events = [

--- a/src/pollypm/cockpit_sections/dashboard.py
+++ b/src/pollypm/cockpit_sections/dashboard.py
@@ -693,7 +693,8 @@ def _build_dashboard(supervisor, config, config_path: Path | None = None) -> str
         if not is_operational_alert(alert.alert_type)
     ]
     try:
-        recent = supervisor.store.recent_events(limit=300)
+        # #1830: route through supervisor facade for pg/sqlite parity.
+        recent = supervisor.recent_events(limit=300)
     except Exception:  # noqa: BLE001
         recent = []
     cutoff_24h = (now - timedelta(hours=24)).isoformat()

--- a/src/pollypm/cockpit_sections/project_dashboard.py
+++ b/src/pollypm/cockpit_sections/project_dashboard.py
@@ -193,7 +193,8 @@ def _render_project_dashboard(
         project_alerts = []
 
     try:
-        system_events = supervisor.store.recent_events(limit=200)
+        # #1830: route through supervisor facade for pg/sqlite parity.
+        system_events = supervisor.recent_events(limit=200)
     except Exception:  # noqa: BLE001
         system_events = []
     system_events = [

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -1113,7 +1113,8 @@ class PollyCockpitApp(App[None]):
             # Reset the recovery-attempt counter so the next failure
             # gets ``_RECOVERY_LIMIT`` retries again instead of slamming
             # straight back into ``recovery_limit``.
-            supervisor.store.upsert_session_runtime(
+            # #1830: route through supervisor facade for pg/sqlite parity.
+            supervisor.upsert_session_runtime(
                 session_name=session_name,
                 status="idle",
                 recovery_attempts=0,
@@ -1158,7 +1159,8 @@ class PollyCockpitApp(App[None]):
                 "recovery_limit",
                 who_cleared="manual:cockpit-restart-session",
             )
-            supervisor.store.upsert_session_runtime(
+            # #1830: route through supervisor facade for pg/sqlite parity.
+            supervisor.upsert_session_runtime(
                 session_name=session_name,
                 status="recovering",
                 recovery_attempts=0,
@@ -2052,7 +2054,7 @@ class PollyCockpitApp(App[None]):
     # ``_update_ticker`` now repaints from the cached event list every
     # tick (cheap, pure-Python), and a worker thread refreshes the
     # cache every ``_TICKER_EVENT_REFRESH_TICKS`` ticks. Before this
-    # split, ``supervisor.store.recent_events(limit=48)`` ran inside
+    # split, ``supervisor.recent_events(limit=48)`` ran inside
     # ``_tick`` on the main thread every 0.8s; under SQLite write
     # contention the SELECT blocked the event loop for seconds at a
     # time, dropping rail keystrokes (#1587).
@@ -2093,7 +2095,8 @@ class PollyCockpitApp(App[None]):
         """Synchronous SQLite read — only safe off the main thread."""
         try:
             supervisor = self.router._load_supervisor()
-            raw_events = list(supervisor.store.recent_events(limit=48))
+            # #1830: route through supervisor facade for pg/sqlite parity.
+            raw_events = list(supervisor.recent_events(limit=48))
         except Exception:  # noqa: BLE001
             return []
         return [

--- a/src/pollypm/control_tui.py
+++ b/src/pollypm/control_tui.py
@@ -864,7 +864,8 @@ class PollyPMApp(App[None]):
                 ),
                 f"{event.created_at}:{event.session_name}:{event.event_type}",
             )
-            for event in supervisor.store.recent_events(limit=50)
+            # #1830: route through supervisor facade for pg/sqlite parity.
+            for event in supervisor.recent_events(limit=50)
         ]
         self._replace_table_rows(self.events_table, rows)
 

--- a/src/pollypm/heartbeats/api.py
+++ b/src/pollypm/heartbeats/api.py
@@ -189,6 +189,9 @@ class SupervisorHeartbeatAPI:
             artifact=artifact,
             snapshot_path=Path(context.snapshot_path),
             memory_backend_name=self.supervisor.config.memory.backend,
+            # #1830: thread the config so pg-mode last_checkpoint_path
+            # writes go to pg.session_runtime, not the legacy StateStore.
+            config=self.supervisor.config,
         )
         # Knowledge extraction now happens in session_intelligence (unified Haiku call)
         # instead of per-checkpoint snapshot learning.
@@ -228,7 +231,9 @@ class SupervisorHeartbeatAPI:
         ]
 
     def set_session_status(self, session_name: str, status: str, *, reason: str = "") -> None:
-        self.supervisor.store.upsert_session_runtime(
+        # #1830: route through the supervisor facade so pg-mode writes
+        # land on pg.session_runtime rather than legacy SQLite.
+        self.supervisor.upsert_session_runtime(
             session_name=session_name,
             status=status,
             last_failure_message=reason or None,

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -748,7 +748,8 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         # Skip disabled sessions (decommissioned via pm worker-stop)
         # Also skip if the operator recently managed workers (avoid race with Polly)
         try:
-            rt = api.supervisor.store.get_session_runtime(context.session_name)
+            # #1830: route through supervisor facade for pg/sqlite parity.
+            rt = api.supervisor.get_session_runtime(context.session_name)
             if rt and rt.status in ("disabled", "switching"):
                 return
         except (AttributeError, Exception):  # noqa: BLE001
@@ -856,7 +857,8 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         ):
             runtime = None
             try:
-                runtime = api.supervisor.store.get_session_runtime(
+                # #1830: route through supervisor facade for pg/sqlite parity.
+                runtime = api.supervisor.get_session_runtime(
                     context.session_name
                 )
             except (AttributeError, Exception):  # noqa: BLE001
@@ -1088,7 +1090,8 @@ class LocalHeartbeatBackend(HeartbeatBackend):
             try:
                 signals = self._context_to_signals(context, api)
                 health = _classify_session_health(signals)
-                runtime = api.supervisor.store.get_session_runtime(context.session_name)
+                # #1830: route through supervisor facade for pg/sqlite parity.
+                runtime = api.supervisor.get_session_runtime(context.session_name)
                 prev = runtime.recovery_attempts if runtime else 0
                 intervention = _select_intervention(health, signals, previous_interventions=prev)
                 # #249 — work-aware interventions. These dispatch before

--- a/src/pollypm/plugins_builtin/core_recurring/maintenance.py
+++ b/src/pollypm/plugins_builtin/core_recurring/maintenance.py
@@ -363,30 +363,18 @@ def audit_watchdog_liveness_probe_handler(
         return summary
 
     def _do_heal(q: Any) -> None:
-        # 1. Throttle: if we already healed inside the last
-        # HEAL_THROTTLE_SECONDS, leave the existing alert in place
-        # and bail. ``has_recent_or_active_dedupe`` is the cheapest
-        # observable proxy: re-enqueue uses dedupe_key="audit.watchdog",
-        # so a recent fire keeps that flag set.
-        recently = getattr(q, "has_recent_or_active_dedupe", None)
-        if callable(recently):
-            since = resolved_now - timedelta(seconds=HEAL_THROTTLE_SECONDS)
-            try:
-                if recently(_WATCHDOG_HANDLER_NAME, since=since):
-                    summary["action"] = "throttled"
-                    return
-            except Exception:  # noqa: BLE001
-                logger.debug(
-                    "audit_watchdog.liveness_probe: "
-                    "has_recent_or_active_dedupe failed",
-                    exc_info=True,
-                )
-
-        # 2. Release any orphaned ``claimed`` rows. The most likely
-        # wedge under the new pg queue is that the previous
+        # 1. Release any orphaned ``claimed`` rows FIRST. The most
+        # likely wedge under the new pg queue is that the previous
         # ``audit.watchdog`` claim is still held by a dead /
         # GC'd worker thread, and the dedupe-on-status='claimed'
         # short-circuit at JobQueue.enqueue blocks every new fire.
+        #
+        # #1829 ordering fix: we used to throttle before this step,
+        # but ``has_recent_or_active_dedupe`` returns true on any
+        # ``claimed`` row — including the orphaned one we are about
+        # to recover — so the throttle would skip recovery and the
+        # wedge would persist. Recovering first lets the throttle
+        # see the post-heal queue state.
         try:
             recovered, pruned = q.recover_orphaned_claims()
             summary["recovered_claims"] = recovered
@@ -399,6 +387,30 @@ def audit_watchdog_liveness_probe_handler(
             )
             summary["recovered_claims"] = 0
             summary["pruned_claims"] = 0
+
+        # 2. Anti-loop throttle: skip the re-enqueue / alert path if
+        # we *already* re-enqueued a heal inside the last
+        # HEAL_THROTTLE_SECONDS. We only consider rows that point at a
+        # prior heal attempt (``status IN ('queued', 'done')`` enqueued
+        # since the window), not a stale ``claimed`` row — that was
+        # the #1829 bug. ``has_recent_or_active_dedupe`` still returns
+        # true on stale ``claimed`` rows, so we additionally require
+        # that ``recovered_claims == 0`` for this iteration (if we
+        # just recovered something, the previous "active dedupe" was
+        # the wedge we're recovering, not a recent legitimate heal).
+        recently = getattr(q, "has_recent_or_active_dedupe", None)
+        if callable(recently) and summary.get("recovered_claims", 0) == 0:
+            since = resolved_now - timedelta(seconds=HEAL_THROTTLE_SECONDS)
+            try:
+                if recently(_WATCHDOG_HANDLER_NAME, since=since):
+                    summary["action"] = "throttled"
+                    return
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "audit_watchdog.liveness_probe: "
+                    "has_recent_or_active_dedupe failed",
+                    exc_info=True,
+                )
 
         # 3. Re-enqueue the cadence job with the canonical dedupe
         # key. If a prior row is queued / claimed at this point the

--- a/src/pollypm/service_api/v1.py
+++ b/src/pollypm/service_api/v1.py
@@ -201,7 +201,8 @@ class PollyPMService:
             configured_window_names.add(launch.window_name)
             if session_name is not None and launch.session.name != session_name:
                 continue
-            runtime = supervisor.store.get_session_runtime(launch.session.name)
+            # #1830: route through supervisor facade for pg/sqlite parity.
+            runtime = supervisor.get_session_runtime(launch.session.name)
             window = window_map.get(launch.window_name)
             lease = lease_map.get(launch.session.name)
             sessions.append(
@@ -236,7 +237,8 @@ class PollyPMService:
             project, _task_number = parsed
             if session_name is not None and window.name != session_name:
                 continue
-            runtime = supervisor.store.get_session_runtime(window.name)
+            # #1830: route through supervisor facade for pg/sqlite parity.
+            runtime = supervisor.get_session_runtime(window.name)
             lease = lease_map.get(window.name)
             sessions.append(
                 {
@@ -444,7 +446,8 @@ class PollyPMService:
         """Override a session's runtime status with an optional failure reason."""
         supervisor = self.load_supervisor()
         supervisor.require_session(session_name)
-        supervisor.store.upsert_session_runtime(
+        # #1830: route through supervisor facade for pg/sqlite parity.
+        supervisor.upsert_session_runtime(
             session_name=session_name,
             status=status,
             last_failure_message=reason or None,
@@ -466,7 +469,8 @@ class PollyPMService:
                 "reason": reason or None,
             },
         )
-        runtime = supervisor.store.get_session_runtime(session_name)
+        # #1830: route through supervisor facade for pg/sqlite parity.
+        runtime = supervisor.get_session_runtime(session_name)
         if runtime is None:
             raise RuntimeError(f"Session runtime for {session_name} was not updated")
         return runtime
@@ -855,6 +859,9 @@ class PollyPMService:
             artifact=checkpoint_artifact,
             snapshot_path=moved.path,
             memory_backend_name=config.memory.backend,
+            # #1830: thread config so pg-mode session_runtime writes
+            # route through pg_sessions instead of legacy StateStore.
+            config=config,
         )
         # #349: audit event lands on the unified ``messages`` table via Store.
         from pollypm.store.registry import get_store

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -502,6 +502,31 @@ class Supervisor:
             return pg_last_event_at(session_name, event_type)
         return self.store.last_event_at(session_name, event_type)
 
+    # --- Public cluster-A facade (#1830) ------------------------------- #
+    # Public wrappers around the private cluster-A dispatch helpers above
+    # so external callers (heartbeats, service_api, cockpit, checkpoints)
+    # can route session/runtime/event reads & writes through the backend-
+    # aware path without reaching into ``supervisor.store`` directly. In
+    # pg mode the legacy SQLite StateStore is invisible to readers of the
+    # unified pg session_runtime/messages tables — see #1830 for the
+    # divergence the indirection prevents.
+
+    def get_session_runtime(self, session_name: str):
+        """Public read for session_runtime rows (pg or sqlite backend)."""
+        return self._get_session_runtime(session_name)
+
+    def upsert_session_runtime(self, **kwargs) -> None:
+        """Public write for session_runtime rows (pg or sqlite backend)."""
+        self._upsert_session_runtime(**kwargs)
+
+    def recent_events(self, limit: int = 20):
+        """Public read for recent session events (pg or sqlite backend)."""
+        return self._recent_events(limit=limit)
+
+    def last_event_at(self, session_name: str, event_type: str):
+        """Public read for the latest event of (scope, subject)."""
+        return self._last_event_at(session_name, event_type)
+
     # --- Cluster D (leases) dispatch helpers -------------------------- #
     # Same pattern as the cluster-A helpers above: route through
     # ``pollypm.storage.pg_leases`` on the pg backend, stay on the
@@ -1921,6 +1946,9 @@ class Supervisor:
                 artifact=artifact,
                 snapshot_path=snapshot_path,
                 memory_backend_name=self.config.memory.backend,
+                # #1830: thread config so pg-mode session_runtime writes
+                # route through pg_sessions instead of legacy StateStore.
+                config=self.config,
             )
             # Proactive capacity rollover: if the account is near its limit
             # (≤ PROACTIVE_ROLLOVER_THRESHOLD_PCT remaining) and no hard

--- a/tests/test_audit_watchdog_liveness_probe.py
+++ b/tests/test_audit_watchdog_liveness_probe.py
@@ -87,8 +87,14 @@ def _write_tick(
 class _FakeQueue:
     """In-memory queue stub that mirrors the parts of ``JobQueue`` the probe uses."""
 
-    def __init__(self, *, dedupe_active: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        dedupe_active: bool = False,
+        recovered_claims: int = 1,
+    ) -> None:
         self._dedupe_active = dedupe_active
+        self._recovered_claims = recovered_claims
         self.recover_calls: int = 0
         self.enqueued: list[tuple[str, str | None]] = []
         self.dedupe_checks: list[tuple[str, datetime]] = []
@@ -104,10 +110,13 @@ class _FakeQueue:
 
     def recover_orphaned_claims(self) -> tuple[int, int]:
         self.recover_calls += 1
-        # Simulate one orphaned claim being recovered — that's the
-        # observable signal the wedge described in #1815 leaves behind
-        # when ``audit.watchdog`` itself was the stuck handler.
-        return (1, 0)
+        # Simulate ``self._recovered_claims`` orphaned claims being
+        # recovered — that's the observable signal the wedge described
+        # in #1815 leaves behind when ``audit.watchdog`` itself was the
+        # stuck handler. #1829 added the recovered-count knob so we can
+        # distinguish "stale claim wedge" (recovered > 0) from "recent
+        # legitimate heal" (recovered == 0).
+        return (self._recovered_claims, 0)
 
     def enqueue(
         self,
@@ -252,25 +261,108 @@ def test_probe_throttles_when_recent_heal_already_landed(
 ) -> None:
     """A recent ``audit.watchdog`` re-enqueue suppresses a second heal.
 
-    The probe checks ``has_recent_or_active_dedupe`` before
-    re-enqueueing. A True return there means a previous probe
-    (within HEAL_THROTTLE_SECONDS) already healed; the alert
-    that probe raised remains open, so this run is a no-op.
+    The probe checks ``has_recent_or_active_dedupe`` after recovering
+    orphaned claims. A True return there means a previous probe
+    (within HEAL_THROTTLE_SECONDS) already healed; the alert that
+    probe raised remains open, so this run is a no-op.
+
+    #1829 invariant: the throttle only suppresses when there's nothing
+    new to recover. ``recovered_claims=0`` here keeps that test
+    consistent with the post-#1829 ordering (recover first, then
+    throttle).
     """
     _write_tick(_isolate_audit_home, ts=now - timedelta(hours=9))
-    queue = _FakeQueue(dedupe_active=True)
+    queue = _FakeQueue(dedupe_active=True, recovered_claims=0)
     summary = audit_watchdog_liveness_probe_handler(
         {}, queue=queue, now=now,
     )
     assert summary["stale"] is True
     assert summary["action"] == "throttled"
-    assert queue.recover_calls == 0
+    # Recovery always runs first now (#1829); the throttle blocks the
+    # subsequent re-enqueue + alert, not the recovery itself.
+    assert queue.recover_calls == 1
     assert queue.enqueued == []
     # The throttle window is HEAL_THROTTLE_SECONDS back from now.
     assert len(queue.dedupe_checks) == 1
     key, since = queue.dedupe_checks[0]
     assert key == AUDIT_WATCHDOG_HANDLER_NAME
     assert abs((now - since).total_seconds() - HEAL_THROTTLE_SECONDS) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# #1829 — throttle must not block the orphaned-claim it should recover
+# ---------------------------------------------------------------------------
+
+
+def test_probe_recovers_orphaned_claim_even_when_dedupe_active(
+    _isolate_audit_home: Path,
+    now: datetime,
+) -> None:
+    """#1829: stale ``claimed`` row must not throttle its own recovery.
+
+    Pre-#1829 the probe consulted ``has_recent_or_active_dedupe``
+    BEFORE recovering orphaned claims. That helper returns True on
+    any row in ``status IN ('queued', 'claimed')`` — including the
+    exact stale claim the probe was trying to clear. Result: the
+    probe blocked itself and the wedge from #1815 persisted.
+
+    The fix recovers first, then throttles only when there was
+    nothing to recover. This test pins the new ordering: even with
+    ``dedupe_active=True`` (because of the wedged claim), as long as
+    ``recover_orphaned_claims`` returns a non-zero count we must
+    proceed to re-enqueue.
+    """
+    _write_tick(_isolate_audit_home, ts=now - timedelta(hours=9))
+    queue = _FakeQueue(dedupe_active=True, recovered_claims=1)
+    summary = audit_watchdog_liveness_probe_handler(
+        {}, queue=queue, now=now,
+    )
+    assert summary["stale"] is True
+    # Recovery ran AND re-enqueue ran — the throttle did not fire.
+    assert summary["action"] == "healed"
+    assert queue.recover_calls == 1
+    assert summary["recovered_claims"] == 1
+    assert queue.enqueued == [
+        (AUDIT_WATCHDOG_HANDLER_NAME, AUDIT_WATCHDOG_HANDLER_NAME),
+    ]
+
+
+def test_probe_fires_twice_when_wedge_re_emerges(
+    _isolate_audit_home: Path,
+    now: datetime,
+) -> None:
+    """#1829: a second wedge in the same throttle window still heals.
+
+    Two consecutive probe runs both encounter an orphaned claim;
+    both must recover + re-enqueue. The anti-loop throttle is only
+    meant to suppress *idle* repeats, never a fresh stale-claim
+    condition.
+    """
+    _write_tick(_isolate_audit_home, ts=now - timedelta(hours=9))
+
+    # First run — wedge present, dedupe slot looks "active" because
+    # the wedged claim itself holds it.
+    queue1 = _FakeQueue(dedupe_active=True, recovered_claims=1)
+    summary1 = audit_watchdog_liveness_probe_handler(
+        {}, queue=queue1, now=now,
+    )
+    assert summary1["action"] == "healed"
+    assert queue1.recover_calls == 1
+    assert len(queue1.enqueued) == 1
+
+    # Second run, well inside the HEAL_THROTTLE_SECONDS window. A
+    # NEW orphaned claim has appeared. The throttle must NOT block
+    # this; it is the exact #1829 failure mode where the probe
+    # would skip recovery because its own prior heal made the
+    # dedupe slot look active.
+    queue2 = _FakeQueue(dedupe_active=True, recovered_claims=1)
+    later = now + timedelta(seconds=HEAL_THROTTLE_SECONDS / 2)
+    summary2 = audit_watchdog_liveness_probe_handler(
+        {}, queue=queue2, now=later,
+    )
+    assert summary2["action"] == "healed"
+    assert queue2.recover_calls == 1
+    assert len(queue2.enqueued) == 1
 
 
 def test_probe_respects_custom_stale_threshold(

--- a/tests/test_pg_sessions.py
+++ b/tests/test_pg_sessions.py
@@ -16,8 +16,6 @@ extension is available — see ``tests/conftest_pg.py``.
 
 from __future__ import annotations
 
-import pytest
-
 
 def _apply_initial_migrations(pg_schema_pool) -> None:
     """Apply the canonical schema migrations onto the per-test pool."""
@@ -339,3 +337,52 @@ def test_pg_session_runtime_explicit_none_clears_column(pg_schema_pool):
     assert row is not None
     assert row.last_failure_type is None
     assert row.last_failure_message is None
+
+
+# --------------------------------------------------------------------- #
+# #1830 — cluster-A caller migration parity
+# --------------------------------------------------------------------- #
+
+
+def test_no_external_supervisor_store_session_callsites() -> None:
+    """#1830: cluster-A session/runtime/event ops must not bypass the facade.
+
+    PR #1828 introduced backend-aware dispatch helpers on Supervisor
+    but left several external call sites (heartbeats, service_api,
+    cockpit, checkpoints, cli) reading & writing session_runtime
+    and events directly on ``supervisor.store`` (the legacy
+    StateStore). In pg mode that splits cluster-A state between
+    Postgres and SQLite — heartbeat recovery status and recent event
+    feeds can drift apart.
+
+    This guard asserts that no caller outside ``supervisor.py``
+    reaches through ``supervisor.store.*`` for cluster-A surface.
+    The supervisor module itself is allowed to keep the SQLite path
+    inside its private ``_upsert_session`` / ``_get_session_runtime``
+    / ``_recent_events`` / ``_last_event_at`` helpers — those are the
+    sqlite branch of the dispatcher.
+    """
+    import subprocess
+
+    pattern = (
+        r"supervisor\.store\.(upsert_session|list_sessions|prune_sessions|"
+        r"get_session_window|record_event|last_event_at|recent_events|"
+        r"upsert_session_runtime|get_session_runtime|list_session_runtimes)\("
+    )
+    result = subprocess.run(
+        ["git", "grep", "-nE", pattern, "--", "src/"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # ``supervisor.py`` is the dispatcher itself and is allowed to
+    # call ``self.store.*`` on the sqlite branch — filter those out.
+    leaked = [
+        line for line in result.stdout.splitlines()
+        if line and not line.startswith("src/pollypm/supervisor.py:")
+    ]
+    assert not leaked, (
+        "Unmigrated cluster-A call sites (#1830) — must go through "
+        "supervisor.get_session_runtime / .upsert_session_runtime / "
+        ".recent_events / .last_event_at:\n" + "\n".join(leaked)
+    )

--- a/tests/test_service_api.py
+++ b/tests/test_service_api.py
@@ -839,6 +839,12 @@ def test_session_status_surfaces_per_task_workers(monkeypatch, tmp_path: Path) -
     class FakeSupervisor:
         store = FakeStore()
 
+        # #1830: session_status now routes runtime reads through the
+        # supervisor facade. The fake mirrors the dispatch by deferring
+        # to its FakeStore on the sqlite branch.
+        def get_session_runtime(self, session_name: str):
+            return self.store.get_session_runtime(session_name)
+
         def status(self):
             # No configured launches; only a per-task window in tmux.
             return ([], [task_window], [], [], [])
@@ -891,6 +897,12 @@ def test_session_status_filter_by_per_task_window_name(monkeypatch, tmp_path: Pa
 
     class FakeSupervisor:
         store = FakeStore()
+
+        # #1830: session_status now routes runtime reads through the
+        # supervisor facade. The fake mirrors the dispatch by deferring
+        # to its FakeStore on the sqlite branch.
+        def get_session_runtime(self, session_name: str):
+            return self.store.get_session_runtime(session_name)
 
         def status(self):
             return ([], windows, [], [], [])


### PR DESCRIPTION
## Summary

Three Codex follow-up issues bundled into one PR. Each one regressed off a PR that merged earlier today (#1826, #1828).

### #1829 — audit_watchdog liveness probe throttled its own recovery

The probe in `maintenance.py` consulted `has_recent_or_active_dedupe(audit.watchdog)` BEFORE recovering orphaned claims. That helper returns `True` on any `status IN ('queued', 'claimed')` row — including the stale claim the probe was supposed to clear — so the probe's anti-loop guard skipped recovery and the #1815 wedge persisted.

**Fix**: reorder. Recover orphaned claims first, then apply the throttle only when `recovered_claims == 0` (i.e. nothing was wedged — the dedupe slot is held by a recent legitimate heal). Two new regression tests pin the new ordering:

- `test_probe_recovers_orphaned_claim_even_when_dedupe_active` — a stale claim must heal even when `dedupe_active=True`.
- `test_probe_fires_twice_when_wedge_re_emerges` — two consecutive wedges inside the same `HEAL_THROTTLE_SECONDS` window both heal.

### #1830 — cluster-A residual StateStore call sites

PR #1828 introduced backend-aware dispatch helpers on `Supervisor` (`_get_session_runtime`, `_upsert_session_runtime`, `_recent_events`, `_last_event_at`) but kept them private and only used them from inside the module. External callers in heartbeats, service_api, cockpit, cli, and checkpoints kept reading & writing through `supervisor.store.*` — which means in pg mode their reads/writes hit the legacy SQLite StateStore while other readers consult Postgres. Cluster-A state can diverge.

**Fix**:
1. Promoted the four dispatch helpers to public `Supervisor` methods (`get_session_runtime`, `upsert_session_runtime`, `recent_events`, `last_event_at`).
2. Migrated every external caller listed in the issue: `heartbeats/api.py`, `heartbeats/local.py` (×3), `service_api/v1.py` (×4), `cockpit_ui.py` (×3), `cockpit_rail.py` (×2), `cockpit_inbox.py`, `cockpit_sections/dashboard.py`, `cockpit_sections/project_dashboard.py`, `cli_features/session_runtime.py` (×2), `cli_features/workers.py` (×2), `control_tui.py`.
3. Threaded `config` through `record_checkpoint()` so pg-mode `last_checkpoint_path` writes go to `pg.session_runtime` — matching the existing read path in `agent_profiles/defaults.py` (added in #1828).
4. Added `test_no_external_supervisor_store_session_callsites` as a parity guard.

Updated FakeSupervisor stubs in `test_service_api.py` to mirror the new facade dispatch (they delegate `get_session_runtime` to their FakeStore).

### #1831 — unused pytest import

Removed `import pytest` from `tests/test_pg_sessions.py`. Trivial.

## Test plan

- [x] `uv run --extra dev pytest tests/test_audit_watchdog_liveness_probe.py tests/test_pg_sessions.py -x -q` — 20 passed
- [x] `uv run --extra dev pytest tests/test_service_api.py -q` — 20 passed (post-FakeSupervisor update)
- [x] `uv run --extra dev pytest tests/test_audit_watchdog_liveness_probe.py tests/test_pg_sessions.py tests/test_service_api.py tests/test_workers.py tests/test_heartbeat_cascade_foundation.py tests/test_cockpit_rail_routes.py -q` — 105 passed
- [x] `uv run --extra dev python -c "import pollypm; from pollypm.config import load_config; load_config()"` — clean
- [x] `uv run --extra dev ruff check` on touched files — no new lint errors vs. main (78 pre-existing, 0 new)
- [ ] Operator smoke: `pm up` then `pm worker-switch <name>` should still flip status to `switching` in pg mode

## Hard constraints honored

- Worked in `/tmp/pollypm-codex-followup` worktree; primary tree untouched.
- All `git add` calls used explicit paths (no `-A` / `.`).
- No git hooks bypassed.
- Did not touch the K-state-callers-port dual-mode dispatcher internals (the parallel agent's territory); only promoted private helpers to public and migrated the explicit call sites the issues called out.

Closes #1829, #1830, #1831, #1737.

🤖 Generated with [Claude Code](https://claude.com/claude-code)