### PR TITLE
fix(per-task-lifecycle): cap atomicity + counter race + reviewer kickoff (closes #1906 #1908 #1910)

### DIFF
--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -115,6 +115,20 @@ def _now_iso() -> datetime:
     return datetime.now(UTC)
 
 
+def _is_cap_exceeded_error(exc: BaseException) -> bool:
+    """Return True when ``exc`` is a ``WorkerCapExceededError`` (#1906).
+
+    Matched by qualified class name to avoid importing
+    ``pollypm.work.session_manager`` at module-load time (the session
+    manager imports this service in some wiring paths, so the explicit
+    import would risk circularity).
+    """
+    for cls in type(exc).__mro__:
+        if cls.__name__ == "WorkerCapExceededError":
+            return True
+    return False
+
+
 def _coerce_status(raw: str) -> WorkStatus:
     try:
         return WorkStatus(raw)
@@ -1667,7 +1681,92 @@ class PgWorkService:
                     actor,
                     exc,
                 )
+                # #1906 — atomic cap reserve can still lose the race
+                # AFTER the claim transition has already committed. The
+                # session manager already released its placeholder cap
+                # slot via _release_cap_slot_on_failure; revert the
+                # task back to queued so auto-claim re-picks it instead
+                # of stranding it ``in_progress`` with no worker. See
+                # the sqlite counterpart in service_transition_manager.
+                if _is_cap_exceeded_error(exc) and target_status is (
+                    WorkStatus.IN_PROGRESS
+                ):
+                    self._rollback_claim_to_queued(
+                        task.project,
+                        task.task_number,
+                        node_id,
+                        actor,
+                        exc,
+                    )
         return result
+
+    def _rollback_claim_to_queued(
+        self,
+        project: str,
+        task_number: int,
+        node_id: str,
+        actor: str,
+        exc: BaseException,
+    ) -> None:
+        """Revert an in_progress claim back to queued (#1906).
+
+        Postgres counterpart of
+        ``WorkTransitionManager._rollback_claim_to_queued``. Best-effort:
+        a failed rollback is logged so the operator still sees
+        ``last_provision_error`` and can run ``pm task release``
+        manually rather than silently wedging the task.
+        """
+        now = _now_iso()
+        try:
+            with self._pool.connection() as conn:
+                conn.autocommit = False
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE work_tasks SET work_status = %s, "
+                        "updated_at = %s "
+                        "WHERE project = %s AND task_number = %s",
+                        (
+                            WorkStatus.QUEUED.value,
+                            now,
+                            project,
+                            task_number,
+                        ),
+                    )
+                    cur.execute(
+                        "UPDATE work_node_executions SET status = %s, "
+                        "ended_at = %s "
+                        "WHERE task_project = %s AND task_number = %s "
+                        "AND node_id = %s AND status = %s",
+                        (
+                            ExecutionStatus.ABANDONED.value,
+                            now,
+                            project,
+                            task_number,
+                            node_id,
+                            ExecutionStatus.ACTIVE.value,
+                        ),
+                    )
+                    self._insert_transition_locked(
+                        cur,
+                        project,
+                        task_number,
+                        WorkStatus.IN_PROGRESS.value,
+                        WorkStatus.QUEUED.value,
+                        actor,
+                        None,
+                    )
+                conn.commit()
+            logger.warning(
+                "claim rollback: %s/%d returned to queued after "
+                "post-commit provision failure (%s)",
+                project, task_number, exc,
+            )
+        except Exception as rollback_exc:  # noqa: BLE001
+            logger.warning(
+                "claim rollback failed for %s/%d: %s (task remains "
+                "in_progress; operator must release manually)",
+                project, task_number, rollback_exc,
+            )
 
     def next(  # noqa: A003
         self,

--- a/src/pollypm/work/service_transition_manager.py
+++ b/src/pollypm/work/service_transition_manager.py
@@ -85,6 +85,21 @@ def _looks_like_stale_base(reason: str) -> bool:
     return any(hint in detail for hint in _STALE_BASE_REASON_HINTS)
 
 
+def _is_cap_exceeded_error(exc: BaseException) -> bool:
+    """Return True when ``exc`` is a ``WorkerCapExceededError`` (#1906).
+
+    Walks the exception class hierarchy by qualified name so the
+    transition manager doesn't have to import
+    ``pollypm.work.session_manager`` at module-load time (the
+    session-manager module imports transition helpers in some test
+    paths, so a top-level import would risk circularity).
+    """
+    for cls in type(exc).__mro__:
+        if cls.__name__ == "WorkerCapExceededError":
+            return True
+    return False
+
+
 @dataclass(slots=True)
 class _PMRepairCallSiteOutcome:
     """Internal wrapper that the reject() call site consumes (#1026)."""
@@ -643,6 +658,24 @@ class WorkTransitionManager:
                         actor,
                         exc,
                     )
