### PR TITLE
polish(tmux-ui): unified footer status bar (refs #1988)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Added, Changed, and Removed.
 
 ## [Unreleased]
 
+### Fixed
+- `render_footer_status()` in `pollypm.cockpit_footer_status` no longer
+  overflows the width budget for very narrow alert-only layouts. The
+  alert-only path previously emitted `"⚠ h…"` (4 plain chars) at
+  `width=3` because `_truncate_alert` returned a 2-char ellipsis stub
+  even when the budget could only fit 1 char. The contract is now
+  enforced explicitly: when the truncation can't fit at least 1 body
+  char plus the ellipsis, the formatter drops to `""` per the existing
+  full → compact → alert-only → empty cascade. PR #2014 review blocker.
+
 ### Added
 - `pm cli-reference --json` dumps the full Typer command tree (commands,
   subcommands, flags, types, help text, defaults) as a single JSON

--- a/src/pollypm/cockpit_footer_status.py
+++ b/src/pollypm/cockpit_footer_status.py
@@ -74,7 +74,10 @@ def _truncate_alert(alert: str, budget: int) -> str:
     """Trim an alert string to fit ``budget`` chars, ellipsis on overflow.
 
     Returns ``""`` when ``budget <= 0`` so the caller can drop the alert
-    chunk entirely on a very narrow rail.
+    chunk entirely on a very narrow rail. The output is guaranteed to
+    satisfy ``len(result) <= budget`` — when overflow would force the
+    ellipsis to consume the whole budget alone (``budget < 2``), the
+    function returns ``""`` instead of a single ``…``.
     """
     if budget <= 0:
         return ""
@@ -83,8 +86,11 @@ def _truncate_alert(alert: str, budget: int) -> str:
         return ""
     if len(flat) <= budget:
         return flat
-    # Reserve 1 char for the ellipsis.
-    return flat[: max(1, budget - 1)].rstrip() + "…"
+    # Overflow path: need ``head + "…"`` to fit in ``budget``.
+    # That requires at least 1 char of body + 1 char of ellipsis.
+    if budget < 2:
+        return ""
+    return flat[: budget - 1].rstrip() + "…"
 
 
 def render_footer_status(

--- a/src/pollypm/cockpit_footer_status.py
+++ b/src/pollypm/cockpit_footer_status.py
@@ -1,0 +1,213 @@
+"""Unified footer status-bar formatter for the cockpit.
+
+Per the 2026-05-20 tmux UI audit, the cockpit footer today is a 4-line
+hodgepodge: ``⚙ Settings`` row, event ticker, key hint, and a wrapping
+heartbeat-offline warning. The audit recommended collapsing those into
+one coherent status line of the shape::
+
+    12 projects · 38 agents · 23 inbox  |  ⚠ heartbeat 26h offline
+
+This module ships the pure formatter for that string with explicit
+truncation rules + per-state color cues. It is intentionally a leaf
+module — no Textual / Rich primitive imports, no I/O. Call sites pass
+in already-resolved counts and (optionally) an alert string; the
+formatter returns Rich-markup ready text the caller can hand to a
+``Static`` widget or the rail's row builder.
+
+Wiring is intentionally NOT included in this PR — the audit doc flagged
+the rail's footer rendering loop as the higher-risk surface to touch
+last. Landing the formatter + its tests independently lets future
+follow-ups adopt it from any of the candidate sites
+(``PollyCockpitApp._update_hint``, ``cockpit_rail._format_event_ticker``,
+the headless ``pm rail``) without re-deciding the format.
+
+Contract:
+- Inputs: ``project_count`` / ``agent_count`` / ``inbox_count`` ints,
+  an optional ``alert`` string, and a ``width`` budget in chars.
+- Outputs: a Rich markup ``str`` ready for inline rendering.
+- Side effects: none.
+- Allowed dependencies: stdlib + ``pollypm.cockpit_theme``.
+"""
+
+from __future__ import annotations
+
+from pollypm.cockpit_theme import Glyph, State
+
+
+# Bracket form used between the count chunk and the alert chunk so the
+# alert reads as a distinct second column instead of "yet another · chip".
+_SEPARATOR_MAJOR = "  |  "
+
+# Inter-chunk separator inside the counts section. Matches the existing
+# event-ticker affordance (`events · heartbeat error`) so the operator's
+# eye already trains to "·" as a chunk break.
+_SEPARATOR_MINOR = " · "  # " · "
+
+
+def _format_count_chunk(value: int, label_singular: str, label_plural: str) -> str:
+    """Compose a single ``<N> <noun>`` chunk."""
+    noun = label_singular if value == 1 else label_plural
+    return f"{value} {noun}"
+
+
+def _color_for_inbox(inbox_count: int) -> str:
+    """Inbox count gets the WAITING amber when non-empty, MUTED at rest.
+
+    The whole point of the inbox count is to signal whether the operator
+    has unread work; coloring it amber the moment ``inbox_count > 0``
+    folds the rail's "(N)" badge affordance into the footer without
+    needing a second glyph.
+    """
+    return State.WAITING if inbox_count > 0 else State.MUTED
+
+
+def _wrap(markup: str, color: str) -> str:
+    """Wrap ``markup`` in Rich-markup ``[color]…[/color]``.
+
+    Centralised so the consumers (and tests) don't have to repeat the
+    ``f"[{color}]{value}[/{color}]"`` pattern eight times.
+    """
+    return f"[{color}]{markup}[/{color}]"
+
+
+def _truncate_alert(alert: str, budget: int) -> str:
+    """Trim an alert string to fit ``budget`` chars, ellipsis on overflow.
+
+    Returns ``""`` when ``budget <= 0`` so the caller can drop the alert
+    chunk entirely on a very narrow rail.
+    """
+    if budget <= 0:
+        return ""
+    flat = " ".join(alert.split()).strip()
+    if not flat:
+        return ""
+    if len(flat) <= budget:
+        return flat
+    # Reserve 1 char for the ellipsis.
+    return flat[: max(1, budget - 1)].rstrip() + "…"
+
+
+def render_footer_status(
+    *,
+    project_count: int,
+    agent_count: int,
+    inbox_count: int,
+    alert: str | None = None,
+    width: int = 80,
+) -> str:
+    """Compose the unified footer status string with per-state color cues.
+
+    Layout::
+
+        <projects> · <agents> · <inbox>  |  <alert>
+
+    Truncation rules (least to most aggressive):
+
+    1. **Full**: width >= projects + agents + inbox + alert. Render all
+       four chunks with separators + color.
+    2. **Drop labels**: width below the full budget but enough to keep
+       all four counts. Counts collapse to ``"12·38·23"`` (no spaces).
+    3. **Drop alert truncation**: alert string gets ellipsis-trimmed so
+       the count column always survives, since the heartbeat alert can
+       be very long and counts are the more frequently-useful signal.
+    4. **Drop counts**: only the alert renders, since it is the
+       higher-priority signal. Falls out for very small ``width``.
+    5. **Empty**: width < 1 or no chunks to render.
+
+    Per-state colors (sourced from :mod:`pollypm.cockpit_theme`):
+
+    - counts: :attr:`State.MUTED` (chrome / metadata)
+    - inbox count, when non-zero: :attr:`State.WAITING` (amber)
+    - alert glyph (``⚠``) + alert text: :attr:`State.BLOCKED` (red)
+    - separators: :attr:`State.IDLE` (dim slate)
+    """
+    project_chunk = _format_count_chunk(project_count, "project", "projects")
+    agent_chunk = _format_count_chunk(agent_count, "agent", "agents")
+    inbox_chunk = _format_count_chunk(inbox_count, "inbox", "inbox")
+    inbox_color = _color_for_inbox(inbox_count)
+
+    alert_text = (alert or "").strip()
+    has_alert = bool(alert_text)
+
+    # ---- Pre-compute candidate renderings (plain text, sans markup) ----
+    plain_full_counts = _SEPARATOR_MINOR.join(
+        (project_chunk, agent_chunk, inbox_chunk)
+    )
+    plain_compact_counts = "·".join(  # "·" no spaces
+        (str(project_count), str(agent_count), str(inbox_count))
+    )
+    plain_alert_prefix = f"{Glyph.STUCK} " if has_alert else ""
+
+    # ---- Pick a layout based on width budget ----
+    if width <= 0:
+        return ""
+
+    # Pick Layout 1 (full labels) when the full count chunk plus the
+    # full alert (no truncation) fits inside ``width`` outright. As soon
+    # as the alert would need to truncate to fit, switch to the compact
+    # count form so the alert text stays as readable as possible.
+    plain_alert_full = (
+        plain_alert_prefix + " ".join(alert_text.split()) if has_alert else ""
+    )
+    full_layout_plain_len = (
+        len(plain_full_counts)
+        + (len(_SEPARATOR_MAJOR) + len(plain_alert_full) if has_alert else 0)
+    )
+
+    counts_markup: str
+    if not has_alert or full_layout_plain_len <= width:
+        # Layout 1 — full counts (with labels) fit alongside the full alert.
+        counts_plain = plain_full_counts
+        counts_markup = (
+            _wrap(project_chunk, State.MUTED)
+            + _wrap(_SEPARATOR_MINOR, State.IDLE)
+            + _wrap(agent_chunk, State.MUTED)
+            + _wrap(_SEPARATOR_MINOR, State.IDLE)
+            + _wrap(inbox_chunk, inbox_color)
+        )
+    else:
+        # Layout 2 — compact counts (drop labels) so the alert gets more
+        # room. Uses sparing-of-spaces "·" join.
+        counts_plain = plain_compact_counts
+        counts_markup = (
+            _wrap(str(project_count), State.MUTED)
+            + _wrap("·", State.IDLE)
+            + _wrap(str(agent_count), State.MUTED)
+            + _wrap("·", State.IDLE)
+            + _wrap(str(inbox_count), inbox_color)
+        )
+
+    if has_alert:
+        # Reserve at least 4 chars of alert body so the alert isn't
+        # truncated past the point of usefulness. Below that threshold
+        # the operator gets more value from a clear "⚠ <first word>…"
+        # alert-only line than from a "999·999·999  |  ⚠ he…" stub.
+        _MIN_ALERT_BODY = 4
+        remaining = width - len(counts_plain) - len(_SEPARATOR_MAJOR) - len(plain_alert_prefix)
+        if remaining >= _MIN_ALERT_BODY:
+            truncated_alert = _truncate_alert(alert_text, remaining)
+            if truncated_alert:
+                alert_markup = _wrap(
+                    f"{Glyph.STUCK} {truncated_alert}",
+                    State.BLOCKED,
+                )
+                return (
+                    counts_markup
+                    + _wrap(_SEPARATOR_MAJOR, State.IDLE)
+                    + alert_markup
+                )
+        # Alert can't fit usefully alongside counts — promote to
+        # alert-only so the more-actionable signal survives.
+        alert_only_budget = max(0, width - len(plain_alert_prefix))
+        truncated_alert = _truncate_alert(alert_text, alert_only_budget)
+        if truncated_alert:
+            return _wrap(f"{Glyph.STUCK} {truncated_alert}", State.BLOCKED)
+        # Alert can't render at all (width too narrow even for the
+        # glyph) — fall through to counts-only.
+
+    if len(counts_plain) <= width:
+        return counts_markup
+    return ""
+
+
+__all__ = ["render_footer_status"]

--- a/tests/test_cockpit_footer_status.py
+++ b/tests/test_cockpit_footer_status.py
@@ -150,6 +150,66 @@ def test_total_width_stays_under_budget() -> None:
         assert len(plain) <= w, f"width={w}, len(plain)={len(plain)}, plain={plain!r}"
 
 
+@pytest.mark.parametrize("width", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize(
+    "project_count,agent_count,inbox_count",
+    [(0, 0, 0), (1, 1, 1), (12, 38, 23), (999, 999, 999)],
+)
+@pytest.mark.parametrize(
+    "alert",
+    [None, "", "x", "heartbeat offline", "heartbeat 999h offline since the dawn of time"],
+)
+def test_narrow_widths_never_overflow_budget(
+    width: int,
+    project_count: int,
+    agent_count: int,
+    inbox_count: int,
+    alert: str | None,
+) -> None:
+    """Regression for PR #2014: very narrow widths (1..5) must never overflow.
+
+    The alert-only layout previously emitted ``"⚠ h…"`` (4 chars) at
+    ``width=3`` because the ellipsis truncation reserved less budget
+    than the glyph-prefix consumed. Per the layout-promotion cascade
+    (full → compact → alert-only → empty), the formatter must drop to
+    empty when even the alert glyph + first body char + ellipsis can't
+    fit, rather than overflow ``width``.
+    """
+    result = render_footer_status(
+        project_count=project_count,
+        agent_count=agent_count,
+        inbox_count=inbox_count,
+        alert=alert,
+        width=width,
+    )
+    plain = _plain(result)
+    assert len(plain) <= width, (
+        f"width={width}, len(plain)={len(plain)}, plain={plain!r}, "
+        f"counts=({project_count},{agent_count},{inbox_count}), alert={alert!r}"
+    )
+
+
+def test_codex_repro_width_3_alert_only_returns_empty() -> None:
+    """Pin the exact Codex repro from PR #2014 comment 4502598259.
+
+    With ``width=3`` and an alert that can't fit alongside the alert
+    glyph + a useful ellipsis-trimmed body, the formatter must return
+    ``""`` rather than ``"⚠ h…"`` (which previously overflowed at 4
+    plain chars vs a budget of 3).
+    """
+    result = render_footer_status(
+        project_count=999,
+        agent_count=999,
+        inbox_count=999,
+        alert="heartbeat offline",
+        width=3,
+    )
+    plain = _plain(result)
+    assert len(plain) <= 3
+    # Specifically, the old overflow string must not reappear.
+    assert plain != "⚠ h…"
+
+
 def test_zero_or_negative_width_returns_empty_string() -> None:
     assert render_footer_status(
         project_count=10, agent_count=10, inbox_count=10, alert="x", width=0,

--- a/tests/test_cockpit_footer_status.py
+++ b/tests/test_cockpit_footer_status.py
@@ -1,0 +1,204 @@
+"""Tests for the unified cockpit footer status formatter.
+
+Pin the format + per-state color cues + truncation rules so a future
+caller can't accidentally break the operator-visible status line.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from pollypm.cockpit_footer_status import render_footer_status
+from pollypm.cockpit_theme import State
+
+
+_MARKUP_RE = re.compile(r"\[/?[^\]]+\]")
+
+
+def _plain(markup: str) -> str:
+    """Strip Rich markup tags for length-budget assertions."""
+    return _MARKUP_RE.sub("", markup)
+
+
+def test_full_layout_includes_all_three_counts_and_alert() -> None:
+    """At a comfortable width the formatter renders every chunk."""
+    result = render_footer_status(
+        project_count=12,
+        agent_count=38,
+        inbox_count=23,
+        alert="heartbeat 26h offline",
+        width=80,
+    )
+    plain = _plain(result)
+    assert "12 projects" in plain
+    assert "38 agents" in plain
+    assert "23 inbox" in plain
+    assert "heartbeat 26h offline" in plain
+    assert "  |  " in plain  # major separator between counts + alert
+
+
+def test_color_cues_match_state_constants() -> None:
+    """Each chunk must be wrapped in the right ``State.*`` color tag."""
+    result = render_footer_status(
+        project_count=1,
+        agent_count=2,
+        inbox_count=5,
+        alert="heartbeat offline",
+        width=80,
+    )
+    # Counts ride on MUTED; non-zero inbox count flips to WAITING amber.
+    assert f"[{State.MUTED}]1 project" in result
+    assert f"[{State.MUTED}]2 agents" in result
+    assert f"[{State.WAITING}]5 inbox" in result
+    # Alert chunk wraps the glyph + text in BLOCKED red.
+    assert f"[{State.BLOCKED}]⚠ heartbeat offline" in result
+    # Separators are IDLE slate.
+    assert f"[{State.IDLE}] · " in result
+
+
+def test_inbox_zero_renders_muted_not_amber() -> None:
+    """An empty inbox shouldn't pretend to need attention."""
+    result = render_footer_status(
+        project_count=5,
+        agent_count=0,
+        inbox_count=0,
+        width=80,
+    )
+    assert f"[{State.MUTED}]0 inbox" in result
+    assert f"[{State.WAITING}]0 inbox" not in result
+
+
+def test_singular_label_for_one() -> None:
+    """1 project / 1 agent should not pluralise to 'projects' / 'agents'."""
+    result = render_footer_status(
+        project_count=1,
+        agent_count=1,
+        inbox_count=1,
+        width=80,
+    )
+    plain = _plain(result)
+    assert "1 project " in plain or plain.endswith("1 project")
+    assert "1 agent " in plain or "1 agent " in plain or "1 agent" in plain
+    # ``inbox`` is its own plural — no ``inboxes``.
+    assert "1 inbox" in plain
+    assert "inboxes" not in plain
+
+
+def test_no_alert_drops_separator_and_alert_chunk() -> None:
+    """When alert is None / empty the major separator must not render."""
+    result = render_footer_status(
+        project_count=3,
+        agent_count=4,
+        inbox_count=0,
+        width=80,
+    )
+    plain = _plain(result)
+    assert "|" not in plain
+    assert "⚠" not in plain
+
+
+def test_compact_layout_drops_count_labels_to_make_room_for_alert() -> None:
+    """When the alert needs space, counts collapse to bare digits joined
+    by ``·`` (no spaces) instead of ``N projects · N agents``."""
+    # Pick a width where the full count chunk + a long alert won't fit
+    # but the compact form will.
+    result = render_footer_status(
+        project_count=12,
+        agent_count=38,
+        inbox_count=23,
+        alert="heartbeat offline — open Settings",
+        width=55,
+    )
+    plain = _plain(result)
+    # Compact counts join with bare "·".
+    assert "12·38·23" in plain
+    # The alert still gets some text (truncated or whole, depending).
+    assert "heartbeat" in plain
+
+
+def test_alert_truncates_with_ellipsis_when_overlong() -> None:
+    """A very long alert should ellipsis-tail-trim before falling off the
+    rail rather than overflow the width budget."""
+    long_alert = "heartbeat offline since cycle 26 — open Settings to repair"
+    result = render_footer_status(
+        project_count=0,
+        agent_count=0,
+        inbox_count=0,
+        alert=long_alert,
+        width=40,
+    )
+    plain = _plain(result)
+    assert plain.endswith("…")
+    assert "heartbeat" in plain
+    # Plain rendering must still fit the width budget.
+    assert len(plain) <= 40
+
+
+def test_total_width_stays_under_budget() -> None:
+    """Truncation guarantees the rendered plain text fits ``width``."""
+    for w in (20, 32, 50, 80, 120):
+        result = render_footer_status(
+            project_count=99,
+            agent_count=99,
+            inbox_count=99,
+            alert="heartbeat 999h offline since the dawn of time",
+            width=w,
+        )
+        plain = _plain(result)
+        assert len(plain) <= w, f"width={w}, len(plain)={len(plain)}, plain={plain!r}"
+
+
+def test_zero_or_negative_width_returns_empty_string() -> None:
+    assert render_footer_status(
+        project_count=10, agent_count=10, inbox_count=10, alert="x", width=0,
+    ) == ""
+    assert render_footer_status(
+        project_count=10, agent_count=10, inbox_count=10, width=-5,
+    ) == ""
+
+
+def test_alert_only_layout_when_counts_overflow() -> None:
+    """When the counts themselves overflow ``width`` but an alert is set,
+    the formatter prefers surfacing the alert over showing nothing —
+    the heartbeat warning is the more actionable signal."""
+    # Width chosen below ``11 (compact counts) + 5 (major sep) + 2 (glyph)``,
+    # i.e. the compact-counts column itself can't make room for an alert
+    # glyph + any text. The formatter must drop the counts entirely and
+    # render only the alert.
+    result = render_footer_status(
+        project_count=999,
+        agent_count=999,
+        inbox_count=999,
+        alert="heartbeat offline",
+        width=15,
+    )
+    plain = _plain(result)
+    # Alert glyph + at least the first word must survive.
+    assert "⚠" in plain
+    assert "heartbeat" in plain
+    assert "999" not in plain  # counts dropped entirely
+    assert len(plain) <= 15
+
+
+@pytest.mark.parametrize(
+    "project_count,agent_count,inbox_count",
+    [(0, 0, 0), (1, 1, 1), (50, 100, 25), (999, 999, 999)],
+)
+def test_no_alert_renders_only_count_chunks(
+    project_count: int, agent_count: int, inbox_count: int,
+) -> None:
+    result = render_footer_status(
+        project_count=project_count,
+        agent_count=agent_count,
+        inbox_count=inbox_count,
+        alert=None,
+        width=80,
+    )
+    plain = _plain(result)
+    assert str(project_count) in plain
+    assert str(agent_count) in plain
+    assert str(inbox_count) in plain
+    assert "⚠" not in plain  # no alert glyph
+    assert "|" not in plain


### PR DESCRIPTION
## Summary

Ships the formatter half of the 2026-05-20 audit's "unified status bar" recommendation as a standalone, side-effect-free helper.

- New leaf module ``src/pollypm/cockpit_footer_status.py`` exposing ``render_footer_status(*, project_count, agent_count, inbox_count, alert=None, width=80) -> str``.
- Output shape: ``12 projects · 38 agents · 23 inbox  |  ⚠ heartbeat 26h offline``.
- Per-state color cues route through ``pollypm.cockpit_theme.State`` (counts → ``MUTED``; inbox flips to ``WAITING`` amber when > 0; alert chunk → ``BLOCKED`` red; separators → ``IDLE`` slate).
- Truncation cascade: full-labels → compact-counts (``12·38·23``) → alert-tail-ellipsis → alert-only layout (when counts + separator can't leave 4 chars of alert body) → empty for ``width <= 0``.
- 11 test functions pinning format, colors, plural noun resolution, width-budget invariants, and the layout-promotion ladder.

**Wiring is intentionally NOT in this PR.** The audit doc flagged the rail's footer rendering loop as the higher-risk surface to touch last; landing the pure formatter + tests independently lets future follow-ups adopt it from any candidate site (``PollyCockpitApp._update_hint``, ``cockpit_rail._format_event_ticker``, headless ``pm rail``) without re-deciding the format or risking the live cockpit Sam is monitoring.

## Test plan

- [x] Direct test runner executes all 11 assertions green: format, color cues, inbox amber/muted toggle, singular/plural nouns, compact-counts activation, ellipsis truncation, width budget for w∈{20,32,50,80,120}, alert-only promotion, ``width<=0`` no-render.
- [x] Module imports clean (no Textual / Rich deps; only stdlib + ``cockpit_theme``).
- [ ] CI pytest run.
- [ ] Future PR wires this into ``PollyCockpitApp._update_hint`` once Sam is at the keyboard to watch the rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)