### PR TITLE
fix(pg): notification dedupe race + accounts timestamptz roundtrip + orphaned-claim shared handler + embedding dim provider-prefix + unused import (closes #1841 #1842 #1843 #1844 #1845, #1737)

### DIFF
--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -663,12 +663,24 @@ def _parse_storage_settings(
     # error at parse-time so the misconfiguration surfaces at startup
     # rather than at the first embed write.
     EMBEDDING_SCHEMA_DIM = 1536
-    if provider_value.lower() == "openai":
+    # #1844: ``model`` may be either a bare model id
+    # (``text-embedding-3-large``) or the documented provider-namespaced
+    # form (``openai:text-embedding-3-large``). The dim table is keyed
+    # on bare model ids — without this normalisation a provider-
+    # prefixed 3072-dim model slips past the guard. The provider key
+    # comes from either the explicit ``provider`` field or the prefix.
+    if ":" in model_value:
+        prefix, _, bare_model = model_value.partition(":")
+        effective_provider = (provider_value or prefix).strip()
+    else:
+        bare_model = model_value
+        effective_provider = provider_value
+    if effective_provider.lower() == "openai":
         try:
             from pollypm.storage.embedder import _OPENAI_MODEL_DIMS
         except Exception:  # noqa: BLE001 — never block config parse on import errors
             _OPENAI_MODEL_DIMS = {}
-        declared_dim = _OPENAI_MODEL_DIMS.get(model_value)
+        declared_dim = _OPENAI_MODEL_DIMS.get(bare_model)
         if declared_dim is not None and declared_dim != EMBEDDING_SCHEMA_DIM:
             raise ValueError(
                 f"[storage.embedding] model {model_value!r} produces "

--- a/src/pollypm/jobs/queue.py
+++ b/src/pollypm/jobs/queue.py
@@ -649,11 +649,21 @@ class JobQueue:
                 if recovered_handlers:
                     # Step 2 — collapse the legacy NULL-dedupe-key
                     # backlog for the handlers we just recovered. We
-                    # keep the newest row per handler (so the cadence
-                    # can still fire) and drop the older duplicates.
-                    # Distinct dedupe_keyed rows are filtered out by
-                    # the ``dedupe_key IS NULL`` clause, so payload-
-                    # differentiated work survives untouched.
+                    # keep the newest row per (handler, payload) pair
+                    # and drop the older duplicates. Two refinements:
+                    #
+                    # * Distinct dedupe_keyed rows are filtered out by
+                    #   the ``dedupe_key IS NULL`` clause, so payload-
+                    #   differentiated work *with* a dedupe key
+                    #   survives untouched (#1822).
+                    # * Grouping by ``payload_json`` as well as handler
+                    #   means arbitrary user/plugin jobs that happen
+                    #   to share a handler with the legacy cadence
+                    #   backlog — but carry distinct payloads — are
+                    #   never collapsed. Only true duplicates (same
+                    #   handler, same payload, no dedupe key) get
+                    #   pruned, matching the original cadence-backlog
+                    #   shape this step is for (#1843).
                     cur.execute(
                         """
                         DELETE FROM work_jobs
@@ -665,7 +675,7 @@ class JobQueue:
                             WHERE status = 'queued'
                               AND dedupe_key IS NULL
                               AND handler_name = ANY(%s)
-                            GROUP BY handler_name
+                            GROUP BY handler_name, payload_json
                           )
                         """,
                         (recovered_handlers, recovered_handlers),

--- a/src/pollypm/storage/pg_migration_tool.py
+++ b/src/pollypm/storage/pg_migration_tool.py
@@ -163,12 +163,18 @@ TABLE_SPECS: tuple[TableSpec, ...] = (
     TableSpec(
         sqlite_table="account_usage",
         pg_table="account_usage",
-        ts_cols=("reset_at", "updated_at"),
+        # #1842 — ``reset_at`` is a provider display string, not an
+        # ISO timestamp, so it stays as ``text`` in pg and must NOT be
+        # coerced through ``_parse_iso_timestamp`` (which silently
+        # drops values like "Monday 1am").
+        ts_cols=("updated_at",),
     ),
     TableSpec(
         sqlite_table="account_runtime",
         pg_table="account_runtime",
-        ts_cols=("available_at", "access_expires_at", "updated_at"),
+        # #1842 — ``available_at`` and ``access_expires_at`` are
+        # display strings, see ``account_usage.reset_at`` above.
+        ts_cols=("updated_at",),
         bool_cols=("refresh_available",),
     ),
     TableSpec(

--- a/src/pollypm/storage/pg_notifications.py
+++ b/src/pollypm/storage/pg_notifications.py
@@ -119,24 +119,34 @@ def record_notification(
 
 
 def _advisory_lock_keys(
-    session_name: str, task_id: str, execution_version: int, scope: str
+    session_name: str, task_id: str, execution_version: int
 ) -> tuple[int, int]:
     """Hash the claim tuple into a two-int key for ``pg_advisory_xact_lock``.
 
     Postgres's two-int advisory-lock variant takes ``(int4, int4)``;
     we derive both halves from a stable SHA-1 of the dedupe tuple so
-    two concurrent callers with the same ``(session, task, version,
-    scope)`` always collide on the same lock, while distinct tuples
-    are virtually guaranteed not to. Collisions across distinct
-    tuples are harmless (one waits a few ms on a key that doesn't
-    apply to it); the safety property we need is that the *same*
-    tuple always serialises.
+    two concurrent callers with the same ``(session, task, version)``
+    always collide on the same lock, while distinct tuples are
+    virtually guaranteed not to. Collisions across distinct tuples
+    are harmless (one waits a few ms on a key that doesn't apply to
+    it); the safety property we need is that the *same* tuple always
+    serialises.
+
+    Why the key omits ``dedupe_scope`` (#1841)
+    ------------------------------------------
+    The normal-scope predicate matches rows of *any* scope (so a
+    forced kickoff also throttles ordinary follow-up sweeps). If the
+    lock were keyed on scope, a concurrent ``normal`` + ``forced_kickoff``
+    pair for the same tuple would land on different advisory keys,
+    both pass their check-and-insert, and both insert. Keying the
+    lock on ``(session, task, version)`` alone forces every claim
+    against the same tuple to serialise, regardless of scope.
     """
     import hashlib
 
     blob = (
         f"pollypm:notif:{session_name}\x00{task_id}\x00"
-        f"{int(execution_version)}\x00{scope}"
+        f"{int(execution_version)}"
     ).encode("utf-8")
     digest = hashlib.sha1(blob).digest()
     # Two signed 32-bit ints — that's what pg_advisory_xact_lock(int4, int4)
@@ -167,17 +177,20 @@ def claim_notification_slot(
     the empty SELECT.
 
     * Returns ``None`` when a row already exists for
-      ``(session, task, execution_version, dedupe_scope)`` inside the
-      ``window_seconds`` window.
+      ``(session, task, execution_version)`` inside the
+      ``window_seconds`` window, regardless of the existing row's
+      ``dedupe_scope`` (#1841 — concurrent normal-vs-forced calls
+      must dedupe to a single ping).
     * Otherwise inserts a placeholder row with
       ``delivery_status='pending'`` and returns its ``id``. The caller
       then attempts the send and stamps the resulting status via
       :func:`update_notification_status`.
 
-    Normal-scope claims match any recent scope so a forced kickoff
-    also throttles ordinary follow-up sweeps; scoped claims only
-    match the same scope so a stale normal row can't suppress the
-    forced kickoff.
+    The "forced kickoff bypasses stale normal" semantic from #922/#952
+    is preserved by the *caller's* ``window_seconds``: forced-kickoff
+    callers pass a short ``RECENT_SWEEPER_PING_SECONDS`` window, so a
+    truly stale normal row (older than ~60s) is filtered by the
+    ``created_at`` cutoff and the forced kickoff still fires.
 
     Why an advisory lock (#1821)
     ----------------------------
@@ -207,16 +220,12 @@ def claim_notification_slot(
             "dedupe_scope": scope,
         }
     )
-    # For ``normal`` claims, the dedupe predicate matches any scope, so
-    # the lock must collapse on a single ``normal`` key per tuple —
-    # otherwise two normal-scope callers could pick different ``scope``
-    # values (they can't here, both pass ``"normal"``, but a future
-    # caller wrapping this fn must not be able to bypass dedupe by
-    # varying scope). For non-normal claims we key on the scope so a
-    # forced kickoff and a normal sweep don't block each other.
-    lock_scope = scope if scope != "normal" else "normal"
+    # The advisory key collapses on ``(session, task, version)`` —
+    # scope is intentionally excluded so concurrent ``normal`` and
+    # non-normal callers serialise around the shared check-and-insert.
+    # See :func:`_advisory_lock_keys` for the full reasoning (#1841).
     key_a, key_b = _advisory_lock_keys(
-        session_name, task_id, int(execution_version), lock_scope
+        session_name, task_id, int(execution_version)
     )
     with pool.connection() as conn, conn.cursor() as cur:
         # Acquire a transaction-scoped advisory lock keyed on the
@@ -226,6 +235,21 @@ def claim_notification_slot(
         # with no existing row would both pass the SELECT and both
         # INSERT.
         cur.execute("SELECT pg_advisory_xact_lock(%s, %s)", (key_a, key_b))
+        # #1841: the predicate matches rows of any scope inside the
+        # ``window_seconds`` cutoff. Combined with the scope-agnostic
+        # advisory key above this serialises a concurrent
+        # ``normal`` + ``forced_kickoff`` race and the second caller
+        # sees the first's just-inserted row regardless of scope.
+        #
+        # The "forced bypasses stale normal" semantic from #922/#952 is
+        # preserved by the *caller's* window: forced-kickoff callers
+        # pass ``window_seconds=RECENT_SWEEPER_PING_SECONDS`` (60s),
+        # while normal sweeps pass the much longer throttle window. A
+        # stale normal row outside the forced caller's 60s cutoff is
+        # filtered by ``created_at >= cutoff`` and the forced kickoff
+        # still fires. What this predicate change *does* fix is the
+        # narrow "same-instant concurrent claim" race that produces
+        # duplicate pings.
         cur.execute(
             """
             SELECT 1 FROM messages
@@ -233,13 +257,6 @@ def claim_notification_slot(
               AND scope = %s
               AND sender = %s
               AND COALESCE((payload_json->>'execution_version')::int, 0) = %s
-              AND (
-                %s = 'normal'
-                OR (
-                    %s != 'normal'
-                    AND payload_json->>'dedupe_scope' = %s
-                )
-              )
               AND created_at >= %s
             LIMIT 1
             """,
@@ -247,9 +264,6 @@ def claim_notification_slot(
                 session_name,
                 task_id,
                 int(execution_version),
-                scope,
-                scope,
-                scope,
                 cutoff,
             ),
         )

--- a/src/pollypm/storage/pg_schema.py
+++ b/src/pollypm/storage/pg_schema.py
@@ -116,7 +116,12 @@ CREATE TABLE IF NOT EXISTS account_usage (
     raw_text      text NOT NULL,
     used_pct      int,
     remaining_pct int,
-    reset_at      timestamptz,
+    -- #1842 — reset_at carries provider display strings ("Monday 1am",
+    -- "10:09 on 5 May", "Apr 10 at 1am"), not parseable timestamps. It
+    -- must be ``text`` to match the sqlite StateStore contract and to
+    -- avoid Postgres rejecting/silently corrupting normal provider
+    -- output. See tests/test_provider_sdk.py + the pg_accounts facade.
+    reset_at      text,
     period_label  text,
     updated_at    timestamptz NOT NULL
 );
@@ -126,8 +131,11 @@ CREATE TABLE IF NOT EXISTS account_runtime (
     provider            text NOT NULL,
     status              text NOT NULL,
     reason              text NOT NULL,
-    available_at        timestamptz,
-    access_expires_at   timestamptz,
+    -- #1842 — available_at / access_expires_at are display strings
+    -- from the account-runtime sampler, not parseable timestamps.
+    -- Stored as ``text`` to round-trip the sqlite StateStore contract.
+    available_at        text,
+    access_expires_at   text,
     refresh_available   boolean NOT NULL DEFAULT false,
     updated_at          timestamptz NOT NULL
 );

--- a/tests/test_job_queue.py
+++ b/tests/test_job_queue.py
@@ -437,6 +437,48 @@ def test_recover_orphaned_claims_preserves_distinct_payloads_same_handler(
     assert q.get(b) is not None and q.get(b).status is JobStatus.QUEUED
 
 
+def test_recover_orphaned_claims_preserves_recovered_sibling_distinct_payload(
+    pg_job_queue: JobQueue,
+) -> None:
+    """#1843 — recovered claim must survive when a sibling queued row has a different payload.
+
+    Scenario:
+      1. Enqueue ``user.handler`` with ``{"p": "orphan"}`` and claim
+         it as a crashed worker (dedupe_key=None).
+      2. Enqueue another ``user.handler`` with ``{"p": "live"}``
+         (also dedupe_key=None).
+      3. Run ``recover_orphaned_claims``.
+
+    The recovered orphan must survive the prune because its payload
+    differs from the live row. The pre-fix prune grouped by
+    ``handler_name`` alone, so it kept ``MAX(id)`` (the live row) and
+    deleted the recovered orphan — silently dropping durable work.
+    """
+    q = pg_job_queue
+    orphan = q.enqueue("user.handler", {"p": "orphan"})
+    (claimed_job,) = q.claim("crashed-worker")
+    assert claimed_job.id == orphan
+
+    live = q.enqueue("user.handler", {"p": "live"})
+
+    recovered, pruned = q.recover_orphaned_claims()
+    assert recovered == 1, "the orphan must be requeued"
+    assert pruned == 0, (
+        "distinct-payload rows must NOT be collapsed — the prune step "
+        "is for the legacy cadence backlog where every row has an "
+        "identical (typically empty) payload"
+    )
+
+    orphan_row = q.get(orphan)
+    live_row = q.get(live)
+    assert orphan_row is not None, (
+        "the recovered orphan disappeared — the prune step deleted "
+        "durable work it had just requeued (#1843)."
+    )
+    assert orphan_row.status is JobStatus.QUEUED
+    assert live_row is not None and live_row.status is JobStatus.QUEUED
+
+
 def test_null_dedupe_key_does_not_deduplicate(pg_job_queue: JobQueue) -> None:
     q = pg_job_queue
     jid1 = q.enqueue("sweep", {"p": "a"})

--- a/tests/test_pg_accounts.py
+++ b/tests/test_pg_accounts.py
@@ -146,3 +146,70 @@ def test_pg_account_runtime_list(pg_schema_pool):
 
     rows = list_account_runtimes(pool=pg_schema_pool)
     assert [r.account_name for r in rows] == ["alpha", "beta"]
+
+
+# ---------------------------------------------------------------------------
+# #1842 — provider display strings must round-trip through pg_accounts
+# ---------------------------------------------------------------------------
+
+
+def test_pg_account_usage_reset_at_display_string_roundtrip(pg_schema_pool):
+    """#1842 — provider ``reset_at`` strings round-trip without corruption.
+
+    The account usage sampler emits human-readable display strings
+    such as ``"Monday 1am"``, ``"10:09 on 5 May"``, ``"Apr 10 at 1am"``
+    (see ``tests/test_provider_sdk.py`` + the sampler). The pg
+    schema's pre-#1842 ``timestamptz`` either rejected these with
+    ``InvalidDatetimeFormat`` or silently coerced them to nonsense
+    timestamps. After the schema flip to ``text`` they round-trip
+    exactly.
+    """
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_accounts import (
+        get_account_usage,
+        upsert_account_usage,
+    )
+
+    for display in ("Monday 1am", "10:09 on 5 May", "Apr 10 at 1am"):
+        upsert_account_usage(
+            account_name="primary",
+            provider="claude-cli",
+            plan="max",
+            health="ok",
+            usage_summary="42%",
+            raw_text="raw",
+            reset_at=display,
+            period_label="weekly",
+            pool=pg_schema_pool,
+        )
+        row = get_account_usage("primary", pool=pg_schema_pool)
+        assert row is not None
+        assert row.reset_at == display, (
+            f"reset_at must round-trip the provider display string; "
+            f"got {row.reset_at!r}, wrote {display!r}"
+        )
+
+
+def test_pg_account_runtime_available_at_display_string_roundtrip(pg_schema_pool):
+    """#1842 — ``available_at`` / ``access_expires_at`` round-trip as text."""
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_accounts import (
+        get_account_runtime,
+        upsert_account_runtime,
+    )
+
+    upsert_account_runtime(
+        account_name="primary",
+        provider="claude-cli",
+        status="rate_limited",
+        reason="quota",
+        available_at="Monday 1am",
+        access_expires_at="Apr 10 at 1am",
+        refresh_available=True,
+        pool=pg_schema_pool,
+    )
+
+    row = get_account_runtime("primary", pool=pg_schema_pool)
+    assert row is not None
+    assert row.available_at == "Monday 1am"
+    assert row.access_expires_at == "Apr 10 at 1am"

--- a/tests/test_pg_gap_sweep_2.py
+++ b/tests/test_pg_gap_sweep_2.py
@@ -25,7 +25,6 @@ suites and the focused tests at the bottom of this file.
 from __future__ import annotations
 
 import json
-import os
 import threading
 from pathlib import Path
 
@@ -400,6 +399,74 @@ def test_embedding_config_accepts_matching_model(tmp_path):
     project = ProjectSettings(state_db=tmp_path / "state.db")
     settings = _parse_storage_settings(raw, project=project)
     assert settings.embedding.model == "text-embedding-3-small"
+
+
+def test_embedding_config_rejects_provider_prefixed_3072_dim_model(
+    tmp_path, monkeypatch
+):
+    """#1844 — provider-prefixed 3072-dim model must also be rejected.
+
+    The dim table is keyed on bare model ids, but ``model`` accepts
+    either ``text-embedding-3-large`` or ``openai:text-embedding-3-large``
+    (the documented provider-namespaced form). The pre-#1844 guard
+    only looked up the raw ``model_value``, so the provider-prefixed
+    form slipped past and the operator still hit the runtime
+    pgvector dimension failure.
+    """
+    from pollypm.config import _parse_storage_settings
+    from pollypm.models import ProjectSettings
+
+    raw = {
+        "storage": {
+            "embedding": {
+                "model": "openai:text-embedding-3-large",
+                "provider": "openai",
+            }
+        }
+    }
+    project = ProjectSettings(state_db=tmp_path / "state.db")
+    with pytest.raises(ValueError, match="vectors, but the pgvector schema"):
+        _parse_storage_settings(raw, project=project)
+
+
+def test_embedding_config_accepts_provider_prefixed_matching_model(tmp_path):
+    """#1844 — ``openai:text-embedding-3-small`` (1536-dim) must parse."""
+    from pollypm.config import _parse_storage_settings
+    from pollypm.models import ProjectSettings
+
+    raw = {
+        "storage": {
+            "embedding": {
+                "model": "openai:text-embedding-3-small",
+                "provider": "openai",
+            }
+        }
+    }
+    project = ProjectSettings(state_db=tmp_path / "state.db")
+    settings = _parse_storage_settings(raw, project=project)
+    assert settings.embedding.model == "openai:text-embedding-3-small"
+
+
+def test_embedding_config_provider_prefix_without_explicit_provider(tmp_path):
+    """#1844 — ``provider`` may be implied by the model prefix.
+
+    Operators sometimes set only ``model = "openai:..."`` and omit
+    ``provider`` (the embedder resolves it from the prefix). The dim
+    guard must still fire in that case.
+    """
+    from pollypm.config import _parse_storage_settings
+    from pollypm.models import ProjectSettings
+
+    raw = {
+        "storage": {
+            "embedding": {
+                "model": "openai:text-embedding-3-large",
+            }
+        }
+    }
+    project = ProjectSettings(state_db=tmp_path / "state.db")
+    with pytest.raises(ValueError, match="vectors, but the pgvector schema"):
+        _parse_storage_settings(raw, project=project)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pg_notifications_race.py
+++ b/tests/test_pg_notifications_race.py
@@ -128,3 +128,58 @@ def test_concurrent_distinct_tasks_both_succeed(pg_schema_pool) -> None:
         f"both distinct-task claims must succeed; got {results!r}"
     )
     assert results[0] != results[1]
+
+
+def test_concurrent_normal_and_forced_claim_one_winner(pg_schema_pool) -> None:
+    """#1841 — a ``normal`` and ``forced_kickoff`` claim must serialise.
+
+    The normal-scope dedupe predicate matches rows of *any* scope, so
+    a concurrent ``normal`` + ``forced_kickoff`` pair for the same
+    ``(session, task, version)`` tuple must hit the same advisory key
+    and produce exactly one row. The pre-fix key included ``scope``,
+    so both callers landed on different keys, both passed the empty
+    SELECT, and both inserted.
+    """
+    _apply_initial_migrations(pg_schema_pool)
+    from pollypm.storage.pg_notifications import claim_notification_slot
+
+    barrier = threading.Barrier(2)
+    results: list[object] = [None, None]
+    errors: list[BaseException | None] = [None, None]
+    scopes = ("normal", "forced_kickoff")
+
+    def _worker(slot: int) -> None:
+        try:
+            barrier.wait(timeout=10)
+            results[slot] = claim_notification_slot(
+                session_name="session-mixed",
+                task_id="mixed:1",
+                window_seconds=1800,
+                execution_version=0,
+                project="mixed",
+                message="kickoff",
+                dedupe_scope=scopes[slot],
+                pool=pg_schema_pool,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            errors[slot] = exc
+
+    t1 = threading.Thread(target=_worker, args=(0,))
+    t2 = threading.Thread(target=_worker, args=(1,))
+    t1.start()
+    t2.start()
+    t1.join(timeout=15)
+    t2.join(timeout=15)
+
+    assert errors == [None, None], f"workers raised: {errors!r}"
+
+    winners = [r for r in results if r is not None]
+    losers = [r for r in results if r is None]
+    assert len(winners) == 1, (
+        f"normal-vs-forced concurrent claims must produce exactly one "
+        f"row; got results={results!r}. Two non-None ids means the "
+        f"advisory lock is scope-keyed and the dedupe predicate is "
+        f"bypassed — the #1841 race."
+    )
+    assert len(losers) == 1
+    assert isinstance(winners[0], int) and winners[0] > 0


### PR DESCRIPTION
## Summary

Codex r2 audit found five regressions in PRs #1836, #1837, #1838. All five fixed in one bundle with regression tests for the four real bugs.

## Per-issue fix

### #1841 — pg_notifications normal/forced race past dedupe
Two changes in `src/pollypm/storage/pg_notifications.py`:

1. `_advisory_lock_keys()` no longer hashes `dedupe_scope` — the key collapses to `(session, task, version)` so concurrent normal and non-normal callers serialise.
2. The check-and-insert SELECT no longer asymmetrically filters by scope — it dedupes on any row inside `window_seconds`. The "forced bypasses stale normal" semantic from #922/#952 is preserved by the caller's shorter `window_seconds` (forced uses `RECENT_SWEEPER_PING_SECONDS=60`, stale normal sits outside that cutoff).

```diff
-    blob = (
-        f"pollypm:notif:{session_name}\x00{task_id}\x00"
-        f"{int(execution_version)}\x00{scope}"
-    ).encode("utf-8")
+    blob = (
+        f"pollypm:notif:{session_name}\x00{task_id}\x00"
+        f"{int(execution_version)}"
+    ).encode("utf-8")
```

```diff
-              AND (
-                %s = 'normal'
-                OR (
-                    %s != 'normal'
-                    AND payload_json->>'dedupe_scope' = %s
-                )
-              )
               AND created_at >= %s
```

### #1842 — pg_accounts timestamptz vs display strings
`src/pollypm/storage/pg_schema.py`: `reset_at`, `available_at`, `access_expires_at` flipped from `timestamptz` to `text` to match the sqlite StateStore contract. Provider strings like `Monday 1am` and `Apr 10 at 1am` now round-trip exactly. The migrator's `ts_cols` entries for those columns are dropped so `_parse_iso_timestamp` no longer silently drops them.

```diff
-    reset_at      timestamptz,
+    reset_at      text,
...
-    available_at        timestamptz,
-    access_expires_at   timestamptz,
+    available_at        text,
+    access_expires_at   text,
```

### #1843 — orphaned-claim recovery dropping shared-handler siblings
`src/pollypm/jobs/queue.py`: the prune step now groups by `(handler_name, payload_json)` instead of `handler_name` alone, so an arbitrary user/plugin job that shares a handler with a sibling but carries a distinct payload survives recovery.

```diff
                             GROUP BY handler_name
+                            -- group by payload too so distinct-payload
+                            -- siblings aren't collapsed (#1843)
+                            , payload_json
```

### #1844 — embedding dim guard misses provider-prefixed models
`src/pollypm/config.py`: normalise `model_value` by splitting on `:` before the `_OPENAI_MODEL_DIMS` lookup. Handles both `openai:text-embedding-3-large` (explicit prefix) and bare `text-embedding-3-large`. Also infers the provider from the prefix when `[storage.embedding].provider` is unset.

```diff
-    if provider_value.lower() == "openai":
+    if ":" in model_value:
+        prefix, _, bare_model = model_value.partition(":")
+        effective_provider = (provider_value or prefix).strip()
+    else:
+        bare_model = model_value
+        effective_provider = provider_value
+    if effective_provider.lower() == "openai":
         ...
-        declared_dim = _OPENAI_MODEL_DIMS.get(model_value)
+        declared_dim = _OPENAI_MODEL_DIMS.get(bare_model)
```

### #1845 — unused os import
`tests/test_pg_gap_sweep_2.py`: dropped.

## Regression tests

| Issue | Test |
| --- | --- |
| #1841 | `test_concurrent_normal_and_forced_claim_one_winner` in `tests/test_pg_notifications_race.py` |
| #1842 | `test_pg_account_usage_reset_at_display_string_roundtrip` + `test_pg_account_runtime_available_at_display_string_roundtrip` in `tests/test_pg_accounts.py` |
| #1843 | `test_recover_orphaned_claims_preserves_recovered_sibling_distinct_payload` in `tests/test_job_queue.py` |
| #1844 | `test_embedding_config_rejects_provider_prefixed_3072_dim_model` + `test_embedding_config_accepts_provider_prefixed_matching_model` + `test_embedding_config_provider_prefix_without_explicit_provider` in `tests/test_pg_gap_sweep_2.py` |

## Test plan

- [x] `uv run pytest tests/test_pg_notifications*.py tests/test_pg_storage_facades.py tests/test_jobs*.py tests/test_pg_gap_sweep_2.py -x -q` → 71 passed
- [x] `uv run pytest tests/test_pg_accounts.py tests/test_pg_migration_tool.py tests/test_account_usage.py tests/test_accounts.py tests/test_config.py -x -q` → all pass
- [x] focused ruff check on the issue's quoted file set → clean
- [x] `uv run python -c "import pollypm; from pollypm.config import load_config; load_config()"` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)