### PR TITLE
perf(rail-r7): TTL contract + off-thread roster/inbox/static + batched scans (closes #1957 #1958 #1959 #1960 #1961)

### DIFF
--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -1341,6 +1341,55 @@ def _build_synthetic_storage_row(
 _WORKER_ROSTER_TTL_SECONDS = 1.0
 _WORKER_ROSTER_CACHE: dict[int, tuple[float, tuple["WorkerRosterRow", ...]]] = {}
 
+# #1958 perf — when the cached roster is stale, return the last-known
+# snapshot immediately and kick a single background refresh so the next
+# rail tick observes fresh data without the click/render path ever
+# blocking on a multi-second tmux/db/git sweep.
+#
+# The "in-flight" set is keyed on ``id(config)`` and guarded by a small
+# lock; we never enqueue two refreshes for the same config in parallel.
+# An empty cache (cold start) still falls through to the sync sweep so
+# the first tick can populate it — subsequent stale reads then surface
+# immediately while the background thread re-walks.
+import threading as _threading  # noqa: E402
+
+_WORKER_ROSTER_REFRESH_LOCK = _threading.Lock()
+_WORKER_ROSTER_REFRESH_INFLIGHT: set[int] = set()
+
+
+def _spawn_worker_roster_refresh(config) -> None:
+    """Kick a single background refresh of ``_gather_worker_roster``.
+
+    Used by callers that hold a stale snapshot and want fresh data on
+    the next rail tick without blocking the current click/render path.
+    Idempotent per ``id(config)``: concurrent calls coalesce.
+    """
+    import time as _time
+
+    cache_key = id(config)
+    with _WORKER_ROSTER_REFRESH_LOCK:
+        if cache_key in _WORKER_ROSTER_REFRESH_INFLIGHT:
+            return
+        _WORKER_ROSTER_REFRESH_INFLIGHT.add(cache_key)
+
+    def _refresh() -> None:
+        try:
+            result = _gather_worker_roster_uncached(config)
+            completed_at = _time.monotonic()
+            _WORKER_ROSTER_CACHE[cache_key] = (completed_at, tuple(result))
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            with _WORKER_ROSTER_REFRESH_LOCK:
+                _WORKER_ROSTER_REFRESH_INFLIGHT.discard(cache_key)
+
+    t = _threading.Thread(
+        target=_refresh,
+        name="worker-roster-refresh",
+        daemon=True,
+    )
+    t.start()
+
 
 def _gather_worker_roster(config) -> list[WorkerRosterRow]:
     """Walk every tracked project's work-service + tmux state.
@@ -1365,6 +1414,15 @@ def _gather_worker_roster(config) -> list[WorkerRosterRow]:
     now = _time.monotonic()
     cached = _WORKER_ROSTER_CACHE.get(cache_key)
     if cached is not None and now - cached[0] < _WORKER_ROSTER_TTL_SECONDS:
+        return list(cached[1])
+
+    # #1958 perf — if we have ANY prior snapshot, serve it immediately
+    # and refresh in the background. Only the first cold tick pays for
+    # the full per-project work-service + tmux + git-log sweep; every
+    # subsequent stale read returns the last-known roster instantly so
+    # the click/render path never blocks on the multi-second walk.
+    if cached is not None:
+        _spawn_worker_roster_refresh(config)
         return list(cached[1])
 
     result = _gather_worker_roster_uncached(config)

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -1368,6 +1368,10 @@ def _gather_worker_roster(config) -> list[WorkerRosterRow]:
         return list(cached[1])
 
     result = _gather_worker_roster_uncached(config)
+    # #1957 perf — stamp the cache AFTER the uncached sweep returns so a
+    # cold roster build that exceeds the TTL doesn't write a born-expired
+    # entry that forces the next rail tick to recompute.
+    completed_at = _time.monotonic()
     # Best-effort eviction so the cache doesn't grow across long-lived
     # processes with config reloads (each reload yields a fresh
     # ``id(config)``). Cheap because the dict is typically tiny — one
@@ -1375,10 +1379,10 @@ def _gather_worker_roster(config) -> list[WorkerRosterRow]:
     if len(_WORKER_ROSTER_CACHE) > 8:
         for stale_key in [
             k for k, (ts, _v) in _WORKER_ROSTER_CACHE.items()
-            if now - ts >= _WORKER_ROSTER_TTL_SECONDS
+            if completed_at - ts >= _WORKER_ROSTER_TTL_SECONDS
         ]:
             _WORKER_ROSTER_CACHE.pop(stale_key, None)
-    _WORKER_ROSTER_CACHE[cache_key] = (now, tuple(result))
+    _WORKER_ROSTER_CACHE[cache_key] = (completed_at, tuple(result))
     return result
 
 

--- a/src/pollypm/cockpit_pg_aggregates.py
+++ b/src/pollypm/cockpit_pg_aggregates.py
@@ -115,13 +115,17 @@ def all_tasks_grouped(
         return {key: list(rows) for key, rows in snapshot.items()}
 
     result = _all_tasks_grouped_uncached(config)
+    # #1957 perf — stamp the cache AFTER the uncached scan returns so a
+    # cold ``SELECT * FROM work_tasks`` that exceeds the TTL doesn't
+    # write a born-expired entry that forces the next caller to recompute.
+    completed_at = time.monotonic()
     # Best-effort eviction so the cache doesn't grow across long-lived
     # processes with config reloads (each reload yields a fresh
     # ``id(config)``).
     if len(_ALL_TASKS_GROUPED_CACHE) > 8:
         for stale_key in [
             k for k, (ts, _v) in _ALL_TASKS_GROUPED_CACHE.items()
-            if now - ts >= _ALL_TASKS_GROUPED_TTL_SECONDS
+            if completed_at - ts >= _ALL_TASKS_GROUPED_TTL_SECONDS
         ]:
             _ALL_TASKS_GROUPED_CACHE.pop(stale_key, None)
     snapshot = (
@@ -129,7 +133,7 @@ def all_tasks_grouped(
         if result is None
         else {key: tuple(rows) for key, rows in result.items()}
     )
-    _ALL_TASKS_GROUPED_CACHE[cache_key] = (now, snapshot)
+    _ALL_TASKS_GROUPED_CACHE[cache_key] = (completed_at, snapshot)
     return result
 
 

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -863,6 +863,13 @@ class CockpitRouter:
         self._project_categorizations_cache_key: int | None = None
         self._project_categorizations_cache: dict[str, str] | None = None
         self._project_categorizations_cached_at: float = 0.0
+        # #1961 perf — per-window-target ``list_panes`` cache so static
+        # rail click bursts don't each shell out to the same tmux
+        # subprocess. value: (cached_at_monotonic, panes_or_None).
+        # ``panes`` may be ``None`` when the underlying subprocess
+        # failed/timed-out; cached so a wedged tmux doesn't keep
+        # spawning more subprocesses inside the TTL window.
+        self._static_list_panes_cache: dict[str, tuple[float, object]] = {}
 
     def _presence(self) -> CockpitPresence:
         presence = getattr(self, "presence", None)
@@ -3270,6 +3277,17 @@ class CockpitRouter:
     # the click as sluggish.
     _ROUTE_TIMING_WARN_SECONDS: float = 0.25
 
+    # #1961 perf — static-route ``list_panes`` cache. Static rail clicks
+    # (Operator, Workers, Inbox, …) all share the same cockpit window
+    # target, so back-to-back clicks repeatedly shell out to the same
+    # ``tmux list-panes -t <session>:polly-cockpit`` subprocess. A short
+    # TTL cache collapses click bursts onto a single subprocess call
+    # without keeping stale layout data past the user's perception
+    # window. Set ``None`` to mark "tmux failed last time" so the static
+    # route still falls through to its safe ``show_static`` path on the
+    # repeat hit instead of a synthetic empty list.
+    _STATIC_LIST_PANES_TTL_SECONDS: float = 0.5
+
     def _route_supervisor_free_static(self, key: str) -> bool:
         if key not in self._SUPERVISOR_FREE_STATIC_KEYS:
             return False
@@ -3293,11 +3311,30 @@ class CockpitRouter:
         # #1832 — wrap each tmux sub-step in a timing probe so a slow
         # subprocess shows up in logs without users needing to enable
         # debug tracing. The probe is a no-op below the warn threshold.
+        #
+        # #1961 perf — collapse static-route click bursts onto a single
+        # ``tmux list-panes`` subprocess via a short-TTL cache keyed on
+        # the window target. Static rail items (Operator, Workers,
+        # Inbox, …) all share the same target; back-to-back clicks
+        # previously each spawned a tmux subprocess gated by the 15s
+        # default timeout, which dominated user-perceived click latency
+        # when the tmux server was slow or contended. The cache also
+        # captures ``None`` (tmux failed) so a wedged server doesn't
+        # keep spawning subprocesses inside the TTL window.
         t_start = time.monotonic()
-        try:
-            panes = self.tmux.list_panes(window_target)
-        except Exception:  # noqa: BLE001
-            panes = None
+        cached_entry = self._static_list_panes_cache.get(window_target)
+        if (
+            cached_entry is not None
+            and t_start - cached_entry[0]
+            < self._STATIC_LIST_PANES_TTL_SECONDS
+        ):
+            panes = cached_entry[1]
+        else:
+            try:
+                panes = self.tmux.list_panes(window_target)
+            except Exception:  # noqa: BLE001
+                panes = None
+            self._static_list_panes_cache[window_target] = (t_start, panes)
         self._maybe_log_route_step("list_panes", key, t_start)
         if has_mount_state:
             if panes is None:

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -1410,12 +1410,22 @@ class CockpitRouter:
         grouped_registrations = self._grouped_rail_registrations(config, registry)
         grouped: dict[str, list[CockpitItem]] = {name: [] for name in RAIL_SECTIONS}
         project_session_map = self._project_session_map(launches)
-        project_rollups = self._project_state_rollups(config, alerts)
+        # #1960 perf — the rollup and categorization paths each issue
+        # broad pg scans (``all_tasks_grouped`` + ``list_worker_sessions``
+        # + ``pm_inbox_awaits_user_list``). They have no data dependency
+        # on each other, so we fire them in parallel on a tiny thread
+        # pool instead of running them back-to-back on the rail tick.
+        # Under their own per-call TTL caches a warm tick is still a
+        # ~free dict lookup; the win is on cold/expired ticks where the
+        # sequential ~1s + ~1s collapses to ~max(1s, 1s).
+        #
         # #1572 — canonical operator-facing categorization (Waiting /
         # Working / Idle / Paused). Single source shared with the
         # operator dashboard so the rail glyph and the dashboard
         # section can never disagree on a project.
-        project_states = self._project_categorizations(config)
+        project_rollups, project_states = self._fanout_rail_pg_scans(
+            config, alerts,
+        )
 
         for section, registrations in grouped_registrations.items():
             for reg in registrations:
@@ -1847,6 +1857,44 @@ class CockpitRouter:
         if rollup.state is ProjectRailState.WORKING:
             return "project-working"
         return fallback
+
+    def _fanout_rail_pg_scans(
+        self,
+        config: object,
+        alerts: list[object],
+    ) -> tuple[dict[str, ProjectStateRollup], dict[str, str]]:
+        """Run rollups + categorizations concurrently on a tiny pool.
+
+        #1960 perf — these two helpers each issue broad pg scans on a
+        cold TTL tick (``all_tasks_grouped`` + ``list_worker_sessions``
+        + ``pm_inbox_awaits_user_list``). They have no data dependency
+        on each other; running them sequentially stacks the worst-case
+        latencies. A two-thread fanout collapses cold ticks toward
+        ``max(rollups, categorizations)``. Warm ticks hit per-call TTL
+        caches and complete in microseconds, so the pool overhead is
+        bounded.
+
+        Failures fall back to empty dicts to mirror the existing
+        best-effort contract of each underlying helper.
+        """
+        from concurrent.futures import ThreadPoolExecutor
+
+        with ThreadPoolExecutor(
+            max_workers=2, thread_name_prefix="rail-pg-scan",
+        ) as pool:
+            rollups_future = pool.submit(
+                self._project_state_rollups, config, alerts,
+            )
+            states_future = pool.submit(self._project_categorizations, config)
+            try:
+                rollups = rollups_future.result()
+            except Exception:  # noqa: BLE001
+                rollups = {}
+            try:
+                states = states_future.result()
+            except Exception:  # noqa: BLE001
+                states = {}
+        return rollups, states
 
     def _project_categorizations(self, config: object) -> dict[str, str]:
         """Canonical operator-facing categorization per project (#1572).

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -6308,7 +6308,12 @@ class PollyInboxApp(App[None]):
         )
         self._render_list(select_first=select_first)
 
-    def _render_list(self, *, select_first: bool = False) -> None:
+    def _render_list(
+        self,
+        *,
+        select_first: bool = False,
+        defer_detail_hydration: bool = False,
+    ) -> None:
         previous_row_key = self._selected_row_key
         previous_task_id = self._selected_task_id
         self.list_view.clear()
@@ -6395,12 +6400,57 @@ class PollyInboxApp(App[None]):
             row_ref = visible_rows[restore_index]
             self._selected_task_id = row_ref.task_id
             self._selected_row_key = row_ref.key
-            self._render_detail(row_ref.task_id)
+            if defer_detail_hydration:
+                # #1959 perf — paint the list first; defer the synchronous
+                # task/replies/context fetch onto the next event-loop tick
+                # so the inbox list appears immediately and detail
+                # hydrates asynchronously.
+                self._schedule_deferred_detail_hydration(row_ref.task_id)
+            else:
+                self._render_detail(row_ref.task_id)
         elif restore_index is not None and 0 <= restore_index < len(visible_rows):
             row_ref = visible_rows[restore_index]
             self._selected_task_id = row_ref.task_id
             self._selected_row_key = row_ref.key
         self._update_status(total=total, shown=len(visible))
+
+    def _schedule_deferred_detail_hydration(self, task_id: str) -> None:
+        """Defer ``_render_detail`` onto the next event-loop tick.
+
+        #1959 perf — the inbox initial-load completion callback runs on
+        the UI thread; calling ``_render_detail`` synchronously inside
+        that callback blocks first-paint on a work-service open + task
+        + replies + context fetch. Showing a "Loading…" placeholder and
+        scheduling the hydration via ``set_timer(0)`` lets the list
+        paint immediately; the timer fires in the next event-loop tick
+        and runs the same code path against the same task_id. If the
+        user has navigated away by then we skip hydration.
+        """
+        try:
+            self.detail.update("[dim]Loading detail…[/dim]")
+        except Exception:  # noqa: BLE001
+            pass
+
+        def _hydrate() -> None:
+            # Cancellable / stale-result guard: only hydrate if the user
+            # is still on this row (no navigation away during the gap).
+            if self._selected_task_id != task_id:
+                return
+            try:
+                self._render_detail(task_id)
+            except Exception:  # noqa: BLE001
+                pass
+
+        try:
+            self.set_timer(0, _hydrate)
+        except Exception:  # noqa: BLE001
+            # Defensive: if the timer can't be scheduled (shutdown), fall
+            # back to the synchronous path so the user isn't stranded on
+            # the placeholder.
+            try:
+                self._render_detail(task_id)
+            except Exception:  # noqa: BLE001
+                pass
 
     def _update_status(self, *, total: int, shown: int) -> None:
         """Render the bottom counter strip — folds in active filters.
@@ -6525,7 +6575,10 @@ class PollyInboxApp(App[None]):
             tasks, unread, replies_by_task,
         )
         try:
-            self._render_list(select_first=True)
+            # #1959 perf — paint the list now and hydrate the first
+            # row's detail on the next event-loop tick so the click
+            # doesn't block on a synchronous task/replies/context fetch.
+            self._render_list(select_first=True, defer_detail_hydration=True)
         except Exception:  # noqa: BLE001
             pass
 

--- a/src/pollypm/dashboard/operator_view.py
+++ b/src/pollypm/dashboard/operator_view.py
@@ -205,18 +205,22 @@ def _prefetch_project_state(config, svc) -> tuple[  # noqa: ANN001
         )
 
     result = _prefetch_project_state_uncached(svc)
+    # #1957 perf — stamp the cache AFTER the uncached prefetch returns so
+    # a cold task+session sweep that exceeds the TTL doesn't write a
+    # born-expired entry that forces the next rail tick to recompute.
+    completed_at = time.monotonic()
     # Best-effort eviction so the cache doesn't grow across long-lived
     # processes with config reloads (each reload yields a fresh
     # ``id(config)``).
     if len(_PREFETCH_PROJECT_STATE_CACHE) > 8:
         for stale_key in [
             k for k, (ts, _v) in _PREFETCH_PROJECT_STATE_CACHE.items()
-            if now - ts >= _PREFETCH_PROJECT_STATE_TTL_SECONDS
+            if completed_at - ts >= _PREFETCH_PROJECT_STATE_TTL_SECONDS
         ]:
             _PREFETCH_PROJECT_STATE_CACHE.pop(stale_key, None)
     tasks_by_alias, workers_by_alias = result
     _PREFETCH_PROJECT_STATE_CACHE[cache_key] = (
-        now,
+        completed_at,
         (
             {key: tuple(rows) for key, rows in tasks_by_alias.items()},
             {key: tuple(rows) for key, rows in workers_by_alias.items()},

--- a/src/pollypm/storage/work_transition_queries.py
+++ b/src/pollypm/storage/work_transition_queries.py
@@ -121,16 +121,20 @@ def activity_feed_transition_rows(
     result = _activity_feed_transition_rows_uncached(
         since_ts=since_ts, limit=limit, config=config,
     )
+    # #1957 perf — stamp the cache AFTER the uncached call returns so a
+    # cold query that exceeds the TTL doesn't write a born-expired entry
+    # that forces the next caller to recompute.
+    completed_at = time.monotonic()
     # Best-effort eviction so the cache doesn't grow across long-lived
     # processes that build successive configs or vary ``since_ts``.
     if len(_ACTIVITY_FEED_ROWS_CACHE) > 16:
         for stale_key in [
             k for k, (ts, _v) in _ACTIVITY_FEED_ROWS_CACHE.items()
-            if now - ts >= _ACTIVITY_FEED_ROWS_TTL_SECONDS
+            if completed_at - ts >= _ACTIVITY_FEED_ROWS_TTL_SECONDS
         ]:
             _ACTIVITY_FEED_ROWS_CACHE.pop(stale_key, None)
     _ACTIVITY_FEED_ROWS_CACHE[cache_key] = (
-        now, tuple(dict(row) for row in result),
+        completed_at, tuple(dict(row) for row in result),
     )
     return result
 


### PR DESCRIPTION
## Summary

Five rail-perf wedges from Codex's deeper audit (round R7). Each fix is an architectural change, not a TTL cache adjustment — the obvious duplicate-query caches were already shipped in #1907 / #1928 / #1948.

- **#1957** TTL caches were born expired when the cold call exceeded the 1s TTL. Stamp ``completed_at = time.monotonic()`` AFTER the uncached call returns so the next caller within the same tick hits the cache. Fixes ``activity_feed_transition_rows`` / ``_gather_worker_roster`` / ``all_tasks_grouped`` / ``_prefetch_project_state``.
- **#1958** Workers rail row blocked on the full per-project work-service + tmux + git-log sweep every cold tick. Adopt stale-while-revalidate: serve the last-known snapshot immediately and refresh in a background thread (lock-guarded in-flight set coalesces refreshes per ``id(config)``).
- **#1959** Inbox initial-load completion ran ``_render_detail`` synchronously on the UI thread, blocking first-paint on a work-service open + task + replies + context fetch. Add ``defer_detail_hydration`` to ``_render_list``; paint the list, show "Loading detail…", and re-enter ``_render_detail`` via ``set_timer(0, ...)`` with a stale-result guard.
- **#1960** Rail ``build_items()`` ran ``_project_state_rollups`` and ``_project_categorizations`` back-to-back on the rail worker, stacking two broad pg scans. They share no data dependency — fan them out across a 2-thread ``ThreadPoolExecutor`` so cold ticks collapse toward ``max()`` instead of ``sum()``.
- **#1961** Static rail clicks shelled out to ``tmux list-panes`` before painting, gated by the 15s default tmux timeout. Cache the result per ``window_target`` with a 500ms TTL so click bursts collapse onto a single subprocess; ``None`` is cached too so a wedged tmux server doesn't keep spawning subprocesses.

Output identity is unchanged across all five — only freshness/scheduling moves.

## Test plan

- [ ] Cockpit rail refresh visibly responsive after rail-rerender ticks
- [ ] Workers rail row keeps showing roster after a config reload (cache repopulates on cold start)
- [ ] Clicking Inbox paints the list immediately; right pane shows "Loading detail…" then hydrates within ~1 tick
- [ ] Static rail clicks (Operator, Workers, Inbox, …) repaint quickly even when tmux server is contended
- [ ] No regression in operator dashboard categorization / project rollup state

Closes #1957
Closes #1958
Closes #1959
Closes #1960
Closes #1961

Generated with [Claude Code](https://claude.com/claude-code)