### PR TITLE
chore(version): bump to 1.0.0rc3-dev to force uv cache-miss on dev installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pollypm"
-version = "1.0.0rc2"
+version = "1.0.0rc3-dev"
 description = "Tmux-first orchestration for interactive CLI coding agents."
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` version from `1.0.0rc2` to `1.0.0rc3-dev` so every `uv tool install --force --reinstall .` during the RC stretch produces a fresh wheel name and cache-misses uv's wheel cache. PEP 440 normalizes this to `1.0.0rc3.dev0` at runtime.
- Closes #1983 (uv tool install silently uses cached wheel instead of rebuilding from source).
- Version stays at `1.0.0rc3-dev` during the RC stretch; bump to actual `1.0.0` when ready to tag final.

## Why this shape

The deeper fix (switch internal install paths to `--editable`, add a CI canary, etc.) is in scope for a follow-up. This single-line bump is the immediate operator unblock: any operator running `uv tool install --force --reinstall .` while the version string changes will get the new code. No source or test changes needed — the three `1.0.0rc2` references in `tests/test_rail_update_pill.py`, `tests/test_upgrade.py`, and `tests/test_upgrade_notice.py` are upgrade-flow mock fixtures (the "from" version in a simulated upgrade) and should not be touched.

## Test plan

- [x] `uv cache clean pollypm` (best-effort)
- [x] `uv tool install --force --reinstall .` from the worktree — installs `pollypm==1.0.0rc3.dev0`
- [x] `pm --version` reports `pollypm 1.0.0rc3.dev0`
- [x] `diff` of installed `session_intelligence.py` vs source — byte-identical (confirms cache-miss, fresh wheel built)

🤖 Generated with [Claude Code](https://claude.com/claude-code)