### PR TITLE
fix(profiles): thread project.persona_name through architect prompt materialization (follow-up to #1872)

### DIFF
--- a/src/pollypm/plugins_builtin/project_planning/plugin.py
+++ b/src/pollypm/plugins_builtin/project_planning/plugin.py
@@ -79,25 +79,45 @@ class MarkdownPromptProfile:
                     "architect",
                     fallback_text=prompt,
                 )
-        # Substitute the ``{persona_name}`` placeholder so the architect's
-        # baked-in identity matches the project's configured persona.
-        # Pre-fix the profile was a static "You are Archie, the architect"
-        # — when the project's chat-open primer greeted the agent as
-        # "Sage" (samblog's configured persona_name), the agent's system
-        # prompt and the user-facing greeting contradicted each other.
-        # The fallback keeps the historical role default ("Archie") for
-        # projects that never picked a persona, mirroring the precedence
-        # used by ``_resolve_project_chat_persona`` for the rail label
-        # and the per-project primer (#1866 follow-up).
+        # Resolve the architect persona from the project config, then
+        # substitute it into the prompt body. This is the precedence used
+        # by ``_resolve_project_chat_persona`` for the rail label and the
+        # per-project primer (#1866 follow-up): the project's explicit
+        # ``persona_name`` wins; everything else falls back to the
+        # historical role default "Archie".
+        #
+        # We handle two cases so the materialised system prompt always
+        # matches the project's configured persona:
+        #
+        # 1. The built-in profile / freshly-forked guides use the explicit
+        #    ``{persona_name}`` placeholder (#1872). Substitute it.
+        # 2. Legacy project-local forks (``<project>/.pollypm/project-guides
+        #    /architect.md``) were forked BEFORE #1872 and have "Archie"
+        #    baked in literally — no placeholder. ``resolve_project_guide_text``
+        #    returns that forked body, so step 1 finds nothing to replace
+        #    and the agent's system prompt contradicts the chat-open primer
+        #    ("Hi Sage" vs. "You are Archie"). Detected on Sam's live
+        #    samblog config where ``persona_name = "Sage"`` but the
+        #    materialised system prompt still read "You are Archie, the
+        #    architect" (follow-up to #1872). To rescue legacy forks, also
+        #    replace the literal kickoff identity ``"You are Archie, the
+        #    architect"`` when a non-default persona is configured. The
+        #    string is precise enough to avoid collateral damage in other
+        #    text that happens to mention "Archie".
+        persona = "Archie"
+        if context is not None:
+            project = context.config.projects.get(context.session.project)
+            if project is not None:
+                persona_raw = getattr(project, "persona_name", None)
+                if isinstance(persona_raw, str) and persona_raw.strip():
+                    persona = persona_raw.strip()
         if "{persona_name}" in prompt:
-            persona = "Archie"
-            if context is not None:
-                project = context.config.projects.get(context.session.project)
-                if project is not None:
-                    persona_raw = getattr(project, "persona_name", None)
-                    if isinstance(persona_raw, str) and persona_raw.strip():
-                        persona = persona_raw.strip()
             prompt = prompt.replace("{persona_name}", persona)
+        if persona != "Archie":
+            prompt = prompt.replace(
+                "You are Archie, the architect",
+                f"You are {persona}, the architect",
+            )
         return prompt or None
 
 

