### PR TITLE
feat(worker): per-task parallel worker sessions with project cap (architectural alignment, refs #1737)

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -62,7 +62,7 @@ import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 
 from pollypm.audit.log import (
     EVENT_MARKER_CREATED,
@@ -1374,6 +1374,7 @@ def _detect_role_session_missing(
     open_tasks: Sequence[Any] | None = None,
     storage_window_names: Sequence[str] | None = None,
     project: str = "",
+    worker_cap_back_pressure: Mapping[str, bool] | None = None,
 ) -> list[Finding]:
     """Rule 6: in-flight task whose assigned role has no tmux session.
 
@@ -1384,11 +1385,19 @@ def _detect_role_session_missing(
 
     The window-name list is passed in (not queried here) so the pure
     detector can be unit-tested without spinning up tmux.
+
+    #1737 — ``worker_cap_back_pressure`` maps ``project_key -> bool``;
+    when True, queued worker-role tasks for that project are treated
+    as normal back-pressure (the project is already at
+    ``max_parallel_workers``) and no finding is emitted. The cadence
+    handler computes the flag from live worker-session counts +
+    project cap before invoking ``scan_events``.
     """
     findings: list[Finding] = []
     if not open_tasks or storage_window_names is None:
         return findings
     window_set = {str(name).strip() for name in storage_window_names if name}
+    back_pressure = worker_cap_back_pressure or {}
 
     for task in open_tasks:
         status = getattr(task, "work_status", None)
@@ -1441,6 +1450,19 @@ def _detect_role_session_missing(
                 # so this is the right default when no roles are set.
                 role_used = "worker"
         if role_used is None:
+            continue
+        # #1737 — queued worker-role tasks for a project at the
+        # ``max_parallel_workers`` ceiling are not a missing-session
+        # condition; they are normal back-pressure. The auto-claim
+        # sweep + per-task spawn-on-claim already gate fresh workers
+        # against the cap, so suppress the tier-1 finding here to
+        # avoid a noisy false-positive loop. ``in_progress`` workers
+        # already have a session, so no special-case needed there.
+        if (
+            role_used == "worker"
+            and status_value == "queued"
+            and back_pressure.get(task_project)
+        ):
             continue
         expected_window = f"{role_used}-{task_project}"
         if expected_window in window_set:
@@ -2576,6 +2598,7 @@ def scan_events(
     plan_missing_clears: Sequence[Any] | None = None,
     state_db_probes: Sequence[Any] | None = None,
     run_safety_net_probes: bool = True,
+    worker_cap_back_pressure: Mapping[str, bool] | None = None,
 ) -> list[Finding]:
     """Run every detection rule against ``events`` and return findings.
 
@@ -2650,6 +2673,7 @@ def scan_events(
         open_tasks=open_tasks,
         storage_window_names=storage_window_names,
         project=project,
+        worker_cap_back_pressure=worker_cap_back_pressure,
     ))
     findings.extend(_detect_worker_session_dead_loop(
         materialised, now=now, config=config,
@@ -2737,6 +2761,7 @@ def scan_project(
     plan_missing_clears: Sequence[Any] | None = None,
     state_db_probes: Sequence[Any] | None = None,
     run_safety_net_probes: bool = True,
+    worker_cap_back_pressure: Mapping[str, bool] | None = None,
 ) -> list[Finding]:
     """Read audit events for ``project`` and scan them.
 
@@ -2785,6 +2810,7 @@ def scan_project(
         plan_missing_clears=plan_missing_clears,
         state_db_probes=state_db_probes,
         run_safety_net_probes=run_safety_net_probes,
+        worker_cap_back_pressure=worker_cap_back_pressure,
     )
 
 

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -739,6 +739,7 @@ def _parse_known_projects(raw: dict[str, object], *, base: Path) -> dict[str, Kn
             continue
         auto_claim_raw = item_raw.get("auto_claim")
         max_concurrent_raw = item_raw.get("max_concurrent_workers")
+        max_parallel_raw = item_raw.get("max_parallel_workers")
         projects[project_key] = KnownProject(
             key=project_key,
             path=_resolve_path(base, item_raw["path"]),
@@ -755,6 +756,11 @@ def _parse_known_projects(raw: dict[str, object], *, base: Path) -> dict[str, Kn
             max_concurrent_workers=(
                 int(max_concurrent_raw)
                 if isinstance(max_concurrent_raw, int) and max_concurrent_raw > 0
+                else None
+            ),
+            max_parallel_workers=(
+                int(max_parallel_raw)
+                if isinstance(max_parallel_raw, int) and max_parallel_raw > 0
                 else None
             ),
         )

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -1408,7 +1408,47 @@ class LocalHeartbeatBackend(HeartbeatBackend):
 
         The send is routed through the same rate-limit path used for
         ordinary nudges so we don't spam a worker that's slow to pick up.
+
+        #1737 — per-task worker sessions (window name
+        ``task-<project>-<N>``) are spawned for one specific task and
+        torn down on accept/cancel; they should not be polling the
+        queue for new work. When the silent_worker rule fires on a
+        per-task session it means the task lost its claim without the
+        worker tearing down — escalate instead of pushing ``pm task
+        next`` (which would steal another task into a dying window).
         """
+        session_name = context.session_name or ""
+        if session_name.startswith("task-"):
+            try:
+                from pollypm.events.summaries import activity_summary
+
+                api.supervisor.msg_store.append_event(
+                    scope=session_name,
+                    sender=session_name,
+                    subject="silent_worker_per_task_skipped",
+                    payload={
+                        "message": activity_summary(
+                            summary=(
+                                "Per-task worker is silent without an "
+                                "active claim; skipping `pm task next` "
+                                "(per-task workers should not poll the "
+                                "queue). The auto-claim recovery sweep "
+                                "will release the stale claim and a "
+                                "fresh `pm task claim` will spawn a new "
+                                "worker."
+                            ),
+                            severity="recommendation",
+                            verb="skipped",
+                            subject=session_name,
+                        ),
+                    },
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "silent_worker per-task skip event failed for %s",
+                    session_name, exc_info=True,
+                )
+            return
         try:
             self._send_worker_message(
                 api,

--- a/src/pollypm/models.py
+++ b/src/pollypm/models.py
@@ -78,6 +78,15 @@ class KnownProject:
     # #768 auto-claim overrides. ``None`` means "defer to planner defaults".
     auto_claim: bool | None = None
     max_concurrent_workers: int | None = None
+    # #1737 per-task parallel worker cap. When set, ``provision_worker``
+    # refuses to spawn a new per-task worker once the project already has
+    # this many active worker sessions. ``None`` defers to the default
+    # (``DEFAULT_MAX_PARALLEL_WORKERS``, currently 5). This is distinct
+    # from ``max_concurrent_workers`` (which the auto-claim sweep uses to
+    # rate-limit DB-level claims): the cap here is the hard ceiling on
+    # concurrently-spawned worker tmux windows per project, regardless of
+    # how the claim was initiated.
+    max_parallel_workers: int | None = None
     # Per-project override of ``[planner].enforce_plan``. ``None`` defers
     # to the global setting; ``False`` bypasses the plan-presence gate
     # for this project (single-task / cleanup / one-off work that doesn't

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -946,6 +946,70 @@ def _gather_storage_windows(storage_closet_name: str | None) -> list[str]:
         return []
 
 
+def _gather_worker_cap_back_pressure(
+    project_key: str,
+    project_path: Path | None,
+    config_path: Path | None,
+) -> dict[str, bool]:
+    """Compute the cap-back-pressure flag for ``project_key`` (#1737).
+
+    Returns ``{project_key: True}`` when the project's currently-active
+    per-task worker session count is at or above
+    ``max_parallel_workers``; an empty dict otherwise. Best effort: any
+    error returns an empty dict so a transient store failure doesn't
+    suppress legitimate ``role_session_missing`` findings.
+
+    The detector consumes this to suppress queued-worker
+    ``role_session_missing`` findings when the project is at cap —
+    those queued tasks are normal back-pressure, not a missing-session
+    fault.
+    """
+    if not project_key or project_path is None:
+        return {}
+    try:
+        from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+        from pollypm.work import create_work_service
+        from pollypm.work.session_manager import (
+            DEFAULT_MAX_PARALLEL_WORKERS,
+        )
+
+        cfg_path = config_path
+        if cfg_path is None and DEFAULT_CONFIG_PATH.exists():
+            cfg_path = DEFAULT_CONFIG_PATH
+        cfg = load_config(cfg_path) if cfg_path else None
+        cap = DEFAULT_MAX_PARALLEL_WORKERS
+        if cfg is not None:
+            proj = (getattr(cfg, "projects", {}) or {}).get(project_key)
+            if proj is not None:
+                override = getattr(proj, "max_parallel_workers", None)
+                if isinstance(override, int) and override > 0:
+                    cap = override
+                else:
+                    legacy = getattr(proj, "max_concurrent_workers", None)
+                    if isinstance(legacy, int) and legacy > 0:
+                        cap = legacy
+        svc = create_work_service(project_path=project_path)
+        try:
+            records = svc.list_worker_sessions(
+                project=project_key, active_only=True,
+            )
+            active = len(list(records))
+        finally:
+            try:
+                svc.close()
+            except Exception:  # noqa: BLE001
+                pass
+        if active >= cap:
+            return {project_key: True}
+        return {}
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.watchdog: worker_cap_back_pressure probe failed for %s",
+            project_key, exc_info=True,
+        )
+        return {}
+
+
 def _architect_window_target(
     storage_closet_name: str | None, project_key: str,
 ) -> str | None:
@@ -2849,6 +2913,12 @@ def _scan_one_project(
         p for p in (state_db_probes or [])
         if p.project_key == project_key
     ]
+    # #1737 — compute per-project worker-cap back-pressure so the
+    # ``role_session_missing`` detector can suppress queued-worker
+    # findings when the project is already at ``max_parallel_workers``.
+    worker_cap_back_pressure = _gather_worker_cap_back_pressure(
+        project_key, project_path, config_path,
+    )
     try:
         findings = scan_project(
             project_key,
@@ -2863,6 +2933,7 @@ def _scan_one_project(
             legacy_db_shadows=project_shadows or None,
             plan_missing_clears=project_clears or None,
             state_db_probes=project_state_probes or None,
+            worker_cap_back_pressure=worker_cap_back_pressure or None,
         )
     except Exception:  # noqa: BLE001
         logger.debug(

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -1478,7 +1478,7 @@ class PgWorkService:
     # Slice C alongside the audit / sync adapter ports.
     # ------------------------------------------------------------------
 
-    def claim(self, task_id: str, actor: str, skip_gates: bool = False) -> Task:  # noqa: ARG002
+    def claim(self, task_id: str, actor: str, skip_gates: bool = False) -> Task:
         """Atomically claim a queued task.
 
         Loads the flow template, resolves the start (or current) node,
@@ -1547,6 +1547,20 @@ class PgWorkService:
             if node.type == NodeType.REVIEW
             else WorkStatus.IN_PROGRESS
         )
+        # #1737 — pre-claim cap check. Mirrors the sqlite transition
+        # manager so a Postgres-backed workspace also refuses cap-exceeded
+        # claims cleanly instead of leaving the task ``in_progress`` with
+        # no worker. See ``SessionManager.check_parallel_cap``.
+        if (
+            target_status is WorkStatus.IN_PROGRESS
+            and not skip_gates
+            and self._session_mgr is not None
+        ):
+            check_cap = getattr(
+                self._session_mgr, "check_parallel_cap", None,
+            )
+            if callable(check_cap):
+                check_cap(task.project, task_id)
         now = _now_iso()
         with self._pool.connection() as conn:
             conn.autocommit = False

--- a/src/pollypm/work/service_transition_manager.py
+++ b/src/pollypm/work/service_transition_manager.py
@@ -548,6 +548,22 @@ class WorkTransitionManager:
             if claim_node.type == NodeType.REVIEW
             else WorkStatus.IN_PROGRESS
         )
+        # #1737 — enforce the per-project parallel-worker cap BEFORE the
+        # DB transition so a cap-exceeded claim surfaces a clean error
+        # instead of leaving the task ``in_progress`` with no worker.
+        # Review claims and skip_gates bypass the cap (review windows
+        # have their own naming + lifecycle; skip_gates is the operator
+        # escape hatch).
+        if (
+            target_status is WorkStatus.IN_PROGRESS
+            and not skip_gates
+            and self.service._session_mgr is not None
+        ):
+            check_cap = getattr(
+                self.service._session_mgr, "check_parallel_cap", None,
+            )
+            if callable(check_cap):
+                check_cap(task.project, task_id)
         latest_execution = self._latest_node_execution(task, node_id)
         resume_blocked_execution = (
             task.current_node_id is not None

--- a/src/pollypm/work/session_manager.py
+++ b/src/pollypm/work/session_manager.py
@@ -48,6 +48,25 @@ class ProvisionError(RuntimeError):
     """
 
 
+class WorkerCapExceededError(ProvisionError):
+    """Raised when a project already has ``max_parallel_workers`` active.
+
+    #1737 — distinct from generic ``ProvisionError`` so callers (and the
+    audit watchdog) can recognise normal back-pressure vs. a genuine
+    provisioning failure. The auto-claim sweep already rate-limits via
+    ``max_concurrent_workers``; this cap is the hard ceiling on per-task
+    worker tmux windows regardless of who initiated the claim.
+    """
+
+
+# Default per-project cap on concurrent per-task worker sessions.
+# #1737 architectural alignment: per Sam's flow-chart, the per-task
+# parallel model replaces the per-project sequential worker. 5 is the
+# product default; users can opt-in to a different value via
+# ``[projects.<key>].max_parallel_workers`` in pollypm.toml.
+DEFAULT_MAX_PARALLEL_WORKERS = 5
+
+
 # ---------------------------------------------------------------------------
 # Data models
 # ---------------------------------------------------------------------------
@@ -225,6 +244,14 @@ class SessionManager:
         if existing is not None:
             self._reap_dead_existing_session(task_id, existing)
 
+        # #1737 — enforce the per-project parallel-worker cap before any
+        # filesystem or tmux mutation. Counting at this point (after the
+        # idempotent existing-session short-circuit above) means a
+        # re-claim of an already-active task does not consume a cap slot
+        # but a fresh task does. Raised as ``WorkerCapExceededError`` so
+        # the audit watchdog can recognise normal back-pressure.
+        self._enforce_parallel_cap(project, task_id)
+
         # Derive slug from task_id for branch/path naming
         task_slug = f"{project}-{task_number}"
         branch_name = f"task/{task_slug}"
@@ -264,6 +291,10 @@ class SessionManager:
             if existing is not None:
                 self._reap_dead_existing_session(task_id, existing)
 
+            # #1737 — re-check the cap under the lock so two racing
+            # claims can't both squeeze past a single open slot.
+            self._enforce_parallel_cap(project, task_id)
+
             worker_session = self._provision_locked(
                 task_id=task_id,
                 agent_name=agent_name,
@@ -282,6 +313,97 @@ class SessionManager:
                         "provision_worker[%s]: failed to release session lock: %s",
                         task_id, exc,
                     )
+
+    # ------------------------------------------------------------------
+    # Per-project parallel cap (#1737)
+    # ------------------------------------------------------------------
+
+    def _resolve_parallel_cap(self, project: str) -> int:
+        """Return the per-task worker cap for ``project``.
+
+        Precedence: per-project ``max_parallel_workers`` →
+        ``max_concurrent_workers`` (legacy field, kept for back-compat with
+        operators who already set it) → :data:`DEFAULT_MAX_PARALLEL_WORKERS`.
+        A non-positive override is ignored so a typo can't silently disable
+        worker spawning (use ``auto_claim=false`` to gate claims at the
+        sweep level).
+        """
+        config = self._config
+        if config is None:
+            return DEFAULT_MAX_PARALLEL_WORKERS
+        projects = getattr(config, "projects", {}) or {}
+        proj = projects.get(project)
+        if proj is None:
+            return DEFAULT_MAX_PARALLEL_WORKERS
+        override = getattr(proj, "max_parallel_workers", None)
+        if isinstance(override, int) and override > 0:
+            return override
+        legacy = getattr(proj, "max_concurrent_workers", None)
+        if isinstance(legacy, int) and legacy > 0:
+            return legacy
+        return DEFAULT_MAX_PARALLEL_WORKERS
+
+    def _count_active_workers(self, project: str) -> int:
+        """Return the number of currently active worker sessions for a project.
+
+        Counts ``work_sessions`` rows with ``ended_at IS NULL``. The
+        teardown path stamps ``ended_at`` on accept / cancel so this
+        count tracks live per-task tmux windows in steady state. Best
+        effort: a DB error returns 0 so a transient failure doesn't
+        spuriously raise the cap and lock out new claims.
+        """
+        try:
+            records = self._svc.list_worker_sessions(
+                project=project, active_only=True,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "provision_worker[%s]: active-worker count failed: %s; "
+                "treating as zero",
+                project, exc,
+            )
+            return 0
+        return len(list(records))
+
+    def _enforce_parallel_cap(self, project: str, task_id: str) -> None:
+        """Raise ``WorkerCapExceededError`` when the project is at cap.
+
+        See :class:`WorkerCapExceededError` for the contract. The caller
+        is expected to have already short-circuited on an existing-alive
+        session for ``task_id`` so a re-claim of an active task doesn't
+        consume a cap slot.
+        """
+        # If this task already has an active session, a fresh claim is a
+        # no-op (handled upstream) — don't let it tip the cap detector.
+        try:
+            existing = self.session_for_task(task_id)
+        except Exception:  # noqa: BLE001
+            existing = None
+        if existing is not None and self._existing_session_is_alive(existing):
+            return
+        cap = self._resolve_parallel_cap(project)
+        active = self._count_active_workers(project)
+        if active < cap:
+            return
+        raise WorkerCapExceededError(
+            f"Cannot spawn worker for {task_id}: project {project!r} "
+            f"already has {active} active worker sessions (cap={cap}). "
+            "Why it matters: per-task workers run in parallel up to a "
+            "per-project ceiling so a queue burst doesn't burn every "
+            "provider session at once. "
+            "Fix: wait for one of the running workers to finish, or "
+            "raise the cap by setting "
+            f"`max_parallel_workers = <N>` under `[projects.{project}]` "
+            "in pollypm.toml."
+        )
+
+    # Public alias — pre-claim callers (transition managers) check the
+    # cap *before* the DB transition so a cap-exceeded claim is refused
+    # cleanly. Provisioning re-checks under the per-task lock to close
+    # the race window between two concurrent claims.
+    def check_parallel_cap(self, project: str, task_id: str) -> None:
+        """Public entry point for the pre-claim cap probe (#1737)."""
+        self._enforce_parallel_cap(project, task_id)
 
     # ------------------------------------------------------------------
     # Existing-session liveness (#1012)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -403,6 +403,48 @@ path = "wire"
     assert config.sessions["worker_wire"].cwd == project_root
 
 
+def test_load_config_reads_project_max_parallel_workers(tmp_path: Path) -> None:
+    """#1737 — ``max_parallel_workers`` lands on KnownProject."""
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        """
+[project]
+name = "PollyPM"
+tmux_session = "pollypm"
+
+[pollypm]
+controller_account = "claude_primary"
+
+[accounts.claude_primary]
+provider = "claude"
+home = ".pollypm/homes/claude_primary"
+
+[sessions.heartbeat]
+role = "heartbeat-supervisor"
+provider = "claude"
+account = "claude_primary"
+cwd = "."
+
+[sessions.operator]
+role = "operator-pm"
+provider = "claude"
+account = "claude_primary"
+cwd = "."
+
+[projects.samblog]
+path = "samblog"
+max_parallel_workers = 3
+"""
+    )
+    (tmp_path / "samblog").mkdir()
+
+    config = load_config(config_path)
+
+    assert config.projects["samblog"].max_parallel_workers == 3
+    # Legacy field unaffected when only the new field is set.
+    assert config.projects["samblog"].max_concurrent_workers is None
+
+
 def test_load_config_reads_project_local_planner_enforce_plan(tmp_path: Path) -> None:
     """Per-project ``[planner].enforce_plan`` lands on KnownProject."""
     project_root = tmp_path / "wire"

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1599,3 +1599,299 @@ class TestClaudeCwdEncoding:
 
         encoded = _encode_claude_cwd(Path("/Users/sam/dev/foo/.pollypm/worktrees/foo-1"))
         assert encoded == "-Users-sam-dev-foo--pollypm-worktrees-foo-1"
+
+
+# ---------------------------------------------------------------------------
+# Per-project parallel worker cap (#1737)
+# ---------------------------------------------------------------------------
+
+
+class _StubProject:
+    """Minimal project stand-in for cap-resolution tests."""
+
+    def __init__(
+        self,
+        *,
+        max_parallel_workers: int | None = None,
+        max_concurrent_workers: int | None = None,
+    ) -> None:
+        self.max_parallel_workers = max_parallel_workers
+        self.max_concurrent_workers = max_concurrent_workers
+
+
+class _StubConfig:
+    """Minimal config stand-in with a ``projects`` mapping."""
+
+    def __init__(self, projects: dict[str, object] | None = None) -> None:
+        self.projects = projects or {}
+
+
+def _seed_active_workers(svc: _StubWorkService, project: str, count: int) -> None:
+    """Insert ``count`` active worker_session rows for ``project``."""
+    for i in range(count):
+        # Insert a task row to satisfy the FK.
+        svc._conn.execute(
+            "INSERT OR IGNORE INTO work_tasks (project, task_number) "
+            "VALUES (?, ?)",
+            (project, 100 + i),
+        )
+        svc._conn.execute(
+            "INSERT INTO work_sessions "
+            "(task_project, task_number, agent_name, pane_id, "
+            "worktree_path, branch_name, started_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                project, 100 + i, "worker",
+                f"%seed{i}",
+                f"/tmp/{project}-{100 + i}",
+                f"task/{project}-{100 + i}",
+                "2026-01-01T00:00:00+00:00",
+            ),
+        )
+    svc._conn.commit()
+
+
+class TestParallelWorkerCap:
+    """#1737 — per-project parallel worker cap enforcement."""
+
+    def test_default_cap_is_five_when_no_config(self, manager) -> None:
+        from pollypm.work.session_manager import DEFAULT_MAX_PARALLEL_WORKERS
+
+        assert DEFAULT_MAX_PARALLEL_WORKERS == 5
+        assert manager._resolve_parallel_cap("proj") == 5
+
+    def test_resolve_cap_prefers_max_parallel_workers(
+        self, mock_tmux, mock_svc, tmp_project,
+    ) -> None:
+        config = _StubConfig(
+            projects={"proj": _StubProject(max_parallel_workers=3)},
+        )
+        mgr = SessionManager(
+            mock_tmux, mock_svc, tmp_project, config=config,
+        )
+        assert mgr._resolve_parallel_cap("proj") == 3
+
+    def test_resolve_cap_falls_back_to_max_concurrent_workers(
+        self, mock_tmux, mock_svc, tmp_project,
+    ) -> None:
+        config = _StubConfig(
+            projects={"proj": _StubProject(max_concurrent_workers=2)},
+        )
+        mgr = SessionManager(
+            mock_tmux, mock_svc, tmp_project, config=config,
+        )
+        assert mgr._resolve_parallel_cap("proj") == 2
+
+    def test_resolve_cap_uses_default_when_overrides_invalid(
+        self, mock_tmux, mock_svc, tmp_project,
+    ) -> None:
+        # Non-positive override is ignored — never silently disable spawn.
+        config = _StubConfig(
+            projects={
+                "proj": _StubProject(
+                    max_parallel_workers=0,
+                    max_concurrent_workers=-1,
+                ),
+            },
+        )
+        mgr = SessionManager(
+            mock_tmux, mock_svc, tmp_project, config=config,
+        )
+        assert mgr._resolve_parallel_cap("proj") == 5
+
+    def test_check_parallel_cap_passes_under_cap(self, manager) -> None:
+        _seed_active_workers(manager._svc, "proj", 2)
+        # Default cap is 5; 2 active < 5 → no raise.
+        manager.check_parallel_cap("proj", "proj/200")
+
+    def test_check_parallel_cap_raises_at_cap(
+        self, mock_tmux, mock_svc, tmp_project,
+    ) -> None:
+        from pollypm.work.session_manager import WorkerCapExceededError
+
+        config = _StubConfig(
+            projects={"proj": _StubProject(max_parallel_workers=5)},
+        )
+        mgr = SessionManager(
+            mock_tmux, mock_svc, tmp_project, config=config,
+        )
+        _seed_active_workers(mock_svc, "proj", 5)
+        with pytest.raises(WorkerCapExceededError) as exc_info:
+            mgr.check_parallel_cap("proj", "proj/999")
+        msg = str(exc_info.value)
+        assert "max_parallel_workers" in msg
+        assert "proj" in msg
+        assert "cap=5" in msg
+
+    def test_check_parallel_cap_isolates_projects(
+        self, mock_tmux, mock_svc, tmp_project,
+    ) -> None:
+        # 5 active workers on ``other`` must NOT block ``proj``.
+        config = _StubConfig(
+            projects={
+                "proj": _StubProject(max_parallel_workers=5),
+                "other": _StubProject(max_parallel_workers=5),
+            },
+        )
+        mgr = SessionManager(
+            mock_tmux, mock_svc, tmp_project, config=config,
+        )
+        _seed_active_workers(mock_svc, "other", 5)
+        # No raise for proj.
+        mgr.check_parallel_cap("proj", "proj/1")
+
+    def test_check_parallel_cap_ignores_active_session_for_same_task(
+        self, mock_tmux, mock_svc, tmp_project,
+    ) -> None:
+        """Re-claim of an already-active task must not consume a cap slot.
+
+        Otherwise a transient cap-aware re-provision would refuse to
+        honour the idempotent return of an existing live session.
+        """
+        # Cap=1, project already has the same task active.
+        config = _StubConfig(
+            projects={"proj": _StubProject(max_parallel_workers=1)},
+        )
+        mgr = SessionManager(
+            mock_tmux, mock_svc, tmp_project, config=config,
+        )
+        mock_svc._conn.execute(
+            "INSERT OR IGNORE INTO work_tasks (project, task_number) "
+            "VALUES (?, ?)",
+            ("proj", 7),
+        )
+        mock_svc._conn.execute(
+            "INSERT INTO work_sessions "
+            "(task_project, task_number, agent_name, pane_id, "
+            "worktree_path, branch_name, started_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                "proj", 7, "worker", "%alive",
+                "/tmp/proj-7", "task/proj-7",
+                "2026-01-01T00:00:00+00:00",
+            ),
+        )
+        mock_svc._conn.commit()
+        # The pane is "alive" per the mock_tmux fixture (is_pane_alive
+        # returns True), so the re-claim short-circuits to the existing
+        # session and the cap check does NOT raise.
+        mgr.check_parallel_cap("proj", "proj/7")
+
+    def test_provision_worker_raises_when_at_cap(
+        self, mock_tmux, mock_svc, tmp_project,
+    ) -> None:
+        from pollypm.work.session_manager import WorkerCapExceededError
+
+        config = _StubConfig(
+            projects={"proj": _StubProject(max_parallel_workers=2)},
+        )
+        mgr = SessionManager(
+            mock_tmux, mock_svc, tmp_project, config=config,
+        )
+        _seed_active_workers(mock_svc, "proj", 2)
+        # Insert the target task row so a partial-success path wouldn't
+        # blow up on FK before the cap check.
+        mock_svc._conn.execute(
+            "INSERT OR IGNORE INTO work_tasks (project, task_number) "
+            "VALUES (?, ?)",
+            ("proj", 42),
+        )
+        mock_svc._conn.commit()
+        with pytest.raises(WorkerCapExceededError):
+            mgr.provision_worker("proj/42", "worker")
+
+
+# ---------------------------------------------------------------------------
+# Per-task silent_worker skip (#1737)
+# ---------------------------------------------------------------------------
+
+
+class TestRoleSessionMissingCapAware:
+    """#1737 — cap-back-pressure suppresses queued worker_role findings."""
+
+    def test_queued_worker_at_cap_emits_no_finding(self) -> None:
+        from pollypm.audit.watchdog import (
+            RULE_ROLE_SESSION_MISSING,
+            scan_events,
+        )
+
+        class _T:
+            def __init__(self, project, n, status, roles):
+                self.project = project
+                self.task_number = n
+                self.work_status = status
+                self.roles = roles
+                self.assignee = None
+
+        # 3 queued worker-role tasks; project is at cap; storage closet
+        # has no per-project worker window — pre-#1737 this would emit
+        # 3 findings. With back-pressure flag set, zero.
+        tasks = [
+            _T("samblog", n, "queued", {"worker": "worker"})
+            for n in (6, 7, 8)
+        ]
+        findings = scan_events(
+            [],
+            now=datetime(2026, 5, 19, tzinfo=timezone.utc),
+            open_tasks=tasks,
+            storage_window_names=["architect-samblog"],
+            project="samblog",
+            worker_cap_back_pressure={"samblog": True},
+        )
+        assert not any(f.rule == RULE_ROLE_SESSION_MISSING for f in findings)
+
+    def test_queued_worker_not_at_cap_still_fires(self) -> None:
+        from pollypm.audit.watchdog import (
+            RULE_ROLE_SESSION_MISSING,
+            scan_events,
+        )
+
+        class _T:
+            def __init__(self, project, n, status, roles):
+                self.project = project
+                self.task_number = n
+                self.work_status = status
+                self.roles = roles
+                self.assignee = None
+
+        # Same shape but back_pressure False → legacy detector behaviour.
+        tasks = [_T("samblog", 9, "queued", {"worker": "worker"})]
+        findings = scan_events(
+            [],
+            now=datetime(2026, 5, 19, tzinfo=timezone.utc),
+            open_tasks=tasks,
+            storage_window_names=["architect-samblog"],
+            project="samblog",
+            worker_cap_back_pressure={"samblog": False},
+        )
+        matched = [f for f in findings if f.rule == RULE_ROLE_SESSION_MISSING]
+        assert len(matched) == 1
+
+    def test_in_progress_worker_finding_unaffected_by_back_pressure(self) -> None:
+        """Back-pressure only suppresses queued; in_progress still fires
+        because an active claim with no window is a real fault."""
+        from pollypm.audit.watchdog import (
+            RULE_ROLE_SESSION_MISSING,
+            scan_events,
+        )
+
+        class _T:
+            def __init__(self, project, n, status, roles):
+                self.project = project
+                self.task_number = n
+                self.work_status = status
+                self.roles = roles
+                self.assignee = None
+
+        tasks = [_T("samblog", 4, "in_progress", {"worker": "worker"})]
+        findings = scan_events(
+            [],
+            now=datetime(2026, 5, 19, tzinfo=timezone.utc),
+            open_tasks=tasks,
+            storage_window_names=["architect-samblog"],
+            project="samblog",
+            worker_cap_back_pressure={"samblog": True},
+        )
+        matched = [f for f in findings if f.rule == RULE_ROLE_SESSION_MISSING]
+        assert len(matched) == 1
+        assert matched[0].subject == "samblog/4"


### PR DESCRIPTION
## Summary

Architectural alignment per Sam's flow chart: per-task workers (window
shape ``task-<project>-<N>``, already in place) now enforce a
per-project parallel-worker ceiling so a queue burst can't exhaust every
provider session at once. Adds the
``[projects.<key>].max_parallel_workers`` TOML knob (default 5),
fail-closed cap checks at provision time and pre-claim, and a
cap-aware bypass for the audit watchdog's ``role_session_missing``
detector so queued worker tasks on a capped project register as normal
back-pressure rather than missing-session faults.

