### PR TITLE
test(pg): complete K-source-ripout port-back (refs #1824)

### DIFF
--- a/tests/test_pg_cli_bug_report.py
+++ b/tests/test_pg_cli_bug_report.py
@@ -1,0 +1,200 @@
+"""Pg re-coverage for the ``pm bug-report`` CLI subcommand (#1824).
+
+Slice K-tests part 5 (#1737, commit 04285152) deleted
+``tests/test_cli_bug_report.py`` (#1569). The bug-report CLI is
+backend-agnostic — it shells out to ``gh`` via subprocess and only
+touches the audit log + (when invoked) a sqlite messages table.
+
+Re-locks the contract surface against the root CLI app:
+
+* On a fresh create, echoes ``filed:#<n>``.
+* On a recent-window dedup match, echoes ``deduped:#<n>``.
+* Refuses empty title / empty body.
+* Accepts body from stdin with ``-``.
+* Surfaces gh-unavailable as a non-zero exit.
+* Does **not** write an inbox row — the whole point of the
+  command is to route the observation to GitHub, not enqueue a
+  user-actionable notify.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import text
+from typer.testing import CliRunner
+
+from pollypm.cli import app as root_app
+from pollypm.store import SQLAlchemyStore
+
+
+runner = CliRunner()
+
+
+def _completed(stdout: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr="",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_audit(tmp_path, monkeypatch):
+    monkeypatch.setenv("POLLYPM_AUDIT_HOME", str(tmp_path / "audit"))
+    monkeypatch.setenv("POLLYPM_BUG_REPORTER_REPO", "owner/repo")
+
+
+@pytest.fixture
+def _gh_available(monkeypatch):
+    from pollypm.audit import bug_reporter
+
+    monkeypatch.setattr(bug_reporter, "_gh_available", lambda: True)
+
+
+def test_cli_filed_echoes_issue_number(_gh_available, tmp_path):
+    """First-pass bug-report → ``filed:#<n>`` after gh create returns
+    the issue URL."""
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return _completed(stdout="[]\n")
+        return _completed(
+            stdout="https://github.com/owner/repo/issues/1011\n",
+        )
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = runner.invoke(
+            root_app,
+            [
+                "bug-report",
+                "Inbox panel double-renders on rail switch",
+                "Repro: switch rails 3x, panel doubles.",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert "filed:#1011" in result.output
+
+
+def test_cli_dedup_echoes_existing_number(_gh_available):
+    """Recent-window dedup match → ``deduped:#<n>`` without a create call."""
+    from datetime import datetime, timedelta, timezone
+
+    recent_iso = (
+        datetime.now(timezone.utc) - timedelta(seconds=60)
+    ).isoformat().replace("+00:00", "Z")
+
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return _completed(
+                stdout=json.dumps(
+                    [
+                        {
+                            "number": 42,
+                            "title": "Same observation",
+                            "createdAt": recent_iso,
+                        }
+                    ]
+                )
+            )
+        raise AssertionError(f"create should not run: {cmd!r}")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = runner.invoke(
+            root_app,
+            ["bug-report", "Same observation", "x"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "deduped:#42" in result.output
+
+
+def test_cli_refuses_empty_title(_gh_available):
+    result = runner.invoke(
+        root_app,
+        ["bug-report", "   ", "body"],
+    )
+    assert result.exit_code != 0
+    assert "title must not be empty" in result.output
+
+
+def test_cli_refuses_empty_body(_gh_available):
+    result = runner.invoke(
+        root_app,
+        ["bug-report", "title", "   "],
+    )
+    assert result.exit_code != 0
+    assert "body must not be empty" in result.output
+
+
+def test_cli_body_from_stdin(_gh_available):
+    """Pass ``-`` as body to read from stdin (the typical pipe-from-Polly
+    invocation shape)."""
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return _completed(stdout="[]\n")
+        return _completed(stdout="https://github.com/owner/repo/issues/9\n")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = runner.invoke(
+            root_app,
+            ["bug-report", "stdin smoke", "-"],
+            input="multi\nline\nbody\n",
+        )
+    assert result.exit_code == 0, result.output
+    assert "filed:#9" in result.output
+
+
+def test_cli_gh_missing_exits_non_zero(monkeypatch):
+    """When ``gh`` isn't on PATH, surface a non-zero exit so caller
+    scripts can branch on the failure."""
+    from pollypm.audit import bug_reporter
+
+    monkeypatch.setattr(bug_reporter, "_gh_available", lambda: False)
+
+    result = runner.invoke(
+        root_app,
+        ["bug-report", "gh-missing", "x"],
+    )
+    assert result.exit_code != 0
+    assert "gh CLI unavailable" in result.output
+
+
+def test_cli_writes_no_inbox_row(_gh_available, tmp_path: Path):
+    """The whole point of the command is to bypass the inbox.
+
+    Set up a fresh state.db, run ``pm bug-report``, then assert
+    ``messages`` is empty — the helper went out to GitHub (mocked)
+    and did not enqueue a notify row.
+    """
+    db_path = tmp_path / "state.db"
+
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[:3] == ["gh", "issue", "list"]:
+            return _completed(stdout="[]\n")
+        return _completed(
+            stdout="https://github.com/owner/repo/issues/123\n",
+        )
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = runner.invoke(
+            root_app,
+            ["bug-report", "no-inbox-write", "evidence"],
+        )
+    assert result.exit_code == 0, result.output
+
+    # bug-report does not auto-create the state DB — verify by
+    # creating it manually and confirming no rows exist (the test's
+    # contract is "no inbox row was written").
+    if db_path.exists():
+        store = SQLAlchemyStore(f"sqlite:///{db_path}")
+        try:
+            with store.read_engine.connect() as conn:
+                rows = conn.execute(
+                    text("SELECT count(*) FROM messages")
+                ).scalar() or 0
+            assert rows == 0
+        finally:
+            store.close()
+    # If db_path was not created at all, that's also a pass — the
+    # helper never touched the inbox layer.

--- a/tests/test_pg_doctor_enhancements.py
+++ b/tests/test_pg_doctor_enhancements.py
@@ -1,0 +1,1028 @@
+"""Extended ``pm doctor`` coverage beyond PR #1931 (#1824).
+
+PR #1931 (commit a8f8620e9) added
+``tests/test_doctor_enhancements_recovery.py`` with the PASS/WARN/
+FAIL monkeypatch coverage for the comprehensive checks. This module
+extends that with the surfaces #1931 explicitly deferred:
+
+* End-to-end CLI ``doctor`` invocations: exit codes (--all-pass /
+  warnings-only / any-error), ``--fix`` invocation + verification,
+  ``--fix-dry-run`` enumeration, ``--json`` AutoFix metadata.
+* ``--fix`` anti-lie guards from #1063 + #1064
+  (``test_fix_cli_does_not_lie_when_handler_noops``,
+  ``test_verify_fix_results_demotes_missing_check``).
+* ``AutoFixPlan`` plumbing on the per-tool checks (tmux / claude-cli
+  / codex-cli) + the renderer / JSON output that consumes it.
+* The ``check_scheduler_last_fired`` cadence sweep — needs a
+  bootstrapped sqlite messages table for the event rows, so it sits
+  in this file rather than the PR #1931 monkeypatch-only one.
+* ``check_sessions_table_populated`` + ``check_sessions_table_vs_tmux``
+  (session drift) — these need a bootstrapped sqlite state DB for
+  the ``sessions`` row count.
+* The ``check_inbox_aggregator_path`` checks against
+  ``pollypm.work.cli._resolve_db_path``.
+* Pluralisation guards on the ``render_fix_summary`` /
+  ``render_fix_dry_run`` footers and on the maintenance-handler
+  result lines.
+* The ``--fix`` fixer plumbing for plan-gate, task-assignment
+  sweeper-DBs, agent-worktree prune, and logs-dir rotate.
+
+Pure-helper coverage (each check's PASS/WARN/FAIL via monkeypatch)
+lives in ``tests/test_doctor_enhancements_recovery.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from pollypm import doctor
+
+
+# --------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------- #
+
+
+def _make_state_db(path: Path, *, sessions: int = 0) -> Path:
+    """Synthetic state DB with the ``sessions`` shape the doctor reads.
+
+    Installs the ``sessions`` table (still a domain table owned by
+    :class:`StateStore`, #342-followup) plus bootstraps the unified
+    ``messages`` schema via :class:`SQLAlchemyStore` so the cadence
+    check can read ``type='event'`` rows.
+    """
+    from pollypm.store import SQLAlchemyStore
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS sessions (
+                name TEXT PRIMARY KEY,
+                role TEXT,
+                project TEXT,
+                provider TEXT,
+                account TEXT,
+                cwd TEXT,
+                window_name TEXT
+            );
+            """
+        )
+        for i in range(sessions):
+            conn.execute(
+                "INSERT INTO sessions "
+                "(name, role, project, provider, account, cwd, window_name) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (f"sess{i}", "worker", "demo", "claude", "acct", "/tmp",
+                 f"worker-{i}"),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    SQLAlchemyStore(f"sqlite:///{path}").close()
+    return path
+
+
+def _record_event(db_path: Path, event_type: str, *, age_seconds: int = 0) -> None:
+    """Insert a ``type='event'`` row into the unified ``messages`` table."""
+    import json as _json
+    from datetime import UTC, datetime, timedelta
+
+    from sqlalchemy import insert as _insert
+
+    from pollypm.store import SQLAlchemyStore
+    from pollypm.store.schema import messages as _messages
+
+    created_at = datetime.now(UTC) - timedelta(seconds=age_seconds)
+    msg_store = SQLAlchemyStore(f"sqlite:///{db_path}")
+    try:
+        with msg_store.transaction() as conn:
+            conn.execute(
+                _insert(_messages),
+                {
+                    "scope": "system",
+                    "type": "event",
+                    "tier": "immediate",
+                    "recipient": "*",
+                    "sender": "system",
+                    "state": "open",
+                    "subject": event_type,
+                    "body": "ok",
+                    "payload_json": _json.dumps({"event_type": event_type}),
+                    "labels": "[]",
+                    "created_at": created_at,
+                    "updated_at": created_at,
+                },
+            )
+    finally:
+        msg_store.close()
+
+
+# --------------------------------------------------------------------- #
+# Pipeline — additional check coverage that needs real-fs assertions.
+# --------------------------------------------------------------------- #
+
+
+def test_task_assignment_sweeper_dbs_pass(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """One project, state.db present → ok status with singular project."""
+    project_path = tmp_path / "proj-a"
+    db = project_path / ".pollypm" / "state.db"
+    db.parent.mkdir(parents=True)
+    db.write_text("")
+    fake_project = type("P", (), {"path": project_path, "tracked": True})
+    fake_config = type("C", (), {"projects": {"proj-a": fake_project}})
+    monkeypatch.setattr(
+        doctor, "_safe_load_config", lambda: (Path("/tmp/x"), fake_config),
+    )
+    result = doctor.check_task_assignment_sweeper_dbs()
+    assert result.passed
+    assert "1 tracked project" in result.status
+
+
+def test_project_local_guide_drift_pass(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    project_path = tmp_path / "proj-a"
+    project_path.mkdir()
+    fake_project = type("P", (), {"path": project_path, "name": "Project A"})
+    fake_config = type("C", (), {"projects": {"proj-a": fake_project}})
+    monkeypatch.setattr(
+        doctor, "_safe_load_config", lambda: (Path("/tmp/x"), fake_config),
+    )
+    monkeypatch.setattr(doctor, "_list_drifted_project_guides", lambda _path: [])
+    result = doctor.check_project_local_guide_drift()
+    assert result.passed
+    assert "no stale project-local guides" in result.status
+
+
+# --------------------------------------------------------------------- #
+# Scheduler cadence — needs a bootstrapped messages table for events.
+# --------------------------------------------------------------------- #
+
+
+def test_scheduler_cadence_pass(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    db = _make_state_db(tmp_path / "state.db")
+    for handler in doctor._HANDLER_MAX_GAP_SECONDS:
+        _record_event(db, handler, age_seconds=10)
+    monkeypatch.setattr(doctor, "_primary_state_db", lambda: db)
+    result = doctor.check_scheduler_last_fired()
+    assert result.passed
+    assert "within cadence" in result.status
+
+
+def test_scheduler_cadence_warn_when_overdue(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    db = _make_state_db(tmp_path / "state.db")
+    _record_event(db, "db.vacuum", age_seconds=5 * 86400)
+    monkeypatch.setattr(doctor, "_primary_state_db", lambda: db)
+    result = doctor.check_scheduler_last_fired()
+    assert not result.passed
+    assert result.severity == "warning"
+    assert "overdue" in result.status
+
+
+def test_scheduler_cadence_pass_when_no_events(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Fresh-install case: no events yet, no overdue → passes."""
+    db = _make_state_db(tmp_path / "state.db")
+    monkeypatch.setattr(doctor, "_primary_state_db", lambda: db)
+    result = doctor.check_scheduler_last_fired()
+    assert result.passed
+
+
+# --------------------------------------------------------------------- #
+# Resources — state DB size error path (fixable) + tmux/claude/codex
+# AutoFix plans.
+# --------------------------------------------------------------------- #
+
+
+def test_state_db_size_error_and_fixable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """``stat``-based size lookup at 3 GB → error + fixable."""
+    db = tmp_path / "huge.db"
+    db.write_bytes(b"\0")
+    real_stat = db.stat()
+
+    class _BigStat:
+        st_size = 3 * 1024 * 1024 * 1024  # 3 GB
+
+        def __getattr__(self, name: str):
+            return getattr(real_stat, name)
+
+    monkeypatch.setattr(
+        Path, "stat", lambda self, **kw: _BigStat() if self == db else real_stat,
+    )
+    monkeypatch.setattr(doctor, "_state_db_candidates", lambda: [db])
+    result = doctor.check_state_db_size()
+    assert not result.passed
+    assert result.severity == "error"
+    assert result.fixable
+    assert callable(result.fix_fn)
+
+
+# --------------------------------------------------------------------- #
+# Sessions table population — sqlite state DB read.
+# --------------------------------------------------------------------- #
+
+
+def test_sessions_table_populated_pass(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    db = _make_state_db(tmp_path / "state.db", sessions=3)
+    monkeypatch.setattr(doctor, "_supervisor_state_db", lambda: db)
+    monkeypatch.setattr(doctor, "_primary_state_db", lambda: db)
+    result = doctor.check_sessions_table_populated()
+    assert result.passed
+    assert "3 row" in result.status
+
+
+def test_sessions_table_populated_warn_when_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    db = _make_state_db(tmp_path / "state.db", sessions=0)
+    monkeypatch.setattr(doctor, "_supervisor_state_db", lambda: db)
+    monkeypatch.setattr(doctor, "_primary_state_db", lambda: db)
+    result = doctor.check_sessions_table_populated()
+    assert not result.passed
+    assert result.severity == "warning"
+    assert result.fixable
+    assert callable(result.fix_fn)
+
+
+def test_sessions_table_populated_skip_without_db(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(doctor, "_supervisor_state_db", lambda: None)
+    monkeypatch.setattr(doctor, "_primary_state_db", lambda: None)
+    result = doctor.check_sessions_table_populated()
+    assert result.passed and result.skipped
+
+
+# --------------------------------------------------------------------- #
+# Sessions drift vs tmux — sqlite + monkeypatched tmux probe.
+# --------------------------------------------------------------------- #
+
+
+def test_session_drift_pass(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    db = _make_state_db(tmp_path / "state.db")
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO sessions "
+        "(name, role, project, provider, account, cwd, window_name) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("worker-x", "worker", "demo", "claude", "acct", "/tmp", "worker-x"),
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(doctor, "_supervisor_state_db", lambda: db)
+    monkeypatch.setattr(doctor, "_primary_state_db", lambda: db)
+    monkeypatch.setattr(
+        doctor, "_tool_path",
+        lambda name: "/usr/bin/tmux" if name == "tmux" else None,
+    )
+    monkeypatch.setattr(
+        doctor, "_run_cmd", lambda cmd, **kw: (0, "polly:worker-x"),
+    )
+    result = doctor.check_sessions_table_vs_tmux()
+    assert result.passed
+
+
+def test_session_drift_warn(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    db = _make_state_db(tmp_path / "state.db")
+    monkeypatch.setattr(doctor, "_supervisor_state_db", lambda: db)
+    monkeypatch.setattr(doctor, "_primary_state_db", lambda: db)
+    monkeypatch.setattr(
+        doctor, "_tool_path",
+        lambda name: "/usr/bin/tmux" if name == "tmux" else None,
+    )
+    monkeypatch.setattr(
+        doctor, "_run_cmd", lambda cmd, **kw: (0, "polly:worker-rogue"),
+    )
+    result = doctor.check_sessions_table_vs_tmux()
+    assert not result.passed
+    assert result.severity == "warning"
+    assert "worker-rogue" in result.status
+
+
+def test_session_drift_skip_without_tmux(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(doctor, "_tool_path", lambda name: None)
+    result = doctor.check_sessions_table_vs_tmux()
+    assert result.passed and result.skipped
+
+
+# --------------------------------------------------------------------- #
+# Inbox aggregator path probe.
+# --------------------------------------------------------------------- #
+
+
+def test_inbox_aggregator_pass(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "ws"
+    resolved = workspace / ".pollypm" / "state.db"
+    resolved.parent.mkdir(parents=True)
+
+    fake_project = type("P", (), {"workspace_root": workspace})
+    fake_config = type("C", (), {"project": fake_project})
+    monkeypatch.setattr(
+        doctor, "_safe_load_config", lambda: (Path("/tmp/x"), fake_config),
+    )
+
+    import pollypm.work.cli as work_cli
+    monkeypatch.setattr(
+        work_cli, "_resolve_db_path", lambda db, project=None: resolved,
+    )
+    result = doctor.check_inbox_aggregator_path()
+    assert result.passed
+    assert str(resolved) in result.status
+
+
+def test_inbox_aggregator_warn_when_outside_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    resolved = tmp_path / "elsewhere" / ".pollypm" / "state.db"
+    resolved.parent.mkdir(parents=True)
+
+    fake_project = type("P", (), {"workspace_root": workspace})
+    fake_config = type("C", (), {"project": fake_project})
+    monkeypatch.setattr(
+        doctor, "_safe_load_config", lambda: (Path("/tmp/x"), fake_config),
+    )
+
+    import pollypm.work.cli as work_cli
+    monkeypatch.setattr(
+        work_cli, "_resolve_db_path", lambda db, project=None: resolved,
+    )
+    result = doctor.check_inbox_aggregator_path()
+    assert not result.passed
+    assert result.severity == "warning"
+    assert "not under workspace root" in result.status
+
+
+# --------------------------------------------------------------------- #
+# CLI exit codes + --fix / --fix-dry-run semantics
+# --------------------------------------------------------------------- #
+
+
+def test_exit_code_zero_when_all_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _pass() -> doctor.CheckResult:
+        return doctor._ok("ok")
+
+    monkeypatch.setattr(
+        doctor, "_registered_checks",
+        lambda: [doctor.Check("only", _pass, "pipeline")],
+    )
+    import pollypm.cli as cli_mod
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.app, ["doctor"])
+    assert result.exit_code == 0
+
+
+def test_exit_code_zero_when_warnings_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Spec: warnings do not flip the exit code."""
+    def _warn() -> doctor.CheckResult:
+        return doctor._fail("w", why="x", fix="y", severity="warning")
+
+    monkeypatch.setattr(
+        doctor, "_registered_checks",
+        lambda: [doctor.Check("warns", _warn, "resources", severity="warning")],
+    )
+    import pollypm.cli as cli_mod
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.app, ["doctor"])
+    assert result.exit_code == 0
+
+
+def test_exit_code_one_when_any_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _err() -> doctor.CheckResult:
+        return doctor._fail("e", why="x", fix="y", severity="error")
+
+    monkeypatch.setattr(
+        doctor, "_registered_checks",
+        lambda: [doctor.Check("breaks", _err, "pipeline")],
+    )
+    import pollypm.cli as cli_mod
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.app, ["doctor"])
+    assert result.exit_code == 1
+
+
+def test_fix_runs_registered_fixers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#1063 — --fix verifies via re-running the check, so the fixture
+    must actually flip fail -> pass when the fixer runs.
+    """
+    invoked = {"count": 0}
+    state = {"healed": False}
+
+    def _fixer() -> tuple[bool, str]:
+        invoked["count"] += 1
+        state["healed"] = True
+        return (True, "fixed")
+
+    def _check() -> doctor.CheckResult:
+        if state["healed"]:
+            return doctor._ok("now ok")
+        return doctor._fail(
+            "broken", why="w", fix="f",
+            fixable=True, fix_fn=_fixer, severity="warning",
+        )
+
+    monkeypatch.setattr(
+        doctor, "_registered_checks",
+        lambda: [doctor.Check("fixme", _check, "resources", severity="warning")],
+    )
+    import pollypm.cli as cli_mod
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.app, ["doctor", "--fix"])
+    assert result.exit_code == 0
+    assert invoked["count"] == 1
+    assert "fixed" in result.stdout
+
+
+def test_fix_cli_does_not_lie_when_handler_noops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1063 — --fix MUST NOT report 'Applied' when the handler returned
+    (True, ...) but the check still fails on re-run.
+    """
+    def _liar_fix() -> tuple[bool, str]:
+        return (True, "did nothing")
+
+    def _stuck_check() -> doctor.CheckResult:
+        return doctor._fail(
+            "still broken", why="w", fix="run a thing",
+            fixable=True, fix_fn=_liar_fix, severity="warning",
+        )
+
+    monkeypatch.setattr(
+        doctor, "_registered_checks",
+        lambda: [doctor.Check("liar", _stuck_check, "resources", severity="warning")],
+    )
+    import pollypm.cli as cli_mod
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.app, ["doctor", "--fix"])
+    assert result.exit_code == 0
+    assert "Applied 1 fix" not in result.stdout
+    assert "Applied 0 fixes" in result.stdout
+    assert "ran but check" in result.stdout
+    assert "liar" in result.stdout
+
+
+def test_verify_fix_results_demotes_missing_check() -> None:
+    """#1064 — when the post-fix report lacks a check entry, the
+    verification step demotes the handler's self-report rather than
+    trusting it.
+    """
+    raw = [("ghost-check", True, "handler says it worked")]
+    empty_report = doctor.DoctorReport(results=[])
+    verified = doctor.verify_fix_results(raw, empty_report)
+
+    assert len(verified) == 1
+    name, ok, message = verified[0]
+    assert name == "ghost-check"
+    assert ok is False
+    assert "unavailable to verify" in message
+
+
+def test_fix_dry_run_lists_planned_fixes_without_mutating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--fix-dry-run enumerates fixable checks but never invokes fix_fn."""
+    invoked = {"count": 0}
+
+    def _fixer() -> tuple[bool, str]:
+        invoked["count"] += 1
+        return (True, "fixed")
+
+    def _check() -> doctor.CheckResult:
+        return doctor._fail(
+            "broken", why="w",
+            fix="Trigger a one-off prune\nOr run:  pm doctor --fix",
+            fixable=True, fix_fn=_fixer, severity="warning",
+        )
+
+    monkeypatch.setattr(
+        doctor, "_registered_checks",
+        lambda: [doctor.Check("fixme", _check, "resources", severity="warning")],
+    )
+    import pollypm.cli as cli_mod
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.app, ["doctor", "--fix-dry-run"])
+    assert result.exit_code == 0
+    assert "Would apply 1 fix" in result.stdout
+    assert "fixme" in result.stdout
+    assert invoked["count"] == 0
+
+
+def test_fix_dry_run_lists_manual_issues(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cycle 56 — manual-intervention summary pluralises per count."""
+    def _manual() -> doctor.CheckResult:
+        return doctor._fail(
+            "cant auto-fix", why="w",
+            fix="Install Python manually",
+            severity="error",
+        )
+
+    monkeypatch.setattr(
+        doctor, "_registered_checks",
+        lambda: [doctor.Check("needs-hands", _manual, "system")],
+    )
+    import pollypm.cli as cli_mod
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.app, ["doctor", "--fix-dry-run"])
+    assert result.exit_code == 1
+    assert "1 issue requires manual intervention" in result.stdout
+    assert "needs-hands" in result.stdout
+
+
+def test_fix_dry_run_helpers_do_not_invoke_fixers() -> None:
+    """``planned_fixes`` / ``manual_fixes`` never call ``fix_fn``."""
+    invoked = {"count": 0}
+
+    def _never() -> tuple[bool, str]:
+        invoked["count"] += 1
+        return (True, "nope")
+
+    def _check() -> doctor.CheckResult:
+        return doctor._fail(
+            "x", why="w", fix="f1\nf2",
+            fixable=True, fix_fn=_never, severity="warning",
+        )
+
+    report = doctor.run_checks([
+        doctor.Check("c", _check, "pipeline", severity="warning"),
+    ])
+    planned = doctor.planned_fixes(report)
+    manual = doctor.manual_fixes(report)
+    assert planned == [("c", "f1")]
+    assert manual == []
+    assert invoked["count"] == 0
+
+
+# --------------------------------------------------------------------- #
+# Fix summary renderer pluralisation
+# --------------------------------------------------------------------- #
+
+
+def test_fix_summary_footer_counts_applied_and_remaining() -> None:
+    """Cycle 56 — ``fix(es)`` / ``issue(s)`` parenthetical bans."""
+    manual = [("needs-hands", "edit config manually"), ("another", "restart")]
+    fix_results = [
+        ("worktrees", True, "pruned 3"),
+        ("logs", True, "rotated 1"),
+        ("plan-gate", False, "write failed: permission denied"),
+    ]
+    summary = doctor.render_fix_summary(fix_results, manual)
+    assert "Applied 2 fixes" in summary
+    assert "worktrees" in summary and "logs" in summary
+    assert "1 fix failed" in summary
+    assert "plan-gate" in summary
+    assert "2 issues remain" in summary
+    assert "needs-hands" in summary
+    assert "(es)" not in summary
+    assert "(s)" not in summary
+
+
+def test_fix_summary_footer_singular_pluralisation() -> None:
+    one_applied = doctor.render_fix_summary(
+        [("worktrees", True, "pruned 3")],
+        [("needs-hands", "edit config")],
+    )
+    assert "Applied 1 fix:" in one_applied
+    assert "1 issue remains" in one_applied
+    assert "(es)" not in one_applied
+    assert "(s)" not in one_applied
+
+
+def test_fix_dry_run_pluralisation() -> None:
+    one = doctor.render_fix_dry_run(
+        [("worktrees", "would prune merged worktrees")],
+        [("needs-hands", "edit config manually")],
+    )
+    assert "Would apply 1 fix:" in one
+    assert "1 issue requires manual intervention" in one
+    assert "(es)" not in one
+    assert "(s)" not in one
+
+    many = doctor.render_fix_dry_run(
+        [("a", "intent-a"), ("b", "intent-b"), ("c", "intent-c")],
+        [("m1", "do x"), ("m2", "do y")],
+    )
+    assert "Would apply 3 fixes:" in many
+    assert "2 issues require manual intervention" in many
+    assert "(es)" not in many
+    assert "(s)" not in many
+
+
+def test_manual_fixes_excludes_skipped_and_passing() -> None:
+    """manual_fixes only lists failures that cannot auto-run."""
+    def _pass() -> doctor.CheckResult:
+        return doctor._ok("fine")
+
+    def _skip_c() -> doctor.CheckResult:
+        return doctor._skip("n/a")
+
+    def _fixable() -> doctor.CheckResult:
+        return doctor._fail(
+            "x", why="w", fix="f",
+            fixable=True, fix_fn=lambda: (True, "ok"),
+        )
+
+    def _manual_c() -> doctor.CheckResult:
+        return doctor._fail("y", why="w", fix="do by hand")
+
+    report = doctor.run_checks([
+        doctor.Check("a", _pass, "pipeline"),
+        doctor.Check("b", _skip_c, "pipeline"),
+        doctor.Check("c", _fixable, "pipeline"),
+        doctor.Check("d", _manual_c, "pipeline"),
+    ])
+    manual = doctor.manual_fixes(report)
+    names = [n for n, _ in manual]
+    assert names == ["d"]
+
+
+# --------------------------------------------------------------------- #
+# AutoFixPlan — system-tool missing exposes auto-fix command.
+# --------------------------------------------------------------------- #
+
+
+def test_tmux_missing_exposes_brew_auto_fix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        doctor, "_tool_path",
+        lambda name: "/opt/homebrew/bin/brew" if name == "brew" else None,
+    )
+    monkeypatch.setattr(doctor, "_current_platform", lambda: "macos")
+    result = doctor.check_tmux()
+    assert not result.passed
+    assert result.auto_fix is not None
+    assert result.auto_fix.command == ["brew", "install", "tmux"]
+    assert result.auto_fix.platforms == ["macos"]
+
+
+def test_tmux_missing_exposes_linux_package_manager_auto_fix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _tool_path(name: str) -> str | None:
+        return "/usr/bin/apt-get" if name == "apt-get" else None
+
+    monkeypatch.setattr(doctor, "_tool_path", _tool_path)
+    monkeypatch.setattr(doctor, "_current_platform", lambda: "linux")
+    result = doctor.check_tmux()
+    assert not result.passed
+    assert result.auto_fix is not None
+    assert result.auto_fix.requires_sudo is True
+    assert result.auto_fix.command == [
+        "sudo", "apt-get", "install", "-y", "tmux",
+    ]
+
+
+def test_claude_cli_missing_has_auto_fix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _tool_path(name: str) -> str | None:
+        return "/usr/bin/npm" if name == "npm" else None
+
+    monkeypatch.setattr(doctor, "_tool_path", _tool_path)
+    monkeypatch.setattr(doctor, "_current_platform", lambda: "linux")
+    result = doctor.check_claude_cli()
+    assert not result.passed
+    assert result.auto_fix is not None
+    assert result.auto_fix.command == [
+        "npm", "i", "-g", "@anthropic-ai/claude-code",
+    ]
+
+
+def test_codex_cli_missing_has_auto_fix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _tool_path(name: str) -> str | None:
+        return "/usr/bin/npm" if name == "npm" else None
+
+    monkeypatch.setattr(doctor, "_tool_path", _tool_path)
+    monkeypatch.setattr(doctor, "_current_platform", lambda: "linux")
+    result = doctor.check_codex_cli()
+    assert not result.passed
+    assert result.auto_fix is not None
+    assert result.auto_fix.command == ["npm", "i", "-g", "@openai/codex"]
+
+
+def test_render_human_shows_fix_badge_for_supported_auto_fix() -> None:
+    auto_fix = doctor.AutoFixPlan(
+        description="Install tmux",
+        command=["brew", "install", "tmux"],
+        platforms=["macos", "linux"],
+    )
+
+    def _fail() -> doctor.CheckResult:
+        return doctor._fail(
+            "missing tmux", why="x", fix="y", auto_fix=auto_fix,
+        )
+
+    report = doctor.run_checks([doctor.Check("tmux", _fail, "system")])
+    text = doctor.render_human(report)
+    assert "[f] Fix" in text
+
+
+def test_render_human_hides_fix_badge_for_unsupported_platform(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auto_fix = doctor.AutoFixPlan(
+        description="Install tmux",
+        command=["brew", "install", "tmux"],
+        platforms=["macos"],
+    )
+    monkeypatch.setattr(doctor, "_current_platform", lambda: "windows")
+
+    def _fail() -> doctor.CheckResult:
+        return doctor._fail(
+            "missing tmux", why="x", fix="y", auto_fix=auto_fix,
+        )
+
+    report = doctor.run_checks([doctor.Check("tmux", _fail, "system")])
+    text = doctor.render_human(report)
+    assert "[f] Fix" not in text
+
+
+def test_json_output_includes_auto_fix_metadata() -> None:
+    auto_fix = doctor.AutoFixPlan(
+        description="Install Claude Code globally",
+        command=["npm", "i", "-g", "@anthropic-ai/claude-code"],
+        platforms=["macos", "linux"],
+    )
+
+    def _fail() -> doctor.CheckResult:
+        return doctor._fail("missing", why="x", fix="y", auto_fix=auto_fix)
+
+    report = doctor.run_checks([doctor.Check("claude", _fail, "system")])
+    payload = json.loads(doctor.render_json(report))
+    check = payload["checks"][0]
+    assert check["auto_fix"]["description"] == "Install Claude Code globally"
+    assert check["auto_fix"]["command"] == [
+        "npm", "i", "-g", "@anthropic-ai/claude-code",
+    ]
+    assert check["auto_fix_available"] is True
+
+
+def test_apply_fixes_runs_supported_auto_fix_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auto_fix = doctor.AutoFixPlan(
+        description="Install Claude Code globally",
+        command=["npm", "i", "-g", "@anthropic-ai/claude-code"],
+        platforms=["macos", "linux"],
+    )
+
+    def _fail() -> doctor.CheckResult:
+        return doctor._fail("missing", why="x", fix="y", auto_fix=auto_fix)
+
+    monkeypatch.setattr(
+        doctor, "run_auto_fix", lambda plan: (True, plan.description),
+    )
+    report = doctor.run_checks([doctor.Check("claude", _fail, "system")])
+    assert doctor.apply_fixes(report) == [
+        ("claude", True, "Install Claude Code globally"),
+    ]
+
+
+def test_planned_and_manual_fix_lists_treat_supported_auto_fix_as_runnable() -> None:
+    auto_fix = doctor.AutoFixPlan(
+        description="Install tmux",
+        command=["brew", "install", "tmux"],
+        platforms=["macos", "linux"],
+    )
+
+    def _fail() -> doctor.CheckResult:
+        return doctor._fail(
+            "missing tmux", why="x", fix="Install tmux", auto_fix=auto_fix,
+        )
+
+    report = doctor.run_checks([doctor.Check("tmux", _fail, "system")])
+    assert doctor.planned_fixes(report) == [("tmux", "Install tmux")]
+    assert doctor.manual_fixes(report) == []
+
+
+# --------------------------------------------------------------------- #
+# Plan-gate --fix rewriter + sweeper-DBs --fix initialiser.
+# --------------------------------------------------------------------- #
+
+
+def test_plan_gate_fix_rewrites_config_with_backup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """--fix on disabled plan gate writes a new config + .bak backup."""
+    cfg_path = tmp_path / "pollypm.toml"
+    cfg_path.write_text(
+        "[project]\nname = 'x'\n\n[planner]\n"
+        "enforce_plan = false\nplan_dir = 'docs/plan'\n"
+    )
+
+    fake_planner = type("P", (), {"enforce_plan": False, "plan_dir": "docs/plan"})
+    fake_config = type("C", (), {"planner": fake_planner})
+    monkeypatch.setattr(
+        doctor, "_safe_load_config", lambda: (cfg_path, fake_config),
+    )
+    result = doctor.check_plan_presence_gate()
+    assert not result.passed
+    assert result.fixable
+    assert callable(result.fix_fn)
+
+    success, message = result.fix_fn()
+    assert success, message
+    bak = cfg_path.with_suffix(cfg_path.suffix + ".bak")
+    assert bak.is_file()
+    assert "enforce_plan = false" in bak.read_text()
+    new_text = cfg_path.read_text()
+    assert "enforce_plan = true" in new_text
+    assert "enforce_plan = false" not in new_text
+
+
+def test_plan_gate_fix_inserts_section_when_missing(tmp_path: Path) -> None:
+    """The rewriter appends [planner] when no section exists yet."""
+    cfg_path = tmp_path / "pollypm.toml"
+    cfg_path.write_text("[project]\nname = 'x'\n")
+    ok, _message = doctor._rewrite_planner_enforce_plan(cfg_path)
+    assert ok
+    text = cfg_path.read_text()
+    assert "[planner]" in text
+    assert "enforce_plan = true" in text
+
+
+def test_task_assignment_sweeper_fix_initialises_state_dbs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """--fix creates state.db files for known-but-missing projects."""
+    proj_a = tmp_path / "proj-a"
+    proj_a.mkdir()
+    proj_b = tmp_path / "proj-b"
+    proj_b.mkdir()
+    fake_projects = {
+        "proj-a": type("P", (), {"path": proj_a, "tracked": True}),
+        "proj-b": type("P", (), {"path": proj_b, "tracked": True}),
+    }
+    fake_config = type("C", (), {"projects": fake_projects})
+    monkeypatch.setattr(
+        doctor, "_safe_load_config", lambda: (Path("/tmp/x"), fake_config),
+    )
+    result = doctor.check_task_assignment_sweeper_dbs()
+    assert not result.passed
+    assert result.fixable
+    success, message = result.fix_fn()
+    assert success, message
+    assert (proj_a / ".pollypm" / "state.db").is_file()
+    assert (proj_b / ".pollypm" / "state.db").is_file()
+
+
+# --------------------------------------------------------------------- #
+# Maintenance-handler invocations + pluralisation.
+# --------------------------------------------------------------------- #
+
+
+def test_agent_worktree_count_fix_invokes_prune(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """--fix on an over-threshold worktree dir calls the prune handler."""
+    fake_dirs = [tmp_path / f"agent-{i}" for i in range(60)]
+    for d in fake_dirs:
+        d.mkdir()
+    monkeypatch.setattr(doctor, "_agent_worktree_dirs", lambda: fake_dirs)
+    result = doctor.check_agent_worktree_count()
+    assert not result.passed
+    assert result.fixable
+    assert callable(result.fix_fn)
+
+    called = {"n": 0}
+
+    def _fake_handler(payload: dict) -> dict:
+        called["n"] += 1
+        return {
+            "pruned": 3, "skipped_active": 0, "warned_stale": 0, "errors": 0,
+        }
+
+    from pollypm import maintenance_handlers_registry as reg
+    monkeypatch.setattr(
+        reg, "_handlers", {reg.AGENT_WORKTREE_PRUNE: _fake_handler},
+    )
+    success, message = result.fix_fn()
+    assert success
+    assert called["n"] == 1
+    assert "pruned 3" in message
+
+
+def test_logs_dir_size_fix_invokes_rotate(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "big.log").write_bytes(b"\0" * (600 * 1024 * 1024))
+    monkeypatch.setattr(doctor, "_logs_dir_candidates", lambda: [logs])
+    result = doctor.check_logs_dir_size()
+    assert not result.passed
+    assert result.fixable
+    assert callable(result.fix_fn)
+
+    called = {"payload": None}
+
+    def _fake_handler(payload: dict) -> dict:
+        called["payload"] = payload
+        return {"rotated": 1, "deleted": 0, "errors": 0}
+
+    from pollypm import maintenance_handlers_registry as reg
+    monkeypatch.setattr(reg, "_handlers", {reg.LOG_ROTATE: _fake_handler})
+    success, message = result.fix_fn()
+    assert success
+    assert called["payload"] == {"logs_dir": str(logs)}
+    assert "rotated 1" in message
+
+
+def test_log_rotate_handler_message_pluralisation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """``pm doctor --fix`` log-rotate message bans ``(s)`` parentheticals."""
+    from pollypm import maintenance_handlers_registry as reg
+
+    monkeypatch.setattr(
+        reg, "_handlers",
+        {reg.LOG_ROTATE: lambda payload: {
+            "rotated": 1, "deleted": 1, "errors": 1,
+        }},
+    )
+    success, message = doctor._invoke_log_rotate_handler(tmp_path)
+    assert not success
+    assert "rotated 1 log," in message
+    assert "deleted 1 old archive," in message
+    assert "1 error" in message
+    assert "(s)" not in message
+
+    monkeypatch.setattr(
+        reg, "_handlers",
+        {reg.LOG_ROTATE: lambda payload: {
+            "rotated": 4, "deleted": 2, "errors": 0,
+        }},
+    )
+    success, message = doctor._invoke_log_rotate_handler(tmp_path)
+    assert success
+    assert "rotated 4 logs," in message
+    assert "deleted 2 old archives," in message
+    assert "0 errors" in message
+    assert "(s)" not in message
+
+
+def test_prune_handler_message_pluralisation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pollypm import maintenance_handlers_registry as reg
+
+    monkeypatch.setattr(
+        reg, "_handlers",
+        {reg.AGENT_WORKTREE_PRUNE: lambda payload: {
+            "pruned": 1, "warned_stale": 0, "errors": 1,
+        }},
+    )
+    success, message = doctor._invoke_prune_handler()
+    assert not success
+    assert "pruned 1 merged worktree," in message
+    assert "1 error" in message
+    assert "(s)" not in message
+
+    monkeypatch.setattr(
+        reg, "_handlers",
+        {reg.AGENT_WORKTREE_PRUNE: lambda payload: {
+            "pruned": 5, "warned_stale": 0, "errors": 0,
+        }},
+    )
+    success, message = doctor._invoke_prune_handler()
+    assert success
+    assert "pruned 5 merged worktrees," in message
+    assert "0 errors" in message
+    assert "(s)" not in message

--- a/tests/test_pg_plan_review_flow.py
+++ b/tests/test_pg_plan_review_flow.py
@@ -1,0 +1,366 @@
+"""Pg re-coverage for backend-neutral plan_review helpers (#1824).
+
+Slice K-tests part 6 (#1737, commit 5a1b58845) deleted
+``tests/test_plan_review_flow.py`` (1928 LOC) because the Pilot-driven
+inbox-app cases depended on a project-root sqlite state.db. This
+module re-locks the pure-helper half: sidecar-label extraction,
+round-trip detection, PM primers (approval + denial), and the plan
+markdown summary / judgment-calls extractors that feed the cockpit's
+Action Needed card.
+
+What's intentionally **not** ported
+-----------------------------------
+
+* Pilot-driven ``PollyInboxApp`` / ``PollyProjectDashboardApp`` UI
+  tests — those instantiate the cockpit against a project-root
+  ``state.db`` and exercise the v/d/A/D keybindings end-to-end. They
+  belong with the cockpit-UI pg port-back (#1794 follow-up), not
+  with the pure helper layer.
+* Persona lookup tests (``PollyInboxApp._project_persona_name``) —
+  these read ``pollypm.toml`` and require the inbox-app constructor.
+  Out of scope for the helper-only port.
+* Deferred-approve / undo-window tests — instantiate the inbox app
+  with a sqlite svc.approve patched and exercise the 10s timer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pollypm.cockpit_ui import (
+    PollyProjectDashboardApp,
+    _build_plan_review_denial_primer,
+    _build_plan_review_primer,
+    _extract_plan_judgment_calls,
+    _extract_plan_review_meta,
+    _extract_plan_summary_block,
+    _plan_review_has_round_trip,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sidecar label parsing.
+# ---------------------------------------------------------------------------
+
+
+class TestPlanReviewMeta:
+    def test_extract_meta_parses_sidecar_labels(self) -> None:
+        labels = [
+            "plan_review",
+            "project:demo",
+            "plan_task:demo/7",
+            "explainer:/abs/path/reports/plan-review.html",
+        ]
+        meta = _extract_plan_review_meta(labels)
+        assert meta["plan_task_id"] == "demo/7"
+        assert meta["explainer_path"] == "/abs/path/reports/plan-review.html"
+        assert meta["project"] == "demo"
+        assert meta["fast_track"] is False
+
+    def test_extract_meta_fast_track_flag(self) -> None:
+        meta = _extract_plan_review_meta([
+            "plan_review", "project:demo", "plan_task:demo/1",
+            "explainer:/x.html", "fast_track",
+        ])
+        assert meta["fast_track"] is True
+
+    def test_extract_meta_handles_empty_or_none(self) -> None:
+        """Empty / ``None`` label lists yield ``{"fast_track": False}``.
+        Defensive against the architect emitting a card without sidecar
+        labels (the early-#1408 shape)."""
+        assert _extract_plan_review_meta(None) == {"fast_track": False}
+        assert _extract_plan_review_meta([]) == {"fast_track": False}
+
+    def test_extract_meta_skips_non_string_entries(self) -> None:
+        """Bad data on the label list (e.g. a leftover dict) is ignored —
+        the helper never blows up on a malformed row."""
+        meta = _extract_plan_review_meta([
+            "plan_review",
+            {"junk": 1},  # type: ignore[list-item]
+            "project:demo",
+            42,           # type: ignore[list-item]
+            "plan_task:demo/3",
+        ])
+        assert meta["project"] == "demo"
+        assert meta["plan_task_id"] == "demo/3"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip detection — pure.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeEntry:
+    actor: str
+
+
+class TestPlanReviewRoundTrip:
+    def test_only_reviewer_does_not_unlock(self) -> None:
+        assert not _plan_review_has_round_trip(
+            [_FakeEntry("user")], requester="user",
+        )
+
+    def test_only_pm_side_does_not_unlock(self) -> None:
+        assert not _plan_review_has_round_trip(
+            [_FakeEntry("architect")], requester="user",
+        )
+
+    def test_both_voices_present_unlocks(self) -> None:
+        assert _plan_review_has_round_trip(
+            [_FakeEntry("user"), _FakeEntry("architect")],
+            requester="user",
+        )
+
+    def test_fast_track_uses_polly_as_requester(self) -> None:
+        """Fast-track items use requester=polly; round-trip needs a
+        non-polly actor on the other side."""
+        assert not _plan_review_has_round_trip(
+            [_FakeEntry("polly"), _FakeEntry("polly")],
+            requester="polly",
+        )
+        assert _plan_review_has_round_trip(
+            [_FakeEntry("polly"), _FakeEntry("architect")],
+            requester="polly",
+        )
+
+    def test_empty_replies_does_not_unlock(self) -> None:
+        assert not _plan_review_has_round_trip([], requester="user")
+        assert not _plan_review_has_round_trip(None, requester="user")
+
+    def test_blank_actor_strings_ignored(self) -> None:
+        """A reply with an empty actor string must not count as either
+        side of the round-trip."""
+        entries = [_FakeEntry(""), _FakeEntry("   "), _FakeEntry("user")]
+        assert not _plan_review_has_round_trip(entries, requester="user")
+
+    def test_requester_default_is_user(self) -> None:
+        """The ``requester`` kwarg defaults to ``user``."""
+        assert _plan_review_has_round_trip(
+            [_FakeEntry("user"), _FakeEntry("polly")],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Approval primer — pure.
+# ---------------------------------------------------------------------------
+
+
+class TestPlanReviewApprovalPrimer:
+    def test_primer_contains_coached_conversation_brief(self) -> None:
+        primer = _build_plan_review_primer(
+            project_key="demo",
+            plan_path="/abs/docs/plan/plan.md",
+            explainer_path="/abs/reports/plan-review.html",
+            plan_task_id="demo/7",
+            reviewer_name="Sam",
+        )
+        assert not primer.startswith("re: inbox/")
+        assert "plan review for project: demo" in primer
+        assert "/abs/docs/plan/plan.md" in primer
+        assert "/abs/reports/plan-review.html" in primer
+        assert "Co-refine the plan with Sam" in primer
+        assert "smallest reasonable tasks" in primer
+        assert "record approval for plan task demo/7 as user" in primer
+        assert "pm task approve" not in primer
+
+    def test_primer_swaps_to_polly_when_fast_tracked(self) -> None:
+        primer = _build_plan_review_primer(
+            project_key="demo",
+            plan_path="/abs/docs/plan/plan.md",
+            explainer_path="/abs/reports/plan-review.html",
+            plan_task_id="demo/7",
+            reviewer_name="Polly",
+        )
+        assert "plan review for project: demo" in primer
+        assert "Co-refine the plan with Polly" in primer
+        assert "record approval for plan task demo/7 as polly" in primer
+        assert "pm task approve" not in primer
+
+    def test_primer_defaults_reviewer_name_to_sam(self) -> None:
+        """An empty / whitespace reviewer name falls back to ``Sam``."""
+        primer = _build_plan_review_primer(
+            project_key="demo",
+            plan_path="/p.md",
+            explainer_path="/e.html",
+            plan_task_id="demo/1",
+            reviewer_name="",
+        )
+        assert "Co-refine the plan with Sam" in primer
+        assert "record approval for plan task demo/1 as user" in primer
+
+
+# ---------------------------------------------------------------------------
+# Denial primer — pure (#1403).
+# ---------------------------------------------------------------------------
+
+
+class TestPlanReviewDenialPrimer:
+    def test_primer_includes_denial_reason_and_successor(self) -> None:
+        primer = _build_plan_review_denial_primer(
+            project_key="demo",
+            cancelled_plan_task_id="demo/3",
+            successor_plan_task_id="demo/4",
+            denial_reason="Backlog is too coarse — break it down further.",
+            reviewer_name="Sam",
+        )
+        assert "denied plan task demo/3" in primer
+        assert "Successor plan task: demo/4" in primer
+        assert "Backlog is too coarse" in primer
+        assert "Sit with Sam on the concerns" in primer
+        assert "plan_review_denied" in primer
+
+    def test_primer_swaps_to_polly_when_fast_track(self) -> None:
+        primer = _build_plan_review_denial_primer(
+            project_key="demo",
+            cancelled_plan_task_id="demo/3",
+            successor_plan_task_id="demo/4",
+            denial_reason="not enough decomposition",
+            reviewer_name="Polly",
+        )
+        assert "Polly just denied plan task demo/3" in primer
+        assert "Sit with Polly on the concerns" in primer
+
+    def test_primer_omits_trailing_newline(self) -> None:
+        """Output ends WITHOUT a trailing newline so the PM CLI can
+        append the user's typed follow-up directly."""
+        primer = _build_plan_review_denial_primer(
+            project_key="demo",
+            cancelled_plan_task_id="demo/3",
+            successor_plan_task_id="demo/4",
+            denial_reason="too lumpy",
+        )
+        assert primer == primer.rstrip("\n")
+
+
+# ---------------------------------------------------------------------------
+# Plan markdown summary + judgment-calls extractors (#1397).
+# ---------------------------------------------------------------------------
+
+
+class TestPlanInlineRendering:
+    def test_summary_block_extracts_paragraph_under_summary_header(self) -> None:
+        text = (
+            "# Project plan\n\n"
+            "## Summary\n"
+            "Ship the rendering pipeline in three steps; each step lands\n"
+            "as its own task so we can pause between phases.\n\n"
+            "## Judgment calls\n- foo\n"
+        )
+        summary = _extract_plan_summary_block(text)
+        assert summary.startswith("Ship the rendering pipeline")
+        assert "three steps" in summary
+        # Stops at the next header.
+        assert "foo" not in summary
+
+    def test_summary_block_falls_back_to_first_paragraph(self) -> None:
+        text = (
+            "# Old-style plan\n\n"
+            "This is the leading paragraph that doubles as a summary.\n\n"
+            "## Some other header\nThe rest.\n"
+        )
+        summary = _extract_plan_summary_block(text)
+        assert summary.startswith("This is the leading paragraph")
+
+    def test_summary_block_empty_input_returns_empty(self) -> None:
+        assert _extract_plan_summary_block("") == ""
+        assert _extract_plan_summary_block("   \n  \n") == ""
+
+    def test_summary_block_case_insensitive_header_match(self) -> None:
+        """``## SUMMARY`` / ``## summary`` both resolve."""
+        text = "# t\n\n## SUMMARY\nLine one.\n"
+        assert _extract_plan_summary_block(text) == "Line one."
+
+    def test_judgment_calls_extracts_bullet_list(self) -> None:
+        text = (
+            "## Summary\nA paragraph.\n\n"
+            "## Judgment calls\n"
+            "- Whether to ship the rename in a single PR or split it\n"
+            "- The cache eviction strategy\n"
+            "- Stamping plan_version on every transition or only on user_approval\n\n"
+            "## Plan body\nActual plan...\n"
+        )
+        points = _extract_plan_judgment_calls(text)
+        assert len(points) == 3
+        assert points[0].startswith("Whether to ship the rename")
+        assert "cache eviction" in points[1]
+
+    def test_judgment_calls_returns_empty_when_section_missing(self) -> None:
+        assert _extract_plan_judgment_calls(
+            "# A plan\n\nNo judgment section.",
+        ) == []
+
+    def test_judgment_calls_respects_limit_arg(self) -> None:
+        """``limit`` caps the returned bullet count so the cockpit's
+        Action Needed card doesn't grow unbounded."""
+        text = (
+            "## Judgment calls\n"
+            "- one\n- two\n- three\n- four\n- five\n- six\n"
+        )
+        capped = _extract_plan_judgment_calls(text, limit=3)
+        assert len(capped) == 3
+        assert capped == ["one", "two", "three"]
+
+    def test_judgment_calls_accepts_judgement_spelling(self) -> None:
+        """The architect occasionally emits ``Judgement`` (British spelling).
+        Both should resolve."""
+        text = "## Judgement calls\n- a flagged point\n"
+        assert _extract_plan_judgment_calls(text) == ["a flagged point"]
+
+
+# ---------------------------------------------------------------------------
+# Action Needed card body — pure render helper on ``PollyProjectDashboardApp``.
+# ---------------------------------------------------------------------------
+
+
+class TestActionCardBody:
+    def test_renders_judgment_calls_for_plan_review(self) -> None:
+        """The Action Needed card surfaces the architect's flagged
+        judgment-call points right under the summary so the user knows
+        what to weigh in on (#1397)."""
+        # The dashboard app's instance method is pure (no self state
+        # consumed) — we can call it via ``__new__`` without
+        # constructing the textual App.
+        app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+        item = {
+            "is_plan_review": True,
+            "plain_prompt": "A short plan summary appears here.",
+            "judgment_calls": [
+                "Whether to ship in one PR or split it.",
+                "The cache eviction strategy.",
+            ],
+            "unblock_steps": ["Open the plan review surface."],
+            "decision_question": "Is this ready to become tasks?",
+        }
+        body = app._render_action_card_body(item, compact=False)
+        assert "Flagged judgment calls" in body
+        assert "Whether to ship in one PR" in body
+        assert "cache eviction" in body
+        assert "A short plan summary appears here" in body
+
+    def test_caps_long_summary_at_80_chars(self) -> None:
+        """#1397 — in the inbox-row preview the plan summary can be a
+        full paragraph; cap it at ~80 chars so the rail row stays
+        readable."""
+        app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+        long_summary = "x" * 200
+        item = {
+            "is_plan_review": True,
+            "plain_prompt": long_summary,
+            "judgment_calls": [],
+            "unblock_steps": [],
+            "decision_question": "Ready?",
+        }
+        body = app._render_action_card_body(item, compact=False)
+        assert "x" * 100 not in body
+        assert "..." in body
+
+    def test_omits_judgment_calls_when_not_plan_review(self) -> None:
+        app = PollyProjectDashboardApp.__new__(PollyProjectDashboardApp)
+        item = {
+            "plain_prompt": "Generic message.",
+            "unblock_steps": ["Step 1.", "Step 2."],
+            "decision_question": "Choose.",
+        }
+        body = app._render_action_card_body(item, compact=False)
+        assert "Flagged judgment calls" not in body

--- a/tests/test_pg_task_assignment_notify.py
+++ b/tests/test_pg_task_assignment_notify.py
@@ -1,0 +1,530 @@
+"""Pg re-coverage for task-assignment notify against PgWorkService (#1824).
+
+PR #1931 (commit a8f8620e9) added
+``tests/test_task_assignment_notify_helpers.py`` covering the
+backend-neutral pure helpers (role resolution, ping formatting,
+StateStore dedupe / escalation). This module extends that coverage
+to the surfaces that need the **PgWorkService** harness:
+
+* The sweeper's per-tick fanout via
+  :func:`task_assignment_sweep_handler` running against a
+  pg-backed work service, including the #921 per-task session
+  recognition and the dedupe-cooldown skip.
+* End-to-end ``create -> queue -> TaskAssignmentEvent`` emission
+  through the bus against ``PgWorkService``.
+* Per-task worker recognition + the #1439
+  singleton-roles-never-route-to-per-task-pane invariants (these
+  belong here because they probe ``SessionRoleIndex`` resolution
+  for per-task windows that PR #1931 didn't exercise).
+
+Pure-helper coverage that does *not* need a work-service fixture
+(``role_candidate_names`` invariants, ``format_ping_for_role``
+strings, ``notify`` dedupe + escalation against a tmp_path
+``StateStore``, payload round-trip) lives in
+``tests/test_task_assignment_notify_helpers.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from pollypm.plugins_builtin.task_assignment_notify.handlers.sweep import (
+    task_assignment_sweep_handler,
+)
+from pollypm.plugins_builtin.task_assignment_notify.resolver import (
+    _RuntimeServices,
+)
+from pollypm.storage.state import StateStore
+from pollypm.work import task_assignment as bus
+from pollypm.work.models import ActorType
+from pollypm.work.task_assignment import (
+    SessionRoleIndex,
+    TaskAssignmentEvent,
+    role_candidate_names,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeHandle:
+    name: str
+
+
+@dataclass
+class FakeSessionService:
+    handles: list[FakeHandle]
+    sent: list[tuple[str, str]] = field(default_factory=list)
+    send_failure: Exception | None = None
+    busy: set[str] = field(default_factory=set)
+
+    def list(self) -> list[FakeHandle]:
+        return list(self.handles)
+
+    def send(self, name: str, text: str, *, press_enter: bool = True) -> None:
+        if self.send_failure is not None:
+            raise self.send_failure
+        self.sent.append((name, text))
+
+    def is_turn_active(self, name: str) -> bool:
+        return name in self.busy
+
+
+def _event(
+    *,
+    task_id: str = "demo/1",
+    project: str = "demo",
+    actor_type: ActorType = ActorType.ROLE,
+    actor_name: str = "worker",
+    current_node: str = "do_work",
+    current_node_kind: str = "work",
+    work_status: str = "queued",
+) -> TaskAssignmentEvent:
+    return TaskAssignmentEvent(
+        task_id=task_id,
+        project=project,
+        task_number=int(task_id.split("/", 1)[1]),
+        title="Build the thing",
+        current_node=current_node,
+        current_node_kind=current_node_kind,
+        actor_type=actor_type,
+        actor_name=actor_name,
+        work_status=work_status,
+        priority="normal",
+        transitioned_at=datetime.now(timezone.utc),
+        transitioned_by="tester",
+    )
+
+
+@pytest.fixture
+def state_store(tmp_path):
+    """Per-test StateStore (still sqlite, #342-followup)."""
+    store = StateStore(tmp_path / "state.db")
+    yield store
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# SessionRoleIndex — multiple-matches selection.
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_matches_prefers_least_busy():
+    """When both dash and underscore candidates exist, the resolver picks
+    the one with fewer in-progress claims."""
+
+    class FakeWork:
+        def list_tasks(self, *, work_status=None, assignee=None, **kw):
+            if assignee == "worker-demo":
+                return [
+                    type("T", (), {
+                        "work_status": type("S", (), {"value": "in_progress"})(),
+                        "assignee": "worker-demo",
+                    })()
+                    for _ in range(3)
+                ]
+            return []
+
+    svc = FakeSessionService(handles=[
+        FakeHandle("worker-demo"),
+        FakeHandle("worker_demo"),
+    ])
+    index = SessionRoleIndex(svc, work_service=FakeWork())
+    handle = index.resolve(ActorType.ROLE, "worker", "demo")
+    assert handle is not None
+    assert handle.name == "worker_demo"
+
+
+# ---------------------------------------------------------------------------
+# Reviewer-routing dedicated test against StateStore alert dispatch (#1439).
+# ---------------------------------------------------------------------------
+
+
+class TestReviewerNotifyRouting:
+    def test_review_ping_targets_reviewer_not_task_worker(self, state_store):
+        """#1439 — review pings must land on the long-lived reviewer
+        lane even when the per-task worker window for that task is
+        still alive."""
+        from pollypm.plugins_builtin.task_assignment_notify.resolver import (
+            notify,
+        )
+
+        svc = FakeSessionService(handles=[
+            FakeHandle("task-savethenovel-12"),
+            FakeHandle("reviewer_savethenovel"),
+        ])
+        services = _RuntimeServices(
+            session_service=svc,
+            state_store=state_store,
+            work_service=None,
+            project_root=Path("."),
+        )
+        event = _event(
+            task_id="savethenovel/12",
+            project="savethenovel",
+            actor_name="reviewer",
+            current_node="code_review",
+            current_node_kind="review",
+            work_status="review",
+        )
+        outcome = notify(event, services=services)
+        assert outcome["outcome"] == "sent"
+        assert outcome["session"] == "reviewer_savethenovel"
+        assert svc.sent[0][0] == "reviewer_savethenovel"
+        assert "Review needed" in svc.sent[0][1]
+
+
+# ---------------------------------------------------------------------------
+# Sweeper — pg work service driven through fake session service.
+# ---------------------------------------------------------------------------
+
+
+class TestSweeperPg:
+    def _services(self, pg_work_service, state_store, session_handles):
+        return _RuntimeServices(
+            session_service=FakeSessionService(handles=list(session_handles)),
+            state_store=state_store,
+            work_service=pg_work_service,
+            project_root=Path("."),
+        )
+
+    def test_sweeper_picks_up_preexisting_queued_task(
+        self, pg_work_service, state_store, monkeypatch,
+    ):
+        bus.clear_listeners()
+        services = self._services(
+            pg_work_service, state_store, [FakeHandle("worker-proj")],
+        )
+        task = pg_work_service.create(
+            title="Preexisting work",
+            description="Make stuff",
+            type="task",
+            project="proj",
+            flow_template="standard",
+            roles={"worker": "agent-1", "reviewer": "agent-2"},
+            priority="normal",
+        )
+        pg_work_service.queue(task.task_id, "pm")
+
+        monkeypatch.setattr(
+            "pollypm.plugins_builtin.task_assignment_notify.handlers.sweep.load_runtime_services",
+            lambda *, config_path=None: services,
+        )
+
+        result = task_assignment_sweep_handler({})
+        assert result["outcome"] == "swept"
+        assert result["considered"] >= 1
+        assert result["by_outcome"].get("sent", 0) >= 1
+        assert any(
+            "New work" in text for _name, text in services.session_service.sent
+        )
+        bus.clear_listeners()
+
+    def test_sweeper_recognises_per_task_session_for_in_progress(
+        self, pg_work_service, state_store, monkeypatch,
+    ):
+        """#921 — in_progress task with a live ``task-<proj>-<N>``
+        session must NOT raise ``no_session``."""
+        bus.clear_listeners()
+        task = pg_work_service.create(
+            title="Add charts",
+            description="Implement",
+            type="task",
+            project="blackjack-trainer",
+            flow_template="standard",
+            roles={"worker": "agent-1", "reviewer": "agent-2"},
+            priority="normal",
+        )
+        pg_work_service.queue(task.task_id, "pm")
+        pg_work_service.claim(task.task_id, "worker")
+        live_window = f"task-{task.project}-{task.task_number}"
+        services = _RuntimeServices(
+            session_service=FakeSessionService(handles=[FakeHandle(live_window)]),
+            state_store=state_store,
+            work_service=pg_work_service,
+            project_root=Path("."),
+            msg_store=state_store,
+        )
+
+        monkeypatch.setattr(
+            "pollypm.plugins_builtin.task_assignment_notify.handlers.sweep.load_runtime_services",
+            lambda *, config_path=None: services,
+        )
+
+        result = task_assignment_sweep_handler({})
+        assert result["outcome"] == "swept"
+        assert result["by_outcome"].get("no_session", 0) == 0
+        assert any(
+            name == live_window for name, _t in services.session_service.sent
+        )
+        assert [
+            a for a in state_store.open_alerts()
+            if a.alert_type == "no_session"
+        ] == []
+        assert [
+            a for a in state_store.open_alerts()
+            if a.alert_type.startswith("no_session_for_assignment:")
+        ] == []
+        bus.clear_listeners()
+
+    def test_sweeper_skips_already_notified_within_cooldown(
+        self, pg_work_service, state_store, monkeypatch,
+    ):
+        bus.clear_listeners()
+        services = self._services(
+            pg_work_service, state_store, [FakeHandle("worker-proj")],
+        )
+        task = pg_work_service.create(
+            title="Preexisting work",
+            description="Desc",
+            type="task",
+            project="proj",
+            flow_template="standard",
+            roles={"worker": "agent-1", "reviewer": "agent-2"},
+            priority="normal",
+        )
+        pg_work_service.queue(task.task_id, "pm")
+
+        state_store.record_notification(
+            session_name="worker-proj",
+            task_id=task.task_id,
+            project="proj",
+            message="stub",
+            delivery_status="sent",
+        )
+
+        monkeypatch.setattr(
+            "pollypm.plugins_builtin.task_assignment_notify.handlers.sweep.load_runtime_services",
+            lambda *, config_path=None: services,
+        )
+
+        result = task_assignment_sweep_handler({})
+        assert result["by_outcome"].get("deduped", 0) >= 1
+        assert len(services.session_service.sent) == 0
+        bus.clear_listeners()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: task transition emits TaskAssignmentEvent through bus.
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndTransitionPg:
+    def test_queue_fires_event(self, pg_work_service):
+        bus.clear_listeners()
+        events: list[TaskAssignmentEvent] = []
+        bus.register_listener(events.append)
+        try:
+            task = pg_work_service.create(
+                title="Ship it",
+                description="Implement feature X",
+                type="task",
+                project="proj",
+                flow_template="standard",
+                roles={"worker": "agent-1", "reviewer": "agent-2"},
+                priority="normal",
+            )
+            pg_work_service.queue(task.task_id, "pm")
+
+            assert events, "Queue transition should emit a TaskAssignmentEvent"
+            event = events[-1]
+            assert event.task_id == task.task_id
+            assert event.project == "proj"
+            assert event.actor_type is ActorType.ROLE
+            assert event.actor_name == "worker"
+            assert event.work_status == "queued"
+            assert event.current_node_kind == "work"
+        finally:
+            bus.clear_listeners()
+
+    def test_human_node_does_not_emit(self, pg_work_service):
+        """A transition into a HUMAN review node should not ping a session."""
+        bus.clear_listeners()
+        events: list[TaskAssignmentEvent] = []
+        bus.register_listener(events.append)
+        try:
+            task = pg_work_service.create(
+                title="With human review",
+                description="Needs a human signoff",
+                type="task",
+                project="proj",
+                flow_template="standard",
+                roles={"worker": "agent-1", "reviewer": "agent-2"},
+                priority="normal",
+                requires_human_review=True,
+            )
+            pg_work_service.queue(task.task_id, "pm", skip_gates=True)
+            events.clear()
+
+            pg_work_service.claim(task.task_id, "agent-1")
+            from pollypm.work.models import (
+                Artifact,
+                ArtifactKind,
+                OutputType,
+                WorkOutput,
+            )
+
+            out = WorkOutput(
+                type=OutputType.CODE_CHANGE,
+                summary="Implemented feature X",
+                artifacts=[Artifact(
+                    kind=ArtifactKind.COMMIT,
+                    description="feat: X",
+                    ref="abc123",
+                )],
+            )
+            pg_work_service.node_done(
+                task.task_id, "agent-1", work_output=out, skip_gates=True,
+            )
+            assert all(e.actor_type is not ActorType.HUMAN for e in events)
+        finally:
+            bus.clear_listeners()
+
+
+# ---------------------------------------------------------------------------
+# Per-task worker recognition — pure resolver behaviour.
+# ---------------------------------------------------------------------------
+
+
+class TestPerTaskWorkerRecognition:
+    """#919 — when the caller knows the task number, the per-task window
+    candidate comes first so a freshly-spawned per-task worker pane
+    gets the kickoff ping."""
+
+    def test_role_candidates_prepend_per_task_window(self):
+        cands = role_candidate_names("worker", "blackjack", task_number=12)
+        assert cands[0] == "task-blackjack-12"
+        assert "worker-blackjack" in cands
+
+    def test_role_candidates_no_task_number_unchanged(self):
+        cands = role_candidate_names("worker", "demo")
+        assert "task-demo-1" not in cands
+        assert cands == ["worker-demo", "worker_demo"]
+
+    def test_resolver_picks_task_window_over_legacy_worker(self):
+        svc = FakeSessionService(handles=[
+            FakeHandle("task-demo-7"),
+            FakeHandle("worker-demo"),
+        ])
+        index = SessionRoleIndex(svc)
+        handle = index.resolve(
+            ActorType.ROLE, "worker", "demo", task_number=7,
+        )
+        assert handle is not None
+        assert handle.name == "task-demo-7"
+
+    def test_resolver_falls_back_to_legacy_worker_when_no_task_window(self):
+        svc = FakeSessionService(handles=[FakeHandle("worker-demo")])
+        index = SessionRoleIndex(svc)
+        handle = index.resolve(
+            ActorType.ROLE, "worker", "demo", task_number=7,
+        )
+        assert handle is not None
+        assert handle.name == "worker-demo"
+
+    def test_resolver_does_not_match_sibling_task_window(self):
+        """A per-task window for a different task number must not be
+        picked when resolving a different task's worker."""
+        svc = FakeSessionService(handles=[FakeHandle("task-demo-7")])
+        index = SessionRoleIndex(svc)
+        handle = index.resolve(
+            ActorType.ROLE, "worker", "demo", task_number=8,
+        )
+        assert handle is None
+
+
+class TestSingletonRolesNeverRouteToPerTaskPane:
+    """#1439 — singleton-only roles (reviewer / operator / triage /
+    heartbeat) must NEVER route to per-task panes, even when the
+    per-task pane's project matches.
+    """
+
+    def test_reviewer_kickoff_does_not_route_to_per_task_worker(self):
+        svc = FakeSessionService(handles=[
+            FakeHandle("task-demo-7"),
+            FakeHandle("reviewer_demo"),
+        ])
+        index = SessionRoleIndex(svc)
+        handle = index.resolve(
+            ActorType.ROLE, "reviewer", "demo", task_number=7,
+        )
+        assert handle is not None
+        assert handle.name == "reviewer_demo"
+
+    def test_reviewer_kickoff_returns_none_when_only_per_task_pane_alive(self):
+        svc = FakeSessionService(handles=[FakeHandle("task-demo-7")])
+        index = SessionRoleIndex(svc)
+        assert index.resolve(
+            ActorType.ROLE, "reviewer", "demo", task_number=7,
+        ) is None
+
+    def test_operator_kickoff_does_not_route_to_per_task_worker(self):
+        svc = FakeSessionService(handles=[
+            FakeHandle("task-demo-7"),
+            FakeHandle("operator_demo"),
+        ])
+        index = SessionRoleIndex(svc)
+        handle = index.resolve(
+            ActorType.ROLE, "operator", "demo", task_number=7,
+        )
+        assert handle is not None
+        assert handle.name == "operator_demo"
+
+    def test_triage_kickoff_does_not_route_to_per_task_worker(self):
+        svc = FakeSessionService(handles=[
+            FakeHandle("task-demo-7"),
+            FakeHandle("triage_demo"),
+        ])
+        index = SessionRoleIndex(svc)
+        handle = index.resolve(
+            ActorType.ROLE, "triage", "demo", task_number=7,
+        )
+        assert handle is not None
+        assert handle.name == "triage_demo"
+
+    def test_heartbeat_kickoff_does_not_route_to_per_task_worker(self):
+        svc = FakeSessionService(handles=[
+            FakeHandle("task-demo-7"),
+            FakeHandle("pm-heartbeat"),
+        ])
+        index = SessionRoleIndex(svc)
+        handle = index.resolve(
+            ActorType.ROLE, "heartbeat", "demo", task_number=7,
+        )
+        assert handle is not None
+        assert handle.name == "pm-heartbeat"
+
+    def test_role_candidates_for_reviewer_omits_per_task_pane(self):
+        cands = role_candidate_names("reviewer", "demo", task_number=7)
+        assert "task-demo-7" not in cands
+
+    def test_role_candidates_for_operator_omits_per_task_pane(self):
+        cands = role_candidate_names("operator", "demo", task_number=7)
+        assert "task-demo-7" not in cands
+
+    def test_role_candidates_for_triage_omits_per_task_pane(self):
+        cands = role_candidate_names("triage", "demo", task_number=7)
+        assert "task-demo-7" not in cands
+
+    def test_role_candidates_for_heartbeat_omits_per_task_pane(self):
+        cands = role_candidate_names("heartbeat", "demo", task_number=7)
+        assert "task-demo-7" not in cands
+
+    def test_worker_role_still_resolves_to_per_task_pane(self):
+        svc = FakeSessionService(handles=[
+            FakeHandle("task-demo-7"),
+            FakeHandle("worker-demo"),
+        ])
+        index = SessionRoleIndex(svc)
+        handle = index.resolve(
+            ActorType.ROLE, "worker", "demo", task_number=7,
+        )
+        assert handle is not None
+        assert handle.name == "task-demo-7"


### PR DESCRIPTION
## Summary

Closes out the remaining surfaces from the K-source-ripout test-deletion umbrella (#1824). Builds on the round-3 work in #1931 (commit a8f8620e9) without duplicating it.

## Surfaces ported

- **task_assignment plugin** (``test_pg_task_assignment_notify.py``, 22 tests, 530 LOC) — extends #1931's pure-helper coverage with the PgWorkService-driven surfaces: sweeper fanout (#921), end-to-end queue → ``TaskAssignmentEvent`` emission through the bus, per-task worker recognition (#919), the #1439 singleton-roles-never-route-to-per-task-pane invariants, and the multi-match least-busy selection.
- **doctor enhancements** (``test_pg_doctor_enhancements.py``, 43 tests, 1028 LOC) — extends #1931's monkeypatch-only PASS/WARN/FAIL coverage with the surfaces that need real fixtures: end-to-end CLI ``doctor`` invocations (exit codes / --fix / --fix-dry-run), the #1063 / #1064 anti-lie guards, AutoFixPlan plumbing on system-tool checks, ``check_scheduler_last_fired`` cadence sweep, ``check_sessions_table_populated`` + ``check_sessions_table_vs_tmux``, the ``check_inbox_aggregator_path`` check, pluralisation guards on the fix-summary renderer + maintenance-handler messages, and the --fix fixer plumbing for plan-gate / sweeper-DBs / worktree-prune / log-rotate.
- **plan_review_flow** (``test_pg_plan_review_flow.py``, 28 tests, 366 LOC) — re-locks the pure-helper half of the deleted 1928 LOC module: sidecar-label extraction, round-trip detection, PM primers (approval + denial), plan markdown summary / judgment-calls extractors, and the Action Needed card body renderer.
- **bug-report CLI** (``test_pg_cli_bug_report.py``, 7 tests, 200 LOC) — re-locks the seven invariants from the deleted ``test_cli_bug_report.py`` (filed/deduped echo, empty-title / empty-body refusal, stdin body, gh-missing exit, no-inbox-row contract).

## Deferred / out of scope

- **EventBuffer / activity-feed projector deeper coverage** — EventBuffer is sqlite-only (the pg backend inserts synchronously, per ``PgStore.append_event``); the existing ``test_pg_activity_feed_projector.py`` already covers 15 projector scenarios. No coverage gap.
- **flow_progression git-merge gates** — ``PgWorkService.approve`` still flags ``resume_merge`` as Slice C work (per the existing ``test_pg_flow_progression.py`` docstring). The git-merge gates haven't been ported, so there's nothing to test on the pg side yet.
- **Other CLI surface gaps beyond #1923** — ``backfill-kinds``, ``inbox aggregator``, ``inbox dedup`` and friends: the post-cutover ``backfill_kinds`` removed the ``--db`` override in favour of ``get_store(load_config())``, so a port requires a ``load_config`` monkeypatch fixture that wasn't in scope for this PR's LOC budget. Suggest a follow-up.

LOC: 4 new test files, +2124. No production-code edits.

## Test plan

- [x] ``uv run --extra dev ruff check tests/test_pg_task_assignment_notify.py tests/test_pg_doctor_enhancements.py tests/test_pg_plan_review_flow.py tests/test_pg_cli_bug_report.py`` — passes.
- [x] Module imports succeed under the dev extras.
- [ ] CI runs the new modules (per the agent constraint, pytest was not run locally).