### PR TITLE
polish(tmux-ui): migrate inbox/activity palette to cockpit_theme (refs #1988)

### DIFF
--- a/src/pollypm/cockpit_activity.py
+++ b/src/pollypm/cockpit_activity.py
@@ -26,32 +26,38 @@ from textual.widgets import DataTable, Input, Static
 
 from pollypm.cockpit_alerts import _action_view_alerts
 from pollypm.cockpit_palette import _open_keyboard_help
+from pollypm.cockpit_theme import State
 from pollypm.config import load_config
 
 
+# Event-type to semantic-color map. Rich-markup callers pass the returned
+# hex string straight into a ``[<color>]…[/<color>]`` markup span. Sourced
+# from ``cockpit_theme.State`` so a palette tweak lands here without
+# touching this file — see the 2026-05-20 audit (PR #1988) for why the
+# inline hex literals lived in five duplicated copies before.
 _ACTIVITY_TYPE_COLOURS: dict[str, str] = {
-    "task.done": "#3ddc84",
-    "task_done": "#3ddc84",
-    "task.approved": "#3ddc84",
-    "approve": "#3ddc84",
-    "approved": "#3ddc84",
-    "completed": "#3ddc84",
-    "task.created": "#f0c45a",
-    "task_created": "#f0c45a",
-    "task.queued": "#f0c45a",
-    "queued": "#f0c45a",
-    "created": "#f0c45a",
-    "alert": "#ff5f6d",
-    "error": "#ff5f6d",
-    "stuck": "#ff5f6d",
-    "rejection": "#ff5f6d",
-    "rejected": "#ff5f6d",
-    "state_drift": "#ff5f6d",
-    "persona_swap": "#ff5f6d",
-    "heartbeat": "#6b7a88",
-    "ran": "#6b7a88",
-    "tick": "#6b7a88",
-    "poll": "#6b7a88",
+    "task.done": State.WORKING,
+    "task_done": State.WORKING,
+    "task.approved": State.WORKING,
+    "approve": State.WORKING,
+    "approved": State.WORKING,
+    "completed": State.WORKING,
+    "task.created": State.WAITING,
+    "task_created": State.WAITING,
+    "task.queued": State.WAITING,
+    "queued": State.WAITING,
+    "created": State.WAITING,
+    "alert": State.BLOCKED,
+    "error": State.BLOCKED,
+    "stuck": State.BLOCKED,
+    "rejection": State.BLOCKED,
+    "rejected": State.BLOCKED,
+    "state_drift": State.BLOCKED,
+    "persona_swap": State.BLOCKED,
+    "heartbeat": State.MUTED,
+    "ran": State.MUTED,
+    "tick": State.MUTED,
+    "poll": State.MUTED,
 }
 
 
@@ -62,18 +68,18 @@ def _activity_type_colour(kind: str, severity: str | None = None) -> str:
     if colour is not None:
         return colour
     if "reject" in lowered or "drift" in lowered or "swap" in lowered:
-        return "#ff5f6d"
+        return State.BLOCKED
     if "done" in lowered or "approve" in lowered or "complete" in lowered:
-        return "#3ddc84"
+        return State.WORKING
     if "create" in lowered or "queue" in lowered:
-        return "#f0c45a"
+        return State.WAITING
     if "heartbeat" in lowered or "tick" in lowered or "poll" in lowered or "ran" in lowered:
-        return "#6b7a88"
+        return State.MUTED
     if severity == "critical":
-        return "#ff5f6d"
+        return State.BLOCKED
     if severity == "recommendation":
-        return "#f0c45a"
-    return "#97a6b2"
+        return State.WAITING
+    return State.NEUTRAL
 
 
 def _format_activity_relative(timestamp: str) -> str:
@@ -448,7 +454,7 @@ class PollyActivityFeedApp(App[None]):
     def _paint_loading_skeleton(self) -> None:
         """Render a minimal "Loading…" placeholder before any IO."""
         try:
-            self.topbar.update("[b #eef6ff]Activity[/b #eef6ff]")
+            self.topbar.update(f"[b {State.HEADING_BRIGHT}]Activity[/b {State.HEADING_BRIGHT}]")
         except Exception:  # noqa: BLE001
             pass
         try:
@@ -494,7 +500,7 @@ class PollyActivityFeedApp(App[None]):
         self._initial_load_done = True
         try:
             self.topbar.update(
-                f"[#ff5f6d]Error loading activity:[/#ff5f6d] {_escape(error)}"
+                f"[{State.BLOCKED}]Error loading activity:[/{State.BLOCKED}] {_escape(error)}"
             )
         except Exception:  # noqa: BLE001
             pass
@@ -507,7 +513,7 @@ class PollyActivityFeedApp(App[None]):
             entries = self._gather()
         except Exception as exc:  # noqa: BLE001
             self.topbar.update(
-                f"[#ff5f6d]Error loading activity:[/#ff5f6d] {_escape(str(exc))}"
+                f"[{State.BLOCKED}]Error loading activity:[/{State.BLOCKED}] {_escape(str(exc))}"
             )
             return
         self._entries = list(entries)[: self.MAX_ROWS_IN_MEMORY]
@@ -550,7 +556,7 @@ class PollyActivityFeedApp(App[None]):
     def _refresh_failed(self, error: str) -> None:
         try:
             self.topbar.update(
-                f"[#ff5f6d]Error loading activity:[/#ff5f6d] {_escape(error)}"
+                f"[{State.BLOCKED}]Error loading activity:[/{State.BLOCKED}] {_escape(error)}"
             )
         except Exception:  # noqa: BLE001
             pass
@@ -661,10 +667,10 @@ class PollyActivityFeedApp(App[None]):
             hidden_noise_count = sum(
                 1 for entry in self._entries if _is_low_signal_activity(entry)
             )
-        title_bits = ["[b #eef6ff]Activity[/b #eef6ff]"]
+        title_bits = [f"[b {State.HEADING_BRIGHT}]Activity[/b {State.HEADING_BRIGHT}]"]
         if self._filter_project:
             title_bits.append(
-                f"[#5b8aff]\u00b7 project: [b]{_escape(self._filter_project)}[/b][/#5b8aff]"
+                f"[{State.INFO}]\u00b7 project: [b]{_escape(self._filter_project)}[/b][/{State.INFO}]"
             )
         self.topbar.update("  ".join(title_bits))
 
@@ -674,11 +680,11 @@ class PollyActivityFeedApp(App[None]):
         ]
         filter_description = self._describe_filters()
         if filter_description:
-            chips.append(f"[#97a6b2]filters: {filter_description}[/#97a6b2]")
+            chips.append(f"[{State.NEUTRAL}]filters: {filter_description}[/{State.NEUTRAL}]")
         if hidden_noise_count:
             chips.append(f"[dim]{hidden_noise_count} system noise hidden[/dim]")
         chips.append(
-            "[#3ddc84]follow on[/#3ddc84]" if self._follow_on else "[dim]follow off[/dim]"
+            f"[{State.WORKING}]follow on[/{State.WORKING}]" if self._follow_on else "[dim]follow off[/dim]"
         )
         self.counters.update("  \u00b7  ".join(chips))
 
@@ -712,14 +718,14 @@ class PollyActivityFeedApp(App[None]):
     def _render_table(self, rows: list) -> None:
         self.table.clear()
         for entry in rows:
-            time_text = Text(_format_activity_relative(entry.timestamp), style="#97a6b2")
+            time_text = Text(_format_activity_relative(entry.timestamp), style=State.NEUTRAL)
             project_label = entry.project or "\u2014"
             if self._filter_project and (entry.project or "") == self._filter_project:
-                project_text = Text(project_label, style="bold #eef6ff")
+                project_text = Text(project_label, style=f"bold {State.HEADING_BRIGHT}")
             elif entry.project:
-                project_text = Text(project_label, style="#5b8aff")
+                project_text = Text(project_label, style=State.INFO)
             else:
-                project_text = Text(project_label, style="#6b7a88")
+                project_text = Text(project_label, style=State.MUTED)
             verb_text = entry.verb or entry.kind or ""
             # When the summary literally equals the verb/kind (the
             # legacy ``_fallback_summary`` path picks the event's own
