### PR TITLE
fix: dual-provider routing in launches + advisor enqueue config + plan-review filter + stuck_draft predicate (closes #1879 #1880 #1881 #1869)

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -735,6 +735,31 @@ def _detect_stuck_drafts(
                 continue
             created_events.append(ev)
 
+    # #1869 — when ``open_tasks`` is supplied (production cadence
+    # path), cross-check the event-based candidates against the
+    # live task state. The state-based path is authoritative; the
+    # event-based path was firing on tasks long since promoted to
+    # ``done``/``cancelled`` because the audit-event window can
+    # miss the corresponding ``task.status_changed`` event (the
+    # window read for the watchdog is narrower than a long-lived
+    # task's lifecycle, so an old ``task.created`` re-read after a
+    # log rotation or pg backfill arrived without its matching
+    # status-change history). Build a current-state index from
+    # ``open_tasks`` and skip event-based findings whose task is
+    # not actually in ``draft`` right now.
+    current_status_by_subject: dict[str, str] = {}
+    if open_tasks:
+        for task in open_tasks:
+            project = getattr(task, "project", "") or ""
+            task_number = getattr(task, "task_number", None)
+            if not project or task_number is None:
+                continue
+            subject_key = f"{project}/{task_number}"
+            status = getattr(task, "work_status", None)
+            status_value = getattr(status, "value", status)
+            if isinstance(status_value, str):
+                current_status_by_subject[subject_key] = status_value
+
     for ev in created_events:
         if ev.subject in promoted_subjects:
             continue
@@ -743,6 +768,12 @@ def _detect_stuck_drafts(
         key = _task_subject_key(ev.subject)
         if key is None:
             continue
+        # #1869 — when open_tasks is supplied, only fire on tasks
+        # actually in ``draft`` right now. A task that's known to the
+        # canonical store but not in draft must not be flagged stuck.
+        if open_tasks is not None and ev.subject in current_status_by_subject:
+            if current_status_by_subject[ev.subject] != "draft":
+                continue
         project, task_number = key
         seen_subjects.add(ev.subject)
         findings.append(Finding(

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -40,11 +40,13 @@ _GLOBAL_ROLE_ASSIGNMENT_KEYS = (
     "architect",
     "worker",
     "reviewer",
+    "advisor",
 )
 _PROJECT_ROLE_ASSIGNMENT_KEYS = (
     "architect",
     "worker",
     "reviewer",
+    "advisor",
 )
 
 _log = logging.getLogger(__name__)

--- a/src/pollypm/plugins_builtin/advisor/handlers/advisor_tick.py
+++ b/src/pollypm/plugins_builtin/advisor/handlers/advisor_tick.py
@@ -219,9 +219,15 @@ def enqueue_advisor_review(
         # ``resolve_work_db_path`` and always lands on the workspace-root
         # state.db, so advisor tasks are visible to every engine that
         # reads canonical (the throttle in particular).
+        #
+        # #1881 — thread ``config`` so the factory picks the configured
+        # backend (postgres on pg workspaces). Without it the factory
+        # defaulted to sqlite and advisor reviews landed in stale
+        # per-project state.db files instead of pg.
         work_service = create_work_service(
             project_path=project_path,
             project_key=project_key,
+            config=config,
         )
         close_service = True
 
@@ -238,6 +244,7 @@ def enqueue_advisor_review(
                 project_key=project_key,
                 work_service=work_service,
                 project_path=project_path,
+                config=config,
             ):
                 logger.debug(
                     "advisor: enqueue skipped for %s — sibling tick "
@@ -283,6 +290,7 @@ def has_in_progress_advisor_task(
     project_key: str,
     work_service: Any,
     project_path: Path | None = None,
+    config: Any | None = None,
 ) -> bool:
     """Return True if any advisor task is currently active for the project.
 
@@ -315,9 +323,12 @@ def has_in_progress_advisor_task(
         try:
             from pollypm.work import create_work_service
 
+            # #1881 — thread ``config`` so the throttle reads from the
+            # configured backend (pg on pg workspaces).
             work_service = create_work_service(
                 project_path=project_path,
                 project_key=project_key,
+                config=config,
             )
             close_service = True
         except Exception as exc:  # noqa: BLE001
@@ -364,6 +375,7 @@ def has_project_stagnation_candidate(
     project_key: str,
     project_path: Path,
     work_service: Any,
+    config: Any | None = None,
 ) -> bool:
     """Return True when a quiet project still has non-terminal work.
 
@@ -378,9 +390,12 @@ def has_project_stagnation_candidate(
             from pollypm.work import create_work_service
 
             # Canonical resolver only — see #1004 / advisor.tick spam fix.
+            # #1881 — thread ``config`` so the stagnation probe reads
+            # the configured backend (pg on pg workspaces).
             work_service = create_work_service(
                 project_path=project_path,
                 project_key=project_key,
+                config=config,
             )
             close_service = True
         except Exception:  # noqa: BLE001
@@ -473,6 +488,7 @@ def _should_review(
     settings: AdvisorSettings,
     now_utc: datetime,
     work_service: Any,
+    config: Any | None = None,
 ) -> tuple[bool, str]:
     """Return (review?, reason). Reason is a short machine-parseable tag."""
     if not settings.enabled:
@@ -511,6 +527,7 @@ def _should_review(
             project_key=project_key,
             project_path=project_path,
             work_service=work_service,
+            config=config,
         ):
             return False, "no-changes"
         reason = "stagnation-candidate"
@@ -521,6 +538,7 @@ def _should_review(
         project_key=project_key,
         work_service=work_service,
         project_path=project_path,
+        config=config,
     ):
         return False, "in-progress"
 
@@ -624,6 +642,7 @@ def advisor_tick_handler(payload: dict[str, Any]) -> dict[str, Any]:
             settings=settings,
             now_utc=now_utc,
             work_service=work_service,
+            config=config,
         )
 
         entry: dict[str, Any] = {

--- a/src/pollypm/plugins_builtin/default_launch_planner/planner.py
+++ b/src/pollypm/plugins_builtin/default_launch_planner/planner.py
@@ -29,7 +29,11 @@ from pollypm.projects import ensure_session_lock
 from pollypm.providers import get_provider
 from pollypm.providers.args import sanitize_provider_args
 from pollypm.providers.base import LaunchCommand
-from pollypm.role_routing import resolved_provider_kind, resolve_role_assignment
+from pollypm.role_routing import (
+    rewrite_assignment_for_provider as _rewrite_assignment_for_provider,
+    resolved_provider_kind,
+    resolve_role_assignment,
+)
 from pollypm.runtime_env import codex_home_dir
 from pollypm.runtimes import get_runtime
 
@@ -37,7 +41,7 @@ if TYPE_CHECKING:
     from pollypm.config import PollyPMConfig
 from pollypm.models import CONTROL_ROLES as _CONTROL_ROLES
 
-_ROUTED_ROLES = frozenset({"operator-pm", "architect", "worker", "reviewer"})
+_ROUTED_ROLES = frozenset({"operator-pm", "architect", "worker", "reviewer", "advisor"})
 _ROUND_START_ENV_KEYS = (
     "ROUND_START_ISO_TS",
     "ROUND_START_ERRNO24",
@@ -422,7 +426,38 @@ class DefaultLaunchPlanner:
                     session.name,
                 )
             else:
-                if routed_assignment.source != "fallback":
+                provider_matches = effective.provider is routed_provider
+                # #1879 — when the routing source is ``fallback`` (no
+                # explicit project/global role assignment) and the
+                # resolver wants a different provider than the session's
+                # effective provider, don't fight the session config or
+                # runtime override. Rewrite the alias to the matching
+                # single-provider entry so launch argv still carries a
+                # sensible ``--model`` flag. Explicit role assignments
+                # (project/global source) still switch provider+account
+                # via the branch below so users can deliberately rehome
+                # a session via config.
+                if (
+                    not provider_matches
+                    and routed_assignment.source == "fallback"
+                ):
+                    rewritten = _rewrite_assignment_for_provider(
+                        session.role,
+                        effective.provider,
+                        ctx.config,
+                    )
+                    if rewritten is not None:
+                        routed_assignment = rewritten
+                        try:
+                            routed_provider = resolved_provider_kind(routed_assignment)
+                        except ValueError:
+                            routed_assignment = None
+                            provider_matches = False
+                        else:
+                            provider_matches = effective.provider is routed_provider
+                if routed_assignment is None:
+                    pass
+                elif routed_assignment.source != "fallback":
                     account_name = _first_account_for_provider(
                         ctx.config,
                         provider=routed_provider,
@@ -454,7 +489,7 @@ class DefaultLaunchPlanner:
                             routed_assignment.model,
                             routed_assignment.source,
                         )
-                elif effective.provider is routed_provider:
+                elif provider_matches:
                     _log.info(
                         "Role routing resolved %s session %s to %s/%s from %s.",
                         session.role,

--- a/src/pollypm/role_routing.py
+++ b/src/pollypm/role_routing.py
@@ -208,6 +208,45 @@ def resolve_role_assignment(
     return fallback
 
 
+def rewrite_assignment_for_provider(
+    role: str,
+    provider: ProviderKind | str,
+    config: PollyPMConfig | None,
+    *,
+    registry: Registry | None = None,
+) -> ResolvedAssignment | None:
+    """Return a ``ResolvedAssignment`` whose provider matches ``provider``.
+
+    Used by the launch planner (#1879) when a runtime account override
+    has pinned the session's provider but the role-routing fallback
+    table named a different provider. Picks the alias from the
+    matching single-provider table so the launch argv still carries
+    a sensible ``--model`` flag.
+    """
+    try:
+        canonical = _canonical_role(role)
+    except ValueError:
+        return None
+    provider_value = getattr(provider, "value", provider)
+    if not isinstance(provider_value, str) or not provider_value:
+        return None
+    if provider_value == "claude":
+        assignment = _CLAUDE_ONLY_DEFAULTS.get(canonical)
+    elif provider_value == "codex":
+        assignment = _CODEX_ONLY_DEFAULTS.get(canonical)
+    else:
+        assignment = None
+    if assignment is None:
+        return None
+    resolved_registry = registry or load_registry()
+    return _resolved_from_assignment(
+        canonical,
+        assignment,
+        source="fallback",
+        registry=resolved_registry,
+    )
+
+
 class RoleRoutingFacade:
     def __init__(self, config_path: Path) -> None:
         self._config_path = config_path
@@ -229,4 +268,5 @@ __all__ = [
     "RoleRoutingFacade",
     "resolved_provider_kind",
     "resolve_role_assignment",
+    "rewrite_assignment_for_provider",
 ]

--- a/src/pollypm/work/inbox_plan_reviews.py
+++ b/src/pollypm/work/inbox_plan_reviews.py
@@ -44,6 +44,24 @@ def is_plan_task_approved(svc: Any, project: str, task_number: int) -> bool:
     return task_user_approval_is_approved(task)
 
 
+def _resolve_backend_name(config: object | None) -> str:
+    """Return the configured backend string, defaulting to ``"sqlite"``.
+
+    Mirrors :func:`pollypm.work.factory._resolve_backend` defensively
+    without importing the private symbol so callers (#1880) can pick
+    between shared-pg and per-sqlite paths without coupling.
+    """
+    if config is None:
+        return "sqlite"
+    storage = getattr(config, "storage", None)
+    if storage is None:
+        return "sqlite"
+    backend = getattr(storage, "backend", "sqlite")
+    if not isinstance(backend, str) or not backend.strip():
+        return "sqlite"
+    return backend.strip()
+
+
 def approved_plan_review_refs(
     *,
     refs_by_db: dict[str, set[tuple[str, int]]],
@@ -53,23 +71,25 @@ def approved_plan_review_refs(
 ) -> set[str]:
     """Return ``project/N`` refs whose plan-review task is already approved.
 
-    ``config`` is forwarded to the factory so the resolver routes to
-    the configured backend; without it the factory fell back to sqlite
-    even on a pg workspace, opening a stale ``state.db`` per project
-    refs ref-set (#1634).
+    Backend-aware (#1880):
+
+    * On Postgres every ``db_key`` resolves to the same pool, so a
+      single shared service handles every ref-set. We open it via
+      ``service_factory(config=config)``.
+    * On sqlite each ``db_key`` still maps to its own per-project
+      ``state.db``. The caller has already collected explicit
+      ``(db_path, project_path)`` pairs in ``project_db_paths``; we
+      walk them per ref-set so legacy per-project DBs are not bypassed.
     """
     if service_factory is None:
         from pollypm.work.factory import create_work_service
 
         service_factory = create_work_service
     approved_refs: set[str] = set()
-    # On the pg backend every db_key resolves to the same pool, so
-    # one shared svc handles every ref-set. On sqlite each db_key
-    # still maps to its own canonical workspace ``state.db`` (which
-    # the factory resolves identically per call), so the shared
-    # handle is also correct there.
+    backend = _resolve_backend_name(config)
+    use_shared = backend == "postgres" and config is not None
     shared_svc = None
-    if config is not None:
+    if use_shared:
         try:
             shared_svc = service_factory(config=config)
         except Exception:  # noqa: BLE001
@@ -83,7 +103,14 @@ def approved_plan_review_refs(
             svc = shared_svc
             opened_local = False
         else:
-            db_path, project_path = project_db_paths[db_key]
+            try:
+                db_path, project_path = project_db_paths[db_key]
+            except KeyError:
+                logger.debug(
+                    "inbox: no db_path for %s during plan-review check",
+                    db_key,
+                )
+                continue
             try:
                 svc = service_factory(
                     db_path=db_path,

--- a/tests/test_advisor_tick_config.py
+++ b/tests/test_advisor_tick_config.py
@@ -1,0 +1,114 @@
+"""Tests for advisor lazy work-service opens threading ``config`` (#1881)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pollypm.work as _pollypm_work
+from pollypm.plugins_builtin.advisor.handlers import advisor_tick as advisor_module
+
+
+class _FakeTask:
+    def __init__(self, task_id: str = "demo/1") -> None:
+        self.task_id = task_id
+        self.labels: list[str] = []
+
+
+class _FakeSvc:
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+
+    def list_tasks(self, **kwargs: Any) -> list[Any]:
+        return []
+
+    def create(self, **kwargs: Any) -> Any:
+        self.created.append(kwargs)
+        return _FakeTask()
+
+    def queue(self, task_id: str, actor: str) -> Any:
+        return SimpleNamespace(task_id=task_id)
+
+    def close(self) -> None:
+        pass
+
+
+def _install_factory(monkeypatch, factory):
+    monkeypatch.setattr(_pollypm_work, "create_work_service", factory)
+
+
+def test_enqueue_advisor_review_threads_config_to_factory(monkeypatch, tmp_path: Path) -> None:
+    """#1881: enqueue must pass ``config`` to the factory so the
+    configured backend (pg) is selected over the sqlite default."""
+    calls: list[dict[str, Any]] = []
+
+    def factory(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return _FakeSvc()
+
+    _install_factory(monkeypatch, factory)
+
+    config = SimpleNamespace(storage=SimpleNamespace(backend="postgres"))
+    project_path = tmp_path / "demo"
+    project_path.mkdir(parents=True, exist_ok=True)
+
+    result = advisor_module.enqueue_advisor_review(
+        project_key="demo",
+        project_path=project_path,
+        config=config,
+    )
+
+    assert result.get("enqueued") is True
+    assert calls, "factory was not called"
+    assert calls[0].get("config") is config, calls
+
+
+def test_has_in_progress_advisor_task_threads_config(monkeypatch, tmp_path: Path) -> None:
+    """#1881: throttle's lazy work-service open must pass config=."""
+    calls: list[dict[str, Any]] = []
+
+    def factory(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return _FakeSvc()
+
+    _install_factory(monkeypatch, factory)
+
+    config = SimpleNamespace(storage=SimpleNamespace(backend="postgres"))
+    project_path = tmp_path / "demo"
+    project_path.mkdir(parents=True, exist_ok=True)
+
+    advisor_module.has_in_progress_advisor_task(
+        project_key="demo",
+        work_service=None,
+        project_path=project_path,
+        config=config,
+    )
+
+    assert calls, "factory was not called"
+    assert calls[0].get("config") is config, calls
+
+
+def test_has_project_stagnation_candidate_threads_config(monkeypatch, tmp_path: Path) -> None:
+    """#1881: stagnation probe's lazy work-service open must pass config=."""
+    calls: list[dict[str, Any]] = []
+
+    def factory(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return _FakeSvc()
+
+    _install_factory(monkeypatch, factory)
+
+    config = SimpleNamespace(storage=SimpleNamespace(backend="postgres"))
+    project_path = tmp_path / "demo"
+    project_path.mkdir(parents=True, exist_ok=True)
+
+    advisor_module.has_project_stagnation_candidate(
+        project_key="demo",
+        project_path=project_path,
+        work_service=None,
+        config=config,
+    )
+
+    assert calls, "factory was not called"
+    assert calls[0].get("config") is config, calls

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -290,6 +290,86 @@ def test_stuck_draft_silenced_by_cancellation(now: datetime) -> None:
     assert findings == []
 
 
+def test_stuck_draft_event_path_cross_checks_open_tasks_status(now: datetime) -> None:
+    """#1869: when ``open_tasks`` is supplied, the event-based fallback
+    must not fire for tasks that are no longer in draft state.
+
+    Reproduces the false-positive sweep that was raising stuck_draft
+    against tasks that the canonical store shows as ``done`` /
+    ``cancelled`` — the event-window can lose the matching
+    ``task.status_changed`` after a log rotation while still re-reading
+    an old ``task.created``. The state cross-check is the safety net.
+    """
+    class _FakeTaskMin:
+        class _Status:
+            def __init__(self, value: str) -> None:
+                self.value = value
+
+        def __init__(self, project: str, task_number: int, work_status: str) -> None:
+            self.project = project
+            self.task_number = task_number
+            self.work_status = self._Status(work_status)
+
+    events = [
+        _make_event(
+            event=EVENT_TASK_CREATED,
+            subject="pollypm/9",
+            project="pollypm",
+            ts=now - timedelta(minutes=30),
+        ),
+    ]
+    open_tasks = [_FakeTaskMin("pollypm", 9, "done")]
+    findings = [
+        f
+        for f in scan_events(events, now=now, open_tasks=open_tasks)
+        if f.rule == RULE_STUCK_DRAFT
+    ]
+    assert findings == []
+
+
+def test_stuck_draft_event_path_still_fires_for_actual_draft_in_open_tasks(
+    now: datetime,
+) -> None:
+    """#1869: a task still in draft state (and present in open_tasks)
+    must still surface via either path. State path is authoritative,
+    but the event path acting on the same subject must not be
+    suppressed when the task is genuinely draft."""
+    class _FakeTaskMin:
+        class _Status:
+            def __init__(self, value: str) -> None:
+                self.value = value
+
+        def __init__(self, project: str, task_number: int, work_status: str,
+                     created_at: datetime | None = None) -> None:
+            self.project = project
+            self.task_number = task_number
+            self.work_status = self._Status(work_status)
+            self.created_at = created_at
+            self.created_by = "polly"
+            self.title = "draft test"
+
+    events = [
+        _make_event(
+            event=EVENT_TASK_CREATED,
+            subject="demo/2",
+            project="demo",
+            ts=now - timedelta(minutes=30),
+        ),
+    ]
+    # State-based path fires (created_at supplied, status draft, older
+    # than cutoff). Event path would dedupe to one finding.
+    open_tasks = [
+        _FakeTaskMin("demo", 2, "draft", created_at=now - timedelta(minutes=30)),
+    ]
+    findings = [
+        f
+        for f in scan_events(events, now=now, open_tasks=open_tasks)
+        if f.rule == RULE_STUCK_DRAFT
+    ]
+    assert len(findings) == 1
+    assert findings[0].subject == "demo/2"
+
+
 # ---------------------------------------------------------------------------
 # Rule 4: cancellation without promotion
 # ---------------------------------------------------------------------------

--- a/tests/test_inbox_plan_reviews.py
+++ b/tests/test_inbox_plan_reviews.py
@@ -1,0 +1,129 @@
+"""Tests for ``pollypm.work.inbox_plan_reviews`` (#1880)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from pollypm.work.inbox_plan_reviews import approved_plan_review_refs
+from pollypm.work.models import Decision, ExecutionStatus
+
+
+class _FakeExec:
+    node_id = "user_approval"
+    status = ExecutionStatus.COMPLETED
+    decision = Decision.APPROVED
+
+
+class _FakeTask:
+    def __init__(self) -> None:
+        self.executions = [_FakeExec()]
+
+
+class _SharedSvc:
+    def get(self, task_id: str) -> Any:
+        raise KeyError(task_id)
+
+    def close(self) -> None:
+        pass
+
+
+class _PerDbSvc:
+    def __init__(self, approved: dict[str, Any]) -> None:
+        self._approved = approved
+
+    def get(self, task_id: str) -> Any:
+        return self._approved[task_id]
+
+    def close(self) -> None:
+        pass
+
+
+def test_approved_plan_review_refs_uses_per_db_on_sqlite(tmp_path: Path) -> None:
+    """#1880: with sqlite backend, the function must walk per-project
+    sqlite DBs via the explicit ``db_path`` rather than falling back to
+    a single shared svc that bypasses legacy per-project state.dbs."""
+    calls: list[dict[str, Any]] = []
+
+    def factory(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        if kwargs.get("db_path") is None:
+            return _SharedSvc()
+        return _PerDbSvc({"demo/1": _FakeTask()})
+
+    config = SimpleNamespace(storage=SimpleNamespace(backend="sqlite"))
+    db_path = tmp_path / "legacy/demo/.pollypm/state.db"
+    project_path = tmp_path / "legacy/demo"
+
+    approved = approved_plan_review_refs(
+        refs_by_db={"demo": {("demo", 1)}},
+        project_db_paths={"demo": (db_path, project_path)},
+        service_factory=factory,
+        config=config,
+    )
+
+    assert approved == {"demo/1"}
+    # Factory was called with explicit per-db path, not the shared one.
+    assert any(c.get("db_path") == db_path for c in calls), calls
+    # Shared-svc path was not taken.
+    assert not any(
+        "db_path" not in c and c.get("config") is config for c in calls
+    )
+
+
+def test_approved_plan_review_refs_uses_shared_on_postgres(tmp_path: Path) -> None:
+    """#1880: with pg backend, the function opens a single shared svc."""
+    calls: list[dict[str, Any]] = []
+
+    pg_approved: dict[str, Any] = {"demo/1": _FakeTask()}
+
+    class _PgSvc:
+        def get(self, task_id: str) -> Any:
+            return pg_approved[task_id]
+
+        def close(self) -> None:
+            pass
+
+    def factory(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return _PgSvc()
+
+    config = SimpleNamespace(storage=SimpleNamespace(backend="postgres"))
+    db_path = tmp_path / "anywhere/state.db"
+    project_path = tmp_path / "anywhere"
+
+    approved = approved_plan_review_refs(
+        refs_by_db={"demo": {("demo", 1)}},
+        project_db_paths={"demo": (db_path, project_path)},
+        service_factory=factory,
+        config=config,
+    )
+
+    assert approved == {"demo/1"}
+    # One shared svc open without explicit db_path.
+    assert calls == [{"config": config}]
+
+
+def test_approved_plan_review_refs_per_db_when_no_config() -> None:
+    """When ``config`` is None the function still walks per-db paths."""
+    calls: list[dict[str, Any]] = []
+
+    def factory(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return _PerDbSvc({"demo/1": _FakeTask()})
+
+    db_path = Path("/legacy/demo/.pollypm/state.db")
+    project_path = Path("/legacy/demo")
+
+    approved = approved_plan_review_refs(
+        refs_by_db={"demo": {("demo", 1)}},
+        project_db_paths={"demo": (db_path, project_path)},
+        service_factory=factory,
+        config=None,
+    )
+
+    assert approved == {"demo/1"}
+    assert calls == [
+        {"db_path": db_path, "project_path": project_path, "config": None}
+    ]


### PR DESCRIPTION
## Summary

Four targeted bundled fixes from the cea58bd3..6e74f922 review pass.

### #1879 — profiles: dual-provider defaults reach launches; advisor route accepted
**Root cause:** the planner only kept routed assignments when (a) the source was project/global, or (b) the source was fallback AND the resolver's provider already matched the session's effective provider. Dual-provider workspaces had the fallback alias dropped on every provider mismatch, so launch argv lost ``--model``. Additionally, ``advisor`` wasn't in the planner's ``_ROUTED_ROLES`` gate, and ``[pollypm.roles.advisor]`` was rejected by the config parser.

**Fix:** when ``source == "fallback"`` and the resolver's provider differs from the session's effective provider, rewrite the alias to the matching single-provider entry (``_CLAUDE_ONLY_DEFAULTS`` / ``_CODEX_ONLY_DEFAULTS``) via the new ``rewrite_assignment_for_provider`` helper. The launch argv now carries a sensible ``--model`` regardless of which provider the runtime locks in. Explicit ``project``/``global`` assignments still switch provider+account. Added ``"advisor"`` to ``_ROUTED_ROLES`` and to both global and per-project role-assignment key tuples.

### #1880 — inbox: config-aware plan-review filter preserves legacy sqlite DBs
**Root cause:** ``approved_plan_review_refs`` opened one shared ``service_factory(config=config)`` and reused it for every ``db_key``. Correct for Postgres (single pool), but on sqlite the explicit per-project ``state.db`` paths were silently bypassed, so legacy per-project plan-review tasks were never marked approved.

**Fix:** detect the configured backend; use the shared svc only on Postgres, walk per-db paths on sqlite.

### #1881 — advisor: production enqueue and throttle threading config
**Root cause:** ``advisor_tick_handler`` loaded ``config`` and passed it to ``enqueue_advisor_review``, but the lazy ``create_work_service`` opens inside enqueue + throttle + stagnation paths called the factory **without** ``config=``. On a Postgres workspace the factory defaulted to sqlite, so advisor reviews landed in stale per-project DBs.

**Fix:** thread ``config`` through ``enqueue_advisor_review``, ``has_in_progress_advisor_task``, ``has_project_stagnation_candidate``, and ``_should_review``, then into each ``create_work_service`` call.

### #1869 — audit_watchdog stuck_draft false positives on non-draft tasks
**Root cause:** the event-based fallback path in ``_detect_stuck_drafts`` was firing for tasks long since promoted to ``done`` / ``cancelled``. The watchdog's event window is narrower than a long-lived task's lifecycle, so an old ``task.created`` re-read after a log rotation arrived without its matching ``task.status_changed`` — the suppression logic missed the promotion.

**Fix:** when ``open_tasks`` is supplied (production cadence path), build a current-status index and skip event-based findings for any subject the canonical store reports as not-draft. State path stays authoritative; event path remains a safety net for fixture-driven tests that don't pass ``open_tasks``.

## Test plan

- [x] ``tests/test_launch_planner.py`` — 18 passed
- [x] ``tests/test_role_routing.py`` — 5 passed
- [x] ``tests/test_inbox_plan_reviews.py`` (new) — 3 passed (sqlite per-db, pg shared, no-config)
- [x] ``tests/test_advisor_tick_config.py`` (new) — 3 passed (enqueue + throttle + stagnation all forward ``config=``)
- [x] ``tests/test_audit_watchdog.py`` — 95 passed (incl. 2 new #1869 regressions)
- [x] ``tests/test_audit_watchdog_liveness_probe.py`` — 10 passed
- [x] Named tests from #1879 now pass: ``test_control_session_args_follow_override_provider``, ``test_codex_control_launches_use_agents_md_instead_of_visible_prompt``
- [x] Full advisor suite — 116 passed, 1 unrelated pre-existing failure (``test_task_transitions_sqlite_fallback_uses_storage_query`` fails on main; not touched by this PR)

Closes #1879
Closes #1880
Closes #1881
Closes #1869

🤖 Generated with [Claude Code](https://claude.com/claude-code)