### PR TITLE
fix(inbox): cockpit pg-mode leaks + V1-RC crash (closes #1812 #1817)

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -596,16 +596,29 @@ def render_inbox_panel(service, projects: list[object] | None = None) -> str:
 def _render_inbox_panel(config) -> str:
     """Render the inbox panel for the active cockpit config.
 
-    Opens every tracked project's work-service DB, queries the inbox from
-    each, and renders the combined view. Projects with no DB are silently
-    skipped so a fresh install stays usable.
+    Backend-aware (#1817). On the configured backend:
+
+    * ``postgres`` — open ONE shared work-service handle and fetch every
+      task in a single bulk query, then group locally. The previous
+      per-project ``state.db`` fanout silently opened a fresh sqlite
+      handle (emitting ``work_db.opened`` 15×/min into
+      ``_workspace.jsonl``) AND rendered stale sqlite data on a pg
+      workspace.
+    * ``sqlite`` — walk the per-project state.db files as before; this
+      is the only correct path on sqlite where each project owns its
+      own file.
+
+    Projects with no DB are silently skipped so a fresh install stays
+    usable.
     """
     from typing import Any
 
     from pollypm.work import create_work_service
+    from pollypm.work.factory import _resolve_backend
 
-    # Aggregate inbox tasks across all tracked projects. Each project has its
-    # own SQLite db; we open each, query, then close.
+    # Aggregate inbox tasks across all tracked projects. On sqlite each
+    # project has its own DB so we open per-project; on pg we collapse
+    # to a single shared handle (#1817).
     class _AggregateService:
         """Adapter exposing the subset of WorkService used by inbox_view."""
 
@@ -635,26 +648,47 @@ def _render_inbox_panel(config) -> str:
     agg = _AggregateService()
     opened: list[Any] = []
     seen_task_ids: set[str] = set()
+    backend = _resolve_backend(config)
     try:
-        for project_key, db_path, project_path in _inbox_db_sources(config):
-            if not db_path.exists():
-                continue
+        if backend == "postgres":
+            # One shared svc, one bulk list_tasks (no project filter) —
+            # zero per-project SQLite opens, zero ``work_db.opened``
+            # noise.
             try:
-                svc = create_work_service(
-                    db_path=db_path, project_path=project_path, config=config,
-                )
+                svc = create_work_service(config=config)
             except Exception:  # noqa: BLE001
-                continue
-            opened.append(svc)
-            agg._flows_by_svc.append(svc)
-            try:
-                for task in svc.list_tasks(project=project_key):
-                    if task.task_id in seen_task_ids:
-                        continue
-                    seen_task_ids.add(task.task_id)
-                    agg._tasks.append(task)
-            except Exception:  # noqa: BLE001
-                pass
+                svc = None
+            if svc is not None:
+                opened.append(svc)
+                agg._flows_by_svc.append(svc)
+                try:
+                    for task in svc.list_tasks():
+                        if task.task_id in seen_task_ids:
+                            continue
+                        seen_task_ids.add(task.task_id)
+                        agg._tasks.append(task)
+                except Exception:  # noqa: BLE001
+                    pass
+        else:
+            for project_key, db_path, project_path in _inbox_db_sources(config):
+                if not db_path.exists():
+                    continue
+                try:
+                    svc = create_work_service(
+                        db_path=db_path, project_path=project_path, config=config,
+                    )
+                except Exception:  # noqa: BLE001
+                    continue
+                opened.append(svc)
+                agg._flows_by_svc.append(svc)
+                try:
+                    for task in svc.list_tasks(project=project_key):
+                        if task.task_id in seen_task_ids:
+                            continue
+                        seen_task_ids.add(task.task_id)
+                        agg._tasks.append(task)
+                except Exception:  # noqa: BLE001
+                    pass
 
         projects_iter = list(getattr(config, "projects", {}).values())
         return render_inbox_panel(agg, projects=projects_iter)

--- a/src/pollypm/cockpit_inbox_items.py
+++ b/src/pollypm/cockpit_inbox_items.py
@@ -659,7 +659,27 @@ def load_inbox_entries(
     *,
     session_read_ids: set[str] | None = None,
 ) -> tuple[list[InboxEntry], set[str], dict[str, list]]:
-    """Load Store-backed messages and task-backed inbox items together."""
+    """Load Store-backed messages and task-backed inbox items together.
+
+    Backend-aware (#1817). On the configured ``[storage] backend``:
+
+    * ``postgres`` — collapse the per-project fanout into a small fixed
+      number of pg queries: one bulk ``messages`` read via
+      :func:`pollypm.cockpit_pg_aggregates.open_messages`, one bulk
+      ``inbox_tasks`` via
+      :func:`pollypm.cockpit_pg_aggregates.inbox_tasks_grouped`, and
+      one read-marker + one bulk-replies query against a single shared
+      :class:`PgWorkService` handle. Previously this function walked
+      every tracked project's ``state.db`` and opened a fresh
+      ``SQLAlchemyStore`` per project; on a pg workspace that surfaced
+      stale sqlite data AND emitted ``work_db.opened`` ~15×/min into
+      ``_workspace.jsonl``.
+    * ``sqlite`` — keep the per-project ``state.db`` walk; on sqlite
+      each project owns its own file so the fanout is the only correct
+      shape.
+    """
+    from pollypm.work.factory import _resolve_backend
+
     session_read_ids = session_read_ids or set()
     items: list[InboxEntry] = []
     unread: set[str] = set()
@@ -673,140 +693,294 @@ def load_inbox_entries(
     # the filter can fall back to it when a referenced project has no
     # per-project state.db (#1103 follow-up).
     project_db_paths: dict[str, tuple[Path, Path]] = {}
-    for project_key, db_path, project_path in _inbox_db_sources(config):
-        if not db_path.exists():
-            continue
-        source_key = project_key or _WORKSPACE_DB_KEY
-        if project_key:
-            project_db_paths[project_key] = (db_path, project_path)
-        else:
-            project_db_paths[_WORKSPACE_DB_KEY] = (db_path, project_path)
+    backend = _resolve_backend(config)
+
+    if backend == "postgres":
+        # ------------------------------------------------------------------ #
+        # pg path: one shared svc + bulk aggregates. No per-project sqlite
+        # opens, no SQLAlchemyStore opens, no ``work_db.opened`` flood.
+        # ------------------------------------------------------------------ #
+        from pollypm.cockpit_pg_aggregates import (
+            inbox_tasks_for_project,
+            inbox_tasks_grouped,
+            open_messages,
+        )
+
+        # Build the project_db_paths map for the downstream plan_review
+        # filter without opening anything — the helper just walks paths.
+        for project_key, db_path, project_path in _inbox_db_sources(config):
+            if project_key:
+                project_db_paths[project_key] = (db_path, project_path)
+            else:
+                project_db_paths[_WORKSPACE_DB_KEY] = (db_path, project_path)
+
+        # Messages — one pg query for the whole workspace.
+        pg_messages = open_messages(config, known_projects=known_projects)
+        if pg_messages:
+            for row in pg_messages:
+                if _row_is_dev_channel(row.get("labels")):
+                    continue
+                scope = (row.get("scope") or "").strip()
+                if scope and scope in known_projects:
+                    source_key = scope
+                    entry_db = project_db_paths.get(scope, (None, None))[0]
+                else:
+                    source_key = _WORKSPACE_DB_KEY
+                    entry_db = project_db_paths.get(
+                        _WORKSPACE_DB_KEY, (None, None),
+                    )[0]
+                item = annotate_inbox_entry(
+                    message_row_to_inbox_entry(
+                        row,
+                        source_key=source_key,
+                        db_path=entry_db or Path("."),
+                    ),
+                    known_projects=known_projects,
+                )
+                items.append(item)
+                if item.task_id not in session_read_ids:
+                    unread.add(item.task_id)
+
+        # Tasks — one pg query, partitioned by project alias.
+        pg_inbox_grouped = inbox_tasks_grouped(config)
+
+        # Read-markers + replies — one shared svc handle for the
+        # whole-workspace context-entry queries. The per-project
+        # signatures on ``task_numbers_with_context_entry`` /
+        # ``bulk_list_replies`` haven't changed, but with one handle
+        # the cost is N pg queries (cheap; same pool) instead of N
+        # fresh service opens.
+        shared_svc = None
         try:
-            store = SQLAlchemyStore(f"sqlite:///{db_path}")
+            shared_svc = create_work_service(config=config)
         except Exception:  # noqa: BLE001
             logger.warning(
-                "load_inbox_entries: SQLAlchemyStore(%s) init failed; "
-                "skipping message rows for this source",
-                db_path, exc_info=True,
+                "load_inbox_entries: pg shared create_work_service failed; "
+                "treating read-markers + replies as empty",
+                exc_info=True,
             )
-            store = None
-        if store is not None:
-            try:
-                try:
-                    rows = store.query_messages(
-                        recipient="user",
-                        state="open",
-                        type=["notify", "inbox_task", "alert"],
+
+        try:
+            for project_key, db_path, _project_path in _inbox_db_sources(config):
+                if pg_inbox_grouped is None:
+                    project_tasks = []
+                elif project_key:
+                    project_tasks = inbox_tasks_for_project(
+                        pg_inbox_grouped, config, project_key,
                     )
-                except Exception:  # noqa: BLE001
-                    logger.warning(
-                        "load_inbox_entries: query_messages on %s failed; "
-                        "treating as empty",
-                        db_path, exc_info=True,
-                    )
-                    rows = []
-                for row in rows:
-                    if _row_is_dev_channel(row.get("labels")):
+                else:
+                    # Workspace-root source has no tasks of its own —
+                    # workspace notifications live in ``messages``.
+                    project_tasks = []
+                if not project_tasks:
+                    continue
+                project_for_query = project_key if project_key else "inbox"
+                read_marker_numbers: set[int] = set()
+                replies_by_number: dict[int, list] = {}
+                if shared_svc is not None:
+                    try:
+                        read_marker_numbers = (
+                            shared_svc.task_numbers_with_context_entry(
+                                project=project_for_query, entry_type="read",
+                            )
+                        )
+                    except Exception:  # noqa: BLE001
+                        logger.warning(
+                            "load_inbox_entries: task_numbers_with_context_entry"
+                            "(project=%s) failed; treating as empty read-marker set",
+                            project_for_query, exc_info=True,
+                        )
+                    try:
+                        replies_by_number = shared_svc.bulk_list_replies(
+                            project=project_for_query,
+                        )
+                    except Exception:  # noqa: BLE001
+                        logger.warning(
+                            "load_inbox_entries: bulk_list_replies(project=%s) "
+                            "failed; treating as empty replies map",
+                            project_for_query, exc_info=True,
+                        )
+                for task in project_tasks:
+                    if task.task_id in seen_task_ids:
                         continue
-                    item = annotate_inbox_entry(
-                        message_row_to_inbox_entry(
-                            row,
-                            source_key=source_key,
-                            db_path=db_path,
-                        ),
-                        known_projects=known_projects,
+                    seen_task_ids.add(task.task_id)
+                    task_labels = {
+                        str(lbl) for lbl in (getattr(task, "labels", []) or [])
+                    }
+                    if "plan_review" in task_labels:
+                        emit = not _task_user_approval_is_approved(task)
+                        logger.warning(
+                            "PLAN_REVIEW_SYNTH project=%s task_id=%s emit=%s "
+                            "reason=%s",
+                            getattr(task, "project", "") or "",
+                            task.task_id,
+                            emit,
+                            "user_approval_pending"
+                            if emit else "user_approval_approved",
+                        )
+                        if not emit:
+                            continue
+                    items.append(
+                        annotate_inbox_entry(
+                            task_to_inbox_entry(task, db_path=db_path),
+                            known_projects=known_projects,
+                        )
                     )
-                    items.append(item)
-                    if item.task_id not in session_read_ids:
-                        unread.add(item.task_id)
-            finally:
+                    if task.task_number not in read_marker_numbers:
+                        unread.add(task.task_id)
+                    replies = replies_by_number.get(task.task_number, [])
+                    if replies:
+                        replies_by_task[task.task_id] = replies
+        finally:
+            if shared_svc is not None:
                 try:
-                    store.close()
+                    shared_svc.close()
                 except Exception:  # noqa: BLE001
                     pass
-        try:
-            svc = create_work_service(
-                db_path=db_path, project_path=project_path, config=config,
-            )
-        except Exception:  # noqa: BLE001
-            logger.warning(
-                "load_inbox_entries: create_work_service(%s) failed; "
-                "skipping task rows for project=%s",
-                db_path, project_key, exc_info=True,
-            )
-            continue
-        try:
+    else:
+        # ------------------------------------------------------------------ #
+        # sqlite path: per-project state.db walk (canonical on sqlite where
+        # each project owns its own file).
+        # ------------------------------------------------------------------ #
+        for project_key, db_path, project_path in _inbox_db_sources(config):
+            if not db_path.exists():
+                continue
+            source_key = project_key or _WORKSPACE_DB_KEY
+            if project_key:
+                project_db_paths[project_key] = (db_path, project_path)
+            else:
+                project_db_paths[_WORKSPACE_DB_KEY] = (db_path, project_path)
             try:
-                project_tasks = inbox_tasks(svc, project=project_key)
+                store = SQLAlchemyStore(f"sqlite:///{db_path}")
             except Exception:  # noqa: BLE001
                 logger.warning(
-                    "load_inbox_entries: inbox_tasks(project=%s) failed; "
-                    "treating as empty",
-                    project_key, exc_info=True,
+                    "load_inbox_entries: SQLAlchemyStore(%s) init failed; "
+                    "skipping message rows for this source",
+                    db_path, exc_info=True,
                 )
-                project_tasks = []
-            # N+1 escape: pre-fetch read-markers and replies for every
-            # task in this project in one query each, then bucket
-            # locally. Was 2 roundtrips per task on the 8s refresh tick.
-            project_for_query = project_key if project_key else "inbox"
+                store = None
+            if store is not None:
+                try:
+                    try:
+                        rows = store.query_messages(
+                            recipient="user",
+                            state="open",
+                            type=["notify", "inbox_task", "alert"],
+                        )
+                    except Exception:  # noqa: BLE001
+                        logger.warning(
+                            "load_inbox_entries: query_messages on %s failed; "
+                            "treating as empty",
+                            db_path, exc_info=True,
+                        )
+                        rows = []
+                    for row in rows:
+                        if _row_is_dev_channel(row.get("labels")):
+                            continue
+                        item = annotate_inbox_entry(
+                            message_row_to_inbox_entry(
+                                row,
+                                source_key=source_key,
+                                db_path=db_path,
+                            ),
+                            known_projects=known_projects,
+                        )
+                        items.append(item)
+                        if item.task_id not in session_read_ids:
+                            unread.add(item.task_id)
+                finally:
+                    try:
+                        store.close()
+                    except Exception:  # noqa: BLE001
+                        pass
             try:
-                read_marker_numbers = svc.task_numbers_with_context_entry(
-                    project=project_for_query, entry_type="read",
+                svc = create_work_service(
+                    db_path=db_path, project_path=project_path, config=config,
                 )
             except Exception:  # noqa: BLE001
                 logger.warning(
-                    "load_inbox_entries: task_numbers_with_context_entry"
-                    "(project=%s) failed; treating as empty read-marker set",
-                    project_for_query, exc_info=True,
+                    "load_inbox_entries: create_work_service(%s) failed; "
+                    "skipping task rows for project=%s",
+                    db_path, project_key, exc_info=True,
                 )
-                read_marker_numbers = set()
+                continue
             try:
-                replies_by_number = svc.bulk_list_replies(project=project_for_query)
-            except Exception:  # noqa: BLE001
-                logger.warning(
-                    "load_inbox_entries: bulk_list_replies(project=%s) failed; "
-                    "treating as empty replies map",
-                    project_for_query, exc_info=True,
-                )
-                replies_by_number = {}
-            for task in project_tasks:
-                if task.task_id in seen_task_ids:
-                    continue
-                seen_task_ids.add(task.task_id)
-                # Synth-source filter for plan_review (#1103, 4th
-                # attempt). Check the task's own user_approval
-                # execution directly: if it's COMPLETED + APPROVED,
-                # the plan review is already done and emitting the row
-                # would be a phantom action.
-                task_labels = {str(lbl) for lbl in (getattr(task, "labels", []) or [])}
-                if "plan_review" in task_labels:
-                    emit = not _task_user_approval_is_approved(task)
+                try:
+                    project_tasks = inbox_tasks(svc, project=project_key)
+                except Exception:  # noqa: BLE001
                     logger.warning(
-                        "PLAN_REVIEW_SYNTH project=%s task_id=%s emit=%s "
-                        "reason=%s",
-                        getattr(task, "project", "") or "",
-                        task.task_id,
-                        emit,
-                        "user_approval_pending" if emit else "user_approval_approved",
+                        "load_inbox_entries: inbox_tasks(project=%s) failed; "
+                        "treating as empty",
+                        project_key, exc_info=True,
                     )
-                    if not emit:
+                    project_tasks = []
+                # N+1 escape: pre-fetch read-markers and replies for every
+                # task in this project in one query each, then bucket
+                # locally. Was 2 roundtrips per task on the 8s refresh tick.
+                project_for_query = project_key if project_key else "inbox"
+                try:
+                    read_marker_numbers = svc.task_numbers_with_context_entry(
+                        project=project_for_query, entry_type="read",
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "load_inbox_entries: task_numbers_with_context_entry"
+                        "(project=%s) failed; treating as empty read-marker set",
+                        project_for_query, exc_info=True,
+                    )
+                    read_marker_numbers = set()
+                try:
+                    replies_by_number = svc.bulk_list_replies(
+                        project=project_for_query,
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "load_inbox_entries: bulk_list_replies(project=%s) failed; "
+                        "treating as empty replies map",
+                        project_for_query, exc_info=True,
+                    )
+                    replies_by_number = {}
+                for task in project_tasks:
+                    if task.task_id in seen_task_ids:
                         continue
-                items.append(
-                    annotate_inbox_entry(
-                        task_to_inbox_entry(task, db_path=db_path),
-                        known_projects=known_projects,
+                    seen_task_ids.add(task.task_id)
+                    # Synth-source filter for plan_review (#1103, 4th
+                    # attempt). Check the task's own user_approval
+                    # execution directly: if it's COMPLETED + APPROVED,
+                    # the plan review is already done and emitting the row
+                    # would be a phantom action.
+                    task_labels = {
+                        str(lbl) for lbl in (getattr(task, "labels", []) or [])
+                    }
+                    if "plan_review" in task_labels:
+                        emit = not _task_user_approval_is_approved(task)
+                        logger.warning(
+                            "PLAN_REVIEW_SYNTH project=%s task_id=%s emit=%s "
+                            "reason=%s",
+                            getattr(task, "project", "") or "",
+                            task.task_id,
+                            emit,
+                            "user_approval_pending"
+                            if emit else "user_approval_approved",
+                        )
+                        if not emit:
+                            continue
+                    items.append(
+                        annotate_inbox_entry(
+                            task_to_inbox_entry(task, db_path=db_path),
+                            known_projects=known_projects,
+                        )
                     )
-                )
-                if task.task_number not in read_marker_numbers:
-                    unread.add(task.task_id)
-                replies = replies_by_number.get(task.task_number, [])
-                if replies:
-                    replies_by_task[task.task_id] = replies
-        finally:
-            try:
-                svc.close()
-            except Exception:  # noqa: BLE001
-                pass
+                    if task.task_number not in read_marker_numbers:
+                        unread.add(task.task_id)
+                    replies = replies_by_number.get(task.task_number, [])
+                    if replies:
+                        replies_by_task[task.task_id] = replies
+            finally:
+                try:
+                    svc.close()
+                except Exception:  # noqa: BLE001
+                    pass
     items = _dedupe_replayed_plan_reviews(items)
     items = _dedupe_message_vs_task_plan_reviews(items)
     items = _filter_approved_plan_reviews(
@@ -827,52 +1001,101 @@ def load_inbox_action_preview(
     This helper is only for the cockpit-pane prepaint path, where showing the
     first action rows quickly matters more than reply counts or task-backed
     rows that will arrive with the Textual app's normal refresh.
+
+    Backend-aware (#1817). On pg this is one bulk pg query via
+    :func:`pollypm.cockpit_pg_aggregates.open_messages`; the historic
+    per-project SQLAlchemyStore fanout would otherwise surface stale
+    sqlite data on a pg workspace.
     """
+    from pollypm.work.factory import _resolve_backend
+
     preview_limit = max(int(limit), 1)
     rows_per_source = max(preview_limit * 4, 48)
     known_projects = set(getattr(config, "projects", {}).keys())
     items: list[InboxEntry] = []
+    backend = _resolve_backend(config)
 
-    for project_key, db_path, _project_path in _inbox_db_sources(config):
-        if not db_path.exists():
-            continue
-        try:
-            store = SQLAlchemyStore(f"sqlite:///{db_path}")
-        except Exception:  # noqa: BLE001
-            continue
-        try:
+    if backend == "postgres":
+        from pollypm.cockpit_pg_aggregates import open_messages
+
+        # Build a project -> db_path lookup so the entries carry a
+        # plausible db_path (downstream filters key off it).
+        project_db_paths: dict[str, Path] = {}
+        ws_db: Path | None = None
+        for project_key, db_path, _project_path in _inbox_db_sources(config):
+            if project_key:
+                project_db_paths[project_key] = db_path
+            else:
+                ws_db = db_path
+        pg_messages = open_messages(config, known_projects=known_projects)
+        rows_iter: list[dict] = list(pg_messages or [])
+        # Match the sqlite path's per-source cap roughly — pg returns
+        # rows newest-first already, slice to keep the prepaint snappy.
+        rows_iter = rows_iter[: max(rows_per_source * 4, 96)]
+        for row in rows_iter:
+            if _row_is_dev_channel(row.get("labels")):
+                continue
+            scope = (row.get("scope") or "").strip()
+            if scope and scope in known_projects:
+                source_key = scope
+                entry_db = project_db_paths.get(scope, ws_db) or Path(".")
+            else:
+                source_key = _WORKSPACE_DB_KEY
+                entry_db = ws_db or Path(".")
+            item = annotate_inbox_entry(
+                message_row_to_inbox_entry(
+                    row, source_key=source_key, db_path=entry_db,
+                ),
+                known_projects=known_projects,
+            )
+            if project and (getattr(item, "project", "") or "") != project:
+                continue
+            if getattr(item, "is_orphaned", False):
+                continue
+            if not getattr(item, "needs_action", False):
+                continue
+            items.append(item)
+    else:
+        for project_key, db_path, _project_path in _inbox_db_sources(config):
+            if not db_path.exists():
+                continue
             try:
-                rows = store.query_messages(
-                    recipient="user",
-                    state="open",
-                    type=["notify", "inbox_task", "alert"],
-                    limit=rows_per_source,
-                )
+                store = SQLAlchemyStore(f"sqlite:///{db_path}")
             except Exception:  # noqa: BLE001
-                rows = []
-            for row in rows:
-                if _row_is_dev_channel(row.get("labels")):
-                    continue
-                item = annotate_inbox_entry(
-                    message_row_to_inbox_entry(
-                        row,
-                        source_key=project_key or _WORKSPACE_DB_KEY,
-                        db_path=db_path,
-                    ),
-                    known_projects=known_projects,
-                )
-                if project and (getattr(item, "project", "") or "") != project:
-                    continue
-                if getattr(item, "is_orphaned", False):
-                    continue
-                if not getattr(item, "needs_action", False):
-                    continue
-                items.append(item)
-        finally:
+                continue
             try:
-                store.close()
-            except Exception:  # noqa: BLE001
-                pass
+                try:
+                    rows = store.query_messages(
+                        recipient="user",
+                        state="open",
+                        type=["notify", "inbox_task", "alert"],
+                        limit=rows_per_source,
+                    )
+                except Exception:  # noqa: BLE001
+                    rows = []
+                for row in rows:
+                    if _row_is_dev_channel(row.get("labels")):
+                        continue
+                    item = annotate_inbox_entry(
+                        message_row_to_inbox_entry(
+                            row,
+                            source_key=project_key or _WORKSPACE_DB_KEY,
+                            db_path=db_path,
+                        ),
+                        known_projects=known_projects,
+                    )
+                    if project and (getattr(item, "project", "") or "") != project:
+                        continue
+                    if getattr(item, "is_orphaned", False):
+                        continue
+                    if not getattr(item, "needs_action", False):
+                        continue
+                    items.append(item)
+            finally:
+                try:
+                    store.close()
+                except Exception:  # noqa: BLE001
+                    pass
 
     if not items:
         return [], set(), 0

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -7772,11 +7772,14 @@ class PollyInboxApp(App[None]):
         return tasks, unread, replies_by_task
 
     def _svc_for_task(self, task_id: str):
-        """Open a SQLiteWorkService rooted at the project owning ``task_id``.
+        """Open a WorkService rooted at the project owning ``task_id``.
 
         The cockpit inbox spans every tracked project, so archive/reply
-        actions must target the project-specific DB. We resolve the
-        project from the task_id prefix and look up its path in config.
+        actions must target the project-specific service. We resolve
+        the project from the task_id prefix and route through
+        :func:`open_work_service_for_task` which honours
+        ``[storage] backend`` (#1812 — pg-aware after the sqlite-only
+        gate was dropped).
         """
         config = load_config(self.config_path)
         from pollypm.work.inbox_actions import open_work_service_for_task
@@ -7784,12 +7787,14 @@ class PollyInboxApp(App[None]):
         return open_work_service_for_task(config, task_id)
 
     def _resolve_inbox_svc(self, item, task_id: str):
-        """Best-effort resolve a SQLiteWorkService for a cockpit inbox row.
+        """Best-effort resolve a work service for a cockpit inbox row.
 
-        First tries :meth:`_svc_for_task` (the project-key path), then
-        falls back to opening the work-service directly at the inbox
-        entry's ``db_path`` — this is the unified resolver that fixes
-        the family of "Could not open project database" toast bugs
+        Returns whichever backend the configured ``[storage] backend``
+        selects (sqlite or postgres — #1812). First tries
+        :meth:`_svc_for_task` (the project-key path), then falls back to
+        opening the work-service directly at the inbox entry's
+        ``db_path`` — this is the unified resolver that fixes the
+        family of "Could not open project database" toast bugs
         (#1087, #1091, #1099, #1101) where the task row's project key
         doesn't match the registered key (e.g. ``polly_remote`` vs.
         ``polly-remote``) but the entry was loaded from a known DB.

--- a/src/pollypm/work/inbox_actions.py
+++ b/src/pollypm/work/inbox_actions.py
@@ -10,23 +10,39 @@ logger = logging.getLogger(__name__)
 
 
 def open_work_service_for_task(config: Any, task_id: str) -> Any | None:
-    """Open the work service for the registered project owning ``task_id``."""
+    """Open the work service for the registered project owning ``task_id``.
+
+    Backend-aware (#1812). On the sqlite backend we still gate on the
+    per-project ``.pollypm/state.db`` existing on disk — that's the file
+    the service will read. On the pg backend there is no per-project
+    file; the only gate is "the task's project key is registered" so
+    :func:`create_work_service` is asked for a service against the
+    workspace-wide pg store with ``project_key`` set. The previous
+    blanket ``db_path.exists()`` short-circuit silently disabled the
+    primary resolver path under pg.
+    """
     project_key = task_id.split("/", 1)[0]
     project = getattr(config, "projects", {}).get(project_key)
     if project is None:
         return None
     db_path = project.path / ".pollypm" / "state.db"
-    if not db_path.exists():
+    try:
+        from pollypm.work.factory import _resolve_backend, create_work_service
+    except Exception:  # noqa: BLE001
+        return None
+
+    backend = _resolve_backend(config)
+    if backend != "postgres" and not db_path.exists():
+        # sqlite-only gate kept: there is literally no DB file to open.
+        # On pg the file is irrelevant so we skip this check.
         return None
     try:
-        from pollypm.work.factory import create_work_service
-
         # Forward ``config`` so ``[storage] backend`` is honoured (#1369,
         # #1737). ``db_path`` is ignored on the pg backend per the factory
         # docstring; on sqlite the per-project file is used as before.
         return create_work_service(
             config=config,
-            db_path=db_path,
+            db_path=db_path if backend != "postgres" else None,
             project_path=project.path,
             project_key=project_key,
         )
@@ -38,25 +54,20 @@ def resolve_inbox_work_service(config: Any, item: Any, task_id: str) -> Any | No
     """Resolve a work service for a cockpit inbox row.
 
     The task-id project key is tried first. If that does not map to a
-    registered project DB, or if that DB exists but does not contain the
-    task that produced the inbox row, the inbox entry's source
+    registered project, or if the registered service does not contain
+    the task that produced the inbox row, the inbox entry's source
     ``db_path`` is used as a best-effort fallback.
+
+    Backend-agnostic (#1812). Previously this helper used a sqlite-only
+    ``svc._db_path`` getattr to short-circuit the ``svc.get(task_id)``
+    probe; under pg that attribute is missing, so ``same_db`` was always
+    ``False`` and the probe always ran (which is the safer default
+    anyway). Now we always probe — the cost is one extra select per
+    inbox row and the resolver behaves identically across backends.
     """
     db_path = getattr(item, "db_path", None) if item is not None else None
     svc = open_work_service_for_task(config, task_id)
     if svc is not None:
-        item_db_path = Path(db_path) if db_path is not None else None
-        svc_db_path = getattr(svc, "_db_path", None)
-        try:
-            same_db = (
-                item_db_path is not None
-                and svc_db_path is not None
-                and item_db_path.resolve() == Path(svc_db_path).resolve()
-            )
-        except Exception:  # noqa: BLE001
-            same_db = False
-        if item_db_path is None or same_db:
-            return svc
         try:
             svc.get(task_id)
             return svc
@@ -66,7 +77,7 @@ def resolve_inbox_work_service(config: Any, item: Any, task_id: str) -> Any | No
             except Exception:  # noqa: BLE001
                 pass
             logger.debug(
-                "cockpit inbox: registered project db did not contain %s; "
+                "cockpit inbox: registered project svc did not contain %s; "
                 "falling back to source db_path=%r",
                 task_id,
                 db_path,

--- a/src/pollypm/work/service.py
+++ b/src/pollypm/work/service.py
@@ -259,6 +259,27 @@ class WorkService(Protocol):
         """
         ...
 
+    def list_replies(self, task_id: str) -> list[ContextEntry]:
+        """Return reply entries for ``task_id`` oldest-first (#1812).
+
+        Thin wrapper around :meth:`get_context` with
+        ``entry_type='reply'`` plus a reversal so the inbox detail pane
+        renders the thread in natural reading order. Pinned on the
+        protocol so cockpit code never has to ``hasattr`` past a
+        backend that forgot to implement it.
+        """
+        ...
+
+    def bulk_list_replies(self, *, project: str) -> dict[int, list[ContextEntry]]:
+        """Return ``task_number -> [reply entries (oldest first)]`` (#1812).
+
+        One project-wide query, bucketed in Python. Replaces a per-task
+        :meth:`list_replies` loop on the inbox loader hot path. Pinned
+        on the protocol so the bulk path is part of the WorkService
+        contract rather than a backend-specific optimisation.
+        """
+        ...
+
     # ------------------------------------------------------------------
     # Relationships
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two stacked fixes for V1-RC cockpit inbox blockers on the pg backend.

### closes #1812 — inbox detail crashes with `PgWorkService has no list_replies`
- **Bug A** (`PgWorkService.list_replies` / `bulk_list_replies` missing on the protocol): both methods already exist on the concrete service; pinned them on the `WorkService` Protocol so the cockpit detail pane can't crash on a backend that forgot to implement them.
- **Bug B** (`open_work_service_for_task` sqlite-only existence gate): drops the unconditional `db_path.exists()` short-circuit. On the pg backend there is no per-project `state.db` so the gate silently disabled the primary resolver path and forced every inbox open through the legacy sqlite fallback. Now backend-aware.
- **Bug C** (`resolve_inbox_work_service` uses sqlite-only `_db_path` getattr): drops the same_db optimisation; always runs the `svc.get(task_id)` probe. Resolver behaves identically across backends.
- Stale `SQLiteWorkService` docstrings in `cockpit_ui.py` refreshed.

### closes #1817 — cockpit inbox panel reads from stale SQLite on pg backend
- `_render_inbox_panel` (`cockpit_inbox.py`): on pg, opens ONE shared `WorkService` and runs one bulk `list_tasks()` — no per-project sqlite fanout, no stale data.
- `load_inbox_entries` (`cockpit_inbox_items.py`): on pg, routes through `cockpit_pg_aggregates.open_messages` + `inbox_tasks_grouped` for the bulk surface plus one shared `WorkService` for read-markers + `bulk_list_replies`. No `SQLAlchemyStore` opens, no per-project work-service opens, no `work_db.opened` flood.
- `load_inbox_action_preview` (`cockpit_inbox_items.py`): pg prepaint uses `open_messages`.
- sqlite paths are unchanged.

## Test plan
- [ ] On a pg workspace: `pm inbox awaits-user --json` returns expected items (already pg-routed via `pm_inbox_awaits_user_list`; not regressed)
- [ ] On a pg workspace: `pm cockpit-pane inbox` renders the inbox panel and the detail pane opens without `'PgWorkService' has no attribute 'list_replies'`
- [ ] On a pg workspace: tail `~/.pollypm/audit/_workspace.jsonl` while the cockpit refreshes — `work_db.opened` cadence should drop from ~15/min on three sqlite subjects to zero from the inbox-panel paths
- [ ] On a sqlite workspace: cockpit inbox rendering unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)