### PR TITLE
fix(doctor): delegate _built_in_guide_body to writer source (closes #1984)

### DIFF
--- a/src/pollypm/doctor.py
+++ b/src/pollypm/doctor.py
@@ -2494,6 +2494,20 @@ def _git_last_change_ref(path: Path | None) -> str | None:
 
 @lru_cache(maxsize=None)
 def _built_in_guide_body(role: str) -> str:
+    # Delegate to the writer's source-of-truth so the doctor's drift
+    # detector and ``init_project_guide`` agree by construction. The
+    # previous bespoke implementation read ``worker_prompt()`` for the
+    # worker role while the writer reads ``docs/worker-guide.md`` —
+    # producing two different digests for the same role and wedging
+    # drift detection on the fallback path.
+    project_guides = _project_guides_module()
+    if project_guides is not None:
+        getter = getattr(project_guides, "built_in_guide_text", None)
+        if callable(getter):
+            try:
+                return getter(role)
+            except Exception:  # noqa: BLE001
+                pass
     if role == "architect":
         source = _guide_source_path(role)
         if source is None:

--- a/src/pollypm/project_guides.py
+++ b/src/pollypm/project_guides.py
@@ -109,10 +109,15 @@ def project_guide_drift_info(
     if not target.exists():
         return None
     guide = _read_project_guide_path(target)
-    upstream_body = built_in_guide_text(normalized).strip()
+    # Hash the raw built-in text — exactly what ``init_project_guide``
+    # passes when it records ``forked_from``. Stripping here previously
+    # produced a different sha256 from the writer, wedging drift
+    # detection in packaged installs (where the git-sha fallback path
+    # is unavailable). See ``fix/guide-drift-source-mismatch``.
+    raw_upstream = built_in_guide_text(normalized)
     current_ref = built_in_guide_fork_ref(
         normalized,
-        content=upstream_body,
+        content=raw_upstream,
         source_path=built_in_guide_source_path(normalized),
     )
     return ProjectGuideDriftInfo(
@@ -122,7 +127,7 @@ def project_guide_drift_info(
         current_ref=current_ref,
         drifted=(guide.forked_from != current_ref),
         body=guide.body,
-        upstream_body=upstream_body,
+        upstream_body=raw_upstream.strip(),
     )
 
 

--- a/tests/test_project_guide_drift_source_consistency.py
+++ b/tests/test_project_guide_drift_source_consistency.py
@@ -1,0 +1,118 @@
+"""Regression: writer's ``forked_from`` digest must equal what the drift
+detector computes as ``current_ref`` for the same role.
+
+Background: in a packaged install (no git history for the bundled
+source files), the writer's ``built_in_guide_fork_ref`` hashes the raw
+built-in guide text while ``project_guide_drift_info`` hashed a
+``.strip()``-ed copy of the same text. The two sha256 values
+disagreed, so freshly-written guides were reported as drifted forever
+and ``pm project init-guide ROLE --force`` could not clear ``pm
+doctor``'s ``project-guide-drift`` alert.
+
+The doctor's fallback ``_built_in_guide_body`` also disagreed with the
+writer for the worker role (it read ``worker_prompt()`` while the
+writer reads ``docs/worker-guide.md``). Both surfaces are pinned here
+so they cannot diverge again.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from pollypm import doctor, project_guides
+
+
+ROLES = ("architect", "reviewer", "worker")
+
+
+def _force_sha_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``_git_sha_for_path`` return ``None`` so both writer and
+    detector exercise the ``sha256:`` content-hash path. This is the
+    realistic state in a packaged install where the bundled source
+    files have no enclosing git repo."""
+
+    monkeypatch.setattr(project_guides, "_git_sha_for_path", lambda _path: None)
+
+
+@pytest.mark.parametrize("role", ROLES)
+def test_writer_forked_from_matches_drift_current_ref(
+    role: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After ``init_project_guide`` runs, ``project_guide_drift_info``
+    must report ``drifted=False`` and emit the same ref the writer
+    recorded."""
+
+    _force_sha_fallback(monkeypatch)
+
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+
+    info = project_guides.init_project_guide(project_dir, role)
+    drift = project_guides.project_guide_drift_info(project_dir, role)
+
+    assert drift is not None, f"drift info missing for role {role}"
+    assert drift.forked_from == info.forked_from, (
+        f"forked_from drifted between read paths for role {role}: "
+        f"writer-stored {info.forked_from!r} != drift-side {drift.forked_from!r}"
+    )
+    assert drift.current_ref == info.forked_from, (
+        f"writer and detector disagree on source digest for role {role}: "
+        f"writer recorded forked_from={info.forked_from!r} but "
+        f"detector computed current_ref={drift.current_ref!r}"
+    )
+    assert drift.drifted is False, (
+        f"freshly-initialised {role} guide reported as drifted: "
+        f"forked_from={drift.forked_from!r} current_ref={drift.current_ref!r}"
+    )
+
+
+@pytest.mark.parametrize("role", ROLES)
+def test_doctor_body_matches_writer_source(
+    role: str,
+) -> None:
+    """The doctor's ``_built_in_guide_body`` must return the same text
+    the writer reads (the bespoke worker branch previously read
+    ``worker_prompt()`` instead of ``docs/worker-guide.md``)."""
+
+    # Clear the lru_cache so repeated parametrised calls don't leak.
+    doctor._built_in_guide_body.cache_clear()  # type: ignore[attr-defined]
+    doctor._project_guides_module.cache_clear()  # type: ignore[attr-defined]
+
+    writer_body = project_guides.built_in_guide_text(role)
+    doctor_body = doctor._built_in_guide_body(role)
+
+    assert doctor_body == writer_body, (
+        f"doctor._built_in_guide_body diverges from "
+        f"project_guides.built_in_guide_text for role {role}"
+    )
+
+
+@pytest.mark.parametrize("role", ROLES)
+def test_doctor_fallback_branch_does_not_raise(
+    role: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit defence-in-depth: when ``project_guides`` is
+    unavailable, the bespoke fallback branch must still return a body
+    string. We don't assert byte-equality here (the bespoke branch is
+    known to disagree for worker — that's why we delegate when
+    project_guides is present)."""
+
+    doctor._built_in_guide_body.cache_clear()  # type: ignore[attr-defined]
+    doctor._project_guides_module.cache_clear()  # type: ignore[attr-defined]
+    real_module = sys.modules.get("pollypm.project_guides")
+    monkeypatch.setitem(sys.modules, "pollypm.project_guides", types.ModuleType("stub"))
+    try:
+        out = doctor._built_in_guide_body(role)
+        assert isinstance(out, str) and out
+    finally:
+        if real_module is not None:
+            sys.modules["pollypm.project_guides"] = real_module
+        doctor._built_in_guide_body.cache_clear()  # type: ignore[attr-defined]
+        doctor._project_guides_module.cache_clear()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- `pm doctor` reported a persistent `project-guide-drift` alert for a role even after running `pm project init-guide <role> --project <key> --force`. Root cause: doctor's drift detector and the init-guide writer hashed different sources for the same role, so the digests never matched and drift could never clear.
- Delegate `doctor._built_in_guide_body(role)` to `project_guides.built_in_guide_text(role)` (the writer's source-of-truth) and stop `.strip()`-ing the upstream text before hashing it in `project_guide_drift_info` — match what the writer records in `forked_from`.
- Adds a regression test pinning writer/detector digest equality across all built-in roles plus a doctor-fallback defence-in-depth case.

Closes #1984.

## Detail

Two independent disagreements between writer and detector:

1. `doctor._built_in_guide_body` had a bespoke branch for the worker role that read `worker_prompt()` (digest `5bbf11cf...`) while the writer reads `defaults/docs/worker-guide.md` (digest `808e65ea...`). Same role, two digests.
2. `project_guide_drift_info` hashed a `.strip()`-ed copy of the built-in text while `init_project_guide` recorded a `forked_from` computed from the raw (unstripped) text via `built_in_guide_fork_ref`. The two `sha256:` values disagreed on the content-hash fallback path that packaged installs hit.

Either failure on its own is sufficient to wedge `pm doctor`. Both are pinned by the regression test so they can't diverge again.

## Test plan

- [x] New regression test `tests/test_project_guide_drift_source_consistency.py` passes against this branch via direct-import smoke run (9/9 cases pass: writer/detector digest match for architect/reviewer/worker, doctor body matches writer for all three roles, doctor fallback branch returns non-empty for all three roles).
- [x] Same test would fail on `main` for the worker role on the doctor-body case and for architect+worker on the writer/detector case (verified by running the smoke test against a non-fix checkout).
- [ ] Reviewer to confirm: in a packaged install, `pm project init-guide worker --project <key> --force && pm doctor` no longer flags `project-guide-drift: worker`.

## Scope

v1 RC stability. Narrow surface (`src/pollypm/doctor.py` +14 lines, `src/pollypm/project_guides.py` net +8 lines, +118 line regression test). No behavioural change for non-drifted guides.

Generated with [Claude Code](https://claude.com/claude-code)