### PR TITLE
feat(reviewer): per-task ephemeral reviewer sessions (closes architectural alignment, refs #1737)

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -1464,7 +1464,13 @@ def _detect_role_session_missing(
             and back_pressure.get(task_project)
         ):
             continue
-        expected_window = f"{role_used}-{task_project}"
+        # #1737 — reviewers are per-task ephemeral
+        # (``reviewer-<project>-<N>``) so the watchdog must check the
+        # task-scoped window, not the legacy per-project lane.
+        if role_used == "reviewer" and status_value == "review":
+            expected_window = f"reviewer-{task_project}-{int(task_number)}"
+        else:
+            expected_window = f"{role_used}-{task_project}"
         if expected_window in window_set:
             continue
         findings.append(Finding(
@@ -1487,6 +1493,7 @@ def _detect_role_session_missing(
                 "expected_window": expected_window,
                 "role": role_used,
                 "status": status_value,
+                "task_id": f"{task_project}/{int(task_number)}",
             },
         ))
     return findings

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -1459,7 +1459,8 @@ def _self_heal_role_session_missing(
     about how many lanes were actually created.
     """
     counters = {"worker_lane_spawned": 0, "worker_lane_failed": 0}
-    role = (finding.metadata or {}).get("role") or ""
+    meta = finding.metadata or {}
+    role = meta.get("role") or ""
     if not role:
         counters["worker_lane_failed"] += 1
         return counters
@@ -1469,6 +1470,66 @@ def _self_heal_role_session_missing(
         # leak memory (see ``pm worker-start --role worker`` for the
         # rationale). Treat as a no-op so the cadence handler isn't
         # blamed for a lane it can't structurally repair.
+        return counters
+    if role == "reviewer":
+        # #1737 — reviewers are per-task ephemeral. Re-use the
+        # ``SessionManager.provision_reviewer`` path the transition
+        # manager hits on review-handoff so the spawn semantics
+        # (idempotency, persona injection, account routing) stay
+        # consistent.
+        task_id = meta.get("task_id") or ""
+        if not task_id:
+            # Reconstruct from the finding subject (``<project>/<N>``).
+            task_id = finding.subject or ""
+        if not task_id or "/" not in task_id:
+            counters["worker_lane_failed"] += 1
+            return counters
+        try:
+            from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+            from pollypm.work import create_work_service
+            from pollypm.work.session_manager import SessionManager
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "audit.watchdog: reviewer per-task spawn imports failed "
+                "for %s", task_id, exc_info=True,
+            )
+            counters["worker_lane_failed"] += 1
+            return counters
+        cfg_path = config_path
+        if cfg_path is None and DEFAULT_CONFIG_PATH.exists():
+            cfg_path = DEFAULT_CONFIG_PATH
+        if cfg_path is None:
+            counters["worker_lane_failed"] += 1
+            return counters
+        try:
+            cfg = load_config(cfg_path)
+        except Exception:  # noqa: BLE001
+            counters["worker_lane_failed"] += 1
+            return counters
+        try:
+            with create_work_service(
+                project_path=project_path,
+                project_key=project_key,
+            ) as svc:
+                from pollypm.tmux.client import TmuxClient
+
+                tmux = TmuxClient()
+                mgr = SessionManager(
+                    tmux, svc, project_path or cfg.project.root_dir,
+                    config=cfg,
+                )
+                window = mgr.provision_reviewer(task_id)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "audit.watchdog: reviewer per-task spawn failed for %s",
+                task_id, exc_info=True,
+            )
+            counters["worker_lane_failed"] += 1
+            return counters
+        if window is None:
+            counters["worker_lane_failed"] += 1
+        else:
+            counters["worker_lane_spawned"] += 1
         return counters
     try:
         from pollypm import cli as cli_mod

--- a/src/pollypm/work/service_transition_manager.py
+++ b/src/pollypm/work/service_transition_manager.py
@@ -694,6 +694,10 @@ class WorkTransitionManager:
                         task_id,
                         exc,
                     )
+            # #1737 — kill any per-task reviewer window on cancel.
+            # Idempotent: no-op if the window does not exist (e.g. the
+            # task was cancelled before reaching review).
+            self._teardown_per_task_reviewer(task_id)
             # #927: clear the no_session_for_assignment alerts the
             # heartbeat sweep raised while this task was active. The
             # per-task alert is unambiguous (alert key is the task id);
@@ -1139,15 +1143,28 @@ class WorkTransitionManager:
                             task_id,
                             exc,
                         )
+                # #1737 — kill the per-task reviewer window on terminal
+                # done. Safe to call whether or not the task ever
+                # visited a review node (idempotent: no-op if the
+                # window does not exist).
+                self._teardown_per_task_reviewer(task_id)
                 self.service._on_task_done(task_id, actor)
             elif result.work_status == WorkStatus.REVIEW:
-                # #1413 — when a worker finishes a node and the task
-                # advances to a review node, make sure the project has
-                # a reviewer session ready to consume the queue. The
-                # bootstrap sweep handles fresh-boot tracked projects;
-                # this hook catches projects registered AFTER bootstrap
-                # (or whose reviewer session was manually torn down)
-                # without waiting for the heartbeat's 60s threshold.
+                # #1737 — spawn the per-task reviewer window so a
+                # dedicated Russell session reviews THIS task (and
+                # remembers what it flagged across reject -> rework
+                # -> resubmit cycles). Idempotent: if the window
+                # already exists we re-use it. Replaces the older
+                # per-project reviewer-lane bootstrap (#1413) which
+                # spawned a single ``reviewer-<project>`` window that
+                # tried to multiplex every task.
+                self._provision_per_task_reviewer(result)
+                # #1413 — keep the per-project bootstrap call as a
+                # belt-and-suspenders hook for installs that still
+                # have ``reviewer_<project>`` entries in their toml
+                # (Sam's deployed config is migrating session-by-
+                # session). The function is idempotent: when no
+                # static reviewer session is configured it no-ops.
                 self._ensure_reviewer_for_review_handoff(result)
 
         return self._finish(
@@ -1155,6 +1172,63 @@ class WorkTransitionManager:
             task.work_status.value,
             after_reload=_before_sync,
         )
+
+    def _provision_per_task_reviewer(self, task: Task) -> None:
+        """Spawn the per-task reviewer window on a review handoff.
+
+        Architectural alignment per #1737: reviewers move from
+        per-project persistent (``reviewer-<project>``) to per-task
+        ephemeral (``reviewer-<project>-<task_number>``). Each task in
+        review gets its own dedicated Russell window that persists
+        across reject -> rework -> resubmit cycles for that task and is
+        torn down on accept or terminal cancel.
+
+        Best-effort: any failure logs and swallows so the transition
+        completes. The watchdog's ``role_session_missing`` detector
+        will retry within ~5 minutes if the spawn failed.
+        """
+        if self.service._session_mgr is None:
+            return
+        provision_fn = getattr(
+            self.service._session_mgr, "provision_reviewer", None,
+        )
+        if not callable(provision_fn):
+            return
+        try:
+            window_name = provision_fn(task.task_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "provision_per_task_reviewer failed for %s: %s",
+                task.task_id, exc,
+            )
+            return
+        if window_name:
+            logger.info(
+                "provisioned per-task reviewer %s for %s",
+                window_name, task.task_id,
+            )
+
+    def _teardown_per_task_reviewer(self, task_id: str) -> None:
+        """Kill the per-task reviewer window on terminal done / cancel.
+
+        Best-effort: any error logs and swallows so the transition
+        completes. Idempotent — safe to call whether or not the task
+        ever visited a review node (#1737 architectural alignment).
+        """
+        if self.service._session_mgr is None:
+            return
+        teardown_fn = getattr(
+            self.service._session_mgr, "teardown_reviewer", None,
+        )
+        if not callable(teardown_fn):
+            return
+        try:
+            teardown_fn(task_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "teardown_per_task_reviewer failed for %s: %s",
+                task_id, exc,
+            )
 
     def _ensure_reviewer_for_review_handoff(self, task: Task) -> None:
         """Fire-and-forget provision of a reviewer session for ``task.project``.
@@ -1345,6 +1419,12 @@ class WorkTransitionManager:
                             task_id,
                             exc,
                         )
+                # #1737 — per-task reviewer windows are torn down on
+                # accept (the reviewer's job for this task is complete).
+                # The same window is preserved across reject -> rework
+                # -> resubmit cycles (the reviewer remembers what it
+                # flagged); only the terminal-done transition kills it.
+                self._teardown_per_task_reviewer(task_id)
                 self.service._on_task_done(task_id, actor)
             # #953: clear the per-task no_session_for_assignment alert
             # the heartbeat sweep raised while the task was sitting in

--- a/src/pollypm/work/session_manager.py
+++ b/src/pollypm/work/session_manager.py
@@ -107,6 +107,19 @@ def task_window_name(project: str, task_number: int) -> str:
     return f"task-{project}-{int(task_number)}"
 
 
+def reviewer_window_name(project: str, task_number: int) -> str:
+    """Return the canonical tmux window name for a per-task reviewer.
+
+    Per the architectural alignment locked in #1737, reviewers are
+    spawned per task (one window per task in review, persists across
+    approve/reject cycles for that task, killed on accept or terminal
+    cancel). The window-name convention is ``reviewer-<project>-<N>``
+    so the watchdog's ``role_session_missing`` detector and the
+    transition manager's spawn/teardown hooks all agree.
+    """
+    return f"reviewer-{project}-{int(task_number)}"
+
+
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -1149,6 +1162,333 @@ class SessionManager:
         )
 
     # ------------------------------------------------------------------
+    # Per-task reviewer lifecycle (#1737 architectural alignment)
+    # ------------------------------------------------------------------
+
+    def provision_reviewer(self, task_id: str) -> str | None:
+        """Spawn a per-task reviewer tmux window. Idempotent.
+
+        Window name: ``reviewer-<project>-<N>`` — one per task in review,
+        persists across reject -> rework -> re-submit cycles for the
+        same task so the reviewer remembers what it previously flagged.
+        Torn down on ``approve`` (terminal done) or ``cancel``.
+
+        Mirrors the worker-provision path (``_worker_launch_bundle`` +
+        ``_launch_worker_window``) but does NOT create a per-task
+        worktree: reviewers read the worker's worktree (or the project
+        root for review nodes whose work_status entered ``review``
+        without a per-task worktree). The reviewer launches with the
+        Russell persona prompt baked into the system prompt via the
+        Claude ``--append-system-prompt-file`` convention (mirrors the
+        architect persona-injection landed under #1870/#1873).
+
+        Best-effort: any failure logs and swallows so the transition
+        completes — the heartbeat watchdog (``role_session_missing``)
+        catches stragglers within ~5 minutes.
+
+        Returns the window name on success (newly spawned or already
+        alive), or ``None`` when provisioning failed.
+        """
+        try:
+            project, task_number = _parse_task_id(task_id)
+        except ValueError:
+            logger.warning("provision_reviewer: bad task_id %r", task_id)
+            return None
+
+        window_name = reviewer_window_name(project, task_number)
+        session_name = self._storage_closet_name
+
+        # Idempotency: if the window already exists in the storage
+        # closet, the reviewer is still live for this task (the
+        # reject -> rework -> resubmit cycle MUST hit the same window
+        # so the reviewer keeps its prior context).
+        try:
+            if self._tmux.has_session(session_name):
+                windows = self._tmux.list_windows(session_name)
+                for w in windows:
+                    if getattr(w, "name", None) == window_name:
+                        logger.debug(
+                            "provision_reviewer: window %s already alive "
+                            "for %s (re-using across review cycle)",
+                            window_name, task_id,
+                        )
+                        return window_name
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "provision_reviewer: pre-check has_session/list_windows "
+                "failed for %s: %s (will attempt spawn anyway)",
+                task_id, exc,
+            )
+
+        if self._config is None:
+            # Test harnesses without a config can't route through the
+            # provider/runtime adapters. Spawn a no-op shell window so
+            # the watchdog stops firing and tests can assert the
+            # window-creation path was reached.
+            try:
+                self._tmux.create_window(
+                    session_name, window_name, ":", detached=True,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "provision_reviewer: stub create_window failed for "
+                    "%s: %s", task_id, exc,
+                )
+                return None
+            return window_name
+
+        try:
+            reviewer_cmd, _provider, _account = self._reviewer_launch_bundle(
+                window_name=window_name,
+                project=project,
+                task_number=task_number,
+            )
+        except ProvisionError as exc:
+            logger.warning(
+                "provision_reviewer: launch-bundle failed for %s: %s",
+                task_id, exc,
+            )
+            return None
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "provision_reviewer: unexpected launch-bundle error for "
+                "%s: %s", task_id, exc, exc_info=True,
+            )
+            return None
+
+        try:
+            if not self._tmux.has_session(session_name):
+                self._tmux.create_session(
+                    session_name, window_name, reviewer_cmd,
+                )
+            else:
+                self._tmux.create_window(
+                    session_name, window_name, reviewer_cmd, detached=True,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "provision_reviewer: tmux spawn failed for %s: %s",
+                task_id, exc,
+            )
+            return None
+
+        # Best-effort forensic event so operators can grep the audit
+        # log for spawn cadence. Mirrors the worker provision audit
+        # surface but uses the existing session.provisioned event so
+        # the watchdog quantifier (#1414) keeps working unchanged.
+        try:
+            from pollypm.audit import emit as _audit_emit
+            from pollypm.audit.log import EVENT_SESSION_PROVISIONED
+
+            _audit_emit(
+                event=EVENT_SESSION_PROVISIONED,
+                project=project,
+                subject=window_name,
+                actor="system",
+                status="ok",
+                metadata={
+                    "role": "reviewer",
+                    "project": project,
+                    "task_number": task_number,
+                    "task_id": task_id,
+                    "reason": "per_task_review_handoff",
+                },
+                project_path=self._project_path,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "provision_reviewer: audit emit failed for %s",
+                task_id, exc_info=True,
+            )
+
+        return window_name
+
+    def teardown_reviewer(self, task_id: str) -> bool:
+        """Kill the per-task reviewer window. Idempotent.
+
+        Called from the approve (terminal-done) and cancel transition
+        paths. Best-effort: a kill failure is logged and swallowed so
+        the transition completes — a stale reviewer window is a
+        cosmetic nuisance, not a correctness violation.
+
+        Returns True when the kill succeeded (or there was nothing to
+        kill), False on tmux error.
+        """
+        try:
+            project, task_number = _parse_task_id(task_id)
+        except ValueError:
+            logger.warning("teardown_reviewer: bad task_id %r", task_id)
+            return False
+
+        window_name = reviewer_window_name(project, task_number)
+        target = f"{self._storage_closet_name}:{window_name}"
+        try:
+            self._tmux.kill_window(target)
+            return True
+        except _CalledProcessError:
+            # "no such window" is the normal idempotent path.
+            return True
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "teardown_reviewer: kill_window failed for %s: %s",
+                target, exc,
+            )
+            return False
+
+    def _reviewer_launch_bundle(
+        self,
+        *,
+        window_name: str,
+        project: str,
+        task_number: int,
+    ) -> tuple[str, str, str]:
+        """Build the launch command for a per-task reviewer window.
+
+        Returns ``(command, provider_name, account_name)``. Routes
+        through the configured provider/runtime adapter pair so the
+        reviewer obeys the same account, runtime, and permissions
+        policy as the worker. Materialises the reviewer persona prompt
+        to disk and appends ``--append-system-prompt-file`` for Claude
+        launches (mirrors #1870/#1873 architect persona injection).
+        """
+        from pollypm.models import ProviderKind, SessionConfig
+        from pollypm.onboarding import default_session_args
+        from pollypm.providers import get_provider
+        from pollypm.role_routing import (
+            resolved_provider_kind,
+            resolve_role_assignment,
+        )
+        from pollypm.runtimes import get_runtime
+
+        config = self._config
+        accounts = getattr(config, "accounts", {}) or {}
+        routed_assignment = resolve_role_assignment(
+            "reviewer", project, config=config,
+        )
+        try:
+            routed_provider = resolved_provider_kind(routed_assignment)
+        except ValueError as exc:
+            raise ProvisionError(
+                f"Reviewer routing for project {project} resolved an "
+                f"unknown provider {routed_assignment.provider!r}: {exc}"
+            ) from exc
+
+        unavailable_accounts = _unavailable_account_names(config)
+        pollypm_settings = getattr(config, "pollypm", None)
+        failover_accounts: list[str] = list(
+            getattr(pollypm_settings, "failover_accounts", []) or []
+        )
+        preferred_names = [
+            getattr(pollypm_settings, "controller_account", ""),
+            *failover_accounts,
+        ]
+        account_name, account = _first_matching_account(
+            accounts,
+            provider=routed_provider,
+            preferred_names=preferred_names,
+            excluded_names=unavailable_accounts,
+        )
+        if account is None and accounts:
+            # Final fallback: ignore the unavailable filter so we still
+            # produce a launch bundle. The supervisor's recovery ladder
+            # will observe and resolve the failure.
+            account_name, account = _first_matching_account(
+                accounts,
+                provider=routed_provider,
+                preferred_names=preferred_names,
+            )
+        if account is None:
+            raise ProvisionError(
+                "Could not provision a reviewer because no configured "
+                f"account is available for routed provider "
+                f"{routed_provider.value}. Add at least one matching "
+                "account to PollyPM config, then retry."
+            )
+
+        session_provider = account.provider
+        session_model: str | None = None
+        if account.provider is routed_provider:
+            session_model = routed_assignment.model
+
+        session_args = default_session_args(
+            session_provider,
+            open_permissions=config.pollypm.open_permissions_by_default,
+            role="reviewer",
+            model=session_model,
+        )
+        session_cwd = self._project_path
+
+        session = SessionConfig(
+            name=window_name,
+            role="reviewer",
+            provider=session_provider,
+            account=account_name,
+            cwd=session_cwd,
+            project=project,
+            window_name=window_name,
+            args=session_args,
+        )
+        provider = get_provider(
+            session_provider, root_dir=config.project.root_dir,
+        )
+        runtime = get_runtime(
+            account.runtime, root_dir=config.project.root_dir,
+        )
+
+        # Resolve the reviewer persona prompt with project.persona_name
+        # override (matches the architect persona resolution in
+        # #1870/#1873 — project's persona_name wins over the role
+        # default).
+        persona_prompt = _resolve_reviewer_persona_prompt(config, project)
+
+        launch = provider.build_launch_command(session, account)
+        # For Claude, bake the persona prompt into the system prompt
+        # via the on-disk file convention used by the architect.
+        # For other providers (Codex), fall through and rely on
+        # send-keys / AGENTS.md materialisation handled at supervisor
+        # send-input time — out of scope for this hook.
+        if (
+            session_provider is ProviderKind.CLAUDE
+            and persona_prompt
+            and account.home is not None
+        ):
+            target = (
+                account.home
+                / ".pollypm"
+                / "system-prompts"
+                / f"reviewer_{project}_{int(task_number)}.md"
+            )
+            try:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(
+                    persona_prompt.rstrip() + "\n", encoding="utf-8",
+                )
+                from dataclasses import replace as _replace
+
+                launch = _replace(
+                    launch,
+                    argv=list(launch.argv) + [
+                        "--append-system-prompt-file", str(target),
+                    ],
+                )
+                if launch.resume_argv is not None:
+                    launch = _replace(
+                        launch,
+                        resume_argv=list(launch.resume_argv) + [
+                            "--append-system-prompt-file", str(target),
+                        ],
+                    )
+            except OSError as exc:
+                logger.warning(
+                    "provision_reviewer: failed to materialise persona "
+                    "prompt at %s: %s (launching without persona)",
+                    target, exc,
+                )
+
+        command = runtime.wrap_command(launch, account, config.project)
+        return command, account.provider.value, account_name
+
+    # ------------------------------------------------------------------
     # Rejection
     # ------------------------------------------------------------------
 
