### PR TITLE
fix(profiles): persona_name template in architect profile + suppress chat-open primer on existing sessions (closes #1867, refs #1870, refs #1737)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -3673,6 +3673,19 @@ class CockpitRouter:
         across re-mounts so clicking PM Chat twice does not spam the agent.
         Failures are best-effort — the mount has already succeeded; a
         primer that does not land does not roll back attachment.
+
+        #1867 (and the persona-template follow-up that closes it):
+        in addition to the persisted ``pm_primed_sessions`` marker, this
+        also inspects the live pane for an established conversation
+        before sending. If the architect's pane already shows
+        substantive output (more than a fresh-launch banner), the primer
+        is suppressed and the session is marked as primed. This guards
+        against the "primer fires every ``c`` press" failure mode the
+        screenshot in #1867 captured: even when the persisted marker is
+        somehow cleared (a stray rewrite, a manual edit, a state-cache
+        race), the pane-content gate prevents the primer from being
+        injected on top of an active conversation and contradicting the
+        persona the user is mid-conversation with.
         """
         try:
             state = self._load_state()
@@ -3683,6 +3696,22 @@ class CockpitRouter:
                 primed = set()
             if session_name in primed:
                 return
+            right_pane_id = self._right_pane_id(window_target)
+            target = right_pane_id if right_pane_id else window_target
+            # First-attach gate (#1867): if the pane already carries an
+            # established conversation, do not inject a "Hey <persona>"
+            # primer on top of it. The primer was designed for the very
+            # first attach to a fresh session; firing it mid-conversation
+            # (after a state-cache reset, or any path that misses the
+            # persisted marker) parses as a system-authority reset to
+            # the agent and contradicts the persona it has been answering
+            # as. Mark the session primed so the regular early-return on
+            # the next attach is correct.
+            if self._pane_has_established_conversation(target):
+                primed.add(session_name)
+                state["pm_primed_sessions"] = sorted(primed)
+                self._write_state(state)
+                return
             primer = _build_project_pm_primer(
                 supervisor,
                 project_key,
@@ -3690,8 +3719,6 @@ class CockpitRouter:
             )
             if not primer:
                 return
-            right_pane_id = self._right_pane_id(window_target)
-            target = right_pane_id if right_pane_id else window_target
             try:
                 self.tmux.send_keys(target, primer, press_enter=True)
             except Exception:  # noqa: BLE001
@@ -3701,6 +3728,35 @@ class CockpitRouter:
             self._write_state(state)
         except Exception:  # noqa: BLE001
             return
+
+    def _pane_has_established_conversation(self, target: str | None) -> bool:
+        """Return ``True`` when ``target`` shows a substantive conversation.
+
+        Used by :meth:`_maybe_prime_project_pm_session` as a
+        belt-and-suspenders first-attach gate (#1867). A "fresh" Claude
+        pane shows only its welcome banner + a blank prompt box; an
+        established conversation has many lines of agent + user turns
+        scrolled into the pane. The check is intentionally conservative
+        — we look at a 200-line capture and count distinct non-empty
+        lines; any pane with significantly more content than a baseline
+        Claude/Codex banner is treated as "in a conversation, do not
+        re-prime". On capture failure we fall back to the historical
+        "send the primer" behaviour rather than silently skipping it.
+        """
+        if not target:
+            return False
+        try:
+            pane_text = self.tmux.capture_pane(target, lines=200)
+        except Exception:  # noqa: BLE001
+            return False
+        if not isinstance(pane_text, str) or not pane_text:
+            return False
+        non_empty = [line for line in pane_text.splitlines() if line.strip()]
+        # Baseline Claude/Codex banners are well under ~30 non-empty
+        # lines on first launch (including the box-drawing prompt). A
+        # real conversation grows the scrollback well past that
+        # threshold within a single exchange.
+        return len(non_empty) >= 40
 
     def _show_live_session(self, supervisor, session_name: str, window_target: str) -> None:
         # Mount-time identity check (replaces the legacy bare-string

--- a/src/pollypm/plugins_builtin/project_planning/plugin.py
+++ b/src/pollypm/plugins_builtin/project_planning/plugin.py
@@ -79,6 +79,25 @@ class MarkdownPromptProfile:
                     "architect",
                     fallback_text=prompt,
                 )
+        # Substitute the ``{persona_name}`` placeholder so the architect's
+        # baked-in identity matches the project's configured persona.
+        # Pre-fix the profile was a static "You are Archie, the architect"
+        # — when the project's chat-open primer greeted the agent as
+        # "Sage" (samblog's configured persona_name), the agent's system
+        # prompt and the user-facing greeting contradicted each other.
+        # The fallback keeps the historical role default ("Archie") for
+        # projects that never picked a persona, mirroring the precedence
+        # used by ``_resolve_project_chat_persona`` for the rail label
+        # and the per-project primer (#1866 follow-up).
+        if "{persona_name}" in prompt:
+            persona = "Archie"
+            if context is not None:
+                project = context.config.projects.get(context.session.project)
+                if project is not None:
+                    persona_raw = getattr(project, "persona_name", None)
+                    if isinstance(persona_raw, str) and persona_raw.strip():
+                        persona = persona_raw.strip()
+            prompt = prompt.replace("{persona_name}", persona)
         return prompt or None
 
 

--- a/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
+++ b/src/pollypm/plugins_builtin/project_planning/profiles/architect.md
@@ -40,7 +40,7 @@ Stage-0 (Research) additionally produces `docs/planning-context.md` via a ReAct 
 </output_contract>
 
 <kickoff>
-You are Archie, the architect. On session start:
+You are {persona_name}, the architect. On session start:
 
 1. Claim your work: run `pm task next` to find the highest-priority queued `plan_project` task routed to you. If nothing is queued yet, wait for a ping from the task-assignment bus — the sweeper will re-notify every few minutes.
 2. Walk the `plan_project` flow stages in order: research → discover → decompose → test_strategy → magic → critic_panel → synthesize → plan_review → user_approval → emit_backlog.

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -2047,6 +2047,151 @@ def test_project_pm_primer_falls_back_to_architect_default_when_persona_unset() 
     assert "Hey Bea" not in sent[0][1]
 
 
+def test_project_pm_primer_suppressed_when_pane_has_existing_conversation() -> None:
+    """First-attach gate for the chat-open primer (#1867).
+
+    Pre-fix, the per-project PM primer fired whenever the persisted
+    ``pm_primed_sessions`` marker was missing — including after a
+    state-cache reset that left a real, in-progress conversation on the
+    pane. Sam's screenshot in #1867 caught exactly that: the primer
+    landed AFTER he had already asked the agent "who are you?" twice,
+    parsing as a system-authority reset on top of an active turn.
+
+    The fix gates the primer on pane content: if a 200-line capture of
+    the target pane shows substantive output (>= 40 non-empty lines),
+    treat the session as already established and suppress the primer.
+    The session is still marked as primed so the next attach hits the
+    fast early-return.
+    """
+    sent: list[tuple[str, str]] = []
+    primed_state: dict[str, object] = {}
+
+    # Substantive conversation: well over the 40 non-empty-line bar.
+    pane_text = "\n".join(f"line {n}: agent or user turn" for n in range(60))
+
+    class _FakeTmux:
+        def send_keys(self, target, text, press_enter=True):  # noqa: ARG002
+            sent.append((target, text))
+
+        def capture_pane(self, target, lines=200):  # noqa: ARG002
+            return pane_text
+
+    class _Project:
+        key = "samblog"
+        name = "samblog"
+        path = Path("/tmp/samblog-no-db")
+        persona_name = "Sage"
+
+    class _FakeConfig:
+        projects = {"samblog": _Project()}
+
+    class _FakeSupervisor:
+        config = _FakeConfig()
+
+        def plan_launches(self):
+            class _Sess:
+                name = "architect_samblog"
+                role = "architect"
+                project = "samblog"
+
+            class _L:
+                session = _Sess()
+
+            return [_L()]
+
+    router = CockpitRouter.__new__(CockpitRouter)
+    router.config_path = Path("/tmp/pollypm.toml")
+    router.tmux = _FakeTmux()
+    router._right_pane_id = lambda window_target: "%right"  # type: ignore[assignment]
+    router._load_state = lambda: dict(primed_state)  # type: ignore[assignment]
+
+    def _write(data):
+        primed_state.clear()
+        primed_state.update(data)
+
+    router._write_state = _write  # type: ignore[assignment]
+
+    router._maybe_prime_project_pm_session(  # type: ignore[attr-defined]
+        _FakeSupervisor(),
+        "samblog",
+        "architect_samblog",
+        "pollypm:PollyPM",
+    )
+
+    # No primer was injected, but the session was marked primed so the
+    # next attach short-circuits on the fast-path.
+    assert sent == []
+    assert "architect_samblog" in primed_state.get("pm_primed_sessions", [])
+
+
+def test_project_pm_primer_still_fires_on_fresh_pane() -> None:
+    """The first-attach gate (#1867) must not regress fresh sessions.
+
+    A pane that just launched (a baseline Claude/Codex banner, ~20
+    non-empty lines) is still well under the 40-line "established
+    conversation" threshold, so the primer fires exactly once and the
+    persisted ``pm_primed_sessions`` marker is updated.
+    """
+    sent: list[tuple[str, str]] = []
+    primed_state: dict[str, object] = {}
+
+    # Baseline banner: well under the 40 non-empty-line bar.
+    pane_text = "\n".join(f"banner line {n}" for n in range(15))
+
+    class _FakeTmux:
+        def send_keys(self, target, text, press_enter=True):  # noqa: ARG002
+            sent.append((target, text))
+
+        def capture_pane(self, target, lines=200):  # noqa: ARG002
+            return pane_text
+
+    class _Project:
+        key = "samblog"
+        name = "samblog"
+        path = Path("/tmp/samblog-no-db")
+        persona_name = "Sage"
+
+    class _FakeConfig:
+        projects = {"samblog": _Project()}
+
+    class _FakeSupervisor:
+        config = _FakeConfig()
+
+        def plan_launches(self):
+            class _Sess:
+                name = "architect_samblog"
+                role = "architect"
+                project = "samblog"
+
+            class _L:
+                session = _Sess()
+
+            return [_L()]
+
+    router = CockpitRouter.__new__(CockpitRouter)
+    router.config_path = Path("/tmp/pollypm.toml")
+    router.tmux = _FakeTmux()
+    router._right_pane_id = lambda window_target: "%right"  # type: ignore[assignment]
+    router._load_state = lambda: dict(primed_state)  # type: ignore[assignment]
+
+    def _write(data):
+        primed_state.clear()
+        primed_state.update(data)
+
+    router._write_state = _write  # type: ignore[assignment]
+
+    router._maybe_prime_project_pm_session(  # type: ignore[attr-defined]
+        _FakeSupervisor(),
+        "samblog",
+        "architect_samblog",
+        "pollypm:PollyPM",
+    )
+
+    assert len(sent) == 1
+    assert "Hey Sage" in sent[0][1]
+    assert "architect_samblog" in primed_state.get("pm_primed_sessions", [])
+
+
 class _PersonaProject:
     def __init__(self, key: str, persona_name: str | None) -> None:
         self.key = key

--- a/tests/test_project_planning_plugin.py
+++ b/tests/test_project_planning_plugin.py
@@ -588,6 +588,139 @@ def test_architect_profile_points_at_research_stage() -> None:
     assert "research" in text.lower()
 
 
+def _make_architect_context(tmp_path: Path, *, persona_name: str | None):
+    """Build an ``AgentProfileContext`` keyed to the architect session.
+
+    Used by the persona-template tests below — they exercise
+    :class:`MarkdownPromptProfile`'s ``{persona_name}`` substitution
+    branch, which is keyed off the project's configured ``persona_name``
+    with a fallback to the architect-role default ("Archie").
+    """
+    from pollypm.agent_profiles.base import AgentProfileContext
+    from pollypm.models import (
+        AccountConfig,
+        KnownProject,
+        PollyPMConfig,
+        PollyPMSettings,
+        ProjectKind,
+        ProjectSettings,
+        ProviderKind,
+        SessionConfig,
+    )
+
+    project_root = tmp_path / "repo"
+    project_root.mkdir(exist_ok=True)
+    config = PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=tmp_path,
+            base_dir=tmp_path / ".pollypm",
+            logs_dir=tmp_path / ".pollypm/logs",
+            snapshots_dir=tmp_path / ".pollypm/snapshots",
+            state_db=tmp_path / ".pollypm/state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account="claude_primary"),
+        accounts={
+            "claude_primary": AccountConfig(
+                name="claude_primary",
+                provider=ProviderKind.CLAUDE,
+                home=tmp_path / ".pollypm/homes/claude_primary",
+            )
+        },
+        sessions={
+            "architect": SessionConfig(
+                name="architect",
+                role="architect",
+                provider=ProviderKind.CLAUDE,
+                account="claude_primary",
+                cwd=project_root,
+                project="demo",
+                agent_profile="architect",
+            )
+        },
+        projects={
+            "demo": KnownProject(
+                key="demo",
+                path=project_root,
+                name="Demo",
+                kind=ProjectKind.GIT,
+                persona_name=persona_name,
+            )
+        },
+    )
+    return AgentProfileContext(
+        config=config,
+        session=config.sessions["architect"],
+        account=config.accounts["claude_primary"],
+    )
+
+
+def test_architect_profile_substitutes_project_persona_name(
+    tmp_path: Path,
+) -> None:
+    """``architect.md`` ships with a ``{persona_name}`` placeholder; when
+    a project configures ``persona_name`` (e.g. samblog → "Sage") the
+    rendered system prompt must greet the agent with that name, not the
+    architect-role default.
+
+    Regression for the self-contradicting-identity bug captured in the
+    #1867 follow-up: pre-fix the architect's system prompt said "You
+    are Archie" while the cockpit chat-open primer addressed the same
+    session as "Sage", leaving the agent visibly confused about its
+    own name. The substitution happens at prompt-build time so the
+    file written by ``_write_claude_system_prompt_to_disk`` carries
+    the correct persona before the launch argv references it.
+    """
+    from pollypm.plugin_host import ExtensionHost
+
+    host = ExtensionHost(tmp_path)
+    profile = host.get_agent_profile("architect")
+    context = _make_architect_context(tmp_path, persona_name="Sage")
+    prompt = profile.build_prompt(context)
+    assert prompt is not None
+    assert "You are Sage, the architect" in prompt
+    assert "{persona_name}" not in prompt
+    assert "You are Archie, the architect" not in prompt
+
+
+def test_architect_profile_falls_back_to_archie_without_persona(
+    tmp_path: Path,
+) -> None:
+    """Projects that never picked a ``persona_name`` keep the historical
+    architect default ("Archie") so the fallback path mirrors
+    ``role_contract.py``'s role-registry default. This is the same
+    precedence ``_resolve_project_chat_persona`` uses for the rail
+    label, keeping the two surfaces in lockstep.
+    """
+    from pollypm.plugin_host import ExtensionHost
+
+    host = ExtensionHost(tmp_path)
+    profile = host.get_agent_profile("architect")
+    context = _make_architect_context(tmp_path, persona_name=None)
+    prompt = profile.build_prompt(context)
+    assert prompt is not None
+    assert "You are Archie, the architect" in prompt
+    assert "{persona_name}" not in prompt
+
+
+def test_architect_profile_no_context_falls_back_to_archie(
+    tmp_path: Path,
+) -> None:
+    """Callers that pass ``context=None`` (existing
+    :func:`test_profile_prompt_is_substantive` parametrized case)
+    must still see the placeholder substituted — otherwise the
+    rendered file would contain a literal ``{persona_name}`` token
+    and the agent would read its own name as a template variable.
+    """
+    from pollypm.plugin_host import ExtensionHost
+
+    host = ExtensionHost(tmp_path)
+    profile = host.get_agent_profile("architect")
+    prompt = profile.build_prompt(context=None)
+    assert prompt is not None
+    assert "{persona_name}" not in prompt
+    assert "You are Archie, the architect" in prompt
+
+
 # ---------------------------------------------------------------------------
 # pp05 — tree-of-plans: 2-3 candidates, critics evaluate all, synthesis picks winner
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two coordinated fixes for the self-contradicting-identity screenshot in
#1867's follow-up:

- **Persona template substitution** in `architect.md` so the system
  prompt written by #1870's planner code carries the project's
  configured `persona_name` (e.g. samblog → "Sage") instead of the
  hard-coded "Archie".
- **First-attach gate** on the chat-open primer so it no longer fires
  on top of an established conversation when the persisted marker is
  missing.

Before the fix the agent's system prompt said "You are Archie" while
the cockpit primer addressed the same session as "Sage" — Archie
itself flagged the contradiction in Sam's screenshot. Sam also saw
the primer firing AFTER he had already asked "who are you?" twice,
as if the conversation had reset.

## Fix 1 — `{persona_name}` template

`src/pollypm/plugins_builtin/project_planning/profiles/architect.md`:

```diff
 <kickoff>
-You are Archie, the architect. On session start:
+You are {persona_name}, the architect. On session start:
```

`src/pollypm/plugins_builtin/project_planning/plugin.py` (in
`MarkdownPromptProfile.build_prompt`):

```diff
+        # Substitute the ``{persona_name}`` placeholder so the architect's
+        # baked-in identity matches the project's configured persona.
+        if "{persona_name}" in prompt:
+            persona = "Archie"
+            if context is not None:
+                project = context.config.projects.get(context.session.project)
+                if project is not None:
+                    persona_raw = getattr(project, "persona_name", None)
+                    if isinstance(persona_raw, str) and persona_raw.strip():
+                        persona = persona_raw.strip()
+            prompt = prompt.replace("{persona_name}", persona)
         return prompt or None
```

Fallback to `"Archie"` when no `persona_name` is configured, mirroring
`_resolve_project_chat_persona`'s precedence so the rail "PM Chat (…)"
label and the system prompt stay in lockstep. `role_contract.py`'s
"Archie" default for projects without `persona_name` is preserved.

## Fix 2 — first-attach gate on chat-open primer

`src/pollypm/cockpit_rail.py` (`_maybe_prime_project_pm_session`):

```diff
+            right_pane_id = self._right_pane_id(window_target)
+            target = right_pane_id if right_pane_id else window_target
+            # First-attach gate (#1867): if the pane already carries an
+            # established conversation, do not inject a "Hey <persona>"
+            # primer on top of it.
+            if self._pane_has_established_conversation(target):
+                primed.add(session_name)
+                state["pm_primed_sessions"] = sorted(primed)
+                self._write_state(state)
+                return
```

New helper `_pane_has_established_conversation` captures 200 lines via
`self.tmux.capture_pane` and counts distinct non-empty lines; >= 40
lines means an active conversation, treat as primed and skip. Capture
failures fall back to the historical "send the primer" behaviour so
this is a strict addition, not a regression risk.

## Manual verification

`architect.md` template substitution rendered for `samblog`
(persona_name="Sage"):

```
<kickoff>
You are Sage, the architect. On session start:
...
```

Rendered for a project without `persona_name`:

```
<kickoff>
You are Archie, the architect. On session start:
...
```

`{persona_name}` token leak: none — the literal is gone after
substitution in both branches.

## Tests

Five new tests, all passing locally:

- `test_architect_profile_substitutes_project_persona_name` — samblog →
  "You are Sage, the architect"
- `test_architect_profile_falls_back_to_archie_without_persona` —
  no persona_name → historical "Archie" default
- `test_architect_profile_no_context_falls_back_to_archie` —
  `context=None` callers still see the placeholder substituted
- `test_project_pm_primer_suppressed_when_pane_has_existing_conversation`
  — primer suppressed when the pane shows 60 lines of conversation,
  session still marked as primed
- `test_project_pm_primer_still_fires_on_fresh_pane` — a 15-line
  banner is below the threshold, primer fires once for "Hey Sage"

## Test plan

- [x] `uv run pytest tests/test_launch_planner.py tests/test_cockpit_rail*.py tests/test_core_agent_profiles.py tests/test_project_planning_plugin.py -q` (151 pass)
- [x] `uv run pytest tests/test_cockpit.py -q` (200 pass, 3 pre-existing flakes deselected — unrelated event-ticker / activity-card tests fail on main too)
- [x] `uv run ruff check` on touched files — clean (3 pre-existing F401s in `test_project_planning_plugin.py` are upstream)
- [ ] Post-restart smoke (Sam): `pm reset --force && pm up`, wait ~25s. Read `~/.pollypm/agent_homes/claude_2/.pollypm/system-prompts/architect_samblog.md` — confirm "Sage" not "Archie". First `c` on SamBlog: primer fires once. Switch away, back, press `c` again: no primer, attach silently.

0 issues/* files added.

Closes #1867. Refs #1870, #1737.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>