### PR TITLE
fix(cockpit): rail "PM Chat (...)" label + primer use project persona_name (follow-up to #1866)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -480,6 +480,28 @@ def _project_pm_persona_for_role(session_role: object) -> str | None:
     return None
 
 
+def _resolve_project_chat_persona(
+    project: object, session_role: object,
+) -> str | None:
+    """Return the persona that should label/greet a project's PM Chat.
+
+    Follow-up to #1866: the project's explicit ``persona_name`` always
+    wins over the architect-role default ("Archie"). When the project
+    has no configured persona we fall back to the architect-role default
+    so projects that never picked a persona keep the historical label.
+
+    Shared by the rail "PM Chat (…)" label
+    (:mod:`pollypm.plugins_builtin.core_rail_items.plugin`) and the
+    per-project PM primer (:func:`_build_project_pm_primer`) so the
+    glyph in the rail and the greeting injected into the PM session
+    never disagree.
+    """
+    persona_raw = getattr(project, "persona_name", None)
+    if isinstance(persona_raw, str) and persona_raw.strip():
+        return persona_raw.strip()
+    return _project_pm_persona_for_role(session_role)
+
+
 def _session_role_for_name(supervisor, session_name: str | None) -> object | None:
     if not session_name:
         return None
@@ -519,16 +541,16 @@ def _build_project_pm_primer(
     project = supervisor.config.projects.get(project_key)
     if project is None:
         return None
-    persona = _project_pm_persona_for_role(
+    # Follow-up to #1866: the project's ``persona_name`` wins over the
+    # architect-role default. The previous ordering let the architect
+    # default ("Archie") shadow projects that explicitly configured a
+    # PM name (e.g. samblog → "Sage"), so the primer greeted the wrong
+    # persona on attach. Shared helper keeps the rail label + primer
+    # in lockstep.
+    persona = _resolve_project_chat_persona(
+        project,
         _session_role_for_name(supervisor, session_name),
     )
-    if persona is None:
-        persona_raw = getattr(project, "persona_name", None)
-        persona = (
-            persona_raw.strip()
-            if isinstance(persona_raw, str) and persona_raw.strip()
-            else None
-        )
     project_name = project.name or project_key
     project_path = str(project.path)
 

--- a/src/pollypm/plugins_builtin/core_rail_items/plugin.py
+++ b/src/pollypm/plugins_builtin/core_rail_items/plugin.py
@@ -357,21 +357,16 @@ def _selected_key(ctx: RailContext) -> str:
 
 
 def _project_chat_persona(project: Any, session_role: Any) -> str:
-    if isinstance(session_role, str) and session_role.strip():
-        try:
-            from pollypm.role_contract import canonical_role, persona_for
+    # Follow-up to #1866: the project's explicit ``persona_name`` wins
+    # over the architect-role default ("Archie"). samblog set
+    # ``persona_name = "Sage"`` and also has an architect session — the
+    # old ordering returned "Archie" before consulting project config,
+    # so the rail rendered ``PM Chat (Archie)``. Delegate to the
+    # shared resolver so the rail label and the PM primer agree.
+    from pollypm.cockpit_rail import _resolve_project_chat_persona
 
-            if canonical_role(session_role) == "architect":
-                return persona_for("architect")
-        except ValueError:
-            pass
-
-    persona_raw = getattr(project, "persona_name", None)
-    return (
-        persona_raw.strip()
-        if isinstance(persona_raw, str) and persona_raw.strip()
-        else "Project PM"
-    )
+    persona = _resolve_project_chat_persona(project, session_role)
+    return persona if persona else "Project PM"
 
 
 def _project_rows(ctx: RailContext) -> list[RailRow]:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -1910,9 +1910,21 @@ def test_cockpit_router_primes_per_project_pm_session_distinctly() -> None:
     assert len(sent) == 2  # unchanged
 
 
-def test_project_pm_primer_matches_architect_session_persona() -> None:
-    """An architect-backed PM Chat should greet Archie, not the project's
-    worker persona (#1321).
+def test_project_pm_primer_greets_project_persona_over_architect_default() -> None:
+    """Follow-up to #1866: when the project explicitly configures a
+    ``persona_name`` it must win over the architect-role default in the
+    primer too, mirroring the rail "PM Chat (…)" label.
+
+    Pre-#1866 the rail label and primer both deferred to the architect
+    default ("Archie") whenever an architect-role session existed for
+    the project, which let "Archie" shadow projects that had picked
+    their own PM name (e.g. samblog → "Sage"). The primer greeting is
+    the most visible regression — Sam saw "Hey Archie" injected into
+    the PM session for samblog despite the project config saying
+    "Sage". The fix here is the same precedence used by the rail label:
+    project ``persona_name`` first, architect-role default only as a
+    fallback. (Originally regression-tested for #1321; the assertion
+    has been inverted now that the precedence is correct.)
     """
     sent: list[tuple[str, str]] = []
     primed_state: dict[str, object] = {}
@@ -1964,6 +1976,70 @@ def test_project_pm_primer_matches_architect_session_persona() -> None:
         supervisor,
         "pollypm:PollyPM",
         ProjectRoute(project_key="bikepath", sub_view="session"),
+    )
+
+    assert len(sent) == 1
+    assert "Hey Bea" in sent[0][1]
+    assert "Hey Archie" not in sent[0][1]
+
+
+def test_project_pm_primer_falls_back_to_architect_default_when_persona_unset() -> None:
+    """A project without an explicit ``persona_name`` still gets the
+    architect-role default ("Archie") in the primer when an architect
+    session backs the PM Chat. The follow-up to #1866 only changes
+    *precedence* — projects that relied on the role-default greeting
+    must not regress.
+    """
+    sent: list[tuple[str, str]] = []
+    primed_state: dict[str, object] = {}
+
+    class _FakeTmux:
+        def send_keys(self, target, text, press_enter=True):  # noqa: ARG002
+            sent.append((target, text))
+
+    class _Project:
+        key = "booktalk"
+        name = "booktalk"
+        path = Path("/tmp/booktalk-no-db")
+        persona_name = None
+
+    class _FakeConfig:
+        projects = {"booktalk": _Project()}
+
+    class _FakeSupervisor:
+        config = _FakeConfig()
+
+        def plan_launches(self):
+            class _Sess:
+                name = "architect_booktalk"
+                role = "architect"
+                project = "booktalk"
+
+            class _L:
+                session = _Sess()
+
+            return [_L()]
+
+    router = CockpitRouter.__new__(CockpitRouter)
+    router.config_path = Path("/tmp/pollypm.toml")
+    router.tmux = _FakeTmux()
+    router._right_pane_id = lambda window_target: "%right"  # type: ignore[assignment]
+    router._load_state = lambda: dict(primed_state)  # type: ignore[assignment]
+
+    def _write(data):
+        primed_state.clear()
+        primed_state.update(data)
+
+    router._write_state = _write  # type: ignore[assignment]
+    router._session_available_for_mount = lambda *a, **k: True  # type: ignore[assignment]
+    router._show_live_session = lambda *a, **k: None  # type: ignore[assignment]
+
+    supervisor = _FakeSupervisor()
+
+    router._route_project_selection(
+        supervisor,
+        "pollypm:PollyPM",
+        ProjectRoute(project_key="booktalk", sub_view="session"),
     )
 
     assert len(sent) == 1

--- a/tests/test_core_rail_items.py
+++ b/tests/test_core_rail_items.py
@@ -139,7 +139,13 @@ def test_polly_state_ignores_expired_live_chat_network_dead_notice(
 @pytest.mark.parametrize(
     ("session_role", "expected_label"),
     [
-        ("architect", "  PM Chat (Archie)"),
+        # Follow-up to #1866: the project's configured ``persona_name``
+        # wins over the architect-role default ("Archie"). Bikepath
+        # explicitly picked "Bea", so the rail must surface "Bea"
+        # regardless of which control-role session backs the PM Chat
+        # window. (Worker-role sessions never carried a baked-in name,
+        # so this column was already correct pre-fix.)
+        ("architect", "  PM Chat (Bea)"),
         ("worker", "  PM Chat (Bea)"),
     ],
 )
@@ -224,6 +230,60 @@ def test_pm_chat_label_uses_project_pm_fallback(monkeypatch, tmp_path: Path) -> 
 
     session_row = next(row for row in rows if row.key == "project:booktalk:session")
     assert session_row.label == "  PM Chat (Project PM)"
+
+
+def test_pm_chat_label_falls_back_to_architect_default_when_persona_unset(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Follow-up to #1866: projects without an explicit ``persona_name``
+    still surface the architect-role default ("Archie") when their PM
+    Chat is backed by an architect session. The fix only changes
+    *precedence* — it must not regress projects that relied on the
+    role-default label.
+    """
+    project = KnownProject(
+        key="booktalk",
+        path=tmp_path,
+        name="Booktalk",
+        persona_name=None,
+        kind=ProjectKind.GIT,
+    )
+    config = type("Config", (), {"projects": {"booktalk": project}})()
+
+    class _Router:
+        def _session_state(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            return "idle"
+
+    monkeypatch.setattr(
+        core_rail_items_plugin,
+        "_classify_projects",
+        lambda ctx: ([("booktalk", project)], [], {"booktalk": False}),
+    )
+    monkeypatch.setattr(
+        core_rail_items_plugin,
+        "active_task_numbers",
+        lambda project, *, config=None: [],
+    )
+    ctx = RailContext(
+        router=_Router(),
+        config=config,
+        launches=[
+            _FakeLaunch(
+                "architect_booktalk",
+                "architect",
+                "booktalk",
+                "architect-booktalk",
+            ),
+        ],
+        cockpit_state={"selected": "project:booktalk"},
+    )
+
+    rows = core_rail_items_plugin._project_rows(ctx)
+
+    session_row = next(
+        row for row in rows if row.key == "project:booktalk:session"
+    )
+    assert session_row.label == "  PM Chat (Archie)"
 
 
 def _fake_supervisor(


### PR DESCRIPTION
## Summary

#1866 fixed the topbar `_project_pm_persona` so a project's explicit `persona_name` wins over the architect-role default ("Archie"). Two adjacent sites still deferred to the role default and surfaced "Archie" for samblog (which has `persona_name = "Sage"`):

- **Rail row label** (`plugins_builtin/core_rail_items/plugin.py` → `_project_chat_persona`) returned `persona_for("architect")` before consulting `project.persona_name`, so the rail rendered `PM Chat (Archie)` for samblog.
- **Per-project PM primer** (`cockpit_rail.py` → `_build_project_pm_primer`) called `_project_pm_persona_for_role(...)` first and only fell back to `project.persona_name` if no architect session existed, so it injected `Hey Archie — ...` into samblog's PM session on attach.

Both sites now share `_resolve_project_chat_persona` in `cockpit_rail.py` — project `persona_name` first, architect-role default only as a fallback — so the rail glyph and the primer greeting stay in lockstep. Verified end-to-end against the real `~/.pollypm/pollypm.toml`: samblog renders `PM Chat (Sage)` and primes with `Hey Sage — ...`, while a `persona_name = None` project backed by an architect session still falls back to `Archie`.

## Files changed

- `src/pollypm/cockpit_rail.py` — new `_resolve_project_chat_persona`; primer uses it.
- `src/pollypm/plugins_builtin/core_rail_items/plugin.py` — `_project_chat_persona` delegates to the shared resolver.
- `tests/test_core_rail_items.py` — parametrized label test now asserts `PM Chat (Bea)` for both roles; new architect-fallback test pins the no-`persona_name` case to `Archie`.
- `tests/test_cockpit.py` — #1321 primer test inverted to assert `Hey Bea` (was `Hey Archie`); new fallback test pins the role-default greeting.

## Test plan

- [x] `uv run pytest tests/test_core_rail_items.py -k "persona or pm_chat or fallback"` — 4 passed.
- [x] `uv run pytest tests/test_cockpit.py -k "primer or persona"` — 5 passed.
- [x] `uv run pytest tests/test_cockpit*.py -k "persona or rail_pm or primer or pm_chat"` — 10 passed.
- [x] Manual verification: tmux capture of the live cockpit (on main) shows the bug — samblog renders `PM Chat (Archie)`. Python harness on the branch against the real `~/.pollypm/pollypm.toml` returns `PM Chat (Sage)` and `Hey Sage — ...` for samblog, and `PM Chat (Archie)` / `Hey Archie — ...` for a no-persona project with an architect session.
- [x] No `issues/*` filed.

Three test failures in `tests/test_cockpit.py` (event ticker, dashboard activity) and three in `tests/test_core_rail_items.py` (waiting task ids, classify/active tasks) reproduce on `origin/main` unchanged — pre-existing, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)