@@ -1499,6 +1839,84 @@ def _parse_task_id(task_id: str) -> tuple[str, int]:
     if len(parts) != 2:
         raise ValueError(f"Invalid task_id: {task_id}")
     return parts[0], int(parts[1])
+
+
+def _resolve_reviewer_persona_prompt(
+    config: object, project_key: str,
+) -> str | None:
+    """Resolve the reviewer persona prompt for ``project_key``.
+
+    Mirrors the architect persona resolution landed under #1870/#1873:
+
+    * Base prompt: ``reviewer_prompt()`` from
+      :mod:`pollypm.agent_profiles.defaults` (the Russell persona body).
+    * Project-local fork override: when
+      ``<project>/.pollypm/project-guides/reviewer.md`` exists, that
+      forked body replaces the base.
+    * Persona substitution: ``project.persona_name`` (when set) wins
+      over the role default ``"Russell"``. Both the
+      ``{persona_name}`` placeholder and the legacy literal
+      ``"You are Russell, the code reviewer"`` kickoff identity are
+      substituted so legacy forked guides stay correct without a
+      manual reset.
+
+    Returns ``None`` when the base prompt could not be loaded (the
+    caller will fall back to a launch without ``--append-system-prompt-file``).
+    """
+    try:
+        from pollypm.agent_profiles.defaults import reviewer_prompt
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "_resolve_reviewer_persona_prompt: import failed",
+            exc_info=True,
+        )
+        return None
+
+    try:
+        base = reviewer_prompt()
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "_resolve_reviewer_persona_prompt: reviewer_prompt() raised",
+            exc_info=True,
+        )
+        return None
+
+    prompt = base
+    project = None
+    projects = getattr(config, "projects", {}) or {}
+    project = projects.get(project_key) if hasattr(projects, "get") else None
+
+    if project is not None:
+        try:
+            from pollypm.project_guides import resolve_project_guide_text
+
+            prompt = resolve_project_guide_text(
+                project.path,
+                "reviewer",
+                fallback_text=prompt,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "_resolve_reviewer_persona_prompt: project-guide read "
+                "failed for %s", project_key, exc_info=True,
+            )
+
+    persona = "Russell"
+    if project is not None:
+        persona_raw = getattr(project, "persona_name", None)
+        if isinstance(persona_raw, str) and persona_raw.strip():
+            persona = persona_raw.strip()
+
+    if "{persona_name}" in prompt:
+        prompt = prompt.replace("{persona_name}", persona)
+    if persona != "Russell":
+        # Legacy forked guides have ``You are Russell, the code reviewer``
+        # baked in literally — rescue them so persona stays in sync.
+        prompt = prompt.replace(
+            "You are Russell, the code reviewer",
+            f"You are {persona}, the code reviewer",
+        )
+    return prompt or None
 
 
 def _shell_quote(s: str) -> str:

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -615,7 +615,13 @@ class _FakeTask:
 
 
 def test_role_session_missing_fires_when_window_absent(now: datetime) -> None:
-    """A review-state task with no reviewer-<project> window fires."""
+    """A review-state task with no reviewer-<project>-<N> window fires.
+
+    #1737 — reviewers moved from per-project (``reviewer-<project>``) to
+    per-task ephemeral (``reviewer-<project>-<N>``). The detector now
+    checks the task-scoped window so legacy per-project windows that
+    were retired no longer mask a missing per-task reviewer.
+    """
     from pollypm.audit.watchdog import RULE_ROLE_SESSION_MISSING
 
     task = _FakeTask(
@@ -628,15 +634,46 @@ def test_role_session_missing_fires_when_window_absent(now: datetime) -> None:
         [],
         now=now,
         open_tasks=[task],
-        storage_window_names=["worker-savethenovel", "architect-savethenovel"],
+        # Even the legacy per-project ``reviewer-savethenovel`` is now
+        # treated as a stranger window — the detector demands the
+        # task-scoped form.
+        storage_window_names=[
+            "worker-savethenovel",
+            "architect-savethenovel",
+            "reviewer-savethenovel",
+        ],
         project="savethenovel",
     )
     matched = [f for f in findings if f.rule == RULE_ROLE_SESSION_MISSING]
     assert len(matched) == 1
     f = matched[0]
     assert f.subject == "savethenovel/10"
