### PR TITLE
fix(sqlite-ripout): close remaining SQLite defaults + escape hatches (closes #1939 #1940 #1941 #1942)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,10 +87,11 @@ pythonpath = ["src"]
 testpaths = ["tests"]
 markers = [
   "benchmark: performance benchmark tests (recall latency, etc.)",
-  # #1737 Slice F: the ``work_service`` dispatch fixture in
-  # ``tests/conftest.py`` reads this marker to decide whether a test runs
-  # against ``SQLiteWorkService`` (default), ``PgWorkService``, or both.
-  # Usage: ``@pytest.mark.backend('postgres')`` / ``('sqlite')`` /
-  # ``('both')``. Unmarked tests stay on sqlite until Slice K cuts over.
+  # #1737 Slice F / #1942: the ``work_service`` dispatch fixture in
+  # ``tests/conftest.py`` reads this marker to decide whether a test
+  # runs against ``PgWorkService`` (default after the #1942 flip),
+  # ``SQLiteWorkService`` (legacy opt-in), or both. Usage:
+  # ``@pytest.mark.backend('postgres')`` / ``('sqlite')`` / ``('both')``.
+  # Unmarked tests run against pg; unknown values raise UsageError.
   "backend(name): pin a test to a work-service backend ('sqlite', 'postgres', or 'both')",
 ]

--- a/src/pollypm/cli_features/session_runtime.py
+++ b/src/pollypm/cli_features/session_runtime.py
@@ -76,11 +76,13 @@ def _resolve_notify_store(db: str):
     """Return the configured-backend ``Store`` for ``pm notify`` writes.
 
     Mirrors :func:`pollypm.work.cli._svc` backend dispatch (#1369,
-    #1737) and the inbox-CLI helper added for #1790. When ``--db`` is
-    the canonical workspace default, route through
+    #1737, #1940) and the inbox-CLI helper added for #1790. When
+    ``--db`` is the canonical workspace default, route through
     :func:`pollypm.store.get_store` so ``[storage].backend = "postgres"``
-    actually writes to the pg pool. When ``--db`` is overridden (the
-    test / CI escape hatch) pin to sqlite at the supplied path.
+    actually writes to the pg pool. When ``--db`` is a Postgres DSN
+    (``postgresql://…``, #1940) pin to pg at the supplied DSN. Any
+    other override is treated as a sqlite path (the test / CI escape
+    hatch).
 
     The returned ``Store`` is a process-wide singleton — do NOT
     ``close()`` it.
@@ -91,10 +93,16 @@ def _resolve_notify_store(db: str):
     postgres, so live pg readers never saw the alert and the
     immediate-priority inbox task fan-out hit a non-existent row.
     """
+    from pollypm.storage.pg_pool import _looks_like_pg_dsn
     from pollypm.work.db_resolver import (
         WORKSPACE_DEFAULT_DB_PATH,
         resolve_work_db_path,
     )
+
+    if _looks_like_pg_dsn(db):
+        from pollypm.store import get_store_by_url
+
+        return get_store_by_url(db.strip(), backend="postgres")
 
     if db != WORKSPACE_DEFAULT_DB_PATH:
         from pollypm.store import get_store_by_url
@@ -1324,7 +1332,11 @@ def notify(
     db: str = typer.Option(
         ".pollypm/state.db",
         "--db",
-        help="Path to SQLite database (default: same resolution as `pm inbox`).",
+        help=(
+            "Work-service connection: sqlite path (default) or Postgres "
+            "DSN (``postgresql://…``). Default routes through "
+            "``[storage].backend`` (#1940)."
+        ),
     ),
 ) -> None:
     """Create a work-service inbox item for the human user."""

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -8021,13 +8021,15 @@ class PollyInboxApp(App[None]):
             return
         if not is_task_inbox_entry(item):
             try:
-                from pollypm.store import SQLAlchemyStore
+                # #1941 — route messages-store writes through the
+                # configured-backend singleton so a pg-cutover workspace
+                # closes the row on the live pg ``messages`` table
+                # instead of an empty per-project sqlite shadow. The
+                # store is a process-wide singleton — do NOT close().
+                from pollypm.store import get_store
 
-                store = SQLAlchemyStore(f"sqlite:///{item.db_path}")
-                try:
-                    store.close_message(int(item.message_id))
-                finally:
-                    store.close()
+                store = get_store(load_config(self.config_path))
+                store.close_message(int(item.message_id))
             except Exception as exc:  # noqa: BLE001
                 self.notify(f"Archive failed: {exc}", severity="error")
                 return
@@ -9267,13 +9269,14 @@ class PollyInboxApp(App[None]):
             _celebrate_first_shipped(self)
         if is_message_item and item is not None:
             try:
-                from pollypm.store import SQLAlchemyStore
+                # #1941 — backend-aware close_message: route through the
+                # configured-backend singleton instead of the empty
+                # per-project sqlite shadow that the pre-cutover code
+                # opened. Singleton — do NOT close().
+                from pollypm.store import get_store
 
-                store = SQLAlchemyStore(f"sqlite:///{item.db_path}")
-                try:
-                    store.close_message(int(item.message_id))
-                finally:
-                    store.close()
+                store = get_store(load_config(self.config_path))
+                store.close_message(int(item.message_id))
             except Exception:  # noqa: BLE001
                 pass
         else:
@@ -9724,35 +9727,36 @@ class PollyInboxApp(App[None]):
     # ------------------------------------------------------------------
 
     def _emit_event(self, task_id: str, event_type: str, message: str) -> None:
-        """Record an activity-feed event on the project-root state.db.
+        """Record an activity-feed event via the configured store.
 
         Matches the shape used by ``pm notify`` so the same consumers see
         inbox.read / archived / reply alongside inbox.message.created.
         Fire-and-forget — we never block the UI on event bookkeeping.
         #349: routes through the unified ``messages`` table via Store.
+        #1941: backend-aware — uses the configured-backend singleton so
+        a pg-cutover workspace writes events to the live pg pool
+        instead of an empty per-project sqlite shadow.
         """
         try:
-            from pollypm.store import SQLAlchemyStore
+            from pollypm.store import get_store
+
             project_key = task_id.split("/", 1)[0]
             config = load_config(self.config_path)
-            project = config.projects.get(project_key)
-            if project is None:
+            # Gate on a registered project so unsolicited callers can't
+            # fire events for unknown task IDs; the pre-cutover code
+            # used the project's existence + state.db existence as the
+            # gate, and we preserve the project gate even though the
+            # store is no longer per-project.
+            if config.projects.get(project_key) is None:
                 return
-            db_path = project.path / ".pollypm" / "state.db"
-            if not db_path.exists():
-                return
-            store = SQLAlchemyStore(f"sqlite:///{db_path}")
-            try:
-                store.append_event(
-                    scope="cockpit",
-                    sender="cockpit",
-                    subject=event_type,
-                    payload={"message": message},
-                )
-            finally:
-                close = getattr(store, "close", None)
-                if callable(close):
-                    close()
+            store = get_store(config)
+            # Singleton — do NOT close().
+            store.append_event(
+                scope="cockpit",
+                sender="cockpit",
+                subject=event_type,
+                payload={"message": message},
+            )
         except Exception:  # noqa: BLE001
             pass
 
@@ -10978,17 +10982,18 @@ def _project_storage_aliases(config: object, project_key: str) -> list[str]:
 def _dashboard_discover_db_aliases(
     db_path: Path, aliases: list[str],
 ) -> list[str]:
-    """Return DB-stored project labels case-insensitively matching ``aliases``.
+    """Return work-service project labels case-insensitively matching ``aliases``.
 
     #915 — defends against any casing/slug variant that the static alias
-    list may have missed by inspecting what the work DB actually has.
-    Performs a single ``SELECT DISTINCT project`` scan; returns only the
-    labels that case-fold-match an alias OR slugify to the same key as
-    an alias. Failures are swallowed — the caller falls back to the
-    static alias list.
+    list may have missed by inspecting what the work service actually
+    has. #1941 — drops the direct ``sqlite3.connect(readonly_uri(...))``
+    + raw ``SELECT DISTINCT project FROM work_tasks`` scan in favour of
+    the backend-aware :func:`pollypm.work.create_work_service` /
+    ``list_tasks`` path; the pre-cutover code missed live pg rows on a
+    pg-configured workspace because it pointed at the empty per-project
+    sqlite shadow. Failures are swallowed — the caller falls back to
+    the static alias list.
     """
-    import sqlite3
-
     try:
         from pollypm.projects import slugify_project_key
     except Exception:  # noqa: BLE001
@@ -11005,36 +11010,62 @@ def _dashboard_discover_db_aliases(
 
     discovered: list[str] = []
     try:
-        from pollypm.storage.sqlite_pragmas import readonly_uri
-        conn = sqlite3.connect(readonly_uri(db_path), uri=True)
+        from pollypm.config import load_config
+        from pollypm.work import create_work_service
     except Exception:  # noqa: BLE001
         return discovered
+
     try:
+        config = load_config()
+    except Exception:  # noqa: BLE001
+        config = None
+
+    labels: set[str] = set()
+    try:
+        with create_work_service(config=config) as svc:
+            for task in svc.list_tasks():
+                project = getattr(task, "project", None)
+                if isinstance(project, str) and project.strip():
+                    labels.add(project)
+    except Exception:  # noqa: BLE001
+        # Sqlite-install fallback: read the per-project DB directly so
+        # the legacy code path keeps working until the cutover is
+        # complete on every workspace.
+        import sqlite3
+
         try:
-            rows = conn.execute(
-                "SELECT DISTINCT project FROM work_tasks",
-            ).fetchall()
+            from pollypm.storage.sqlite_pragmas import readonly_uri
+            conn = sqlite3.connect(readonly_uri(db_path), uri=True)
         except Exception:  # noqa: BLE001
             return discovered
-        for (label,) in rows:
-            if not isinstance(label, str) or not label.strip():
-                continue
-            if label in aliases or label in discovered:
-                continue
-            if label.casefold() in folded:
-                discovered.append(label)
-                continue
-            if slugify_project_key is not None:
-                try:
-                    if slugify_project_key(label) in slugged:
-                        discovered.append(label)
-                except Exception:  # noqa: BLE001
-                    continue
-    finally:
         try:
-            conn.close()
-        except Exception:  # noqa: BLE001
-            pass
+            try:
+                rows = conn.execute(
+                    "SELECT DISTINCT project FROM work_tasks",
+                ).fetchall()
+            except Exception:  # noqa: BLE001
+                return discovered
+            for (label,) in rows:
+                if isinstance(label, str) and label.strip():
+                    labels.add(label)
+        finally:
+            try:
+                conn.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    for label in labels:
+        if label in aliases or label in discovered:
+            continue
+        if label.casefold() in folded:
+            discovered.append(label)
+            continue
+        if slugify_project_key is not None:
+            try:
+                if slugify_project_key(label) in slugged:
+                    discovered.append(label)
+            except Exception:  # noqa: BLE001
+                continue
     return discovered
 
 
@@ -11928,84 +11959,102 @@ def _dashboard_inbox_collect_messages(
     project_path: Path,
     known_projects: set,
 ) -> list[dict]:
-    """Open each message-source DB and append message-shaped inbox items."""
-    from pollypm.store import SQLAlchemyStore
+    """Append message-shaped inbox items via the configured store.
+
+    #1941: routes through :func:`pollypm.store.get_store` so a pg-cutover
+    workspace reads the live ``messages`` table on the pg pool. The
+    ``message_sources`` list is preserved as a parameter (callers may
+    still iterate per-project paths on a sqlite install for legacy
+    layouts) but the open path is now a single backend-aware singleton
+    fetch; ``source_db`` per-row metadata stays the per-source path so
+    downstream item builders preserve the existing cross-source dedup +
+    project-scope filtering. The store is a process-wide singleton —
+    do NOT close().
+    """
     from pollypm.cockpit_inbox_sources import _row_is_dev_channel
+    from pollypm.store import get_store
 
     items: list[dict] = []
-    seen_messages: set[tuple[str, object]] = set()
-    for source_key, source_db in message_sources:
-        try:
-            store = SQLAlchemyStore(f"sqlite:///{source_db}")
-        except Exception:  # noqa: BLE001
+    try:
+        store = get_store(config)
+    except Exception:  # noqa: BLE001
+        return items
+
+    seen_messages: set[object] = set()
+    try:
+        rows = store.query_messages(
+            state="open",
+            type=["notify", "inbox_task", "alert", "event"],
+            limit=250,
+        )
+    except Exception:  # noqa: BLE001
+        rows = []
+
+    # Pick a representative source-key / source-db for the legacy item
+    # builder. Callers historically passed [(project_key, project_db),
+    # ("__workspace__", workspace_db)]; the configured store now serves
+    # both, so collapse to the first entry and let the dedup happen on
+    # the row id alone.
+    primary_source_key = (
+        message_sources[0][0] if message_sources else project_key
+    )
+    primary_source_db = (
+        message_sources[0][1] if message_sources
+        else project_path / ".pollypm" / "state.db"
+    )
+
+    for row in rows:
+        row_id = row.get("id")
+        if row_id is None or row_id in seen_messages:
             continue
-        try:
-            try:
-                rows = store.query_messages(
-                    state="open",
-                    type=["notify", "inbox_task", "alert", "event"],
-                    limit=250,
+        seen_messages.add(row_id)
+        if _row_is_dev_channel(row.get("labels")):
+            continue
+        payload = row.get("payload") or {}
+        if not isinstance(payload, dict):
+            payload = {}
+        labels = _dashboard_inbox_labels_from_row(row)
+        is_blocker_summary = (
+            payload.get("event_type") == "project_blocker_summary"
+            or row.get("subject") == "project.blocker_summary"
+        )
+        if row.get("type") == "event" and not is_blocker_summary:
+            continue
+        if project_key not in _dashboard_inbox_message_projects(row, config):
+            continue
+        if is_blocker_summary:
+            raw_updated_at = (
+                row.get("updated_at") or row.get("created_at") or ""
+            )
+            if hasattr(raw_updated_at, "isoformat"):
+                raw_updated_at = raw_updated_at.isoformat()
+            items.append(
+                _dashboard_build_blocker_summary_item(
+                    row,
+                    payload,
+                    project_key,
+                    sort_value=_dashboard_inbox_sort_value(raw_updated_at),
                 )
-            except Exception:  # noqa: BLE001
-                rows = []
-            for row in rows:
-                row_id = row.get("id")
-                message_key = (str(source_db), row_id)
-                if row_id is None or message_key in seen_messages:
-                    continue
-                seen_messages.add(message_key)
-                if _row_is_dev_channel(row.get("labels")):
-                    continue
-                payload = row.get("payload") or {}
-                if not isinstance(payload, dict):
-                    payload = {}
-                labels = _dashboard_inbox_labels_from_row(row)
-                is_blocker_summary = (
-                    payload.get("event_type") == "project_blocker_summary"
-                    or row.get("subject") == "project.blocker_summary"
-                )
-                if row.get("type") == "event" and not is_blocker_summary:
-                    continue
-                if project_key not in _dashboard_inbox_message_projects(row, config):
-                    continue
-                if is_blocker_summary:
-                    raw_updated_at = (
-                        row.get("updated_at") or row.get("created_at") or ""
-                    )
-                    if hasattr(raw_updated_at, "isoformat"):
-                        raw_updated_at = raw_updated_at.isoformat()
-                    items.append(
-                        _dashboard_build_blocker_summary_item(
-                            row,
-                            payload,
-                            project_key,
-                            sort_value=_dashboard_inbox_sort_value(raw_updated_at),
-                        )
-                    )
-                    continue
-                # Some PM handoff notes arrive through shell-escaped paths and
-                # persist literal "\n" sequences. Normalize before extracting
-                # blocker paragraphs and numbered action steps.
-                message_body = str(row.get("body") or "").replace("\\n", "\n")
-                items.append(
-                    _dashboard_inbox_build_message_item(
-                        row=row,
-                        payload=payload,
-                        labels=labels,
-                        source_key=source_key,
-                        source_db=source_db,
-                        project_key=project_key,
-                        project_path=project_path,
-                        known_projects=known_projects,
-                        message_body=message_body,
-                        sort_value=_dashboard_inbox_sort_value,
-                    )
-                )
-        finally:
-            try:
-                store.close()
-            except Exception:  # noqa: BLE001
-                pass
+            )
+            continue
+        # Some PM handoff notes arrive through shell-escaped paths and
+        # persist literal "\n" sequences. Normalize before extracting
+        # blocker paragraphs and numbered action steps.
+        message_body = str(row.get("body") or "").replace("\\n", "\n")
+        items.append(
+            _dashboard_inbox_build_message_item(
+                row=row,
+                payload=payload,
+                labels=labels,
+                source_key=primary_source_key,
+                source_db=primary_source_db,
+                project_key=project_key,
+                project_path=project_path,
+                known_projects=known_projects,
+                message_body=message_body,
+                sort_value=_dashboard_inbox_sort_value,
+            )
+        )
     return items
 
 

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -561,10 +561,13 @@ def _parse_storage_settings(
     Recognised keys:
 
     * ``backend`` — entry-point name under ``pollypm.store_backend``.
-      Defaults to ``"sqlite"`` (registered by this package).
-    * ``url`` — SQLAlchemy URL. When empty/missing, the resolver derives
-      ``sqlite:///<project.state_db>`` so first-run users don't have to
-      think about connection strings.
+      Defaults to ``"postgres"`` after the #1737 cutover (issue #1939);
+      ``"sqlite"`` remains registered for explicit opt-in.
+    * ``url`` — SQLAlchemy URL. When empty/missing on the sqlite
+      backend, the resolver derives ``sqlite:///<project.state_db>`` so
+      first-run users don't have to think about connection strings. On
+      the postgres backend an empty ``url`` lets the pg pool resolve
+      the DSN itself (``[storage.pg].dsn`` / ``POLLYPM_PG_DSN``).
 
     Missing section yields defaults. Fat-fingered value types (non-str)
     silently fall back to defaults — a broken ``[storage]`` block must
@@ -573,17 +576,20 @@ def _parse_storage_settings(
     storage_raw = raw.get("storage", {})
     if not isinstance(storage_raw, dict):
         storage_raw = {}
-    backend_raw = storage_raw.get("backend", "sqlite")
+    backend_raw = storage_raw.get("backend", "postgres")
     if not isinstance(backend_raw, str) or not backend_raw.strip():
-        backend_raw = "sqlite"
+        backend_raw = "postgres"
     url_raw = storage_raw.get("url", "")
     if not isinstance(url_raw, str):
         url_raw = ""
     url_stripped = url_raw.strip()
-    if not url_stripped:
-        # Default-derive from the already-resolved state_db path. The
-        # resolver downstream uses this URL verbatim, so emit an absolute
-        # path that survives chdir.
+    if not url_stripped and backend_raw.strip().lower() == "sqlite":
+        # Sqlite-only fallback: derive from the already-resolved state_db
+        # path so the legacy escape hatch keeps working without explicit
+        # URLs. The postgres backend reads its DSN from ``[storage.pg]``
+        # (or ``POLLYPM_PG_DSN``); leaving ``url`` empty lets the pool
+        # resolver pick it up rather than fabricating a sqlite URL on a
+        # postgres install (issue #1939).
         url_stripped = f"sqlite:///{project.state_db.resolve()}"
 
     # ``[storage.pg]`` subsection (issue #1737, Slice A). Missing /

--- a/src/pollypm/models.py
+++ b/src/pollypm/models.py
@@ -336,20 +336,22 @@ class StorageSettings:
     dataclass holds the config values the resolver feeds into
     :func:`pollypm.store.registry.get_store`.
 
-    ``backend`` — entry-point name. ``"sqlite"`` is the built-in default
-    registered by this package; third-party packages (e.g. the future
-    ``pollypm-store-postgres``) can register additional names.
+    ``backend`` — entry-point name. ``"postgres"`` is the canonical
+    default after the #1737 cutover (issue #1939); ``"sqlite"`` remains
+    registered for explicit opt-in (tests, legacy migration). Third-party
+    packages can register additional names.
     ``url`` — SQLAlchemy URL passed to the backend constructor. Empty
-    string means "derive from ``config.project.state_db``" —
-    ``sqlite:///<resolved-state-db-path>``.
+    string means "use the backend's own default" — for ``postgres`` that
+    is the DSN resolved by :func:`pollypm.storage.pg_pool.resolve_dsn`;
+    for ``sqlite`` it derives ``sqlite:///<resolved-state-db-path>``.
 
     ``pg`` / ``embedding`` — sub-section knobs for the Postgres backend
-    (#1737, Slice A). Defaults are safe to read on a sqlite install —
-    they're only consulted when ``backend == "postgres"`` or the
-    embedding writer fires.
+    (#1737, Slice A). Defaults are safe to read regardless of backend
+    selection — they're only consulted when the backend resolves to
+    postgres or the embedding writer fires.
     """
 
-    backend: str = "sqlite"
+    backend: str = "postgres"
     url: str = ""
     pg: PgStorageSettings = field(default_factory=PgStorageSettings)
     embedding: EmbeddingSettings = field(default_factory=EmbeddingSettings)

--- a/src/pollypm/plugins_builtin/project_planning/cli/project.py
+++ b/src/pollypm/plugins_builtin/project_planning/cli/project.py
@@ -443,15 +443,11 @@ def blocker_summary_cmd(
         )
         raise typer.Exit(code=1)
     project_path = Path(project_cfg.path)
-    db_path = _planner_db_path(project_path, config_path=config_path)
-    if not db_path.exists():
-        typer.echo(
-            f"Project {project!r} has no work-service DB at {db_path}. "
-            "Initialize the project first with `pm project plan` or "
-            "`pm task new`.",
-            err=True,
-        )
-        raise typer.Exit(code=1)
+    # #1941 — the pre-cutover gate required a per-project ``state.db``;
+    # on a pg-cutover workspace there is no such file and the command
+    # refused every legitimate invocation. Backend-aware ``get_store`` +
+    # ``create_work_service(config=cfg)`` now route through
+    # ``[storage].backend``, so any registered project is fair game.
 
     summary = ProjectBlockerSummary(
         project=project,
@@ -462,25 +458,20 @@ def blocker_summary_cmd(
         unblock_condition=unblock_when,
     )
 
-    from pollypm.store import SQLAlchemyStore
+    from pollypm.store import get_store
     from pollypm.work import create_work_service
 
-    store = SQLAlchemyStore(f"sqlite:///{db_path}")
-    try:
-        with create_work_service(
-            db_path=db_path, project_path=project_path,
-        ) as svc:
-            result = record_project_blocker_summary(
-                store=store,
-                work_service=svc,
-                summary=summary,
-                actor=actor,
-            )
-    finally:
-        try:
-            store.close()
-        except Exception:  # noqa: BLE001
-            pass
+    # Singleton — do NOT close() the store (see registry.get_store).
+    store = get_store(cfg)
+    with create_work_service(
+        project_path=project_path, config=cfg, project_key=project,
+    ) as svc:
+        result = record_project_blocker_summary(
+            store=store,
+            work_service=svc,
+            summary=summary,
+            actor=actor,
+        )
 
     typer.echo(f"Recorded blocker summary for {project} (event {result['event_id']}).")
     if result.get("task_id"):

--- a/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
+++ b/src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py
@@ -1983,27 +1983,30 @@ def _open_workspace_project_work_service(project: Any, services: Any) -> Any | N
 
 
 def _open_project_work_service(project: Any, services: Any) -> Any | None:
-    """Open a per-project ``SQLiteWorkService`` if its state.db exists.
+    """Open a backend-aware work service for ``project``.
 
-    Returns ``None`` when the project path has no state.db yet (fresh
-    registration, never-touched project) or when any open-time error
-    prevents connecting. Never raises — the sweeper skips silently and
-    moves on to the next project.
+    #1941 — drops the per-project ``state.db`` precondition + the
+    ``db_path=``-forced sqlite dispatch (which silently picked sqlite
+    even when ``config`` selected postgres, since the previous call
+    omitted ``config=``). Threads ``config`` from ``services`` so the
+    factory honours ``[storage].backend``. Never raises — the sweeper
+    skips silently and moves on to the next project.
     """
     project_path = getattr(project, "path", None)
     if project_path is None:
         return None
-    db_path = Path(project_path) / ".pollypm" / "state.db"
-    if not db_path.exists():
-        return None
     try:
         from pollypm.work import create_work_service
 
-        svc = create_work_service(db_path=db_path, project_path=Path(project_path))
+        svc = create_work_service(
+            project_path=Path(project_path),
+            config=getattr(services, "config", None),
+            project_key=getattr(project, "key", None),
+        )
     except Exception:  # noqa: BLE001
         logger.debug(
-            "task_assignment sweep: failed to open per-project DB at %s",
-            db_path, exc_info=True,
+            "task_assignment sweep: failed to open work service for %s",
+            project_path, exc_info=True,
         )
         return None
 

--- a/src/pollypm/store/registry.py
+++ b/src/pollypm/store/registry.py
@@ -63,16 +63,24 @@ _STORE_LOCK = threading.Lock()
 def _resolve_url(config: "PollyPMConfig") -> str:
     """Return the SQLAlchemy URL for ``config``.
 
-    Honours ``config.storage.url`` verbatim when set. Otherwise derives
-    ``sqlite:///<project.state_db>`` so the resolver always produces a
-    concrete URL — backends never have to re-implement the fallback.
-    The config parser already applies the same default, but we re-check
-    here so test doubles and hand-built configs still work.
+    Honours ``config.storage.url`` verbatim when set. Otherwise:
+
+    * For the sqlite backend, derives
+      ``sqlite:///<project.state_db>`` so the resolver always produces a
+      concrete URL — backends never have to re-implement the fallback.
+    * For the postgres backend (#1939), returns an empty string and
+      lets the pg pool resolver pick the DSN up from
+      ``[storage.pg].dsn`` / ``POLLYPM_PG_DSN``. Fabricating a
+      ``sqlite:///`` URL on a postgres install was the silent-fallback
+      failure mode the cutover was supposed to remove.
     """
     url = (config.storage.url or "").strip()
     if url:
         return url
-    return f"sqlite:///{config.project.state_db.resolve()}"
+    backend = (config.storage.backend or "").strip().lower()
+    if backend == "sqlite":
+        return f"sqlite:///{config.project.state_db.resolve()}"
+    return ""
 
 
 def _available_backends() -> list[str]:

--- a/src/pollypm/task_assignment_notify.py
+++ b/src/pollypm/task_assignment_notify.py
@@ -1047,25 +1047,30 @@ def _wire_session_manager(svc: Any, project_root: Path, services: Any) -> None:
 
 
 def _open_project_work_service(project: Any, services: Any) -> Any | None:
-    """Open a per-project ``SQLiteWorkService`` if its state DB exists."""
+    """Open a backend-aware work service for ``project``.
+
+    #1941 — drops the per-project ``state.db`` precondition and the
+    ``db_path=`` forced-sqlite dispatch. On a pg-cutover workspace the
+    per-project file no longer exists; gating the sweeper on
+    ``db_path.exists()`` skipped every project. The factory now
+    honours ``config.storage.backend``; the sqlite branch still
+    resolves a path via ``work.db_resolver``.
+    """
     project_path = getattr(project, "path", None)
     if project_path is None:
-        return None
-    db_path = Path(project_path) / ".pollypm" / "state.db"
-    if not db_path.exists():
         return None
     try:
         from pollypm.work import create_work_service
 
         svc = create_work_service(
-            db_path=db_path,
             project_path=Path(project_path),
             config=getattr(services, "config", None),
+            project_key=getattr(project, "key", None),
         )
     except Exception:  # noqa: BLE001
         logger.debug(
-            "task_assignment sweep: failed to open per-project DB at %s",
-            db_path,
+            "task_assignment sweep: failed to open work service for %s",
+            project_path,
             exc_info=True,
         )
         return None

--- a/src/pollypm/work/__init__.py
+++ b/src/pollypm/work/__init__.py
@@ -1,25 +1,31 @@
 # Work service: sealed work management for PollyPM.
-"""Public construction surface for the SQLite-backed work service.
+"""Public construction surface for the configured work-service backend.
 
 Canonical usage outside ``pollypm.work.*``::
 
     from pollypm.work import create_work_service
 
-    with create_work_service(project_path=project.path) as svc:
+    with create_work_service(project_path=project.path, config=config) as svc:
         ...
 
-The factory resolves the canonical DB path via
-:func:`pollypm.work.db_resolver.resolve_work_db_path` and constructs the
-:class:`pollypm.work.sqlite_service.SQLiteWorkService`.
+The factory reads ``config.storage.backend`` and dispatches to the
+matching backend implementation. After the #1737 cutover (issue #1939)
+the default is ``"postgres"`` — :class:`pollypm.work.pg_service.PgWorkService`,
+wired against :mod:`pollypm.storage.pg_pool`. ``"sqlite"`` remains
+registered for explicit opt-in (tests, legacy migration); it constructs
+:class:`pollypm.work.sqlite_service.SQLiteWorkService` against the path
+resolved by :func:`pollypm.work.db_resolver.resolve_work_db_path`.
 
-Direct construction of ``SQLiteWorkService`` from outside the work
+Direct construction of either concrete service from outside the work
 package is discouraged: it forces every callsite to know the on-disk
 layout (workspace-vs-per-project, dual-DB confusion, etc.) and bypasses
 future resolver enhancements (env overrides, fallbacks, telemetry).
 
-Escape valve: callers that genuinely need a non-canonical path (legacy
-migration, tests, explicit ``--db`` overrides) may pass ``db_path=...``
-explicitly. That makes the deviation visible at the callsite.
+Escape valve: callers that genuinely need a non-canonical sqlite path
+(legacy migration, tests, explicit ``--db`` overrides) may pass
+``db_path=...`` explicitly. That makes the deviation visible at the
+callsite AND forces sqlite dispatch — without an explicit ``db_path``
+the factory honours ``config.storage.backend``.
 """
 
 from pollypm.work.factory import create_work_service

--- a/src/pollypm/work/cli.py
+++ b/src/pollypm/work/cli.py
@@ -66,7 +66,15 @@ flow_app = typer.Typer(
 # Helpers
 # ---------------------------------------------------------------------------
 
-_DB_OPTION = typer.Option(".pollypm/state.db", "--db", help="Path to SQLite database.")
+_DB_OPTION = typer.Option(
+    ".pollypm/state.db",
+    "--db",
+    help=(
+        "Work-service connection: sqlite file path (default) or Postgres "
+        "DSN (``postgresql://…``). Default routes through "
+        "``[storage].backend`` (#1940)."
+    ),
+)
 _PROJECT_OPTION = typer.Option(None, "--project", "-p", help="Project filter.")
 _JSON_OPTION = typer.Option(False, "--json", help="Output as JSON.")
 
@@ -194,9 +202,69 @@ def _project_from_task_id(task_id: str) -> str | None:
     return None
 
 
+def _config_with_pg_dsn_override(config: object | None, dsn: str) -> object:
+    """Return a config-shaped object that forces ``backend='postgres'`` + ``dsn``.
+
+    The factory + pg pool resolver both read ``config.storage.backend``
+    and ``config.storage.pg.dsn``. When ``--db`` is a Postgres DSN
+    (#1940) we want to honour the DSN override without making the
+    operator edit their ``pollypm.toml``. We build a thin override on
+    top of the loaded config so other config knobs (projects, plugin
+    settings) remain visible to session-manager wiring downstream.
+
+    When the base ``config`` is ``None`` (config-load failed), fall
+    through to a minimal shim that carries just enough for the factory
+    + pg pool to dispatch.
+    """
+    import dataclasses
+
+    if config is not None:
+        storage = getattr(config, "storage", None)
+        pg = getattr(storage, "pg", None) if storage is not None else None
+        if storage is not None and pg is not None:
+            try:
+                new_pg = dataclasses.replace(pg, dsn=dsn.strip())
+                new_storage = dataclasses.replace(
+                    storage, backend="postgres", pg=new_pg,
+                )
+                return dataclasses.replace(config, storage=new_storage)
+            except TypeError:
+                # ``config`` / ``storage`` may not be a dataclass in test
+                # doubles — fall through to the minimal shim below.
+                pass
+
+    class _PgOverridePg:
+        __slots__ = ("dsn", "pool_min", "pool_max", "min_version")
+
+        def __init__(self, dsn: str) -> None:
+            self.dsn = dsn
+            self.pool_min = 1
+            self.pool_max = 10
+            self.min_version = "16.0"
+
+    class _PgOverrideStorage:
+        __slots__ = ("backend", "url", "pg")
+
+        def __init__(self, dsn: str) -> None:
+            self.backend = "postgres"
+            self.url = ""
+            self.pg = _PgOverridePg(dsn)
+
+    class _PgOverrideConfig:
+        __slots__ = ("storage", "projects", "project")
+
+        def __init__(self, dsn: str) -> None:
+            self.storage = _PgOverrideStorage(dsn)
+            self.projects = {}
+            self.project = None
+
+    return _PgOverrideConfig(dsn.strip())
+
+
 def _svc(db: str, project: str | None = None) -> "WorkService":
     import atexit
 
+    from pollypm.storage.pg_pool import _looks_like_pg_dsn
     from pollypm.work.db_resolver import WORKSPACE_DEFAULT_DB_PATH
     from pollypm.work.factory import create_work_service
     from pollypm.work.sync import SyncManager
@@ -215,17 +283,41 @@ def _svc(db: str, project: str | None = None) -> "WorkService":
     except Exception:  # noqa: BLE001
         config_obj = None
 
-    # ``--db`` is the explicit test / CI escape hatch — a non-default
-    # value means the caller is pinning a specific sqlite file. The
-    # factory normally ignores ``db_path`` on the pg backend, so honour
-    # the override by routing through sqlite dispatch even when config
-    # selects postgres. ``config_obj`` is kept around for the
-    # SessionManager wiring below.
-    backend_config: object | None = config_obj
-    if db != WORKSPACE_DEFAULT_DB_PATH:
-        backend_config = None
+    # #1940 — ``--db`` now accepts either a sqlite path (the canonical
+    # escape hatch for tests / CI) or a Postgres DSN (``postgresql://…``).
+    # Default value routes through ``[storage].backend`` so a pg-configured
+    # workspace transparently lands on the pg pool.
+    db_is_default = db == WORKSPACE_DEFAULT_DB_PATH
+    db_is_pg_dsn = _looks_like_pg_dsn(db)
 
-    db_path = _resolve_db_path(db, project=project)
+    if db_is_pg_dsn:
+        # Synthesize a pg-pinned config that carries the override DSN so
+        # the factory's pg dispatch sees the explicit override. Other
+        # config knobs (project paths, etc.) come from ``config_obj`` so
+        # session-manager wiring downstream still works.
+        backend_config = _config_with_pg_dsn_override(config_obj, db)
+        db_path_for_factory: Path | None = None
+    elif not db_is_default:
+        # Sqlite escape hatch: explicit non-default filesystem path.
+        # Force sqlite dispatch by passing ``config=None`` AND a
+        # concrete ``db_path``; the factory honours the override even
+        # when the configured backend is postgres.
+        backend_config = None
+        db_path_for_factory = _resolve_db_path(db, project=project)
+    else:
+        # Canonical default: honour the configured backend. Pass
+        # ``db_path=None`` so the pg branch isn't forced down sqlite by
+        # the explicit-override rule introduced for #1939.
+        backend_config = config_obj
+        db_path_for_factory = None
+
+    # Resolve a concrete sqlite path for ancillary wiring (sync adapter,
+    # session manager) even when the factory ultimately routes to pg —
+    # ``project_root`` derivation below relies on it.
+    db_path = _resolve_db_path(
+        db if not db_is_pg_dsn else WORKSPACE_DEFAULT_DB_PATH,
+        project=project,
+    )
     db_path.parent.mkdir(parents=True, exist_ok=True)
     db_derived_root = db_path.parent.parent
 
@@ -269,14 +361,16 @@ def _svc(db: str, project: str | None = None) -> "WorkService":
     sync.register(FileSyncAdapter(issues_root=project_root / "issues"))
 
     # Route through the factory so ``[storage] backend`` is honoured
-    # (#1369, #1737). ``db_path`` / ``project_path`` / ``sync_manager``
-    # are sqlite-only; the pg backend ignores them per the factory
-    # docstring. An explicit ``--db`` override forces sqlite dispatch
-    # (see ``backend_config`` above) so the test / CI escape hatch
-    # keeps working on machines whose ``pollypm.toml`` selects postgres.
+    # (#1369, #1737, #1940). ``db_path`` / ``project_path`` /
+    # ``sync_manager`` are sqlite-only; the pg backend ignores them per
+    # the factory docstring. Three dispatch modes (see above):
+    #   * ``--db`` is a pg DSN → factory routes to pg with the override.
+    #   * ``--db`` is a non-default sqlite path → factory routes to sqlite.
+    #   * ``--db`` is the canonical default → factory honours
+    #     ``config.storage.backend``.
     svc = create_work_service(
         config=backend_config,
-        db_path=db_path,
+        db_path=db_path_for_factory,
         project_path=project_root,
         project_key=project,
         sync_manager=sync,

--- a/src/pollypm/work/factory.py
+++ b/src/pollypm/work/factory.py
@@ -7,28 +7,31 @@ or heartbeat code is suspect — see issue #1369. Migrating those callers
 through this factory means the resolver is the single point of truth
 for "where does work data live".
 
-Backend dispatch (#1737, Slice A)
----------------------------------
+Backend dispatch (#1737, Slice A; #1939)
+----------------------------------------
 
 Reads ``config.storage.backend``:
 
-* ``"sqlite"`` (default) → :class:`pollypm.work.sqlite_service.SQLiteWorkService`,
+* ``"postgres"`` (default after #1737 cutover) →
+  :class:`pollypm.work.pg_service.PgWorkService`, wired against the
+  lazy pool singleton in :mod:`pollypm.storage.pg_pool`.
+* ``"sqlite"`` → :class:`pollypm.work.sqlite_service.SQLiteWorkService`,
   resolved via :func:`pollypm.work.db_resolver.resolve_work_db_path`.
-* ``"postgres"`` → :class:`pollypm.work.pg_service.PgWorkService`, wired
-  against the lazy pool singleton in :mod:`pollypm.storage.pg_pool`.
+  Retained for explicit opt-in (tests, legacy migration).
 
-Any other value falls through to sqlite so a fat-fingered backend
-string doesn't brick the CLI; the doctor's ``storage-backend`` check
-surfaces the typo through its own error path.
+Any other (unknown / fat-fingered) value falls through to ``postgres``
+so the cutover defaults stay consistent (#1939) — the doctor's
+``storage-backend`` check surfaces the typo through its own error path.
 
 Escape valve
 ------------
-A caller that genuinely needs a non-canonical path (legacy migration,
-explicit override, test fixture) may pass ``db_path=...`` directly.
-That keeps the callsite visibly different from the canonical pattern,
-which is the point: "this one is not using the resolver" should never
-be invisible. ``db_path`` is sqlite-specific and is ignored on the pg
-backend.
+A caller that genuinely needs a non-canonical sqlite path (legacy
+migration, explicit override, test fixture) may pass ``db_path=...``
+directly. That keeps the callsite visibly different from the canonical
+pattern, which is the point: "this one is not using the resolver"
+should never be invisible. ``db_path`` is sqlite-specific and forces
+the sqlite dispatch even when ``config.storage.backend`` selects
+postgres.
 """
 
 from __future__ import annotations
@@ -46,20 +49,23 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_backend(config: "PollyPMConfig | None") -> str:
-    """Return the configured backend string, defaulting to ``"sqlite"``.
+    """Return the configured backend string, defaulting to ``"postgres"``.
 
     Reads ``config.storage.backend`` defensively — a missing attribute
-    or non-string value falls back to sqlite. The doctor's
-    ``storage-backend`` check surfaces real typos.
+    or non-string value falls back to postgres after the #1737 cutover
+    (issue #1939). The previous sqlite default silently routed
+    pg-configured workspaces to an empty sqlite shadow when a caller
+    omitted ``config=``; the doctor's ``storage-backend`` check surfaces
+    real typos through its own error path.
     """
     if config is None:
-        return "sqlite"
+        return "postgres"
     storage = getattr(config, "storage", None)
     if storage is None:
-        return "sqlite"
-    backend = getattr(storage, "backend", "sqlite")
+        return "postgres"
+    backend = getattr(storage, "backend", "postgres")
     if not isinstance(backend, str) or not backend.strip():
-        return "sqlite"
+        return "postgres"
     return backend.strip()
 
 
@@ -104,12 +110,19 @@ def create_work_service(
         instance. The concrete type depends on the configured backend.
     """
     backend = _resolve_backend(config)
-    if backend == "postgres":
+    # An explicit ``db_path`` is the sqlite escape hatch (#1939 / #1369).
+    # It's sqlite-specific by construction (a filesystem path), so a
+    # caller that supplied one is asking for sqlite regardless of the
+    # configured backend. This preserves the test / CI / legacy-migration
+    # contract without re-introducing the silent-fallback failure mode
+    # that #1939 was filed to close.
+    if db_path is None and backend != "sqlite":
         from pollypm.work.pg_service import PgWorkService
 
         return PgWorkService(config=config, project_key=project_key)
 
-    # sqlite (the default, and the fallback for unknown backends).
+    # sqlite path: either ``backend == "sqlite"`` or an explicit
+    # ``db_path=`` override forced us here.
     from pollypm.work.sqlite_service import SQLiteWorkService
 
     resolved_path: Path

--- a/src/pollypm/work/inbox_cli.py
+++ b/src/pollypm/work/inbox_cli.py
@@ -252,19 +252,20 @@ def _resolve_messages_store(db: str) -> Any:
     """Return the configured-backend ``Store`` for the inbox CLI.
 
     Mirrors the :func:`pollypm.work.cli._svc` backend dispatch (#1369,
-    #1737, #1811) so ``pm inbox`` and its bulk-archive helpers read the
-    same messages corpus as the rest of the system:
+    #1737, #1811, #1940) so ``pm inbox`` and its bulk-archive helpers
+    read the same messages corpus as the rest of the system:
 
     * When ``--db`` is the canonical workspace default
       (``.pollypm/state.db``), route through
       :func:`pollypm.store.get_store` so the active backend
       (``[storage].backend = "sqlite"`` vs ``"postgres"``) decides
       whether reads land on the sqlite file or the pg pool.
-    * When ``--db`` is a non-default override — the explicit test / CI
-      escape hatch — pin to sqlite at the supplied path via
-      :func:`pollypm.store.get_store_by_url` so harness tests with a
-      bespoke ``state.db`` keep working even on a machine whose
-      ``pollypm.toml`` selects postgres.
+    * When ``--db`` is a Postgres DSN (``postgresql://…``, #1940),
+      pin to the pg backend at the supplied DSN via
+      :func:`pollypm.store.get_store_by_url`.
+    * When ``--db`` is any other non-default value, treat it as a
+      sqlite path override — the explicit test / CI escape hatch —
+      and pin to sqlite at the supplied path.
 
     The returned ``Store`` is a process-wide singleton — callers MUST
     NOT ``close()`` it (see :func:`pollypm.store.registry.get_store`
@@ -273,7 +274,13 @@ def _resolve_messages_store(db: str) -> Any:
     went un-served; this helper closes that gap for the rest of the
     ``pm inbox`` surface (#1790).
     """
+    from pollypm.storage.pg_pool import _looks_like_pg_dsn
     from pollypm.work.db_resolver import WORKSPACE_DEFAULT_DB_PATH
+
+    if _looks_like_pg_dsn(db):
+        from pollypm.store import get_store_by_url
+
+        return get_store_by_url(db.strip(), backend="postgres")
 
     if db != WORKSPACE_DEFAULT_DB_PATH:
         from pollypm.store import get_store_by_url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,7 +148,7 @@ pytest_plugins = ["tests.conftest_pg"]
 
 
 # ----------------------------------------------------------------------
-# Work-service backend dispatch (issue #1737, Slice F)
+# Work-service backend dispatch (issue #1737, Slice F; #1942)
 # ----------------------------------------------------------------------
 #
 # The ``work_service`` fixture below is the single entry point tests
@@ -156,15 +156,21 @@ pytest_plugins = ["tests.conftest_pg"]
 # which backend is providing it. Behaviour is controlled by an opt-in
 # ``@pytest.mark.backend(...)`` marker:
 #
-# * ``@pytest.mark.backend("sqlite")`` — force the sqlite path.
 # * ``@pytest.mark.backend("postgres")`` — force the pg path (requires
 #   the ``pg_schema_pool`` machinery in ``conftest_pg.py``; skipped if
-#   Docker / a local pg is unavailable).
+#   Docker / a local pg is unavailable). This is the default.
+# * ``@pytest.mark.backend("sqlite")`` — force the sqlite path.
+#   Retained for explicit opt-in (legacy coverage, migration tests).
 # * ``@pytest.mark.backend("both")`` — parameterise the test against
 #   both backends; the test runs twice and the active backend is
 #   identifiable via ``request.node.callspec.id``.
-# * No marker — sqlite. Slice K (the ripout) flips this default to pg
-#   and deletes the sqlite branch.
+# * No marker — postgres (#1942 default flip). The pre-cutover default
+#   was sqlite, which let large parts of the suite continue exercising
+#   the removed backend long after the #1737 cutover; unknown-marker
+#   typos also fell back to sqlite and silently masked pg regressions.
+#
+# Unknown backend markers now raise ``pytest.UsageError`` so a typo
+# fails the run instead of silently routing through a different backend.
 #
 # Tests that need the concrete service class (i.e. that today instantiate
 # ``SQLiteWorkService(...)`` directly) should migrate to the dispatch
@@ -173,7 +179,12 @@ pytest_plugins = ["tests.conftest_pg"]
 
 
 def _build_sqlite_work_service(tmp_path):
-    """Build a fresh ``SQLiteWorkService`` against a tmp-path DB."""
+    """Build a fresh ``SQLiteWorkService`` against a tmp-path DB.
+
+    Retained for ``@pytest.mark.backend('sqlite')`` opt-in coverage.
+    New tests should not reach for this path without a deliberate
+    reason — the production runtime is pg-only post-cutover (#1737).
+    """
     from pollypm.work.sqlite_service import SQLiteWorkService
 
     return SQLiteWorkService(db_path=tmp_path / "work.db")
@@ -190,27 +201,24 @@ def _build_pg_work_service(request):
 
 
 def _resolve_backend_marker(request) -> str:
-    """Read the ``@pytest.mark.backend(...)`` marker, default ``sqlite``.
+    """Read the ``@pytest.mark.backend(...)`` marker, default ``postgres``.
 
     Returns the marker argument as a lowercase string. Unknown values
-    fall back to sqlite so a typo doesn't silently route to the wrong
-    backend — the dispatch path logs a warning when this happens.
+    raise ``pytest.UsageError`` so a typo fails the run rather than
+    silently routing to the wrong backend. Missing marker → postgres
+    after the #1942 default flip; the pre-cutover default was sqlite.
     """
     marker = request.node.get_closest_marker("backend")
     if marker is None:
-        return "sqlite"
+        return "postgres"
     if not marker.args:
-        return "sqlite"
+        return "postgres"
     raw = str(marker.args[0]).strip().lower()
     if raw not in {"sqlite", "postgres", "both"}:
-        import warnings
-
-        warnings.warn(
-            f"Unknown @pytest.mark.backend({marker.args[0]!r}); "
-            "defaulting to 'sqlite'. Valid values: 'sqlite', 'postgres', 'both'.",
-            stacklevel=2,
+        raise pytest.UsageError(
+            f"Unknown @pytest.mark.backend({marker.args[0]!r}). "
+            "Valid values: 'sqlite', 'postgres', 'both'."
         )
-        return "sqlite"
     return raw
 
 
@@ -230,11 +238,11 @@ def work_service(request, tmp_path):
         # parametrize hook below — when this fixture is invoked under a
         # ``both`` marker, the parametrize layer has already picked one
         # of ``sqlite`` / ``postgres`` and stashed it on the request.
-        chosen = getattr(request, "param", "sqlite")
+        chosen = getattr(request, "param", "postgres")
         backend = chosen
-    if backend == "postgres":
-        return _build_pg_work_service(request)
-    return _build_sqlite_work_service(tmp_path)
+    if backend == "sqlite":
+        return _build_sqlite_work_service(tmp_path)
+    return _build_pg_work_service(request)
 
 
 def pytest_generate_tests(metafunc):


### PR DESCRIPTION
## Summary

Codex audited the PG cutover (#1737) and found four places where SQLite remained the silent default or the only escape hatch. This PR closes all four in one bundle, one commit per issue:

- **#1939** — Config / store / work-service defaults silently chose SQLite. Flips the default backend to ``"postgres"`` at every layer (``models.StorageSettings``, ``config._parse_storage_settings``, ``store.registry._resolve_url``, ``work.factory._resolve_backend``). Unknown / missing-config callsites now resolve to pg; sqlite stays registered as the explicit opt-in via ``db_path=`` (factory escape valve) and the ``sqlite`` entry point.
- **#1940** — CLI ``--db`` escape hatch was sqlite-only by construction. ``--db`` now accepts a sqlite path (default + canonical override) or a Postgres DSN (``postgresql://…``). ``_svc`` / ``_resolve_messages_store`` / ``_resolve_notify_store`` all dispatch three-way: pg DSN → ``get_store_by_url(dsn, backend='postgres')`` (or pg-pinned factory config), non-default sqlite path → sqlite-pinned ``get_store_by_url``, canonical default → ``get_store(load_config())``.
- **#1941** — Cockpit and plugin paths opened ``SQLAlchemyStore(sqlite:///{db_path})`` directly against per-project ``state.db`` files. ``action_archive_selected``, the post-completion message archive, ``_emit_event``, ``_dashboard_inbox_collect_messages``, and ``_dashboard_discover_db_aliases`` in ``cockpit_ui.py`` now route through ``get_store(load_config(...))`` / ``create_work_service(config=...)``. The task-assignment sweeper (both the legacy module and the plugin handler) and ``pm project blocker-summary`` drop the per-project ``state.db.exists()`` precondition and the forced sqlite ``db_path=`` dispatch.
- **#1942** — The pytest ``work_service`` dispatch fixture defaulted to sqlite and silently accepted unknown markers. Flipped to default pg; unknown ``@pytest.mark.backend(...)`` values now raise ``pytest.UsageError`` instead of warning + falling through. Sqlite stays available only via the explicit ``@pytest.mark.backend('sqlite')`` opt-in.

## Test plan

- [x] ``ruff check`` clean on every touched file outside ``cockpit_ui.py`` (verified locally).
- [x] ``ruff check`` on ``cockpit_ui.py`` produces no NEW violations relative to ``origin/main`` (49 pre-existing errors, count unchanged).
- [ ] CI: pytest suite (skipped locally per v1 RC stability priority + worktree harness limits).
- [ ] Manual: ``pm task list --db postgresql://…`` succeeds on a pg-only workspace.
- [ ] Manual: ``pm inbox`` / ``pm notify`` on a pg-configured workspace land on the live pg pool.
- [ ] Manual: ``pm project blocker-summary <proj>`` works on a pg workspace without a per-project ``state.db``.

## Notes

- v1 RC stability — surgical, additive changes only. The backend-aware tripwire (``tests/test_pg_cli_coverage_tripwire.py``) still guards against re-introducing direct ``SQLAlchemyStore("sqlite:///")`` constructions.
- The ``pyproject.toml`` ``sqlite`` entry point under ``pollypm.store_backend`` stays registered — sqlite remains a valid backend selection, just no longer the silent default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)