+                    # #1906 — the atomic cap reserve can still lose the
+                    # race after the claim transition has already
+                    # committed (two queued tasks both pass the pre-check,
+                    # one wins the atomic reserve, the other commits its
+                    # task transition and then raises WorkerCapExceededError
+                    # from the reserve). Without this rollback the loser
+                    # is left ``in_progress`` with no worker, no tmux
+                    # window, and no worktree — auto-claim won't naturally
+                    # re-pick it because it's no longer ``queued``.
+                    #
+                    # The session manager already released its placeholder
+                    # cap slot via _release_cap_slot_on_failure, so all
+                    # that's left is reverting the work_tasks row + the
+                    # active node execution so the next tick re-claims.
+                    if _is_cap_exceeded_error(exc):
+                        self._rollback_claim_to_queued(
+                            task, node_id, actor, exc,
+                        )
 
         result = self._finish(
             task_id,
@@ -650,6 +683,76 @@ class WorkTransitionManager:
             after_sync=_after_sync,
         )
         return result
+
+    def _rollback_claim_to_queued(
+        self,
+        task: Task,
+        node_id: str,
+        actor: str,
+        exc: BaseException,
+    ) -> None:
+        """Revert an in_progress claim back to queued (#1906).
+
+        Called when post-commit ``provision_worker`` fails with a
+        cap-exceeded error. Drops the active node execution row that
+        the claim mutate inserted and stamps the task back to
+        ``queued`` so the next auto-claim tick can re-pick it.
+
+        Best-effort: any DB error is logged and swallowed because the
+        provision exception in ``last_provision_error`` is the primary
+        operator signal. Without the rollback the task is silently
+        wedged; with a failed rollback the operator still sees the
+        provision error and can run ``pm task release`` manually.
+        """
+        now = _now()
+        try:
+            self._commit(
+                lambda: (
+                    self.service._conn.execute(
+                        "UPDATE work_tasks SET work_status = ?, "
+                        "updated_at = ? "
+                        "WHERE project = ? AND task_number = ?",
+                        (
+                            WorkStatus.QUEUED.value,
+                            now,
+                            task.project,
+                            task.task_number,
+                        ),
+                    ),
+                    self.service._conn.execute(
+                        "UPDATE work_node_executions SET status = ?, "
+                        "ended_at = ? "
+                        "WHERE task_project = ? AND task_number = ? "
+                        "AND node_id = ? AND status = ?",
+                        (
+                            ExecutionStatus.ABANDONED.value,
+                            now,
+                            task.project,
+                            task.task_number,
+                            node_id,
+                            ExecutionStatus.ACTIVE.value,
+                        ),
+                    ),
+                    self.service._record_transition(
+                        task.project,
+                        task.task_number,
+                        WorkStatus.IN_PROGRESS.value,
+                        WorkStatus.QUEUED.value,
+                        actor,
+                    ),
+                )
+            )
+            logger.warning(
+                "claim rollback: %s/%d returned to queued after "
+                "post-commit provision failure (%s)",
+                task.project, task.task_number, exc,
+            )
+        except Exception as rollback_exc:  # noqa: BLE001
+            logger.warning(
+                "claim rollback failed for %s/%d: %s (task remains "
+                "in_progress; operator must release manually)",
+                task.project, task.task_number, rollback_exc,
+            )
 
     def cancel(self, task_id: str, actor: str, reason: str) -> Task:
         task = self.service.get(task_id)

--- a/src/pollypm/work/session_manager.py
+++ b/src/pollypm/work/session_manager.py
@@ -1348,7 +1348,12 @@ class SessionManager:
             return window_name
 
         try:
-            reviewer_cmd, _provider, _account = self._reviewer_launch_bundle(
+            (
+                reviewer_cmd,
+                reviewer_provider,
+                reviewer_account,
+                reviewer_cwd,
+            ) = self._reviewer_launch_bundle(
                 window_name=window_name,
                 project=project,
                 task_number=task_number,
@@ -1366,21 +1371,73 @@ class SessionManager:
             )
             return None
 
-        try:
-            if not self._tmux.has_session(session_name):
-                self._tmux.create_session(
-                    session_name, window_name, reviewer_cmd,
+        # #1910 — the reviewer needs a task-specific kickoff or it
+        # launches in the right cwd but sits idle waiting for input.
+        # Build the kickoff message (mirrors the worker's prompt-file
+        # convention from _provision_locked) and route through the
+        # SessionService when configured so the kickoff is delivered as
+        # initial input after the stabilize window. Falls back to the
+        # legacy raw-tmux path for test harnesses that wire a bare
+        # SessionManager without a SessionService.
+        reviewer_kickoff = (
+            f"Review task {task_id}. Inspect the diff between the task "
+            f"branch and main, read the worker's "
+            f".pollypm-task-prompt.md, and decide. If the work meets the "
+            f"bar, approve with `pm task approve {task_id}`. If it "
+            f"needs changes, reject with "
+            f"`pm task reject {task_id} --reason '<why>'`."
+        )
+
+        if self._session_service is not None:
+            marker_dir = self._project_path / ".pollypm" / "worker-markers"
+            try:
+                marker_dir.mkdir(parents=True, exist_ok=True)
+                marker_path = marker_dir / f"{window_name}.fresh"
+                marker_path.write_text(_now())
+            except OSError as marker_exc:
+                logger.warning(
+                    "provision_reviewer: could not write fresh-launch "
+                    "marker for %s: %s (kickoff may not be delivered)",
+                    task_id, marker_exc,
                 )
-            else:
-                self._tmux.create_window(
-                    session_name, window_name, reviewer_cmd, detached=True,
+                marker_path = None
+            try:
+                self._session_service.create(
+                    name=window_name,
+                    provider=reviewer_provider,
+                    account=reviewer_account,
+                    cwd=reviewer_cwd,
+                    command=reviewer_cmd,
+                    window_name=window_name,
+                    tmux_session=session_name,
+                    stabilize=True,
+                    initial_input=reviewer_kickoff,
+                    fresh_launch_marker=marker_path,
+                    session_role="reviewer",
                 )
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "provision_reviewer: tmux spawn failed for %s: %s",
-                task_id, exc,
-            )
-            return None
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "provision_reviewer: session-service spawn failed for "
+                    "%s: %s", task_id, exc,
+                )
+                return None
+        else:
+            try:
+                if not self._tmux.has_session(session_name):
+                    self._tmux.create_session(
+                        session_name, window_name, reviewer_cmd,
+                    )
+                else:
+                    self._tmux.create_window(
+                        session_name, window_name, reviewer_cmd,
+                        detached=True,
+                    )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "provision_reviewer: tmux spawn failed for %s: %s",
+                    task_id, exc,
+                )
+                return None
 
         # Best-effort forensic event so operators can grep the audit
         # log for spawn cadence. Mirrors the worker provision audit
@@ -1451,15 +1508,21 @@ class SessionManager:
         window_name: str,
         project: str,
         task_number: int,
-    ) -> tuple[str, str, str]:
+    ) -> tuple[str, str, str, Path]:
         """Build the launch command for a per-task reviewer window.
 
-        Returns ``(command, provider_name, account_name)``. Routes
+        Returns ``(command, provider_name, account_name, cwd)``. Routes
         through the configured provider/runtime adapter pair so the
         reviewer obeys the same account, runtime, and permissions
         policy as the worker. Materialises the reviewer persona prompt
         to disk and appends ``--append-system-prompt-file`` for Claude
         launches (mirrors #1870/#1873 architect persona injection).
+
+        ``cwd`` is the resolved working directory — the worker's task
+        worktree when present, otherwise the project root (#1886). The
+        caller passes this back into ``SessionService.create`` so the
+        reviewer kickoff (#1910) lands in the same directory the
+        launch command targets.
         """
         from pollypm.models import ProviderKind, SessionConfig
         from pollypm.onboarding import default_session_args
@@ -1615,7 +1678,7 @@ class SessionManager:
                 )
 
         command = runtime.wrap_command(launch, account, config.project)
-        return command, account.provider.value, account_name
+        return command, account.provider.value, account_name, session_cwd
 
     # ------------------------------------------------------------------
     # Rejection

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -4081,12 +4081,30 @@ class SQLiteWorkService:
                 return False
             # Reserve the slot with a placeholder. Subsequent COUNT
             # calls from other concurrent claims see it immediately.
