### PR TITLE
fix(cockpit): conversation wipe on project PM chat re-entry (closes #1631 followup, refs #1634)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -2507,8 +2507,26 @@ class CockpitRouter:
                 storage_session = supervisor.storage_closet_session_name()
                 window_name = self._mounted_window_name(supervisor, mounted)
                 if window_name is not None and self.tmux.has_session(storage_session):
+                    # #1631 follow-up — idempotent break-pane.  When the
+                    # rail crashes mid-conversation and the worker pane
+                    # is the lone survivor, the prior behaviour broke
+                    # it back into storage even if storage already held
+                    # the canonical name (the live conversation we just
+                    # left).  That double would then cause the user's
+                    # next click on PM Chat to mount onto the wrong
+                    # window and lose state.
                     try:
-                        self.tmux.break_pane(panes[0].pane_id, storage_session, window_name)
+                        from pollypm.cockpit_storage_park import (
+                            safe_break_pane_to_storage,
+                        )
+                        safe_break_pane_to_storage(
+                            self.tmux,
+                            source_pane_id=panes[0].pane_id,
+                            storage_session=storage_session,
+                            window_name=window_name,
+                            audit_emit=self._audit_emit_for_storage_park,
+                            subject=mounted,
+                        )
                     except Exception:  # noqa: BLE001
                         pass
             state.pop("right_pane_id", None)
@@ -4045,6 +4063,30 @@ class CockpitRouter:
                 "storage_windows_after": sorted(w.name for w in after),
                 "reoccupied_dead_indices": [w.index for w in dead_existing],
             },
+        )
+
+    def _audit_emit_for_storage_park(
+        self,
+        event_name: str,
+        status: str,
+        metadata: dict,
+    ) -> None:
+        """Adapter for :func:`cockpit_storage_park.safe_break_pane_to_storage`.
+
+        #1631 follow-up — the helper takes a small callback so it can
+        emit audit events without importing ``cockpit_rail``.  This
+        method routes the helper's events through
+        :meth:`_emit_cockpit_audit` so they land on the same audit
+        surface as the original ``cockpit.park_skipped_existing`` from
+        :meth:`_park_mounted_session`.  The helper passes ``subject``
+        inside ``metadata``; we lift it back into the audit envelope.
+        """
+        subject = metadata.pop("subject", metadata.get("window_name", "unknown"))
+        self._emit_cockpit_audit(
+            event_name=event_name,
+            subject=subject,
+            status=status,
+            metadata=metadata,
         )
 
     def _storage_window_is_live(self, window) -> bool:

--- a/src/pollypm/cockpit_storage_park.py
+++ b/src/pollypm/cockpit_storage_park.py
@@ -1,0 +1,145 @@
+"""Idempotent ``tmux break-pane`` into the storage-closet (#1631 follow-up).
+
+PollyPM has historically had multiple call sites that ``tmux break-pane``
+a cockpit right-pane back into the storage closet under a fixed window
+name (``architect-<project>``, ``pm-operator``, ``worker-<project>``,
+etc.).  When such a window already existed in storage — typically because
+a prior park collision left the canonical name occupied — the bare
+``break-pane`` silently created a SECOND window with the same name.  The
+next rail mount then had two same-named candidates to choose between,
+and the user-visible damage from #1631 (conversation wipe on PM Chat
+re-entry) followed.
+
+#1635 fixed this for one call site (`_park_mounted_session`), but three
+other paths still bypass the idempotency:
+
+* ``cockpit_window_manager.park_live_to_storage`` — invoked from the
+  ``show_static`` flow when ``park=`` is supplied.
+* ``core/console_window.py`` — invoked when the cockpit console window
+  exits and the surviving worker pane is parked back.
+* ``cockpit_rail.ensure_cockpit_layout`` — invoked when only the worker
+  pane survived a rail crash and needs parking back before the rail can
+  be respawned.
+
+This module exposes :func:`safe_break_pane_to_storage`, a pure helper
+that all four paths can share.  It encapsulates the dup-check logic so
+the mount-side selector (``_select_storage_window_for_mount``) never
+sees more than one live window per name, eliminating the wipe surface.
+
+The helper is intentionally tmux-shape agnostic: callers pass a
+``tmux`` client plus a small audit-emit callback, and the helper does
+the rest.  Pure-function design makes testing without tmux trivial.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+# Live-provider definitions mirror ``cockpit_rail._storage_window_is_live``
+# and ``_select_storage_window_for_mount``.  Keeping the literal set
+# duplicated here (rather than importing from cockpit_rail) avoids the
+# import cycle that ``cockpit_window_manager`` would otherwise hit.
+_LIVE_PROVIDER_COMMANDS: frozenset[str] = frozenset({"node", "claude", "codex"})
+
+
+def _window_is_live(window: Any) -> bool:
+    """Return True iff ``window``'s pane looks like a live provider.
+
+    Mirrors :meth:`cockpit_rail.CockpitRouter._storage_window_is_live`.
+    A window whose pane reports a version-string command (e.g.
+    ``2.1.144``) is treated as live — those panes are the Claude CLI
+    after its first turn, and they hold real conversation state.
+    """
+    if getattr(window, "pane_dead", False):
+        return False
+    cmd = getattr(window, "pane_current_command", "") or ""
+    if cmd in _LIVE_PROVIDER_COMMANDS:
+        return True
+    if cmd and all(c.isdigit() or c == "." for c in cmd):
+        return True
+    return False
+
+
+def safe_break_pane_to_storage(
+    tmux: Any,
+    *,
+    source_pane_id: str,
+    storage_session: str,
+    window_name: str,
+    audit_emit: Callable[[str, str, dict[str, Any]], None] | None = None,
+    subject: str | None = None,
+) -> bool:
+    """Break ``source_pane_id`` into ``storage_session`` only if safe.
+
+    Returns ``True`` when the break-pane actually ran (or no duplicate
+    blocked it), ``False`` when the helper refused to break because a
+    live duplicate already owns the canonical name.
+
+    Behaviour:
+      * If the storage closet already holds a live window of the same
+        name → skip ``break-pane``, kill ``source_pane_id`` (it would
+        otherwise leak as an unparented pane after the cockpit reclaims
+        its real estate), emit ``cockpit.park_skipped_existing`` audit,
+        and return ``False``.  Callers MUST treat this as a successful
+        park: the storage window is already the persistent home.
+      * If only dead-named duplicates exist → kill the dead windows so
+        break-pane re-occupies the canonical name, then break.
+      * No duplicates → break unconditionally.
+
+    The helper centralizes the #1631/#1635 fix so every break-pane site
+    in the cockpit gets the same dup-check.  See module docstring for
+    the full list of historical bypass sites.
+    """
+    try:
+        storage_windows = tmux.list_windows(storage_session)
+    except Exception:  # noqa: BLE001
+        storage_windows = []
+
+    existing_same_name = [
+        w for w in storage_windows
+        if getattr(w, "name", None) == window_name
+    ]
+    live_existing = [w for w in existing_same_name if _window_is_live(w)]
+    dead_existing = [w for w in existing_same_name if not _window_is_live(w)]
+
+    if live_existing:
+        # Persistent home already owns the canonical name.  Refuse the
+        # break-pane.  The caller's surviving cockpit pane (the one we
+        # would have parked) is now an orphan duplicate of the storage
+        # window's process — kill it so it doesn't pile up as garbage.
+        try:
+            tmux.kill_pane(source_pane_id)
+        except Exception:  # noqa: BLE001
+            pass
+        if audit_emit is not None:
+            try:
+                audit_emit(
+                    "cockpit.park_skipped_existing",
+                    "warn",
+                    {
+                        "subject": subject or window_name,
+                        "window_name": window_name,
+                        "storage_session": storage_session,
+                        "source_pane_id": source_pane_id,
+                        "live_duplicate_indices": [
+                            getattr(w, "index", None) for w in live_existing
+                        ],
+                        "dead_duplicate_indices": [
+                            getattr(w, "index", None) for w in dead_existing
+                        ],
+                        "reason": "live_existing_storage_window",
+                    },
+                )
+            except Exception:  # noqa: BLE001
+                pass
+        return False
+
+    for window in dead_existing:
+        try:
+            tmux.kill_window(f"{storage_session}:{getattr(window, 'index', '')}")
+        except Exception:  # noqa: BLE001
+            continue
+
+    tmux.break_pane(source_pane_id, storage_session, window_name)
+    return True

--- a/src/pollypm/cockpit_window_manager.py
+++ b/src/pollypm/cockpit_window_manager.py
@@ -514,9 +514,25 @@ class CockpitWindowManager:
             )
 
         before = self._window_key_set(park.storage_session)
-        self.tmux.break_pane(right_id, park.storage_session, park.window_name)
-        actions.append(f"break_live:{right_id}->{park.storage_session}:{park.window_name}")
-        self._rename_created_window(park.storage_session, before, park.window_name, actions)
+        # #1631 follow-up — route through the idempotent helper so a
+        # live duplicate in the closet doesn't get a second window
+        # silently appended.  When the helper returns False, the
+        # storage window IS the persistent home; our right pane has
+        # been killed and we just clear mount state below.
+        from pollypm.cockpit_storage_park import safe_break_pane_to_storage
+        broke = safe_break_pane_to_storage(
+            self.tmux,
+            source_pane_id=right_id,
+            storage_session=park.storage_session,
+            window_name=park.window_name,
+        )
+        if broke:
+            actions.append(f"break_live:{right_id}->{park.storage_session}:{park.window_name}")
+            self._rename_created_window(park.storage_session, before, park.window_name, actions)
+        else:
+            actions.append(
+                f"park_skipped_live_duplicate:{park.storage_session}:{park.window_name}"
+            )
         state = state.cleared_mount()
 
         panes = self.tmux.list_panes(self.spec.window_target)

--- a/src/pollypm/core/console_window.py
+++ b/src/pollypm/core/console_window.py
@@ -160,8 +160,21 @@ class ConsoleWindowManager:
             )
             storage_session = self._storage_closet_session_name()
             if launch is not None and tmux.has_session(storage_session):
+                # #1631 follow-up — idempotent park.  If the storage
+                # closet already holds a live window with this name,
+                # ``safe_break_pane_to_storage`` skips the break-pane
+                # (killing our surviving pane instead) so the next
+                # mount can't pick the wrong duplicate.
                 try:
-                    tmux.break_pane(pane.pane_id, storage_session, launch.window_name)
+                    from pollypm.cockpit_storage_park import (
+                        safe_break_pane_to_storage,
+                    )
+                    safe_break_pane_to_storage(
+                        tmux,
+                        source_pane_id=pane.pane_id,
+                        storage_session=storage_session,
+                        window_name=launch.window_name,
+                    )
                 except Exception:  # noqa: BLE001
                     pass
 

--- a/tests/test_cockpit_storage_park.py
+++ b/tests/test_cockpit_storage_park.py
@@ -1,0 +1,298 @@
+"""Regression tests for :mod:`pollypm.cockpit_storage_park` (#1631 follow-up).
+
+#1631 — Sam lost an in-progress Polly conversation by clicking away and
+back.  The repro generalises to any per-project PM window
+(``architect-<project>`` for non-Polly projects).  #1635 fixed the
+park-side bug in ``_park_mounted_session`` but three other call sites
+(``cockpit_window_manager.park_live_to_storage``,
+``core/console_window.py``, ``cockpit_rail.ensure_cockpit_layout``)
+still called ``tmux break-pane`` without the dup-check, so the same
+wipe surface was reachable through those paths.
+
+These tests pin the contract of :func:`safe_break_pane_to_storage`:
+
+* Live duplicate in storage → break-pane is skipped, the source pane
+  is killed (no orphan pile-up), the audit fires, and the helper
+  returns ``False`` so callers can branch.
+* Dead duplicates → killed before break-pane so the freshly-parked
+  pane re-occupies the canonical name.
+* No duplicates → unconditional break-pane.
+
+The smoking-gun scenario from Sam's 2026-05-19 wipe (architect-samblog
+duplicated at indices 22 and 42 in the closet) is reproduced as
+``test_safe_break_does_not_add_third_when_two_duplicates_exist``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pollypm.cockpit_storage_park import safe_break_pane_to_storage
+
+
+class _FakeWindow:
+    """Minimal tmux window shape used by the helper.
+
+    Mirrors the ``TmuxWindow`` dataclass surface the helper inspects:
+    ``index``, ``name``, ``pane_current_command``, ``pane_dead``.
+    """
+
+    def __init__(
+        self,
+        index: int,
+        name: str,
+        command: str = "claude",
+        pane_dead: bool = False,
+    ) -> None:
+        self.index = index
+        self.name = name
+        self.pane_current_command = command
+        self.pane_dead = pane_dead
+
+
+class _FakeTmux:
+    """Deterministic in-memory tmux stand-in for the helper's surface."""
+
+    def __init__(self, windows: list[_FakeWindow] | None = None) -> None:
+        self.windows: list[_FakeWindow] = list(windows or [])
+        self.break_calls: list[tuple[str, str, str]] = []
+        self.kill_window_calls: list[str] = []
+        self.kill_pane_calls: list[str] = []
+
+    def list_windows(self, session: str) -> list[_FakeWindow]:
+        return list(self.windows)
+
+    def break_pane(
+        self, source: str, target_session: str, window_name: str
+    ) -> None:
+        self.break_calls.append((source, target_session, window_name))
+        next_index = max(
+            (w.index for w in self.windows), default=-1
+        ) + 1
+        self.windows.append(_FakeWindow(next_index, window_name, command="claude"))
+
+    def kill_window(self, target: str) -> None:
+        self.kill_window_calls.append(target)
+        try:
+            idx = int(target.split(":", 1)[1])
+        except (IndexError, ValueError):
+            return
+        self.windows = [w for w in self.windows if w.index != idx]
+
+    def kill_pane(self, target: str) -> None:
+        self.kill_pane_calls.append(target)
+
+
+def _collect_audit() -> tuple[list[dict[str, Any]], Any]:
+    """Return (events, callback) suitable for ``audit_emit=``.
+
+    The callback signature matches the helper's contract:
+    ``(event_name, status, metadata)``.
+    """
+
+    events: list[dict[str, Any]] = []
+
+    def _emit(event_name: str, status: str, metadata: dict[str, Any]) -> None:
+        events.append(
+            {"event_name": event_name, "status": status, "metadata": metadata}
+        )
+
+    return events, _emit
+
+
+def test_safe_break_unconditional_when_no_existing_window() -> None:
+    """No duplicate → helper just breaks the pane, returns True."""
+    tmux = _FakeTmux(windows=[])
+    audit_events, audit_emit = _collect_audit()
+
+    broke = safe_break_pane_to_storage(
+        tmux,
+        source_pane_id="%99",
+        storage_session="pollypm-storage-closet",
+        window_name="architect-samblog",
+        audit_emit=audit_emit,
+        subject="architect_samblog",
+    )
+
+    assert broke is True
+    assert tmux.break_calls == [
+        ("%99", "pollypm-storage-closet", "architect-samblog")
+    ]
+    assert tmux.kill_window_calls == []
+    assert tmux.kill_pane_calls == []
+    assert audit_events == []
+    assert [w.name for w in tmux.windows] == ["architect-samblog"]
+
+
+def test_safe_break_skipped_when_live_duplicate_exists() -> None:
+    """Live duplicate → helper refuses to break-pane.
+
+    This is the #1631 wipe surface: parking on top of an existing live
+    window would silently double the canonical name and the next mount
+    would land on the wrong one.
+    """
+    existing = _FakeWindow(22, "architect-samblog", command="claude")
+    tmux = _FakeTmux(windows=[existing])
+    audit_events, audit_emit = _collect_audit()
+
+    broke = safe_break_pane_to_storage(
+        tmux,
+        source_pane_id="%99",
+        storage_session="pollypm-storage-closet",
+        window_name="architect-samblog",
+        audit_emit=audit_emit,
+        subject="architect_samblog",
+    )
+
+    assert broke is False
+    assert tmux.break_calls == []
+    # Source pane was killed so it doesn't orphan in the cockpit.
+    assert tmux.kill_pane_calls == ["%99"]
+    # Storage closet still has exactly one architect-samblog window.
+    same_name = [w for w in tmux.windows if w.name == "architect-samblog"]
+    assert len(same_name) == 1
+    # Audit captures the skip with the duplicate's index.
+    assert len(audit_events) == 1
+    event = audit_events[0]
+    assert event["event_name"] == "cockpit.park_skipped_existing"
+    assert event["status"] == "warn"
+    assert event["metadata"]["live_duplicate_indices"] == [22]
+    assert event["metadata"]["window_name"] == "architect-samblog"
+    assert event["metadata"]["storage_session"] == "pollypm-storage-closet"
+    assert event["metadata"]["subject"] == "architect_samblog"
+
+
+def test_safe_break_kills_dead_duplicates_then_breaks() -> None:
+    """Dead-named duplicate → killed first so break-pane re-occupies."""
+    dead = _FakeWindow(7, "architect-samblog", command="bash", pane_dead=True)
+    tmux = _FakeTmux(windows=[dead])
+    audit_events, audit_emit = _collect_audit()
+
+    broke = safe_break_pane_to_storage(
+        tmux,
+        source_pane_id="%99",
+        storage_session="pollypm-storage-closet",
+        window_name="architect-samblog",
+        audit_emit=audit_emit,
+        subject="architect_samblog",
+    )
+
+    assert broke is True
+    assert tmux.kill_window_calls == ["pollypm-storage-closet:7"]
+    assert tmux.break_calls == [
+        ("%99", "pollypm-storage-closet", "architect-samblog")
+    ]
+    # The dead window was killed; the new break-pane added a fresh one
+    # at the canonical name.  No duplicate accumulation.
+    same_name = [w for w in tmux.windows if w.name == "architect-samblog"]
+    assert len(same_name) == 1
+    assert audit_events == []  # No skip event for the dead-only case.
+
+
+def test_safe_break_does_not_add_third_when_two_duplicates_exist() -> None:
+    """Smoking gun from Sam's 2026-05-19 wipe.
+
+    The storage closet already had two ``architect-samblog`` windows
+    (indices 22 and 42) when the user clicked away from PM Chat.  A
+    naive break-pane would push the count to three.  The helper must
+    refuse and leave the closet exactly as it found it.
+    """
+    tmux = _FakeTmux(
+        windows=[
+            _FakeWindow(22, "architect-samblog", command="node"),
+            _FakeWindow(42, "architect-samblog", command="node"),
+        ]
+    )
+    audit_events, audit_emit = _collect_audit()
+
+    broke = safe_break_pane_to_storage(
+        tmux,
+        source_pane_id="%5099",
+        storage_session="pollypm-storage-closet",
+        window_name="architect-samblog",
+        audit_emit=audit_emit,
+        subject="architect_samblog",
+    )
+
+    assert broke is False
+    assert tmux.break_calls == []
+    assert tmux.kill_pane_calls == ["%5099"]
+    same_name = [w for w in tmux.windows if w.name == "architect-samblog"]
+    assert len(same_name) == 2, (
+        "Helper must NOT add a third architect-samblog window — that's "
+        "the #1631 conversation-wipe surface"
+    )
+    assert len(audit_events) == 1
+    assert audit_events[0]["metadata"]["live_duplicate_indices"] == [22, 42]
+
+
+def test_safe_break_treats_version_string_command_as_live() -> None:
+    """Live-provider definition mirrors the cockpit selector.
+
+    The Claude CLI reports its version string (e.g. ``2.1.144``) as the
+    pane command after the first turn.  The helper must treat such
+    panes as live so the user's first-turn-completed conversation
+    isn't classified as dead and silently duplicated.
+    """
+    existing = _FakeWindow(22, "architect-samblog", command="2.1.144")
+    tmux = _FakeTmux(windows=[existing])
+    audit_events, audit_emit = _collect_audit()
+
+    broke = safe_break_pane_to_storage(
+        tmux,
+        source_pane_id="%99",
+        storage_session="pollypm-storage-closet",
+        window_name="architect-samblog",
+        audit_emit=audit_emit,
+        subject="architect_samblog",
+    )
+
+    assert broke is False
+    assert tmux.break_calls == []
+    assert len(audit_events) == 1
+    assert audit_events[0]["event_name"] == "cockpit.park_skipped_existing"
+
+
+def test_safe_break_swallows_list_windows_errors() -> None:
+    """A flaky tmux must not block the park path.
+
+    If ``list_windows`` raises, the helper has no signal about
+    duplicates — falling back to the bare break-pane keeps the park
+    path moving rather than wedging the cockpit.  (The helper's
+    conservative default is to break-pane when in doubt; in the worst
+    case a duplicate is created but the cockpit stays usable.)
+    """
+
+    class _ExplodingTmux(_FakeTmux):
+        def list_windows(self, session: str) -> list[_FakeWindow]:
+            raise RuntimeError("tmux server unreachable")
+
+    tmux = _ExplodingTmux(windows=[])
+    broke = safe_break_pane_to_storage(
+        tmux,
+        source_pane_id="%99",
+        storage_session="pollypm-storage-closet",
+        window_name="architect-samblog",
+    )
+
+    assert broke is True
+    assert tmux.break_calls == [
+        ("%99", "pollypm-storage-closet", "architect-samblog")
+    ]
+
+
+def test_safe_break_audit_callback_is_optional() -> None:
+    """Helper must work without an audit callback (low-level callers)."""
+    existing = _FakeWindow(22, "pm-operator", command="claude")
+    tmux = _FakeTmux(windows=[existing])
+
+    broke = safe_break_pane_to_storage(
+        tmux,
+        source_pane_id="%99",
+        storage_session="pollypm-storage-closet",
+        window_name="pm-operator",
+    )
+
+    assert broke is False
+    assert tmux.break_calls == []
+    assert tmux.kill_pane_calls == ["%99"]

