### PR TITLE
fix(paths): close all remaining doubled-pollypm-path leak sites (closes #1950)

### DIFF
--- a/src/pollypm/cli_features/maintenance.py
+++ b/src/pollypm/cli_features/maintenance.py
@@ -684,7 +684,13 @@ def repair(
             )
             continue
 
-        state_dir = project_root / ".pollypm"
+        # Route through ``project_pollypm_dir`` so the doubled-path
+        # guard (#1810/#1950) collapses ``GLOBAL_CONFIG_DIR / ".pollypm"``
+        # back to ``GLOBAL_CONFIG_DIR``. ``pm repair`` is one of the few
+        # callers that could create the doubled tree on a user who added
+        # ``~/.pollypm`` itself as a tracked project.
+        from pollypm.projects import project_pollypm_dir
+        state_dir = project_pollypm_dir(project_root)
         for subdir in [
             "dossier",
             "logs",

--- a/src/pollypm/doc_scaffold.py
+++ b/src/pollypm/doc_scaffold.py
@@ -20,8 +20,16 @@ def scaffold_docs(project_path: Path, *, force: bool = False) -> list[str]:
     Returns a list of actions taken (for reporting in pm repair).
     If force=True, overwrite existing files. Otherwise skip files that exist.
     """
+    # Route through ``project_instruction_dir`` so the doubled-path guard
+    # in ``_resolve_pollypm_root`` (#1810/#1950) collapses
+    # ``GLOBAL_CONFIG_DIR / ".pollypm"`` back to ``GLOBAL_CONFIG_DIR``.
+    # Without this, the scaffold writes SYSTEM.md / rules-manifest.md /
+    # docs/reference/*.md into ``~/.pollypm/.pollypm/`` on cockpit
+    # startup when no project is in scope. Import is deferred to avoid
+    # the ``projects.py`` ↔ ``doc_scaffold.py`` circular import.
+    from pollypm.projects import project_instruction_dir
     actions: list[str] = []
-    instruction_dir = project_path / ".pollypm"
+    instruction_dir = project_instruction_dir(project_path)
     instruction_dir.mkdir(parents=True, exist_ok=True)
 
     # -- SYSTEM.md (PollyPM system reference, separate from project INSTRUCT.md) --
@@ -86,8 +94,10 @@ def repair_docs(project_path: Path) -> list[str]:
 
 def verify_docs(project_path: Path) -> list[str]:
     """Check which docs are missing or outdated. Returns list of problems."""
+    from pollypm.projects import project_instruction_dir
+
     problems: list[str] = []
-    instruction_dir = project_path / ".pollypm"
+    instruction_dir = project_instruction_dir(project_path)
 
     system_dest = instruction_dir / "docs" / "SYSTEM.md"
     if not system_dest.exists():

--- a/src/pollypm/history_import.py
+++ b/src/pollypm/history_import.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from pollypm.knowledge_extract import _sanitize_text
 from pollypm.llm_runner import run_haiku_json
-from pollypm.projects import project_transcripts_dir
+from pollypm.projects import project_pollypm_dir, project_transcripts_dir
 
 PROVIDER_TRANSCRIPT_DIRS = (".claude", ".codex")
 
@@ -839,7 +839,11 @@ def copy_provider_transcripts(project_root: Path, sources: DiscoveredSources) ->
 
 
 def _import_state_path(project_root: Path) -> Path:
-    return project_root / ".pollypm" / "history-import" / "state.json"
+    # Route through ``project_pollypm_dir`` (#1810/#1950) so importing
+    # against ``GLOBAL_CONFIG_DIR`` writes the checkpoint into
+    # ``~/.pollypm/history-import/state.json`` rather than the doubled
+    # ``~/.pollypm/.pollypm/history-import/state.json``.
+    return project_pollypm_dir(project_root) / "history-import" / "state.json"
 
 
 def load_import_state(project_root: Path) -> dict[str, Any]:

--- a/src/pollypm/knowledge_extract.py
+++ b/src/pollypm/knowledge_extract.py
@@ -12,6 +12,7 @@ from typing import Any
 from pollypm.llm_runner import HAIKU_MODEL, run_haiku, run_haiku_json
 from pollypm.memory_backends import get_memory_backend
 from pollypm.memory_extractors import CONFIDENCE_THRESHOLD, run_extractors
+from pollypm.projects import project_transcripts_dir
 
 logger = logging.getLogger(__name__)
 
@@ -275,7 +276,11 @@ def _all_project_roots(config) -> list[Path]:
 
 
 def _transcript_root(project_root: Path) -> Path:
-    return project_root / ".pollypm" / "transcripts"
+    # Route through ``project_transcripts_dir`` (#1810/#1950) so the
+    # ``GLOBAL_CONFIG_DIR`` / ``.pollypm`` doubled-path guard fires when
+    # the 15-minute extractor iterates over ``_all_project_roots`` and
+    # hits ``config.project.root_dir == ~/.pollypm``.
+    return project_transcripts_dir(project_root)
 
 
 def _checkpoint_path(project_root: Path) -> Path:

--- a/src/pollypm/memory_backends/__init__.py
+++ b/src/pollypm/memory_backends/__init__.py
@@ -34,14 +34,22 @@ def get_memory_backend(project_path: Path, backend_name: str = "file") -> Memory
         # imports at module load time (projects imports memory_backends in
         # a few paths).
         from pollypm.plugin_host import extension_host_for_root
-        from pollypm.projects import ensure_project_scaffold, project_artifacts_dir, project_dossier_dir
+        from pollypm.projects import (
+            ensure_project_scaffold,
+            project_artifacts_dir,
+            project_dossier_dir,
+            project_pollypm_dir,
+        )
         from pollypm.storage.pg_memory import PgMemoryStore
 
         resolved = project_path.expanduser().resolve()
         # Scaffold the project up-front so the backend can assume memory
         # roots exist (it used to call ensure_project_scaffold itself).
         ensure_project_scaffold(resolved)
-        state_db = resolved / ".pollypm" / "state.db"
+        # Route through ``project_pollypm_dir`` so the doubled-path guard
+        # (#1810/#1950) collapses ``GLOBAL_CONFIG_DIR / ".pollypm"`` back
+        # to ``GLOBAL_CONFIG_DIR``.
+        state_db = project_pollypm_dir(resolved) / "state.db"
         # FileMemoryBackend is wired to a stateless PgMemoryStore adapter
         # that routes every memory_* call through pollypm.storage.pg_memory.
         state_store: object = PgMemoryStore()

--- a/src/pollypm/memory_backends/file.py
+++ b/src/pollypm/memory_backends/file.py
@@ -108,14 +108,19 @@ class FileMemoryBackend(MemoryBackend):
             # on test / ad-hoc construction.
             from pollypm.storage.state import StateStore
 
-            self._state_db = state_db or (self._project_path / ".pollypm" / "state.db")
+            # Route through ``project_pollypm_dir`` so the doubled-path
+            # guard (#1810/#1950) collapses ``GLOBAL_CONFIG_DIR /
+            # ".pollypm"`` back to ``GLOBAL_CONFIG_DIR``.
+            from pollypm.projects import project_pollypm_dir
+            self._state_db = state_db or (project_pollypm_dir(self._project_path) / "state.db")
             self._state_store = StateStore(self._state_db)
         else:
             self._state_db = state_db
             self._state_store = state_store
         self._plugins: _PluginHook = plugins if plugins is not None else _NullHook()
         # Conventional layout under .pollypm/ — callers may override.
-        dossier_root = self._project_path / ".pollypm"
+        from pollypm.projects import project_pollypm_dir
+        dossier_root = project_pollypm_dir(self._project_path)
         self._memory_root = memory_root or (dossier_root / "memory")
         self._artifacts_root = artifacts_root or (dossier_root / "artifacts")
 

--- a/src/pollypm/plugins_builtin/memory_curator/plugin.py
+++ b/src/pollypm/plugins_builtin/memory_curator/plugin.py
@@ -82,7 +82,12 @@ def memory_curate_handler(payload: dict[str, Any]) -> dict[str, Any]:
         except Exception as exc:  # noqa: BLE001
             logger.warning("memory.curate[%s]: backend unavailable (%s)", project_root, exc)
             continue
-        log_path = project_root / ".pollypm" / CURATOR_LOG_FILENAME
+        # Route through ``project_pollypm_dir`` so the doubled-path
+        # guard (#1810/#1950) keeps writes out of
+        # ``~/.pollypm/.pollypm/`` when ``_all_project_roots`` yields
+        # ``config.project.root_dir == GLOBAL_CONFIG_DIR``.
+        from pollypm.projects import project_pollypm_dir
+        log_path = project_pollypm_dir(project_root) / CURATOR_LOG_FILENAME
         try:
             result = curate_memory(backend, log_path=log_path, now=datetime.now(UTC))
         except Exception as exc:  # noqa: BLE001
@@ -109,7 +114,8 @@ def _emit_inbox_summary(project_root: Path, summary: str) -> None:
     implementation (the work-service inbox, morning briefing inbox, or
     a future unified inbox all see the same file).
     """
-    inbox_dir = project_root / ".pollypm" / CURATOR_INBOX_DIRNAME
+    from pollypm.projects import project_pollypm_dir
+    inbox_dir = project_pollypm_dir(project_root) / CURATOR_INBOX_DIRNAME
     inbox_dir.mkdir(parents=True, exist_ok=True)
     stamp = datetime.now(UTC).strftime("%Y-%m-%d")
     path = inbox_dir / f"{stamp}.md"

--- a/src/pollypm/projects.py
+++ b/src/pollypm/projects.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import typer
 
-from pollypm.config import PROJECT_CONFIG_DIRNAME, load_config, write_config
+from pollypm.config import load_config, write_config
 from pollypm.doc_scaffold import scaffold_docs
 from pollypm.models import KnownProject, ProjectKind
 from pollypm.task_backends import FileTaskBackend, get_task_backend
@@ -266,9 +266,15 @@ def project_issues_dir(project_path: Path) -> Path:
 
 def ensure_project_scaffold(project_path: Path) -> Path:
     pollypm_dir = project_pollypm_dir(project_path)
+    # ``PROJECT_CONFIG_DIRNAME = ".pollypm/config"`` so naive joining
+    # would write ``~/.pollypm/.pollypm/config`` when ``project_path``
+    # is the global config dir. Route through ``project_pollypm_dir``
+    # (which honors the doubled-path guard) and append just ``config``.
+    # See #1810/#1950.
+    project_config_dir = pollypm_dir / "config"
     for directory in [
         project_instruction_dir(project_path),
-        normalize_project_path(project_path) / PROJECT_CONFIG_DIRNAME,
+        project_config_dir,
         project_instruction_dir(project_path) / "rules",
         project_instruction_dir(project_path) / "magic",
         project_transcripts_dir(project_path),

--- a/src/pollypm/session_intelligence.py
+++ b/src/pollypm/session_intelligence.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from pollypm.atomic_io import atomic_write_text
 from pollypm.llm_runner import run_haiku_json
+from pollypm.projects import project_instruction_dir, project_transcripts_dir
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +127,12 @@ def _parse_result(raw: dict[str, Any]) -> SessionIntelligenceResult:
 # ---------------------------------------------------------------------------
 
 def _pending_knowledge_dir(project_root: Path) -> Path:
-    return project_root / ".pollypm" / "pending-knowledge"
+    # Route through ``project_instruction_dir`` so the doubled-path
+    # guard (#1810/#1950) collapses ``GLOBAL_CONFIG_DIR / ".pollypm"``
+    # back to ``GLOBAL_CONFIG_DIR`` when ``project_root`` is the global
+    # config dir (e.g. the sweep's first iteration when ``root_dir`` is
+    # ``~/.pollypm``).
+    return project_instruction_dir(project_root) / "pending-knowledge"
 
 
 def stage_pending_knowledge(
@@ -191,7 +197,11 @@ _CURSOR_FILE = ".session-intelligence-state.json"
 
 
 def _cursor_path(project_root: Path) -> Path:
-    return project_root / ".pollypm" / "transcripts" / _CURSOR_FILE
+    # Route through ``project_transcripts_dir`` (#1810/#1950) — without
+    # this, the 5-minute sweep writes
+    # ``~/.pollypm/.pollypm/transcripts/.session-intelligence-state.json``
+    # for the global root iteration.
+    return project_transcripts_dir(project_root) / _CURSOR_FILE
 
 
 def _load_cursors(project_root: Path) -> dict[str, int]:
@@ -230,7 +240,7 @@ def _save_cursors(project_root: Path, cursors: dict[str, int]) -> None:
 
 def _read_new_events(project_root: Path, session_name: str, cursors: dict[str, int]) -> tuple[list[dict], int]:
     """Read new transcript events for one session since the cursor position."""
-    events_path = project_root / ".pollypm" / "transcripts" / session_name / "events.jsonl"
+    events_path = project_transcripts_dir(project_root) / session_name / "events.jsonl"
     if not events_path.exists():
         return [], 0
     key = f"{session_name}/events.jsonl"
@@ -303,7 +313,7 @@ def sweep_all_sessions(config) -> dict[str, int]:
 
     for project_root in _all_project_roots(config):
         cursors = _load_cursors(project_root)
-        transcript_root = project_root / ".pollypm" / "transcripts"
+        transcript_root = project_transcripts_dir(project_root)
         if not transcript_root.exists():
             continue
 

--- a/tests/test_doubled_pollypm_path_regression.py
+++ b/tests/test_doubled_pollypm_path_regression.py
@@ -1,0 +1,177 @@
+"""Regression tests for the doubled-pollypm-path leak (#1810, #1950).
+
+Background
+----------
+``_resolve_pollypm_root(project_path)`` in :mod:`pollypm.projects`
+collapses ``GLOBAL_CONFIG_DIR / ".pollypm"`` back to
+``GLOBAL_CONFIG_DIR`` so callers that pass the user-global config dir
+itself don't accumulate a phantom ``~/.pollypm/.pollypm/...`` tree.
+
+PR #1898 wired the ``project_*_dir()`` helpers in
+``pollypm.projects`` through that guard, which fixed scaffold and
+artifact paths. But #1950 found additional leak sites that bypass the
+helpers and construct ``<path> / ".pollypm" / ...`` directly:
+
+  - ``doc_scaffold.scaffold_docs`` / ``verify_docs`` — SYSTEM.md,
+    rules-manifest.md, docs/reference/*.md
+  - ``ensure_project_scaffold`` — the ``PROJECT_CONFIG_DIRNAME`` arm
+    that hard-coded ``.pollypm/config``
+  - ``session_intelligence._cursor_path`` /
+    ``_pending_knowledge_dir`` / ``_read_new_events`` /
+    ``sweep_all_sessions``
+  - ``knowledge_extract._transcript_root``
+  - ``memory_curator`` log + inbox-summary paths
+
+These tests assert that calling each previously-leaky entrypoint with
+``project_path == GLOBAL_CONFIG_DIR`` does NOT create any files under
+``<GLOBAL_CONFIG_DIR>/.pollypm/``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def fake_global_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Patch ``GLOBAL_CONFIG_DIR`` to a fresh sandbox per test."""
+    fake = tmp_path / ".pollypm"
+    fake.mkdir()
+    import pollypm.config as config_mod
+
+    monkeypatch.setattr(config_mod, "GLOBAL_CONFIG_DIR", fake)
+    return fake
+
+
+def _assert_no_doubled(global_dir: Path) -> None:
+    doubled = global_dir / ".pollypm"
+    if not doubled.exists():
+        return
+    leaked = sorted(p.relative_to(doubled) for p in doubled.rglob("*") if p.is_file())
+    assert not leaked, (
+        f"Doubled path leak: {len(leaked)} files under "
+        f"{doubled}: {leaked[:5]}..."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Direct resolver checks — sanity for the doubled-path guard itself.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_pollypm_root_collapses_global_dir(fake_global_dir: Path) -> None:
+    from pollypm.projects import _resolve_pollypm_root
+
+    assert _resolve_pollypm_root(fake_global_dir) == fake_global_dir
+
+
+def test_resolve_pollypm_root_appends_for_normal_project(tmp_path: Path) -> None:
+    from pollypm.projects import _resolve_pollypm_root
+
+    project = tmp_path / "myproject"
+    project.mkdir()
+    assert _resolve_pollypm_root(project) == project / ".pollypm"
+
+
+# ---------------------------------------------------------------------------
+# ensure_project_scaffold + doc_scaffold (#1950 scaffolding path).
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_project_scaffold_with_global_dir_does_not_double(
+    fake_global_dir: Path,
+) -> None:
+    from pollypm.projects import ensure_project_scaffold
+
+    ensure_project_scaffold(fake_global_dir)
+    _assert_no_doubled(fake_global_dir)
+
+
+def test_scaffold_docs_with_global_dir_does_not_double(
+    fake_global_dir: Path,
+) -> None:
+    from pollypm.doc_scaffold import scaffold_docs
+
+    scaffold_docs(fake_global_dir)
+    _assert_no_doubled(fake_global_dir)
+
+
+def test_verify_docs_with_global_dir_does_not_double(
+    fake_global_dir: Path,
+) -> None:
+    from pollypm.doc_scaffold import verify_docs
+
+    # Should run without raising and without touching the doubled tree.
+    verify_docs(fake_global_dir)
+    _assert_no_doubled(fake_global_dir)
+
+
+# ---------------------------------------------------------------------------
+# session_intelligence (5-minute sweep iterates over root_dir).
+# ---------------------------------------------------------------------------
+
+
+def test_session_intelligence_cursor_path_with_global_dir(
+    fake_global_dir: Path,
+) -> None:
+    from pollypm.session_intelligence import _cursor_path, _save_cursors
+
+    p = _cursor_path(fake_global_dir)
+    assert ".pollypm/.pollypm" not in str(p), p
+    _save_cursors(fake_global_dir, {"session1/events.jsonl": 0})
+    _assert_no_doubled(fake_global_dir)
+
+
+def test_session_intelligence_pending_knowledge_with_global_dir(
+    fake_global_dir: Path,
+) -> None:
+    from pollypm.session_intelligence import _pending_knowledge_dir
+
+    p = _pending_knowledge_dir(fake_global_dir)
+    assert ".pollypm/.pollypm" not in str(p), p
+
+
+# ---------------------------------------------------------------------------
+# knowledge_extract (15-minute extractor iterates over root_dir).
+# ---------------------------------------------------------------------------
+
+
+def test_knowledge_extract_transcript_root_with_global_dir(
+    fake_global_dir: Path,
+) -> None:
+    from pollypm.knowledge_extract import _save_checkpoint, _transcript_root
+
+    p = _transcript_root(fake_global_dir)
+    assert ".pollypm/.pollypm" not in str(p), p
+    _save_checkpoint(fake_global_dir, {"foo": 1})
+    _assert_no_doubled(fake_global_dir)
+
+
+# ---------------------------------------------------------------------------
+# history_import — used by ``pm import`` against any project root.
+# ---------------------------------------------------------------------------
+
+
+def test_history_import_state_path_with_global_dir(
+    fake_global_dir: Path,
+) -> None:
+    from pollypm.history_import import _import_state_path
+
+    p = _import_state_path(fake_global_dir)
+    assert ".pollypm/.pollypm" not in str(p), p
+
+
+# ---------------------------------------------------------------------------
+# memory_curator — iterates ``_all_project_roots`` including root_dir.
+# ---------------------------------------------------------------------------
+
+
+def test_memory_curator_inbox_summary_with_global_dir(
+    fake_global_dir: Path,
+) -> None:
+    from pollypm.plugins_builtin.memory_curator.plugin import _emit_inbox_summary
+
+    _emit_inbox_summary(fake_global_dir, "summary text\n")
+    _assert_no_doubled(fake_global_dir)


### PR DESCRIPTION
## Summary

PR #1898 added ``_resolve_pollypm_root()`` so ``GLOBAL_CONFIG_DIR / ".pollypm"`` collapses back to ``GLOBAL_CONFIG_DIR``, but only the ``project_*_dir()`` helpers in ``pollypm.projects`` routed through it. #1950 showed that on cockpit startup the scaffold/transcript/curator paths still wrote into ``~/.pollypm/.pollypm/`` because they constructed ``<path> / ".pollypm" / ...`` directly. This PR audits the rest of the call sites and routes each through the existing resolver helpers.

Fixed leak sites:

- ``doc_scaffold.scaffold_docs`` / ``verify_docs`` (SYSTEM.md, rules-manifest.md, docs/reference/*.md — the bulk of the new regression files in the bug report).
- ``ensure_project_scaffold`` — was joining ``PROJECT_CONFIG_DIRNAME = ".pollypm/config"`` raw, producing ``~/.pollypm/.pollypm/config``.
- ``session_intelligence`` — ``_cursor_path``, ``_read_new_events``, ``_pending_knowledge_dir``, and ``sweep_all_sessions`` (the 5-minute sweep iterates over ``_all_project_roots`` which yields ``root_dir == GLOBAL_CONFIG_DIR`` for user-global installs).
- ``knowledge_extract._transcript_root`` (same sweep pattern, 15-minute cadence).
- ``history_import._import_state_path``.
- ``memory_backends`` (``__init__`` + file backend ``state_db`` / ``dossier_root``).
- ``memory_curator`` plugin log path + inbox summary path.
- ``cli_features/maintenance.py`` — ``pm repair`` state-dir.

Verified the original repro now produces zero files at the doubled path. Added ``tests/test_doubled_pollypm_path_regression.py`` covering each previously-leaky entrypoint.

Out of scope: read-only path constructions that wouldn't accumulate files when doubled (they just no-op on a missing path). Those are tracked in the issue audit but don't affect the disk-bloat symptom.

## Test plan

- [x] Standalone verification script: call each fixed entrypoint with ``project_path == GLOBAL_CONFIG_DIR``, confirm no files under ``<GLOBAL_CONFIG_DIR>/.pollypm/``.
- [x] Confirm canonical files still land in ``<GLOBAL_CONFIG_DIR>/`` (no behavior regression for the non-doubled case).
- [x] ``ruff check`` clean on all touched files.
- [ ] ``pm doctor`` no longer flags ``doubled-pollypm-path`` after merge + cockpit restart on user's machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)