### PR TITLE
refactor(boundaries): extract activity-feed + metrics-rail shared modules (refs #1363 #1367)

### DIFF
--- a/src/pollypm/activity_feed_protocol.py
+++ b/src/pollypm/activity_feed_protocol.py
@@ -1,0 +1,149 @@
+"""Shared activity-feed contracts consumed by core + the activity_feed plugin (#1363).
+
+Core modules (``cockpit_activity``, ``cockpit``) previously had to lazy-import
+``pollypm.plugins_builtin.activity_feed.cockpit.feed_panel`` to format relative
+timestamps and render entry detail views. That coupling makes the
+``activity_feed`` plugin effectively non-optional — disabling it would break
+core paths silently.
+
+This module hosts:
+
+* :class:`ActivityFeedEntry` — a ``Protocol`` describing the shape every entry
+  rendered by the cockpit needs (id / timestamp / kind / actor / summary /
+  payload / …). The plugin's concrete ``FeedEntry`` dataclass satisfies it
+  structurally so nothing in the projection path has to change.
+* :func:`format_relative_time` — pure string-in/string-out helper. No plugin
+  coupling, no projector dependency.
+* :func:`render_entry_detail` — entry-detail plain-text renderer. Takes the
+  protocol shape, so the cockpit can render any source of feed entries
+  without importing from ``plugins_builtin``.
+
+The plugin re-exports these names from ``feed_panel`` so existing callers
+keep working without churn.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ActivityFeedEntry(Protocol):
+    """Structural shape of a single activity-feed row.
+
+    Mirrors the fields on the plugin's ``FeedEntry`` dataclass so the
+    concrete class satisfies this protocol without modification. Core
+    renderers only read these attributes — nothing constructs entries
+    through this protocol.
+    """
+
+    id: str
+    timestamp: str
+    project: str | None
+    kind: str
+    actor: str
+    subject: str | None
+    verb: str
+    summary: str
+    severity: str
+    payload: dict[str, Any]
+    pinned: bool
+    source: str
+
+
+def format_relative_time(
+    timestamp: str, *, now: datetime | None = None,
+) -> str:
+    """Return a relative-time label (``"3m ago"``, ``"2h ago"``).
+
+    ``timestamp`` is an ISO-8601 string (the projector always produces
+    these). Unparseable values fall back to the raw string. ``now`` is
+    injectable for deterministic tests.
+    """
+    if not timestamp:
+        return "—"
+    try:
+        when = datetime.fromisoformat(timestamp)
+    except ValueError:
+        return timestamp
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=UTC)
+    anchor = now or datetime.now(UTC)
+    delta = anchor - when
+    seconds = int(delta.total_seconds())
+    if seconds < 0:
+        return "just now"
+    if seconds < 60:
+        return f"{seconds}s ago"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes}m ago"
+    hours = minutes // 60
+    if hours < 24:
+        return f"{hours}h ago"
+    days = hours // 24
+    return f"{days}d ago"
+
+
+def render_entry_detail(
+    entry: ActivityFeedEntry, *, now: datetime | None = None,
+) -> str:
+    """Render the per-entry detail view as plain text (lf04).
+
+    Shows absolute + relative timestamps, project / actor / verb,
+    severity, a pretty-printed payload JSON, and suggested follow-up
+    navigation (task / session links) inferred from the payload.
+    """
+    lines: list[str] = []
+    abs_ts = entry.timestamp
+    rel_ts = format_relative_time(entry.timestamp, now=now)
+    lines.append(f"Activity entry · {entry.id}")
+    lines.append("")
+    lines.append(f"When: {abs_ts}  ({rel_ts})")
+    lines.append(f"Kind: {entry.kind}")
+    if entry.project:
+        lines.append(f"Project: {entry.project}")
+    lines.append(f"Actor: {entry.actor}")
+    if entry.subject:
+        lines.append(f"Subject: {entry.subject}")
+    lines.append(f"Verb: {entry.verb}")
+    lines.append(f"Severity: {entry.severity}")
+    if entry.pinned:
+        lines.append("Pinned: yes")
+    lines.append("")
+    lines.append("Summary:")
+    lines.append(f"  {entry.summary}")
+    # Navigation hints — task / session links inferred from the payload.
+    task_project = entry.payload.get("task_project")
+    task_number = entry.payload.get("task_number")
+    if task_project and task_number is not None:
+        lines.append("")
+        lines.append(
+            f"Related task: project:{task_project}:task:{task_number}  "
+            f"(use the rail to open)"
+        )
+    elif entry.source == "work_transitions" and entry.subject:
+        lines.append("")
+        lines.append(f"Related task: {entry.subject}")
+    if entry.actor and entry.source == "events":
+        lines.append("")
+        lines.append(f"Related session: {entry.actor}")
+    # Payload dump (pretty-printed).
+    lines.append("")
+    lines.append("Payload:")
+    try:
+        rendered = json.dumps(entry.payload, indent=2, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        rendered = repr(entry.payload)
+    for line in rendered.splitlines():
+        lines.append(f"  {line}")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "ActivityFeedEntry",
+    "format_relative_time",
+    "render_entry_detail",
+]

--- a/src/pollypm/cockpit.py
+++ b/src/pollypm/cockpit.py
@@ -910,41 +910,11 @@ def _gather_metrics_snapshot(config) -> MetricsSnapshot:
     )
 
 
-def _register_metrics_rail_item(registry, router) -> None:
-    """Add the ``top.Metrics`` rail row if not already registered.
-
-    Kept next to the worker-roster registration so both observability
-    rows sit at the top of the rail. Safe to call repeatedly — the
-    registry dedupes on ``(plugin_name, section, label)``.
-    """
-    try:
-        from pollypm.plugin_api.v1 import RailItemRegistration, PanelSpec
-    except Exception:  # noqa: BLE001
-        return
-
-    def _state(_ctx) -> str:
-        return "watch"
-
-    def _handler(ctx):
-        try:
-            router.route_selected("metrics")
-        except Exception:  # noqa: BLE001
-            pass
-        return PanelSpec(widget=None, focus_hint="metrics")
-
-    reg = RailItemRegistration(
-        plugin_name="cockpit_metrics",
-        section="top",
-        index=28,  # after Workers (25), before Projects (30+)
-        label="Metrics",
-        handler=_handler,
-        key="metrics",
-        state_provider=_state,
-    )
-    try:
-        registry.add(reg)
-    except Exception:  # noqa: BLE001
-        pass
+# ``_register_metrics_rail_item`` moved to ``pollypm.cockpit_metrics_rail``
+# (#1367) so ``cockpit_rail`` can import it at module load time instead of
+# lazy-importing ``cockpit`` to break a cycle. Re-exported here for any
+# legacy callers / monkeypatch paths.
+from pollypm.cockpit_metrics_rail import _register_metrics_rail_item  # noqa: F401,E402
 
 
 def _render_metrics_panel(config_path: Path) -> str:

--- a/src/pollypm/cockpit_activity.py
+++ b/src/pollypm/cockpit_activity.py
@@ -81,9 +81,9 @@ def _format_activity_relative(timestamp: str) -> str:
     if not timestamp:
         return "\u2014"
     try:
-        from pollypm.plugins_builtin.activity_feed.cockpit.feed_panel import (
-            format_relative_time,
-        )
+        # #1363: pulled from the shared protocol module so this file no
+        # longer depends on ``plugins_builtin`` for plain-text formatting.
+        from pollypm.activity_feed_protocol import format_relative_time
 
         return format_relative_time(timestamp)
     except Exception:  # noqa: BLE001
@@ -754,9 +754,9 @@ class PollyActivityFeedApp(App[None]):
             self.detail.display = False
             return
         try:
-            from pollypm.plugins_builtin.activity_feed.cockpit.feed_panel import (
-                render_entry_detail,
-            )
+            # #1363: shared renderer lives in the core protocol module so
+            # this surface no longer reaches into ``plugins_builtin``.
+            from pollypm.activity_feed_protocol import render_entry_detail
 
             text = render_entry_detail(entry)
         except Exception:  # noqa: BLE001

--- a/src/pollypm/cockpit_metrics_rail.py
+++ b/src/pollypm/cockpit_metrics_rail.py
@@ -1,0 +1,53 @@
+"""Rail-item registration for the cockpit Metrics pane (#1367).
+
+Extracted from :mod:`pollypm.cockpit` so :mod:`pollypm.cockpit_rail` can
+import the registration helper at module load time. Previously the helper
+lived in ``cockpit.py``, which top-imports ``cockpit_rail`` — closing the
+cycle and forcing ``cockpit_rail`` to use a lazy in-function import.
+
+This module is deliberately thin: it only owns the small ``RailItemRegistration``
+factory for the Metrics row. The pane render + data-gather helpers stay in
+``pollypm.cockpit`` / ``pollypm.cockpit_metrics`` where they belong.
+"""
+
+from __future__ import annotations
+
+
+def _register_metrics_rail_item(registry, router) -> None:
+    """Add the ``top.Metrics`` rail row if not already registered.
+
+    Kept next to the worker-roster registration so both observability
+    rows sit at the top of the rail. Safe to call repeatedly — the
+    registry dedupes on ``(plugin_name, section, label)``.
+    """
+    try:
+        from pollypm.plugin_api.v1 import RailItemRegistration, PanelSpec
+    except Exception:  # noqa: BLE001
+        return
+
+    def _state(_ctx) -> str:
+        return "watch"
+
+    def _handler(ctx):
+        try:
+            router.route_selected("metrics")
+        except Exception:  # noqa: BLE001
+            pass
+        return PanelSpec(widget=None, focus_hint="metrics")
+
+    reg = RailItemRegistration(
+        plugin_name="cockpit_metrics",
+        section="top",
+        index=28,  # after Workers (25), before Projects (30+)
+        label="Metrics",
+        handler=_handler,
+        key="metrics",
+        state_provider=_state,
+    )
+    try:
+        registry.add(reg)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+__all__ = ["_register_metrics_rail_item"]

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -49,6 +49,8 @@ from pollypm.cockpit_content import (
     TextualCommandPane,
     resolve_cockpit_content,
 )
+from pollypm.cockpit_inbox import _register_worker_roster_rail_item
+from pollypm.cockpit_metrics_rail import _register_metrics_rail_item
 from pollypm.cockpit_window_manager import (
     CockpitWindowManager,
     CockpitWindowSpec,
@@ -1641,15 +1643,11 @@ class CockpitRouter:
         except Exception:  # noqa: BLE001
             core_enabled = True
         if core_enabled:
-            # Deferred imports: the worker roster + metrics registrations
-            # live in ``pollypm.cockpit`` alongside the gather helpers
-            # they call into. Importing them at module load time would
-            # create a cycle (cockpit imports cockpit_rail to re-export
-            # the router), so we resolve them per-tick instead.
-            from pollypm.cockpit import (
-                _register_metrics_rail_item,
-                _register_worker_roster_rail_item,
-            )
+            # #1367: imports moved to module top once the metrics-rail
+            # registration was hoisted to ``cockpit_metrics_rail`` and
+            # the worker-roster registration was sourced from its real
+            # home in ``cockpit_inbox`` — both break the historical
+            # cockpit <-> cockpit_rail cycle.
             _register_worker_roster_rail_item(registry, self)
             _register_metrics_rail_item(registry, self)
         return registry

--- a/src/pollypm/plugins_builtin/activity_feed/cockpit/feed_panel.py
+++ b/src/pollypm/plugins_builtin/activity_feed/cockpit/feed_panel.py
@@ -21,7 +21,6 @@ projection only runs when something changed.
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
@@ -167,38 +166,11 @@ _SEVERITY_COLOURS = {
 }
 
 
-def format_relative_time(
-    timestamp: str, *, now: datetime | None = None,
-) -> str:
-    """Return a relative-time label (``"3m ago"``, ``"2h ago"``).
-
-    ``timestamp`` is an ISO-8601 string (the projector always produces
-    these). Unparseable values fall back to the raw string. ``now`` is
-    injectable for deterministic tests.
-    """
-    if not timestamp:
-        return "—"
-    try:
-        when = datetime.fromisoformat(timestamp)
-    except ValueError:
-        return timestamp
-    if when.tzinfo is None:
-        when = when.replace(tzinfo=UTC)
-    anchor = now or datetime.now(UTC)
-    delta = anchor - when
-    seconds = int(delta.total_seconds())
-    if seconds < 0:
-        return "just now"
-    if seconds < 60:
-        return f"{seconds}s ago"
-    minutes = seconds // 60
-    if minutes < 60:
-        return f"{minutes}m ago"
-    hours = minutes // 60
-    if hours < 24:
-        return f"{hours}h ago"
-    days = hours // 24
-    return f"{days}d ago"
+# Re-exported from the core shared module so callers in ``pollypm.cockpit*``
+# (and other peer plugins) can use the helper without importing through
+# ``plugins_builtin`` (#1363). The plugin keeps the name on its own surface
+# for back-compat with existing imports + monkeypatch paths.
+from pollypm.activity_feed_protocol import format_relative_time  # noqa: F401, E402
 
 
 def _project_label(entry: FeedEntry) -> str:
@@ -286,57 +258,10 @@ def render_entries_as_text(entries: Iterable[FeedEntry]) -> str:
     return "\n".join(rows)
 
 
-def render_entry_detail(entry: FeedEntry, *, now: datetime | None = None) -> str:
-    """Render the per-entry detail view as plain text (lf04).
-
-    Shows absolute + relative timestamps, project / actor / verb,
-    severity, a pretty-printed payload JSON, and suggested follow-up
-    navigation (task / session links) inferred from the payload.
-    """
-    lines: list[str] = []
-    abs_ts = entry.timestamp
-    rel_ts = format_relative_time(entry.timestamp, now=now)
-    lines.append(f"Activity entry · {entry.id}")
-    lines.append("")
-    lines.append(f"When: {abs_ts}  ({rel_ts})")
-    lines.append(f"Kind: {entry.kind}")
-    if entry.project:
-        lines.append(f"Project: {entry.project}")
-    lines.append(f"Actor: {entry.actor}")
-    if entry.subject:
-        lines.append(f"Subject: {entry.subject}")
-    lines.append(f"Verb: {entry.verb}")
-    lines.append(f"Severity: {entry.severity}")
-    if entry.pinned:
-        lines.append("Pinned: yes")
-    lines.append("")
-    lines.append("Summary:")
-    lines.append(f"  {entry.summary}")
-    # Navigation hints — task / session links inferred from the payload.
-    task_project = entry.payload.get("task_project")
-    task_number = entry.payload.get("task_number")
-    if task_project and task_number is not None:
-        lines.append("")
-        lines.append(
-            f"Related task: project:{task_project}:task:{task_number}  "
-            f"(use the rail to open)"
-        )
-    elif entry.source == "work_transitions" and entry.subject:
-        lines.append("")
-        lines.append(f"Related task: {entry.subject}")
-    if entry.actor and entry.source == "events":
-        lines.append("")
-        lines.append(f"Related session: {entry.actor}")
-    # Payload dump (pretty-printed).
-    lines.append("")
-    lines.append("Payload:")
-    try:
-        rendered = json.dumps(entry.payload, indent=2, sort_keys=True, default=str)
-    except (TypeError, ValueError):
-        rendered = repr(entry.payload)
-    for line in rendered.splitlines():
-        lines.append(f"  {line}")
-    return "\n".join(lines)
+# Re-exported from the core shared module (#1363). The plugin's ``FeedEntry``
+# dataclass satisfies ``ActivityFeedEntry`` structurally, so the renderer
+# accepts the existing concrete type unchanged.
+from pollypm.activity_feed_protocol import render_entry_detail  # noqa: F401, E402
 
 
 def render_activity_feed_text(config: Any, *, limit: int = 50) -> str:


### PR DESCRIPTION
## Summary

Two narrow module-boundary extracts. Each one is a single, scoped slice — these PRs do **not** close the parent issues; remaining work stays tracked.

### Slice for #1367 — break `cockpit <-> cockpit_rail` cycle
- `cockpit_rail` previously had to lazy-import `_register_metrics_rail_item` and `_register_worker_roster_rail_item` from `cockpit` because `cockpit` top-imports `cockpit_rail` for the router re-export.
- Moved `_register_metrics_rail_item` into a new leaf module `pollypm.cockpit_metrics_rail` (50 lines, no `pollypm.cockpit*` deps).
- Sourced `_register_worker_roster_rail_item` from its real home in `cockpit_inbox` (`cockpit.py` only re-exports it).
- `cockpit_rail` now top-imports both. `cockpit.py` keeps a thin re-export for legacy / monkeypatch paths.

### Slice for #1363 — extract activity-feed text helpers from `plugins_builtin`
- Core's `cockpit_activity` lazy-imported `format_relative_time` and `render_entry_detail` from `plugins_builtin/activity_feed/cockpit/feed_panel.py`, making the "optional" plugin effectively non-optional.
- Moved both pure helpers plus a structural `ActivityFeedEntry` `Protocol` to a new `pollypm.activity_feed_protocol` module that core and the plugin both depend on.
- The plugin re-exports the names from `feed_panel` so existing imports + tests work without churn.

## Out of scope (still tracked)
- #1363: `activity_feed.cockpit.feed_panel.render_activity_feed_text` (depends on the projector, requires a larger inversion) and `project_planning.proposals` / `project_planning.memory` accept/reject helpers used from `cockpit_ui`.
- #1367: cockpit_palette ↔ cockpit_ui cycle, work/sqlite_service intra-package cluster, heartbeats ↔ supervisor, onboarding ↔ onboarding_tui, etc.

## Test plan
- [ ] `ruff check` on the touched files (clean — pre-existing E402 in `cockpit.py` is unrelated).
- [ ] Import smoke test: `pollypm.cockpit_rail`, `pollypm.cockpit`, `pollypm.cockpit_activity`, `pollypm.activity_feed_protocol`, `pollypm.plugins_builtin.activity_feed.cockpit.feed_panel` all import cleanly.
- [ ] Existing `test_activity_feed_filters.py` keeps working via the plugin's re-export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)