### PR TITLE
fix(reaper): demote reaped tasks + escalate on 3rd reap (closes #1999)

### DIFF
--- a/src/pollypm/storage/pg_schema.py
+++ b/src/pollypm/storage/pg_schema.py
@@ -328,6 +328,7 @@ CREATE TABLE IF NOT EXISTS work_tasks (
     kind                    text NOT NULL DEFAULT 'legacy',
     roles                   jsonb NOT NULL DEFAULT '{}'::jsonb,
     external_refs           jsonb NOT NULL DEFAULT '{}'::jsonb,
+    reap_count              int NOT NULL DEFAULT 0,
     created_at              timestamptz NOT NULL,
     created_by              text NOT NULL,
     updated_at              timestamptz NOT NULL,
@@ -748,6 +749,32 @@ ALTER TABLE IF EXISTS tier4_promotion_state
 
 
 # --------------------------------------------------------------------- #
+# 0005 — work_tasks.reap_count counter for #1999.
+# --------------------------------------------------------------------- #
+#
+# #1999: ``worker_marker_reaper`` deletes a stale fresh-launch marker
+# whenever the tmux window has vanished for a non-terminal task, but it
+# never demoted the task back to ``queued`` or surfaced repeat reaps to
+# the operator. Sam-approved policy:
+#
+# * 1st + 2nd reap on the same task → demote silently
+# * 3rd+ reap on the same task → demote AND escalate to the inbox
+#
+# The counter must persist across cockpit restarts (Sam may restart
+# between reaps), so it lives as a column on ``work_tasks``. The
+# reaper UPDATE bumps + reads it atomically via RETURNING.
+#
+# Migration is idempotent: ``ADD COLUMN IF NOT EXISTS`` is a no-op when
+# the column is already present (fresh installs pick it up from
+# ``INITIAL_SCHEMA_DDL``; deployed installs gain it via this migration).
+
+_MIGRATION_0005_WORK_TASKS_REAP_COUNT = """
+ALTER TABLE IF EXISTS work_tasks
+    ADD COLUMN IF NOT EXISTS reap_count int NOT NULL DEFAULT 0;
+"""
+
+
+# --------------------------------------------------------------------- #
 # Migration list — forward-only, append-only.
 # --------------------------------------------------------------------- #
 
@@ -759,6 +786,7 @@ MIGRATIONS: list[tuple[int, str, str]] = [
     (2, "0002_alert_dedupe_tuple", _MIGRATION_0002_ALERT_DEDUPE),
     (3, "0003_account_columns_text", _MIGRATION_0003_ACCOUNT_COLUMNS_TEXT),
     (4, "0004_tier4_terminal_handoff", _MIGRATION_0004_TIER4_TERMINAL_HANDOFF),
+    (5, "0005_work_tasks_reap_count", _MIGRATION_0005_WORK_TASKS_REAP_COUNT),
 ]
 
 

--- a/src/pollypm/storage/work_task_state.py
+++ b/src/pollypm/storage/work_task_state.py
@@ -87,17 +87,19 @@ def bump_reap_count_and_demote(
 
     Called by :func:`pollypm.work.worker_marker_reaper._classify_marker`
     when a fresh-launch marker is reaped because the tmux window has
-    vanished while the task is still non-terminal (#1999). The single
-    UPDATE bumps ``reap_count`` and demotes the task in one round-trip,
-    returning the post-increment count so the caller can decide whether
-    to escalate (3rd+ reap → inbox notify).
+    vanished while the task is in one of the *active/retry* statuses
+    (#1999). The single UPDATE bumps ``reap_count`` and demotes the
+    task in one round-trip, returning the post-increment count so the
+    caller can decide whether to escalate (3rd+ reap → inbox notify).
 
-    The update is conservative: it only fires when the task is still in
-    a non-terminal status (``in_progress`` / ``review`` / ``queued`` /
-    ``rework``). If a competing actor already cancelled or completed the
-    task between marker classification and this call, the row guard
-    prevents us from clobbering the terminal state — we return ``None``
-    in that case and the reaper skips the escalation.
+    The update uses an **explicit allowlist**: it only fires when the
+    task's current ``work_status`` is one of
+    ``{'in_progress', 'review', 'queued', 'rework'}``. Statuses such as
+    ``blocked``, ``on_hold``, ``draft``, ``done``, ``cancelled``, and
+    ``abandoned`` are intentionally excluded — a stale marker must not
+    clobber a deliberate user/operator hold or a terminal state. If the
+    row doesn't match the allowlist we return ``None`` and the reaper
+    skips the escalation.
 
     Returns
     -------
@@ -127,7 +129,9 @@ def bump_reap_count_and_demote(
                     "    assignee = NULL, "
                     "    updated_at = now() "
                     "WHERE project = %s AND task_number = %s "
-                    "  AND work_status NOT IN ('done', 'cancelled', 'abandoned') "
+                    "  AND work_status IN ("
+                    "        'in_progress', 'review', 'queued', 'rework'"
+                    "      ) "
                     "RETURNING reap_count",
                     (project_key, int(task_number)),
                 )
@@ -140,8 +144,9 @@ def bump_reap_count_and_demote(
                 conn.rollback()
                 return None
             if row is None:
-                # No row matched — either the task is gone or it's
-                # already terminal. Either way, no demote, no escalate.
+                # No row matched — either the task is gone, already
+                # terminal, or in a deliberate non-active status
+                # (blocked / on_hold / draft). No demote, no escalate.
                 conn.rollback()
                 return None
             try:

--- a/src/pollypm/storage/work_task_state.py
+++ b/src/pollypm/storage/work_task_state.py
@@ -77,6 +77,88 @@ def task_status_probe(
         return False, None
 
 
+def bump_reap_count_and_demote(
+    *,
+    project_key: str,
+    task_number: int,
+    config: "PollyPMConfig | None" = None,
+) -> int | None:
+    """Atomically demote a reaped task back to ``queued`` and bump ``reap_count``.
+
+    Called by :func:`pollypm.work.worker_marker_reaper._classify_marker`
+    when a fresh-launch marker is reaped because the tmux window has
+    vanished while the task is still non-terminal (#1999). The single
+    UPDATE bumps ``reap_count`` and demotes the task in one round-trip,
+    returning the post-increment count so the caller can decide whether
+    to escalate (3rd+ reap → inbox notify).
+
+    The update is conservative: it only fires when the task is still in
+    a non-terminal status (``in_progress`` / ``review`` / ``queued`` /
+    ``rework``). If a competing actor already cancelled or completed the
+    task between marker classification and this call, the row guard
+    prevents us from clobbering the terminal state — we return ``None``
+    in that case and the reaper skips the escalation.
+
+    Returns
+    -------
+    int | None
+        The post-increment ``reap_count`` value (>= 1) when the demote
+        landed. ``None`` when the row could not be found, the row was
+        already terminal, or the pool / query failed.
+    """
+    try:
+        from pollypm.storage.pg_pool import get_rw_pool
+    except Exception:  # noqa: BLE001
+        logger.debug("bump_reap_count_and_demote: pg_pool import failed", exc_info=True)
+        return None
+    try:
+        rw_ctx = get_rw_pool(config).connection()
+    except Exception:  # noqa: BLE001
+        logger.debug("bump_reap_count_and_demote: get_rw_pool failed", exc_info=True)
+        return None
+
+    try:
+        with rw_ctx as conn, conn.cursor() as cur:
+            try:
+                cur.execute(
+                    "UPDATE work_tasks "
+                    "SET reap_count = reap_count + 1, "
+                    "    work_status = 'queued', "
+                    "    assignee = NULL, "
+                    "    updated_at = now() "
+                    "WHERE project = %s AND task_number = %s "
+                    "  AND work_status NOT IN ('done', 'cancelled', 'abandoned') "
+                    "RETURNING reap_count",
+                    (project_key, int(task_number)),
+                )
+                row = cur.fetchone()
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "bump_reap_count_and_demote: UPDATE failed for %s/%s",
+                    project_key, task_number, exc_info=True,
+                )
+                conn.rollback()
+                return None
+            if row is None:
+                # No row matched — either the task is gone or it's
+                # already terminal. Either way, no demote, no escalate.
+                conn.rollback()
+                return None
+            try:
+                count = int(row[0])
+            except (TypeError, ValueError):
+                conn.rollback()
+                return None
+            conn.commit()
+            return count
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "bump_reap_count_and_demote: connection failed for %s/%s",
+            project_key, task_number, exc_info=True,
+        )
+        return None
+
+
 def task_numbers_with_statuses(
     *,
     project_key: str,

--- a/src/pollypm/work/worker_marker_reaper.py
+++ b/src/pollypm/work/worker_marker_reaper.py
@@ -86,6 +86,22 @@ WORKER_MARKER_REAPABLE_STATUSES: frozenset[str] = (
 )
 
 
+# Active/retry statuses that the #1999 demote path is allowed to touch.
+#
+# Explicit allowlist — must stay in lockstep with the SQL guard in
+# :func:`pollypm.storage.work_task_state.bump_reap_count_and_demote`.
+# Statuses like ``blocked``, ``on_hold``, and ``draft`` are intentionally
+# excluded: a stale marker (tmux window vanished) must NOT clobber a
+# deliberate user/operator hold or a not-yet-queued draft just because
+# the corresponding tmux window is absent.
+WORKER_MARKER_DEMOTE_ALLOWED_STATUSES: frozenset[str] = frozenset({
+    "in_progress",
+    "review",
+    "queued",
+    "rework",
+})
+
+
 def _emit_worker_session_reaped(decision: "ReapedMarker") -> None:
     """Best-effort audit emit for one reaped marker.
 
@@ -301,10 +317,14 @@ class ReapedMarker:
 
     ``window_missing_for_non_terminal`` flags the specific case the
     #1999 fix targets: the marker is being reaped because the worker's
-    tmux window has vanished but the task is still in a non-terminal
-    status. Only this branch triggers the demote-and-maybe-escalate
-    flow; the terminal-task and missing-row branches leave the task
-    untouched (it's already terminal / already gone).
+    tmux window has vanished AND the task is in one of the
+    active/retry statuses listed in
+    :data:`WORKER_MARKER_DEMOTE_ALLOWED_STATUSES`
+    (``in_progress`` / ``review`` / ``queued`` / ``rework``). Only this
+    branch triggers the demote-and-maybe-escalate flow. Tasks in
+    ``blocked`` / ``on_hold`` / ``draft`` keep their state — a stale
+    marker must not clobber a deliberate user/operator hold. Terminal
+    and missing-row branches likewise leave the task untouched.
     """
 
     project_key: str
@@ -431,6 +451,12 @@ def _classify_marker(
         )
 
     if window_name not in live_window_names:
+        # Only fire the demote/escalate branch when the task is in one
+        # of the active/retry statuses. ``blocked`` / ``on_hold`` /
+        # ``draft`` tasks intentionally keep their state even if the
+        # tmux window is gone — a stale marker must not undo an
+        # operator hold or push a draft into the queue.
+        demote_allowed = status in WORKER_MARKER_DEMOTE_ALLOWED_STATUSES
         return ReapedMarker(
             project_key=project_key,
             window_name=window_name,
@@ -441,7 +467,7 @@ def _classify_marker(
             ),
             task_project=parsed_project,
             task_number=task_number,
-            window_missing_for_non_terminal=True,
+            window_missing_for_non_terminal=demote_allowed,
         )
 
     return None
@@ -605,6 +631,7 @@ def sweep_worker_markers(
 __all__ = [
     "REAP_ESCALATION_THRESHOLD",
     "ReapedMarker",
+    "WORKER_MARKER_DEMOTE_ALLOWED_STATUSES",
     "WORKER_MARKER_REAPABLE_STATUSES",
     "reap_orphan_worker_markers",
     "sweep_worker_markers",

--- a/src/pollypm/work/worker_marker_reaper.py
+++ b/src/pollypm/work/worker_marker_reaper.py
@@ -58,9 +58,20 @@ from pollypm.work.task_state import (
     TERMINAL_TASK_STATUSES,
     parse_task_window_name,
 )
-from pollypm.storage.work_task_state import task_status_probe
+from pollypm.storage.work_task_state import (
+    bump_reap_count_and_demote,
+    task_status_probe,
+)
 
 logger = logging.getLogger(__name__)
+
+# Sam-approved policy threshold for #1999: silently demote on the first
+# two reaps of the same task; emit an inbox escalation on the 3rd+ reap.
+# The counter is persisted on ``work_tasks.reap_count`` so the threshold
+# survives cockpit restarts. We intentionally do NOT reset on terminal
+# transition — the field measures "how many interruptions has THIS task
+# endured", which is per-task history, not a windowed sliding count.
+REAP_ESCALATION_THRESHOLD = 3
 
 
 # Statuses that mean "this worker marker should be reaped".
@@ -122,6 +133,157 @@ def _emit_worker_session_reaped(decision: "ReapedMarker") -> None:
         )
 
 
+def _emit_repeat_reap_inbox_escalation(
+    *,
+    config: Any,
+    project_key: str,
+    task_project: str,
+    task_number: int,
+    reap_count: int,
+) -> None:
+    """Create an inbox notify task when ``reap_count`` crosses the threshold.
+
+    Sam-approved policy for #1999: silent on the first two reaps, escalate
+    on the third+. Each subsequent reap re-fires this — the inbox row is
+    a fresh signal that the systemic issue is still active. Dedupes via a
+    ``reap_repeat:<project>/<task>`` label so a single in-flight escalation
+    row doesn't get re-posted on every sweep.
+
+    Best-effort: any failure logs and returns. The demote already
+    landed; the operator-visible escalation is the secondary signal.
+    """
+    task_id = f"{task_project}/{task_number}"
+    title = (
+        f"Task {task_id} reaped {reap_count} times — "
+        "likely systemic issue"
+    )
+    dedupe_label = f"reap_repeat:{task_id}"
+    try:
+        from pollypm.work.factory import create_work_service
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "worker_marker_reaper: create_work_service import failed",
+            exc_info=True,
+        )
+        return
+
+    try:
+        work = create_work_service(config=config, project_key=task_project)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "worker_marker_reaper: create_work_service open failed for %s",
+            task_project, exc_info=True,
+        )
+        return
+
+    # Dedupe: if a prior escalation is still queued/in_progress with the
+    # same dedupe label, skip — the operator already has the signal.
+    try:
+        existing = []
+        for status in ("queued", "in_progress", "draft"):
+            try:
+                existing.extend(
+                    work.list_tasks(project=task_project, work_status=status)
+                )
+            except Exception:  # noqa: BLE001
+                continue
+        for existing_task in existing:
+            labels = getattr(existing_task, "labels", None) or ()
+            if dedupe_label in labels:
+                logger.debug(
+                    "worker_marker_reaper: escalation already open for %s",
+                    task_id,
+                )
+                return
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "worker_marker_reaper: dedupe scan failed for %s",
+            task_id, exc_info=True,
+        )
+
+    body = (
+        f"Task `{task_id}` has been reaped {reap_count} times by the "
+        f"worker marker reaper — the tmux window keeps vanishing while "
+        f"the task is still active.\n\n"
+        f"Likely systemic issue. Investigate or cancel "
+        f"(`pm task cancel {task_id}`)."
+    )
+    try:
+        work.create(
+            title=title,
+            description=body,
+            type="task",
+            project=task_project,
+            flow_template="chat",
+            labels=[
+                "notify",
+                "reap_escalation",
+                dedupe_label,
+            ],
+            roles={"requester": "worker_marker_reaper", "operator": "user"},
+            created_by="worker_marker_reaper",
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "worker_marker_reaper: escalation inbox-task create failed for %s",
+            task_id, exc_info=True,
+        )
+
+
+def _demote_and_maybe_escalate(
+    *,
+    config: Any,
+    decision: "ReapedMarker",
+) -> None:
+    """Bump ``reap_count``, demote the task, maybe post an inbox escalation.
+
+    The full #1999 recovery: when the reaper has decided to delete a
+    marker because the worker's tmux window has vanished but the task
+    is still non-terminal, this helper:
+
+    1. Atomically bumps ``work_tasks.reap_count`` and sets
+       ``work_status='queued'`` (and clears ``assignee``) so the next
+       claim cycle can re-spawn a worker — see
+       :func:`pollypm.storage.work_task_state.bump_reap_count_and_demote`.
+    2. If the post-increment count is at or beyond
+       :data:`REAP_ESCALATION_THRESHOLD`, posts a ``notify``-labeled
+       inbox task addressed to the user so the operator sees the loop.
+
+    Best-effort: any failure logs and returns; the marker unlink and
+    audit emit already happened upstream so the reaper still made
+    forward progress.
+    """
+    if not decision.window_missing_for_non_terminal:
+        return
+    if decision.task_project is None or decision.task_number is None:
+        return
+    new_count = bump_reap_count_and_demote(
+        project_key=decision.task_project,
+        task_number=decision.task_number,
+        config=config,
+    )
+    if new_count is None:
+        logger.debug(
+            "worker_marker_reaper: demote skipped (no row / terminal) "
+            "for %s/%s",
+            decision.task_project, decision.task_number,
+        )
+        return
+    logger.warning(
+        "worker_marker_reaper: demoted %s/%s back to queued "
+        "(reap_count=%d)",
+        decision.task_project, decision.task_number, new_count,
+    )
+    if new_count >= REAP_ESCALATION_THRESHOLD:
+        _emit_repeat_reap_inbox_escalation(
+            config=config,
+            project_key=decision.project_key,
+            task_project=decision.task_project,
+            task_number=decision.task_number,
+            reap_count=new_count,
+        )
+
+
 @dataclass(frozen=True, slots=True)
 class ReapedMarker:
     """Record of a worker marker that was unlinked by the reaper.
@@ -130,12 +292,28 @@ class ReapedMarker:
     the project the marker lived under, the tmux window name encoded
     in the file stem, the on-disk path, and the reason the reaper
     decided to remove it.
+
+    ``task_project`` / ``task_number`` are populated when the window
+    name parses cleanly as ``task-<project>-<N>`` — the #1999 demote
+    path needs them to issue the ``reap_count`` UPDATE. Both are
+    ``None`` for non-task markers (e.g. future advisor markers) so the
+    demote helper can skip cleanly.
+
+    ``window_missing_for_non_terminal`` flags the specific case the
+    #1999 fix targets: the marker is being reaped because the worker's
+    tmux window has vanished but the task is still in a non-terminal
+    status. Only this branch triggers the demote-and-maybe-escalate
+    flow; the terminal-task and missing-row branches leave the task
+    untouched (it's already terminal / already gone).
     """
 
     project_key: str
     window_name: str
     marker_path: Path
     reason: str
+    task_project: str | None = None
+    task_number: int | None = None
+    window_missing_for_non_terminal: bool = False
 
 
 def _iter_worker_markers(project_path: Path) -> Iterable[Path]:
@@ -238,6 +416,8 @@ def _classify_marker(
             window_name=window_name,
             marker_path=marker,
             reason="orphan: no work_tasks row",
+            task_project=parsed_project,
+            task_number=task_number,
         )
 
     if status in WORKER_MARKER_REAPABLE_STATUSES:
@@ -246,6 +426,8 @@ def _classify_marker(
             window_name=window_name,
             marker_path=marker,
             reason=f"task in terminal status '{status}'",
+            task_project=parsed_project,
+            task_number=task_number,
         )
 
     if window_name not in live_window_names:
@@ -257,6 +439,9 @@ def _classify_marker(
                 f"tmux window missing for non-terminal task "
                 f"(status='{status}')"
             ),
+            task_project=parsed_project,
+            task_number=task_number,
+            window_missing_for_non_terminal=True,
         )
 
     return None
@@ -357,6 +542,20 @@ def reap_orphan_worker_markers(
                 f"in {decision.project_key}: {decision.reason}",
                 flush=True,
             )
+            # #1999 — when the marker was reaped because the worker's
+            # tmux window vanished while the task is still non-terminal,
+            # bump ``reap_count`` and demote the task back to ``queued``
+            # so the next claim cycle can re-spawn a worker. On the 3rd+
+            # reap of the same task we also post an inbox escalation so
+            # the operator sees the loop. The helper is a no-op for the
+            # other reap reasons (terminal task / missing row).
+            try:
+                _demote_and_maybe_escalate(config=config, decision=decision)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "worker_marker_reaper: demote/escalate failed for %s",
+                    decision.window_name, exc_info=True,
+                )
             reaped.append(decision)
     return reaped
 
@@ -404,6 +603,7 @@ def sweep_worker_markers(
 
 
 __all__ = [
+    "REAP_ESCALATION_THRESHOLD",
     "ReapedMarker",
     "WORKER_MARKER_REAPABLE_STATUSES",
     "reap_orphan_worker_markers",

--- a/tests/test_pg_reaper_demote_and_escalate.py
+++ b/tests/test_pg_reaper_demote_and_escalate.py
@@ -40,27 +40,50 @@ from pollypm.storage.work_task_state import bump_reap_count_and_demote
 
 
 def _make_inprogress_task(svc, *, project: str = "demo", title: str = "T") -> str:
-    """Create a task and drive it to ``in_progress``.
+    """Create a task and drop it directly into ``in_progress``.
 
-    Mirrors the production lifecycle for a task that a worker is
-    actively claiming. The reaper's #1999 branch only triggers when the
-    task is non-terminal — ``in_progress`` is the most common case in
-    the wild (see issue evidence: 10× in_progress, 5× review, 5×
-    queued).
+    The reaper's #1999 branch only triggers when the task is non-terminal —
+    ``in_progress`` is the most common case in the wild (see issue
+    evidence: 10× in_progress, 5× review, 5× queued). We bypass the full
+    ``queue`` + ``claim`` flow (which would need a flow-template wire-up
+    that's orthogonal to what we're testing) and stamp the row directly
+    via the pg pool.
     """
     task = svc.create(
         title=title,
         description="seed",
         type="task",
         project=project,
-        flow_template="default",
+        flow_template="standard",
         roles={"worker": "alice"},
         priority="normal",
         created_by="seed",
     )
-    svc.queue(task.task_id, actor="seed")
-    svc.claim(task.task_id, actor="alice")
+    # Drop straight into ``in_progress`` with an assignee so the demote
+    # path can verify both ``work_status -> queued`` and ``assignee ->
+    # NULL`` mutations.
+    with svc._pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "UPDATE work_tasks SET work_status = 'in_progress', "
+            "assignee = 'alice', updated_at = now() "
+            "WHERE project = %s AND task_number = %s",
+            (task.project, task.task_number),
+        )
+        conn.commit()
     return task.task_id
+
+
+def _force_inprogress(svc, task_id: str) -> None:
+    """Re-pin a task at ``in_progress`` after a demote (helper for re-reap)."""
+    project, num = task_id.split("/")
+    with svc._pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "UPDATE work_tasks SET work_status = 'in_progress', "
+            "assignee = 'alice', updated_at = now() "
+            "WHERE project = %s AND task_number = %s",
+            (project, int(num)),
+        )
+        conn.commit()
 
 
 def _fake_config() -> Any:
@@ -109,7 +132,7 @@ class TestBumpReapCountAndDemote:
             project_key=project, task_number=int(num), config=None,
         )
         # Simulate re-claim then re-reap.
-        svc.claim(task_id, actor="alice")
+        _force_inprogress(svc, task_id)
         count = bump_reap_count_and_demote(
             project_key=project, task_number=int(num), config=None,
         )
@@ -123,7 +146,7 @@ class TestBumpReapCountAndDemote:
             bump_reap_count_and_demote(
                 project_key=project, task_number=int(num), config=None,
             )
-            svc.claim(task_id, actor="alice")
+            _force_inprogress(svc, task_id)
         count = bump_reap_count_and_demote(
             project_key=project, task_number=int(num), config=None,
         )
@@ -135,7 +158,17 @@ class TestBumpReapCountAndDemote:
         svc = pg_work_service
         task_id = _make_inprogress_task(svc)
         project, num = task_id.split("/")
-        svc.cancel(task_id, actor="user", reason="not needed")
+        # Force the task into a terminal state via direct SQL — going
+        # through ``svc.cancel`` would need the cancel-gate machinery
+        # wired which is orthogonal to what this test exercises.
+        with svc._pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(
+                "UPDATE work_tasks SET work_status = 'cancelled', "
+                "updated_at = now() "
+                "WHERE project = %s AND task_number = %s",
+                (project, int(num)),
+            )
+            conn.commit()
         count = bump_reap_count_and_demote(
             project_key=project, task_number=int(num), config=None,
         )
@@ -204,7 +237,7 @@ class TestThreeStrikeEscalation:
 
         _demote_and_maybe_escalate(config=config, decision=marker)
         # Re-claim then re-reap to simulate the wild lifecycle.
-        svc.claim(task_id, actor="alice")
+        _force_inprogress(svc, task_id)
         _demote_and_maybe_escalate(config=config, decision=marker)
 
         assert _count_escalation_inbox_tasks(
@@ -222,7 +255,7 @@ class TestThreeStrikeEscalation:
 
         for _ in range(2):
             _demote_and_maybe_escalate(config=config, decision=marker)
-            svc.claim(task_id, actor="alice")
+            _force_inprogress(svc, task_id)
         # Third reap → demote AND escalate.
         _demote_and_maybe_escalate(config=config, decision=marker)
 

--- a/tests/test_pg_reaper_demote_and_escalate.py
+++ b/tests/test_pg_reaper_demote_and_escalate.py
@@ -305,3 +305,103 @@ class TestThreeStrikeEscalation:
         # Task should still be in_progress — the helper short-circuited.
         task = svc.get(task_id)
         assert task.work_status.value == "in_progress"
+
+
+# ---------------------------------------------------------------------------
+# Re-review guard (Codex blocker on PR #2006): explicit allowlist must
+# protect deliberate non-active statuses (``blocked`` / ``on_hold`` /
+# ``draft``) from being clobbered by a stale marker.
+# ---------------------------------------------------------------------------
+
+
+def _stamp_status(svc, task_id: str, *, status: str, assignee: str | None) -> None:
+    """Force ``work_status`` and ``assignee`` directly via the pg pool."""
+    project, num = task_id.split("/")
+    with svc._pool.connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            "UPDATE work_tasks SET work_status = %s, "
+            "assignee = %s, updated_at = now() "
+            "WHERE project = %s AND task_number = %s",
+            (status, assignee, project, int(num)),
+        )
+        conn.commit()
+
+
+class TestDemoteAllowlistProtectsNonActiveStatuses:
+    """Statuses outside the active/retry allowlist must not be demoted.
+
+    The SQL guard in :func:`bump_reap_count_and_demote` is an explicit
+    allowlist of ``{in_progress, review, queued, rework}``. A stale
+    fresh-launch marker (tmux window vanished) for a task currently in
+    ``blocked`` / ``on_hold`` / ``draft`` must leave the row untouched —
+    no status change, no assignee clear, no ``reap_count`` bump.
+    """
+
+    def test_blocked_task_with_stale_marker_does_not_demote(
+        self, pg_work_service,
+    ):
+        svc = pg_work_service
+        task_id = _make_inprogress_task(svc)
+        project, num = task_id.split("/")
+        _stamp_status(svc, task_id, status="blocked", assignee="alice")
+
+        count = bump_reap_count_and_demote(
+            project_key=project, task_number=int(num), config=None,
+        )
+
+        assert count is None
+        task = svc.get(task_id)
+        assert task.work_status.value == "blocked"
+        assert task.assignee == "alice"
+
+    def test_on_hold_task_with_stale_marker_does_not_demote(
+        self, pg_work_service,
+    ):
+        svc = pg_work_service
+        task_id = _make_inprogress_task(svc)
+        project, num = task_id.split("/")
+        _stamp_status(svc, task_id, status="on_hold", assignee="alice")
+
+        count = bump_reap_count_and_demote(
+            project_key=project, task_number=int(num), config=None,
+        )
+
+        assert count is None
+        task = svc.get(task_id)
+        assert task.work_status.value == "on_hold"
+        assert task.assignee == "alice"
+
+    def test_draft_task_with_stale_marker_does_not_demote(
+        self, pg_work_service,
+    ):
+        svc = pg_work_service
+        task_id = _make_inprogress_task(svc)
+        project, num = task_id.split("/")
+        # Drafts typically have no assignee; clear it to match the wild
+        # shape (and prove the guard short-circuits before assignee=NULL).
+        _stamp_status(svc, task_id, status="draft", assignee=None)
+
+        count = bump_reap_count_and_demote(
+            project_key=project, task_number=int(num), config=None,
+        )
+
+        assert count is None
+        task = svc.get(task_id)
+        assert task.work_status.value == "draft"
+
+    def test_in_progress_task_with_stale_marker_still_demotes(
+        self, pg_work_service,
+    ):
+        """The existing happy-path must still fire under the allowlist."""
+        svc = pg_work_service
+        task_id = _make_inprogress_task(svc)
+        project, num = task_id.split("/")
+
+        count = bump_reap_count_and_demote(
+            project_key=project, task_number=int(num), config=None,
+        )
+
+        assert count == 1
+        task = svc.get(task_id)
+        assert task.work_status.value == "queued"
+        assert task.assignee is None

--- a/tests/test_pg_reaper_demote_and_escalate.py
+++ b/tests/test_pg_reaper_demote_and_escalate.py
@@ -1,0 +1,274 @@
+"""Regression tests for #1999 — reaper demote + 3-strike escalation.
+
+Sam-approved policy:
+
+* 1st reap on a task → demote silently (queue, no inbox noise)
+* 2nd reap on a task → demote silently
+* 3rd+ reap on a task → demote AND escalate to the inbox
+
+The ``reap_count`` counter is persisted on ``work_tasks.reap_count`` so
+the threshold survives cockpit restarts. These tests assert the
+end-to-end shape:
+
+* :func:`bump_reap_count_and_demote` atomically demotes the task back to
+  ``queued`` and returns the post-increment count.
+* The reaper integration emits a ``notify``-labelled inbox task only on
+  the 3rd+ reap (titled ``Task <id> reaped N times — likely systemic issue``).
+* Subsequent reaps of an already-terminal task are no-ops (defensive
+  guard against clobbering a cancelled task).
+
+The tests exercise the pg backend via the shared ``pg_work_service`` /
+``pg_schema_pool`` fixtures so the counter lands in real pg rows. The
+filesystem half of the reaper (marker unlink, tmux probe) is covered
+by the legacy ``tests/test_worker_marker_reaper.py``; here we focus on
+the new mutation + escalation path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pollypm.work.worker_marker_reaper import (
+    REAP_ESCALATION_THRESHOLD,
+    ReapedMarker,
+    _demote_and_maybe_escalate,
+)
+from pollypm.storage.work_task_state import bump_reap_count_and_demote
+
+
+def _make_inprogress_task(svc, *, project: str = "demo", title: str = "T") -> str:
+    """Create a task and drive it to ``in_progress``.
+
+    Mirrors the production lifecycle for a task that a worker is
+    actively claiming. The reaper's #1999 branch only triggers when the
+    task is non-terminal — ``in_progress`` is the most common case in
+    the wild (see issue evidence: 10× in_progress, 5× review, 5×
+    queued).
+    """
+    task = svc.create(
+        title=title,
+        description="seed",
+        type="task",
+        project=project,
+        flow_template="default",
+        roles={"worker": "alice"},
+        priority="normal",
+        created_by="seed",
+    )
+    svc.queue(task.task_id, actor="seed")
+    svc.claim(task.task_id, actor="alice")
+    return task.task_id
+
+
+def _fake_config() -> Any:
+    """Minimal config object the reaper helpers consult."""
+
+    class _Cfg:
+        # No projects map needed — the inbox-emit path resolves the
+        # work-service via the pg pool, not the config's projects dict.
+        projects: dict = {}
+
+        class storage:  # noqa: N801 — match attribute shape
+            backend = "postgres"
+
+        class project:  # noqa: N801
+            workspace_root = None
+            base_dir = None
+            tmux_session = "test-pm"
+
+    return _Cfg()
+
+
+# ---------------------------------------------------------------------------
+# bump_reap_count_and_demote
+# ---------------------------------------------------------------------------
+
+
+class TestBumpReapCountAndDemote:
+    def test_first_bump_demotes_and_returns_one(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _make_inprogress_task(svc)
+        project, num = task_id.split("/")
+        count = bump_reap_count_and_demote(
+            project_key=project, task_number=int(num), config=None,
+        )
+        assert count == 1
+        # Task is back in queued, assignee cleared.
+        task = svc.get(task_id)
+        assert task.work_status.value == "queued"
+        assert task.assignee is None
+
+    def test_second_bump_returns_two(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _make_inprogress_task(svc)
+        project, num = task_id.split("/")
+        bump_reap_count_and_demote(
+            project_key=project, task_number=int(num), config=None,
+        )
+        # Simulate re-claim then re-reap.
+        svc.claim(task_id, actor="alice")
+        count = bump_reap_count_and_demote(
+            project_key=project, task_number=int(num), config=None,
+        )
+        assert count == 2
+
+    def test_third_bump_returns_three(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _make_inprogress_task(svc)
+        project, num = task_id.split("/")
+        for _ in range(2):
+            bump_reap_count_and_demote(
+                project_key=project, task_number=int(num), config=None,
+            )
+            svc.claim(task_id, actor="alice")
+        count = bump_reap_count_and_demote(
+            project_key=project, task_number=int(num), config=None,
+        )
+        assert count == 3
+        assert count >= REAP_ESCALATION_THRESHOLD
+
+    def test_terminal_task_does_not_bump(self, pg_work_service):
+        """A cancelled task must not be demoted back to queued."""
+        svc = pg_work_service
+        task_id = _make_inprogress_task(svc)
+        project, num = task_id.split("/")
+        svc.cancel(task_id, actor="user", reason="not needed")
+        count = bump_reap_count_and_demote(
+            project_key=project, task_number=int(num), config=None,
+        )
+        assert count is None
+        task = svc.get(task_id)
+        assert task.work_status.value == "cancelled"
+
+    def test_missing_row_returns_none(self, pg_work_service):
+        count = bump_reap_count_and_demote(
+            project_key="ghost", task_number=999, config=None,
+        )
+        assert count is None
+
+
+# ---------------------------------------------------------------------------
+# _demote_and_maybe_escalate — three-strike escalation policy
+# ---------------------------------------------------------------------------
+
+
+def _reaped_marker_for(task_id: str, *, project_key: str = "demo") -> ReapedMarker:
+    project, num = task_id.split("/")
+    return ReapedMarker(
+        project_key=project_key,
+        window_name=f"task-{project}-{num}",
+        marker_path=Path(f"/tmp/dummy-marker-{project}-{num}.fresh"),
+        reason=f"tmux window missing for non-terminal task (status='in_progress')",
+        task_project=project,
+        task_number=int(num),
+        window_missing_for_non_terminal=True,
+    )
+
+
+def _count_escalation_inbox_tasks(svc, *, project: str, task_id: str) -> int:
+    dedupe_label = f"reap_repeat:{task_id}"
+    found = 0
+    for status in ("queued", "in_progress", "draft"):
+        for task in svc.list_tasks(project=project, work_status=status):
+            labels = getattr(task, "labels", []) or []
+            if dedupe_label in labels:
+                found += 1
+    return found
+
+
+class TestThreeStrikeEscalation:
+    def test_first_reap_demotes_no_inbox_item(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _make_inprogress_task(svc)
+        project, _ = task_id.split("/")
+        marker = _reaped_marker_for(task_id)
+        config = _fake_config()
+
+        _demote_and_maybe_escalate(config=config, decision=marker)
+
+        task = svc.get(task_id)
+        assert task.work_status.value == "queued"
+        assert _count_escalation_inbox_tasks(
+            svc, project=project, task_id=task_id,
+        ) == 0
+
+    def test_second_reap_still_no_inbox_item(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _make_inprogress_task(svc)
+        project, _ = task_id.split("/")
+        marker = _reaped_marker_for(task_id)
+        config = _fake_config()
+
+        _demote_and_maybe_escalate(config=config, decision=marker)
+        # Re-claim then re-reap to simulate the wild lifecycle.
+        svc.claim(task_id, actor="alice")
+        _demote_and_maybe_escalate(config=config, decision=marker)
+
+        assert _count_escalation_inbox_tasks(
+            svc, project=project, task_id=task_id,
+        ) == 0
+        task = svc.get(task_id)
+        assert task.work_status.value == "queued"
+
+    def test_third_reap_demotes_and_emits_inbox_item(self, pg_work_service):
+        svc = pg_work_service
+        task_id = _make_inprogress_task(svc)
+        project, _ = task_id.split("/")
+        marker = _reaped_marker_for(task_id)
+        config = _fake_config()
+
+        for _ in range(2):
+            _demote_and_maybe_escalate(config=config, decision=marker)
+            svc.claim(task_id, actor="alice")
+        # Third reap → demote AND escalate.
+        _demote_and_maybe_escalate(config=config, decision=marker)
+
+        task = svc.get(task_id)
+        assert task.work_status.value == "queued"
+
+        # An inbox task carrying the dedupe label exists with the
+        # canonical "reaped N times — likely systemic issue" title.
+        dedupe_label = f"reap_repeat:{task_id}"
+        matched = []
+        for status in ("queued", "in_progress", "draft"):
+            for inbox_task in svc.list_tasks(
+                project=project, work_status=status,
+            ):
+                labels = getattr(inbox_task, "labels", []) or []
+                if dedupe_label in labels:
+                    matched.append(inbox_task)
+        assert len(matched) == 1, (
+            f"expected 1 escalation inbox task, got {len(matched)}"
+        )
+        escalation = matched[0]
+        assert "reaped 3 times" in escalation.title
+        assert "likely systemic issue" in escalation.title
+        labels = list(getattr(escalation, "labels", []) or [])
+        assert "notify" in labels
+        assert "reap_escalation" in labels
+
+    def test_non_terminal_marker_branch_is_required(self, pg_work_service):
+        """Markers reaped for other reasons must NOT touch reap_count."""
+        svc = pg_work_service
+        task_id = _make_inprogress_task(svc)
+        project, num = task_id.split("/")
+
+        terminal_marker = ReapedMarker(
+            project_key="demo",
+            window_name=f"task-{project}-{num}",
+            marker_path=Path("/tmp/dummy.fresh"),
+            reason="task in terminal status 'done'",
+            task_project=project,
+            task_number=int(num),
+            window_missing_for_non_terminal=False,  # critical
+        )
+        config = _fake_config()
+
+        _demote_and_maybe_escalate(config=config, decision=terminal_marker)
+
+        # Task should still be in_progress — the helper short-circuited.
+        task = svc.get(task_id)
+        assert task.work_status.value == "in_progress"


### PR DESCRIPTION
## Summary

Worker-marker reaper now demotes reaped tasks back to `queued` and escalates after three consecutive reaps — closes the #1999 silent-stall regression. Field evidence: 20 `worker.session_reaped` events over 2 days with `itsalive/48` reaped 3× in a row with no recovery signal.

- New `work_tasks.reap_count int NOT NULL DEFAULT 0` column (migration 0004 + initial-schema entry, both idempotent). The counter persists across cockpit restarts.
- `bump_reap_count_and_demote` does one atomic UPDATE: increments `reap_count`, sets `work_status='queued'`, clears `assignee`, returns the post-increment count via RETURNING. Guards against clobbering already-terminal tasks.
- Sam-approved 3-strike policy in the reaper: silent demote on reaps 1 + 2; on reap 3+ also create a `notify`-labelled inbox task addressed to the user (`Task <id> reaped N times — likely systemic issue`), deduped on `reap_repeat:<project>/<task>`.
- Demote + escalate fires only on the `tmux window missing for non-terminal task` branch — terminal-task and missing-row reaps still leave the task untouched.

The existing audit emit and watchdog `worker_session_dead_loop` rule remain in place; this PR adds the persistent counter + operator-visible escalation that the issue called out as missing.

## Test plan

- [x] Added `tests/test_pg_reaper_demote_and_escalate.py` — pg-backed regression suite covering: 1st reap demotes silently, 2nd reap still silent, 3rd reap demotes AND emits the inbox escalation, terminal tasks are not clobbered, missing rows return `None`, non-`window_missing` reasons short-circuit cleanly.
- [x] Migration is idempotent (`ADD COLUMN IF NOT EXISTS`).
- [x] Smoke import of `pollypm.supervisor` + reaper module passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)