### PR TITLE
fix(watchdog): switch escalation template to imperative ACTION format

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -3726,7 +3726,16 @@ def _brief_fallback(finding: Finding) -> list[str]:
     Covers orphan_marker / marker_leaked / stuck_draft /
     cancel_no_promotion — all of which already carry human-readable
     ``message``/``recommendation`` fields, so we re-use those.
+
+    Format is **imperative**: the watchdog cascade was failing because
+    architects were treating the brief as advisory (Mode B in issue
+    #1974 — 210 tier-4 escalations, 0 corresponding ``task.queued`` /
+    ``task.cancelled`` events). The evidence section stays at the top;
+    the action block leads with ``ACTION REQUIRED`` and an explicit
+    command list, plus a "reply only AFTER executing" prohibition so
+    text-only acknowledgements stop counting as resolution.
     """
+    subject = finding.subject or "<task-id>"
     lines: list[str] = []
     lines.append("Stuck for: see message")
     lines.append("Observed evidence:")
@@ -3735,15 +3744,20 @@ def _brief_fallback(finding: Finding) -> list[str]:
     if finding.recommendation:
         lines.append(f"- Recommendation: {finding.recommendation}")
     lines.append("")
+    lines.append("ACTION REQUIRED: execute exactly one of:")
     lines.append(
-        "Your job: investigate the evidence above and unstick the "
-        "task. Generate hypotheses fresh from the evidence rather "
-        "than ratifying the recommendation."
+        f"  pm task queue {subject}     "
+        "(if the task should proceed)"
     )
     lines.append(
-        "Cli levers available: act on the recommendation above, take "
-        "a different action you judge appropriate, or escalate to "
-        "user via `pm notify`."
+        f"  pm task cancel {subject}    "
+        "(if the task should be discarded)"
+    )
+    lines.append("")
+    lines.append(
+        "Reply only AFTER executing the command. Do not reply with "
+        "analysis alone — the watchdog is checking for the task-state "
+        "change, not your reasoning."
     )
     return lines
 

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -915,6 +915,58 @@ def test_format_unstick_brief_dead_loop_quotes_count() -> None:
     assert "pm task cancel demo/4" in brief
 
 
+def test_format_unstick_brief_fallback_is_imperative() -> None:
+    """Stuck-draft / orphan-marker / cancel_no_promotion findings route
+    through ``_brief_fallback``. Issue #1974 (Mode B): the cross-project
+    audit log showed architects ack'ing these briefs with text-only
+    analysis ("X is already cancelled, skipping") and never executing
+    the queue/cancel command, so the cascade never resolved.
+
+    The template must be **imperative**:
+    - contains the verb ``execute`` (the action lead-in)
+    - contains both ``pm task queue`` and ``pm task cancel`` with the
+      finding's subject substituted (so it's copy-pasteable)
+    - forbids analysis-only replies (``Reply only AFTER`` clause), so
+      the architect cannot satisfy the brief by replying with text.
+    - drops the old advisory phrasings ("Your job: investigate", "rather
+      than ratifying the recommendation") that read as optional.
+    """
+    from pollypm.audit.watchdog import (
+        RULE_STUCK_DRAFT,
+        format_unstick_brief,
+    )
+
+    finding = Finding(
+        rule=RULE_STUCK_DRAFT,
+        project="pollypm",
+        subject="pollypm/29",
+        message="Draft task pollypm/29 has sat unpromoted for >30 min.",
+        recommendation=(
+            "Promote with `pm task queue pollypm/29` or discard "
+            "with `pm task cancel pollypm/29`."
+        ),
+        metadata={"detected_via": "state"},
+    )
+    brief = format_unstick_brief(finding)
+
+    # Imperative shape required by #1974 (Lever 3).
+    assert "ACTION REQUIRED" in brief
+    assert "execute" in brief
+    assert "pm task queue pollypm/29" in brief
+    assert "pm task cancel pollypm/29" in brief
+    assert "Reply only AFTER" in brief
+
+    # Old advisory phrasings must be gone — they were the failure mode.
+    assert "Your job: investigate" not in brief
+    assert "ratifying" not in brief
+
+    # Evidence section still leads (the finding's message/recommendation
+    # are not deleted — only the trailing advisory block is replaced).
+    evidence_idx = brief.index("Observed evidence:")
+    action_idx = brief.index("ACTION REQUIRED")
+    assert evidence_idx < action_idx
+
+
 # ---------------------------------------------------------------------------
 # Throttle — was_recently_dispatched
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Closes #1974 (Lever 3 of the recovery-cascade fix).
- Architects were treating ``_brief_fallback`` (the brief body for ``stuck_draft`` / ``orphan_marker`` / ``marker_leaked`` / ``cancel_no_promotion``) as advisory input. Cross-project audit-log scan: **210 tier-4 escalations across 10 projects, 0 corresponding ``task.queued`` / ``task.cancelled`` events** (Mode B in the issue). The architect replied with text reasoning ("pollypm/29 is cancelled, skipping") instead of executing the command — and the cascade never resolved.
- Replaces the trailing "Your job: investigate ... rather than ratifying the recommendation" block with an imperative ``ACTION REQUIRED: execute exactly one of: ...`` block plus a "Reply only AFTER executing" prohibition. Evidence section stays above the action (unchanged). Subject is interpolated so the commands are copy-pasteable.

## Before / after
**Before:**
> Your job: investigate the evidence above and unstick the task. Generate hypotheses fresh from the evidence rather than ratifying the recommendation.
> Cli levers available: act on the recommendation above, take a different action you judge appropriate, or escalate to user via \`pm notify\`.

**After:**
> ACTION REQUIRED: execute exactly one of:
>   pm task queue pollypm/29     (if the task should proceed)
>   pm task cancel pollypm/29    (if the task should be discarded)
>
> Reply only AFTER executing the command. Do not reply with analysis alone — the watchdog is checking for the task-state change, not your reasoning.

## Surgical scope
Only ``_brief_fallback`` is touched. The other per-rule helpers (``task_review_stale``, ``task_progress_stale``, ``role_session_missing``, ``worker_session_dead_loop``, etc.) keep their tailored levers because they describe non-binary actions (``pm task done`` + ``pm chat`` + ``pm notify``) where a strict queue/cancel imperative would be incorrect.

## Test plan
- [x] New ``test_format_unstick_brief_fallback_is_imperative`` asserts:
  - ``ACTION REQUIRED`` and ``execute`` are present
  - Both ``pm task queue <subject>`` and ``pm task cancel <subject>`` are present with the subject substituted
  - ``Reply only AFTER`` clause is present (forbids analysis-only replies)
  - Old advisory phrasings (``Your job: investigate``, ``ratifying``) are absent
  - Evidence section (``Observed evidence:``) precedes the action block
- [x] Smoke-tested ``format_unstick_brief`` directly under Python with a representative stuck_draft finding — emits the new shape exactly.

## Out of scope
- Lever 1 (live checkpoint state) — separate PR #1978.
- Lever 2 (auth/signing) and Lever 4 (inbox cleanup) — deferred per direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)