--- a/tests/test_cockpit_window_manager.py
+++ b/tests/test_cockpit_window_manager.py
@@ -626,6 +626,65 @@ def test_park_live_to_storage_breaks_right_and_replaces_static_content() -> None
     assert storage_windows[0].pane_id == right_id
 
 
+def test_park_live_to_storage_skips_when_live_duplicate_exists() -> None:
+    """#1631 follow-up — ``park_live_to_storage`` must NOT silently
+    add a second window when storage already holds a live one of the
+    same name.
+
+    Sam's 2026-05-19 wipe: ``architect-samblog`` was duplicated at
+    indices 22 and 42 in the closet, and a click away from PM Chat
+    would have grown that to three before the fix.  The manager now
+    routes through :func:`safe_break_pane_to_storage`, which refuses
+    the break-pane when a live duplicate exists.
+
+    Regression contract:
+      * Storage closet ends up with exactly one ``architect-samblog``
+        window (the pre-existing live one, untouched).
+      * ``break_pane`` is never called.
+      * The result still ``ok`` — the manager treats this as a
+        successful park because the persistent home already exists.
+      * Mount state is cleared so the next mount can re-attach via
+        the rail selector.
+    """
+    tmux = FakeTmux()
+    # Pre-existing live conversation in the closet.
+    tmux.add_window(
+        "pollypm-storage-closet",
+        "architect-samblog",
+        [("claude", 0)],
+    )
+    cockpit = tmux.add_window("pollypm", "PollyPM", [("uv", 0), ("claude", 100)])
+    right_id = cockpit.panes[1].pane_id
+    manager = _manager(tmux)
+
+    result = manager.park_live_to_storage(
+        CockpitWindowState(
+            right_pane_id=right_id,
+            mounted_session="architect_samblog",
+            mounted_window_name="architect-samblog",
+        ),
+        park=ParkPaneSpec(
+            storage_session="pollypm-storage-closet",
+            window_name="architect-samblog",
+            mounted_session="architect_samblog",
+        ),
+    )
+
+    assert result.ok
+    storage_windows = tmux.list_windows("pollypm-storage-closet")
+    same_name = [w for w in storage_windows if w.name == "architect-samblog"]
+    assert len(same_name) == 1, (
+        "park_live_to_storage must not duplicate architect-samblog — "
+        "that's the #1631 conversation-wipe surface"
+    )
+    # No break-pane to storage was emitted.
+    assert not any(
+        call[0] == "break_pane" for call in tmux.calls
+    ), "break-pane must be skipped when a live duplicate already exists"
+    assert "park_skipped_live_duplicate:pollypm-storage-closet:architect-samblog" in result.actions
+    assert result.state.mounted_session is None
+
+
 def test_focus_right_selects_content_pane_and_shows_hint() -> None:
     tmux = FakeTmux()
     cockpit = tmux.add_window("pollypm", "PollyPM", [("uv", 0), ("pm", 100)])