- Cap default 5; per-project override via
  ``[projects.<key>].max_parallel_workers = N`` in pollypm.toml
- ``WorkerCapExceededError`` (subclass of ``ProvisionError``) carries a
  user-actionable message naming the project + cap
- Pre-claim refuse keeps capped claims from leaving tasks
  ``in_progress`` with no worker; review claims + ``skip_gates`` bypass
- Cap-aware watchdog: queued worker findings on a capped project are
  suppressed; ``in_progress`` (real claim, no window) still fires
- Per-task ``silent_worker`` no-ops on ``task-<project>-<N>`` windows
  (per-task workers shouldn't poll the queue; auto-claim handles the
  next task on a fresh worker)

## Hook locations

| Concern | File / Function |
| --- | --- |
| Cap probe + raise | ``SessionManager._enforce_parallel_cap`` / ``check_parallel_cap`` (``src/pollypm/work/session_manager.py``); re-checked under the per-task session lock |
| Pre-claim gate (sqlite) | ``ServiceTransitionManager.claim`` in ``src/pollypm/work/service_transition_manager.py`` |
| Pre-claim gate (pg) | ``PgWorkService.claim`` in ``src/pollypm/work/pg_service.py`` |
| Cap-back-pressure probe | ``_gather_worker_cap_back_pressure`` in ``src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py`` |
| Detector skip | ``_detect_role_session_missing`` in ``src/pollypm/audit/watchdog.py`` (new ``worker_cap_back_pressure`` parameter, threaded through ``scan_events`` / ``scan_project``) |
| Per-task silent_worker | ``LocalHeartbeatBackend._apply_prompt_pm_task_next`` in ``src/pollypm/heartbeats/local.py`` |
| New project field | ``KnownProject.max_parallel_workers`` in ``src/pollypm/models.py``; parsed in ``src/pollypm/config.py`` |

