### PR TITLE
chore: lint cleanup + verify auto-closed issues (closes #1858 #1761 #1768)

### DIFF
--- a/src/pollypm/storage/legacy_per_project_db.py
+++ b/src/pollypm/storage/legacy_per_project_db.py
@@ -41,7 +41,7 @@ import shutil
 import sqlite3
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from pollypm.storage.sqlite_pragmas import readonly_uri
 

--- a/tests/test_pg_storage_facades.py
+++ b/tests/test_pg_storage_facades.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from pathlib import Path
 
 import pytest
 


### PR DESCRIPTION
## Summary

- Lint cleanups: drop two unused imports flagged by Ruff F401. Closes #1858 and #1761.
- Triage of four likely-auto-closed bugs against `main` (HEAD `6e74f922`). One verified closed in real time; the others still need work.

## Lint fixes (this PR)

| # | File | Change |
| - | - | - |
| #1858 | `src/pollypm/storage/legacy_per_project_db.py` | Drop unused `typing.Any` (left behind by #1849). |
| #1761 | `tests/test_pg_storage_facades.py` | Drop unused `pathlib.Path`. |

`uvx ruff check` is clean on both files post-edit.

## Verify-or-close verdicts (no code change here)

| # | Verdict | Notes |
| - | - | - |
| #1768 | **Closed** | `PgWorkService.node_done()` now invokes `_write_review_summary_after_transition()` (pg_service.py:1838) which writes a `PLAIN_SUMMARY_ENTRY_TYPE` entry; landed in #1777. Closed via `gh issue close`. |
| #1812 | **Partial — left open** | Bug A (missing `list_replies`/`bulk_list_replies`) fixed by #1784. Bugs B (`open_work_service_for_task` existence-gate) and C (`_db_path` getattr probe) still live in `src/pollypm/work/inbox_actions.py`. Comment posted with proof. |
| #1820 | **Still broken — left open** | `PgStore.execute()` (pg_store.py:851) still raises; production callers in `cockpit.py:671`, `plugin.py:315/388`, `maintenance.py:617/684` still select it via `hasattr` or direct call. Re-verification comment posted. |
| #1808 | **Still broken — left open** | `~/.pollypm/audit/_workspace.jsonl` is 1.7 GB / 6.3M lines; last 1000 events are 100% `work_db.opened` (~115/min). #1837 did not touch the emit site at `sqlite_service.py:626` and added no rotation. Re-verification comment posted. |

## Test plan

- [x] `uvx ruff check src/pollypm/storage/legacy_per_project_db.py tests/test_pg_storage_facades.py` clean.
- [x] `python -c "import pollypm.storage.legacy_per_project_db"` succeeds.
- [ ] CI green.