### PR TITLE
feat(cockpit): per-project PM sessions — independent Claude session per tracked project (refs #1737, refs #1634)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -1635,44 +1635,73 @@ class CockpitRouter:
     def _project_session_map(self, launches) -> dict[str, str]:
         """Resolve ``project_key -> session_name`` for project PM Chat routing.
 
-        Per Sam's clarification (project PM == project architect):
-        ``architect_<project>`` is the canonical per-project PM persona.
-        It already runs as a long-lived session primed with the project
-        persona; "Chat PM" should attach to that conversation rather
-        than a sibling worker / advisor / generic operator.
+        The map drives ``project:<key>:session`` (a.k.a. the rail's PM
+        Chat sub-item) and the dashboard's ``c chat`` keystroke.
 
-        Selection rules (priority order, control roles skipped):
-          1. ``architect`` — the canonical project PM persona.
-          2. ``worker``    — per-task worker (PM persona only when no
-             architect exists for the project).
+        Per-project-pm rollout: ``pm_<project>`` (an ``operator-pm``
+        session scoped to the project) is the canonical per-project
+        PM persona. These sessions are auto-injected by the launch
+        planner so existing installs pick them up without a config
+        migration; when present they ALWAYS win for project chat —
+        that's the conversation surface the user expects "Chat PM for
+        project X" to attach to.
+
+        Selection rules (priority order, ties broken by launch index
+        for deterministic first-wins behavior within a tier):
+
+          0. ``operator-pm`` (per-project, name != ``"operator"``) —
+             dedicated per-project PM, the canonical answer post-
+             per-project-pm-rollout.
+          1. ``architect`` — historical PM persona for non-Polly
+             projects (#1861). Stays as the next-best option for
+             installs without a per-project PM yet (no compatible
+             account, etc.).
+          2. ``worker`` — per-task worker; PM persona only when no
+             architect / per-project PM exists.
           3. Anything else (``advisor``, custom roles) — last-resort
-             fallback so projects that ship without an architect still
-             have a routable PM target.
+             fallback so projects that ship without architect / PM
+             still have a routable target.
 
-        Within a priority tier the first launch wins (deterministic on
-        ``plan_launches`` ordering). Control roles (operator-pm,
-        reviewer, etc.) remain excluded — they are routed through the
-        workspace-level rail keys, never as a project's PM.
+        Control roles other than the per-project operator-pm
+        (workspace ``operator``, ``reviewer``, ``heartbeat-supervisor``,
+        ``triage``) are excluded — they're routed through workspace-
+        level rail keys, never as a project's PM.
         """
         from pollypm.models import CONTROL_ROLES
 
-        _ROLE_PRIORITY = {"architect": 0, "worker": 1}
-        _DEFAULT_PRIORITY = 2
+        # Per-project operator-pm wins outright (priority 0). The
+        # historical architect / worker / default priorities follow
+        # #1861's deterministic-tier ordering so installs without a
+        # per-project PM keep their architect-first routing.
+        _ROLE_PRIORITY = {"architect": 1, "worker": 2}
+        _DEFAULT_PRIORITY = 3
+        _PROJECT_PM_PRIORITY = 0
 
         ranked: dict[str, tuple[int, int, str]] = {}
         for index, launch in enumerate(launches):
-            role = getattr(launch.session, "role", "") or ""
-            if role in CONTROL_ROLES:
-                continue
-            project = getattr(launch.session, "project", None)
-            name = getattr(launch.session, "name", None)
+            session = getattr(launch, "session", None)
+            role = getattr(session, "role", "") or ""
+            project = getattr(session, "project", None)
+            name = getattr(session, "name", None)
             if not project or not name:
                 continue
-            priority = _ROLE_PRIORITY.get(role, _DEFAULT_PRIORITY)
+            if role == "operator-pm":
+                # Workspace-level Polly owns the workspace rail row,
+                # not per-project Chat PM. Skip it here regardless of
+                # its ``project`` field (historically ``"pollypm"``).
+                if name == "operator":
+                    continue
+                priority = _PROJECT_PM_PRIORITY
+            elif role in CONTROL_ROLES:
+                # Reviewers / heartbeat-supervisors / triage are
+                # control-plane; they don't own a project's Chat PM.
+                continue
+            else:
+                priority = _ROLE_PRIORITY.get(role, _DEFAULT_PRIORITY)
             existing = ranked.get(project)
-            # Strictly lower priority wins; on ties keep the earlier launch
-            # so behavior stays deterministic and matches the prior
-            # first-wins semantics inside a priority tier.
+            # Strictly lower priority wins; on ties keep the earlier
+            # launch so behavior stays deterministic and matches
+            # #1861's first-wins semantics inside a priority tier.
             if existing is None or priority < existing[0]:
                 ranked[project] = (priority, index, name)
         return {project: entry[2] for project, entry in ranked.items()}
@@ -2322,9 +2351,15 @@ class CockpitRouter:
     # bikepath repro shows the architect window is what holds the
     # ongoing conversation while a stale or never-launched worker
     # session entry can make the literal lookup return None.
+    # Per-project-pm rollout: ``pm-<project>`` is now the canonical
+    # per-project PM persona window (auto-injected by the launch
+    # planner). Try it first; architect / worker fallbacks are kept
+    # for installs that haven't picked up the per-project PM yet, and
+    # for the historical pattern where the architect window held the
+    # ongoing PM conversation for non-Polly projects (#1636).
     _PROJECT_PM_WINDOW_PREFIXES: tuple[str, ...] = (
-        "architect-",
         "pm-",
+        "architect-",
         "worker-",
     )
 

--- a/src/pollypm/plugins_builtin/core_rail_items/plugin.py
+++ b/src/pollypm/plugins_builtin/core_rail_items/plugin.py
@@ -361,7 +361,13 @@ def _project_chat_persona(project: Any, session_role: Any) -> str:
         try:
             from pollypm.role_contract import canonical_role, persona_for
 
-            if canonical_role(session_role) == "architect":
+            canonical = canonical_role(session_role)
+            # ``operator-pm`` per-project sessions carry the project's
+            # configured persona name (Archie / Sage / etc.). Fall
+            # through to the persona_name lookup below so we surface
+            # the project-specific name rather than the generic
+            # "Polly" persona.
+            if canonical == "architect":
                 return persona_for("architect")
         except ValueError:
             pass
@@ -389,18 +395,35 @@ def _project_rows(ctx: RailContext) -> list[RailRow]:
     selected = _selected_key(ctx)
     config = _config(ctx)
 
-    # Map project -> session name/role for session_state fallback and label copy.
+    # Map project -> (session name, role) for session_state fallback
+    # and the PM Chat label persona pick. Mirrors
+    # ``CockpitRouter._project_session_map`` selection priority — the
+    # per-project ``operator-pm`` session (when present) wins over
+    # worker/architect for label/state purposes so the rail PM Chat
+    # row shows the dedicated per-project PM's state, not whichever
+    # worker happens to be live.
     from pollypm.models import CONTROL_ROLES
 
-    project_session_map: dict[str, tuple[str, str]] = {}
+    pm_session_map: dict[str, tuple[str, str]] = {}
+    other_session_map: dict[str, tuple[str, str]] = {}
     for launch in _launches(ctx):
         role = getattr(launch.session, "role", "")
+        name = getattr(launch.session, "name", "")
+        project = getattr(launch.session, "project", "")
+        if not project or not name:
+            continue
+        if role == "operator-pm":
+            # Skip the workspace-level Polly — she owns the workspace
+            # rail row, not per-project Chat PM (#per-project-pm).
+            if name == "operator":
+                continue
+            pm_session_map.setdefault(project, (name, role))
+            continue
         if role in CONTROL_ROLES:
             continue
-        project_session_map.setdefault(
-            launch.session.project,
-            (launch.session.name, role),
-        )
+        other_session_map.setdefault(project, (name, role))
+    project_session_map: dict[str, tuple[str, str]] = dict(other_session_map)
+    project_session_map.update(pm_session_map)
 
     rows: list[RailRow] = []
 

--- a/src/pollypm/plugins_builtin/default_launch_planner/planner.py
+++ b/src/pollypm/plugins_builtin/default_launch_planner/planner.py
@@ -20,7 +20,7 @@ from dataclasses import replace
 import logging
 import os
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pollypm.launch_planner_protocol import DefaultLaunchPlannerContext
 from pollypm.models import AccountConfig, ProviderKind, SessionConfig, SessionLaunchSpec
@@ -43,6 +43,23 @@ _ROUND_START_ENV_KEYS = (
     "ROUND_START_HBFAIL",
     "ROUND_START_MISSING_WINDOW",
 )
+# Synthetic per-project PM session entries are named ``pm_<project>``
+# with the persona-named tmux window ``pm-<project>``. The launch planner
+# auto-injects one entry per tracked project that doesn't already carry a
+# project-scoped ``operator-pm`` session in the static config — see
+# :meth:`DefaultLaunchPlanner._synthesize_project_pm_sessions`. This
+# parallels how reviewer sessions are auto-provisioned at bootstrap
+# (#1413 / ``recovery.reviewer_provisioning``) but keeps the per-project
+# PM purely synthetic so we don't have to mutate ``pollypm.toml`` on
+# every ``pm up`` for an existing install (Sam's deployed config stays
+# untouched per the per-project PM rollout migration plan).
+_PROJECT_PM_SESSION_PREFIX = "pm_"
+_PROJECT_PM_WINDOW_PREFIX = "pm-"
+# The workspace-level Polly session is uniquely identified by name
+# ``"operator"`` (the onboarding flow hard-codes this); the workspace
+# operator-pm exists for cross-project / non-project chat and stays
+# active regardless of the per-project PMs added below.
+_WORKSPACE_OPERATOR_SESSION_NAME = "operator"
 _log = logging.getLogger(__name__)
 
 
@@ -164,7 +181,19 @@ class DefaultLaunchPlanner:
             return self._cached_launches
         launches: list[SessionLaunchSpec] = []
         worker_projects: dict[str, str] = {}
-        for session in ctx.config.sessions.values():
+        # Compose the static-config sessions with the synthetic
+        # per-project PM sessions auto-injected for every tracked
+        # project that doesn't already carry an enabled project-scoped
+        # ``operator-pm`` entry. The synthetic entries are appended in
+        # a stable (project-key sorted) order so the launch plan is
+        # deterministic across runs even though dict iteration in
+        # ``ctx.config.sessions`` is insertion-ordered.
+        composed_sessions = list(ctx.config.sessions.values())
+        synthetic_pm_sessions = self._synthesize_project_pm_sessions(
+            existing_sessions=composed_sessions,
+        )
+        composed_sessions.extend(synthetic_pm_sessions)
+        for session in composed_sessions:
             effective = self.effective_session(session, controller_account)
             if not effective.enabled:
                 continue
@@ -294,7 +323,23 @@ class DefaultLaunchPlanner:
                             exc_info=True,
                         )
         if session.role in _ROUTED_ROLES:
-            project_key = None if session.role == "operator-pm" else session.project
+            # ``operator-pm`` covers two distinct lanes today: the
+            # workspace-level Polly (``session.name == "operator"``) and
+            # the per-project PM sessions auto-injected by
+            # ``_synthesize_project_pm_sessions``. The workspace lane
+            # explicitly ignores per-project role overrides — Polly is
+            # the workspace operator and her routing is global by
+            # design. The per-project lane must consult per-project
+            # ``role_assignments`` so users can pin (say) Codex for
+            # ``operator-pm`` on a single project without flipping the
+            # global default. Mirrors how worker / architect / reviewer
+            # already consult per-project routing.
+            if session.role == "operator-pm" and session.name == _WORKSPACE_OPERATOR_SESSION_NAME:
+                project_key = None
+            elif session.role == "operator-pm":
+                project_key = session.project
+            else:
+                project_key = session.project
             routed_assignment = resolve_role_assignment(
                 session.role,
                 project_key,
@@ -461,6 +506,189 @@ class DefaultLaunchPlanner:
     def invalidate_cache(self) -> None:
         """Drop the cached launch plan."""
         self._cached_launches = None
+
+    # ── Per-project PM session synthesis ──────────────────────────────────
+
+    def _synthesize_project_pm_sessions(
+        self, *, existing_sessions: list[SessionConfig],
+    ) -> list[SessionConfig]:
+        """Return synthetic ``pm_<project>`` SessionConfigs for tracked projects.
+
+        Each tracked project gets a dedicated per-project PM session so
+        clicking "Chat PM" for a project routes to its OWN long-lived
+        Claude conversation rather than a single shared ``pm-operator``
+        window with persona swaps. The single shared window is the
+        documented architectural bug closed by the per-project PM PR:
+        when ``pm-operator`` was respawned (during ``pm install`` /
+        restart / window-mount churn) the conversation history for every
+        project was wiped because there was no per-project conversation
+        persistence — just persona primes on top of one shared session.
+
+        The synthetic entries are NEVER written to ``pollypm.toml`` —
+        they exist purely in the launch plan so existing installs pick
+        up per-project PMs on the next ``pm up`` without an explicit
+        config migration. Projects that already carry an explicit
+        ``operator-pm`` session entry for the same project key win — the
+        synthesizer skips them, leaving the static config authoritative.
+
+        The workspace-level ``operator`` session (Polly for non-project
+        / cross-project chat) is excluded from the "already has an
+        operator-pm" check because its ``project`` field points at the
+        workspace project (``"pollypm"``) but it owns the workspace-level
+        rail row, not the project-PM lane. See
+        :func:`pollypm.cockpit_rail._project_session_map` for the rail
+        side of this contract.
+
+        Selection rules per project:
+
+        * ``project.tracked == True`` is the only auto-inject gate;
+          untracked projects opt out of every auto-provision sweep
+          (matches reviewer auto-provisioning in
+          :mod:`pollypm.recovery.reviewer_provisioning`).
+        * The workspace project (``"pollypm"``) is skipped — the
+          workspace-level ``operator`` session already serves it.
+        * Provider/account routing goes through
+          :func:`pollypm.role_routing.resolve_role_assignment` for the
+          ``"operator-pm"`` role with the project key, so per-project
+          ``role_assignments`` overrides win. Without a compatible
+          account configured the project is silently skipped (matches
+          the existing routed-role behavior — no compatible account →
+          warn-and-skip, surface friendlier failure modes at use time).
+
+        Failures in any per-project step are logged and swallowed so a
+        single misconfigured project can't block planner output for the
+        rest of the workspace.
+        """
+        ctx = self._ctx
+        existing_by_project: dict[str, str] = {}
+        for session in existing_sessions:
+            if (
+                session.role == "operator-pm"
+                and session.name != _WORKSPACE_OPERATOR_SESSION_NAME
+                and session.enabled
+            ):
+                existing_by_project.setdefault(session.project, session.name)
+        projects = getattr(ctx.config, "projects", {}) or {}
+        synthesized: list[SessionConfig] = []
+        # Sort by project key for deterministic launch order — dict
+        # iteration of ``config.projects`` is insertion-ordered, but
+        # the order in which projects were added to the user's config
+        # is incidental and we don't want it influencing launch plan
+        # diffs in tests / forensics.
+        for project_key in sorted(projects.keys()):
+            project = projects[project_key]
+            if not getattr(project, "tracked", False):
+                continue
+            if project_key == "pollypm":
+                # Workspace project — served by the workspace-level
+                # ``operator`` session entry already in the static
+                # config. Auto-injecting a duplicate would create two
+                # rail rows pointing at the same conceptual surface.
+                continue
+            if project_key in existing_by_project:
+                # An explicit project-scoped operator-pm session in the
+                # static config wins. Don't overwrite the user's choice.
+                continue
+            try:
+                synthetic = self._build_project_pm_session(project_key, project)
+            except Exception:  # noqa: BLE001
+                _log.warning(
+                    "default_launch_planner: per-project PM synthesis "
+                    "failed for %s",
+                    project_key,
+                    exc_info=True,
+                )
+                continue
+            if synthetic is None:
+                continue
+            synthesized.append(synthetic)
+        return synthesized
+
+    def _build_project_pm_session(
+        self,
+        project_key: str,
+        project: Any,
+    ) -> SessionConfig | None:
+        """Build a synthetic ``pm_<project>`` SessionConfig.
+
+        Returns ``None`` when no compatible account is available for
+        the routed ``operator-pm`` provider — the project is left
+        without a per-project PM rather than crashing the planner.
+
+        The CWD points at the project's actual on-disk path (not a
+        worktree) because the per-project PM observes / coordinates;
+        it does not write code. Workers + architects keep their
+        worktree CWDs unchanged.
+        """
+        ctx = self._ctx
+        accounts = getattr(ctx.config, "accounts", {}) or {}
+        if not accounts:
+            return None
+        try:
+            assignment = resolve_role_assignment(
+                "operator-pm", project_key, config=ctx.config,
+            )
+            provider = resolved_provider_kind(assignment)
+        except Exception:  # noqa: BLE001
+            # Role routing failed; fall back to the workspace
+            # operator's provider/account so the per-project PM at
+            # least lands somewhere reasonable.
+            controller = ctx.config.pollypm.controller_account
+            if not controller or controller not in accounts:
+                return None
+            provider = accounts[controller].provider
+            account_name: str | None = controller
+        else:
+            account_name = self._account_for_pm_provider(provider)
+            if account_name is None:
+                # No compatible account; skip cleanly.
+                return None
+        project_path = getattr(project, "path", None)
+        if project_path is None:
+            return None
+        session_name = f"{_PROJECT_PM_SESSION_PREFIX}{project_key}"
+        window_name = f"{_PROJECT_PM_WINDOW_PREFIX}{project_key}"
+        return SessionConfig(
+            name=session_name,
+            role="operator-pm",
+            provider=provider,
+            account=account_name,
+            cwd=project_path,
+            project=project_key,
+            window_name=window_name,
+            # Profile is "polly" — the persona name (Archie / Sage /
+            # etc.) is layered on at jump-to-PM time via the cockpit's
+            # ``_maybe_prime_project_pm_session`` re-anchoring primer
+            # so the agent recovers project identity across re-mounts
+            # (see #958 / cockpit_rail._build_project_pm_primer).
+            agent_profile="polly",
+        )
+
+    def _account_for_pm_provider(self, provider: ProviderKind) -> str | None:
+        """Return the first account whose provider matches.
+
+        Walks the controller / failover / accounts list in priority
+        order (same shape as ``_preferred_account_names``) so the
+        per-project PM lands on the operator's preferred account when
+        possible.
+        """
+        ctx = self._ctx
+        accounts = ctx.config.accounts
+        controller = ctx.config.pollypm.controller_account
+        candidates: list[str] = []
+        if controller:
+            candidates.append(controller)
+        for name in ctx.config.pollypm.failover_accounts:
+            if name and name not in candidates:
+                candidates.append(name)
+        for name in accounts:
+            if name not in candidates:
+                candidates.append(name)
+        for name in candidates:
+            account = accounts.get(name)
+            if account is not None and account.provider is provider:
+                return name
+        return None
 
     # ── Per-task launch synthesis (#924) ──────────────────────────────────
 

--- a/tests/test_cockpit_rail_project_pm_fallback.py
+++ b/tests/test_cockpit_rail_project_pm_fallback.py
@@ -166,11 +166,15 @@ def test_project_pm_fallback_skips_dead_sibling() -> None:
 
 
 def test_project_pm_fallback_walks_priority_order() -> None:
-    """Architect > pm > worker.
+    """PM > architect > worker.
 
-    Worker-name patterns can outnumber architect/pm in a busy project,
-    but the PM persona by convention lives in ``architect-<project>``
-    for non-Polly projects. The ordering test pins that contract.
+    Per-project-pm rollout: ``pm-<project>`` is now the canonical
+    per-project PM persona window (auto-injected by the launch
+    planner), so it wins over the historical ``architect-<project>``
+    fallback. The architect/worker fallbacks remain for installs that
+    haven't picked up the per-project PM yet (no compatible account
+    routing, etc.) and for legacy non-Polly projects where the
+    architect window held the ongoing PM conversation pre-#1636.
     """
     router = _bare_router()
     _capture_audit(router)
@@ -185,25 +189,34 @@ def test_project_pm_fallback_walks_priority_order() -> None:
     )
     result = router._select_storage_window_for_mount(
         [worker, pm, architect],
-        "worker-bikepath",  # literal would match worker, but we want architect
+        "worker-bikepath",  # literal would match worker, but we want pm
         "worker_bikepath",
         project_key="bikepath",
     )
     # The literal lookup matched ``worker-bikepath`` directly (single
     # match), so the sibling fallback never fired — this asserts the
-    # fallback only triggers when the literal lookup fails. To force
-    # the architect pick, drop the worker name from storage.
+    # fallback only triggers when the literal lookup fails.
     assert result is worker
 
     # Now remove the worker window entirely — the literal lookup fails
-    # and the fallback walks the priority order, picking architect.
+    # and the fallback walks the priority order, picking ``pm-bikepath``
+    # (the canonical per-project PM persona).
     result_no_worker = router._select_storage_window_for_mount(
         [pm, architect],
         "worker-bikepath",
         "worker_bikepath",
         project_key="bikepath",
     )
-    assert result_no_worker is architect
+    assert result_no_worker is pm
+
+    # Drop the pm window too — fall through to architect-<project>.
+    result_no_pm = router._select_storage_window_for_mount(
+        [architect],
+        "worker-bikepath",
+        "worker_bikepath",
+        project_key="bikepath",
+    )
+    assert result_no_pm is architect
 
 
 def test_project_pm_fallback_falls_through_to_pm_when_no_architect() -> None:

--- a/tests/test_pm_per_project_sessions.py
+++ b/tests/test_pm_per_project_sessions.py
@@ -1,0 +1,376 @@
+"""Per-project PM session synthesis.
+
+The launch planner auto-injects a synthetic ``pm_<project>``
+``operator-pm`` SessionConfig for every tracked project that doesn't
+already carry an explicit project-scoped operator-pm session in the
+static config. The synthesis runs inside ``plan_launches`` so existing
+installs pick up per-project PMs on the next ``pm up`` without an
+explicit config migration — Sam's deployed ``pollypm.toml`` stays
+untouched (per the per-project PM rollout migration plan).
+
+These tests pin:
+
+* Three tracked projects → three ``pm_<project>`` synthetic entries.
+* The workspace project (``pollypm``) is NOT auto-synthesized — its
+  workspace-level ``operator`` session already serves that lane.
+* Untracked projects opt out of synthesis (matches reviewer
+  auto-provisioning's tracked-only contract).
+* Explicit ``operator-pm`` session entries in the static config WIN
+  — the synthesizer leaves them alone (no double-injection).
+* No compatible account → the project is silently skipped (project
+  is left without a per-project PM, doesn't crash the planner).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pollypm.models import (
+    AccountConfig,
+    KnownProject,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectKind,
+    ProjectSettings,
+    ProviderKind,
+    SessionConfig,
+)
+from pollypm.plugins_builtin.default_launch_planner.planner import (
+    DefaultLaunchPlannerContext,
+)
+from pollypm.supervisor import Supervisor
+
+
+def _planner_ctx_from_supervisor(sup: Supervisor) -> DefaultLaunchPlannerContext:
+    return DefaultLaunchPlannerContext(
+        config=sup.config,
+        store=sup.store,
+        readonly_state=sup.readonly_state,
+        effective_account=sup._effective_account,
+        apply_role_launch_restrictions=sup._apply_role_launch_restrictions,
+        resolve_profile_prompt=sup._resolve_profile_prompt,
+        storage_closet_session_name=sup.storage_closet_session_name,
+    )
+
+
+def _base_config(
+    tmp_path: Path, *, tracked_projects: dict[str, Path] | None = None,
+) -> PollyPMConfig:
+    """Shape mirrors tests/test_launch_planner.py::_config, with a few extra
+    tracked projects so the synthesis path has something to chew on.
+
+    Every project listed in ``tracked_projects`` is registered with
+    ``tracked=True``; the workspace ``pollypm`` project is registered
+    unconditionally (matches every real install).
+    """
+    projects: dict[str, KnownProject] = {
+        "pollypm": KnownProject(
+            key="pollypm",
+            path=tmp_path,
+            name="PollyPM",
+            kind=ProjectKind.FOLDER,
+            tracked=True,
+        ),
+    }
+    for key, path in (tracked_projects or {}).items():
+        path.mkdir(parents=True, exist_ok=True)
+        projects[key] = KnownProject(
+            key=key,
+            path=path,
+            name=key,
+            kind=ProjectKind.FOLDER,
+            tracked=True,
+            persona_name=f"PMof{key}",
+        )
+    return PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            base_dir=tmp_path / ".pollypm",
+            logs_dir=tmp_path / ".pollypm/logs",
+            snapshots_dir=tmp_path / ".pollypm/snapshots",
+            state_db=tmp_path / ".pollypm/state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account="claude_controller"),
+        accounts={
+            "claude_controller": AccountConfig(
+                name="claude_controller",
+                provider=ProviderKind.CLAUDE,
+                email="claude@example.com",
+                home=tmp_path / ".pollypm/homes/claude_controller",
+            ),
+        },
+        sessions={
+            "heartbeat": SessionConfig(
+                name="heartbeat",
+                role="heartbeat-supervisor",
+                provider=ProviderKind.CLAUDE,
+                account="claude_controller",
+                cwd=tmp_path,
+                project="pollypm",
+                window_name="pm-heartbeat",
+            ),
+            "operator": SessionConfig(
+                name="operator",
+                role="operator-pm",
+                provider=ProviderKind.CLAUDE,
+                account="claude_controller",
+                cwd=tmp_path,
+                project="pollypm",
+                window_name="pm-operator",
+            ),
+        },
+        projects=projects,
+    )
+
+
+def test_three_tracked_projects_emit_three_pm_sessions(tmp_path: Path) -> None:
+    """Per the spec: 3 tracked projects → 3 ``pm_<project>`` entries."""
+    config = _base_config(
+        tmp_path,
+        tracked_projects={
+            "samblog": tmp_path / "samblog",
+            "savethenovel": tmp_path / "savethenovel",
+            "blackjack-trainer": tmp_path / "blackjack-trainer",
+        },
+    )
+    sup = Supervisor(config)
+    sup.ensure_layout()
+
+    launches = sup.plan_launches()
+    pm_launches = [
+        spec for spec in launches
+        if spec.session.role == "operator-pm"
+        and spec.session.name != "operator"
+    ]
+    pm_names = sorted(spec.session.name for spec in pm_launches)
+    assert pm_names == ["pm_blackjack-trainer", "pm_samblog", "pm_savethenovel"]
+
+    # Each synthetic PM is scoped to its project, lands in
+    # ``pm-<project>`` (the canonical per-project PM window), and
+    # routes through Claude (the dual-provider role-routing default
+    # for ``operator-pm`` is ``opus-4.7``).
+    samblog = next(spec for spec in pm_launches if spec.session.name == "pm_samblog")
+    assert samblog.session.project == "samblog"
+    assert samblog.window_name == "pm-samblog"
+    assert samblog.session.provider is ProviderKind.CLAUDE
+    # CWD points at the project's actual on-disk path (not a worktree)
+    # because the PM observes / coordinates; it does not write code.
+    assert samblog.session.cwd == tmp_path / "samblog"
+    # Profile is ``polly`` so the agent gets the canonical operator
+    # prompt; the project persona (Archie / Sage / etc.) is injected
+    # at jump-to-PM time via the cockpit's PM-session re-anchoring
+    # primer (cockpit_rail._build_project_pm_primer).
+    assert samblog.session.agent_profile == "polly"
+
+
+def test_workspace_pollypm_project_is_not_auto_synthesized(tmp_path: Path) -> None:
+    """The workspace project is served by the workspace ``operator`` session.
+
+    Auto-injecting a duplicate would create two rail rows pointing at
+    the same conceptual surface (PM Chat for pollypm vs the workspace
+    Polly row). The synthesizer skips ``project_key == "pollypm"``.
+    """
+    config = _base_config(
+        tmp_path,
+        tracked_projects={"samblog": tmp_path / "samblog"},
+    )
+    sup = Supervisor(config)
+    sup.ensure_layout()
+    pm_names = sorted(
+        spec.session.name for spec in sup.plan_launches()
+        if spec.session.role == "operator-pm" and spec.session.name != "operator"
+    )
+    assert pm_names == ["pm_samblog"]
+    assert "pm_pollypm" not in pm_names
+
+
+def test_untracked_projects_opt_out_of_synthesis(tmp_path: Path) -> None:
+    """Untracked projects don't get a per-project PM session.
+
+    Mirrors the reviewer auto-provisioning contract — untracked
+    projects opt out of every auto-provision sweep (see
+    recovery.reviewer_provisioning and project_v1_tag memory).
+    """
+    config = _base_config(tmp_path)
+    # Add a project that is NOT tracked.
+    untracked_path = tmp_path / "untracked"
+    untracked_path.mkdir()
+    config.projects["untracked"] = KnownProject(
+        key="untracked",
+        path=untracked_path,
+        name="untracked",
+        kind=ProjectKind.FOLDER,
+        tracked=False,
+    )
+    sup = Supervisor(config)
+    sup.ensure_layout()
+    pm_names = sorted(
+        spec.session.name for spec in sup.plan_launches()
+        if spec.session.role == "operator-pm" and spec.session.name != "operator"
+    )
+    assert pm_names == []  # only the workspace operator, no synthesized PMs
+
+
+def test_explicit_pm_session_in_config_wins_over_synthesis(tmp_path: Path) -> None:
+    """A user-declared project-scoped operator-pm session is authoritative.
+
+    The static-config entry is left alone — no double-injection.
+    """
+    config = _base_config(
+        tmp_path,
+        tracked_projects={"samblog": tmp_path / "samblog"},
+    )
+    config.sessions["pm_samblog"] = SessionConfig(
+        name="pm_samblog",
+        role="operator-pm",
+        provider=ProviderKind.CLAUDE,
+        account="claude_controller",
+        cwd=tmp_path / "samblog",
+        project="samblog",
+        window_name="pm-samblog",
+        agent_profile="polly",
+    )
+    sup = Supervisor(config)
+    sup.ensure_layout()
+    pm_launches = [
+        spec for spec in sup.plan_launches()
+        if spec.session.role == "operator-pm" and spec.session.name != "operator"
+    ]
+    # Exactly one ``pm_samblog`` — the explicit static-config entry,
+    # not a duplicate from synthesis.
+    assert [spec.session.name for spec in pm_launches] == ["pm_samblog"]
+
+
+def test_planner_skips_pm_synthesis_when_no_compatible_account(tmp_path: Path) -> None:
+    """No compatible account → project is silently skipped, no crash.
+
+    Mirrors the existing routed-role behavior in ``effective_session``
+    (no compatible account → warn-and-skip). The launch plan still
+    produces something useful for the rest of the workspace.
+    """
+    config = _base_config(
+        tmp_path,
+        tracked_projects={"samblog": tmp_path / "samblog"},
+    )
+    # Pin samblog's operator-pm role to a Codex alias, but configure
+    # zero Codex accounts → no compatible account, project skipped.
+    from pollypm.models import ModelAssignment
+
+    config.projects["samblog"].role_assignments["operator_pm"] = ModelAssignment(
+        alias="codex-gpt-5.4",
+    )
+    sup = Supervisor(config)
+    sup.ensure_layout()
+    pm_launches = [
+        spec for spec in sup.plan_launches()
+        if spec.session.role == "operator-pm" and spec.session.name != "operator"
+    ]
+    # No ``pm_samblog`` because Codex routing has no compatible
+    # account; the rest of the plan is unaffected.
+    assert pm_launches == []
+    # The plan itself is still produced (heartbeat + workspace operator).
+    other_names = sorted(spec.session.name for spec in sup.plan_launches())
+    assert "heartbeat" in other_names
+    assert "operator" in other_names
+
+
+def test_synthesizer_uses_per_project_role_override(tmp_path: Path) -> None:
+    """Per-project ``role_assignments`` for ``operator_pm`` flow through.
+
+    The default for dual-Claude+Codex setups is Opus on Claude; pin
+    samblog to Codex via a per-project override (with a Codex account
+    available) and confirm the synthesized session lands on Codex.
+    """
+    from pollypm.models import ModelAssignment
+
+    config = _base_config(
+        tmp_path,
+        tracked_projects={"samblog": tmp_path / "samblog"},
+    )
+    # Add a Codex account so the override can resolve.
+    config.accounts["codex_backup"] = AccountConfig(
+        name="codex_backup",
+        provider=ProviderKind.CODEX,
+        email="codex@example.com",
+        home=tmp_path / ".pollypm/homes/codex_backup",
+    )
+    config.projects["samblog"].role_assignments["operator_pm"] = ModelAssignment(
+        alias="codex-gpt-5.4",
+    )
+    sup = Supervisor(config)
+    sup.ensure_layout()
+    samblog = next(
+        spec for spec in sup.plan_launches() if spec.session.name == "pm_samblog"
+    )
+    assert samblog.session.provider is ProviderKind.CODEX
+    assert samblog.session.account == "codex_backup"
+
+
+def test_rail_project_session_map_prefers_per_project_pm_over_worker() -> None:
+    """``CockpitRouter._project_session_map`` routes Chat PM to the
+    per-project PM session, not the worker / architect.
+
+    Pre-per-project-pm-rollout: ``_project_session_map`` skipped all
+    control roles (including ``operator-pm``) and picked the first
+    project session — typically a worker. After the rollout, the
+    synthetic ``pm_<project>`` operator-pm wins for project chat.
+
+    The workspace ``operator`` session (workspace Polly) is excluded
+    from the map even though its ``session.project`` is ``"pollypm"``
+    — the workspace operator owns the workspace rail row, not the
+    per-project Chat PM lane.
+    """
+    from pollypm.cockpit_rail import CockpitRouter
+
+    router = CockpitRouter.__new__(CockpitRouter)
+
+    class _Launch:
+        def __init__(self, name: str, role: str, project: str) -> None:
+            self.session = type(
+                "_S",
+                (),
+                {"name": name, "role": role, "project": project},
+            )()
+
+    launches = [
+        _Launch("operator", "operator-pm", "pollypm"),
+        _Launch("worker_samblog", "worker", "samblog"),
+        _Launch("pm_samblog", "operator-pm", "samblog"),
+        _Launch("architect_savethenovel", "architect", "savethenovel"),
+        # Bikepath has only a worker (no per-project PM provisioned).
+        _Launch("worker_bikepath", "worker", "bikepath"),
+    ]
+    mapping = router._project_session_map(launches)
+    # Per-project PM wins for samblog.
+    assert mapping["samblog"] == "pm_samblog"
+    # No per-project PM → fall back to the legacy worker/architect pick.
+    assert mapping["savethenovel"] == "architect_savethenovel"
+    assert mapping["bikepath"] == "worker_bikepath"
+    # Workspace operator does NOT appear under the workspace project.
+    assert "pollypm" not in mapping
+
+
+def test_synthesis_is_deterministic_across_calls(tmp_path: Path) -> None:
+    """plan_launches() caches; repeated calls return identical plans.
+
+    Regression guard: synthesis is purely a function of config; the
+    cached path returns the same instance and an invalidated path
+    returns an equal plan.
+    """
+    config = _base_config(
+        tmp_path,
+        tracked_projects={
+            "samblog": tmp_path / "samblog",
+            "savethenovel": tmp_path / "savethenovel",
+        },
+    )
+    sup = Supervisor(config)
+    sup.ensure_layout()
+    first = sup.plan_launches()
+    assert sup.plan_launches() is first  # cached
+    sup.invalidate_launch_cache()
+    refreshed = sup.plan_launches()
+    assert refreshed is not first
+    assert [spec.session.name for spec in refreshed] == [
+        spec.session.name for spec in first
+    ]