-    assert f.metadata["expected_window"] == "reviewer-savethenovel"
+    assert f.metadata["expected_window"] == "reviewer-savethenovel-10"
     assert f.metadata["role"] == "reviewer"
+    assert f.metadata["task_id"] == "savethenovel/10"
+
+
+def test_role_session_missing_silent_when_per_task_reviewer_present(
+    now: datetime,
+) -> None:
+    """A review-state task whose per-task reviewer window IS in the
+    storage closet must NOT fire ``role_session_missing`` (#1737)."""
+    from pollypm.audit.watchdog import RULE_ROLE_SESSION_MISSING
+
+    task = _FakeTask(
+        project="samblog",
+        task_number=26,
+        work_status="review",
+        roles={"reviewer": "claude:reviewer"},
+    )
+    findings = scan_events(
+        [],
+        now=now,
+        open_tasks=[task],
+        storage_window_names=["reviewer-samblog-26"],
+        project="samblog",
+    )
+    assert not any(f.rule == RULE_ROLE_SESSION_MISSING for f in findings)
 
 
 def test_role_session_missing_silent_when_window_present(now: datetime) -> None:

--- a/tests/test_heartbeat_cascade_foundation.py
+++ b/tests/test_heartbeat_cascade_foundation.py
@@ -836,6 +836,48 @@ def test_tier1_healer_role_session_missing_skips_worker_role() -> None:
     assert counters["worker_lane_failed"] == 0
 
 
