### PR TITLE
fix(pg_store+cockpit): pinned-prune + inbox preview limit (closes #1912 #1913)

### DIFF
--- a/src/pollypm/cockpit_inbox_items.py
+++ b/src/pollypm/cockpit_inbox_items.py
@@ -1069,11 +1069,19 @@ def load_inbox_action_preview(
                 project_db_paths[project_key] = db_path
             else:
                 ws_db = db_path
-        pg_messages = open_messages(config, known_projects=known_projects)
+        # Push the per-source cap into SQL (#1913): the prepaint preview
+        # only renders ``preview_limit`` rows, so fetching every open
+        # inbox-shaped row before slicing was making first-paint
+        # proportional to total open-message volume. ``open_messages``
+        # orders by ``created_at DESC, id DESC`` so a SQL LIMIT yields
+        # the same newest-first slice the in-memory cap used to.
+        pg_preview_cap = max(rows_per_source * 4, 96)
+        pg_messages = open_messages(
+            config,
+            known_projects=known_projects,
+            limit=pg_preview_cap,
+        )
         rows_iter: list[dict] = list(pg_messages or [])
-        # Match the sqlite path's per-source cap roughly — pg returns
-        # rows newest-first already, slice to keep the prepaint snappy.
-        rows_iter = rows_iter[: max(rows_per_source * 4, 96)]
         for row in rows_iter:
             if _row_is_dev_channel(row.get("labels")):
                 continue

--- a/src/pollypm/cockpit_pg_aggregates.py
+++ b/src/pollypm/cockpit_pg_aggregates.py
@@ -192,6 +192,7 @@ def open_messages(
     config: "PollyPMConfig | None",
     *,
     known_projects: set[str],
+    limit: int | None = None,
 ) -> list[dict[str, Any]] | None:
     """Return every open inbox-shaped messages row in one pg query.
 
@@ -204,6 +205,10 @@ def open_messages(
     The ``known_projects`` set scopes the SQL to scopes the user owns
     so a workspace row referencing a non-tracked project doesn't leak
     into the badge count.
+
+    Pass ``limit`` to push a SQL ``LIMIT`` into the query (#1913). The
+    prepaint preview path only needs the first dozen newest rows; the
+    rail/cockpit unbounded paths still call without a limit.
 
     Returns ``None`` on pool / query failure so the caller can fall back
     to its per-project walk.
@@ -242,6 +247,9 @@ def open_messages(
         sql += " AND (scope = '' OR scope = 'inbox' OR scope = ANY(%s))"
         params.append(list(known_projects))
     sql += " ORDER BY created_at DESC, id DESC"
+    if limit is not None and limit > 0:
+        sql += " LIMIT %s"
+        params.append(int(limit))
 
     try:
         with pool.connection() as conn, conn.cursor() as cur:

--- a/src/pollypm/store/backends/pg_store.py
+++ b/src/pollypm/store/backends/pg_store.py
@@ -822,10 +822,16 @@ class PgStore:
                 params.append(state)
         if exclude_pinned:
             # ``payload_json`` is ``jsonb`` on pg. ``->>`` extracts the
-            # value as text; ``IS DISTINCT FROM`` makes NULL behave like
-            # "not pinned" (matches sqlite's coalesce(...,0) != 1).
+            # value as text, so JSON booleans surface as ``'true'`` /
+            # ``'false'`` and JSON ints as ``'1'`` / ``'0'``. The
+            # protocol (#1912) treats any truthy ``pinned`` payload as
+            # "preserve" — sqlite's ``json_extract(...) != 1`` does so
+            # implicitly because it coerces JSON ``true`` to ``1``. On
+            # pg we have to enumerate the truthy text forms ourselves
+            # (and let NULL fall through to "not pinned" via NOT IN).
             where.append(
-                "(payload_json->>'pinned') IS DISTINCT FROM '1'"
+                "COALESCE(payload_json->>'pinned', '') "
+                "NOT IN ('1', 'true', 't', 'True')"
             )
         sql = f"DELETE FROM messages WHERE {' AND '.join(where)}"
         with self.transaction() as conn, conn.cursor() as cur:

--- a/tests/test_pg_store.py
+++ b/tests/test_pg_store.py
@@ -330,6 +330,49 @@ def test_prune_messages_by_type_and_age(pg_schema_pool):
     assert {row["type"] for row in remaining} == {"notify"}
 
 
+def test_prune_messages_exclude_pinned_preserves_boolean_and_int(pg_schema_pool):
+    """Regression for #1912: ``exclude_pinned=True`` must preserve rows whose
+    ``payload_json`` carries any truthy ``pinned`` value — JSON ``true`` and
+    JSON ``1`` alike — and only delete rows where ``pinned`` is absent or
+    falsy. The previous SQL compared the text form against ``'1'`` only, so
+    JSON booleans (which round-trip as text ``'true'``) were pruned. That
+    silently dropped first-shipped markers written via ``"pinned": True``.
+    """
+    store = _new_store(pg_schema_pool)
+    # Three event rows: pinned via int, pinned via bool, and unpinned.
+    store.enqueue_message(
+        type="event", tier="immediate", recipient="*",
+        sender="s", subject="int-pinned", body="", scope="p",
+        payload={"pinned": 1},
+    )
+    store.enqueue_message(
+        type="event", tier="immediate", recipient="*",
+        sender="s", subject="bool-pinned", body="", scope="p",
+        payload={"pinned": True},
+    )
+    store.enqueue_message(
+        type="event", tier="immediate", recipient="*",
+        sender="s", subject="unpinned", body="", scope="p",
+        payload={"note": "no pin"},
+    )
+    with store.transaction() as conn, conn.cursor() as cur:
+        cur.execute(
+            "UPDATE messages SET created_at = now() - interval '7 days' "
+            "WHERE type = 'event'"
+        )
+    cutoff = datetime.now(timezone.utc) - timedelta(days=1)
+    removed = store.prune_messages(
+        type="event", older_than=cutoff, exclude_pinned=True,
+    )
+    assert removed == 1
+    remaining = store.query_messages(type="event")
+    assert len(remaining) == 2
+    pinned_values = sorted(
+        repr((row["payload"] or {}).get("pinned")) for row in remaining
+    )
+    assert pinned_values == ["1", "True"]
+
+
 def test_execute_raises_not_implemented(pg_schema_pool):
     store = _new_store(pg_schema_pool)
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
## Summary

Two Codex audit fixes landed as one branch / two commits.

### #1912 (CRITICAL — data loss): pg ``prune_messages(exclude_pinned=True)`` deleted JSON boolean pinned rows

The pg predicate compared the text form of ``payload_json->>'pinned'`` against ``'1'`` only. ``->>`` surfaces JSON ``true`` as text ``'true'``, so a row written via ``"pinned": True`` (e.g. ``src/pollypm/work/first_shipped.py``) was treated as not-pinned and pruned on pg, while sqlite kept it via ``json_extract(...) != 1`` coercion. Cross-backend Store contract violated; pinned first-shipped/activity markers silently disappearing after retention sweeps on pg workspaces.

Fix: enumerate the truthy text forms — ``'1'``, ``'true'``, ``'t'``, ``'True'`` — under a ``NOT IN`` predicate; ``COALESCE`` keeps NULL = "not pinned" parity. Regression test exercises both ``{"pinned": 1}`` and ``{"pinned": True}`` against the schema-isolated pg pool.

### #1913 (perf): inbox action preview fetched every open message before applying preview limit

``load_inbox_action_preview`` (PR #1896) called ``cockpit_pg_aggregates.open_messages`` with no SQL bound, then sliced in Python. On a pg workspace with a large open ``messages`` table the cockpit prepaint paid for fetching and decoding every notify/inbox_task/alert row before showing the first dozen.

Fix: add a ``limit`` kwarg to ``open_messages`` that emits ``LIMIT %s`` after the existing ``ORDER BY created_at DESC, id DESC``, and have the preview path pass its per-source cap (``max(rows_per_source * 4, 96)``) into it. Unbounded rail/cockpit callers stay unchanged.

## Test plan

- [ ] ``ruff check`` passes on the four touched files (preexisting F401 in ``cockpit_inbox_items.py`` from a prior PR is not in changed lines).
- [ ] ``pytest tests/test_pg_store.py::test_prune_messages_exclude_pinned_preserves_boolean_and_int`` passes against a real pg pool.
- [ ] Manual pg-mode smoke: open cockpit on a workspace with > 100 open inbox-shaped rows and confirm preview prepaint no longer materializes all rows (check pg query log for ``LIMIT``).
- [ ] Existing ``test_prune_messages_by_type_and_age`` still passes.

Closes #1912
Closes #1913

🤖 Generated with [Claude Code](https://claude.com/claude-code)