### PR DESCRIPTION
## Architectural change

The cockpit's "Chat PM" action for any project routed every project's PM conversation through a single shared `pm-operator` tmux window with persona-prime swaps ("you are Archie for samblog", "you are Sage for savethenovel"). When `pm-operator` was respawned (during `pm install` / restart / window-mount churn) every project's conversation history was wiped because there was no per-project conversation persistence — just persona primes layered on top of one shared Claude session. This PR adds a dedicated `pm_<project>` `operator-pm` session per tracked project so each project owns its own long-lived Claude conversation. The workspace-level `operator` session stays alive — it serves workspace-level / cross-project chat. The per-project PM windows are new additions, never replacements.

## File-by-file

**`src/pollypm/plugins_builtin/default_launch_planner/planner.py`** — Launch planner change
`plan_launches` now auto-injects synthetic `pm_<project>` `operator-pm` SessionConfig entries for every tracked project that doesn't already carry an explicit project-scoped operator-pm session in the static config. The synthesis is purely runtime — `~/.pollypm/pollypm.toml` stays untouched. Provider/account routing flows through `resolve_role_assignment("operator-pm", project_key)` so per-project role overrides win. Workspace project (`pollypm`) is skipped — the workspace `operator` already serves it. Projects without a compatible account are silently skipped (no crash). `effective_session` operator-pm branch now consults per-project role overrides for non-workspace PMs.

