### PR TITLE
fix(install): bootstrap config-create + pgvector friendly error + SQL injection + lint (closes #1888 #1889 #1890 #1892)

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -2380,7 +2380,7 @@ def _detect_state_db_missing(
             project=project_key,
             subject=project_key,
             message=(
-                f"Workspace canonical state.db is missing"
+                "Workspace canonical state.db is missing"
                 + (f" at {canonical_db_path_str}" if canonical_db_path_str else "")
                 + (
                     " — only legacy archives remain (state.db.legacy-*)."
@@ -2390,10 +2390,10 @@ def _detect_state_db_missing(
                 )
             ),
             recommendation=(
-                f"Re-create the workspace state.db by opening it via "
-                f"``create_work_service`` (the schema replay rebuilds "
-                f"the tables); the heartbeat self-heal does this "
-                f"automatically."
+                "Re-create the workspace state.db by opening it via "
+                "``create_work_service`` (the schema replay rebuilds "
+                "the tables); the heartbeat self-heal does this "
+                "automatically."
             ),
             metadata={
                 "project_key": project_key,

--- a/src/pollypm/cli_features/storage.py
+++ b/src/pollypm/cli_features/storage.py
@@ -154,26 +154,37 @@ def _brew_service_running(svc: str) -> bool:
 
 
 def _pg_db_exists(db_name: str) -> bool:
-    """Return True if ``psql`` reports ``db_name`` already created."""
-    psql = _which("psql")
-    if psql is None:
+    """Return True if the local Postgres reports ``db_name`` already created.
+
+    Uses psycopg with a parameter-bound ``%s`` placeholder against the
+    ``postgres`` admin database. The previous implementation f-string'd
+    ``db_name`` directly into a SQL literal passed to ``psql -c`` — that
+    would let a hostile ``--db`` value inject SQL against the local
+    superuser session (#1890). Parameter binding makes the input data,
+    not code, regardless of what characters it contains.
+
+    Returns False on any connection / import / runtime error: the
+    bootstrap planner treats False as "assume the db doesn't exist
+    yet, plan a createdb step" which is the safe default for first run.
+    """
+    try:
+        import psycopg
+    except ImportError:
         return False
     try:
-        result = subprocess.run(  # noqa: S603
-            [
-                psql,
-                "-tAc",
-                f"SELECT 1 FROM pg_database WHERE datname='{db_name}'",
-                "postgres",
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=20,
-        )
-    except (OSError, subprocess.TimeoutExpired):
+        with psycopg.connect(
+            "postgresql://localhost:5432/postgres",
+            connect_timeout=5,
+        ) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM pg_database WHERE datname = %s",
+                    (db_name,),
+                )
+                row = cur.fetchone()
+                return row is not None and row[0] == 1
+    except Exception:  # noqa: BLE001 — any failure means "unknown, plan createdb"
         return False
-    return result.returncode == 0 and result.stdout.strip() == "1"
 
 
 def _plan_steps(
@@ -258,15 +269,15 @@ def _plan_steps(
             ),
         )
     )
+    # Pure-Python step: routed through ``_create_vector_extension`` so a
+    # missing pgvector contrib package surfaces the same friendly hint
+    # ``apply_migrations`` would raise (issue #1889). The previous
+    # implementation shelled out to ``psql -c`` here, which bypassed
+    # the ``PgVectorExtensionMissing`` wrapper entirely.
     steps.append(
         _Step(
             label="CREATE EXTENSION IF NOT EXISTS vector",
-            cmd=[
-                "psql",
-                db_name,
-                "-c",
-                "CREATE EXTENSION IF NOT EXISTS vector",
-            ],
+            cmd=None,
         )
     )
     steps.append(
@@ -294,6 +305,13 @@ def _print_plan(steps: list[_Step], *, dry_run: bool) -> None:
             continue
         if step.cmd is None:
             typer.echo(f"  {idx}. {step.label}")
+            if step.label.startswith("CREATE EXTENSION"):
+                # Pure-Python equivalent of ``psql -c "CREATE EXTENSION
+                # ..."`` — surface the SQL so the plan stays scrutable
+                # even though there's no literal shell command behind it.
+                typer.echo(
+                    "       psycopg: CREATE EXTENSION IF NOT EXISTS vector"
+                )
         else:
             typer.echo(f"  {idx}. {step.label}")
             typer.echo(f"       $ {' '.join(step.cmd)}")
@@ -316,29 +334,78 @@ def _run_cmd(cmd: list[str]) -> None:
         raise typer.Exit(code=exc.returncode) from exc
 
 
-def _write_storage_block(config_path: Path, dsn: str) -> bool:
-    """Append a ``[storage]`` block to ``config_path`` if absent.
+def _create_vector_extension(db_name: str) -> None:
+    """Run ``CREATE EXTENSION IF NOT EXISTS vector`` on ``db_name``.
 
-    Returns True if the block was written, False if it was already
-    there. Idempotent: a second run is a no-op.
+    Routes the DDL through psycopg + the ``PgVectorExtensionMissing``
+    wrapper from ``pg_migrations`` so the friendly install hint fires
+    on every first-run path — not just the ``apply_migrations`` step.
+    The previous implementation shelled out to ``psql -c`` here, which
+    surfaced the bare server-side ``feature_not_supported`` error and
+    bypassed the #1750 wrapper entirely (#1889).
     """
+    from pollypm.storage.pg_migrations import PgVectorExtensionMissing
+
+    import psycopg
+
+    dsn = f"postgresql://localhost:5432/{db_name}"
+    typer.echo(f"  $ psycopg.execute(\"CREATE EXTENSION IF NOT EXISTS vector\") @ {dsn}")
+    try:
+        with psycopg.connect(dsn, connect_timeout=10) as conn:
+            with conn.cursor() as cur:
+                cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+            conn.commit()
+    except Exception as exc:  # noqa: BLE001 — re-raise as friendly
+        raise PgVectorExtensionMissing(
+            "Could not install the `vector` extension on this Postgres "
+            "instance. PollyPM requires pgvector for semantic recall "
+            "and embeddings (see issue #1737).\n\n"
+            "Fix (macOS/Homebrew):\n"
+            "  brew install pgvector\n"
+            "  brew services restart postgresql@17\n"
+            "  # then re-run `pm bootstrap-pg --yes`\n\n"
+            "Other platforms: https://github.com/pgvector/pgvector "
+            "#installation-notes\n\n"
+            f"Underlying error: {exc}"
+        ) from exc
+
+
+def _write_storage_block(config_path: Path, dsn: str) -> bool:
+    """Write or append a ``[storage]`` block to ``config_path``.
+
+    Returns True if the block was written (either as new file or
+    appended to an existing one), False if the block was already
+    present. Idempotent: a second run on a configured file is a no-op.
+
+    On a brand-new install ``~/.pollypm/pollypm.toml`` does not yet
+    exist (``pm bootstrap-pg`` is meant to be the FIRST command an
+    operator runs). The previous implementation bailed in that case
+    and left the runtime without a DSN; we now scaffold a minimal
+    config containing just the ``[storage]`` block (#1888). ``pm
+    example-config`` can still backfill the richer defaults later.
+    """
+    snippet = (
+        "[storage]\n"
+        f'url = "{dsn}"\n'
+        "# Postgres is the required backend (sqlite was removed in "
+        "the #1737 cutover).\n"
+    )
     if not config_path.exists():
-        typer.echo(
-            f"  config {config_path} does not exist; create it with "
-            "`pm example-config` first.",
-            err=True,
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        header = (
+            "# pollypm.toml — created by `pm bootstrap-pg` on first "
+            "run.\n"
+            "# Run `pm example-config --force` later to backfill the "
+            "full default config.\n\n"
         )
-        return False
+        config_path.write_text(header + snippet, encoding="utf-8")
+        return True
     current = config_path.read_text(encoding="utf-8")
     if "\n[storage]\n" in current or current.startswith("[storage]\n"):
         return False
-    snippet = (
-        "\n[storage]\n"
-        f'url = "{dsn}"\n'
-        '# Postgres is the required backend (sqlite was removed in '
-        "the #1737 cutover).\n"
+    config_path.write_text(
+        current.rstrip() + "\n\n" + snippet, encoding="utf-8"
     )
-    config_path.write_text(current.rstrip() + "\n" + snippet, encoding="utf-8")
     return True
 
 
@@ -442,6 +509,19 @@ def bootstrap_pg(
             continue
 
         # Pure-Python steps. Labels are stable keys for now.
+        if step.label.startswith("CREATE EXTENSION"):
+            from pollypm.storage.pg_migrations import (
+                PgVectorExtensionMissing,
+            )
+
+            try:
+                _create_vector_extension(db_name)
+            except PgVectorExtensionMissing as exc:
+                typer.echo(str(exc), err=True)
+                raise typer.Exit(code=3) from exc
+            typer.echo("  extension `vector` ready")
+            continue
+
         if step.label.startswith("apply_migrations"):
             from pollypm.storage import pg_migrations, pg_pool
 

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -52,9 +52,6 @@ from pollypm.audit.watchdog import (
     RULE_TASK_PROGRESS_STALE,
     RULE_TASK_REVIEW_STALE,
     RULE_WORKER_SESSION_DEAD_LOOP,
-    TIER_1,
-    TIER_2,
-    TIER_3,
     WATCHDOG_ALERT_TYPE,
     WatchdogConfig,
     emit_escalation_dispatched,
@@ -1310,7 +1307,7 @@ def _self_heal_duplicate_advisor_tasks(
     )
     if not duplicate_ids:
         return counters
-    reason = f"duplicate advisor_review (auto-cleanup #1510)"
+    reason = "duplicate advisor_review (auto-cleanup #1510)"
     try:
         from pollypm.work import create_work_service
 

--- a/tests/test_bootstrap_pg_cli.py
+++ b/tests/test_bootstrap_pg_cli.py
@@ -145,9 +145,115 @@ def test_write_storage_block_is_idempotent(tmp_path: Path) -> None:
     assert text_after_first == cfg.read_text(encoding="utf-8")
 
 
-def test_write_storage_block_missing_config_returns_false(tmp_path: Path) -> None:
-    """Writing to a non-existent config emits a hint and returns False."""
-    cfg = tmp_path / "does-not-exist.toml"
-    wrote = storage_cli._write_storage_block(cfg, dsn="postgresql://x/y")
-    assert wrote is False
+def test_write_storage_block_creates_missing_config(tmp_path: Path) -> None:
+    """First run on a fresh install creates ``pollypm.toml`` with [storage] (#1888).
+
+    The earlier behavior bailed and returned False when the file did
+    not exist — leaving a brand-new ``pm bootstrap-pg`` operator with
+    no DSN written. The fix scaffolds a minimal config so the runtime
+    has a backend on next launch.
+    """
+    cfg = tmp_path / "subdir" / "pollypm.toml"
     assert not cfg.exists()
+
+    wrote = storage_cli._write_storage_block(cfg, dsn="postgresql://x/y")
+    assert wrote is True
+    assert cfg.exists()
+    text = cfg.read_text(encoding="utf-8")
+    assert "[storage]" in text
+    assert 'url = "postgresql://x/y"' in text
+
+    # Re-running on the now-existing file is idempotent.
+    wrote_again = storage_cli._write_storage_block(cfg, dsn="postgresql://x/y")
+    assert wrote_again is False
+    # No duplicate sections.
+    assert text == cfg.read_text(encoding="utf-8")
+
+
+def test_pg_db_exists_uses_parameter_binding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_pg_db_exists` must not f-string the db name into SQL (#1890).
+
+    Regression guard: a hostile ``--db`` value containing a single
+    quote / SQL fragment should not be reflected back as part of the
+    query text. The probe goes through psycopg with a ``%s`` placeholder.
+    """
+    captured: dict[str, object] = {}
+
+    class _FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):  # noqa: D401
+            return False
+
+        def execute(self, sql: str, params: tuple[object, ...]) -> None:
+            captured["sql"] = sql
+            captured["params"] = params
+
+        def fetchone(self):
+            return (1,)
+
+    class _FakeConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):  # noqa: D401
+            return False
+
+        def cursor(self):
+            return _FakeCursor()
+
+    class _FakePsycopg:
+        @staticmethod
+        def connect(dsn: str, **kwargs):  # noqa: ARG004
+            captured["dsn"] = dsn
+            return _FakeConn()
+
+    monkeypatch.setitem(__import__("sys").modules, "psycopg", _FakePsycopg)
+
+    hostile = "pollypm'; DROP TABLE foo; --"
+    assert storage_cli._pg_db_exists(hostile) is True
+
+    # The SQL text must be the parameterized form — the db name must
+    # NOT appear interpolated in the SQL.
+    sql = captured["sql"]
+    assert "%s" in sql
+    assert hostile not in sql
+    # The hostile value must travel as a bound parameter, not SQL.
+    assert captured["params"] == (hostile,)
+
+
+def test_bootstrap_pg_vector_step_is_python_not_psql_subprocess() -> None:
+    """The pgvector pre-step is a Python step routed through the friendly wrapper (#1889).
+
+    Regression guard: the previous implementation shelled out to ``psql
+    -c "CREATE EXTENSION ..."`` which bypassed
+    ``PgVectorExtensionMissing``. After the fix, the planner emits a
+    pure-Python step (``cmd is None``) so the executor can wrap the
+    DDL with the same friendly error.
+    """
+    steps = storage_cli._plan_steps(pg_version="postgresql@17", db_name="pollypm")
+    vector_steps = [s for s in steps if s.label.startswith("CREATE EXTENSION")]
+    assert len(vector_steps) == 1
+    assert vector_steps[0].cmd is None, (
+        "pgvector step must be a Python step so the friendly "
+        "PgVectorExtensionMissing wrapper fires."
+    )
+
+
+def test_create_vector_extension_wraps_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_create_vector_extension` re-raises connection errors with the install hint (#1889)."""
+    from pollypm.storage.pg_migrations import PgVectorExtensionMissing
+
+    class _ExplodingPsycopg:
+        @staticmethod
+        def connect(dsn: str, **kwargs):  # noqa: ARG004
+            raise RuntimeError("pgvector .so not on disk")
+
+    monkeypatch.setitem(__import__("sys").modules, "psycopg", _ExplodingPsycopg)
+
+    with pytest.raises(PgVectorExtensionMissing) as excinfo:
+        storage_cli._create_vector_extension("pollypm")
+    msg = str(excinfo.value)
+    assert "brew install pgvector" in msg
+    assert "vector" in msg


### PR DESCRIPTION
## Summary

Codex audit caught four regressions in the just-landed install-polish bundle (#1882). Fixed together so first-run ``pm bootstrap-pg`` is safe and self-documenting.

### #1888 — `pm bootstrap-pg` config write was a no-op on first run

`_write_storage_block` previously bailed and returned False when `~/.pollypm/pollypm.toml` did not exist, leaving a brand-new install with no DSN written. Since `pm bootstrap-pg` is meant to be the FIRST command an operator runs, the file usually doesn't exist. We now scaffold a minimal config containing just the `[storage]` block, with a header pointing at `pm example-config --force` for the full defaults.

### #1889 — pgvector pre-step bypassed the friendly missing-extension error

The `CREATE EXTENSION IF NOT EXISTS vector` pre-step in `_plan_steps` shelled out to `psql -c "..."`, which surfaced the bare server-side `feature_not_supported` error and bypassed the `PgVectorExtensionMissing` wrapper added in #1750. Replaced with a pure-Python `_create_vector_extension` helper that runs the DDL through psycopg and re-raises any failure with the same copy-paste install hint `apply_migrations` would emit.

### #1890 — SQL injection in `_pg_db_exists`

`_pg_db_exists` f-string'd the `--db` value directly into a SQL literal passed to `psql -tAc`. A hostile `--db` argument would inject SQL against the local `postgres` superuser session. Replaced with a psycopg `%s`-bound query against the admin DB — real parameter binding, no shell-escape workaround.

### #1892 — Ruff cleanup

Fixed F541 (extraneous f-strings, 6 occurrences across `audit/watchdog.py` and `plugins_builtin/core_recurring/audit_watchdog.py`) and F401 (unused `TIER_1/2/3` imports in `core_recurring/audit_watchdog.py`).

## Test plan

- [x] `uv run pytest tests/test_bootstrap_pg_cli.py -x -q` — 10/10 pass (includes 3 new regression tests for #1888, #1889, #1890)
- [x] `uvx ruff check src/pollypm/work/session_manager.py src/pollypm/audit/watchdog.py src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py` — All checks passed
- [x] `uv run pytest tests/test_audit_watchdog.py tests/test_pg_migrations.py tests/test_pg_migrations_pgvector_error.py -q` — 108/108 pass

Regression tests added:
- `test_write_storage_block_creates_missing_config` — verifies #1888 fix (file created with `[storage]` block when absent)
- `test_pg_db_exists_uses_parameter_binding` — verifies #1890 fix (hostile `--db` value travels as bound param, never lands in SQL text)
- `test_bootstrap_pg_vector_step_is_python_not_psql_subprocess` — verifies #1889 fix (vector step has `cmd is None` so the Python executor + friendly wrapper fires)
- `test_create_vector_extension_wraps_failures` — verifies #1889 friendly-error path

The existing `test_write_storage_block_missing_config_returns_false` was inverted — it asserted the old (broken) behavior — so it was rewritten to assert the new (correct) behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)