+def test_tier1_healer_role_session_missing_reviewer_role_routes_per_task(
+    tmp_path: Path,
+) -> None:
+    """#1737 — when the finding role is ``reviewer``, the healer routes
+    through :meth:`SessionManager.provision_reviewer` (task-scoped)
+    rather than the legacy per-project worker-session create path.
+
+    Without a real config_path on disk the helper short-circuits with
+    ``worker_lane_failed`` — we assert that path so we know the
+    reviewer branch is taken (not silently falling through to the
+    legacy create_worker_session call which would spawn the retired
+    per-project lane).
+    """
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _self_heal_role_session_missing,
+    )
+
+    finding = Finding(
+        rule=RULE_ROLE_SESSION_MISSING,
+        tier=TIER_1,
+        project="samblog",
+        subject="samblog/26",
+        metadata={
+            "role": "reviewer",
+            "expected_window": "reviewer-samblog-26",
+            "task_id": "samblog/26",
+            "status": "review",
+        },
+    )
+    counters = _self_heal_role_session_missing(
+        finding,
+        project_key="samblog",
+        project_path=None,
+        config_path=tmp_path / "does-not-exist.toml",
+    )
+    # No real config to load -> reviewer branch increments failed
+    # (not spawned). Critically: it does NOT raise, and it does NOT
+    # call the legacy worker-session create path.
+    assert counters["worker_lane_spawned"] == 0
+    assert counters["worker_lane_failed"] == 1
+
+
 # ---------------------------------------------------------------------------
 # Tier-3 operator dispatch — throttle, audit emit, no-op for ineligible rules
 # ---------------------------------------------------------------------------

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1895,3 +1895,130 @@ class TestRoleSessionMissingCapAware:
         matched = [f for f in findings if f.rule == RULE_ROLE_SESSION_MISSING]
         assert len(matched) == 1
         assert matched[0].subject == "samblog/4"
