### PR TITLE
fix(storage): timestamptz migration + cache_read_tokens + doctor pg probes + activity_feed projector (closes #1850 #1857 #1856 #1816, refs #1737)

### DIFF
--- a/src/pollypm/doctor.py
+++ b/src/pollypm/doctor.py
@@ -631,6 +631,25 @@ def _latest_work_migration_version() -> int | None:
         return None
 
 
+def _doctor_config_or_none() -> "PollyPMConfig | None":
+    """Best-effort loader for the operator config inside doctor checks.
+
+    Used by the probe shims below so each check forwards the active
+    config to :mod:`pollypm.storage.doctor_state_probes` — that's what
+    drives the pg-vs-sqlite routing fix in #1856. Loader failures are
+    swallowed so a missing / unreadable config keeps the legacy sqlite
+    probe path active.
+    """
+    try:
+        from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+
+        if not DEFAULT_CONFIG_PATH.exists():
+            return None
+        return load_config(DEFAULT_CONFIG_PATH)
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _applied_version_from_sqlite(db_path: Path, table: str) -> int | None:
     """Return ``MAX(version)`` from a schema-version table, or ``None``.
 
@@ -638,8 +657,14 @@ def _applied_version_from_sqlite(db_path: Path, table: str) -> int | None:
     :func:`pollypm.storage.doctor_state_probes.applied_schema_version_ro` —
     kept for backwards compatibility with anything that imported the
     private helper. New callers should use the storage facade directly.
+
+    #1856: forwards the active operator config so a pg-mode install
+    reads ``schema_migrations`` from the pg pool instead of a stale
+    sqlite file at ``db_path``.
     """
-    return applied_schema_version_ro(db_path, table)
+    return applied_schema_version_ro(
+        db_path, table, config=_doctor_config_or_none(),
+    )
 
 
 def _workspace_state_db_path(config: PollyPMConfig | None = None) -> Path | None:

--- a/src/pollypm/plugins_builtin/activity_feed/handlers/event_projector.py
+++ b/src/pollypm/plugins_builtin/activity_feed/handlers/event_projector.py
@@ -297,22 +297,69 @@ class EventProjector:
         for entry in entries: ...
     """
 
-    __slots__ = ("_state_db", "_work_dbs")
+    __slots__ = ("_state_db", "_work_dbs", "_config")
 
     def __init__(
         self,
         state_db_path: Path,
         work_db_paths: Iterable[tuple[str, Path]] = (),
+        *,
+        config: Any | None = None,
     ) -> None:
         self._state_db = Path(state_db_path)
         # list of (project_key, work_db_path) for per-project work stores.
         self._work_dbs: list[tuple[str, Path]] = [
             (key, Path(path)) for key, path in work_db_paths
         ]
+        # #1816: when ``config`` is provided and ``[storage] backend ==
+        # "postgres"`` we route state-store reads through the pg-backed
+        # Store instead of the sqlite file. Without the config the
+        # projector keeps its legacy sqlite-only behaviour so existing
+        # callers (mostly tests) don't have to thread a config in.
+        self._config = config
 
     # ------------------------------------------------------------------
     # Per-source projectors.
     # ------------------------------------------------------------------
+
+    def _open_state_store(self):
+        """Return a :class:`Store` for the state DB, or ``None``.
+
+        #1816: when the active backend is pg, route through
+        :func:`get_store` so the projector reads ``messages`` rows from
+        pg instead of the (stale) sqlite file. Falls back to the legacy
+        ``sqlite:///<state_db>`` path when no config is in scope or the
+        backend is sqlite.
+        """
+        try:
+            from pollypm.store.registry import get_store, get_store_by_url
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "activity_feed: failed to import store registry",
+                exc_info=True,
+            )
+            return None
+
+        if self._config is not None:
+            try:
+                from pollypm.storage._backend_dispatch import is_pg_backend
+            except Exception:  # noqa: BLE001
+                is_pg_backend = lambda _config=None: False  # type: ignore[assignment]
+            try:
+                if is_pg_backend(self._config):
+                    return get_store(self._config)
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "activity_feed: get_store(pg) failed; falling back to sqlite",
+                )
+
+        if not self._state_db.exists():
+            return None
+        try:
+            return get_store_by_url(f"sqlite:///{self._state_db}")
+        except Exception:  # noqa: BLE001
+            logger.exception("activity_feed: failed to open Store")
+            return None
 
     def _project_from_state_store(
         self,
@@ -329,24 +376,15 @@ class EventProjector:
         'notify', 'alert')`` and reshape each row into a
         :class:`FeedEntry`.
         """
-        if not self._state_db.exists():
+        store = self._open_state_store()
+        if store is None:
             return []
 
-        try:
-            from pollypm.store.registry import get_store_by_url
-        except Exception:  # noqa: BLE001
-            logger.warning(
-                "activity_feed: failed to import store registry",
-                exc_info=True,
-            )
-            return []
-
-        try:
-            store = get_store_by_url(f"sqlite:///{self._state_db}")
-        except Exception:  # noqa: BLE001
-            logger.exception("activity_feed: failed to open Store")
-            return []
-
+        # ``get_store`` / ``get_store_by_url`` return a process-wide
+        # cached singleton — closing it would tear down the shared engine
+        # for every other caller in the process. The projector borrows
+        # the singleton and lets the registry's shutdown hook own the
+        # close() call.
         try:
             filters: dict[str, Any] = {
                 "type": ["event", "notify", "alert"],
@@ -364,11 +402,9 @@ class EventProjector:
                     "activity_feed: query_messages failed"
                 )
                 rows = []
-        finally:
-            try:
-                store.close()
-            except Exception:  # noqa: BLE001
-                pass
+        except Exception:  # noqa: BLE001
+            logger.exception("activity_feed: query_messages outer failure")
+            rows = []
 
         entries: list[FeedEntry] = []
         for row in rows:

--- a/src/pollypm/plugins_builtin/activity_feed/projector_factory.py
+++ b/src/pollypm/plugins_builtin/activity_feed/projector_factory.py
@@ -46,7 +46,14 @@ def build_projector(config: Any) -> EventProjector | None:
     state_db = getattr(getattr(config, "project", None), "state_db", None)
     if state_db is None:
         return None
-    return EventProjector(state_db, _collect_work_db_paths(config))
+    # #1816: thread the config through so the projector can detect a
+    # pg backend and route state-store reads to the pg-backed Store
+    # instead of the (possibly stale) sqlite file at ``state_db``.
+    return EventProjector(
+        state_db,
+        _collect_work_db_paths(config),
+        config=config,
+    )
 
 
 __all__ = ["build_projector"]

--- a/src/pollypm/storage/doctor_state_probes.py
+++ b/src/pollypm/storage/doctor_state_probes.py
@@ -1,11 +1,21 @@
 """Read-only state probes used by ``pm doctor``.
 
 Following Slice K-state-callers-port (#1737) the probes prefer the
-Postgres backend: when the process-wide RO pool is reachable, every
-probe runs against pg. When the pool is unreachable or the install
-hasn't migrated yet, the probes fall back to the sqlite file passed
-via ``db_path`` so doctor checks against legacy / fixture DBs keep
-working.
+Postgres backend: when the caller supplies a config whose active backend
+is ``"postgres"``, the probes go straight to pg via the process-wide RO
+pool. When the active backend is sqlite (or no config is in scope), the
+probes fall back to the sqlite file passed via ``db_path`` so doctor
+checks against legacy / fixture DBs keep working.
+
+#1856: previously every probe read the sqlite file *first* whenever the
+file happened to exist on disk — even when ``[storage] backend =
+"postgres"`` was set. A stale ``~/.pollypm/state.db`` from a pre-cutover
+install would mask the live pg state and make the doctor report read
+from the wrong source. Backend dispatch now runs before the sqlite probe
+whenever a ``config`` is in scope. (Callers that don't pass a ``config``
+keep the legacy sqlite-first path so test harnesses that construct fake
+db_paths without booting a config don't accidentally hit the user's
+real pg pool.)
 
 Every probe is:
 
@@ -22,12 +32,28 @@ import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from pollypm.storage._backend_dispatch import is_pg_backend
 from pollypm.storage.sqlite_pragmas import apply_workspace_pragmas, readonly_uri
 
 if TYPE_CHECKING:
     from pollypm.models import PollyPMConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _should_route_to_pg(config: "PollyPMConfig | None") -> bool:
+    """Return True when this call should bypass sqlite and read pg.
+
+    Only diverts when an explicit ``config`` was supplied AND its
+    storage backend is postgres. A ``None`` config preserves the legacy
+    sqlite-first behaviour so callers that don't thread a config through
+    (older test harnesses, anything that hand-builds a ``db_path`` for a
+    fixture) keep working without picking up the user's process-wide
+    real config.
+    """
+    if config is None:
+        return False
+    return is_pg_backend(config)
 
 
 def _pg_ro_conn(config: "PollyPMConfig | None" = None):
@@ -77,38 +103,39 @@ def applied_schema_version_ro(
 ) -> int | None:
     """Return ``MAX(version)`` from a schema-version table, or ``None``.
 
-    When ``db_path`` is a readable sqlite file we read from it (the
-    table the caller named); otherwise we fall through to the pg
-    ``schema_migrations`` table.
+    When the active backend is postgres we read ``schema_migrations`` via
+    the RO pool. Otherwise we read the sqlite file at ``db_path``.
     """
-    conn = _connect_readonly(db_path)
-    if conn is not None:
+    if _should_route_to_pg(config):
+        ctx = _pg_ro_conn(config)
+        if ctx is None:
+            return None
         try:
-            try:
-                row = conn.execute(
-                    f"SELECT COALESCE(MAX(version), 0) FROM {table}"
-                ).fetchone()
-            except sqlite3.Error:
-                return None
-            return int(row[0]) if row and row[0] is not None else 0
-        finally:
-            conn.close()
+            with ctx as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations"
+                    )
+                    row = cur.fetchone()
+                except Exception:  # noqa: BLE001
+                    return None
+                return int(row[0]) if row and row[0] is not None else 0
+        except Exception:  # noqa: BLE001
+            return None
 
-    ctx = _pg_ro_conn(config)
-    if ctx is None:
+    conn = _connect_readonly(db_path)
+    if conn is None:
         return None
     try:
-        with ctx as conn, conn.cursor() as cur:
-            try:
-                cur.execute(
-                    "SELECT COALESCE(MAX(version), 0) FROM schema_migrations"
-                )
-                row = cur.fetchone()
-            except Exception:  # noqa: BLE001
-                return None
-            return int(row[0]) if row and row[0] is not None else 0
-    except Exception:  # noqa: BLE001
-        return None
+        try:
+            row = conn.execute(
+                f"SELECT COALESCE(MAX(version), 0) FROM {table}"
+            ).fetchone()
+        except sqlite3.Error:
+            return None
+        return int(row[0]) if row and row[0] is not None else 0
+    finally:
+        conn.close()
 
 
 def count_work_tasks_ro(
@@ -118,49 +145,51 @@ def count_work_tasks_ro(
 ) -> int | None:
     """Return ``COUNT(*) FROM work_tasks``, or ``None``.
 
-    Reads the sqlite file at ``db_path`` when it's a regular file;
-    otherwise falls through to the pg schema.
+    When the active backend is postgres we query the pg schema; otherwise
+    we read the sqlite file at ``db_path``.
     """
-    conn = _connect_readonly(db_path)
-    if conn is not None:
+    if _should_route_to_pg(config):
+        ctx = _pg_ro_conn(config)
+        if ctx is None:
+            return None
         try:
-            try:
-                row = conn.execute(
-                    "SELECT name FROM sqlite_master "
-                    "WHERE type='table' AND name='work_tasks'"
-                ).fetchone()
-            except sqlite3.Error:
-                return None
-            if row is None:
-                return None
-            try:
-                row = conn.execute("SELECT COUNT(*) FROM work_tasks").fetchone()
-            except sqlite3.Error:
-                return None
-            return int(row[0]) if row and row[0] is not None else 0
-        finally:
-            conn.close()
+            with ctx as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        "SELECT 1 FROM information_schema.tables "
+                        "WHERE table_schema = current_schema() "
+                        "AND table_name = 'work_tasks'"
+                    )
+                    if cur.fetchone() is None:
+                        return None
+                    cur.execute("SELECT COUNT(*) FROM work_tasks")
+                    row = cur.fetchone()
+                except Exception:  # noqa: BLE001
+                    return None
+                return int(row[0]) if row and row[0] is not None else 0
+        except Exception:  # noqa: BLE001
+            return None
 
-    ctx = _pg_ro_conn(config)
-    if ctx is None:
+    conn = _connect_readonly(db_path)
+    if conn is None:
         return None
     try:
-        with ctx as conn, conn.cursor() as cur:
-            try:
-                cur.execute(
-                    "SELECT 1 FROM information_schema.tables "
-                    "WHERE table_schema = current_schema() "
-                    "AND table_name = 'work_tasks'"
-                )
-                if cur.fetchone() is None:
-                    return None
-                cur.execute("SELECT COUNT(*) FROM work_tasks")
-                row = cur.fetchone()
-            except Exception:  # noqa: BLE001
-                return None
-            return int(row[0]) if row and row[0] is not None else 0
-    except Exception:  # noqa: BLE001
-        return None
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='work_tasks'"
+            ).fetchone()
+        except sqlite3.Error:
+            return None
+        if row is None:
+            return None
+        try:
+            row = conn.execute("SELECT COUNT(*) FROM work_tasks").fetchone()
+        except sqlite3.Error:
+            return None
+        return int(row[0]) if row and row[0] is not None else 0
+    finally:
+        conn.close()
 
 
 def has_messages_table_ro(
@@ -169,36 +198,38 @@ def has_messages_table_ro(
     config: "PollyPMConfig | None" = None,
 ) -> bool:
     """Return ``True`` when the schema carries a ``messages`` table."""
-    conn = _connect_readonly(db_path)
-    if conn is not None:
+    if _should_route_to_pg(config):
+        ctx = _pg_ro_conn(config)
+        if ctx is None:
+            return False
         try:
-            try:
-                row = conn.execute(
-                    "SELECT name FROM sqlite_master "
-                    "WHERE type='table' AND name='messages'"
-                ).fetchone()
-            except sqlite3.Error:
-                return False
-            return row is not None
-        finally:
-            conn.close()
+            with ctx as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        "SELECT 1 FROM information_schema.tables "
+                        "WHERE table_schema = current_schema() "
+                        "AND table_name = 'messages'"
+                    )
+                    return cur.fetchone() is not None
+                except Exception:  # noqa: BLE001
+                    return False
+        except Exception:  # noqa: BLE001
+            return False
 
-    ctx = _pg_ro_conn(config)
-    if ctx is None:
+    conn = _connect_readonly(db_path)
+    if conn is None:
         return False
     try:
-        with ctx as conn, conn.cursor() as cur:
-            try:
-                cur.execute(
-                    "SELECT 1 FROM information_schema.tables "
-                    "WHERE table_schema = current_schema() "
-                    "AND table_name = 'messages'"
-                )
-                return cur.fetchone() is not None
-            except Exception:  # noqa: BLE001
-                return False
-    except Exception:  # noqa: BLE001
-        return False
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='messages'"
+            ).fetchone()
+        except sqlite3.Error:
+            return False
+        return row is not None
+    finally:
+        conn.close()
 
 
 def sessions_row_count_ro(
@@ -207,37 +238,39 @@ def sessions_row_count_ro(
     config: "PollyPMConfig | None" = None,
 ) -> int | None:
     """Return ``COUNT(*) FROM sessions``, or ``None``."""
-    conn = _connect_readonly(db_path)
-    if conn is not None:
+    if _should_route_to_pg(config):
+        ctx = _pg_ro_conn(config)
+        if ctx is None:
+            return None
         try:
-            try:
-                row = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
-            except sqlite3.Error:
-                return None
-            return int(row[0]) if row and row[0] is not None else 0
-        finally:
-            conn.close()
+            with ctx as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        "SELECT 1 FROM information_schema.tables "
+                        "WHERE table_schema = current_schema() "
+                        "AND table_name = 'sessions'"
+                    )
+                    if cur.fetchone() is None:
+                        return None
+                    cur.execute("SELECT COUNT(*) FROM sessions")
+                    row = cur.fetchone()
+                except Exception:  # noqa: BLE001
+                    return None
+                return int(row[0]) if row and row[0] is not None else 0
+        except Exception:  # noqa: BLE001
+            return None
 
-    ctx = _pg_ro_conn(config)
-    if ctx is None:
+    conn = _connect_readonly(db_path)
+    if conn is None:
         return None
     try:
-        with ctx as conn, conn.cursor() as cur:
-            try:
-                cur.execute(
-                    "SELECT 1 FROM information_schema.tables "
-                    "WHERE table_schema = current_schema() "
-                    "AND table_name = 'sessions'"
-                )
-                if cur.fetchone() is None:
-                    return None
-                cur.execute("SELECT COUNT(*) FROM sessions")
-                row = cur.fetchone()
-            except Exception:  # noqa: BLE001
-                return None
-            return int(row[0]) if row and row[0] is not None else 0
-    except Exception:  # noqa: BLE001
-        return None
+        try:
+            row = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
+        except sqlite3.Error:
+            return None
+        return int(row[0]) if row and row[0] is not None else 0
+    finally:
+        conn.close()
 
 
 def session_window_names_ro(
@@ -246,43 +279,45 @@ def session_window_names_ro(
     config: "PollyPMConfig | None" = None,
 ) -> set[str] | None:
     """Return the set of ``window_name`` values in ``sessions``, or ``None``."""
-    conn = _connect_readonly(db_path)
-    if conn is not None:
+    if _should_route_to_pg(config):
+        ctx = _pg_ro_conn(config)
+        if ctx is None:
+            return None
         try:
-            windows: set[str] = set()
-            try:
-                for row in conn.execute("SELECT window_name FROM sessions"):
-                    if row and row[0]:
-                        windows.add(str(row[0]))
-            except sqlite3.Error:
-                return None
-            return windows
-        finally:
-            conn.close()
+            with ctx as conn, conn.cursor() as cur:
+                try:
+                    cur.execute(
+                        "SELECT 1 FROM information_schema.tables "
+                        "WHERE table_schema = current_schema() "
+                        "AND table_name = 'sessions'"
+                    )
+                    if cur.fetchone() is None:
+                        return None
+                    cur.execute("SELECT window_name FROM sessions")
+                    windows: set[str] = set()
+                    for row in cur.fetchall():
+                        if row and row[0]:
+                            windows.add(str(row[0]))
+                    return windows
+                except Exception:  # noqa: BLE001
+                    return None
+        except Exception:  # noqa: BLE001
+            return None
 
-    ctx = _pg_ro_conn(config)
-    if ctx is None:
+    conn = _connect_readonly(db_path)
+    if conn is None:
         return None
     try:
-        with ctx as conn, conn.cursor() as cur:
-            try:
-                cur.execute(
-                    "SELECT 1 FROM information_schema.tables "
-                    "WHERE table_schema = current_schema() "
-                    "AND table_name = 'sessions'"
-                )
-                if cur.fetchone() is None:
-                    return None
-                cur.execute("SELECT window_name FROM sessions")
-                windows: set[str] = set()
-                for row in cur.fetchall():
-                    if row and row[0]:
-                        windows.add(str(row[0]))
-                return windows
-            except Exception:  # noqa: BLE001
-                return None
-    except Exception:  # noqa: BLE001
-        return None
+        windows: set[str] = set()
+        try:
+            for row in conn.execute("SELECT window_name FROM sessions"):
+                if row and row[0]:
+                    windows.add(str(row[0]))
+        except sqlite3.Error:
+            return None
+        return windows
+    finally:
+        conn.close()
 
 
 __all__ = [

--- a/src/pollypm/storage/pg_schema.py
+++ b/src/pollypm/storage/pg_schema.py
@@ -690,6 +690,37 @@ CREATE UNIQUE INDEX IF NOT EXISTS messages_open_alert_uniq
 
 
 # --------------------------------------------------------------------- #
+# 0003 — account_usage.reset_at + account_runtime.available_at /
+# access_expires_at converted from ``timestamptz`` to ``text``.
+# --------------------------------------------------------------------- #
+#
+# #1850: PR #1848 fixed the INITIAL_SCHEMA_DDL so these three columns
+# are ``text`` on fresh installs (they carry provider display strings
+# like "Monday 1am" — never ISO-8601 timestamps). Existing deployed pg
+# databases were left on the old ``timestamptz`` columns and silently
+# reject every upsert with a parse error.
+#
+# Forward fix: ``ALTER COLUMN ... TYPE text USING <col>::text``. The
+# ``USING`` clause coerces any pre-existing timestamp rows into their
+# ISO-8601 text form so no data is lost (best-effort — the columns are
+# nullable and most deployed rows are NULL). ``IF EXISTS`` keeps the
+# migration idempotent against fresh installs where 0001's schema
+# already declared ``text``: pg's ALTER COLUMN is a no-op when the
+# target type matches the current type.
+
+_MIGRATION_0003_ACCOUNT_COLUMNS_TEXT = """
+ALTER TABLE IF EXISTS account_usage
+    ALTER COLUMN reset_at TYPE text USING reset_at::text;
+
+ALTER TABLE IF EXISTS account_runtime
+    ALTER COLUMN available_at TYPE text USING available_at::text;
+
+ALTER TABLE IF EXISTS account_runtime
+    ALTER COLUMN access_expires_at TYPE text USING access_expires_at::text;
+"""
+
+
+# --------------------------------------------------------------------- #
 # Migration list — forward-only, append-only.
 # --------------------------------------------------------------------- #
 
@@ -699,6 +730,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS messages_open_alert_uniq
 MIGRATIONS: list[tuple[int, str, str]] = [
     (1, "0001_initial", INITIAL_SCHEMA_DDL),
     (2, "0002_alert_dedupe_tuple", _MIGRATION_0002_ALERT_DEDUPE),
+    (3, "0003_account_columns_text", _MIGRATION_0003_ACCOUNT_COLUMNS_TEXT),
 ]
 
 

--- a/src/pollypm/transcript_ledger.py
+++ b/src/pollypm/transcript_ledger.py
@@ -377,10 +377,17 @@ def token_usage_costs(
     from pollypm.storage.pg_pool import get_ro_pool
 
     pool = get_ro_pool()
+    # #1857: ``cache_read_tokens`` is not in the pg ``token_usage_hourly``
+    # schema (and pg_token_usage doesn't track it on the write side).
+    # Dropping the SUM here so the query stops crashing the cost view
+    # under pg; the report renders ``cache_read_tokens=0`` until the
+    # column is added on both sides.
+    # TODO(#1857): when pg_token_usage starts tracking cache reads, add
+    # a ``cache_read_tokens bigint`` column via a forward migration and
+    # restore ``SUM(cache_read_tokens)`` here.
     sql = (
         "SELECT LOWER(project_key) AS project_key, "
         "       SUM(tokens_used) AS total, "
-        "       SUM(cache_read_tokens) AS cache_total, "
         "       COUNT(DISTINCT substr(hour_bucket, 1, 10)) AS days_active "
         "FROM token_usage_hourly "
         "WHERE hour_bucket >= (NOW() - (%s || ' days')::interval)::text "
@@ -403,8 +410,8 @@ def token_usage_costs(
             TokenCostSummary(
                 project_key=project_key,
                 tokens_used=int(row[1]),
-                cache_read_tokens=int(row[2] or 0),
-                days_active=int(row[3]),
+                cache_read_tokens=0,
+                days_active=int(row[2]),
             )
         )
     return out

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -514,6 +514,12 @@ def test_state_migrations_pluralises_db_word(
     flip to the singular ``state DB`` at count=1 — the boundary that
     fires when the user has exactly one tracked project.
     """
+    # #1856: ``_applied_version_from_sqlite`` now forwards the operator
+    # config so pg-mode installs read pg instead of stale sqlite. This
+    # test is a pure sqlite-path test — stub the config loader to keep
+    # the legacy sqlite probe path active regardless of the host's real
+    # pollypm.toml.
+    monkeypatch.setattr(doctor, "_doctor_config_or_none", lambda: None)
     one_behind = tmp_path / "behind.db"
     conn = sqlite3.connect(one_behind)
     try:
@@ -549,6 +555,9 @@ def test_work_migrations_pluralises_db_word(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
     """Same shape as state-migrations: ``work DB`` / ``work DBs`` per count."""
+    # #1856: stub the config loader so this sqlite-path test isn't
+    # diverted to the operator's real pg pool when run on a pg-mode host.
+    monkeypatch.setattr(doctor, "_doctor_config_or_none", lambda: None)
     one_behind = tmp_path / "behind.db"
     conn = sqlite3.connect(one_behind)
     try:

--- a/tests/test_pg_migrations.py
+++ b/tests/test_pg_migrations.py
@@ -1,0 +1,210 @@
+"""Forward-migration tests for ``pg_migrations`` (issues #1737, #1850).
+
+The applier itself has unit coverage in :mod:`tests/test_pg_schema.py`.
+This module exercises the per-version upgrade paths — specifically the
+"start from an older schema → apply forward → assert new shape" flow
+that :mod:`tests/test_pg_schema.py` does not cover.
+"""
+
+from __future__ import annotations
+
+
+def _column_type(pool, table: str, column: str) -> str | None:
+    """Return ``information_schema.columns.data_type`` for ``table.column``."""
+    with pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT data_type FROM information_schema.columns "
+            "WHERE table_schema = current_schema() "
+            "AND table_name = %s AND column_name = %s",
+            (table, column),
+        )
+        row = cur.fetchone()
+    return None if row is None else str(row[0])
+
+
+def test_0003_converts_account_columns_from_timestamptz_to_text(pg_schema_pool):
+    """#1850 — old deployments declared the three account columns as
+    ``timestamptz``; migration 0003 must convert them to ``text``
+    in-place so subsequent upserts of provider display strings
+    ("Monday 1am") stop crashing.
+    """
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    # Create the pre-0003 shape by hand: applier wouldn't naturally
+    # reach this state on a fresh schema (0001 already declares the
+    # columns as text after PR #1848), so we simulate the legacy
+    # deployment that was migrated up to 0002 with the old DDL.
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE account_usage (
+                account_name  text PRIMARY KEY,
+                provider      text NOT NULL,
+                plan          text NOT NULL,
+                health        text NOT NULL,
+                usage_summary text NOT NULL,
+                raw_text      text NOT NULL,
+                used_pct      int,
+                remaining_pct int,
+                reset_at      timestamptz,
+                period_label  text,
+                updated_at    timestamptz NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE account_runtime (
+                account_name        text PRIMARY KEY,
+                provider            text NOT NULL,
+                status              text NOT NULL,
+                reason              text NOT NULL,
+                available_at        timestamptz,
+                access_expires_at   timestamptz,
+                refresh_available   boolean NOT NULL DEFAULT false,
+                updated_at          timestamptz NOT NULL
+            )
+            """
+        )
+        # Record migrations 0001/0002 as applied so the applier skips
+        # straight to 0003 and exercises the forward path under test.
+        cur.execute(
+            """
+            CREATE TABLE schema_migrations (
+                version     bigint PRIMARY KEY,
+                label       text NOT NULL,
+                applied_at  timestamptz NOT NULL DEFAULT now()
+            )
+            """
+        )
+        cur.execute(
+            "INSERT INTO schema_migrations (version, label) VALUES "
+            "(1, '0001_initial'), (2, '0002_alert_dedupe_tuple')"
+        )
+        conn.commit()
+
+    # Sanity: pre-migration types are ``timestamp with time zone``.
+    assert _column_type(pg_schema_pool, "account_usage", "reset_at") == (
+        "timestamp with time zone"
+    )
+    assert _column_type(pg_schema_pool, "account_runtime", "available_at") == (
+        "timestamp with time zone"
+    )
+    assert _column_type(
+        pg_schema_pool, "account_runtime", "access_expires_at",
+    ) == "timestamp with time zone"
+
+    result = apply_migrations(pg_schema_pool)
+    assert [v for v, _ in result.applied] == [3]
+
+    # Post-migration types must be ``text``.
+    assert _column_type(pg_schema_pool, "account_usage", "reset_at") == "text"
+    assert _column_type(pg_schema_pool, "account_runtime", "available_at") == (
+        "text"
+    )
+    assert _column_type(
+        pg_schema_pool, "account_runtime", "access_expires_at",
+    ) == "text"
+
+
+def test_0003_is_idempotent_on_fresh_schema(pg_schema_pool):
+    """A fresh install (0001+0002+0003 in one pass) leaves the columns
+    declared as ``text``; running the applier a second time must be a
+    no-op rather than re-emitting the ALTER COLUMN.
+    """
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    first = apply_migrations(pg_schema_pool)
+    assert [v for v, _ in first.applied] == [1, 2, 3]
+
+    second = apply_migrations(pg_schema_pool)
+    assert not second.did_anything
+
+    assert _column_type(pg_schema_pool, "account_usage", "reset_at") == "text"
+    assert _column_type(pg_schema_pool, "account_runtime", "available_at") == (
+        "text"
+    )
+    assert _column_type(
+        pg_schema_pool, "account_runtime", "access_expires_at",
+    ) == "text"
+
+
+def test_0003_preserves_existing_rows(pg_schema_pool):
+    """Pre-existing rows survive the type conversion: their old
+    ``timestamptz`` values become their ISO-8601 text representations
+    (``USING reset_at::text``).
+    """
+    from pollypm.storage.pg_migrations import apply_migrations
+
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE account_usage (
+                account_name  text PRIMARY KEY,
+                provider      text NOT NULL,
+                plan          text NOT NULL,
+                health        text NOT NULL,
+                usage_summary text NOT NULL,
+                raw_text      text NOT NULL,
+                used_pct      int,
+                remaining_pct int,
+                reset_at      timestamptz,
+                period_label  text,
+                updated_at    timestamptz NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE account_runtime (
+                account_name        text PRIMARY KEY,
+                provider            text NOT NULL,
+                status              text NOT NULL,
+                reason              text NOT NULL,
+                available_at        timestamptz,
+                access_expires_at   timestamptz,
+                refresh_available   boolean NOT NULL DEFAULT false,
+                updated_at          timestamptz NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE schema_migrations (
+                version     bigint PRIMARY KEY,
+                label       text NOT NULL,
+                applied_at  timestamptz NOT NULL DEFAULT now()
+            )
+            """
+        )
+        cur.execute(
+            "INSERT INTO schema_migrations (version, label) VALUES "
+            "(1, '0001_initial'), (2, '0002_alert_dedupe_tuple')"
+        )
+        cur.execute(
+            """
+            INSERT INTO account_usage
+                (account_name, provider, plan, health, usage_summary,
+                 raw_text, reset_at, updated_at)
+            VALUES
+                ('primary', 'claude-cli', 'max', 'ok', '50%', '',
+                 TIMESTAMPTZ '2026-05-20T00:00:00+00:00',
+                 TIMESTAMPTZ '2026-05-19T00:00:00+00:00')
+            """
+        )
+        conn.commit()
+
+    apply_migrations(pg_schema_pool)
+
+    with pg_schema_pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT reset_at FROM account_usage WHERE account_name = 'primary'"
+        )
+        row = cur.fetchone()
+    assert row is not None
+    # Casting a ``timestamptz`` to text yields the canonical pg display
+    # string. We don't assert an exact wire shape (it varies with the
+    # server TZ + DateStyle), only that the value survived as a
+    # non-empty string carrying the year.
+    assert isinstance(row[0], str)
+    assert "2026" in row[0]


