### PR TITLE
chore(except): tighten worst-offender silent-except sites (refs #1355)

### DIFF
--- a/src/pollypm/checkpoints.py
+++ b/src/pollypm/checkpoints.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import shutil
 import subprocess
 import uuid
@@ -13,6 +14,8 @@ from typing import Any
 from pollypm.models import PollyPMConfig, SessionLaunchSpec
 from pollypm.memory_backends import get_memory_backend
 from pollypm.projects import ensure_project_scaffold, ensure_session_lock, project_checkpoints_dir, session_scoped_dir
+
+logger = logging.getLogger(__name__)
 
 HAIKU_MODEL = "claude-3-5-haiku-latest"
 TRANSCRIPT_CAP_CHARS = 16000  # ~4000 tokens
@@ -701,7 +704,10 @@ def record_checkpoint(
             source="checkpoint",
         )
     except Exception:  # noqa: BLE001
-        pass
+        logger.warning(
+            "checkpoint memory-backend write failed for %s",
+            launch.session.name, exc_info=True,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -1041,12 +1041,22 @@ def _start_foreground_core_rail_workers(plan) -> bool:
         if LaunchAction.START_RAIL_DAEMON in getattr(plan, "actions", ()):
             return False
     except Exception:  # noqa: BLE001
-        pass
+        # A silent failure here defaults to "run foreground workers",
+        # which can race a daemon launch. Surface so the race is debuggable.
+        logger.warning(
+            "_start_foreground_core_rail_workers: launch-plan probe failed; "
+            "defaulting to foreground workers",
+            exc_info=True,
+        )
     try:
         if _rail_daemon_live():
             return False
     except Exception:  # noqa: BLE001
-        pass
+        logger.warning(
+            "_start_foreground_core_rail_workers: rail-daemon-live probe "
+            "failed; defaulting to foreground workers",
+            exc_info=True,
+        )
     return True
 
 

--- a/src/pollypm/error_notifications.py
+++ b/src/pollypm/error_notifications.py
@@ -144,7 +144,12 @@ class CriticalErrorNotificationHandler(logging.Handler):
             if self._mark_first_delivery(notification.alert_type):
                 self._send_desktop(notification)
         except Exception:  # noqa: BLE001
-            pass
+            # Inside a logging.Handler — never re-log directly (would
+            # recurse through this handler). Defer to ``handleError``
+            # which honors ``logging.raiseExceptions`` and writes to
+            # stderr in debug mode rather than silently dropping the
+            # original critical error.
+            self.handleError(record)
         finally:
             self._emit_guard.active = False
 

--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -225,8 +225,12 @@ def _collect_work_service_signals(
                     ts = ts.replace(tzinfo=timezone.utc)
                 out["active_claim_task_id"] = claim_task_id
                 out["claim_age_seconds"] = int((now - ts).total_seconds())
-            except Exception:  # noqa: BLE001
-                pass
+            except (ValueError, TypeError):
+                # Malformed started_at — fall through without claim metadata.
+                logger.debug(
+                    "work-signal: bad started_at %r for %s",
+                    claim_started_at, claim_task_id,
+                )
 
         # Git commit timestamp on the claimed task's worktree.
         if worktree_path:
@@ -616,7 +620,11 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                         severity=_SignalSeverity.CRITICAL,
                     )
                 except Exception:  # noqa: BLE001
-                    pass
+                    logger.warning(
+                        "heartbeat: failed to emit heartbeat_error event for %s "
+                        "(original session error: %s)",
+                        context.session_name, exc, exc_info=True,
+                    )
         from pollypm.events.summaries import activity_summary
 
         open_alerts = api.open_alerts()
@@ -950,7 +958,10 @@ class LocalHeartbeatBackend(HeartbeatBackend):
             elif intervention and intervention.action == "escalate":
                 self._escalate(api, context, intervention.reason)
         except Exception:  # noqa: BLE001
-            pass
+            logger.warning(
+                "heartbeat: intervention dispatch failed for %s",
+                context.session_name, exc_info=True,
+            )
 
     def _handle_pane_health_alerts(
         self,
@@ -1456,7 +1467,10 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                     f"Stuck on {task_id}: {intervention.reason[:140]}",
                 )
             except Exception:  # noqa: BLE001
-                pass
+                logger.debug(
+                    "resume_ping: stuck_on_task alert upsert failed for %s/%s",
+                    context.session_name, task_id, exc_info=True,
+                )
         except Exception:  # noqa: BLE001
             logger.debug(
                 "resume_ping apply failed for %s",
@@ -1537,7 +1551,10 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                     },
                 )
             except Exception:  # noqa: BLE001
-                pass
+                logger.debug(
+                    "silent_worker_prompt audit emit failed for %s",
+                    context.session_name, exc_info=True,
+                )
         except Exception:  # noqa: BLE001
             logger.debug(
                 "prompt_pm_task_next apply failed for %s",
@@ -1578,7 +1595,10 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                     return
                 break
         except Exception:  # noqa: BLE001
-            pass
+            logger.debug(
+                "_escalate: dedupe scan failed for %s",
+                context.session_name, exc_info=True,
+            )
 
         try:
             _emit_routed_alert(
@@ -1614,7 +1634,10 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                 },
             )
         except Exception:  # noqa: BLE001
-            pass
+            logger.warning(
+                "_escalate: stuck_session alert/audit emit failed for %s",
+                context.session_name, exc_info=True,
+            )
 
     def _context_to_signals(self, context: HeartbeatSessionContext, api) -> SessionSignals:
         """Bridge HeartbeatSessionContext to SessionSignals for the classification engine."""
@@ -1807,7 +1830,10 @@ class LocalHeartbeatBackend(HeartbeatBackend):
             if most_recent_age is not None and most_recent_age < self._NUDGE_COOLDOWN_SECONDS:
                 return
         except Exception:  # noqa: BLE001
-            pass
+            logger.debug(
+                "nudge gate failed for %s — proceeding with nudge",
+                context.session_name, exc_info=True,
+            )
         # Context-aware nudge for the worker
         snippet = (context.pane_text or "").strip().splitlines()[-1][:80] if context.pane_text else ""
         if "permission" in snippet.lower() or "approve" in snippet.lower():
@@ -1838,7 +1864,10 @@ class LocalHeartbeatBackend(HeartbeatBackend):
                 },
             )
         except Exception:  # noqa: BLE001
