### PR TITLE
fix(cockpit): Home view ctx.store crash + pm task list 41s perf (closes #1862, #1863, refs #1737)

### DIFF
--- a/src/pollypm/architect_lifecycle.py
+++ b/src/pollypm/architect_lifecycle.py
@@ -188,8 +188,19 @@ def resolve_launch_argv(
     confirm and clear) or it explicitly fails. Leaving the token
     means a crash partway through resume doesn't lose the warm
     context — the next attempt picks up from the same UUID.
+
+    ``store`` may be ``None`` for read-only callers (e.g. the
+    dashboard's :func:`plan_launches_readonly` shell) — we route the
+    token lookup through the pg facade directly in that case so the
+    planner stays usable without a legacy StateStore (#1862; #1737).
     """
-    record = store.get_architect_resume_token(project_key)
+    if store is None:
+        from pollypm.storage.pg_architect_resume import (
+            get_architect_resume_token as _pg_get_token,
+        )
+        record = _pg_get_token(project_key)
+    else:
+        record = store.get_architect_resume_token(project_key)
     if record is None or record.provider != provider.name:
         # No token, or token belongs to a different provider (e.g.
         # account was switched). Always fall back to fresh launch.

--- a/src/pollypm/plugins_builtin/default_launch_planner/planner.py
+++ b/src/pollypm/plugins_builtin/default_launch_planner/planner.py
@@ -195,7 +195,16 @@ class DefaultLaunchPlanner:
             # place until the resumed architect produces output (the
             # heartbeat sweep clears it on first non-empty snapshot).
             if effective.role == "architect" and effective.project:
-                resume_token = ctx.store.get_architect_resume_token(effective.project)
+                # Use the pg facade directly rather than ``ctx.store`` —
+                # ``plan_launches_readonly`` (dashboard / Home view) builds
+                # a Supervisor shell with ``store=None`` and the planner
+                # must keep working for those read-only callers. The
+                # facade resolves its own pool, so we skip the legacy
+                # StateStore hop entirely (#1862; pg cutover #1737).
+                from pollypm.storage.pg_architect_resume import (
+                    get_architect_resume_token,
+                )
+                resume_token = get_architect_resume_token(effective.project)
                 if resume_token is not None and resume_token.provider == account.provider.value:
                     from pollypm.acct.registry import get_provider as _get_acct_provider
                     acct_adapter = _get_acct_provider(account.provider.value)

--- a/src/pollypm/storage/pg_pool.py
+++ b/src/pollypm/storage/pg_pool.py
@@ -37,6 +37,7 @@ wire into this module; the unit tests cover the primitive contract.
 
 from __future__ import annotations
 
+import atexit
 import logging
 import os
 import threading
@@ -77,6 +78,27 @@ DEFAULT_POOL_MAX = 10
 _RW_POOL: "ConnectionPool | None" = None
 _RO_POOL: "ConnectionPool | None" = None
 _POOL_LOCK = threading.Lock()
+_ATEXIT_REGISTERED = False
+
+
+def _ensure_atexit_shutdown() -> None:
+    """Register a one-time interpreter-exit hook that closes both pools.
+
+    Without this, ``psycopg_pool``'s own ``__del__`` runs at finalisation
+    and blocks 5s per worker thread it fails to join — which on the
+    default ``min_size=1`` / ``max_size=10`` pool sizing turns into ~40s
+    of "stuck on exit" for every short-lived CLI invocation (e.g.
+    ``pm task list``; #1863). Calling :func:`pg_pool_shutdown` from an
+    atexit hook closes the pools cleanly before the threads turn into
+    daemon-thread join warnings.
+
+    Registration is idempotent — only the first pool open arms the hook.
+    """
+    global _ATEXIT_REGISTERED
+    if _ATEXIT_REGISTERED:
+        return
+    atexit.register(pg_pool_shutdown)
+    _ATEXIT_REGISTERED = True
 
 
 # --------------------------------------------------------------------- #
@@ -303,6 +325,7 @@ def get_rw_pool(config: "PollyPMConfig | None" = None) -> "ConnectionPool":
             read_only=False,
             application_name="pollypm/rw",
         )
+        _ensure_atexit_shutdown()
         return _RW_POOL
 
 
@@ -335,6 +358,7 @@ def get_ro_pool(config: "PollyPMConfig | None" = None) -> "ConnectionPool":
             read_only=True,
             application_name="pollypm/ro",
         )
+        _ensure_atexit_shutdown()
         return _RO_POOL
 
 

--- a/tests/test_launch_planner.py
+++ b/tests/test_launch_planner.py
@@ -322,3 +322,59 @@ def test_launch_by_session_unknown_raises(tmp_path: Path) -> None:
         assert "nonexistent" in str(exc)
     else:
         raise AssertionError("Expected KeyError for unknown session")
+
+
+def test_planner_handles_none_store_for_architect_session(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The planner must not crash when ``ctx.store`` is ``None`` (#1862).
+
+    The Home view dashboard builds a Supervisor shell via
+    :func:`pollypm.service_api.plan_launches_readonly` and passes
+    ``store=None`` through. Pre-fix, the architect-resume code path
+    called ``ctx.store.get_architect_resume_token(...)`` and raised
+    ``AttributeError: 'NoneType' object has no attribute
+    'get_architect_resume_token'``. The fix routes the lookup through
+    the pg facade directly, so a ``None`` store is a non-event for
+    architect sessions that have no warm token.
+    """
+    # Stub the pg facade so the test doesn't need a live Postgres.
+    from pollypm.storage import pg_architect_resume as _resume_mod
+
+    monkeypatch.setattr(
+        _resume_mod, "get_architect_resume_token", lambda key: None
+    )
+
+    config = _config(tmp_path)
+    config.projects["pollypm"].role_assignments["architect"] = ModelAssignment(
+        alias="sonnet-4.6"
+    )
+    config.sessions["architect"] = SessionConfig(
+        name="architect",
+        role="architect",
+        provider=ProviderKind.CLAUDE,
+        account="claude_controller",
+        cwd=tmp_path,
+        project="pollypm",
+        window_name="architect-pollypm",
+    )
+    sup = Supervisor(config)
+    sup.ensure_layout()
+
+    ctx = _planner_ctx_from_supervisor(sup)
+    # Mimic the readonly shell that ``plan_launches_readonly`` builds —
+    # store is ``None`` because the dashboard read path bypassed it.
+    ctx = DefaultLaunchPlannerContext(
+        config=ctx.config,
+        store=None,
+        readonly_state=True,
+        effective_account=ctx.effective_account,
+        apply_role_launch_restrictions=ctx.apply_role_launch_restrictions,
+        resolve_profile_prompt=ctx.resolve_profile_prompt,
+        storage_closet_session_name=ctx.storage_closet_session_name,
+    )
+    planner = DefaultLaunchPlanner(ctx)
+    # Must not raise AttributeError.
+    plan = planner.plan_launches()
+    architect = next(item for item in plan if item.session.name == "architect")
+    assert architect.session.provider is ProviderKind.CLAUDE

--- a/tests/test_pg_pool.py
+++ b/tests/test_pg_pool.py
@@ -235,6 +235,41 @@ def test_pg_pool_shutdown_is_idempotent(monkeypatch):
     mod.pg_pool_shutdown()  # second call must not raise
 
 
+def test_pool_creation_arms_atexit_shutdown(monkeypatch):
+    """Opening a pool must register the interpreter-exit shutdown hook (#1863).
+
+    Without this hook, ``psycopg_pool``'s finalisation waits 5 s per
+    worker thread it cannot stop — which on the default pool sizing
+    adds ~40 s of "stuck on exit" to every short-lived CLI invocation
+    (``pm task list``, etc.). The fix arms an :mod:`atexit` callback
+    on first pool open so the interpreter can shut down promptly.
+
+    We don't need a live pg here — we stub ``_build_pool`` and assert
+    the atexit registration flag flips.
+    """
+    monkeypatch.delenv("POLLYPM_PG_DSN", raising=False)
+    mod = _reload_pool_module()
+
+    registered: list[object] = []
+    monkeypatch.setattr(mod.atexit, "register", registered.append)
+
+    class _FakePool:
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(mod, "_build_pool", lambda *a, **kw: _FakePool())
+
+    assert mod._ATEXIT_REGISTERED is False
+    mod.get_rw_pool(None)
+    assert mod._ATEXIT_REGISTERED is True
+    assert mod.pg_pool_shutdown in registered
+
+    # Opening the RO pool after must not register a second hook.
+    registered.clear()
+    mod.get_ro_pool(None)
+    assert registered == []
+
+
 def test_bad_dsn_raises_on_first_use(monkeypatch):
     """A DSN that points nowhere must fail loudly when used.
 


### PR DESCRIPTION
## Summary

Two blocking regressions surfaced right after a fresh `pm reset --force && pm up`:

### #1862 — Home view crash

`DefaultLaunchPlanner` raised `AttributeError: 'NoneType' object has no attribute 'get_architect_resume_token'` whenever the cockpit's Home view (and any other read-only caller) gathered launches.

**Root cause:** `pollypm.service_api.plan_launches_readonly` builds a Supervisor shell with `store=None`. The architect warm-resume branch in the planner reached for `ctx.store.get_architect_resume_token(project)` directly, so any read-only gather that included an architect session blew up.

**Fix:** Route the token lookup through the `pollypm.storage.pg_architect_resume` facade (landed in #1737 phase 2b) — it resolves its own pool, so the planner no longer needs the legacy StateStore for this read. Mirrored the `store=None` tolerance into `architect_lifecycle.resolve_launch_argv` so the same surface stays usable for read-only callers.

### #1863 — `pm task list` 41 s

`pm task list --project samblog --json` consistently returned in ~41 s on the pg backend.

**Root cause:** Not the query — that completes in <1 s. The cost was at interpreter exit. `psycopg_pool` opens worker threads at pool construction; its `__del__` then waits 5 s per worker it can't join. With the default sizing the RW + RO pools together leave ~8 worker/scheduler threads, so 5 s × 8 ≈ 40 s of "stuck on exit" on every short-lived CLI invocation.

**Fix:** Register a one-time `atexit` hook on first pool open that calls `pg_pool_shutdown()`. The pools close cleanly before interpreter finalisation; no more daemon-thread join warnings.

**Timing:**

| | before | after |
| --- | --- | --- |
| `pm task list --project samblog --json` | 41.1 s | 0.93 s |

(Second invocation: 0.89 s — the perf win is consistent, not a cold-start artefact.)

## Test plan

- [x] `tests/test_launch_planner.py::test_planner_handles_none_store_for_architect_session` — regression guard for #1862 (planner doesn't crash with `ctx.store=None` on an architect session)
- [x] `tests/test_pg_pool.py::test_pool_creation_arms_atexit_shutdown` — regression guard for #1863 (atexit hook armed on first pool open, idempotent on second)
- [x] Full local sweep of `tests/test_pg_pool.py tests/test_launch_planner.py tests/test_architect_lifecycle.py tests/test_pg_pool_config.py` (51 passed)
- [x] Manual: `pm task list --project samblog --json` returns in <2 s (0.93 s)
- [x] Manual: `plan_launches_readonly(config, None)` returns all 38 launches without raising; `dashboard_data.gather(config, None)` returns a populated `DashboardData`

🤖 Generated with [Claude Code](https://claude.com/claude-code)