### PR TITLE
fix(cockpit): operator fast-path + mount-verify + rail-click defer + activity async paint

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -3358,6 +3358,15 @@ class CockpitRouter:
                 pass
             self._end_layout_mutation(token)
 
+    # #1832 — timing-log threshold for the static route's tmux sub-steps.
+    # When any of ``list_panes`` / ``try_show_static_fast`` / ``show_static``
+    # blocks longer than this, log the path + elapsed ms at WARNING so a
+    # wedged tmux server is identifiable from logs without enabling debug
+    # tracing. Picked at 250ms because the static fast path normally
+    # completes in <50ms; anything past 250ms means the user perceives
+    # the click as sluggish.
+    _ROUTE_TIMING_WARN_SECONDS: float = 0.25
+
     def _route_supervisor_free_static(self, key: str) -> bool:
         if key not in self._SUPERVISOR_FREE_STATIC_KEYS:
             return False
@@ -3377,10 +3386,16 @@ class CockpitRouter:
         # timeout. In the common case (cockpit layout is already
         # healthy), reusing this single ``list_panes`` keeps the
         # static route at two tmux subprocess calls total.
+        #
+        # #1832 — wrap each tmux sub-step in a timing probe so a slow
+        # subprocess shows up in logs without users needing to enable
+        # debug tracing. The probe is a no-op below the warn threshold.
+        t_start = time.monotonic()
         try:
             panes = self.tmux.list_panes(window_target)
         except Exception:  # noqa: BLE001
             panes = None
+        self._maybe_log_route_step("list_panes", key, t_start)
         if has_mount_state:
             if panes is None:
                 return False
@@ -3424,17 +3439,47 @@ class CockpitRouter:
         # layouts (and for safety when ``list_panes`` itself failed).
         result = None
         if panes is not None:
+            t_fast = time.monotonic()
             result = manager.try_show_static_fast(
                 command,
                 window_state,
                 panes=panes,
             )
+            self._maybe_log_route_step("try_show_static_fast", key, t_fast)
         if result is None:
+            t_slow = time.monotonic()
             result = manager.show_static(command, window_state)
+            # show_static covers list_panes + ensure_layout + respawn_pane;
+            # a slow result here pins blame on the layout-repair chain.
+            self._maybe_log_route_step("show_static", key, t_slow)
         if not result.ok:
             self._handle_invalid_static_route(result)
         self._write_window_state(result.state, base=state)
         return True
+
+    def _maybe_log_route_step(
+        self, step: str, key: str, start_monotonic: float,
+    ) -> None:
+        """#1832 — log a warning when a static-route tmux sub-step
+        blocks the route worker for more than
+        :attr:`_ROUTE_TIMING_WARN_SECONDS`.
+
+        The route worker runs off the Textual main thread, so this
+        does not affect cockpit responsiveness — but a slow subprocess
+        still delays the user-visible ``respawn_pane`` paint. Logging
+        the elapsed ms per step makes it possible to identify which
+        tmux call is wedged (list-panes, ensure-layout, etc.) from
+        ``~/.pollypm/audit/*.log`` after a slow click.
+        """
+        elapsed = time.monotonic() - start_monotonic
+        if elapsed < self._ROUTE_TIMING_WARN_SECONDS:
+            return
+        logger.warning(
+            "Cockpit static route step %s for key=%s took %.0fms",
+            step,
+            key,
+            elapsed * 1000.0,
+        )
 
     def _handle_invalid_static_route(self, result) -> None:
         errors = "; ".join(result.postcondition.errors)

