### PR TITLE
fix(release-check): module-level GLOBAL_CONFIG_DIR import (closes #2008)

### DIFF
--- a/src/pollypm/release_check.py
+++ b/src/pollypm/release_check.py
@@ -25,6 +25,7 @@ from typing import Any
 from packaging.version import InvalidVersion, Version
 
 import pollypm
+from pollypm.config import GLOBAL_CONFIG_DIR
 
 
 _DEFAULT_OWNER = "samhotchkiss"
@@ -248,7 +249,7 @@ def _resolve_channel(config_path: Path | None) -> str:
     raising — the update check is a nice-to-have signal, never a
     startup blocker.
     """
-    from pollypm.config import DEFAULT_CONFIG_PATH, GLOBAL_CONFIG_DIR, load_config
+    from pollypm.config import DEFAULT_CONFIG_PATH, load_config
 
     path = config_path or DEFAULT_CONFIG_PATH
     if not path.exists():


### PR DESCRIPTION
## Summary

- Regression from #2003 — `pm doctor` crashed with `NameError: name 'GLOBAL_CONFIG_DIR' is not defined` because `_cache_path()` referenced the symbol at module scope while only `_resolve_channel()` imported it (lazily, inside the function body).
- Hoists `from pollypm.config import GLOBAL_CONFIG_DIR` to module scope and drops the now-redundant lazy import.

## Test plan

- [x] Reproduce pre-fix: `PYTHONPATH=src python -c "from pollypm.release_check import _cache_path; _cache_path()"` raises `NameError`
- [x] Post-fix: same command returns `~/.pollypm/release-check.json`
- [x] Post-fix: `from pollypm.release_check import *` imports clean
- [x] Post-fix: `_resolve_channel(None)` returns `"stable"`
- [ ] CI: full pytest run (gating)

Closes #2008