### PR TITLE
test(pg): re-add flow_progression + cockpit + workflow coverage (closes #1785 #1794 #1824)

### DIFF
--- a/tests/test_pg_flow_progression.py
+++ b/tests/test_pg_flow_progression.py
@@ -1,0 +1,585 @@
+"""Pg re-coverage of flow progression (#1785).
+
+Replaces the sqlite-bound ``tests/test_flow_progression.py`` that
+Slice K-tests part 4 (#1786) deleted. Ports the backend-neutral parts
+of the deleted suite — ``node_done``, ``approve``, ``reject``, ``block``,
+spike flow, and ``get_execution`` filter coverage — against the
+``pg_work_service`` fixture.
+
+What stays sqlite-only / out of scope here
+------------------------------------------
+
+The deleted module also exercised the filesystem ``project_path`` git
+auto-merge path (``approve`` against a real repo with task-branch
+worktree, uncommitted-changes gate, ``.gitignore`` add/add union,
+issues/ scaffold allow-list, itsalive scaffold allow-list, #946/#947
+pre-stage + preserve-local-only logic). PgWorkService.approve still
+flags ``resume_merge`` as Slice C ("git auto-merge is Slice C") so the
+git-side gates haven't been ported to pg yet. Those tests are
+intentionally not re-added here — they belong with the git-merge port
+(see #1785 follow-up + the pg-side seam tracker).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pollypm.rejection_feedback import (
+    feedback_target_task_id,
+    is_rejection_feedback_task,
+    rejection_feedback_preview,
+)
+from pollypm.work.models import (
+    Artifact,
+    ArtifactKind,
+    Decision,
+    ExecutionStatus,
+    OutputType,
+    WorkOutput,
+    WorkStatus,
+)
+from pollypm.work.service_support import (
+    InvalidTransitionError,
+    ValidationError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_task(svc, flow="standard", **kwargs):
+    defaults = dict(
+        title="Test task",
+        description="A test task",
+        type="task",
+        project="proj",
+        flow_template=flow,
+        roles={"worker": "pete", "reviewer": "polly"},
+        priority="normal",
+        created_by="tester",
+    )
+    defaults.update(kwargs)
+    return svc.create(**defaults)
+
+
+def _create_spike_task(svc, **kwargs):
+    defaults = dict(
+        title="Spike task",
+        description="Research something",
+        type="spike",
+        project="proj",
+        flow_template="spike",
+        roles={"worker": "pete"},
+        priority="normal",
+        created_by="tester",
+    )
+    defaults.update(kwargs)
+    return svc.create(**defaults)
+
+
+def _valid_work_output():
+    return WorkOutput(
+        type=OutputType.CODE_CHANGE,
+        summary="Implemented the feature",
+        artifacts=[
+            Artifact(
+                kind=ArtifactKind.COMMIT,
+                description="feat: add new feature",
+                ref="abc123",
+            ),
+        ],
+    )
+
+
+def _claim_task(svc, task):
+    """Queue and claim a task, returning the claimed task."""
+    svc.queue(task.task_id, "pm")
+    return svc.claim(task.task_id, "pete")
+
+
+def _current_work_node(svc, task):
+    """Return the active work node id from the flow template."""
+    flow = svc.get_flow(task.flow_template_id)
+    for node_id, node in flow.nodes.items():
+        if getattr(node.type, "value", node.type) == "work":
+            return node_id
+    raise AssertionError("no work node in flow")
+
+
+# ---------------------------------------------------------------------------
+# node_done
+# ---------------------------------------------------------------------------
+
+
+class TestNodeDone:
+    def test_node_done_advances_to_review(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_task(svc)
+        claimed = _claim_task(svc, task)
+        assert claimed.work_status == WorkStatus.IN_PROGRESS
+        work_node = claimed.current_node_id
+
+        result = svc.node_done(task.task_id, "pete", _valid_work_output())
+        assert result.work_status == WorkStatus.REVIEW
+
+        # The work execution should be completed
+        execs = svc.get_execution(task.task_id, node_id=work_node)
+        assert len(execs) == 1
+        assert execs[0].status == ExecutionStatus.COMPLETED
+        assert execs[0].completed_at is not None
+
+        # A new review execution should be active
+        review_node = result.current_node_id
+        review_execs = svc.get_execution(task.task_id, node_id=review_node)
+        assert len(review_execs) == 1
+        assert review_execs[0].status == ExecutionStatus.ACTIVE
+
+    def test_node_done_without_work_output_rejected(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_task(svc)
+        _claim_task(svc, task)
+
+        # After wg03, the error message is longer (three-question rule)
+        # but still mentions --output, which is the actionable fix.
+        with pytest.raises(ValidationError, match="--output"):
+            svc.node_done(task.task_id, "pete", None)
+
+    def test_node_done_with_empty_artifacts_rejected(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_task(svc)
+        _claim_task(svc, task)
+
+        bad_output = WorkOutput(
+            type=OutputType.CODE_CHANGE,
+            summary="Did something",
+            artifacts=[],
+        )
+        with pytest.raises(ValidationError, match="at least one artifact"):
+            svc.node_done(task.task_id, "pete", bad_output)
+
+    def test_node_done_wrong_actor_rejected(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_task(svc)
+        _claim_task(svc, task)
+
+        with pytest.raises(ValidationError, match="does not match role"):
+            svc.node_done(task.task_id, "polly", _valid_work_output())
+
+    def test_node_done_not_in_progress_rejected(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_task(svc)
+        # Task is in draft state — node_done can't run.
+        with pytest.raises(InvalidTransitionError):
+            svc.node_done(task.task_id, "pete", _valid_work_output())
+
+
+# ---------------------------------------------------------------------------
+# approve
+# ---------------------------------------------------------------------------
+
+
+class TestApprove:
+    def test_approve_advances_to_done(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_task(svc)
+        _claim_task(svc, task)
+        svc.node_done(task.task_id, "pete", _valid_work_output())
+
+        result = svc.approve(task.task_id, "polly")
+        assert result.work_status == WorkStatus.DONE
+        assert result.current_node_id is None
+
+    def test_approve_wrong_actor_rejected(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_task(svc)
+        _claim_task(svc, task)
+        svc.node_done(task.task_id, "pete", _valid_work_output())
+
+        with pytest.raises(ValidationError, match="does not match role"):
+            svc.approve(task.task_id, "pete")
+
+    def test_approve_not_in_review_rejected(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_task(svc)
+        _claim_task(svc, task)
+        # Task is in_progress, not review
+        with pytest.raises(InvalidTransitionError):
+            svc.approve(task.task_id, "polly")
+
+    def test_approve_at_terminal_makes_done(self, pg_work_service):
+        """Standard flow: after review approve, task is done."""
+        svc = pg_work_service
+        task = _create_task(svc)
+        _claim_task(svc, task)
+        done = svc.node_done(task.task_id, "pete", _valid_work_output())
+        review_node = done.current_node_id
+
+        result = svc.approve(task.task_id, "polly", reason="LGTM")
+        assert result.work_status == WorkStatus.DONE
+
+        # Check the review execution has approved decision
+        review_execs = svc.get_execution(task.task_id, node_id=review_node)
+        assert len(review_execs) == 1
+        assert review_execs[0].decision == Decision.APPROVED
+        assert review_execs[0].decision_reason == "LGTM"
+
+
+# ---------------------------------------------------------------------------
+# reject
+# ---------------------------------------------------------------------------
+
+
+class TestReject:
+    def test_reject_loops_back_to_rework(self, pg_work_service):
+        """#777 — reviewer rejection now lands the task in an explicit
+        REWORK state. The rework node + assignee are still active so
+        a worker can re-claim and continue."""
+        svc = pg_work_service
+        task = _create_task(svc)
+        claimed = _claim_task(svc, task)
+        work_node = claimed.current_node_id
+        svc.node_done(task.task_id, "pete", _valid_work_output())
+
+        result = svc.reject(task.task_id, "polly", "Needs more tests")
+        assert result.work_status == WorkStatus.REWORK
+        assert result.current_node_id == work_node
+
+        # New execution at the work node with visit=2
+        impl_execs = svc.get_execution(task.task_id, node_id=work_node)
+        assert len(impl_execs) == 2
+        assert impl_execs[0].visit == 1
+        assert impl_execs[0].status == ExecutionStatus.COMPLETED
+        assert impl_execs[1].visit == 2
+        assert impl_execs[1].status == ExecutionStatus.ACTIVE
+
+    def test_rework_can_advance_via_node_done(self, pg_work_service):
+        """#777 — after rejection, the worker re-runs the work node and
+        calls node_done. REWORK must be a valid source state for the
+        node-done transition.
+        """
+        svc = pg_work_service
+        task = _create_task(svc)
+        _claim_task(svc, task)
+        svc.node_done(task.task_id, "pete", _valid_work_output())
+        rejected = svc.reject(task.task_id, "polly", "needs more tests")
+        assert rejected.work_status == WorkStatus.REWORK
+
+        re_done = svc.node_done(task.task_id, "pete", _valid_work_output())
+        # Next node is review again, so status moves to REVIEW.
+        assert re_done.work_status == WorkStatus.REVIEW
+
+    def test_reject_without_reason_rejected(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_task(svc)
+        _claim_task(svc, task)
+        svc.node_done(task.task_id, "pete", _valid_work_output())
+
+        with pytest.raises(ValidationError, match="Reason is required"):
+            svc.reject(task.task_id, "polly", "")
+
+    def test_reject_creates_feedback_inbox_item(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_task(svc)
+        _claim_task(svc, task)
+        svc.node_done(task.task_id, "pete", _valid_work_output())
+
+        svc.reject(task.task_id, "polly", "Needs better rollback coverage")
+
+        feedback_tasks = [
+            candidate
+            for candidate in svc.list_tasks(project="proj")
+            if is_rejection_feedback_task(candidate)
+        ]
+        assert len(feedback_tasks) == 1
+        feedback = feedback_tasks[0]
+        assert feedback_target_task_id(feedback) == task.task_id
+        assert (
+            rejection_feedback_preview(feedback)
+            == "Needs better rollback coverage"
+        )
+
+    def test_full_rejection_cycle(self, pg_work_service):
+        """implement(v1) -> review -> reject -> implement(v2) -> review -> approve -> done"""
+        svc = pg_work_service
+        task = _create_task(svc)
+        claimed = _claim_task(svc, task)
+        work_node = claimed.current_node_id
+
+        # v1: implement -> review -> reject
+        svc.node_done(task.task_id, "pete", _valid_work_output())
+        rejected = svc.reject(task.task_id, "polly", "Needs work")
+        # capture review_node from the v1 cycle
+        v1_review_execs = svc.get_execution(task.task_id)
+        review_node = next(
+            (
+                row.node_id
+                for row in v1_review_execs
+                if row.node_id != work_node
+            ),
+            None,
+        )
+        assert review_node is not None
+        assert rejected.work_status == WorkStatus.REWORK
+
+        # v2: implement -> review -> approve
+        wo2 = WorkOutput(
+            type=OutputType.CODE_CHANGE,
+            summary="Fixed the issues",
+            artifacts=[
+                Artifact(
+                    kind=ArtifactKind.COMMIT,
+                    description="fix: address review feedback",
+                    ref="def456",
+                ),
+            ],
+        )
+        svc.node_done(task.task_id, "pete", wo2)
+        result = svc.approve(task.task_id, "polly")
+
+        assert result.work_status == WorkStatus.DONE
+
+        # Should have 4 execution records total:
+        # work v1, review v1, work v2, review v2
+        all_execs = svc.get_execution(task.task_id)
+        assert len(all_execs) == 4
+
+        impl_execs = svc.get_execution(task.task_id, node_id=work_node)
+        assert len(impl_execs) == 2
+        assert impl_execs[0].visit == 1
+        assert impl_execs[1].visit == 2
+
+        review_execs = svc.get_execution(task.task_id, node_id=review_node)
+        assert len(review_execs) == 2
+        assert review_execs[0].visit == 1
+        assert review_execs[0].decision == Decision.REJECTED
+        assert review_execs[1].visit == 2
+        assert review_execs[1].decision == Decision.APPROVED
+
+
+# ---------------------------------------------------------------------------
+# block
+# ---------------------------------------------------------------------------
+
+
+class TestBlock:
+    def test_block_sets_status(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_task(svc)
+        claimed = _claim_task(svc, task)
+        work_node = claimed.current_node_id
+
+        blocker = _create_task(svc, title="Blocker task")
+
+        result = svc.block(task.task_id, "pm", blocker.task_id)
+        assert result.work_status == WorkStatus.BLOCKED
+
+        # Execution should be blocked
+        execs = svc.get_execution(task.task_id, node_id=work_node)
+        assert len(execs) == 1
+        assert execs[0].status == ExecutionStatus.BLOCKED
+
+    def test_block_persists_dependency_row(self, pg_work_service):
+        """block() must INSERT a blocks row so auto-unblock can find it
+        when the blocker reaches done (issue #133)."""
+        svc = pg_work_service
+        task = _create_task(svc)
+        _claim_task(svc, task)
+
+        blocker = _create_task(svc, title="Blocker task")
+
+        svc.block(task.task_id, "pm", blocker.task_id)
+
+        # The dependency row is on the task — blocked_by should reflect it
+        blocked = svc.get(task.task_id)
+        assert (blocker.project, blocker.task_number) in blocked.blocked_by
+
+        # dependents() from the blocker's side should list the blocked task
+        deps = svc.dependents(blocker.task_id)
+        assert any(d.task_id == task.task_id for d in deps)
+
+    def test_block_then_blocker_done_auto_unblocks(self, pg_work_service):
+        """After block(), marking the blocker done should auto-unblock the
+        task via the auto-unblock cascade (issue #133)."""
+        svc = pg_work_service
+        task = _create_task(svc)
+        _claim_task(svc, task)
+
+        blocker = _create_task(svc, title="Blocker task")
+
+        svc.block(task.task_id, "pm", blocker.task_id)
+        assert svc.get(task.task_id).work_status == WorkStatus.BLOCKED
+
+        # Move blocker to done — auto-unblock should fire.
+        svc.mark_done(blocker.task_id, "agent-1")
+
+        # Task was IN_PROGRESS before block; auto-unblock returns it to queued.
+        unblocked = svc.get(task.task_id)
+        assert unblocked.work_status == WorkStatus.QUEUED
+
+    def test_block_fires_sync_adapters(self, pg_schema_pool):
+        """block() must call _sync_transition so adapters see the blocked
+        state (issue #136)."""
+        from pollypm.work.pg_service import PgWorkService
+        from pollypm.work.sync import SyncManager
+
+        events: list[tuple[str, str, str]] = []
+
+        class RecordingAdapter:
+            name = "recorder"
+
+            def on_create(self, task):
+                events.append(("create", task.task_id, ""))
+
+            def on_transition(self, task, old_status, new_status):
+                events.append(("transition", old_status, new_status))
+
+            def on_update(self, task, changed_fields):
+                events.append(("update", task.task_id, ",".join(changed_fields)))
+
+        mgr = SyncManager()
+        mgr.register(RecordingAdapter())
+        svc = PgWorkService(pool=pg_schema_pool, ro_pool=None, sync_manager=mgr)
+
+        task = _create_task(svc)
+        _claim_task(svc, task)
+        blocker = _create_task(svc, title="Blocker task")
+
+        events.clear()
+        svc.block(task.task_id, "pm", blocker.task_id)
+
+        # Must have fired a transition event with new_status == 'blocked'
+        transition_events = [e for e in events if e[0] == "transition"]
+        assert any(
+            new == WorkStatus.BLOCKED.value for _, _, new in transition_events
+        ), f"Expected blocked transition in {transition_events}"
+
+
+# ---------------------------------------------------------------------------
+# spike flow (no review)
+# ---------------------------------------------------------------------------
+
+
+class TestSpikeFlow:
+    def test_spike_flow_no_review(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_spike_task(svc)
+        svc.queue(task.task_id, "pm")
+        svc.claim(task.task_id, "pete")
+
+        wo = WorkOutput(
+            type=OutputType.DOCUMENT,
+            summary="Research findings",
+            artifacts=[
+                Artifact(
+                    kind=ArtifactKind.NOTE,
+                    description="Found that X is better than Y",
+                ),
+            ],
+        )
+        result = svc.node_done(task.task_id, "pete", wo)
+        assert result.work_status == WorkStatus.DONE
+        assert result.current_node_id is None
+
+
+# ---------------------------------------------------------------------------
+# get_execution filters
+# ---------------------------------------------------------------------------
+
+
+class TestGetExecution:
+    def test_execution_audit_trail(self, pg_work_service):
+        """Full lifecycle with one rejection."""
+        svc = pg_work_service
+        task = _create_task(svc)
+        _claim_task(svc, task)
+        svc.node_done(task.task_id, "pete", _valid_work_output())
+        svc.reject(task.task_id, "polly", "Not good enough")
+        svc.node_done(task.task_id, "pete", _valid_work_output())
+        svc.approve(task.task_id, "polly")
+
+        all_execs = svc.get_execution(task.task_id)
+        # work v1, review v1, work v2, review v2
+        assert len(all_execs) == 4
+
+        # All should be completed
+        for ex in all_execs:
+            assert ex.status == ExecutionStatus.COMPLETED
+
+        # Check decisions — find the review-node executions by decision presence
+        review_execs = [e for e in all_execs if e.decision is not None]
+        assert len(review_execs) == 2
+        review_execs.sort(key=lambda e: e.visit)
+        assert review_execs[0].decision == Decision.REJECTED
+        assert review_execs[0].decision_reason == "Not good enough"
+        assert review_execs[1].decision == Decision.APPROVED
+
+    def test_work_output_stored_on_execution(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_task(svc)
+        claimed = _claim_task(svc, task)
+        work_node = claimed.current_node_id
+
+        wo = WorkOutput(
+            type=OutputType.CODE_CHANGE,
+            summary="Built the feature",
+            artifacts=[
+                Artifact(
+                    kind=ArtifactKind.COMMIT,
+                    description="feat: the thing",
+                    ref="sha123",
+                ),
+                Artifact(
+                    kind=ArtifactKind.FILE_CHANGE,
+                    description="Modified src/main.py",
+                    path="src/main.py",
+                ),
+            ],
+        )
+        svc.node_done(task.task_id, "pete", wo)
+
+        execs = svc.get_execution(task.task_id, node_id=work_node)
+        assert len(execs) == 1
+        stored = execs[0].work_output
+        assert stored is not None
+        assert stored.type == OutputType.CODE_CHANGE
+        assert stored.summary == "Built the feature"
+        assert len(stored.artifacts) == 2
+        assert stored.artifacts[0].kind == ArtifactKind.COMMIT
+        assert stored.artifacts[0].ref == "sha123"
+        assert stored.artifacts[1].path == "src/main.py"
+
+    def test_get_execution_filters(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_task(svc)
+        claimed = _claim_task(svc, task)
+        work_node = claimed.current_node_id
+        done = svc.node_done(task.task_id, "pete", _valid_work_output())
+        review_node = done.current_node_id
+
+        svc.reject(task.task_id, "polly", "Redo it")
+        svc.node_done(task.task_id, "pete", _valid_work_output())
+        svc.approve(task.task_id, "polly")
+
+        # Filter by node_id
+        impl_only = svc.get_execution(task.task_id, node_id=work_node)
+        assert len(impl_only) == 2
+
+        review_only = svc.get_execution(task.task_id, node_id=review_node)
+        assert len(review_only) == 2
+
+        # Filter by visit
+        visit1 = svc.get_execution(task.task_id, visit=1)
+        assert all(e.visit == 1 for e in visit1)
+
+        visit2 = svc.get_execution(task.task_id, visit=2)
+        assert all(e.visit == 2 for e in visit2)
+
+        # Filter by both
+        impl_v2 = svc.get_execution(
+            task.task_id, node_id=work_node, visit=2
+        )
+        assert len(impl_v2) == 1
+        assert impl_v2[0].node_id == work_node
+        assert impl_v2[0].visit == 2

--- a/tests/test_pg_inbox_actions.py
+++ b/tests/test_pg_inbox_actions.py
@@ -1,0 +1,211 @@
+"""Pg re-coverage of work-service inbox interaction methods (#1794).
+
+Replaces the sqlite-bound ``tests/test_inbox_actions.py`` that
+Slice K-tests part 6 (#1795) deleted. The deleted module's body was
+gated behind a module-level ``xfail`` referencing #1776 (PgWorkService
+missing add_reply/list_replies/mark_read/archive_task). #1776 closed
+in #1784 — these methods are live on PgWorkService — so the xfail can
+come off and the assertions can run for real.
+
+Covers the four methods the cockpit Textual inbox screen calls:
+``add_reply``, ``list_replies``, ``mark_read``, ``archive_task``.
+
+The deleted module also contained a ``TestResolveInboxWorkService``
+class that exercised dual-DB resolution between workspace and per-
+project sqlite state.dbs. That code path doesn't exist under pg
+(``resolve_work_db_path`` was a sqlite-only seam) — there is no pg
+equivalent to port, so that test class is intentionally not
+re-added.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from pollypm.work.models import WorkStatus
+from pollypm.work.service_support import (
+    TaskNotFoundError,
+    ValidationError,
+)
+
+
+def _inbox_task(svc, *, title: str = "Hello Sam", body: str = "Read me.") -> str:
+    """Create a chat-flow task in the same shape ``pm notify`` does."""
+    task = svc.create(
+        title=title,
+        description=body,
+        type="task",
+        project="demo",
+        flow_template="chat",
+        roles={"requester": "user", "operator": "polly"},
+        priority="normal",
+        created_by="polly",
+    )
+    return task.task_id
+
+
+# ---------------------------------------------------------------------------
+# add_reply
+# ---------------------------------------------------------------------------
+
+
+class TestAddReply:
+    def test_reply_persisted_as_reply_entry_type(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        entry = svc.add_reply(task_id, "Thanks for the update.", actor="user")
+        assert entry.entry_type == "reply"
+        assert entry.actor == "user"
+        assert entry.text == "Thanks for the update."
+
+    def test_reply_strips_whitespace(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        entry = svc.add_reply(task_id, "  hi  ", actor="user")
+        assert entry.text == "hi"
+
+    def test_empty_reply_rejected(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        with pytest.raises(ValidationError):
+            svc.add_reply(task_id, "   ", actor="user")
+
+    def test_reply_to_missing_task_raises(self, pg_work_service):
+        svc = pg_work_service
+        with pytest.raises(TaskNotFoundError):
+            svc.add_reply("demo/999", "ping", actor="user")
+
+    def test_multiple_replies_are_independent_rows(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        svc.add_reply(task_id, "one", actor="user")
+        svc.add_reply(task_id, "two", actor="user")
+        svc.add_reply(task_id, "three", actor="user")
+        entries = svc.list_replies(task_id)
+        assert [e.text for e in entries] == ["one", "two", "three"]
+
+
+# ---------------------------------------------------------------------------
+# list_replies
+# ---------------------------------------------------------------------------
+
+
+class TestListReplies:
+    def test_returns_replies_oldest_first(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        svc.add_reply(task_id, "first", actor="user")
+        time.sleep(0.01)
+        svc.add_reply(task_id, "second", actor="user")
+        entries = svc.list_replies(task_id)
+        assert [e.text for e in entries] == ["first", "second"]
+
+    def test_excludes_non_reply_context(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        svc.add_context(task_id, "system", "a note")
+        svc.add_reply(task_id, "a reply", actor="user")
+        entries = svc.list_replies(task_id)
+        # Only the reply row surfaces in list_replies.
+        assert [e.text for e in entries] == ["a reply"]
+        assert all(e.entry_type == "reply" for e in entries)
+
+    def test_empty_when_no_replies(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        assert svc.list_replies(task_id) == []
+
+
+# ---------------------------------------------------------------------------
+# mark_read
+# ---------------------------------------------------------------------------
+
+
+class TestMarkRead:
+    def test_first_read_writes_marker(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        assert svc.mark_read(task_id, actor="user") is True
+
+    def test_repeat_read_is_idempotent(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        assert svc.mark_read(task_id, actor="user") is True
+        # Second call must not write a duplicate row and must return
+        # False so callers can gate event emission on it.
+        assert svc.mark_read(task_id, actor="user") is False
+
+    def test_marker_lives_as_read_entry_type(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        svc.mark_read(task_id, actor="user")
+        reads = svc.get_context(task_id, entry_type="read")
+        assert len(reads) == 1
+        assert reads[0].entry_type == "read"
+
+    def test_read_markers_do_not_pollute_replies(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        svc.mark_read(task_id, actor="user")
+        svc.add_reply(task_id, "hey", actor="user")
+        # Reply list ignores the read marker; mark_read is idempotent
+        # so no duplicate read rows exist either.
+        assert len(svc.list_replies(task_id)) == 1
+        assert len(svc.get_context(task_id, entry_type="read")) == 1
+
+    def test_mark_read_on_missing_task_raises(self, pg_work_service):
+        svc = pg_work_service
+        with pytest.raises(TaskNotFoundError):
+            svc.mark_read("demo/404", actor="user")
+
+
+# ---------------------------------------------------------------------------
+# archive_task
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveTask:
+    def test_archive_flips_status_to_done(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        archived = svc.archive_task(task_id, actor="user")
+        assert archived.work_status == WorkStatus.DONE
+
+    def test_archive_records_transition(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        svc.archive_task(task_id, actor="user")
+        task = svc.get(task_id)
+        # The transition row is written with actor="user" and a
+        # recognisable reason tag so consumers can tell it apart from
+        # the standard mark_done path.
+        assert any(
+            tr.to_state == WorkStatus.DONE.value
+            and tr.actor == "user"
+            and (tr.reason or "").startswith("inbox.archive")
+            for tr in task.transitions
+        )
+
+    def test_archive_is_idempotent(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _inbox_task(svc)
+        first = svc.archive_task(task_id, actor="user")
+        second = svc.archive_task(task_id, actor="user")
+        assert first.work_status == WorkStatus.DONE
+        assert second.work_status == WorkStatus.DONE
+        # Second call must not append a second transition — otherwise
+        # dashboard counts would double-count an archive click.
+        task = svc.get(task_id)
+        archive_transitions = [
+            tr for tr in task.transitions
+            if tr.to_state == WorkStatus.DONE.value
+            and (tr.reason or "").startswith("inbox.archive")
+        ]
+        assert len(archive_transitions) == 1
+
+    def test_archive_on_missing_task_raises(self, pg_work_service):
+        svc = pg_work_service
+        with pytest.raises(TaskNotFoundError):
+            svc.archive_task("demo/777", actor="user")

--- a/tests/test_pg_inbox_kind.py
+++ b/tests/test_pg_inbox_kind.py
@@ -1,0 +1,98 @@
+"""Inbox-kind taxonomy + pg round-trip coverage (#1794).
+
+Replaces the backend-neutral half of the deleted
+``tests/test_inbox_kind_schema.py``:
+
+* Enum stability — every on-disk value is fixed so a typo can't orphan
+  legacy rows.
+* ``coerce_kind`` fallback semantics (None / unknown → LEGACY).
+* ``work_tasks.kind`` round-trip through :meth:`PgWorkService.create`.
+
+The deleted module also exercised the SQLite pre-migration backfill
+path (raw ``CREATE TABLE`` with the old column shape, then run
+``SQLiteWorkService``'s migrator). The pg backend doesn't have a
+pre-migration legacy DB shape to backfill from — the migrations
+applier provisions ``kind`` with the row creation — so that test
+is intentionally not re-added.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pollypm.inbox.kind import InboxItemKind, coerce_kind
+
+
+# ---------------------------------------------------------------------------
+# Enum stability
+# ---------------------------------------------------------------------------
+
+
+def test_inbox_item_kind_values_are_stable():
+    """The on-disk strings must never drift. If you add a member, do
+    it here; if you find yourself wanting to rename one, don't — every
+    legacy row holds the literal string."""
+    assert {k.value for k in InboxItemKind} == {
+        "plan_review_pending",
+        "approval_request",
+        "pm_question_unanswered",
+        "watchdog_operator_dispatch",
+        "manual_decision",
+        "completion_fyi",
+        "self_bug_report",
+        "activity_event",
+        "info",
+        "legacy",
+    }
+
+
+def test_coerce_kind_handles_unknown_and_none():
+    assert coerce_kind(None) is InboxItemKind.LEGACY
+    assert coerce_kind("not-a-real-kind") is InboxItemKind.LEGACY
+    assert (
+        coerce_kind("plan_review_pending")
+        is InboxItemKind.PLAN_REVIEW_PENDING
+    )
+    assert (
+        coerce_kind(InboxItemKind.MANUAL_DECISION)
+        is InboxItemKind.MANUAL_DECISION
+    )
+
+
+# ---------------------------------------------------------------------------
+# work_tasks.kind — pg round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", list(InboxItemKind))
+def test_work_tasks_kind_round_trip_via_create(pg_work_service, kind):
+    """Every enum value survives create() -> get() unchanged on pg."""
+    svc = pg_work_service
+    task = svc.create(
+        title=f"task for {kind.value}",
+        description="round-trip",
+        type="task",
+        project="proj",
+        flow_template="standard",
+        roles={"worker": "agent-1", "reviewer": "agent-2"},
+        created_by="tester",
+        kind=kind.value,
+    )
+    loaded = svc.get(task.task_id)
+    assert loaded.kind is kind
+
+
+def test_work_tasks_kind_defaults_to_legacy(pg_work_service):
+    """No explicit ``kind`` argument should default to LEGACY."""
+    svc = pg_work_service
+    task = svc.create(
+        title="no kind specified",
+        description="default",
+        type="task",
+        project="proj",
+        flow_template="standard",
+        roles={"worker": "agent-1", "reviewer": "agent-2"},
+        created_by="tester",
+    )
+    loaded = svc.get(task.task_id)
+    assert loaded.kind is InboxItemKind.LEGACY

--- a/tests/test_pg_sync_adapters.py
+++ b/tests/test_pg_sync_adapters.py
@@ -1,0 +1,388 @@
+"""Pg re-coverage of sync adapters + SyncManager + work-service sync API (#1785).
+
+Replaces the sqlite-bound ``tests/test_sync_adapters.py`` that Slice
+K-tests part 4 (#1786) deleted. The deleted module covered:
+
+* :class:`FileSyncAdapter` — file/markdown writes, status mapping,
+  auto-commit, scaffold-issue-tracker idempotence (backend-neutral).
+* :class:`GitHubSyncAdapter` — ``gh`` shell-outs for create / transition /
+  update; status label mapping (mostly backend-neutral; one test
+  exercises the work-service constructor's ``sync_manager`` kwarg).
+* :class:`SyncManager` — fan-out + failure isolation (backend-neutral).
+* :mod:`pollypm.work.migrate` — ``migrate_issues`` happy-path + idempotence
+  (touches work-service ``create`` / ``list_tasks``).
+* The work-service's ``sync_status`` / ``trigger_sync`` Protocol surface —
+  this is the part that was blocked by #1775 (now closed): pg's
+  :class:`PgWorkService` constructor accepts ``sync_manager`` and the
+  protocol methods land sync_state rows.
+
+This module re-ports the work-service-coupled tests (TestSyncStatus +
+TestTriggerSync + the GitHub-ref persistence smoke + the migrate
+happy-path) against the ``pg_work_service`` fixture so the contract
+re-enters CI under the pg backend. The adapter-only tests
+(FileSyncAdapter, GitHubSyncAdapter, SyncManager, _parse_filename,
+_parse_content) are backend-agnostic — they don't go through the
+work-service at all — so they're omitted here to keep the file
+focused on the actual gap (#1785). Those backend-neutral tests can
+be restored separately if they're not covered elsewhere.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pollypm.work.migrate import migrate_issues
+from pollypm.work.models import WorkStatus
+from pollypm.work.service_support import TaskNotFoundError
+from pollypm.work.sync import SyncManager
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(svc, title="Test task", description="A description", **kwargs):
+    """Standard task on the pg work-service."""
+    defaults = dict(
+        title=title,
+        description=description,
+        type="task",
+        project="proj",
+        flow_template="standard",
+        roles={"worker": "agent-1", "reviewer": "agent-2"},
+        priority="normal",
+        created_by="tester",
+    )
+    defaults.update(kwargs)
+    return svc.create(**defaults)
+
+
+class _RecordingAdapter:
+    """Adapter that records every dispatch and can be told to fail."""
+
+    def __init__(self, name: str = "rec", fail: bool = False) -> None:
+        self.name = name
+        self.fail = fail
+        self.creates: list[str] = []
+        self.transitions: list[tuple[str, str, str]] = []
+        self.updates: list[tuple[str, list[str]]] = []
+
+    def on_create(self, task):
+        if self.fail:
+            raise RuntimeError(f"{self.name}: boom")
+        self.creates.append(task.task_id)
+
+    def on_transition(self, task, old_status, new_status):
+        self.transitions.append((task.task_id, old_status, new_status))
+
+    def on_update(self, task, changed_fields):
+        self.updates.append((task.task_id, list(changed_fields)))
+
+
+# ---------------------------------------------------------------------------
+# PgWorkService.sync_status — Protocol surface (#1785)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncStatus:
+    def test_sync_status_unknown_task_raises(self, pg_work_service):
+        with pytest.raises(TaskNotFoundError):
+            pg_work_service.sync_status("proj/999")
+
+    def test_sync_status_no_adapters(self, pg_work_service):
+        """A task with no sync adapters returns an empty dict."""
+        task = _make_task(pg_work_service)
+        assert pg_work_service.sync_status(task.task_id) == {}
+
+    def test_sync_status_lists_registered_adapters_with_no_row(
+        self, pg_schema_pool
+    ):
+        """Adapters that have never synced show as ``attempts=0``."""
+        from pollypm.work.pg_service import PgWorkService
+
+        mgr = SyncManager()
+        mgr.register(_RecordingAdapter(name="rec"))
+        svc = PgWorkService(pool=pg_schema_pool, ro_pool=None, sync_manager=mgr)
+        task = _make_task(svc)
+
+        status = svc.sync_status(task.task_id)
+        assert "rec" in status
+        assert status["rec"]["attempts"] == 0
+        assert status["rec"]["last_synced_at"] is None
+        assert status["rec"]["last_error"] is None
+
+
+# ---------------------------------------------------------------------------
+# PgWorkService.trigger_sync — Protocol surface (#1785)
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerSync:
+    def test_trigger_sync_all_tasks(self, pg_schema_pool):
+        from pollypm.work.pg_service import PgWorkService
+
+        mgr = SyncManager()
+        ad = _RecordingAdapter(name="rec")
+        mgr.register(ad)
+        svc = PgWorkService(pool=pg_schema_pool, ro_pool=None, sync_manager=mgr)
+
+        t1 = _make_task(svc, title="A")
+        t2 = _make_task(svc, title="B")
+        # Drop the on_create dispatches that fired during svc.create().
+        ad.creates.clear()
+
+        result = svc.trigger_sync()
+        assert result["synced"] == 2
+        assert set(ad.creates) == {t1.task_id, t2.task_id}
+
+        # sync_status reflects the successful sync with attempts incremented
+        status = svc.sync_status(t1.task_id)
+        assert status["rec"]["attempts"] >= 1
+        assert status["rec"]["last_error"] is None
+        assert status["rec"]["last_synced_at"] is not None
+
+    def test_trigger_sync_specific_task(self, pg_schema_pool):
+        from pollypm.work.pg_service import PgWorkService
+
+        mgr = SyncManager()
+        ad = _RecordingAdapter(name="rec")
+        mgr.register(ad)
+        svc = PgWorkService(pool=pg_schema_pool, ro_pool=None, sync_manager=mgr)
+
+        t1 = _make_task(svc, title="A")
+        _make_task(svc, title="B")
+        ad.creates.clear()
+
+        result = svc.trigger_sync(task_id=t1.task_id)
+        assert result["synced"] == 1
+        assert ad.creates == [t1.task_id]
+
+    def test_trigger_sync_adapter_filter(self, pg_schema_pool):
+        from pollypm.work.pg_service import PgWorkService
+
+        mgr = SyncManager()
+        a1 = _RecordingAdapter(name="one")
+        a2 = _RecordingAdapter(name="two")
+        mgr.register(a1)
+        mgr.register(a2)
+        svc = PgWorkService(pool=pg_schema_pool, ro_pool=None, sync_manager=mgr)
+
+        t = _make_task(svc)
+        a1.creates.clear()
+        a2.creates.clear()
+
+        result = svc.trigger_sync(adapter="one")
+        assert result["synced"] == 1
+        assert a1.creates == [t.task_id]
+        assert a2.creates == []
+
+    def test_trigger_sync_records_errors(self, pg_schema_pool):
+        from pollypm.work.pg_service import PgWorkService
+
+        mgr = SyncManager()
+        failing = _RecordingAdapter(name="boomer", fail=True)
+        mgr.register(failing)
+        svc = PgWorkService(pool=pg_schema_pool, ro_pool=None, sync_manager=mgr)
+        task = _make_task(svc)
+
+        result = svc.trigger_sync()
+        assert result["synced"] == 0
+        assert task.task_id in result["errors"]["boomer"]
+
+        # sync_status must surface the last_error and a bumped attempt count
+        status = svc.sync_status(task.task_id)
+        assert "boom" in status["boomer"]["last_error"]
+        assert status["boomer"]["attempts"] >= 1
+
+    def test_trigger_sync_unknown_task_raises(self, pg_work_service):
+        with pytest.raises(TaskNotFoundError):
+            pg_work_service.trigger_sync(task_id="proj/999")
+
+    def test_trigger_sync_no_adapters(self, pg_work_service):
+        """Without a sync manager attached, returns an empty summary."""
+        _make_task(pg_work_service)
+        result = pg_work_service.trigger_sync()
+        assert result == {"synced": 0, "errors": {}}
+
+
+# ---------------------------------------------------------------------------
+# GitHub adapter — work-service round-trip of external_refs (#1785)
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubAdapterWorkServiceIntegration:
+    """Verify the ``sync_manager=`` constructor kwarg actually wires
+    the GitHub adapter so the ``external_refs`` it stamps survive the
+    create transaction. This is the half of the deleted test that was
+    blocked by #1775."""
+
+    def test_work_service_persists_created_issue_ref(self, pg_schema_pool):
+        from unittest.mock import MagicMock, patch
+
+        from pollypm.work.pg_service import PgWorkService
+        from pollypm.work.sync_github import GitHubSyncAdapter
+
+        manager = SyncManager()
+        manager.register(GitHubSyncAdapter(repo="owner/repo"))
+        svc = PgWorkService(
+            pool=pg_schema_pool, ro_pool=None, sync_manager=manager
+        )
+
+        with patch("pollypm.work.sync_github._run_gh") as mock_gh:
+            mock_gh.return_value = MagicMock(
+                stdout="https://github.com/owner/repo/issues/42\n"
+            )
+            task = _make_task(svc)
+
+        reloaded = svc.get(task.task_id)
+        assert reloaded.external_refs.get("github_issue") == "42"
+
+
+# ---------------------------------------------------------------------------
+# Migration tool — work-service create() round-trip (#1785)
+# ---------------------------------------------------------------------------
+
+
+class TestMigration:
+    def _setup_issue_file(
+        self, issues_dir: Path, folder: str, filename: str, content: str
+    ):
+        dirpath = issues_dir / folder
+        dirpath.mkdir(parents=True, exist_ok=True)
+        filepath = dirpath / filename
+        filepath.write_text(content, encoding="utf-8")
+        return filepath
+
+    def test_creates_tasks(self, pg_work_service, tmp_path):
+        svc = pg_work_service
+        issues_dir = tmp_path / "issues"
+        self._setup_issue_file(
+            issues_dir,
+            "00-not-ready",
+            "0001-setup-project.md",
+            "# Setup Project\n\nInitial setup tasks.",
+        )
+        self._setup_issue_file(
+            issues_dir,
+            "01-ready",
+            "0002-add-auth.md",
+            "# Add Authentication\n\nImplement login flow.",
+        )
+        self._setup_issue_file(
+            issues_dir,
+            "02-in-progress",
+            "0003-fix-bug.md",
+            "# Fix Bug\n\nResolve the crash.",
+        )
+
+        result = migrate_issues(issues_dir, svc, project="proj")
+
+        assert result.created == 3
+        assert result.skipped == 0
+        assert result.errors == []
+
+        tasks = svc.list_tasks(project="proj")
+        assert len(tasks) == 3
+
+    def test_preserves_content(self, pg_work_service, tmp_path):
+        svc = pg_work_service
+        issues_dir = tmp_path / "issues"
+        self._setup_issue_file(
+            issues_dir,
+            "00-not-ready",
+            "0001-my-task.md",
+            "# My Task\n\nThis is the detailed description.\n\n"
+            "With multiple paragraphs.",
+        )
+
+        result = migrate_issues(issues_dir, svc, project="proj")
+
+        assert result.created == 1
+        task = svc.list_tasks(project="proj")[0]
+        assert "detailed description" in task.description
+        assert "multiple paragraphs" in task.description
+
+    def test_idempotent(self, pg_work_service, tmp_path):
+        svc = pg_work_service
+        issues_dir = tmp_path / "issues"
+        self._setup_issue_file(
+            issues_dir,
+            "00-not-ready",
+            "0001-task-a.md",
+            "# Task A\n\nDescription A.",
+        )
+        self._setup_issue_file(
+            issues_dir,
+            "01-ready",
+            "0002-task-b.md",
+            "# Task B\n\nDescription B.",
+        )
+
+        result1 = migrate_issues(issues_dir, svc, project="proj")
+        assert result1.created == 2
+
+        result2 = migrate_issues(issues_dir, svc, project="proj")
+        assert result2.created == 0
+        assert result2.skipped == 2
+
+        tasks = svc.list_tasks(project="proj")
+        assert len(tasks) == 2
+
+    def test_handles_completed(self, pg_work_service, tmp_path):
+        """Completed issues end up as done in work service."""
+        svc = pg_work_service
+        issues_dir = tmp_path / "issues"
+        self._setup_issue_file(
+            issues_dir,
+            "05-completed",
+            "0001-old-task.md",
+            "# Old Task\n\nThis was already done.",
+        )
+
+        result = migrate_issues(issues_dir, svc, project="proj")
+
+        assert result.created == 1
+        task = svc.list_tasks(project="proj")[0]
+        assert task.work_status == WorkStatus.DONE
+
+    def test_handles_ready_as_queued(self, pg_work_service, tmp_path):
+        svc = pg_work_service
+        issues_dir = tmp_path / "issues"
+        self._setup_issue_file(
+            issues_dir,
+            "01-ready",
+            "0001-ready-task.md",
+            "# Ready Task\n\nWaiting to start.",
+        )
+
+        result = migrate_issues(issues_dir, svc, project="proj")
+
+        assert result.created == 1
+        task = svc.list_tasks(project="proj")[0]
+        assert task.work_status == WorkStatus.QUEUED
+
+    def test_handles_missing_dir(self, pg_work_service, tmp_path):
+        svc = pg_work_service
+        missing_dir = tmp_path / "nonexistent"
+        result = migrate_issues(missing_dir, svc, project="proj")
+        assert result.created == 0
+        assert len(result.errors) == 1
+
+    def test_skips_non_md_files(self, pg_work_service, tmp_path):
+        svc = pg_work_service
+        issues_dir = tmp_path / "issues"
+        state_dir = issues_dir / "00-not-ready"
+        state_dir.mkdir(parents=True)
+        (state_dir / "notes.txt").write_text("not a task")
+        self._setup_issue_file(
+            issues_dir,
+            "00-not-ready",
+            "0001-real-task.md",
+            "# Real Task\n\nActual task.",
+        )
+
+        result = migrate_issues(issues_dir, svc, project="proj")
+        assert result.created == 1

--- a/tests/test_pg_work_service_extra.py
+++ b/tests/test_pg_work_service_extra.py
@@ -1,0 +1,382 @@
+"""Gap-fill coverage for PgWorkService (#1794, Pattern B).
+
+Re-adds the workflow / transition / audit-emission coverage that
+Slice K-tests part 6 (#1795) deleted with ``tests/test_work_service.py``.
+The pg parity suite in ``tests/test_pg_work_service_parity.py`` and the
+Slice B coverage in ``tests/test_pg_work_service_full.py`` cover the
+read+CRUD+single-state-transition surface, but the deleted module had
+~50 tests and several of the higher-value contracts are still gaps:
+
+* Full lifecycle transition audit trail (the ``TestTransitions`` class).
+* Hold from queued / resume routing rules (in_progress vs queued).
+* Cancel from in_progress / on_hold / terminal-rejected.
+* Plan-task predecessor metadata + audit-event emission
+  (``EVENT_PLAN_SUCCESSOR_CREATED``, ``EVENT_PLAN_VERSION_INCREMENTED``).
+* Block validation: malformed blocker id rejected.
+
+This module fills those gaps against ``pg_work_service``. The sqlite-
+only seams (filesystem project_path flow resolution, ``_conn`` raw
+SQL, ``_record_transition`` private enforcement) are out of scope —
+PgWorkService doesn't expose those.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pollypm.work.models import (
+    Priority,
+    TaskType,
+    WorkStatus,
+)
+from pollypm.work.service_support import (
+    InvalidTransitionError,
+    TaskNotFoundError,
+    ValidationError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_standard_task(
+    svc,
+    project: str = "proj",
+    title: str = "My task",
+    description: str = "Do the thing",
+    **kwargs,
+):
+    defaults = dict(
+        title=title,
+        description=description,
+        type="task",
+        project=project,
+        flow_template="standard",
+        roles={"worker": "agent-1", "reviewer": "agent-2"},
+        priority="normal",
+        created_by="tester",
+    )
+    defaults.update(kwargs)
+    return svc.create(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# create — fields round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestCreateFieldsRoundTrip:
+    """A condensed version of the deleted ``TestCreateTask.test_create_task``
+    smoke; the parity suite covers ids + per-project isolation but doesn't
+    assert on every field of the round-trip."""
+
+    def test_create_round_trips_all_fields(self, pg_work_service):
+        task = _create_standard_task(pg_work_service)
+        assert task.project == "proj"
+        assert task.task_number == 1
+        assert task.title == "My task"
+        assert task.description == "Do the thing"
+        assert task.type == TaskType.TASK
+        assert task.work_status == WorkStatus.DRAFT
+        assert task.flow_template_id == "standard"
+        assert task.priority == Priority.NORMAL
+        assert task.current_node_id is None
+        assert task.assignee is None
+        assert task.roles == {"worker": "agent-1", "reviewer": "agent-2"}
+        assert task.created_at is not None
+        assert task.created_by == "tester"
+
+
+# ---------------------------------------------------------------------------
+# Cancel — all source states
+# ---------------------------------------------------------------------------
+
+
+class TestCancel:
+    def test_cancel_from_draft(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_standard_task(svc)
+        cancelled = svc.cancel(task.task_id, "pm", "not needed")
+        assert cancelled.work_status == WorkStatus.CANCELLED
+
+    def test_cancel_from_queued(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_standard_task(svc, description="Queue it")
+        svc.queue(task.task_id, "pm")
+        cancelled = svc.cancel(task.task_id, "pm", "changed mind")
+        assert cancelled.work_status == WorkStatus.CANCELLED
+
+    def test_cancel_from_in_progress(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_standard_task(svc, description="Claim it")
+        svc.queue(task.task_id, "pm")
+        svc.claim(task.task_id, "agent-1")
+        cancelled = svc.cancel(task.task_id, "pm", "abort")
+        assert cancelled.work_status == WorkStatus.CANCELLED
+
+    def test_cancel_from_on_hold(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_standard_task(svc, description="Hold it")
+        svc.queue(task.task_id, "pm")
+        svc.claim(task.task_id, "agent-1")
+        svc.hold(task.task_id, "pm")
+        cancelled = svc.cancel(task.task_id, "pm", "done waiting")
+        assert cancelled.work_status == WorkStatus.CANCELLED
+
+    def test_cancel_from_terminal_rejected(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_standard_task(svc)
+        svc.cancel(task.task_id, "pm", "bye")
+        with pytest.raises(InvalidTransitionError):
+            svc.cancel(task.task_id, "pm", "double cancel")
+
+
+# ---------------------------------------------------------------------------
+# Hold / Resume — source-state coverage + execution-aware routing
+# ---------------------------------------------------------------------------
+
+
+class TestHoldResume:
+    def test_hold_from_in_progress(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_standard_task(svc, description="Work")
+        svc.queue(task.task_id, "pm")
+        svc.claim(task.task_id, "agent-1")
+        held = svc.hold(task.task_id, "pm", reason="waiting for info")
+        assert held.work_status == WorkStatus.ON_HOLD
+
+    def test_hold_from_queued(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_standard_task(svc, description="Queued")
+        svc.queue(task.task_id, "pm")
+        held = svc.hold(task.task_id, "pm")
+        assert held.work_status == WorkStatus.ON_HOLD
+
+    def test_hold_from_wrong_state_rejected(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_standard_task(svc)
+        with pytest.raises(InvalidTransitionError):
+            svc.hold(task.task_id, "pm")
+
+    def test_resume_from_on_hold_with_active_execution(self, pg_work_service):
+        """Resume goes to in_progress when a flow node is active
+        (claim was issued before hold)."""
+        svc = pg_work_service
+        task = _create_standard_task(svc, description="Hold me")
+        svc.queue(task.task_id, "pm")
+        svc.claim(task.task_id, "agent-1")
+        svc.hold(task.task_id, "pm")
+        resumed = svc.resume(task.task_id, "pm")
+        assert resumed.work_status == WorkStatus.IN_PROGRESS
+
+    def test_resume_from_on_hold_without_execution(self, pg_work_service):
+        """Resume goes to queued when no flow node is active
+        (held while still in queued)."""
+        svc = pg_work_service
+        task = _create_standard_task(svc, description="Hold me")
+        svc.queue(task.task_id, "pm")
+        svc.hold(task.task_id, "pm")
+        resumed = svc.resume(task.task_id, "pm")
+        assert resumed.work_status == WorkStatus.QUEUED
+
+    def test_resume_from_wrong_state_rejected(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_standard_task(svc, description="Not on hold")
+        svc.queue(task.task_id, "pm")
+        with pytest.raises(InvalidTransitionError):
+            svc.resume(task.task_id, "pm")
+
+
+# ---------------------------------------------------------------------------
+# Full lifecycle transition trail
+# ---------------------------------------------------------------------------
+
+
+class TestTransitions:
+    def test_full_lifecycle_records_every_transition(self, pg_work_service):
+        """Queue -> claim -> hold -> resume -> cancel."""
+        svc = pg_work_service
+        task = _create_standard_task(svc, description="Full lifecycle")
+        tid = task.task_id
+
+        svc.queue(tid, "pm")
+        svc.claim(tid, "agent-1")
+        svc.hold(tid, "pm", reason="waiting")
+        svc.resume(tid, "pm")
+        svc.cancel(tid, "pm", "done")
+
+        final = svc.get(tid)
+        states = [(t.from_state, t.to_state) for t in final.transitions]
+        # The exact transitions: draft->queued->in_progress->on_hold->
+        # in_progress->cancelled. PgWorkService should record all five.
+        assert ("draft", "queued") in states
+        assert ("queued", "in_progress") in states
+        assert ("in_progress", "on_hold") in states
+        assert ("on_hold", "in_progress") in states
+        assert ("in_progress", "cancelled") in states
+        assert len(final.transitions) >= 5
+
+        # All transitions have timestamps and actors
+        for t in final.transitions:
+            assert t.timestamp is not None
+            assert t.actor in ("pm", "agent-1")
+
+        # Cancel transition has a reason
+        cancel_tr = next(t for t in final.transitions if t.to_state == "cancelled")
+        assert cancel_tr.reason == "done"
+
+
+# ---------------------------------------------------------------------------
+# Block — validation of blocker id format
+# ---------------------------------------------------------------------------
+
+
+class TestBlockValidation:
+    def test_block_rejects_malformed_blocker_id(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_standard_task(svc, description="Blocking target")
+        svc.queue(task.task_id, "pm")
+        svc.claim(task.task_id, "agent-1")
+
+        with pytest.raises(ValidationError):
+            svc.block(task.task_id, "pm", "bad-blocker-id")
+
+
+# ---------------------------------------------------------------------------
+# Plan-task metadata + audit-event emission (#1398)
+# ---------------------------------------------------------------------------
+
+
+class TestPlanTaskMetadata:
+    def test_create_defaults_plan_version_to_1(self, pg_work_service):
+        task = _create_standard_task(pg_work_service)
+        assert task.plan_version == 1
+        assert task.predecessor_task_id is None
+
+    def test_create_with_predecessor_records_link(self, pg_work_service):
+        svc = pg_work_service
+        first = _create_standard_task(svc, title="original")
+        successor = _create_standard_task(
+            svc,
+            title="replan",
+            predecessor_task_id=first.task_id,
+        )
+        assert successor.predecessor_task_id == first.task_id
+        # Re-read to confirm persistence.
+        refetched = svc.get(successor.task_id)
+        assert refetched.predecessor_task_id == first.task_id
+
+    def test_list_successors_returns_replan_chain(self, pg_work_service):
+        svc = pg_work_service
+        first = _create_standard_task(svc, title="original")
+        s1 = _create_standard_task(
+            svc, title="replan-1", predecessor_task_id=first.task_id
+        )
+        s2 = _create_standard_task(
+            svc, title="replan-2", predecessor_task_id=first.task_id
+        )
+        # Unrelated task should NOT appear.
+        _create_standard_task(svc, title="unrelated")
+
+        successors = svc.list_successors(first.task_id)
+        ids = {s.task_id for s in successors}
+        assert ids == {s1.task_id, s2.task_id}
+
+    def test_increment_plan_version_bumps_value(self, pg_work_service):
+        svc = pg_work_service
+        task = _create_standard_task(svc)
+        assert task.plan_version == 1
+        bumped = svc.increment_plan_version(task.task_id, actor="architect")
+        assert bumped.plan_version == 2
+        refetched = svc.get(task.task_id)
+        assert refetched.plan_version == 2
+
+    def test_increment_plan_version_unknown_task_raises(self, pg_work_service):
+        with pytest.raises(TaskNotFoundError):
+            pg_work_service.increment_plan_version("ghost/999")
+
+    def test_create_with_malformed_predecessor_raises(self, pg_work_service):
+        svc = pg_work_service
+        with pytest.raises(ValidationError):
+            _create_standard_task(
+                svc,
+                title="bad replan",
+                predecessor_task_id="not-a-task-id",
+            )
+
+    def test_increment_plan_version_emits_audit_event(
+        self, pg_work_service, tmp_path, monkeypatch
+    ):
+        """``plan.version_incremented`` should fire with old/new versions."""
+        from pollypm.audit import read_events
+        from pollypm.audit.log import EVENT_PLAN_VERSION_INCREMENTED
+
+        # Redirect the central audit tail to a temp dir so the test never
+        # touches the user's real ~/.pollypm/audit/ tree.
+        audit_home = tmp_path / "audit-home"
+        monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+        task = _create_standard_task(pg_work_service, project="auditproj")
+        pg_work_service.increment_plan_version(
+            task.task_id, actor="architect", reason="refined plan"
+        )
+
+        events = read_events(
+            "auditproj", event=EVENT_PLAN_VERSION_INCREMENTED
+        )
+        assert len(events) == 1, (
+            f"expected one plan.version_incremented event, "
+            f"got: {[e.event for e in events]}"
+        )
+        evt = events[0]
+        assert evt.subject == task.task_id
+        assert evt.actor == "architect"
+        assert evt.metadata["old_version"] == 1
+        assert evt.metadata["new_version"] == 2
+        assert evt.metadata["task_id"] == task.task_id
+        assert evt.metadata.get("reason") == "refined plan"
+
+    def test_create_successor_emits_plan_successor_audit_event(
+        self, pg_work_service, tmp_path, monkeypatch
+    ):
+        from pollypm.audit import read_events
+        from pollypm.audit.log import EVENT_PLAN_SUCCESSOR_CREATED
+
+        audit_home = tmp_path / "audit-home"
+        monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+        svc = pg_work_service
+        first = _create_standard_task(svc, project="replanproj")
+        successor = _create_standard_task(
+            svc,
+            project="replanproj",
+            title="replan",
+            predecessor_task_id=first.task_id,
+        )
+
+        events = read_events(
+            "replanproj", event=EVENT_PLAN_SUCCESSOR_CREATED
+        )
+        assert len(events) == 1
+        evt = events[0]
+        assert evt.subject == successor.task_id
+        assert evt.metadata["predecessor"] == first.task_id
+        assert evt.metadata["successor"] == successor.task_id
+
+    def test_create_no_predecessor_does_not_emit_successor_event(
+        self, pg_work_service, tmp_path, monkeypatch
+    ):
+        """A regular task create must NOT emit ``plan.successor_created``."""
+        from pollypm.audit import read_events
+        from pollypm.audit.log import EVENT_PLAN_SUCCESSOR_CREATED
+
+        audit_home = tmp_path / "audit-home"
+        monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(audit_home))
+
+        _create_standard_task(pg_work_service, project="noreplan")
+        events = read_events(
+            "noreplan", event=EVENT_PLAN_SUCCESSOR_CREATED
+        )
+        assert events == []

--- a/tests/test_sync_manager.py
+++ b/tests/test_sync_manager.py
@@ -1,0 +1,87 @@
+"""Backend-neutral :class:`SyncManager` dispatch + failure isolation (#1794).
+
+Restores the ``TestSyncManager`` half of the deleted
+``tests/test_sync_adapters.py``. These tests don't touch the work
+service — they probe the manager's fan-out behaviour using
+``MagicMock`` adapters, so there's no sqlite or pg coupling to port.
+The work-service-coupled half (``sync_status`` / ``trigger_sync``
+contract, GitHub adapter ``external_refs`` round-trip) lives in
+``tests/test_pg_sync_adapters.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from pollypm.work.models import Task, TaskType
+from pollypm.work.sync import SyncManager
+
+
+def _bare_task(title: str = "Test") -> Task:
+    return Task(
+        project="proj",
+        task_number=1,
+        title=title,
+        type=TaskType.TASK,
+    )
+
+
+def test_dispatches_to_all_registered_adapters():
+    """Registering N adapters fans on_create out to all of them."""
+    manager = SyncManager()
+    adapter1 = MagicMock()
+    adapter1.name = "a1"
+    adapter2 = MagicMock()
+    adapter2.name = "a2"
+
+    manager.register(adapter1)
+    manager.register(adapter2)
+
+    task = _bare_task()
+    manager.on_create(task)
+
+    adapter1.on_create.assert_called_once_with(task)
+    adapter2.on_create.assert_called_once_with(task)
+
+
+def test_isolates_failures_between_adapters():
+    """One adapter raising must not prevent the other from running."""
+    manager = SyncManager()
+
+    failing = MagicMock()
+    failing.name = "failing"
+    failing.on_create.side_effect = RuntimeError("boom")
+
+    succeeding = MagicMock()
+    succeeding.name = "succeeding"
+
+    manager.register(failing)
+    manager.register(succeeding)
+
+    task = _bare_task()
+    manager.on_create(task)
+
+    failing.on_create.assert_called_once()
+    succeeding.on_create.assert_called_once()
+
+
+def test_dispatches_transition_to_all_adapters():
+    manager = SyncManager()
+    adapter = MagicMock()
+    adapter.name = "test"
+    manager.register(adapter)
+
+    task = _bare_task()
+    manager.on_transition(task, "draft", "queued")
+    adapter.on_transition.assert_called_once_with(task, "draft", "queued")
+
+
+def test_dispatches_update_to_all_adapters():
+    manager = SyncManager()
+    adapter = MagicMock()
+    adapter.name = "test"
+    manager.register(adapter)
+
+    task = _bare_task()
+    manager.on_update(task, ["title"])
+    adapter.on_update.assert_called_once_with(task, ["title"])

--- a/tests/test_task_invariants.py
+++ b/tests/test_task_invariants.py
@@ -1,0 +1,432 @@
+"""Tests for the task workflow invariant checker (#886).
+
+Re-added under #1794 (Pattern B in the bulk re-coverage plan). The
+deleted ``tests/test_task_invariants.py`` had two halves:
+
+1. Backend-neutral coverage of :mod:`pollypm.task_invariants` —
+   the transition table, capacity / recovery-lane derivations,
+   ``check_task_invariants`` doctor rules, and the violation
+   summary formatter. These exercise pure functions; nothing
+   touches the work-service.
+2. SQLite-only ``_record_transition`` enforcement tests that called
+   ``SQLiteWorkService._record_transition`` and inspected
+   ``svc._conn`` directly. The pg backend's equivalent enforcement
+   lives inside ``PgWorkService._write_transition``-class helpers
+   without a directly equivalent public seam.
+
+This module restores (1). The (2) sqlite-internal regression
+guards are intentionally not re-added — they probed a private
+seam that doesn't exist on pg. The behaviour they guarded
+(rejecting forbidden transitions, escape-hatch for migrations)
+is exercised end-to-end via the public ``approve``/``reject``/
+``mark_done`` surface in ``tests/test_pg_flow_progression.py``
+and ``tests/test_pg_work_service_full.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pollypm.task_invariants import (
+    InvariantViolation,
+    StateOwner,
+    TaskCheckContext,
+    TaskRow,
+    ViolationKind,
+    all_statuses_have_metadata,
+    check_task_invariants,
+    is_capacity_consuming,
+    is_transition_allowed,
+    metadata_for,
+    requires_recovery_lane,
+    validate_transition,
+)
+from pollypm.work.models import WorkStatus
+
+
+# ---------------------------------------------------------------------------
+# Coverage: every WorkStatus has metadata
+# ---------------------------------------------------------------------------
+
+
+def test_every_workstatus_has_metadata() -> None:
+    """The release gate (#889) consults this. An enum value
+    missing from the table is a launch blocker."""
+    assert all_statuses_have_metadata() == ()
+
+
+def test_metadata_for_returns_canonical_entry() -> None:
+    meta = metadata_for(WorkStatus.IN_PROGRESS)
+    assert meta.status is WorkStatus.IN_PROGRESS
+    assert meta.owner is StateOwner.WORKER
+    assert meta.consumes_capacity is True
+    assert meta.requires_recovery_lane is True
+
+
+def test_terminal_states_are_marked() -> None:
+    """``DONE`` and ``CANCELLED`` are terminal — no allowed
+    transitions out, no capacity consumption, hidden by default."""
+    for status in (WorkStatus.DONE, WorkStatus.CANCELLED):
+        meta = metadata_for(status)
+        assert meta.is_terminal is True
+        assert meta.allowed_next == frozenset()
+        assert meta.consumes_capacity is False
+        assert meta.visible_in_cockpit_default is False
+
+
+def test_done_counts_as_done_cancelled_does_not() -> None:
+    """Metric accounting must distinguish completion from cancel."""
+    assert metadata_for(WorkStatus.DONE).counts_as_done is True
+    assert metadata_for(WorkStatus.CANCELLED).counts_as_done is False
+
+
+# ---------------------------------------------------------------------------
+# Capacity contract — the #816 fix
+# ---------------------------------------------------------------------------
+
+
+def test_in_progress_consumes_capacity() -> None:
+    assert is_capacity_consuming(WorkStatus.IN_PROGRESS) is True
+
+
+def test_rework_also_consumes_capacity() -> None:
+    """The audit's #816 root cause: REWORK was missed by the
+    capacity manager because its inline allowlist did not include
+    it. Reading from the table fixes that class of bug."""
+    assert is_capacity_consuming(WorkStatus.REWORK) is True
+
+
+def test_review_does_not_consume_capacity() -> None:
+    """REVIEW waits on the user — no worker capacity used."""
+    assert is_capacity_consuming(WorkStatus.REVIEW) is False
+
+
+def test_queued_does_not_consume_capacity() -> None:
+    assert is_capacity_consuming(WorkStatus.QUEUED) is False
+
+
+# ---------------------------------------------------------------------------
+# Recovery lane contract — the #770 / #771 / #816 fix
+# ---------------------------------------------------------------------------
+
+
+def test_in_progress_requires_recovery_lane() -> None:
+    assert requires_recovery_lane(WorkStatus.IN_PROGRESS) is True
+
+
+def test_rework_requires_recovery_lane() -> None:
+    """#816: REWORK must be visited by recovery so dead-worker
+    rework does not get stuck."""
+    assert requires_recovery_lane(WorkStatus.REWORK) is True
+
+
+def test_terminal_does_not_require_recovery() -> None:
+    assert requires_recovery_lane(WorkStatus.DONE) is False
+    assert requires_recovery_lane(WorkStatus.CANCELLED) is False
+
+
+# ---------------------------------------------------------------------------
+# Transition validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "from_s, to_s",
+    [
+        (WorkStatus.QUEUED, WorkStatus.IN_PROGRESS),
+        (WorkStatus.IN_PROGRESS, WorkStatus.REVIEW),
+        (WorkStatus.REVIEW, WorkStatus.DONE),
+        (WorkStatus.REVIEW, WorkStatus.REWORK),
+        (WorkStatus.REWORK, WorkStatus.IN_PROGRESS),
+    ],
+)
+def test_canonical_transitions_allowed(
+    from_s: WorkStatus, to_s: WorkStatus
+) -> None:
+    """The happy-path transitions every flow needs."""
+    assert is_transition_allowed(from_s, to_s) is True
+
+
+@pytest.mark.parametrize(
+    "from_s, to_s",
+    [
+        (WorkStatus.DONE, WorkStatus.IN_PROGRESS),
+        (WorkStatus.CANCELLED, WorkStatus.QUEUED),
+        # ``QUEUED -> DONE`` is now a canonical fast-complete /
+        # archive path (#909); the historically-asserted invalid
+        # case is replaced with ``REVIEW -> DRAFT``, which has
+        # never been a legal transition.
+        (WorkStatus.REVIEW, WorkStatus.DRAFT),
+        (WorkStatus.DRAFT, WorkStatus.REVIEW),
+    ],
+)
+def test_invalid_transitions_rejected(
+    from_s: WorkStatus, to_s: WorkStatus
+) -> None:
+    """Transitions outside the canonical table must be rejected.
+    The audit's #806 case (recovery jumping to flow-start) must
+    not be allowed."""
+    assert is_transition_allowed(from_s, to_s) is False
+
+
+def test_validate_transition_returns_none_on_allowed() -> None:
+    assert (
+        validate_transition(
+            task_id="t1",
+            from_status=WorkStatus.QUEUED,
+            to_status=WorkStatus.IN_PROGRESS,
+        )
+        is None
+    )
+
+
+def test_validate_transition_returns_violation_on_forbidden() -> None:
+    """The work service uses this to refuse forbidden transitions
+    at write time. #806's recovery-deletes-history came from not
+    validating; the validator catches it."""
+    v = validate_transition(
+        task_id="t1",
+        from_status=WorkStatus.DONE,
+        to_status=WorkStatus.IN_PROGRESS,
+    )
+    assert v is not None
+    assert v.kind is ViolationKind.INVALID_TRANSITION
+    assert "done" in v.detail
+    assert "in_progress" in v.detail
+
+
+# ---------------------------------------------------------------------------
+# check_task_invariants — the doctor
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_clean_run_returns_no_violations() -> None:
+    """A healthy snapshot must produce zero violations."""
+    context = TaskCheckContext(
+        tasks=(
+            TaskRow(
+                task_id="demo/1",
+                status=WorkStatus.IN_PROGRESS,
+                current_role="worker",
+            ),
+        ),
+        live_worker_session_task_ids=frozenset({"demo/1"}),
+        reachable_role_sessions=frozenset({"worker", "reviewer"}),
+        recovered_task_ids=frozenset(),
+        capacity_consumed_task_ids=frozenset({"demo/1"}),
+    )
+    assert check_task_invariants(context) == ()
+
+
+def test_doctor_flags_in_progress_without_owner() -> None:
+    """The audit's #770 / #771 root cause."""
+    context = TaskCheckContext(
+        tasks=(
+            TaskRow(
+                task_id="demo/1",
+                status=WorkStatus.IN_PROGRESS,
+                current_role="worker",
+            ),
+        ),
+        live_worker_session_task_ids=frozenset(),
+        reachable_role_sessions=frozenset({"worker"}),
+    )
+    out = check_task_invariants(context)
+    assert any(
+        v.kind is ViolationKind.IN_PROGRESS_NO_OWNER for v in out
+    )
+
+
+def test_doctor_flags_rework_outside_recovery() -> None:
+    """The audit's #816 root cause."""
+    context = TaskCheckContext(
+        tasks=(
+            TaskRow(
+                task_id="demo/2",
+                status=WorkStatus.REWORK,
+                current_role="worker",
+            ),
+        ),
+        live_worker_session_task_ids=frozenset({"demo/2"}),
+        reachable_role_sessions=frozenset({"worker"}),
+        recovered_task_ids=frozenset(),  # Not visited.
+    )
+    out = check_task_invariants(context)
+    kinds = {v.kind for v in out}
+    assert ViolationKind.REWORK_OUTSIDE_RECOVERY_LANE in kinds
+
+
+def test_doctor_flags_queued_without_role_session() -> None:
+    """The audit's case: queued tasks waiting for a role that has
+    no live session anywhere."""
+    context = TaskCheckContext(
+        tasks=(
+            TaskRow(
+                task_id="demo/3",
+                status=WorkStatus.QUEUED,
+                current_role="reviewer",
+            ),
+        ),
+        reachable_role_sessions=frozenset({"worker"}),
+    )
+    out = check_task_invariants(context)
+    assert any(
+        v.kind is ViolationKind.QUEUED_NO_ROLE_SESSION for v in out
+    )
+
+
+def test_doctor_flags_blocked_with_no_unblock_path() -> None:
+    """Blocked task with no recorded dependency and no unblock
+    signal is genuinely stuck — surface it so the user can decide
+    to cancel or unblock manually."""
+    context = TaskCheckContext(
+        tasks=(
+            TaskRow(
+                task_id="demo/4",
+                status=WorkStatus.BLOCKED,
+                current_role=None,
+                blocked_on_dependency=False,
+                last_unblock_signal_seconds_ago=None,
+            ),
+        ),
+    )
+    out = check_task_invariants(context)
+    assert any(
+        v.kind is ViolationKind.BLOCKED_NO_UNBLOCK_PATH for v in out
+    )
+
+
+def test_doctor_does_not_flag_blocked_with_dependency() -> None:
+    """Blocked + dependency recorded is the normal case — no
+    violation."""
+    context = TaskCheckContext(
+        tasks=(
+            TaskRow(
+                task_id="demo/5",
+                status=WorkStatus.BLOCKED,
+                current_role=None,
+                blocked_on_dependency=True,
+            ),
+        ),
+    )
+    out = check_task_invariants(context)
+    assert all(
+        v.kind is not ViolationKind.BLOCKED_NO_UNBLOCK_PATH for v in out
+    )
+
+
+def test_doctor_flags_dead_claim_consuming_capacity() -> None:
+    """Capacity reservation outliving the worker session is a waste
+    of capacity slot — the cockpit must see it (#816)."""
+    context = TaskCheckContext(
+        tasks=(
+            TaskRow(
+                task_id="demo/6",
+                status=WorkStatus.IN_PROGRESS,
+                current_role="worker",
+            ),
+        ),
+        live_worker_session_task_ids=frozenset(),  # No live session.
+        capacity_consumed_task_ids=frozenset({"demo/6"}),  # Still counted.
+    )
+    out = check_task_invariants(context)
+    kinds = {v.kind for v in out}
+    assert ViolationKind.DEAD_CLAIM_CONSUMES_CAPACITY in kinds
+
+
+def test_doctor_flags_planner_critic_synthetic_leak() -> None:
+    """The audit's #395 root cause: critic / planner synthetic
+    tasks leaking into the user task list."""
+    context = TaskCheckContext(
+        tasks=(
+            TaskRow(
+                task_id="critic-evaluate-1",
+                status=WorkStatus.IN_PROGRESS,
+                current_role="worker",
+            ),
+        ),
+        live_worker_session_task_ids=frozenset({"critic-evaluate-1"}),
+    )
+    out = check_task_invariants(context)
+    kinds = {v.kind for v in out}
+    assert ViolationKind.PLANNER_CRITIC_LEAKED_INTO_TASKS in kinds
+
+
+def test_doctor_emits_one_violation_per_kind_per_task() -> None:
+    """A task in REWORK without recovery and without a live worker
+    should report both the IN_PROGRESS_NO_OWNER and
+    REWORK_OUTSIDE_RECOVERY_LANE violations — they're different
+    classes of failure."""
+    context = TaskCheckContext(
+        tasks=(
+            TaskRow(
+                task_id="demo/7",
+                status=WorkStatus.REWORK,
+                current_role="worker",
+            ),
+        ),
+        live_worker_session_task_ids=frozenset(),
+        recovered_task_ids=frozenset(),
+    )
+    out = check_task_invariants(context)
+    kinds = {v.kind for v in out}
+    assert ViolationKind.IN_PROGRESS_NO_OWNER in kinds
+    assert ViolationKind.REWORK_OUTSIDE_RECOVERY_LANE in kinds
+
+
+# ---------------------------------------------------------------------------
+# _project_is_idle — derived from the canonical terminal table
+# ---------------------------------------------------------------------------
+
+
+def test_project_idle_uses_canonical_terminal_table() -> None:
+    """#899 / #816 — the ``_project_is_idle`` helper now derives
+    its non-terminal set from the canonical metadata table, so a
+    REWORK task correctly keeps a project non-idle. Earlier the
+    inline list omitted REWORK and quietly broke milestone digest
+    flushing for rejected tasks."""
+    from pollypm.notification_staging import _project_is_idle
+
+    class _Task:
+        def __init__(self, status: WorkStatus) -> None:
+            self.work_status = status
+
+    class _Svc:
+        def __init__(self, statuses: list[WorkStatus]) -> None:
+            self._tasks = [_Task(s) for s in statuses]
+
+        def list_tasks(self, project: str):
+            return self._tasks
+
+    # REWORK keeps the project non-idle.
+    assert _project_is_idle(_Svc([WorkStatus.REWORK]), "demo") is False
+    # Only terminal states → idle.
+    assert (
+        _project_is_idle(
+            _Svc([WorkStatus.DONE, WorkStatus.CANCELLED]), "demo"
+        )
+        is True
+    )
+    # Empty project → idle (matches docstring contract).
+    assert _project_is_idle(_Svc([]), "demo") is True
+    # Drafts alone → idle (drafts don't block per docstring).
+    assert _project_is_idle(_Svc([WorkStatus.DRAFT]), "demo") is True
+
+
+# ---------------------------------------------------------------------------
+# Violation summary formatter
+# ---------------------------------------------------------------------------
+
+
+def test_violation_summary_is_actionable() -> None:
+    """The summary is rendered in the cockpit. It must name the
+    task id and the violation kind clearly."""
+    v = InvariantViolation(
+        kind=ViolationKind.IN_PROGRESS_NO_OWNER,
+        task_id="demo/9",
+        detail="no live worker session",
+    )
+    s = v.summary
+    assert "demo/9" in s
+    assert "in_progress_no_owner" in s
+    assert "no live worker session" in s


### PR DESCRIPTION
## Summary

Batch B of the PG-fixture test re-coverage effort. Closes the three issues filed
when Slice K-source-ripout (the sqlite -> postgres migration PR series) deleted
~37,000 LOC of test coverage without porting it to pg fixtures.

- **#1785** — `test_flow_progression.py` (1459 LOC) + `test_sync_adapters.py`
  (970 LOC) re-added against `pg_work_service` (`#1775` unblocked the
  `sync_manager=` constructor surface). Ports `node_done` / `approve` /
  `reject` / `block` / spike-flow / `get_execution`, plus `sync_status` /
  `trigger_sync` + GitHub adapter `external_refs` round-trip + migrate_issues.
- **#1794** — bulk re-coverage of the workflow contracts deleted by Slice
  K-tests part 6 (37 modules, ~37,800 LOC). Adds inbox interaction methods
  (`#1776` now closed), inbox-kind round-trip, work-service gap-fills
  (lifecycle transitions, hold/resume routing, cancel from all states, plan-task
  metadata + audit-event emission), restored backend-neutral task-invariants
  unit tests, restored SyncManager unit tests.
- **#1824** (meta) — closed by this PR as far as the in-scope deletions go;
  see "What's still uncovered" below.

## Files added

- `tests/test_pg_flow_progression.py` (~585 LOC, 25 tests)
- `tests/test_pg_sync_adapters.py` (~388 LOC, 18 tests)
- `tests/test_pg_inbox_actions.py` (~211 LOC, 18 tests)
- `tests/test_pg_inbox_kind.py` (~98 LOC, 12 tests parametrized)
- `tests/test_pg_work_service_extra.py` (~382 LOC, 24 tests)
- `tests/test_task_invariants.py` (~432 LOC, ~30 tests — backend-neutral pure functions)
- `tests/test_sync_manager.py` (~87 LOC, 4 tests — backend-neutral)

Total: ~2,180 LOC, ~130 tests. Zero changes to `src/pollypm/`.

## Issue cross-reference for #1824

The meta-issue lists 10 high-impact deletions. Coverage status after this PR:

| Deleted file | Status |
| --- | --- |
| `test_cockpit_inbox_ui.py` (-3,342) | Pattern A — covered by `test_dashboard_data_pg.py` / `test_cockpit_rail_pg.py` per #1794 |
| `test_project_dashboard_ui.py` (-7,068) | Pattern A — same |
| `test_task_assignment_notify.py` (-2,518) | NOT covered here — Pattern C, plugin-coupled, needs separate batch |
| `test_plan_review_flow.py` (-1,928) | NOT covered here — Pattern B, partial overlap with `test_pg_flow_progression.py` reject/feedback coverage |
| `test_flow_progression.py` (-1,459) | **Covered by this PR (#1785)** |
| `test_work_service.py` (-1,218) | **Covered by existing pg parity + this PR (#1794)** |
| `test_doctor_enhancements.py` (-2,305) | NOT covered — separate batch |
| `test_auto_claim_sweep.py` (-1,237) | Tracked in #1788 (batch A: sweep/lifecycle harness) |
| `test_worker_roster_ui.py` (-1,113) | Pattern A — covered by cockpit rail/dashboard pg tests |
| `test_sync_adapters.py` (-970) | **Covered by this PR (#1785 + #1794 SyncManager unit tests)** |

## What's still uncovered (after all of batch A + B)

These need future batches:

1. **task_assignment plugin integration** (`test_task_assignment_notify.py`,
   `test_task_assignment_fanout.py`) — sqlite + plugin runtime + StateStore
   seeding. Needs a pg-aware plugin runtime harness.
2. **doctor enhancements** (`test_doctor_enhancements.py`) — sqlite-bound
   doctor probes.
3. **plan_review_flow integration** (`test_plan_review_flow.py`) — the cockpit
   plan-review surface end-to-end. Partially covered by pg reject/feedback
   coverage in this PR; the inbox aggregator + cockpit UI surface still needs a
   pg fixture.
4. **CLI surface** — tracked by #1790 (batch A; blocked until inbox_cli /
   notify CLI port to pg).
5. **flow_progression git auto-merge gates** — pg's `approve(resume_merge=...)`
   is still flagged as Slice C ("git auto-merge is Slice C"). The
   `project_path`-bound git-merge tests will land with that port.
6. **EventBuffer / activity-feed projector / retention sweep** — tracked by
   #1789 (batch A).

## Skipped tests + rationale

- **`test_flow_progression.py` git-merge tests** — PgWorkService.approve marks
  `resume_merge` as Slice C; the filesystem `project_path` git auto-merge path
  isn't ported yet. ~15 tests deferred.
- **`test_inbox_actions.py::TestResolveInboxWorkService`** — exercised
  dual-DB workspace+per-project sqlite resolution; no pg equivalent.
- **`test_task_invariants.py` sqlite `_record_transition` enforcement** —
  probed a private seam that doesn't exist on pg. Public surface
  (`approve`/`reject`/`mark_done`) is covered end-to-end elsewhere.
- **`test_inbox_kind_schema.py` SQLite pre-migration backfill** — no pg
  equivalent legacy DB shape.

## Test plan

- [x] `ruff check tests/test_pg_flow_progression.py tests/test_pg_sync_adapters.py
      tests/test_pg_inbox_actions.py tests/test_pg_inbox_kind.py
      tests/test_pg_work_service_extra.py tests/test_task_invariants.py
      tests/test_sync_manager.py` → All checks passed
- [x] Branched off `origin/main` at `ca9295d3`
- [x] No `src/pollypm/` changes — tests only
- [x] No production-code bugs surfaced while authoring (per instruction: would have stopped and reported)
- [x] Each issue referenced in title + body
- [ ] Run pytest against pg fixture in CI (out of scope per task constraints)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>