### PR TITLE
refactor(boundaries): close remaining core→plugin imports (closes #1363)

### DIFF
--- a/src/pollypm/activity_feed_protocol.py
+++ b/src/pollypm/activity_feed_protocol.py
@@ -17,6 +17,12 @@ This module hosts:
 * :func:`render_entry_detail` — entry-detail plain-text renderer. Takes the
   protocol shape, so the cockpit can render any source of feed entries
   without importing from ``plugins_builtin``.
+* :func:`format_entry_row` / :func:`compute_project_column_width` /
+  :func:`render_entries_as_text` — multi-row plain-text renderers, also pure.
+* :func:`render_activity_feed_text` — config-in/text-out shim used by the
+  cockpit's static-pane fallback. Resolves the projector through
+  :mod:`pollypm.activity_projector_registry` so core never reaches into the
+  optional plugin tree.
 
 The plugin re-exports these names from ``feed_panel`` so existing callers
 keep working without churn.
@@ -25,8 +31,12 @@ keep working without churn.
 from __future__ import annotations
 
 import json
+import logging
 from datetime import UTC, datetime
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Iterable, Protocol, runtime_checkable
+
+
+logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
@@ -142,8 +152,128 @@ def render_entry_detail(
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# Multi-row plain-text renderers — used by the cockpit's static-pane fallback
+# and ``pm activity``. Pure helpers (no plugin / projector dependency).
+# ---------------------------------------------------------------------------
+
+
+def _project_label(entry: ActivityFeedEntry) -> str:
+    """Project key as displayed in the feed (``"-"`` for empty).
+
+    Centralised so the auto-fit width math and :func:`format_entry_row`
+    agree on the same string. Empty / ``None`` falls back to ``"-"`` so
+    an unknown project still aligns in the column.
+    """
+    return entry.project or "-"
+
+
+def compute_project_column_width(
+    entries: Iterable[ActivityFeedEntry], *, minimum: int = 1,
+) -> int:
+    """Width of the widest project key in ``entries`` (auto-fit).
+
+    Used by :func:`format_entry_row` so the project column expands to
+    fit long keys like ``blackjack-trainer`` while keeping every row
+    aligned. Empty input falls back to ``minimum`` so a header-only
+    render still produces a sane column. See #929.
+    """
+    widest = minimum
+    for entry in entries:
+        widest = max(widest, len(_project_label(entry)))
+    return widest
+
+
+def format_entry_row(
+    entry: ActivityFeedEntry,
+    *,
+    now: datetime | None = None,
+    project_width: int | None = None,
+) -> str:
+    """Render one feed entry as a single plain-text row.
+
+    Layout:: ``[rel] [project] [actor] verb summary``. Severity is not
+    encoded here — the Textual renderer applies colour; the plain-text
+    renderer prefixes a ``!`` on critical entries so ``pm activity`` can
+    stay unstyled but still draw attention.
+
+    ``project_width`` left-pads the project key inside the brackets so
+    multi-row renders align even when project keys differ in length
+    (auto-fit; see :func:`compute_project_column_width` and #929). When
+    ``None`` the column is sized to the project key itself — the
+    single-row default that preserves the historical layout.
+    """
+    rel = format_relative_time(entry.timestamp, now=now)
+    project = _project_label(entry)
+    actor = entry.actor or "system"
+    verb = entry.verb or entry.kind
+    # #1033: distinguish create vs clear in the alert lifecycle so a
+    # quick scan tells the user which way the row is pointing. Only
+    # rewrite the verb when the emitter didn't supply a richer one
+    # (e.g. ``activity_summary(verb='alerted', ...)``) so structured
+    # events keep their authored verb intact.
+    if entry.kind == "alert" and verb in ("alert", entry.kind):
+        verb = "alert↑"
+    elif entry.kind == "alert.cleared" and verb in ("alert.cleared", entry.kind):
+        verb = "alert↓"
+    prefix = "!" if entry.severity == "critical" else " "
+    pin = "\U0001f4cc " if entry.pinned else ""
+    width = max(project_width or len(project), len(project))
+    project_cell = f"{project:<{width}}"
+    return f"{prefix} {rel:>8}  [{project_cell}]  [{actor}]  {verb}: {pin}{entry.summary}"
+
+
+def render_entries_as_text(entries: Iterable[ActivityFeedEntry]) -> str:
+    """Render a list of feed entries as multi-line plain text.
+
+    Empty input renders a friendly placeholder so the cockpit panel
+    doesn't look broken on a brand-new install. The project column
+    auto-fits to the widest key in the batch so long keys like
+    ``blackjack-trainer`` aren't visually clipped (see #929).
+    """
+    materialised = list(entries)
+    if not materialised:
+        return (
+            "No activity yet.\n\n"
+            "Events accumulate as sessions start, tasks transition, "
+            "and heartbeats fire. Check back after the next sweep."
+        )
+    width = compute_project_column_width(materialised)
+    rows = [format_entry_row(e, project_width=width) for e in materialised]
+    return "\n".join(rows)
+
+
+def render_activity_feed_text(config: Any, *, limit: int = 50) -> str:
+    """Render the feed as plain text for the cockpit's static pane path.
+
+    Resolves the projector through
+    :func:`pollypm.activity_projector_registry.build_activity_projector`
+    so core never reaches into the optional ``activity_feed`` plugin.
+    Missing config or missing factory yields the same friendly
+    placeholder as an empty feed.
+    """
+    header = "Activity Feed"
+    # Import lazily so the protocol module stays usable in environments
+    # where the registry hasn't been wired (test harnesses, doctor probes).
+    from pollypm.activity_projector_registry import build_activity_projector
+
+    projector = build_activity_projector(config)
+    if projector is None:
+        return f"{header}\n\nNo state store configured — nothing to show yet."
+    try:
+        entries = projector.project(limit=limit)
+    except Exception:  # noqa: BLE001
+        logger.exception("activity_feed: projection failed for text render")
+        return f"{header}\n\nFailed to read activity events."
+    return f"{header}\n\n{render_entries_as_text(entries)}"
+
+
 __all__ = [
     "ActivityFeedEntry",
+    "compute_project_column_width",
+    "format_entry_row",
     "format_relative_time",
+    "render_activity_feed_text",
+    "render_entries_as_text",
     "render_entry_detail",
 ]

--- a/src/pollypm/cli.py
+++ b/src/pollypm/cli.py
@@ -190,6 +190,18 @@ app.add_typer(plugins_app, name="plugins")
 from pollypm.rail_cli import rail_app
 app.add_typer(rail_app, name="rail")
 
+# ---------------------------------------------------------------------------
+# Built-in plugin CLI registrations (#1363).
+#
+# ``cli.py`` IS the sanctioned plugin-host edge for ``pm <subcommand>``
+# Typer apps — every built-in plugin that ships a CLI is mounted here so
+# the unified ``pm`` help surface is assembled at process start. The
+# original boundary-debt issue called these out as the only acceptable
+# core→``plugins_builtin`` imports, on the condition that no other core
+# module reaches in. With the activity_feed + project_planning slices
+# closed, that condition holds; these stay.
+# ---------------------------------------------------------------------------
+
 from pollypm.plugins_builtin.activity_feed.cli import activity_app
 app.add_typer(activity_app, name="activity")
 

--- a/src/pollypm/cockpit.py
+++ b/src/pollypm/cockpit.py
@@ -145,9 +145,11 @@ def _build_cockpit_detail_dispatch(supervisor, config_path: Path, kind: str, tar
         return _render_metrics_panel(config_path)
 
     if kind == "activity":
-        from pollypm.plugins_builtin.activity_feed.cockpit.feed_panel import (
-            render_activity_feed_text,
-        )
+        # #1363 — resolve via the core protocol module so the cockpit
+        # never reaches into the optional ``activity_feed`` plugin. The
+        # protocol's renderer goes through the projector registry seam,
+        # so a disabled plugin degrades cleanly to the empty placeholder.
+        from pollypm.activity_feed_protocol import render_activity_feed_text
 
         return render_activity_feed_text(config)
 

--- a/src/pollypm/plugins_builtin/activity_feed/cockpit/feed_panel.py
+++ b/src/pollypm/plugins_builtin/activity_feed/cockpit/feed_panel.py
@@ -25,7 +25,7 @@ import logging
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Iterable
 
 from pollypm.plugins_builtin.activity_feed.handlers.event_projector import (
     EventProjector,
@@ -167,120 +167,20 @@ _SEVERITY_COLOURS = {
 
 
 # Re-exported from the core shared module so callers in ``pollypm.cockpit*``
-# (and other peer plugins) can use the helper without importing through
-# ``plugins_builtin`` (#1363). The plugin keeps the name on its own surface
-# for back-compat with existing imports + monkeypatch paths.
-from pollypm.activity_feed_protocol import format_relative_time  # noqa: F401, E402
-
-
-def _project_label(entry: FeedEntry) -> str:
-    """Project key as displayed in the feed (``"-"`` for empty).
-
-    Centralised so the auto-fit width math and ``format_entry_row``
-    agree on the same string. Empty / ``None`` falls back to ``"-"``
-    so an unknown project still aligns in the column.
-    """
-    return entry.project or "-"
-
-
-def compute_project_column_width(
-    entries: Iterable[FeedEntry], *, minimum: int = 1,
-) -> int:
-    """Width of the widest project key in ``entries`` (auto-fit).
-
-    Used by :func:`format_entry_row` so the project column expands to
-    fit long keys like ``blackjack-trainer`` while keeping every row
-    aligned. Empty input falls back to ``minimum`` so a header-only
-    render still produces a sane column. See #929.
-    """
-    widest = minimum
-    for entry in entries:
-        widest = max(widest, len(_project_label(entry)))
-    return widest
-
-
-def format_entry_row(
-    entry: FeedEntry,
-    *,
-    now: datetime | None = None,
-    project_width: int | None = None,
-) -> str:
-    """Render one FeedEntry as a single plain-text row.
-
-    Layout:: ``[rel] [project] [actor] verb summary``. Severity is not
-    encoded here — the Textual renderer applies colour; the plain-text
-    renderer prefixes a ``!`` on critical entries so `pm activity` can
-    stay unstyled but still draw attention.
-
-    ``project_width`` left-pads the project key inside the brackets so
-    multi-row renders align even when project keys differ in length
-    (auto-fit; see :func:`compute_project_column_width` and #929). When
-    ``None`` the column is sized to the project key itself — the
-    single-row default that preserves the historical layout.
-    """
-    rel = format_relative_time(entry.timestamp, now=now)
-    project = _project_label(entry)
-    actor = entry.actor or "system"
-    verb = entry.verb or entry.kind
-    # #1033: distinguish create vs clear in the alert lifecycle so a
-    # quick scan tells the user which way the row is pointing. Only
-    # rewrite the verb when the emitter didn't supply a richer one
-    # (e.g. ``activity_summary(verb='alerted', ...)``) so structured
-    # events keep their authored verb intact.
-    if entry.kind == "alert" and verb in ("alert", entry.kind):
-        verb = "alert↑"
-    elif entry.kind == "alert.cleared" and verb in ("alert.cleared", entry.kind):
-        verb = "alert↓"
-    prefix = "!" if entry.severity == "critical" else " "
-    pin = "📌 " if entry.pinned else ""
-    width = max(project_width or len(project), len(project))
-    project_cell = f"{project:<{width}}"
-    return f"{prefix} {rel:>8}  [{project_cell}]  [{actor}]  {verb}: {pin}{entry.summary}"
-
-
-def render_entries_as_text(entries: Iterable[FeedEntry]) -> str:
-    """Render a list of FeedEntry rows as multi-line plain text.
-
-    Empty input renders a friendly placeholder so the cockpit panel
-    doesn't look broken on a brand-new install. The project column
-    auto-fits to the widest key in the batch so long keys like
-    ``blackjack-trainer`` aren't visually clipped (see #929).
-    """
-    materialised = list(entries)
-    if not materialised:
-        return (
-            "No activity yet.\n\n"
-            "Events accumulate as sessions start, tasks transition, "
-            "and heartbeats fire. Check back after the next sweep."
-        )
-    width = compute_project_column_width(materialised)
-    rows = [format_entry_row(e, project_width=width) for e in materialised]
-    return "\n".join(rows)
-
-
-# Re-exported from the core shared module (#1363). The plugin's ``FeedEntry``
-# dataclass satisfies ``ActivityFeedEntry`` structurally, so the renderer
-# accepts the existing concrete type unchanged.
-from pollypm.activity_feed_protocol import render_entry_detail  # noqa: F401, E402
-
-
-def render_activity_feed_text(config: Any, *, limit: int = 50) -> str:
-    """Render the feed as plain text for the cockpit's static pane path.
-
-    Picks up the projector from :func:`build_projector` — missing config
-    or missing state DB yields the same friendly placeholder as an
-    empty feed.
-    """
-    header = "Activity Feed"
-    projector = build_projector(config)
-    if projector is None:
-        return f"{header}\n\nNo state store configured — nothing to show yet."
-    try:
-        entries = projector.project(limit=limit)
-    except Exception:  # noqa: BLE001
-        logger.exception("activity_feed: projection failed for text render")
-        return f"{header}\n\nFailed to read activity events."
-    return f"{header}\n\n{render_entries_as_text(entries)}"
+# (and other peer plugins) can use these helpers without importing through
+# ``plugins_builtin`` (#1363). The plugin keeps the names on its own surface
+# for back-compat with existing imports + monkeypatch paths. The plugin's
+# ``FeedEntry`` dataclass satisfies ``ActivityFeedEntry`` structurally, so
+# the renderers accept the existing concrete type unchanged.
+from pollypm.activity_feed_protocol import (  # noqa: F401, E402
+    compute_project_column_width,
+    format_entry_row,
+    format_relative_time,
+    render_activity_feed_text,
+    render_entries_as_text,
+    render_entry_detail,
+)
+from pollypm.activity_feed_protocol import _project_label  # noqa: F401, E402
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the final core→`plugins_builtin` imports tracked in #1363, complementing the slices landed by PR #1909 (activity-feed text helpers) and PR #1930 (project_planning proposal/memory helpers).

- **`cockpit.py:148`** — the operator-dashboard activity pane lazy-imported `render_activity_feed_text` from the activity_feed plugin. Hoisted the four plain-text renderers (`format_entry_row`, `compute_project_column_width`, `render_entries_as_text`, `render_activity_feed_text`) plus the `_project_label` helper into `pollypm.activity_feed_protocol` next to the existing `format_relative_time` / `render_entry_detail` shared helpers. The config-in/text-out shim resolves the projector through `pollypm.activity_projector_registry.build_activity_projector` so the cockpit never reaches into `plugins_builtin`. `feed_panel.py` re-exports the names so the plugin's CLI + tests keep working unchanged.
- **`cli.py:193,196,199` (+ `:208,211` advisor/downtime)** — confirmed as the sanctioned plugin-host edge per the original issue. Added a doc-comment above the registrations so future readers don't try to "fix" them. With all other core slices closed, this is the only place core mounts plugin CLI subcommands into the unified `pm` help surface.

Gate check after the slice + the PR #1930 rebase:

```
$ grep -rn 'from pollypm.plugins_builtin\|import plugins_builtin' src/pollypm/ --include='*.py' | grep -v plugins_builtin/
src/pollypm/cli.py:205:from pollypm.plugins_builtin.activity_feed.cli import activity_app
src/pollypm/cli.py:208:from pollypm.plugins_builtin.morning_briefing.cli import briefing_app
src/pollypm/cli.py:211:from pollypm.plugins_builtin.project_planning.cli import project_app
src/pollypm/cli.py:220:from pollypm.plugins_builtin.advisor.cli.advisor_cli import advisor_app
src/pollypm/cli.py:223:from pollypm.plugins_builtin.downtime.cli import downtime_app
src/pollypm/cockpit_project_advisor_log.py:29:from pollypm.plugins_builtin.advisor.handlers.history_log import (
```

The `cli.py` entries are the sanctioned plugin-host edge (now documented). `cockpit_project_advisor_log.py` is a separate leak that postdates #1363 (introduced by #1899) and should be tracked in its own issue rather than expanding this PR's scope.

No behaviour change — implementations are copied verbatim and the renderer accepts the same `FeedEntry` shape structurally via the `ActivityFeedEntry` Protocol.

## Test plan

- [ ] `ruff check` clean on touched files (verified — no new errors introduced; 33 pre-existing E402 violations in `cli.py` are unrelated).
- [ ] `pm cockpit-pane activity` static fallback still renders the feed (text path).
- [ ] `pm activity` CLI still renders rows (unchanged — same helpers via plugin re-export).
- [ ] `tests/test_activity_feed_filters.py` still imports `FeedFilter`, `apply_filter`, `render_entry_detail` from `feed_panel` (unchanged surface).
- [ ] Boundary tests in `tests/test_import_boundary.py` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)