### PR TITLE
refactor(boundaries): extract project_planning shared module (refs #1363)

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -8744,7 +8744,7 @@ class PollyInboxApp(App[None]):
             task, labels=labels,
         )
         project_key = task.project
-        from pollypm.plugins_builtin.project_planning.proposals import (
+        from pollypm.project_planning_protocol import (
             accept_proposal as _accept_helper,
         )
         # #1101: unified resolver.
@@ -8823,11 +8823,9 @@ class PollyInboxApp(App[None]):
             self.reply_input.value = ""
             self.list_view.focus()
             return
-        from pollypm.plugins_builtin.project_planning.memory import (
-            record_proposal_rejection,
-        )
-        from pollypm.plugins_builtin.project_planning.proposals import (
+        from pollypm.project_planning_protocol import (
             memkey_from_labels,
+            record_proposal_rejection,
         )
         memkey = memkey_from_labels(labels) or ""
         project_key = task.project

--- a/src/pollypm/plugins_builtin/project_planning/memory.py
+++ b/src/pollypm/plugins_builtin/project_planning/memory.py
@@ -24,10 +24,19 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+# Improvement-proposal rejection memory now lives in the shared
+# core module so the cockpit UI can call it without importing from
+# ``plugins_builtin`` (#1363). Re-exported here so callers that already
+# import from ``project_planning.memory`` keep working unchanged.
+from pollypm.project_planning_protocol import (  # noqa: F401
+    REJECTIONS_FILE,
+    is_proposal_rejected,
+    record_proposal_rejection,
+)
+
 
 MEMORY_DIR = Path.home() / ".pollypm" / "memory"
 MEMORY_FILE = MEMORY_DIR / "planner.jsonl"
-REJECTIONS_FILE = MEMORY_DIR / "planner_rejections.jsonl"
 
 
 @dataclass(slots=True)
@@ -193,76 +202,9 @@ def summarise_for_prompt(entries: list[PlannerMemoryEntry]) -> str:
 # in :func:`read_entries`. One line per rejection, append-only. We never
 # need to enumerate rejections, only predicate-check them, so this file is
 # kept dead simple.
+#
+# The implementation moved to :mod:`pollypm.project_planning_protocol`
+# (#1363) so core (the cockpit's Accept/Reject keybindings) can call
+# these helpers without importing from ``plugins_builtin``. The names
+# are re-exported at the top of this module for back-compat.
 # ---------------------------------------------------------------------------
-
-
-def _rejections_path(override: Path | None = None) -> Path:
-    """Return the active rejections file path (defaults to REJECTIONS_FILE)."""
-    return override if override is not None else REJECTIONS_FILE
-
-
-def record_proposal_rejection(
-    *,
-    project_key: str,
-    planner_memory_key: str,
-    rationale: str = "",
-    path: Path | None = None,
-) -> Path:
-    """Append a rejection record. Idempotent — duplicate rejections are a no-op.
-
-    The file layout is append-only JSONL; each line carries the project
-    key, the memkey, the optional free-form rationale, and a timestamp
-    for future analytics. The predicate :func:`is_proposal_rejected`
-    matches on (project_key, planner_memory_key) only, so re-adding the
-    same pair is harmless but wastes a byte or two.
-    """
-    target = _rejections_path(path)
-    target.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
-        "project": project_key,
-        "planner_memory_key": planner_memory_key,
-        "rationale": (rationale or "").strip(),
-        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        "entry_type": "proposal_rejected",
-    }
-    with target.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(payload, ensure_ascii=False))
-        fh.write("\n")
-    return target
-
-
-def is_proposal_rejected(
-    *,
-    project_key: str,
-    planner_memory_key: str,
-    path: Path | None = None,
-) -> bool:
-    """Predicate: has this (project, memkey) pair been rejected before?
-
-    Returns False when the rejections file doesn't exist yet (fresh
-    install). Malformed lines are skipped — the predicate degrades to
-    "no rejection found" rather than crashing the planner.
-    """
-    target = _rejections_path(path)
-    if not target.is_file():
-        return False
-    try:
-        content = target.read_text(encoding="utf-8")
-    except OSError:
-        return False
-    for raw in content.splitlines():
-        line = raw.strip()
-        if not line:
-            continue
-        try:
-            obj = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(obj, dict):
-            continue
-        if (
-            obj.get("project") == project_key
-            and obj.get("planner_memory_key") == planner_memory_key
-        ):
-            return True
-    return False

