### PR TITLE
feat(cockpit): per-project Advisor settings tab

### DIFF
--- a/src/pollypm/cockpit_project_advisor_log.py
+++ b/src/pollypm/cockpit_project_advisor_log.py
@@ -1,0 +1,106 @@
+"""Renderer for the per-project Advisor settings tab.
+
+Contract:
+- Inputs: the advisor ``base_dir`` (resolved from config) and the
+  cockpit's current ``project_key``.
+- Outputs: a single multi-line string ready to drop into a ``Static``
+  widget — newest event first, capped to ``limit`` rows.
+- Side effects: none beyond the read performed by the advisor's own
+  history facade.
+
+The advisor stores its emit/silent decisions in
+``<base_dir>/advisor-log.jsonl`` (one JSON object per line). We reuse
+``recent_entries_for_project`` from the advisor plugin so the renderer
+is purely a presentation layer — it never opens the file itself, never
+mutates the schema, and stays robust to malformed lines (the facade
+already skips them).
+
+Each row renders as ``HH:MM:SS  event_type  summary`` where
+``event_type`` is ``emit/<topic>``, ``emit``, or ``silent`` — chosen so
+the row is short enough to scan without wrapping. Summary falls back to
+the silent rationale when ``decision == "silent"``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from pollypm.plugins_builtin.advisor.handlers.history_log import (
+    HistoryEntry,
+    recent_entries_for_project,
+)
+
+
+_EMPTY_STATE = "No advisor events yet for this project."
+
+
+def _format_timestamp(raw: str) -> str:
+    """Render the entry timestamp as ``HH:MM:SS``.
+
+    Falls back to ``--:--:--`` for malformed values so the column stays
+    aligned. The advisor stores timestamps as ISO-8601 UTC strings, but
+    we tolerate naive inputs by treating them as UTC unchanged — the
+    Advisor tab is a read-only audit view, so timezone fidelity matters
+    less than the row staying readable.
+    """
+    if not raw:
+        return "--:--:--"
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return "--:--:--"
+    return dt.strftime("%H:%M:%S")
+
+
+def _event_type(entry: HistoryEntry) -> str:
+    """Render the entry's decision as a compact event-type token."""
+    if entry.decision == "emit":
+        if entry.topic:
+            return f"emit/{entry.topic}"
+        return "emit"
+    return "silent"
+
+
+def _summary_text(entry: HistoryEntry) -> str:
+    """Pick the most informative one-liner from the entry."""
+    if entry.decision == "emit":
+        return entry.summary or "(no summary)"
+    return entry.rationale_if_silent or entry.summary or "(no rationale)"
+
+
+def format_entry_line(entry: HistoryEntry) -> str:
+    """One row: ``HH:MM:SS  event_type  summary``."""
+    when = _format_timestamp(entry.timestamp)
+    return f"{when}  {_event_type(entry)}  {_summary_text(entry)}"
+
+
+def render_advisor_log_lines(
+    *,
+    base_dir: Path,
+    project_key: str,
+    limit: int = 200,
+) -> str:
+    """Return the formatted advisor log text for ``project_key``.
+
+    Newest event first, capped to ``limit`` rows. Empty result returns
+    the empty-state message so the caller can update the widget with
+    a single ``.update()`` call regardless of whether the log has
+    entries.
+    """
+    entries = recent_entries_for_project(
+        Path(base_dir), project_key, limit=limit,
+    )
+    if not entries:
+        return _EMPTY_STATE
+    # ``recent_entries_for_project`` returns chronological order (oldest
+    # → newest); reverse for the UI so the most recent decision shows
+    # at the top of the scroll.
+    lines = [format_entry_line(e) for e in reversed(entries)]
+    return "\n".join(lines)
+
+
+__all__ = [
+    "format_entry_line",
+    "render_advisor_log_lines",
+]

--- a/src/pollypm/cockpit_project_settings.py
+++ b/src/pollypm/cockpit_project_settings.py
@@ -19,11 +19,22 @@ from rich.text import Text
 from textual import on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.containers import Horizontal, Vertical
-from textual.widgets import Button, DataTable, Input, RadioButton, RadioSet, Select, Static
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.widgets import (
+    Button,
+    DataTable,
+    Input,
+    RadioButton,
+    RadioSet,
+    Select,
+    Static,
+    TabbedContent,
+    TabPane,
+)
 
 from pollypm.account_usage_sampler import load_cached_account_usage
 from pollypm.config import load_config, write_config
+from pollypm.cockpit_project_advisor_log import render_advisor_log_lines
 from pollypm.cockpit_settings_confirm import _SettingsConfirmModal
 from pollypm.cockpit_settings_history import (
     UndoAction,
@@ -239,6 +250,22 @@ class PollyProjectSettingsApp(App[None]):
         height: auto;
         color: #c8d3dd;
     }
