### PR TITLE
fix(persona): thread project persona_name into recovery preamble (closes #1976)

### DIFF
--- a/src/pollypm/supervisor.py
+++ b/src/pollypm/supervisor.py
@@ -189,19 +189,28 @@ _OWNER_PREFIXES = {
 # in the table for backwards-compat with any legacy callers, but the
 # recovery prompt is no longer injected into heartbeat panes (#1007 —
 # see the gate in :meth:`Supervisor.restart_session`).
+#
+# #1976: the persona name embedded in the preamble is a ``{persona_name}``
+# template token. ``_identity_preamble_for_role`` substitutes it with the
+# project's configured ``persona_name`` (samblog → "Sage") before
+# returning, falling back to the role default in :data:`_ROLE_DEFAULT_PERSONA`
+# when the project did not pick a custom name. The "Not X" parenthetical
+# at the end of each line keeps the role-default name as a contrast cue
+# (the agent has seen it in older transcripts), so the preamble still
+# reads naturally even after substitution.
 _ROLE_IDENTITY_PREAMBLE: dict[str, str] = {
     "operator-pm": (
-        "Quick reminder: in this session you're playing Polly, the "
+        "Quick reminder: in this session you're playing {persona_name}, the "
         "PollyPM operator — managing the project workspace from the "
         "cockpit's operator session. (Not Russell, not a project PM.)"
     ),
     "reviewer": (
-        "Quick reminder: in this session you're playing Russell, the "
+        "Quick reminder: in this session you're playing {persona_name}, the "
         "code reviewer — approve/reject decisions on completed work. "
         "(Not Polly, not a project PM.)"
     ),
     "architect": (
-        "Quick reminder: in this session you're playing Archie, the "
+        "Quick reminder: in this session you're playing {persona_name}, the "
         "architect — designing plans for the worker to implement. "
         "(Not the worker who executes them.)"
     ),
@@ -210,6 +219,21 @@ _ROLE_IDENTITY_PREAMBLE: dict[str, str] = {
         "supervisor — checking mechanical session health only, not "
         "owning task work."
     ),
+}
+
+
+# Role-default persona names used when the project did not configure a
+# custom ``persona_name``. Mirrors the role-registry defaults in
+# :mod:`pollypm.role_contract` and the per-role fallbacks used by
+# :func:`pollypm.plugins_builtin.project_planning.plugin.MarkdownPromptProfile.build_prompt`
+# (architect → "Archie") and
+# :func:`pollypm.work.session_manager._resolve_reviewer_persona_prompt`
+# (reviewer → "Russell"). Kept local so the preamble lookup stays a
+# pure-data helper without re-importing the role registry.
+_ROLE_DEFAULT_PERSONA: dict[str, str] = {
+    "operator-pm": "Polly",
+    "reviewer": "Russell",
+    "architect": "Archie",
 }
 
 
@@ -239,16 +263,47 @@ def _parse_supervisor_iso(value: object) -> datetime | None:
     return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
 
 
-def _identity_preamble_for_role(role: str | None) -> str:
+def _identity_preamble_for_role(
+    role: str | None,
+    *,
+    persona_name: str | None = None,
+) -> str:
     """Return an identity preamble for ``role`` (#869).
 
     Short string the supervisor prepends to the recovery prompt so a
     role-scoped agent does not slide into a different persona after
     reading the project-context section.
+
+    ``persona_name`` (#1976) overrides the role-default persona name
+    inside the preamble. Used by ``Supervisor.restart_session`` to thread
+    the project's configured ``KnownProject.persona_name`` (samblog →
+    "Sage") so the recovery preamble injected into the architect /
+    reviewer / operator-pm pane greets the agent with its real project
+    persona instead of leaking the role default ("Archie" / "Russell" /
+    "Polly"). Mirrors the precedence used by the architect system-prompt
+    builder (``MarkdownPromptProfile.build_prompt``) and the reviewer
+    persona prompt resolver (``_resolve_reviewer_persona_prompt``):
+    explicit project persona wins, role default backs it.
+
+    The ``heartbeat-supervisor`` preamble does not embed a persona name —
+    the heartbeat is a process role, not a chat persona — so substitution
+    is a no-op for it.
     """
     if not role:
         return ""
-    return _ROLE_IDENTITY_PREAMBLE.get(role, "")
+    template = _ROLE_IDENTITY_PREAMBLE.get(role, "")
+    if not template:
+        return ""
+    resolved = (
+        persona_name.strip()
+        if isinstance(persona_name, str) and persona_name.strip()
+        else _ROLE_DEFAULT_PERSONA.get(role, "")
+    )
+    if "{persona_name}" not in template:
+        # ``heartbeat-supervisor`` and any future role without an embedded
+        # persona — return the template as-is.
+        return template
+    return template.replace("{persona_name}", resolved)
 
 
 def _prefix_for_owner(owner: str, text: str) -> str:
@@ -3755,8 +3810,25 @@ class Supervisor:
                     provider=launch.session.provider,
                 )
                 rendered = recovery.render()
+                # #1976 — thread the project's configured ``persona_name``
+                # into the identity preamble so the architect / reviewer /
+                # operator-pm recovery message greets the agent with its
+                # project-scoped persona (samblog → "Sage") instead of
+                # leaking the role default ("Archie" / "Russell" / "Polly").
+                # Mirrors the precedence used by the architect system-prompt
+                # builder and the reviewer persona resolver: explicit
+                # project ``persona_name`` wins; role default backs it.
+                project_persona: str | None = None
+                project_key = launch.session.project
+                if project_key:
+                    project_cfg = self.config.projects.get(project_key)
+                    if project_cfg is not None:
+                        persona_raw = getattr(project_cfg, "persona_name", None)
+                        if isinstance(persona_raw, str) and persona_raw.strip():
+                            project_persona = persona_raw.strip()
                 identity_preamble = _identity_preamble_for_role(
                     launch.session.role,
+                    persona_name=project_persona,
                 )
                 if identity_preamble and rendered.strip():
                     rendered = f"{identity_preamble}\n\n{rendered}"

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -33,6 +33,7 @@ from pollypm.supervisor import (
     _extract_claude_model_name,
     _extract_codex_model_name,
     _extract_token_metrics,
+    _identity_preamble_for_role,
 )
 from pollypm.tmux.client import TmuxPane, TmuxWindow
 
@@ -2517,3 +2518,140 @@ def test_restart_session_skips_recovery_prompt_for_heartbeat(
     runtime = supervisor.store.get_session_runtime("heartbeat")
     assert runtime is not None
     assert runtime.status == "healthy"
+
+
+def test_identity_preamble_threads_project_persona_for_architect() -> None:
+    """#1976 — when the project configures a custom ``persona_name``
+    (samblog → "Sage") the architect recovery preamble must greet the
+    agent with that name instead of the role default "Archie".
+
+    Pre-fix: ``_identity_preamble_for_role("architect")`` returned a
+    hardcoded "Quick reminder: in this session you're playing Archie,
+    the architect …" message and ``Supervisor.restart_session`` sent it
+    verbatim into the architect pane on every recovery. The cockpit
+    sidebar correctly read "Sage" from ``KnownProject.persona_name``
+    but the architect itself, anchored by the recovery preamble, kept
+    self-identifying as Archie ("Hi — Archie, settled in"). The fix
+    threads ``persona_name`` through ``_identity_preamble_for_role``.
+
+    The "Not <other>" parenthetical at the end of each line keeps the
+    role default mentioned as a contrast cue (the assertion below
+    deliberately tolerates that — only the leading identity claim has
+    to flip from Archie to the configured persona).
+    """
+    preamble = _identity_preamble_for_role("architect", persona_name="Sage")
+    assert "you're playing Sage, the architect" in preamble
+    assert "you're playing Archie, the architect" not in preamble
+
+
+def test_identity_preamble_falls_back_to_role_default_for_architect() -> None:
+    """Projects that never picked a ``persona_name`` keep the historical
+    role default ("Archie") so the fallback path mirrors the precedence
+    used by ``MarkdownPromptProfile.build_prompt`` (architect system
+    prompt builder) and ``_resolve_reviewer_persona_prompt``: explicit
+    project persona wins, role default backs it.
+    """
+    preamble = _identity_preamble_for_role("architect", persona_name=None)
+    assert "you're playing Archie, the architect" in preamble
+    # Blank persona override must NOT leak ``{persona_name}`` into the message.
+    blank = _identity_preamble_for_role("architect", persona_name="   ")
+    assert "{persona_name}" not in blank
+    assert "you're playing Archie, the architect" in blank
+
+
+def test_identity_preamble_threads_persona_for_reviewer_and_operator() -> None:
+    """The same leak existed for the reviewer ("Russell") and
+    operator-pm ("Polly") preambles — both are now persona-aware so a
+    project that renamed its reviewer/operator persona stays consistent
+    across the system prompt, sidebar label, and recovery preamble.
+    """
+    reviewer = _identity_preamble_for_role("reviewer", persona_name="Rook")
+    assert "you're playing Rook, the code reviewer" in reviewer
+    assert "you're playing Russell, the code reviewer" not in reviewer
+
+    operator = _identity_preamble_for_role("operator-pm", persona_name="Ruby")
+    assert "you're playing Ruby, the PollyPM operator" in operator
+    assert "you're playing Polly, the PollyPM operator" not in operator
+
+
+def test_identity_preamble_for_heartbeat_is_persona_agnostic() -> None:
+    """``heartbeat-supervisor`` is a process role, not a chat persona —
+    its preamble does not embed a name and the persona override is a
+    no-op. Guards against an over-eager template substitution wiping
+    out the heartbeat string.
+    """
+    preamble = _identity_preamble_for_role(
+        "heartbeat-supervisor", persona_name="Sage",
+    )
+    assert "Heartbeat supervisor" in preamble
+    assert "{persona_name}" not in preamble
+
+
+def test_restart_session_recovery_preamble_uses_project_persona(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """#1976 end-to-end — ``Supervisor.restart_session`` on an architect
+    session whose project sets ``persona_name = "Sage"`` must inject a
+    recovery prompt whose identity preamble greets the agent as Sage,
+    not Archie. The send_keys payload is the load-bearing surface —
+    pre-fix this carried "playing Archie" into samblog's architect pane
+    despite the project-guide and system prompt already reading "Sage".
+    """
+    config = _config(tmp_path)
+    # Add an architect session and rebrand the project's persona.
+    config.sessions["architect"] = SessionConfig(
+        name="architect",
+        role="architect",
+        provider=ProviderKind.CLAUDE,
+        account="claude_controller",
+        cwd=tmp_path,
+        project="pollypm",
+        window_name="pm-architect",
+    )
+    config.projects["pollypm"] = KnownProject(
+        key="pollypm",
+        path=tmp_path,
+        name="PollyPM",
+        kind=ProjectKind.FOLDER,
+        persona_name="Sage",
+    )
+    supervisor = Supervisor(config)
+
+    monkeypatch.setattr(
+        supervisor.session_service.tmux, "has_session", lambda _name: False,
+    )
+    monkeypatch.setattr(
+        supervisor, "launch_session", lambda _name: None,
+    )
+    sent: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        supervisor.session_service.tmux,
+        "send_keys",
+        lambda target, text, **kw: sent.append((target, text)),
+    )
+    # Bypass the (launch, target) window match guard so the test isn't
+    # gated on a real tmux topology — we only care about the rendered
+    # preamble that would be sent into the pane.
+    monkeypatch.setattr(
+        supervisor, "_target_window_matches_launch",
+        lambda _launch, _target: True,
+    )
+    monkeypatch.setattr(
+        supervisor, "_pane_already_bootstrapped_as_other_role",
+        lambda _role, _target: False,
+    )
+    monkeypatch.setattr(
+        supervisor, "_resolve_send_target",
+        lambda _launch: "pm-control:pm-architect",
+    )
+
+    supervisor.restart_session(
+        "architect", "claude_controller", failure_type="pane_dead",
+    )
+
+    assert sent, "restart_session must inject a recovery prompt for architect"
+    payload = sent[0][1]
+    assert "you're playing Sage, the architect" in payload, (
+        f"recovery preamble leaked the role default; got:\n{payload[:400]}"
+    )
+    assert "you're playing Archie, the architect" not in payload


### PR DESCRIPTION
## Summary

- `_ROLE_IDENTITY_PREAMBLE` hardcoded persona names ("Archie", "Russell", "Polly") by role, ignoring the project's configured `persona_name`.
- Cockpit sidebar showed "Sage" for samblog but the architect identified itself as "Archie" in chat — the leak was the recovery-preamble injection path.
- Templates `{persona_name}` into the 3 persona-bearing preambles; `_identity_preamble_for_role` now takes a `persona_name` override; `Supervisor.restart_session` threads the project's `KnownProject.persona_name` through.
- `heartbeat-supervisor` preamble untouched (process role, no persona embed).

Closes #1976. Related: persona resolution PRs #1866 #1868 #1870 #1872 #1873.

## Test plan

- [x] `test_identity_preamble_threads_project_persona_for_architect` — project persona wins
- [x] `test_identity_preamble_falls_back_to_role_default_for_architect` — backward compat (None + blank)
- [x] `test_identity_preamble_threads_persona_for_reviewer_and_operator` — reviewer + operator-pm
- [x] `test_identity_preamble_for_heartbeat_is_persona_agnostic` — heartbeat untouched
- [x] `test_restart_session_recovery_preamble_uses_project_persona` — end-to-end integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)