+
+
+# ---------------------------------------------------------------------------
+# Per-task reviewer lifecycle (#1737)
+# ---------------------------------------------------------------------------
+
+
+class TestPerTaskReviewerLifecycle:
+    """Reviewer spawn/teardown/idempotency under the new per-task model.
+
+    Architectural alignment per #1737: reviewer windows are
+    ``reviewer-<project>-<N>`` (one per task), persist across reject ->
+    rework -> resubmit cycles, and are torn down on terminal done or
+    cancel. The pre-#1737 ``reviewer-<project>`` per-project lane was
+    retired (its toml entries are removed in a follow-up doc step).
+    """
+
+    def test_reviewer_window_name_shape(self):
+        from pollypm.work.session_manager import reviewer_window_name
+
+        assert reviewer_window_name("samblog", 26) == "reviewer-samblog-26"
+
+    def test_provision_reviewer_creates_window_when_absent(
+        self, manager, mock_tmux, tmp_project,
+    ):
+        """No existing window -> spawn the per-task reviewer."""
+        mock_tmux.has_session.return_value = False
+        result = manager.provision_reviewer("proj/1")
+        assert result == "reviewer-proj-1"
+        # With config=None (test harness path), the stub create_window
+        # is invoked with a ``:`` no-op shell command.
+        assert mock_tmux.create_window.called
+
+    def test_provision_reviewer_is_idempotent_across_reject_cycles(
+        self, manager, mock_tmux, tmp_project,
+    ):
+        """The same task being re-submitted MUST hit the same reviewer
+        window — that's how Russell keeps context about what he
+        flagged on the prior cycle. The second provision call must
+        not spawn a duplicate window."""
+        mock_tmux.has_session.return_value = True
+        # First call sees an empty storage closet; spawns.
+        mock_tmux.list_windows.return_value = []
+        first = manager.provision_reviewer("proj/1")
+        assert first == "reviewer-proj-1"
+        spawn_calls = mock_tmux.create_window.call_count
+
+        # Subsequent call sees the already-spawned window — must no-op.
+        existing_window = MagicMock()
+        existing_window.name = "reviewer-proj-1"
+        existing_window.pane_id = "%99"
+        mock_tmux.list_windows.return_value = [existing_window]
+        second = manager.provision_reviewer("proj/1")
+        assert second == "reviewer-proj-1"
+        assert mock_tmux.create_window.call_count == spawn_calls
+
+    def test_teardown_reviewer_kills_window(
+        self, manager, mock_tmux,
+    ):
+        ok = manager.teardown_reviewer("proj/1")
+        assert ok is True
+        mock_tmux.kill_window.assert_called_once_with(
+            "pollypm-storage-closet:reviewer-proj-1"
+        )
+
+    def test_teardown_reviewer_idempotent_when_window_gone(
+        self, manager, mock_tmux,
+    ):
+        """A kill_window CalledProcessError ('no such window') must be
+        treated as success — the window is already gone."""
+        mock_tmux.kill_window.side_effect = subprocess.CalledProcessError(
+            1, "tmux kill-window",
+        )
+        ok = manager.teardown_reviewer("proj/1")
+        assert ok is True
+
+    def test_provision_reviewer_uses_persona_name_when_set(self, tmp_path):
+        """When ``project.persona_name`` is set (e.g. samblog -> "Sage"),
+        the materialised persona prompt substitutes the role default
+        "Russell" for the project's persona. Mirrors the architect
+        persona-name resolution under #1870/#1873."""
+        from pollypm.work.session_manager import (
+            _resolve_reviewer_persona_prompt,
+        )
+        from pollypm.models import KnownProject, ProjectKind
+
+        class _Cfg:
+            projects = {
+                "samblog": KnownProject(
+                    key="samblog",
+                    path=tmp_path / "samblog",
+                    name="samblog",
+                    persona_name="Sage",
+                    kind=ProjectKind.FOLDER,
+                    tracked=True,
+                ),
+            }
+
+        prompt = _resolve_reviewer_persona_prompt(_Cfg(), "samblog")
+        assert prompt is not None
+        assert "You are Sage, the code reviewer" in prompt
+        assert "You are Russell, the code reviewer" not in prompt
+
+    def test_provision_reviewer_falls_back_to_russell_without_override(
+        self, tmp_path,
+    ):
+        """No project.persona_name -> "Russell" stays as the persona."""
+        from pollypm.work.session_manager import (
+            _resolve_reviewer_persona_prompt,
+        )
+        from pollypm.models import KnownProject, ProjectKind
+
+        class _Cfg:
+            projects = {
+                "demo": KnownProject(
+                    key="demo",
+                    path=tmp_path / "demo",
+                    name="demo",
+                    persona_name="",
+                    kind=ProjectKind.FOLDER,
+                    tracked=True,
+                ),
+            }
+
+        prompt = _resolve_reviewer_persona_prompt(_Cfg(), "demo")
+        assert prompt is not None
+        assert "You are Russell, the code reviewer" in prompt