--- a/src/pollypm/plugins_builtin/project_planning/proposals.py
+++ b/src/pollypm/plugins_builtin/project_planning/proposals.py
@@ -28,9 +28,18 @@ import hashlib
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Iterable
 
 from pollypm.inbox.kind import InboxItemKind
+
+# Helpers consumed by core (``cockpit_ui``) now live in the shared
+# protocol module so disabling this plugin doesn't break the inbox's
+# Accept/Reject keybindings (#1363). Re-exported here so existing
+# callers keep working unchanged.
+from pollypm.project_planning_protocol import (  # noqa: F401
+    accept_proposal,
+    memkey_from_labels,
+)
 
 
 # Severity values accepted on a proposal. Kept deliberately short so the
@@ -151,14 +160,6 @@ def is_proposal_task(task) -> bool:
     return PROPOSAL_LABEL in labels
 
 
-def memkey_from_labels(labels: Iterable[str]) -> str | None:
-    """Pull the ``memkey:<hash>`` label off a task, if present."""
-    for label in labels or []:
-        if isinstance(label, str) and label.startswith("memkey:"):
-            return label.split(":", 1)[1]
-    return None
-
-
 def severity_from_labels(labels: Iterable[str]) -> str | None:
     for label in labels or []:
         if isinstance(label, str) and label.startswith("severity:"):
