### PR TITLE
fix(tests): isolate ~/.pollypm writes + reap orphan subprocesses (closes #1902)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,13 +7,48 @@ Module-specific fixtures live beside their tests.
 from __future__ import annotations
 
 import os
+import signal
+import subprocess
 import tempfile
+import time
 from pathlib import Path
 
 import pytest
 
 
-def pytest_configure(config):  # noqa: ARG001
+# Subdirectories of ``~/.pollypm/`` that production code legitimately
+# writes to during normal operation but tests MUST NEVER touch outside
+# their own ``tmp_path``. The write-guard fixture below snapshots these
+# before each test and fails the test if any new entry appears.
+#
+# Background (issue #1902): a runaway pytest in a stalled Codex
+# worktree was caught writing to ``~/.pollypm/artifacts/checkpoints/``
+# AND spawning an orphaned ``claude --append-system-prompt-file ...``
+# subprocess that survived the parent's exit by 87 minutes. The
+# orphan's transcript leaked pytest-fixture paths into the operator's
+# checkpoints, which the cockpit then rendered to the user during
+# v1-RC user-flow testing. This guard is the defensive backstop:
+# tests that *would* have polluted production state now fail loudly
+# instead of silently corrupting the dev machine.
+_POLLYPM_HOME_GUARDED_DIRS = (
+    "artifacts",
+    "checkpoints",
+    "agent_homes",
+    "homes",
+    "transcripts",
+    "snapshots",
+    "worktrees",
+    "dossier",
+)
+
+# Subprocess command names whose orphans the reaper fixture should
+# clean up. These are the binaries PollyPM spawns into tmux panes;
+# any process by these names that appears DURING a test but persists
+# AFTER the test is an orphan the test failed to tear down.
+_POLLYPM_REAP_NAMES = ("claude", "codex")
+
+
+def pytest_configure(config):
     """Opt every test out of side-effectful daemon spawns.
 
     ``pm up`` normally spawns a detached ``pollypm.rail_daemon``
@@ -51,6 +86,18 @@ def pytest_configure(config):  # noqa: ARG001
             / "audit"
         ),
     )
+    # #1902 — ``pollypm.pm_turn_state`` writes ``pm_turn_state.json``
+    # under ``~/.pollypm/`` by default. The env override exists; honour
+    # it project-wide so heartbeat/turn-tracking tests don't pollute
+    # the dev machine's turn-state file.
+    os.environ.setdefault(
+        "POLLYPM_PM_TURN_STATE_HOME",
+        str(
+            Path(tempfile.gettempdir())
+            / f"pollypm-pytest-{os.getpid()}"
+            / "pm_turn_state"
+        ),
+    )
     # Tests build their config in pytest tmp dirs but ``state_db``
     # defaults to ``~/.pollypm/state.db`` on the dev machine — which
     # may legitimately have pending migrations. Skip the refuse-start
@@ -59,6 +106,15 @@ def pytest_configure(config):  # noqa: ARG001
     # env var in their own monkeypatch fixture (see
     # ``tests/test_migration_gate.py``).
     os.environ.setdefault("POLLYPM_SKIP_MIGRATION_GATE", "1")
+    # #1902 — register the opt-out marker so tests can declare they
+    # intentionally write to ``~/.pollypm/`` (the guard then skips
+    # the snapshot/diff for that test).
+    config.addinivalue_line(
+        "markers",
+        "allows_home_writes: opt-out of the ~/.pollypm/ write-guard "
+        "(use only when a test explicitly monkeypatches Path.home / "
+        "GLOBAL_CONFIG_DIR to a sandbox).",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -203,3 +259,316 @@ def pytest_generate_tests(metafunc):
         indirect=True,
         ids=["sqlite", "postgres"],
     )
+
+
+# ----------------------------------------------------------------------
+# Production-state pollution guard — issue #1902
+# ----------------------------------------------------------------------
+#
+# Two autouse fixtures defend against the failure mode that bit us
+# during v1-RC user-flow testing: a runaway pytest writing to the
+# real ``~/.pollypm/`` and spawning orphan Claude subprocesses that
+# survived the test's exit.
+#
+# 1) ``_pollypm_home_write_guard`` — snapshots the entry-set of
+#    write-prone subdirectories under ``~/.pollypm/`` before the
+#    test, then diffs the post-test set. Any new files written
+#    DURING the test that landed in the real home dir are surfaced
+#    as a hard test failure. Tests that genuinely need to write to
+#    ``~/.pollypm/`` (typically because they've already monkeypatched
+#    ``Path.home``) opt out via ``@pytest.mark.allows_home_writes``.
+#
+# 2) ``_pollypm_orphan_reaper`` — records the PIDs of any running
+#    ``claude``/``codex`` processes (owned by the current user)
+#    BEFORE the test runs, and after the test KILLS any new PIDs
+#    of those names that appeared. This catches the 87-minute orphan
+#    Claude scenario from #1902: a test spawns ``claude --append-
+#    system-prompt-file ...`` (directly or indirectly), the parent
+#    pytest exits without reaping it, and the orphan keeps writing
+#    to the real cockpit.
+#
+# Both fixtures are best-effort: a missing home dir, a stat race, or
+# an inaccessible /proc on a sandboxed CI worker is treated as
+# "nothing to guard / nothing to reap" rather than blocking the run.
+
+
+def _real_pollypm_home() -> Path | None:
+    """Return the dev machine's ``~/.pollypm`` (or ``None`` if unset).
+
+    Uses ``os.path.expanduser`` rather than ``Path.home()`` so a test
+    that monkeypatched ``Path.home`` doesn't accidentally redirect the
+    guard at its own sandbox — we want the *real* home here.
+    """
+    home = os.environ.get("HOME") or os.path.expanduser("~")
+    if not home or home == "~":
+        return None
+    candidate = Path(home) / ".pollypm"
+    return candidate if candidate.is_dir() else None
+
+
+# Cap the per-subdir scan so a pre-existing 281K-file scaffold leak
+# (the doubled-path family from #1810, now fixed but possibly still
+# on long-lived dev machines) doesn't make every test pay an
+# O(scaffold) walk cost. When a subdir exceeds the cap, the guard
+# falls back to the entry-set of its immediate children, which is
+# still enough to catch a NEW top-level write (the #1902 shape
+# was a fresh ``operator/`` checkpoint dir appearing).
+_GUARD_SNAPSHOT_FILE_CAP = 5000
+
+
+def _snapshot_guarded_dirs(pollypm_home: Path) -> dict[str, set[Path]]:
+    """Return ``{subdir: {paths under that subdir}}`` for the guarded set.
+
+    Each value is the recursive set of file paths under the subdir at
+    snapshot time, capped at ``_GUARD_SNAPSHOT_FILE_CAP``. Comparison
+    post-test uses set difference so the guard surfaces NEW files
+    specifically (rather than counting or mtime-windowing, which is
+    racy under parallel pytest workers).
+    """
+    snapshot: dict[str, set[Path]] = {}
+    for name in _POLLYPM_HOME_GUARDED_DIRS:
+        root = pollypm_home / name
+        if not root.is_dir():
+            snapshot[name] = set()
+            continue
+        try:
+            entries: set[Path] = set()
+            for path in root.rglob("*"):
+                if not path.is_file():
+                    continue
+                entries.add(path)
+                if len(entries) >= _GUARD_SNAPSHOT_FILE_CAP:
+                    # Bail out — the dir is too big for a fine-grained
+                    # diff. Switch to the shallow entry-set of the
+                    # subdir's top-level children so the diff still
+                    # catches new session/checkpoint dirs.
+                    entries = {p for p in root.iterdir()}
+                    break
+            snapshot[name] = entries
+        except OSError:
+            # Walk failures (permissions, races) shouldn't break the
+            # test run — fall back to an empty set so the post-diff
+            # records every file as "new" only if the dir later
+            # becomes readable. This is conservative.
+            snapshot[name] = set()
+    return snapshot
+
+
+@pytest.fixture(autouse=True)
+def _pollypm_home_write_guard(request):
+    """Fail any test that writes new files to the real ``~/.pollypm/``.
+
+    See module docstring above for the why (#1902). Skips when:
+
+    - The test carries ``@pytest.mark.allows_home_writes`` (explicit
+      opt-out — typically because the test monkeypatched ``Path.home``).
+    - The real ``~/.pollypm/`` dir doesn't exist (clean dev machine /
+      CI worker; nothing to pollute).
+    """
+    if request.node.get_closest_marker("allows_home_writes") is not None:
+        yield
+        return
+    pollypm_home = _real_pollypm_home()
+    if pollypm_home is None:
+        yield
+        return
+    before = _snapshot_guarded_dirs(pollypm_home)
+    yield
+    after = _snapshot_guarded_dirs(pollypm_home)
+    leaks: list[str] = []
+    for subdir, before_set in before.items():
+        new_files = after.get(subdir, set()) - before_set
+        for path in sorted(new_files):
+            leaks.append(str(path))
+    if leaks:
+        # Best-effort cleanup of the leaked files so the next test
+        # starts clean and the dev machine doesn't accumulate cruft.
+        # Failures to unlink are swallowed — the assertion error
+        # below is the load-bearing signal.
+        for leak in leaks:
+            try:
+                Path(leak).unlink()
+            except OSError:
+                pass
+        joined = "\n  - ".join(leaks)
+        pytest.fail(
+            "Test wrote new files to the real ~/.pollypm/ "
+            "(see issue #1902). Use tmp_path / monkeypatch.setattr "
+            "on pollypm.config.GLOBAL_CONFIG_DIR + Path.home, or mark "
+            "the test with @pytest.mark.allows_home_writes if the "
+            "writes are genuinely intended.\n"
+            f"  - {joined}",
+            pytrace=False,
+        )
+
+
+def _list_process_table() -> list[tuple[int, int, str]]:
+    """Return ``[(pid, ppid, comm), ...]`` for every visible process.
+
+    ``ps -A -o pid=,ppid=,comm=`` works on macOS + Linux and doesn't
+    require ``/proc``. Failures return an empty list — the caller
+    treats that as "no candidates to reap" rather than blocking the
+    test run.
+    """
+    try:
+        out = subprocess.run(
+            ["ps", "-A", "-o", "pid=,ppid=,comm="],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if out.returncode != 0:
+        return []
+    rows: list[tuple[int, int, str]] = []
+    for line in out.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            continue
+        pid_str, ppid_str, comm = parts
+        try:
+            pid_i = int(pid_str)
+            ppid_i = int(ppid_str)
+        except ValueError:
+            continue
+        rows.append((pid_i, ppid_i, comm))
+    return rows
+
+
+def _list_pids_by_name(names: tuple[str, ...]) -> set[int]:
+    """Return PIDs of processes whose ``comm`` basename matches ``names``.
+
+    Used by the reaper to take a before/after snapshot of all
+    claude/codex processes visible to the current user. The
+    descendant-filter (below) is what decides which of those PIDs
+    we're actually allowed to kill — the snapshot itself is
+    intentionally broad so reparented orphans (ppid=1 after the
+    test's pytest worker exited) stay visible.
+    """
+    pids: set[int] = set()
+    for pid, _ppid, comm in _list_process_table():
+        base = os.path.basename(comm)
+        # Match exact basename so e.g. ``claude-flow`` doesn't get
+        # reaped by a ``claude`` filter.
+        if base in names:
+            pids.add(pid)
+    return pids
+
+
+def _descendants_of(root_pid: int) -> set[int]:
+    """Return the transitive set of descendant PIDs of ``root_pid``.
+
+    Walks the process tree from a fresh ``ps`` snapshot — does not
+    include ``root_pid`` itself. Used by the orphan reaper to scope
+    its kill set: only processes whose parent chain traces back to
+    the current pytest worker get reaped, so a cockpit Claude
+    running on the dev machine in parallel with pytest never gets
+    nuked by accident.
+    """
+    rows = _list_process_table()
+    children: dict[int, list[int]] = {}
+    for pid, ppid, _comm in rows:
+        children.setdefault(ppid, []).append(pid)
+    descendants: set[int] = set()
+    stack = [root_pid]
+    while stack:
+        current = stack.pop()
+        for child in children.get(current, ()):
+            if child in descendants:
+                continue
+            descendants.add(child)
+            stack.append(child)
+    return descendants
+
+
+def _reap_pids(pids: set[int]) -> None:
+    """SIGTERM then SIGKILL each PID — best-effort, silent on failure.
+
+    Most well-behaved Claude/Codex CLI children exit cleanly on
+    SIGTERM; the SIGKILL fallback handles the bug-mode case from
+    #1902 where the child had detached from its parent and stuck in
+    a read loop. We pause briefly between signals to give the child
+    a chance to clean up its own tmux pane and transcript file.
+    """
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except (OSError, ProcessLookupError):
+            continue
+    # Give SIGTERMed processes a moment to exit cleanly before the
+    # KILL fallback. 0.2s is short enough not to noticeably slow
+    # tests but long enough for a Python/Node CLI to honour SIGTERM.
+    if pids:
+        time.sleep(0.2)
+    for pid in pids:
+        try:
+            os.kill(pid, 0)  # probe — raises if already dead
+        except (OSError, ProcessLookupError):
+            continue
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except (OSError, ProcessLookupError):
+            continue
+
+
+@pytest.fixture(autouse=True)
+def _pollypm_orphan_reaper():
+    """Kill any ``claude``/``codex`` processes the test left behind.
+
+    Two filters narrow what we actually reap:
+
+    1. PID delta — only PIDs that appeared DURING the test (post-set
+       minus pre-set) are candidates. A claude that was already
+       running when the test started (e.g. the dev's own cockpit
+       pane) is never touched.
+    2. Descendant filter — even among new PIDs, we only kill those
+       whose parent chain traces back to the current pytest worker
+       PID. This protects against the race where a parallel cockpit
+       (running outside pytest) happens to spawn a claude during
+       the test window.
+
+    Both filters re-run from a fresh ``ps`` snapshot so the
+    descendant check sees the post-test process tree, including
+    orphans whose ppid has been reparented to 1 (the canonical
+    failure mode from #1902 — the orphaned ``claude --append-
+    system-prompt-file`` survived parent exit, so by the time we
+    look its ppid was 1, not its original test-spawner). For that
+    reparented case the descendant walk wouldn't find it; we treat
+    a ppid=1 claude that appeared during the test window as an
+    orphan and reap it too.
+
+    Best-effort: ``ps`` failures are swallowed so this fixture can
+    never block a test run.
+    """
+    before = _list_pids_by_name(_POLLYPM_REAP_NAMES)
+    yield
+    after = _list_pids_by_name(_POLLYPM_REAP_NAMES)
+    new_pids = after - before
+    if not new_pids:
+        return
+    # Build a pid -> ppid map from a fresh post-test snapshot so we
+    # can decide which new PIDs are reachable from the pytest worker.
+    rows = _list_process_table()
+    ppid_by_pid = {pid: ppid for pid, ppid, _comm in rows}
+    own_descendants = _descendants_of(os.getpid())
+    reap: set[int] = set()
+    for pid in new_pids:
+        if pid in own_descendants:
+            reap.add(pid)
+            continue
+        # The reparented-orphan case: a Claude that the test spawned
+        # but has since detached from pytest (ppid=1). We can't
+        # prove pytest spawned it, but it (a) didn't exist before
+        # the test, (b) is claude/codex, (c) is now an init child —
+        # that's the exact #1902 shape and the right call is to
+        # reap it. A user-launched cockpit claude would have ppid
+        # pointing at the cockpit pane's tmux server, not init.
+        if ppid_by_pid.get(pid) == 1:
+            reap.add(pid)
+    if reap:
+        _reap_pids(reap)

--- a/tests/test_architect_lifecycle.py
+++ b/tests/test_architect_lifecycle.py
@@ -35,16 +35,45 @@ def store(tmp_path: Path) -> StateStore:
 
 
 @pytest.fixture
-def claude_account() -> AccountConfig:
+def claude_account(tmp_path: Path) -> AccountConfig:
+    """A Claude account whose home points at a per-test tmp dir.
+
+    #1902 — was previously ``home=Path.home()`` which pointed at the
+    dev machine's real ``$HOME``. ``AccountConfig.home`` feeds into
+    ``ClaudeProvider.latest_session_id`` (read-only) and downstream
+    resume-token plumbing; both accept any path. Using ``tmp_path``
+    keeps the unit tests host-agnostic and stops them tugging on the
+    real ``~/.claude/`` cache. The host-probe test below
+    (``test_close_idle_architect_persists_token_when_session_exists``)
+    uses its own fixture that intentionally points at the dev home.
+    """
     return AccountConfig(
-        name="claude_test", provider=ProviderKind.CLAUDE, home=Path.home(),
+        name="claude_test", provider=ProviderKind.CLAUDE, home=tmp_path / "claude_home",
     )
 
 
 @pytest.fixture
-def codex_account() -> AccountConfig:
+def codex_account(tmp_path: Path) -> AccountConfig:
+    """A Codex account whose home points at a per-test tmp dir.
+
+    See ``claude_account`` for the rationale (#1902).
+    """
     return AccountConfig(
-        name="codex_test", provider=ProviderKind.CODEX, home=Path.home(),
+        name="codex_test", provider=ProviderKind.CODEX, home=tmp_path / "codex_home",
+    )
+
+
+@pytest.fixture
+def host_claude_account() -> AccountConfig:
+    """Read-only fixture that points at the real ``$HOME`` for host probes.
+
+    Only the two tests that deliberately scan the dev machine's
+    Claude transcript cache should use this — and both must skip
+    when no live session exists. The fixture name documents intent:
+    this is the host-coupled probe, not the unit-test sandbox.
+    """
+    return AccountConfig(
+        name="claude_test", provider=ProviderKind.CLAUDE, home=Path.home(),
     )
 
 
@@ -97,21 +126,25 @@ def test_should_close_architect_threshold_respected(store):
     )
 
 
-def test_close_idle_architect_persists_token_when_session_exists(store, claude_account):
+def test_close_idle_architect_persists_token_when_session_exists(store, host_claude_account):
     """Real session UUID lookup against the live test environment.
 
     This host-level check only runs when the local Claude transcript
     cache actually has a resumable session for the fixture path.
+    Uses ``host_claude_account`` (not ``claude_account``) because the
+    probe deliberately reads the dev machine's real Claude cache —
+    #1902 split the sandbox fixture from the host fixture so unit
+    tests stop touching real state.
     """
     killed: list[str] = []
     provider = ClaudeProvider()
     cwd = Path("/Users/sam/dev/pollypm")
-    if provider.latest_session_id(claude_account, cwd) is None:
+    if provider.latest_session_id(host_claude_account, cwd) is None:
         pytest.skip("no live Claude session available for architect token capture")
     captured = close_idle_architect(
         store=store,
         provider=provider,
-        account=claude_account,
+        account=host_claude_account,
         project_key="passgen",
         cwd=cwd,
         tmux_kill_window=killed.append,
@@ -239,8 +272,15 @@ def test_manager_architect_launch_cmd_routes_through_token(store, claude_account
     assert "warm-id" in argv
 
 
-def test_manager_latest_session_id_passes_through(claude_account):
-    sid = manager.latest_session_id(claude_account, Path("/Users/sam/dev/pollypm"))
+def test_manager_latest_session_id_passes_through(host_claude_account):
+    """Host-probe: the manager helper returns a UUID-or-None from the real cache.
+
+    Uses ``host_claude_account`` (real ``Path.home()``) because the
+    assertion's point is "the lookup against the dev machine's
+    Claude cache returns the right shape". See #1902 for why this
+    is split from the sandboxed ``claude_account`` fixture.
+    """
+    sid = manager.latest_session_id(host_claude_account, Path("/Users/sam/dev/pollypm"))
     # Test envs that have run claude here will have a session; tolerate
     # both outcomes — what matters is the function returns a string or None,
     # not that it raises.


### PR DESCRIPTION
## Summary

Defensive backstop for the V1-RC test-isolation leak documented in #1902 — a runaway pytest in a stalled Codex worktree was caught writing to the real `~/.pollypm/artifacts/checkpoints/operator/` and spawning an orphan `claude --append-system-prompt-file` subprocess that survived parent exit by 87 minutes. Cockpit Polly · chat rendered those pytest-fixture paths to the user as the operator briefing during user-flow testing.

Tests-only change. No `src/pollypm/` modifications.

## What landed

Two autouse fixtures in `tests/conftest.py`:

- **`_pollypm_home_write_guard`** — snapshots the entry-set of write-prone subdirs under the real `~/.pollypm/` (`artifacts`, `checkpoints`, `agent_homes`, `homes`, `transcripts`, `snapshots`, `worktrees`, `dossier`) before each test, then fails the test if any new files appear post-run. The leaked files are also cleaned up so the next test starts clean. Scan caps at 5k files/subdir so pre-existing scaffold leaks (the #1810 family) don't make every test pay an O(scaffold) walk. Uses `os.path.expanduser("~")` so a test that monkeypatched `Path.home` doesn't accidentally redirect the guard at its own sandbox.

- **`_pollypm_orphan_reaper`** — records claude/codex PIDs before each test and reaps any new PIDs after, but only those that are descendants of the current pytest worker OR have `ppid=1` (the reparented-orphan shape from #1902). A cockpit claude running in parallel on the dev machine is never touched.

Tests that genuinely need to write to `~/.pollypm/` can opt out via `@pytest.mark.allows_home_writes` (none currently do).

Also exports `POLLYPM_PM_TURN_STATE_HOME` from `pytest_configure` so `pm_turn_state.json` writes stop landing on the dev machine's real home.

## Surgical fix

`tests/test_architect_lifecycle.py`'s `claude_account` / `codex_account` fixtures used `home=Path.home()`, pointing at the dev machine's real home. Split into a sandboxed default (`tmp_path`-backed) and a separate `host_claude_account` fixture that the two host-probe tests (`test_close_idle_architect_persists_token_when_session_exists`, `test_manager_latest_session_id_passes_through`) use explicitly. The probes are read-only (no writes were leaking) but the brittleness was a smell adjacent to the #1902 family.

## Test plan

- [ ] Run pytest broadly on the dev machine; no test fails the new write-guard (i.e. no current test was secretly polluting `~/.pollypm/`).
- [ ] Sanity-check: introduce a temporary `Path.home().joinpath(".pollypm/artifacts/x.json").write_text("y")` in a test, confirm the guard catches it and the test fails with the expected message.
- [ ] Sanity-check: spawn a `subprocess.Popen(["sleep", "60"])` named claude in a test (e.g. via a stub renamed to `claude`), confirm the reaper kills it post-test.
- [ ] Confirm `tests/test_architect_lifecycle.py` still skips cleanly when the dev's Claude transcript cache has no live session for `/Users/sam/dev/pollypm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)