### PR TITLE
fix(r7-regressions): notify --db pg dsn + get_store pg dsn precedence + claim-after-rollback + test guard scope (closes #1951 #1952 #1953 #1955)

### DIFF
--- a/src/pollypm/cli_features/session_runtime.py
+++ b/src/pollypm/cli_features/session_runtime.py
@@ -874,7 +874,16 @@ def _create_notify_inbox_task(
     :class:`PollyPMConfig` so ``[storage].backend = "postgres"`` lands
     on the pg pool. ``--db`` non-default values force sqlite dispatch
     via ``db_path`` (mirrors :func:`pollypm.work.cli._svc`).
+
+    #1951 — ``--db <pg-dsn>`` (``postgresql://…``) is treated like
+    :func:`pollypm.work.cli._svc`: synthesize a pg-pinned config carrying
+    the override DSN and call the factory with ``db_path=None`` so the
+    inbox-task row lands on the same Postgres backend as the message.
+    Without this, a non-default ``Path("postgresql://…")`` falls into
+    the sqlite branch (since ``db != WORKSPACE_DEFAULT_DB_PATH``) and
+    the immediate-priority fan-out splits message/task across backends.
     """
+    from pollypm.storage.pg_pool import _looks_like_pg_dsn
     from pollypm.work import create_work_service
     from pollypm.work.db_resolver import (
         WORKSPACE_DEFAULT_DB_PATH,
@@ -882,15 +891,27 @@ def _create_notify_inbox_task(
     )
 
     config_obj = None
-    if db == WORKSPACE_DEFAULT_DB_PATH:
-        try:
-            from pollypm.config import load_config
+    try:
+        from pollypm.config import load_config
 
-            config_obj = load_config()
-        except Exception:  # noqa: BLE001
-            config_obj = None
+        config_obj = load_config()
+    except Exception:  # noqa: BLE001
+        config_obj = None
 
-    if config_obj is not None:
+    if _looks_like_pg_dsn(db):
+        # #1951 — pg DSN override. Mirror ``pollypm.work.cli._svc``:
+        # build a pg-pinned config that carries the override DSN, then
+        # call the factory with ``db_path=None`` so the pg dispatch
+        # branch fires instead of being forced down sqlite by an
+        # explicit ``db_path``.
+        from pollypm.work.cli import _config_with_pg_dsn_override
+
+        backend_config = _config_with_pg_dsn_override(config_obj, db)
+        svc = create_work_service(
+            config=backend_config,
+            project_key=project,
+        )
+    elif db == WORKSPACE_DEFAULT_DB_PATH and config_obj is not None:
         svc = create_work_service(config=config_obj, project_key=project)
     else:
         db_path = resolve_work_db_path(db, project=None)

--- a/src/pollypm/store/registry.py
+++ b/src/pollypm/store/registry.py
@@ -68,11 +68,17 @@ def _resolve_url(config: "PollyPMConfig") -> str:
     * For the sqlite backend, derives
       ``sqlite:///<project.state_db>`` so the resolver always produces a
       concrete URL — backends never have to re-implement the fallback.
-    * For the postgres backend (#1939), returns an empty string and
-      lets the pg pool resolver pick the DSN up from
-      ``[storage.pg].dsn`` / ``POLLYPM_PG_DSN``. Fabricating a
-      ``sqlite:///`` URL on a postgres install was the silent-fallback
-      failure mode the cutover was supposed to remove.
+    * For the postgres backend (#1939), prefers ``[storage.pg].dsn``
+      (#1952) so the dedicated pg knob is honoured even when the legacy
+      shared ``[storage].url`` is blank. Falls back to an empty string,
+      which lets the pg pool resolver pick the DSN up from
+      ``POLLYPM_PG_DSN`` or the built-in default. Without this, a
+      workspace that set ``[storage.pg].dsn`` saw its work-service
+      writes route to the configured DB while ``get_store(config)``
+      message-store callers silently used the default DB — the
+      split-brain failure mode the sqlite ripout was meant to close.
+      Fabricating a ``sqlite:///`` URL on a postgres install was the
+      original silent-fallback failure the cutover removed.
     """
     url = (config.storage.url or "").strip()
     if url:
@@ -80,6 +86,17 @@ def _resolve_url(config: "PollyPMConfig") -> str:
     backend = (config.storage.backend or "").strip().lower()
     if backend == "sqlite":
         return f"sqlite:///{config.project.state_db.resolve()}"
+    if backend == "postgres":
+        # #1952 — honour ``[storage.pg].dsn`` so the dedicated pg knob
+        # routes ``get_store(config)`` to the same DSN that
+        # ``pollypm.storage.pg_pool.resolve_dsn`` would pick. Mirrors the
+        # priority order there: pg.dsn first, then the legacy shared
+        # ``[storage].url`` (already handled above when non-empty).
+        pg_section = getattr(config.storage, "pg", None)
+        if pg_section is not None:
+            pg_dsn = (getattr(pg_section, "dsn", "") or "").strip()
+            if pg_dsn:
+                return pg_dsn
     return ""
 
 

--- a/src/pollypm/work/pg_service.py
+++ b/src/pollypm/work/pg_service.py
@@ -1691,13 +1691,19 @@ class PgWorkService:
                 if _is_cap_exceeded_error(exc) and target_status is (
                     WorkStatus.IN_PROGRESS
                 ):
-                    self._rollback_claim_to_queued(
+                    rollback_committed = self._rollback_claim_to_queued(
                         task.project,
                         task.task_number,
                         node_id,
                         actor,
                         exc,
                     )
+                    if rollback_committed:
+                        # #1953 — refetch so the caller sees the
+                        # rolled-back row (queued, abandoned execution)
+                        # instead of the stale in_progress snapshot
+                        # captured pre-provisioning.
+                        result = self.get(task_id)
         return result
 
     def _rollback_claim_to_queued(
@@ -1707,7 +1713,7 @@ class PgWorkService:
         node_id: str,
         actor: str,
         exc: BaseException,
-    ) -> None:
+    ) -> bool:
         """Revert an in_progress claim back to queued (#1906).
 
         Postgres counterpart of
@@ -1715,6 +1721,11 @@ class PgWorkService:
         a failed rollback is logged so the operator still sees
         ``last_provision_error`` and can run ``pm task release``
         manually rather than silently wedging the task.
+
+        Returns ``True`` when the rollback committed so ``claim()`` can
+        refetch the queued row instead of returning the stale
+        in_progress snapshot it captured before provisioning fired
+        (#1953). ``False`` on rollback failure.
         """
         now = _now_iso()
         try:
@@ -1761,12 +1772,14 @@ class PgWorkService:
                 "post-commit provision failure (%s)",
                 project, task_number, exc,
             )
+            return True
         except Exception as rollback_exc:  # noqa: BLE001
             logger.warning(
                 "claim rollback failed for %s/%d: %s (task remains "
                 "in_progress; operator must release manually)",
                 project, task_number, rollback_exc,
             )
+            return False
 
     def next(  # noqa: A003
         self,

--- a/src/pollypm/work/service_transition_manager.py
+++ b/src/pollypm/work/service_transition_manager.py
@@ -645,6 +645,15 @@ class WorkTransitionManager:
 
         self._commit(_mutate)
 
+        # #1953 — ``_after_sync`` receives the post-commit Task snapshot
+        # that ``_finish`` reloads from the store. When the worker-cap
+        # rollback fires, that snapshot becomes stale (in_progress with
+        # an active execution) even though the DB row is back to
+        # queued/abandoned. Capture the rollback outcome via a closure
+        # cell so the outer claim() can refetch and return the fresh
+        # queued Task instead of the stale in_progress one.
+        rollback_committed = [False]
+
         def _after_sync(_: Task) -> None:
             self.service.last_provision_error = None
             if self.service._session_mgr is not None:
@@ -673,7 +682,7 @@ class WorkTransitionManager:
                     # that's left is reverting the work_tasks row + the
                     # active node execution so the next tick re-claims.
                     if _is_cap_exceeded_error(exc):
-                        self._rollback_claim_to_queued(
+                        rollback_committed[0] = self._rollback_claim_to_queued(
                             task, node_id, actor, exc,
                         )
 
@@ -682,6 +691,11 @@ class WorkTransitionManager:
             WorkStatus.QUEUED.value,
             after_sync=_after_sync,
         )
+        if rollback_committed[0]:
+            # #1953 — refetch so the caller sees the rolled-back row
+            # (queued, no active execution) instead of the stale
+            # in_progress snapshot ``_finish`` captured pre-rollback.
+            result = self.service.get(task_id)
         return result
 
     def _rollback_claim_to_queued(
@@ -690,7 +704,7 @@ class WorkTransitionManager:
         node_id: str,
         actor: str,
         exc: BaseException,
-    ) -> None:
+    ) -> bool:
         """Revert an in_progress claim back to queued (#1906).
 
         Called when post-commit ``provision_worker`` fails with a
@@ -703,6 +717,13 @@ class WorkTransitionManager:
         operator signal. Without the rollback the task is silently
         wedged; with a failed rollback the operator still sees the
         provision error and can run ``pm task release`` manually.
+
+        Returns ``True`` when the rollback committed successfully so
+        callers can refetch the now-queued task instead of returning
+        the stale in_progress snapshot they captured before
+        provisioning fired (#1953). ``False`` on rollback failure —
+        the row is still in_progress, the stale snapshot is still
+        accurate.
         """
         now = _now()
         try:
@@ -747,12 +768,14 @@ class WorkTransitionManager:
                 "post-commit provision failure (%s)",
                 task.project, task.task_number, exc,
             )