-            pass
+            logger.debug(
+                "nudge audit emit failed for %s",
+                context.session_name, exc_info=True,
+            )
 
     def _has_pending_work(self, api, context: HeartbeatSessionContext) -> bool:
         """Check if a worker's project has ready/in-progress tasks.

--- a/src/pollypm/job_runner.py
+++ b/src/pollypm/job_runner.py
@@ -263,7 +263,9 @@ def _run_gc_maintenance(supervisor: Supervisor, payload: dict[str, Any]) -> None
                 target = f"{session_name}:{window.name}"
                 supervisor.tmux.set_pane_history_limit(target, 200)
     except Exception:  # noqa: BLE001
-        pass
+        logger.debug(
+            "gc_maintenance: scrollback trim failed", exc_info=True,
+        )
 
 
 @register_job("prune_state")

--- a/src/pollypm/knowledge_extract.py
+++ b/src/pollypm/knowledge_extract.py
@@ -5,12 +5,15 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 import json
+import logging
 import re
 from typing import Any
 
 from pollypm.llm_runner import HAIKU_MODEL, run_haiku, run_haiku_json
 from pollypm.memory_backends import get_memory_backend
 from pollypm.memory_extractors import CONFIDENCE_THRESHOLD, run_extractors
+
+logger = logging.getLogger(__name__)
 
 EXTRACTION_INTERVAL_SECONDS = 15 * 60
 SUMMARY_HEADER = "## Summary"
@@ -148,7 +151,10 @@ def store_snapshot_learnings(
         try:
             backend.compact(scope)
         except Exception:  # noqa: BLE001
-            pass
+            logger.debug(
+                "knowledge_extract: memory-backend compact failed for %s",
+                scope, exc_info=True,
+            )
     return count
 
 

--- a/src/pollypm/notification_staging.py
+++ b/src/pollypm/notification_staging.py
@@ -562,6 +562,9 @@ def _project_is_idle(svc, project: str) -> bool:
     try:
         tasks = svc.list_tasks(project=project)
     except Exception:  # noqa: BLE001
+        logger.debug(
+            "_project_is_idle: list_tasks failed for %s", project, exc_info=True,
+        )
         return False
     for t in tasks:
         meta = metadata_for(t.work_status)

--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 import re
 import shlex
 import shutil
@@ -50,6 +51,8 @@ from pollypm.onboarding_ui import (  # noqa: F401  (re-exported)
     render_provider_choices as _render_provider_choices,
 )
 from pollypm.session_services import create_tmux_client
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from pollypm.tmux.client import TmuxClient
@@ -718,7 +721,10 @@ def add_selected_projects(config_path: Path, selected_paths: list[Path]) -> list
         try:
             commit_initial_scaffold(normalized)
         except Exception:  # noqa: BLE001
-            pass
+            logger.warning(
+                "onboarding: initial scaffold commit failed for %s",
+                normalized, exc_info=True,
+            )
         added.append(project)
     if added:
         write_config(config, path=config_path, force=True)

--- a/src/pollypm/plugins_builtin/core_recurring/sweeps.py
+++ b/src/pollypm/plugins_builtin/core_recurring/sweeps.py
@@ -101,7 +101,10 @@ def _work_progress_sweep_one(
                         counters["skipped_active_turn"] += 1
                         continue
                 except Exception:  # noqa: BLE001
-                    pass
+                    logger.debug(
+                        "work.progress_sweep: is_turn_active probe failed for %s",
+                        target_name, exc_info=True,
+                    )
 
         try:
             resolver = getattr(work, "_resolve_project_path", None)
@@ -154,7 +157,10 @@ def _work_progress_sweep_one(
                             target_name, "state_drift", message,
                         )
                 except Exception:  # noqa: BLE001
-                    pass
+                    logger.warning(
+                        "work.progress_sweep: state_drift audit emit failed for %s",
+                        task.task_id, exc_info=True,
+                    )
                 alert_type = f"state_drift:{task.task_id}"
                 try:
                     is_new = not _open_alert_exists(
@@ -186,7 +192,10 @@ def _work_progress_sweep_one(
                     if is_new:
                         counters["drift_alerted"] += 1
                 except Exception:  # noqa: BLE001
-                    pass
+                    logger.warning(
+                        "work.progress_sweep: drift alert upsert failed for %s",
+                        task.task_id, exc_info=True,
+                    )
 
             if is_worker_session_name(target_name):
                 try:
@@ -226,7 +235,10 @@ def _work_progress_sweep_one(
                         else str(last_ts_stamp)
                     )
             except Exception:  # noqa: BLE001
-                pass
+                logger.debug(
+                    "work.progress_sweep: recent-event probe via msg_store failed for %s",
+                    target_name, exc_info=True,
+                )
         if recent_ts is None and state_store is not None:
             recent_events = getattr(state_store, "recent_events", None)
             if callable(recent_events):
@@ -243,7 +255,10 @@ def _work_progress_sweep_one(
                             )
                             break
                 except Exception:  # noqa: BLE001
-                    pass
+                    logger.debug(
+                        "work.progress_sweep: recent-event probe via state_store failed for %s",
+                        target_name, exc_info=True,
+                    )
         if recent_ts is not None:
             try:
                 last_ts = datetime.fromisoformat(recent_ts)
@@ -292,7 +307,11 @@ def _work_progress_sweep_one(
                         ),
                     )
                 except Exception:  # noqa: BLE001
-                    pass
+                    logger.warning(
+                        "work.progress_sweep: stuck_on_task alert upsert "
+                        "failed for %s/%s", target_name, event.task_id,
+                        exc_info=True,
+                    )
 
     return True
 
@@ -589,7 +608,11 @@ def _pane_text_classify_body(
                                     },
                                 )
                         except Exception:  # noqa: BLE001
-                            pass
+                            logger.debug(
+                                "pane_text_classify: pane.classify.match audit emit "
+                                "failed for %s/%s", session_name, rule_name,
+                                exc_info=True,
+                            )
                 except Exception:  # noqa: BLE001
                     logger.debug(
                         "pane_text_classify: upsert_alert failed "
@@ -622,7 +645,10 @@ def _pane_text_classify_body(
                             state_store.clear_alert(session_name, alert_type)
                         alerts_cleared += 1
                 except Exception:  # noqa: BLE001
-                    pass
+                    logger.warning(
+                        "pane_text_classify: clear_alert failed for %s/%s",
+                        session_name, alert_type, exc_info=True,
+                    )
 
     return {
         "outcome": "swept",
@@ -664,7 +690,10 @@ def _emit_pane_pattern_inbox_item(
                     if dedupe_label in labels:
                         return False
     except Exception:  # noqa: BLE001
-        pass
+        logger.debug(
+            "pane_text_classify: dedupe scan failed for %s",
+            dedupe_label, exc_info=True,
+        )
 
     title_map = {
         "context_full": (
@@ -761,7 +790,10 @@ def _emit_pane_pattern_inbox_item(
                 },
             )
         except Exception:  # noqa: BLE001
-            pass
+            logger.debug(
+                "pane_text_classify: inbox_emitted audit append failed for %s/%s",
+                session_name, rule_name, exc_info=True,
+            )
     return True
 
 
@@ -859,7 +891,10 @@ def worktree_state_audit_handler(payload: dict[str, Any]) -> dict[str, Any]:
                             (msg_store or store).clear_alert(session_key, alert_type)
                             alerts_cleared += 1
                         except Exception:  # noqa: BLE001
-                            pass
+                            logger.warning(
+                                "worktree.state_audit: clear_alert failed for %s/%s",
+                                session_key, alert_type, exc_info=True,
+                            )
                     continue
 
                 if state is WorktreeState.MERGE_CONFLICT:
@@ -946,7 +981,10 @@ def worktree_state_audit_handler(payload: dict[str, Any]) -> dict[str, Any]:
                                 (msg_store or store).clear_alert(session_key, alert_type)
                                 alerts_cleared += 1
                             except Exception:  # noqa: BLE001
-                                pass
+                                logger.warning(
+                                    "worktree.state_audit: clear_alert failed for %s/%s",
+                                    session_key, alert_type, exc_info=True,
+                                )
 
                 elif state is WorktreeState.ORPHAN_BRANCH:
                     age_days = float(classification.metadata.get("age_days", 0.0))
@@ -1027,7 +1065,10 @@ def _emit_inbox_task(
             if dedupe_label in labels:
                 return False
     except Exception:  # noqa: BLE001
-        pass
+        logger.debug(
+            "worktree.state_audit: inbox dedupe scan failed for %s",
+            dedupe_label, exc_info=True,
+        )
 
     try:
         work.create(

--- a/src/pollypm/service_api/v1.py
+++ b/src/pollypm/service_api/v1.py
@@ -27,6 +27,7 @@ from dataclasses import asdict, is_dataclass
 from dataclasses import dataclass
 from datetime import datetime
 import json
+import logging
 from pathlib import Path
 
 from pollypm.accounts import (
@@ -74,6 +75,9 @@ from pollypm.workers import (
     stop_worker_session,
     suggest_worker_prompt,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_task_window_name(name: str) -> tuple[str, int] | None:
@@ -389,6 +393,13 @@ class PollyPMService:
                 limit=200,
             )
         except Exception:  # noqa: BLE001
+            # Silent fallback used to mask the failure as
+            # "Unknown alert id"; log so an actual store outage is
+            # distinguishable from a stale-id from the caller.
+            logger.warning(
+                "resolve_alert: query_messages failed; treating as empty",
+                exc_info=True,
+            )
             rows = []
         target = next((row for row in rows if int(row.get("id", 0)) == alert_id), None)
         if target is None:
@@ -396,7 +407,13 @@ class PollyPMService:
         try:
             supervisor.msg_store.close_message(alert_id)
         except Exception:  # noqa: BLE001
-            pass
+            # The alert row stays open on a close-message failure, so the
+            # next resolve call retries. Surface the failure so a broken
+            # close path doesn't masquerade as success.
+            logger.warning(
+                "resolve_alert: close_message(%d) failed", alert_id,
+                exc_info=True,
+            )
         payload = target.get("payload") or {}
         subject = str(target.get("subject") or "")
         message_text = (

--- a/src/pollypm/session_intelligence.py
+++ b/src/pollypm/session_intelligence.py
@@ -332,7 +332,10 @@ def sweep_all_sessions(config) -> dict[str, int]:
                 if snapshot_path.exists():
                     snapshot = snapshot_path.read_text()[-1500:]
             except Exception:  # noqa: BLE001
-                pass
+                logger.debug(
+                    "session_intelligence: snapshot fetch failed for %s",
+                    session_name, exc_info=True,
+                )
 
             session_cfg = config.sessions.get(session_name)
             role = session_cfg.role if session_cfg else "worker"
@@ -355,7 +358,11 @@ def sweep_all_sessions(config) -> dict[str, int]:
                         sup.send_input(session_name, msg, owner="pollypm", force=True)
                         counts["actions_taken"] += 1
                     except Exception:  # noqa: BLE001
-                        pass
+                        logger.warning(
+                            "session_intelligence: send_input failed for %s "
+                            "(action=%s)", session_name, intel.action,
+                            exc_info=True,
+                        )
 
                 if intel.knowledge_entries:
                     stage_pending_knowledge(project_root, session_name, intel.knowledge_entries)

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -1116,6 +1116,11 @@ class Supervisor:
         try:
             launches = self.plan_launches()
         except Exception:  # noqa: BLE001
+            logger.warning(
+                "patch_missing_session_rows: plan_launches failed; "
+                "skipping reconciliation",
+                exc_info=True,
+            )
             return 0
 
         upserted = 0
@@ -1136,6 +1141,10 @@ class Supervisor:
             except Exception:  # noqa: BLE001
                 # Per-session failure is non-fatal — we want to patch as
                 # many rows as we can.
+                logger.debug(
+                    "patch_missing_session_rows: upsert failed for %s",
+                    launch.session.name, exc_info=True,
+                )
                 continue
         return upserted
 
@@ -1753,7 +1762,13 @@ class Supervisor:
         try:
             self.ensure_heartbeat_schedule()
         except Exception:  # noqa: BLE001
-            pass  # Schedule failure shouldn't discard a successful sweep
+            # Schedule failure shouldn't discard a successful sweep, but a
+            # silently dropped re-arm means the heartbeat could permanently
+            # stop — make sure the failure shows up in the log.
+            logger.warning(
+                "ensure_heartbeat_schedule failed; next sweep may not be re-armed",
+                exc_info=True,
+            )
 
         return alerts
 
@@ -2211,7 +2226,12 @@ class Supervisor:
                 payload={"session_name": session_name, "owner": owner},
             )
         except Exception:  # noqa: BLE001
-            pass  # Best-effort — lease still works without auto-release
+            # Best-effort — lease still works without auto-release, but a
+            # silent failure means the lease never auto-expires; surface it.
+            logger.warning(
+                "claim_lease: failed to schedule auto-release for %s (owner=%s)",
+                session_name, owner, exc_info=True,
+            )
 
     def release_lease(self, session_name: str, expected_owner: str | None = None) -> None:
         self._require_session(session_name)

--- a/src/pollypm/task_assignment_notify.py
+++ b/src/pollypm/task_assignment_notify.py
@@ -177,7 +177,10 @@ def notify(
         try:
             msg_store.clear_alert("task_assignment", _alert_type_for(event))
         except Exception:  # noqa: BLE001
-            pass
+            logger.debug(
+                "task_assignment_notify: clear_alert(task_assignment) failed for %s",
+                event.task_id, exc_info=True,
+            )
         # #921: also clear the sweep-level ``(worker-<project>, no_session)``
         # alert raised by ``_emit_no_session_alert``. That alert is
         # keyed by the candidate session name we *would* expect, not by
@@ -194,7 +197,10 @@ def notify(
                 try:
                     msg_store.clear_alert(candidate, "no_session")
                 except Exception:  # noqa: BLE001
-                    pass
+                    logger.debug(
+                        "task_assignment_notify: clear_alert(no_session) failed for %s",
+                        candidate, exc_info=True,
+                    )
 
     try:
         session_svc.send(target_name, message)
@@ -211,7 +217,10 @@ def notify(
                         delivery_status=failure_status,
                     )
                 except Exception:  # noqa: BLE001
-                    pass
+                    logger.debug(
+                        "task_assignment_notify: update_notification_status "
+                        "(failure) failed for %s", event.task_id, exc_info=True,
+                    )
             else:
                 try:
                     store.record_notification(
@@ -223,7 +232,10 @@ def notify(
                         execution_version=execution_version,
                     )
                 except Exception:  # noqa: BLE001
-                    pass
+                    logger.debug(
+                        "task_assignment_notify: record_notification "
+                        "(failure) failed for %s", event.task_id, exc_info=True,
+                    )
         return {
             "outcome": "send_failed",
             "task_id": event.task_id,
@@ -680,7 +692,10 @@ def _escalate_no_session_service(event: TaskAssignmentEvent, store: Any | None) 
             ),
         )
     except Exception:  # noqa: BLE001
-        pass
+        logger.debug(
+            "task_assignment_notify: no_session_service alert upsert failed",
+            exc_info=True,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -965,7 +980,10 @@ def _recover_dead_claims(
                     },
                 )
             except Exception:  # noqa: BLE001
-                pass
+                logger.warning(
+                    "auto_claim_sweep: worker_session_recovered audit emit "
+                    "failed for %s", task_id, exc_info=True,
+                )
 
 
 def _wire_session_manager(svc: Any, project_root: Path, services: Any) -> None:

--- a/src/pollypm/web_api/sse.py
+++ b/src/pollypm/web_api/sse.py
@@ -326,8 +326,10 @@ async def stream_audit_events(
         producer_task.cancel()
         try:
             await producer_task
-        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+        except asyncio.CancelledError:
             pass
+        except Exception:  # noqa: BLE001
+            logger.debug("sse producer task raised on shutdown", exc_info=True)
 
     # If we never sent anything, emit one keep-alive so test clients
     # that drain bytes don't see an empty stream.


### PR DESCRIPTION
## Summary

Targeted slice of #1355 (silent ``except Exception: pass`` cleanup —
1066+ sites tree-wide). Converts ~38 of the worst Tier-1 / Tier-2
offenders across 14 files to logged or narrowed catches. No behavior
change beyond "the error now logs" or "the catch is narrower" —
control flow preserved.

This will **not** close #1355. Follow-on slices needed for the
remaining 433 silent sites, dominated by cockpit_ui.py (148, deferred
to #1354) and other cockpit_*.py modules.

### Tier-1 (state mutation / audit emission / notification path) — 13 files

- **supervisor.py** — launch reconciliation, lease auto-release
  scheduler, heartbeat re-arm.
- **heartbeats/local.py** — claim ``started_at`` parse (narrowed to
  ValueError/TypeError), heartbeat_error event emit on session-processing
  failure, intervention dispatch, resume_ping ``stuck_on_task`` alert,
  ``silent_worker_prompt`` audit, ``_escalate`` dedupe scan +
  ``stuck_session`` emit, nudge cooldown gate + audit.
- **plugins_builtin/core_recurring/sweeps.py** — ``state_drift`` audit,
  drift alert upsert, ``stuck_on_task`` alert, ``pane.classify.match`` /
  ``clear`` / ``inbox_emitted`` audits, worktree state-audit
  ``clear_alert``, dedupe scans.
- **task_assignment_notify.py** — ``clear_alert`` paths after delivery,
  notification status update failure, ``no_session_service`` alert,
  ``worker_session_recovered`` audit.
- **error_notifications.py** — logging-handler ``emit`` now routes
  through ``Handler.handleError`` instead of silently dropping a
  critical-error write.
- **notification_staging.py** — ``_project_is_idle`` ``list_tasks``
  failure now logs (was returning False silently).
- **service_api/v1.py** — ``resolve_alert`` ``query_messages`` /
  ``close_message`` failures.
- **session_intelligence.py** — triage ``send_input`` failure
  (worker push).
- **cli.py** — foreground-rail-workers probe failures (silent
  default-to-True could race a daemon launch — exactly the bug the
  function tries to prevent).
- **checkpoints.py**, **knowledge_extract.py**, **job_runner.py**,
  **onboarding.py** — memory-backend / compact / gc / initial-scaffold
  commit failures.

### Tier-2 (user-visible probes) — 1 file

- **web_api/sse.py** — split shutdown ``CancelledError`` from genuine
  exceptions in producer-task cleanup.

### Out of scope (per #1355)

- ``cockpit_ui.py`` and other ``cockpit_*.py`` (handled by #1354 module
  split).
- Tier-3 best-effort cleanup paths (``.close()`` after ``finally``,
  cache-miss fallbacks, ``OSError`` on optional unlink, etc.).

## Counts

| Metric | Before | After | Δ |
|---|---|---|---|
| Silent ``except: pass`` (no logger before pass) | 470 | 433 | -37 |
| Total ``except:`` clauses in src/pollypm | 1080 | 1086 | +6¹ |

¹ Total grew slightly during the slice because origin/main moved forward
with additional code. Net signal is the -37 silent count.

## Test plan

- [ ] ``ruff check`` on touched files — verified: same 61 pre-existing
  errors, **zero new** errors (all are E402 unrelated to this change
  and pre-existing).
- [ ] ``python -c "import <module>"`` for each touched module — verified
  all 14 modules import clean post-edit.
- [ ] Manual diff review — each silent ``pass`` now logs at the
  appropriate level (``debug`` for high-volume probes, ``warning`` for
  state-mutation paths that should never silently drop).
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)