### PR TITLE
refactor: break up next-3 long functions (refs #1356)

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -3382,6 +3382,372 @@ def build_urgent_human_handoff(
     )
 
 
+def _brief_task_on_hold_stale(
+    finding: Finding,
+    subject: str,
+    meta: dict,
+) -> list[str]:
+    """Brief body for ``task_on_hold_stale`` (DEFAULT: fix and re-submit)."""
+    stuck_minutes = meta.get("stuck_minutes")
+    on_hold_since = meta.get("on_hold_since")
+    from_state = meta.get("from") or "<unknown>"
+    reason = meta.get("reason")
+    routing = meta.get("routing") or ON_HOLD_ARCHITECT_TAG
+    reviewer_evidence = meta.get("reviewer_evidence") or []
+    lines: list[str] = []
+    lines.append(
+        f"Stuck for: {stuck_minutes} minutes" if stuck_minutes
+        else "Stuck for: unknown duration"
+    )
+    lines.append(f"Routing: {routing}")
+    lines.append("Observed evidence:")
+    if on_hold_since:
+        lines.append(
+            f"- Task transitioned {from_state} -> on_hold at {on_hold_since}"
+        )
+    if reviewer_evidence:
+        lines.append(
+            "- Recent reviewer/inbox rationale evidence "
+            "(authoritative if it differs from the transition reason):"
+        )
+        for entry in reviewer_evidence:
+            # Each entry is a one-line string already shaped by
+            # the cadence handler (exec row OR inbox message).
+            lines.append(f"  * {entry}")
+    else:
+        lines.append(
+            "- No additional reviewer execution rows or inbox "
+            "messages were available."
+        )
+    if reason:
+        lines.append(f"- On-hold transition reason: {reason}")
+    else:
+        lines.append("- No transition reason was recorded.")
+    lines.append("")
+    lines.append(
+        "Your job (DEFAULT: fix and re-submit). Read the evidence "
+        "above and generate hypotheses fresh from the reviewer's "
+        "findings — do NOT ratify any framing in this brief."
+    )
+    lines.append(
+        f"Cli levers available: `pm task queue {subject}`, "
+        f"`pm task approve {subject}`, `pm notify --priority immediate`. "
+        "Parking on the user is the failure mode this rule exists "
+        "to prevent."
+    )
+    return lines
+
+
+def _brief_task_review_stale(
+    finding: Finding,
+    subject: str,
+    meta: dict,
+) -> list[str]:
+    """Brief body for ``task_review_stale`` (reviewer absent/stuck)."""
+    stuck_minutes = meta.get("stuck_minutes")
+    review_since = meta.get("review_since")
+    lines: list[str] = []
+    lines.append(
+        f"Stuck for: {stuck_minutes} minutes" if stuck_minutes
+        else "Stuck for: unknown duration"
+    )
+    lines.append("Observed evidence:")
+    if review_since:
+        lines.append(f"- Task transitioned to status=review at {review_since}")
+    lines.append(
+        "- No subsequent task.status_changed for this subject"
+    )
+    lines.append(
+        "- Reviewer agent appears to be absent or stuck"
+    )
+    lines.append("")
+    lines.append(
+        "Your job: investigate the evidence above and unstick the "
+        "task. Generate hypotheses fresh from the data — do NOT "
+        "ratify the framing in this brief."
+    )
+    lines.append(
+        f"Cli levers available: `pm task done {subject}`, "
+        "`pm chat <project> --role reviewer`, `pm notify`."
+    )
+    return lines
+
+
+def _brief_task_progress_stale(
+    finding: Finding,
+    subject: str,
+    meta: dict,
+) -> list[str]:
+    """Brief body for ``task_progress_stale`` (worker alive but quiet)."""
+    stuck_minutes = meta.get("stuck_minutes")
+    in_progress_minutes = meta.get("in_progress_minutes")
+    in_progress_since = meta.get("in_progress_since")
+    last_activity_at = meta.get("last_activity_at")
+    last_activity_kind = meta.get("last_activity_kind") or "<unknown>"
+    assignee = meta.get("assignee") or "<unknown>"
+    node = meta.get("current_node_id") or "<unknown>"
+    lines: list[str] = []
+    lines.append(
+        f"Stuck for: {stuck_minutes} minutes without progress activity"
+        if stuck_minutes else "Stuck for: unknown duration"
+    )
+    if in_progress_minutes:
+        lines.append(f"In progress for: {in_progress_minutes} minutes")
+    lines.append("Observed evidence:")
+    if in_progress_since:
+        lines.append(
+            f"- Task transitioned to status=in_progress at {in_progress_since}"
+        )
+    if last_activity_at:
+        lines.append(
+            f"- Last progress signal: {last_activity_kind} at {last_activity_at}"
+        )
+    lines.append(f"- Assignee: {assignee}; node: {node}")
+    lines.append(
+        "- Worker pane may be alive but unproductive: common causes "
+        "include auth failure, sandbox denial, quota/capacity, or "
+        "worker logic stuck after a nudge."
+    )
+    lines.append("")
+    lines.append(
+        "Your job: investigate the evidence above and unstick the "
+        "task. Auth / sandbox / quota / worker logic are the usual "
+        "root-cause families — generate hypotheses fresh from the "
+        "evidence rather than ratifying any framing in this brief."
+    )
+    lines.append(
+        f"Cli levers available: `pm task cancel {subject}`, "
+        "`pm chat <project>`, `pm notify`."
+    )
+    return lines
+
+
+def _brief_role_session_missing(
+    finding: Finding,
+    project: str,
+    meta: dict,
+) -> list[str]:
+    """Brief body for ``role_session_missing`` (missing tmux role lane)."""
+    expected = meta.get("expected_window") or "<unknown>"
+    role = meta.get("role") or "<unknown>"
+    status = meta.get("status") or "<unknown>"
+    lines: list[str] = []
+    lines.append("Stuck for: a watchdog cycle (>= 5 minutes)")
+    lines.append("Observed evidence:")
+    lines.append(f"- Task at status={status} with role={role}")
+    lines.append(
+        f"- No '{expected}' window in the storage-closet "
+        f"tmux session"
+    )
+    lines.append(
+        "- Without the role session, the task cannot make progress"
+    )
+    lines.append("")
+    lines.append(
+        "Your job: spawn the missing role lane or reassign the task. "
+        "Generate hypotheses fresh from the evidence — do NOT ratify "
+        "the framing in this brief."
+    )
+    lines.append(
+        f"Cli levers available: `pm chat {project} --role {role}`, "
+        "`pm notify`."
+    )
+    return lines
+
+
+def _brief_plan_review_missing(
+    finding: Finding,
+    subject: str,
+    meta: dict,
+) -> list[str]:
+    """Brief body for ``plan_review_missing`` (backfill is automatic)."""
+    plan_task_id = meta.get("plan_task_id") or subject
+    flow_id = meta.get("flow_template_id") or "<unknown>"
+    labels = meta.get("labels") or []
+    created_at = meta.get("created_at")
+    lines: list[str] = []
+    lines.append("Stuck for: plan_review never emitted")
+    lines.append("Observed evidence:")
+    lines.append(
+        f"- Plan-shaped task {plan_task_id} reached done on flow={flow_id}"
+    )
+    if labels:
+        label_preview = ", ".join(str(label) for label in labels[:6])
+        lines.append(f"- Labels: {label_preview}")
+    if created_at:
+        lines.append(f"- Created at: {created_at}")
+    lines.append(
+        "- The cockpit's plan_review approval card needs a "
+        "messages-table row with labels=[plan_review, "
+        f"plan_task:{plan_task_id}] but none exists."
+    )
+    lines.append("")
+    lines.append(
+        "Your job: the watchdog will backfill the plan_review row on "
+        "this tick via plan_review_emit.emit_plan_review_for_task. "
+        "No manual action required unless the backfill itself fails "
+        "in the cadence logs."
+    )
+    return lines
+
+
+def _brief_plan_review_bypassed_approval(
+    finding: Finding,
+    subject: str,
+    meta: dict,
+) -> list[str]:
+    """Brief body for ``plan_review_bypassed_approval`` (synthesize card)."""
+    plan_task_id = meta.get("plan_task_id") or subject
+    actor = meta.get("approval_actor") or "<unknown>"
+    completed = meta.get("approval_completed_at")
+    lines: list[str] = []
+    lines.append("Stuck for: plan approved by non-user actor")
+    lines.append("Observed evidence:")
+    lines.append(
+        f"- plan_project task {plan_task_id} reached done with "
+        f"user_approval completed by actor='{actor}'"
+    )
+    if completed:
+        lines.append(f"- Approval completed at: {completed}")
+    lines.append(
+        "- No plan_review inbox card exists for the task. The user "
+        "never saw the 'approve the plan?' surface."
+    )
+    lines.append("")
+    lines.append(
+        "Your job: the watchdog will synthesize a plan_review inbox "
+        "card on this tick via "
+        "plan_review_emit.emit_plan_review_for_task. The user gets "
+        "the gate they were supposed to get; nothing else changes."
+    )
+    return lines
+
+
+def _brief_rejection_loop(
+    finding: Finding,
+    meta: dict,
+) -> list[str]:
+    """Brief body for ``rejection_loop`` (structural rejection cycle)."""
+    evidence = finding.evidence or {}
+    node_id = evidence.get("node_id") or meta.get("node_id") or "<unknown>"
+    reject_count = (
+        evidence.get("reject_count")
+        or meta.get("reject_count")
+        or "?"
+    )
+    attempts = evidence.get("attempts") or []
+    shared_tokens = evidence.get("shared_tokens") or []
+    window_seconds = (
+        evidence.get("window_seconds")
+        or meta.get("window_seconds")
+        or REJECTION_LOOP_WINDOW_SECONDS
+    )
+    try:
+        window_minutes = max(1, int(window_seconds) // 60)
+    except (TypeError, ValueError):
+        window_minutes = 120
+    lines: list[str] = []
+    lines.append(
+        f"Stuck for: {reject_count} rejections at node '{node_id}' in the "
+        f"last {window_minutes} min"
+    )
+    lines.append("Observed evidence:")
+    for entry in attempts:
+        if not isinstance(entry, dict):
+            continue
+        attempt_node = entry.get("node") or "?"
+        completed = entry.get("completed_at") or "?"
+        reason = entry.get("reason") or ""
+        line = (
+            f"- attempt at {attempt_node} @ {completed}"
+        )
+        if reason:
+            clipped = reason.strip().splitlines()[0][:240]
+            line = f"{line} reason: {clipped}"
+        lines.append(line)
+    if shared_tokens:
+        lines.append(
+            "- Pattern across rejections (shared tokens): "
+            f"{', '.join(str(t) for t in shared_tokens[:8])}"
+        )
+    lines.append("")
+    lines.append(
+        "Your job: this task is in a structural rejection loop. The "
+        "worker can't escape its dependency-and-runtime context "
+        "locally. Generate hypotheses fresh from the evidence above "
+        "rather than ratifying any framing in this brief."
+    )
+    lines.append(
+        "Decisions in scope: retry-with-structural-change, "
+        "restructure-the-work-itself (cancel + recreate with a "
+        "different approach), or escalate-to-Polly. Do NOT "
+        "auto-cancel — let the PM choose."
+    )
+    return lines
+
+
+def _brief_worker_session_dead_loop(
+    finding: Finding,
+    subject: str,
+    meta: dict,
+) -> list[str]:
+    """Brief body for ``worker_session_dead_loop`` (reap-respawn cycle)."""
+    reap_count = meta.get("reap_count") or "?"
+    latest_reason = meta.get("latest_reason") or "<unknown>"
+    lines: list[str] = []
+    lines.append(
+        f"Stuck for: {reap_count} reaps in the last 10 minutes"
+    )
+    lines.append("Observed evidence:")
+    lines.append(
+        f"- Worker session for {subject} reaped {reap_count} times"
+    )
+    lines.append(f"- Most recent reaper reason: {latest_reason}")
+    lines.append(
+        "- The reaper is firing in a loop — the session keeps "
+        "dying after spawn"
+    )
+    lines.append("")
+    lines.append(
+        "Your job: investigate the evidence above and unstick the "
+        "task. The reaper firing in a loop is a session-spawn root "
+        "cause — generate hypotheses fresh from the evidence rather "
+        "than ratifying any framing in this brief."
+    )
+    lines.append(
+        f"Cli levers available: `pm task cancel {subject}`, `pm notify`."
+    )
+    return lines
+
+
+def _brief_fallback(finding: Finding) -> list[str]:
+    """Generic brief body for rules without a tailored template.
+
+    Covers orphan_marker / marker_leaked / stuck_draft /
+    cancel_no_promotion — all of which already carry human-readable
+    ``message``/``recommendation`` fields, so we re-use those.
+    """
+    lines: list[str] = []
+    lines.append("Stuck for: see message")
+    lines.append("Observed evidence:")
+    if finding.message:
+        lines.append(f"- {finding.message}")
+    if finding.recommendation:
+        lines.append(f"- Recommendation: {finding.recommendation}")
+    lines.append("")
+    lines.append(
+        "Your job: investigate the evidence above and unstick the "
+        "task. Generate hypotheses fresh from the evidence rather "
+        "than ratifying the recommendation."
+    )
+    lines.append(
+        "Cli levers available: act on the recommendation above, take "
+        "a different action you judge appropriate, or escalate to "
+        "user via `pm notify`."
+    )
+    return lines
+
+
 def format_unstick_brief(finding: Finding) -> str:
     """Render a finding as a structured brief for the architect.
 
@@ -3400,291 +3766,21 @@ def format_unstick_brief(finding: Finding) -> str:
     lines.append(f"Subject: {subject}")
 
     if finding.rule == RULE_TASK_ON_HOLD_STALE:
-        stuck_minutes = meta.get("stuck_minutes")
-        on_hold_since = meta.get("on_hold_since")
-        from_state = meta.get("from") or "<unknown>"
-        reason = meta.get("reason")
-        routing = meta.get("routing") or ON_HOLD_ARCHITECT_TAG
-        reviewer_evidence = meta.get("reviewer_evidence") or []
-        lines.append(
-            f"Stuck for: {stuck_minutes} minutes" if stuck_minutes
-            else "Stuck for: unknown duration"
-        )
-        lines.append(f"Routing: {routing}")
-        lines.append("Observed evidence:")
-        if on_hold_since:
-            lines.append(
-                f"- Task transitioned {from_state} -> on_hold at {on_hold_since}"
-            )
-        if reviewer_evidence:
-            lines.append(
-                "- Recent reviewer/inbox rationale evidence "
-                "(authoritative if it differs from the transition reason):"
-            )
-            for entry in reviewer_evidence:
-                # Each entry is a one-line string already shaped by
-                # the cadence handler (exec row OR inbox message).
-                lines.append(f"  * {entry}")
-        else:
-            lines.append(
-                "- No additional reviewer execution rows or inbox "
-                "messages were available."
-            )
-        if reason:
-            lines.append(f"- On-hold transition reason: {reason}")
-        else:
-            lines.append("- No transition reason was recorded.")
-        lines.append("")
-        lines.append(
-            "Your job (DEFAULT: fix and re-submit). Read the evidence "
-            "above and generate hypotheses fresh from the reviewer's "
-            "findings — do NOT ratify any framing in this brief."
-        )
-        lines.append(
-            f"Cli levers available: `pm task queue {subject}`, "
-            f"`pm task approve {subject}`, `pm notify --priority immediate`. "
-            "Parking on the user is the failure mode this rule exists "
-            "to prevent."
-        )
+        lines.extend(_brief_task_on_hold_stale(finding, subject, meta))
     elif finding.rule == RULE_TASK_REVIEW_STALE:
-        stuck_minutes = meta.get("stuck_minutes")
-        review_since = meta.get("review_since")
-        lines.append(
-            f"Stuck for: {stuck_minutes} minutes" if stuck_minutes
-            else "Stuck for: unknown duration"
-        )
-        lines.append("Observed evidence:")
-        if review_since:
-            lines.append(f"- Task transitioned to status=review at {review_since}")
-        lines.append(
-            "- No subsequent task.status_changed for this subject"
-        )
-        lines.append(
-            "- Reviewer agent appears to be absent or stuck"
-        )
-        lines.append("")
-        lines.append(
-            "Your job: investigate the evidence above and unstick the "
-            "task. Generate hypotheses fresh from the data — do NOT "
-            "ratify the framing in this brief."
-        )
-        lines.append(
-            f"Cli levers available: `pm task done {subject}`, "
-            "`pm chat <project> --role reviewer`, `pm notify`."
-        )
+        lines.extend(_brief_task_review_stale(finding, subject, meta))
     elif finding.rule == RULE_TASK_PROGRESS_STALE:
-        stuck_minutes = meta.get("stuck_minutes")
-        in_progress_minutes = meta.get("in_progress_minutes")
-        in_progress_since = meta.get("in_progress_since")
-        last_activity_at = meta.get("last_activity_at")
-        last_activity_kind = meta.get("last_activity_kind") or "<unknown>"
-        assignee = meta.get("assignee") or "<unknown>"
-        node = meta.get("current_node_id") or "<unknown>"
-        lines.append(
-            f"Stuck for: {stuck_minutes} minutes without progress activity"
-            if stuck_minutes else "Stuck for: unknown duration"
-        )
-        if in_progress_minutes:
-            lines.append(f"In progress for: {in_progress_minutes} minutes")
-        lines.append("Observed evidence:")
-        if in_progress_since:
-            lines.append(
-                f"- Task transitioned to status=in_progress at {in_progress_since}"
-            )
-        if last_activity_at:
-            lines.append(
-                f"- Last progress signal: {last_activity_kind} at {last_activity_at}"
-            )
-        lines.append(f"- Assignee: {assignee}; node: {node}")
-        lines.append(
-            "- Worker pane may be alive but unproductive: common causes "
-            "include auth failure, sandbox denial, quota/capacity, or "
-            "worker logic stuck after a nudge."
-        )
-        lines.append("")
-        lines.append(
-            "Your job: investigate the evidence above and unstick the "
-            "task. Auth / sandbox / quota / worker logic are the usual "
-            "root-cause families — generate hypotheses fresh from the "
-            "evidence rather than ratifying any framing in this brief."
-        )
-        lines.append(
-            f"Cli levers available: `pm task cancel {subject}`, "
-            "`pm chat <project>`, `pm notify`."
-        )
+        lines.extend(_brief_task_progress_stale(finding, subject, meta))
     elif finding.rule == RULE_ROLE_SESSION_MISSING:
-        expected = meta.get("expected_window") or "<unknown>"
-        role = meta.get("role") or "<unknown>"
-        status = meta.get("status") or "<unknown>"
-        lines.append("Stuck for: a watchdog cycle (>= 5 minutes)")
-        lines.append("Observed evidence:")
-        lines.append(f"- Task at status={status} with role={role}")
-        lines.append(
-            f"- No '{expected}' window in the storage-closet "
-            f"tmux session"
-        )
-        lines.append(
-            "- Without the role session, the task cannot make progress"
-        )
-        lines.append("")
-        lines.append(
-            "Your job: spawn the missing role lane or reassign the task. "
-            "Generate hypotheses fresh from the evidence — do NOT ratify "
-            "the framing in this brief."
-        )
-        lines.append(
-            f"Cli levers available: `pm chat {project} --role {role}`, "
-            "`pm notify`."
-        )
+        lines.extend(_brief_role_session_missing(finding, project, meta))
     elif finding.rule == RULE_PLAN_REVIEW_MISSING:
-        plan_task_id = meta.get("plan_task_id") or subject
-        flow_id = meta.get("flow_template_id") or "<unknown>"
-        labels = meta.get("labels") or []
-        created_at = meta.get("created_at")
-        lines.append("Stuck for: plan_review never emitted")
-        lines.append("Observed evidence:")
-        lines.append(
-            f"- Plan-shaped task {plan_task_id} reached done on flow={flow_id}"
-        )
-        if labels:
-            label_preview = ", ".join(str(label) for label in labels[:6])
-            lines.append(f"- Labels: {label_preview}")
-        if created_at:
-            lines.append(f"- Created at: {created_at}")
-        lines.append(
-            "- The cockpit's plan_review approval card needs a "
-            "messages-table row with labels=[plan_review, "
-            f"plan_task:{plan_task_id}] but none exists."
-        )
-        lines.append("")
-        lines.append(
-            "Your job: the watchdog will backfill the plan_review row on "
-            "this tick via plan_review_emit.emit_plan_review_for_task. "
-            "No manual action required unless the backfill itself fails "
-            "in the cadence logs."
-        )
+        lines.extend(_brief_plan_review_missing(finding, subject, meta))
     elif finding.rule == RULE_PLAN_REVIEW_BYPASSED_APPROVAL:
-        plan_task_id = meta.get("plan_task_id") or subject
-        actor = meta.get("approval_actor") or "<unknown>"
-        completed = meta.get("approval_completed_at")
-        lines.append("Stuck for: plan approved by non-user actor")
-        lines.append("Observed evidence:")
-        lines.append(
-            f"- plan_project task {plan_task_id} reached done with "
-            f"user_approval completed by actor='{actor}'"
-        )
-        if completed:
-            lines.append(f"- Approval completed at: {completed}")
-        lines.append(
-            "- No plan_review inbox card exists for the task. The user "
-            "never saw the 'approve the plan?' surface."
-        )
-        lines.append("")
-        lines.append(
-            "Your job: the watchdog will synthesize a plan_review inbox "
-            "card on this tick via "
-            "plan_review_emit.emit_plan_review_for_task. The user gets "
-            "the gate they were supposed to get; nothing else changes."
-        )
+        lines.extend(_brief_plan_review_bypassed_approval(finding, subject, meta))
     elif finding.rule == RULE_REJECTION_LOOP:
-        node_id = (finding.evidence or {}).get("node_id") or meta.get(
-            "node_id",
-        ) or "<unknown>"
-        reject_count = (
-            (finding.evidence or {}).get("reject_count")
-            or meta.get("reject_count")
-            or "?"
-        )
-        attempts = (finding.evidence or {}).get("attempts") or []
-        shared_tokens = (finding.evidence or {}).get("shared_tokens") or []
-        window_seconds = (
-            (finding.evidence or {}).get("window_seconds")
-            or meta.get("window_seconds")
-            or REJECTION_LOOP_WINDOW_SECONDS
-        )
-        try:
-            window_minutes = max(1, int(window_seconds) // 60)
-        except (TypeError, ValueError):
-            window_minutes = 120
-        lines.append(
-            f"Stuck for: {reject_count} rejections at node '{node_id}' in the "
-            f"last {window_minutes} min"
-        )
-        lines.append("Observed evidence:")
-        for entry in attempts:
-            if not isinstance(entry, dict):
-                continue
-            attempt_node = entry.get("node") or "?"
-            completed = entry.get("completed_at") or "?"
-            reason = entry.get("reason") or ""
-            line = (
-                f"- attempt at {attempt_node} @ {completed}"
-            )
-            if reason:
-                clipped = reason.strip().splitlines()[0][:240]
-                line = f"{line} reason: {clipped}"
-            lines.append(line)
-        if shared_tokens:
-            lines.append(
-                "- Pattern across rejections (shared tokens): "
-                f"{', '.join(str(t) for t in shared_tokens[:8])}"
-            )
-        lines.append("")
-        lines.append(
-            "Your job: this task is in a structural rejection loop. The "
-            "worker can't escape its dependency-and-runtime context "
-            "locally. Generate hypotheses fresh from the evidence above "
-            "rather than ratifying any framing in this brief."
-        )
-        lines.append(
-            "Decisions in scope: retry-with-structural-change, "
-            "restructure-the-work-itself (cancel + recreate with a "
-            "different approach), or escalate-to-Polly. Do NOT "
-            "auto-cancel — let the PM choose."
-        )
+        lines.extend(_brief_rejection_loop(finding, meta))
     elif finding.rule == RULE_WORKER_SESSION_DEAD_LOOP:
-        reap_count = meta.get("reap_count") or "?"
-        latest_reason = meta.get("latest_reason") or "<unknown>"
-        lines.append(
-            f"Stuck for: {reap_count} reaps in the last 10 minutes"
-        )
-        lines.append("Observed evidence:")
-        lines.append(
-            f"- Worker session for {subject} reaped {reap_count} times"
-        )
-        lines.append(f"- Most recent reaper reason: {latest_reason}")
-        lines.append(
-            "- The reaper is firing in a loop — the session keeps "
-            "dying after spawn"
-        )
-        lines.append("")
-        lines.append(
-            "Your job: investigate the evidence above and unstick the "
-            "task. The reaper firing in a loop is a session-spawn root "
-            "cause — generate hypotheses fresh from the evidence rather "
-            "than ratifying any framing in this brief."
-        )
-        lines.append(
-            f"Cli levers available: `pm task cancel {subject}`, `pm notify`."
-        )
+        lines.extend(_brief_worker_session_dead_loop(finding, subject, meta))
     else:
-        # Fallback: orphan_marker / marker_leaked / stuck_draft / cancel_no_promotion
-        # all have human-readable messages already; we re-use those.
-        lines.append("Stuck for: see message")
-        lines.append("Observed evidence:")
-        if finding.message:
-            lines.append(f"- {finding.message}")
-        if finding.recommendation:
-            lines.append(f"- Recommendation: {finding.recommendation}")
-        lines.append("")
-        lines.append(
-            "Your job: investigate the evidence above and unstick the "
-            "task. Generate hypotheses fresh from the evidence rather "
-            "than ratifying the recommendation."
-        )
-        lines.append(
-            "Cli levers available: act on the recommendation above, take "
-            "a different action you judge appropriate, or escalate to "
-            "user via `pm notify`."
-        )
+        lines.extend(_brief_fallback(finding))
     return "\n".join(lines)

--- a/src/pollypm/cli_features/session_runtime.py
+++ b/src/pollypm/cli_features/session_runtime.py
@@ -20,6 +20,7 @@ import logging
 import os
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import typer
@@ -953,6 +954,274 @@ def _kind_for_notify(
     return InboxItemKind.LEGACY.value
 
 
+@dataclass(frozen=True)
+class _NotifyArgs:
+    """Normalized ``pm notify`` arguments after validation.
+
+    Produced by :func:`_normalize_notify_args`; bundles every field the
+    enqueue path needs so the top-level command stays a thin driver.
+    """
+
+    channel_name: str
+    body: str
+    actor: str
+    current_session_name: str | None
+    project: str
+    resolved_priority: str
+    requester_role: str
+    label_list: list[str]
+    milestone_key: str | None
+    user_prompt_payload: dict[str, object] | None
+
+
+def _normalize_notify_args(
+    helpers,
+    *,
+    subject: str,
+    body: str,
+    actor: str,
+    project: str,
+    priority: str,
+    milestone: str,
+    labels: list[str] | None,
+    requester: str,
+    user_prompt_json: str,
+    channel: str,
+) -> _NotifyArgs:
+    """Validate + normalize the raw ``pm notify`` arguments.
+
+    Centralizes every error-and-exit / classification / inference step
+    so the top-level ``notify`` body can stay focused on the enqueue
+    pipeline. Behavior is identical to the inline version: each
+    ``typer.Exit`` site is preserved verbatim, and the helpers
+    (``_infer_notify_actor``, ``_infer_notify_project``,
+    ``_validate_user_prompt_payload``, the classifier import) are
+    called in the same order with the same arguments.
+    """
+    if not subject.strip():
+        typer.echo("Error: subject must not be empty.", err=True)
+        raise typer.Exit(code=1)
+
+    channel_name = (channel or "inbox").strip().lower()
+    if channel_name not in {"inbox", "dev"}:
+        typer.echo(
+            f"Error: --channel must be 'inbox' or 'dev' (got {channel!r}).",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    # #1076 — auto-route Polly's "Nth fake RECOVERY MODE injection"
+    # meta-reports to channel:dev so they don't pollute the user-
+    # facing inbox. Gated behind ``POLLYPM_DEV_FAKE_RECOVERY_INBOX``
+    # so harness work that explicitly wants these in the inbox can
+    # still opt in (off by default — the user-facing inbox is the
+    # default surface and dev scaffolding doesn't belong there).
+    if (
+        channel_name == "inbox"
+        and _is_fake_recovery_injection_subject(subject)
+        and not _fake_recovery_inbox_override_enabled()
+    ):
+        channel_name = "dev"
+
+    if body == "-":
+        body = sys.stdin.read()
+    if not body.strip():
+        typer.echo(
+            "Error: body must not be empty (pass '-' to read from stdin).",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    resolved_config_path = helpers._discover_config_path(DEFAULT_CONFIG_PATH)
+    actor, current_session_name = _infer_notify_actor(
+        resolved_config_path,
+        actor,
+    )
+
+    # #1425 — when the caller didn't pass ``--project``, infer it
+    # from the calling pane's session config so a reviewer running
+    # in ``reviewer-savethenovel`` lands its notify on
+    # ``project=savethenovel`` instead of the synthetic global
+    # ``inbox`` bucket. Explicit ``--project inbox`` (or any other
+    # value) still wins so global broadcasts and bootstrap scripts
+    # keep working from inside a project-scoped pane.
+    if not (project or "").strip():
+        inferred_project = _infer_notify_project(resolved_config_path)
+        project = inferred_project or "inbox"
+
+    from pollypm.store.classifier import classify_priority, validate_priority
+
+    requested = (priority or "auto").strip().lower()
+    if requested == "auto":
+        resolved_priority = classify_priority(subject, body)
+    else:
+        try:
+            resolved_priority = validate_priority(requested)
+        except ValueError as exc:
+            typer.echo(f"Error: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+
+    requester_role = (requester or "user").strip().lower()
+    if requester_role not in ("user", "polly"):
+        typer.echo(
+            f"Error: --requester must be 'user' or 'polly' (got {requester!r}).",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    label_list = [label for label in (labels or []) if label and label.strip()]
+    # Channel separation (#754): dev-channel messages carry a
+    # ``channel:dev`` label so the default inbox view (and the
+    # cockpit rail count) can skip them. Regular user-facing
+    # notifications inherit the implicit ``channel:inbox`` label.
+    if channel_name == "dev":
+        if "channel:dev" not in label_list:
+            label_list.append("channel:dev")
+    milestone_key = milestone.strip() or None
+    user_prompt_payload = _validate_user_prompt_payload(user_prompt_json)
+
+    return _NotifyArgs(
+        channel_name=channel_name,
+        body=body,
+        actor=actor,
+        current_session_name=current_session_name,
+        project=project,
+        resolved_priority=resolved_priority,
+        requester_role=requester_role,
+        label_list=label_list,
+        milestone_key=milestone_key,
+        user_prompt_payload=user_prompt_payload,
+    )
+
+
+def _maybe_warn_user_prompt_fallback(args: _NotifyArgs) -> None:
+    """Emit the producer-side diagnostic note about heuristic fallback.
+
+    The dashboard has a heuristic fallback when producers omit
+    ``--user-prompt-json``. Keep that fallback quiet by default: role
+    panes often stream stderr into user-facing logs, where a
+    ``Warning:`` prefix reads like a broken escalation. Developers
+    debugging producer payloads can opt into this diagnostic note via
+    :func:`_notify_user_prompt_fallback_note_enabled`.
+    """
+    if (
+        args.user_prompt_payload is None
+        and args.resolved_priority == "immediate"
+        and args.requester_role == "user"
+        and args.channel_name == "inbox"
+        and _notify_user_prompt_fallback_note_enabled()
+    ):
+        typer.echo(
+            "note: posting an immediate-priority user-facing "
+            "notify without --user-prompt-json. The dashboard's "
+            "Action Needed card is using body-heuristic fallback "
+            "and lose structured steps + decision question + "
+            "contextual buttons. Pass --user-prompt-json '{...}' "
+            "with at least one of summary/steps/question for a "
+            "first-class action surface.",
+            err=True,
+        )
+
+
+def _enqueue_notify_message(
+    store,
+    *,
+    subject: str,
+    args: _NotifyArgs,
+    dedup_key: str,
+    notify_kind: str,
+) -> str:
+    """Dispatch the notify message: dedup-bump or first-write insert.
+
+    #1013 — dedup-key collapsing for repeated alert patterns. When
+    ``--dedup-key`` is set and a matching open notify exists, increment
+    its ``count`` + refresh ``last_seen`` instead of spawning a second
+    row. Empty key (the default) keeps the legacy insert-every-time
+    behavior so existing callers don't silently change semantics.
+
+    The ``store`` is the process-wide singleton from
+    :func:`_resolve_notify_store` (#1790); the caller must NOT close it
+    after this returns.
+    """
+    from pollypm.inbox_dedup import (
+        bump_dedup_message,
+        find_open_dedup_message,
+        initial_dedup_payload,
+    )
+
+    tier_state = {
+        "immediate": "open",
+        "digest": "staged",
+        "silent": "closed",
+    }[args.resolved_priority]
+
+    payload: dict[str, object] = {
+        "actor": args.actor,
+        "project": args.project,
+        "milestone_key": args.milestone_key,
+        "requester": args.requester_role,
+    }
+    if args.user_prompt_payload is not None:
+        payload["user_prompt"] = args.user_prompt_payload
+
+    dedup_key_value = (dedup_key or "").strip()
+    existing_dedup_row = (
+        find_open_dedup_message(
+            store,
+            dedup_key_value,
+            recipient=args.requester_role,
+        )
+        if dedup_key_value
+        else None
+    )
+
+    try:
+        if existing_dedup_row is not None:
+            # Bump path — caller signaled "this is the same alert
+            # I posted before". Refresh subject/body/payload so the
+            # most recent context wins, and increment count.
+            message_id = bump_dedup_message(
+                store,
+                existing_dedup_row,
+                subject=subject,
+                body=args.body,
+                payload={**payload, "dedup_key": dedup_key_value},
+                labels=args.label_list or None,
+                tier=args.resolved_priority,
+            )
+        else:
+            # First-write path. Annotate payload with count=1 +
+            # last_seen so a future bump has a stable shape to
+            # increment.
+            seeded_payload = (
+                initial_dedup_payload(payload, dedup_key_value)
+                if dedup_key_value
+                else payload
+            )
+            message_id = store.enqueue_message(
+                type="notify",
+                tier=args.resolved_priority,
+                recipient=args.requester_role,
+                sender=args.actor,
+                subject=subject,
+                body=args.body,
+                scope=args.project,
+                labels=args.label_list or None,
+                payload=seeded_payload,
+                state=(
+                    "closed"
+                    if args.resolved_priority == "immediate"
+                    else tier_state
+                ),
+                kind=notify_kind,
+            )
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(f"Failed to enqueue notify message: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    return message_id
+
+
 def notify(
     helpers,
     subject: str = typer.Argument(..., help="Short title for the inbox item."),
@@ -1059,225 +1328,75 @@ def notify(
     ),
 ) -> None:
     """Create a work-service inbox item for the human user."""
-    if not subject.strip():
-        typer.echo("Error: subject must not be empty.", err=True)
-        raise typer.Exit(code=1)
-
-    channel_name = (channel or "inbox").strip().lower()
-    if channel_name not in {"inbox", "dev"}:
-        typer.echo(
-            f"Error: --channel must be 'inbox' or 'dev' (got {channel!r}).",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-
-    # #1076 — auto-route Polly's "Nth fake RECOVERY MODE injection"
-    # meta-reports to channel:dev so they don't pollute the user-
-    # facing inbox. Gated behind ``POLLYPM_DEV_FAKE_RECOVERY_INBOX``
-    # so harness work that explicitly wants these in the inbox can
-    # still opt in (off by default — the user-facing inbox is the
-    # default surface and dev scaffolding doesn't belong there).
-    if (
-        channel_name == "inbox"
-        and _is_fake_recovery_injection_subject(subject)
-        and not _fake_recovery_inbox_override_enabled()
-    ):
-        channel_name = "dev"
-
-    if body == "-":
-        body = sys.stdin.read()
-    if not body.strip():
-        typer.echo(
-            "Error: body must not be empty (pass '-' to read from stdin).",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-
-    resolved_config_path = helpers._discover_config_path(DEFAULT_CONFIG_PATH)
-    actor, current_session_name = _infer_notify_actor(
-        resolved_config_path,
-        actor,
+    args = _normalize_notify_args(
+        helpers,
+        subject=subject,
+        body=body,
+        actor=actor,
+        project=project,
+        priority=priority,
+        milestone=milestone,
+        labels=labels,
+        requester=requester,
+        user_prompt_json=user_prompt_json,
+        channel=channel,
     )
-
-    # #1425 — when the caller didn't pass ``--project``, infer it
-    # from the calling pane's session config so a reviewer running
-    # in ``reviewer-savethenovel`` lands its notify on
-    # ``project=savethenovel`` instead of the synthetic global
-    # ``inbox`` bucket. Explicit ``--project inbox`` (or any other
-    # value) still wins so global broadcasts and bootstrap scripts
-    # keep working from inside a project-scoped pane.
-    if not (project or "").strip():
-        inferred_project = _infer_notify_project(resolved_config_path)
-        project = inferred_project or "inbox"
-
-    from pollypm.store.classifier import classify_priority, validate_priority
-
-    requested = (priority or "auto").strip().lower()
-    if requested == "auto":
-        resolved_priority = classify_priority(subject, body)
-    else:
-        try:
-            resolved_priority = validate_priority(requested)
-        except ValueError as exc:
-            typer.echo(f"Error: {exc}", err=True)
-            raise typer.Exit(code=1) from exc
-
-    requester_role = (requester or "user").strip().lower()
-    if requester_role not in ("user", "polly"):
-        typer.echo(
-            f"Error: --requester must be 'user' or 'polly' (got {requester!r}).",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-
-    label_list = [label for label in (labels or []) if label and label.strip()]
-    # Channel separation (#754): dev-channel messages carry a
-    # ``channel:dev`` label so the default inbox view (and the
-    # cockpit rail count) can skip them. Regular user-facing
-    # notifications inherit the implicit ``channel:inbox`` label.
-    if channel_name == "dev":
-        if "channel:dev" not in label_list:
-            label_list.append("channel:dev")
-    milestone_key = milestone.strip() or None
-    user_prompt_payload = _validate_user_prompt_payload(user_prompt_json)
-
-    # The dashboard has a heuristic fallback when producers omit
-    # ``--user-prompt-json``. Keep that fallback quiet by default:
-    # role panes often stream stderr into user-facing logs, where a
-    # "Warning:" prefix reads like a broken escalation. Developers
-    # debugging producer payloads can opt into this diagnostic note.
-    if (
-        user_prompt_payload is None
-        and resolved_priority == "immediate"
-        and requester_role == "user"
-        and channel_name == "inbox"
-        and _notify_user_prompt_fallback_note_enabled()
-    ):
-        typer.echo(
-            "note: posting an immediate-priority user-facing "
-            "notify without --user-prompt-json. The dashboard's "
-            "Action Needed card is using body-heuristic fallback "
-            "and lose structured steps + decision question + "
-            "contextual buttons. Pass --user-prompt-json '{...}' "
-            "with at least one of summary/steps/question for a "
-            "first-class action surface.",
-            err=True,
-        )
+    _maybe_warn_user_prompt_fallback(args)
 
     # Backend-aware Store dispatch (#1790). Singleton — do NOT close.
     store = _resolve_notify_store(db)
-    tier_state = {
-        "immediate": "open",
-        "digest": "staged",
-        "silent": "closed",
-    }[resolved_priority]
-
-    payload = {
-        "actor": actor,
-        "project": project,
-        "milestone_key": milestone_key,
-        "requester": requester_role,
-    }
-    if user_prompt_payload is not None:
-        payload["user_prompt"] = user_prompt_payload
-
-    # #1013 — dedup-key collapsing for repeated alert patterns.
-    # When --dedup-key is set and a matching open notify exists,
-    # increment its ``count`` + refresh ``last_seen`` instead of
-    # spawning a second row. Empty key (the default) keeps the
-    # legacy insert-every-time behavior so existing callers don't
-    # silently change semantics.
-    from pollypm.inbox_dedup import (
-        bump_dedup_message,
-        find_open_dedup_message,
-        initial_dedup_payload,
-    )
-
-    dedup_key_value = (dedup_key or "").strip()
-    existing_dedup_row = (
-        find_open_dedup_message(
-            store,
-            dedup_key_value,
-            recipient=requester_role,
-        )
-        if dedup_key_value
-        else None
-    )
-
     notify_kind = _kind_for_notify(
-        label_list,
-        requester=requester_role,
-        user_prompt_payload=user_prompt_payload,
+        args.label_list,
+        requester=args.requester_role,
+        user_prompt_payload=args.user_prompt_payload,
     )
-    try:
-        if existing_dedup_row is not None:
-            # Bump path — caller signaled "this is the same alert
-            # I posted before". Refresh subject/body/payload so the
-            # most recent context wins, and increment count.
-            message_id = bump_dedup_message(
-                store,
-                existing_dedup_row,
-                subject=subject,
-                body=body,
-                payload={**payload, "dedup_key": dedup_key_value},
-                labels=label_list or None,
-                tier=resolved_priority,
-            )
-        else:
-            # First-write path. Annotate payload with count=1 +
-            # last_seen so a future bump has a stable shape to
-            # increment.
-            seeded_payload = (
-                initial_dedup_payload(payload, dedup_key_value)
-                if dedup_key_value
-                else payload
-            )
-            message_id = store.enqueue_message(
-                type="notify",
-                tier=resolved_priority,
-                recipient=requester_role,
-                sender=actor,
-                subject=subject,
-                body=body,
-                scope=project,
-                labels=label_list or None,
-                payload=seeded_payload,
-                state="closed" if resolved_priority == "immediate" else tier_state,
-                kind=notify_kind,
-            )
-    except Exception as exc:  # noqa: BLE001
-        typer.echo(f"Failed to enqueue notify message: {exc}", err=True)
-        raise typer.Exit(code=1) from exc
-    # ``store`` is the process-wide singleton from
-    # :func:`_resolve_notify_store` (#1790); do NOT close it.
+    message_id = _enqueue_notify_message(
+        store,
+        subject=subject,
+        args=args,
+        dedup_key=dedup_key,
+        notify_kind=notify_kind,
+    )
+
+    # Rebuild the payload shape that ``_create_notify_inbox_task``
+    # consumes. Mirrors the seed dict in :func:`_enqueue_notify_message`
+    # so the inbox-task projection matches the message-row payload.
+    payload: dict[str, object] = {
+        "actor": args.actor,
+        "project": args.project,
+        "milestone_key": args.milestone_key,
+        "requester": args.requester_role,
+    }
+    if args.user_prompt_payload is not None:
+        payload["user_prompt"] = args.user_prompt_payload
 
     inbox_task_id: str | None = None
-    if resolved_priority == "immediate":
+    if args.resolved_priority == "immediate":
         inbox_task_id = _create_notify_inbox_task(
             db=db,
             store=store,
             message_id=message_id,
             subject=subject,
-            body=body,
-            project=project,
-            actor=actor,
-            requester_role=requester_role,
-            label_list=label_list,
+            body=args.body,
+            project=args.project,
+            actor=args.actor,
+            requester_role=args.requester_role,
+            label_list=args.label_list,
             notify_kind=notify_kind,
             payload=payload,
         )
 
     _hold_review_tasks_for_notify(
-        actor=actor,
-        current_session_name=current_session_name,
-        priority=resolved_priority,
+        actor=args.actor,
+        current_session_name=args.current_session_name,
+        priority=args.resolved_priority,
         subject=subject,
-        body=body,
+        body=args.body,
     )
 
-    if resolved_priority == "silent":
+    if args.resolved_priority == "silent":
         typer.echo("silent")
-    elif resolved_priority == "digest":
+    elif args.resolved_priority == "digest":
         typer.echo(f"digest:{message_id}")
     else:
         typer.echo(str(inbox_task_id or message_id))

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -15403,6 +15403,261 @@ class PollyProjectDashboardApp(App[None]):
         budget = width - 9
         return max(32, min(budget, 100))
 
+    def _inbox_remainder_blocked_block(
+        self, data: "ProjectDashboardData",
+    ) -> list[str]:
+        """Render the fallback block for blocked tasks without action cards.
+
+        Suppresses output when the plan-ready pill is already
+        showing (#1716). Otherwise picks one of three calmer copies
+        depending on whether existing blocker context is present and
+        whether every blocked task is queued behind a progressing
+        dependency (#1015 / #1025).
+        """
+        plan_ready_active = (
+            (getattr(data, "status_label", "") == "plan ready")
+            or (
+                bool(getattr(data, "plan_path", None))
+                and not any(
+                    item.get("is_plan_review")
+                    for item in (getattr(data, "action_items", []) or [])
+                )
+            )
+        )
+        if plan_ready_active:
+            return []
+        existing_blocker = _existing_blocker_context(data)
+        lines: list[str] = []
+        if (
+            existing_blocker is None
+            and not _blocked_only_on_progressing_deps(data)
+        ):
+            lines.append("[#f0c45a][b]Blocked, but summary missing[/b][/]")
+            lines.append(
+                "  [dim]This project is blocked, but Polly has not posted "
+                "an unblock note yet.[/dim]"
+            )
+            lines.append(
+                "  [dim]Press [b]c[/b] to ask the PM for a blocker summary.[/dim]"
+            )
+            lines.append("")
+        elif existing_blocker is None:
+            # All blocked tasks are waiting on progressing deps —
+            # render a short "queued behind" line instead of the
+            # missing-summary nag. The user gets a coherent story
+            # and no false alarm.
+            lines.append("[#3ddc84][b]Blocked on progressing dependencies[/b][/]")
+            lines.append(
+                "  [dim]Each blocked task is queued behind another task "
+                "that is currently in progress or in review — no action "
+                "needed.[/dim]"
+            )
+            lines.append("")
+        else:
+            kind = existing_blocker.get("kind")
+            if kind == "blocker_summary":
+                lines.append("[#f0c45a][b]Blocked[/b][/]")
+                lines.append(
+                    "  [dim]Polly's blocker summary is in the inbox below — "
+                    "press [b]i[/b] to open it.[/dim]"
+                )
+            else:
+                num = existing_blocker.get("task_number")
+                num_part = f" #{num}" if num is not None else ""
+                lines.append("[#f0c45a][b]Blocked[/b][/]")
+                lines.append(
+                    f"  [dim]The blocker reason is on task{num_part} "
+                    "in Task pipeline below.[/dim]"
+                )
+            lines.append("")
+        return lines
+
+    def _inbox_remainder_on_hold_block(
+        self, data: "ProjectDashboardData",
+    ) -> list[str]:
+        """Render the on-hold fallback block when no Action Needed cards
+        render and no blocked tasks pre-empt the slot.
+
+        Surfaces the two oldest on-hold items with a ``Decision:`` lead
+        line first (so overflow never eats the actionable copy —
+        #1542) plus per-item title, summary, and step list. Uses
+        :meth:`_inbox_text_width` to hard-wrap continuation rows on a
+        bullet-aligned hanging indent rather than letting Textual
+        soft-wrap drop them back to column 0.
+        """
+        lines: list[str] = ["[#f0c45a][b]On hold[/b][/]"]
+        on_hold_items = data.task_buckets.get("on_hold", [])[:2]
+        # #1542 — pre-compute the panel-text budget so continuation
+        # lines under each on-hold bullet keep the bullet-aligned
+        # indent. The previous version let Textual soft-wrap the
+        # raw string, which dropped continuation rows back to
+        # column 0 and read as a malformed indent on long
+        # descriptions (and chopped the actionable "Decide
+        # whether to approve…" line mid-clause).
+        wrap_width = self._inbox_text_width()
+        if on_hold_items:
+            # Lift the actionable "Decision" line *above* the
+            # description so it can never be the part overflow
+            # eats. This is the smaller of the two issue-suggested
+            # directions (the other being a "(press i for full)"
+            # hint), and it also dodges the need for an ellipsis
+            # affordance — the actionable line is now first, not
+            # last. The literal ``Decision:`` token is also what
+            # the release-invariants action-copy gate looks for
+            # when classifying on-hold-only dashboards as having
+            # usable action copy (see scripts/release_invariants
+            # ``_dashboard_body_has_action_copy``).
+            lines.append(
+                "  [#f0c45a][b]Decision:[/b][/] [dim]approve, "
+                "split, or provide missing access. Detail "
+                "below.[/dim]"
+            )
+            lines.append(
+                "  [dim]These are the root holds keeping downstream "
+                "work waiting.[/dim]"
+            )
+            for item in on_hold_items:
+                num = item.get("task_number")
+                num_part = f"#{num} " if num is not None else ""
+                title = _escape(item.get("title") or "")
+                lines.append(f"  [#f0c45a]◆[/#f0c45a] [b]{num_part}{title}[/b]")
+                summary = _escape(item.get("summary") or "")
+                if summary:
+                    # Hard-wrap so the second + later lines still
+                    # carry the bullet-aligned 4-space indent.
+                    lines.extend(
+                        _wrap_with_hanging_indent(
+                            summary, indent="    ", width=wrap_width,
+                        )
+                    )
+                for idx, step in enumerate(item.get("steps") or [], start=1):
+                    prefix = f"    [dim]{idx}.[/dim] "
+                    # Step rows pre-pend ``[dim]N.[/dim]``; wrap
+                    # continuation lines on a 7-char-aligned indent
+                    # so they sit under the step text rather than
+                    # under the number.
+                    step_text = _escape(str(step))
+                    wrapped = _wrap_with_hanging_indent(
+                        step_text, indent="    " + "   ",
+                        width=wrap_width,
+                    ) or [""]
+                    first, rest = wrapped[0], wrapped[1:]
+                    # Replace the leading indent on the first line
+                    # with the numbered prefix so ``1. step body``
+                    # aligns with ``2. step body`` continuation.
+                    if first:
+                        first_text = first.lstrip()
+                        lines.append(f"{prefix}{first_text}")
+                    for line in rest:
+                        lines.append(line)
+        else:
+            lines.extend(
+                _wrap_with_hanging_indent(
+                    "No user inbox action is requested yet. Open Tasks "
+                    "for the held work item and resume it when "
+                    "appropriate.",
+                    indent="  ", width=wrap_width, wrap_markup="dim",
+                )
+            )
+        lines.append("")
+        return lines
+
+    def _inbox_remainder_previews_block(
+        self,
+        data: "ProjectDashboardData",
+        *,
+        action_ids: set[str],
+        blocked_total: int,
+        on_hold_total: int,
+    ) -> tuple[list[str], bool]:
+        """Render the inbox preview rows + overflow / empty-state lines.
+
+        Returns ``(lines, has_spillover)``. ``has_spillover`` drives
+        the "Press i to jump to the inbox" CTA in the caller — kept
+        as a return value so the CTA placement stays in the top-level
+        function (it sits *after* the previews block).
+        """
+        count = data.inbox_count
+        preview_items = [
+            item for item in data.inbox_top
+            if str(item.get("task_id") or "") not in action_ids
+            and str(item.get("primary_ref") or "") not in action_ids
+        ]
+        # Only print the ◆ N need action overflow line when the
+        # rendered Action Needed cards do *not* already enumerate the
+        # full set. When count == cards displayed, the user can see
+        # them above and saying "2 need action" under "2 cards" is
+        # noise. When count > cards displayed there's something off
+        # screen and the line tells Sam to jump to the inbox for more.
+        displayed_actions = len(data.action_items[:2])
+        lines: list[str] = []
+        if count and count > displayed_actions:
+            # Verb agreement, sister to cycle 117's action-bar fix:
+            # ``1 needs action``, ``2 need action``. The overflow line
+            # only fires when count > displayed_actions, so the
+            # singular case (1 inbox item, 0 cards rendered) is reachable.
+            verb = "needs" if count == 1 else "need"
+            lines.append(
+                f"[#f0c45a]◆[/#f0c45a] [b]{count}[/b] "
+                f"[dim]{verb} action[/dim]"
+            )
+        # Split preview_items into "actually needs action" vs the
+        # rest. With no action cards rendered, lumping a "completed
+        # update" item under a "2 need action" header (because both
+        # happen to be in the top inbox slice) reads as
+        # "wait, which 2?" — the count says 2 but the list shows 3.
+        # Section the action-needed items first under the count
+        # header, then the remainder under an explicit "Other open
+        # items" subhead.
+        action_previews = [
+            item for item in preview_items
+            if item.get("needs_action")
+        ]
+        info_previews = [
+            item for item in preview_items
+            if not item.get("needs_action")
+        ]
+
+        def _emit_preview_row(item: dict) -> None:
+            title = _escape(item.get("title") or "")
+            age = _format_relative_age(item.get("updated_at") or "")
+            age_part = f"  [dim]{_escape(age)}[/dim]" if age else ""
+            label = item.get("triage_label") or ""
+            label_part = (
+                f"  [dim]{_escape(str(label))}[/dim]" if label else ""
+            )
+            lines.append(f"  · {title}{label_part}{age_part}")
+
+        for item in action_previews[:3]:
+            _emit_preview_row(item)
+        if info_previews:
+            if data.action_items or action_previews:
+                lines.append("[dim]Other open items[/dim]")
+            for item in info_previews[:3]:
+                _emit_preview_row(item)
+        if (
+            not count
+            and not preview_items
+            and not data.action_items
+            and not on_hold_total
+            and not blocked_total
+        ):
+            # Only print the "no items" reassurance when the section
+            # really is empty. The on-hold / blocked branches above
+            # already rendered something; saying "No project inbox
+            # items are open." right under a held-task card reads as
+            # the panel contradicting itself (#794).
+            lines.append("[dim]No project inbox items are open.[/dim]")
+        # FYI/info preview rows (completed updates, etc.) do *not*
+        # count as spillover: they're already visible under "Other
+        # open items" and there's no hidden user action behind them,
+        # so the CTA would just repeat the footer keybinding (#1650).
+        has_spillover = (
+            (count and count > displayed_actions)
+            or bool(action_previews)
+        )
+        return lines, has_spillover
+
     def _render_inbox_remainder(self, data: ProjectDashboardData) -> str:
         """Render the post-action-cards portion of the inbox section.
 
@@ -15412,7 +15667,6 @@ class PollyProjectDashboardApp(App[None]):
         ``Press i`` CTA. Mounted in the trailing ``inbox_body`` Static
         so it sits under both action-card groups.
         """
-        count = data.inbox_count
         blocked_total = int(data.task_counts.get("blocked", 0))
         on_hold_total = int(data.task_counts.get("on_hold", 0))
         action_ids: set[str] = set()
@@ -15470,237 +15724,25 @@ class PollyProjectDashboardApp(App[None]):
                         )
             lines.append("")
         elif blocked_total:
-            # #1015 — only nag about a missing summary when no blocker
-            # context exists anywhere (no on-hold reason, no blocker
-            # note on a blocked task, no project-level blocker_summary
-            # inbox item). When ANY of those exist, the user already
-            # has the answer on screen and the nag is wrong.
-            # #1025 — also suppress when every blocked task is waiting
-            # on a dependency that is actively progressing (in_progress
-            # or review). Bikepath's #11/#12/#14 were correctly queued
-            # behind #10 (review) and #13 (in_progress); the project
-            # is moving, not halted. Don't claim "summary missing" for
-            # what is actually healthy dep ordering.
-            # #1716 — likewise suppress when the plan-ready pill from
-            # #1715 is showing: the banner's "Plan ready — your turn"
-            # CTA already tells Sam the project's next step, and
-            # rendering the blocked-summary-missing nag directly under
-            # it reads as the panel contradicting itself.
-            plan_ready_active = (
-                (getattr(data, "status_label", "") == "plan ready")
-                or (
-                    bool(getattr(data, "plan_path", None))
-                    and not any(
-                        item.get("is_plan_review")
-                        for item in (getattr(data, "action_items", []) or [])
-                    )
-                )
-            )
-            existing_blocker = _existing_blocker_context(data)
-            if plan_ready_active:
-                pass
-            elif (
-                existing_blocker is None
-                and not _blocked_only_on_progressing_deps(data)
-            ):
-                lines.append("[#f0c45a][b]Blocked, but summary missing[/b][/]")
-                lines.append(
-                    "  [dim]This project is blocked, but Polly has not posted "
-                    "an unblock note yet.[/dim]"
-                )
-                lines.append(
-                    "  [dim]Press [b]c[/b] to ask the PM for a blocker summary.[/dim]"
-                )
-                lines.append("")
-            elif existing_blocker is None:
-                # All blocked tasks are waiting on progressing deps —
-                # render a short "queued behind" line instead of the
-                # missing-summary nag. The user gets a coherent story
-                # and no false alarm.
-                lines.append("[#3ddc84][b]Blocked on progressing dependencies[/b][/]")
-                lines.append(
-                    "  [dim]Each blocked task is queued behind another task "
-                    "that is currently in progress or in review — no action "
-                    "needed.[/dim]"
-                )
-                lines.append("")
-            else:
-                kind = existing_blocker.get("kind")
-                if kind == "blocker_summary":
-                    lines.append("[#f0c45a][b]Blocked[/b][/]")
-                    lines.append(
-                        "  [dim]Polly's blocker summary is in the inbox below — "
-                        "press [b]i[/b] to open it.[/dim]"
-                    )
-                else:
-                    num = existing_blocker.get("task_number")
-                    num_part = f" #{num}" if num is not None else ""
-                    lines.append("[#f0c45a][b]Blocked[/b][/]")
-                    lines.append(
-                        f"  [dim]The blocker reason is on task{num_part} "
-                        "in Task pipeline below.[/dim]"
-                    )
-                lines.append("")
+            # #1015 / #1025 / #1716 — blocked-summary copy variants;
+            # see :meth:`_inbox_remainder_blocked_block`.
+            lines.extend(self._inbox_remainder_blocked_block(data))
         elif on_hold_total:
-            lines.append("[#f0c45a][b]On hold[/b][/]")
-            on_hold_items = data.task_buckets.get("on_hold", [])[:2]
-            # #1542 \u2014 pre-compute the panel-text budget so continuation
-            # lines under each on-hold bullet keep the bullet-aligned
-            # indent. The previous version let Textual soft-wrap the
-            # raw string, which dropped continuation rows back to
-            # column 0 and read as a malformed indent on long
-            # descriptions (and chopped the actionable "Decide
-            # whether to approve\u2026" line mid-clause).
-            wrap_width = self._inbox_text_width()
-            if on_hold_items:
-                # Lift the actionable "Decision" line *above* the
-                # description so it can never be the part overflow
-                # eats. This is the smaller of the two issue-suggested
-                # directions (the other being a "(press i for full)"
-                # hint), and it also dodges the need for an ellipsis
-                # affordance \u2014 the actionable line is now first, not
-                # last. The literal ``Decision:`` token is also what
-                # the release-invariants action-copy gate looks for
-                # when classifying on-hold-only dashboards as having
-                # usable action copy (see scripts/release_invariants
-                # ``_dashboard_body_has_action_copy``).
-                lines.append(
-                    "  [#f0c45a][b]Decision:[/b][/] [dim]approve, "
-                    "split, or provide missing access. Detail "
-                    "below.[/dim]"
-                )
-                lines.append(
-                    "  [dim]These are the root holds keeping downstream "
-                    "work waiting.[/dim]"
-                )
-                for item in on_hold_items:
-                    num = item.get("task_number")
-                    num_part = f"#{num} " if num is not None else ""
-                    title = _escape(item.get("title") or "")
-                    lines.append(f"  [#f0c45a]\u25c6[/#f0c45a] [b]{num_part}{title}[/b]")
-                    summary = _escape(item.get("summary") or "")
-                    if summary:
-                        # Hard-wrap so the second + later lines still
-                        # carry the bullet-aligned 4-space indent.
-                        lines.extend(
-                            _wrap_with_hanging_indent(
-                                summary, indent="    ", width=wrap_width,
-                            )
-                        )
-                    for idx, step in enumerate(item.get("steps") or [], start=1):
-                        prefix = f"    [dim]{idx}.[/dim] "
-                        # Step rows pre-pend ``[dim]N.[/dim]``; wrap
-                        # continuation lines on a 7-char-aligned indent
-                        # so they sit under the step text rather than
-                        # under the number.
-                        step_text = _escape(str(step))
-                        wrapped = _wrap_with_hanging_indent(
-                            step_text, indent="    " + "   ",
-                            width=wrap_width,
-                        ) or [""]
-                        first, rest = wrapped[0], wrapped[1:]
-                        # Replace the leading indent on the first line
-                        # with the numbered prefix so ``1. step body``
-                        # aligns with ``2. step body`` continuation.
-                        if first:
-                            first_text = first.lstrip()
-                            lines.append(f"{prefix}{first_text}")
-                        for line in rest:
-                            lines.append(line)
-            else:
-                lines.extend(
-                    _wrap_with_hanging_indent(
-                        "No user inbox action is requested yet. Open Tasks "
-                        "for the held work item and resume it when "
-                        "appropriate.",
-                        indent="  ", width=wrap_width, wrap_markup="dim",
-                    )
-                )
-            lines.append("")
+            lines.extend(self._inbox_remainder_on_hold_block(data))
 
-        preview_items = [
-            item for item in data.inbox_top
-            if str(item.get("task_id") or "") not in action_ids
-            and str(item.get("primary_ref") or "") not in action_ids
-        ]
-        # Only print the \u25c6 N need action overflow line when the
-        # rendered Action Needed cards do *not* already enumerate the
-        # full set. When count == cards displayed, the user can see
-        # them above and saying "2 need action" under "2 cards" is
-        # noise. When count > cards displayed there's something off
-        # screen and the line tells Sam to jump to the inbox for more.
-        displayed_actions = len(data.action_items[:2])
-        if count and count > displayed_actions:
-            # Verb agreement, sister to cycle 117's action-bar fix:
-            # ``1 needs action``, ``2 need action``. The overflow line
-            # only fires when count > displayed_actions, so the
-            # singular case (1 inbox item, 0 cards rendered) is reachable.
-            verb = "needs" if count == 1 else "need"
-            lines.append(
-                f"[#f0c45a]\u25c6[/#f0c45a] [b]{count}[/b] "
-                f"[dim]{verb} action[/dim]"
-            )
-        # Split preview_items into "actually needs action" vs the
-        # rest. With no action cards rendered, lumping a "completed
-        # update" item under a "2 need action" header (because both
-        # happen to be in the top inbox slice) reads as
-        # "wait, which 2?" \u2014 the count says 2 but the list shows 3.
-        # Section the action-needed items first under the count
-        # header, then the remainder under an explicit "Other open
-        # items" subhead.
-        action_previews = [
-            item for item in preview_items
-            if item.get("needs_action")
-        ]
-        info_previews = [
-            item for item in preview_items
-            if not item.get("needs_action")
-        ]
-
-        def _emit_preview_row(item: dict) -> None:
-            title = _escape(item.get("title") or "")
-            age = _format_relative_age(item.get("updated_at") or "")
-            age_part = f"  [dim]{_escape(age)}[/dim]" if age else ""
-            label = item.get("triage_label") or ""
-            label_part = (
-                f"  [dim]{_escape(str(label))}[/dim]" if label else ""
-            )
-            lines.append(f"  \u00b7 {title}{label_part}{age_part}")
-
-        for item in action_previews[:3]:
-            _emit_preview_row(item)
-        if info_previews:
-            if data.action_items or action_previews:
-                lines.append("[dim]Other open items[/dim]")
-            for item in info_previews[:3]:
-                _emit_preview_row(item)
-        if (
-            not count
-            and not preview_items
-            and not data.action_items
-            and not on_hold_total
-            and not blocked_total
-        ):
-            # Only print the "no items" reassurance when the section
-            # really is empty. The on-hold / blocked branches above
-            # already rendered something; saying "No project inbox
-            # items are open." right under a held-task card reads as
-            # the panel contradicting itself (#794).
-            lines.append("[dim]No project inbox items are open.[/dim]")
+        preview_lines, has_spillover = self._inbox_remainder_previews_block(
+            data,
+            action_ids=action_ids,
+            blocked_total=blocked_total,
+            on_hold_total=on_hold_total,
+        )
+        lines.extend(preview_lines)
         # Show the "press i" CTA only when the inbox actually has more
         # to offer than what we just rendered. When every action item
         # is already on screen as a card and there are no other open
         # items, the line is redundant with the screen footer ("i
         # inbox") and just adds vertical noise. Keep it when the
         # inbox has spillover so the user knows where to look.
-        # FYI/info preview rows (completed updates, etc.) do *not*
-        # count as spillover: they're already visible under "Other
-        # open items" and there's no hidden user action behind them,
-        # so the CTA would just repeat the footer keybinding (#1650).
-        has_spillover = (
-            (count and count > displayed_actions)
-            or bool(action_previews)
-        )
         if has_spillover:
             lines.append("")
             lines.append("[dim]Press [b]i[/b] to jump to the inbox[/dim]")


### PR DESCRIPTION
## Summary

Next slice of #1356 — round 2 picking up where PR #1917 left off. PR #1917 broke up the three largest functions (`_dashboard_inbox`, `_process_session`, `load_inbox_entries`); this PR takes the next three. PURE refactor, no behavior change.

| Function | Before | After | Helpers extracted |
|---|---:|---:|---|
| `notify` (`cli_features/session_runtime.py`) | 328 | 178 (~60 LOC body; rest is Typer signature) | `_normalize_notify_args` + `_NotifyArgs`, `_maybe_warn_user_prompt_fallback`, `_enqueue_notify_message` |
| `format_unstick_brief` (`audit/watchdog.py`) | 306 | 36 | 9 per-rule formatters (`_brief_task_on_hold_stale`, `_brief_task_review_stale`, `_brief_task_progress_stale`, `_brief_role_session_missing`, `_brief_plan_review_missing`, `_brief_plan_review_bypassed_approval`, `_brief_rejection_loop`, `_brief_worker_session_dead_loop`, `_brief_fallback`) |
| `_render_inbox_remainder` (`cockpit_ui.py`) | 302 | 89 | `_inbox_remainder_blocked_block`, `_inbox_remainder_on_hold_block`, `_inbox_remainder_previews_block` |

Each helper is a real abstraction (a validation/normalization step, a rule-specific brief formatter, a self-contained UI sub-section), not a split at line N. One commit per function so reviewers can step through. The remaining ~8 functions over 200 LOC stay open under #1356.

`notify`'s body is now ~60 LOC; the 178-LOC AST measure is dominated by its long Typer parameter signature (~110 LOC of `typer.Option(...)` declarations + help text). The next slice of #1356 can move that signature into a Pydantic-style model if the lint floor still bites.

## Test plan

- [ ] `pm notify` end-to-end: silent / digest / immediate priorities, `--dedup-key` bump path, `--user-prompt-json` payload, `--channel dev` routing, fake-recovery auto-route to dev
- [ ] Watchdog escalation briefs render identically for each rule (`task_on_hold_stale`, `task_review_stale`, `task_progress_stale`, `role_session_missing`, `plan_review_missing`, `plan_review_bypassed_approval`, `rejection_loop`, `worker_session_dead_loop`, and the fallback rules)
- [ ] Cockpit dashboard inbox section renders the same lines for projects in all four configurations: action-cards + on-hold tail, blocked-only (each of the 4 sub-cases), on-hold-only, and the previews + ``Press i`` CTA spillover branch
- [ ] `ruff check` on touched files reports no new errors (verified: cockpit_ui pre-existing 49, unchanged; session_runtime + watchdog clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)