### PR TITLE
feat(path-resolution): typed helpers + literal-join lint gate (refs #1972)

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -360,6 +360,25 @@ def _build_record(
     }
 
 
+def _assert_no_doubled_pollypm(path: Path) -> None:
+    """Raise loudly if ``path`` contains ``.pollypm/.pollypm`` (#1972).
+
+    Belt-and-suspenders for the typed-helpers design fix: a writer that
+    bypasses the helpers and constructs a doubled-path target is a bug.
+    Converting the silent leak (~280K files / 1.8 GB in production —
+    see #1810) into a loud crash makes the regression catch fire in
+    CI / smoke tests instead of accumulating on user disks. The lint
+    gate (``tests/test_no_raw_pollypm_path_joins.py``) is the primary
+    defence; this is the runtime backstop.
+    """
+    if ".pollypm/.pollypm" in str(path) or ".pollypm\\.pollypm" in str(path):
+        raise RuntimeError(
+            f"doubled-pollypm-path write blocked (#1972): {path!s}. "
+            "Construct via pollypm.projects.project_audit_log_path() "
+            "or another typed helper instead of joining '.pollypm' inline."
+        )
+
+
 def _append_line(path: Path, line: str) -> None:
     """Append a single line to ``path``, creating parents as needed.
 
@@ -370,6 +389,7 @@ def _append_line(path: Path, line: str) -> None:
     a long-lived handle, so a crashed writer can't leak an FD into
     the audit file.
     """
+    _assert_no_doubled_pollypm(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     # Newline added here so the encoded record stays a single
     # JSON object on its own line.

--- a/src/pollypm/projects.py
+++ b/src/pollypm/projects.py
@@ -158,6 +158,130 @@ def project_transcripts_dir(project_path: Path) -> Path:
     return project_instruction_dir(project_path) / "transcripts"
 
 
+# ---------------------------------------------------------------------------
+# Typed path helpers (#1972 design fix slice 1).
+#
+# Every project-scoped ``.pollypm/<subdir>`` path lives behind one of
+# these helpers. The helpers funnel through ``_resolve_pollypm_root``
+# so the doubled-path guard always fires for callers that happen to
+# pass ``GLOBAL_CONFIG_DIR`` itself as the project root. The
+# accompanying lint gate in ``tests/test_no_raw_pollypm_path_joins.py``
+# bans raw ``/ ".pollypm" /`` joins in ``src/pollypm/`` so new features
+# can't reintroduce the bug by skipping the helpers.
+# ---------------------------------------------------------------------------
+
+
+def project_state_db_path(project_path: Path) -> Path:
+    """Per-project work-state SQLite DB (``<project>/.pollypm/state.db``)."""
+    return project_pollypm_dir(project_path) / "state.db"
+
+
+def project_audit_log_path(project_path: Path) -> Path:
+    """Per-project audit JSONL (``<project>/.pollypm/audit.jsonl``)."""
+    return project_pollypm_dir(project_path) / "audit.jsonl"
+
+
+def project_advisor_log_path(project_path: Path) -> Path:
+    """Per-project advisor log JSONL (``<project>/.pollypm/advisor-log.jsonl``)."""
+    return project_pollypm_dir(project_path) / "advisor-log.jsonl"
+
+
+def project_plugins_dir(project_path: Path) -> Path:
+    """Per-project plugin overrides (``<project>/.pollypm/plugins``)."""
+    return project_pollypm_dir(project_path) / "plugins"
+
+
+def project_gates_dir(project_path: Path) -> Path:
+    """Per-project gate config (``<project>/.pollypm/gates``)."""
+    return project_pollypm_dir(project_path) / "gates"
+
+
+def project_flows_dir(project_path: Path) -> Path:
+    """Per-project flow templates (``<project>/.pollypm/flows``)."""
+    return project_pollypm_dir(project_path) / "flows"
+
+
+def project_rules_dir(project_path: Path) -> Path:
+    """Per-project rules (``<project>/.pollypm/rules``)."""
+    return project_pollypm_dir(project_path) / "rules"
+
+
+def project_magic_dir(project_path: Path) -> Path:
+    """Per-project magic commands (``<project>/.pollypm/magic``)."""
+    return project_pollypm_dir(project_path) / "magic"
+
+
+def project_config_dir(project_path: Path) -> Path:
+    """Per-project config dir (``<project>/.pollypm/config``)."""
+    return project_pollypm_dir(project_path) / "config"
+
+
+def project_docs_dir(project_path: Path) -> Path:
+    """Per-project shipped docs (``<project>/.pollypm/docs``)."""
+    return project_pollypm_dir(project_path) / "docs"
+
+
+def project_content_dir(project_path: Path) -> Path:
+    """Per-project content fixtures (``<project>/.pollypm/content``)."""
+    return project_pollypm_dir(project_path) / "content"
+
+
+def project_inbox_dir(project_path: Path) -> Path:
+    """Per-project inbox dir (``<project>/.pollypm/inbox``)."""
+    return project_pollypm_dir(project_path) / "inbox"
+
+
+def project_worker_markers_dir(project_path: Path) -> Path:
+    """Per-project worker markers (``<project>/.pollypm/worker-markers``)."""
+    return project_pollypm_dir(project_path) / "worker-markers"
+
+
+def project_session_markers_dir(home_dir: Path) -> Path:
+    """Per-account session markers (``<account.home>/.pollypm/session-markers``).
+
+    Distinct from the other helpers: this is rooted at an *agent home*
+    (``account.home``), not a project root. It's still routed through
+    the resolver because some callers happen to pass the global config
+    dir as the account home in tests, and we want the same collapse
+    behaviour for consistency.
+    """
+    return project_pollypm_dir(home_dir) / "session-markers"
+
+
+def project_system_prompts_dir(home_dir: Path) -> Path:
+    """Per-account system prompt overrides (``<home>/.pollypm/system-prompts``)."""
+    return project_pollypm_dir(home_dir) / "system-prompts"
+
+
+def project_project_guides_dir(project_path: Path) -> Path:
+    """Per-project role-guide forks (``<project>/.pollypm/project-guides``).
+
+    Mirrors :func:`pollypm.project_guides.project_guides_dir` but lives
+    here so call sites that already import from ``pollypm.projects``
+    don't need to take a second dependency.
+    """
+    return project_pollypm_dir(project_path) / "project-guides"
+
+
+def project_control_prompts_dir(project_path: Path) -> Path:
+    """Per-project kickoff prompts (``<project>/.pollypm/control-prompts``)."""
+    return project_pollypm_dir(project_path) / "control-prompts"
+
+
+def global_pollypm_dir() -> Path:
+    """Return ``~/.pollypm`` (the user-global PollyPM config dir).
+
+    Thin wrapper over :data:`pollypm.config.GLOBAL_CONFIG_DIR` so call
+    sites that want the global tree can express it without a raw
+    ``Path.home() / ".pollypm"`` join (which the #1972 lint gate
+    rejects). Use ``GLOBAL_CONFIG_DIR`` directly when you specifically
+    need the module-level constant.
+    """
+    from pollypm.config import GLOBAL_CONFIG_DIR
+
+    return GLOBAL_CONFIG_DIR
+
+
 def session_scoped_dir(base_dir: Path, session_id: str) -> Path:
     return base_dir / session_id
 

--- a/src/pollypm/work/sqlite_service.py
+++ b/src/pollypm/work/sqlite_service.py
@@ -614,6 +614,21 @@ class SQLiteWorkService:
         sync_manager: SyncManager | None = None,
         session_manager: object | None = None,
     ) -> None:
+        # #1972 design fix: belt-and-suspenders precondition. If a
+        # caller bypasses the typed helpers (``project_state_db_path``)
+        # and constructs a doubled-pollypm-path target by hand, fail
+        # loudly here instead of silently opening a phantom SQLite DB
+        # under ``~/.pollypm/.pollypm/state.db``. The lint gate
+        # (``tests/test_no_raw_pollypm_path_joins.py``) is the primary
+        # defence; this is the runtime backstop for any join that
+        # slips past it (e.g. dynamically constructed paths).
+        _db_str = str(db_path)
+        if ".pollypm/.pollypm" in _db_str or ".pollypm\\.pollypm" in _db_str:
+            raise RuntimeError(
+                f"doubled-pollypm-path state.db blocked (#1972): {db_path!s}. "
+                "Construct via pollypm.projects.project_state_db_path() "
+                "instead of joining '.pollypm' inline."
+            )
         self._db_path = db_path
         self._project_path = project_path
         self._sync = sync_manager

--- a/tests/test_doubled_path_preconditions.py
+++ b/tests/test_doubled_path_preconditions.py
@@ -1,0 +1,148 @@
+"""Runtime preconditions for doubled-pollypm-path (#1972).
+
+The typed-helpers + lint gate (PR 1 of #1972) is the primary defence.
+This file pins the runtime backstop: any opener that bypasses the
+helpers and is handed a path containing ``.pollypm/.pollypm`` raises
+``RuntimeError`` loudly rather than silently leaking into the
+phantom tree (per the architectural analysis in #1972).
+
+Two openers carry the precondition:
+
+* ``SQLiteWorkService.__init__`` — the work state DB. The biggest
+  leak vector historically (~280K files / 1.8 GB).
+* ``pollypm.audit.log._append_line`` — the audit writer that #1966
+  identified as the most recent regression site.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_sqlite_work_service_rejects_doubled_path(tmp_path: Path) -> None:
+    """Opening a state DB at ``.pollypm/.pollypm/state.db`` raises."""
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    doubled = tmp_path / ".pollypm" / ".pollypm" / "state.db"
+    doubled.parent.mkdir(parents=True, exist_ok=True)
+
+    with pytest.raises(RuntimeError, match=r"doubled-pollypm-path"):
+        SQLiteWorkService(db_path=doubled, project_path=tmp_path)
+
+
+def test_sqlite_work_service_accepts_single_path(tmp_path: Path) -> None:
+    """Sanity: a normal single ``.pollypm/state.db`` still opens."""
+    from pollypm.work.sqlite_service import SQLiteWorkService
+
+    project = tmp_path / "myproject"
+    project.mkdir()
+    db_path = project / ".pollypm" / "state.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    svc = SQLiteWorkService(db_path=db_path, project_path=project)
+    assert svc is not None
+
+
+def test_audit_append_line_rejects_doubled_path(tmp_path: Path) -> None:
+    """Writing audit to a doubled path raises."""
+    from pollypm.audit.log import _append_line
+
+    doubled = tmp_path / ".pollypm" / ".pollypm" / "audit.jsonl"
+
+    with pytest.raises(RuntimeError, match=r"doubled-pollypm-path"):
+        _append_line(doubled, '{"foo":"bar"}')
+
+
+def test_audit_append_line_accepts_single_path(tmp_path: Path) -> None:
+    """Sanity: a normal single ``.pollypm/audit.jsonl`` still writes."""
+    from pollypm.audit.log import _append_line
+
+    target = tmp_path / "myproject" / ".pollypm" / "audit.jsonl"
+    _append_line(target, '{"foo":"bar"}')
+
+    assert target.read_text().rstrip() == '{"foo":"bar"}'
+
+
+# ---------------------------------------------------------------------------
+# Helper sanity — quick smoke tests for the new typed helpers (#1972 PR 1).
+# Full migration tests live in test_doubled_pollypm_path_regression.py.
+# ---------------------------------------------------------------------------
+
+
+def test_project_state_db_path_normal(tmp_path: Path) -> None:
+    from pollypm.projects import project_state_db_path
+
+    project = tmp_path / "myproject"
+    project.mkdir()
+    assert project_state_db_path(project) == project / ".pollypm" / "state.db"
+
+
+def test_project_state_db_path_collapses_global_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When ``project_path == GLOBAL_CONFIG_DIR`` the join collapses (no doubled)."""
+    import pollypm.config as config_mod
+    from pollypm.projects import project_state_db_path
+
+    fake_global = tmp_path / ".pollypm"
+    fake_global.mkdir()
+    monkeypatch.setattr(config_mod, "GLOBAL_CONFIG_DIR", fake_global)
+
+    db = project_state_db_path(fake_global)
+    assert ".pollypm/.pollypm" not in str(db), db
+    assert db == fake_global / "state.db"
+
+
+def test_project_audit_log_path_collapses_global_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1966 reproducer: audit log under GLOBAL_CONFIG_DIR doesn't double."""
+    import pollypm.config as config_mod
+    from pollypm.projects import project_audit_log_path
+
+    fake_global = tmp_path / ".pollypm"
+    fake_global.mkdir()
+    monkeypatch.setattr(config_mod, "GLOBAL_CONFIG_DIR", fake_global)
+
+    log = project_audit_log_path(fake_global)
+    assert ".pollypm/.pollypm" not in str(log), log
+    assert log == fake_global / "audit.jsonl"
+
+
+def test_typed_helpers_chain_through_resolver(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every typed helper collapses when given GLOBAL_CONFIG_DIR."""
+    import pollypm.config as config_mod
+    from pollypm import projects as p
+
+    fake_global = tmp_path / ".pollypm"
+    fake_global.mkdir()
+    monkeypatch.setattr(config_mod, "GLOBAL_CONFIG_DIR", fake_global)
+
+    helpers = [
+        p.project_state_db_path,
+        p.project_audit_log_path,
+        p.project_advisor_log_path,
+        p.project_plugins_dir,
+        p.project_gates_dir,
+        p.project_flows_dir,
+        p.project_rules_dir,
+        p.project_magic_dir,
+        p.project_config_dir,
+        p.project_docs_dir,
+        p.project_content_dir,
+        p.project_inbox_dir,
+        p.project_worker_markers_dir,
+        p.project_session_markers_dir,
+        p.project_system_prompts_dir,
+        p.project_project_guides_dir,
+        p.project_control_prompts_dir,
+    ]
+    for helper in helpers:
+        result = helper(fake_global)
+        assert ".pollypm/.pollypm" not in str(result), (
+            f"{helper.__name__}({fake_global}) -> {result} doubles!"
+        )

--- a/tests/test_no_raw_pollypm_path_joins.py
+++ b/tests/test_no_raw_pollypm_path_joins.py
@@ -1,0 +1,333 @@
+"""Lint gate: ratchet on raw ``/ ".pollypm" /`` joins in ``src/pollypm/`` (#1972).
+
+Why this exists
+---------------
+The doubled-pollypm-path leak (#1810, #1950, #1966, #1972) keeps
+returning because ``_resolve_pollypm_root()`` is opt-in: every new
+feature that joins ``some_path / ".pollypm" / ...`` inline can
+silently produce ``~/.pollypm/.pollypm/...`` when its caller happens
+to be operating on the global config dir as a project root.
+
+Per-PR audits (#1898, #1954) close known leak sites but don't
+prevent the next one. The architectural fix (#1972) is to:
+
+1. Funnel every ``.pollypm/<subdir>`` construction through a typed
+   helper in :mod:`pollypm.projects` (``project_state_db_path``,
+   ``project_audit_log_path``, etc.). Helpers chain through
+   ``_resolve_pollypm_root`` so the doubled-path guard always fires.
+2. Mechanically forbid NEW raw ``/ ".pollypm" /`` joins in
+   ``src/pollypm/``. This test is the gate.
+
+Ratchet design
+--------------
+Migrating all 155+ existing call sites in one PR is too big for v1
+RC. So the gate ships as a **ratchet**: ``_BASELINE`` captures the
+pre-fix count of raw joins per file. The test fails if:
+
+* A file's count INCREASES (new leak site introduced), OR
+* A file appears in the diff that isn't in the baseline (new file
+  with a raw join), OR
+* The baseline lists a file that no longer exists / has zero
+  offenders (must shrink the baseline so future regressions land
+  inside it).
+
+The migration PRs (PR 2 + PR 3 under #1972) shrink the baseline
+counts to zero. Once everything's zero, this test enforces "no
+raw joins, ever."
+
+Exclusion list
+--------------
+The gate is intentionally strict. The only allowed call sites are:
+
+* ``src/pollypm/projects.py`` — the helper module itself defines
+  ``_resolve_pollypm_root`` and the typed helpers, all of which
+  construct the ``.pollypm`` segment internally. This is the one
+  legitimate constructor.
+* ``src/pollypm/config.py`` — defines ``GLOBAL_CONFIG_DIR =
+  Path.home() / ".pollypm"``, the canonical source of truth that
+  the resolver and helpers reference. Allowed at the constant
+  definition only; other joins in this file should use the helpers.
+
+Per-line escape hatch
+---------------------
+A line carrying ``# noqa: pollypm-path-join`` is permitted and is
+NOT counted against the baseline. Use this sparingly — comments
+accompanying these joins should explain why the helper API doesn't
+fit (e.g. constructing a fixture path in the package install tree,
+where no project root exists).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SRC_ROOT = _REPO_ROOT / "src" / "pollypm"
+
+# The literal pattern we ban. Matches ``/ ".pollypm" /`` and
+# ``/ ".pollypm"`` followed by a closing context (string end, paren,
+# comma, etc.). We use a deliberately tight pattern so we catch the
+# load-bearing case (``X / ".pollypm" / "..."``) and the trailing
+# case (``X / ".pollypm"`` building the pollypm dir itself) without
+# matching the string ``".pollypm"`` in comments / docstrings.
+_BAN_PATTERN = re.compile(r'/\s*"\.pollypm"')
+
+# Files that ARE allowed to construct the ``.pollypm`` segment — see
+# module docstring for rationale.
+_ALLOWED_FILES = {
+    "projects.py",  # typed helpers + resolver
+    "config.py",    # GLOBAL_CONFIG_DIR constant
+}
+
+# Per-line escape hatch.
+_NOQA_PRAGMA = "noqa: pollypm-path-join"
+
+
+# ---------------------------------------------------------------------------
+# Baseline (#1972 PR 1 — design fix slice 1).
+#
+# Pre-migration count of raw joins per file in src/pollypm/. PRs 2
+# and 3 under #1972 shrink these to zero. New files with raw joins
+# (not in the baseline) and any increase against a baselined file
+# both fail this test.
+#
+# When you migrate a file in #1972 PR 2 / PR 3:
+#   - Reduce the entry's count by the number of joins you routed
+#     through a typed helper.
+#   - When the entry hits 0, remove it.
+#
+# When a legitimate raw join must remain (e.g. a constructor for a
+# path inside the package install tree, where no project root
+# exists), tag the line with ``# noqa: pollypm-path-join`` instead
+# of leaving it in the baseline.
+# ---------------------------------------------------------------------------
+_BASELINE: dict[str, int] = {
+    "src/pollypm/__main__.py": 1,
+    "src/pollypm/accounts.py": 1,
+    "src/pollypm/agent_profiles/defaults.py": 4,
+    "src/pollypm/audit/log.py": 2,
+    "src/pollypm/cli_features/projects.py": 2,
+    "src/pollypm/cockpit.py": 1,
+    "src/pollypm/cockpit_inbox.py": 2,
+    "src/pollypm/cockpit_inbox_sources.py": 2,
+    "src/pollypm/cockpit_project_settings.py": 4,
+    "src/pollypm/cockpit_sections/insights.py": 1,
+    "src/pollypm/cockpit_sections/project_dashboard.py": 2,
+    "src/pollypm/cockpit_settings_gather.py": 1,
+    "src/pollypm/cockpit_settings_history.py": 1,
+    "src/pollypm/cockpit_settings_projects.py": 1,
+    "src/pollypm/cockpit_tasks.py": 3,
+    "src/pollypm/cockpit_ui.py": 13,
+    "src/pollypm/config_patches.py": 10,
+    "src/pollypm/control_tui.py": 1,
+    "src/pollypm/dashboard_data.py": 2,
+    "src/pollypm/doctor.py": 10,
+    "src/pollypm/doctor/filesystem.py": 2,
+    "src/pollypm/heartbeats/local.py": 2,
+    "src/pollypm/heartbeats/stall_classifier.py": 1,
+    "src/pollypm/itsalive.py": 1,
+    "src/pollypm/llm_runner.py": 1,
+    "src/pollypm/memory_cli.py": 1,
+    "src/pollypm/model_registry.py": 1,
+    "src/pollypm/onboarding.py": 2,
+    "src/pollypm/plugin_cli.py": 2,
+    "src/pollypm/plugin_host.py": 6,
+    "src/pollypm/plugins_builtin/activity_feed/projector_factory.py": 1,
+    "src/pollypm/plugins_builtin/core_rail_items/plugin.py": 2,
+    "src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py": 2,
+    "src/pollypm/plugins_builtin/core_recurring/sweeps.py": 1,
+    "src/pollypm/plugins_builtin/default_launch_planner/planner.py": 1,
+    "src/pollypm/plugins_builtin/morning_briefing/handlers/gather_yesterday.py": 3,
+    "src/pollypm/plugins_builtin/morning_briefing/handlers/identify_priorities.py": 1,
+    "src/pollypm/plugins_builtin/project_planning/cli/project.py": 4,
+    "src/pollypm/plugins_builtin/project_planning/memory.py": 1,
+    "src/pollypm/plugins_builtin/project_planning/plugin.py": 2,
+    "src/pollypm/plugins_builtin/task_assignment_notify/handlers/sweep.py": 1,
+    "src/pollypm/pm_turn_state.py": 1,
+    "src/pollypm/project_paths.py": 2,
+    "src/pollypm/project_planning_protocol.py": 1,
+    "src/pollypm/providers/claude/adapter.py": 2,
+    "src/pollypm/providers/codex/adapter.py": 2,
+    "src/pollypm/rail_cli.py": 2,
+    "src/pollypm/rail_daemon_launchd.py": 1,
+    "src/pollypm/recovery_prompt.py": 1,
+    "src/pollypm/release_check.py": 1,
+    "src/pollypm/rules.py": 4,
+    "src/pollypm/runtime_services.py": 1,
+    "src/pollypm/session_services/tmux.py": 1,
+    "src/pollypm/storage/legacy_per_project_db.py": 1,
+    "src/pollypm/storage/pg_migration_tool.py": 2,
+    "src/pollypm/store/migrations.py": 1,
+    "src/pollypm/supervisor.py": 4,
+    "src/pollypm/task_backends/__init__.py": 1,
+    "src/pollypm/upgrade.py": 1,
+    "src/pollypm/web_api/token.py": 1,
+    "src/pollypm/work/db_resolver.py": 2,
+    "src/pollypm/work/first_shipped.py": 2,
+    "src/pollypm/work/flow_engine.py": 4,
+    "src/pollypm/work/gates.py": 4,
+    "src/pollypm/work/inbox_actions.py": 1,
+    "src/pollypm/work/service_factory.py": 1,
+    "src/pollypm/work/session_manager.py": 8,
+    "src/pollypm/work/worker_marker_reaper.py": 1,
+}
+
+
+def _iter_src_files() -> list[Path]:
+    return sorted(_SRC_ROOT.rglob("*.py"))
+
+
+def _is_excluded(path: Path) -> bool:
+    """Return True for files allowed to construct ``.pollypm`` joins.
+
+    Exclusion is by filename, not full path, because the helper file
+    is ``pollypm/projects.py`` regardless of where the package lives
+    on disk. ``config.py`` likewise.
+    """
+    if path.name not in _ALLOWED_FILES:
+        return False
+    # Sanity check the file lives directly under ``src/pollypm/``,
+    # not a third-party plugin shadowing the name.
+    return path.parent == _SRC_ROOT
+
+
+def _find_offending_lines(path: Path) -> list[tuple[int, str]]:
+    out: list[tuple[int, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return out
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if not _BAN_PATTERN.search(line):
+            continue
+        # Skip if the line carries the noqa escape hatch.
+        if _NOQA_PRAGMA in line:
+            continue
+        # Skip comment-only lines (docstrings are harder to detect
+        # without parsing; rely on the noqa pragma for those).
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        out.append((lineno, line.rstrip()))
+    return out
+
+
+def _current_counts() -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for path in _iter_src_files():
+        if _is_excluded(path):
+            continue
+        n = len(_find_offending_lines(path))
+        if n:
+            rel = str(path.relative_to(_REPO_ROOT))
+            counts[rel] = n
+    return counts
+
+
+def test_lint_gate_ratchet() -> None:
+    """Fail on new raw joins or increases over the baseline.
+
+    Three failure modes:
+
+    1. A file's offender count INCREASED — new leak site introduced.
+    2. A file appeared with offenders that isn't in the baseline — new
+       leak site in a new file.
+    3. A baseline entry no longer exists / has zero offenders — the
+       baseline must shrink as we migrate. Stale entries hide future
+       regressions inside the cleaned file.
+
+    Migration PRs (#1972 PRs 2 + 3) shrink the baseline. Once
+    everything is zero we have an absolute "no raw joins" gate.
+    """
+    current = _current_counts()
+    failures: list[str] = []
+
+    # Check every baseline entry vs current.
+    for rel, baseline in sorted(_BASELINE.items()):
+        actual = current.get(rel, 0)
+        if actual > baseline:
+            failures.append(
+                f"{rel}: offender count went UP "
+                f"({baseline} → {actual}). Migrate the new join "
+                "through a typed helper in pollypm.projects, or "
+                "add `# noqa: pollypm-path-join` with a comment."
+            )
+        elif actual < baseline:
+            failures.append(
+                f"{rel}: offender count went DOWN "
+                f"({baseline} → {actual}). Update _BASELINE in "
+                "tests/test_no_raw_pollypm_path_joins.py to match "
+                "(remove the entry if it hit zero) so the ratchet "
+                "stays tight."
+            )
+
+    # Check for new files with offenders not in the baseline.
+    for rel, actual in sorted(current.items()):
+        if rel not in _BASELINE:
+            failures.append(
+                f"{rel}: new file with {actual} raw ``.pollypm`` "
+                "join(s). Route through a typed helper in "
+                "pollypm.projects, or add `# noqa: pollypm-path-join`."
+            )
+
+    if failures:
+        msg = "\n".join(["#1972 lint-gate ratchet failed:", "", *failures])
+        raise AssertionError(msg)
+
+
+def test_helper_module_only_internal_joins() -> None:
+    """The helper module is the ONLY constructor of ``.pollypm``.
+
+    Sanity-check the exclusion list: the helper file must still
+    contain the joins (otherwise the helpers can't construct
+    paths), and ``config.py`` must still define ``GLOBAL_CONFIG_DIR``.
+    If a future refactor moves the resolver elsewhere, this test
+    catches the drift so the exclusion list gets updated.
+    """
+    helpers = _SRC_ROOT / "projects.py"
+    config = _SRC_ROOT / "config.py"
+
+    helpers_text = helpers.read_text(encoding="utf-8")
+    assert "_resolve_pollypm_root" in helpers_text, (
+        f"{helpers}: expected to host _resolve_pollypm_root (helper module). "
+        "If this moved, update _ALLOWED_FILES in this test."
+    )
+    assert 'GLOBAL_CONFIG_DIR = Path.home() / ".pollypm"' in (
+        config.read_text(encoding="utf-8")
+    ), (
+        f"{config}: expected to define GLOBAL_CONFIG_DIR. "
+        "If this moved, update _ALLOWED_FILES in this test."
+    )
+
+
+def test_noqa_pragma_recognised(tmp_path: Path) -> None:
+    """A line tagged with the noqa pragma is permitted.
+
+    Belt-and-suspenders for the pragma path: if we ever break the
+    escape hatch, the gate becomes unusable. This test pins it.
+    """
+    fake = tmp_path / "fake.py"
+    fake.write_text(
+        'x = some_path / ".pollypm" / "foo"  # noqa: pollypm-path-join — test\n'
+    )
+    offenders = _find_offending_lines(fake)
+    assert offenders == [], (
+        f"Expected noqa pragma to suppress the gate but got: {offenders}"
+    )
+
+
+def test_inline_join_without_pragma_caught(tmp_path: Path) -> None:
+    """A bare inline join is caught by the gate.
+
+    Pin the positive case: if the regex stops matching, the gate
+    silently lets new leak sites through.
+    """
+    fake = tmp_path / "fake.py"
+    fake.write_text('x = some_path / ".pollypm" / "foo"\n')
+    offenders = _find_offending_lines(fake)
+    assert len(offenders) == 1, (
+        f"Expected gate to catch raw join but got: {offenders}"
+    )
+    assert offenders[0][0] == 1


### PR DESCRIPTION
## Summary

First slice of the #1972 design fix for the recurring doubled-pollypm-path leak. The opt-in ``_resolve_pollypm_root()`` model can't prevent the next leak site; the architecture needs typed helpers + a mechanical ban on raw joins.

- **Typed helpers in ``pollypm.projects``** for every ``.pollypm/<subdir>`` pattern in the inventory: ``project_state_db_path`` (66 sites), ``project_audit_log_path`` (the #1966 site), ``project_advisor_log_path``, ``project_plugins_dir``, ``project_gates_dir``, ``project_flows_dir``, ``project_rules_dir``, ``project_magic_dir``, ``project_config_dir``, ``project_docs_dir``, ``project_content_dir``, ``project_inbox_dir``, ``project_worker_markers_dir``, ``project_session_markers_dir``, ``project_system_prompts_dir``, ``project_project_guides_dir``, ``project_control_prompts_dir``, ``global_pollypm_dir``. Each funnels through ``_resolve_pollypm_root`` so the doubled-path guard always fires.
- **Lint gate** (``tests/test_no_raw_pollypm_path_joins.py``) — ratchet-style: ``_BASELINE`` pins the current 155 raw ``/ ".pollypm" /`` joins across 68 files; any NEW join or any increase against the baseline fails the test. ``noqa: pollypm-path-join`` is the per-line escape hatch for legitimate joins. ``projects.py`` + ``config.py`` are the only files allowed to construct the segment internally.
- **Runtime preconditions** in ``SQLiteWorkService.__init__`` and ``audit.log._append_line``: any path containing ``.pollypm/.pollypm`` raises loudly. Belt-and-suspenders for joins that slip past the lint gate (e.g. dynamically constructed paths).

## Why ratchet, not zero-baseline

Migrating all 155 sites in one PR is too big for v1 RC. The ratchet ships immediately, blocks new regressions, and shrinks as PR 2 / PR 3 (refs #1972) migrate batches of call sites. Each migration PR removes entries from the baseline; once it hits zero, the gate is absolute.

## Test plan

- [x] ``pytest tests/test_no_raw_pollypm_path_joins.py`` — 4/4 passed (gate itself + noqa pragma + helper-module sanity)
- [x] ``pytest tests/test_doubled_path_preconditions.py tests/test_doubled_pollypm_path_regression.py`` — 18/18 passed (new preconditions + existing regression suite still green)
- [ ] **Sam to verify:** review the helper list — anything missing from the inventory?
- [ ] **Sam to verify:** review the lint gate's exclusion list — too narrow? Too wide?

## Refs

Closes #1973. Refs #1972, #1810, #1950, #1954, #1966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)