--- a/tests/test_project_planning_plugin.py
+++ b/tests/test_project_planning_plugin.py
@@ -721,6 +721,43 @@ def test_architect_profile_no_context_falls_back_to_archie(
     assert "You are Archie, the architect" in prompt
 
 
+def test_architect_profile_rescues_legacy_forked_project_guide(
+    tmp_path: Path,
+) -> None:
+    """Regression: legacy project-local forks of ``architect.md`` were
+    forked BEFORE #1872 added the ``{persona_name}`` placeholder, so the
+    forked body has ``"You are Archie, the architect"`` baked in
+    literally. ``MarkdownPromptProfile.build_prompt`` reads the forked
+    file via ``resolve_project_guide_text`` and the original #1872 logic
+    found no ``{persona_name}`` token to substitute — the materialised
+    system prompt contradicted the cockpit chat-open primer ("Hi Sage"
+    vs. "You are Archie") on Sam's live samblog config.
+    The fix also substitutes the legacy literal kickoff identity when a
+    non-default persona is configured, so forked guides stay correct
+    without the user re-running ``pm project guide reset``.
+    """
+    from pollypm.plugin_host import ExtensionHost
+
+    host = ExtensionHost(tmp_path)
+    profile = host.get_agent_profile("architect")
+    context = _make_architect_context(tmp_path, persona_name="Sage")
+    # Fork a legacy-style project guide (no ``{persona_name}`` placeholder).
+    project_path = context.config.projects["demo"].path
+    guides_dir = project_path / ".pollypm" / "project-guides"
+    guides_dir.mkdir(parents=True, exist_ok=True)
+    legacy_body = (
+        "<identity>\nYou are the PollyPM Architect.\n</identity>\n\n"
+        "<kickoff>\nYou are Archie, the architect. On session start:\n"
+        "Do the architect things.\n</kickoff>\n"
+    )
+    (guides_dir / "architect.md").write_text(legacy_body, encoding="utf-8")
+
+    prompt = profile.build_prompt(context)
+    assert prompt is not None
+    assert "You are Sage, the architect" in prompt
+    assert "You are Archie, the architect" not in prompt
+
+
 # ---------------------------------------------------------------------------
 # pp05 — tree-of-plans: 2-3 candidates, critics evaluate all, synthesis picks winner
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR #1872 added a `{persona_name}` placeholder in `architect.md` and substitution in `MarkdownPromptProfile.build_prompt`. On Sam's live samblog config the materialized system prompt at `~/.pollypm/agent_homes/claude_2/.pollypm/system-prompts/architect_samblog.md` still read `You are Archie, the architect` despite `persona_name = "Sage"`.

## Trace

1. Planner (`default_launch_planner/planner.py:309`) calls `_write_claude_system_prompt_to_disk(account, effective, launch.initial_input)`.
2. `launch.initial_input` was built from the role profile prompt resolved via `Supervisor._resolve_profile_prompt` (`supervisor.py:813`) which passes a proper `AgentProfileContext(config, session, account)`.
3. `MarkdownPromptProfile.build_prompt` (`project_planning/plugin.py:66`) reads `architect.md`, then for architects calls `resolve_project_guide_text(project.path, "architect", fallback_text=prompt)`.
4. Samblog has a project-local guide fork at `/Users/sam/dev/samblog/.pollypm/project-guides/architect.md`. The fork was forked BEFORE #1872, so its body has `"You are Archie, the architect"` baked in literally with NO `{persona_name}` token.
5. `resolve_project_guide_text` returns the forked body. The #1872 `if "{persona_name}" in prompt: ... replace(...)` finds nothing and is a no-op.
6. Materialized file says "Archie". `grep -c "{persona_name}"` on the live file confirms 0 placeholders.

The planner passes context correctly — the bug is in build_prompt's substitution branch, which only fires when the placeholder exists. Legacy forks have no placeholder.

## Fix (one logical change)

`src/pollypm/plugins_builtin/project_planning/plugin.py:build_prompt`:
- Resolve `persona` once from `context.config.projects.get(session.project).persona_name` (fallback `"Archie"`).
- Substitute `{persona_name}` if present (existing #1872 behavior, covers built-in + freshly forked guides).
- ALSO replace the legacy literal `"You are Archie, the architect"` when a non-default persona is configured — rescues pre-#1872 project-local guide forks without requiring users to re-run `pm project guide reset`.

## Verification

```
$ uv run python3 -c "...build_prompt for architect_samblog..."
'You are Sage, the architect. On session start:'   # samblog (persona=Sage) — was "Archie" pre-fix
'You are Archie, the architect. On session start:' # itsalive (no persona)  — unchanged
'You are Archie, the architect. On session start:' # pollypm  (no persona)  — unchanged
```

## Test plan

- [x] New regression: `test_architect_profile_rescues_legacy_forked_project_guide` — fork a legacy-style guide (no placeholder, literal "Archie") + persona_name="Sage", assert resolved prompt contains "You are Sage".
- [x] `tests/test_project_planning_plugin.py` — 115 passing.
- [x] `tests/test_persona_swap_detection.py tests/test_persona_drift.py tests/test_role_contract.py tests/test_architect_stage_transitions.py` — 225 passing combined.

0 issues/* confirmation: no entries in `issues/00-not-ready/` were touched; `issues/05-completed/` not touched.