### PR TITLE
fix(audit): thread project_path into tier4 sweep emits (closes #1998)

### DIFF
--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -2854,8 +2854,16 @@ def _sweep_tier4_budget_and_demotion(
     except Exception:  # noqa: BLE001
         logger.debug("tier4: list_active raised", exc_info=True)
         return counters
+    # #1998 — build a project_key → project_path map so the per-row
+    # emits can pass ``project_path`` to ``audit.log.emit``. Without
+    # this the sweep's audit lines (tier4_demoted, tier4_budget_exhausted)
+    # only landed in the central tail — operators tailing
+    # ``~/dev/<project>/.pollypm/audit.jsonl`` saw promotions but never
+    # the matching exhaustion/demotion, hiding the cascade's lifecycle.
+    project_paths = _build_project_path_map(services)
     for state in active_rows:
         try:
+            project_path = project_paths.get(state.project)
             # 1) Finding-resolved demotion. Only runs when the caller
             # supplied a seen-hash set — otherwise we can't safely
             # distinguish "finding gone" from "no scan happened yet".
@@ -2873,6 +2881,7 @@ def _sweep_tier4_budget_and_demotion(
                         project=state.project,
                         root_cause_hash_value=state.root_cause_hash,
                         reason="finding_resolved",
+                        project_path=project_path,
                     )
                     counters["tier4_demoted_cleared"] += 1
                 continue
@@ -2891,6 +2900,7 @@ def _sweep_tier4_budget_and_demotion(
                     urgent_handoff_subject=(
                         f"Tier-4 budget exhausted on {state.project}/{state.rule}"
                     ),
+                    project_path=project_path,
                 )
                 _route_tier4_to_terminal(
                     state=state, services=services, now=now,
@@ -2907,6 +2917,30 @@ def _sweep_tier4_budget_and_demotion(
                 state.root_cause_hash, exc_info=True,
             )
     return counters
+
+
+def _build_project_path_map(services: Any) -> dict[str, Path]:
+    """Return ``{project_key: project_path}`` from ``services.known_projects``.
+
+    Used by :func:`_sweep_tier4_budget_and_demotion` to thread the
+    per-project audit log path through ``_emit_tier4_*`` so cascade
+    lifecycle events land in ``<project>/.pollypm/audit.jsonl`` next to
+    the matching promotion rows. Best-effort; non-mappable entries are
+    silently skipped so a malformed project descriptor can't break the
+    sweep for everyone.
+    """
+    paths: dict[str, Path] = {}
+    known = getattr(services, "known_projects", None) or ()
+    for project in known:
+        key = getattr(project, "key", None) or getattr(project, "name", None)
+        path_raw = getattr(project, "path", None)
+        if not key or path_raw is None:
+            continue
+        try:
+            paths[str(key)] = Path(path_raw)
+        except TypeError:
+            continue
+    return paths
 
 
 def clear_tier4_for_finding(

--- a/tests/test_heartbeat_cascade_tier4.py
+++ b/tests/test_heartbeat_cascade_tier4.py
@@ -782,6 +782,80 @@ def test_budget_exhaustion_routes_to_terminal_path(
 # ---------------------------------------------------------------------------
 
 
+def test_sweep_threads_project_path_to_per_project_audit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, now: datetime,
+) -> None:
+    """#1998 — tier4 sweep emits land in both central + per-project audit.
+
+    Pre-fix: ``_emit_tier4_budget_exhausted`` and ``_emit_tier4_demoted``
+    were called without ``project_path`` from the sweep, so per-project
+    audit (``<root>/.pollypm/audit.jsonl``) carried promotions but never
+    the matching exhaustion/demotion. Operators tailing the per-project
+    log thought tier-4 promoted forever and never resolved or exhausted.
+
+    Post-fix: the sweep resolves project_path from ``services.known_projects``
+    and threads it through both emits so the per-project audit reflects
+    the full cascade lifecycle.
+    """
+    from pollypm.plugins_builtin.core_recurring import audit_watchdog as cadence
+    from pollypm.audit.log import project_log_path
+
+    db_path = tmp_path / "state.db"
+    _patch_workspace_db(monkeypatch, db_path)
+
+    project_root = tmp_path / "demo-project"
+    (project_root / ".pollypm").mkdir(parents=True)
+
+    class _StubProject:
+        key = "demo"
+        path = project_root
+
+    services = _StubServices(db_path)
+    services.known_projects = (_StubProject(),)
+
+    # --- budget-exhausted leg -------------------------------------------------
+    tracker = Tier4PromotionTracker(db_path)
+    finding = _finding(project="demo", subject="demo")
+    tracker.record_promotion(
+        finding, now=now, promotion_path=PROMOTION_PATH_WATCHDOG,
+    )
+    later = now + timedelta(seconds=TIER4_BUDGET_SECONDS + 600)
+    cadence._sweep_tier4_budget_and_demotion(
+        services=services, now=later,
+    )
+
+    per_project_log = project_log_path(project_root)
+    assert per_project_log is not None and per_project_log.exists(), (
+        "per-project audit log should be created by the sweep emit"
+    )
+    body = per_project_log.read_text()
+    assert "audit.tier4_budget_exhausted" in body, (
+        "per-project audit must carry tier4_budget_exhausted "
+        "(was central-only pre-#1998)"
+    )
+
+    # --- finding-resolved demotion leg ---------------------------------------
+    finding2 = _finding(
+        project="demo", subject="demo",
+        evidence={"queued_subjects": ["demo/9"]},  # distinct hash
+    )
+    tracker.record_promotion(
+        finding2, now=later, promotion_path=PROMOTION_PATH_WATCHDOG,
+    )
+    much_later = later + timedelta(minutes=10)
+    cadence._sweep_tier4_budget_and_demotion(
+        services=services,
+        now=much_later,
+        seen_root_cause_hashes=set(),  # finding gone → demote
+    )
+    body2 = per_project_log.read_text()
+    assert "audit.tier4_demoted" in body2, (
+        "per-project audit must carry tier4_demoted "
+        "(was central-only pre-#1998)"
+    )
+    services.close()
+
+
 def test_clear_tier4_for_finding_emits_demoted(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, now: datetime,
 ) -> None:


### PR DESCRIPTION
## Summary

- Tier-4 cascade lifecycle is now visible in per-project audit logs (not just the central tail).
- Found while triaging an unrelated bug (#1997 — tier-4 infinite re-promote loop); the audit gap is the reason that bug stayed hidden for ~50 hours across 8 projects.
- Forensics-only fix; zero behavior change in the cascade itself.

## Why

`_sweep_tier4_budget_and_demotion` calls `_emit_tier4_demoted` and `_emit_tier4_budget_exhausted` without `project_path`. `pollypm.audit.log.emit` only writes the per-project audit (`<project>/.pollypm/audit.jsonl`) when `project_path` is non-None. The promotion-side helpers (`_emit_tier4_promoted`, `_emit_tier4_dispatched`) already pass the path, so per-project audit shows promotions but not exhaustions/demotions.

Concrete evidence from this morning's audit-log scan across 12 active projects:

```
grep -hE "tier4_budget_exhausted|tier4_demoted" ~/.pollypm/audit/*.jsonl | wc -l   # 162
grep -hE "tier4_budget_exhausted|tier4_demoted" ~/dev/*/.pollypm/audit.jsonl | wc -l   # 0  ← gap
```

## Change

- New helper `_build_project_path_map(services)` materializes `{project_key: project_path}` from `services.known_projects` once per sweep tick.
- `_sweep_tier4_budget_and_demotion` looks up the path per-row and threads it into both `_emit_tier4_demoted` and `_emit_tier4_budget_exhausted`.
- Best-effort: malformed project descriptors are silently skipped so one bad entry can't break the sweep for everyone.

## Test plan

- [x] New `test_sweep_threads_project_path_to_per_project_audit` regression test passes: asserts both `tier4_budget_exhausted` and `tier4_demoted` land in the per-project audit log after a sweep tick on a real `.pollypm/` directory. Verified pass locally (141s solo, fixture-startup-heavy).
- [ ] Existing budget-exhaustion + demotion sweep tests still pass (default `_StubServices.known_projects = ()` → empty map → existing per-test behavior unchanged).
- [ ] Smoke: tail a per-project audit during a real tier-4 budget exhaustion event and confirm the lifecycle row appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)