**`src/pollypm/cockpit_rail.py` + `src/pollypm/plugins_builtin/core_rail_items/plugin.py`** — Cockpit routing change
`_project_session_map` ranks per-project `operator-pm` ABOVE architect / worker / advisor. The #1861 tier order (architect → worker → default) is preserved as the fallback for installs without a per-project PM yet. `_PROJECT_PM_WINDOW_PREFIXES` re-prioritises `pm-` first so the #1636 sibling fallback prefers the new canonical per-project PM window. The dashboard's `c chat` keystroke flows through `_resolve_pm_target` → `project:<key>:session` → `_project_session_map` so it automatically inherits the new routing.

**Persona priming** — no changes needed
`_build_project_pm_primer` / `_maybe_prime_project_pm_session` in `cockpit_rail.py` already inject a project re-anchoring brief ("you are `<persona_name>`, the PM for `<project>`") on first mount of a per-project PM session. The synthesizer carries `agent_profile="polly"` so launch-time prompt is canonical operator prompt; project persona layered on at jump-to-PM time.

**`tests/test_pm_per_project_sessions.py` (new)** — 8 cases
3 tracked projects emit 3 `pm_<project>` entries; workspace project skipped; untracked opt out; explicit static-config PM wins over synthesis; no-compatible-account silently skipped; per-project `role_assignments` flow through; rail `_project_session_map` prefers per-project PM over worker; plan is deterministic across calls.

