### PR TITLE
feat(profiles): dual-account default — Opus for PM/Polly/review, Codex for workers/architects/advisors (#1737)

### DIFF
--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -1185,6 +1185,21 @@ def _build_example_config(root: Path, *, tmux_session: str = "pollypm") -> Polly
             heartbeat_backend="local",
             scheduler_backend="inline",
             lease_timeout_minutes=30,
+            # #1737 — when both a Claude and a Codex account are
+            # configured, brand-new sessions route per these defaults:
+            # Opus drives PM/operator/reviewer (judgment-heavy roles),
+            # Codex drives worker/architect/advisor (tool-heavy roles).
+            # The fallback resolver in pollypm.role_routing computes
+            # the same table at runtime, so these entries are
+            # informational documentation that survives `pm
+            # example-config` round-trips — delete any line to opt back
+            # into the computed fallback.
+            role_assignments={
+                "operator_pm": ModelAssignment(alias="opus-4.7"),
+                "architect": ModelAssignment(alias="codex-gpt-5.4"),
+                "worker": ModelAssignment(alias="codex-gpt-5.4"),
+                "reviewer": ModelAssignment(alias="opus-4.7"),
+            },
         ),
         accounts={
             "codex_primary": AccountConfig(

--- a/src/pollypm/role_routing.py
+++ b/src/pollypm/role_routing.py
@@ -12,6 +12,42 @@ from pollypm.models import ModelAssignment, PollyPMConfig, ProviderKind
 
 _log = logging.getLogger(__name__)
 _ROLE_KEYS = ("operator_pm", "architect", "worker", "reviewer", "advisor")
+
+# Default role -> alias table when BOTH Claude and Codex accounts are
+# configured. Opus drives the PM-style roles (operator, reviewer) where
+# nuanced project judgment matters; Codex drives the heavy tool-use
+# roles (worker, architect, advisor) where its tool dispatch shines.
+# See #1737.
+_DUAL_PROVIDER_DEFAULTS: dict[str, ModelAssignment] = {
+    "operator_pm": ModelAssignment(alias="opus-4.7"),
+    "architect": ModelAssignment(alias="codex-gpt-5.4"),
+    "worker": ModelAssignment(alias="codex-gpt-5.4"),
+    "reviewer": ModelAssignment(alias="opus-4.7"),
+    "advisor": ModelAssignment(alias="codex-gpt-5.4"),
+}
+
+# Single-provider defaults — when only Claude (or only Codex) accounts
+# are configured, every role falls back to that provider's strongest
+# alias. Preserves the "config still works with one provider" invariant.
+_CLAUDE_ONLY_DEFAULTS: dict[str, ModelAssignment] = {
+    "operator_pm": ModelAssignment(alias="opus-4.7"),
+    "architect": ModelAssignment(alias="opus-4.7"),
+    "worker": ModelAssignment(alias="opus-4.7"),
+    "reviewer": ModelAssignment(alias="opus-4.7"),
+    "advisor": ModelAssignment(alias="opus-4.7"),
+}
+_CODEX_ONLY_DEFAULTS: dict[str, ModelAssignment] = {
+    "operator_pm": ModelAssignment(alias="codex-gpt-5.4"),
+    "architect": ModelAssignment(alias="codex-gpt-5.4"),
+    "worker": ModelAssignment(alias="codex-gpt-5.4"),
+    "reviewer": ModelAssignment(alias="codex-gpt-5.4"),
+    "advisor": ModelAssignment(alias="codex-gpt-5.4"),
+}
+
+# Static safety net used when no PollyPMConfig is in hand or no
+# accounts are configured (e.g. some unit tests). Matches the historical
+# table that shipped before #1737 so anything reaching this branch
+# behaves like the pre-#1737 system.
 _FALLBACK_ASSIGNMENTS: dict[str, ModelAssignment] = {
     "operator_pm": ModelAssignment(alias="codex-gpt-5.4"),
     "architect": ModelAssignment(alias="opus-4.7"),
@@ -19,6 +55,51 @@ _FALLBACK_ASSIGNMENTS: dict[str, ModelAssignment] = {
     "reviewer": ModelAssignment(alias="sonnet-4.6"),
     "advisor": ModelAssignment(alias="opus-4.7"),
 }
+
+
+def _configured_providers(config: PollyPMConfig | None) -> frozenset[str]:
+    """Return the set of provider names with at least one account configured."""
+    if config is None:
+        return frozenset()
+    providers: set[str] = set()
+    for account in getattr(config, "accounts", {}).values():
+        provider = getattr(account, "provider", None)
+        # ProviderKind enum has a .value attribute; coerce defensively
+        # so tests that pass raw strings keep working.
+        if provider is None:
+            continue
+        value = getattr(provider, "value", provider)
+        if isinstance(value, str) and value:
+            providers.add(value)
+    return frozenset(providers)
+
+
+def _select_fallback_assignment(
+    canonical_role: str,
+    config: PollyPMConfig | None,
+) -> ModelAssignment:
+    """Pick the fallback assignment for ``canonical_role``.
+
+    Selection rule (#1737):
+
+    * Both Claude and Codex accounts configured -> dual-provider table
+      (Opus for PM/operator/reviewer, Codex for worker/architect/advisor).
+    * Only Claude accounts -> Opus across the board.
+    * Only Codex accounts -> Codex across the board.
+    * Neither (no config or empty accounts) -> legacy static table.
+    """
+    providers = _configured_providers(config)
+    has_claude = "claude" in providers
+    has_codex = "codex" in providers
+    if has_claude and has_codex:
+        table = _DUAL_PROVIDER_DEFAULTS
+    elif has_claude:
+        table = _CLAUDE_ONLY_DEFAULTS
+    elif has_codex:
+        table = _CODEX_ONLY_DEFAULTS
+    else:
+        table = _FALLBACK_ASSIGNMENTS
+    return table[canonical_role]
 
 
 @dataclass(slots=True, frozen=True)
@@ -105,12 +186,23 @@ def resolve_role_assignment(
         if resolved is not None:
             return resolved
 
+    fallback_assignment = _select_fallback_assignment(canonical_role, current_config)
     fallback = _resolved_from_assignment(
         canonical_role,
-        _FALLBACK_ASSIGNMENTS[canonical_role],
+        fallback_assignment,
         source="fallback",
         registry=resolved_registry,
     )
+    if fallback is None:
+        # Resolved alias miss against the live registry — fall back to
+        # the static legacy table, which is hand-aligned with the
+        # baked-in registry in :mod:`pollypm.model_registry`.
+        fallback = _resolved_from_assignment(
+            canonical_role,
+            _FALLBACK_ASSIGNMENTS[canonical_role],
+            source="fallback",
+            registry=resolved_registry,
+        )
     if fallback is None:
         raise RuntimeError(f"Fallback role assignment for {canonical_role} is invalid")
     return fallback

--- a/tests/test_role_routing.py
+++ b/tests/test_role_routing.py
@@ -71,13 +71,81 @@ def test_global_assignment_used_when_project_has_no_override(tmp_path: Path) -> 
 
 
 def test_fallback_assignment_used_when_no_configured_assignment(tmp_path: Path) -> None:
+    # #1737 — claude-only configs fall back to Opus across the board
+    # (no Codex account means we can't route worker/architect to Codex).
     config = _config(tmp_path)
 
     resolved = resolve_role_assignment("reviewer", "demo", config=config)
 
-    assert resolved.alias == "sonnet-4.6"
+    assert resolved.alias == "opus-4.7"
     assert resolved.provider == "claude"
     assert resolved.source == "fallback"
+
+
+def test_dual_provider_fallback_table(tmp_path: Path) -> None:
+    # #1737 — with both Claude and Codex accounts configured but NO
+    # explicit role_assignments, each role falls back to the
+    # dual-provider default table:
+    #   operator_pm / reviewer  -> Opus (Claude)
+    #   worker / architect       -> Codex
+    #   advisor                  -> Codex
+    config = _config(tmp_path)
+    config.accounts["codex_main"] = AccountConfig(
+        name="codex_main",
+        provider=ProviderKind.CODEX,
+        home=tmp_path / ".pollypm" / "homes" / "codex_main",
+    )
+
+    expectations = {
+        "operator_pm": ("opus-4.7", "claude"),
+        "reviewer": ("opus-4.7", "claude"),
+        "worker": ("codex-gpt-5.4", "codex"),
+        "architect": ("codex-gpt-5.4", "codex"),
+        "advisor": ("codex-gpt-5.4", "codex"),
+    }
+    for role, (alias, provider) in expectations.items():
+        # operator_pm is global-only — pass project_key=None
+        project = None if role == "operator_pm" else "demo"
+        resolved = resolve_role_assignment(role, project, config=config)
+        assert resolved.alias == alias, f"role {role}: expected {alias}, got {resolved.alias}"
+        assert resolved.provider == provider, f"role {role}: expected {provider}, got {resolved.provider}"
+        assert resolved.source == "fallback"
+
+
+def test_codex_only_fallback_routes_all_roles_to_codex(tmp_path: Path) -> None:
+    # #1737 — single-provider (Codex only) fallback: every role
+    # collapses to the strongest Codex alias because there's no
+    # Claude account to route Opus-favoring roles to.
+    config = _config(tmp_path)
+    # Replace claude account with codex-only configuration.
+    config.accounts.clear()
+    config.accounts["codex_main"] = AccountConfig(
+        name="codex_main",
+        provider=ProviderKind.CODEX,
+        home=tmp_path / ".pollypm" / "homes" / "codex_main",
+    )
+
+    for role in ("operator_pm", "architect", "worker", "reviewer", "advisor"):
+        project = None if role == "operator_pm" else "demo"
+        resolved = resolve_role_assignment(role, project, config=config)
+        assert resolved.provider == "codex"
+        assert resolved.alias == "codex-gpt-5.4"
+        assert resolved.source == "fallback"
+
+
+def test_claude_only_fallback_routes_all_roles_to_claude(tmp_path: Path) -> None:
+    # #1737 — single-provider (Claude only) fallback: every role
+    # routes to Opus.
+    config = _config(tmp_path)
+    # Default _config already has only a single claude account; no
+    # additional setup needed.
+
+    for role in ("operator_pm", "architect", "worker", "reviewer", "advisor"):
+        project = None if role == "operator_pm" else "demo"
+        resolved = resolve_role_assignment(role, project, config=config)
+        assert resolved.provider == "claude"
+        assert resolved.alias == "opus-4.7"
+        assert resolved.source == "fallback"
 
 
 def test_unknown_alias_falls_through_to_next_precedence_level(


### PR DESCRIPTION
## Summary

When a user has BOTH a Claude account and a Codex account configured,
new sessions now default to:

| Role              | Provider | Model            |
|-------------------|----------|------------------|
| operator_pm (Polly / Project PMs) | Claude   | opus-4.7         |
| reviewer (Russell)                | Claude   | opus-4.7         |
| worker                            | Codex    | codex-gpt-5.4    |
| architect                         | Codex    | codex-gpt-5.4    |
| advisor                           | Codex    | codex-gpt-5.4    |

Opus drives the judgment-heavy PM/operator/reviewer roles; Codex drives
the heavy tool-use worker/architect/advisor roles.

Single-provider configs preserve current behavior:
- Only Claude accounts → every role routes to Opus.
- Only Codex accounts → every role routes to codex-gpt-5.4.
- Neither (no `PollyPMConfig` supplied) → legacy static fallback table,
  preserved as a defensive guard for tests that call the resolver
  without a config.

## Where the defaults live

- `src/pollypm/role_routing.py` — new `_DUAL_PROVIDER_DEFAULTS` /
  `_CLAUDE_ONLY_DEFAULTS` / `_CODEX_ONLY_DEFAULTS` tables and the
  `_select_fallback_assignment(role, config)` resolver that picks the
  right table based on which providers have at least one configured
  account.
- `src/pollypm/config.py` — `_build_example_config` now emits explicit
  `[pollypm.roles.*]` tables documenting the dual-account defaults
  (informational — deleting any line opts back into the computed
  fallback).

## Tests

- `tests/test_role_routing.py`:
  - Updated `test_fallback_assignment_used_when_no_configured_assignment`
    — claude-only config now falls back to `opus-4.7` for reviewer
    instead of `sonnet-4.6`.
  - New `test_dual_provider_fallback_table` — both providers configured
    → exact table above.
  - New `test_codex_only_fallback_routes_all_roles_to_codex`.
  - New `test_claude_only_fallback_routes_all_roles_to_claude`.

```
$ uv run pytest tests/test_core_agent_profiles.py tests/test_launch_planner.py tests/test_config.py tests/test_role_routing.py -q
49 passed
```

## Scope notes

- Affects NEW sessions for users with dual accounts. Existing
  configured `role_assignments` (global or per-project) still win over
  the fallback — Sam's deployed routing and any user's per-project
  overrides are unchanged.
- Does not touch `~/.pollypm/pollypm.toml`, dual-mode storage facades,
  or operator/dashboard perf code.

## Test plan

- [x] `uv run pytest tests/test_core_agent_profiles.py tests/test_launch_planner.py tests/test_config.py tests/test_role_routing.py -q` (49 passed)
- [x] `uv run python -c "import pollypm; from pollypm.config import load_config; load_config()"` (clean)
- [x] `pm example-config` round-trip shows the new `[pollypm.roles.*]` table