+            #
+            # #1908 — must NOT use ``INSERT OR REPLACE``: that variant
+            # deletes the existing row before insert, wiping
+            # ``total_input_tokens`` / ``total_output_tokens`` that the
+            # ``upsert_worker_session`` path intentionally preserves
+            # across re-provision cycles (#1014 Bug B). Mirror the pg
+            # conflict update shape: insert a placeholder on missing
+            # rows; on conflict update only the active-session
+            # placeholder columns and clear ``ended_at`` / ``archive_path``
+            # so the slot is treated as live again. Token counters fall
+            # through unchanged.
             conn.execute(
-                "INSERT OR REPLACE INTO work_sessions ("
+                "INSERT INTO work_sessions ("
                 "task_project, task_number, agent_name, pane_id, "
-                "worktree_path, branch_name, started_at, ended_at, "
-                "archive_path"
-                ") VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL)",
+                "worktree_path, branch_name, started_at"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT (task_project, task_number) DO UPDATE SET "
+                "agent_name = excluded.agent_name, "
+                "pane_id = excluded.pane_id, "
+                "worktree_path = excluded.worktree_path, "
+                "branch_name = excluded.branch_name, "
+                "started_at = excluded.started_at, "
+                "ended_at = NULL, "
+                "archive_path = NULL",
                 (
                     task_project,
                     task_number,


### PR DESCRIPTION
## Summary

Codex r5 audit of the per-task lifecycle (#1875 / #1878 / #1895) found three follow-on regressions in the worker-cap + reviewer paths. One branch, three commits, one per issue.

### closes #1908 — sqlite reserve wipes token counters

`SQLiteWorkService.reserve_worker_cap_slot()` used `INSERT OR REPLACE`, which deletes/recreates the `work_sessions` row and wipes `total_input_tokens` / `total_output_tokens` that the normal `upsert_worker_session` path intentionally preserves across re-provision cycles (#1014 Bug B). Mirror the pg conflict-update shape: `INSERT ... ON CONFLICT DO UPDATE SET` only the active-session placeholder columns and clear `ended_at` / `archive_path`. Token counters fall through unchanged.

### closes #1906 — claim left in_progress on post-commit cap loss

The atomic cap reserve fires inside `SessionManager._provision_locked()`, AFTER the claim transition has already committed. Two queued tasks can both pass the non-atomic pre-check; the loser commits its task row first and then raises `WorkerCapExceededError` from the atomic reserve. Pre-fix the exception was swallowed into `last_provision_error` and the task was stranded `in_progress` with no worker — auto-claim doesn't pick it up because it's no longer `queued`.

Detect `WorkerCapExceededError` in the post-commit provision callback (both sqlite `service_transition_manager` and pg `pg_service.claim`) and roll the work_tasks row back to `queued`, abandon the active node-execution row, and write the `in_progress -> queued` transition. The session manager already releases its placeholder cap slot via `_release_cap_slot_on_failure`. Rollback failures log but don't raise — `last_provision_error` remains the primary operator signal.

### closes #1910 — per-task reviewer launches without a kickoff

#1886 moved per-task reviewer windows into the worker worktree, but `provision_reviewer()` still called `tmux.create_window` directly with just the launch command. The agent booted in the right cwd, parsed its persona prompt, then sat idle waiting for input — review handoffs created a tmux window that never reviewed anything.

Route the reviewer through `SessionService.create()` (the same path the worker uses in `_launch_worker_window`) with an `initial_input` kickoff that names the task and points at `pm task approve` / `pm task reject`. Gated on a fresh-launch marker so it only fires on new windows, not on the reject -> rework -> resubmit re-entry path. `_reviewer_launch_bundle` now also returns the resolved cwd so the SessionService call uses the same worker-worktree-or-project-root logic. Legacy raw-tmux fallback preserved for test harnesses without a wired SessionService.

## Test plan

- [ ] sqlite reserve preserves token counters when re-reserving an ended row (issue #1908 repro)
- [ ] sqlite cap-exceeded post-commit failure returns task to `queued` and auto-claim re-picks it (issue #1906 repro on FakeMgr)
- [ ] pg cap-exceeded post-commit failure returns task to `queued`
- [ ] per-task reviewer window receives kickoff (visible in pane after stabilize), reviewer can run `pm task approve` without operator nudge
- [ ] reviewer idempotency holds: second `provision_reviewer` for the same task during reject -> rework -> resubmit does NOT re-fire the kickoff

Touched files: `src/pollypm/work/sqlite_service.py`, `src/pollypm/work/service_transition_manager.py`, `src/pollypm/work/pg_service.py`, `src/pollypm/work/session_manager.py`. Ruff clean on all touched files.

Refs: #1875 (per-task worker), #1878 (per-task reviewer), #1895 (worker-cap atomicity), #1886 (reviewer worktree).