### PR TITLE
fix(infra): audit churn + pg_store.execute + doctor doubled-path (closes #1808 #1820 #1810)

### DIFF
--- a/src/pollypm/cli_features/session_runtime.py
+++ b/src/pollypm/cli_features/session_runtime.py
@@ -335,18 +335,31 @@ def reset(
     cockpit_state = supervisor.config.project.base_dir / "cockpit_state.json"
     cockpit_state.unlink(missing_ok=True)
     try:
-        from sqlalchemy import delete
-
-        from pollypm.store.schema import messages
-
+        # ``supervisor.store`` is the StateStore (sqlite-only — it owns
+        # the ``leases`` / ``session_runtime`` tables that don't have
+        # a pg equivalent yet, tracked separately). ``msg_store`` may
+        # be either SQLAlchemyStore or PgStore; route the alert wipe
+        # through the typed ``prune_messages`` (#1820) so we don't
+        # depend on the SQLAlchemy ``execute`` escape hatch.
         supervisor.store.execute("DELETE FROM leases")
         supervisor.store.execute("DELETE FROM session_runtime")
-        supervisor.msg_store.execute(
-            delete(messages).where(
-                messages.c.type == "alert",
-                messages.c.state == "open",
+        try:
+            supervisor.msg_store.prune_messages(type="alert", state="open")
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "Failed to prune open alerts via typed path; "
+                "falling back to SQLAlchemy execute()",
+                exc_info=True,
             )
-        )
+            from sqlalchemy import delete
+            from pollypm.store.schema import messages
+
+            supervisor.msg_store.execute(
+                delete(messages).where(
+                    messages.c.type == "alert",
+                    messages.c.state == "open",
+                )
+            )
         supervisor.store.commit()
     except Exception:  # noqa: BLE001
         logger.warning(

--- a/src/pollypm/cockpit.py
+++ b/src/pollypm/cockpit.py
@@ -666,8 +666,24 @@ def _failure_section(day_events: list, store=None) -> MetricsSection:
     if store is not None:
         try:
             from datetime import UTC, datetime, timedelta
-            cutoff = (datetime.now(UTC) - timedelta(hours=24)).isoformat()
-            if hasattr(store, "execute"):
+            cutoff_dt = datetime.now(UTC) - timedelta(hours=24)
+            # #1820 — prefer the typed ``query_messages`` path on both
+            # backends. The legacy ``hasattr(store, "execute")`` branch
+            # selected PgStore.execute (which used to raise), so the
+            # ``no_session`` count read as a permanent zero on pg. The
+            # typed path post-filters in Python — the sender prefix is
+            # narrow enough that the row count stays small.
+            if hasattr(store, "query_messages"):
+                rows_24h = store.query_messages(
+                    type=["alert"],
+                    since=cutoff_dt,
+                )
+                no_session = sum(
+                    1 for row in rows_24h
+                    if "no_session" in str(row.get("sender") or "")
+                )
+            elif hasattr(store, "execute"):
+                cutoff = cutoff_dt.isoformat()
                 rows = store.execute(
                     """
                     SELECT sender FROM messages
@@ -678,15 +694,6 @@ def _failure_section(day_events: list, store=None) -> MetricsSection:
                     (cutoff,),
                 ).fetchall()
                 no_session = len(rows)
-            elif hasattr(store, "query_messages"):
-                rows_24h = store.query_messages(
-                    type=["alert"],
-                    since=datetime.fromisoformat(cutoff),
-                )
-                no_session = sum(
-                    1 for row in rows_24h
-                    if "no_session" in str(row.get("sender") or "")
-                )
         except Exception:  # noqa: BLE001
             no_session = 0
 

--- a/src/pollypm/doctor.py
+++ b/src/pollypm/doctor.py
@@ -64,6 +64,21 @@ from pollypm.storage.doctor_state_probes import (
 __path__ = [str(Path(__file__).resolve().with_name("doctor"))]
 
 
+def _pg_mode_active() -> bool:
+    """Return True when the resolved storage backend is Postgres.
+
+    Cheap probe used to short-circuit sqlite-flavored checks during
+    the pg cutover (#1810). Failure to resolve the backend returns
+    ``False`` — the legacy sqlite path stays the default.
+    """
+    try:
+        from pollypm.storage._backend_dispatch import is_pg_backend
+
+        return is_pg_backend()
+    except Exception:  # noqa: BLE001 — defensive
+        return False
+
+
 # --------------------------------------------------------------------- #
 # Result model
 # --------------------------------------------------------------------- #
@@ -631,6 +646,91 @@ def _latest_work_migration_version() -> int | None:
         return None
 
 
+def _latest_pg_migration_version() -> int | None:
+    """Highest declared pg migration version, or ``None`` if unavailable."""
+    try:
+        from pollypm.storage.pg_schema import MIGRATIONS as _PG_MIGRATIONS
+
+        if not _PG_MIGRATIONS:
+            return None
+        return max(v for v, _, _ in _PG_MIGRATIONS)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _applied_pg_schema_version() -> int | None:
+    """``MAX(version)`` from pg's ``schema_migrations`` table, or ``None``."""
+    try:
+        from pollypm.storage.doctor_state_probes import applied_schema_version_ro
+    except Exception:  # noqa: BLE001
+        return None
+    config = _doctor_config_or_none()
+    if config is None:
+        return None
+    # The pg branch ignores ``db_path``; pass a dummy path so the
+    # routing helper picks the pg conn regardless of file existence.
+    return applied_schema_version_ro(Path("/dev/null"), "schema_migrations", config=config)
+
+
+def _pg_state_migrations_probe() -> CheckResult:
+    """pg-mode counterpart to :func:`check_state_migrations`."""
+    latest = _latest_pg_migration_version()
+    if latest is None:
+        return _skip("state migration check skipped (pg migrations list empty)")
+    applied = _applied_pg_schema_version()
+    if applied is None:
+        return _skip(
+            "state migration check skipped (pg schema_migrations unreadable)"
+        )
+    if applied < latest:
+        return _fail(
+            f"pg schema_migrations @v{applied}, latest v{latest}",
+            why=(
+                "Pg schema is behind head. Subsystems that expect tables / "
+                "columns from later migrations will error at runtime."
+            ),
+            fix=(
+                "Apply outstanding pg migrations —\n"
+                "  pm up   # runs apply_migrations on cockpit boot\n"
+                "Or directly:\n"
+                "  python -c 'from pollypm.storage.pg_pool import get_rw_pool; "
+                "from pollypm.storage.pg_migrations import apply_migrations; "
+                "apply_migrations(get_rw_pool())'\n"
+                "Recheck: pm doctor"
+            ),
+            data={"latest": latest, "applied": applied},
+        )
+    return _ok(
+        f"pg schema_migrations on v{latest}",
+        data={"latest": latest, "applied": applied},
+    )
+
+
+def _pg_work_migrations_probe() -> CheckResult:
+    """In pg-mode the work schema is folded into ``schema_migrations``.
+
+    Returns OK when the pg schema is at-head; a separate ``work``
+    migration table doesn't exist on the pg backend (#1737).
+    """
+    latest = _latest_pg_migration_version()
+    if latest is None:
+        return _skip("work migration check skipped (pg migrations list empty)")
+    applied = _applied_pg_schema_version()
+    if applied is None:
+        return _skip(
+            "work migration check skipped (pg schema_migrations unreadable)"
+        )
+    if applied < latest:
+        return _skip(
+            f"work migration check folded into pg schema_migrations "
+            f"(@v{applied}/{latest}); see state-migrations probe"
+        )
+    return _ok(
+        f"work schema folded into pg schema_migrations @v{latest}",
+        data={"latest": latest, "applied": applied},
+    )
+
+
 def _doctor_config_or_none() -> "PollyPMConfig | None":
     """Best-effort loader for the operator config inside doctor checks.
 
@@ -824,6 +924,13 @@ def check_product_state() -> CheckResult:
 
 
 def check_state_migrations() -> CheckResult:
+    # #1810 — in pg-mode, the sqlite state migrations table is no longer
+    # the source of truth. Probe the live pg ``schema_migrations`` via
+    # the storage facade instead of walking stale sqlite files. A
+    # successful pg probe with the matching latest version returns OK;
+    # anything else falls back to a benign skip with operator guidance.
+    if _pg_mode_active():
+        return _pg_state_migrations_probe()
     latest = _latest_state_migration_version()
     if latest is None:
         return _skip("state migration check skipped (no migrations defined)")
@@ -862,6 +969,11 @@ def check_state_migrations() -> CheckResult:
 
 
 def check_work_migrations() -> CheckResult:
+    # #1810 — in pg-mode the work-schema lives in pg, not in the
+    # legacy ``work_schema_version`` sqlite table. Skip the sqlite walk
+    # and route to the pg probe.
+    if _pg_mode_active():
+        return _pg_work_migrations_probe()
     latest = _latest_work_migration_version()
     if latest is None:
         return _skip("work migration check skipped (no migrations defined)")
@@ -1040,7 +1152,15 @@ def check_db_layout_canonical() -> CheckResult:
 
     Any leftover legacy state directory is noise from a pre-#339 install.
     Nothing reads it; we just flag it so the user can remove it.
+
+    #1810 — skipped in pg-mode: the sqlite "two state.db files" layout
+    is the wrong abstraction once the cutover lands.
     """
+    if _pg_mode_active():
+        return _skip(
+            "db-layout-canonical skipped (pg-mode: sqlite state.db is a "
+            "legacy artifact)"
+        )
     from pollypm.config import DEFAULT_CONFIG_PATH, load_config
 
     user_db = Path.home() / ".pollypm" / "state.db"
@@ -1207,6 +1327,9 @@ def _read_recent_work_db_opened_events(
 def check_dual_db_work_tasks_drift() -> CheckResult:
     """Detect work-tables stamped on the messages-side DB (savethenovel class).
 
+    #1810 — in pg-mode there's only one DB (the pg cluster); the
+    sqlite "dual DB" concept doesn't apply, so the probe short-circuits.
+
     PollyPM keeps two state DBs that look similar but serve different
     purposes:
 
@@ -1242,6 +1365,10 @@ def check_dual_db_work_tasks_drift() -> CheckResult:
     readers go through ``resolve_work_db_path``, so the canonical
     workspace DB is still authoritative for the live system.
     """
+    if _pg_mode_active():
+        return _skip(
+            "dual-db drift check skipped (pg-mode: single store)"
+        )
     _path, config = _safe_load_config()
     if config is None:
         return _skip("dual-db check skipped (no config)")
@@ -1508,10 +1635,17 @@ def check_doubled_pollypm_path() -> CheckResult:
     if not doubled.exists():
         return _ok("no doubled ~/.pollypm/.pollypm/ path", data=data)
 
-    # Walk the tree once, summing sizes and tracking newest mtime.
+    # #1810 — bound the rglob scan. The artifact has been observed at
+    # 281K files / 1.8 GB in the wild; the original unbounded walk
+    # took >60s and dominated ``pm doctor`` runtime. We only need to
+    # know "large + newest-mtime"; a 10K-file cap captures both with
+    # bounded latency. A ``capped`` data field tells the operator the
+    # number is a lower bound.
+    _SCAN_CAP = 10_000
     total_bytes = 0
     file_count = 0
     newest_mtime = 0.0
+    capped = False
     try:
         for entry in doubled.rglob("*"):
             try:
@@ -1521,6 +1655,9 @@ def check_doubled_pollypm_path() -> CheckResult:
                     file_count += 1
                     if stat.st_mtime > newest_mtime:
                         newest_mtime = stat.st_mtime
+                    if file_count >= _SCAN_CAP:
+                        capped = True
+                        break
             except OSError:
                 continue
     except OSError as exc:
@@ -1546,6 +1683,7 @@ def check_doubled_pollypm_path() -> CheckResult:
             "size_bytes": total_bytes,
             "file_count": file_count,
             "newest_mtime": newest_mtime,
+            "capped": capped,
         }
     )
 
@@ -1572,10 +1710,11 @@ def check_doubled_pollypm_path() -> CheckResult:
     age_days = age_seconds / 86400.0
     size_kib = total_bytes / 1024.0
     word = "file" if file_count == 1 else "files"
+    plus = "+" if capped else ""
     return _fail(
         (
-            f"~/.pollypm/.pollypm/ holds {file_count} {word} "
-            f"({size_kib:.1f} KiB, newest {age_days:.1f}d old)"
+            f"~/.pollypm/.pollypm/ holds {file_count}{plus} {word} "
+            f"({size_kib:.1f} KiB{plus}, newest {age_days:.1f}d old)"
         ),
         why=(
             "config.py:_resolve_path documents this artifact: an older "
@@ -2719,7 +2858,16 @@ def check_task_assignment_sweeper_dbs() -> CheckResult:
     per-project DB still survives (we treat both as a successful probe
     so the cockpit's pattern A — try per-project, fall back to
     workspace — keeps passing during the deprecation window).
+
+    #1810 — in pg-mode the per-project sqlite walk is meaningless;
+    the sweeper reads work_tasks from the pg pool, partitioned by the
+    ``project`` column.
     """
+    if _pg_mode_active():
+        return _skip(
+            "task-assignment sweeper check skipped (pg-mode: work_tasks "
+            "is a single pg table partitioned by project)"
+        )
     _path, config = _safe_load_config()
     if config is None:
         return _skip("task-assignment sweeper check skipped (no config)")
@@ -3192,6 +3340,15 @@ _SESSION_RSS_WARN_BYTES = 1024 * 1024 * 1024
 
 def check_state_db_size() -> CheckResult:
     """Warn at 500 MB, error at 2 GB. Recommends ``pm doctor --fix``."""
+    if _pg_mode_active():
+        # #1810 — the legacy sqlite ``state.db`` is irrelevant in
+        # pg-mode (pg has no analogue of incremental_vacuum on a per-
+        # file basis). Skip the file-stat probe so the post-cutover
+        # 4 GB sqlite artifact stops reading as an active ERROR.
+        return _skip(
+            "state.db size check skipped (pg-mode active; sqlite state.db "
+            "is a legacy artifact and can be removed once cutover is final)"
+        )
     candidates = _state_db_candidates()
     if not candidates:
         return _skip("state.db size check skipped (no tracked DBs)")

--- a/src/pollypm/plugins_builtin/core_recurring/maintenance.py
+++ b/src/pollypm/plugins_builtin/core_recurring/maintenance.py
@@ -609,21 +609,17 @@ def events_retention_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
                 | HIGH_VOLUME_EVENT_SUBJECTS
             )
             try:
-                from sqlalchemy import and_ as _and
-                from sqlalchemy import delete as _delete
-
-                from pollypm.store.schema import messages as _messages
-
-                result = msg_store.execute(
-                    _delete(_messages).where(
-                        _and(
-                            _messages.c.type == "event",
-                            _messages.c.subject.notin_(tuple(known)),
-                            _messages.c.created_at < default_cutoff,
-                        )
+                # #1820 — typed prune_messages so pg and sqlite share
+                # one delete shape; the legacy execute(_delete(...))
+                # form raised on PgStore and was silently swallowed.
+                deleted_default = int(
+                    msg_store.prune_messages(
+                        type="event",
+                        subject_not_in=tuple(known),
+                        older_than=default_cutoff,
                     )
+                    or 0
                 )
-                deleted_default = int(getattr(result, "rowcount", 0) or 0)
             except Exception:  # noqa: BLE001
                 logger.debug(
                     "events.retention_sweep: default-tier delete failed",
@@ -674,23 +670,20 @@ def events_retention_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def _prune_event_subject(msg_store: Any, subject: str, cutoff: Any) -> int:
-    """Delete ``type='event'`` rows matching ``subject`` older than ``cutoff``."""
+    """Delete ``type='event'`` rows matching ``subject`` older than ``cutoff``.
+
+    #1820 — typed prune_messages so pg + sqlite share one shape; the
+    previous execute(_delete(...)) raised on PgStore and was swallowed.
+    """
     try:
-        from sqlalchemy import and_ as _and
-        from sqlalchemy import delete as _delete
-
-        from pollypm.store.schema import messages as _messages
-
-        result = msg_store.execute(
-            _delete(_messages).where(
-                _and(
-                    _messages.c.type == "event",
-                    _messages.c.subject == subject,
-                    _messages.c.created_at < cutoff,
-                )
+        return int(
+            msg_store.prune_messages(
+                type="event",
+                subject=subject,
+                older_than=cutoff,
             )
+            or 0
         )
-        return int(getattr(result, "rowcount", 0) or 0)
     except Exception:  # noqa: BLE001
         logger.debug(
             "events.retention_sweep: delete failed for subject=%s",

--- a/src/pollypm/plugins_builtin/core_recurring/plugin.py
+++ b/src/pollypm/plugins_builtin/core_recurring/plugin.py
@@ -306,27 +306,20 @@ def events_retention_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
                 | HIGH_VOLUME_EVENT_SUBJECTS
             )
             try:
-                from sqlalchemy import and_ as _and
-                from sqlalchemy import delete as _delete
-                from sqlalchemy import func as _func
-
-                from pollypm.store.schema import messages as _messages
-
-                result = msg_store.execute(
-                    _delete(_messages).where(
-                        _and(
-                            _messages.c.type == "event",
-                            _messages.c.subject.notin_(tuple(known)),
-                            _messages.c.created_at < default_cutoff,
-                            _func.coalesce(
-                                _func.json_extract(_messages.c.payload_json, "$.pinned"),
-                                0,
-                            )
-                            != 1,
-                        )
+                # #1820 — route through the typed Store method so pg and
+                # sqlite share one delete shape. The legacy
+                # ``msg_store.execute(_delete(...).where(...))`` form
+                # raised on PgStore, which silently skipped the
+                # default-tier prune on the pg backend.
+                deleted_default = int(
+                    msg_store.prune_messages(
+                        type="event",
+                        subject_not_in=tuple(known),
+                        older_than=default_cutoff,
+                        exclude_pinned=True,
                     )
+                    or 0
                 )
-                deleted_default = int(getattr(result, "rowcount", 0) or 0)
             except Exception:  # noqa: BLE001
                 logger.debug(
                     "events.retention_sweep: default-tier delete failed",
@@ -377,29 +370,24 @@ def events_retention_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def _prune_event_subject(msg_store: Any, subject: str, cutoff: Any) -> int:
-    """Delete ``type='event'`` rows matching ``subject`` older than ``cutoff``."""
+    """Delete ``type='event'`` rows matching ``subject`` older than ``cutoff``.
+
+    #1820 — uses the typed :meth:`Store.prune_messages` so the sqlite
+    and pg backends share one delete shape. The previous SQLAlchemy
+    ``execute(_delete(...).where(...))`` form raised on ``PgStore`` and
+    the broad ``except`` swallowed it, silently leaving old event rows
+    in pg forever.
+    """
     try:
-        from sqlalchemy import and_ as _and
-        from sqlalchemy import delete as _delete
-        from sqlalchemy import func as _func
-
-        from pollypm.store.schema import messages as _messages
-
-        result = msg_store.execute(
-            _delete(_messages).where(
-                _and(
-                    _messages.c.type == "event",
-                    _messages.c.subject == subject,
-                    _messages.c.created_at < cutoff,
-                    _func.coalesce(
-                        _func.json_extract(_messages.c.payload_json, "$.pinned"),
-                        0,
-                    )
-                    != 1,
-                )
+        return int(
+            msg_store.prune_messages(
+                type="event",
+                subject=subject,
+                older_than=cutoff,
+                exclude_pinned=True,
             )
+            or 0
         )
-        return int(getattr(result, "rowcount", 0) or 0)
     except Exception:  # noqa: BLE001
         logger.debug(
             "events.retention_sweep: delete failed for subject=%s",

--- a/src/pollypm/projects.py
+++ b/src/pollypm/projects.py
@@ -96,12 +96,38 @@ def detect_project_kind(path: Path) -> ProjectKind:
     return ProjectKind.GIT if (normalized / ".git").exists() else ProjectKind.FOLDER
 
 
+def _resolve_pollypm_root(project_path: Path) -> Path:
+    """Return the canonical ``.pollypm`` root for ``project_path``.
+
+    Normal case: ``<project>/.pollypm``.
+
+    Doubled-path guard (#1810): when the caller passed the global
+    config dir itself (``~/.pollypm``) we'd otherwise produce
+    ``~/.pollypm/.pollypm`` and the entire scaffold (transcripts,
+    artifacts/checkpoints, dossier, ...) writes into that doubled
+    tree. Production builds this up to ~280K files / 1.8 GB. Detect
+    the case and return the global dir verbatim so all the helpers
+    that chain through ``project_instruction_dir`` (artifacts,
+    transcripts, worktrees, ...) stop emitting into the doubled path.
+    """
+    from pollypm.config import GLOBAL_CONFIG_DIR
+
+    normalized = normalize_project_path(project_path)
+    try:
+        global_dir = GLOBAL_CONFIG_DIR.expanduser().resolve()
+    except Exception:  # noqa: BLE001 — defensive; never break pathing
+        global_dir = GLOBAL_CONFIG_DIR
+    if normalized == global_dir:
+        return normalized
+    return normalized / ".pollypm"
+
+
 def project_pollypm_dir(project_path: Path) -> Path:
-    return normalize_project_path(project_path) / ".pollypm"
+    return _resolve_pollypm_root(project_path)
 
 
 def project_instruction_dir(project_path: Path) -> Path:
-    return normalize_project_path(project_path) / ".pollypm"
+    return _resolve_pollypm_root(project_path)
 
 
 def project_instruction_file(project_path: Path) -> Path:

--- a/src/pollypm/store/backends/pg_store.py
+++ b/src/pollypm/store/backends/pg_store.py
@@ -24,13 +24,17 @@ Design
   Executable surface does NOT travel cleanly across the dialect boundary
   for our schema (no ``RETURNING`` round-trip on sqlite, ``jsonb`` vs
   ``TEXT`` for payload columns, etc.).
-* **``execute()`` raises.** The legacy ``execute()`` escape hatch on
-  :class:`SQLAlchemyStore` accepts a SQLAlchemy ``Executable``. The pg
-  backend cannot honour that contract without bolting SQLAlchemy back
-  on, so it raises ``NotImplementedError`` with a three-question message.
-  No production caller hits ``execute()`` against pg in v1 — every
-  pg-backed writer goes through a typed method on this class or the
-  pg work-service.
+* **``execute()`` is wired through the pool (#1820).** The legacy
+  ``execute()`` escape hatch on :class:`SQLAlchemyStore` accepts a
+  SQLAlchemy ``Executable``. Five production call sites still select
+  ``execute()`` via ``hasattr(store, "execute")`` and broad ``except
+  Exception``, so a raising stub silently broke the cockpit
+  no-session metric and skipped event retention deletes on pg. The
+  pg implementation compiles the Executable to the postgresql
+  dialect and runs it on the rw pool, returning a small adapter
+  exposing ``rowcount`` / ``fetchall()``. New callers should prefer
+  the typed methods (:meth:`prune_messages`, :meth:`query_messages`,
+  ...) so the protocol stays portable.
 """
 
 from __future__ import annotations
@@ -66,6 +70,61 @@ _SUPPORTED_QUERY_FILTERS = frozenset(
 
 def _now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+class _ExecuteResult:
+    """Cursor-shaped adapter returned by :meth:`PgStore.execute`.
+
+    Mirrors the bits of SQLAlchemy's ``CursorResult`` that the existing
+    callers actually read: ``rowcount`` on writes and ``fetchall()`` on
+    reads. No fancier methods are added on purpose — if a caller wants
+    more, it should move to a typed method on :class:`PgStore`.
+    """
+
+    __slots__ = ("rowcount", "_rows")
+
+    def __init__(self, *, rowcount: int | None, rows: list[Any]) -> None:
+        self.rowcount = int(rowcount) if rowcount is not None else 0
+        self._rows = rows
+
+    def fetchall(self) -> list[Any]:
+        return list(self._rows)
+
+    def fetchone(self) -> Any:
+        return self._rows[0] if self._rows else None
+
+
+def _rewrite_qmark_to_percent_s(sql: str) -> str:
+    """Rewrite sqlite ``?`` placeholders to psycopg ``%s``.
+
+    Skips ``?`` inside single-quoted string literals so a SQL fragment
+    like ``WHERE label = 'a?b'`` isn't mangled. Doubled quotes (escaped
+    quotes inside strings) are handled by toggling the in-string state
+    only on un-escaped quotes.
+
+    This is deliberately a narrow rewrite — pg-native callers should
+    use ``%s`` directly. The rewrite is just a backstop for the legacy
+    ``DELETE FROM leases``-style call sites that pre-date the cutover.
+    """
+    out: list[str] = []
+    in_string = False
+    i = 0
+    while i < len(sql):
+        ch = sql[i]
+        if ch == "'":
+            # Doubled '' inside a string stays in-string.
+            if in_string and i + 1 < len(sql) and sql[i + 1] == "'":
+                out.append("''")
+                i += 2
+                continue
+            in_string = not in_string
+            out.append(ch)
+        elif ch == "?" and not in_string:
+            out.append("%s")
+        else:
+            out.append(ch)
+        i += 1
+    return "".join(out)
 
 
 class PgStore:
@@ -689,15 +748,32 @@ class PgStore:
         *,
         type: str | list[str] | tuple[str, ...] | set[str] | None = None,
         older_than: datetime | None = None,
+        subject: str | list[str] | tuple[str, ...] | set[str] | None = None,
+        subject_not_in: list[str] | tuple[str, ...] | set[str] | None = None,
+        state: str | list[str] | tuple[str, ...] | set[str] | None = None,
+        exclude_pinned: bool = False,
     ) -> int:
-        """Delete messages matching ``type`` and older than ``older_than``."""
-        if type is None and older_than is None:
+        """Delete messages matching the given filters.
+
+        Extended in #1820 to mirror :meth:`SQLAlchemyStore.prune_messages`
+        — adds ``subject`` / ``subject_not_in`` / ``state`` filters so
+        the event-retention sweep and ``pm reset`` alert wipe can stay
+        on the typed protocol surface instead of falling through to
+        :meth:`execute` (which previously raised on the pg backend).
+        """
+        if (
+            type is None
+            and older_than is None
+            and subject is None
+            and subject_not_in is None
+            and state is None
+        ):
             raise ValueError(
                 "prune_messages requires at least one filter. "
                 "An unfiltered delete would truncate the ``messages`` table, "
                 "which is never the intent. "
-                "Fix: pass ``type=...`` (scalar or sequence) and/or "
-                "``older_than=<datetime>`` to scope the delete."
+                "Fix: pass one of ``type=``, ``older_than=``, "
+                "``subject=``, ``subject_not_in=``, or ``state=``."
             )
         self._ensure_schema()
         where: list[str] = []
@@ -716,6 +792,41 @@ class PgStore:
         if older_than is not None:
             where.append("created_at < %s")
             params.append(older_than)
+        if subject is not None:
+            if isinstance(subject, (list, tuple, set, frozenset)):
+                vals = list(subject)
+                if not vals:
+                    return 0
+                placeholders = ",".join(["%s"] * len(vals))
+                where.append(f"subject IN ({placeholders})")
+                params.extend(vals)
+            else:
+                where.append("subject = %s")
+                params.append(subject)
+        if subject_not_in is not None:
+            vals = list(subject_not_in)
+            if vals:
+                placeholders = ",".join(["%s"] * len(vals))
+                where.append(f"subject NOT IN ({placeholders})")
+                params.extend(vals)
+        if state is not None:
+            if isinstance(state, (list, tuple, set, frozenset)):
+                vals = list(state)
+                if not vals:
+                    return 0
+                placeholders = ",".join(["%s"] * len(vals))
+                where.append(f"state IN ({placeholders})")
+                params.extend(vals)
+            else:
+                where.append("state = %s")
+                params.append(state)
+        if exclude_pinned:
+            # ``payload_json`` is ``jsonb`` on pg. ``->>`` extracts the
+            # value as text; ``IS DISTINCT FROM`` makes NULL behave like
+            # "not pinned" (matches sqlite's coalesce(...,0) != 1).
+            where.append(
+                "(payload_json->>'pinned') IS DISTINCT FROM '1'"
+            )
         sql = f"DELETE FROM messages WHERE {' AND '.join(where)}"
         with self.transaction() as conn, conn.cursor() as cur:
             cur.execute(sql, tuple(params))
@@ -845,32 +956,94 @@ class PgStore:
             )
 
     # ------------------------------------------------------------------
-    # SQLAlchemy escape hatch — deliberately not supported on pg.
+    # SQLAlchemy / raw-SQL escape hatch
     # ------------------------------------------------------------------
 
-    def execute(self, stmt: Any) -> Any:
-        """Not supported on the pg backend.
+    def execute(self, stmt: Any, params: Any = None) -> Any:
+        """Execute a SQLAlchemy Executable or a raw SQL string on the pg pool.
 
-        :class:`SQLAlchemyStore` accepts a SQLAlchemy ``Executable`` here
-        as an escape hatch for callers writing to tables outside the
-        store's owned surface. Honouring that on pg would require
-        bolting SQLAlchemy back onto a psycopg-only stack, which defeats
-        the migration's reason for existing.
+        #1820 — historically this raised ``NotImplementedError`` on pg,
+        but five production callers select it via ``hasattr(store,
+        "execute")`` and broad ``except Exception``, so under
+        ``[storage] backend = "postgres"`` the cockpit no-session
+        metric reported zero and event retention silently skipped
+        pruning. Wiring this through to the pool restores parity with
+        :meth:`SQLAlchemyStore.execute` for the existing callers.
 
-        Every in-tree caller writes to pg via a typed method on this
-        class or through :class:`pollypm.work.pg_service.PgWorkService`.
-        If a new caller needs raw-SQL access, route it through the pg
-        pool directly via :func:`pollypm.storage.pg_pool.get_rw_pool`.
+        Two accepted call shapes:
+
+        * **SQLAlchemy Core ``Executable``** — compiled with the
+          ``postgresql`` dialect (no literal-binds) and executed through
+          a psycopg cursor. Returns a small adapter exposing
+          ``rowcount`` and ``fetchall()`` so existing callers that read
+          ``result.rowcount`` keep working.
+
+        * **Raw SQL string (+ optional params tuple)** — passed to
+          ``cur.execute()`` after a sqlite ``?`` → pg ``%s`` rewrite
+          so the few raw-SQL call sites that drifted in don't have to
+          branch on backend.
+
+        The implementation deliberately stays narrow: callers wanting
+        full SQLAlchemy ORM semantics should still use the typed methods
+        (:meth:`prune_messages`, :meth:`query_messages`, ...). This is
+        the escape hatch the Store protocol promises (#1820), not a
+        full SQLAlchemy execution surface.
         """
-        raise NotImplementedError(
-            "PgStore.execute is not supported. "
-            "The SQLAlchemy Executable escape hatch only exists on the "
-            "sqlite backend; routing arbitrary SQLAlchemy through psycopg "
-            "would require dragging SQLAlchemy onto the pg path. "
-            "Fix: call a typed method on PgStore, use PgWorkService, "
-            "or obtain a connection via pg_pool.get_rw_pool() and write "
-            "the psycopg statement directly."
-        )
+        self._ensure_schema()
+
+        # Branch 1: raw SQL string. Rewrite sqlite ``?`` placeholders
+        # to psycopg ``%s`` so the legacy ``DELETE FROM leases``-style
+        # call sites stay backend-agnostic. The rewrite is a literal
+        # substitution that skips ``?`` inside single-quoted strings.
+        if isinstance(stmt, str):
+            sql = _rewrite_qmark_to_percent_s(stmt)
+            args = tuple(params) if params else ()
+            with self.transaction() as conn, conn.cursor() as cur:
+                cur.execute(sql, args)
+                rowcount = cur.rowcount
+                rows: list[Any] = []
+                try:
+                    if cur.description is not None:
+                        rows = list(cur.fetchall())
+                except Exception:  # noqa: BLE001 — non-SELECTs have no rows
+                    rows = []
+            return _ExecuteResult(rowcount=rowcount, rows=rows)
+
+        # Branch 2: SQLAlchemy Executable. Compile to a pg dialect
+        # string + bind-parameter dict, then run through psycopg.
+        try:
+            from sqlalchemy.dialects import postgresql as _pg_dialect
+        except ImportError as exc:  # pragma: no cover — sqlalchemy is a hard dep
+            raise NotImplementedError(
+                "PgStore.execute received a SQLAlchemy Executable but "
+                "SQLAlchemy isn't importable in this environment."
+            ) from exc
+
+        try:
+            compiled = stmt.compile(
+                dialect=_pg_dialect.dialect(),
+                compile_kwargs={"render_postcompile": True},
+            )
+        except AttributeError as exc:
+            raise TypeError(
+                "PgStore.execute expects a SQLAlchemy Executable or a "
+                f"SQL string; got {type(stmt).__name__}."
+            ) from exc
+
+        sql_text = str(compiled)
+        bind_params = dict(getattr(compiled, "params", {}) or {})
+
+        with self.transaction() as conn, conn.cursor() as cur:
+            # psycopg accepts named placeholders via a dict mapping.
+            cur.execute(sql_text, bind_params)
+            rowcount = cur.rowcount
+            rows = []
+            try:
+                if cur.description is not None:
+                    rows = list(cur.fetchall())
+            except Exception:  # noqa: BLE001 — non-SELECTs have no rows
+                rows = []
+        return _ExecuteResult(rowcount=rowcount, rows=rows)
 
     # ------------------------------------------------------------------
     # Test-only conveniences — do NOT call from production paths.

--- a/src/pollypm/store/protocol.py
+++ b/src/pollypm/store/protocol.py
@@ -106,11 +106,31 @@ class Store(Protocol):
         *,
         type: str | list[str] | tuple[str, ...] | set[str] | None = None,
         older_than: Any = None,
+        subject: str | list[str] | tuple[str, ...] | set[str] | None = None,
+        subject_not_in: list[str] | tuple[str, ...] | set[str] | None = None,
+        state: str | list[str] | tuple[str, ...] | set[str] | None = None,
+        exclude_pinned: bool = False,
     ) -> int:
-        """Delete messages matching ``type`` and older than ``older_than``.
+        """Delete messages matching the given filters.
 
         At least one filter is required — an unbounded delete would
         truncate the table. Returns the number of rows removed.
+
+        Filters:
+
+        * ``type`` — scalar or sequence; passed through to ``type = ?`` /
+          ``type IN (...)``.
+        * ``older_than`` — ``created_at < <datetime>``.
+        * ``subject`` — scalar or sequence; ``subject = ?`` / ``IN (...)``.
+        * ``subject_not_in`` — ``subject NOT IN (...)``; used by the
+          retention sweep's default-tier (delete events whose subject
+          isn't on any known tier list).
+        * ``state`` — scalar or sequence; ``state = ?`` / ``IN (...)``.
+          Used by ``pm reset`` to clear open alerts.
+        * ``exclude_pinned`` — when ``True``, rows whose
+          ``payload_json`` carries ``"pinned": 1`` (or truthy) are
+          retained. Implementations use ``json_extract`` (sqlite) or
+          ``payload_json->>'pinned'`` (pg).
         """
         ...
 

--- a/src/pollypm/store/sqlalchemy_store.py
+++ b/src/pollypm/store/sqlalchemy_store.py
@@ -676,34 +676,41 @@ class SQLAlchemyStore:
         *,
         type: str | list[str] | tuple[str, ...] | set[str] | None = None,
         older_than: datetime | None = None,
+        subject: str | list[str] | tuple[str, ...] | set[str] | None = None,
+        subject_not_in: list[str] | tuple[str, ...] | set[str] | None = None,
+        state: str | list[str] | tuple[str, ...] | set[str] | None = None,
+        exclude_pinned: bool = False,
     ) -> int:
-        """Delete messages matching ``type`` and older than ``older_than``.
+        """Delete messages matching the given filters.
 
         Replaces the legacy tiered ``events`` retention sweep (folded in
         from :mod:`pollypm.storage.events_retention` when #342 retired
-        the legacy tables). Callers pass a ``type`` filter (scalar or
-        sequence) and a ``created_at`` cutoff; every matching row is
-        deleted inside the single-connection writer pool, so the call
-        serializes cleanly with inserts from
-        :meth:`append_event` / :meth:`enqueue_message`.
+        the legacy tables). Also serves as the typed entry point for
+        ``pm reset``'s alert wipe (#1820) so callers don't reach into
+        SQLAlchemy ``delete()`` through :meth:`execute`.
 
-        Returns the number of rows deleted. ``0`` is a valid (and common)
-        result — silent no-op when nothing is old enough.
+        At least one filter is required. Returns the number of rows
+        deleted. ``0`` is a valid (and common) result.
 
         Raises
         ------
         ValueError
-            If neither ``type`` nor ``older_than`` is supplied. We refuse
-            to delete the whole table accidentally; pass one of the two
-            filters (or both) to make the intent explicit.
+            If no filter is supplied. We refuse to delete the whole
+            table accidentally; pass at least one filter.
         """
-        if type is None and older_than is None:
+        if (
+            type is None
+            and older_than is None
+            and subject is None
+            and subject_not_in is None
+            and state is None
+        ):
             raise ValueError(
                 "prune_messages requires at least one filter. "
                 "An unfiltered delete would truncate the ``messages`` "
                 "table, which is never the intent. "
-                "Fix: pass ``type=...`` (scalar or sequence) and/or "
-                "``older_than=<datetime>`` to scope the delete."
+                "Fix: pass one of ``type=``, ``older_than=``, "
+                "``subject=``, ``subject_not_in=``, or ``state=``."
             )
         conditions = []
         if type is not None:
@@ -713,6 +720,30 @@ class SQLAlchemyStore:
                 conditions.append(messages.c.type == type)
         if older_than is not None:
             conditions.append(messages.c.created_at < older_than)
+        if subject is not None:
+            if isinstance(subject, (list, tuple, set, frozenset)):
+                conditions.append(messages.c.subject.in_(list(subject)))
+            else:
+                conditions.append(messages.c.subject == subject)
+        if subject_not_in is not None:
+            vals = list(subject_not_in)
+            if vals:
+                conditions.append(messages.c.subject.notin_(vals))
+        if state is not None:
+            if isinstance(state, (list, tuple, set, frozenset)):
+                conditions.append(messages.c.state.in_(list(state)))
+            else:
+                conditions.append(messages.c.state == state)
+        if exclude_pinned:
+            from sqlalchemy import func as _func
+
+            conditions.append(
+                _func.coalesce(
+                    _func.json_extract(messages.c.payload_json, "$.pinned"),
+                    0,
+                )
+                != 1
+            )
         stmt = delete(messages).where(and_(*conditions))
         with self.transaction() as conn:
             result = conn.execute(stmt)

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -81,6 +81,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Per-process dedup for the ``work_db.opened`` audit row (#1808). The
+# event is a doctor / heartbeat diagnostic stamped at first open of a
+# given (subject, project_path) pair — subsequent opens within the
+# same interpreter are noise. The sqlite service applies the same
+# pattern; keep them symmetric so a future audit-volume regression is
+# easier to spot.
+_emitted_pg_work_db_opened: set[tuple[str, str | None]] = set()
+
 
 def _parse_task_id(task_id: str) -> tuple[str, int]:
     """Split ``project/number`` into ``(project, int(number))``.
@@ -296,31 +304,41 @@ class PgWorkService:
         # audit trail. Without this, central tail watchers and ``pm
         # doctor`` cannot tell when a pg-backed service was opened.
         # Best-effort — audit failure must never block init.
-        try:
-            from pollypm.audit import emit as _audit_emit
-            from pollypm.audit.log import EVENT_WORK_DB_OPENED
+        #
+        # #1808: dedup per (subject, project_path) per process. Cockpit
+        # panels reopen the service multiple times per second; the
+        # event is a startup stamp, not a per-call signal.
+        _dedup_key = (
+            "postgres",
+            str(self._project_path) if self._project_path is not None else None,
+        )
+        if _dedup_key not in _emitted_pg_work_db_opened:
+            _emitted_pg_work_db_opened.add(_dedup_key)
+            try:
+                from pollypm.audit import emit as _audit_emit
+                from pollypm.audit.log import EVENT_WORK_DB_OPENED
 
-            _audit_emit(
-                event=EVENT_WORK_DB_OPENED,
-                project="_workspace",
-                subject="postgres",
-                actor="system",
-                metadata={
-                    "backend": "postgres",
-                    "tables_created": bool(applied_versions),
-                    "applied_migrations": applied_versions,
-                    "project_path": (
-                        str(self._project_path)
-                        if self._project_path is not None
-                        else None
-                    ),
-                },
-                project_path=self._project_path,
-            )
-        except Exception:  # noqa: BLE001 — audit must never break init
-            logger.debug(
-                "pg work DB opened audit emit failed", exc_info=True
-            )
+                _audit_emit(
+                    event=EVENT_WORK_DB_OPENED,
+                    project="_workspace",
+                    subject="postgres",
+                    actor="system",
+                    metadata={
+                        "backend": "postgres",
+                        "tables_created": bool(applied_versions),
+                        "applied_migrations": applied_versions,
+                        "project_path": (
+                            str(self._project_path)
+                            if self._project_path is not None
+                            else None
+                        ),
+                    },
+                    project_path=self._project_path,
+                )
+            except Exception:  # noqa: BLE001 — audit must never break init
+                logger.debug(
+                    "pg work DB opened audit emit failed", exc_info=True
+                )
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -33,11 +33,56 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 _DISABLE_WORK_DB_OPENED_AUDIT_ENV = "POLLYPM_DISABLE_WORK_DB_OPENED_AUDIT"
+_ENABLE_WORK_DB_OPENED_AUDIT_ENV = "POLLYPM_ENABLE_WORK_DB_OPENED_AUDIT"
+
+# Per-process dedup: which (subject) db paths have already emitted a
+# ``work_db.opened`` row in this interpreter. The audit row exists to
+# stamp "first-time open of this DB in this process" — a doctor /
+# heartbeat diagnostic, not a per-call event. Re-opens of the same
+# path within the same process are noise and were producing 99.8% of
+# the bytes in ``~/.pollypm/audit/_workspace.jsonl`` (#1808).
+_emitted_work_db_opened_subjects: set[str] = set()
 
 
 def _work_db_opened_audit_disabled() -> bool:
-    value = os.environ.get(_DISABLE_WORK_DB_OPENED_AUDIT_ENV, "")
-    return value.strip().lower() not in {"", "0", "false", "no", "off"}
+    """Return ``True`` when the ``work_db.opened`` emit should be skipped.
+
+    Default policy (v1 RC, #1808): SUPPRESSED. The event was emitting
+    at ~15 events/min sustained because every cockpit panel render
+    reopened the sqlite work service; 99.8% of ``_workspace.jsonl``
+    was ``work_db.opened`` churn (1.87 GB file). Operators who still
+    want the event can opt in via ``POLLYPM_ENABLE_WORK_DB_OPENED_AUDIT=1``.
+
+    The legacy ``POLLYPM_DISABLE_WORK_DB_OPENED_AUDIT`` env is honored
+    for forward-compat but is now a no-op default — kept so existing
+    shell rc files / config snippets don't break.
+    """
+    # Active backend short-circuit: if we're running pg-mode then the
+    # sqlite work service is a legacy/migration path; any DB it opens
+    # is by definition not the runtime store. Suppress unconditionally.
+    try:
+        from pollypm.storage._backend_dispatch import is_pg_backend
+
+        if is_pg_backend():
+            return True
+    except Exception:  # noqa: BLE001 — never break init on a config probe
+        pass
+
+    enable_value = os.environ.get(_ENABLE_WORK_DB_OPENED_AUDIT_ENV, "")
+    if enable_value.strip().lower() in {"1", "true", "yes", "on"}:
+        # Explicit opt-in; honor the legacy disable flag if also set.
+        disable_value = os.environ.get(_DISABLE_WORK_DB_OPENED_AUDIT_ENV, "")
+        return disable_value.strip().lower() in {"1", "true", "yes", "on"}
+    # Default: suppressed.
+    return True
+
+
+def _should_emit_work_db_opened(subject: str) -> bool:
+    """Per-process dedup gate. ``True`` only on first call for ``subject``."""
+    if subject in _emitted_work_db_opened_subjects:
+        return False
+    _emitted_work_db_opened_subjects.add(subject)
+    return True
 
 
 # #894 — register the work_service module as an emitter that routes
@@ -623,7 +668,9 @@ class SQLiteWorkService:
         # broad try/except so audit infra failure cannot block work-
         # service init — matches the pattern used at the other audit
         # callsites in this module.
-        if not _work_db_opened_audit_disabled():
+        if not _work_db_opened_audit_disabled() and _should_emit_work_db_opened(
+            str(db_path)
+        ):
             try:
                 from pollypm.audit import emit as _audit_emit
                 from pollypm.audit.log import EVENT_WORK_DB_OPENED


### PR DESCRIPTION
## Summary

Three v1 RC "polish before ship" infra fixes, one branch, one PR. Each commit stands alone and closes its issue.

- **#1808 audit churn** — `work_db.opened` was emitting at 15/min sustained (99.8% of bytes in `~/.pollypm/audit/_workspace.jsonl`, 1.87 GB). Default-suppressed in sqlite-mode, hard-skipped in pg-mode, per-process dedup on both backends.
- **#1820 pg_store.execute() raises** — five production callers hit `NotImplementedError` and the broad `except Exception` swallowed it. Extended `Store.prune_messages` with `subject` / `subject_not_in` / `state` / `exclude_pinned` filters; migrated the event-retention sweep + `pm reset` open-alert wipe to the typed surface. Also wired `PgStore.execute()` through the rw pool as a backstop (compiles SQLAlchemy to the postgresql dialect; accepts raw SQL with `?`→`%s` rewrite).
- **#1810 pm doctor** — doubled-path root cause in `projects.py` (`project_pollypm_dir(GLOBAL_CONFIG_DIR)` produced `~/.pollypm/.pollypm`); pg-mode short-circuits on five sqlite-flavored checks; bounded `check_doubled_pollypm_path` scan at 10K files (the 281K-file walk dominated the 180s runtime).

## Commits

1. `fix(audit): drop work_db.opened churn in pg-mode (closes #1808)`
2. `fix(pg_store): wire execute() to pool or remove with caller migration (closes #1820)`
3. `fix(doctor): doubled-path root-cause + pg-mode probes + 180s reduction (closes #1810)`

## Test plan

- [ ] Smoke `pm doctor` on a fresh pg-mode install — confirm state-migrations / work-migrations / state-db-size / dual-db / db-layout-canonical / task-assignment-sweeper-dbs all return either OK (pg probe at-head) or skip (pg-mode).
- [ ] Smoke `pm doctor` on a sqlite install — confirm the sqlite probes still run (no behavior regression).
- [ ] Confirm `~/.pollypm/audit/_workspace.jsonl` stops accumulating `work_db.opened` rows after restart (cockpit open + a few panel renders should produce zero new rows in sqlite-mode and at most one per (subject, project_path) in pg-mode).
- [ ] Confirm event retention sweep runs on pg without raising. Inspect `events.retention_sweep` audit event payload for non-zero `deleted_*` counts when there are old events to prune.
- [ ] Confirm cockpit no_session metric > 0 after a synthetic no_session alert lands in pg.
- [ ] Confirm new transcripts/checkpoints/artifacts write into `<workspace>/.pollypm/...` not `~/.pollypm/.pollypm/...` when project_path resolves to GLOBAL_CONFIG_DIR.

NOTE on user-side cleanup: the existing ~/.pollypm/.pollypm/ 281K-file artifact tree is NOT deleted by this PR. Operator should `rm -rf ~/.pollypm/.pollypm/` (or move to a `.bak` directory) once they confirm nothing depends on it. The code fix ensures the doubled-path stops growing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)