### PR TITLE
fix(watchdog): dedup-state + tier-4 config_path (closes #1914 #1915)

### DIFF
--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -2473,6 +2473,7 @@ def _dispatch_to_operator_tier4(
     promotion_path: str,
     justification: str = "",
     tracker: Any | None = None,
+    config_path: Path | None = None,
 ) -> str:
     """Tier-4 dispatch: route a finding to broader-authority Polly.
 
@@ -2490,6 +2491,12 @@ def _dispatch_to_operator_tier4(
     self-promote CLI) decides whether to call this; it does not gate
     on ``_OPERATOR_DISPATCHABLE_RULES`` because tier-4 dispatch is
     promotion-driven, not rule-driven.
+
+    ``config_path`` (#1914 fix) — mirrors the tier-3 fix from #1546.
+    Alternate-config heartbeat runs need the inbox write to land on
+    the same backend the projector reads from; pre-fix tier-4 always
+    resolved against ``DEFAULT_CONFIG_PATH`` so cards could land in
+    the wrong workspace/backend on pg cutover or test setups.
     """
     from pollypm.audit.tier4 import root_cause_hash
 
@@ -2536,6 +2543,7 @@ def _dispatch_to_operator_tier4(
             subject=subject_text,
             body=body,
             dedup_key=dedup_key,
+            config_path=config_path,
         )
     except Exception:  # noqa: BLE001
         logger.warning(
@@ -3214,12 +3222,18 @@ def _scan_one_project(
             if tracker is not None:
                 try:
                     if tracker.should_auto_promote(finding, now=now):
+                        # #1914 fix — thread ``config_path`` so
+                        # alternate-config heartbeat runs route the
+                        # tier-4 inbox write to the same backend the
+                        # tier-3 fix already covers. Pre-fix tier-4
+                        # always resolved ``DEFAULT_CONFIG_PATH``.
                         outcome = _dispatch_to_operator_tier4(
                             finding,
                             project_path=project_path,
                             now=now,
                             promotion_path="watchdog",
                             tracker=tracker,
+                            config_path=config_path,
                         )
                         if outcome == "dispatched":
                             counters["tier4_dispatches_sent"] += 1

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -2061,6 +2061,12 @@ def _create_operator_inbox_task(
                 initial_dedup_payload(payload, dedup_key)
                 if dedup_key else payload
             )
+            # #1915 fix — dedup row MUST stay live ("open") so the
+            # next tick's ``find_open_dedup_message`` can collapse onto
+            # it via ``bump_dedup_message``. Pre-fix this was
+            # ``state="closed"`` and the dedup query (which only scans
+            # ``state in ('open', 'staged')``) never matched, so every
+            # tick stacked a new notify row + chat task.
             message_id = store.enqueue_message(
                 type="notify",
                 tier="immediate",
@@ -2071,7 +2077,7 @@ def _create_operator_inbox_task(
                 scope=project_key,
                 labels=["notify", "watchdog"],
                 payload=seeded_payload,
-                state="closed",
+                state="open",
                 kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
             )
 
@@ -2266,6 +2272,12 @@ def _create_operator_tier4_inbox_task(
                 initial_dedup_payload(payload, dedup_key)
                 if dedup_key else payload
             )
+            # #1915 fix — dedup row MUST stay live ("open") so the
+            # next tick's ``find_open_dedup_message`` can collapse onto
+            # it via ``bump_dedup_message``. Pre-fix this was
+            # ``state="closed"`` and the dedup query (which only scans
+            # ``state in ('open', 'staged')``) never matched, so every
+            # tick stacked a new notify row + chat task.
             message_id = store.enqueue_message(
                 type="notify",
                 tier="immediate",
@@ -2276,7 +2288,7 @@ def _create_operator_tier4_inbox_task(
                 scope=project_key,
                 labels=["notify", "watchdog", "tier4"],
                 payload=seeded_payload,
-                state="closed",
+                state="open",
                 kind=InboxItemKind.WATCHDOG_OPERATOR_DISPATCH.value,
             )
 


### PR DESCRIPTION
## Summary

Two regression fixes for `audit_watchdog.py`, audited by Codex against PR #1901 (watchdog dedup pg-mode).

### #1915 - dedup row never matched

The tier-3 and tier-4 operator-dispatch notify inserts wrote rows as `state="closed"`, but `find_open_dedup_message` only scans live rows (`state in ('open', 'staged')`). The dedup lookup therefore never matched and every watchdog tick stacked a new notify + chat task, growing the cockpit inbox/action surface and worsening rail/content load time.

Flip the seeded insert to `state="open"` in both `_create_operator_inbox_task` and `_create_operator_tier4_inbox_task` so the next tick collapses onto the existing row via `bump_dedup_message`. Added an inline comment in both sites explaining the dedup-state contract.

### #1914 - tier-4 dispatch ignored config_path

PR #1901's pg-routing fix added `config_path` to `_create_operator_tier4_inbox_task` but no caller passed it. `_dispatch_to_operator_tier4` had no `config_path` parameter, so the auto-promote branch in `_scan_one_project` couldn't thread the active cadence config through. Result: alternate-config heartbeat runs routed tier-3 dispatches to the right backend (via the #1546 fix) but tier-4 auto-promoted writes still fell back to `DEFAULT_CONFIG_PATH`.

Added `config_path` to `_dispatch_to_operator_tier4` (defaulting to `None` for back-compat with the tier4 actions registry protocol) and forwarded it to the inbox-task helper. The auto-promote caller in `_scan_one_project` now passes its in-scope `config_path`.

## Scope

- Touches ONLY `src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py` (v1 RC stability priority).
- Two commits, one per issue, both with explanatory inline comments.
- `ruff check` passes on the touched file.
- Tests not run per instructions; the registry-based self-promote CLI invocation path keeps prior behavior because the new `config_path` parameter defaults to `None` (matches the `DispatchToOperatorTier4` Protocol shape).

## Test plan

- [ ] Heartbeat with `--config /path/to/alt.toml` triggering a tier-4 auto-promote: verify the notify row lands in the alt-config backend's `messages` table.
- [ ] Trigger the same watchdog finding twice on pg: verify the second tick bumps the existing notify row (count > 1) instead of stacking.
- [ ] Same on sqlite (default): verify dedup still collapses across ticks.
- [ ] Confirm tier4 actions registry-based CLI dispatch path still works (defaults to `config_path=None`, matching the old behavior).

Closes #1914
Closes #1915

Generated with [Claude Code](https://claude.com/claude-code)