### PR TITLE
fix(sqlite-ripout): deregister sqlite from production runtime (closes #1956)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,16 @@ dev = [
 pm = "pollypm.cli:app"
 pollypm = "pollypm.cli:app"
 
+# #1956: sqlite is intentionally NOT entry-pointed any more. The
+# pg cutover (#1737) made postgres the production backend; leaving
+# ``sqlite`` registered here let a misconfigured ``[storage].backend
+# = "sqlite"`` silently open an empty sqlite shadow alongside the
+# real pg state. ``get_store(config)`` now raises
+# ``StoreBackendNotFound`` for ``backend == "sqlite"`` unless a
+# caller has explicitly opted back in via
+# :func:`pollypm.store.registry.register_backend` (tests, legacy
+# ``--db <path>`` escape hatches). See ``store/registry.py``.
 [project.entry-points."pollypm.store_backend"]
-sqlite = "pollypm.store.sqlalchemy_store:SQLAlchemyStore"
 postgres = "pollypm.store.backends.pg_store:PgStore"
 
 # Phase B (#397) — both providers extracted into their own packages.

--- a/src/pollypm/cli_features/session_runtime.py
+++ b/src/pollypm/cli_features/session_runtime.py
@@ -105,8 +105,17 @@ def _resolve_notify_store(db: str):
         return get_store_by_url(db.strip(), backend="postgres")
 
     if db != WORKSPACE_DEFAULT_DB_PATH:
-        from pollypm.store import get_store_by_url
+        # #1956: sqlite is no longer entry-pointed. ``--db <path>`` is
+        # the documented sqlite escape hatch (test / CI / legacy
+        # migration), so opt the backend back in for this process.
+        # ``register_backend`` warn-logs unless we're under pytest.
+        from pollypm.store import (
+            SQLAlchemyStore,
+            get_store_by_url,
+            register_backend,
+        )
 
+        register_backend("sqlite", SQLAlchemyStore)
         db_path = resolve_work_db_path(db, project=None)
         return get_store_by_url(f"sqlite:///{db_path}")
 

--- a/src/pollypm/plugins_builtin/activity_feed/handlers/event_projector.py
+++ b/src/pollypm/plugins_builtin/activity_feed/handlers/event_projector.py
@@ -356,6 +356,17 @@ class EventProjector:
         if not self._state_db.exists():
             return None
         try:
+            # #1956: sqlite is no longer in the
+            # ``pollypm.store_backend`` entry-point group. This
+            # fallback only runs when the operator is still on the
+            # sqlite-shaped state DB (legacy installs, sqlite-pinned
+            # tests). Opt sqlite back in for this process so the call
+            # below resolves; ``register_backend`` warn-logs unless
+            # we're under pytest.
+            from pollypm.store import SQLAlchemyStore
+            from pollypm.store.registry import register_backend
+
+            register_backend("sqlite", SQLAlchemyStore)
             return get_store_by_url(f"sqlite:///{self._state_db}")
         except Exception:  # noqa: BLE001
             logger.exception("activity_feed: failed to open Store")

--- a/src/pollypm/store/__init__.py
+++ b/src/pollypm/store/__init__.py
@@ -22,7 +22,12 @@ from __future__ import annotations
 
 from pollypm.store.engine import is_sqlite, make_engines
 from pollypm.store.protocol import Store
-from pollypm.store.registry import get_store
+from pollypm.store.registry import (
+    get_store,
+    get_store_by_url,
+    register_backend,
+    unregister_backend,
+)
 from pollypm.store.sqlalchemy_store import SQLAlchemyStore
 from pollypm.store.title_contract import apply_title_contract
 
@@ -31,6 +36,9 @@ __all__ = [
     "Store",
     "apply_title_contract",
     "get_store",
+    "get_store_by_url",
     "is_sqlite",
     "make_engines",
+    "register_backend",
+    "unregister_backend",
 ]

--- a/src/pollypm/store/registry.py
+++ b/src/pollypm/store/registry.py
@@ -8,30 +8,43 @@ public entry point for resolving a backend from a loaded
 Design
 ------
 
-* **Entry points — not a hard-coded switch.** Built-in SQLite is
-  registered by PollyPM itself in ``pyproject.toml``. Third-party
-  packages (e.g. the future ``pollypm-store-postgres`` shipped via
-  :mod:`pollypm.store.backends.postgres_stub`) register their own
-  entry points under the same group and become selectable without any
-  code change in this repo.
+* **Entry points — not a hard-coded switch.** Postgres is registered
+  by PollyPM itself in ``pyproject.toml``. Third-party packages
+  register their own entry points under the same group and become
+  selectable without any code change in this repo.
+* **Sqlite is not entry-pointed (#1956).** The pg cutover (#1737)
+  made postgres the supported production backend; leaving sqlite
+  registered let a misconfigured ``[storage].backend = "sqlite"``
+  silently open an empty shadow alongside the real pg state. Sqlite
+  is now opt-in via :func:`register_backend` — tests and the legacy
+  ``pm notify --db <path>`` / ``pm inbox --db <path>`` escape hatches
+  call it explicitly; ``get_store(config)`` with backend=="sqlite"
+  on a stock install fails loud with :class:`StoreBackendNotFound`.
 * **URL resolution lives in one place.** If ``config.storage.url`` is
-  empty, we derive ``sqlite:///<project.state_db>`` so a first-run user
-  who never touched ``[storage]`` still gets a working DB at the path
-  the rest of PollyPM already uses.
+  empty and the backend is sqlite (i.e. an opt-in caller registered
+  it), we derive ``sqlite:///<project.state_db>`` so a test using
+  the default ``state_db`` path still gets a working DB. On
+  postgres (the production default) an empty URL lets the pg pool
+  resolver pick the DSN up from ``[storage.pg].dsn`` /
+  ``POLLYPM_PG_DSN``.
 * **Unknown backend fails loud.** :class:`StoreBackendNotFound` lists
-  the backends that *are* installed so a typo is immediately visible
-  (three-question rule — issue #240).
+  the backends that *are* installed (entry-point + in-process
+  registry union) so a typo is immediately visible (three-question
+  rule — issue #240).
 
 The registry returns a :class:`pollypm.store.Store`-satisfying object.
-The entry-point target must be a callable taking a ``url=`` keyword —
-both :class:`SQLAlchemyStore` and the Postgres stub honour that shape.
+Every backend factory must be a callable taking a ``url=`` keyword —
+both :class:`SQLAlchemyStore` and the Postgres backend honour that.
 """
 
 from __future__ import annotations
 
 import importlib.metadata
+import logging
+import os
+import sys
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from pollypm.errors import StoreBackendNotFound
 
@@ -41,6 +54,121 @@ if TYPE_CHECKING:
 
 
 ENTRY_POINT_GROUP = "pollypm.store_backend"
+
+logger = logging.getLogger(__name__)
+
+# #1956: sqlite was removed from the ``pollypm.store_backend`` entry-point
+# group in ``pyproject.toml`` so a misconfigured ``[storage].backend
+# = "sqlite"`` fails loud at :func:`get_store` instead of silently
+# opening an empty sqlite shadow next to the real pg state. Tests and
+# the legacy ``--db <path>`` CLI escape hatches that legitimately need
+# sqlite call :func:`register_backend` to opt back in.
+#
+# Lookup order in the resolvers below:
+#   1. ``_REGISTERED_BACKENDS`` (this in-process map; tests + opt-in
+#      callers register here).
+#   2. ``importlib.metadata.entry_points(group=ENTRY_POINT_GROUP)``
+#      (installed packages; only ``postgres`` ships by default).
+_REGISTERED_BACKENDS: dict[str, Callable[..., "Store"]] = {}
+_REGISTRATION_LOCK = threading.Lock()
+
+
+def _running_under_pytest() -> bool:
+    """Return True when the active interpreter is a pytest run.
+
+    Used by :func:`register_backend` to suppress the production-sqlite
+    warn-log under the test suite (where re-registering sqlite is the
+    documented opt-in path; see ``tests/conftest.py``). The check is
+    deliberately permissive — either ``PYTEST_CURRENT_TEST`` (set by
+    pytest for the duration of each item) or ``pytest`` being imported
+    is enough; we'd rather under-warn in a niche test harness than
+    spam the rail in production.
+    """
+    if "PYTEST_CURRENT_TEST" in os.environ:
+        return True
+    if "pytest" in sys.modules:
+        return True
+    return False
+
+
+def register_backend(
+    name: str,
+    factory: Callable[..., "Store"],
+    *,
+    quiet: bool = False,
+) -> None:
+    """Register ``factory`` as the in-process backend for ``name``.
+
+    The opt-in companion to removing sqlite from the
+    ``pollypm.store_backend`` entry-point group (#1956). Callers that
+    legitimately need a backend not shipped by the installed
+    distribution — the pytest suite, the ``pm notify --db <path>``
+    escape hatch — call this to plug the factory back in for the rest
+    of the process.
+
+    Parameters
+    ----------
+    name
+        The backend key, e.g. ``"sqlite"``. Matches against
+        ``config.storage.backend`` and the ``backend=`` kwarg on
+        :func:`get_store_by_url`.
+    factory
+        Anything callable with ``url=<str>`` returning a
+        :class:`~pollypm.store.protocol.Store`. Typically
+        :class:`~pollypm.store.sqlalchemy_store.SQLAlchemyStore`.
+    quiet
+        When ``True``, suppress the production warn-log. The test
+        conftest sets this; production opt-ins should leave it
+        ``False`` so the operator sees the sqlite path was reached.
+
+    Notes
+    -----
+    Idempotent: re-registering the same ``(name, factory)`` pair is a
+    no-op. Re-registering with a different factory replaces the prior
+    entry — the test suite relies on that during teardown.
+    """
+    with _REGISTRATION_LOCK:
+        _REGISTERED_BACKENDS[name] = factory
+    if (
+        not quiet
+        and name == "sqlite"
+        and not _running_under_pytest()
+    ):
+        logger.warning(
+            "pollypm.store: sqlite backend registered in a production "
+            "process (#1956). The pg cutover (#1737) made postgres the "
+            "supported backend; sqlite remains reachable only as a "
+            "test / legacy --db escape hatch. Verify the caller is one "
+            "of those before relying on this path."
+        )
+
+
+def unregister_backend(name: str) -> None:
+    """Drop ``name`` from the in-process backend registry.
+
+    Used by test teardown to keep the registry isolated between
+    pytest sessions. Missing keys are silently ignored.
+    """
+    with _REGISTRATION_LOCK:
+        _REGISTERED_BACKENDS.pop(name, None)
+
+
+def _resolve_backend_factory(name: str) -> Callable[..., "Store"] | None:
+    """Return the factory callable for ``name`` or ``None``.
+
+    Checks the in-process registry first (tests / opt-in prod
+    callers), then falls back to the installed
+    ``pollypm.store_backend`` entry-point group. Returning ``None``
+    lets the caller raise :class:`StoreBackendNotFound` with the
+    full list of available names attached.
+    """
+    factory = _REGISTERED_BACKENDS.get(name)
+    if factory is not None:
+        return factory
+    for ep in importlib.metadata.entry_points(group=ENTRY_POINT_GROUP):
+        if ep.name == name:
+            return ep.load()
+    return None
 
 # Module-level cache of live ``Store`` instances, keyed by
 # ``(backend, resolved_url)``. Every call site that reaches for
@@ -84,11 +212,20 @@ def _resolve_url(config: "PollyPMConfig") -> str:
 
 
 def _available_backends() -> list[str]:
-    """Return sorted entry-point names registered under our group."""
-    return sorted(
+    """Return sorted union of registered + entry-point backend names.
+
+    Includes the in-process :data:`_REGISTERED_BACKENDS` map so a
+    ``StoreBackendNotFound`` raised after a test or escape-hatch
+    caller has registered sqlite still lists it as installed. Without
+    that, the error message would point operators at a backend table
+    that disagrees with the resolver they just hit.
+    """
+    names = {
         ep.name
         for ep in importlib.metadata.entry_points(group=ENTRY_POINT_GROUP)
-    )
+    }
+    names.update(_REGISTERED_BACKENDS.keys())
+    return sorted(names)
 
 
 def get_store(config: "PollyPMConfig") -> "Store":
@@ -136,12 +273,11 @@ def get_store(config: "PollyPMConfig") -> "Store":
         cached = _STORES.get(key)
         if cached is not None:
             return cached
-        for ep in importlib.metadata.entry_points(group=ENTRY_POINT_GROUP):
-            if ep.name == backend:
-                cls = ep.load()
-                instance = cls(url=url)
-                _STORES[key] = instance
-                return instance
+        factory = _resolve_backend_factory(backend)
+        if factory is not None:
+            instance = factory(url=url)
+            _STORES[key] = instance
+            return instance
     raise StoreBackendNotFound(
         backend,
         available=_available_backends(),
@@ -157,6 +293,14 @@ def get_store_by_url(url: str, *, backend: str = "sqlite") -> "Store":
     engine pool. Rail-hot callers that used to construct a fresh
     ``SQLAlchemyStore`` per call would pin ~16 SQLite handles per
     invocation; routing through this helper keeps the pool singleton.
+
+    #1956: sqlite is no longer entry-pointed. The default
+    ``backend="sqlite"`` kwarg keeps the historical signature but
+    callers reaching for sqlite must ensure :func:`register_backend`
+    has been invoked first (tests/conftest, ``pm notify --db`` escape
+    hatches). An un-registered sqlite call raises
+    :class:`StoreBackendNotFound` listing the backends that *are*
+    available.
     """
     key = (backend, url)
     cached = _STORES.get(key)
@@ -166,12 +310,11 @@ def get_store_by_url(url: str, *, backend: str = "sqlite") -> "Store":
         cached = _STORES.get(key)
         if cached is not None:
             return cached
-        for ep in importlib.metadata.entry_points(group=ENTRY_POINT_GROUP):
-            if ep.name == backend:
-                cls = ep.load()
-                instance = cls(url=url)
-                _STORES[key] = instance
-                return instance
+        factory = _resolve_backend_factory(backend)
+        if factory is not None:
+            instance = factory(url=url)
+            _STORES[key] = instance
+            return instance
     raise StoreBackendNotFound(
         backend,
         available=_available_backends(),
@@ -210,5 +353,7 @@ __all__ = [
     "ENTRY_POINT_GROUP",
     "get_store",
     "get_store_by_url",
+    "register_backend",
     "reset_store_cache",
+    "unregister_backend",
 ]

--- a/src/pollypm/work/inbox_cli.py
+++ b/src/pollypm/work/inbox_cli.py
@@ -283,8 +283,18 @@ def _resolve_messages_store(db: str) -> Any:
         return get_store_by_url(db.strip(), backend="postgres")
 
     if db != WORKSPACE_DEFAULT_DB_PATH:
-        from pollypm.store import get_store_by_url
+        # #1956: sqlite is no longer entry-pointed. ``--db <path>`` is
+        # the documented sqlite escape hatch (test / CI), so opt the
+        # backend back in here. ``register_backend`` warn-logs unless
+        # we're under pytest, so a prod operator who hits this path
+        # by accident still sees the message.
+        from pollypm.store import (
+            SQLAlchemyStore,
+            get_store_by_url,
+            register_backend,
+        )
 
+        register_backend("sqlite", SQLAlchemyStore)
         db_path = _resolve_db_path(db, project=None)
         return get_store_by_url(f"sqlite:///{db_path}")
 

--- a/src/pollypm/work/service_notifications.py
+++ b/src/pollypm/work/service_notifications.py
@@ -82,6 +82,15 @@ def _ensure_staging_table(conn: sqlite3.Connection) -> None:
 
 
 def _message_store(service: _WorkService) -> SQLAlchemyStore:
+    # #1956: sqlite is no longer in the ``pollypm.store_backend``
+    # entry-point group. This helper only runs from inside
+    # ``SQLiteWorkService`` (per the ``_WorkService`` protocol), so we
+    # know the caller has already committed to sqlite — register the
+    # factory if no-one upstream has. ``register_backend`` is
+    # idempotent and warn-logs only outside pytest.
+    from pollypm.store.registry import register_backend
+
+    register_backend("sqlite", SQLAlchemyStore)
     return get_store_by_url(f"sqlite:///{service._db_path}")  # type: ignore[return-value]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,28 @@ def pytest_configure(config):
         "(use only when a test explicitly monkeypatches Path.home / "
         "GLOBAL_CONFIG_DIR to a sandbox).",
     )
+    # #1956 — sqlite was removed from the ``pollypm.store_backend``
+    # entry-point group in ``pyproject.toml`` so a stock prod install
+    # cannot silently pick it up from ``[storage].backend = "sqlite"``.
+    # The test suite still relies on sqlite via
+    # ``@pytest.mark.backend("sqlite")``, the legacy ``--db <path>``
+    # CLI escape paths, and direct ``get_store_by_url`` calls in
+    # ``tests/test_cli_inbox_backend_aware.py`` /
+    # ``tests/test_cli_notify_backend_aware.py``. Register the
+    # backend in-process for the whole pytest run so those paths
+    # keep resolving. ``quiet=True`` suppresses the production
+    # warn-log under pytest.
+    try:
+        from pollypm.store import SQLAlchemyStore
+        from pollypm.store.registry import register_backend
+
+        register_backend("sqlite", SQLAlchemyStore, quiet=True)
+    except Exception:  # noqa: BLE001
+        # The store package may not be importable in the very early
+        # phase of some sub-suite runs (e.g. tooling-only tests with
+        # mocked sys.modules). Tests that actually need sqlite will
+        # re-register from their own fixtures.
+        pass
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

- Removes `sqlite = "pollypm.store.sqlalchemy_store:SQLAlchemyStore"` from the `pollypm.store_backend` entry-point group in `pyproject.toml`. A stock prod install now exposes only `postgres`, so `[storage].backend = "sqlite"` fails loud at `get_store(config)` with `StoreBackendNotFound` instead of silently opening an empty sqlite shadow next to the live pg state.
- Adds an in-process backend registry (`register_backend` / `unregister_backend`) to `pollypm.store.registry`. Resolution checks the in-process map first, then falls back to entry-points; `_available_backends()` returns the union so error messages always match the resolver. `register_backend("sqlite", ...)` warn-logs unless the caller is under pytest, making any production sqlite reach immediately visible in the rail log.
- Opts the four documented sqlite escape paths back in via `register_backend("sqlite", SQLAlchemyStore)`: `pm notify --db <path>` (`cli_features/session_runtime.py`), `pm inbox --db <path>` (`work/inbox_cli.py`), `SQLiteWorkService` notification staging (`work/service_notifications.py`), and the activity-feed projector fallback (`plugins_builtin/activity_feed/handlers/event_projector.py`). They keep working but emit a warn-log on a stock install.
- `tests/conftest.py` `pytest_configure` registers sqlite with `quiet=True` so `@pytest.mark.backend("sqlite")` and the direct `get_store_by_url(f"sqlite:///...")` callers in `tests/test_cli_inbox_backend_aware.py` / `tests/test_cli_notify_backend_aware.py` keep resolving.

## Why

PR #1949 closed the silent sqlite defaults at config/CLI/cockpit/factory, but Codex's deeper audit (#1956) caught that sqlite remained a registered runtime backend — so a misconfigured `[storage].backend = "sqlite"` could still silently resolve. This change finishes the "deregister from production runtime" half of the ripout: the entry point is gone, the registry is opt-in, the warn-log fires on any sqlite open outside pytest, and the test fixtures keep working via the same opt-in path.

This is the "soft" shape called out in the issue (keep registered but gate behind explicit opt-in, with a warn-log) implemented as a hard-ish path: the entry point itself is removed, and the legitimate escape paths re-register the backend at their own callsites with a visible warning.

## Test plan

- [ ] `pytest` (sanity for the `@pytest.mark.backend("sqlite")` suite, the inbox/notify `--db` CLI tests, and the activity-feed projector tests). Not run in this commit per task constraints.
- [ ] Manual: `python -c "from pollypm.config import load_config; from pollypm.store import get_store; cfg = load_config(); cfg.storage.backend = 'sqlite'; get_store(cfg)"` on a fresh `uv tool install` of this branch raises `StoreBackendNotFound`.
- [ ] Manual: `pm notify --db /tmp/test.db ...` continues to work and emits the new warn-log on first call.
- [ ] `ruff check` on touched files (passes; one pre-existing E731 in `event_projector.py` is untouched by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)