### PR TITLE
fix(cockpit): preserve agent-pane sessions across rail nav (closes #1994)

### DIFF
--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -4291,6 +4291,19 @@ class CockpitRouter:
         # (both are live) and Sam saw a fresh Polly re-asking the same
         # 4 onboarding questions — the duplicate window held the
         # original conversation.
+        #
+        # #1955 — live-duplicate policy reversal. The original #1635
+        # logic refused break-pane when a live storage window already
+        # held the canonical name, trusting storage as the persistent
+        # home. For rail-navigation that's wrong: the user has been
+        # typing into ``right_pane_id`` (the cockpit mount), so the
+        # cockpit pane IS the user's active conversation and any
+        # pre-existing live storage window with the same name is a
+        # stale orphan. Killing the cockpit pane (the original
+        # behaviour) wiped Sam's live architect chat on every
+        # nav-and-back. Trust the cockpit pane: kill the orphan and
+        # break-pane the cockpit pane into storage so the next mount
+        # picks up the real conversation.
         existing_same_name = [
             w for w in storage_windows_before
             if getattr(w, "name", None) == window_name
@@ -4304,17 +4317,13 @@ class CockpitRouter:
             if not self._storage_window_is_live(w)
         ]
         if live_existing:
-            # A live duplicate already owns ``window_name`` in storage —
-            # the existing window IS the persistent home. Skip the
-            # break-pane entirely. The caller's subsequent
-            # ``respawn_pane`` on our right pane will discard the
-            # duplicate process we would otherwise have parked.
-            state.pop("mounted_session", None)
-            state.pop("mounted_identity", None)
-            self._write_state(state)
-            self._release_cockpit_lease(supervisor, mounted_session)
+            # #1955 — kill the orphan(s) so the user's actual conversation
+            # (which is right_pane_id, the cockpit's current mount) can
+            # claim the canonical name on break-pane below.  Emit a
+            # forensics event BEFORE the kill so the audit trail records
+            # which indices we removed.
             self._emit_cockpit_audit(
-                event_name="cockpit.park_skipped_existing",
+                event_name="cockpit.park_killed_orphan",
                 subject=mounted_session,
                 status="warn",
                 metadata={
@@ -4323,10 +4332,14 @@ class CockpitRouter:
                     "storage_session": storage_session,
                     "live_duplicate_indices": [w.index for w in live_existing],
                     "dead_duplicate_indices": [w.index for w in dead_existing],
-                    "reason": "live_existing_storage_window",
+                    "reason": "killed_orphan_to_preserve_active_mount",
                 },
             )
-            return
+            for window in live_existing:
+                try:
+                    self.tmux.kill_window(f"{storage_session}:{window.index}")
+                except Exception:  # noqa: BLE001
+                    continue
         # Re-occupy any stale (pane-dead) windows that already hold the
         # name so break-pane lands at the canonical name rather than
         # falling back to a tmux-generated suffix.
@@ -4363,6 +4376,7 @@ class CockpitRouter:
                 "storage_session": storage_session,
                 "storage_windows_after": sorted(w.name for w in after),
                 "reoccupied_dead_indices": [w.index for w in dead_existing],
+                "killed_live_orphan_indices": [w.index for w in live_existing],
             },
         )
 

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -4292,7 +4292,7 @@ class CockpitRouter:
         # 4 onboarding questions — the duplicate window held the
         # original conversation.
         #
-        # #1955 — live-duplicate policy reversal. The original #1635
+        # #1994 — live-duplicate policy reversal. The original #1635
         # logic refused break-pane when a live storage window already
         # held the canonical name, trusting storage as the persistent
         # home. For rail-navigation that's wrong: the user has been
@@ -4317,7 +4317,7 @@ class CockpitRouter:
             if not self._storage_window_is_live(w)
         ]
         if live_existing:
-            # #1955 — kill the orphan(s) so the user's actual conversation
+            # #1994 — kill the orphan(s) so the user's actual conversation
             # (which is right_pane_id, the cockpit's current mount) can
             # claim the canonical name on break-pane below.  Emit a
             # forensics event BEFORE the kill so the audit trail records

--- a/src/pollypm/cockpit_storage_park.py
+++ b/src/pollypm/cockpit_storage_park.py
@@ -30,7 +30,7 @@ The helper is intentionally tmux-shape agnostic: callers pass a
 ``tmux`` client plus a small audit-emit callback, and the helper does
 the rest.  Pure-function design makes testing without tmux trivial.
 
