### PR TITLE
fix(install): gitignore build/ + reinstall-trap note (closes #2009)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,19 @@ __pycache__/
 *.pyc
 src/*.egg-info/
 
+# #2009: `python -m build` (or any wheel build via
+# ``setuptools.build_meta``) drops a snapshot of ``src/pollypm/``
+# into ``build/lib/pollypm/``. If that directory survives a code
+# change, the next ``uv tool install --force --reinstall .`` can
+# pick the stale snapshot up instead of the current ``src/`` tree
+# and silently ship pre-edit code (the "build/ shadows src/"
+# regression trap). Keep ``build/`` out of git so it's obvious that
+# wiping it between dev installs is safe — and so a stray local
+# build artifact never gets committed.
+build/
+dist/
+*.egg-info/
+
 .pollypm/
 .claude/worktrees/
 reports/

--- a/README.md
+++ b/README.md
@@ -184,6 +184,24 @@ brew steps fall through to a hint pointing at
 the database / extension / schema / config steps still run against any
 reachable Postgres.
 
+> **Reinstall trap ([#2009](https://github.com/samhotchkiss/pollypm/issues/2009)).**
+> If a previous `python -m build` (or any wheel build via
+> `setuptools.build_meta`) left a `build/` directory at the repo root,
+> a subsequent `uv tool install --force --reinstall .` can silently
+> pick up the stale `build/lib/pollypm/` tree instead of `src/pollypm/`.
+> Symptoms look like "I just edited that file, why is the old behavior
+> still showing up?" or `ImportError` for symbols that exist in `src/`
+> but not in the snapshot. **Wipe it first:**
+>
+> ```bash
+> rm -rf build/ dist/
+> uv tool install --force --reinstall .
+> ```
+>
+> `build/` is gitignored as of #2009 so it never gets committed, but
+> the artifact itself still needs to be cleaned between dev installs
+> when you've run `python -m build` locally.
+
 After onboarding:
 
 ```bash


### PR DESCRIPTION
## Summary

- A previous `python -m build` (or any wheel build via `setuptools.build_meta`) drops a snapshot of `src/pollypm/` into `build/lib/pollypm/`. If that directory survives a code change, a subsequent `uv tool install --force --reinstall .` can silently pick the stale snapshot up instead of the current `src/` tree and ship pre-edit code. Tonight's post-merge reinstall hit this with an `ImportError` (no `register_backend`).
- Gitignore `build/`, `dist/`, `*.egg-info/` so the dirty artifacts are clearly disposable and never get committed.
- Add a *Reinstall trap* callout to the README's *Install From Source* section that names the symptom and the one-liner cleanup (`rm -rf build/ dist/`).

There is no clean pyproject knob to make `setuptools.build_meta` always wipe `build/` between runs — the v1-RC mitigation is the gitignore + README note rather than a deeper build-system rewire.

## Test plan

- [x] `build/` is already untracked locally; new gitignore entries cover it explicitly going forward
- [x] README change renders as a blockquote callout in the *Install From Source* section
- [ ] Manual: drop a stale `build/` in repo, `rm -rf build/ dist/`, `uv tool install --force --reinstall .`, verify current `src/` ships

Closes #2009