### PR TITLE
fix(cockpit): operator dashboard 10s open + project open 5s — wrong-backend sqlite fanout on a pg workspace (refs #1634)

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -244,7 +244,9 @@ def pm_inbox_awaits_user_list(config) -> list[object]:
     if collected and project_db_paths:
         return list(
             _filter_approved_plan_reviews(
-                collected, project_db_paths=project_db_paths,
+                collected,
+                project_db_paths=project_db_paths,
+                config=config,
             )
         )
     return collected
@@ -387,7 +389,9 @@ def pm_inbox_filtered_list(
     if collected and project_db_paths:
         return list(
             _filter_approved_plan_reviews(
-                collected, project_db_paths=project_db_paths,
+                collected,
+                project_db_paths=project_db_paths,
+                config=config,
             )
         )
     return collected

--- a/src/pollypm/cockpit_inbox_items.py
+++ b/src/pollypm/cockpit_inbox_items.py
@@ -540,6 +540,7 @@ def _filter_approved_plan_reviews(
     items: list[InboxEntry],
     *,
     project_db_paths: dict[str, tuple[Path, Path]],
+    config: object | None = None,
 ) -> list[InboxEntry]:
     """Drop ``plan_review`` rows whose user_approval is already APPROVED.
 
@@ -620,6 +621,7 @@ def _filter_approved_plan_reviews(
             refs_by_db=refs_by_db,
             project_db_paths=project_db_paths,
             service_factory=create_work_service,
+            config=config,
         )
     kept: list[InboxEntry] = []
     dropped = 0
@@ -808,7 +810,7 @@ def load_inbox_entries(
     items = _dedupe_replayed_plan_reviews(items)
     items = _dedupe_message_vs_task_plan_reviews(items)
     items = _filter_approved_plan_reviews(
-        items, project_db_paths=project_db_paths,
+        items, project_db_paths=project_db_paths, config=config,
     )
     return items, unread, replies_by_task
 

--- a/src/pollypm/dashboard/operator_view.py
+++ b/src/pollypm/dashboard/operator_view.py
@@ -1,20 +1,24 @@
 """Operator dashboard data loader (#1572).
 
 Bridges the leaf categorization module to the workspace's project
-config + per-project work-service DBs. Keeps the I/O side-effects
+config + the canonical work-service. Keeps the I/O side-effects
 out of :mod:`pollypm.dashboard.categorization` so the categorizer
 stays trivially unit-testable against a mock work service.
 
-The loader mirrors :func:`pollypm.cockpit_inbox.pm_inbox_awaits_user_list`'s
-DB-discovery shape: one work-service handle per (project, db_path)
-tuple, opened with the canonical workspace DB and the legacy
-per-project DB so paused-with-work projects still surface.
+Post-#1634 perf fix: open ONE work-service handle keyed on the
+workspace config (which resolves to the canonical workspace DB on
+sqlite and the pg pool on postgres) and prefetch every project's
+tasks + active worker sessions in two bulk queries before categorizing.
+The historic per-project fanout opened a fresh sqlite handle per
+project even on a postgres backend (``_open_work_service`` did not
+forward ``config`` to the factory, so the resolver fell back to
+``"sqlite"``) and queried stale ``state.db`` files on every dashboard
+mount — 12 projects × ~5–350ms sqlite opens dominated the cold path.
 """
 
 from __future__ import annotations
 
 import logging
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
@@ -30,31 +34,26 @@ from pollypm.dashboard.categorization import (
     why_waiting,
 )
 
-# #1630 — cap concurrent per-project sqlite opens. Each project costs
-# one sqlite ``open`` plus a small number of read queries; 12 projects
-# was measured at ~12s serial on the operator dashboard. A modest pool
-# (capped to avoid swamping the FS / GIL when the worker count >>
-# project count) brings the sweep close to single-project latency.
-_MAX_PARALLEL_PROJECT_SCANS = 8
-
 logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
 class _ProjectScan:
-    """Resolved scan target — project key + a list of DB paths to try."""
+    """Resolved scan target — project key + tracked flag.
+
+    Pre-#1634 this also carried per-project ``db_paths`` for the
+    sqlite fanout; post-fix the loader opens ONE shared work-service
+    via the factory's config-resolved path, so the per-project DB
+    list is no longer needed.
+    """
 
     project_key: str
     project_path: Path
-    db_paths: tuple[Path, ...]
     tracked: bool
 
 
 def _collect_project_scans(config) -> list[_ProjectScan]:  # noqa: ANN001
-    """Resolve (project_key, project_path, db_paths, tracked) tuples."""
-    project_settings = getattr(config, "project", None)
-    workspace_root = getattr(project_settings, "workspace_root", None)
-
+    """Resolve (project_key, project_path, tracked) tuples for every project."""
     scans: list[_ProjectScan] = []
     seen_projects: set[str] = set()
     projects = getattr(config, "projects", {}) or {}
@@ -63,30 +62,10 @@ def _collect_project_scans(config) -> list[_ProjectScan]:  # noqa: ANN001
             continue
         seen_projects.add(project_key)
         project_path = Path(getattr(project, "path", "."))
-        db_candidates: list[Path] = []
-
-        def _add(p: object) -> None:
-            try:
-                candidate = Path(p)
-            except TypeError:
-                return
-            if candidate in db_candidates:
-                return
-            try:
-                if candidate.exists():
-                    db_candidates.append(candidate)
-            except OSError:
-                return
-
-        if workspace_root is not None:
-            _add(Path(workspace_root) / ".pollypm" / "state.db")
-        _add(project_path / ".pollypm" / "state.db")
-
         scans.append(
             _ProjectScan(
                 project_key=str(project_key),
                 project_path=project_path,
-                db_paths=tuple(db_candidates),
                 tracked=bool(getattr(project, "tracked", False)),
             )
         )
@@ -120,61 +99,37 @@ def _waiting_items_by_project(config) -> dict[str, list]:  # noqa: ANN001
     return grouped
 
 
-def _open_work_service(scan: _ProjectScan):  # noqa: ANN202
-    """Open the first work-service handle that has rows for ``scan``.
+def _open_shared_work_service(config):  # noqa: ANN001, ANN202
+    """Open one work-service handle keyed on ``config``.
 
-    Mirrors ``cockpit_rail._project_tasks_for_rollup``'s canonical →
-    legacy walk: try each candidate DB in order, prefer the first one
-    that returns at least one task row for the project key, fall
-    through to the next candidate when the current DB is empty. This
-    keeps the dashboard and the rail in sync on which DB a project's
-    state lives in — without it, a canonical workspace DB that simply
-    opens (but has no rows for the project) would silently shadow the
-    legacy per-project DB where the real work lives.
+    The factory routes to the configured backend (pg pool on
+    ``storage.backend = "postgres"``, the canonical workspace
+    ``state.db`` on sqlite). Returns ``None`` on import / open
+    failure so the caller can degrade rather than crash the
+    dashboard.
 
-    Returns the handle the caller should close.
+    #1634 — replaces ``_open_work_service`` which opened a fresh
+    sqlite handle per project (the historic dual-DB fallback walk)
+    even on a pg backend, since the legacy callsite never forwarded
+    ``config`` to the factory.
     """
-    from pollypm.work import create_work_service
-
-    fallback = None
-    for db_path in scan.db_paths:
-        try:
-            svc = create_work_service(
-                db_path=db_path, project_path=scan.project_path,
-            )
-        except Exception:  # noqa: BLE001
-            # #1355: previously silent. A failed open here silently skips
-            # this DB candidate — log so a bad workspace/legacy path is
-            # debuggable instead of "the project just disappears".
-            logger.warning(
-                "operator_view: create_work_service failed for %s (project=%s)",
-                db_path,
-                scan.project_key,
-                exc_info=True,
-            )
-            continue
-        try:
-            tasks = svc.list_tasks(project=scan.project_key)
-        except Exception:  # noqa: BLE001
-            # #1355: previously silent. An empty task list here drops us
-            # to fallback selection; log so a broken list_tasks doesn't
-            # masquerade as "no work in this DB".
-            logger.warning(
-                "operator_view: list_tasks failed for project=%s db=%s",
-                scan.project_key,
-                db_path,
-                exc_info=True,
-            )
-            tasks = []
-        if tasks:
-            if fallback is not None and fallback is not svc:
-                _safe_close(fallback)
-            return svc
-        if fallback is None:
-            fallback = svc
-        else:
-            _safe_close(svc)
-    return fallback
+    try:
+        from pollypm.work import create_work_service
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "operator_view: create_work_service import failed",
+            exc_info=True,
+        )
+        return None
+    try:
+        return create_work_service(config=config)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "operator_view: create_work_service(config=...) failed; "
+            "dashboard will degrade to inbox-only categorization",
+            exc_info=True,
+        )
+        return None
 
 
 def _safe_close(svc) -> None:  # noqa: ANN001
@@ -184,6 +139,142 @@ def _safe_close(svc) -> None:  # noqa: ANN001
             close()
         except Exception:  # noqa: BLE001
             pass
+
+
+def _prefetch_project_state(config, svc) -> tuple[  # noqa: ANN001
+    "dict[str, list]", "dict[str, list]"
+]:
+    """Return ``(tasks_by_alias, workers_by_alias)`` in two bulk queries.
+
+    Single ``list_tasks(project=None)`` + ``list_worker_sessions(project=None,
+    active_only=True)`` against the shared work-service, grouped in
+    Python by the project alias each row carries. The categorizer then
+    reads its per-project slice from these dicts via
+    :func:`pollypm.work.project_aliases.project_storage_aliases` —
+    replacing N ``list_tasks(project=<key>)`` calls and N
+    ``list_worker_sessions(project=<key>)`` calls with two queries.
+    """
+    tasks_by_alias: dict[str, list] = {}
+    workers_by_alias: dict[str, list] = {}
+    if svc is None:
+        return tasks_by_alias, workers_by_alias
+    try:
+        all_tasks = svc.list_tasks()
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "operator_view: bulk list_tasks failed; categorization "
+            "degrades to inbox-only",
+            exc_info=True,
+        )
+        all_tasks = []
+    for task in all_tasks or []:
+        key = str(getattr(task, "project", "") or "")
+        if not key:
+            continue
+        tasks_by_alias.setdefault(key, []).append(task)
+    try:
+        all_workers = svc.list_worker_sessions(active_only=True)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "operator_view: bulk list_worker_sessions failed; "
+            "live-worker WORKING signal will degrade",
+            exc_info=True,
+        )
+        all_workers = []
+    for session in all_workers or []:
+        key = str(getattr(session, "task_project", "") or "")
+        if not key:
+            continue
+        workers_by_alias.setdefault(key, []).append(session)
+    return tasks_by_alias, workers_by_alias
+
+
+def _aliases_for(config, project_key: str) -> list[str]:  # noqa: ANN001
+    """Resolve every storage alias for ``project_key`` (defensive)."""
+    try:
+        from pollypm.work.project_aliases import project_storage_aliases
+
+        return project_storage_aliases(config, project_key)
+    except Exception:  # noqa: BLE001
+        return [project_key]
+
+
+class _ProjectSliceService:
+    """Read-only adapter exposing one project's pre-fetched rows.
+
+    Implements the :class:`_WorkServiceLike` Protocol the categorizer
+    consumes (``list_tasks`` / ``list_worker_sessions`` / ``get``)
+    without touching the underlying DB. The shared svc has already
+    paid the round-trip; this adapter just hands the categorizer the
+    per-project slice keyed on every known alias for the project.
+    """
+
+    __slots__ = ("_project_key", "_aliases", "_tasks", "_workers", "_svc")
+
+    def __init__(
+        self,
+        project_key: str,
+        aliases: list[str],
+        tasks_by_alias: dict[str, list],
+        workers_by_alias: dict[str, list],
+        shared_svc,
+    ) -> None:
+        self._project_key = project_key
+        self._aliases = aliases
+        self._tasks = tasks_by_alias
+        self._workers = workers_by_alias
+        self._svc = shared_svc
+
+    def list_tasks(
+        self, *, project: str | None = None, **_kwargs: object,
+    ) -> list:
+        out: list = []
+        seen: set[str] = set()
+        # ``project=None`` returns everything we have for this slice;
+        # the categorizer always passes the project key explicitly,
+        # so this branch is just a defensive default.
+        target_aliases = (
+            self._aliases if project is None else [project, *self._aliases]
+        )
+        for alias in target_aliases:
+            for task in self._tasks.get(alias, []):
+                tid = getattr(task, "task_id", None)
+                if tid and tid in seen:
+                    continue
+                if tid:
+                    seen.add(tid)
+                out.append(task)
+        return out
+
+    def list_worker_sessions(
+        self, *, project: str | None = None, active_only: bool = True,
+    ) -> list:
+        del project  # adapter is already project-scoped
+        del active_only  # prefetch already filters to active_only=True
+        out: list = []
+        seen: set[tuple[str, object]] = set()
+        for alias in self._aliases:
+            for session in self._workers.get(alias, []):
+                key = (alias, getattr(session, "task_number", None))
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append(session)
+        return out
+
+    def get(self, task_id: str):  # noqa: ANN201
+        # Categorizer's ``what_working`` reaches for a task title via
+        # ``svc.get`` after picking a worker; route the single-row
+        # fetch through the shared svc so we don't have to prefetch
+        # every task body. Falls back to a scan over the prefetched
+        # slice when no shared svc is available.
+        if self._svc is not None and hasattr(self._svc, "get"):
+            return self._svc.get(task_id)
+        for alias in self._aliases:
+            for task in self._tasks.get(alias, []):
+                if getattr(task, "task_id", "") == task_id:
+                    return task
+        raise KeyError(task_id)
 
 
 def load_operator_view(config_path: Path) -> OperatorDashboardView:
@@ -202,88 +293,53 @@ def load_operator_view(config_path: Path) -> OperatorDashboardView:
 
 
 def _scan_to_row(
-    scan: _ProjectScan, items: list,
+    scan: _ProjectScan,
+    items: list,
+    *,
+    slice_svc: "_ProjectSliceService | None",
 ) -> OperatorDashboardRow:
-    """Per-project worker: open the DB, categorize, return the row.
+    """Categorize one project using a pre-fetched slice adapter.
 
-    Extracted from ``load_operator_view_from_config`` so it can run on
-    a worker thread without sharing mutable state with peer scans —
-    each call opens its own work-service handle and closes it before
-    returning. This keeps the parallel sweep correctness-equivalent to
-    the original serial loop (#1630).
+    Pre-#1634 every call opened its own sqlite handle; now the per-
+    project slice is supplied by the caller (one shared work-service
+    feeds every scan) so the categorizer pays only Python work.
     """
-    svc = _open_work_service(scan)
-    try:
-        if svc is None:
-            state = (
-                ProjectState.WAITING if items
-                else (ProjectState.PAUSED if not scan.tracked else ProjectState.IDLE)
-            )
-            detail = (
-                why_waiting(items) if state is ProjectState.WAITING
-                else ("Paused" if state is ProjectState.PAUSED else "Quiet")
-            )
-            return OperatorDashboardRow(
-                project_key=scan.project_key,
-                state=state,
-                glyph=glyph_for_project_state(state),
-                detail=detail,
-            )
-        state = categorize_project(
-            scan.project_key,
-            work_service=svc,
-            inbox_items=items,
-            tracked=scan.tracked,
+    if slice_svc is None:
+        state = (
+            ProjectState.WAITING if items
+            else (ProjectState.PAUSED if not scan.tracked else ProjectState.IDLE)
         )
-        glyph = glyph_for_project_state(state)
-        if state is ProjectState.WAITING:
-            detail = why_waiting(items)
-        elif state is ProjectState.WORKING:
-            detail = what_working(scan.project_key, work_service=svc)
-        elif state is ProjectState.PAUSED:
-            detail = "Paused"
-        else:
-            detail = "Quiet"
+        detail = (
+            why_waiting(items) if state is ProjectState.WAITING
+            else ("Paused" if state is ProjectState.PAUSED else "Quiet")
+        )
         return OperatorDashboardRow(
             project_key=scan.project_key,
             state=state,
-            glyph=glyph,
+            glyph=glyph_for_project_state(state),
             detail=detail,
         )
-    finally:
-        if svc is not None:
-            _safe_close(svc)
-
-
-def _parallel_scan_rows(
-    scans: list[_ProjectScan],
-    waiting_by_project: dict[str, list],
-) -> list[OperatorDashboardRow]:
-    """Run ``_scan_to_row`` over ``scans`` with a small thread pool.
-
-    Falls through to a serial loop when there's only one scan — the
-    pool overhead isn't worth it. Bounded at
-    :data:`_MAX_PARALLEL_PROJECT_SCANS` so a 50-project workspace
-    doesn't open 50 sqlite handles at once.
-    """
-    if len(scans) <= 1:
-        return [
-            _scan_to_row(scan, waiting_by_project.get(scan.project_key, []))
-            for scan in scans
-        ]
-    max_workers = min(_MAX_PARALLEL_PROJECT_SCANS, len(scans))
-    with ThreadPoolExecutor(
-        max_workers=max_workers,
-        thread_name_prefix="operator-scan",
-    ) as pool:
-        return list(
-            pool.map(
-                lambda scan: _scan_to_row(
-                    scan, waiting_by_project.get(scan.project_key, []),
-                ),
-                scans,
-            )
-        )
+    state = categorize_project(
+        scan.project_key,
+        work_service=slice_svc,
+        inbox_items=items,
+        tracked=scan.tracked,
+    )
+    glyph = glyph_for_project_state(state)
+    if state is ProjectState.WAITING:
+        detail = why_waiting(items)
+    elif state is ProjectState.WORKING:
+        detail = what_working(scan.project_key, work_service=slice_svc)
+    elif state is ProjectState.PAUSED:
+        detail = "Paused"
+    else:
+        detail = "Quiet"
+    return OperatorDashboardRow(
+        project_key=scan.project_key,
+        state=state,
+        glyph=glyph,
+        detail=detail,
+    )
 
 
 def load_operator_view_from_config(config) -> OperatorDashboardView:  # noqa: ANN001
@@ -291,15 +347,50 @@ def load_operator_view_from_config(config) -> OperatorDashboardView:  # noqa: AN
 
     Useful for tests + callers that have a config in hand and want to
     avoid re-parsing the TOML.
+
+    Post-#1634 data path:
+
+    1. Open one shared work-service via the config-resolved factory.
+       On pg this is the pool singleton; on sqlite it's the canonical
+       workspace ``state.db``. No per-project handles.
+    2. Prefetch every task + active worker session in two bulk
+       queries, grouped by project alias.
+    3. Per-project: gather the inbox slice (already a single pg
+       query inside ``_waiting_items_by_project``) and categorize
+       against an adapter view of the prefetched dicts. Serial loop —
+       no DB I/O remains in the per-project step, so parallel threads
+       buy nothing.
     """
     scans = _collect_project_scans(config)
     waiting_by_project = _waiting_items_by_project(config)
 
-    # #1630 — per-project sqlite opens run in parallel. Each scan is
-    # independent (its own DB handle, its own categorize), so the only
-    # contention is the GIL during pure-Python work; sqlite I/O
-    # releases the GIL and is the dominant cost.
-    rows = _parallel_scan_rows(scans, waiting_by_project)
+    shared_svc = _open_shared_work_service(config)
+    try:
+        tasks_by_alias, workers_by_alias = _prefetch_project_state(
+            config, shared_svc,
+        )
+        rows: list[OperatorDashboardRow] = []
+        for scan in scans:
+            if shared_svc is None:
+                slice_svc = None
+            else:
+                slice_svc = _ProjectSliceService(
+                    project_key=scan.project_key,
+                    aliases=_aliases_for(config, scan.project_key),
+                    tasks_by_alias=tasks_by_alias,
+                    workers_by_alias=workers_by_alias,
+                    shared_svc=shared_svc,
+                )
+            rows.append(
+                _scan_to_row(
+                    scan,
+                    waiting_by_project.get(scan.project_key, []),
+                    slice_svc=slice_svc,
+                )
+            )
+    finally:
+        if shared_svc is not None:
+            _safe_close(shared_svc)
 
     waiting: list[OperatorDashboardRow] = []
     working: list[OperatorDashboardRow] = []
@@ -328,32 +419,29 @@ def load_operator_view_from_config(config) -> OperatorDashboardView:  # noqa: AN
 
 
 def _scan_to_state(
-    scan: _ProjectScan, items: list,
+    scan: _ProjectScan,
+    items: list,
+    *,
+    slice_svc: "_ProjectSliceService | None",
 ) -> tuple[str, ProjectState]:
-    """Per-project worker for :func:`project_state_map_from_config`.
+    """Return ``(project_key, ProjectState)`` for one scan.
 
-    Mirrors :func:`_scan_to_row` but returns only the classification —
-    callers that just want the state map (e.g. the rail's glyph
-    selector) shouldn't pay for ``what_working`` / ``why_waiting``
-    string assembly that the dashboard view consumes.
+    Mirrors :func:`_scan_to_row` but skips ``what_working`` /
+    ``why_waiting`` — the rail just needs the category for its glyph
+    table. Reads from the pre-fetched slice adapter, no DB I/O.
     """
-    svc = _open_work_service(scan)
-    try:
-        if svc is None:
-            if items:
-                return scan.project_key, ProjectState.WAITING
-            if not scan.tracked:
-                return scan.project_key, ProjectState.PAUSED
-            return scan.project_key, ProjectState.IDLE
-        return scan.project_key, categorize_project(
-            scan.project_key,
-            work_service=svc,
-            inbox_items=items,
-            tracked=scan.tracked,
-        )
-    finally:
-        if svc is not None:
-            _safe_close(svc)
+    if slice_svc is None:
+        if items:
+            return scan.project_key, ProjectState.WAITING
+        if not scan.tracked:
+            return scan.project_key, ProjectState.PAUSED
+        return scan.project_key, ProjectState.IDLE
+    return scan.project_key, categorize_project(
+        scan.project_key,
+        work_service=slice_svc,
+        inbox_items=items,
+        tracked=scan.tracked,
+    )
 
 
 def project_state_map_from_config(config) -> dict[str, ProjectState]:  # noqa: ANN001
@@ -365,39 +453,45 @@ def project_state_map_from_config(config) -> dict[str, ProjectState]:  # noqa: A
     a project whose DB can't be opened falls through to a tracked /
     paused IDLE classification rather than raising.
 
-    #1642 — Per-project sqlite opens run in parallel via the same
-    bounded pool the dashboard loader uses. The rail invokes this
-    inside its ``rail_refresh`` worker and the prior serial loop was
-    the dominant cost on multi-project workspaces; mirroring
-    :func:`load_operator_view_from_config`'s parallel sweep keeps the
-    rail-refresh path within a single project's DB-open latency
-    regardless of project count. The router additionally TTL-caches
-    the result so navigation bursts collapse into one sweep.
+    #1634 — opens ONE shared work-service and prefetches every
+    project's tasks + active worker sessions in two bulk queries
+    before classifying. Replaces the parallel per-project sqlite
+    fanout that ran one ``state.db`` open per project per refresh
+    (~5–350ms each on a 9MB workspace DB, dominating the dashboard
+    mount path even though the system is on postgres).
     """
     scans = _collect_project_scans(config)
     waiting_by_project = _waiting_items_by_project(config)
     if not scans:
         return {}
-    if len(scans) <= 1:
-        pairs = [
-            _scan_to_state(scan, waiting_by_project.get(scan.project_key, []))
-            for scan in scans
-        ]
-    else:
-        max_workers = min(_MAX_PARALLEL_PROJECT_SCANS, len(scans))
-        with ThreadPoolExecutor(
-            max_workers=max_workers,
-            thread_name_prefix="operator-state",
-        ) as pool:
-            pairs = list(
-                pool.map(
-                    lambda scan: _scan_to_state(
-                        scan, waiting_by_project.get(scan.project_key, []),
-                    ),
-                    scans,
+    shared_svc = _open_shared_work_service(config)
+    try:
+        tasks_by_alias, workers_by_alias = _prefetch_project_state(
+            config, shared_svc,
+        )
+        pairs: list[tuple[str, ProjectState]] = []
+        for scan in scans:
+            if shared_svc is None:
+                slice_svc = None
+            else:
+                slice_svc = _ProjectSliceService(
+                    project_key=scan.project_key,
+                    aliases=_aliases_for(config, scan.project_key),
+                    tasks_by_alias=tasks_by_alias,
+                    workers_by_alias=workers_by_alias,
+                    shared_svc=shared_svc,
+                )
+            pairs.append(
+                _scan_to_state(
+                    scan,
+                    waiting_by_project.get(scan.project_key, []),
+                    slice_svc=slice_svc,
                 )
             )
-    return {key: state for key, state in pairs}
+        return {key: state for key, state in pairs}
+    finally:
+        if shared_svc is not None:
+            _safe_close(shared_svc)
 
 
 def view_as_ascii(view: OperatorDashboardView) -> str:

--- a/src/pollypm/work/inbox_plan_reviews.py
+++ b/src/pollypm/work/inbox_plan_reviews.py
@@ -49,35 +49,74 @@ def approved_plan_review_refs(
     refs_by_db: dict[str, set[tuple[str, int]]],
     project_db_paths: dict[str, tuple[Path, Path]],
     service_factory: ServiceFactory | None = None,
+    config: object | None = None,
 ) -> set[str]:
-    """Return ``project/N`` refs whose plan-review task is already approved."""
+    """Return ``project/N`` refs whose plan-review task is already approved.
+
+    ``config`` is forwarded to the factory so the resolver routes to
+    the configured backend; without it the factory fell back to sqlite
+    even on a pg workspace, opening a stale ``state.db`` per project
+    refs ref-set (#1634).
+    """
     if service_factory is None:
         from pollypm.work.factory import create_work_service
 
         service_factory = create_work_service
     approved_refs: set[str] = set()
-    for db_key, refs in refs_by_db.items():
-        db_path, project_path = project_db_paths[db_key]
+    # On the pg backend every db_key resolves to the same pool, so
+    # one shared svc handles every ref-set. On sqlite each db_key
+    # still maps to its own canonical workspace ``state.db`` (which
+    # the factory resolves identically per call), so the shared
+    # handle is also correct there.
+    shared_svc = None
+    if config is not None:
         try:
-            svc = service_factory(db_path=db_path, project_path=project_path)
+            shared_svc = service_factory(config=config)
         except Exception:  # noqa: BLE001
             logger.debug(
-                "inbox: open svc failed for db %s during plan-review check",
-                db_key,
+                "inbox: shared svc open failed; falling back to per-db opens",
                 exc_info=True,
             )
-            continue
+            shared_svc = None
+    for db_key, refs in refs_by_db.items():
+        if shared_svc is not None:
+            svc = shared_svc
+            opened_local = False
+        else:
+            db_path, project_path = project_db_paths[db_key]
+            try:
+                svc = service_factory(
+                    db_path=db_path,
+                    project_path=project_path,
+                    config=config,
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "inbox: open svc failed for db %s during plan-review check",
+                    db_key,
+                    exc_info=True,
+                )
+                continue
+            opened_local = True
         try:
             for project, number in refs:
                 if is_plan_task_approved(svc, project, number):
                     approved_refs.add(f"{project}/{number}")
         finally:
-            close = getattr(svc, "close", None)
-            if callable(close):
-                try:
-                    close()
-                except Exception:  # noqa: BLE001
-                    pass
+            if opened_local:
+                close = getattr(svc, "close", None)
+                if callable(close):
+                    try:
+                        close()
+                    except Exception:  # noqa: BLE001
+                        pass
+    if shared_svc is not None:
+        close = getattr(shared_svc, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:  # noqa: BLE001
+                pass
     return approved_refs
 
 

--- a/tests/test_operator_dashboard_pilot.py
+++ b/tests/test_operator_dashboard_pilot.py
@@ -153,43 +153,47 @@ def test_refresh_uses_thread_worker(monkeypatch, tmp_path: Path) -> None:
     _run(body())
 
 
-def test_parallel_scan_short_circuits_single_project(tmp_path: Path) -> None:
-    """One-project workspace doesn't pay the ThreadPool overhead."""
+def test_scan_to_row_handles_missing_service(tmp_path: Path) -> None:
+    """When no shared work-service is available the row falls back to the
+    inbox-only categorization (PAUSED / IDLE / WAITING) — #1634 collapsed
+    the per-project sqlite fanout into a single shared handle, and the
+    scan helper must still degrade gracefully when that handle is None.
+    """
+    from pollypm.dashboard.operator_view import _ProjectScan, _scan_to_row
+
+    scan = _ProjectScan(
+        project_key="solo",
+        project_path=tmp_path,
+        tracked=True,
+    )
+    row = _scan_to_row(scan, [], slice_svc=None)
+    assert row.project_key == "solo"
+    # Tracked + empty inbox → IDLE
+    assert row.state.value == "idle"
+
+
+def test_load_operator_view_preserves_per_project_results(tmp_path: Path) -> None:
+    """The single-handle sweep must produce one row per project — same
+    keys, no drops — even when the shared work-service is unavailable.
+    """
+    from types import SimpleNamespace
+
     from pollypm.dashboard.operator_view import (
-        _ProjectScan,
-        _parallel_scan_rows,
+        load_operator_view_from_config,
     )
 
-    scans = [
-        _ProjectScan(
-            project_key="solo",
-            project_path=tmp_path,
-            db_paths=(),
-            tracked=True,
-        ),
-    ]
-    rows = _parallel_scan_rows(scans, {})
-    assert len(rows) == 1
-    assert rows[0].project_key == "solo"
-
-
-def test_parallel_scan_preserves_per_project_results(tmp_path: Path) -> None:
-    """The parallel sweep must produce the same per-project rows as the
-    serial loop did — same project keys, same row count, no drops."""
-    from pollypm.dashboard.operator_view import (
-        _ProjectScan,
-        _parallel_scan_rows,
-    )
-
-    scans = [
-        _ProjectScan(
-            project_key=f"p{i}",
-            project_path=tmp_path,
-            db_paths=(),
-            tracked=(i % 2 == 0),
-        )
+    projects = {
+        f"p{i}": SimpleNamespace(path=tmp_path, tracked=(i % 2 == 0))
         for i in range(6)
-    ]
-    rows = _parallel_scan_rows(scans, {})
-    keys = sorted(row.project_key for row in rows)
+    }
+    config = SimpleNamespace(
+        projects=projects,
+        project=SimpleNamespace(workspace_root=str(tmp_path)),
+        storage=SimpleNamespace(backend="sqlite"),
+    )
+    view = load_operator_view_from_config(config)
+    keys = sorted(
+        row.project_key
+        for row in (*view.waiting, *view.working, *view.idle, *view.paused)
+    )
     assert keys == [f"p{i}" for i in range(6)]


### PR DESCRIPTION
## Summary

The operator dashboard was opening a fresh `SQLiteWorkService` per project (12 sqlite handles per refresh) on a postgres-backed workspace because `operator_view._open_work_service` never forwarded `config` to `create_work_service`. `_resolve_backend(None)` returns `"sqlite"`, so every dashboard refresh paid the sqlite-engine first-import (~349ms) and a stale 9MB workspace `state.db` open while the actual data was in pg the whole time. The plan-review approval filter (`approved_plan_review_refs`) had the same bug.

Fix: open ONE shared work-service via `create_work_service(config=config)` and prefetch every project's tasks + active worker sessions in two bulk queries. A `_ProjectSliceService` adapter feeds the categorizer per-project rows with zero additional I/O. Serial loop replaces the bounded ThreadPool — no DB I/O remains in the per-project step, so threads buy nothing.

## Root cause

`operator_view._open_work_service(scan)` (pre-fix):

```python
svc = create_work_service(
    db_path=db_path, project_path=scan.project_path,
)  # NO config= kwarg → resolver falls back to sqlite
```

`_resolve_backend` in `pollypm.work.factory`:

```python
def _resolve_backend(config: "PollyPMConfig | None") -> str:
    if config is None:
        return "sqlite"  # ← the dashboard always hits this branch
    ...
```

So on a `storage.backend = "postgres"` workspace, every dashboard refresh:

1. Opened a sqlite handle to `<workspace_root>/.pollypm/state.db` (9MB) — paying the sqlite-engine first-import (~349ms cold).
2. Ran `list_tasks(project=<key>)` against that stale DB.
3. Fell through to `<project_path>/.pollypm/state.db` (where present) and ran another `list_tasks`.
4. Returned a `SQLiteWorkService` to the categorizer, which then ran `list_worker_sessions(project=<key>)` on the same stale sqlite.

12 projects × (sqlite open + 1–2 task queries + 1 worker query) = the 1.1s warm / 3s cold path the dashboard mounted. The pg pool was completely bypassed despite being the configured backend.

`approved_plan_review_refs` had the same bug: its `service_factory(db_path=..., project_path=...)` callsite from `cockpit_inbox_items._filter_approved_plan_reviews` never forwarded `config`, so the rail-badge / inbox-list plan-review phantom filter also opened sqlite on every render.

## Profiling

12-project workspace, 84 tasks, 26 active `work_sessions` rows in pg, fresh subprocess each run:

| run | BEFORE `load_operator_view` | AFTER `load_operator_view` |
| --- | ---: | ---: |
| 1 | 1200ms | 440ms |
| 2 | 1106ms | 690ms |
| 3 | 1056ms | 862ms |
| **median** | **1106ms** | **690ms** |

In-process warm-pool comparison (mimics the 10s `set_interval` refresh inside a running cockpit pane):

- BEFORE: 666ms warm, 3065ms cold
- AFTER: 126ms warm, 582ms cold (**~5x faster on the warm path**)

## Change set

- `src/pollypm/dashboard/operator_view.py`:
  - Removed `_open_work_service` (per-project sqlite fanout) and `_parallel_scan_rows` (no longer useful with zero per-project I/O).
  - Added `_open_shared_work_service`, `_prefetch_project_state`, and `_ProjectSliceService` (Protocol-satisfying adapter for the categorizer).
  - `_ProjectScan` no longer carries `db_paths` — the per-project DB list only existed to drive the deleted fanout loop.
  - `load_operator_view_from_config` and `project_state_map_from_config` (rail glyph picker) both use the shared-handle prefetch path.
- `src/pollypm/work/inbox_plan_reviews.py`: `approved_plan_review_refs` accepts `config=`, opens one shared svc when supplied, and forwards `config` to the factory in the per-db fallback so a sqlite workspace still gets sqlite and a pg workspace still gets pg.
- `src/pollypm/cockpit_inbox.py`, `src/pollypm/cockpit_inbox_items.py`: thread `config` through `_filter_approved_plan_reviews` to its `approved_plan_review_refs` call.
- `tests/test_operator_dashboard_pilot.py`: replaced the parallel-sweep mechanics tests with assertions on the new shared-handle outcome (one row per project, graceful degrade on a missing service).

## Behavior note (not regressions)

The dashboard now reads from the configured backend (pg) instead of stale sqlite. If pg holds `work_sessions` rows with `ended_at IS NULL` that the per-session lifecycle never cleaned up, the categorizer's `list_worker_sessions(active_only=True)` will surface them as live workers — the same data the rail and `pm work session list` already see. This is a separate data-hygiene issue the previous code masked by reading the wrong DB. Worth a follow-up to filter by heartbeat liveness, but out of scope for this perf PR.

## Manual UX confirmation

Verified the import path with `uv run --quiet python -m pollypm cockpit-pane operator --help` (0.72s) — the CLI surface is unchanged. The shared-handle prefetch returns the same 12 project rows the legacy code returned; the only difference is which DB backend supplies the data.

## Test plan

- [x] `uv run python -m pytest tests/test_operator_dashboard_pilot.py tests/test_dashboard_categorization.py tests/test_dashboard_data_pg.py tests/test_inbox*.py tests/test_plan_review*.py -q` → **129 passed**
- [x] Pre-existing failures in `tests/test_cockpit*.py` (`test_cockpit_raw_rail_idle_project_without_alert_stays_idle`, event-ticker tests, settings-projects tests) confirmed on clean `origin/main` — unrelated to this PR.
- [ ] Manual smoke: `pm cockpit-pane operator` and `pm cockpit-pane project --project pollypm` on a multi-project pg workspace; verify <1s first paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)