@@ -238,45 +239,7 @@ def filter_rejected(
 # ---------------------------------------------------------------------------
 # Accept helper — used by the cockpit UI
 # ---------------------------------------------------------------------------
-
-
-def accept_proposal(
-    service,
-    *,
-    task_id: str,
-    proposal_spec: dict[str, Any],
-    project_key: str,
-    actor: str = "user",
-):
-    """Create a follow-on work_tasks row for an accepted proposal.
-
-    Returns the newly-created :class:`Task`. The caller is expected to
-    archive the inbox row and record a ``proposal_accepted`` context
-    entry on it separately.
-    """
-    spec = proposal_spec or {}
-    title = (spec.get("title") or "").strip() or "Proposal follow-up"
-    description = (spec.get("description") or "").strip()
-    acceptance_criteria = spec.get("acceptance_criteria") or None
-    # The user-review flow has reviewer as ``actor_type: human``, so no
-    # ``reviewer=`` role assignment is needed. Previously this used the
-    # ``standard`` flow with ``reviewer=user`` — that's the savethenovel
-    # bug shape (``user`` is not an autonomous agent that can claim a
-    # role-typed review node). The user-review flow is the structurally
-    # correct way to express "worker implements, human reviews".
-    task = service.create(
-        title=title,
-        description=description,
-        type="task",
-        project=project_key,
-        flow_template="user-review",
-        roles={"worker": "worker", "requester": "user"},
-        priority="normal",
-        created_by=actor,
-        acceptance_criteria=acceptance_criteria,
-        labels=["from_proposal", f"project:{project_key}"],
-    )
-    # Context entry on the ORIGINATING inbox task is the caller's job
-    # (``task_id`` above) — that way they can use their own service
-    # handle and keep transaction boundaries obvious.
-    return task
+#
+# Implementation moved to :mod:`pollypm.project_planning_protocol` (#1363)
+# so the cockpit can call it without importing from ``plugins_builtin``.
+# Re-exported at the top of this module for back-compat.

--- a/src/pollypm/project_planning_protocol.py
+++ b/src/pollypm/project_planning_protocol.py
@@ -1,0 +1,186 @@
+"""Shared project-planning helpers consumed by core + the plugin (#1363).
+
+Core modules (``cockpit_ui``) previously had to lazy-import
+``pollypm.plugins_builtin.project_planning.proposals`` and
+``pollypm.plugins_builtin.project_planning.memory`` to honour the
+inbox's Accept/Reject keybindings on improvement-proposal rows. That
+coupling makes the ``project_planning`` plugin effectively non-optional
+— disabling it would break a core UI path silently.
+
+This module hosts the small set of helpers the cockpit actually needs:
+
+* :func:`memkey_from_labels` — pure label-list parser. No plugin
+  coupling, no filesystem.
+* :func:`record_proposal_rejection` / :func:`is_proposal_rejected` —
+  append-only JSONL helpers backing the planner's rejection memory.
+  File-IO only; no plugin internals.
+* :func:`accept_proposal` — orchestrates a follow-on ``work_tasks`` row
+  via the provided ``WorkService``. Takes the service through the
+  argument list, so no plugin imports are needed.
+
+The plugin re-exports these names from ``proposals`` / ``memory`` so
+existing callers (tests, planner code, CLI) keep working without
+churn. The plugin's ``memory.REJECTIONS_FILE`` re-exports the constant
+defined here so both sides agree on the path.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+# Canonical on-disk location for the planner's improvement-proposal
+# rejection log. The plugin's ``memory`` module re-exports this as
+# ``REJECTIONS_FILE`` for back-compat. Kept here (not in the plugin)
+# because :func:`record_proposal_rejection` / :func:`is_proposal_rejected`
+# live in this module and need a single source of truth.
+REJECTIONS_FILE = Path.home() / ".pollypm" / "memory" / "planner_rejections.jsonl"
+
+
+def _rejections_path(override: Path | None = None) -> Path:
+    """Return the active rejections file path (defaults to :data:`REJECTIONS_FILE`)."""
+    return override if override is not None else REJECTIONS_FILE
+
+
+# ---------------------------------------------------------------------------
+# Label parsing
+# ---------------------------------------------------------------------------
+
+
+def memkey_from_labels(labels: Iterable[str]) -> str | None:
+    """Pull the ``memkey:<hash>`` label off a task, if present."""
+    for label in labels or []:
+        if isinstance(label, str) and label.startswith("memkey:"):
+            return label.split(":", 1)[1]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Rejection memory — append-only JSONL
+# ---------------------------------------------------------------------------
+
+
+def record_proposal_rejection(
+    *,
+    project_key: str,
+    planner_memory_key: str,
+    rationale: str = "",
+    path: Path | None = None,
+) -> Path:
+    """Append a rejection record. Idempotent — duplicate rejections are a no-op.
+
+    The file layout is append-only JSONL; each line carries the project
+    key, the memkey, the optional free-form rationale, and a timestamp
+    for future analytics. The predicate :func:`is_proposal_rejected`
+    matches on (project_key, planner_memory_key) only, so re-adding the
+    same pair is harmless but wastes a byte or two.
+    """
+    target = _rejections_path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "project": project_key,
+        "planner_memory_key": planner_memory_key,
+        "rationale": (rationale or "").strip(),
+        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "entry_type": "proposal_rejected",
+    }
+    with target.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload, ensure_ascii=False))
+        fh.write("\n")
+    return target
+
+
+def is_proposal_rejected(
+    *,
+    project_key: str,
+    planner_memory_key: str,
+    path: Path | None = None,
+) -> bool:
+    """Predicate: has this (project, memkey) pair been rejected before?
+
+    Returns False when the rejections file doesn't exist yet (fresh
+    install). Malformed lines are skipped — the predicate degrades to
+    "no rejection found" rather than crashing the planner.
+    """
+    target = _rejections_path(path)
+    if not target.is_file():
+        return False
+    try:
+        content = target.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        if (
+            obj.get("project") == project_key
+            and obj.get("planner_memory_key") == planner_memory_key
+        ):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Accept helper — used by the cockpit UI
+# ---------------------------------------------------------------------------
+
+
+def accept_proposal(
+    service,
+    *,
+    task_id: str,
+    proposal_spec: dict[str, Any],
+    project_key: str,
+    actor: str = "user",
+):
+    """Create a follow-on work_tasks row for an accepted proposal.
+
+    Returns the newly-created ``Task``. The caller is expected to
+    archive the inbox row and record a ``proposal_accepted`` context
+    entry on it separately.
+    """
+    spec = proposal_spec or {}
+    title = (spec.get("title") or "").strip() or "Proposal follow-up"
+    description = (spec.get("description") or "").strip()
+    acceptance_criteria = spec.get("acceptance_criteria") or None
+    # The user-review flow has reviewer as ``actor_type: human``, so no
+    # ``reviewer=`` role assignment is needed. Previously this used the
+    # ``standard`` flow with ``reviewer=user`` — that's the savethenovel
+    # bug shape (``user`` is not an autonomous agent that can claim a
+    # role-typed review node). The user-review flow is the structurally
+    # correct way to express "worker implements, human reviews".
+    task = service.create(
+        title=title,
+        description=description,
+        type="task",
+        project=project_key,
+        flow_template="user-review",
+        roles={"worker": "worker", "requester": "user"},
+        priority="normal",
+        created_by=actor,
+        acceptance_criteria=acceptance_criteria,
+        labels=["from_proposal", f"project:{project_key}"],
+    )
+    # Context entry on the ORIGINATING inbox task is the caller's job
+    # (``task_id`` above) — that way they can use their own service
+    # handle and keep transaction boundaries obvious.
+    return task
+
+
+__all__ = [
+    "REJECTIONS_FILE",
+    "accept_proposal",
+    "is_proposal_rejected",
+    "memkey_from_labels",
+    "record_proposal_rejection",
+]


### PR DESCRIPTION
## Summary

Next slice for #1363 — eliminating core modules' lazy-imports from `plugins_builtin`. Sibling to #1909, which handled the activity-feed text helpers.

`cockpit_ui.action_accept_proposal` and `_finish_reject_proposal` previously lazy-imported three helpers from `plugins_builtin.project_planning`:

- `proposals.accept_proposal` — orchestrates a follow-on `work_tasks` row through the `WorkService`.
- `proposals.memkey_from_labels` — pure label-list parser.
- `memory.record_proposal_rejection` — JSONL append for the planner's rejection memory.

Disabling the plugin would silently break the cockpit inbox's `A`/`R` keybindings on improvement-proposal rows.

## Changes

- New `pollypm/project_planning_protocol.py` (187 lines) hosts the four moved helpers plus their `is_proposal_rejected` predicate pair and the `REJECTIONS_FILE` path constant.
- `plugins_builtin/project_planning/memory.py` re-exports `REJECTIONS_FILE`, `record_proposal_rejection`, `is_proposal_rejected` from the protocol module (back-compat for tests / CLI / planner code).
- `plugins_builtin/project_planning/proposals.py` re-exports `accept_proposal`, `memkey_from_labels` from the protocol module.
- `cockpit_ui.py` now lazy-imports straight from `pollypm.project_planning_protocol` — zero `plugins_builtin` imports remain in this file.

Implementations are copied verbatim; identity is preserved across the re-export boundary so monkeypatches still work.

## Out of scope (still tracked under #1363)

- `cockpit.py:147` `render_activity_feed_text` — depends on the projector; requires a larger inversion (called out in #1909 too).
- `cli.py` plugin CLI registrations — plugin-host edge, likely acceptable as-is.

## Test plan
- [x] `ruff check` on the three touched plugin/core files — clean. (Pre-existing E402/F401 in `cockpit_ui.py` are unrelated, count unchanged at 629.)
- [x] Import smoke test: `pollypm.project_planning_protocol`, `pollypm.plugins_builtin.project_planning.memory`, `pollypm.plugins_builtin.project_planning.proposals`, `pollypm.cockpit_ui` all import cleanly.
- [x] Identity check: `mem.record_proposal_rejection is protocol.record_proposal_rejection`, etc. — all four re-exports preserve identity.
- [ ] Existing `tests/test_project_planning_plugin.py` keeps working via the plugin's re-exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)