### PR TITLE
perf(rail): cache roster + activity + rollup queries (closes #1943 #1944 #1945)

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -1319,6 +1319,29 @@ def _build_synthetic_storage_row(
     )
 
 
+# #1634 #1943 perf — per-process TTL cache for ``_gather_worker_roster``.
+#
+# The roster walk opens a work-service per project, runs
+# ``list_worker_sessions(active_only=True)`` + ``list_tasks(project=...)``,
+# and per-row shells out to ``git log`` (with a 2s subprocess timeout) for
+# the last-commit age. On every rail ``build_items()`` tick the workers
+# rail row invokes it TWICE — once from the label provider (for the count
+# badge) and once from the state provider (for the working/stuck/idle
+# glyph). On a large workspace that doubles a multi-second IO sweep just
+# to paint one rail row.
+#
+# Mirrors the same wedge PRs #1907 + #1928 used for
+# ``pm_inbox_awaits_user_list`` and ``Supervisor.status()``: a tiny
+# module-level dict keyed on ``id(config)`` with a short TTL. The
+# cockpit router invalidates its config cache on mtime change, so a
+# reload yields a fresh identity and bypasses this cache automatically.
+# TTL matches the inbox/status caches (1s) so freshly-stuck workers
+# surface within ~1 rail tick. Callers receive a fresh ``list`` copy
+# so downstream mutation cannot leak into the cached snapshot.
+_WORKER_ROSTER_TTL_SECONDS = 1.0
+_WORKER_ROSTER_CACHE: dict[int, tuple[float, tuple["WorkerRosterRow", ...]]] = {}
+
+
 def _gather_worker_roster(config) -> list[WorkerRosterRow]:
     """Walk every tracked project's work-service + tmux state.
 
@@ -1328,6 +1351,43 @@ def _gather_worker_roster(config) -> list[WorkerRosterRow]:
 
     Always best-effort: a bad DB or missing tmux session degrades one
     project's worth of rows, never the whole roster.
+
+    #1634 #1943 perf — results are memoised per ``config`` identity with
+    a short TTL (:data:`_WORKER_ROSTER_TTL_SECONDS`) so the rail row's
+    label provider (count badge) and state provider (working/stuck/idle
+    glyph) share a single computation per tick instead of each running
+    a full per-project work-service + tmux + git-log sweep. Callers
+    receive a fresh ``list`` copy so mutation is safe.
+    """
+    import time as _time
+
+    cache_key = id(config)
+    now = _time.monotonic()
+    cached = _WORKER_ROSTER_CACHE.get(cache_key)
+    if cached is not None and now - cached[0] < _WORKER_ROSTER_TTL_SECONDS:
+        return list(cached[1])
+
+    result = _gather_worker_roster_uncached(config)
+    # Best-effort eviction so the cache doesn't grow across long-lived
+    # processes with config reloads (each reload yields a fresh
+    # ``id(config)``). Cheap because the dict is typically tiny — one
+    # entry per live config.
+    if len(_WORKER_ROSTER_CACHE) > 8:
+        for stale_key in [
+            k for k, (ts, _v) in _WORKER_ROSTER_CACHE.items()
+            if now - ts >= _WORKER_ROSTER_TTL_SECONDS
+        ]:
+            _WORKER_ROSTER_CACHE.pop(stale_key, None)
+    _WORKER_ROSTER_CACHE[cache_key] = (now, tuple(result))
+    return result
+
+
+def _gather_worker_roster_uncached(config) -> list[WorkerRosterRow]:
+    """Underlying implementation of :func:`_gather_worker_roster`.
+
+    Separated from the public entry point so the cache wrapper stays
+    trivially readable. Tests that need to bypass the cache can call
+    this directly (or clear :data:`_WORKER_ROSTER_CACHE`).
     """
     from pollypm.work import create_work_service
 

--- a/src/pollypm/cockpit_pg_aggregates.py
+++ b/src/pollypm/cockpit_pg_aggregates.py
@@ -20,6 +20,7 @@ crash the rail.
 from __future__ import annotations
 
 import logging
+import time
 from typing import TYPE_CHECKING, Any
 
 from pollypm.work.inbox_view import inbox_tasks
@@ -29,6 +30,32 @@ if TYPE_CHECKING:
     from pollypm.work.models import Task
 
 logger = logging.getLogger(__name__)
+
+
+# #1634 #1945 perf — per-process TTL cache for ``all_tasks_grouped``.
+#
+# Each rail ``build_items()`` tick runs ``_project_state_rollups``
+# (which calls ``all_tasks_grouped(config)``) AND, when the rail's
+# per-router 2s categorization TTL has expired, ``_project_categorizations``
+# (which opens its own shared work-service and runs the same broad
+# ``svc.list_tasks()`` against pg through :mod:`operator_view`). On
+# overlapping rail builds the two paths produce two bulk task reads
+# milliseconds apart. Caching ``all_tasks_grouped`` itself collapses
+# repeat calls within a tick onto a single pg roundtrip; pair this
+# with the ``_prefetch_project_state`` cache in :mod:`operator_view`
+# to handle the second access path.
+#
+# Mirrors the same wedge PRs #1907 + #1928 used for
+# ``pm_inbox_awaits_user_list`` and ``Supervisor.status()``: a tiny
+# module-level dict keyed on ``id(config)`` with a short TTL. The
+# cockpit router invalidates its config cache on mtime change, so a
+# reload yields a fresh identity and bypasses this cache automatically.
+# Callers receive a fresh dict + fresh inner lists so downstream
+# mutation cannot leak into the cached snapshot.
+_ALL_TASKS_GROUPED_TTL_SECONDS = 1.0
+_ALL_TASKS_GROUPED_CACHE: dict[
+    int, tuple[float, "dict[str, tuple[Task, ...]] | None"]
+] = {}
 
 
 # --------------------------------------------------------------------------- #
@@ -71,6 +98,49 @@ def all_tasks_grouped(
 
     Returns ``None`` when the pg backend isn't available so the caller
     falls back to its sqlite walk.
+
+    #1634 #1945 perf — results are memoised per ``id(config)`` with a
+    short TTL (:data:`_ALL_TASKS_GROUPED_TTL_SECONDS`) so the rail
+    rollup path and any other broad-task caller within the same tick
+    share a single pg roundtrip. Callers receive a fresh dict + fresh
+    inner lists so downstream mutation is safe.
+    """
+    cache_key = id(config)
+    now = time.monotonic()
+    cached = _ALL_TASKS_GROUPED_CACHE.get(cache_key)
+    if cached is not None and now - cached[0] < _ALL_TASKS_GROUPED_TTL_SECONDS:
+        snapshot = cached[1]
+        if snapshot is None:
+            return None
+        return {key: list(rows) for key, rows in snapshot.items()}
+
+    result = _all_tasks_grouped_uncached(config)
+    # Best-effort eviction so the cache doesn't grow across long-lived
+    # processes with config reloads (each reload yields a fresh
+    # ``id(config)``).
+    if len(_ALL_TASKS_GROUPED_CACHE) > 8:
+        for stale_key in [
+            k for k, (ts, _v) in _ALL_TASKS_GROUPED_CACHE.items()
+            if now - ts >= _ALL_TASKS_GROUPED_TTL_SECONDS
+        ]:
+            _ALL_TASKS_GROUPED_CACHE.pop(stale_key, None)
+    snapshot = (
+        None
+        if result is None
+        else {key: tuple(rows) for key, rows in result.items()}
+    )
+    _ALL_TASKS_GROUPED_CACHE[cache_key] = (now, snapshot)
+    return result
+
+
+def _all_tasks_grouped_uncached(
+    config: "PollyPMConfig | None",
+) -> dict[str, list["Task"]] | None:
+    """Underlying implementation of :func:`all_tasks_grouped`.
+
+    Separated from the public entry point so the cache wrapper stays
+    trivially readable. Tests that need to bypass the cache can call
+    this directly (or clear :data:`_ALL_TASKS_GROUPED_CACHE`).
     """
     svc = _open_pg_service(config)
     if svc is None:

--- a/src/pollypm/dashboard/operator_view.py
+++ b/src/pollypm/dashboard/operator_view.py
@@ -19,6 +19,7 @@ mount — 12 projects × ~5–350ms sqlite opens dominated the cold path.
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
@@ -35,6 +36,38 @@ from pollypm.dashboard.categorization import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# #1634 #1945 perf — per-process TTL cache for ``_prefetch_project_state``.
+#
+# When the rail's 2s categorization TTL expires, the same rail
+# ``build_items()`` tick runs both ``_project_state_rollups`` (which
+# pulls bulk tasks via :func:`pollypm.cockpit_pg_aggregates.all_tasks_grouped`)
+# and ``_project_categorizations`` → :func:`project_state_map_from_config`,
+# which opens its own shared work-service and runs
+# ``svc.list_tasks()`` + ``svc.list_worker_sessions(active_only=True)``
+# against pg. Two broad task reads, milliseconds apart, before the
+# rail can render.
+#
+# Mirrors the same wedge PRs #1907 + #1928 used for
+# ``pm_inbox_awaits_user_list`` and ``Supervisor.status()``: a tiny
+# module-level dict keyed on ``id(config)`` with a short TTL. The
+# ``svc`` argument is intentionally excluded from the key because the
+# resolved backend (pg pool or sqlite handle) is uniquely determined
+# by ``config``; the work-service handle is just a thin shim and a
+# fresh one each call would otherwise defeat the cache. The cockpit
+# router invalidates its config cache on mtime change, so a reload
+# yields a fresh ``id(config)`` and bypasses this cache automatically.
+# Callers receive fresh dict + inner-list copies so downstream
+# mutation cannot leak into the cached snapshot.
+_PREFETCH_PROJECT_STATE_TTL_SECONDS = 1.0
+_PREFETCH_PROJECT_STATE_CACHE: dict[
+    int,
+    tuple[
+        float,
+        tuple[dict[str, tuple], dict[str, tuple]],
+    ],
+] = {}
 
 
 @dataclass(frozen=True, slots=True)
@@ -153,6 +186,53 @@ def _prefetch_project_state(config, svc) -> tuple[  # noqa: ANN001
     :func:`pollypm.work.project_aliases.project_storage_aliases` —
     replacing N ``list_tasks(project=<key>)`` calls and N
     ``list_worker_sessions(project=<key>)`` calls with two queries.
+
+    #1634 #1945 perf — results are memoised per ``id(config)`` with a
+    short TTL (:data:`_PREFETCH_PROJECT_STATE_TTL_SECONDS`) so the
+    rail glyph categorization shares its bulk task/session reads
+    across the multiple rail-build surfaces that hit
+    :func:`project_state_map_from_config` on overlapping ticks.
+    Callers receive fresh dict + inner-list copies so mutation is safe.
+    """
+    cache_key = id(config)
+    now = time.monotonic()
+    cached = _PREFETCH_PROJECT_STATE_CACHE.get(cache_key)
+    if cached is not None and now - cached[0] < _PREFETCH_PROJECT_STATE_TTL_SECONDS:
+        tasks_snap, workers_snap = cached[1]
+        return (
+            {key: list(rows) for key, rows in tasks_snap.items()},
+            {key: list(rows) for key, rows in workers_snap.items()},
+        )
+
+    result = _prefetch_project_state_uncached(svc)
+    # Best-effort eviction so the cache doesn't grow across long-lived
+    # processes with config reloads (each reload yields a fresh
+    # ``id(config)``).
+    if len(_PREFETCH_PROJECT_STATE_CACHE) > 8:
+        for stale_key in [
+            k for k, (ts, _v) in _PREFETCH_PROJECT_STATE_CACHE.items()
+            if now - ts >= _PREFETCH_PROJECT_STATE_TTL_SECONDS
+        ]:
+            _PREFETCH_PROJECT_STATE_CACHE.pop(stale_key, None)
+    tasks_by_alias, workers_by_alias = result
+    _PREFETCH_PROJECT_STATE_CACHE[cache_key] = (
+        now,
+        (
+            {key: tuple(rows) for key, rows in tasks_by_alias.items()},
+            {key: tuple(rows) for key, rows in workers_by_alias.items()},
+        ),
+    )
+    return result
+
+
+def _prefetch_project_state_uncached(svc) -> tuple[  # noqa: ANN001
+    "dict[str, list]", "dict[str, list]"
+]:
+    """Underlying implementation of :func:`_prefetch_project_state`.
+
+    Separated from the public entry point so the cache wrapper stays
+    trivially readable. Tests that need to bypass the cache can call
+    this directly (or clear :data:`_PREFETCH_PROJECT_STATE_CACHE`).
     """
     tasks_by_alias: dict[str, list] = {}
     workers_by_alias: dict[str, list] = {}

--- a/src/pollypm/storage/work_transition_queries.py
+++ b/src/pollypm/storage/work_transition_queries.py
@@ -11,6 +11,7 @@ but is unused.
 from __future__ import annotations
 
 import logging
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -18,6 +19,33 @@ if TYPE_CHECKING:
     from pollypm.models import PollyPMConfig
 
 logger = logging.getLogger(__name__)
+
+
+# #1634 #1944 perf — per-process TTL cache for ``activity_feed_transition_rows``.
+#
+# On the pg backend the function ignores ``db_path`` and runs a single
+# global ``SELECT ... FROM work_transitions ...`` query. The activity-feed
+# rail badge builds an :class:`EventProjector` which then loops over
+# ``self._work_dbs`` and calls this helper once per configured project —
+# producing N identical global queries for one badge update on a
+# workspace with N projects. The downstream filter/sort/dedupe layer
+# in :mod:`event_projector` then has to chew through N copies of the
+# same rows before slicing to the limit.
+#
+# Mirrors PR #1907's ``pm_inbox_awaits_user_list`` wedge and PR #1928's
+# ``Supervisor.status()`` wedge: a tiny module-level dict keyed on
+# ``(id(config), since_ts, limit)`` with a short TTL. ``db_path`` is
+# intentionally excluded from the key because the pg implementation
+# already ignores it — every per-project call within a rail tick
+# resolves to the same global result. The cockpit router invalidates
+# its config cache on mtime change, so a reload yields a fresh
+# ``id(config)`` and bypasses this cache automatically. Callers
+# receive a fresh ``list`` of row dicts so downstream mutation cannot
+# leak into the cached snapshot.
+_ACTIVITY_FEED_ROWS_TTL_SECONDS = 1.0
+_ACTIVITY_FEED_ROWS_CACHE: dict[
+    tuple[int, str | None, int], tuple[float, tuple[dict[str, Any], ...]]
+] = {}
 
 
 _ADVISOR_TRANSITION_PG_SQL = (
@@ -73,8 +101,52 @@ def activity_feed_transition_rows(
     limit: int,
     config: "PollyPMConfig | None" = None,
 ) -> list[dict[str, Any]]:
-    """Return recent work-transition rows for activity-feed projection."""
+    """Return recent work-transition rows for activity-feed projection.
+
+    #1634 #1944 perf — results are memoised per ``(id(config), since_ts,
+    limit)`` with a short TTL (:data:`_ACTIVITY_FEED_ROWS_TTL_SECONDS`)
+    so the activity-feed projector's per-project ``_work_dbs`` loop
+    collapses onto a single global query instead of repeating identical
+    reads (``db_path`` is unused on the pg backend). Callers receive a
+    fresh list of row dicts so downstream mutation is safe.
+    """
     del db_path  # unused on pg backend
+
+    cache_key = (id(config), since_ts, int(limit))
+    now = time.monotonic()
+    cached = _ACTIVITY_FEED_ROWS_CACHE.get(cache_key)
+    if cached is not None and now - cached[0] < _ACTIVITY_FEED_ROWS_TTL_SECONDS:
+        return [dict(row) for row in cached[1]]
+
+    result = _activity_feed_transition_rows_uncached(
+        since_ts=since_ts, limit=limit, config=config,
+    )
+    # Best-effort eviction so the cache doesn't grow across long-lived
+    # processes that build successive configs or vary ``since_ts``.
+    if len(_ACTIVITY_FEED_ROWS_CACHE) > 16:
+        for stale_key in [
+            k for k, (ts, _v) in _ACTIVITY_FEED_ROWS_CACHE.items()
+            if now - ts >= _ACTIVITY_FEED_ROWS_TTL_SECONDS
+        ]:
+            _ACTIVITY_FEED_ROWS_CACHE.pop(stale_key, None)
+    _ACTIVITY_FEED_ROWS_CACHE[cache_key] = (
+        now, tuple(dict(row) for row in result),
+    )
+    return result
+
+
+def _activity_feed_transition_rows_uncached(
+    *,
+    since_ts: str | None,
+    limit: int,
+    config: "PollyPMConfig | None" = None,
+) -> list[dict[str, Any]]:
+    """Underlying implementation of :func:`activity_feed_transition_rows`.
+
+    Separated from the public entry point so the cache wrapper stays
+    trivially readable. Tests that need to bypass the cache can call
+    this directly (or clear :data:`_ACTIVITY_FEED_ROWS_CACHE`).
+    """
     try:
         from pollypm.storage.pg_pool import get_ro_pool
     except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## Summary

Three more rail-perf duplicate-query hotspots from the #1634 meta, each
wrapped with the established ``_FUNCTION_CACHE`` + 1s TTL pattern from
PRs #1907 (``pm_inbox_awaits_user_list``) and #1928 (``Supervisor.status()``).

- **#1943** Workers rail row's label provider (count badge) and state
  provider (working/stuck/idle glyph) both called
  ``_gather_worker_roster(cfg)`` on the same ``build_items()`` tick,
  doubling a multi-project work-service + tmux + ``git log`` sweep.
- **#1944** Activity-feed rail badge runs
  ``activity_feed_transition_rows`` once per configured project, but
  the pg implementation ignores ``db_path`` — N identical global
  ``work_transitions`` queries for one badge update on a workspace
  with N projects.
- **#1945** When the rail router's 2s categorization TTL expires, the
  same tick runs ``all_tasks_grouped(config)`` for project rollups
  AND ``svc.list_tasks()`` + ``svc.list_worker_sessions()`` through
  ``_prefetch_project_state`` for categorization — two broad task
  reads milliseconds apart.

Each fix follows the same shape: pure ``_*_uncached()`` helper +
thin cache wrapper keyed on ``id(config)`` (or
``(id(config), since_ts, limit)`` for the activity-feed badge) with
``_*_TTL_SECONDS = 1.0``. Callers receive fresh ``list``/``dict``
copies so downstream mutation cannot leak into the cached snapshot.
The cockpit router invalidates its config cache on mtime change, so
a reload yields a fresh ``id(config)`` and bypasses all three caches
automatically.

Touched 3 files (one per issue):
- ``src/pollypm/cockpit_inbox.py``
- ``src/pollypm/storage/work_transition_queries.py``
- ``src/pollypm/cockpit_pg_aggregates.py`` + ``src/pollypm/dashboard/operator_view.py``

Refs #1634.

## Test plan
- [ ] Open cockpit on a multi-project workspace, confirm workers rail
      row still renders count badge + working/stuck/idle glyph
      correctly.
- [ ] Confirm activity-feed rail badge still shows new event counts
      after fresh transitions land.
- [ ] Confirm rail glyphs for project categorization (Waiting /
      Working / Idle / Paused) still match the operator dashboard
      sections.
- [ ] Reload config (``pm up`` / restart) and confirm caches drop
      (fresh ``id(config)`` should bypass).