## TOML migration

The new knob is opt-in. To raise the cap for a project, add it to the
top-level ``pollypm.toml``:

```toml
[projects.samblog]
path = "samblog"
max_parallel_workers = 8   # override; absent or invalid falls back to 5
```

Precedence inside ``_resolve_parallel_cap``:
1. ``max_parallel_workers`` (new, recommended)
2. ``max_concurrent_workers`` (legacy field, used by the auto-claim
   sweep; honoured here so operators who already set it keep their
   intent)
3. ``DEFAULT_MAX_PARALLEL_WORKERS`` = 5

Non-positive overrides are ignored (use ``auto_claim = false`` to gate
claims entirely).

## Naming decision

Window naming intentionally kept at ``task-<project>-<N>`` — that shape
is parsed by 15+ call sites (cockpit_inbox, cockpit_rail, supervisor,
task_assignment, worker_marker_reaper, etc.). The spec locked in
"cosmetic project-first rename deferred"; a rename touches too many
parsers for v1 RC stability.

## Test plan

- [x] ``TestParallelWorkerCap`` (9 cases) — default cap, override
  precedence, under-cap pass, at-cap raise (with actionable message),
  project isolation, same-task re-claim doesn't consume a slot, full
  ``provision_worker`` integration path
- [x] ``TestRoleSessionMissingCapAware`` (3 cases) — back-pressure
  suppresses queued worker findings; doesn't suppress when flag is off;
  never suppresses ``in_progress`` (real fault)
- [x] ``test_load_config_reads_project_max_parallel_workers`` — TOML
  parsing for the new field
- [x] Full suite ``tests/test_session_manager.py`` +
  ``tests/test_pg_work_service*.py`` +
  ``tests/test_audit_watchdog*.py`` +
  ``tests/test_heartbeat_cascade_foundation.py`` — 168 pass, no new
  failures (3 pre-existing failures on main unchanged)
- [ ] Manual verification: claim 6 samblog tasks → 5 workers spawn,
  6th raises ``WorkerCapExceededError`` with a message naming the
  project and cap (deferred; covered by the integration test
  ``test_provision_worker_raises_when_at_cap``)

🤖 Generated with [Claude Code](https://claude.com/claude-code)