@@ -741,9 +747,9 @@ class PollyActivityFeedApp(App[None]):
             self.table.add_row(
                 time_text,
                 project_text,
-                Text(entry.actor or "system", style="#d6dee5"),
+                Text(entry.actor or "system", style=State.BODY_BRIGHT),
                 Text(verb_text, style=_activity_type_colour(entry.kind or "", entry.severity)),
-                Text(_truncate_summary(summary_text), style="#d6dee5"),
+                Text(_truncate_summary(summary_text), style=State.BODY_BRIGHT),
                 key=entry.id,
             )
 

--- a/src/pollypm/cockpit_theme.py
+++ b/src/pollypm/cockpit_theme.py
@@ -94,9 +94,42 @@ class State:
     # inbox "bold subject"). The brightest neutral in the palette.
     HEADING = "#eef2f4"
 
+    # Topbar / panel-title text — one notch more blue than ``HEADING``.
+    # Activity feed + several other panels use this for the ``[b]Activity[/b]``
+    # style topbar string so the panel title reads as "current view" not
+    # "current row".
+    HEADING_BRIGHT = "#eef6ff"
+
     # Body / label color for non-selected rail rows. One step dimmer
     # than HEADING.
     LABEL = "#b8c4cf"
+
+    # Body text under a selected/highlighted row — one step dimmer than
+    # ``HEADING`` but still readable, used for inbox plan-review summary
+    # text and other multi-line body content where ``LABEL`` would feel
+    # too prominent and ``MUTED`` too dim.
+    BODY = "#c8d2da"
+
+    # Body text for tabular rows (activity feed cells, list-pane rows).
+    # One step brighter than ``BODY`` so cells read as data, not commentary.
+    BODY_BRIGHT = "#d6dee5"
+
+    # Tonal variants used for read/dim states. Promoted from inline hex
+    # in the inbox formatter so all colors flow through ``State.*``:
+    # - ``LABEL_DIM`` — read version of ``LABEL`` (judgment-call bullets)
+    # - ``MUTED_DIM`` — extra-dim age text on reply rows (one step below
+    #   ``MUTED`` so reply metadata sits visually below the parent row)
+    # - ``WAITING_DIM`` — dimmed ``WAITING`` for read plan-review heading
+    # - ``ATTENTION_BRIGHT`` — warmer orange prefix for the rejection
+    #   feedback (🔄) emoji where ``WAITING`` would feel too dull
+    # - ``NEUTRAL`` — warm gray used as the unknown-event fallback in the
+    #   activity feed AND the "deleted project" badge in the inbox; lives
+    #   between ``LABEL`` and ``MUTED`` in tone
+    LABEL_DIM = "#a9b4be"
+    MUTED_DIM = "#586773"
+    WAITING_DIM = "#d6a93f"
+    ATTENTION_BRIGHT = "#ffb454"
+    NEUTRAL = "#97a6b2"
 
 
 class Glyph:

--- a/src/pollypm/cockpit_ui_inbox_format.py
+++ b/src/pollypm/cockpit_ui_inbox_format.py
@@ -43,6 +43,7 @@ from rich.text import Text
 from pollypm.cockpit_inbox import InboxThreadRow
 from pollypm.cockpit_inbox_items import is_task_inbox_entry
 from pollypm.cockpit_markup import _escape