### PR DESCRIPTION
## Summary

Bundles four storage/schema correctness fixes that were each individually small but share the same backend-dispatch theme.

### #1850 — pg account-column timestamptz to text forward migration
PR #1848 changed `account_usage.reset_at` + `account_runtime.{available_at, access_expires_at}` to `text` for **fresh** databases. Existing deployed pg installs (e.g. Sam's) stayed on `timestamptz` and rejected every upsert of a provider display string (`"Monday 1am"`, `"Apr 10 at 1am"`).

Adds migration `0003_account_columns_text`:

```sql
ALTER TABLE IF EXISTS account_usage
    ALTER COLUMN reset_at TYPE text USING reset_at::text;
ALTER TABLE IF EXISTS account_runtime
    ALTER COLUMN available_at TYPE text USING available_at::text;
ALTER TABLE IF EXISTS account_runtime
    ALTER COLUMN access_expires_at TYPE text USING access_expires_at::text;
```

Idempotent: on fresh installs the columns are already `text` from 0001 and the ALTER is a no-op. Pre-existing `timestamptz` rows survive — the `USING <col>::text` clause coerces them to their ISO-8601 display form.

New `tests/test_pg_migrations.py` covers the upgrade path explicitly (creates the old shape, applies 0003, asserts columns are now `text`), idempotency on a fresh install, and row preservation.