+    TabPane {
+        padding: 1 0 0 0;
+    }
+    #advisor-log-header {
+        height: 1;
+        color: #5b8aff;
+        text-style: bold;
+        padding-bottom: 1;
+    }
+    #advisor-log-body {
+        height: 1fr;
+        background: #111820;
+        border: round #253140;
+        padding: 1;
+        color: #c8d3dd;
+    }
     """
     BINDINGS = [
         Binding("u", "undo_recent_change", "Undo", show=False),
@@ -289,54 +316,61 @@ class PollyProjectSettingsApp(App[None]):
         yield self.title_bar
         yield self.message_bar
         yield self.preview_bar
-        with Vertical(classes="settings-section"):
-            yield Static("Worker Session", classes="section-label")
-            yield Static("", id="worker-info")
-        with Vertical(classes="settings-section"):
-            yield Static("Model & Account", classes="section-label")
-            yield Static("", id="model-info")
-        with Vertical(classes="settings-section"):
-            yield Static("Role Assignments", classes="section-label")
-            yield self.role_table
-            with Horizontal(id="project-role-editor"):
-                yield self.role_alias_select
-                yield self.role_provider_input
-                yield self.role_model_input
-                yield Button("Inherit Global", id="project-role-inherit")
-                yield Static(
-                    "Pick an alias or type both fields to save a custom override.",
-                    id="project-role-note",
-                )
-            yield Static("", id="project-role-detail", markup=True)
-        with Vertical(classes="settings-section"):
-            yield Static("Recent Tasks", classes="section-label")
-            yield Static("", id="task-info")
-        with Vertical(classes="settings-section"):
-            yield Static("Project Guides", classes="section-label")
-            yield Static("", id="guide-info")
-        with Vertical(classes="settings-section", id="release-channel-section"):
-            yield Static("Release channel", classes="section-label")
-            yield Static(
-                "Stable: Production builds. Recommended.\n"
-                "Beta: Pre-release builds. Faster features, occasional breakage.",
-                id="release-channel-explainer",
-            )
-            yield RadioSet(
-                RadioButton("Stable", id="release-channel-stable"),
-                RadioButton("Beta", id="release-channel-beta"),
-                id="release-channel-radio",
-            )
-        with Horizontal(id="actions"):
-            yield Button(Text("[R] Reset Session"), id="reset-session", variant="warning")
-            yield Button(Text("[C] Switch to Claude"), id="switch-claude", variant="primary")
-            yield Button(Text("[X] Switch to Codex"), id="switch-codex", variant="primary")
-            yield Button(Text("[U] Undo"), id="undo", variant="default")
+        with TabbedContent(initial="project-settings-tab", id="project-settings-tabs"):
+            with TabPane("Settings", id="project-settings-tab"):
+                with Vertical(classes="settings-section"):
+                    yield Static("Worker Session", classes="section-label")
+                    yield Static("", id="worker-info")
+                with Vertical(classes="settings-section"):
+                    yield Static("Model & Account", classes="section-label")
+                    yield Static("", id="model-info")
+                with Vertical(classes="settings-section"):
+                    yield Static("Role Assignments", classes="section-label")
+                    yield self.role_table
+                    with Horizontal(id="project-role-editor"):
+                        yield self.role_alias_select
+                        yield self.role_provider_input
+                        yield self.role_model_input
+                        yield Button("Inherit Global", id="project-role-inherit")
+                        yield Static(
+                            "Pick an alias or type both fields to save a custom override.",
+                            id="project-role-note",
+                        )
+                    yield Static("", id="project-role-detail", markup=True)
+                with Vertical(classes="settings-section"):
+                    yield Static("Recent Tasks", classes="section-label")
+                    yield Static("", id="task-info")
+                with Vertical(classes="settings-section"):
+                    yield Static("Project Guides", classes="section-label")
+                    yield Static("", id="guide-info")
+                with Vertical(classes="settings-section", id="release-channel-section"):
+                    yield Static("Release channel", classes="section-label")
+                    yield Static(
+                        "Stable: Production builds. Recommended.\n"
+                        "Beta: Pre-release builds. Faster features, occasional breakage.",
+                        id="release-channel-explainer",
+                    )
+                    yield RadioSet(
+                        RadioButton("Stable", id="release-channel-stable"),
+                        RadioButton("Beta", id="release-channel-beta"),
+                        id="release-channel-radio",
+                    )
+                with Horizontal(id="actions"):
+                    yield Button(Text("[R] Reset Session"), id="reset-session", variant="warning")
+                    yield Button(Text("[C] Switch to Claude"), id="switch-claude", variant="primary")
+                    yield Button(Text("[X] Switch to Codex"), id="switch-codex", variant="primary")
+                    yield Button(Text("[U] Undo"), id="undo", variant="default")
+            with TabPane("Advisor", id="project-settings-advisor-tab"):
+                yield Static("", id="advisor-log-header", markup=True)
+                with VerticalScroll(id="advisor-log-body"):
+                    yield Static("", id="advisor-log-content", markup=False)
 
     def on_mount(self) -> None:
         self.role_table.cursor_type = "row"
         self.role_table.zebra_stripes = True
         self.role_table.add_columns("Role", "Configured", "Resolved", "Source", "Warn")
         self._refresh()
+        self._refresh_advisor_log()
 
     def _refresh(self) -> None:
         config = load_config(self.config_path)
@@ -928,8 +962,56 @@ class PollyProjectSettingsApp(App[None]):
             return
         self._refresh()
 
+    def _refresh_advisor_log(self) -> None:
+        """Reload the per-project advisor log into the Advisor tab.
+
+        Reads the last 200 entries for ``self.project_key`` from the
+        advisor history log via the existing read facade and renders
+        them newest-first as ``HH:MM:SS  event_type  summary`` rows.
+        Failures (missing config, IO errors) fall back to a friendly
+        empty-state line so a broken advisor never blocks the rest of
+        the settings UI.
+        """
+        try:
+            header = self.query_one("#advisor-log-header", Static)
+            body = self.query_one("#advisor-log-content", Static)
+        except Exception:  # noqa: BLE001
+            return
+        header.update(f"[b]{self.project_key}[/b] [dim]advisor log[/dim]")
+        try:
+            config = load_config(self.config_path)
+            base_dir = Path(getattr(config.project, "base_dir", Path.home() / ".pollypm"))
+        except Exception as exc:  # noqa: BLE001
+            body.update(f"Advisor log unavailable: {exc}")
+            return
+        try:
+            text = render_advisor_log_lines(
+                base_dir=base_dir,
+                project_key=self.project_key,
+                limit=200,
+            )
+        except Exception as exc:  # noqa: BLE001
+            body.update(f"Advisor log read failed: {exc}")
+            return
+        body.update(text)
+
+    @on(TabbedContent.TabActivated, "#project-settings-tabs")
+    def on_settings_tab_activated(
+        self, event: TabbedContent.TabActivated
+    ) -> None:
+        # Refresh on focus only (no auto-poll) so the user sees fresh
+        # advisor events whenever they switch back to the tab without
+        # paying for a background timer.
+        try:
+            tab_id = event.tab.id or ""
+        except Exception:  # noqa: BLE001
+            return
+        if tab_id.endswith("project-settings-advisor-tab"):
+            self._refresh_advisor_log()
+
     def action_refresh(self) -> None:
         self._refresh()
+        self._refresh_advisor_log()
 
     def action_undo_recent_change(self) -> None:
         action = self._undo_action


### PR DESCRIPTION
## Summary

- Adds an **Advisor** tab to the per-project Settings cockpit (`PollyProjectSettingsApp`) so the operator can audit what the advisor has emitted for that project without surfacing the advisor anywhere else in the UI. The advisor remains an internal background system.
- Reuses the advisor plugin's existing `recent_entries_for_project` reader from `pollypm.plugins_builtin.advisor.handlers.history_log` — no new storage abstraction, no schema change.
- Refresh on tab focus only (no auto-poll); manual refresh action also refreshes the log.

## Behavior

- Header: `<project_key> advisor log`
- Each row: `HH:MM:SS  event_type  summary` (`event_type` is `emit/<topic>`, `emit`, or `silent`)
- Newest event at the top, capped at 200 entries
- Empty state: `No advisor events yet for this project.`

## Notes for the reviewer

- The prompt described the advisor log as "pg-backed"; in the current tree it is actually a JSONL file at `<base_dir>/advisor-log.jsonl` (the same backing store the existing CLI `pm advisor history` and the dashboard `Insights` section already read). I used the existing read facade as instructed and did not introduce a pg-mode shim — this matches "Use the existing read facade if there is one."
- Only two files touched:
  - `src/pollypm/cockpit_project_settings.py` — wraps the existing sections in `TabbedContent` / `TabPane` and adds the Advisor pane + `TabActivated` handler.
  - `src/pollypm/cockpit_project_advisor_log.py` — thin renderer module (format helpers + `render_advisor_log_lines`).
- No changes to the advisor plugin, no changes to storage facades.

## Test plan

- [ ] Open the cockpit project settings for a project with advisor history; confirm the **Advisor** tab appears next to **Settings** and renders entries newest-first.
- [ ] Open the same screen for a project with no advisor activity; confirm the empty-state message renders.
- [ ] Switch away from the Advisor tab and back; confirm the log re-reads (no auto-poll between focus events).
- [ ] Press `r` (refresh action) while on the Advisor tab; confirm content updates.
- [ ] `ruff check src/pollypm/cockpit_project_settings.py src/pollypm/cockpit_project_advisor_log.py` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)