### PR DESCRIPTION
## Summary

Move reviewer windows from per-project persistent (`reviewer-<project>`, one window multiplexing every review-state task) to per-task ephemeral (`reviewer-<project>-<task_number>`, one window per task, persists across reject -> rework -> resubmit cycles for that task, killed on accept or terminal cancel).

## Spawn trigger

`WorkTransitionManager._provision_per_task_reviewer` fires from `complete_node` whenever a task transitions to `WorkStatus.REVIEW`. It calls the new `SessionManager.provision_reviewer(task_id)` which:

- Resolves the window name via `reviewer_window_name(project, N)` -> `reviewer-<project>-<N>`.
- **Idempotent**: if the window already exists in the storage closet, the spawn is a no-op so the same Russell session sees both the original review AND the post-rework resubmit (he remembers what he flagged).
- Resolves the persona prompt with `project.persona_name` override (samblog -> "Sage", others -> "Russell") and materialises it to `<account_home>/.pollypm/system-prompts/reviewer_<project>_<N>.md`, threaded into the Claude launch argv via `--append-system-prompt-file` (mirrors the architect persona injection landed under #1870/#1873).
- Routes through `resolve_role_assignment("reviewer", project)` for provider/account selection — same plumbing as workers.

The pre-existing `_ensure_reviewer_for_review_handoff` per-project bootstrap call is preserved as a belt-and-suspenders for installs that still have `reviewer_<project>` toml entries; once those are pruned the call becomes a no-op.

## Teardown trigger

`WorkTransitionManager._teardown_per_task_reviewer` runs in three places:

- `approve` after the task reaches `WorkStatus.DONE`
- `complete_node` whenever a node-complete transition lands the task in `DONE`
- `cancel` for terminal-state cancellation

Each calls `SessionManager.teardown_reviewer(task_id)`. Idempotent: a `CalledProcessError` from `kill_window` (no such window) is treated as success.

## Idempotency proof

`test_provision_reviewer_is_idempotent_across_reject_cycles` — a second `provision_reviewer("proj/1")` call when the window is already alive does NOT increment `create_window` call count. The review -> reject -> rework -> resubmit cycle re-uses the same window, so reviewer context survives.

## Watchdog alignment

- `_detect_role_session_missing` now expects `reviewer-<project>-<N>` for review-state tasks (and stamps `task_id` in the finding metadata).
- The tier-1 self-heal `_self_heal_role_session_missing` routes reviewer findings through `SessionManager.provision_reviewer` (per-task) instead of the legacy `create_worker_session` (per-project) path.

## Persona resolution check

`_resolve_reviewer_persona_prompt(config, "samblog")` returns "You are Sage, the code reviewer" (`persona_name` override wins). With no override the prompt falls back to "You are Russell, the code reviewer" — the role default in `role_contract._REVIEWER_CONTRACT`.

## Toml migration steps for Sam

The 11 `[sessions.reviewer_<project>]` blocks in `~/.pollypm/pollypm.toml` are now redundant. On next `pm up` they will still launch their per-project lanes, but the new per-task reviewer is spawned independently on review handoff. To complete the migration:

1. `pm reset` (or manually kill) the legacy `reviewer-<project>` tmux windows in the storage closet.
2. Edit `~/.pollypm/pollypm.toml` and delete the 11 `[sessions.reviewer_<project>]` blocks (`bikepath`, `pollypm`, `savethenovel`, `coffeeboardnm`, `booktalk`, `health_coach`, `itsalive`, `media`, `polly_remote`, `smoketest`, `samblog`).
3. Restart `pm up`. Any task already in REVIEW will get its `reviewer-<project>-<task_id>` window spawned by the new hook; the watchdog will catch stragglers within ~5 minutes.

The PR deliberately does NOT auto-edit Sam's toml — that's a documented manual step so the live install change is auditable.

## Out of scope (intentionally deferred)

- **Naming convention flip** (`<role>-<project>` -> `<project>_<role>`) — cosmetic-only follow-up; would break 4 read-side coupling sites (cockpit_inbox, cockpit_rail PM-Chat fallback, audit_watchdog briefs, heartbeats normalizer). Deferred per locked decision.
- **Worker role per-task lifecycle changes** — Wave 2-E, separate agent.

## Test plan

- [x] `tests/test_session_manager.py::TestPerTaskReviewerLifecycle` — 7 new tests covering window-name shape, spawn-when-absent, idempotency across reject cycles, teardown happy path + idempotent teardown, persona override resolution, persona fallback.
- [x] `tests/test_audit_watchdog.py::test_role_session_missing_fires_when_window_absent` — updated for new task-scoped window name + new `task_id` metadata.
- [x] `tests/test_audit_watchdog.py::test_role_session_missing_silent_when_per_task_reviewer_present` — new test confirming the detector is quiet when `reviewer-<project>-<N>` is alive.
- [x] `tests/test_heartbeat_cascade_foundation.py::test_tier1_healer_role_session_missing_reviewer_role_routes_per_task` — confirms reviewer findings route through the new per-task spawn branch, not the legacy per-project path.
- [x] Full focused sweep: `tests/test_session_manager.py tests/test_audit_watchdog.py tests/test_reviewer_provisioning.py tests/test_pg_work_service.py tests/test_pg_work_service_full.py tests/test_heartbeat_cascade_foundation.py` — all new tests pass. Three pre-existing failures in `test_session_manager.py` (claude-opus-4-7 model arg + auth_broken account filter + legacy hyphen form) exist on `origin/main` and are unrelated to this PR.