### PR TITLE
feat(session-auth): emit PollyPM-Auth marker in watchdog briefs + recovery preamble (refs #2012)

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -3903,14 +3903,30 @@ def _brief_fallback(finding: Finding) -> list[str]:
     return lines
 
 
-def format_unstick_brief(finding: Finding) -> str:
+def format_unstick_brief(
+    finding: Finding,
+    *,
+    auth_token: str | None = None,
+) -> str:
     """Render a finding as a structured brief for the architect.
 
     Each rule produces a tailored brief — the framing is the same
     (``WATCHDOG ESCALATION`` header + structured fields + decision
     options) but the ``Observed evidence`` and ``Your job`` lines vary
     so the architect knows which lever to pull first.
+
+    #2012 — Lever 2 of the recovery cascade: when ``auth_token`` is
+    provided, the brief is prepended with
+    ``[PollyPM-Auth: <token>]\\n`` so the receiving agent can verify
+    the message originated from PollyPM (not a prompt-injection
+    attack). Sessions without a token (legacy / pre-migration) pass
+    ``None``/``""`` and the brief renders unchanged. The marker is
+    added LAST so call-site composition stays simple: every body
+    builder still works on plain text. See
+    :mod:`pollypm.session_auth` for the contract.
     """
+    from pollypm.session_auth import format_auth_marker
+
     project = finding.project or "<unknown>"
     subject = finding.subject or "<unknown>"
     meta = finding.metadata or {}
@@ -3938,4 +3954,6 @@ def format_unstick_brief(finding: Finding) -> str:
         lines.extend(_brief_worker_session_dead_loop(finding, subject, meta))
     else:
         lines.extend(_brief_fallback(finding))
-    return "\n".join(lines)
+    body = "\n".join(lines)
+    marker = format_auth_marker(auth_token)
+    return f"{marker}{body}" if marker else body

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -923,6 +923,25 @@ def load_config(path: Path = DEFAULT_CONFIG_PATH) -> PollyPMConfig:
         events=events,
         storage=storage,
     )