+            return True
         except Exception as rollback_exc:  # noqa: BLE001
             logger.warning(
                 "claim rollback failed for %s/%d: %s (task remains "
                 "in_progress; operator must release manually)",
                 task.project, task.task_number, rollback_exc,
             )
+            return False
 
     def cancel(self, task_id: str, actor: str, reason: str) -> Task:
         task = self.service.get(task_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -377,7 +377,8 @@ def _pytest_provenance_tokens() -> tuple[str, ...]:
       vars at ``pytest_configure`` time (``pollypm-pytest-<pid>``).
     - The conventional pytest tmp marker (``pytest-of-<user>``).
     - The literal ``tmp_path`` token, which appears in tracebacks /
-      transcripts when a test path leaks into rendered output.
+      transcripts when a test path leaks into rendered output (#1955 —
+      the docstring claimed this was in the list, but it wasn't).
     """
     tokens: list[str] = []
     tokens.append(f"pollypm-pytest-{os.getpid()}")
@@ -388,7 +389,77 @@ def _pytest_provenance_tokens() -> tuple[str, ...]:
     # CI runners where USER may not be populated; still pytest-specific
     # enough that no production cockpit code would emit it.
     tokens.append("pytest-of-")
+    # #1955 — the original docstring claimed ``tmp_path`` was in this
+    # list but the implementation never included it. A test that
+    # rendered ``tmp_path`` into a cockpit artifact and dropped it in
+    # the real ~/.pollypm/ would slip past the token check.
+    tokens.append("tmp_path")
     return tuple(tokens)
+
+
+def _live_cockpit_running() -> bool:
+    """Return True iff a live PollyPM cockpit appears to be running.
+
+    Checks ``~/.pollypm/rail_daemon.pid`` for a PID that names a live
+    process. When the cockpit is up, the home-write guard can't safely
+    treat every post-test write as a leak — the rail daemon and
+    heartbeat continuously stage checkpoints / snapshots / state.db
+    journals into the same dirs. Without this check we'd flag real
+    operator artifacts and unlink them mid-flight (the #1938
+    regression). When NO cockpit is running, any new file under
+    ``~/.pollypm/`` written during the test is by definition test
+    induced — that's the #1955 surface the original token-only guard
+    was missing.
+
+    Best-effort: a missing pid file, an unreadable pid value, or a
+    process-table probe that fails are all treated as "no live cockpit"
+    so the guard falls back to the stricter timestamp-based check.
+    """
+    pollypm_home = _real_pollypm_home()
+    if pollypm_home is None:
+        return False
+    pid_path = pollypm_home / "rail_daemon.pid"
+    try:
+        pid_text = pid_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return False
+    try:
+        pid = int(pid_text.splitlines()[0])
+    except (ValueError, IndexError):
+        return False
+    if pid <= 0:
+        return False
+    # ``os.kill(pid, 0)`` is the portable liveness probe — ``OSError``
+    # with ``errno == ESRCH`` means the PID is dead, ``EPERM`` means
+    # alive-but-not-ours (still alive). Anything else is treated as
+    # "can't tell, assume no cockpit" so the guard stays strict.
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+
+
+def _file_written_during_test(path: Path, test_start: float) -> bool:
+    """Return True iff ``path`` was created/modified after ``test_start``.
+
+    Uses ``mtime`` because it's the field PollyPM writers actually
+    update on each rewrite. ``ctime`` would catch the inode change too
+    but is platform-dependent. A stat race that loses the file is
+    treated as "not during the test" — the snapshot diff already proved
+    the path is new since pre-test, so the worst case is we miss a
+    single leak we'd otherwise have caught by mtime, never a false
+    positive.
+    """
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        return False
+    return mtime >= test_start
 
 
 def _looks_test_induced(path: Path, tokens: tuple[str, ...]) -> bool:
@@ -444,8 +515,18 @@ def _pollypm_home_write_guard(request):
     a test writing pytest-fixture paths into the real cockpit; that
     shape is still caught because the writes carry pytest provenance
     tokens (pytest-of-<user>, pollypm-pytest-<pid>, ``tmp_path``).
-    Files lacking those markers are logged as warnings but NOT
-    unlinked and do NOT fail the test.
+
+    #1955 — the #1938 narrowing was too aggressive: a test that
+    writes a plain artifact (no pytest token in path or content) to
+    the real ~/.pollypm/ silently passed. When no live PollyPM
+    cockpit is running, ANY new file written under ~/.pollypm/ during
+    the test is by definition test induced — we fail those regardless
+    of token presence. When a live cockpit IS running, we still
+    require either a pytest provenance token OR mtime evidence that
+    falls outside what a background writer could plausibly have done
+    in the test window; in practice the simpler signal there is the
+    token, so we keep the original token-only fallback to avoid
+    flagging real operator artifacts.
     """
     if request.node.get_closest_marker("allows_home_writes") is not None:
         yield
@@ -454,6 +535,8 @@ def _pollypm_home_write_guard(request):
     if pollypm_home is None:
         yield
         return
+    test_start = time.time()
+    cockpit_live = _live_cockpit_running()
     before = _snapshot_guarded_dirs(pollypm_home)
     yield
     after = _snapshot_guarded_dirs(pollypm_home)
@@ -468,7 +551,17 @@ def _pollypm_home_write_guard(request):
     leaks: list[str] = []
     unattributed: list[str] = []
     for path in candidates:
-        if _looks_test_induced(path, tokens):
+        token_match = _looks_test_induced(path, tokens)
+        # #1955 — when NO live cockpit is running, any file written
+        # during the test window is test induced (there's no other
+        # writer that could have produced it). When a cockpit IS
+        # running, fall back to the token-only check so we don't
+        # delete real background-process artifacts.
+        if token_match:
+            leaks.append(str(path))
+        elif not cockpit_live and _file_written_during_test(
+            path, test_start,
+        ):
             leaks.append(str(path))
         else:
             unattributed.append(str(path))


### PR DESCRIPTION
## Summary

Four Codex-found regressions on tonight's R5/R6 PRs (#1923/#1947/#1949). One PR, four commits.

- **#1951** — `pm notify --priority immediate --db postgresql://…` wrote the message to pg but created the linked inbox task on a fabricated sqlite file (`Path('postgresql://…')` normalized to `postgresql:/…`). `_create_notify_inbox_task` now mirrors `pollypm.work.cli._svc`: detects `_looks_like_pg_dsn(db)`, builds a pg-pinned config via `_config_with_pg_dsn_override`, and calls `create_work_service(config=…, project_key=…)` so the inbox row lands on the same backend as the message.
- **#1952** — `_resolve_url` returned `""` for the postgres backend whenever `[storage].url` was blank, so `PgStore(url="")` fell back to `POLLYPM_PG_DSN` or the built-in default. Workspaces that configured only `[storage.pg].dsn` saw split-brain routing: work-service writes hit the configured DB while message-store callers used the default. `_resolve_url` now mirrors the pg pool resolver priority (`pg.dsn` first, then `[storage].url`, then empty).
- **#1953** — After a post-commit worker-cap rollback, `claim()` returned the pre-rollback `in_progress` Task snapshot even though the DB row was reverted to `queued`/`abandoned`. `_rollback_claim_to_queued` now returns a `bool`; both the sqlite (`WorkTransitionManager.claim`) and pg (`PgWorkService.claim`) paths refetch when rollback committed.
- **#1955** — The #1938 narrowing only flagged home-dir leaks when a pytest provenance token (`pollypm-pytest-<pid>`, `pytest-of-<user>`) was present in the path or first 64 KiB of content. Tests that wrote plain content slipped through silently. The guard now detects a live cockpit via `~/.pollypm/rail_daemon.pid` + `os.kill(pid, 0)`; when no cockpit is running, any new file written under the guarded dirs during the test window is treated as a leak regardless of tokens. Also adds the literal `tmp_path` token the docstring claimed was already there.

## Test plan

- [ ] `pm notify --priority immediate --db postgresql://…` lands message AND inbox task on pg (no `postgresql:/…` directory created)
- [ ] `get_store(config)` with `[storage.pg].dsn` set + `[storage].url` blank returns a PgStore pinned to the configured DSN
- [ ] `claim()` after a forced `WorkerCapExceededError` returns `Task(work_status=queued)` with `abandoned` execution (matches a fresh `service.get(task_id)`)
- [ ] Test that writes a plain `~/.pollypm/.../leak.txt` (no tokens) fails the home-write guard when no cockpit is running, and is left alone when one is

🤖 Generated with [Claude Code](https://claude.com/claude-code)