### PR TITLE
refactor(boundaries): break onboarding ↔ onboarding_tui circular import (refs #1367)

### DIFF
--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -435,7 +435,7 @@ def _require_pollypm_session(supervisor) -> None:
 
 
 def _first_run_setup_and_launch(config_path: Path) -> None:
-    from pollypm.onboarding import run_onboarding
+    from pollypm.onboarding_tui import run_onboarding
     path = run_onboarding(config_path=config_path, force=False)
     _install_global_pollypm(path.parent)
     # #1111 — pass phantom_client=False explicitly. Calling the
@@ -621,7 +621,7 @@ def onboard(
     config_path: Path = typer.Option(DEFAULT_CONFIG_PATH, "--config", help="Path to write the onboarding config."),
     force: bool = typer.Option(False, "--force", help="Overwrite an existing config file."),
 ) -> None:
-    from pollypm.onboarding import run_onboarding
+    from pollypm.onboarding_tui import run_onboarding
     path = run_onboarding(config_path=config_path, force=force)
     installed, install_output = _install_global_pollypm(path.parent)
     typer.echo("")

--- a/src/pollypm/onboarding.py
+++ b/src/pollypm/onboarding.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import typer
 
 from pollypm.agent_profiles.defaults import heartbeat_prompt, polly_prompt
-from pollypm.config import DEFAULT_CONFIG_PATH, load_config, write_config
+from pollypm.config import load_config, write_config
 from pollypm.models import (
     AccountConfig,
     KnownProject,
@@ -1320,49 +1320,6 @@ def _render_welcome_back_summary(config: PollyPMConfig) -> list[str]:
         for project in config.projects.values():
             lines.append(f"- {project.display_label()} -> {project.path}")
     return lines
-
-
-def run_onboarding(
-    config_path: Path = DEFAULT_CONFIG_PATH,
-    force: bool = False,
-    *,
-    no_animation: bool = False,
-) -> OnboardingResult:
-    from pollypm.onboarding_tui import run_onboarding_app
-
-    if not force and config_path.exists():
-        try:
-            config = load_config(config_path)
-        except Exception:  # noqa: BLE001
-            config = None
-        if config is not None:
-            for line in _render_welcome_back_summary(config):
-                typer.echo(line)
-            typer.echo("")
-            typer.echo("1. Open cockpit")
-            typer.echo("2. Add another account")
-            typer.echo("3. Re-run full onboarding")
-            choice = typer.prompt("Choose", default="1")
-            if choice == "1":
-                result = OnboardingResult(config_path=config_path, launch_requested=True)
-                if _launch_onboarding_experience(result):
-                    raise typer.Exit()
-                return result
-            if choice == "2":
-                result = run_onboarding_app(config_path=config_path, force=False, no_animation=no_animation)
-                if result.launch_requested and _launch_onboarding_experience(result):
-                    raise typer.Exit()
-                return result
-            if choice == "3":
-                result = run_onboarding_app(config_path=config_path, force=True, no_animation=no_animation)
-                if result.launch_requested and _launch_onboarding_experience(result):
-                    raise typer.Exit()
-                return result
-
-    result = run_onboarding_app(config_path=config_path, force=force, no_animation=no_animation)
-    if result.launch_requested and _launch_onboarding_experience(result):
-        raise typer.Exit()
-    return result
 
 
 def relogin_account(config_path: Path, identifier: str) -> tuple[str, str]:

--- a/src/pollypm/onboarding_tui.py
+++ b/src/pollypm/onboarding_tui.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import shutil
 import time
 
+import typer
 from rich.console import Console
 from rich.console import Group
 from rich.panel import Panel
@@ -18,8 +19,9 @@ from textual.screen import ModalScreen
 from textual.worker import Worker, WorkerState
 from textual.widgets import Button, Checkbox, Footer, RadioButton, RadioSet, SelectionList, Static
 
+from pollypm import onboarding as _onboarding_module
 from pollypm.cli_shortcuts import shortcut_rows
-from pollypm.config import write_config
+from pollypm.config import DEFAULT_CONFIG_PATH, load_config, write_config
 from pollypm.doctor import (
     AutoFixPlan,
     check_claude_cli,
@@ -43,6 +45,7 @@ from pollypm.onboarding import (
     demo_project_fallback_destination,
     discover_recent_project_candidates,
     provision_demo_project_fallback,
+    seed_demo_project_task,
 )
 from pollypm.onboarding_models import OnboardingResult
 from pollypm.projects import ensure_project_scaffold, make_project_key
@@ -1155,8 +1158,6 @@ class OnboardingApp(App[OnboardingResult | None]):
         self.state.recent_projects = [demo_path]
         self.state.selected_project_paths = [demo_path]
         if choice == "keep":
-            from pollypm.onboarding import seed_demo_project_task
-
             project_key = make_project_key(demo_path, set(self.state.known_projects))
             try:
                 task_id = seed_demo_project_task(demo_path, project_key=project_key)
@@ -1201,4 +1202,56 @@ def run_onboarding_app(config_path: Path, force: bool = False, no_animation: boo
     result = app.run(mouse=True)
     if result is None:
         raise SystemExit(1)
+    return result
+
+
+def run_onboarding(
+    config_path: Path = DEFAULT_CONFIG_PATH,
+    force: bool = False,
+    *,
+    no_animation: bool = False,
+) -> OnboardingResult:
+    # ``_onboarding_module`` indirection (vs a direct ``from pollypm.onboarding
+    # import _launch_onboarding_experience``) keeps the monkeypatch seam used
+    # by ``tests/test_onboarding.py`` honoured — test code replaces the
+    # attribute on the ``pollypm.onboarding`` module and expects this caller
+    # to pick up the substitute. Refactor slice 2 of #1367 moved this entry
+    # point out of ``pollypm.onboarding`` to break the onboarding ↔
+    # onboarding_tui import cycle (the lazy ``run_onboarding_app`` import in
+    # ``onboarding.py`` is now unnecessary).
+    launch = _onboarding_module._launch_onboarding_experience
+    render_welcome_back = _onboarding_module._render_welcome_back_summary
+
+    if not force and config_path.exists():
+        try:
+            config = load_config(config_path)
+        except Exception:  # noqa: BLE001
+            config = None
+        if config is not None:
+            for line in render_welcome_back(config):
+                typer.echo(line)
+            typer.echo("")
+            typer.echo("1. Open cockpit")
+            typer.echo("2. Add another account")
+            typer.echo("3. Re-run full onboarding")
+            choice = typer.prompt("Choose", default="1")
+            if choice == "1":
+                result = OnboardingResult(config_path=config_path, launch_requested=True)
+                if launch(result):
+                    raise typer.Exit()
+                return result
+            if choice == "2":
+                result = run_onboarding_app(config_path=config_path, force=False, no_animation=no_animation)
+                if result.launch_requested and launch(result):
+                    raise typer.Exit()
+                return result
+            if choice == "3":
+                result = run_onboarding_app(config_path=config_path, force=True, no_animation=no_animation)
+                if result.launch_requested and launch(result):
+                    raise typer.Exit()
+                return result
+
+    result = run_onboarding_app(config_path=config_path, force=force, no_animation=no_animation)
+    if result.launch_requested and launch(result):
+        raise typer.Exit()
     return result

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -320,7 +320,7 @@ def test_run_onboarding_launches_seeded_demo_experience(monkeypatch, tmp_path: P
     )
 
     with pytest.raises(ClickExit):
-        __import__("pollypm.onboarding", fromlist=["run_onboarding"]).run_onboarding(
+        __import__("pollypm.onboarding_tui", fromlist=["run_onboarding"]).run_onboarding(
             config_path=result.config_path,
             force=True,
         )


### PR DESCRIPTION
## Summary

- Second slice of #1367 cleanup (first slice: #1909 broke ``cockpit_rail ↔ cockpit``).
- Moves ``run_onboarding`` from ``pollypm.onboarding`` into ``pollypm.onboarding_tui``. ``onboarding.py`` no longer references ``onboarding_tui`` at all — the function-level lazy ``from pollypm.onboarding_tui import run_onboarding_app`` is gone, and the cycle collapses to a one-way ``onboarding_tui -> onboarding`` edge.
- Promotes the previously-lazy ``seed_demo_project_task`` import in ``onboarding_tui`` to the module-level import block now that the cycle is gone.

## Behaviour-preservation notes

- ``run_onboarding`` accesses ``_launch_onboarding_experience`` and ``_render_welcome_back_summary`` through the ``pollypm.onboarding`` module object (via a private ``_onboarding_module`` alias) so the existing monkeypatch seam in ``tests/test_onboarding.py`` (``monkeypatch.setattr("pollypm.onboarding._launch_onboarding_experience", ...)``) keeps working unchanged.
- ``run_onboarding_app`` is referenced as a module-level global from inside ``run_onboarding`` (same module), so ``monkeypatch.setattr("pollypm.onboarding_tui.run_onboarding_app", ...)`` still takes effect.
- CLI call sites (``_first_run_setup_and_launch``, ``onboard``) are switched to the new import path. The one test that imported via ``__import__("pollypm.onboarding", fromlist=["run_onboarding"])`` is updated to use ``pollypm.onboarding_tui``.

## Touched files (4)

- ``src/pollypm/onboarding.py`` — delete ``run_onboarding``; drop unused ``DEFAULT_CONFIG_PATH`` import.
- ``src/pollypm/onboarding_tui.py`` — add ``run_onboarding``; add ``typer``, ``DEFAULT_CONFIG_PATH``, ``load_config``, ``_onboarding_module`` alias, ``seed_demo_project_task`` to imports; drop the redundant lazy ``seed_demo_project_task`` import inside the demo-task handler.
- ``src/pollypm/cli.py`` — two lazy import sites repointed.
- ``tests/test_onboarding.py`` — one ``__import__`` path repointed.

## Verification

- ``ruff check`` on touched files: 33 errors before vs 33 errors after the diff (all pre-existing E402 in ``cli.py``); no new lint regressions.
- ``python -c \"import pollypm.cli, pollypm.onboarding, pollypm.onboarding_tui\"`` succeeds; ``hasattr(pollypm.onboarding_tui, 'run_onboarding')`` is True and ``hasattr(pollypm.onboarding, 'run_onboarding')`` is False.
- Grep ``onboarding_tui|# circular`` in ``onboarding.py``: zero hits (the only remaining ``TYPE_CHECKING`` block in that file is for ``TmuxClient``, unrelated).
- Per task constraints: pytest not run.

## Test plan

- [ ] ``pytest tests/test_onboarding.py``
- [ ] ``pytest tests/test_import_boundary.py``
- [ ] Smoke: ``pm onboard --help`` and a real onboarding pass through the welcome-back fork.

## Cycles still open (for slice 3+)

- ``cockpit_palette ↔ cockpit_ui`` — palette lazy-imports 7 App classes from ``cockpit_ui`` (in ``cockpit_palette.py`` ~lines 411 and 661); ``cockpit_ui`` re-exports a large block from ``cockpit_palette`` at module load. Not touched here per the simpler-of-two rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)