### PR TITLE
fix(cockpit): per-project persona_name wins over architect role default (PM Chat label)

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -6587,6 +6587,17 @@ def _task_recent_timestamp(task) -> float | None:
 
 
 def _project_pm_persona(config: object, project_key: str, project: object) -> str | None:
+    # #1862 — the project's explicit ``persona_name`` wins over the
+    # architect-role default. SamBlog configures ``persona_name = "Sage"``
+    # but also registers an ``architect-samblog`` session; the previous
+    # ordering returned the architect's default ("Archie") before the
+    # project's own configuration was consulted, so PM Chat surfaced the
+    # wrong name. Resolve project config first, then fall back to the
+    # role default for projects that never picked a persona.
+    persona = getattr(project, "persona_name", None)
+    if isinstance(persona, str) and persona.strip():
+        return persona.strip()
+
     sessions = getattr(config, "sessions", {}) or {}
     session_role: object | None = None
     if isinstance(sessions, dict):
@@ -6612,8 +6623,7 @@ def _project_pm_persona(config: object, project_key: str, project: object) -> st
         except ValueError:
             pass
 
-    persona = getattr(project, "persona_name", None)
-    return persona.strip() if isinstance(persona, str) and persona.strip() else None
+    return None
 
 
 def _project_pm_label(config: object, project_key: str, project: object) -> str:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -1971,6 +1971,76 @@ def test_project_pm_primer_matches_architect_session_persona() -> None:
     assert "Hey Bea" not in sent[0][1]
 
 
+class _PersonaProject:
+    def __init__(self, key: str, persona_name: str | None) -> None:
+        self.key = key
+        self.name = key
+        self.path = Path(f"/tmp/{key}")
+        self.persona_name = persona_name
+
+
+class _PersonaSession:
+    def __init__(self, project: str, role: str, enabled: bool = True) -> None:
+        self.project = project
+        self.role = role
+        self.enabled = enabled
+
+
+class _PersonaConfig:
+    def __init__(self, project_key: str, persona_name: str | None, sessions: dict) -> None:
+        self.projects = {project_key: _PersonaProject(project_key, persona_name)}
+        self.sessions = sessions
+
+
+def test_project_pm_persona_prefers_project_persona_over_architect_default() -> None:
+    """#1862 — the project's configured ``persona_name`` wins over the
+    architect-role default.
+
+    SamBlog set ``persona_name = "Sage"`` in its project config but also
+    runs an ``architect-samblog`` session. The old resolution order
+    matched the architect role first and surfaced "Archie" in the PM
+    Chat label, ignoring the project-level configuration. The label must
+    reflect the user's explicit choice.
+    """
+    from pollypm.cockpit_ui import _project_pm_label, _project_pm_persona
+
+    sessions = {"architect_samblog": _PersonaSession("samblog", "architect")}
+    config = _PersonaConfig("samblog", persona_name="Sage", sessions=sessions)
+    project = config.projects["samblog"]
+
+    assert _project_pm_persona(config, "samblog", project) == "Sage"
+    assert _project_pm_label(config, "samblog", project) == "PM: Sage"
+
+
+def test_project_pm_persona_falls_back_to_architect_default_when_unset() -> None:
+    """A project that never picked a ``persona_name`` should still get
+    the architect's default ("Archie") when an architect session is
+    registered — the fallback path keeps the #1321 primer/label working
+    for unconfigured projects.
+    """
+    from pollypm.cockpit_ui import _project_pm_persona
+
+    sessions = {"architect_demo": _PersonaSession("demo", "architect")}
+    config = _PersonaConfig("demo", persona_name=None, sessions=sessions)
+    project = config.projects["demo"]
+
+    assert _project_pm_persona(config, "demo", project) == "Archie"
+
+
+def test_project_pm_persona_returns_none_when_neither_configured() -> None:
+    """No project persona, no architect session → no PM label. Caller
+    suppresses the topbar PM meta entirely instead of rendering a
+    placeholder (#1542).
+    """
+    from pollypm.cockpit_ui import _project_pm_label, _project_pm_persona
+
+    config = _PersonaConfig("orphan", persona_name=None, sessions={})
+    project = config.projects["orphan"]
+
+    assert _project_pm_persona(config, "orphan", project) is None
+    assert _project_pm_label(config, "orphan", project) == ""
+
+
 def test_create_worker_and_route_targets_pm_chat_session_when_worker_exists() -> None:
     """#964 regression: after :meth:`create_worker_and_route` spawns
     the per-project worker (or finds a pre-existing one), it MUST route


### PR DESCRIPTION
## Root cause

Sam opened SamBlog's PM Chat from the cockpit and the topbar label read ``PM Chat (Archie)`` even though ``samblog`` has ``persona_name = "Sage"`` configured. ``_project_pm_persona`` in ``src/pollypm/cockpit_ui.py`` resolved sessions first: when it found an ``architect-<project>`` session it returned the architect-role default ("Archie") and never fell through to the project's own ``persona_name``. Any project with both an explicit persona and an architect session lost the user's chosen label. The fix flips the order — project ``persona_name`` wins; the architect default is the fallback for unconfigured projects, preserving #1321 behavior. Minimal diff to one helper; the primer code path (separate helpers in ``cockpit_rail.py``) is untouched per the brief.

## Test plan
- [x] ``tests/test_cockpit.py::test_project_pm_persona_prefers_project_persona_over_architect_default`` — explicit ``persona_name="Sage"`` + architect session → ``"Sage"``
- [x] ``tests/test_cockpit.py::test_project_pm_persona_falls_back_to_architect_default_when_unset`` — no ``persona_name`` + architect session → ``"Archie"``
- [x] ``tests/test_cockpit.py::test_project_pm_persona_returns_none_when_neither_configured`` — neither → ``None`` (topbar suppresses PM meta per #1542)
- [x] Existing ``test_project_pm_primer_matches_architect_session_persona`` (#1321) still passes — primer helper untouched
- [ ] Visual check: open SamBlog PM Chat in cockpit, confirm label reads ``PM: Sage``

🤖 Generated with [Claude Code](https://claude.com/claude-code)