### PR TITLE
fix(storage+inbox+advisor): backend-aware reads (closes #1811 #1755 #1757)

### DIFF
--- a/src/pollypm/plugins_builtin/advisor/handlers/advisor_tick.py
+++ b/src/pollypm/plugins_builtin/advisor/handlers/advisor_tick.py
@@ -80,6 +80,7 @@ def detect_changes(
     *,
     project_key: str | None = None,
     work_service: Any | None = None,
+    config: Any | None = None,
 ) -> bool:
     """Return True when the project has a commit or task transition since ``since``.
 
@@ -88,6 +89,9 @@ def detect_changes(
     monkeypatch this symbol to force particular outcomes; ad03's
     context-packing imports the full :class:`ChangeReport` directly
     from ``detect_changes.py``.
+
+    ``config`` is forwarded so PG transition reads honour the active
+    ``[storage].backend`` (#1757).
     """
     from pollypm.plugins_builtin.advisor.handlers.detect_changes import (
         detect_changes as _detect,
@@ -97,6 +101,7 @@ def detect_changes(
         since,
         project_key=project_key,
         work_service=work_service,
+        config=config,
     )
     return report.has_changes
 
@@ -513,11 +518,22 @@ def _should_review(
                     project_path, since,
                     project_key=project_key,
                     work_service=work_service,
+                    config=config,
                 )
             )
         except TypeError:
-            # Backwards-compat: some tests patch a two-arg stub.
-            changed = bool(_self.detect_changes(project_path, since))
+            # Backwards-compat: some tests patch a two-arg stub, or an
+            # older signature that doesn't accept ``config``.
+            try:
+                changed = bool(
+                    _self.detect_changes(
+                        project_path, since,
+                        project_key=project_key,
+                        work_service=work_service,
+                    )
+                )
+            except TypeError:
+                changed = bool(_self.detect_changes(project_path, since))
     except Exception as exc:  # noqa: BLE001
         logger.debug("advisor: detect_changes failed for %s: %s", project_key, exc)
         return False, "detect-error"

--- a/src/pollypm/plugins_builtin/advisor/handlers/detect_changes.py
+++ b/src/pollypm/plugins_builtin/advisor/handlers/detect_changes.py
@@ -249,19 +249,47 @@ def _transitions_db_path(project_path: Path) -> Path | None:
     return db_path
 
 
+def _is_pg_backend(config: Any | None) -> bool:
+    """Return ``True`` when the active storage backend is Postgres.
+
+    Mirrors :func:`pollypm.storage._backend_dispatch.is_pg_backend` but
+    inlined to keep the advisor handler decoupled from the storage
+    package's private dispatch helper. Defaults to sqlite when the
+    config can't be read.
+    """
+    if config is None:
+        try:
+            from pollypm.config import load_config
+
+            config = load_config()
+        except Exception:  # noqa: BLE001
+            return False
+    storage = getattr(config, "storage", None)
+    if storage is None:
+        return False
+    backend = getattr(storage, "backend", "sqlite")
+    if not isinstance(backend, str):
+        return False
+    return backend.strip().lower() == "postgres"
+
+
 def _gather_task_transitions(
     project_path: Path,
     project_key: str,
     since: datetime | None,
     *,
     work_service: Any | None = None,
+    config: Any | None = None,
 ) -> list[TaskTransitionRecord]:
     """Return transitions for ``project_key`` after ``since``.
 
     Prefers a caller-supplied work-service handle (tests inject an
-    in-memory fake). Falls back to a read-only sqlite open of the
-    project's ``.pollypm/state.db`` through the storage query facade so
-    the advisor doesn't own raw SQLite connection details.
+    in-memory fake). On the Postgres backend, calls the
+    :func:`pollypm.storage.work_transition_queries.advisor_transition_rows`
+    facade directly with ``db_path=None`` — there's no per-project
+    SQLite file to gate on (#1757). On the SQLite backend, falls back
+    to a read-only open of the project's workspace-root ``state.db``
+    through the same facade.
     """
     since_iso = since.isoformat() if since else _default_since_iso()
 
@@ -276,17 +304,34 @@ def _gather_task_transitions(
                 rows = []
             return list(rows)
 
-    db_path = _transitions_db_path(project_path)
-    if db_path is None or not db_path.exists():
-        return []
-
     from pollypm.storage.work_transition_queries import advisor_transition_rows
 
-    rows = advisor_transition_rows(
-        db_path,
-        project_key=project_key,
-        since_iso=since_iso,
-    )
+    # #1757: the SQLite existence gate must NOT short-circuit the PG
+    # branch. On a migrated install with `[storage].backend = "postgres"`
+    # the per-project state.db is intentionally absent, so probing for
+    # its existence dropped every advisor tick to zero transitions and
+    # suppressed assessment signals.
+    if _is_pg_backend(config):
+        # ``db_path`` is unused by the facade on the pg branch — pass
+        # a placeholder so the signature matches without resolving the
+        # legacy sqlite path. Thread ``config`` through so a non-default
+        # ``--config`` reaches the right pg pool (#1755 dovetail).
+        rows = advisor_transition_rows(
+            project_path,  # placeholder; facade discards on pg backend
+            project_key=project_key,
+            since_iso=since_iso,
+            config=config,
+        )
+    else:
+        db_path = _transitions_db_path(project_path)
+        if db_path is None or not db_path.exists():
+            return []
+        rows = advisor_transition_rows(
+            db_path,
+            project_key=project_key,
+            since_iso=since_iso,
+            config=config,
+        )
 
     out: list[TaskTransitionRecord] = []
     for r in rows:
@@ -331,12 +376,17 @@ def detect_changes(
     project_key: str | None = None,
     work_service: Any | None = None,
     git_timeout: float = DEFAULT_GIT_TIMEOUT,
+    config: Any | None = None,
 ) -> ChangeReport:
     """Build a :class:`ChangeReport` for a project since ``since``.
 
     ``project_key`` defaults to the basename of ``project_path`` when
     not supplied — the advisor tick always passes it explicitly, but
     the default keeps stand-alone testing cheap.
+
+    ``config`` is forwarded to the transition-row facade so the
+    advisor honours the active ``[storage].backend`` (#1757) and any
+    non-default ``[storage.pg].dsn`` (#1755 dovetail).
 
     Results are cached per-tick keyed by ``(project_path, since)`` so
     a tick that makes multiple passes over the same project (e.g.
@@ -353,7 +403,9 @@ def detect_changes(
     commit_shas = _gather_commits(project_path, since, timeout=git_timeout)
     changed_files = _gather_changed_files(project_path, commit_shas, timeout=git_timeout)
     transitions = _gather_task_transitions(
-        project_path, key_name, since, work_service=work_service,
+        project_path, key_name, since,
+        work_service=work_service,
+        config=config,
     )
 
     n_commits = len(commit_shas)

--- a/src/pollypm/storage/pg_accounts.py
+++ b/src/pollypm/storage/pg_accounts.py
@@ -40,6 +40,8 @@ from pollypm.storage.records import AccountRuntimeRecord, AccountUsageRecord
 if TYPE_CHECKING:
     from psycopg_pool import ConnectionPool
 
+    from pollypm.models import PollyPMConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -80,6 +82,7 @@ def upsert_account_usage(
     reset_at: str | None = None,
     period_label: str | None = None,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Insert-or-update an ``account_usage`` row.
 
@@ -89,7 +92,7 @@ def upsert_account_usage(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = _now_iso()
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
@@ -131,12 +134,13 @@ def get_account_usage(
     account_name: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> AccountUsageRecord | None:
     """Return the ``account_usage`` row for ``account_name`` or ``None``."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -168,12 +172,13 @@ def get_account_usage(
 def list_account_usage(
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[AccountUsageRecord]:
     """Return every ``account_usage`` row, sorted by ``account_name``."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -217,6 +222,7 @@ def upsert_account_runtime(
     access_expires_at: str | None = None,
     refresh_available: bool = False,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Insert-or-update an ``account_runtime`` row.
 
@@ -226,7 +232,7 @@ def upsert_account_runtime(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = _now_iso()
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
@@ -262,12 +268,13 @@ def get_account_runtime(
     account_name: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> AccountRuntimeRecord | None:
     """Return the ``account_runtime`` row for ``account_name`` or ``None``."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -296,12 +303,13 @@ def get_account_runtime(
 def list_account_runtimes(
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[AccountRuntimeRecord]:
     """Return every ``account_runtime`` row, sorted by ``account_name``."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """

--- a/src/pollypm/storage/pg_alerts.py
+++ b/src/pollypm/storage/pg_alerts.py
@@ -41,6 +41,8 @@ from pollypm.storage.records import AlertRecord
 if TYPE_CHECKING:
     from psycopg_pool import ConnectionPool
 
+    from pollypm.models import PollyPMConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -129,6 +131,7 @@ def upsert_alert(
     message: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Insert-or-update an open alert keyed on ``(scope=session_name, sender=alert_type)``.
 
@@ -141,7 +144,7 @@ def upsert_alert(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = _now_iso()
     subject = f"[Alert] {message}"
     with pool.connection() as conn, conn.cursor() as cur:
@@ -244,6 +247,7 @@ def clear_alert(
     alert_type: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Close every open alert whose ``(scope, sender)`` matches.
 
@@ -253,7 +257,7 @@ def clear_alert(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = _now_iso()
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
@@ -272,12 +276,13 @@ def clear_alert(
 def open_alerts(
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[AlertRecord]:
     """Return every open alert, newest ``updated_at`` first."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -295,6 +300,7 @@ def get_alert(
     alert_id: int,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> AlertRecord | None:
     """Return a single alert row by id, or ``None`` if absent.
 
@@ -304,7 +310,7 @@ def get_alert(
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -324,6 +330,7 @@ def clear_alert_by_id(
     alert_id: int,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> AlertRecord | None:
     """Close one specific alert row by id.
 
@@ -338,7 +345,7 @@ def clear_alert_by_id(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = _now_iso()
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
@@ -355,6 +362,7 @@ def clear_alert_by_id(
 def deduplicate_alerts(
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> int:
     """Drop duplicate open alerts, keeping the most recently updated row.
 
@@ -367,7 +375,7 @@ def deduplicate_alerts(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """

--- a/src/pollypm/storage/pg_architect_resume.py
+++ b/src/pollypm/storage/pg_architect_resume.py
@@ -29,6 +29,8 @@ from pollypm.storage.records import ArchitectResumeRecord
 if TYPE_CHECKING:
     from psycopg_pool import ConnectionPool
 
+    from pollypm.models import PollyPMConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -63,6 +65,7 @@ def upsert_architect_resume_token(
     session_id: str,
     last_active_at: str,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Insert-or-replace the resume token row for ``project_key``.
 
@@ -73,7 +76,7 @@ def upsert_architect_resume_token(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     captured_at = _now_iso()
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
@@ -95,12 +98,13 @@ def get_architect_resume_token(
     project_key: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> ArchitectResumeRecord | None:
     """Return the resume token for ``project_key``, or ``None``."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -125,12 +129,13 @@ def clear_architect_resume_token(
     project_key: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Delete the resume token row for ``project_key`` (no-op if missing)."""
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             "DELETE FROM architect_resume_tokens WHERE project_key = %s",
@@ -141,12 +146,13 @@ def clear_architect_resume_token(
 def list_architect_resume_tokens(
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[ArchitectResumeRecord]:
     """Return every stored resume token (unordered)."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """

--- a/src/pollypm/storage/pg_checkpoints.py
+++ b/src/pollypm/storage/pg_checkpoints.py
@@ -28,6 +28,8 @@ from pollypm.storage.records import CheckpointRecord
 if TYPE_CHECKING:
     from psycopg_pool import ConnectionPool
 
+    from pollypm.models import PollyPMConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -65,6 +67,7 @@ def record_checkpoint(
     snapshot_path: str,
     summary_text: str,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Append a checkpoint row.
 
@@ -76,7 +79,7 @@ def record_checkpoint(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     created_at = _now_iso()
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
@@ -103,12 +106,13 @@ def latest_checkpoint(
     session_name: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> CheckpointRecord | None:
     """Return the most recently inserted checkpoint for ``session_name``."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """

--- a/src/pollypm/storage/pg_heartbeats.py
+++ b/src/pollypm/storage/pg_heartbeats.py
@@ -33,6 +33,8 @@ from pollypm.storage.records import HeartbeatRecord
 if TYPE_CHECKING:
     from psycopg_pool import ConnectionPool
 
+    from pollypm.models import PollyPMConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -59,6 +61,7 @@ def record_heartbeat(
     snapshot_path: str,
     snapshot_hash: str,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Append a heartbeat row.
 
@@ -70,7 +73,7 @@ def record_heartbeat(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = _now_iso()
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
@@ -99,12 +102,13 @@ def latest_heartbeat(
     session_name: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> HeartbeatRecord | None:
     """Return the most-recent heartbeat row for ``session_name``, or ``None``."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -128,12 +132,13 @@ def recent_heartbeats(
     limit: int = 3,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[HeartbeatRecord]:
     """Return up to ``limit`` most-recent heartbeats for ``session_name``."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -153,6 +158,7 @@ def recent_heartbeats(
 def last_heartbeat_at(
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> str | None:
     """Return the ISO timestamp of the most-recent heartbeat sweep event.
 
@@ -163,7 +169,7 @@ def last_heartbeat_at(
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """

--- a/src/pollypm/storage/pg_leases.py
+++ b/src/pollypm/storage/pg_leases.py
@@ -38,6 +38,8 @@ from pollypm.storage.records import LeaseRecord
 if TYPE_CHECKING:
     from psycopg_pool import ConnectionPool
 
+    from pollypm.models import PollyPMConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -59,6 +61,7 @@ def set_lease(
     note: str = "",
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Insert-or-update a lease row.
 
@@ -69,7 +72,7 @@ def set_lease(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = _now_iso()
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
@@ -89,12 +92,13 @@ def clear_lease(
     session_name: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Delete the lease row for ``session_name``. Idempotent (no-op when absent)."""
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             "DELETE FROM leases WHERE session_name = %s",
@@ -106,12 +110,13 @@ def get_lease(
     session_name: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> LeaseRecord | None:
     """Return the lease row for ``session_name``, or ``None`` if absent."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -135,12 +140,13 @@ def get_lease(
 def list_leases(
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[LeaseRecord]:
     """Return every lease row, sorted by session_name."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """

--- a/src/pollypm/storage/pg_memory.py
+++ b/src/pollypm/storage/pg_memory.py
@@ -57,6 +57,8 @@ from pollypm.storage.records import MemoryEntryRecord, MemorySummaryRecord
 if TYPE_CHECKING:
     from psycopg_pool import ConnectionPool
 
+    from pollypm.models import PollyPMConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -155,6 +157,7 @@ def record_memory_entry(
     ttl_at: str | None = None,
     scope_tier: str = "project",
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> MemoryEntryRecord:
     """Append a memory entry and return the populated record.
 
@@ -165,7 +168,7 @@ def record_memory_entry(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = _now_iso()
     tags_json = json.dumps([str(tag) for tag in tags], ensure_ascii=True)
     with pool.connection() as conn, conn.cursor() as cur:
@@ -222,12 +225,13 @@ def get_memory_entry(
     entry_id: int,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> MemoryEntryRecord | None:
     """Return a single memory entry by id, or ``None`` if absent."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -252,6 +256,7 @@ def list_memory_entries(
     scope_tier: str | None = None,
     limit: int = 50,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[MemoryEntryRecord]:
     """List memory entries with optional filters, newest first.
 
@@ -276,7 +281,7 @@ def list_memory_entries(
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             f"""
@@ -297,12 +302,13 @@ def delete_memory_entry(
     entry_id: int,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> bool:
     """Hard-delete a memory entry by id. Returns True when a row was removed."""
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             "DELETE FROM memory_entries WHERE id = %s",
@@ -321,6 +327,7 @@ def update_memory_entry(
     superseded_by: int | None = None,
     clear_superseded: bool = False,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> bool:
     """Patch a subset of fields on a memory row. Returns True on change.
 
@@ -357,7 +364,7 @@ def update_memory_entry(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             f"UPDATE memory_entries SET {', '.join(sets)} WHERE id = %s",
@@ -379,6 +386,7 @@ def recall_memory_entries(
     tier_scope_pairs: list[tuple[str, str]] | None = None,
     include_superseded: bool = False,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[tuple[MemoryEntryRecord, float | None]]:
     """Keyword-only recall against ``memory_entries.title_body_tsv``.
 
@@ -433,7 +441,7 @@ def recall_memory_entries(
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
 
     where = " AND ".join(clauses)
     if query_text:
@@ -487,6 +495,7 @@ def purge_session_scope(
     session_id: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> int:
     """Delete every session-tier memory entry with ``scope = session_id``.
 
@@ -496,7 +505,7 @@ def purge_session_scope(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             "DELETE FROM memory_entries WHERE scope_tier = 'session' AND scope = %s",
@@ -511,6 +520,7 @@ def expire_task_scope(
     terminal_at: str | None = None,
     ttl_days: int = 30,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> int:
     """Stamp a 30-day TTL on task-tier entries with ``scope = task_id``.
 
@@ -528,7 +538,7 @@ def expire_task_scope(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -545,6 +555,7 @@ def expire_task_scope(
 def sweep_expired_memory_entries(
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> int:
     """Drop ``memory_entries`` whose ``ttl_at`` has elapsed.
 
@@ -554,7 +565,7 @@ def sweep_expired_memory_entries(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             "DELETE FROM memory_entries WHERE ttl_at IS NOT NULL AND ttl_at < now()"
@@ -574,12 +585,13 @@ def record_memory_summary(
     summary_path: str,
     entry_count: int,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> MemorySummaryRecord:
     """Append a memory_summary row and return the populated record."""
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = _now_iso()
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
@@ -606,12 +618,13 @@ def latest_memory_summary(
     scope: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> MemorySummaryRecord | None:
     """Return the most-recently inserted summary for ``scope`` or ``None``."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """

--- a/src/pollypm/storage/pg_notifications.py
+++ b/src/pollypm/storage/pg_notifications.py
@@ -57,6 +57,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from psycopg_pool import ConnectionPool
 
+    from pollypm.models import PollyPMConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -74,6 +76,7 @@ def record_notification(
     delivery_status: str = "sent",
     execution_version: int = 0,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Record a task-assignment ping sent to ``session_name``.
 
@@ -86,7 +89,7 @@ def record_notification(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     payload = json.dumps(
         {
             "project": project,
@@ -177,6 +180,7 @@ def claim_notification_slot(
     message: str = "",
     dedupe_scope: str = "normal",
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> int | None:
     """Atomically claim a dedupe slot for a ``(session, task, version)`` ping.
 
@@ -226,7 +230,7 @@ def claim_notification_slot(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     scope = (dedupe_scope or "normal").strip() or "normal"
     now = _now()
     cutoff = now - timedelta(seconds=window_seconds)
@@ -331,6 +335,7 @@ def update_notification_status(
     delivery_status: str,
     message: str | None = None,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Update the delivery status / body of a previously-claimed slot.
 
@@ -343,7 +348,7 @@ def update_notification_status(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = _now()
     with pool.connection() as conn, conn.cursor() as cur:
         if message is None:
@@ -384,6 +389,7 @@ def was_notified_within(
     execution_version: int = 0,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> bool:
     """Return ``True`` if ``(session, task, version)`` was pinged inside the window.
 
@@ -397,7 +403,7 @@ def was_notified_within(
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     cutoff = _now() - timedelta(seconds=window_seconds)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
@@ -427,6 +433,7 @@ def recent_notifications(
     task_id: str | None = None,
     limit: int = 500,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[dict[str, Any]]:
     """Return a reverse-chronological slice of pickup notifications.
 
@@ -435,7 +442,7 @@ def recent_notifications(
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     clauses: list[str] = []
     params: list[Any] = []
     if since_seconds is not None:

--- a/src/pollypm/storage/pg_sessions.py
+++ b/src/pollypm/storage/pg_sessions.py
@@ -64,6 +64,8 @@ from pollypm.storage.records import EventRecord, SessionRecord, SessionRuntimeRe
 if TYPE_CHECKING:
     from psycopg_pool import ConnectionPool
 
+    from pollypm.models import PollyPMConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -120,6 +122,7 @@ def upsert_session(
     cwd: str,
     window_name: str,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Insert-or-update a session row.
 
@@ -129,7 +132,7 @@ def upsert_session(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -150,12 +153,13 @@ def upsert_session(
 def list_sessions(
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[SessionRecord]:
     """Return every row in the ``sessions`` table as a SessionRecord."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             "SELECT name, role, project, provider, account, cwd, window_name FROM sessions"
@@ -179,6 +183,7 @@ def prune_sessions(
     valid_session_names: set[str],
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Delete sessions / leases / session-tier memory not in ``valid_session_names``.
 
@@ -200,7 +205,7 @@ def prune_sessions(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = _now_iso()
     with pool.connection() as conn, conn.cursor() as cur:
         if valid_session_names:
@@ -259,12 +264,13 @@ def get_session_window(
     session_name: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> str | None:
     """Return the tmux window_name for ``session_name``, or None if missing."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             "SELECT window_name FROM sessions WHERE name = %s",
@@ -287,6 +293,7 @@ def record_event(
     message: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Append an event row into ``messages`` with type='event'.
 
@@ -298,7 +305,7 @@ def record_event(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = _now_iso()
     payload = json.dumps(
         {
@@ -334,12 +341,13 @@ def last_event_at(
     event_type: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> str | None:
     """Return the ISO timestamp of the most recent matching event, or None."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             "SELECT created_at FROM messages "
@@ -357,6 +365,7 @@ def recent_events(
     limit: int = 20,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[EventRecord]:
     """Return the ``limit`` most recent event rows.
 
@@ -368,7 +377,7 @@ def recent_events(
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -421,6 +430,7 @@ def upsert_session_runtime(
     retry_at: str | None | object = _UNSET,
     last_recovered_at: str | None | object = _UNSET,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Insert-or-update a row in ``session_runtime``.
 
@@ -439,7 +449,7 @@ def upsert_session_runtime(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = _now_iso()
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
@@ -513,12 +523,13 @@ def get_session_runtime(
     session_name: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> SessionRuntimeRecord | None:
     """Return the runtime row for ``session_name``, or None if absent."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -553,12 +564,13 @@ def get_session_runtime(
 def list_session_runtimes(
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[SessionRuntimeRecord]:
     """Return every row in the ``session_runtime`` table."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """

--- a/src/pollypm/storage/pg_token_usage.py
+++ b/src/pollypm/storage/pg_token_usage.py
@@ -31,6 +31,8 @@ from pollypm.storage.records import TokenSampleRecord, TokenUsageHourlyRecord
 if TYPE_CHECKING:
     from psycopg_pool import ConnectionPool
 
+    from pollypm.models import PollyPMConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -70,12 +72,13 @@ def get_token_sample(
     session_name: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> TokenSampleRecord | None:
     """Return the latest cumulative-token sample for ``session_name``."""
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -110,6 +113,7 @@ def record_token_sample(
     cumulative_tokens: int,
     observed_at: str | None = None,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> int:
     """Observe a cumulative-token reading and roll forward the hourly bucket.
 
@@ -132,7 +136,7 @@ def record_token_sample(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = observed_at or _now_iso()
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
@@ -216,6 +220,7 @@ def upsert_token_sample(
     cumulative_tokens: int,
     observed_at: str,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Raw upsert of a cumulative-token sample (no delta tracking).
 
@@ -227,7 +232,7 @@ def upsert_token_sample(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -260,6 +265,7 @@ def replace_token_usage_hourly(
     *,
     account_names: list[str] | None = None,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Atomically delete-and-reinsert the hourly aggregate.
 
@@ -272,7 +278,7 @@ def replace_token_usage_hourly(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         if account_names:
             cur.execute(
@@ -305,6 +311,7 @@ def recent_token_usage(
     limit: int = 24,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[TokenUsageHourlyRecord]:
     """Return the most recent hourly aggregate rows (newest hour first).
 
@@ -315,7 +322,7 @@ def recent_token_usage(
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
@@ -346,6 +353,7 @@ def daily_token_usage(
     days: int = 30,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[tuple[str, int]]:
     """Return the last ``days`` days as ``(YYYY-MM-DD, total_tokens)`` pairs.
 
@@ -356,7 +364,7 @@ def daily_token_usage(
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             """

--- a/src/pollypm/storage/pg_workspace_state.py
+++ b/src/pollypm/storage/pg_workspace_state.py
@@ -36,6 +36,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from psycopg_pool import ConnectionPool
 
+    from pollypm.models import PollyPMConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -55,6 +57,7 @@ def set_workspace_state(
     *,
     actor: str = "system",
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Upsert one ``workspace_state`` row.
 
@@ -79,7 +82,7 @@ def set_workspace_state(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     payload = json.dumps(value)
     set_at = _now_iso()
     with pool.connection() as conn, conn.cursor() as cur:
@@ -100,6 +103,7 @@ def get_workspace_state(
     key: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> dict[str, Any] | None:
     """Return the JSON payload stored under ``key``, or ``None``.
 
@@ -119,7 +123,7 @@ def get_workspace_state(
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     try:
         with pool.connection() as conn, conn.cursor() as cur:
             cur.execute(
@@ -151,6 +155,7 @@ def clear_workspace_state(
     key: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> bool:
     """Delete the row at ``key``; return ``True`` iff a row was removed.
 
@@ -168,7 +173,7 @@ def clear_workspace_state(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
             "DELETE FROM workspace_state WHERE key = %s",

--- a/src/pollypm/storage/pg_worktrees.py
+++ b/src/pollypm/storage/pg_worktrees.py
@@ -30,6 +30,8 @@ from pollypm.storage.records import WorktreeRecord
 if TYPE_CHECKING:
     from psycopg_pool import ConnectionPool
 
+    from pollypm.models import PollyPMConfig
+
 logger = logging.getLogger(__name__)
 
 
@@ -68,6 +70,7 @@ def upsert_worktree(
     branch: str,
     status: str,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Insert-or-update the worktree row for ``(project, lane, status)``.
 
@@ -80,7 +83,7 @@ def upsert_worktree(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = _now_iso()
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
@@ -137,6 +140,7 @@ def update_worktree_status(
     status: str,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> None:
     """Promote the ``active`` row for ``(project, lane)`` to ``status``.
 
@@ -147,7 +151,7 @@ def update_worktree_status(
     if pool is None:
         from pollypm.storage.pg_pool import get_rw_pool
 
-        pool = get_rw_pool()
+        pool = get_rw_pool(config)
     now = _now_iso()
     with pool.connection() as conn, conn.cursor() as cur:
         cur.execute(
@@ -167,6 +171,7 @@ def list_worktrees(
     project_key: str | None = None,
     *,
     pool: "ConnectionPool | None" = None,
+    config: "PollyPMConfig | None" = None,
 ) -> list[WorktreeRecord]:
     """Return every worktree row, ordered most-recently-updated first.
 
@@ -176,7 +181,7 @@ def list_worktrees(
     if pool is None:
         from pollypm.storage.pg_pool import get_ro_pool
 
-        pool = get_ro_pool()
+        pool = get_ro_pool(config)
     with pool.connection() as conn, conn.cursor() as cur:
         if project_key is None:
             cur.execute(

--- a/src/pollypm/work/inbox_cli.py
+++ b/src/pollypm/work/inbox_cli.py
@@ -1250,13 +1250,31 @@ def _bulk_archive_deleted_project_messages(*, db: str, dry_run: bool) -> None:
 
 
 _BACKFILL_HINT = (
-    "Re-run with --commit to apply; unmatched rows stay legacy and "
-    "remain visible to the awaits_user predicate."
+    "Re-run with --commit to apply; unmatched rows stay legacy."
 )
 
 
+def _resolve_backfill_store() -> Any:
+    """Return the configured-backend ``Store`` for backfill reads/writes.
+
+    Routes through :func:`pollypm.store.get_store` so the helper honours
+    ``[storage].backend`` (sqlite vs postgres) rather than hard-coding a
+    sqlite URL. On postgres, the returned :class:`PgStore` shares the
+    process-wide RW pool — the caller must NOT ``close()`` the singleton
+    (see :func:`pollypm.store.registry.get_store` docstring).
+
+    Issue #1811: the pre-cutover path constructed ``SQLAlchemyStore(
+    sqlite:///...)`` directly, which silently read the empty sqlite shadow
+    when the active backend was postgres and reported "0 legacy rows" while
+    live pg traffic went un-reclassified.
+    """
+    from pollypm.config import load_config
+    from pollypm.store import get_store
+
+    return get_store(load_config())
+
+
 def _legacy_message_rows(
-    db_path: str,
     *,
     project: str | None,
 ) -> list[dict[str, Any]]:
@@ -1270,23 +1288,18 @@ def _legacy_message_rows(
     ``query_messages`` does not accept ``kind`` as a server-side filter,
     so we trim in Python after the call. The volume is bounded (low
     hundreds for the original 2026-05-17 sample); a wider filter would
-    require widening :meth:`SQLAlchemyStore.query_messages` and is out
-    of scope for the one-shot migration helper.
+    require widening the Store protocol and is out of scope for the
+    one-shot migration helper.
     """
-    from pollypm.store import SQLAlchemyStore
-
-    store = SQLAlchemyStore(f"sqlite:///{db_path}")
-    try:
-        filters: dict[str, Any] = dict(
-            recipient="user",
-            state="open",
-            type=["notify", "inbox_task", "alert"],
-        )
-        if project:
-            filters["scope"] = project
-        rows = store.query_messages(**filters)
-    finally:
-        store.close()
+    store = _resolve_backfill_store()
+    filters: dict[str, Any] = dict(
+        recipient="user",
+        state="open",
+        type=["notify", "inbox_task", "alert"],
+    )
+    if project:
+        filters["scope"] = project
+    rows = store.query_messages(**filters)
 
     legacy_rows: list[dict[str, Any]] = []
     for row in rows:
@@ -1315,19 +1328,19 @@ def _title_preview(title: str, limit: int = 60) -> str:
 
 
 def _apply_kind_update(
-    db_path: str,
     *,
     msg_id: int,
     new_kind: InboxItemKind,
 ) -> None:
-    """Persist a single ``messages.kind`` reclassification."""
-    from pollypm.store import SQLAlchemyStore
+    """Persist a single ``messages.kind`` reclassification.
 
-    store = SQLAlchemyStore(f"sqlite:///{db_path}")
-    try:
-        store.update_message(msg_id, kind=new_kind.value)
-    finally:
-        store.close()
+    Routes through :func:`_resolve_backfill_store` so the write hits
+    whichever backend ``[storage].backend`` resolves to. The singleton
+    Store is NOT closed here — that's the registry's responsibility on
+    process shutdown.
+    """
+    store = _resolve_backfill_store()
+    store.update_message(msg_id, kind=new_kind.value)
 
 
 def _emit_backfill_audit(
@@ -1365,7 +1378,6 @@ def _emit_backfill_audit(
 
 
 def _legacy_task_rows(
-    db_path: str,
     *,
     project: str | None,
 ) -> list[Any]:
@@ -1377,15 +1389,17 @@ def _legacy_task_rows(
     intentionally included: the user's 2026-05-17 dashboard surfaced
     cancelled ``audit_watchdog`` rows, and the awaits-user predicate
     treats ``legacy`` as visible regardless of work_status.
+
+    Routes through :func:`pollypm.work.create_work_service` with the
+    loaded config so the factory's backend dispatch picks the active
+    ``[storage].backend`` (#1811). Passing ``db_path`` here would force
+    the sqlite branch and read the empty pre-cutover shadow.
     """
+    from pollypm.config import load_config
     from pollypm.work import create_work_service
 
-    from pathlib import Path
-
-    svc = create_work_service(
-        db_path=db_path,
-        project_path=Path(db_path).parent.parent,
-    )
+    config = load_config()
+    svc = create_work_service(config=config, project_key=project)
     try:
         tasks = svc.list_tasks(project=project)
     finally:
@@ -1406,20 +1420,22 @@ def _task_classification(task: Any) -> Classification | None:
 
 
 def _apply_task_kind_update(
-    db_path: str,
     *,
     task_id: str,
     new_kind: InboxItemKind,
+    project: str | None,
 ) -> None:
-    """Persist a single ``work_tasks.kind`` reclassification."""
+    """Persist a single ``work_tasks.kind`` reclassification.
+
+    Routes through :func:`pollypm.work.create_work_service` with the
+    loaded config so backend dispatch matches the read path in
+    :func:`_legacy_task_rows` (#1811).
+    """
+    from pollypm.config import load_config
     from pollypm.work import create_work_service
 
-    from pathlib import Path
-
-    svc = create_work_service(
-        db_path=db_path,
-        project_path=Path(db_path).parent.parent,
-    )
+    config = load_config()
+    svc = create_work_service(config=config, project_key=project)
     try:
         svc.backfill_kind(task_id, new_kind=new_kind.value)
     finally:
@@ -1478,10 +1494,15 @@ def backfill_kinds(
     # Default = dry-run. --commit is the explicit opt-in to mutation.
     effective_commit = bool(commit)
 
-    db_path = _resolve_db_path(db, project=project)
+    # ``--db`` is accepted but no longer used directly — the configured
+    # backend (sqlite vs postgres) is resolved via ``load_config()`` so
+    # the helper reads the same DB ``pm inbox`` reads. See #1811: the
+    # pre-cutover path hard-coded a sqlite URL and silently missed
+    # everything during the pg cutover.
+    del db
 
     try:
-        message_rows = _legacy_message_rows(db_path, project=project)
+        message_rows = _legacy_message_rows(project=project)
     except Exception as exc:  # noqa: BLE001
         typer.echo(
             f"Error: failed to read legacy inbox rows ({exc}).",
@@ -1490,7 +1511,7 @@ def backfill_kinds(
         raise typer.Exit(code=1) from exc
 
     try:
-        task_rows = _legacy_task_rows(db_path, project=project)
+        task_rows = _legacy_task_rows(project=project)
     except Exception as exc:  # noqa: BLE001
         typer.echo(
             f"Error: failed to read legacy work_task rows ({exc}).",
@@ -1548,7 +1569,7 @@ def backfill_kinds(
                 continue
             try:
                 _apply_kind_update(
-                    db_path, msg_id=msg_id, new_kind=classification.kind,
+                    msg_id=msg_id, new_kind=classification.kind,
                 )
             except Exception as exc:  # noqa: BLE001
                 msg_failures.append((msg_id, str(exc)))
@@ -1596,9 +1617,9 @@ def backfill_kinds(
                 continue
             try:
                 _apply_task_kind_update(
-                    db_path,
                     task_id=task_id,
                     new_kind=classification.kind,
+                    project=project,
                 )
             except Exception as exc:  # noqa: BLE001
                 task_failures.append((task_id, str(exc)))

--- a/src/pollypm/work/session_queries.py
+++ b/src/pollypm/work/session_queries.py
@@ -9,25 +9,35 @@ directly. Schema and connection details stay behind
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pollypm.storage.work_session_queries import (
     aggregate_project_session_tokens as _aggregate_project_session_tokens,
 )
+
+if TYPE_CHECKING:
+    from pollypm.models import PollyPMConfig
 
 
 def project_session_token_totals(
     db_path: Path,
     *,
     project_key: str,
+    config: "PollyPMConfig | None" = None,
 ) -> tuple[int, int] | None:
     """Return ``(input_tokens, output_tokens)`` summed across worker sessions.
 
     Returns ``None`` when the workspace DB is missing or the
     ``work_sessions`` table is absent so the caller can render an
     ``(n/a)`` fallback rather than break.
+
+    ``config`` is forwarded to the storage facade so callers with a
+    non-default ``--config`` (e.g. custom ``[storage.pg].dsn``) reach
+    the right pool. Omitting ``config`` falls back to the global
+    process-singleton pool (#1755).
     """
     return _aggregate_project_session_tokens(
-        Path(db_path), project_key=project_key,
+        Path(db_path), project_key=project_key, config=config,
     )
 
 

--- a/src/pollypm/work/task_state.py
+++ b/src/pollypm/work/task_state.py
@@ -45,6 +45,7 @@ def active_task_numbers(project: Any, *, config: Any = None) -> list[int]:
         project_path=Path(project_path),
         statuses=ACTIVE_TASK_STATUSES,
         workspace_root=_workspace_root(config),
+        config=config,
     )
 
 
@@ -62,6 +63,7 @@ def user_waiting_task_ids(config: Any) -> frozenset[str]:
             project_path=Path(project_path),
             statuses=USER_WAITING_STATUSES,
             workspace_root=None,
+            config=config,
         )
         out.update(f"{project_key}/{number}" for number in numbers)
     return frozenset(out)
@@ -71,15 +73,17 @@ def has_work_tasks_in_db(
     db_path: Path,
     *,
     project_key: str | None = None,
+    config: Any = None,
 ) -> bool:
     """Return whether a work DB has task rows without exposing SQLite to callers."""
-    return has_work_task_rows(Path(db_path), project_key=project_key)
+    return has_work_task_rows(Path(db_path), project_key=project_key, config=config)
 
 
 def project_task_total_fast_count(
     db_path: Path,
     *,
     project_key: str,
+    config: Any = None,
 ) -> int | None:
     """Return a project's work-task count quickly, or ``None`` if the DB is busy.
 
@@ -87,7 +91,9 @@ def project_task_total_fast_count(
     blocking the UI mount on a locked DB; ``None`` lets callers surface
     a ``busy`` label instead of waiting on the writer.
     """
-    return project_task_total_fast(Path(db_path), project_key=project_key)
+    return project_task_total_fast(
+        Path(db_path), project_key=project_key, config=config,
+    )
 
 
 def project_activity(
@@ -106,6 +112,7 @@ def project_activity(
         project_path=Path(project_path),
         cutoff_iso=cutoff_iso,
         workspace_root=_workspace_root(config),
+        config=config,
     )
 
 
@@ -142,6 +149,7 @@ def task_window_terminal_or_missing(config: Any, name: str) -> bool:
         task_number=task_number,
         project_path=Path(project_path),
         workspace_root=_workspace_root(config),
+        config=config,
     )
     if status is None:
         return True


### PR DESCRIPTION
## Summary

Three backend-awareness fixes for the in-flight PG cutover, stacked as separate commits on one branch:

- **#1811** (`fix(inbox-cli)`) — `pm inbox backfill-kinds` hard-coded `SQLAlchemyStore(sqlite:///...)` and silently read the empty pre-cutover shadow when `storage.backend = "postgres"`. Route through `get_store(load_config())` (messages) and `create_work_service(config=...)` (tasks). Drop the now-false "remain visible to the awaits_user predicate" hint.
- **#1755** (`fix(storage)`) — Every `pg_*` facade now accepts an optional `config: PollyPMConfig | None` and forwards it to `get_ro_pool(config)` / `get_rw_pool(config)`, so callers with a non-default `--config` (custom `[storage.pg].dsn`, test fixtures) reach the right pool. Also threads `config` through the immediate `work/task_state.py` and `work/session_queries.py` wrappers called out in the issue body. Wider call-site cleanups (accounts.py, capacity.py, supervisor.py, etc.) are deliberately deferred — the facade-level seam unblocks operators today without changing public API.
- **#1757** (`fix(advisor)`) — `_gather_task_transitions` short-circuited on `db_path.exists()` before calling `advisor_transition_rows()`. On a migrated PG install there is no per-project `state.db`, so the gate dropped every advisor tick to zero transitions. Add an `_is_pg_backend(config)` probe; on PG, skip the file gate; on sqlite, keep it. Thread `config` from the advisor tick through `detect_changes` so a non-default `--config` reaches the right pool.

## Test plan

- [ ] `ruff check` clean on every modified file (verified locally)
- [ ] All modified modules import without error (verified locally)
- [ ] `pm inbox backfill-kinds --dry-run` on a pg-backed install lists live pg rows instead of the empty sqlite shadow
- [ ] Advisor change-detection report shows non-zero transitions on a pg install after seeded transitions
- [ ] Existing sqlite-backend behaviour unchanged (default config path)

## Notes

- v1 RC scope — surgical changes only. The new `config` kwarg is keyword-only and additive, so no existing callers break.
- Rebased onto current `origin/main` (which now includes #1812/#1817 cockpit pg-mode fixes); no semantic conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)