**`tests/test_cockpit_rail_project_pm_fallback.py`** — sibling priority test updated to pm → architect → worker (was architect → pm → worker pre-rollout).

## Migration

For users with existing `pollypm.toml` configs without per-project `pm_*` session entries: the launch planner auto-injects the missing session entries on the next `pm up` (or any `plan_launches()` call). The on-disk config is NEVER modified — the auto-spawn is a pure runtime addition. Installs that pre-declare a project-scoped `operator-pm` session in their config keep that entry authoritative.

## Test plan

- [x] `uv run pytest tests/test_pm_per_project_sessions.py -x -q` — 8 new cases pass
- [x] `uv run pytest tests/test_cockpit_rail_project_pm_fallback.py tests/test_cockpit_rail_routes.py tests/test_launch_planner.py -x -q` — regression suite clean
- [x] `uv run pytest tests/test_cockpit.py::test_project_session_map_prefers_architect_over_worker_and_advisor -x -q` — #1861's architect-priority contract still holds for installs without per-project PMs
- [x] `uv run ruff check src/pollypm/plugins_builtin/default_launch_planner/planner.py src/pollypm/cockpit_rail.py src/pollypm/plugins_builtin/core_rail_items/plugin.py tests/test_pm_per_project_sessions.py tests/test_cockpit_rail_project_pm_fallback.py` — clean
- [ ] Manual: `pm install && pm up`, navigate to a tracked project in cockpit, press `c` → confirm routes to `pm-<project>` window (not `pm-operator`). Capture tmux windows showing new `pm-samblog` window after restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)