### PR TITLE
polish(tmux-ui): consolidate hex literals into cockpit_theme.py

### DIFF
--- a/src/pollypm/cockpit_rail_item.py
+++ b/src/pollypm/cockpit_rail_item.py
@@ -38,6 +38,7 @@ from pollypm.cockpit_rail import (
     CockpitPresence,
     _alert_type_is_user_action_waiting,
 )
+from pollypm.cockpit_theme import Glyph, State
 
 
 class RailItem(ListItem):
@@ -118,7 +119,7 @@ class RailItem(ListItem):
 
         text = Text()
         if self.has_class("active-view"):
-            text.append("▌ ", style="#5b8aff")
+            text.append("▌ ", style=State.INFO)
         else:
             text.append("  ")
         indicator, indicator_style = self._indicator()
@@ -150,9 +151,9 @@ class RailItem(ListItem):
                 # #989 — Dim subtitle picks up severity tint so the
                 # subtitle reads as the same alert as the row badge.
                 subtitle_style = (
-                    "#f0c45a dim"
+                    f"{State.WAITING} dim"
                     if self.item.alert_severity == "warn"
-                    else "#ff5f6d dim"
+                    else f"{State.BLOCKED} dim"
                 )
                 for chunk in _wrap_alert_reason(
                     reason,
@@ -168,7 +169,7 @@ class RailItem(ListItem):
         # error (red) read as different states even when the row label
         # / state string are identical.
         alert_color = (
-            "#f0c45a" if self.item.alert_severity == "warn" else "#ff5f6d"
+            State.WAITING if self.item.alert_severity == "warn" else State.BLOCKED
         )
         if self.item.key.startswith("project:"):
             # #1390 — Approval-pending takes precedence over the rollup
@@ -179,9 +180,9 @@ class RailItem(ListItem):
                 getattr(self.item, "approvals_pending", 0) > 0
                 and self.item.state != "project-red"
             ):
-                return "▶", "#ff5f6d"
+                return Glyph.DECISION, State.BLOCKED
             if self.item.state == "project-red":
-                return "▲", alert_color
+                return Glyph.BLOCKED, alert_color
             # #1520 — A "Waiting on you:" alert family on the project's
             # sessions (plan_missing, worker_question, recovery_limit,
             # auth_broken, stuck_on_task:, no_session_for_assignment:,
@@ -196,17 +197,17 @@ class RailItem(ListItem):
             if _alert_type_is_user_action_waiting(
                 getattr(self.item, "alert_type", None)
             ):
-                return "◆", "#f0a030"
+                return Glyph.ATTENTION, State.ATTENTION
             if self.item.state == "project-yellow":
                 # #1092 — use ◆ to match the dashboard's "needs attention"
                 # diamond. ``•`` and the idle ``·`` are visually
                 # indistinguishable in many terminal fonts, so a project
                 # with held tasks read as idle in the rail.
-                return "◆", "#f0a030"
+                return Glyph.ATTENTION, State.ATTENTION
             if self.item.state == "project-green":
-                return "•", "#3ddc84"
+                return Glyph.LIVE, State.WORKING
             if self.item.state == "project-working":