+from pollypm.cockpit_theme import State
 from pollypm.config import load_config
 from pollypm.notify_task import strip_routing_tag_prefix
 from pollypm.rejection_feedback import (
@@ -195,7 +196,7 @@ def _render_user_prompt_block(payload: object) -> str | None:
 
     lines: list[str] = []
     if summary:
-        lines.append(f"[#f0c45a]◆[/#f0c45a] {_escape(summary)}")
+        lines.append(f"[{State.WAITING}]◆[/{State.WAITING}] {_escape(summary)}")
     heading = _plain(prompt.get("steps_heading")) or "What to do"
     if steps:
         lines.append(f"  [b]{_escape(heading)}[/b]")
@@ -236,7 +237,7 @@ def _render_heuristic_action_block(body: object) -> str | None:
         return None
     lines: list[str] = []
     if summary:
-        lines.append(f"[#f0c45a]◆[/#f0c45a] {_escape(summary)}")
+        lines.append(f"[{State.WAITING}]◆[/{State.WAITING}] {_escape(summary)}")
     if steps:
         lines.append("  [b]What to do[/b]")
         for idx, step in enumerate(steps, start=1):
@@ -262,13 +263,13 @@ def _render_inbox_triage_banner(item) -> str | None:
     project = (getattr(item, "project", "") or "").strip()
     if bucket == "action":
         return (
-            f"[b #f0c45a]Action Required[/b #f0c45a]"
+            f"[b {State.WAITING}]Action Required[/b {State.WAITING}]"
             f"  [dim]· {_escape(label)}[/dim]"
         )
     if bucket == "orphaned":
         detail = f"{project} is no longer a tracked project." if project else "This project is no longer tracked."
         return (
-            f"[b #97a6b2]Deleted Project[/b #97a6b2]"
+            f"[b {State.NEUTRAL}]Deleted Project[/b {State.NEUTRAL}]"
             f"  [dim]· {_escape(detail)}[/dim]"
         )
     if label and label != "update":
@@ -297,15 +298,15 @@ def _format_inbox_row(
 
     text = Text(no_wrap=True, overflow="ellipsis")
     if tree_marker:
-        text.append(tree_marker, style="#6b7a88")
+        text.append(tree_marker, style=State.MUTED)
     if is_unread:
-        text.append("◆ ", style="#f0c45a")  # yellow diamond
+        text.append("◆ ", style=State.WAITING)  # yellow diamond
     else:
-        text.append("○ ", style="#4a5568")  # dim circle
+        text.append("○ ", style=State.IDLE)  # dim circle
     subject_prefix = ""
     if is_rejection_feedback_task(task):
         subject_prefix = "🔄 "
-        text.append(subject_prefix, style="#ffb454")
+        text.append(subject_prefix, style=State.ATTENTION_BRIGHT)
     subject = task.title or "(no subject)"
     # Drop the "[Action]" prefix from action-bucket rows. The inbox
     # already groups action-needed items under their own header, so
@@ -324,10 +325,10 @@ def _format_inbox_row(
     )
     if len(subject) > max_subject:
         subject = subject[: max_subject - 1] + "…"
-    subject_style = "bold #eef2f4" if is_unread else "bold #b8c4cf"
+    subject_style = f"bold {State.HEADING}" if is_unread else f"bold {State.LABEL}"
     text.append(subject, style=subject_style)
     if reply_suffix:
-        text.append(reply_suffix, style="#6b7a88")
+        text.append(reply_suffix, style=State.MUTED)
 
     # Line 2: project · age, dim. Indent by 2 so it lines up under the
     # subject text (past the marker glyph).
@@ -349,7 +350,7 @@ def _format_inbox_row(
     meta_indent = " " * max(2, len(tree_marker) + 2)
     meta_line = meta_indent + "  ·  ".join(meta_bits)
     text.append("\n")
-    text.append(meta_line, style="#6b7a88")
+    text.append(meta_line, style=State.MUTED)
     return text
 
 
@@ -419,11 +420,13 @@ def _format_inbox_plan_review_row(
     """
     text = Text(no_wrap=True, overflow="ellipsis")
     if tree_marker:
-        text.append(tree_marker, style="#6b7a88")
+        text.append(tree_marker, style=State.MUTED)
 
     # Red play glyph — same affordance as the rail's "needs decision"
-    # signal so the operator's eye trains to the same shape.
-    text.append("▶ ", style="bold #ff6b5b")
+    # signal so the operator's eye trains to the same shape. Standardised
+    # on ``State.BLOCKED`` (``#ff5f6d``); historical drift to ``#ff6b5b``
+    # was an accidental copy-paste flagged in the 2026-05-20 audit.
+    text.append("▶ ", style=f"bold {State.BLOCKED}")
 
     # Heading: ``Approve plan: <project>/<task_number>`` (the inbox
     # task_id is already in ``<project>/<n>`` shape, so we don't need
@@ -439,7 +442,7 @@ def _format_inbox_plan_review_row(
         ref = "?"
     heading_label = "Approve plan: "
     heading_ref = ref
-    heading_style = "bold #f0c45a" if is_unread else "bold #d6a93f"
+    heading_style = f"bold {State.WAITING}" if is_unread else f"bold {State.WAITING_DIM}"
     text.append(heading_label, style=heading_style)
     text.append(heading_ref, style=heading_style)
 
@@ -470,8 +473,8 @@ def _format_inbox_plan_review_row(
 
     indent = " " * max(2, len(tree_marker) + 2)
     text.append("\n")
-    text.append(indent, style="#6b7a88")
-    text.append(summary_line, style="#c8d2da")
+    text.append(indent, style=State.MUTED)
+    text.append(summary_line, style=State.BODY)
 
     # Optional flagged-judgment-calls sub-section — only shown when the
     # row is highlighted/expanded so the list stays compact at rest.
@@ -492,8 +495,8 @@ def _format_inbox_plan_review_row(
             if not trimmed:
                 continue
             text.append("\n")
-            text.append(indent + "  • ", style="#f0c45a")
-            text.append(trimmed, style="#a9b4be")
+            text.append(indent + "  • ", style=State.WAITING)
+            text.append(trimmed, style=State.LABEL_DIM)
 
     return text
 
@@ -513,15 +516,15 @@ def _format_inbox_reply_row(task, reply, *, width: int = 38) -> Text:
     max_subject = max(8, width - len(prefix) - len(header))
     if len(subject) > max_subject:
         subject = subject[: max_subject - 1] + "…"
-    text.append(prefix, style="#6b7a88")
-    text.append(header, style="#97a6b2")
-    text.append(subject, style="#c8d2da")
+    text.append(prefix, style=State.MUTED)
+    text.append(header, style=State.NEUTRAL)
+    text.append(subject, style=State.BODY)
 
     stamped = getattr(reply, "timestamp", None)
     iso = stamped.isoformat() if hasattr(stamped, "isoformat") else str(stamped or "")
     age = format_relative(iso) if iso else ""
     text.append("\n")
-    text.append("    " + (age or "reply"), style="#586773")
+    text.append("    " + (age or "reply"), style=State.MUTED_DIM)
     return text
 
 


### PR DESCRIPTION
## Summary

Batch 2 of the cockpit hex-literal consolidation following PR #1989.

- Migrates every Rich-markup ``#rrggbb`` literal in ``cockpit_ui_inbox_format.py`` and ``cockpit_activity.py`` to ``pollypm.cockpit_theme.State.*``.
- Resolves the ``#ff6b5b`` vs. ``#ff5f6d`` red drift on the inbox plan-review row by collapsing to the rail's ``State.BLOCKED`` (``#ff5f6d``, more uses across the cockpit).
- Adds 7 semantic tonal constants to ``State`` (``HEADING_BRIGHT``, ``BODY``, ``BODY_BRIGHT``, ``LABEL_DIM``, ``MUTED_DIM``, ``WAITING_DIM``, ``ATTENTION_BRIGHT``, ``NEUTRAL``) needed to absorb the previously-inline shades.
- CSS-block hex literals (chrome backgrounds, borders) intentionally untouched — that's the audit doc's PR C / dashboard-CSS-palette work. ``cockpit_alert_detail.py`` is CSS-only and already aligned with the rail's red/amber, so it folds into the same future PR.

## Test plan

- [x] ``pollypm.cockpit_theme.State.BLOCKED == "#ff5f6d"`` lock-in test (test_cockpit_theme.py) passes.
- [x] Direct-import smoke run: every value in ``State`` is a valid ``#rrggbb`` and ``cockpit_ui_inbox_format`` / ``cockpit_activity`` / ``cockpit_rail_item`` all import clean.
- [x] ``test_event_type_colour_resolution`` hex assertions still match ``State.WORKING`` / ``State.WAITING`` / ``State.BLOCKED`` / ``State.MUTED`` byte-for-byte.
- [x] No remaining inline-markup ``#rrggbb`` in either file (``grep -n -E '#[0-9a-fA-F]{6}'`` is empty except for a documentation comment recording the red-drift history).
- [ ] Cockpit visual check after reinstall — inbox plan-review row should now use ``#ff5f6d`` instead of the slightly-warmer ``#ff6b5b``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)