### PR TITLE
fix(tier4): persistent terminal_handoff_at gate against infinite re-promotion (closes #1997)

### DIFF
--- a/src/pollypm/audit/tier4.py
+++ b/src/pollypm/audit/tier4.py
@@ -175,6 +175,18 @@ class Tier4State:
     tier4_active: bool
     last_finding_signature: str
     updated_at: datetime | None
+    #: #1997 — persistent terminal-handoff gate. Set by
+    #: :meth:`Tier4PromotionTracker.mark_terminal_handoff` when the
+    #: cascade fires the terminal product-broken + urgent-inbox path.
+    #: While non-None the auto-promote gate refuses to re-promote the
+    #: same ``root_cause_hash`` — without this, ``tracker.clear`` on
+    #: budget exhaustion looks identical to a fresh-resolution clear
+    #: and ``should_auto_promote`` would re-greenlight the next cycle,
+    #: producing an infinite tier-4 promotion loop. Cleared (NULLed)
+    #: when the finding actually resolves (``finding_resolved`` /
+    #: ``finding_cleared``) so a future, distinct occurrence of the
+    #: same hash can promote again.
+    terminal_handoff_at: datetime | None = None
 
     def dispatch_count_in_window(
         self, now: datetime, window_seconds: int,
@@ -243,7 +255,8 @@ class Tier4PromotionTracker:
                 """
                 SELECT root_cause_hash, project, rule, dispatch_history_json,
                        last_promotion_at, promotion_path, tier4_entered_at,
-                       tier4_active, last_finding_signature, updated_at
+                       tier4_active, last_finding_signature, updated_at,
+                       terminal_handoff_at
                 FROM tier4_promotion_state
                 WHERE root_cause_hash = ?
                 """,
@@ -334,6 +347,15 @@ class Tier4PromotionTracker:
         # hash — let the existing tier-4 invocation finish (or the
         # budget exhaust) before we issue another promotion.
         if state.tier4_active:
+            return False
+        # #1997 — once the terminal handoff has fired for this hash,
+        # refuse to re-promote until the finding actually resolves
+        # (which NULLs ``terminal_handoff_at`` via ``clear`` with a
+        # non-budget reason). Without this gate, budget-exhausted
+        # ``tracker.clear`` flips ``tier4_active`` to 0 and the next
+        # tick's dispatch counter trivially re-crosses K, producing an
+        # infinite escalation loop on a permanently-stuck finding.
+        if state.terminal_handoff_at is not None:
             return False
         count = state.dispatch_count_in_window(
             now, self.auto_promote_window_seconds,
@@ -462,6 +484,22 @@ class Tier4PromotionTracker:
             return False
         return remaining <= 0
 
+    #: Reasons that signal "the finding actually resolved" (vs the
+    #: cascade timing out). Used by :meth:`clear` to decide whether to
+    #: NULL ``terminal_handoff_at`` — only a real resolution should
+    #: allow a future occurrence of the same hash to promote again.
+    #:
+    #: ``manual_clear`` is the default reason on ``pm tier4 clear`` —
+    #: the operator explicitly told the cascade "this finding is done,"
+    #: which the issue (#1997) calls out as the canonical gate-release
+    #: path. Anything else (``budget_exhausted``, custom reasons) is
+    #: treated as a non-resolution clear and preserves the gate.
+    _RESOLUTION_REASONS = frozenset({
+        "finding_resolved",
+        "finding_cleared",
+        "manual_clear",
+    })
+
     def clear(
         self,
         root_cause_hash_value: str,
@@ -477,6 +515,66 @@ class Tier4PromotionTracker:
         see the prior tier-4 run. ``reason`` is recorded in
         ``last_finding_signature`` as ``"cleared:<reason>"`` for the
         post-clear forensic trail.
+
+        #1997: when ``reason`` indicates a real resolution
+        (``finding_resolved`` / ``finding_cleared``), the persistent
+        ``terminal_handoff_at`` gate is NULLed so a future, distinct
+        occurrence of the same hash can promote again. When ``reason``
+        is a timeout (``budget_exhausted``), ``terminal_handoff_at`` is
+        preserved — the cascade has already escalated to Sam and must
+        not re-escalate on the next tick.
+        """
+        if not root_cause_hash_value:
+            return False
+        clear_terminal = reason in self._RESOLUTION_REASONS
+        store = self._open_store()
+        try:
+            if clear_terminal:
+                cur = store.execute(
+                    """
+                    UPDATE tier4_promotion_state
+                       SET tier4_active = 0,
+                           updated_at = ?,
+                           last_finding_signature = 'cleared:' || ?,
+                           terminal_handoff_at = NULL
+                     WHERE root_cause_hash = ?
+                    """,
+                    (_iso(now), reason, root_cause_hash_value),
+                )
+            else:
+                cur = store.execute(
+                    """
+                    UPDATE tier4_promotion_state
+                       SET tier4_active = 0,
+                           updated_at = ?,
+                           last_finding_signature = 'cleared:' || ?
+                     WHERE root_cause_hash = ?
+                    """,
+                    (_iso(now), reason, root_cause_hash_value),
+                )
+            store.commit()
+            return (cur.rowcount or 0) > 0
+        finally:
+            store.close()
+
+    def mark_terminal_handoff(
+        self,
+        root_cause_hash_value: str,
+        *,
+        now: datetime,
+    ) -> bool:
+        """Stamp the persistent terminal-handoff gate (#1997).
+
+        Called by the budget-exhaustion sweep AFTER it has successfully
+        routed the row to the terminal path (product-broken + urgent
+        inbox). Sets ``terminal_handoff_at`` so the next call to
+        :meth:`should_auto_promote` for the same hash returns False
+        even after ``tracker.clear`` flips ``tier4_active`` to 0 —
+        breaking the infinite re-promotion loop described in #1997.
+
+        Returns True iff a row was updated. Safe to call multiple
+        times — re-stamping ``terminal_handoff_at`` is harmless (the
+        gate only checks IS NOT NULL, not the value).
         """
         if not root_cause_hash_value:
             return False
@@ -485,12 +583,11 @@ class Tier4PromotionTracker:
             cur = store.execute(
                 """
                 UPDATE tier4_promotion_state
-                   SET tier4_active = 0,
-                       updated_at = ?,
-                       last_finding_signature = 'cleared:' || ?
+                   SET terminal_handoff_at = ?,
+                       updated_at = ?
                  WHERE root_cause_hash = ?
                 """,
-                (_iso(now), reason, root_cause_hash_value),
+                (_iso(now), _iso(now), root_cause_hash_value),
             )
             store.commit()
             return (cur.rowcount or 0) > 0
@@ -510,7 +607,8 @@ class Tier4PromotionTracker:
                 """
                 SELECT root_cause_hash, project, rule, dispatch_history_json,
                        last_promotion_at, promotion_path, tier4_entered_at,
-                       tier4_active, last_finding_signature, updated_at
+                       tier4_active, last_finding_signature, updated_at,
+                       terminal_handoff_at
                 FROM tier4_promotion_state
                 WHERE tier4_active = 1
                 ORDER BY tier4_entered_at ASC
@@ -581,6 +679,11 @@ def _row_to_state(row: Any) -> Tier4State:
         parsed = _parse_iso(ts)
         if parsed is not None:
             history.append(parsed)
+    # #1997 — ``terminal_handoff_at`` is read defensively: pre-#1997
+    # rows materialised by callers that still SELECT 10 columns won't
+    # provide row[10], so we fall back to None. Once all SELECTs in
+    # this module include the column, this branch is just belt-and-braces.
+    terminal_handoff_at = _parse_iso(row[10]) if len(row) > 10 else None
     return Tier4State(
         root_cause_hash=str(row[0] or ""),
         project=str(row[1] or ""),
@@ -592,6 +695,7 @@ def _row_to_state(row: Any) -> Tier4State:
         tier4_active=bool(row[7]),
         last_finding_signature=str(row[8] or ""),
         updated_at=_parse_iso(row[9]),
+        terminal_handoff_at=terminal_handoff_at,
     )
 
 

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -2895,6 +2895,23 @@ def _sweep_tier4_budget_and_demotion(
                 _route_tier4_to_terminal(
                     state=state, services=services, now=now,
                 )
+                # #1997 — stamp the persistent terminal-handoff gate
+                # BEFORE clearing tier4_active. Without this, the
+                # ``tracker.clear`` below flips tier4_active to 0 and
+                # the next watchdog tick's auto-promote gate sees
+                # nothing to stop a fresh promotion on the same hash,
+                # producing an infinite re-promotion loop on a
+                # permanently-stuck finding. mark_terminal_handoff is
+                # idempotent so a partial-failure replay is safe.
+                try:
+                    tracker.mark_terminal_handoff(
+                        state.root_cause_hash, now=now,
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "tier4: mark_terminal_handoff raised for %s",
+                        state.root_cause_hash, exc_info=True,
+                    )
                 tracker.clear(
                     state.root_cause_hash,
                     now=now,
@@ -2929,7 +2946,16 @@ def clear_tier4_for_finding(
         return False
     rch = root_cause_hash(finding)
     state = tracker.get(rch)
-    if state is None or not state.tier4_active:
+    if state is None:
+        return False
+    # #1997 — if the row is already inactive but still carries a
+    # terminal-handoff gate (the cascade has previously escalated and
+    # is currently parked), a real ``finding_resolved`` observation
+    # still needs to release the gate so a future, distinct occurrence
+    # of the same hash can promote again. ``tracker.clear`` with a
+    # resolution reason NULLs ``terminal_handoff_at`` in-place even
+    # when ``tier4_active`` is already 0.
+    if not state.tier4_active and state.terminal_handoff_at is None:
         return False
     cleared = tracker.clear(rch, now=now, reason=reason)
     if cleared:

--- a/src/pollypm/storage/pg_schema.py
+++ b/src/pollypm/storage/pg_schema.py
@@ -591,6 +591,9 @@ CREATE TABLE IF NOT EXISTS workspace_state (
     set_by      text NOT NULL DEFAULT 'system'
 );
 
+-- #1997 — ``terminal_handoff_at`` is the persistent gate that prevents
+-- the infinite re-promotion loop on a permanently-stuck finding (see
+-- the matching block in pollypm.storage.state for the rationale).
 CREATE TABLE IF NOT EXISTS tier4_promotion_state (
     root_cause_hash            text PRIMARY KEY,
     project                    text NOT NULL DEFAULT '',
@@ -601,7 +604,8 @@ CREATE TABLE IF NOT EXISTS tier4_promotion_state (
     tier4_entered_at           timestamptz,
     tier4_active               boolean NOT NULL DEFAULT false,
     last_finding_signature     text NOT NULL DEFAULT '',
-    updated_at                 timestamptz NOT NULL DEFAULT now()
+    updated_at                 timestamptz NOT NULL DEFAULT now(),
+    terminal_handoff_at        timestamptz
 );
 
 CREATE INDEX IF NOT EXISTS idx_tier4_promotion_state_active
@@ -721,6 +725,29 @@ ALTER TABLE IF EXISTS account_runtime
 
 
 # --------------------------------------------------------------------- #
+# 0004 — tier4_promotion_state.terminal_handoff_at gate (#1997).
+# --------------------------------------------------------------------- #
+#
+# Persistent gate against the infinite re-promotion loop described in
+# #1997. Without this column, ``tracker.clear(reason='budget_exhausted')``
+# on the budget-exhaustion sweep flipped ``tier4_active=0`` and the next
+# tick's auto-promote check trivially re-greenlit the same hash — 98
+# promotions / 81 budget-exhausts / 0 demotions across 8 projects over
+# 50h in the wild. With the column present, ``should_auto_promote``
+# refuses to re-promote any hash that has had its terminal handoff fire
+# until the finding actually resolves (which NULLs the column).
+#
+# Column-only migration. Fresh installs already get the column from
+# 0001's INITIAL_SCHEMA_DDL; upgraded DBs run the single ALTER below.
+# ``IF EXISTS`` + ``IF NOT EXISTS`` keep the statement idempotent.
+
+_MIGRATION_0004_TIER4_TERMINAL_HANDOFF = """
+ALTER TABLE IF EXISTS tier4_promotion_state
+    ADD COLUMN IF NOT EXISTS terminal_handoff_at timestamptz;
+"""
+
+
+# --------------------------------------------------------------------- #
 # Migration list — forward-only, append-only.
 # --------------------------------------------------------------------- #
 
@@ -731,6 +758,7 @@ MIGRATIONS: list[tuple[int, str, str]] = [
     (1, "0001_initial", INITIAL_SCHEMA_DDL),
     (2, "0002_alert_dedupe_tuple", _MIGRATION_0002_ALERT_DEDUPE),
     (3, "0003_account_columns_text", _MIGRATION_0003_ACCOUNT_COLUMNS_TEXT),
+    (4, "0004_tier4_terminal_handoff", _MIGRATION_0004_TIER4_TERMINAL_HANDOFF),
 ]
 
 

--- a/src/pollypm/storage/state.py
+++ b/src/pollypm/storage/state.py
@@ -380,6 +380,13 @@ CREATE TABLE IF NOT EXISTS workspace_state (
 -- ``last_finding_signature`` snapshots the structured signature so
 -- forensic reads can reconstruct what hash the row covers without
 -- re-deriving from the original Finding.
+-- #1997 — ``terminal_handoff_at`` is the persistent gate that prevents
+-- the infinite re-promotion loop on a permanently-stuck finding. Once
+-- the budget-exhaustion sweep routes a row to the terminal product-
+-- broken + urgent-inbox path, ``terminal_handoff_at`` is stamped and
+-- ``should_auto_promote`` refuses to re-promote the same root_cause_hash
+-- until the finding actually resolves (``finding_resolved`` /
+-- ``finding_cleared``), at which point ``clear`` NULLs the column.
 CREATE TABLE IF NOT EXISTS tier4_promotion_state (
     root_cause_hash TEXT PRIMARY KEY,
     project TEXT NOT NULL DEFAULT '',
@@ -390,7 +397,8 @@ CREATE TABLE IF NOT EXISTS tier4_promotion_state (
     tier4_entered_at TEXT,
     tier4_active INTEGER NOT NULL DEFAULT 0,
     last_finding_signature TEXT NOT NULL DEFAULT '',
-    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    terminal_handoff_at TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_tier4_promotion_state_active
@@ -786,6 +794,21 @@ class StateStore:
         # DBs pick it up on first open. Dispatch block below adds the
         # column on upgraded DBs via ``_safe_add_column``.
         (18, "Add kind column to messages for structured inbox taxonomy (#1565)", []),
+        # --- Migration 19 ----------------------------------------------
+        # #1997 — persistent terminal-handoff gate on tier4_promotion_state.
+        # Without this column, ``tracker.clear(reason='budget_exhausted')``
+        # on the budget-exhaustion sweep flips ``tier4_active`` to 0 and
+        # the next watchdog tick's auto-promote gate sees nothing
+        # preventing a fresh promotion — producing an infinite loop on a
+        # permanently-stuck finding (98 promotions / 81 budget-exhausts /
+        # 0 demotions across 8 projects over 50h in the wild). Adding
+        # the column gates ``should_auto_promote`` so the same hash
+        # can't re-escalate until the finding actually resolves.
+        # Column-only migration; the column is also declared on the
+        # SCHEMA constant so fresh DBs pick it up on first open.
+        # Dispatch block below adds the column on upgraded DBs via
+        # ``_safe_add_column``.
+        (19, "tier4_promotion_state.terminal_handoff_at gate (#1997)", []),
     ]
 
     def _migrate(self) -> None:
@@ -851,6 +874,17 @@ class StateStore:
             self._migrate_v16_unique_open_alert_index()
         elif version == 18:
             self._migrate_v18_messages_kind_column()
+        elif version == 19:
+            # #1997 — column-only migration. ``_safe_add_column`` is a
+            # no-op on fresh DBs (the SCHEMA constant already includes
+            # the column); on upgraded DBs it runs a single ALTER TABLE.
+            # No backfill: NULL is the correct value for pre-existing
+            # rows — "this hash has never had its terminal handoff fire".
+            self._safe_add_column(
+                "tier4_promotion_state",
+                "terminal_handoff_at",
+                "TEXT",
+            )
 
     def _migrate_v8_memory_typed_columns(self) -> None:
         # Back-fill typed-schema columns on pre-existing memory_entries

--- a/tests/test_heartbeat_cascade_tier4.py
+++ b/tests/test_heartbeat_cascade_tier4.py
@@ -984,6 +984,194 @@ def test_sweep_without_seen_hashes_keeps_legacy_budget_only_behaviour(
 
 
 # ---------------------------------------------------------------------------
+# #1997 — persistent terminal-handoff gate.
+#
+# Repro: tier-4 promotes on a queue_without_motion finding, exhausts the
+# 2h budget, routes to the terminal product-broken + urgent-inbox path,
+# ``tracker.clear(reason='budget_exhausted')`` flips ``tier4_active=0``
+# — but the underlying condition isn't actually fixed, so on the next
+# watchdog tick the finding re-fires, tier-3 dispatch history re-crosses
+# K, and the auto-promote gate trivially re-greenlights another tier-4
+# promotion. 98 promotions / 81 budget-exhausts / 0 demotions across 8
+# projects over 50h in the wild.
+#
+# Fix: ``terminal_handoff_at`` persists across ``tracker.clear`` and
+# ``should_auto_promote`` refuses to re-promote until the finding
+# actually resolves (which NULLs the column).
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_handoff_gate_blocks_re_promotion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, now: datetime,
+) -> None:
+    """End-to-end: after budget-exhaust → terminal, the same hash can't re-promote.
+
+    Asserts the three contracts that close #1997:
+
+    (a) First budget-exhaustion sweep stamps ``terminal_handoff_at`` on
+        the row before flipping ``tier4_active=0``. The stamp is what
+        the auto-promote gate keys on.
+    (b) After the stamp lands, ``should_auto_promote`` returns False
+        for the same root_cause_hash even when the tier-3 dispatch
+        history has K+ entries inside the window — i.e. the gate
+        survives ``tracker.clear``.
+    (c) After a real ``finding_resolved`` clear (e.g. the underlying
+        condition truly gets fixed by an operator later), the gate
+        releases and a future occurrence of the same hash can promote
+        again.
+    """
+    from pollypm.plugins_builtin.core_recurring import audit_watchdog as cadence
+
+    db_path = tmp_path / "state.db"
+    _patch_workspace_db(monkeypatch, db_path)
+    tracker = Tier4PromotionTracker(db_path)
+    finding = _finding(project="loopproject", subject="loopproject")
+    rch = root_cause_hash(finding)
+
+    # Pre-seed dispatch history so the post-clear auto-promote gate has
+    # K+ dispatches inside the window — modelling the watchdog re-firing
+    # on the same un-fixed condition after the clear.
+    for i in range(AUTO_PROMOTE_THRESHOLD + 1):
+        tracker.record_tier3_dispatch(
+            finding, now=now - timedelta(minutes=10 * i),
+        )
+
+    tracker.record_promotion(
+        finding, now=now, promotion_path=PROMOTION_PATH_WATCHDOG,
+    )
+
+    # --- (a) Budget-exhaustion sweep stamps terminal_handoff_at. -----------
+    services = _StubServices(db_path)
+    try:
+        later = now + timedelta(seconds=TIER4_BUDGET_SECONDS + 600)
+        counters = cadence._sweep_tier4_budget_and_demotion(
+            services=services, now=later,
+        )
+        assert counters["tier4_budget_exhausted"] >= 1
+    finally:
+        services.close()
+
+    state = tracker.get(rch)
+    assert state is not None
+    assert state.tier4_active is False, "row should be cleared after budget exhaust"
+    assert state.terminal_handoff_at is not None, (
+        "terminal_handoff_at must be stamped before tracker.clear runs "
+        "so the gate persists across budget-exhaust"
+    )
+
+    # --- (b) Auto-promote refuses for the same hash. ---------------------
+    # Refresh dispatch history at the post-exhaust horizon so the
+    # sliding-window count is unambiguously over the threshold — this
+    # models the watchdog re-firing the same finding on the next tick.
+    refresh = later + timedelta(minutes=5)
+    for _ in range(AUTO_PROMOTE_THRESHOLD + 1):
+        tracker.record_tier3_dispatch(finding, now=refresh)
+    assert tracker.should_auto_promote(finding, now=refresh) is False, (
+        "should_auto_promote must respect terminal_handoff_at gate"
+    )
+
+    # --- (c) finding_resolved clear releases the gate. -------------------
+    cleared = tracker.clear(rch, now=refresh, reason="finding_resolved")
+    assert cleared is True
+    state_after = tracker.get(rch)
+    assert state_after is not None
+    assert state_after.terminal_handoff_at is None, (
+        "finding_resolved must NULL terminal_handoff_at so future "
+        "occurrences of the same hash can promote again"
+    )
+    # Re-arm the dispatch history (clear only resets active flags) and
+    # confirm the gate is open again.
+    later2 = refresh + timedelta(minutes=10)
+    for _ in range(AUTO_PROMOTE_THRESHOLD + 1):
+        tracker.record_tier3_dispatch(finding, now=later2)
+    assert tracker.should_auto_promote(finding, now=later2) is True, (
+        "after a finding_resolved clear the same hash must be able to "
+        "promote again on a future, distinct occurrence"
+    )
+
+
+def test_budget_exhausted_clear_preserves_terminal_handoff_at(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, now: datetime,
+) -> None:
+    """``tracker.clear(reason='budget_exhausted')`` must NOT NULL the gate.
+
+    Without this, the next tick's ``should_auto_promote`` would still
+    re-greenlight the same hash because the gate it keys on was wiped.
+    """
+    db_path = tmp_path / "state.db"
+    _patch_workspace_db(monkeypatch, db_path)
+    tracker = Tier4PromotionTracker(db_path)
+    finding = _finding(project="demo")
+    rch = root_cause_hash(finding)
+
+    tracker.record_promotion(
+        finding, now=now, promotion_path=PROMOTION_PATH_WATCHDOG,
+    )
+    tracker.mark_terminal_handoff(rch, now=now + timedelta(hours=2))
+    tracker.clear(
+        rch, now=now + timedelta(hours=2, minutes=1),
+        reason="budget_exhausted",
+    )
+
+    state = tracker.get(rch)
+    assert state is not None
+    assert state.tier4_active is False
+    assert state.terminal_handoff_at is not None, (
+        "budget_exhausted reason must preserve the persistent gate"
+    )
+
+
+def test_clear_tier4_for_finding_releases_parked_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, now: datetime,
+) -> None:
+    """A real finding_resolved on a parked-gate row must release the gate.
+
+    Scenario: cascade fully escalated (tier4_active=0, terminal_handoff_at
+    set), then later the underlying condition is actually fixed and the
+    public helper observes the finding has terminally resolved. The
+    helper must NULL ``terminal_handoff_at`` so a future distinct
+    occurrence of the same hash can promote again — otherwise the row is
+    permanently gated and the cascade is dead for that hash.
+    """
+    from pollypm.plugins_builtin.core_recurring import audit_watchdog as cadence
+
+    db_path = tmp_path / "state.db"
+    _patch_workspace_db(monkeypatch, db_path)
+    tracker = Tier4PromotionTracker(db_path)
+    finding = _finding(project="demo")
+    rch = root_cause_hash(finding)
+
+    tracker.record_promotion(
+        finding, now=now, promotion_path=PROMOTION_PATH_WATCHDOG,
+    )
+    tracker.mark_terminal_handoff(rch, now=now + timedelta(hours=2))
+    tracker.clear(
+        rch, now=now + timedelta(hours=2, minutes=1),
+        reason="budget_exhausted",
+    )
+    # Sanity: row is parked (inactive + gated).
+    state = tracker.get(rch)
+    assert state is not None
+    assert state.tier4_active is False
+    assert state.terminal_handoff_at is not None
+
+    # Now the underlying finding genuinely resolves. The public helper
+    # MUST release the gate even though tier4_active is already 0.
+    cleared = cadence.clear_tier4_for_finding(
+        finding,
+        now=now + timedelta(hours=3),
+        reason="finding_cleared",
+    )
+    assert cleared is True
+    state_after = tracker.get(rch)
+    assert state_after is not None
+    assert state_after.terminal_handoff_at is None, (
+        "clear_tier4_for_finding with a resolution reason must release "
+        "a parked terminal_handoff_at gate"
+    )
+
+
+# ---------------------------------------------------------------------------
 # #1554 HIGH-2 — failed inbox write must not flip tier4_active=1.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Tier-4 cascade was looping forever on permanently-stuck findings — 98 promotions / 81 budget-exhausts / 0 demotions across 8 projects over 50h, with an urgent inbox row dropped in front of Sam every ~2h.

- Adds persistent `terminal_handoff_at` column to `tier4_promotion_state` (sqlite migration v19, pg migration 0004; both idempotent `ADD COLUMN`).
- Sweep stamps the column AFTER routing to terminal but BEFORE `tracker.clear`, so the gate survives the active-flag flip.
- `should_auto_promote` refuses re-promotion while the column is non-NULL; `tracker.clear` NULLs it only on resolution reasons (`finding_resolved` / `finding_cleared` / `manual_clear` — covers both real resolutions and `pm tier4 clear`), while `budget_exhausted` preserves the gate.
- `clear_tier4_for_finding` extended to release a parked gate even when `tier4_active=0`, so a real later-observed resolution still re-arms the cascade for future occurrences of the same hash.

## Schema change shape

```sql
-- sqlite
ALTER TABLE tier4_promotion_state ADD COLUMN terminal_handoff_at TEXT;
-- pg
ALTER TABLE tier4_promotion_state ADD COLUMN IF NOT EXISTS terminal_handoff_at timestamptz;
```

One nullable column, one table, two backends. No backfill: `NULL` is the correct value for pre-existing rows.

## Test plan

- [x] `test_terminal_handoff_gate_blocks_re_promotion` — end-to-end: budget exhaust stamps gate, `should_auto_promote` refuses with K+ dispatches in window, `finding_resolved` releases gate, re-promotion allowed.
- [x] `test_budget_exhausted_clear_preserves_terminal_handoff_at` — `clear(reason='budget_exhausted')` does NOT NULL the gate.
- [x] `test_clear_tier4_for_finding_releases_parked_gate` — public helper releases parked gate even when `tier4_active=0`.

## Heads-up

`#1999` also reserves pg migration version 4. Whichever PR merges first wins; the second rebases to v5.

Closes #1997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)