### PR TITLE
fix(state): drop getattr shims + sqlite-default callers (closes #1853 #1855)

### DIFF
--- a/src/pollypm/audit/tier4.py
+++ b/src/pollypm/audit/tier4.py
@@ -228,12 +228,10 @@ class Tier4PromotionTracker:
         # TODO(pg-callers-port): tier4_promotion_state uses raw
         # StateStore.execute(SQL) without a corresponding pg facade.
         # Migrating requires building a pg_tier4 facade (filed as
-        # pg-gap). For now this caller stays on StateStore via a
-        # deferred attribute lookup so the gate grep stays clean.
-        from pollypm.storage import state as _state_mod
+        # pg-gap). For now this caller stays on StateStore.
+        from pollypm.storage.state import StateStore
 
-        _cls = getattr(_state_mod, "StateStore")
-        return _cls(self._db_path)
+        return StateStore(self._db_path)
 
     def get(self, root_cause_hash: str) -> Tier4State | None:
         """Return the row for ``root_cause_hash`` or ``None`` if absent."""

--- a/src/pollypm/checkpoints.py
+++ b/src/pollypm/checkpoints.py
@@ -643,32 +643,53 @@ def record_checkpoint(
 ) -> None:
     """Record a checkpoint row and refresh the session_runtime stamp.
 
-    ``store`` and ``config`` are retained for caller compatibility but
-    are no longer used — writes go through the pg facades.
+    Routes writes through the pg facades when the active backend is
+    Postgres; otherwise writes through the injected ``store`` (StateStore).
     """
-    del store  # unused on pg backend
-    del config  # unused on pg backend
-    from pollypm.storage.pg_checkpoints import record_checkpoint as _pg_record_checkpoint
-    from pollypm.storage.pg_sessions import (
-        get_session_runtime as _pg_get_session_runtime,
-        upsert_session_runtime as _pg_upsert_session_runtime,
-    )
+    from pollypm.storage._backend_dispatch import is_pg_backend
 
-    _pg_record_checkpoint(
-        session_name=launch.session.name,
-        project_key=project_key,
-        level=level,
-        json_path=str(artifact.json_path),
-        summary_path=str(artifact.summary_path),
-        snapshot_path=str(snapshot_path),
-        summary_text=artifact.summary_text,
-    )
-    current = _pg_get_session_runtime(launch.session.name)
-    _pg_upsert_session_runtime(
-        session_name=launch.session.name,
-        status=current.status if current is not None else "healthy",
-        last_checkpoint_path=str(artifact.summary_path),
-    )
+    if is_pg_backend(config):
+        from pollypm.storage.pg_checkpoints import record_checkpoint as _pg_record_checkpoint
+        from pollypm.storage.pg_sessions import (
+            get_session_runtime as _pg_get_session_runtime,
+            upsert_session_runtime as _pg_upsert_session_runtime,
+        )
+
+        _pg_record_checkpoint(
+            session_name=launch.session.name,
+            project_key=project_key,
+            level=level,
+            json_path=str(artifact.json_path),
+            summary_path=str(artifact.summary_path),
+            snapshot_path=str(snapshot_path),
+            summary_text=artifact.summary_text,
+        )
+        current = _pg_get_session_runtime(launch.session.name)
+        _pg_upsert_session_runtime(
+            session_name=launch.session.name,
+            status=current.status if current is not None else "healthy",
+            last_checkpoint_path=str(artifact.summary_path),
+        )
+    else:
+        if store is None:
+            raise ValueError(
+                "record_checkpoint requires a StateStore on the sqlite backend"
+            )
+        store.record_checkpoint(  # type: ignore[attr-defined]
+            session_name=launch.session.name,
+            project_key=project_key,
+            level=level,
+            json_path=str(artifact.json_path),
+            summary_path=str(artifact.summary_path),
+            snapshot_path=str(snapshot_path),
+            summary_text=artifact.summary_text,
+        )
+        current = store.get_session_runtime(launch.session.name)  # type: ignore[attr-defined]
+        store.upsert_session_runtime(  # type: ignore[attr-defined]
+            session_name=launch.session.name,
+            status=current.status if current is not None else "healthy",
+            last_checkpoint_path=str(artifact.summary_path),
+        )
     try:
         memory_backend = get_memory_backend(launch.session.cwd, memory_backend_name)
         memory_backend.write_entry(

--- a/src/pollypm/dashboard_data.py
+++ b/src/pollypm/dashboard_data.py
@@ -714,11 +714,14 @@ def _quota_limit_label(period_label: object) -> str:
 def _account_quota_usage(config: PollyPMConfig, store: object | None) -> list[AccountQuotaUsage]:
     """Return cached LLM account quota percentages for the Home dashboard.
 
-    ``store`` is unused (kept for caller compatibility); usage rows are
-    read through :mod:`pollypm.storage.pg_accounts`.
+    Routes through :mod:`pollypm.storage.pg_accounts` on the pg backend;
+    falls back to the injected ``store`` on sqlite.
     """
-    del store  # unused on pg backend
-    from pollypm.storage.pg_accounts import get_account_usage
+    from pollypm.storage._backend_dispatch import is_pg_backend
+
+    use_pg = is_pg_backend(config)
+    if use_pg:
+        from pollypm.storage.pg_accounts import get_account_usage
 
     rows: list[AccountQuotaUsage] = []
     seen_emails: set[str] = set()
@@ -729,7 +732,12 @@ def _account_quota_usage(config: PollyPMConfig, store: object | None) -> list[Ac
                 continue
             seen_emails.add(email)
         try:
-            usage = get_account_usage(account_name)
+            if use_pg:
+                usage = get_account_usage(account_name)
+            elif store is not None:
+                usage = store.get_account_usage(account_name)  # type: ignore[attr-defined]
+            else:
+                usage = None
         except Exception:  # noqa: BLE001
             usage = None
         used_pct = getattr(usage, "used_pct", None) if usage is not None else None
@@ -762,35 +770,53 @@ def _account_quota_usage(config: PollyPMConfig, store: object | None) -> list[Ac
 
 
 def load_dashboard(config_path: Path) -> tuple[PollyPMConfig, DashboardData]:
-    """Load config and gather one blocking dashboard snapshot."""
+    """Load config + state store and gather one blocking dashboard snapshot."""
     config = load_config(config_path)
-    data = gather(config, None)
+    from pollypm.storage._backend_dispatch import is_pg_backend
+
+    if is_pg_backend(config):
+        data = gather(config, None)
+        return config, data
+    from pollypm.storage.state import StateStore
+
+    store = StateStore(config.project.state_db)
+    try:
+        data = gather(config, store)
+    finally:
+        store.close()
     return config, data
 
 
 def gather(config: PollyPMConfig, store: object | None) -> DashboardData:
     """Gather all dashboard data.
 
-    ``store`` is retained for caller compatibility but unused — every
-    read goes through the pg facades.
+    Backend-aware: pg installs read through the pg facades; sqlite
+    installs read through the injected ``store`` (StateStore).
     """
-    del store  # unused on pg backend
     from pollypm.service_api import plan_launches_readonly
-    from pollypm.storage.pg_accounts import get_account_usage  # noqa: F401  (imported for side-effect path resolution)
-    from pollypm.storage.pg_alerts import open_alerts as pg_open_alerts
-    from pollypm.storage.pg_heartbeats import latest_heartbeat as pg_latest_heartbeat
-    from pollypm.storage.pg_sessions import (
-        list_session_runtimes as pg_list_session_runtimes,
-        recent_events as pg_recent_events,
-    )
-    from pollypm.storage.pg_token_usage import daily_token_usage as pg_daily_token_usage
+    from pollypm.storage._backend_dispatch import is_pg_backend
+
+    use_pg = is_pg_backend(config)
+    if use_pg:
+        from pollypm.storage.pg_alerts import open_alerts as pg_open_alerts
+        from pollypm.storage.pg_heartbeats import latest_heartbeat as pg_latest_heartbeat
+        from pollypm.storage.pg_sessions import (
+            list_session_runtimes as pg_list_session_runtimes,
+            recent_events as pg_recent_events,
+        )
+        from pollypm.storage.pg_token_usage import daily_token_usage as pg_daily_token_usage
 
     now = datetime.now(UTC)
 
-    # Active sessions — pg facade reads.
-    all_runtimes = pg_list_session_runtimes()
+    # Active sessions — backend-aware reads.
+    if use_pg:
+        all_runtimes = pg_list_session_runtimes()
+    elif store is not None:
+        all_runtimes = store.list_session_runtimes()  # type: ignore[attr-defined]
+    else:
+        all_runtimes = []
     runtime_map = {rt.session_name: rt for rt in all_runtimes}
-    launches = plan_launches_readonly(config, None)
+    launches = plan_launches_readonly(config, store)
 
     active: list[SessionActivity] = []
     for launch in launches:
@@ -800,7 +826,12 @@ def gather(config: PollyPMConfig, store: object | None) -> DashboardData:
         label = project.display_label() if project else launch.session.project
 
         # Get last snapshot path for description
-        hb = pg_latest_heartbeat(launch.session.name)
+        if use_pg:
+            hb = pg_latest_heartbeat(launch.session.name)
+        elif store is not None:
+            hb = store.latest_heartbeat(launch.session.name)  # type: ignore[attr-defined]
+        else:
+            hb = None
         snapshot_path = hb.snapshot_path if hb else None
 
         desc = _session_description(status, launch.session.role, snapshot_path)
@@ -817,17 +848,27 @@ def gather(config: PollyPMConfig, store: object | None) -> DashboardData:
             status=status, description=desc, age_seconds=age,
         ))
 
-    # Events summary — pg facade read.
-    recent = pg_recent_events(limit=300)
+    # Events summary — backend-aware read.
+    if use_pg:
+        recent = pg_recent_events(limit=300)
+    elif store is not None:
+        recent = store.recent_events(limit=300)  # type: ignore[attr-defined]
+    else:
+        recent = []
     cutoff = (now - timedelta(hours=24)).isoformat()
     day_events = [e for e in recent if e.created_at >= cutoff]
 
     # Token data
-    daily = pg_daily_token_usage(days=30)
+    if use_pg:
+        daily = pg_daily_token_usage(days=30)
+    elif store is not None:
+        daily = store.daily_token_usage(days=30)  # type: ignore[attr-defined]
+    else:
+        daily = []
     values = [t for _, t in daily]
     today_str = now.strftime("%Y-%m-%d")
     today_tokens = next((t for d, t in daily if d == today_str), 0)
-    account_usages = _account_quota_usage(config, None)
+    account_usages = _account_quota_usage(config, store)
 
     commits = _recent_commits(config, hours=24)
     completed = _completed_issues(config, hours=72)
@@ -876,8 +917,14 @@ def gather(config: PollyPMConfig, store: object | None) -> DashboardData:
     # not a fault to surface as a separate alert. Mirrors cycles 45
     # / 53 / 55 dedup at the global polly-dashboard count level.
     user_waiting = _user_waiting_task_ids_across_projects(config)
+    if use_pg:
+        open_alerts = pg_open_alerts()
+    elif store is not None:
+        open_alerts = store.open_alerts()  # type: ignore[attr-defined]
+    else:
+        open_alerts = []
     alert_count = sum(
-        1 for a in pg_open_alerts()
+        1 for a in open_alerts
         if not is_operational_alert(a.alert_type)
         and not _stuck_alert_already_user_waiting(
             a.alert_type, user_waiting,

--- a/src/pollypm/doctor.py
+++ b/src/pollypm/doctor.py
@@ -625,9 +625,9 @@ def _latest_state_migration_version() -> int | None:
     try:
         # The migrations live on the class; avoid instantiating (that opens
         # a real DB). Walk the class var directly.
-        from pollypm.storage import state as _state_mod
+        from pollypm.storage.state import StateStore
 
-        migrations = getattr(_state_mod.StateStore, "_MIGRATIONS", None)
+        migrations = getattr(StateStore, "_MIGRATIONS", None)
         if not migrations:
             return None
         return max(v for v, _, _ in migrations)
@@ -2832,13 +2832,10 @@ def _initialize_project_state_db(db_path: Path) -> tuple[bool, str]:
     the corresponding doctor check is rewired to the pg world.
     """
     # Deferred import: only sqlite installs reach this code path.
-    from pollypm.storage import state as _state_mod
+    from pollypm.storage.state import StateStore
 
-    _cls = getattr(_state_mod, "StateStore", None)
-    if _cls is None:
-        return (False, "StateStore unavailable")
     try:
-        store = _cls(db_path)
+        store = StateStore(db_path)
         try:
             pass
         finally:
@@ -3364,13 +3361,10 @@ def check_state_db_size() -> CheckResult:
         # ``incremental_vacuum`` is meaningless on pg. Deferred import
         # keeps the legacy path callable for sqlite installs until the
         # check itself is rewired.
-        from pollypm.storage import state as _state_mod
+        from pollypm.storage.state import StateStore
 
-        _cls = getattr(_state_mod, "StateStore", None)
-        if _cls is None:
-            return (False, "StateStore unavailable")
         try:
-            store = _cls(biggest)
+            store = StateStore(biggest)
             try:
                 reclaimed = store.incremental_vacuum()
             finally:

--- a/src/pollypm/memory_backends/file.py
+++ b/src/pollypm/memory_backends/file.py
@@ -102,16 +102,14 @@ class FileMemoryBackend(MemoryBackend):
         # still pass a path.
         if state_store is None:
             # Back-compat: callers that pass only a tmp_path (tests,
-            # direct users) still get a sqlite-backed store. Deferred
-            # attribute lookup keeps the gate grep clean. Production
-            # callers (``get_memory_backend``) inject a pg-backed
-            # store explicitly, so this branch only fires on test /
-            # ad-hoc construction.
-            from pollypm.storage import state as _state_mod
+            # direct users) still get a sqlite-backed store.
+            # Production callers (``get_memory_backend``) inject a
+            # pg-backed store explicitly, so this branch only fires
+            # on test / ad-hoc construction.
+            from pollypm.storage.state import StateStore
 
-            _cls = getattr(_state_mod, "StateStore")
             self._state_db = state_db or (self._project_path / ".pollypm" / "state.db")
-            self._state_store = _cls(self._state_db)
+            self._state_store = StateStore(self._state_db)
         else:
             self._state_db = state_db
             self._state_store = state_store

--- a/src/pollypm/runtime_services.py
+++ b/src/pollypm/runtime_services.py
@@ -69,16 +69,13 @@ def load_runtime_services(
         )
     config = load_config(resolved_path)
 
-    # Slice K-state-callers-port: ``store`` is still constructed for
-    # callers that depend on the StateStore-shaped surface (session
-    # service, recovery prompt), but the lookup is now deferred via
-    # attribute access so the import gate counts this site as pg-only.
+    # ``store`` is still constructed for callers that depend on the
+    # StateStore-shaped surface (session service, recovery prompt).
     # The pg cutover work to replace the consumers lives in
     # K-state-finish.
-    from pollypm.storage import state as _state_mod
+    from pollypm.storage.state import StateStore
 
-    _cls = getattr(_state_mod, "StateStore")
-    store = _cls(config.project.state_db)
+    store = StateStore(config.project.state_db)
 
     msg_store: Any | None
     try:

--- a/src/pollypm/storage/work_session_queries.py
+++ b/src/pollypm/storage/work_session_queries.py
@@ -1,19 +1,34 @@
-"""Read-only ``work_sessions`` aggregate queries (Postgres-only).
+"""Read-only ``work_sessions`` aggregate queries.
 
 Presentation/plugin code should not open workspace databases directly;
 this module owns the schema/connection details for small projection
 reads against ``work_sessions``.
 
-Following Slice K-state-callers-port (#1737), this module talks to the
-Postgres RO pool only. The ``db_path`` parameter is kept for caller
-compatibility but is unused.
+The aggregate used by the per-project dashboard's Tokens line lives
+here so the rendering layer (``cockpit_sections``) no longer has to
+``import sqlite3`` or know the table name.
+
+Backend dispatch (#1737)
+------------------------
+
+When ``[storage] backend = "postgres"`` is active, the same aggregate
+runs against the process-wide read-only pool keyed on the
+``task_project`` column (the pg schema uses the same column name as the
+sqlite shape — see :mod:`pollypm.storage.pg_schema`). The sqlite branch
+is preserved verbatim so first-run installs keep their existing
+``file:<path>?mode=ro`` semantics, including the ``apply_workspace_pragmas``
+busy-timeout setup that #1018 introduced.
 """
 
 from __future__ import annotations
 
 import logging
+import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from pollypm.storage._backend_dispatch import is_pg_backend
+from pollypm.storage.sqlite_pragmas import apply_workspace_pragmas, readonly_uri
 
 if TYPE_CHECKING:
     from pollypm.models import PollyPMConfig
@@ -29,13 +44,65 @@ def aggregate_project_session_tokens(
 ) -> tuple[int, int] | None:
     """Return ``(SUM(total_input_tokens), SUM(total_output_tokens))`` for ``project_key``.
 
-    Returns ``None`` if the pool / query can't be reached so the Tokens
-    line in the per-project dashboard can degrade to ``(n/a)`` instead
-    of breaking the render. The ``COALESCE(SUM(...), 0)`` form yields
-    ``(0, 0)`` consistently for the empty-table case. ``db_path`` is
-    unused on the pg backend.
+    Returns ``None`` if the DB is missing or the query fails (e.g. the
+    ``work_sessions`` table does not exist on an old workspace) so the
+    Tokens line in the per-project dashboard can degrade to ``(n/a)``
+    instead of breaking the render.
+
+    A short ``busy_timeout`` is applied via the standard workspace
+    pragmas because the cockpit reader runs alongside JobWorkerPool +
+    heartbeat writers on the same DB (#1018).
     """
-    del db_path  # unused on pg backend
+    if is_pg_backend(config):
+        return _aggregate_pg(project_key=project_key, config=config)
+
+    try:
+        if not db_path.exists():
+            return None
+    except OSError:
+        return None
+    # #1652: open read-only via the ``file:<path>?mode=ro`` URI so the
+    # render-side aggregate cannot mutate the workspace DB (journal
+    # mode, write lock, etc.). #1674: percent-encode the path so ``#``
+    # / ``?`` in the workspace dir don't get parsed as URI fragment /
+    # query syntax.
+    uri = readonly_uri(db_path)
+    try:
+        conn = sqlite3.connect(uri, uri=True)
+    except sqlite3.Error as exc:
+        logger.debug(
+            "work_session_queries: connect failed for %s: %s", db_path, exc,
+        )
+        return None
+    try:
+        apply_workspace_pragmas(conn, readonly=True)
+        try:
+            row = conn.execute(
+                "SELECT COALESCE(SUM(total_input_tokens), 0), "
+                "       COALESCE(SUM(total_output_tokens), 0) "
+                "FROM work_sessions WHERE task_project = ?",
+                (project_key,),
+            ).fetchone()
+        except sqlite3.Error:
+            return None
+    finally:
+        conn.close()
+    if row is None:
+        return 0, 0
+    return int(row[0] or 0), int(row[1] or 0)
+
+
+def _aggregate_pg(
+    *,
+    project_key: str,
+    config: "PollyPMConfig | None",
+) -> tuple[int, int] | None:
+    """Postgres branch for :func:`aggregate_project_session_tokens`.
+
+    Same shape as the sqlite branch: returns ``(in, out)`` tuple
+    (zero-filled on empty rows) or ``None`` when the pool / query
+    can't be reached.
+    """
     try:
         from pollypm.storage.pg_pool import get_ro_pool
     except Exception as exc:  # noqa: BLE001

--- a/src/pollypm/store/migrations.py
+++ b/src/pollypm/store/migrations.py
@@ -108,13 +108,11 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 
 
 def _declared_state_migrations() -> list[tuple[int, str]]:
-    # Deferred attribute access keeps the import gate clean while
     # state.py is still the source of truth for the legacy migration
     # list (pg has its own schema_migrations registry).
-    from pollypm.storage import state as _state_mod
+    from pollypm.storage.state import StateStore
 
-    _cls = getattr(_state_mod, "StateStore")
-    return [(version, desc) for version, desc, _ in _cls._MIGRATIONS]
+    return [(version, desc) for version, desc, _ in StateStore._MIGRATIONS]
 
 
 def _declared_work_migrations() -> list[tuple[int, str]]:
@@ -316,11 +314,10 @@ def _apply_all(db_path: Path) -> None:
     into the unified ``schema_migrations`` audit table so operators have
     a single pane of glass.
     """
-    from pollypm.storage import state as _state_mod
+    from pollypm.storage.state import StateStore
     from pollypm.work import create_work_service
 
-    _cls = getattr(_state_mod, "StateStore")
-    with _cls(db_path) as _store:
+    with StateStore(db_path) as _store:
         pass
 
     with create_work_service(db_path=db_path) as _svc:

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -386,16 +386,14 @@ class Supervisor:
             self._core_rail = core_rail
             self.store = core_rail.get_state_store()
         else:
-            # Deferred attribute access keeps the import gate clean while
             # state.py is still the source of truth for the legacy
             # domain tables Supervisor reads through ``self.store``
             # (cluster-A reads/writes are pg-routed by the
             # ``_upsert_session`` / ``_get_session_runtime`` / ... helpers
             # below).
-            from pollypm.storage import state as _state_mod
+            from pollypm.storage.state import StateStore
 
-            _cls = getattr(_state_mod, "StateStore")
-            self.store = _cls(config.project.state_db, readonly=readonly_state)
+            self.store = StateStore(config.project.state_db, readonly=readonly_state)
             # Lazy-import to avoid import cycles (core imports nothing from
             # supervisor, but keep the reference local to be safe).
             from pollypm.core import CoreRail as _CoreRail

--- a/src/pollypm/transcript_ledger.py
+++ b/src/pollypm/transcript_ledger.py
@@ -298,43 +298,69 @@ def _scan_account_transcripts(config, account_name: str) -> list[TranscriptScanR
 
 
 def sync_token_ledger_for_config(config, *, account: str | None = None) -> list[TranscriptTokenSample]:
-    """Ingest fresh transcript samples through the pg token-usage facade."""
-    from pollypm.storage.pg_token_usage import (
-        replace_token_usage_hourly,
-        upsert_token_sample,
-    )
+    """Ingest fresh transcript samples.
+
+    Backend-aware: pg installs use the pg token-usage facade; sqlite
+    installs route through the per-project StateStore.
+    """
+    from pollypm.storage._backend_dispatch import is_pg_backend
 
     account_names = [account] if account else list(config.accounts)
     ingested: list[TranscriptTokenSample] = []
     rollups: dict[tuple[str, str, str, str, str], int] = {}
     updated_at = datetime.now(UTC).isoformat()
 
-    for account_name in account_names:
-        for result in _scan_account_transcripts(config, account_name):
-            sample = result.final_sample
-            upsert_token_sample(
-                session_name=sample.session_name,
-                account_name=sample.account_name,
-                provider=sample.provider,
-                model_name=sample.model_name,
-                project_key=sample.project_key,
-                cumulative_tokens=sample.cumulative_tokens,
-                observed_at=sample.observed_at.isoformat(),
-            )
-            ingested.append(sample)
-            for event in result.usage_events:
-                hour_bucket = event.observed_at.astimezone(UTC).replace(minute=0, second=0, microsecond=0).isoformat()
-                key = (
-                    hour_bucket,
-                    sample.account_name,
-                    sample.provider,
-                    event.model_name,
-                    event.project_key,
-                )
-                rollups[key] = rollups.get(key, 0) + event.tokens_used
+    use_pg = is_pg_backend(config)
+    store = None
+    if use_pg:
+        from pollypm.storage.pg_token_usage import (
+            replace_token_usage_hourly,
+            upsert_token_sample,
+        )
+    else:
+        # #1019 — close the StateStore on exit (try/finally below) to
+        # avoid WAL/SHM fd leaks under repeated heartbeat ticks.
+        from pollypm.storage.state import StateStore
 
-    replace_token_usage_hourly(
-        [
+        store = StateStore(config.project.state_db)
+
+    try:
+        for account_name in account_names:
+            for result in _scan_account_transcripts(config, account_name):
+                sample = result.final_sample
+                if use_pg:
+                    upsert_token_sample(
+                        session_name=sample.session_name,
+                        account_name=sample.account_name,
+                        provider=sample.provider,
+                        model_name=sample.model_name,
+                        project_key=sample.project_key,
+                        cumulative_tokens=sample.cumulative_tokens,
+                        observed_at=sample.observed_at.isoformat(),
+                    )
+                else:
+                    store.upsert_token_sample(  # type: ignore[union-attr]
+                        session_name=sample.session_name,
+                        account_name=sample.account_name,
+                        provider=sample.provider,
+                        model_name=sample.model_name,
+                        project_key=sample.project_key,
+                        cumulative_tokens=sample.cumulative_tokens,
+                        observed_at=sample.observed_at.isoformat(),
+                    )
+                ingested.append(sample)
+                for event in result.usage_events:
+                    hour_bucket = event.observed_at.astimezone(UTC).replace(minute=0, second=0, microsecond=0).isoformat()
+                    key = (
+                        hour_bucket,
+                        sample.account_name,
+                        sample.provider,
+                        event.model_name,
+                        event.project_key,
+                    )
+                    rollups[key] = rollups.get(key, 0) + event.tokens_used
+
+        records = [
             TokenUsageHourlyRecord(
                 hour_bucket=hour_bucket,
                 account_name=account_name,
@@ -345,10 +371,18 @@ def sync_token_ledger_for_config(config, *, account: str | None = None) -> list[
                 updated_at=updated_at,
             )
             for (hour_bucket, account_name, provider, model_name, project_key), tokens_used in sorted(rollups.items())
-        ],
-        account_names=account_names,
-    )
-    return ingested
+        ]
+        if use_pg:
+            replace_token_usage_hourly(records, account_names=account_names)
+        else:
+            store.replace_token_usage_hourly(records, account_names=account_names)  # type: ignore[union-attr]
+        return ingested
+    finally:
+        if store is not None:
+            try:
+                store.close()
+            except Exception:  # noqa: BLE001
+                pass
 
 
 def sync_token_ledger(config_path: Path, *, account: str | None = None) -> list[TranscriptTokenSample]:

--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -296,7 +296,7 @@ def _svc(db: str, project: str | None = None) -> "WorkService":
             storage_closet_name = "pollypm-storage-closet"
             try:
                 from pollypm.session_services.tmux import TmuxSessionService
-                from pollypm.storage import state as _state_mod
+                from pollypm.storage.state import StateStore
 
                 if config is None:
                     from pollypm.config import load_config
@@ -304,11 +304,7 @@ def _svc(db: str, project: str | None = None) -> "WorkService":
                 storage_closet_name = (
                     f"{config.project.tmux_session}-storage-closet"
                 )
-                # Deferred attribute access keeps the import gate clean
-                # while StateStore consumers still need a handle (see
-                # runtime_services for the same shim).
-                _cls = getattr(_state_mod, "StateStore")
-                store = _cls(config.project.state_db)
+                store = StateStore(config.project.state_db)
                 session_service = TmuxSessionService(config=config, store=store)
             except Exception:  # noqa: BLE001
                 pass

--- a/src/pollypm/workers.py
+++ b/src/pollypm/workers.py
@@ -22,13 +22,26 @@ _log = logging.getLogger(__name__)
 def _effective_control_accounts(config_path: Path) -> set[str]:
     config = load_config(config_path)
     accounts = {config.pollypm.controller_account}
-    # session_runtime lives on the pg cluster-A facade.
-    from pollypm.storage.pg_sessions import get_session_runtime
+    # Backend-aware read: pg installs route through the cluster-A
+    # facade; sqlite installs read session_runtime from the per-project
+    # StateStore.
+    from pollypm.storage._backend_dispatch import is_pg_backend
 
-    for session_name in ("heartbeat", "operator"):
-        runtime = get_session_runtime(session_name)
-        if runtime is not None and runtime.effective_account:
-            accounts.add(runtime.effective_account)
+    if is_pg_backend(config):
+        from pollypm.storage.pg_sessions import get_session_runtime
+
+        for session_name in ("heartbeat", "operator"):
+            runtime = get_session_runtime(session_name)
+            if runtime is not None and runtime.effective_account:
+                accounts.add(runtime.effective_account)
+    else:
+        from pollypm.storage.state import StateStore
+
+        with StateStore(config.project.state_db) as store:
+            for session_name in ("heartbeat", "operator"):
+                runtime = store.get_session_runtime(session_name)
+                if runtime is not None and runtime.effective_account:
+                    accounts.add(runtime.effective_account)
     return {name for name in accounts if name}
 
 
@@ -37,9 +50,17 @@ def _account_is_available(config_path: Path, account_name: str) -> bool:
     account = config.accounts[account_name]
     if not detect_logged_in(account):
         return False
-    from pollypm.storage.pg_accounts import get_account_runtime
+    from pollypm.storage._backend_dispatch import is_pg_backend
 
-    runtime = get_account_runtime(account_name)
+    if is_pg_backend(config):
+        from pollypm.storage.pg_accounts import get_account_runtime
+
+        runtime = get_account_runtime(account_name)
+    else:
+        from pollypm.storage.state import StateStore
+
+        with StateStore(config.project.state_db) as store:
+            runtime = store.get_account_runtime(account_name)
     # Accept both ``auth_broken`` (canonical, written by heartbeats/api.py
     # and supervisor.py) and the legacy hyphenated ``auth-broken`` form
     # so a runtime row written by either side correctly excludes the


### PR DESCRIPTION
## Summary

Two-commit cleanup of fallout from PR #1849 (K-state-callers-port):

- **#1853** — PR #1849 gamed the destructive-action import gate by
  rewriting 10 ``from pollypm.storage.state import StateStore``
  callsites to ``getattr(_state_mod, "StateStore")`` so the gate
  grep returned empty. Runtime behavior was unchanged; the gate was
  satisfied via syntactic obfuscation. **Reverted to direct imports**
  at all 10 sites (``supervisor``, ``runtime_services``, ``doctor``
  x3, ``memory_backends/file``, ``audit/tier4``, ``work/cli``,
  ``store/migrations`` x2). The pg cutover continues in K-state-finish,
  but the gate now reflects reality.

- **#1855** — PR #1849 ported only the pg path in five callers that
  still receive a ``StateStore`` (or ``db_path``) parameter. With the
  config's default ``[storage] backend = "sqlite"``, the injected
  handle was silently discarded and reads/writes hit a process-wide
  pg pool that may not exist. **Restored backend-aware dispatch**
  in:
    - ``checkpoints.record_checkpoint``
    - ``workers._effective_control_accounts`` /
      ``workers._account_is_available``
    - ``dashboard_data.load_dashboard`` / ``gather`` /
      ``_account_quota_usage``
    - ``transcript_ledger.sync_token_ledger_for_config``
    - ``storage.work_session_queries.aggregate_project_session_tokens``

Scope was held tight to the shim sites + the explicit caller list in
#1855 — no incidental refactors, no module deletions.

## Test plan

- [ ] Verify the import gate grep ``getattr(.*StateStore`` now returns
      no hits in ``src/pollypm/``.
- [ ] Default sqlite install: ``record_checkpoint`` writes the
      checkpoint row + updates ``session_runtime.last_checkpoint_path``
      on the injected store.
- [ ] Default sqlite install: worker selection observes
      ``account_runtime`` / ``session_runtime`` rows written to the
      configured per-project ``StateStore``.
- [ ] Default sqlite install: dashboard ``gather`` returns the
      injected store's heartbeats / events / token rows.
- [ ] Default sqlite install: ``sync_token_ledger_for_config`` populates
      the configured sqlite token ledger.
- [ ] Default sqlite install:
      ``aggregate_project_session_tokens(db_path, ...)`` reads from the
      provided sqlite ``db_path``.
- [ ] pg-mode install: every path still routes through the pg facades
      (no regression on the live cluster-A wiring).

Closes #1853
Closes #1855

🤖 Generated with [Claude Code](https://claude.com/claude-code)