### PR TITLE
fix(cockpit): backend-aware heartbeat freshness probe (closes #1986)

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -2371,7 +2371,20 @@ class PollyCockpitApp(App[None]):
             hint_text = "j/k \u21b5open \u00b7 ? help \u00b7 q quit"
         try:
             supervisor = self.router._load_supervisor()
-            last_hb = supervisor.store.last_heartbeat_at()
+            # Backend-aware read: on the pg backend the unified ``messages``
+            # table lives in Postgres, but ``supervisor.store`` is still the
+            # SQLite ``StateStore`` (kept for legacy domain reads). Reading
+            # the sqlite copy yields a stale row from before the pg cutover
+            # and the rail then renders a false-positive "Heartbeat offline
+            # (Nm)" warning. Route through the pg facade when configured.
+            from pollypm.storage._backend_dispatch import is_pg_backend
+            if is_pg_backend(supervisor.config):
+                from pollypm.storage.pg_heartbeats import (
+                    last_heartbeat_at as _pg_last_heartbeat_at,
+                )
+                last_hb = _pg_last_heartbeat_at(config=supervisor.config)
+            else:
+                last_hb = supervisor.store.last_heartbeat_at()
             if last_hb:
                 from datetime import UTC, datetime
                 # Unified ``messages`` table stores SQLite's default


### PR DESCRIPTION
## Summary

- Rail bottom hint shows a permanent `⚠ Heartbeat offline (Nm)` warning on the pg backend because `supervisor.store.last_heartbeat_at()` always reads the SQLite `StateStore`, which returns a stale row from before the pg cutover.
- Route the probe through `is_pg_backend(config)` and the `pg_heartbeats.last_heartbeat_at` facade when pg is configured; sqlite installs are unaffected.
- Adjacent site (`recent_heartbeats` at cockpit_ui.py:11380) needs the same fix but requires adding a pg facade — tracked in #1986, deferred.

## Test plan

- [ ] With `[storage] backend = "postgres"` and `pm heartbeat` running, rail hint must NOT show `Heartbeat offline (Nm)` while `psql -c "SELECT max(created_at) FROM messages WHERE type='event' AND scope='heartbeat' AND subject='heartbeat'"` returns a timestamp within 180s.
- [ ] Stop `pm heartbeat`; wait 3+ minutes; rail hint must show the offline warning correctly.
- [ ] On a sqlite-backend workspace, behaviour is unchanged (still reads via `StateStore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)