### PR TITLE
fix(cockpit): route project Chat PM to existing architect-<project> deterministically (refs #1631, #1634)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -1633,18 +1633,49 @@ class CockpitRouter:
         return registry
 
     def _project_session_map(self, launches) -> dict[str, str]:
+        """Resolve ``project_key -> session_name`` for project PM Chat routing.
+
+        Per Sam's clarification (project PM == project architect):
+        ``architect_<project>`` is the canonical per-project PM persona.
+        It already runs as a long-lived session primed with the project
+        persona; "Chat PM" should attach to that conversation rather
+        than a sibling worker / advisor / generic operator.
+
+        Selection rules (priority order, control roles skipped):
+          1. ``architect`` — the canonical project PM persona.
+          2. ``worker``    — per-task worker (PM persona only when no
+             architect exists for the project).
+          3. Anything else (``advisor``, custom roles) — last-resort
+             fallback so projects that ship without an architect still
+             have a routable PM target.
+
+        Within a priority tier the first launch wins (deterministic on
+        ``plan_launches`` ordering). Control roles (operator-pm,
+        reviewer, etc.) remain excluded — they are routed through the
+        workspace-level rail keys, never as a project's PM.
+        """
         from pollypm.models import CONTROL_ROLES
 
-        project_session_map: dict[str, str] = {}
-        for launch in launches:
-            role = getattr(launch.session, "role", "")
+        _ROLE_PRIORITY = {"architect": 0, "worker": 1}
+        _DEFAULT_PRIORITY = 2
+
+        ranked: dict[str, tuple[int, int, str]] = {}
+        for index, launch in enumerate(launches):
+            role = getattr(launch.session, "role", "") or ""
             if role in CONTROL_ROLES:
                 continue
             project = getattr(launch.session, "project", None)
             name = getattr(launch.session, "name", None)
-            if project and name:
-                project_session_map.setdefault(project, name)
-        return project_session_map
+            if not project or not name:
+                continue
+            priority = _ROLE_PRIORITY.get(role, _DEFAULT_PRIORITY)
+            existing = ranked.get(project)
+            # Strictly lower priority wins; on ties keep the earlier launch
+            # so behavior stays deterministic and matches the prior
+            # first-wins semantics inside a priority tier.
+            if existing is None or priority < existing[0]:
+                ranked[project] = (priority, index, name)
+        return {project: entry[2] for project, entry in ranked.items()}
 
     def _decorate_project_items(
         self,

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -1706,6 +1706,49 @@ def test_cockpit_router_decorates_project_items_with_sparkline_and_pin() -> None
     assert decorated[-1].key == "system"
 
 
+def test_project_session_map_prefers_architect_over_worker_and_advisor() -> None:
+    """The project PM == project architect (Sam's clarification, 2026-05).
+
+    When a project has both an architect and another non-control session
+    (worker, advisor), ``_project_session_map`` must surface the
+    architect so PM Chat lands on the long-lived per-project PM
+    conversation rather than a sibling worker or advisor. Without this
+    rule the resolver picked whichever launch ``plan_launches`` returned
+    first, which can vary by config ordering and made "Chat PM" routing
+    nondeterministic.
+    """
+
+    def _launch(name: str, project: str, role: str):
+        return SimpleNamespace(
+            session=SimpleNamespace(name=name, role=role, project=project),
+        )
+
+    router = CockpitRouter.__new__(CockpitRouter)
+
+    # Architect listed AFTER worker + advisor in the launches list; the
+    # priority rule must still pick architect.
+    launches = [
+        _launch("advisor_samblog", "samblog", "advisor"),
+        _launch("worker_samblog", "samblog", "worker"),
+        _launch("architect_samblog", "samblog", "architect"),
+        # An architect-free project keeps the prior first-wins behaviour
+        # for non-architect tiers.
+        _launch("worker_demo", "demo", "worker"),
+        _launch("advisor_demo", "demo", "advisor"),
+        # An architect-only project surfaces the architect.
+        _launch("architect_bikepath", "bikepath", "architect"),
+        # Control roles are never selectable.
+        _launch("reviewer_samblog", "samblog", "reviewer"),
+        _launch("operator", None, "operator-pm"),
+    ]
+
+    result = router._project_session_map(launches)
+
+    assert result["samblog"] == "architect_samblog"
+    assert result["demo"] == "worker_demo"
+    assert result["bikepath"] == "architect_bikepath"
+
+
 def test_cockpit_router_decorates_and_sorts_project_rollup_status() -> None:
     router = CockpitRouter.__new__(CockpitRouter)
     router.is_project_pinned = lambda key: key == "alpha"  # type: ignore[assignment]


### PR DESCRIPTION
## Summary

- Project PM == project architect (Sam's clarification). ``architect_<project>`` is the canonical per-project PM persona — long-lived, persona-primed, already running in ``architect-<project>`` storage windows.
- Cockpit content routing for ``project:<key>:session`` resolves the live session via ``_project_session_map``, which previously used ``setdefault`` and picked whichever non-control launch ``plan_launches`` returned first. That made PM Chat routing nondeterministic and could shadow the architect with a sibling worker or advisor depending on config ordering.
- Tighten ``_project_session_map`` to prefer roles in priority order: ``architect`` → ``worker`` → other non-control. First-wins is preserved within a tier; ``CONTROL_ROLES`` stay excluded.
- The downstream ``_select_storage_window_for_mount`` already has a #1636 architect-sibling fallback so window-name drift still resolves to the live architect — this change makes the *session* resolver agree with that intent up front.

## Why this is small

No new session types, no new tmux spawn paths, no persona-swap rewiring. The existing storage-closet architect windows and the existing project PM primer (#958) already do the right thing once the session resolver picks the architect; this just makes that pick deterministic.

## Test plan

- [x] New unit test ``test_project_session_map_prefers_architect_over_worker_and_advisor``: samblog with all three roles picks ``architect_samblog``; worker/advisor-only demo picks worker; architect-only bikepath picks architect.
- [x] Existing project-PM fallback tests (``tests/test_cockpit_rail_project_pm_fallback.py``) — 10 passed.
- [x] Existing resolver tests (``tests/test_cockpit_content.py``) — 12 passed.
- [x] Rail-test suite (``tests/test_cockpit_rail*.py``) — 92 passed.
- [x] ``ruff check`` clean on touched files.

## Out of scope

- Renaming the user-facing "PM" / persona label — already correct (``_resolve_pm_target`` returns the persona name when configured).
- Storage-closet duplicate window detection on bootstrap (``architect-samblog`` x2) — ``create_session_window`` already guards via ``window_map`` and ``_auto_spawn_architect`` already guards via ``config.sessions``; the duplicate observed in Sam's storage closet predates this branch and needs its own forensics pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)