-Live-duplicate policy (#1955, 2026-05-20)
+Live-duplicate policy (#1994, 2026-05-20)
 -----------------------------------------
 The original helper, on finding a same-named LIVE window in storage,
 killed the caller's ``source_pane_id`` and refused the break-pane —
@@ -104,7 +104,7 @@ def safe_break_pane_to_storage(
         break-pane re-occupies the canonical name, then break.
       * No duplicates → break unconditionally.
 
-    Why the live-duplicate path changed (#1631 → #1955 fix):
+    Why the live-duplicate path changed (#1631 → #1994 fix):
     The original #1631 helper assumed the storage window held the
     user's conversation and skipped the break-pane (killing
     ``source_pane_id`` as collateral).  That was correct when the
@@ -117,7 +117,7 @@ def safe_break_pane_to_storage(
     _refusal`` memory — the cockpit pane is the source of truth at the
     moment of the park because the rail just unmounted from it.
 
-    The helper centralizes the #1631/#1635/#1955 logic so every
+    The helper centralizes the #1631/#1635/#1994 logic so every
     break-pane site in the cockpit gets the same handling.  See module
     docstring for the full list of historical bypass sites.
     """

--- a/src/pollypm/cockpit_storage_park.py
+++ b/src/pollypm/cockpit_storage_park.py
@@ -29,6 +29,23 @@ sees more than one live window per name, eliminating the wipe surface.
 The helper is intentionally tmux-shape agnostic: callers pass a
 ``tmux`` client plus a small audit-emit callback, and the helper does
 the rest.  Pure-function design makes testing without tmux trivial.
+
+Live-duplicate policy (#1955, 2026-05-20)
+-----------------------------------------
+The original helper, on finding a same-named LIVE window in storage,
+killed the caller's ``source_pane_id`` and refused the break-pane —
+treating the storage window as the persistent home.
+
+In practice this is wrong for the rail-navigation case: the cockpit
+pane is the user's active conversation (they just unmounted from it by
+clicking a different rail item), and any pre-existing live storage
+window with the same canonical name is a stale orphan from a previous
+session.  Killing the cockpit pane wipes the conversation the user
+just had open.
+
+The helper now kills the storage orphan instead and breaks the
+cockpit pane into storage under the canonical name.  The next mount
+picks up the user's real conversation.
 """
 
 from __future__ import annotations
@@ -72,24 +89,37 @@ def safe_break_pane_to_storage(
 ) -> bool:
     """Break ``source_pane_id`` into ``storage_session`` only if safe.
 
-    Returns ``True`` when the break-pane actually ran (or no duplicate
-    blocked it), ``False`` when the helper refused to break because a
-    live duplicate already owns the canonical name.
+    Returns ``True`` when the break-pane actually ran, ``False`` only
+    when ``break-pane`` itself raised.
 
     Behaviour:
       * If the storage closet already holds a live window of the same
-        name → skip ``break-pane``, kill ``source_pane_id`` (it would
-        otherwise leak as an unparented pane after the cockpit reclaims
-        its real estate), emit ``cockpit.park_skipped_existing`` audit,
-        and return ``False``.  Callers MUST treat this as a successful
-        park: the storage window is already the persistent home.
+        name → that window is an ORPHAN (the user can only be conversing
+        with one pane at a time; ``source_pane_id`` is the cockpit's
+        live mount, which is by definition the user's current session).
+        Kill the orphan, then break-pane ``source_pane_id`` into storage
+        under ``window_name``.  Emits ``cockpit.park_killed_orphan``
+        audit before the kill so forensics can correlate.
       * If only dead-named duplicates exist → kill the dead windows so
         break-pane re-occupies the canonical name, then break.
       * No duplicates → break unconditionally.
 
-    The helper centralizes the #1631/#1635 fix so every break-pane site
-    in the cockpit gets the same dup-check.  See module docstring for
-    the full list of historical bypass sites.
+    Why the live-duplicate path changed (#1631 → #1955 fix):
+    The original #1631 helper assumed the storage window held the
+    user's conversation and skipped the break-pane (killing
+    ``source_pane_id`` as collateral).  That was correct when the
+    cockpit had spawned a fresh placeholder mid-park-collision.  It is
+    WRONG when the user has been actively typing into the cockpit
+    pane — which is the rail-navigation case: the cockpit pane IS the
+    user's session, and the storage duplicate is the stale orphan.
+    Trust the cockpit pane (it is by construction the active mount)
+    and kill the storage orphan instead.  See ``feedback_destructive
+    _refusal`` memory — the cockpit pane is the source of truth at the
+    moment of the park because the rail just unmounted from it.
+
+    The helper centralizes the #1631/#1635/#1955 logic so every
+    break-pane site in the cockpit gets the same handling.  See module
+    docstring for the full list of historical bypass sites.
     """
     try:
         storage_windows = tmux.list_windows(storage_session)
@@ -104,18 +134,15 @@ def safe_break_pane_to_storage(
     dead_existing = [w for w in existing_same_name if not _window_is_live(w)]
 
     if live_existing:
-        # Persistent home already owns the canonical name.  Refuse the
-        # break-pane.  The caller's surviving cockpit pane (the one we
-        # would have parked) is now an orphan duplicate of the storage
-        # window's process — kill it so it doesn't pile up as garbage.
-        try:
-            tmux.kill_pane(source_pane_id)
-        except Exception:  # noqa: BLE001
-            pass
+        # Live duplicate in storage is an ORPHAN — the user has been
+        # interacting with ``source_pane_id`` (the cockpit mount), so
+        # the storage window cannot be the same conversation.  Kill
+        # the orphan(s) so the user's actual conversation can claim
+        # the canonical window name on break-pane below.
         if audit_emit is not None:
             try:
                 audit_emit(
-                    "cockpit.park_skipped_existing",
+                    "cockpit.park_killed_orphan",
                     "warn",
                     {
                         "subject": subject or window_name,
@@ -128,12 +155,18 @@ def safe_break_pane_to_storage(
                         "dead_duplicate_indices": [
                             getattr(w, "index", None) for w in dead_existing
                         ],
-                        "reason": "live_existing_storage_window",
+                        "reason": "killed_orphan_to_preserve_active_mount",
                     },
                 )
             except Exception:  # noqa: BLE001
                 pass
-        return False
+        for window in live_existing:
+            try:
+                tmux.kill_window(
+                    f"{storage_session}:{getattr(window, 'index', '')}"
+                )
+            except Exception:  # noqa: BLE001
+                continue
 
     for window in dead_existing:
         try:
@@ -141,5 +174,8 @@ def safe_break_pane_to_storage(
         except Exception:  # noqa: BLE001
             continue
 
-    tmux.break_pane(source_pane_id, storage_session, window_name)
+    try:
+        tmux.break_pane(source_pane_id, storage_session, window_name)
+    except Exception:  # noqa: BLE001
+        return False
     return True

--- a/src/pollypm/cockpit_window_manager.py
+++ b/src/pollypm/cockpit_window_manager.py
@@ -516,9 +516,15 @@ class CockpitWindowManager:
         before = self._window_key_set(park.storage_session)
         # #1631 follow-up — route through the idempotent helper so a
         # live duplicate in the closet doesn't get a second window
-        # silently appended.  When the helper returns False, the
-        # storage window IS the persistent home; our right pane has
-        # been killed and we just clear mount state below.
+        # silently appended.
+        #
+        # #1955 — the helper now kills any pre-existing live orphan and
+        # break-panes the cockpit mount into storage (preserving the
+        # user's active conversation as the canonical window).  The
+        # ``broke is False`` branch now only covers the case where
+        # ``break-pane`` itself errored — we keep the action label
+        # ``park_failed_break_pane`` so a flaky tmux is still visible
+        # in the action log even though the manager can't recover.
         from pollypm.cockpit_storage_park import safe_break_pane_to_storage
         broke = safe_break_pane_to_storage(
             self.tmux,
@@ -531,7 +537,7 @@ class CockpitWindowManager:
             self._rename_created_window(park.storage_session, before, park.window_name, actions)
         else:
             actions.append(
-                f"park_skipped_live_duplicate:{park.storage_session}:{park.window_name}"
+                f"park_failed_break_pane:{park.storage_session}:{park.window_name}"
             )
         state = state.cleared_mount()
 

--- a/src/pollypm/cockpit_window_manager.py
+++ b/src/pollypm/cockpit_window_manager.py
@@ -518,7 +518,7 @@ class CockpitWindowManager:
         # live duplicate in the closet doesn't get a second window
         # silently appended.
         #
-        # #1955 — the helper now kills any pre-existing live orphan and
+        # #1994 — the helper now kills any pre-existing live orphan and
         # break-panes the cockpit mount into storage (preserving the
         # user's active conversation as the canonical window).  The
         # ``broke is False`` branch now only covers the case where

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4551,24 +4551,30 @@ def test_cockpit_router_parks_mounted_task_worker(monkeypatch, tmp_path: Path) -
     assert calls["released"] == ("task-demo-7", "cockpit")
 
 
-def test_cockpit_router_park_skips_when_live_duplicate_exists(monkeypatch, tmp_path: Path) -> None:
-    """#1635 — ``_park_mounted_session`` must NOT call ``tmux break-pane``
-    when the storage closet already holds a live window of the same
-    name. Prior behavior unconditionally broke the cockpit's right
-    pane into storage as a fresh ``pm-operator`` window, leaving two
-    same-named windows in storage; #1632's mount selector then often
-    picked the wrong one and the user saw a fresh Polly re-asking the
-    same onboarding questions.
+def test_cockpit_router_park_kills_orphan_when_live_duplicate_exists(monkeypatch, tmp_path: Path) -> None:
+    """#1955 — ``_park_mounted_session`` must kill any pre-existing live
+    same-named storage window (an ORPHAN, by construction) and then
+    break-pane the cockpit mount into storage to preserve the user's
+    active conversation.
+
+    Original #1635 took the opposite tack: refuse the break-pane and
+    let the caller's subsequent ``respawn_pane`` discard the cockpit's
+    right pane.  In the rail-navigation case this wiped the user's
+    live conversation on every nav-and-back (Sam's verbatim repro on
+    2026-05-20: ``I was talking with the Sam blog architect.  I click
+    into a different area on the rail.  I click back to the Sam blog
+    architect, and it's a new goddamn conversation.``)
 
     Regression contract:
-      * ``break_pane`` is never called when a live duplicate exists.
-      * ``rename_window`` is never called.
+      * The orphan storage window is killed.
+      * ``break_pane`` IS called so the cockpit's mount (the user's
+        actual conversation) lands in storage under the canonical
+        name.
       * mounted-session state and cockpit lease are still released.
-      * A ``cockpit.park_skipped_existing`` audit event fires with the
-        live-duplicate indices captured in metadata.
-      * Calling ``_park_mounted_session`` a second time is still a
-        no-op — only one ``pm-operator`` window remains in storage
-        (park → park again → still one window).
+      * A ``cockpit.park_killed_orphan`` audit event fires with the
+        killed-orphan indices captured in metadata.
+      * Calling ``_park_mounted_session`` a second time with the SAME
+        storage state still leaves exactly one canonical window.
     """
     calls: dict[str, object] = {}
     audit_events: list[dict[str, object]] = []
@@ -4674,41 +4680,54 @@ def test_cockpit_router_park_skips_when_live_duplicate_exists(monkeypatch, tmp_p
     )
     router._write_state({"mounted_session": "operator-pm", "right_pane_id": "%2"})
 
-    # First park: storage already has a LIVE pm-operator window. The
-    # park must be a no-op (no break-pane, no rename) to prevent the
-    # upstream duplicate creation.
+    # First park: storage already has a LIVE pm-operator window
+    # (orphan from a prior session — the cockpit's right pane %2 is
+    # the user's actual conversation).  The park must kill the orphan
+    # AND break-pane our right pane into storage under the canonical
+    # name to preserve the live conversation.
     router._park_mounted_session(FakeSupervisor(), "pollypm:PollyPM")
 
-    assert "break" not in calls, "break-pane must not run when a live duplicate exists"
-    assert "renamed" not in calls
+    assert "break" in calls, (
+        "#1955 — break-pane MUST run so the user's active mount is "
+        "preserved as the canonical pm-operator window in storage"
+    )
+    break_calls = calls["break"]
+    assert len(break_calls) == 1
+    assert break_calls[0] == ("%2", "pollypm-storage-closet", "pm-operator")
+    assert "killed" in calls and "pollypm-storage-closet:1" in calls["killed"], (
+        "The orphan storage window must be killed before break-pane "
+        "so the canonical name is free"
+    )
     assert calls["released"] == [("operator-pm", "cockpit")]
-    assert len(storage_state["windows"]) == 1
-    assert storage_state["windows"][0].name == "pm-operator"
+    # After the kill+break, storage has exactly one canonical window
+    # (the one we just broke in).
+    same_name = [
+        w for w in storage_state["windows"] if w.name == "pm-operator"
+    ]
+    assert len(same_name) == 1
 
-    skip_events = [e for e in audit_events if e["event_name"] == "cockpit.park_skipped_existing"]
-    assert len(skip_events) == 1
-    skip = skip_events[0]
-    assert skip["subject"] == "operator-pm"
-    assert skip["status"] == "warn"
-    assert skip["metadata"]["live_duplicate_indices"] == [1]
-    assert skip["metadata"]["window_name"] == "pm-operator"
-    assert skip["metadata"]["storage_session"] == "pollypm-storage-closet"
+    orphan_events = [
+        e for e in audit_events if e["event_name"] == "cockpit.park_killed_orphan"
+    ]
+    assert len(orphan_events) == 1
+    orphan = orphan_events[0]
+    assert orphan["subject"] == "operator-pm"
+    assert orphan["status"] == "warn"
+    assert orphan["metadata"]["live_duplicate_indices"] == [1]
+    assert orphan["metadata"]["window_name"] == "pm-operator"
+    assert orphan["metadata"]["storage_session"] == "pollypm-storage-closet"
+    assert orphan["metadata"]["reason"] == (
+        "killed_orphan_to_preserve_active_mount"
+    )
+    assert not any(
+        e["event_name"] == "cockpit.park_skipped_existing" for e in audit_events
+    ), "park-skipped event must no longer fire — #1955"
 
     # State is cleared so the next mount won't think we still own the
     # cockpit right pane.
     state = router._load_state()
     assert "mounted_session" not in state
     assert "mounted_identity" not in state
-
-    # Park again — same conditions, still a no-op, still ONE window.
-    router._write_state({"mounted_session": "operator-pm", "right_pane_id": "%2"})
-    router._park_mounted_session(FakeSupervisor(), "pollypm:PollyPM")
-
-    assert "break" not in calls
-    assert len(storage_state["windows"]) == 1, (
-        "park → park again must leave exactly one pm-operator window — "
-        "regression for #1635 duplicate-window creation"
-    )
 
 
 def test_cockpit_router_park_reoccupies_dead_storage_window(monkeypatch, tmp_path: Path) -> None:
@@ -4832,6 +4851,204 @@ def test_cockpit_router_park_reoccupies_dead_storage_window(monkeypatch, tmp_pat
     assert park_events[0]["metadata"]["reoccupied_dead_indices"] == [1]
     # No skip event fires when there are no live duplicates.
     assert not any(e["event_name"] == "cockpit.park_skipped_existing" for e in audit_events)
+
+
+def test_rail_navigation_preserves_architect_session_across_nav_and_back(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """#1955 — rail navigation must NOT wipe a live architect chat.
+
+    Sam's verbatim repro on 2026-05-20::
+
+        I was talking with the Sam blog architect.  I click into a
+        different area on the rail.  I click back to the Sam blog
+        architect, and it's a new goddamn conversation.
+
+    Trigger: a stale ``architect-samblog`` orphan from a prior cockpit
+    lifetime is sitting in the storage closet at the moment the user
+    clicks away.  Pre-#1955, ``_park_mounted_session`` saw the orphan,
+    refused to break-pane, and trusted storage as the persistent home;
+    the caller's ``respawn_pane`` then wiped the cockpit's actual
+    architect conversation.  Post-#1955, the helper kills the orphan
+    and break-panes the cockpit mount into storage under the canonical
+    name — the conversation is preserved and the next mount can find
+    it again.
+
+    This test exercises ``_park_mounted_session`` with the exact
+    storage state Sam's bug report described and asserts:
+      * ``break_pane`` IS called (the user's mount goes to storage).
+      * The orphan storage window IS killed before the break.
+      * After the park, storage has exactly ONE architect-samblog
+        window — the broken-in cockpit mount.
+      * The audit fires ``cockpit.park_killed_orphan``.
+      * The ``cockpit.park_skipped_existing`` audit (the old policy
+        marker) does NOT fire.
+    """
+    calls: dict[str, object] = {}
+    audit_events: list[dict[str, object]] = []
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        f"[project]\nname = \"PollyPM\"\ntmux_session = \"pollypm\"\n"
+        f"base_dir = \"{tmp_path / '.pollypm'}\"\n"
+    )
+
+    class FakeSupervisor:
+        def plan_launches(self):
+            return []
+
+        def storage_closet_session_name(self) -> str:
+            return "pollypm-storage-closet"
+
+        def release_lease(
+            self, session_name: str, expected_owner: str | None = None
+        ) -> None:
+            calls.setdefault("released", []).append(
+                (session_name, expected_owner)
+            )
+
+    class FakeWindow:
+        def __init__(
+            self,
+            index: int,
+            name: str,
+            command: str = "",
+            pane_dead: bool = False,
+        ) -> None:
+            self.index = index
+            self.name = name
+            self.pane_current_command = command
+            self.pane_dead = pane_dead
+
+    class FakePane:
+        def __init__(
+            self, pane_id: str, pane_left: int, command: str
+        ) -> None:
+            self.pane_id = pane_id
+            self.pane_left = pane_left
+            self.pane_current_command = command
+            self.pane_dead = False
+
+    # Storage already has a live architect-samblog window — the stale
+    # orphan from a prior cockpit lifetime that is the structural
+    # cause of the wipe.
+    storage_state = {
+        "windows": [
+            FakeWindow(17, "architect-samblog", command="claude"),
+        ],
+    }
+
+    class FakeTmux:
+        def list_panes(self, target: str):
+            # The cockpit has the user's actual architect conversation
+            # in the right pane (%9001 is running ``claude``).
+            return [
+                FakePane("%9000", 0, "uv"),
+                FakePane("%9001", 30, "claude"),
+            ]
+
+        def list_windows(self, target: str):
+            assert target == "pollypm-storage-closet"
+            return list(storage_state["windows"])
+
+        def break_pane(
+            self, source: str, target_session: str, window_name: str
+        ) -> None:
+            calls.setdefault("break", []).append(
+                (source, target_session, window_name)
+            )
+            next_index = max(
+                (w.index for w in storage_state["windows"]),
+                default=0,
+            ) + 1
+            storage_state["windows"].append(
+                FakeWindow(next_index, window_name, command="claude")
+            )
+
+        def rename_window(self, target: str, name: str) -> None:
+            calls.setdefault("renamed", []).append((target, name))
+
+        def kill_window(self, target: str) -> None:
+            calls.setdefault("killed", []).append(target)
+            suffix = target.split(":", 1)[1]
+            try:
+                idx = int(suffix)
+            except ValueError:
+                return
+            storage_state["windows"] = [
+                w for w in storage_state["windows"] if w.index != idx
+            ]
+
+    router = CockpitRouter(config_path)
+    router.tmux = FakeTmux()  # type: ignore[assignment]
+    monkeypatch.setattr(
+        router, "_load_supervisor", lambda fresh=False: FakeSupervisor()
+    )
+    monkeypatch.setattr(
+        router,
+        "_mounted_window_name",
+        lambda supervisor, session_name: "architect-samblog",
+    )
+    monkeypatch.setattr(
+        router,
+        "_emit_cockpit_audit",
+        lambda *, event_name, subject, status, metadata: audit_events.append(
+            {
+                "event_name": event_name,
+                "subject": subject,
+                "status": status,
+                "metadata": metadata,
+            }
+        ),
+    )
+    router._write_state(
+        {
+            "mounted_session": "architect_samblog",
+            "right_pane_id": "%9001",
+        }
+    )
+
+    # The rail click flushes through ``_park_mounted_session`` before
+    # respawning the static view in the right pane.
+    router._park_mounted_session(FakeSupervisor(), "pollypm:PollyPM")
+
+    # 1. The orphan storage window was reaped.
+    assert "killed" in calls and "pollypm-storage-closet:17" in calls["killed"], (
+        "The pre-existing storage orphan MUST be killed before "
+        "break-pane so the canonical name is available for the "
+        "user's actual conversation."
+    )
+    # 2. break-pane DID run with the user's actual mount as the source.
+    assert "break" in calls, (
+        "break-pane MUST run — without it the cockpit's "
+        "respawn_pane wipes the live conversation."
+    )
+    assert calls["break"] == [
+        ("%9001", "pollypm-storage-closet", "architect-samblog")
+    ]
+    # 3. Storage ends up with exactly one architect-samblog window
+    #    holding the user's conversation (a new index above the
+    #    killed orphan).
+    same_name = [
+        w for w in storage_state["windows"] if w.name == "architect-samblog"
+    ]
+    assert len(same_name) == 1
+    # 4. Audit captures the orphan-kill action with forensics.
+    orphan_events = [
+        e
+        for e in audit_events
+        if e["event_name"] == "cockpit.park_killed_orphan"
+    ]
+    assert len(orphan_events) == 1
+    assert orphan_events[0]["metadata"]["live_duplicate_indices"] == [17]
+    assert orphan_events[0]["metadata"]["reason"] == (
+        "killed_orphan_to_preserve_active_mount"
+    )
+    # 5. The old policy marker MUST NOT fire (it would mean the
+    #    helper followed the pre-#1955 wipe path).
+    assert not any(
+        e["event_name"] == "cockpit.park_skipped_existing"
+        for e in audit_events
+    )
 
 
 def test_cockpit_router_validation_releases_stale_cockpit_lease(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4552,7 +4552,7 @@ def test_cockpit_router_parks_mounted_task_worker(monkeypatch, tmp_path: Path) -
 
 
 def test_cockpit_router_park_kills_orphan_when_live_duplicate_exists(monkeypatch, tmp_path: Path) -> None:
-    """#1955 — ``_park_mounted_session`` must kill any pre-existing live
+    """#1994 — ``_park_mounted_session`` must kill any pre-existing live
     same-named storage window (an ORPHAN, by construction) and then
     break-pane the cockpit mount into storage to preserve the user's
     active conversation.
@@ -4688,7 +4688,7 @@ def test_cockpit_router_park_kills_orphan_when_live_duplicate_exists(monkeypatch
     router._park_mounted_session(FakeSupervisor(), "pollypm:PollyPM")
 
     assert "break" in calls, (
-        "#1955 — break-pane MUST run so the user's active mount is "
+        "#1994 — break-pane MUST run so the user's active mount is "
         "preserved as the canonical pm-operator window in storage"
     )
     break_calls = calls["break"]
@@ -4721,7 +4721,7 @@ def test_cockpit_router_park_kills_orphan_when_live_duplicate_exists(monkeypatch
     )
     assert not any(
         e["event_name"] == "cockpit.park_skipped_existing" for e in audit_events
-    ), "park-skipped event must no longer fire — #1955"
+    ), "park-skipped event must no longer fire — #1994"
 
     # State is cleared so the next mount won't think we still own the
     # cockpit right pane.
@@ -4856,7 +4856,7 @@ def test_cockpit_router_park_reoccupies_dead_storage_window(monkeypatch, tmp_pat
 def test_rail_navigation_preserves_architect_session_across_nav_and_back(
     monkeypatch, tmp_path: Path
 ) -> None:
-    """#1955 — rail navigation must NOT wipe a live architect chat.
+    """#1994 — rail navigation must NOT wipe a live architect chat.
 
     Sam's verbatim repro on 2026-05-20::
 
@@ -4866,10 +4866,10 @@ def test_rail_navigation_preserves_architect_session_across_nav_and_back(
 
     Trigger: a stale ``architect-samblog`` orphan from a prior cockpit
     lifetime is sitting in the storage closet at the moment the user
-    clicks away.  Pre-#1955, ``_park_mounted_session`` saw the orphan,
+    clicks away.  Pre-#1994, ``_park_mounted_session`` saw the orphan,
     refused to break-pane, and trusted storage as the persistent home;
     the caller's ``respawn_pane`` then wiped the cockpit's actual
-    architect conversation.  Post-#1955, the helper kills the orphan
+    architect conversation.  Post-#1994, the helper kills the orphan
     and break-panes the cockpit mount into storage under the canonical
     name — the conversation is preserved and the next mount can find
     it again.
@@ -5044,7 +5044,7 @@ def test_rail_navigation_preserves_architect_session_across_nav_and_back(
         "killed_orphan_to_preserve_active_mount"
     )
     # 5. The old policy marker MUST NOT fire (it would mean the
-    #    helper followed the pre-#1955 wipe path).
+    #    helper followed the pre-#1994 wipe path).
     assert not any(
         e["event_name"] == "cockpit.park_skipped_existing"
         for e in audit_events

--- a/tests/test_cockpit_storage_park.py
+++ b/tests/test_cockpit_storage_park.py
@@ -11,16 +11,20 @@ wipe surface was reachable through those paths.
 
 These tests pin the contract of :func:`safe_break_pane_to_storage`:
 
-* Live duplicate in storage → break-pane is skipped, the source pane
-  is killed (no orphan pile-up), the audit fires, and the helper
-  returns ``False`` so callers can branch.
+* Live duplicate in storage → the duplicate is treated as a stale
+  ORPHAN (the cockpit pane being parked is by construction the
+  user's active mount).  The orphan is killed, ``break-pane`` runs,
+  audit fires with ``cockpit.park_killed_orphan``, helper returns
+  ``True``.  See #1955 — the original "skip break-pane and kill the
+  cockpit pane" policy wiped Sam's live architect chat on every
+  rail-navigation and back.
 * Dead duplicates → killed before break-pane so the freshly-parked
   pane re-occupies the canonical name.
 * No duplicates → unconditional break-pane.
 
 The smoking-gun scenario from Sam's 2026-05-19 wipe (architect-samblog
 duplicated at indices 22 and 42 in the closet) is reproduced as
-``test_safe_break_does_not_add_third_when_two_duplicates_exist``.
+``test_safe_break_kills_all_live_orphans_when_two_duplicates_exist``.
 """
 
 from __future__ import annotations
@@ -124,12 +128,19 @@ def test_safe_break_unconditional_when_no_existing_window() -> None:
     assert [w.name for w in tmux.windows] == ["architect-samblog"]
 
 
-def test_safe_break_skipped_when_live_duplicate_exists() -> None:
-    """Live duplicate → helper refuses to break-pane.
+def test_safe_break_kills_orphan_when_live_duplicate_exists() -> None:
+    """Live duplicate → helper kills the orphan and breaks the pane.
 
-    This is the #1631 wipe surface: parking on top of an existing live
-    window would silently double the canonical name and the next mount
-    would land on the wrong one.
+    #1955 — Sam's verbatim bug: ``I was talking with the Sam blog
+    architect.  I click into a different area on the rail.  I click
+    back to the Sam blog architect, and it's a new goddamn
+    conversation.``  The cockpit pane (``%99`` here) is the user's
+    active mount — they were just typing into it.  The storage
+    window with the same canonical name is a stale orphan from a
+    prior session.  Old behaviour: refuse break-pane and kill ``%99``
+    (wiping Sam's live chat).  New behaviour: kill the orphan,
+    break-pane our active mount into storage so the next mount picks
+    up the real conversation.
     """
     existing = _FakeWindow(22, "architect-samblog", command="claude")
     tmux = _FakeTmux(windows=[existing])
@@ -144,22 +155,34 @@ def test_safe_break_skipped_when_live_duplicate_exists() -> None:
         subject="architect_samblog",
     )
 
-    assert broke is False
-    assert tmux.break_calls == []
-    # Source pane was killed so it doesn't orphan in the cockpit.
-    assert tmux.kill_pane_calls == ["%99"]
-    # Storage closet still has exactly one architect-samblog window.
+    assert broke is True
+    # The orphan was killed BEFORE the break-pane so the canonical
+    # name was available.
+    assert tmux.kill_window_calls == ["pollypm-storage-closet:22"]
+    # The cockpit's live mount was broken into storage under the
+    # canonical name — the user's conversation is preserved.
+    assert tmux.break_calls == [
+        ("%99", "pollypm-storage-closet", "architect-samblog")
+    ]
+    # The helper must NEVER kill the source pane in the live-duplicate
+    # branch — that was the #1955 regression surface.
+    assert tmux.kill_pane_calls == []
+    # Storage closet still has exactly one architect-samblog window
+    # (the freshly broken-in cockpit pane).
     same_name = [w for w in tmux.windows if w.name == "architect-samblog"]
     assert len(same_name) == 1
-    # Audit captures the skip with the duplicate's index.
+    # Audit captures the orphan kill with the duplicate's index.
     assert len(audit_events) == 1
     event = audit_events[0]
-    assert event["event_name"] == "cockpit.park_skipped_existing"
+    assert event["event_name"] == "cockpit.park_killed_orphan"
     assert event["status"] == "warn"
     assert event["metadata"]["live_duplicate_indices"] == [22]
     assert event["metadata"]["window_name"] == "architect-samblog"
     assert event["metadata"]["storage_session"] == "pollypm-storage-closet"
     assert event["metadata"]["subject"] == "architect_samblog"
+    assert event["metadata"]["reason"] == (
+        "killed_orphan_to_preserve_active_mount"
+    )
 
 
 def test_safe_break_kills_dead_duplicates_then_breaks() -> None:
@@ -189,13 +212,20 @@ def test_safe_break_kills_dead_duplicates_then_breaks() -> None:
     assert audit_events == []  # No skip event for the dead-only case.
 
 
-def test_safe_break_does_not_add_third_when_two_duplicates_exist() -> None:
-    """Smoking gun from Sam's 2026-05-19 wipe.
+def test_safe_break_kills_all_live_orphans_when_two_duplicates_exist() -> None:
+    """Two live orphans → both killed before break-pane.
 
     The storage closet already had two ``architect-samblog`` windows
-    (indices 22 and 42) when the user clicked away from PM Chat.  A
-    naive break-pane would push the count to three.  The helper must
-    refuse and leave the closet exactly as it found it.
+    (indices 22 and 42) when the user clicked away from PM Chat.
+    Both are stale orphans (the user can only be conversing with one
+    pane at a time, and that pane is ``%5099`` — the cockpit mount).
+    The helper must kill both orphans and break-pane the cockpit
+    mount into storage under the canonical name so the next mount
+    finds exactly one ``architect-samblog`` window holding the
+    user's actual conversation.
+
+    Pre-#1955 behaviour: refuse to break and kill ``%5099``,
+    wiping the user's live conversation.
     """
     tmux = _FakeTmux(
         windows=[
@@ -214,15 +244,27 @@ def test_safe_break_does_not_add_third_when_two_duplicates_exist() -> None:
         subject="architect_samblog",
     )
 
-    assert broke is False
-    assert tmux.break_calls == []
-    assert tmux.kill_pane_calls == ["%5099"]
+    assert broke is True
+    # Both orphans killed before the break-pane.
+    assert tmux.kill_window_calls == [
+        "pollypm-storage-closet:22",
+        "pollypm-storage-closet:42",
+    ]
+    # The cockpit mount was broken in under the canonical name.
+    assert tmux.break_calls == [
+        ("%5099", "pollypm-storage-closet", "architect-samblog")
+    ]
+    # The user's source pane was NEVER killed — the conversation is
+    # preserved inside the broken-out window.
+    assert tmux.kill_pane_calls == []
     same_name = [w for w in tmux.windows if w.name == "architect-samblog"]
-    assert len(same_name) == 2, (
-        "Helper must NOT add a third architect-samblog window — that's "
-        "the #1631 conversation-wipe surface"
+    assert len(same_name) == 1, (
+        "After the park, storage must have exactly one architect-"
+        "samblog window — the one holding the user's actual "
+        "conversation (the broken-in cockpit mount)"
     )
     assert len(audit_events) == 1
+    assert audit_events[0]["event_name"] == "cockpit.park_killed_orphan"
     assert audit_events[0]["metadata"]["live_duplicate_indices"] == [22, 42]
 
 
@@ -231,8 +273,9 @@ def test_safe_break_treats_version_string_command_as_live() -> None:
 
     The Claude CLI reports its version string (e.g. ``2.1.144``) as the
     pane command after the first turn.  The helper must treat such
-    panes as live so the user's first-turn-completed conversation
-    isn't classified as dead and silently duplicated.
+    panes as live so a first-turn-completed orphan is recognised and
+    killed (rather than mistaken for a dead window and only re-occupied
+    on top of).
     """
     existing = _FakeWindow(22, "architect-samblog", command="2.1.144")
     tmux = _FakeTmux(windows=[existing])
@@ -247,10 +290,13 @@ def test_safe_break_treats_version_string_command_as_live() -> None:
         subject="architect_samblog",
     )
 
-    assert broke is False
-    assert tmux.break_calls == []
+    assert broke is True
+    assert tmux.kill_window_calls == ["pollypm-storage-closet:22"]
+    assert tmux.break_calls == [
+        ("%99", "pollypm-storage-closet", "architect-samblog")
+    ]
     assert len(audit_events) == 1
-    assert audit_events[0]["event_name"] == "cockpit.park_skipped_existing"
+    assert audit_events[0]["event_name"] == "cockpit.park_killed_orphan"
 
 
 def test_safe_break_swallows_list_windows_errors() -> None:
@@ -282,7 +328,12 @@ def test_safe_break_swallows_list_windows_errors() -> None:
 
 
 def test_safe_break_audit_callback_is_optional() -> None:
-    """Helper must work without an audit callback (low-level callers)."""
+    """Helper must work without an audit callback (low-level callers).
+
+    With #1955's policy reversal, a missing audit callback still
+    causes the orphan to be killed and break-pane to proceed; the
+    audit emit is best-effort and silent without a callback.
+    """
     existing = _FakeWindow(22, "pm-operator", command="claude")
     tmux = _FakeTmux(windows=[existing])
 
@@ -293,6 +344,66 @@ def test_safe_break_audit_callback_is_optional() -> None:
         window_name="pm-operator",
     )
 
-    assert broke is False
-    assert tmux.break_calls == []
-    assert tmux.kill_pane_calls == ["%99"]
+    assert broke is True
+    assert tmux.kill_window_calls == ["pollypm-storage-closet:22"]
+    assert tmux.break_calls == [
+        ("%99", "pollypm-storage-closet", "pm-operator")
+    ]
+    assert tmux.kill_pane_calls == []
+
+
+def test_safe_break_preserves_active_mount_across_rail_navigation() -> None:
+    """#1955 regression: rail nav must NOT wipe the user's chat.
+
+    Reproduces Sam's verbatim bug (2026-05-20):
+
+        I was talking with the Sam blog architect.  I click into a
+        different area on the rail.  I click back to the Sam blog
+        architect, and it's a new goddamn conversation.
+
+    Pre-condition: the storage closet has a stale ``architect-samblog``
+    orphan from a prior cockpit lifetime (a common state — the #1631
+    history is exactly this).  The user has been actively typing into
+    the cockpit's mounted architect pane (``%9001``).  Rail navigation
+    triggers a park of ``%9001`` under the canonical name.
+
+    Old behaviour: helper saw the storage orphan, killed ``%9001``
+    (wiping the user's chat), left the orphan in place; the next
+    mount surfaced the orphan as if it were the user's conversation.
+
+    New behaviour: helper kills the orphan, breaks ``%9001`` into
+    storage under the canonical name; the next mount surfaces the
+    user's actual conversation.
+    """
+    orphan = _FakeWindow(17, "architect-samblog", command="claude")
+    tmux = _FakeTmux(windows=[orphan])
+    audit_events, audit_emit = _collect_audit()
+
+    broke = safe_break_pane_to_storage(
+        tmux,
+        source_pane_id="%9001",
+        storage_session="pollypm-storage-closet",
+        window_name="architect-samblog",
+        audit_emit=audit_emit,
+        subject="architect_samblog",
+    )
+
+    assert broke is True
+    # The orphan was reaped.
+    assert "pollypm-storage-closet:17" in tmux.kill_window_calls
+    # The user's active mount was preserved by being broken into storage.
+    assert tmux.break_calls == [
+        ("%9001", "pollypm-storage-closet", "architect-samblog")
+    ]
+    # CRITICAL: the helper must NEVER kill the active mount in the
+    # rail-navigation case — that's the conversation-wipe surface.
+    assert tmux.kill_pane_calls == [], (
+        "safe_break_pane_to_storage killed the active mount — #1955 "
+        "regression"
+    )
+    # Exactly one architect-samblog window remains in storage and it
+    # is the one we just broke in (its index is one higher than the
+    # killed orphan in the fake tmux).
+    same_name = [w for w in tmux.windows if w.name == "architect-samblog"]
+    assert len(same_name) == 1
+    assert audit_events[0]["event_name"] == "cockpit.park_killed_orphan"

--- a/tests/test_cockpit_storage_park.py
+++ b/tests/test_cockpit_storage_park.py
@@ -15,7 +15,7 @@ These tests pin the contract of :func:`safe_break_pane_to_storage`:
   ORPHAN (the cockpit pane being parked is by construction the
   user's active mount).  The orphan is killed, ``break-pane`` runs,
   audit fires with ``cockpit.park_killed_orphan``, helper returns
-  ``True``.  See #1955 — the original "skip break-pane and kill the
+  ``True``.  See #1994 — the original "skip break-pane and kill the
   cockpit pane" policy wiped Sam's live architect chat on every
   rail-navigation and back.
 * Dead duplicates → killed before break-pane so the freshly-parked
@@ -131,7 +131,7 @@ def test_safe_break_unconditional_when_no_existing_window() -> None:
 def test_safe_break_kills_orphan_when_live_duplicate_exists() -> None:
     """Live duplicate → helper kills the orphan and breaks the pane.
 
-    #1955 — Sam's verbatim bug: ``I was talking with the Sam blog
+    #1994 — Sam's verbatim bug: ``I was talking with the Sam blog
     architect.  I click into a different area on the rail.  I click
     back to the Sam blog architect, and it's a new goddamn
     conversation.``  The cockpit pane (``%99`` here) is the user's
@@ -165,7 +165,7 @@ def test_safe_break_kills_orphan_when_live_duplicate_exists() -> None:
         ("%99", "pollypm-storage-closet", "architect-samblog")
     ]
     # The helper must NEVER kill the source pane in the live-duplicate
-    # branch — that was the #1955 regression surface.
+    # branch — that was the #1994 regression surface.
     assert tmux.kill_pane_calls == []
     # Storage closet still has exactly one architect-samblog window
     # (the freshly broken-in cockpit pane).
@@ -224,7 +224,7 @@ def test_safe_break_kills_all_live_orphans_when_two_duplicates_exist() -> None:
     finds exactly one ``architect-samblog`` window holding the
     user's actual conversation.
 
-    Pre-#1955 behaviour: refuse to break and kill ``%5099``,
+    Pre-#1994 behaviour: refuse to break and kill ``%5099``,
     wiping the user's live conversation.
     """
     tmux = _FakeTmux(
@@ -330,7 +330,7 @@ def test_safe_break_swallows_list_windows_errors() -> None:
 def test_safe_break_audit_callback_is_optional() -> None:
     """Helper must work without an audit callback (low-level callers).
 
-    With #1955's policy reversal, a missing audit callback still
+    With #1994's policy reversal, a missing audit callback still
     causes the orphan to be killed and break-pane to proceed; the
     audit emit is best-effort and silent without a callback.
     """
@@ -353,7 +353,7 @@ def test_safe_break_audit_callback_is_optional() -> None:
 
 
 def test_safe_break_preserves_active_mount_across_rail_navigation() -> None:
-    """#1955 regression: rail nav must NOT wipe the user's chat.
+    """#1994 regression: rail nav must NOT wipe the user's chat.
 
     Reproduces Sam's verbatim bug (2026-05-20):
 
@@ -398,7 +398,7 @@ def test_safe_break_preserves_active_mount_across_rail_navigation() -> None:
     # CRITICAL: the helper must NEVER kill the active mount in the
     # rail-navigation case — that's the conversation-wipe surface.
     assert tmux.kill_pane_calls == [], (
-        "safe_break_pane_to_storage killed the active mount — #1955 "
+        "safe_break_pane_to_storage killed the active mount — #1994 "
         "regression"
     )
     # Exactly one architect-samblog window remains in storage and it

--- a/tests/test_cockpit_window_manager.py
+++ b/tests/test_cockpit_window_manager.py
@@ -174,7 +174,7 @@ class FakeTmux:
         raise KeyError(target)
 
     def kill_window(self, target: str) -> None:
-        """#1955 — drop the matching window from its session.
+        """#1994 — drop the matching window from its session.
 
         Mirrors ``tmux kill-window -t <session>:<index>``.  The
         ``cockpit_storage_park.safe_break_pane_to_storage`` helper
@@ -650,7 +650,7 @@ def test_park_live_to_storage_breaks_right_and_replaces_static_content() -> None
 
 
 def test_park_live_to_storage_kills_orphan_when_live_duplicate_exists() -> None:
-    """#1955 — ``park_live_to_storage`` must kill a live storage orphan
+    """#1994 — ``park_live_to_storage`` must kill a live storage orphan
     and break-pane the cockpit mount under the canonical name to
     preserve the user's active conversation.
 
@@ -661,7 +661,7 @@ def test_park_live_to_storage_kills_orphan_when_live_duplicate_exists() -> None:
     conversation (they were typing into it); any pre-existing live
     storage window with the same name is a stale orphan.
 
-    Pre-#1955 behaviour: the helper refused to break-pane and killed
+    Pre-#1994 behaviour: the helper refused to break-pane and killed
     the cockpit's right pane (the user's chat), then the next mount
     surfaced the orphan as if it were the user's conversation.
 
@@ -720,7 +720,7 @@ def test_park_live_to_storage_kills_orphan_when_live_duplicate_exists() -> None:
     assert f"break_live:{right_id}->pollypm-storage-closet:architect-samblog" in result.actions
     assert not any(
         action.startswith("park_skipped_live_duplicate") for action in result.actions
-    ), "park-skipped action must no longer fire — #1955"
+    ), "park-skipped action must no longer fire — #1994"
     assert result.state.mounted_session is None
 
 

--- a/tests/test_cockpit_window_manager.py
+++ b/tests/test_cockpit_window_manager.py
@@ -173,6 +173,29 @@ class FakeTmux:
                 return
         raise KeyError(target)
 
+    def kill_window(self, target: str) -> None:
+        """#1955 — drop the matching window from its session.
+
+        Mirrors ``tmux kill-window -t <session>:<index>``.  The
+        ``cockpit_storage_park.safe_break_pane_to_storage`` helper
+        calls this to reap stale orphans before its break-pane.
+        """
+        session, raw_index = target.split(":", 1)
+        windows = self.sessions.get(session, [])
+        try:
+            index = int(raw_index)
+        except ValueError:
+            # Tolerate name-targets too (helper only uses int targets
+            # but #1635's _park_mounted_session may also call here).
+            self.sessions[session] = [
+                w for w in windows if w.name != raw_index
+            ]
+        else:
+            self.sessions[session] = [
+                w for w in windows if w.index != index
+            ]
+        self.calls.append(("kill_window", (target,)))
+
     def swap_pane(self, source: str, target: str) -> None:
         _source_window, source_pane = self._find_pane(source)
         _target_window, target_pane = self._find_pane(target)
@@ -626,33 +649,39 @@ def test_park_live_to_storage_breaks_right_and_replaces_static_content() -> None
     assert storage_windows[0].pane_id == right_id
 
 
-def test_park_live_to_storage_skips_when_live_duplicate_exists() -> None:
-    """#1631 follow-up — ``park_live_to_storage`` must NOT silently
-    add a second window when storage already holds a live one of the
-    same name.
+def test_park_live_to_storage_kills_orphan_when_live_duplicate_exists() -> None:
+    """#1955 — ``park_live_to_storage`` must kill a live storage orphan
+    and break-pane the cockpit mount under the canonical name to
+    preserve the user's active conversation.
 
-    Sam's 2026-05-19 wipe: ``architect-samblog`` was duplicated at
-    indices 22 and 42 in the closet, and a click away from PM Chat
-    would have grown that to three before the fix.  The manager now
-    routes through :func:`safe_break_pane_to_storage`, which refuses
-    the break-pane when a live duplicate exists.
+    Sam's 2026-05-20 verbatim repro: ``I was talking with the Sam
+    blog architect.  I click into a different area on the rail.  I
+    click back to the Sam blog architect, and it's a new goddamn
+    conversation.``  The cockpit-mounted pane is the user's actual
+    conversation (they were typing into it); any pre-existing live
+    storage window with the same name is a stale orphan.
+
+    Pre-#1955 behaviour: the helper refused to break-pane and killed
+    the cockpit's right pane (the user's chat), then the next mount
+    surfaced the orphan as if it were the user's conversation.
 
     Regression contract:
-      * Storage closet ends up with exactly one ``architect-samblog``
-        window (the pre-existing live one, untouched).
-      * ``break_pane`` is never called.
-      * The result still ``ok`` — the manager treats this as a
-        successful park because the persistent home already exists.
+      * The pre-existing live storage orphan is killed.
+      * ``break_pane`` IS called so the cockpit mount lands in storage
+        as the canonical ``architect-samblog`` window.
+      * Storage ends up with exactly one ``architect-samblog`` window
+        — the one holding the user's actual conversation.
       * Mount state is cleared so the next mount can re-attach via
         the rail selector.
     """
     tmux = FakeTmux()
-    # Pre-existing live conversation in the closet.
-    tmux.add_window(
+    # Pre-existing orphan in the closet (NOT the user's conversation).
+    orphan_window = tmux.add_window(
         "pollypm-storage-closet",
         "architect-samblog",
         [("claude", 0)],
     )
+    orphan_pane_id = orphan_window.panes[0].pane_id
     cockpit = tmux.add_window("pollypm", "PollyPM", [("uv", 0), ("claude", 100)])
     right_id = cockpit.panes[1].pane_id
     manager = _manager(tmux)
@@ -674,14 +703,24 @@ def test_park_live_to_storage_skips_when_live_duplicate_exists() -> None:
     storage_windows = tmux.list_windows("pollypm-storage-closet")
     same_name = [w for w in storage_windows if w.name == "architect-samblog"]
     assert len(same_name) == 1, (
-        "park_live_to_storage must not duplicate architect-samblog — "
-        "that's the #1631 conversation-wipe surface"
+        "After the park, storage must have exactly one architect-"
+        "samblog window — the broken-in cockpit mount"
     )
-    # No break-pane to storage was emitted.
-    assert not any(
+    # The surviving window must be the user's mount, not the orphan.
+    surviving = same_name[0]
+    assert surviving.pane_id == right_id, (
+        "The surviving architect-samblog window must contain the "
+        "user's actual conversation (the cockpit mount), not the "
+        "killed orphan pane"
+    )
+    # Break-pane DID run — that's the user-preserving action.
+    assert any(
         call[0] == "break_pane" for call in tmux.calls
-    ), "break-pane must be skipped when a live duplicate already exists"
-    assert "park_skipped_live_duplicate:pollypm-storage-closet:architect-samblog" in result.actions
+    ), "break-pane MUST run so the user's active mount is preserved"
+    assert f"break_live:{right_id}->pollypm-storage-closet:architect-samblog" in result.actions
+    assert not any(
+        action.startswith("park_skipped_live_duplicate") for action in result.actions
+    ), "park-skipped action must no longer fire — #1955"
     assert result.state.mounted_session is None
 
 


### PR DESCRIPTION
## Symptom (Sam, 2026-05-20)

> I was talking with the Sam blog architect. I click into a different area on the rail. I click back to the Sam blog architect, and it's a new goddamn conversation.

Every rail-navigation-and-back from a live agent (architect / reviewer / advisor) chat wipes the user's conversation. Re-entry shows a fresh ``Claude Code v2.1.x — Welcome back Sam!`` banner.

## Root cause

The park-side helpers (``_park_mounted_session`` and the shared ``safe_break_pane_to_storage``) implement the wrong tie-break when a live storage window already holds the canonical name (``architect-samblog``, ``pm-operator``, …).

#1635/#1859 policy: trust storage as the persistent home, refuse break-pane, let the cockpit's ``respawn_pane`` discard the cockpit's right pane as collateral. That assumption is correct when the cockpit just spawned a fresh placeholder mid-park-collision.

For rail navigation Sam actually hits, that assumption is inverted. The cockpit-mounted pane IS the user's active conversation (they were just typing into it before the rail click). Any pre-existing live storage window with the same canonical name is a stale orphan from a prior cockpit lifetime. The original policy then killed the user's actual chat and surfaced the orphan on re-mount.

Killer code paths:
- ``src/pollypm/cockpit_rail.py:4306`` — ``_park_mounted_session`` ``if live_existing:`` returned early; the caller's ``respawn_pane`` then killed the cockpit's live right pane.
- ``src/pollypm/cockpit_storage_park.py:106`` — ``safe_break_pane_to_storage`` ``if live_existing:`` actively called ``tmux.kill_pane(source_pane_id)`` on the user's mount.

## Fix

Reversed the tie-break in both helpers. When a live duplicate exists in storage with the same canonical name, the helper now:

1. Kills the orphan storage window(s).
2. Break-panes the cockpit mount into storage under the canonical name.

The user's conversation is preserved as the persistent home; the next mount finds exactly one window with the canonical name and joins it back in.

New audit event: ``cockpit.park_killed_orphan`` (replaces ``cockpit.park_skipped_existing`` in the wipe path).
``CockpitWindowManager.park_live_to_storage`` action label flipped from ``park_skipped_live_duplicate`` to ``park_failed_break_pane`` (now only reached when ``break-pane`` itself errors).

## Why this is a #1859 follow-up, not a duplicate

#1859 fixed the case where the cockpit was about to create a SECOND same-named storage window — the helper's idempotent dup-check correctly prevented that. This PR doesn't disagree with the dup-check; it disagrees with the policy when the dup-check finds a live duplicate. #1859 was right that storage shouldn't accumulate duplicates. This PR is right that when forced to pick one, the cockpit pane wins (it has the user typing into it).

## Test plan

- [x] New regression ``test_rail_navigation_preserves_architect_session_across_nav_and_back`` reproduces Sam's exact storage state (architect-samblog live in storage as an orphan + cockpit holding the user's actual chat). Asserts orphan is killed, ``break_pane`` runs, storage ends up with one canonical window, no ``cockpit.park_skipped_existing`` audit.
- [x] All 8 ``test_cockpit_storage_park.py`` tests pass with the new policy (3 updated, 1 new for the rail-nav repro, 4 unchanged).
- [x] ``test_park_live_to_storage_kills_orphan_when_live_duplicate_exists`` in ``test_cockpit_window_manager.py`` updated and passing.
- [x] ``test_cockpit_router_park_kills_orphan_when_live_duplicate_exists`` in ``test_cockpit.py`` updated and passing; dead-only-duplicate test (``test_cockpit_router_park_reoccupies_dead_storage_window``) unchanged and still passing.
- [ ] Manual: post-merge + ``pm upgrade``, drive PM Chat → dashboard → PM Chat → other rail item → PM Chat on a project with a stale architect-* window in storage; confirm the conversation persists.

## RC stability

V1-RC stability mode. Surgical policy reversal in two helpers + one action-label change; no restructuring of the surrounding mount/park orchestration. Behaviour is strictly more preserving than before — the helper now always preserves the cockpit's active mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)