--- a/tests/test_cockpit_route_timing_logs.py
+++ b/tests/test_cockpit_route_timing_logs.py
@@ -1,0 +1,89 @@
+"""#1832 — route timing logs identify which tmux sub-step blocked the click.
+
+The cockpit's static-route worker dispatches one or more tmux subprocess
+calls (``list_panes``, ``try_show_static_fast``, ``show_static``) on its
+way to repainting the right pane. When a tmux server is sluggish, one
+of those calls can consume the bulk of the click-to-paint budget.
+
+To make a wedged subprocess identifiable from logs without enabling
+debug tracing, :class:`pollypm.cockpit_rail.CockpitRouter` wraps each
+sub-step in ``_maybe_log_route_step``. The probe emits a WARNING when a
+step exceeds :attr:`_ROUTE_TIMING_WARN_SECONDS` and stays silent below
+that threshold so quiet, healthy clicks don't pollute the log.
+
+These tests verify both halves of the contract.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from pollypm.cockpit_rail import CockpitRouter
+
+
+class _BareRouter(CockpitRouter):
+    """Construct a router without touching disk / config / tmux.
+
+    The timing probe lives on the class and only reads
+    ``self._ROUTE_TIMING_WARN_SECONDS`` plus the elapsed monotonic time
+    captured by the caller — so a minimally-initialised instance is
+    enough to exercise it.
+    """
+
+    def __init__(self) -> None:  # noqa: D401
+        pass
+
+
+def test_route_timing_log_silent_below_threshold(
+    caplog: logging.LogCaptureFixture,
+) -> None:
+    """Fast clicks must not emit timing-log noise.
+
+    Regression #1832 — the threshold exists so healthy static clicks
+    (which complete in <50ms) leave no trace in the log. Only a
+    sluggish tmux subprocess earns a WARNING.
+    """
+    router = _BareRouter()
+    caplog.set_level(logging.WARNING, logger="pollypm.cockpit_rail")
+    # Pretend the step just completed in 1ms — well below the 250ms
+    # threshold.
+    start = time.monotonic() - 0.001
+    router._maybe_log_route_step("list_panes", "dashboard", start)
+    assert not [
+        rec for rec in caplog.records
+        if "Cockpit static route step" in rec.getMessage()
+    ]
+
+
+def test_route_timing_log_fires_above_threshold(
+    caplog: logging.LogCaptureFixture,
+) -> None:
+    """A slow tmux sub-step must surface in the log with step name +
+    rail key + elapsed ms so the wedged call is identifiable from a
+    post-hoc tail of ``~/.pollypm/audit/*.log``."""
+    router = _BareRouter()
+    caplog.set_level(logging.WARNING, logger="pollypm.cockpit_rail")
+    # Simulate a step that took 500ms — twice the warn threshold.
+    start = time.monotonic() - 0.5
+    router._maybe_log_route_step("show_static", "operator", start)
+    records = [
+        rec for rec in caplog.records
+        if "Cockpit static route step" in rec.getMessage()
+    ]
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert "show_static" in msg
+    assert "operator" in msg
+    # Threshold is 250ms; the synthetic step is 500ms, so the elapsed
+    # value formatted as ms must be present.
+    assert "ms" in msg
+
+
+def test_route_timing_threshold_is_user_visible_slack() -> None:
+    """The threshold should be tight enough that a user-perceptible
+    delay (>250ms) trips it, but loose enough that healthy clicks
+    don't. Lock the value so a future refactor can't quietly raise it
+    to multi-second territory and hide regressions."""
+    assert CockpitRouter._ROUTE_TIMING_WARN_SECONDS <= 0.5
+    assert CockpitRouter._ROUTE_TIMING_WARN_SECONDS >= 0.05


### PR DESCRIPTION
## Summary

Codex re-filed four cockpit-performance issues (#1832, #1833, #1834, #1835) as duplicates of fixes already shipped on 2026-05-18 via #1647 / #1648 / #1649. After auditing the code on `origin/main` against each issue's "Suggested Fix" checklist:

- **#1834** — `operator` is present in both `CockpitRouter._SUPERVISOR_FREE_STATIC_KEYS` (cockpit_rail.py:890) and `PollyCockpitApp._STATIC_RAIL_KEYS` (cockpit_ui.py:2637). Regression test in `tests/test_cockpit_static_fast_path_sets.py`. **Already shipped.**
- **#1833** — `verify_mount_against_tmux` (cockpit_mount_identity.py:221) treats an absent storage window as consistent with a live cockpit-mounted pane (conditional check at line 274-285). Regression test in `tests/test_cockpit_mount_identity.py`. **Already shipped.**
- **#1835** — `PollyActivityFeedApp` paints a skeleton on mount and runs initial, manual-refresh, AND follow-tick gathers off the Textual main thread via `run_worker(thread=True)` (cockpit_activity.py:380-598). Regression test in `tests/test_activity_feed_ui.py`. **Already shipped.**
- **#1832** — Structural fast-path mitigation shipped in #1646 (`try_show_static_fast` skips the layout-repair chain when panes are already healthy). The remaining ask in #1832 — "Add route timing logs around list_panes, ensure_layout, show_static, and respawn_pane" — was not implemented. This PR adds those logs.

This PR also closes the three already-resolved issues so the tracker reflects reality.

## What changed

`src/pollypm/cockpit_rail.py`:
- New `CockpitRouter._ROUTE_TIMING_WARN_SECONDS = 0.25` threshold.
- New `CockpitRouter._maybe_log_route_step(step, key, start_monotonic)` helper — emits a WARNING `Cockpit static route step <name> for key=<key> took <ms>ms` when the elapsed time exceeds the threshold; no-op below it.
- `_route_supervisor_free_static` now wraps `list_panes`, `try_show_static_fast`, and `show_static` in timing probes. The route worker still runs off the Textual main thread, so the probe never blocks the UI — it just identifies which tmux subprocess wedged a slow click from `~/.pollypm/audit/*.log` after the fact.

`tests/test_cockpit_route_timing_logs.py` (new):
- Probe stays silent below threshold.
- Probe emits one WARNING above threshold, with step name, rail key, and elapsed ms in the message.
- Threshold value is bounded to `[0.05, 0.5]` so a future refactor can't hide a regression by quietly raising it to multi-second territory.

## Test plan

- [x] `uv run --extra dev pytest tests/test_cockpit_route_timing_logs.py tests/test_cockpit_static_fast_path_sets.py tests/test_cockpit_mount_identity.py tests/test_activity_feed_ui.py` → 51 passed
- [x] `uv run --extra dev pytest tests/test_cockpit_rail*.py tests/test_cockpit_static*.py tests/test_cockpit_window_manager.py tests/test_cockpit_navigation*.py` → 121 passed
- [x] Pre-existing failure `test_cockpit_raw_rail_idle_project_without_alert_stays_idle` confirmed on `origin/main` and is unrelated to this change (glyph-vocabulary drift from a different commit)
- [ ] Manual smoke: click Operator / Inbox / Dashboard / Activity in cockpit and confirm route timing logs appear only when artificially slowed; healthy clicks stay quiet

Closes #1832, #1833, #1834, #1835. Progress on #1634 (rail-responsiveness meta).