+    # PR #2018 review fix (id 4502598240): mint auth tokens for any
+    # session that lacks one, then persist back to disk. Without this,
+    # legacy sessions stay at auth_token="" and watchdog/recovery
+    # dispatch silently emits unsigned briefs (the advertised Lever 2
+    # signing is inactive). Idempotent — write_config only fires when
+    # ensure_session_auth_tokens actually minted a token.
+    try:
+        from pollypm.session_auth import ensure_session_auth_tokens
+        if ensure_session_auth_tokens(config):
+            try:
+                write_config(config, config_path, force=True)
+            except Exception:  # noqa: BLE001
+                # Persistence failure is non-fatal — tokens stay in
+                # memory for the rest of this process; next load_config
+                # call will re-mint and retry.
+                pass
+    except ImportError:
+        # session_auth not available (older code paths). Skip silently.
+        pass
     try:
         _config_cache[config_path] = (
             config_path.stat().st_mtime,

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -1249,12 +1249,57 @@ def _enrich_finding_metadata(
     )
 
 
+def _architect_auth_token(
+    config_path: Path | None, project_key: str,
+) -> str:
+    """Return the auth_token of the architect session for ``project_key``.
+
+    #2012 — Lever 2 of the recovery cascade. Loads the active config
+    (lazily; expensive, so callers should already be on the dispatch
+    leg) and walks ``config.sessions`` looking for ``architect_<key>``
+    or its underscore-alias form. Returns the empty string when:
+
+    * config cannot be loaded (corrupt, missing, racing rewrite),
+    * no architect session is configured for the project,
+    * the session exists but has no token yet (pre-migration).
+
+    The empty-string fallback is load-bearing: ``format_unstick_brief``
+    treats it the same as "no marker, render legacy shape", so a
+    misconfigured project keeps receiving briefs (just unauthenticated)
+    rather than silently dropping its dispatch path. The
+    ``ensure_session_auth_tokens`` helper migrates legacy sessions in
+    on the next ``write_config`` so the empty path is transient.
+    """
+    if not project_key:
+        return ""
+    try:
+        from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+    except Exception:  # noqa: BLE001
+        return ""
+    cfg_path = config_path or DEFAULT_CONFIG_PATH
+    try:
+        cfg = load_config(cfg_path)
+    except Exception:  # noqa: BLE001
+        return ""
+    sessions = getattr(cfg, "sessions", None) or {}
+    alias = project_key.replace("-", "_")
+    for candidate in (f"architect_{project_key}", f"architect_{alias}"):
+        session = sessions.get(candidate)
+        if session is None:
+            continue
+        token = getattr(session, "auth_token", "") or ""
+        if token:
+            return token
+    return ""
+
+
 def _maybe_dispatch_to_architect(
     finding: Finding,
     *,
     project_path: Path | None,
     storage_closet_name: str | None,
     now: datetime,
+    config_path: Path | None = None,
 ) -> str:
     """Apply throttle + emit + send brief. Returns a status code.
 
@@ -1263,6 +1308,11 @@ def _maybe_dispatch_to_architect(
     * ``"throttled"`` — already dispatched within the throttle window.
     * ``"dispatched"`` — brief sent successfully.
     * ``"send_failed"`` — emit ran, send-keys failed.
+
+    #2012 — when the architect session has an ``auth_token`` set, the
+    brief is signed with ``[PollyPM-Auth: <token>]`` so the agent can
+    distinguish it from a prompt-injection attack. Missing tokens fall
+    back to the legacy unsigned brief shape.
     """
     if finding.rule not in _DISPATCHABLE_RULES:
         return "skipped"
@@ -1280,7 +1330,8 @@ def _maybe_dispatch_to_architect(
         dedup_hash=dedup_hash,
     ):
         return "throttled"
-    brief = format_unstick_brief(finding)
+    auth_token = _architect_auth_token(config_path, finding.project)
+    brief = format_unstick_brief(finding, auth_token=auth_token)
     # Emit the dispatch event BEFORE the send so the throttle window
     # is engaged even if the send fails — otherwise a tmux outage would
     # cause every cadence tick to re-emit and re-attempt.
@@ -3255,6 +3306,7 @@ def _route_one_finding(
         project_path=project_path,
         storage_closet_name=storage_closet_name,
         now=now,
+        config_path=config_path,
     )
     if outcome == "dispatched":
         counters["dispatches_sent"] += 1

--- a/src/pollypm/recovery_prompt.py
+++ b/src/pollypm/recovery_prompt.py
@@ -59,12 +59,24 @@ class RecoveryPrompt:
     session_name: str = ""
     is_fallback: bool = False
     recovery_mode_banner: str = ""
+    # #2012 — Lever 2 of the recovery cascade. When the session has a
+    # configured ``auth_token``, the rendered preamble is prepended
+    # with ``[PollyPM-Auth: <token>]\\n`` so the receiving agent can
+    # distinguish a legitimate RECOVERY MODE injection from a prompt-
+    # injection attack. Empty/missing tokens omit the marker (the
+    # preamble renders identically to pre-Lever-2 behaviour).
+    auth_token: str = ""
 
     def render(self) -> str:
         """Render the full recovery prompt as text."""
+        from pollypm.session_auth import format_auth_marker
+
         if self.provider == ProviderKind.CODEX:
-            return _render_codex(self.sections, self.recovery_mode_banner, self.is_fallback)
-        return _render_claude(self.sections, self.recovery_mode_banner, self.is_fallback)
+            body = _render_codex(self.sections, self.recovery_mode_banner, self.is_fallback)
+        else:
+            body = _render_claude(self.sections, self.recovery_mode_banner, self.is_fallback)
+        marker = format_auth_marker(self.auth_token)
+        return f"{marker}{body}" if marker else body
 
     @property
     def total_chars(self) -> int:
@@ -223,6 +235,7 @@ def _build_from_checkpoint(
         checkpoint_id=checkpoint.checkpoint_id,
         session_name=checkpoint.session_name,
         recovery_mode_banner=recovery_mode_banner,
+        auth_token=_session_auth_token(config, session_name),
     )
 
 
@@ -333,6 +346,7 @@ def _build_fallback_prompt(
         provider=provider,
         is_fallback=True,
         recovery_mode_banner=recovery_mode_banner,
+        auth_token=_session_auth_token(config, session_name),
     )
 
 
@@ -563,6 +577,24 @@ def _live_git_state(
         parts.append("- Working tree clean")
 
     return "\n".join(parts) if len(parts) > 1 else ""
+
+
+def _session_auth_token(
+    config: PollyPMConfig, session_name: str | None,
+) -> str:
+    """Return the session's ``auth_token`` for Lever 2 (#2012) signing.
+
+    Empty string when the session isn't in config or has no token yet
+    — see :func:`pollypm.session_auth.format_auth_marker` for how the
+    empty case degrades to the un-marked legacy preamble.
+    """
+    if not session_name:
+        return ""
+    sessions = getattr(config, "sessions", None) or {}
+    session = sessions.get(session_name)
+    if session is None:
+        return ""
+    return getattr(session, "auth_token", "") or ""
 
 
 def _session_git_root(

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -212,10 +212,15 @@ path = "demo"
         config.sessions["architect_demo"].auth_token
         == "cafebabe1234567890cafebabe1234567890cafebabe1234567890cafebabe12"
     )
-    # Legacy session (no auth_token key) parses to empty string.
-    assert config.sessions["heartbeat"].auth_token == ""
+    # Legacy session (no auth_token key in TOML) is migrated by
+    # load_config: ``ensure_session_auth_tokens`` mints a fresh 64-char
+    # hex token. The persistence write happens in-place, so the loaded
+    # config carries the minted token and the file on disk is updated.
+    heartbeat_token = config.sessions["heartbeat"].auth_token
+    assert len(heartbeat_token) == 64, heartbeat_token
+    assert all(c in "0123456789abcdef" for c in heartbeat_token)
 
-    # Round-trip through write_config.
+    # Round-trip through write_config — both explicit and migrated tokens persist.
     output_path = tmp_path / "out.toml"
     write_config(config, output_path, force=True)
     rendered = output_path.read_text()
@@ -230,9 +235,79 @@ path = "demo"
         reloaded.sessions["architect_demo"].auth_token
         == config.sessions["architect_demo"].auth_token
     )
-    # Legacy session still has no marker emitted.
+    # Migrated heartbeat token is now emitted in the rendered TOML and
+    # stable across the load → write → load cycle.
     heartbeat_block = rendered.split("[sessions.heartbeat]")[1].split("[", 1)[0]
-    assert "auth_token" not in heartbeat_block, heartbeat_block
+    assert f'auth_token = "{heartbeat_token}"' in heartbeat_block, heartbeat_block
+    assert reloaded.sessions["heartbeat"].auth_token == heartbeat_token
+
+
+def test_load_config_migrates_missing_auth_tokens_in_place(tmp_path: Path) -> None:
+    """Real regression for PR #2018 review (id 4502846140).
+
+    ``load_config`` MUST mint tokens for any session missing one AND
+    persist them to disk, so watchdog/recovery dispatch never emits an
+    unsigned brief for a legacy session. Starts from a config where
+    every session lacks an ``auth_token`` key; asserts (a) the loaded
+    config has 64-char hex tokens for every session, (b) the on-disk
+    TOML now contains those tokens, (c) a second load returns the same
+    tokens (stable, not re-minted).
+    """
+    config_path = tmp_path / "pollypm.toml"
+    config_path.write_text(
+        """
+[project]
+name = "PollyPM"
+tmux_session = "pollypm"
+
+[pollypm]
+controller_account = "claude_primary"
+
+[accounts.claude_primary]
+provider = "claude"
+home = ".pollypm/homes/claude_primary"
+
+[sessions.heartbeat]
+role = "heartbeat-supervisor"
+provider = "claude"
+account = "claude_primary"
+cwd = "."
+
+[sessions.architect_demo]
+role = "architect"
+provider = "claude"
+account = "claude_primary"
+cwd = "."
+project = "demo"
+
+[projects.demo]
+path = "demo"
+"""
+    )
+    (tmp_path / "demo").mkdir()
+
+    # No auth_token keys in the source TOML.
+    assert "auth_token" not in config_path.read_text()
+
+    # First load_config: mints + persists.
+    config = load_config(config_path)
+    heartbeat = config.sessions["heartbeat"].auth_token
+    architect = config.sessions["architect_demo"].auth_token
+    assert len(heartbeat) == 64 and len(architect) == 64
+    assert heartbeat != architect  # per-session uniqueness
+
+    # File on disk now carries the tokens.
+    persisted = config_path.read_text()
+    assert f'auth_token = "{heartbeat}"' in persisted
+    assert f'auth_token = "{architect}"' in persisted
+
+    # Second load returns identical tokens (stable, no re-mint).
+    # Bypass the in-process cache so we actually re-read from disk.
+    import pollypm.config as config_mod
+    config_mod._config_cache.clear()
+    reloaded = load_config(config_path)
+    assert reloaded.sessions["heartbeat"].auth_token == heartbeat
+    assert reloaded.sessions["architect_demo"].auth_token == architect
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session_auth_emit.py
+++ b/tests/test_session_auth_emit.py
@@ -1,0 +1,325 @@
+"""Lever 2 (#2012) emit-side tests — PR 2.
+
+Verifies that ``format_unstick_brief`` and the ``RecoveryPrompt``
+renderer prepend ``[PollyPM-Auth: <token>]\\n`` when a token is
+provided, and render the legacy un-marked shape when not. Also covers
+the dispatcher helper that looks up the architect session's token by
+project key.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pollypm.audit.watchdog import (
+    Finding,
+    RULE_STUCK_DRAFT,
+    RULE_TASK_ON_HOLD_STALE,
+    format_unstick_brief,
+)
+from pollypm.models import (
+    AccountConfig,
+    KnownProject,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectKind,
+    ProjectSettings,
+    ProviderKind,
+    SessionConfig,
+)
+from pollypm.recovery_prompt import (
+    RecoveryPrompt,
+    RecoveryPromptSection,
+    _session_auth_token,
+    build_recovery_prompt,
+)
+from pollypm.session_auth import AUTH_MARKER_PREFIX
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _config_with_sessions(
+    tmp_path: Path,
+    *,
+    architect_token: str = "",
+    architect_alias: str = "demo",
+) -> PollyPMConfig:
+    root = tmp_path / "repo"
+    root.mkdir()
+    return PollyPMConfig(
+        project=ProjectSettings(
+            root_dir=root,
+            base_dir=root / ".pollypm",
+            logs_dir=root / ".pollypm/logs",
+            snapshots_dir=root / ".pollypm/snapshots",
+            state_db=root / ".pollypm/state.db",
+        ),
+        pollypm=PollyPMSettings(controller_account="acc"),
+        accounts={
+            "acc": AccountConfig(
+                name="acc", provider=ProviderKind.CLAUDE,
+                home=root / ".pollypm" / "homes" / "acc",
+            ),
+        },
+        sessions={
+            f"architect_{architect_alias}": SessionConfig(
+                name=f"architect_{architect_alias}", role="architect",
+                provider=ProviderKind.CLAUDE, account="acc", cwd=root,
+                project=architect_alias,
+                auth_token=architect_token,
+            ),
+        },
+        projects={
+            architect_alias: KnownProject(
+                key=architect_alias, path=root, name="Demo",
+                kind=ProjectKind.FOLDER,
+            ),
+        },
+    )
+
+
+def _stuck_draft_finding() -> Finding:
+    return Finding(
+        rule=RULE_STUCK_DRAFT,
+        project="pollypm",
+        subject="pollypm/29",
+        message="Draft task pollypm/29 has sat unpromoted for >30 min.",
+        recommendation=(
+            "Promote with `pm task queue pollypm/29` or discard "
+            "with `pm task cancel pollypm/29`."
+        ),
+        metadata={"detected_via": "state"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# format_unstick_brief — auth marker
+# ---------------------------------------------------------------------------
+
+
+def test_brief_unmarked_when_token_missing() -> None:
+    """No token / empty token -> legacy un-marked brief shape.
+
+    The receiving agent currently in flight must still be able to act
+    on briefs emitted before any token landed; the legacy shape is the
+    fallback PR 1 documented in the contract.
+    """
+    brief = format_unstick_brief(_stuck_draft_finding())
+    assert "WATCHDOG ESCALATION" in brief
+    assert AUTH_MARKER_PREFIX not in brief
+
+    # Empty string and None must both yield the same legacy shape.
+    assert format_unstick_brief(_stuck_draft_finding(), auth_token="") == brief
+    assert format_unstick_brief(_stuck_draft_finding(), auth_token=None) == brief
+
+
+def test_brief_signed_when_token_present() -> None:
+    """A real token is prepended with the marker before the header.
+
+    Once the marker lands the agent's contract block (PR 1) recognises
+    the message as a legitimate PollyPM dispatch and will execute its
+    ACTION REQUIRED instructions instead of refusing.
+    """
+    token = "deadbeef" * 8
+    brief = format_unstick_brief(_stuck_draft_finding(), auth_token=token)
+    assert brief.startswith(f"{AUTH_MARKER_PREFIX}{token}]\n")
+    assert "WATCHDOG ESCALATION" in brief
+    # The body still satisfies the imperative-format invariant from #1979.
+    assert "ACTION REQUIRED" in brief
+
+
+def test_brief_marker_distinct_per_token() -> None:
+    """Different tokens produce different markers — the per-session
+    secret is load-bearing for distinguishing one architect from
+    another."""
+    f = _stuck_draft_finding()
+    t1 = "1" * 64
+    t2 = "2" * 64
+    b1 = format_unstick_brief(f, auth_token=t1)
+    b2 = format_unstick_brief(f, auth_token=t2)
+    assert b1 != b2
+    assert t1 in b1 and t1 not in b2
+    assert t2 in b2 and t2 not in b1
+
+
+def test_brief_marker_lands_before_header_line() -> None:
+    """The marker prefixes the whole brief — the ``WATCHDOG ESCALATION``
+    line that the agent's tooling greps for must not move past the
+    first line of output, so the marker uses a trailing ``\\n`` (not a
+    leading one) and the header stays on line 2."""
+    brief = format_unstick_brief(
+        _stuck_draft_finding(), auth_token="c" * 64,
+    )
+    lines = brief.split("\n")
+    assert lines[0].startswith(AUTH_MARKER_PREFIX)
+    assert lines[1] == "WATCHDOG ESCALATION"
+
+
+def test_brief_marker_with_tier2_template() -> None:
+    """Tier-2 template (``task_on_hold_stale``) is signed too.
+
+    The marker logic lives at the bottom of ``format_unstick_brief``
+    after the per-rule body builder runs, so every rule template
+    (fallback + tier-2 templates) is covered by one composition site.
+    """
+    finding = Finding(
+        rule=RULE_TASK_ON_HOLD_STALE,
+        project="demo",
+        subject="demo/7",
+        message="Task demo/7 has been at status=on_hold for ~30 min.",
+        metadata={"routing": "architect-actionable"},
+    )
+    brief = format_unstick_brief(finding, auth_token="d" * 64)
+    assert brief.startswith(AUTH_MARKER_PREFIX + ("d" * 64))
+    assert "WATCHDOG ESCALATION" in brief
+
+
+# ---------------------------------------------------------------------------
+# RecoveryPrompt — auth marker
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_prompt_unsigned_when_token_empty() -> None:
+    """Default RecoveryPrompt has no token -> legacy shape."""
+    prompt = RecoveryPrompt(
+        sections=[RecoveryPromptSection(key="x", heading="Test", content="hi")],
+        provider=ProviderKind.CLAUDE,
+    )
+    rendered = prompt.render()
+    assert AUTH_MARKER_PREFIX not in rendered
+
+
+def test_recovery_prompt_signed_when_token_set() -> None:
+    """auth_token field on RecoveryPrompt prepends the marker."""
+    token = "e" * 64
+    prompt = RecoveryPrompt(
+        sections=[RecoveryPromptSection(key="x", heading="Test", content="hi")],
+        provider=ProviderKind.CLAUDE,
+        auth_token=token,
+    )
+    rendered = prompt.render()
+    assert rendered.startswith(f"{AUTH_MARKER_PREFIX}{token}]\n")
+
+
+def test_recovery_prompt_signed_for_codex_provider() -> None:
+    """Both Claude and Codex preambles get the marker — the contract
+    doesn't gate on provider."""
+    token = "f" * 64
+    prompt = RecoveryPrompt(
+        sections=[RecoveryPromptSection(key="x", heading="Test", content="hi")],
+        provider=ProviderKind.CODEX,
+        auth_token=token,
+    )
+    rendered = prompt.render()
+    assert rendered.startswith(f"{AUTH_MARKER_PREFIX}{token}]\n")
+    assert "RECOVERY CONTEXT" in rendered
+
+
+# ---------------------------------------------------------------------------
+# build_recovery_prompt threads session.auth_token
+# ---------------------------------------------------------------------------
+
+
+def test_build_recovery_prompt_threads_session_token(tmp_path: Path) -> None:
+    """The fallback build path pulls ``auth_token`` from
+    ``config.sessions[session_name]`` so the rendered preamble carries
+    the marker without callers having to plumb it themselves."""
+    token = "abcdef00" * 8
+    config = _config_with_sessions(
+        tmp_path, architect_token=token, architect_alias="demo",
+    )
+    prompt = build_recovery_prompt(
+        config, session_name="architect_demo",
+        project_key="demo", task_prompt="do the thing",
+    )
+    rendered = prompt.render()
+    assert rendered.startswith(f"{AUTH_MARKER_PREFIX}{token}]\n")
+    assert prompt.is_fallback is True
+
+
+def test_build_recovery_prompt_no_token_renders_legacy(
+    tmp_path: Path,
+) -> None:
+    """Session with no auth_token -> preamble renders without marker.
+
+    Backward compat invariant: sessions launched before Lever 2
+    migrated continue to receive the un-marked recovery preamble until
+    the next ``write_config`` mints them a token.
+    """
+    config = _config_with_sessions(
+        tmp_path, architect_token="", architect_alias="demo",
+    )
+    prompt = build_recovery_prompt(
+        config, session_name="architect_demo",
+        project_key="demo", task_prompt="do the thing",
+    )
+    rendered = prompt.render()
+    assert AUTH_MARKER_PREFIX not in rendered
+
+
+def test_session_auth_token_lookup_returns_empty_for_unknown(
+    tmp_path: Path,
+) -> None:
+    config = _config_with_sessions(tmp_path)
+    assert _session_auth_token(config, "ghost_session") == ""
+    assert _session_auth_token(config, None) == ""
+    assert _session_auth_token(config, "") == ""
+
+
+# ---------------------------------------------------------------------------
+# _architect_auth_token (dispatcher helper)
+# ---------------------------------------------------------------------------
+
+
+def test_architect_auth_token_returns_token_for_configured_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dispatcher helper loads the config and returns the
+    architect session's token. Smoke-tests the integration boundary;
+    the unit-level marker formatting is covered above."""
+    from pollypm.config import write_config
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _architect_auth_token,
+    )
+
+    token = "01" * 32
+    config = _config_with_sessions(
+        tmp_path, architect_token=token, architect_alias="demo",
+    )
+    # Add the boilerplate that ``write_config`` expects.
+    config_path = tmp_path / "pollypm.toml"
+    write_config(config, config_path, force=True)
+
+    looked_up = _architect_auth_token(config_path, "demo")
+    assert looked_up == token
+
+
+def test_architect_auth_token_returns_empty_for_unknown_project(
+    tmp_path: Path,
+) -> None:
+    from pollypm.config import write_config
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _architect_auth_token,
+    )
+
+    config = _config_with_sessions(
+        tmp_path, architect_token="ff" * 32, architect_alias="demo",
+    )
+    config_path = tmp_path / "pollypm.toml"
+    write_config(config, config_path, force=True)
+
+    assert _architect_auth_token(config_path, "no_such_project") == ""
+
+
+def test_architect_auth_token_handles_missing_config(tmp_path: Path) -> None:
+    """Missing config path -> empty string fallback (no crash)."""
+    from pollypm.plugins_builtin.core_recurring.audit_watchdog import (
+        _architect_auth_token,
+    )
+
+    assert _architect_auth_token(tmp_path / "nonexistent.toml", "demo") == ""


### PR DESCRIPTION
## Summary

PR 2 of Lever 2 of the recovery-cascade fix (#2012). Builds on #2017 (PR 1: storage + prompt contract). Stacked: merge #2017 first.

Turns on emit-side signing now that the storage and prompt contract are in place:

- `format_unstick_brief(finding, *, auth_token=None)` — when a token is supplied, the brief is prepended with `[PollyPM-Auth: <token>]\n` so the agent's contract block (PR 1) recognises the dispatch as authentic. Missing/empty tokens render the legacy un-marked shape (byte-for-byte identical to pre-Lever-2 output).
- `RecoveryPrompt.auth_token` + renderer marker. `build_recovery_prompt` threads the token from `config.sessions[session_name].auth_token`.
- `_maybe_dispatch_to_architect` looks up the architect session's token via `_architect_auth_token(config_path, project_key)` (walks `architect_<project>` and the underscore-alias form) and passes it to `format_unstick_brief`.

## Backward compat

Sessions without a token (legacy / pre-migration) trigger the empty-string fallback in `format_auth_marker`, so the brief renders unchanged. `ensure_session_auth_tokens` migrates them in on next `write_config`.

## Test plan

- [x] Brief is unsigned when no token is supplied (empty string and None)
- [x] Brief is signed with the literal marker when a token is supplied
- [x] Marker prefixes the brief — `WATCHDOG ESCALATION` lands on line 1, not line 0
- [x] Different tokens produce different markers (per-session secret is load-bearing)
- [x] Tier-2 template (`task_on_hold_stale`) is signed (composition site is rule-agnostic)
- [x] `RecoveryPrompt` signs for both Claude and Codex providers
- [x] `build_recovery_prompt` threads `session.auth_token` end-to-end
- [x] `_architect_auth_token` returns token for configured project, "" for unknown project / missing config

🤖 Generated with [Claude Code](https://claude.com/claude-code)