### PR TITLE
refactor: break up top-3 long functions (refs #1356)

### DIFF
--- a/src/pollypm/cockpit_inbox_items.py
+++ b/src/pollypm/cockpit_inbox_items.py
@@ -654,6 +654,145 @@ def _filter_approved_plan_reviews(
     return kept
 
 
+def _load_inbox_entries_pg(
+    config,
+    *,
+    session_read_ids: set[str],
+    known_projects: set[str],
+    items: list,
+    unread: set[str],
+    replies_by_task: dict[str, list],
+    seen_task_ids: set[str],
+    project_db_paths: dict[str, tuple[Path, Path]],
+) -> None:
+    """Postgres-backend collector for ``load_inbox_entries`` (#1356).
+
+    One shared svc + bulk aggregates. No per-project sqlite opens,
+    no SQLAlchemyStore opens, no ``work_db.opened`` flood
+    (cf. #1817). Mutates the passed-in containers in place to match
+    the prior inline behaviour. ``project_db_paths`` is populated so
+    the downstream ``_filter_approved_plan_reviews`` can resolve any
+    ``plan_task:<project/number>`` ref.
+    """
+    from pollypm.cockpit_pg_aggregates import (
+        inbox_tasks_for_project,
+        inbox_tasks_grouped,
+        open_messages,
+    )
+
+    # Build the project_db_paths map for the downstream plan_review
+    # filter without opening anything — the helper just walks paths.
+    for project_key, db_path, project_path in _inbox_db_sources(config):
+        if project_key:
+            project_db_paths[project_key] = (db_path, project_path)
+        else:
+            project_db_paths[_WORKSPACE_DB_KEY] = (db_path, project_path)
+
+    # Messages — one pg query for the whole workspace.
+    pg_messages = open_messages(config, known_projects=known_projects)
+    if pg_messages:
+        for row in pg_messages:
+            if _row_is_dev_channel(row.get("labels")):
+                continue
+            scope = (row.get("scope") or "").strip()
+            if scope and scope in known_projects:
+                source_key = scope
+                entry_db = project_db_paths.get(scope, (None, None))[0]
+            else:
+                source_key = _WORKSPACE_DB_KEY
+                entry_db = project_db_paths.get(
+                    _WORKSPACE_DB_KEY, (None, None),
+                )[0]
+            item = annotate_inbox_entry(
+                message_row_to_inbox_entry(
+                    row,
+                    source_key=source_key,
+                    db_path=entry_db or Path("."),
+                ),
+                known_projects=known_projects,
+            )
+            items.append(item)
+            if item.task_id not in session_read_ids:
+                unread.add(item.task_id)
+
+    # Tasks — one pg query, partitioned by project alias.
+    pg_inbox_grouped = inbox_tasks_grouped(config)
+
+    # Read-markers + replies — one shared svc handle for the
+    # whole-workspace context-entry queries. The per-project
+    # signatures on ``task_numbers_with_context_entry`` /
+    # ``bulk_list_replies`` haven't changed, but with one handle
+    # the cost is N pg queries (cheap; same pool) instead of N
+    # fresh service opens.
+    shared_svc = None
+    try:
+        shared_svc = create_work_service(config=config)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "load_inbox_entries: pg shared create_work_service failed; "
+            "treating read-markers + replies as empty",
+            exc_info=True,
+        )
+
+    try:
+        for project_key, db_path, _project_path in _inbox_db_sources(config):
+            if pg_inbox_grouped is None:
+                project_tasks = []
+            elif project_key:
+                project_tasks = inbox_tasks_for_project(
+                    pg_inbox_grouped, config, project_key,
+                )
+            else:
+                # Workspace-root source has no tasks of its own —
+                # workspace notifications live in ``messages``.
+                project_tasks = []
+            if not project_tasks:
+                continue
+            project_for_query = project_key if project_key else "inbox"
+            read_marker_numbers: set[int] = set()
+            replies_by_number: dict[int, list] = {}
+            if shared_svc is not None:
+                try:
+                    read_marker_numbers = (
+                        shared_svc.task_numbers_with_context_entry(
+                            project=project_for_query, entry_type="read",
+                        )
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "load_inbox_entries: task_numbers_with_context_entry"
+                        "(project=%s) failed; treating as empty read-marker set",
+                        project_for_query, exc_info=True,
+                    )
+                try:
+                    replies_by_number = shared_svc.bulk_list_replies(
+                        project=project_for_query,
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "load_inbox_entries: bulk_list_replies(project=%s) "
+                        "failed; treating as empty replies map",
+                        project_for_query, exc_info=True,
+                    )
+            _emit_task_inbox_entries(
+                project_tasks,
+                db_path=db_path,
+                known_projects=known_projects,
+                seen_task_ids=seen_task_ids,
+                items=items,
+                unread=unread,
+                replies_by_task=replies_by_task,
+                read_marker_numbers=read_marker_numbers,
+                replies_by_number=replies_by_number,
+            )
+    finally:
+        if shared_svc is not None:
+            try:
+                shared_svc.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+
 def _emit_task_inbox_entries(
     project_tasks,
     *,
@@ -755,127 +894,16 @@ def load_inbox_entries(
     backend = _resolve_backend(config)
 
     if backend == "postgres":
-        # ------------------------------------------------------------------ #
-        # pg path: one shared svc + bulk aggregates. No per-project sqlite
-        # opens, no SQLAlchemyStore opens, no ``work_db.opened`` flood.
-        # ------------------------------------------------------------------ #
-        from pollypm.cockpit_pg_aggregates import (
-            inbox_tasks_for_project,
-            inbox_tasks_grouped,
-            open_messages,
+        _load_inbox_entries_pg(
+            config,
+            session_read_ids=session_read_ids,
+            known_projects=known_projects,
+            items=items,
+            unread=unread,
+            replies_by_task=replies_by_task,
+            seen_task_ids=seen_task_ids,
+            project_db_paths=project_db_paths,
         )
-
-        # Build the project_db_paths map for the downstream plan_review
-        # filter without opening anything — the helper just walks paths.
-        for project_key, db_path, project_path in _inbox_db_sources(config):
-            if project_key:
-                project_db_paths[project_key] = (db_path, project_path)
-            else:
-                project_db_paths[_WORKSPACE_DB_KEY] = (db_path, project_path)
-
-        # Messages — one pg query for the whole workspace.
-        pg_messages = open_messages(config, known_projects=known_projects)
-        if pg_messages:
-            for row in pg_messages:
-                if _row_is_dev_channel(row.get("labels")):
-                    continue
-                scope = (row.get("scope") or "").strip()
-                if scope and scope in known_projects:
-                    source_key = scope
-                    entry_db = project_db_paths.get(scope, (None, None))[0]
-                else:
-                    source_key = _WORKSPACE_DB_KEY
-                    entry_db = project_db_paths.get(
-                        _WORKSPACE_DB_KEY, (None, None),
-                    )[0]
-                item = annotate_inbox_entry(
-                    message_row_to_inbox_entry(
-                        row,
-                        source_key=source_key,
-                        db_path=entry_db or Path("."),
-                    ),
-                    known_projects=known_projects,
-                )
-                items.append(item)
-                if item.task_id not in session_read_ids:
-                    unread.add(item.task_id)
-
-        # Tasks — one pg query, partitioned by project alias.
-        pg_inbox_grouped = inbox_tasks_grouped(config)
-
-        # Read-markers + replies — one shared svc handle for the
-        # whole-workspace context-entry queries. The per-project
-        # signatures on ``task_numbers_with_context_entry`` /
-        # ``bulk_list_replies`` haven't changed, but with one handle
-        # the cost is N pg queries (cheap; same pool) instead of N
-        # fresh service opens.
-        shared_svc = None
-        try:
-            shared_svc = create_work_service(config=config)
-        except Exception:  # noqa: BLE001
-            logger.warning(
-                "load_inbox_entries: pg shared create_work_service failed; "
-                "treating read-markers + replies as empty",
-                exc_info=True,
-            )
-
-        try:
-            for project_key, db_path, _project_path in _inbox_db_sources(config):
-                if pg_inbox_grouped is None:
-                    project_tasks = []
-                elif project_key:
-                    project_tasks = inbox_tasks_for_project(
-                        pg_inbox_grouped, config, project_key,
-                    )
-                else:
-                    # Workspace-root source has no tasks of its own —
-                    # workspace notifications live in ``messages``.
-                    project_tasks = []
-                if not project_tasks:
-                    continue
-                project_for_query = project_key if project_key else "inbox"
-                read_marker_numbers: set[int] = set()
-                replies_by_number: dict[int, list] = {}
-                if shared_svc is not None:
-                    try:
-                        read_marker_numbers = (
-                            shared_svc.task_numbers_with_context_entry(
-                                project=project_for_query, entry_type="read",
-                            )
-                        )
-                    except Exception:  # noqa: BLE001
-                        logger.warning(
-                            "load_inbox_entries: task_numbers_with_context_entry"
-                            "(project=%s) failed; treating as empty read-marker set",
-                            project_for_query, exc_info=True,
-                        )
-                    try:
-                        replies_by_number = shared_svc.bulk_list_replies(
-                            project=project_for_query,
-                        )
-                    except Exception:  # noqa: BLE001
-                        logger.warning(
-                            "load_inbox_entries: bulk_list_replies(project=%s) "
-                            "failed; treating as empty replies map",
-                            project_for_query, exc_info=True,
-                        )
-                _emit_task_inbox_entries(
-                    project_tasks,
-                    db_path=db_path,
-                    known_projects=known_projects,
-                    seen_task_ids=seen_task_ids,
-                    items=items,
-                    unread=unread,
-                    replies_by_task=replies_by_task,
-                    read_marker_numbers=read_marker_numbers,
-                    replies_by_number=replies_by_number,
-                )
-        finally:
-            if shared_svc is not None:
-                try:
-                    shared_svc.close()
-                except Exception:  # noqa: BLE001
-                    pass
     else:
         # ------------------------------------------------------------------ #
         # sqlite path: per-project state.db walk (canonical on sqlite where

--- a/src/pollypm/cockpit_inbox_items.py
+++ b/src/pollypm/cockpit_inbox_items.py
@@ -654,6 +654,65 @@ def _filter_approved_plan_reviews(
     return kept
 
 
+def _emit_task_inbox_entries(
+    project_tasks,
+    *,
+    db_path: Path,
+    known_projects: set[str],
+    seen_task_ids: set[str],
+    items: list,
+    unread: set[str],
+    replies_by_task: dict[str, list],
+    read_marker_numbers: set[int],
+    replies_by_number: dict[int, list],
+) -> None:
+    """Append task-backed inbox entries from one project's task list.
+
+    Shared between the pg and sqlite branches of
+    ``load_inbox_entries`` (#1356). Both branches perform the same
+    per-task work — dedupe by ``task_id``, run the plan_review
+    synth-source filter (#1103), annotate, and bookkeep unread /
+    replies — only the upstream task fetch + read-marker / replies
+    fetch differ. All bookkeeping mutates the passed-in containers in
+    place to match the prior inline behaviour.
+    """
+    for task in project_tasks:
+        if task.task_id in seen_task_ids:
+            continue
+        seen_task_ids.add(task.task_id)
+        # Synth-source filter for plan_review (#1103, 4th attempt).
+        # Check the task's own user_approval execution directly: if
+        # it's COMPLETED + APPROVED, the plan review is already done
+        # and emitting the row would be a phantom action.
+        task_labels = {
+            str(lbl) for lbl in (getattr(task, "labels", []) or [])
+        }
+        if "plan_review" in task_labels:
+            emit = not _task_user_approval_is_approved(task)
+            logger.warning(
+                "PLAN_REVIEW_SYNTH project=%s task_id=%s emit=%s "
+                "reason=%s",
+                getattr(task, "project", "") or "",
+                task.task_id,
+                emit,
+                "user_approval_pending"
+                if emit else "user_approval_approved",
+            )
+            if not emit:
+                continue
+        items.append(
+            annotate_inbox_entry(
+                task_to_inbox_entry(task, db_path=db_path),
+                known_projects=known_projects,
+            )
+        )
+        if task.task_number not in read_marker_numbers:
+            unread.add(task.task_id)
+        replies = replies_by_number.get(task.task_number, [])
+        if replies:
+            replies_by_task[task.task_id] = replies
+
+
 def load_inbox_entries(
     config,
     *,
@@ -800,37 +859,17 @@ def load_inbox_entries(
                             "failed; treating as empty replies map",
                             project_for_query, exc_info=True,
                         )
-                for task in project_tasks:
-                    if task.task_id in seen_task_ids:
-                        continue
-                    seen_task_ids.add(task.task_id)
-                    task_labels = {
-                        str(lbl) for lbl in (getattr(task, "labels", []) or [])
-                    }
-                    if "plan_review" in task_labels:
-                        emit = not _task_user_approval_is_approved(task)
-                        logger.warning(
-                            "PLAN_REVIEW_SYNTH project=%s task_id=%s emit=%s "
-                            "reason=%s",
-                            getattr(task, "project", "") or "",
-                            task.task_id,
-                            emit,
-                            "user_approval_pending"
-                            if emit else "user_approval_approved",
-                        )
-                        if not emit:
-                            continue
-                    items.append(
-                        annotate_inbox_entry(
-                            task_to_inbox_entry(task, db_path=db_path),
-                            known_projects=known_projects,
-                        )
-                    )
-                    if task.task_number not in read_marker_numbers:
-                        unread.add(task.task_id)
-                    replies = replies_by_number.get(task.task_number, [])
-                    if replies:
-                        replies_by_task[task.task_id] = replies
+                _emit_task_inbox_entries(
+                    project_tasks,
+                    db_path=db_path,
+                    known_projects=known_projects,
+                    seen_task_ids=seen_task_ids,
+                    items=items,
+                    unread=unread,
+                    replies_by_task=replies_by_task,
+                    read_marker_numbers=read_marker_numbers,
+                    replies_by_number=replies_by_number,
+                )
         finally:
             if shared_svc is not None:
                 try:
@@ -940,42 +979,17 @@ def load_inbox_entries(
                         project_for_query, exc_info=True,
                     )
                     replies_by_number = {}
-                for task in project_tasks:
-                    if task.task_id in seen_task_ids:
-                        continue
-                    seen_task_ids.add(task.task_id)
-                    # Synth-source filter for plan_review (#1103, 4th
-                    # attempt). Check the task's own user_approval
-                    # execution directly: if it's COMPLETED + APPROVED,
-                    # the plan review is already done and emitting the row
-                    # would be a phantom action.
-                    task_labels = {
-                        str(lbl) for lbl in (getattr(task, "labels", []) or [])
-                    }
-                    if "plan_review" in task_labels:
-                        emit = not _task_user_approval_is_approved(task)
-                        logger.warning(
-                            "PLAN_REVIEW_SYNTH project=%s task_id=%s emit=%s "
-                            "reason=%s",
-                            getattr(task, "project", "") or "",
-                            task.task_id,
-                            emit,
-                            "user_approval_pending"
-                            if emit else "user_approval_approved",
-                        )
-                        if not emit:
-                            continue
-                    items.append(
-                        annotate_inbox_entry(
-                            task_to_inbox_entry(task, db_path=db_path),
-                            known_projects=known_projects,
-                        )
-                    )
-                    if task.task_number not in read_marker_numbers:
-                        unread.add(task.task_id)
-                    replies = replies_by_number.get(task.task_number, [])
-                    if replies:
-                        replies_by_task[task.task_id] = replies
+                _emit_task_inbox_entries(
+                    project_tasks,
+                    db_path=db_path,
+                    known_projects=known_projects,
+                    seen_task_ids=seen_task_ids,
+                    items=items,
+                    unread=unread,
+                    replies_by_task=replies_by_task,
+                    read_marker_numbers=read_marker_numbers,
+                    replies_by_number=replies_by_number,
+                )
             finally:
                 try:
                     svc.close()

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -12537,6 +12537,141 @@ def _dashboard_active_worker(
 _DASHBOARD_INBOX_CACHE: "OrderedDict[tuple[str, float | None], tuple[int, list[dict], list[dict]]]" = OrderedDict()
 
 
+def _dashboard_inbox_build_message_item(
+    *,
+    row: dict[str, object],
+    payload: dict,
+    labels: list[str],
+    source_key: str,
+    source_db: Path,
+    project_key: str,
+    project_path: Path,
+    known_projects: set[str],
+    message_body: str,
+    sort_value,
+) -> dict:
+    """Build a single ``source="message"`` inbox item from a stored message row.
+
+    Pulled out of ``_dashboard_inbox`` (#1356). The row has already been
+    triaged (dev-channel filter, ``project_key`` membership check,
+    blocker-summary short-circuit) by the caller — this helper only
+    handles the message → item projection: decision-producer dispatch
+    (``user_prompt`` → ``plan_review`` → plain body fallback), the
+    #1397 plan-review extras merge, and the final item dict assembly.
+
+    ``message_body`` is the already-normalised body text (caller's
+    ``_message_body`` closure output) and ``sort_value`` is the local
+    iso-or-datetime → epoch float helper. Both are passed in so the
+    helper stays a pure projection.
+    """
+    entry = annotate_inbox_entry(
+        message_row_to_inbox_entry(
+            row,
+            source_key=source_key,
+            db_path=source_db,
+        ),
+        known_projects=known_projects,
+    )
+    updated_at = getattr(entry, "updated_at", "") or ""
+    if hasattr(updated_at, "isoformat"):
+        updated_at = updated_at.isoformat()
+    body = message_body
+    subject = getattr(entry, "title", "") or "(no subject)"
+    steps = _dashboard_steps_from_body(body)
+    task_refs = [
+        match.group(0)
+        for match in _PROJECT_TASK_REF_RE.finditer(
+            "\n".join((subject, body))
+        )
+        if match.group("project") == project_key
+    ]
+    plan_meta = _extract_plan_review_meta(labels)
+    plan_task_id = str(plan_meta.get("plan_task_id") or "")
+    if (
+        plan_task_id
+        and _PROJECT_TASK_REF_RE.fullmatch(plan_task_id)
+        and plan_task_id not in task_refs
+    ):
+        task_refs.insert(0, plan_task_id)
+    primary_ref = task_refs[0] if task_refs else payload.get("task_id")
+    decision = (
+        _dashboard_user_prompt_decision(
+            payload.get("user_prompt"),
+            fallback_task_id=(
+                str(primary_ref)
+                if _PROJECT_TASK_REF_RE.fullmatch(str(primary_ref or ""))
+                else None
+            ),
+        )
+        or _dashboard_plan_review_decision(
+            project_path,
+            labels,
+            body,
+            fallback_task_id=(
+                str(payload.get("task_id") or "")
+                if payload.get("task_id")
+                else None
+            ),
+        )
+        or _dashboard_plain_decision_from_body(subject, body, steps)
+    )
+    # #1397: when this is a plan_review item but
+    # ``_user_prompt_decision`` won the dispatch (the
+    # architect's payload provides a structured user_prompt),
+    # the plan summary / judgment-call points still need to
+    # ride along on the action card so the drilldown surface
+    # renders inline plan content. Always merge those fields
+    # in for plan_review items, regardless of which decision
+    # producer fired.
+    if "plan_review" in labels:
+        plan_review_extras = _dashboard_plan_review_decision(
+            project_path,
+            labels,
+            body,
+            fallback_task_id=(
+                str(payload.get("task_id") or "")
+                if payload.get("task_id")
+                else None
+            ),
+        ) or {}
+        for plan_key in (
+            "plan_summary", "judgment_calls", "plan_text",
+        ):
+            if plan_key in plan_review_extras:
+                decision.setdefault(plan_key, plan_review_extras[plan_key])
+        # Override the prompt with the plan summary when the
+        # user_prompt's summary is the generic boilerplate
+        # (so the card actually surfaces the plan's leading
+        # paragraph instead of "A full project plan is ready
+        # for your review.").
+        plan_summary = plan_review_extras.get("plan_summary") or ""
+        current_prompt = str(decision.get("plain_prompt") or "")
+        if (
+            plan_summary
+            and "ready for your review" in current_prompt.lower()
+        ):
+            decision["plain_prompt"] = plan_summary
+    return {
+        "task_id": entry.task_id,
+        "title": subject,
+        "updated_at": updated_at,
+        "sort_value": sort_value(updated_at),
+        "triage_label": getattr(entry, "triage_label", ""),
+        "triage_rank": int(getattr(entry, "triage_rank", 2) or 2),
+        "needs_action": bool(getattr(entry, "needs_action", False)),
+        "source": "message",
+        "has_user_prompt": payload.get("user_prompt") is not None,
+        "is_plan_review": "plan_review" in labels,
+        "summary": _dashboard_summary_from_body(body),
+        "steps": steps,
+        "next_action": _dashboard_decision_prompt_from_body(
+            subject, body, steps,
+        ),
+        "primary_ref": primary_ref,
+        **decision,
+    }
+
+
 def _dashboard_inbox_finalize(
     items: list[dict],
 ) -> tuple[int, list[dict], list[dict]]:
@@ -12686,35 +12821,10 @@ def _dashboard_inbox(
         return text[: limit - 1].rstrip() + "…"
 
     # Body-parsing helpers (#1356 wedge): the inner ``_summary_from_body``
-    # / ``_steps_from_body`` / ``_requirement_step`` closures here were
-    # near-duplicates of the module-level ``_dashboard_*`` helpers already
-    # used by ``_render_heuristic_action_block`` (line ~6849) and the
-    # blocker-row path in this same function (line ~13359). The bodies
-    # passed in here are pre-normalized via ``_message_body`` so the
-    # module-level versions (which also re-normalize ``\\n``) are
-    # behaviour-compatible supersets. Consolidating trims ~95 LOC and
-    # exposes both legs of the dispatch to the same unit tests.
-    _summary_from_body = _dashboard_summary_from_body
-    _steps_from_body = _dashboard_steps_from_body
-
-    _decision_prompt_from_body = _dashboard_decision_prompt_from_body
-    _user_prompt_decision = _dashboard_user_prompt_decision
-
-    def _plan_review_decision(
-        labels: list[str], body: str, *, fallback_task_id: str | None = None,
-    ) -> dict[str, object] | None:
-        return _dashboard_plan_review_decision(
-            project_path,
-            labels,
-            body,
-            fallback_task_id=fallback_task_id,
-        )
-
-    # #1356 wedge: ``_plain_decision_from_body`` is now a module-level
-    # ``_dashboard_plain_decision_from_body`` so the token-driven branch
-    # table is unit-testable. Keep the local alias to minimise call-site
-    # churn below.
-    _plain_decision_from_body = _dashboard_plain_decision_from_body
+    # / ``_steps_from_body`` / ``_requirement_step`` closures were
+    # already module-level ``_dashboard_*`` helpers; the per-message
+    # builder now calls those directly via
+    # ``_dashboard_inbox_build_message_item``.
 
     known_projects = set(getattr(config, "projects", {}).keys())
     items: list[dict] = []
@@ -12818,111 +12928,19 @@ def _dashboard_inbox(
                         )
                     )
                     continue
-                entry = annotate_inbox_entry(
-                    message_row_to_inbox_entry(
-                        row,
-                        source_key=source_key,
-                        db_path=source_db,
-                    ),
-                    known_projects=known_projects,
-                )
-                updated_at = getattr(entry, "updated_at", "") or ""
-                if hasattr(updated_at, "isoformat"):
-                    updated_at = updated_at.isoformat()
-                body = _message_body(row.get("body"))
-                subject = getattr(entry, "title", "") or "(no subject)"
-                steps = _steps_from_body(body)
-                task_refs = [
-                    match.group(0)
-                    for match in _PROJECT_TASK_REF_RE.finditer(
-                        "\n".join((subject, body))
-                    )
-                    if match.group("project") == project_key
-                ]
-                plan_meta = _extract_plan_review_meta(labels)
-                plan_task_id = str(plan_meta.get("plan_task_id") or "")
-                if (
-                    plan_task_id
-                    and _PROJECT_TASK_REF_RE.fullmatch(plan_task_id)
-                    and plan_task_id not in task_refs
-                ):
-                    task_refs.insert(0, plan_task_id)
-                primary_ref = task_refs[0] if task_refs else payload.get("task_id")
-                decision = (
-                    _user_prompt_decision(
-                        payload.get("user_prompt"),
-                        fallback_task_id=(
-                            str(primary_ref)
-                            if _PROJECT_TASK_REF_RE.fullmatch(str(primary_ref or ""))
-                            else None
-                        ),
-                    )
-                    or _plan_review_decision(
-                        labels,
-                        body,
-                        fallback_task_id=(
-                            str(payload.get("task_id") or "")
-                            if payload.get("task_id")
-                            else None
-                        ),
-                    )
-                    or _plain_decision_from_body(subject, body, steps)
-                )
-                # #1397: when this is a plan_review item but
-                # ``_user_prompt_decision`` won the dispatch (the
-                # architect's payload provides a structured user_prompt),
-                # the plan summary / judgment-call points still need to
-                # ride along on the action card so the drilldown surface
-                # renders inline plan content. Always merge those fields
-                # in for plan_review items, regardless of which decision
-                # producer fired.
-                if "plan_review" in labels:
-                    plan_review_extras = _plan_review_decision(
-                        labels,
-                        body,
-                        fallback_task_id=(
-                            str(payload.get("task_id") or "")
-                            if payload.get("task_id")
-                            else None
-                        ),
-                    ) or {}
-                    for plan_key in (
-                        "plan_summary", "judgment_calls", "plan_text",
-                    ):
-                        if plan_key in plan_review_extras:
-                            decision.setdefault(plan_key, plan_review_extras[plan_key])
-                    # Override the prompt with the plan summary when the
-                    # user_prompt's summary is the generic boilerplate
-                    # (so the card actually surfaces the plan's leading
-                    # paragraph instead of "A full project plan is ready
-                    # for your review.").
-                    plan_summary = plan_review_extras.get("plan_summary") or ""
-                    current_prompt = str(decision.get("plain_prompt") or "")
-                    if (
-                        plan_summary
-                        and "ready for your review" in current_prompt.lower()
-                    ):
-                        decision["plain_prompt"] = plan_summary
                 items.append(
-                    {
-                        "task_id": entry.task_id,
-                        "title": subject,
-                        "updated_at": updated_at,
-                        "sort_value": _sort_value(updated_at),
-                        "triage_label": getattr(entry, "triage_label", ""),
-                        "triage_rank": int(getattr(entry, "triage_rank", 2) or 2),
-                        "needs_action": bool(getattr(entry, "needs_action", False)),
-                        "source": "message",
-                        "has_user_prompt": payload.get("user_prompt") is not None,
-                        "is_plan_review": "plan_review" in labels,
-                        "summary": _summary_from_body(body),
-                        "steps": steps,
-                        "next_action": _decision_prompt_from_body(
-                            subject, body, steps,
-                        ),
-                        "primary_ref": primary_ref,
-                        **decision,
-                    }
+                    _dashboard_inbox_build_message_item(
+                        row=row,
+                        payload=payload,
+                        labels=labels,
+                        source_key=source_key,
+                        source_db=source_db,
+                        project_key=project_key,
+                        project_path=project_path,
+                        known_projects=known_projects,
+                        message_body=_message_body(row.get("body")),
+                        sort_value=_sort_value,
+                    )
                 )
         finally:
             try:

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -12537,6 +12537,55 @@ def _dashboard_active_worker(
 _DASHBOARD_INBOX_CACHE: "OrderedDict[tuple[str, float | None], tuple[int, list[dict], list[dict]]]" = OrderedDict()
 
 
+def _dashboard_inbox_finalize(
+    items: list[dict],
+) -> tuple[int, list[dict], list[dict]]:
+    """Sort the raw inbox items and produce the dashboard ``(count, top, action_items)`` triple.
+
+    Pulled out of ``_dashboard_inbox`` (#1356) so the projection rules
+    (triage rank ordering, the top-3 card list, the deduped 2-slot
+    action list, and the cross-source action count) are individually
+    inspectable. Pure: no IO, no caching side effects.
+    """
+    items.sort(
+        key=lambda item: (
+            int(item.get("triage_rank", 2)),
+            0 if item.get("needs_action") else 1,
+            -float(item.get("sort_value", 0.0) or 0.0),
+            str(item.get("title", "")).lower(),
+        )
+    )
+    top = [
+        {
+            "task_id": item.get("task_id"),
+            "primary_ref": item.get("primary_ref"),
+            "title": item.get("title"),
+            "updated_at": item.get("updated_at"),
+            "triage_label": item.get("triage_label", ""),
+            "source": item.get("source", "task"),
+            # Carry ``needs_action`` so the project dashboard can
+            # split spillover into "action just didn't fit" (keep
+            # the ``Press i`` CTA) vs purely FYI/completed rows
+            # (suppress the redundant CTA, #1650).
+            "needs_action": bool(item.get("needs_action")),
+        }
+        for item in items[:3]
+    ]
+    action_items: list[dict] = []
+    seen_action_refs: set[str] = set()
+    for item in items:
+        if item.get("source") not in {"message", "blocker_summary"} or not item.get("needs_action"):
+            continue
+        dedupe_key = str(item.get("primary_ref") or item.get("title") or "")
+        if dedupe_key in seen_action_refs:
+            continue
+        seen_action_refs.add(dedupe_key)
+        action_items.append(item)
+        if len(action_items) >= 2:
+            break
+    return (_action_count(items, action_items), top, action_items)
+
+
 def _dashboard_inbox(
     config_path: Path, project_key: str, project_path: Path,
 ) -> tuple[int, list[dict], list[dict]]:
@@ -12881,43 +12930,7 @@ def _dashboard_inbox(
             except Exception:  # noqa: BLE001
                 pass
 
-    items.sort(
-        key=lambda item: (
-            int(item.get("triage_rank", 2)),
-            0 if item.get("needs_action") else 1,
-            -float(item.get("sort_value", 0.0) or 0.0),
-            str(item.get("title", "")).lower(),
-        )
-    )
-    top = [
-        {
-            "task_id": item.get("task_id"),
-            "primary_ref": item.get("primary_ref"),
-            "title": item.get("title"),
-            "updated_at": item.get("updated_at"),
-            "triage_label": item.get("triage_label", ""),
-            "source": item.get("source", "task"),
-            # Carry ``needs_action`` so the project dashboard can
-            # split spillover into "action just didn't fit" (keep
-            # the ``Press i`` CTA) vs purely FYI/completed rows
-            # (suppress the redundant CTA, #1650).
-            "needs_action": bool(item.get("needs_action")),
-        }
-        for item in items[:3]
-    ]
-    action_items: list[dict] = []
-    seen_action_refs: set[str] = set()
-    for item in items:
-        if item.get("source") not in {"message", "blocker_summary"} or not item.get("needs_action"):
-            continue
-        dedupe_key = str(item.get("primary_ref") or item.get("title") or "")
-        if dedupe_key in seen_action_refs:
-            continue
-        seen_action_refs.add(dedupe_key)
-        action_items.append(item)
-        if len(action_items) >= 2:
-            break
-    result = (_action_count(items, action_items), top, action_items)
+    result = _dashboard_inbox_finalize(items)
     _dashboard_cache_set(_DASHBOARD_INBOX_CACHE, cache_key, result)
     return result
 

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -934,52 +934,7 @@ class LocalHeartbeatBackend(HeartbeatBackend):
 
         alerts.extend(self._handle_persona_drift(api, context))
 
-        combined_text = "\n".join(part for part in [context.transcript_delta, context.pane_text] if part).lower()
-        status_locked = False
-        if any(pattern in combined_text for pattern in self._AUTH_FAILURE_PATTERNS):
-            _emit_routed_alert(
-                api,
-                session_name=context.session_name,
-                alert_type="auth_broken",
-                severity="error",
-                message=(
-                    f"Window {context.window_name} reported "
-                    f"authentication failure"
-                ),
-                subject=f"{context.session_name} authentication failure",
-                suggested_action=(
-                    "Open Settings to fix the account, then restart the session from Workers."
-                ),
-            )
-            api.mark_account_auth_broken(
-                context.account_name,
-                context.provider,
-                reason="live session reported authentication failure",
-            )
-            self._set_session_status(
-                api,
-                context,
-                "auth_broken",
-                reason="Authentication failure reported",
-            )
-            alerts.append("auth_broken")
-            status_locked = True
-            # #1437 — without this call the recovery ladder never fires
-            # for per-task workers that hit an auth-block on their
-            # provider account. The heartbeat would mark the account
-            # ``auth_broken`` and pin the session status, but the wedged
-            # tmux window kept running until manual ``pm reset``.
-            # ``recover_session`` routes through Supervisor.maybe_recover
-            # which (combined with #1437 Fix #3 in session_manager.py)
-            # picks a healthy failover account on the relaunch.
-            self._recover_session(
-                api,
-                context,
-                failure_type="auth_broken",
-                message="Authentication failure reported",
-            )
-        else:
-            api.clear_alert(context.session_name, "auth_broken")
+        status_locked = self._handle_auth_failure(api, context, alerts)
 
         if context.pane_dead:
             status_locked = True
@@ -1123,6 +1078,73 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                 self._escalate(api, context, intervention.reason)
         except Exception:  # noqa: BLE001
             pass
+
+    def _handle_auth_failure(
+        self,
+        api,
+        context: HeartbeatSessionContext,
+        alerts: list[str],
+    ) -> bool:
+        """Detect provider auth failures in the live transcript and react.
+
+        Extracted from ``_process_session`` (#1356). When a known
+        auth-broken pattern is present in the recent pane/transcript
+        text, this emits the routed alert, marks the underlying
+        provider account broken, pins the session status, kicks off
+        the recovery ladder (#1437), and returns ``True`` so the
+        caller can avoid further status writes that would clobber the
+        ``auth_broken`` pin. When no pattern matches, the
+        ``auth_broken`` alert (if any) is cleared and ``False`` is
+        returned. Appends to ``alerts`` in place to match the prior
+        inline behaviour.
+        """
+        combined_text = "\n".join(
+            part for part in [context.transcript_delta, context.pane_text] if part
+        ).lower()
+        if any(pattern in combined_text for pattern in self._AUTH_FAILURE_PATTERNS):
+            _emit_routed_alert(
+                api,
+                session_name=context.session_name,
+                alert_type="auth_broken",
+                severity="error",
+                message=(
+                    f"Window {context.window_name} reported "
+                    f"authentication failure"
+                ),
+                subject=f"{context.session_name} authentication failure",
+                suggested_action=(
+                    "Open Settings to fix the account, then restart the session from Workers."
+                ),
+            )
+            api.mark_account_auth_broken(
+                context.account_name,
+                context.provider,
+                reason="live session reported authentication failure",
+            )
+            self._set_session_status(
+                api,
+                context,
+                "auth_broken",
+                reason="Authentication failure reported",
+            )
+            alerts.append("auth_broken")
+            # #1437 — without this call the recovery ladder never fires
+            # for per-task workers that hit an auth-block on their
+            # provider account. The heartbeat would mark the account
+            # ``auth_broken`` and pin the session status, but the wedged
+            # tmux window kept running until manual ``pm reset``.
+            # ``recover_session`` routes through Supervisor.maybe_recover
+            # which (combined with #1437 Fix #3 in session_manager.py)
+            # picks a healthy failover account on the relaunch.
+            self._recover_session(
+                api,
+                context,
+                failure_type="auth_broken",
+                message="Authentication failure reported",
+            )
+            return True
+        api.clear_alert(context.session_name, "auth_broken")
+        return False
 
     def _handle_persona_drift(
         self, api, context: HeartbeatSessionContext

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -1087,29 +1087,42 @@ class LocalHeartbeatBackend(HeartbeatBackend):
 
         # Use the structured classification engine for intervention decisions
         if not mechanical_only:
-            try:
-                signals = self._context_to_signals(context, api)
-                health = _classify_session_health(signals)
-                # #1830: route through supervisor facade for pg/sqlite parity.
-                runtime = api.supervisor.get_session_runtime(context.session_name)
-                prev = runtime.recovery_attempts if runtime else 0
-                intervention = _select_intervention(health, signals, previous_interventions=prev)
-                # #249 — work-aware interventions. These dispatch before
-                # the generic worker-triage path so the policy-chosen
-                # action actually runs.
-                if intervention and intervention.action == "resume_ping":
-                    self._apply_resume_ping(api, context, signals, intervention)
-                elif intervention and intervention.action == "prompt_pm_task_next":
-                    self._apply_prompt_pm_task_next(api, context)
-                elif intervention and context.role == "worker":
-                    # Use Haiku to decide the right action for idle workers.
-                    # The LLM reads the snapshot and classifies: push forward,
-                    # nudge, do nothing, or escalate.
-                    self._triage_stalled_worker(api, context)
-                elif intervention and intervention.action == "escalate":
-                    self._escalate(api, context, intervention.reason)
-            except Exception:  # noqa: BLE001
-                pass
+            self._dispatch_health_intervention(api, context)
+
+    def _dispatch_health_intervention(
+        self, api, context: HeartbeatSessionContext
+    ) -> None:
+        """Run the structured-signals classifier and apply the chosen intervention.
+
+        Extracted from ``_process_session`` (#1356) so the dispatch
+        table (``resume_ping`` / ``prompt_pm_task_next`` / worker
+        triage / ``escalate``) is reviewable on its own.
+
+        #249 — work-aware interventions dispatch before the generic
+        worker-triage path so the policy-chosen action actually runs.
+        Exceptions are swallowed to match the prior inline behaviour:
+        a misbehaving classifier must not crash the heartbeat tick.
+        """
+        try:
+            signals = self._context_to_signals(context, api)
+            health = _classify_session_health(signals)
+            # #1830: route through supervisor facade for pg/sqlite parity.
+            runtime = api.supervisor.get_session_runtime(context.session_name)
+            prev = runtime.recovery_attempts if runtime else 0
+            intervention = _select_intervention(health, signals, previous_interventions=prev)
+            if intervention and intervention.action == "resume_ping":
+                self._apply_resume_ping(api, context, signals, intervention)
+            elif intervention and intervention.action == "prompt_pm_task_next":
+                self._apply_prompt_pm_task_next(api, context)
+            elif intervention and context.role == "worker":
+                # Use Haiku to decide the right action for idle workers.
+                # The LLM reads the snapshot and classifies: push forward,
+                # nudge, do nothing, or escalate.
+                self._triage_stalled_worker(api, context)
+            elif intervention and intervention.action == "escalate":
+                self._escalate(api, context, intervention.reason)
+        except Exception:  # noqa: BLE001
+            pass
 
     def _handle_persona_drift(
         self, api, context: HeartbeatSessionContext

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -794,135 +794,8 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         api.record_observation(context)
         api.clear_alert(context.session_name, "missing_window")
 
-        if context.pane_dead:
-            _emit_routed_alert(
-                api,
-                session_name=context.session_name,
-                alert_type="pane_dead",
-                severity="error",
-                message=(
-                    f"Pane {context.pane_id} in window "
-                    f"{context.window_name} has exited"
-                ),
-                subject=f"{context.session_name} pane exited",
-                suggested_action=(
-                    "Open Workers and restart the exited session."
-                ),
-            )
-            self._set_session_status(api, context, "recovering", reason="Pane exited")
-            self._recover_session(
-                api,
-                context,
-                failure_type="pane_dead",
-                message="Pane exited",
-            )
-            alerts.append("pane_dead")
-        else:
-            api.clear_alert(context.session_name, "pane_dead")
-
-        if (context.pane_command or "") in {"bash", "zsh", "sh", "fish"}:
-            _emit_routed_alert(
-                api,
-                session_name=context.session_name,
-                alert_type="shell_returned",
-                severity="warn",
-                message=(
-                    f"Window {context.window_name} appears to be back at "
-                    f"the shell prompt ({context.pane_command})"
-                ),
-                subject=f"{context.session_name} returned to shell",
-                suggested_action=(
-                    "Open Workers and restart the session."
-                ),
-            )
-            alerts.append("shell_returned")
-        else:
-            api.clear_alert(context.session_name, "shell_returned")
-
-        # #1506 — role-respawn-on-crash. The ``shell_returned`` alert
-        # above tells the operator something is wrong; this block does
-        # something about it. When the pane is at a shell prompt
-        # (Claude/codex process exited but tmux pane still alive) AND
-        # the role has active work, treat as crashed and auto-respawn
-        # this tick instead of waiting for ``_MAX_NUDGES_BEFORE_RECOVERY``
-        # ticks of nudge-unresponsive (which never fires when the
-        # Claude PID is gone — there's nothing to nudge).
-        # Distinct from ``pane_dead`` (whole tmux pane gone — already
-        # recovered above) and stalled-but-running (Claude PID alive,
-        # just silent — nudge ladder via #1495 / #1505).
-        if (
-            (context.pane_command or "") in {"bash", "zsh", "sh", "fish"}
-            and context.role in self._CRASH_RECOVERY_ROLES
-            and self._has_pending_work(api, context)
-        ):
-            runtime = None
-            try:
-                # #1830: route through supervisor facade for pg/sqlite parity.
-                runtime = api.supervisor.get_session_runtime(
-                    context.session_name
-                )
-            except (AttributeError, Exception):  # noqa: BLE001
-                pass  # API may not have supervisor (e.g., tests)
-            prev_attempts = runtime.recovery_attempts if runtime else 0
-            if prev_attempts >= self._CRASH_LOOP_ATTEMPT_THRESHOLD:
-                _emit_routed_alert(
-                    api,
-                    session_name=context.session_name,
-                    alert_type="crash_loop",
-                    severity="error",
-                    message=(
-                        f"{context.session_name} crashed and "
-                        f"respawned {prev_attempts} times — "
-                        "escalating to operator."
-                    ),
-                    subject=f"{context.session_name} crash loop",
-                    suggested_action=(
-                        "Check the role's account state and "
-                        "investigate the underlying crash before "
-                        "respawning again."
-                    ),
-                )
-                alerts.append("crash_loop")
-            else:
-                self._set_session_status(
-                    api,
-                    context,
-                    "recovering",
-                    reason="Role pane crashed (process exited)",
-                )
-                self._recover_session(
-                    api,
-                    context,
-                    failure_type="role_crashed",
-                    message=(
-                        f"Role pane returned to shell "
-                        f"({context.pane_command})"
-                    ),
-                )
-                alerts.append("role_crashed")
-        else:
-            api.clear_alert(context.session_name, "crash_loop")
-
         stopped_reason = "Pane process is stopped (SIGSTOP)"
-        if context.pane_stopped:
-            _emit_routed_alert(
-                api,
-                session_name=context.session_name,
-                alert_type="pane_stopped",
-                severity="error",
-                message=(
-                    f"{context.session_name} appears stuck: "
-                    f"{stopped_reason}. Open Workers and resume or "
-                    "restart the stopped session."
-                ),
-                subject=f"{context.session_name} process stopped",
-                suggested_action=(
-                    "Open Workers and resume or restart the stopped session."
-                ),
-            )
-            alerts.append("pane_stopped")
-        else:
-            api.clear_alert(context.session_name, "pane_stopped")
+        self._handle_pane_health_alerts(api, context, alerts, stopped_reason)
 
         # Sessions parked at a prompt are legitimately idle — not an alert condition.
         # Only the suspected_loop detector (below) alerts on sustained identical snapshots.
@@ -1078,6 +951,160 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                 self._escalate(api, context, intervention.reason)
         except Exception:  # noqa: BLE001
             pass
+
+    def _handle_pane_health_alerts(
+        self,
+        api,
+        context: HeartbeatSessionContext,
+        alerts: list[str],
+        stopped_reason: str,
+    ) -> None:
+        """Run the four pane-level health checks and emit/clear their alerts.
+
+        Extracted from ``_process_session`` (#1356). Each check is
+        independent and either emits a routed alert + status update +
+        appends to ``alerts``, or clears the corresponding alert:
+
+          * ``pane_dead`` — whole tmux pane has exited, kick recovery.
+          * ``shell_returned`` — pane is back at a shell prompt
+            (Claude/codex process exited but tmux pane still alive).
+          * Role-respawn-on-crash (#1506) — when shell-returned coincides
+            with pending work for a crash-recovery role; either escalates
+            via ``crash_loop`` or kicks ``role_crashed`` recovery.
+          * ``pane_stopped`` — pane process is SIGSTOPped.
+
+        ``alerts`` is mutated in place to match the prior inline
+        behaviour. ``stopped_reason`` is passed in so the verdict block
+        in the caller can reuse the same string.
+        """
+        if context.pane_dead:
+            _emit_routed_alert(
+                api,
+                session_name=context.session_name,
+                alert_type="pane_dead",
+                severity="error",
+                message=(
+                    f"Pane {context.pane_id} in window "
+                    f"{context.window_name} has exited"
+                ),
+                subject=f"{context.session_name} pane exited",
+                suggested_action=(
+                    "Open Workers and restart the exited session."
+                ),
+            )
+            self._set_session_status(api, context, "recovering", reason="Pane exited")
+            self._recover_session(
+                api,
+                context,
+                failure_type="pane_dead",
+                message="Pane exited",
+            )
+            alerts.append("pane_dead")
+        else:
+            api.clear_alert(context.session_name, "pane_dead")
+
+        if (context.pane_command or "") in {"bash", "zsh", "sh", "fish"}:
+            _emit_routed_alert(
+                api,
+                session_name=context.session_name,
+                alert_type="shell_returned",
+                severity="warn",
+                message=(
+                    f"Window {context.window_name} appears to be back at "
+                    f"the shell prompt ({context.pane_command})"
+                ),
+                subject=f"{context.session_name} returned to shell",
+                suggested_action=(
+                    "Open Workers and restart the session."
+                ),
+            )
+            alerts.append("shell_returned")
+        else:
+            api.clear_alert(context.session_name, "shell_returned")
+
+        # #1506 — role-respawn-on-crash. The ``shell_returned`` alert
+        # above tells the operator something is wrong; this block does
+        # something about it. When the pane is at a shell prompt
+        # (Claude/codex process exited but tmux pane still alive) AND
+        # the role has active work, treat as crashed and auto-respawn
+        # this tick instead of waiting for ``_MAX_NUDGES_BEFORE_RECOVERY``
+        # ticks of nudge-unresponsive (which never fires when the
+        # Claude PID is gone — there's nothing to nudge).
+        # Distinct from ``pane_dead`` (whole tmux pane gone — already
+        # recovered above) and stalled-but-running (Claude PID alive,
+        # just silent — nudge ladder via #1495 / #1505).
+        if (
+            (context.pane_command or "") in {"bash", "zsh", "sh", "fish"}
+            and context.role in self._CRASH_RECOVERY_ROLES
+            and self._has_pending_work(api, context)
+        ):
+            runtime = None
+            try:
+                # #1830: route through supervisor facade for pg/sqlite parity.
+                runtime = api.supervisor.get_session_runtime(
+                    context.session_name
+                )
+            except (AttributeError, Exception):  # noqa: BLE001
+                pass  # API may not have supervisor (e.g., tests)
+            prev_attempts = runtime.recovery_attempts if runtime else 0
+            if prev_attempts >= self._CRASH_LOOP_ATTEMPT_THRESHOLD:
+                _emit_routed_alert(
+                    api,
+                    session_name=context.session_name,
+                    alert_type="crash_loop",
+                    severity="error",
+                    message=(
+                        f"{context.session_name} crashed and "
+                        f"respawned {prev_attempts} times — "
+                        "escalating to operator."
+                    ),
+                    subject=f"{context.session_name} crash loop",
+                    suggested_action=(
+                        "Check the role's account state and "
+                        "investigate the underlying crash before "
+                        "respawning again."
+                    ),
+                )
+                alerts.append("crash_loop")
+            else:
+                self._set_session_status(
+                    api,
+                    context,
+                    "recovering",
+                    reason="Role pane crashed (process exited)",
+                )
+                self._recover_session(
+                    api,
+                    context,
+                    failure_type="role_crashed",
+                    message=(
+                        f"Role pane returned to shell "
+                        f"({context.pane_command})"
+                    ),
+                )
+                alerts.append("role_crashed")
+        else:
+            api.clear_alert(context.session_name, "crash_loop")
+
+        if context.pane_stopped:
+            _emit_routed_alert(
+                api,
+                session_name=context.session_name,
+                alert_type="pane_stopped",
+                severity="error",
+                message=(
+                    f"{context.session_name} appears stuck: "
+                    f"{stopped_reason}. Open Workers and resume or "
+                    "restart the stopped session."
+                ),
+                subject=f"{context.session_name} process stopped",
+                suggested_action=(
+                    "Open Workers and resume or restart the stopped session."
+                ),
+            )
+            alerts.append("pane_stopped")
+        else:
+            api.clear_alert(context.session_name, "pane_stopped")
 
     def _handle_auth_failure(
         self,


### PR DESCRIPTION
## Summary

Targeted slice of #1356. Extracts cohesive blocks from the three currently-longest functions in the codebase. PURE refactor — no behaviour change.

| Function | Before | After | Helpers extracted |
|---|---:|---:|---|
| `_dashboard_inbox` (`cockpit_ui.py`) | 383 | 230 | `_dashboard_inbox_finalize`, `_dashboard_inbox_build_message_item` |
| `_process_session` (`heartbeats/local.py`) | 367 | 173 | `_dispatch_health_intervention`, `_handle_auth_failure`, `_handle_pane_health_alerts` |
| `load_inbox_entries` (`cockpit_inbox_items.py`) | 333 | 177 | `_emit_task_inbox_entries`, `_load_inbox_entries_pg` |

Each helper is a real abstraction (sort + projection tail, per-row builder, decision-tree branch, etc.), not a split at line N. Each lands in its own commit so reviewers can step through. The remaining 11 functions in #1356 stay open under that issue.

`_dashboard_inbox` is still over the 200 LOC bar (230) — its remaining bulk is the cache-check / IO-bail-out / two-pass collection scaffold which doesn't have an obvious further split. Down 40% is still a real win and the per-row builder is now individually unit-testable.

## Test plan

- [ ] Cockpit dashboard inbox renders identically (top-3 cards, action cards, count badge)
- [ ] `pm doctor` / heartbeat tick still classifies auth_broken / pane_dead / pane_stopped sessions correctly
- [ ] Cockpit inbox lens (`pm inbox`) returns the same entries on both sqlite and pg backends
- [ ] `ruff check` on touched files reports no new errors (verified: 54 pre-existing, 0 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)