### PR TITLE
fix(recovery): emit live git state from session cwd in checkpoint messages

### DIFF
--- a/src/pollypm/recovery_prompt.py
+++ b/src/pollypm/recovery_prompt.py
@@ -97,6 +97,7 @@ def build_recovery_prompt(
             provider=provider,
             task_prompt=task_prompt,
             max_chars=max_chars,
+            session_name=session_name,
         )
 
     return _build_from_checkpoint(
@@ -104,6 +105,7 @@ def build_recovery_prompt(
         provider=provider,
         task_prompt=task_prompt,
         max_chars=max_chars,
+        session_name=session_name,
     )
 
 
@@ -114,6 +116,7 @@ def _build_from_checkpoint(
     provider: ProviderKind,
     task_prompt: str,
     max_chars: int,
+    session_name: str | None = None,
 ) -> RecoveryPrompt:
     """Build recovery prompt from checkpoint data."""
     sections: list[RecoveryPromptSection] = []
@@ -162,7 +165,15 @@ def _build_from_checkpoint(
         ))
 
     # Section 4: Current Git State (live, not from checkpoint)
-    git_state = _live_git_state(config, checkpoint.project)
+    # Read from the session's worktree cwd when known — architect /
+    # worker sessions live in per-session worktrees under
+    # ``<project>/.pollypm/worktrees/<session>/`` and the branch +
+    # porcelain count there can differ from the project root. Cross-
+    # project audit-log scans (issue #1974) showed architects rejecting
+    # checkpoints as prompt-injection because the ``Branch:`` line read
+    # from project.path described the canonical repo, not the worktree
+    # the agent inhabited.
+    git_state = _live_git_state(config, checkpoint.project, session_name=session_name)
     if git_state:
         sections.append(RecoveryPromptSection(
             key="git_state",
@@ -273,6 +284,7 @@ def _build_fallback_prompt(
     provider: ProviderKind,
     task_prompt: str,
     max_chars: int,
+    session_name: str | None = None,
 ) -> RecoveryPrompt:
     """Build fallback prompt when no checkpoint exists."""
     sections: list[RecoveryPromptSection] = []
@@ -299,7 +311,7 @@ def _build_fallback_prompt(
             priority=SECTION_TRUNCATION_PRIORITY["what_working_on"],
         ))
 
-    git_state = _live_git_state(config, project_key)
+    git_state = _live_git_state(config, project_key, session_name=session_name)
     if git_state:
         sections.append(RecoveryPromptSection(
             key="git_state",
@@ -502,19 +514,45 @@ def _checkpoint_banner(*, checkpoint_id: str, is_fallback: bool, state: str) -> 
     return f"RECOVERY MODE: RESUMING FROM CHECKPOINT {checkpoint_id} — last state was {state}."
 
 
-def _live_git_state(config: PollyPMConfig, project_key: str) -> str:
-    """Get live git state for the project."""
-    project_root = _project_root(config, project_key)
-    if not (project_root / ".git").is_dir():
+def _live_git_state(
+    config: PollyPMConfig,
+    project_key: str,
+    *,
+    session_name: str | None = None,
+) -> str:
+    """Get live git state for the session's actual working tree.
+
+    Prefers the session's configured ``cwd`` (e.g. a per-session worktree
+    under ``<project>/.pollypm/worktrees/<session>/``) over the project
+    root. This matters because architect/worker sessions check out
+    distinct branches in their own worktrees, and a recovery checkpoint
+    that advertises ``Branch: main`` while the agent is actually on
+    ``fix/foo`` reads to the agent like a prompt-injection attempt and
+    gets refused (issue #1974). Falls back to the project root when no
+    session cwd is known or it is not a git working tree.
+    """
+    git_root = _session_git_root(config, session_name) or _project_root(
+        config, project_key,
+    )
+    if not _is_git_working_tree(git_root):
         return ""
 
     parts: list[str] = ["Git state:"]
 
-    branch = _git_output(str(project_root), ["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    branch = _git_output(
+        str(git_root), ["git", "branch", "--show-current"],
+    )
+    # ``git branch --show-current`` is empty on detached HEAD; fall
+    # back to rev-parse for that case so the section still carries a
+    # useful identifier.
+    if not branch:
+        branch = _git_output(
+            str(git_root), ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        )
     if branch:
         parts.append(f"- Branch: {branch}")
 
-    status = _git_output(str(project_root), ["git", "status", "--porcelain"])
+    status = _git_output(str(git_root), ["git", "status", "--porcelain"])
     if status:
         changed = len(status.strip().splitlines())
         word = "file" if changed == 1 else "files"
@@ -523,6 +561,36 @@ def _live_git_state(config: PollyPMConfig, project_key: str) -> str:
         parts.append("- Working tree clean")
 
     return "\n".join(parts) if len(parts) > 1 else ""
+
+
+def _session_git_root(
+    config: PollyPMConfig, session_name: str | None,
+) -> Path | None:
+    """Return the session's configured cwd when it exists on disk."""
+    if not session_name:
+        return None
+    sessions = getattr(config, "sessions", None) or {}
+    session = sessions.get(session_name)
+    if session is None:
+        return None
+    cwd = getattr(session, "cwd", None)
+    if cwd is None:
+        return None
+    try:
+        return cwd if Path(cwd).is_dir() else None
+    except OSError:
+        return None
+
+
+def _is_git_working_tree(root: Path) -> bool:
+    """True for both regular checkouts and linked worktrees.
+
+    A linked worktree's ``.git`` is a *file* pointing at the main
+    repo's worktree dir, not a directory; the original ``.is_dir()``
+    check missed those.
+    """
+    dot_git = root / ".git"
+    return dot_git.is_dir() or dot_git.is_file()
 
 
 def _git_output(cwd: str, command: list[str]) -> str:

--- a/tests/test_recovery_prompt.py
+++ b/tests/test_recovery_prompt.py
@@ -264,6 +264,185 @@ class TestBuildFromCheckpoint:
 
 
 # ---------------------------------------------------------------------------
+# Live git state (#1974 — checkpoint emitting stale branch → architect
+# rejects the recovery prompt as prompt-injection)
+# ---------------------------------------------------------------------------
+
+
+class TestLiveGitStateFromSessionCwd:
+    """Architect / worker sessions live in per-session worktrees; the
+    git state shown in the recovery prompt must reflect the session's
+    actual ``cwd``, not the project root, or the agent rejects the
+    checkpoint."""
+
+    def test_session_cwd_branch_overrides_project_root(
+        self, tmp_path: Path,
+    ) -> None:
+        import subprocess
+
+        project_root = tmp_path / "repo"
+        project_root.mkdir()
+        # Initialise the project repo on ``main``.
+        subprocess.run(
+            ["git", "init", "-b", "main", str(project_root)],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git",
+             "-c", "user.email=test@example.com",
+             "-c", "user.name=test",
+             "-C", str(project_root), "commit",
+             "--allow-empty", "-m", "init"],
+            check=True, capture_output=True,
+        )
+
+        # Session worktree on a different branch (this is what
+        # architect-<project> sessions look like in production:
+        # ``<project>/.pollypm/worktrees/<session>/`` checked out to
+        # ``fix/some-branch``).
+        worktree = tmp_path / "worktree"
+        subprocess.run(
+            ["git", "-C", str(project_root), "worktree", "add",
+             "-b", "fix/recovery-checkpoint-live-state",
+             str(worktree)],
+            check=True, capture_output=True,
+        )
+
+        config = PollyPMConfig(
+            project=ProjectSettings(
+                root_dir=project_root,
+                base_dir=project_root / ".pollypm",
+                logs_dir=project_root / ".pollypm/logs",
+                snapshots_dir=project_root / ".pollypm/snapshots",
+                state_db=project_root / ".pollypm/state.db",
+            ),
+            pollypm=PollyPMSettings(controller_account="claude_main"),
+            accounts={
+                "claude_main": AccountConfig(
+                    name="claude_main",
+                    provider=ProviderKind.CLAUDE,
+                    home=project_root / ".pollypm" / "homes" / "claude_main",
+                ),
+            },
+            sessions={
+                "architect_test": SessionConfig(
+                    name="architect_test",
+                    role="architect",
+                    provider=ProviderKind.CLAUDE,
+                    account="claude_main",
+                    cwd=worktree,
+                    project="test",
+                ),
+            },
+            projects={
+                "test": KnownProject(
+                    key="test",
+                    path=project_root,
+                    name="TestProject",
+                    kind=ProjectKind.FOLDER,
+                ),
+            },
+        )
+
+        checkpoint = CheckpointData(
+            checkpoint_id="ckpt-1974",
+            session_name="architect_test",
+            project="test",
+            objective="Test live git state",
+        )
+
+        prompt = _build_from_checkpoint(
+            config, checkpoint,
+            provider=ProviderKind.CLAUDE,
+            task_prompt="",
+            max_chars=DEFAULT_MAX_CHARS,
+            session_name="architect_test",
+        )
+
+        rendered = prompt.render()
+        # The worktree's branch must appear — that is the whole bug.
+        assert "Branch: fix/recovery-checkpoint-live-state" in rendered, (
+            "Recovery checkpoint must read live git state from the "
+            "session's cwd (the worktree), not the project root. See "
+            "issue #1974."
+        )
+        # And it must NOT say the main-repo branch, or the architect
+        # treats the mismatch as prompt-injection and refuses.
+        assert "Branch: main" not in rendered
+
+    def test_falls_back_to_project_root_without_session_cwd(
+        self, tmp_path: Path,
+    ) -> None:
+        """When no session_name is supplied (or the session has no
+        cwd configured), the existing behavior — reading from
+        project.path — is preserved."""
+        import subprocess
+
+        project_root = tmp_path / "repo"
+        project_root.mkdir()
+        subprocess.run(
+            ["git", "init", "-b", "main", str(project_root)],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git",
+             "-c", "user.email=test@example.com",
+             "-c", "user.name=test",
+             "-C", str(project_root), "commit",
+             "--allow-empty", "-m", "init"],
+            check=True, capture_output=True,
+        )
+
+        config = _config(tmp_path)
+        # Re-init under the same project root the helper made.
+        # Helper above already created ``repo``, so reuse it: rebuild
+        # config explicitly to point ``test`` at the git repo we just
+        # initialised.
+        config = PollyPMConfig(
+            project=ProjectSettings(
+                root_dir=project_root,
+                base_dir=project_root / ".pollypm",
+                logs_dir=project_root / ".pollypm/logs",
+                snapshots_dir=project_root / ".pollypm/snapshots",
+                state_db=project_root / ".pollypm/state.db",
+            ),
+            pollypm=PollyPMSettings(controller_account="claude_main"),
+            accounts={
+                "claude_main": AccountConfig(
+                    name="claude_main",
+                    provider=ProviderKind.CLAUDE,
+                    home=project_root / ".pollypm" / "homes" / "claude_main",
+                ),
+            },
+            sessions={},
+            projects={
+                "test": KnownProject(
+                    key="test",
+                    path=project_root,
+                    name="TestProject",
+                    kind=ProjectKind.FOLDER,
+                ),
+            },
+        )
+
+        checkpoint = CheckpointData(
+            checkpoint_id="ckpt-fallback",
+            session_name="missing",
+            project="test",
+            objective="Fallback path",
+        )
+        prompt = _build_from_checkpoint(
+            config, checkpoint,
+            provider=ProviderKind.CLAUDE,
+            task_prompt="",
+            max_chars=DEFAULT_MAX_CHARS,
+            # Intentionally omit session_name to exercise the fallback.
+        )
+        rendered = prompt.render()
+        assert "Branch: main" in rendered
+
+
+# ---------------------------------------------------------------------------
 # Truncation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Closes #1974 (Lever 1 of the recovery-cascade fix).
- ``_live_git_state`` was reading branch and porcelain count from the project root, not the session's actual cwd. Architect/worker sessions live in per-session worktrees under ``<project>/.pollypm/worktrees/<session>/``, and a session checked out to ``fix/foo`` received a checkpoint advertising ``Branch: main`` (the project root's branch). The architect treated the mismatch as a probable prompt-injection and refused to act — producing the cross-project cascade failure (210 tier-4 escalations -> 0 ``task.queued``/``task.cancelled`` events).
- Plumbs ``session_name`` through ``build_recovery_prompt`` -> ``_build_from_checkpoint`` / ``_build_fallback_prompt`` -> ``_live_git_state``. The git-state section now reads from ``config.sessions[session_name].cwd`` when available; falls back to project root for direct callers without a session.
- Uses ``git branch --show-current`` (per the spec'd command), with a ``rev-parse`` fallback for detached HEAD.
- Handles linked worktrees: the original ``.git.is_dir()`` check missed worktrees, whose ``.git`` is a *file* pointing at the main worktree dir.

## Why this is surgical
- Single function (``_live_git_state``) plus signature plumbing through two builders. No template restructure. Existing callers without a ``session_name`` keep the old behavior.
- The supervisor call site (``src/pollypm/supervisor.py:3753``) already passes ``session_name`` positionally — no caller changes needed in production.

## Test plan
- [x] New ``TestLiveGitStateFromSessionCwd`` regression test that:
  - initialises a project repo on ``main``
  - adds a linked worktree on ``fix/recovery-checkpoint-live-state``
  - verifies the prompt emits the **worktree's** branch (asserts ``Branch: fix/recovery-checkpoint-live-state`` is present and ``Branch: main`` is NOT)
- [x] Fallback test: when ``session_name`` is omitted, the project root branch is emitted (existing behavior preserved).
- [x] Smoke-tested ``_live_git_state`` directly under Python with both scenarios (worktree + no-session); both pass.

## Out of scope
- Lever 2 (auth/signing), Lever 3 (watchdog imperative format) — separate PRs / issues.
- The 20+ existing inbox items flagged "Nth suspected fake RECOVERY MODE injection" by past architects are NOT cleaned up here; user handles inbox curation separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)