### PR DESCRIPTION
## Symptom
> 'I was chatting with the PM in the SamBlog project, switched to the dashboard, came back, and now I'm in a new chat.' — Sam, 2026-05-19

This is the #1631 wipe pattern reappearing on a per-project PM window (``architect-samblog``) after #1632/#1635 supposedly fixed it.

## Reproduction
- Sam was in PM Chat for SamBlog (``architect-samblog`` session, ``Archie`` persona, claude provider)
- Switched to dashboard
- Came back to PM Chat → fresh conversation, prior chat gone

Storage closet at the time of the report (from ``tmux list-windows -t pollypm-storage-closet``):
```
22: architect-samblog (live, pane %5031 running node)
42: architect-samblog (live, pane %5032 running node)
```
Two same-named live windows ⇒ #1631 selector picks one, user re-enters the empty one.

## Root cause
Audit log shows ``cockpit.park_skipped_existing`` fired correctly at 17:38:25 for ``architect_samblog`` (``live_duplicate_indices:[22]``), proving #1635's ``_park_mounted_session`` idempotency works. But a second duplicate appeared in the closet later **without any subsequent park event** — meaning a different code path created it.

Investigation found three remaining ``tmux break-pane``-to-storage call sites that bypass #1635's dup-check:
1. ``cockpit_window_manager.park_live_to_storage`` (line 517) — invoked from ``show_static`` flow with ``park=``
2. ``core/console_window.py`` (line 164) — invoked on cockpit-window respawn after the console pane exits
3. ``cockpit_rail.ensure_cockpit_layout`` (line 2511) — invoked when only the worker pane survived a rail crash

