### PR TITLE
fix(advisor): persona-prompt delivery + cadence registration + duplicate-spawn guard (closes #1809, refs #1737)

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -215,6 +215,17 @@ EVENT_COCKPIT_PARK_SKIPPED_EXISTING = "cockpit.park_skipped_existing"
 # the audit log instead of re-running the heuristic.
 EVENT_INBOX_KIND_BACKFILLED = "inbox.kind_backfilled"
 
+# #1809 — advisor cadence forensics. ``advisor.tick`` was previously
+# silent in the audit log even when it ran: no operator could tell
+# from grep whether the cadence handler was firing, skipping
+# projects, or never invoked at all. ``advisor.tick.fired`` is
+# emitted once per tick to the workspace audit log with the tracked
+# projects + per-project outcomes in metadata so an operator can
+# trail-grep ``~/.pollypm/audit/_workspace.jsonl`` for cadence
+# evidence.
+EVENT_ADVISOR_TICK_FIRED = "advisor.tick.fired"
+EVENT_ADVISOR_TICK_SKIPPED = "advisor.tick.skipped"
+
 
 @dataclass(slots=True, frozen=True)
 class AuditEvent:

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -2287,6 +2287,16 @@ class CockpitRouter:
         standing-by prompt, prior history gone." Only ``pane_dead=True``
         candidates are killed now; if multiple live duplicates exist,
         emit a ``warn`` audit event and bail without killing anyone.
+
+        #1809 — extends the reaping behaviour to advisor-* duplicates.
+        Advisors are internal background machinery (no user-facing
+        conversation), so when two same-named ``advisor-<project>``
+        windows are live, kill the higher-index duplicate. This is safe
+        because: (1) the advisor profile is loaded from disk on every
+        launch — no per-session conversational state to preserve, and
+        (2) the next ``advisor.tick`` will re-spawn the survivor if
+        somehow both got killed. The conservative pane-dead-only branch
+        is preserved for every other role.
         """
         try:
             windows = self.tmux.list_windows(storage_session)
@@ -2301,6 +2311,34 @@ class CockpitRouter:
             dead = [w for w in dupes if getattr(w, "pane_dead", False)]
             live = [w for w in dupes if not getattr(w, "pane_dead", False)]
             if len(live) > 1:
+                # #1809 — advisor windows are reapable when duplicated
+                # because they carry no conversational state. Keep the
+                # lowest-index live window and kill the rest.
+                if name.startswith("advisor-"):
+                    sorted_live = sorted(live, key=lambda w: w.index)
+                    keep = sorted_live[0]
+                    reap = sorted_live[1:]
+                    killed_indices: list[int] = []
+                    for window in reap:
+                        try:
+                            self.tmux.kill_window(f"{storage_session}:{window.index}")
+                        except Exception:  # noqa: BLE001
+                            continue
+                        killed_indices.append(window.index)
+                    self._emit_cockpit_audit(
+                        event_name="cockpit.duplicate_window_killed",
+                        subject=name,
+                        status="ok",
+                        metadata={
+                            "storage_session": storage_session,
+                            "window_name": name,
+                            "killed_indices": killed_indices,
+                            "kept_index": keep.index,
+                            "rule": "advisor_duplicate_reaped",
+                            "action": "killed_advisor_duplicate",
+                        },
+                    )
+                    continue
                 self._emit_cockpit_audit(
                     event_name="cockpit.duplicate_window_killed",
                     subject=name,

--- a/src/pollypm/plugins_builtin/advisor/handlers/advisor_tick.py
+++ b/src/pollypm/plugins_builtin/advisor/handlers/advisor_tick.py
@@ -550,6 +550,11 @@ def advisor_tick_handler(payload: dict[str, Any]) -> dict[str, Any]:
         else resolve_config_path(DEFAULT_CONFIG_PATH)
     )
     if not config_path.exists():
+        _emit_tick_audit(
+            event="advisor.tick.skipped",
+            reason="no-config",
+            metadata={"config_path": str(config_path)},
+        )
         return {
             "fired": False,
             "reason": "no-config",
@@ -560,11 +565,21 @@ def advisor_tick_handler(payload: dict[str, Any]) -> dict[str, Any]:
         config = load_config(config_path)
     except Exception as exc:  # noqa: BLE001
         logger.warning("advisor: failed to load config %s: %s", config_path, exc)
+        _emit_tick_audit(
+            event="advisor.tick.skipped",
+            reason="config-error",
+            metadata={"error": str(exc)},
+        )
         return {"fired": False, "reason": "config-error", "error": str(exc)}
 
     settings = load_advisor_settings(config_path)
 
     if not settings.enabled:
+        _emit_tick_audit(
+            event="advisor.tick.skipped",
+            reason="plugin-disabled",
+            metadata={},
+        )
         return {"fired": False, "reason": "plugin-disabled"}
 
     override_now = payload.get("now_utc") if isinstance(payload, dict) else None
@@ -684,6 +699,24 @@ def advisor_tick_handler(payload: dict[str, Any]) -> dict[str, Any]:
     # Persist the state (last_tick_at, plus anything mutated per project).
     save_state(base_dir, state)
 
+    # #1809 — emit a forensic event so operators can grep the workspace
+    # audit log for cadence evidence (``advisor.tick.fired``). Without
+    # this an operator cannot tell from grep whether the half-hourly
+    # tick is running at all — the only signals were the per-task
+    # ``Advisor review for <project>`` rows enqueued downstream, and
+    # if ``_should_review`` skips every project the tick was completely
+    # silent.
+    _emit_tick_audit(
+        event="advisor.tick.fired",
+        reason="ok",
+        metadata={
+            "now_utc": now_utc.isoformat(),
+            "tracked": [p for p, _ in projects],
+            "enqueued": enqueued_projects,
+            "skipped_reasons": _summarise_skip_reasons(results),
+        },
+    )
+
     return {
         "fired": True,
         "reason": "ok",
@@ -692,6 +725,50 @@ def advisor_tick_handler(payload: dict[str, Any]) -> dict[str, Any]:
         "enqueued": enqueued_projects,
         "results": results,
     }
+
+
+def _emit_tick_audit(
+    *,
+    event: str,
+    reason: str,
+    metadata: dict[str, Any],
+) -> None:
+    """Best-effort audit emit for the half-hourly tick.
+
+    Audit-log writes are best-effort: an emit failure (e.g. workspace
+    not configured, audit dir missing, disk full) must NEVER block the
+    tick — losing forensics is strictly better than losing cadence.
+    """
+    try:
+        from pollypm.audit import emit as _audit_emit
+
+        merged = dict(metadata)
+        merged.setdefault("reason", reason)
+        _audit_emit(
+            event=event,
+            project="_workspace",
+            subject="advisor.tick",
+            actor="advisor.tick",
+            status="ok" if event.endswith(".fired") else "warn",
+            metadata=merged,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("advisor: tick-audit emit failed", exc_info=True)
+
+
+def _summarise_skip_reasons(results: list[dict[str, Any]]) -> dict[str, int]:
+    """Roll per-project ``reason`` strings up into a small counter dict.
+
+    Keeps the audit metadata compact for grep without dropping the
+    "why didn't this fire?" diagnostic.
+    """
+    counts: dict[str, int] = {}
+    for entry in results:
+        reason = entry.get("reason") if isinstance(entry, dict) else None
+        if not isinstance(reason, str) or not reason:
+            continue
+        counts[reason] = counts.get(reason, 0) + 1
+    return counts
 
 
 # ---------------------------------------------------------------------------

--- a/src/pollypm/plugins_builtin/default_launch_planner/planner.py
+++ b/src/pollypm/plugins_builtin/default_launch_planner/planner.py
@@ -258,7 +258,14 @@ class DefaultLaunchPlanner:
                         account, resume_token.session_id, extra_args,
                     )
                     launch = replace(launch, argv=new_argv)
-            if effective.provider is ProviderKind.CODEX and effective.role in _CONTROL_ROLES and launch.initial_input:
+            if (
+                effective.provider is ProviderKind.CODEX
+                and launch.initial_input
+                and (
+                    effective.role in _CONTROL_ROLES
+                    or effective.role == "advisor"
+                )
+            ):
                 # #1011 — pre-write ``AGENTS.md`` directly into the
                 # account's codex_home instead of stuffing the prompt
                 # into ``PM_CODEX_HOME_AGENTS_MD`` for the runtime
@@ -273,6 +280,15 @@ class DefaultLaunchPlanner:
                 # spawn-attempt history. Writing the file from the
                 # planner side keeps the launch payload small and lets
                 # the runtime launcher just exec codex.
+                #
+                # #1809 — advisor is included so the advisor profile
+                # lands in ``codex_home/AGENTS.md`` before launch. The
+                # advisor role is project-scoped (not in _CONTROL_ROLES)
+                # but its 30-minute cadence means a missed first-prompt
+                # delivery wedges the role for the whole half-hour
+                # window; we cannot rely on the send-keys kickoff race.
+                # The advisor profile is read-mostly and small enough
+                # that overwriting AGENTS.md per-launch is cheap.
                 _write_codex_agents_md_to_disk(account, launch.initial_input)
                 launch = replace(launch, initial_input=None)
             if (

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -339,7 +339,14 @@ class Supervisor:
     # supervisor" tripped Claude's prompt-injection defense (the agent
     # refused the bootstrap as an injection attempt — see #1005, #1007).
     # Direction 2 from #1007: stop trying to bootstrap the pane at all.
-    _INITIAL_INPUT_ROLES = (_CONTROL_ROLES | {"worker", "architect"}) - {
+    # #1809 — ``advisor`` is included so its profile prompt is delivered
+    # on launch via the post-stabilisation send-keys kickoff. Without
+    # this entry the advisor pane booted into the Codex placeholder
+    # because no AGENTS.md was materialised (the planner only writes
+    # ``AGENTS.md`` for ``_CONTROL_ROLES``) AND no kickoff fired (this
+    # set previously excluded ``advisor``). Both delivery paths were
+    # off, so 9-of-9 advisor windows sat idle.
+    _INITIAL_INPUT_ROLES = (_CONTROL_ROLES | {"worker", "architect", "advisor"}) - {
         "heartbeat-supervisor",
     }
     #: Name of the PollyPM console/cockpit window inside a tmux session.
@@ -808,6 +815,14 @@ class Supervisor:
             return "russell"
         if session.role == "architect":
             return "architect"
+        # #1809 — advisor sessions were missing from this mapping, so the
+        # planner's ``_resolve_profile_prompt`` returned None and the
+        # advisor profile was never delivered to the Codex pane. The
+        # session booted into a generic Codex placeholder ("> Run /review
+        # on my current changes…") because no AGENTS.md was materialised
+        # and no kickoff fired.
+        if session.role == "advisor":
+            return "advisor"
         return None
 
     def _resolve_profile_prompt(self, session: SessionConfig, account: AccountConfig) -> str | None:
@@ -3861,6 +3876,22 @@ class Supervisor:
             window_target = f"{tmux_session}:0"
             self.session_service.tmux.set_window_option(window_target, "allow-passthrough", "on")
         else:
+            # #1809 — duplicate-spawn race guard. The in-memory
+            # ``window_map`` snapshot above can go stale before we
+            # reach ``create_window`` if a parallel caller (e.g. the
+            # audit watchdog's role-lane spawn vs. an interactive
+            # ``pm chat`` press) wins the race and creates the
+            # canonical window in between. Re-call ``_window_map`` so
+            # this thread sees the freshest state through the same
+            # owned-sessions filter the snapshot used (avoids
+            # collisions with the host operator's personal tmux
+            # windows). Without this check, both racers passed the
+            # snapshot gate and both called ``create_window`` —
+            # producing the two ``advisor-media`` windows in #1809's
+            # reproduction.
+            fresh_window_map = self._window_map()
+            if (tmux_session, launch.window_name) in fresh_window_map:
+                return launch, None
             new_pane_id = self.session_service.tmux.create_window(tmux_session, launch.window_name, launch.command, detached=True)
             window_target = f"{tmux_session}:{launch.window_name}"
             self.session_service.tmux.set_window_option(window_target, "allow-passthrough", "on")

--- a/tests/test_advisor_cli_ad06.py
+++ b/tests/test_advisor_cli_ad06.py
@@ -410,6 +410,91 @@ class TestStatus:
 
 
 # ---------------------------------------------------------------------------
+# Cadence audit emission — #1809
+# ---------------------------------------------------------------------------
+
+
+class TestTickAuditEmission:
+    """#1809 — the half-hourly tick is silent in the audit log.
+
+    Pre-fix, the only way to tell whether ``advisor.tick`` was firing
+    was to grep for ``Advisor review for <project>`` rows in the work
+    table. If ``_should_review`` skipped every project, the tick left
+    no breadcrumb at all. These tests pin the contract: every tick
+    invocation emits one ``advisor.tick.fired`` (or ``.skipped``) row
+    to the workspace audit log so an operator can reconstruct cadence
+    from grep.
+    """
+
+    def test_tick_emits_fired_audit_event_on_success(
+        self, env, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        emitted: list[dict] = []
+
+        def fake_emit(**kwargs):
+            emitted.append(kwargs)
+
+        monkeypatch.setattr("pollypm.audit.emit", fake_emit)
+        monkeypatch.setattr(tick_module, "detect_changes", lambda *a, **kw: False)
+
+        result = advisor_tick_handler({"config_path": str(env["config_path"])})
+        assert result["fired"] is True
+
+        # Exactly one fired event with the workspace-scoped project key.
+        fired = [e for e in emitted if e.get("event") == "advisor.tick.fired"]
+        assert len(fired) == 1, emitted
+        event = fired[0]
+        assert event["project"] == "_workspace"
+        assert event["actor"] == "advisor.tick"
+        assert event["status"] == "ok"
+        # Metadata carries the operator's "did this cycle do anything?"
+        # question — a list of tracked projects + an enqueued count.
+        meta = event["metadata"]
+        assert meta["tracked"] == ["proj"]
+        assert meta["enqueued"] == []
+        # ``skipped_reasons`` rolls per-project reasons into a counter so
+        # the grep target shows "no-changes: 1" rather than swallowing
+        # the diagnostic.
+        assert isinstance(meta["skipped_reasons"], dict)
+        assert meta["skipped_reasons"].get("no-changes") == 1
+
+    def test_tick_emits_skipped_audit_event_when_plugin_disabled(
+        self, env, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        env["config_path"].write_text("[advisor]\nenabled = false\n")
+        emitted: list[dict] = []
+
+        def fake_emit(**kwargs):
+            emitted.append(kwargs)
+
+        monkeypatch.setattr("pollypm.audit.emit", fake_emit)
+
+        result = advisor_tick_handler({"config_path": str(env["config_path"])})
+        assert result["fired"] is False
+        assert result["reason"] == "plugin-disabled"
+        # One skipped event lands with the disabled reason.
+        skipped = [e for e in emitted if e.get("event") == "advisor.tick.skipped"]
+        assert len(skipped) == 1, emitted
+        assert skipped[0]["metadata"]["reason"] == "plugin-disabled"
+
+    def test_tick_audit_emit_failure_does_not_block_cadence(
+        self, env, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Audit-emit failure must NEVER block the tick — losing
+        forensics is strictly better than losing cadence."""
+
+        def boom(**kwargs):
+            raise RuntimeError("audit dir wedged")
+
+        monkeypatch.setattr("pollypm.audit.emit", boom)
+        monkeypatch.setattr(tick_module, "detect_changes", lambda *a, **kw: False)
+
+        # Must not raise.
+        result = advisor_tick_handler({"config_path": str(env["config_path"])})
+        assert result["fired"] is True
+
+
+# ---------------------------------------------------------------------------
 # [advisor] config — parse + load.
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cockpit_rail_duplicate_window_cleanup.py
+++ b/tests/test_cockpit_rail_duplicate_window_cleanup.py
@@ -111,6 +111,56 @@ def test_cleanup_kills_multiple_dead_duplicates_when_one_live_survivor() -> None
     assert surviving == {2}
 
 
+def test_cleanup_reaps_live_advisor_duplicate() -> None:
+    """#1809 — advisor windows are reapable when duplicated.
+
+    The conservative pane-dead-only behaviour preserves operator /
+    architect / worker conversations, but advisor sessions carry no
+    user-facing conversational state — the persona is loaded from
+    ``profiles/advisor.md`` on every launch. When two ``advisor-media``
+    windows landed in the storage closet (the #1809 reproduction), the
+    plain ``skipped_live_duplicates`` warn left the duplicate idle
+    forever; the next advisor.tick couldn't reach it because both panes
+    sat at the Codex placeholder. The advisor-specific reaper kills the
+    higher-index duplicate so the cadence has a single, primable window
+    to address.
+    """
+    tmux = _FakeTmux([
+        _window(index=31, name="advisor-media", pane_dead=False),
+        _window(index=32, name="advisor-media", pane_dead=False),
+        _window(index=33, name="worker-media", pane_dead=False),
+    ])
+    router = _bare_router(tmux)
+
+    router._cleanup_duplicate_windows("pm-storage-closet")
+
+    # The higher-index duplicate was killed; the canonical low-index
+    # advisor window survived. Worker windows are untouched.
+    assert tmux.killed == ["pm-storage-closet:32"]
+    surviving = {w.index: w.name for w in tmux._windows}
+    assert surviving == {31: "advisor-media", 33: "worker-media"}
+
+
+def test_cleanup_preserves_live_pm_operator_duplicates() -> None:
+    """Worker/operator/architect duplicates must still bail conservatively.
+
+    The #1809 advisor-specific reaper is gated on the ``advisor-``
+    window-name prefix. This guard ensures we didn't accidentally
+    broaden it to a generic kill-the-higher-index policy that would
+    take out the operator's conversation pane (#1562).
+    """
+    tmux = _FakeTmux([
+        _window(index=0, name="pm-operator", pane_dead=False),
+        _window(index=1, name="pm-operator", pane_dead=False),
+    ])
+    router = _bare_router(tmux)
+
+    router._cleanup_duplicate_windows("pm-storage-closet")
+
+    assert tmux.killed == []
+    assert {w.index for w in tmux._windows} == {0, 1}
+
+
 def test_cleanup_no_op_when_no_duplicates() -> None:
     tmux = _FakeTmux([
         _window(index=0, name="pm-operator", pane_dead=False),

--- a/tests/test_launch_planner.py
+++ b/tests/test_launch_planner.py
@@ -334,6 +334,60 @@ def test_planner_skips_claude_system_prompt_file_when_initial_input_empty(
         assert not prompt_file.exists()
 
 
+def test_planner_writes_codex_agents_md_for_advisor(tmp_path: Path) -> None:
+    """#1809 — Codex advisor launches materialise the advisor profile as
+    ``AGENTS.md`` in the account's codex_home, mirroring the
+    control-role behaviour. Pre-fix advisor sessions on Codex booted
+    into the generic ``> Run /review on my current changes…`` placeholder
+    because no AGENTS.md was written (the gate only included
+    ``_CONTROL_ROLES``) AND the post-stabilisation send-keys kickoff
+    never fired (advisor was missing from ``_INITIAL_INPUT_ROLES`` too).
+    """
+    config = _config(tmp_path)
+    config.accounts["codex_backup"] = AccountConfig(
+        name="codex_backup",
+        provider=ProviderKind.CODEX,
+        email="codex@example.com",
+        home=tmp_path / ".pollypm/homes/codex_backup",
+    )
+    config.sessions["advisor_pollypm"] = SessionConfig(
+        name="advisor_pollypm",
+        role="advisor",
+        provider=ProviderKind.CODEX,
+        account="codex_backup",
+        cwd=tmp_path,
+        project="pollypm",
+        window_name="advisor-pollypm",
+    )
+    sup = Supervisor(config)
+    sup.ensure_layout()
+
+    launch = next(
+        item for item in sup.plan_launches()
+        if item.session.name == "advisor_pollypm"
+    )
+
+    # The Codex AGENTS.md write path consumes ``initial_input`` and
+    # nulls it on the launch spec so the runtime launcher just execs
+    # codex. Confirm the file landed in the account's codex_home with
+    # the advisor profile in it.
+    from pollypm.runtime_env import codex_home_dir
+
+    account_home = config.accounts["codex_backup"].home
+    agents_md = codex_home_dir(account_home) / "AGENTS.md"
+    assert agents_md.exists(), f"expected AGENTS.md at {agents_md}"
+    body = agents_md.read_text(encoding="utf-8")
+    # Stable marker — the advisor profile carries a recognisable header
+    # block. Compare a substring rather than the full body so the test
+    # survives routine copy edits.
+    assert (
+        "advisor" in body.lower()
+    ), f"AGENTS.md did not contain the advisor profile body:\n{body[:500]}"
+    # ``initial_input`` is nulled because the prompt is now baked into
+    # the runtime via AGENTS.md, not delivered via send-keys.
+    assert launch.initial_input is None
+
+
 def test_planner_routes_operator_to_codex_when_compatible_account_exists(tmp_path: Path) -> None:
     config = _config(tmp_path)
     config.pollypm.role_assignments["operator_pm"] = ModelAssignment(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -2435,6 +2435,40 @@ def test_initial_input_roles_excludes_heartbeat_supervisor() -> None:
     assert "reviewer" in Supervisor._INITIAL_INPUT_ROLES
     assert "worker" in Supervisor._INITIAL_INPUT_ROLES
     assert "architect" in Supervisor._INITIAL_INPUT_ROLES
+    # #1809 — advisor was previously missing here, so the
+    # post-stabilisation send-keys kickoff never fired for advisor panes.
+    # Combined with the planner's Codex AGENTS.md gate (also previously
+    # excluding advisor), both delivery paths were off and 9-of-9
+    # advisor windows sat idle at the Codex placeholder.
+    assert "advisor" in Supervisor._INITIAL_INPUT_ROLES
+
+
+def test_advisor_default_agent_profile_resolves_to_advisor(tmp_path: Path) -> None:
+    """#1809 — ``_default_agent_profile`` must return ``"advisor"`` for
+    advisor sessions so the planner's ``_resolve_profile_prompt`` lands
+    a non-None body for the advisor profile. Pre-fix advisor was
+    missing from the mapping, so the planner saw an empty
+    ``effective.prompt``, the Codex AGENTS.md write path had nothing
+    to write, and the pane booted into the bare Codex placeholder.
+    """
+    from pollypm.models import (
+        AccountConfig,
+        ProviderKind,
+        SessionConfig,
+    )
+
+    config = _config(tmp_path)
+    sup = Supervisor(config)
+    advisor_session = SessionConfig(
+        name="advisor_pollypm",
+        role="advisor",
+        provider=ProviderKind.CODEX,
+        account="claude_controller",
+        cwd=tmp_path,
+        project="pollypm",
+        window_name="advisor-pollypm",
+    )
+    assert sup._default_agent_profile(advisor_session) == "advisor"
 
 
 def test_restart_session_skips_recovery_prompt_for_heartbeat(


### PR DESCRIPTION
## Summary

Three coordinated fixes for the #1809 reproduction: 9-of-9 ``advisor-*`` tmux windows sat at the Codex placeholder, ``advisor-media`` was duplicated, and the workspace audit log contained ZERO ``advisor.*`` events.

## Root causes

**1. Persona prompt never reached the pane.** Three delivery paths for the advisor profile were all off:

- ``Supervisor._default_agent_profile`` was missing the ``advisor`` → ``"advisor"`` mapping, so the planner's ``_resolve_profile_prompt`` returned ``None`` and the profile body never landed in ``effective.prompt``.
- ``Supervisor._INITIAL_INPUT_ROLES`` excluded ``advisor``, so the post-stabilisation ``send-keys`` kickoff never fired even if a prompt had been present.
- ``DefaultLaunchPlanner``'s Codex ``AGENTS.md`` materialiser was gated on ``effective.role in _CONTROL_ROLES`` — which excludes ``advisor``.

Net result: the pane booted into the generic ``> Run /review on my current changes…`` Codex placeholder and stayed there.

**2. Zero ``advisor.*`` audit events.** ``advisor_tick_handler`` ran every 30 min on cadence, walked its tracked projects, but never called ``audit.emit``. ``grep '"event":"advisor' ~/.pollypm/audit/*.jsonl`` returned nothing because nothing was ever emitted.

**3. Duplicate ``advisor-media`` window.** ``create_session_window`` used a single ``_window_map()`` snapshot taken at function entry, then dispatched to ``create_window`` later. Two racing callers (audit watchdog role-lane spawn vs. an interactive ``pm chat`` press) both passed the snapshot gate, both created the window, and the existing ``_cleanup_duplicate_windows`` then conservatively refused to kill either (correct for operator/architect/worker — preserves #1562 — but wrong for advisor which carries no conversational state).

## Fixes

- **``supervisor.py``** — add ``advisor`` to ``_default_agent_profile`` + ``_INITIAL_INPUT_ROLES``; re-call ``_window_map`` immediately before ``create_window`` so a racing spawn after the snapshot short-circuits.
- **``plugins_builtin/default_launch_planner/planner.py``** — extend Codex ``AGENTS.md`` gate to include ``advisor``, mirroring the reviewer/operator path. Prompt lands at ``codex_home/AGENTS.md`` before launch; ``initial_input`` is nulled so the runtime launcher just execs codex.
- **``plugins_builtin/advisor/handlers/advisor_tick.py``** — emit ``advisor.tick.fired`` to ``_workspace.jsonl`` on every successful tick, ``advisor.tick.skipped`` on no-config / config-error / plugin-disabled. Metadata carries ``{tracked, enqueued, skipped_reasons}`` so grep returns a per-project reason counter. Emit failures are best-effort — losing forensics never blocks cadence.
- **``cockpit_rail.py``** — relax ``_cleanup_duplicate_windows`` for the ``advisor-`` prefix only: when two advisor windows are both live, kill the higher-index duplicate. Operator/architect/worker dups still bail conservatively (#1562's anti-wipe guard).
- **``audit/log.py``** — new ``EVENT_ADVISOR_TICK_FIRED`` / ``EVENT_ADVISOR_TICK_SKIPPED`` constants.

## Test plan

- [x] ``pytest tests/test_launch_planner.py`` — new ``test_planner_writes_codex_agents_md_for_advisor`` pins the AGENTS.md write path.
- [x] ``pytest tests/test_supervisor.py::test_advisor_default_agent_profile_resolves_to_advisor`` — pins the profile mapping.
- [x] ``pytest tests/test_supervisor.py::test_initial_input_roles_excludes_heartbeat_supervisor`` — extended to assert ``advisor`` IS in the set.
- [x] ``pytest tests/test_advisor_cli_ad06.py::TestTickAuditEmission`` — three tests pin (a) ``advisor.tick.fired`` lands with the right shape on success, (b) ``.skipped`` fires when plugin disabled, (c) emit-failure does not block cadence.
- [x] ``pytest tests/test_cockpit_rail_duplicate_window_cleanup.py`` — new ``test_cleanup_reaps_live_advisor_duplicate`` and ``test_cleanup_preserves_live_pm_operator_duplicates`` pin the advisor-only relaxation.
- [ ] Live verification: ``pm reset --force && pm up``; wait one cadence interval; ``grep advisor.tick ~/.pollypm/audit/_workspace.jsonl`` returns at least one ``fired`` row; ``tmux capture-pane`` on any ``advisor-*`` window shows the advisor profile loaded (not the Codex placeholder); ``tmux list-windows -t pollypm-storage-closet | grep advisor-media`` returns exactly one line.

Closes #1809 · refs #1737

🤖 Generated with [Claude Code](https://claude.com/claude-code)