### #1857 — drop cache_read_tokens from transcript_ledger pg query
`token_usage_costs()` referenced `SUM(cache_read_tokens)` on `token_usage_hourly`, but the pg schema doesn't have that column (and `pg_token_usage` never wrote to it). Drops the column from the SELECT and emits `cache_read_tokens=0` with a `TODO(#1857)` so the query stops crashing under pg.

### #1856 — doctor pg-mode probes no longer prefer stale sqlite
`doctor_state_probes.*_ro` now check the active backend before falling through to a sqlite file. New `_should_route_to_pg(config)` helper requires an **explicit** config to flip to pg, so test harnesses that hand-build `db_path`s without booting a config keep hitting sqlite (no accidental host-config leakage in tests).

`doctor.py`'s `_applied_version_from_sqlite` shim loads the operator config via a new `_doctor_config_or_none()` helper and forwards it, so production `pm doctor` runs read `schema_migrations` from pg on pg installs instead of the stale `~/.pollypm/state.db`.

### #1816 — activity_feed projector reads pg on pg backend
`EventProjector` accepts an optional `config`; when `[storage] backend = "postgres"` it routes the `messages`-table read through `get_store(config)` (returning the pg-backed `Store`) instead of hardcoding `sqlite:///<path>`. `projector_factory.build_projector` threads the config through so the cockpit panel + `pm activity` CLI both pick up the pg messages stream.

Also stops calling `store.close()` — `get_store(_by_url)` returns a cached process-wide singleton that other callers still hold, so closing it broke the shared engine.

## Test plan

- [x] `uv run pytest tests/test_pg_schema.py tests/test_pg_migrations.py tests/test_pg_accounts.py -q` — 18 passed
- [x] `uv run pytest tests/test_doctor.py tests/test_doctor_dual_db_health.py -q` — 90 passed
- [x] `uv run pytest tests/test_activity_feed_ui.py tests/test_activity_feed_filters.py -q` — 37 passed
- [x] `uv run pytest tests/test_transcript_ledger.py tests/test_transcript_ingest.py tests/test_transcript_ingest_fd_leak.py -q` — 12 passed, 1 pre-existing failure on main (`test_sync_token_ledger_reads_claude_and_codex_jsonl`, unrelated to this PR)
- [ ] Manual: run `pm doctor` on the deployed pg install and confirm it reports pg-side `schema_migrations`, not a stale sqlite version
- [ ] Manual: open the cockpit activity panel on pg and confirm rows render from `messages` (was empty pre-fix)

Closes #1850 #1857 #1856 #1816, refs #1737.

🤖 Generated with [Claude Code](https://claude.com/claude-code)