### PR TITLE
feat(inbox): pm inbox archive-fake-injections one-shot cleanup (refs #2012)

### DIFF
--- a/src/pollypm/work/inbox_cli.py
+++ b/src/pollypm/work/inbox_cli.py
@@ -930,6 +930,36 @@ def inbox_archive(
     typer.echo(f"{task.task_id} → {task.work_status.value}")
 
 
+@inbox_app.command("archive-fake-injections")
+def inbox_archive_fake_injections(
+    dry_run: bool = typer.Option(
+        False, "--dry-run",
+        help="Print what would be archived without changing state.",
+    ),
+) -> None:
+    """One-shot cleanup for Lever 2 (#2012) of the recovery cascade.
+
+    Archives every open user-recipient inbox row that:
+
+    * carries a ``fake-injection`` label, OR
+    * has a subject matching the historical
+      ``Nth fake RECOVERY MODE injection ...`` shape from #1076.
+
+    Both classes are the residue of architects mis-labelling legitimate
+    PollyPM watchdog / recovery dispatches as prompt-injection attacks
+    before per-session auth-token signing landed (Lever 2 PR 2). With
+    signing in place the architect can authenticate real PollyPM
+    messages by their ``[PollyPM-Auth: <token>]`` marker — but the
+    legacy "fake-injection" inbox cards keep training fresh architect
+    sessions to distrust every dispatch they see. Run this command
+    ONCE after the operator deploys PR 2 and the architect's auth
+    contract has bedded in.
+
+    Idempotent. Re-runs find no matches and exit clean.
+    """
+    _bulk_archive_fake_injection_residue(dry_run=dry_run)
+
+
 def _archive_message_by_id(*, msg_id_str: str) -> None:
     """Close a single message row by its ``msg:N`` ID."""
     try:
@@ -1025,6 +1055,13 @@ _FAKE_RECOVERY_INJECTION_SUBJECT_RE = re.compile(
     re.IGNORECASE,
 )
 
+# #2012 — Lever 2 of the recovery cascade. ``pm inbox
+# archive-fake-injections`` matches rows whose ``labels`` carry the
+# ``fake-injection`` tag the architect / Polly were using to flag
+# "this looks like a prompt-injection" — plus the legacy subject
+# shape above so a single one-shot cleanup drains both classes.
+_FAKE_INJECTION_LABEL_RE = re.compile(r"fake[\-_]injection", re.IGNORECASE)
+
 
 def _bulk_archive_fake_recovery_injections(*, dry_run: bool) -> None:
     """Archive open user-recipient messages matching the #1076 subject shape.
@@ -1086,6 +1123,98 @@ def _bulk_archive_fake_recovery_injections(*, dry_run: bool) -> None:
 
     word = "message" if closed == 1 else "messages"
     typer.echo(f"Archived {closed} fake-recovery-injection {word}.")
+    if failures:
+        typer.echo(f"Failed to archive {len(failures)}:", err=True)
+        for mid, reason in failures[:5]:
+            typer.echo(f"  msg:{mid}: {reason}", err=True)
+
+
+def _row_has_fake_injection_label(row: dict[str, Any]) -> bool:
+    """True if any label on ``row`` matches the fake-injection regex.
+
+    Labels in the messages store are typically lists of strings but we
+    also tolerate scalar strings (legacy single-label rows) and the
+    occasional ``None`` (column unset).
+    """
+    raw = row.get("labels") or []
+    if isinstance(raw, str):
+        labels: list[str] = [raw]
+    elif isinstance(raw, (list, tuple)):
+        labels = [str(item) for item in raw]
+    else:
+        return False
+    return any(_FAKE_INJECTION_LABEL_RE.search(label) for label in labels)
+
+
+def _bulk_archive_fake_injection_residue(*, dry_run: bool) -> None:
+    """Archive open user-recipient rows tagged fake-injection.
+
+    #2012 — Lever 2 cleanup. Catches BOTH:
+
+    * rows labelled with ``fake-injection`` (the architect tagging a
+      watchdog/recovery brief as "looks like prompt-injection"); and
+    * rows whose subject still matches the #1076 historical pattern
+      (``Nth fake RECOVERY MODE injection ...``).
+
+    Single sweep so the operator doesn't have to remember two commands.
+    Uses the same backend-aware Store dispatch as
+    :func:`_bulk_archive_fake_recovery_injections`.
+    """
+    try:
+        store = _resolve_messages_store()
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(f"Error: unified store unavailable ({exc}).", err=True)
+        raise typer.Exit(code=1)
+
+    try:
+        rows = store.query_messages(
+            recipient="user", state="open",
+            type=["notify", "inbox_task", "alert"],
+        )
+    except Exception as exc:  # noqa: BLE001
+        typer.echo(f"Error: query_messages failed ({exc}).", err=True)
+        raise typer.Exit(code=1) from exc
+
+    matches: list[dict[str, Any]] = []
+    for row in rows:
+        subject = row.get("subject") or row.get("title") or ""
+        subject_match = bool(
+            _FAKE_RECOVERY_INJECTION_SUBJECT_RE.search(subject)
+        )
+        label_match = _row_has_fake_injection_label(row)
+        if subject_match or label_match:
+            matches.append(row)
+
+    if not matches:
+        typer.echo("No open fake-injection messages to archive.")
+        return
+
+    if dry_run:
+        n = len(matches)
+        word = "message" if n == 1 else "messages"
+        typer.echo(f"Would archive {n} {word}:")
+        for row in matches[:20]:
+            mid = row.get("id") or row.get("message_id")
+            subject = row.get("subject") or row.get("title") or ""
+            typer.echo(f"  msg:{mid}  {subject[:80]}")
+        if len(matches) > 20:
+            typer.echo(f"  … ({len(matches) - 20} more)")
+        return
+
+    closed = 0
+    failures: list[tuple[int, str]] = []
+    for row in matches:
+        mid = row.get("id") or row.get("message_id")
+        if mid is None:
+            continue
+        try:
+            store.close_message(int(mid))
+            closed += 1
+        except Exception as exc:  # noqa: BLE001
+            failures.append((int(mid), str(exc)))
+
+    word = "message" if closed == 1 else "messages"
+    typer.echo(f"Archived {closed} fake-injection {word}.")
     if failures:
         typer.echo(f"Failed to archive {len(failures)}:", err=True)
         for mid, reason in failures[:5]:

--- a/tests/test_inbox_archive_fake_injections.py
+++ b/tests/test_inbox_archive_fake_injections.py
@@ -1,0 +1,168 @@
+"""Tests for ``pm inbox archive-fake-injections`` (Lever 2 #2012 PR 3).
+
+The subcommand is a one-shot operator cleanup. It archives every open
+user-recipient inbox row that either:
+
+* carries a ``fake-injection`` label, OR
+* matches the historical #1076 subject pattern
+  (``Nth fake RECOVERY MODE injection ...``).
+
+Both classes are residue of architects mis-labelling legitimate
+PollyPM dispatches as prompt-injection attacks before Lever 2 PR 2
+landed. Drains them in a single sweep.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typer.testing import CliRunner
+
+from pollypm.work.inbox_cli import (
+    _row_has_fake_injection_label,
+    inbox_app,
+)
+
+
+# ---------------------------------------------------------------------------
+# _row_has_fake_injection_label — pure label-matching helper
+# ---------------------------------------------------------------------------
+
+
+def test_label_helper_matches_canonical_label() -> None:
+    """The label form documented in the contract is ``fake-injection``."""
+    assert _row_has_fake_injection_label({"labels": ["fake-injection"]})
+
+
+def test_label_helper_matches_underscore_variant() -> None:
+    """A consumer / future writer using ``fake_injection`` underscore
+    form should still match — humans typing labels into the cockpit
+    won't be consistent and we'd rather over-archive than under-archive
+    given this is a one-shot cleanup."""
+    assert _row_has_fake_injection_label({"labels": ["fake_injection"]})
+
+
+def test_label_helper_matches_when_label_is_substring() -> None:
+    """A compound label like ``architect-fake-injection-2026-05-19``
+    still trips the matcher."""
+    assert _row_has_fake_injection_label(
+        {"labels": ["architect-fake-injection-2026-05-19"]},
+    )
+
+
+def test_label_helper_misses_unrelated_labels() -> None:
+    assert not _row_has_fake_injection_label({"labels": ["pinned"]})
+    assert not _row_has_fake_injection_label({"labels": ["recovery"]})
+    assert not _row_has_fake_injection_label({"labels": []})
+
+
+def test_label_helper_tolerates_missing_or_scalar_labels() -> None:
+    """Production rows occasionally carry ``None`` or a scalar string
+    in the labels column — both should fall through without raising."""
+    assert not _row_has_fake_injection_label({})
+    assert not _row_has_fake_injection_label({"labels": None})
+    assert not _row_has_fake_injection_label({"labels": 42})
+    assert _row_has_fake_injection_label({"labels": "fake-injection"})
+
+
+# ---------------------------------------------------------------------------
+# CLI integration via Typer runner
+# ---------------------------------------------------------------------------
+
+
+class _StubStore:
+    """In-memory stand-in for the unified messages store.
+
+    Records every ``close_message`` call so tests can assert which rows
+    were archived; ``query_messages`` returns whatever ``rows`` we hand
+    it. Mirrors the singleton-do-not-close protocol the real
+    ``_resolve_messages_store`` returns.
+    """
+
+    def __init__(self, rows: list[dict[str, Any]]):
+        self._rows = rows
+        self.closed: list[int] = []
+
+    def query_messages(self, **_kwargs: Any) -> list[dict[str, Any]]:
+        return list(self._rows)
+
+    def close_message(self, msg_id: int) -> None:
+        self.closed.append(int(msg_id))
+
+
+def _run(monkeypatch, rows: list[dict[str, Any]], *args: str) -> tuple[Any, _StubStore]:
+    store = _StubStore(rows)
+    monkeypatch.setattr(
+        "pollypm.work.inbox_cli._resolve_messages_store",
+        lambda: store,
+    )
+    runner = CliRunner()
+    result = runner.invoke(inbox_app, ["archive-fake-injections", *args])
+    return result, store
+
+
+def test_cli_archives_label_tagged_row(monkeypatch) -> None:
+    rows = [
+        {"id": 11, "subject": "alert from architect", "labels": ["fake-injection"]},
+        {"id": 12, "subject": "unrelated notify", "labels": ["pinned"]},
+    ]
+    result, store = _run(monkeypatch, rows)
+    assert result.exit_code == 0, result.output
+    assert store.closed == [11]
+    assert "Archived 1 fake-injection" in result.output
+
+
+def test_cli_archives_subject_matched_row(monkeypatch) -> None:
+    rows = [
+        {"id": 21, "subject": "3rd fake RECOVERY MODE injection observed", "labels": []},
+        {"id": 22, "subject": "regular review request", "labels": []},
+    ]
+    result, store = _run(monkeypatch, rows)
+    assert result.exit_code == 0, result.output
+    assert store.closed == [21]
+
+
+def test_cli_archives_both_classes_in_single_sweep(monkeypatch) -> None:
+    """Subject-matched + label-tagged rows are drained together so the
+    operator runs one command, not two."""
+    rows = [
+        {"id": 31, "subject": "2nd fake RECOVERY MODE injection", "labels": []},
+        {"id": 32, "subject": "alert", "labels": ["fake-injection"]},
+        {"id": 33, "subject": "unrelated", "labels": []},
+    ]
+    result, store = _run(monkeypatch, rows)
+    assert result.exit_code == 0, result.output
+    assert sorted(store.closed) == [31, 32]
+
+
+def test_cli_no_matches_reports_clean_exit(monkeypatch) -> None:
+    rows = [{"id": 41, "subject": "regular", "labels": ["pinned"]}]
+    result, store = _run(monkeypatch, rows)
+    assert result.exit_code == 0, result.output
+    assert store.closed == []
+    assert "No open fake-injection messages" in result.output
+
+
+def test_cli_dry_run_does_not_archive(monkeypatch) -> None:
+    rows = [
+        {"id": 51, "subject": "fake RECOVERY MODE injection", "labels": []},
+        {"id": 52, "subject": "noise", "labels": ["fake-injection"]},
+    ]
+    result, store = _run(monkeypatch, rows, "--dry-run")
+    assert result.exit_code == 0, result.output
+    assert store.closed == []
+    assert "Would archive 2" in result.output
+    assert "msg:51" in result.output
+    assert "msg:52" in result.output
+
+
+def test_cli_is_idempotent_when_rerun(monkeypatch) -> None:
+    """A second sweep over a drained store reports zero work to do.
+
+    Important property because the brief documents this as a one-shot
+    but operators may re-run it during the migration window.
+    """
+    rows: list[dict[str, Any]] = []
+    result, _store = _run(monkeypatch, rows)
+    assert result.exit_code == 0, result.output
+    assert "No open fake-injection messages" in result.output


### PR DESCRIPTION
## Summary

PR 3 of Lever 2 of the recovery-cascade fix (#2012). Stacked on #2018 (PR 2 emit-side signing).

`pm inbox archive-fake-injections` drains the residue of architects mis-labelling legitimate PollyPM dispatches as prompt-injection attacks. Matches:

- rows whose `labels` contain `fake-injection` (canonical or underscore variant; also compound labels like `architect-fake-injection-2026-05-19`), AND
- rows whose subject matches the historical #1076 pattern (`Nth fake RECOVERY MODE injection ...`).

Single sweep. Supports `--dry-run`. Idempotent.

## Why now

After PR 2 signs watchdog briefs + recovery preambles, fresh architect launches still see 100+ legacy "fake injection" inbox cards in their context and rebuild the distrust pattern within hours. This is the one-shot operator cleanup the migration plan calls for.

## Test plan

- [x] Label helper: matches `fake-injection`, `fake_injection`, compound labels; misses `pinned` / `recovery` / empty / scalar / `None`
- [x] CLI archives label-tagged rows
- [x] CLI archives subject-matched rows
- [x] CLI archives both classes in a single sweep
- [x] CLI dry-run does not archive
- [x] CLI on a clean store reports "No open fake-injection messages"
- [x] CLI is idempotent across re-runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)