### PR TITLE
fix(worktree-prune): walk-up discovery for cron-tick path (closes #1965)

### DIFF
--- a/src/pollypm/plugins_builtin/core_recurring/maintenance.py
+++ b/src/pollypm/plugins_builtin/core_recurring/maintenance.py
@@ -718,6 +718,30 @@ def memory_ttl_sweep_handler(payload: dict[str, Any]) -> dict[str, Any]:
         return {"deleted": deleted}
 
 
+def _discover_agent_worktrees_root() -> Path | None:
+    """Walk up from cwd + this module's location to find a repo whose
+    ``.claude/worktrees/`` dir exists (#1965).
+
+    Mirrors :func:`pollypm.doctor._agent_worktree_dirs` so the prune
+    handler's target tree matches what the ``agent-worktree-count``
+    alert measures. Without this, the cron-tick path resolves
+    ``repo_root`` from the global config's ``project.root_dir`` —
+    typically ``~/.pollypm/`` for the ``rail_daemon`` — which has no
+    ``.claude/worktrees/`` subtree, so the handler bails before ever
+    inspecting the dev repo where worktrees actually accumulate.
+    """
+    here = Path(__file__).resolve()
+    seen: set[Path] = set()
+    for start in (Path.cwd().resolve(), here):
+        for parent in (start, *start.parents):
+            if parent in seen:
+                continue
+            seen.add(parent)
+            if (parent / ".claude" / "worktrees").is_dir():
+                return parent
+    return None
+
+
 def agent_worktree_prune_handler(payload: dict[str, Any]) -> dict[str, Any]:
     """Prune stale Claude Code harness agent worktrees under ``.claude/worktrees/``."""
     import subprocess
@@ -727,8 +751,16 @@ def agent_worktree_prune_handler(payload: dict[str, Any]) -> dict[str, Any]:
     if hint:
         repo_root = Path(hint)
     else:
-        config = _load_config(payload)
-        repo_root = config.project.root_dir
+        # #1965: prefer a walk-up discovery so the cron-tick path
+        # targets the actual dev repo. Fall back to config.root_dir
+        # only when discovery fails — preserves prior behavior for
+        # callers who have set that up correctly.
+        discovered = _discover_agent_worktrees_root()
+        if discovered is not None:
+            repo_root = discovered
+        else:
+            config = _load_config(payload)
+            repo_root = config.project.root_dir
 
     worktrees_dir = repo_root / ".claude" / "worktrees"
     if not worktrees_dir.is_dir():

--- a/tests/test_agent_worktree_prune.py
+++ b/tests/test_agent_worktree_prune.py
@@ -269,3 +269,44 @@ def test_prunes_locked_merged_worktree(tmp_path: Path) -> None:
     assert result["pruned"] == 1, result
     assert result["errors"] == 0
     assert not wt.exists()
+
+
+def test_empty_payload_discovers_repo_via_cwd_walkup(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """#1965 — empty payload (cron-tick path) discovers the repo root
+    by walking up from cwd, not via the global config's ``root_dir``.
+
+    Before the fix, the ``rail_daemon`` cron tick called the handler
+    with ``{}``. The handler resolved ``repo_root`` from
+    ``config.project.root_dir`` (``~/.pollypm/`` for the daemon), which
+    has no ``.claude/worktrees/`` subtree — so the handler bailed
+    immediately while the dev repo's worktree count grew unbounded.
+
+    Predicate semantics this test pins down:
+      * A merged worktree (older than 1h, branch listed by
+        ``git branch --merged main``) IS reaped when the cron-tick
+        path can discover the repo via cwd walk-up.
+      * Discovery looks for a ``.claude/worktrees/`` dir at cwd OR any
+        parent — matching ``doctor._agent_worktree_dirs``.
+    """
+    repo = _make_repo(tmp_path / "repo")
+    wt = _make_agent_worktree(
+        repo, "cron-tick", merge_to_main=True, age_seconds=2 * 3600,
+    )
+    assert wt.exists()
+
+    # Simulate the rail_daemon cron tick: cwd anywhere inside (or
+    # equal to) the dev repo, payload empty. Use a nested subdir so
+    # the walk-up has to traverse a few levels.
+    nested = repo / "src" / "deep" / "nested"
+    nested.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(nested)
+
+    result = agent_worktree_prune_handler({})
+
+    assert result["pruned"] == 1, result
+    assert result["errors"] == 0
+    assert not wt.exists(), "merged worktree must be reaped via cron-tick path"
+    branches = _run("git", "-C", str(repo), "branch").stdout
+    assert "worktree-agent-cron-tick" not in branches


### PR DESCRIPTION
## Summary

- `agent_worktree.prune` handler was registered + firing on its `23 * * * *` cron, but `pm doctor` `agent-worktree-count` kept climbing (286 → 290 in one session) because the no-payload code path resolved `repo_root` from `config.project.root_dir` — `~/.pollypm/` for the `rail_daemon` — which has no `.claude/worktrees/` subdir. Handler bailed before ever looking at the dev repo.
- Added `_discover_agent_worktrees_root()` that walks up from `Path.cwd()` and from the module's location to find a `.claude/worktrees/` dir, mirroring `doctor._agent_worktree_dirs()`. Handler prefers walk-up on the cron-tick path, falls back to `config.project.root_dir` only if discovery fails.
- Predicate stays conservative: a branch only reaps when it's in `git branch --merged main` (or `origin/main`) **or** `git cherry main <branch>` reports the patch already applied. Unmerged in-progress work is never reaped (warn-then-leave for >7d stale).

## Test plan

- [x] `tests/test_agent_worktree_prune.py::test_empty_payload_discovers_repo_via_cwd_walkup` — new regression covering the cron-tick path (handler called with `{}`, cwd inside repo, merged worktree gets reaped). Passes locally.
- [x] Existing 8 prune tests untouched (they pass `project_root` explicitly, so they exercise the unchanged path).
- [ ] Boot cockpit, watch the 23-past-hour tick reap merged worktrees in the dev repo.

Closes #1965

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

[Claude Code](https://claude.com/claude-code)