Each unconditionally called ``tmux break-pane -n <window_name>`` even when storage already held a same-named live window — exactly the bug #1635 fixed in ``_park_mounted_session`` but never extended elsewhere.

## Fix
Extract the dup-check from ``_park_mounted_session`` into a new shared helper ``pollypm.cockpit_storage_park.safe_break_pane_to_storage`` and wire it at all three bypass sites.

Helper behaviour:
- Live duplicate exists ⇒ skip ``break-pane``, kill the source pane (so it doesn't orphan in the cockpit), emit ``cockpit.park_skipped_existing``, return ``False``.
- Dead duplicates ⇒ killed first so ``break-pane`` re-occupies the canonical name.
- No duplicates ⇒ unchanged.

``_park_mounted_session``'s existing logic is left intact (it has additional state-clearing + lease-release behaviour the helper doesn't need to know about). The helper is additive on the other three call sites.

## Verification
```
.venv/bin/pytest \
  tests/test_cockpit_storage_park.py \
  tests/test_cockpit_window_manager.py \
  tests/test_cockpit_rail_duplicate_resolution.py \
  tests/test_cockpit_rail_duplicate_window_cleanup.py
→ 41 passed
```

New ``test_safe_break_does_not_add_third_when_two_duplicates_exist`` reproduces Sam's exact 17:38 storage-closet state (indices 22 + 42, both live) and asserts the helper refuses to push the count to three.

The 4 pre-existing failures in ``tests/test_cockpit.py`` (event-ticker / detail-dashboard) are unrelated to this change — confirmed they fail on ``cea58bd3`` (origin/main) without my diff.

## pm binary version note
Sam's live pm binary mtime is **2026-05-19 09:06** (today's ``pm upgrade``) — pm 1.0.0rc2 against ``cea58bd3``. So Sam's pm was *current* with origin/main when the wipe hit at 17:38, meaning this was a real gap in the existing #1631/#1635 fix, not a stale-install issue.

**After this lands**: Sam should run ``pm upgrade`` again to pick up the fix.

## Test plan
- [x] New helper unit tests cover: no-duplicate, live-duplicate, dead-duplicate, double-duplicate (smoking gun), version-string command, list_windows failure, optional audit callback
- [x] Window-manager integration test pins ``park_live_to_storage`` to the helper
- [x] Existing #1635 ``_park_mounted_session`` regression tests still pass (logic intact)
- [ ] Manual: drive PM Chat → dashboard → PM Chat sequence in pollypm cockpit after merge + ``pm upgrade``; confirm no ``cockpit.park_skipped_existing`` event for ``architect-samblog`` with mounting yields a fresh claude (positive case: it should reuse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)