-                return "•", "#f0c45a"
+                return Glyph.LIVE, State.WAITING
         if (
             presence is not None
             and self.item.session_name
@@ -219,45 +220,45 @@ class RailItem(ListItem):
             work_glyph, color = self._session_work_glyph(self.item.work_state)
             return f"{pulse}{work_glyph}", color
         if presence is not None and self.item.state in {"heartbeat", "watch"}:
-            return presence.heartbeat_frame(self.spinner_index), "#3ddc84"
+            return presence.heartbeat_frame(self.spinner_index), State.WORKING
         # Alerts (red triangle / amber for warn-tier — #989)
         if self.item.state.startswith("!"):
-            return "▲", alert_color
+            return Glyph.BLOCKED, alert_color
         # Separator
         if self.item.state == "separator":
-            return "", "#4a5568"
+            return "", State.IDLE
         # Top-level agents (Polly, Russell)
         if self.item.key in ("polly", "russell"):
             if self.item.state.endswith("working"):
-                return self.item.state.split(" ", 1)[0], "#3ddc84"  # green spinner
+                return self.item.state.split(" ", 1)[0], State.WORKING  # green spinner
             if self.item.state in {"ready", "idle"}:
-                return "•", "#5b8aff"  # blue dot
-            return "•", "#5b8aff"
+                return Glyph.LIVE, State.INFO  # blue dot
+            return Glyph.LIVE, State.INFO
         # Inbox
         if self.item.key == "inbox":
             label = self.item.label
             if "(" in label and not label.endswith("(0)"):
-                return "◆", "#f0c45a"  # yellow diamond
-            return "◇", "#4a5568"
+                return Glyph.ATTENTION, State.WAITING  # yellow diamond
+            return Glyph.WAITING, State.IDLE
         # Settings
         if self.item.key == "settings":
-            return "⚙", "#6b7a88"
+            return "⚙", State.MUTED
         # Sub-items
         if self.item.state == "sub":
-            return " ", "#4a5568"
+            return " ", State.IDLE
         # Projects keep their status marker quieter than global rows.
         # A full orange unread dot or animated working spinner makes
         # ordinary project rows compete with true alert/action rows in the
         # narrow rail.
         if self.item.key.startswith("project:"):
             if self.item.state == "unread":
-                return "•", "#f0a030"
+                return Glyph.LIVE, State.ATTENTION
             if "working" in self.item.state:
-                return "•", "#f0c45a"
-            return "○", "#4a5568"  # dim circle — idle
+                return Glyph.LIVE, State.WAITING
+            return Glyph.IDLE, State.IDLE  # dim circle — idle
         # Unread
         if self.item.state == "unread":
-            return "●", "#f0a030"  # orange dot
+            return "●", State.ATTENTION  # orange dot
         # Generic "<glyph> working" state — top-level rail rows
         # (e.g. Workers when any worker is currently turning) used
         # to fall through to the idle circle below, so a
@@ -266,28 +267,28 @@ class RailItem(ListItem):
         # state with the spinner / active diamond.
         if self.item.state.endswith("working"):
             if presence is not None:
-                return presence.working_frame(self.spinner_index), "#3ddc84"
-            return "◆", "#f0c45a"
-        return "○", "#4a5568"
+                return presence.working_frame(self.spinner_index), State.WORKING
+            return Glyph.ATTENTION, State.WAITING
+        return Glyph.IDLE, State.IDLE
 
     def _session_work_glyph(self, work_state: str) -> tuple[str, str]:
         presence = self.presence
         if work_state == "writing":
             if presence is not None:
                 if not presence.should_animate():
-                    return "…", "#3ddc84"
-                return presence.working_frame(self.spinner_index), "#3ddc84"
-            return "◆", "#3ddc84"
+                    return "…", State.WORKING
+                return presence.working_frame(self.spinner_index), State.WORKING
+            return Glyph.ATTENTION, State.WORKING
         if work_state == "reviewing":
-            return "✎", "#3ddc84"
+            return Glyph.REVIEWING, State.WORKING
         if work_state == "stuck":
             # #989 — Pick amber for warn-tier alerts so the user can
             # distinguish "answer the prompt" from "account repair".
-            color = "#f0c45a" if self.item.alert_severity == "warn" else "#ff5f6d"
-            return "⚠", color
+            color = State.WAITING if self.item.alert_severity == "warn" else State.BLOCKED
+            return Glyph.STUCK, color
         if work_state == "exited":
-            return "✕", "#4a5568"
-        return "·", "#4a5568"
+            return Glyph.EXITED, State.IDLE
+        return "·", State.IDLE
 
 
 __all__ = ["RailItem"]

--- a/src/pollypm/cockpit_theme.py
+++ b/src/pollypm/cockpit_theme.py
@@ -1,0 +1,151 @@
+"""Semantic palette + glyph vocabulary for the cockpit UI.
+
+Single source of truth for the (color, glyph) pairs used across the
+Textual cockpit. Today the same hex strings (``#f0c45a``, ``#3ddc84``,
+``#ff5f6d``, ``#5b8aff``, ``#4a5568``, ``#6b7a88``) are duplicated
+across ``cockpit_rail_item``, ``cockpit_ui_inbox_format``,
+``cockpit_activity``, ``cockpit_alert_detail``, and the dashboard CSS
+in ``cockpit_ui`` — silently drift-prone (the inbox plan-review row
+ended up at ``#ff6b5b`` instead of the rail's ``#ff5f6d``, an obvious
+accidental copy-paste).
+
+This module exposes two namespaces:
+
+- :class:`State` — semantic state → hex color string (Rich markup ready)
+- :class:`Glyph` — semantic role → single-character glyph
+
+Each ``State`` constant has a matching ``as_tuple`` form for callers
+that drive the raw rail renderer (``cockpit_rail.PALETTE``), which
+historically stored ``(r, g, b)`` triples. Bridging both representations
+lets consumers migrate one site at a time.
+
+Scope/contract:
+- Pure data, no imports beyond ``typing`` / stdlib. Zero side effects.
+- Leaf module: importable from any ``cockpit_*`` module without risking
+  cycles. Specifically does NOT import from ``cockpit_rail``,
+  ``cockpit_ui``, or any Textual primitive.
+- Constants are strings/chars — Rich markup callers can use them inline
+  via f-strings (``f"[{State.WAITING}]◆[/{State.WAITING}]"``).
+- Wedge of the #1354 god-module split: gives downstream modules a small
+  shared dependency so the rail-item / inbox-format / activity colour
+  duplication can be folded into one audit-able place.
+"""
+
+from __future__ import annotations
+
+
+def hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    """Convert ``#rrggbb`` to ``(r, g, b)`` ints in [0, 255].
+
+    Used by the rail's raw renderer (``cockpit_rail.PALETTE``) which
+    historically stored RGB triples. Letting both representations co-exist
+    means the migration off duplicated hex literals can land one consumer
+    at a time without rewriting the rail's renderer.
+    """
+    if not hex_color.startswith("#") or len(hex_color) != 7:
+        raise ValueError(f"expected #rrggbb hex color, got {hex_color!r}")
+    return (
+        int(hex_color[1:3], 16),
+        int(hex_color[3:5], 16),
+        int(hex_color[5:7], 16),
+    )
+
+
+class State:
+    """Semantic state colors.
+
+    Each name describes the operator-visible meaning, not the hue —
+    so a hue tweak (say "amber→orange") happens in one place without
+    losing semantic intent. Hex strings are the ones already present
+    in the cockpit so this is rename-only, not a redesign.
+    """
+
+    # Amber — user action required / decision pending / unread inbox.
+    # Today used as ``#f0c45a`` across rail-item / inbox-format / activity.
+    WAITING = "#f0c45a"
+
+    # Green — agent actively writing / shipped / done. The cockpit
+    # currently does not visually differentiate "working green" from
+    # "shipped green"; if that distinction is wanted later, split this
+    # into ``WORKING`` and ``DONE`` and update consumers.
+    WORKING = "#3ddc84"
+    DONE = "#3ddc84"
+
+    # Red — stuck / error / dead / blocked. Rail uses ``#ff5f6d``; some
+    # surfaces drifted to ``#ff6b5b`` — we standardise on the rail's.
+    BLOCKED = "#ff5f6d"
+
+    # Slate — at rest / idle / disabled. Used for ``○`` icons.
+    IDLE = "#4a5568"
+
+    # Blue — top-level nav highlight / active-view marker / info.
+    INFO = "#5b8aff"
+
+    # Warm gray — metadata, age, project labels, dim subtitles.
+    MUTED = "#6b7a88"
+
+    # Orange — project-yellow rollup glyph + needs-decision pill.
+    # Today rail uses ``#f0a030`` for the "Waiting on you:" diamond
+    # (one step warmer than ``WAITING`` to differentiate "needs your
+    # decision" from "needs your attention").
+    ATTENTION = "#f0a030"
+
+    # Heading text on selected/highlighted rows (rail "sel_text",
+    # inbox "bold subject"). The brightest neutral in the palette.
+    HEADING = "#eef2f4"
+
+    # Body / label color for non-selected rail rows. One step dimmer
+    # than HEADING.
+    LABEL = "#b8c4cf"
+
+
+class Glyph:
+    """Semantic glyph vocabulary.
+
+    Each name describes the operator-visible role, not the shape — so
+    a glyph swap (say ``◆`` → ``◈``) happens in one place. Characters
+    are the ones already in the cockpit so this is rename-only.
+    """
+
+    # ◆ Yellow diamond — "needs attention" / unread / decision-needed.
+    # The dashboard's Action Needed banner and the rail's inbox-has-mail
+    # row both use this — same shape, same color (``State.WAITING``).
+    ATTENTION = "◆"  # ◆
+
+    # • Filled bullet — currently active / live / writing.
+    LIVE = "•"  # •
+
+    # ○ Hollow circle — at rest / idle.
+    IDLE = "○"  # ○
+
+    # ▲ Red triangle — alert / fault / dead row.
+    BLOCKED = "▲"  # ▲
+
+    # ▶ Play arrow — decision pending (plan review, approval).
+    DECISION = "▶"  # ▶
+
+    # ◇ Hollow diamond — paused / waiting-on-plan / inbox empty.
+    WAITING = "◇"  # ◇
+
+    # ◉ Bullseye — task in review status.
+    REVIEW = "◉"  # ◉
+
+    # ♥ / ♡ — tmux session pulse (attached / detached).
+    PULSE_ON = "♥"  # ♥
+    PULSE_OFF = "♡"  # ♡
+
+    # ⚠ — worker stuck.
+    STUCK = "⚠"  # ⚠
+
+    # ✕ — session exited.
+    EXITED = "✕"  # ✕
+
+    # ✎ — reviewer writing.
+    REVIEWING = "✎"  # ✎
+
+    # Arc spinner — animated 4-frame "thinking" indicator. Tuple, not a
+    # single char, so callers index into it with a frame counter.
+    SPINNER = ("◜", "◝", "◞", "◟")  # ◜ ◝ ◞ ◟
+
+
+__all__ = ["State", "Glyph", "hex_to_rgb"]

--- a/tests/test_cockpit_theme.py
+++ b/tests/test_cockpit_theme.py
@@ -1,0 +1,69 @@
+"""Smoke tests for the semantic palette + glyph module.
+
+Guards against the most likely regression: a future palette tweak that
+silently breaks a glyph/color invariant that ``cockpit_rail_item`` (and
+the rest of the cockpit) relies on.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from pollypm.cockpit_theme import Glyph, State, hex_to_rgb
+
+
+_HEX_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [n for n in dir(State) if not n.startswith("_") and isinstance(getattr(State, n), str)],
+)
+def test_state_constants_are_hex_strings(name: str) -> None:
+    value = getattr(State, name)
+    assert _HEX_RE.match(value), f"State.{name} = {value!r} is not a #rrggbb hex string"
+
+
+def test_state_blocked_matches_rail_palette_red() -> None:
+    """Inbox plan-review row historically drifted to ``#ff6b5b`` while the
+    rail used ``#ff5f6d``. We standardise on the rail's; lock that in.
+    """
+    assert State.BLOCKED == "#ff5f6d"
+
+
+def test_glyph_attention_is_yellow_diamond() -> None:
+    """Sanity-check the glyph vocabulary so a stray reshuffle doesn't
+    silently swap meanings (e.g. ATTENTION → ▲ would break the rail).
+    """
+    assert Glyph.ATTENTION == "◆"
+    assert Glyph.BLOCKED == "▲"
+    assert Glyph.DECISION == "▶"
+    assert Glyph.IDLE == "○"
+    assert Glyph.LIVE == "•"
+    assert Glyph.WAITING == "◇"
+    assert Glyph.REVIEW == "◉"
+
+
+def test_glyph_pulse_pair() -> None:
+    assert Glyph.PULSE_ON == "♥"
+    assert Glyph.PULSE_OFF == "♡"
+
+
+def test_glyph_spinner_is_four_frame_arc() -> None:
+    assert Glyph.SPINNER == ("◜", "◝", "◞", "◟")
+    assert len(Glyph.SPINNER) == 4
+
+
+def test_hex_to_rgb_round_trip() -> None:
+    assert hex_to_rgb("#000000") == (0, 0, 0)
+    assert hex_to_rgb("#ffffff") == (255, 255, 255)
+    assert hex_to_rgb(State.WAITING) == (0xf0, 0xc4, 0x5a)
+
+
+def test_hex_to_rgb_rejects_short_or_unprefixed() -> None:
+    with pytest.raises(ValueError):
+        hex_to_rgb("f0c45a")
+    with pytest.raises(ValueError):
+        hex_to_rgb("#fff")


### PR DESCRIPTION
## Summary

Refs #1988.

Introduces a leaf module ``cockpit_theme.py`` exposing two namespaces:

- ``State`` — semantic state → hex color (``WAITING`` / ``WORKING`` / ``BLOCKED`` / ``DONE`` / ``IDLE`` / ``INFO`` / ``MUTED`` / ``ATTENTION`` / ``HEADING`` / ``LABEL``)
- ``Glyph`` — semantic role → glyph char (``ATTENTION`` ◆ / ``LIVE`` • / ``IDLE`` ○ / ``BLOCKED`` ▲ / ``DECISION`` ▶ / ``WAITING`` ◇ / ``REVIEW`` ◉ / ``PULSE_ON`` ♥ / ``PULSE_OFF`` ♡ / ``STUCK`` ⚠ / ``EXITED`` ✕ / ``REVIEWING`` ✎ / ``SPINNER`` ``◜◝◞◟``)

Hex values are the ones already in the cockpit — this is rename-only, not a redesign. The rail's existing ``PALETTE`` (tuple-RGB, for the raw ``pm rail`` renderer) stays; ``hex_to_rgb()`` bridges both forms.

Migrates ``cockpit_rail_item.py`` as the first consumer — it had the most concentrated duplication (8 distinct hex literals × ~15 use sites).

Follow-up PRs will migrate ``cockpit_ui_inbox_format`` (where the red drifted to ``#ff6b5b`` accidentally), ``cockpit_activity`` event-type map, ``cockpit_alert_detail`` modal, and the dashboard CSS in ``cockpit_ui``.

## Test plan

- [x] ``cockpit_rail_item.py`` has zero ``#[0-9a-fA-F]{6}`` literals after the diff
- [x] New ``tests/test_cockpit_theme.py`` smoke tests guard the semantic invariants (``BLOCKED == #ff5f6d`` locked in)
- [x] Direct ``import`` smoke: ``cockpit_rail_item`` still loads with the new theme dependency
- [ ] Existing rail-item assertions (``test_cockpit.py::test_cockpit_ui_rail_item_indicator_combines_pulse_and_work_glyph``, ``test_cockpit_rail_operator_glyphs``) — they assert glyph characters only, which are byte-identical post-rename

## Risk

Low — rename-only. The Rich-markup style strings are interchangeable (``"#f0c45a"`` is identical to ``State.WAITING``). The new module is a leaf with no imports beyond stdlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)