### PR TITLE
refactor(boundaries): break remaining circular imports (refs #1367)

### DIFF
--- a/src/pollypm/heartbeats/local.py
+++ b/src/pollypm/heartbeats/local.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from pollypm.heartbeats.base import HeartbeatBackend, HeartbeatSessionContext
+from pollypm.persona_drift import detect_persona_drift
 from pollypm.recovery.base import (
     InterventionHistoryEntry,
     SessionHealth,
@@ -1199,7 +1200,6 @@ class LocalHeartbeatBackend(HeartbeatBackend):
         Returns the list of alert types raised this tick (empty if no drift).
         """
         try:
-            from pollypm.supervisor import detect_persona_drift
             drifted_to = detect_persona_drift(context.role, context.pane_text or "")
         except Exception:  # noqa: BLE001
             drifted_to = None

--- a/src/pollypm/persona_drift.py
+++ b/src/pollypm/persona_drift.py
@@ -1,0 +1,85 @@
+"""Leaf module for persona-drift detection (extracted from ``supervisor``).
+
+Owns the persona-marker table, identity-claim phrasings, and the
+:func:`detect_persona_drift` predicate used by the heartbeat (#757) to
+catch sessions whose pane text shows a different role's identity claim
+than the one the session was launched with.
+
+Lives here, not on ``pollypm.supervisor``, so that ``heartbeats.local``
+can call :func:`detect_persona_drift` without lazy-importing
+``pollypm.supervisor`` (refs #1367). ``pollypm.supervisor`` keeps the
+historical re-exports for back-compat with tests and any external
+callers.
+"""
+from __future__ import annotations
+
+# Stable persona markers per role. Used both as the source-of-truth for
+# the launch-time persona check (:meth:`Supervisor._schedule_persona_verify`)
+# and as a backstop (see ``Supervisor._schedule_persona_verify``) to catch
+# (launch, target) tuple crosses where one role's control prompt
+# lands in a different role's window. ``worker`` has no stable
+# persona and ``triage`` does not currently brand itself, so both
+# are intentionally omitted.
+_ROLE_PERSONA_MARKER: dict[str, str] = {
+    "operator-pm": "Polly",
+    "reviewer": "Russell",
+    "architect": "Archie",
+    "heartbeat-supervisor": "Heartbeat",
+}
+
+
+# Phrasings that unambiguously claim a persona identity — e.g.
+# "Standing by as Russell", "I'm Polly", "Holding as Russell". Used
+# by :func:`detect_persona_drift` to decide whether the pane shows
+# a DIFFERENT persona's identity claim, which is the symptom of a
+# mid-flight persona swap (#757). Neutral mentions ("let me notify
+# Polly") don't match these patterns.
+_IDENTITY_CLAIM_PATTERNS: tuple[str, ...] = (
+    "standing by as {marker}",
+    "holding as {marker}",
+    "i am {marker}",
+    "i'm {marker}",
+    "continuing as {marker}",
+    "acting as {marker}",
+    "as {marker}, ",
+    "as {marker}.",
+    "as {marker},",
+    "initialized as {marker}",
+)
+
+
+def detect_persona_drift(role: str, pane_text: str) -> str | None:
+    """Return the name of the drifted-to persona, or None on no drift.
+
+    Looks for strong identity-claim phrasings that reference a role
+    OTHER than the session's configured role. Conservative by design:
+    casual mentions of another persona name don't trip the detector —
+    only phrasings the session would use to assert its own identity.
+
+    Used by the heartbeat (#757) to catch sessions that started with
+    the correct role but drifted mid-flight — either through kickoff
+    clobber (#758) or prompt-injection (#755). Kickoff-time drift is
+    caught earlier by :func:`Supervisor._assert_session_launch_matches`.
+
+    Returns the detected persona name (e.g. ``"Russell"``) so callers
+    can surface it in the alert message, or ``None`` when no drift is
+    observed.
+    """
+    if not pane_text or not role:
+        return None
+    expected = _ROLE_PERSONA_MARKER.get(role)
+    lowered = pane_text.lower()
+    for other_role, other_marker in _ROLE_PERSONA_MARKER.items():
+        if other_role == role:
+            continue
+        # Avoid false positives when the expected marker also appears
+        # in the pane — both present means the session is legitimately
+        # discussing multiple personas (e.g. Polly reviewing Russell's
+        # output).
+        if expected and expected.lower() in lowered:
+            continue
+        for pattern in _IDENTITY_CLAIM_PATTERNS:
+            needle = pattern.format(marker=other_marker.lower())
+            if needle in lowered:
+                return other_marker
+    return None

--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -76,6 +76,15 @@ from pollypm.heartbeats.api import SupervisorHeartbeatAPI
 from pollypm.knowledge_extract import EXTRACTION_INTERVAL_SECONDS
 from pollypm.models import AccountConfig, ProviderKind, SessionConfig, SessionLaunchSpec
 from pollypm.onboarding import _prime_claude_home
+# Canonical persona-drift definitions live in :mod:`pollypm.persona_drift`
+# so ``heartbeats.local`` can import :func:`detect_persona_drift` without
+# lazy-importing supervisor (refs #1367). Re-exported below for
+# back-compat with existing callers and tests.
+from pollypm.persona_drift import (  # noqa: F401  (re-exported)
+    _IDENTITY_CLAIM_PATTERNS,
+    _ROLE_PERSONA_MARKER,
+    detect_persona_drift,
+)
 from pollypm.projects import ensure_project_scaffold
 from pollypm.projects import project_checkpoints_dir, project_transcripts_dir, project_worktrees_dir, release_session_lock
 from pollypm.providers.claude.resume import recorded_session_id as _recorded_claude_session_id
@@ -161,13 +170,10 @@ _OWNER_PREFIXES = {
 # (launch, target) tuple crosses where one role's control prompt
 # lands in a different role's window. ``worker`` has no stable
 # persona and ``triage`` does not currently brand itself, so both
-# are intentionally omitted.
-_ROLE_PERSONA_MARKER: dict[str, str] = {
-    "operator-pm": "Polly",
-    "reviewer": "Russell",
-    "architect": "Archie",
-    "heartbeat-supervisor": "Heartbeat",
-}
+# are intentionally omitted. Canonical definitions (the marker table,
+# identity-claim phrasings, and the :func:`detect_persona_drift`
+# predicate) live in :mod:`pollypm.persona_drift` — imported at the
+# top of this module and re-exported for back-compat.
 
 
 # Identity preamble prepended to recovery prompts so the agent does not
@@ -243,63 +249,6 @@ def _identity_preamble_for_role(role: str | None) -> str:
     if not role:
         return ""
     return _ROLE_IDENTITY_PREAMBLE.get(role, "")
-
-
-# Phrasings that unambiguously claim a persona identity — e.g.
-# "Standing by as Russell", "I'm Polly", "Holding as Russell". Used
-# by :func:`detect_persona_drift` to decide whether the pane shows
-# a DIFFERENT persona's identity claim, which is the symptom of a
-# mid-flight persona swap (#757). Neutral mentions ("let me notify
-# Polly") don't match these patterns.
-_IDENTITY_CLAIM_PATTERNS: tuple[str, ...] = (
-    "standing by as {marker}",
-    "holding as {marker}",
-    "i am {marker}",
-    "i'm {marker}",
-    "continuing as {marker}",
-    "acting as {marker}",
-    "as {marker}, ",
-    "as {marker}.",
-    "as {marker},",
-    "initialized as {marker}",
-)
-
-
-def detect_persona_drift(role: str, pane_text: str) -> str | None:
-    """Return the name of the drifted-to persona, or None on no drift.
-
-    Looks for strong identity-claim phrasings that reference a role
-    OTHER than the session's configured role. Conservative by design:
-    casual mentions of another persona name don't trip the detector —
-    only phrasings the session would use to assert its own identity.
-
-    Used by the heartbeat (#757) to catch sessions that started with
-    the correct role but drifted mid-flight — either through kickoff
-    clobber (#758) or prompt-injection (#755). Kickoff-time drift is
-    caught earlier by :func:`Supervisor._assert_session_launch_matches`.
-
-    Returns the detected persona name (e.g. ``"Russell"``) so callers
-    can surface it in the alert message, or ``None`` when no drift is
-    observed.
-    """
-    if not pane_text or not role:
-        return None
-    expected = _ROLE_PERSONA_MARKER.get(role)
-    lowered = pane_text.lower()
-    for other_role, other_marker in _ROLE_PERSONA_MARKER.items():
-        if other_role == role:
-            continue
-        # Avoid false positives when the expected marker also appears
-        # in the pane — both present means the session is legitimately
-        # discussing multiple personas (e.g. Polly reviewing Russell's
-        # output).
-        if expected and expected.lower() in lowered:
-            continue
-        for pattern in _IDENTITY_CLAIM_PATTERNS:
-            needle = pattern.format(marker=other_marker.lower())
-            if needle in lowered:
-                return other_marker
-    return None
 
 
 def _prefix_for_owner(owner: str, text: str) -> str:


### PR DESCRIPTION
## Summary

- Extract ``detect_persona_drift`` + the ``_ROLE_PERSONA_MARKER`` table + ``_IDENTITY_CLAIM_PATTERNS`` phrasings into a new leaf module ``pollypm.persona_drift``.
- ``heartbeats/local.py`` top-imports the predicate directly — the function-level ``from pollypm.supervisor import detect_persona_drift`` lazy is gone.
- ``pollypm.supervisor`` keeps the names as re-exports (``# noqa: F401``) for back-compat with tests (``tests/test_persona_swap_detection.py``) and any external callers.

## #1367 status after this slice

Audit pass (static analysis: ``A`` lazy-imports ``B`` AND ``B`` top-imports ``A``) on the post-rebase tree:

| Original pair | State |
| --- | --- |
| ``cockpit_rail`` ↔ ``cockpit`` | broken in #1909 |
| ``cockpit_palette`` ↔ ``cockpit_ui`` | OPEN — structurally tied to #1354 (palette would need cockpit_ui's ``Polly*App`` classes; 4 of 7 still live in cockpit_ui). Documented intentional lazy with rationale comment. |
| ``cockpit_activity`` ↔ ``cockpit_ui`` | broken in #1909 |
| ``cockpit_sections.dashboard`` ↔ ``cockpit`` | resolved — one-way edge, no top-top cycle |
| ``cockpit_inbox`` ↔ ``cockpit_inbox_items`` | resolved — ``cockpit_inbox_items`` no longer top-imports ``cockpit_inbox``; remaining lazy in ``cockpit_inbox`` is benign defensive (no cycle would form on hoist) |
| ``work.service_*`` cluster (7 pairs) | resolved — all one-way edges per detector |
| ``heartbeats.local`` ↔ ``supervisor`` | **broken in this PR** |
| ``heartbeats.api`` ↔ ``supervisor`` | resolved — ``heartbeats.api`` has no supervisor import |
| ``schedulers.base`` ↔ ``supervisor`` | resolved — TYPE_CHECKING only |
| ``provider_sdk`` ↔ ``providers.base`` | resolved — one-way edge |
| ``accounts`` ↔ ``acct`` | OPEN — Phase A wedge of #397 (``acct.model`` re-exports ``AccountStatus`` from ``accounts`` until Phase D moves the definition). Intentional. |
| ``onboarding`` ↔ ``onboarding_tui`` | broken in #1929 |
| ``plugin_host`` ↔ ``plugin_validate`` | broken in #1462 |
| advisor ``handlers.assess`` ↔ advisor ``inbox`` | broken in #1482 |
| ``activity_feed.plugin`` ↔ ``feed_panel`` | broken in #1909/#1933 |
| ``morning_briefing.handlers.briefing_tick`` ↔ ``morning_briefing`` | resolved per detector |
| ``downtime.handlers.downtime_tick`` ↔ ``downtime.handlers`` | resolved (package ``__init__`` is empty; no back-edge through ``__init__``) |
| ``store.event_buffer`` ↔ ``store.sqlalchemy_store`` | resolved — one-way edge |

Remaining lazy-back-edge pairs flagged by the detector (5) are all new ``cockpit_ui`` god-module split shims tracked by #1354 — each has a module-level docstring explicitly noting the lazy back-import is the intended in-flight pattern (``"importing at module load time would create a cycle (cockpit_ui re-exports from this module for the back-compat shim)"``). They're not in #1367's original pair list; they came in with the slice-by-slice #1354 split.

Real top-level cycles (top-imports ↔ top-imports): **0**.

Keeping #1367 open via ``refs #1367`` — the ``cockpit_palette`` ↔ ``cockpit_ui`` pair from the original list is the only one still genuinely outstanding, and breaking it cleanly requires moving ``PollyInboxApp`` / ``PollySettingsPaneApp`` / ``PollyProjectDashboardApp`` out of ``cockpit_ui.py`` — i.e. a #1354 wedge, not a #1367 wedge.

## Test plan

- [x] Static cycle detector: 0 real cycles, 5 documented #1354 wedges
- [x] Import smoke: ``pollypm.persona_drift``, ``pollypm.supervisor``, ``pollypm.heartbeats.local``, ``pollypm.heartbeats.api``, ``pollypm.heartbeats`` all import; ``supervisor.detect_persona_drift is persona_drift.detect_persona_drift``
- [x] Behavior smoke: ``detect_persona_drift('operator-pm', 'Standing by as Russell now') == 'Russell'`` and ``detect_persona_drift('operator-pm', '') is None``
- [x] ``ruff check`` on touched files — no new error classes; net +1 E402 from the new import line, all pre-existing E402s in ``supervisor.py`` are from imports that already sit after a ``logger = logging.getLogger(__name__)`` statement.
- [ ] ``tests/test_persona_swap_detection.py`` (covers ``_ROLE_PERSONA_MARKER`` access via ``pollypm.supervisor`` — the re-export keeps this path working unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)