### PR TITLE
fix(watchdog): dedupe escalations by root_cause_hash not subject (closes #2015)

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -3036,15 +3036,38 @@ def dispatch_dedup_hash(finding: Finding) -> str:
     ``subject`` / ``message`` / ``recommendation`` (the latter two are
     cosmetic copy).
 
+    **Fallback for detectors without ``evidence`` (PR #2020 review).**
+    Most detector paths populate ``metadata`` but not ``evidence``
+    (``stuck_draft`` being the canonical case). Collapsing on
+    rule+project alone would over-dedupe genuinely different findings
+    that happen to share a rule. So:
+
+    1. If ``finding.evidence`` is non-empty, hash rule + project +
+       canonical evidence JSON (the intended #2015 behavior — collapse
+       sibling subjects whose bodies are identical).
+    2. Else if ``finding.metadata`` carries a stable root-cause key
+       (``root_cause_hash`` or ``dedup_key``), hash that instead. This
+       lets a detector opt into root-cause dedup without copying its
+       evidence shape — used by tier-4 callers that already computed
+       a stable hash upstream.
+    3. Else fall back to including ``subject`` in the hash — i.e.
+       legacy single-finding-per-subject behavior. With nothing
+       structured to compare, subject is the only signal that
+       distinguishes ``demo/1`` from ``demo/2``, and we must not
+       collapse them.
+
     Stable across:
         - Different ``subject`` (the whole point — same root cause
-          across sibling draft tasks).
+          across sibling draft tasks), **iff** ``evidence`` is
+          populated (path 1) or a metadata key is provided (path 2).
         - Different ``message`` / ``recommendation`` text.
         - Re-ordering of keys inside ``evidence``.
 
     Sensitive to:
         - Different ``rule`` or ``project``.
         - Any structural change to the ``evidence`` payload.
+        - ``subject`` when neither ``evidence`` nor a metadata
+          dedup key is present (fallback path 3).
 
     16-hex-char output matches :func:`root_cause_hash` for symmetry;
     collision resistance is fine for the cardinality the throttle sees
@@ -3055,17 +3078,43 @@ def dispatch_dedup_hash(finding: Finding) -> str:
     evidence_raw = getattr(finding, "evidence", None) or {}
     if not isinstance(evidence_raw, dict):
         evidence_raw = {}
-    try:
-        evidence_json = json.dumps(
-            evidence_raw,
-            sort_keys=True,
-            ensure_ascii=False,
-            default=str,
-            separators=(",", ":"),
-        )
-    except (TypeError, ValueError):
-        evidence_json = ""
-    canonical = "|".join([rule, project, evidence_json])
+    metadata_raw = getattr(finding, "metadata", None) or {}
+    if not isinstance(metadata_raw, dict):
+        metadata_raw = {}
+
+    # Path 1: structured evidence wins — collapse across sibling subjects.
+    if evidence_raw:
+        try:
+            evidence_json = json.dumps(
+                evidence_raw,
+                sort_keys=True,
+                ensure_ascii=False,
+                default=str,
+                separators=(",", ":"),
+            )
+        except (TypeError, ValueError):
+            evidence_json = ""
+        canonical = "|".join(["v1", rule, project, evidence_json])
+    else:
+        # Path 2: opt-in via a stable metadata key (root_cause_hash /
+        # dedup_key). Lets a detector dedupe across subjects without
+        # populating evidence.
+        meta_key = ""
+        for candidate in ("root_cause_hash", "dedup_key"):
+            value = metadata_raw.get(candidate)
+            if isinstance(value, str) and value:
+                meta_key = f"{candidate}={value}"
+                break
+        if meta_key:
+            canonical = "|".join(["meta", rule, project, meta_key])
+        else:
+            # Path 3: fallback. No structured body — subject is the
+            # only signal that distinguishes findings. Including it
+            # restores legacy single-finding-per-subject behavior and
+            # prevents the throttle from suppressing distinct
+            # watchdog dispatches (PR #2020 review).
+            subject = str(getattr(finding, "subject", "") or "")
+            canonical = "|".join(["subj", rule, project, subject])
     digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
     return digest[:16]
 

--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -57,6 +57,8 @@ notice when it stops) — the cadence handler calls
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import re
 from dataclasses import dataclass, field
@@ -113,6 +115,7 @@ __all__ = [
     "emit_finding",
     "emit_escalation_dispatched",
     "emit_operator_dispatched",
+    "dispatch_dedup_hash",
     "format_unstick_brief",
     "tier_handoff_prompt",
     "build_urgent_human_handoff",
@@ -3014,6 +3017,59 @@ def emit_finding(finding: Finding) -> None:
 # ---------------------------------------------------------------------------
 
 
+def dispatch_dedup_hash(finding: Finding) -> str:
+    """Subject-independent dedup hash for the dispatch throttle (#2015).
+
+    Distinct from :func:`pollypm.audit.tier4.root_cause_hash` — that
+    hash includes ``subject`` because the tier-4 promotion tracker
+    keys per-task accounting on the hash and needs different tasks to
+    accumulate independent dispatch histories.
+
+    The dispatch throttle has the opposite requirement: when the same
+    root-cause spawns multiple draft tasks (samblog/32-35 burst from
+    the 2026-05-19 architect cascade), each task has a different
+    ``subject`` but the operator sees four inbox entries asking the
+    same question with identical evidence. The throttle must collapse
+    those into one dispatch per window, so we hash only the fields
+    that identify the *finding body* — rule, project, and the
+    structured ``evidence`` payload — and deliberately exclude
+    ``subject`` / ``message`` / ``recommendation`` (the latter two are
+    cosmetic copy).
+
+    Stable across:
+        - Different ``subject`` (the whole point — same root cause
+          across sibling draft tasks).
+        - Different ``message`` / ``recommendation`` text.
+        - Re-ordering of keys inside ``evidence``.
+
+    Sensitive to:
+        - Different ``rule`` or ``project``.
+        - Any structural change to the ``evidence`` payload.
+
+    16-hex-char output matches :func:`root_cause_hash` for symmetry;
+    collision resistance is fine for the cardinality the throttle sees
+    (a handful of distinct finding bodies per project per day).
+    """
+    rule = str(getattr(finding, "rule", "") or "")
+    project = str(getattr(finding, "project", "") or "")
+    evidence_raw = getattr(finding, "evidence", None) or {}
+    if not isinstance(evidence_raw, dict):
+        evidence_raw = {}
+    try:
+        evidence_json = json.dumps(
+            evidence_raw,
+            sort_keys=True,
+            ensure_ascii=False,
+            default=str,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError):
+        evidence_json = ""
+    canonical = "|".join([rule, project, evidence_json])
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
 def was_recently_dispatched(
     *,
     project: str,
@@ -3022,6 +3078,7 @@ def was_recently_dispatched(
     now: datetime,
     project_path: Path | str | None = None,
     throttle_seconds: int = ESCALATION_THROTTLE_SECONDS,
+    dedup_hash: str | None = None,
 ) -> bool:
     """Return True iff the audit log shows a matching dispatch in-window.
 
@@ -3029,7 +3086,15 @@ def was_recently_dispatched(
     heartbeat-process restart doesn't reset the dedup window. We scan
     ``EVENT_WATCHDOG_ESCALATION_DISPATCHED`` for the project in the last
     ``throttle_seconds`` and look for a row whose metadata.finding_type
-    and subject both match.
+    matches.
+
+    #2015 — when ``dedup_hash`` is supplied we match on
+    ``metadata.dedup_hash`` so the same finding body across sibling
+    subjects (samblog/32, /33, /34, /35) collapses into one dispatch
+    per window. The ``subject`` arg stays for forensic logging /
+    back-compat with rows emitted by pre-#2015 versions which have no
+    ``dedup_hash`` in metadata — for those we fall back to the
+    pre-fix subject match so old throttle windows still hold.
     """
     from pollypm.audit.log import read_events
 
@@ -3048,10 +3113,17 @@ def was_recently_dispatched(
         return False
     for ev in recent:
         meta = ev.metadata or {}
-        if (
-            meta.get("finding_type") == finding_type
-            and (ev.subject == subject or meta.get("subject") == subject)
-        ):
+        if meta.get("finding_type") != finding_type:
+            continue
+        # #2015 — prefer dedup_hash when both sides have one; fall
+        # back to subject match for legacy rows.
+        ev_hash = meta.get("dedup_hash") or ""
+        if dedup_hash and ev_hash:
+            if ev_hash == dedup_hash:
+                return True
+            continue
+        # Legacy / no-hash path — original subject-based match.
+        if ev.subject == subject or meta.get("subject") == subject:
             return True
     return False
 
@@ -3063,12 +3135,16 @@ def emit_escalation_dispatched(
     subject: str,
     brief: str,
     project_path: Path | str | None = None,
+    dedup_hash: str = "",
 ) -> None:
     """Emit a ``watchdog.escalation_dispatched`` event.
 
     The metadata carries enough to reconstruct the dispatch decision:
-    finding_type, subject, and the brief that was sent. Best-effort —
-    never raises.
+    finding_type, subject, and the brief that was sent. #2015 — also
+    carries ``dedup_hash`` (the subject-independent finding-body hash
+    from :func:`dispatch_dedup_hash`) so the throttle reader can
+    collapse same-root-cause emits across sibling subjects.
+    Best-effort — never raises.
     """
     from pollypm.audit.log import emit as _audit_emit
     try:
@@ -3082,6 +3158,7 @@ def emit_escalation_dispatched(
                 "finding_type": finding_type,
                 "subject": subject,
                 "brief": brief,
+                "dedup_hash": dedup_hash,
             },
             project_path=project_path,
         )
@@ -3097,6 +3174,7 @@ def was_recently_operator_dispatched(
     now: datetime,
     project_path: Path | str | None = None,
     throttle_seconds: int = OPERATOR_DISPATCH_THROTTLE_SECONDS,
+    dedup_hash: str | None = None,
 ) -> bool:
     """Return True iff a matching tier-3 dispatch landed in the throttle window.
 
@@ -3104,6 +3182,12 @@ def was_recently_operator_dispatched(
     ``EVENT_WATCHDOG_OPERATOR_DISPATCHED`` rows. Same idempotence
     model — the audit log itself is the source of truth, so a
     heartbeat-process restart doesn't reset the dedup window.
+
+    #2015 — when ``dedup_hash`` is supplied we match on
+    ``metadata.dedup_hash`` so finding bodies that span sibling
+    subjects (the samblog/32-35 burst) collapse into one inbox dispatch
+    per window. Legacy rows without the field fall back to the
+    pre-fix subject match.
     """
     from pollypm.audit.log import read_events
 
@@ -3123,10 +3207,14 @@ def was_recently_operator_dispatched(
         return False
     for ev in recent:
         meta = ev.metadata or {}
-        if (
-            meta.get("finding_type") == finding_type
-            and (ev.subject == subject or meta.get("subject") == subject)
-        ):
+        if meta.get("finding_type") != finding_type:
+            continue
+        ev_hash = meta.get("dedup_hash") or ""
+        if dedup_hash and ev_hash:
+            if ev_hash == dedup_hash:
+                return True
+            continue
+        if ev.subject == subject or meta.get("subject") == subject:
             return True
     return False
 
@@ -3139,11 +3227,14 @@ def emit_operator_dispatched(
     inbox_task_id: str | None = None,
     dedup_key: str = "",
     project_path: Path | str | None = None,
+    dedup_hash: str = "",
 ) -> None:
     """Emit a ``watchdog.operator_dispatched`` event.
 
     Symmetric to :func:`emit_escalation_dispatched` but for the
-    tier-3 (operator) leg of the cascade. Best-effort — never raises.
+    tier-3 (operator) leg of the cascade. #2015 — also carries
+    ``dedup_hash`` so the throttle reader can collapse same-root-cause
+    emits across sibling subjects. Best-effort — never raises.
     """
     from pollypm.audit.log import emit as _audit_emit
     try:
@@ -3158,6 +3249,7 @@ def emit_operator_dispatched(
                 "subject": subject,
                 "inbox_task_id": inbox_task_id or "",
                 "dedup_key": dedup_key,
+                "dedup_hash": dedup_hash,
             },
             project_path=project_path,
         )

--- a/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
+++ b/src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py
@@ -55,6 +55,7 @@ from pollypm.audit.watchdog import (
     RULE_WORKER_SESSION_DEAD_LOOP,
     WATCHDOG_ALERT_TYPE,
     WatchdogConfig,
+    dispatch_dedup_hash,
     emit_escalation_dispatched,
     emit_finding,
     emit_heartbeat_tick,
@@ -1265,6 +1266,10 @@ def _maybe_dispatch_to_architect(
     """
     if finding.rule not in _DISPATCHABLE_RULES:
         return "skipped"
+    # #2015 — throttle on the subject-independent finding-body hash so
+    # the same root-cause across sibling subjects (e.g. samblog/32-35)
+    # collapses to one architect dispatch per window.
+    dedup_hash = dispatch_dedup_hash(finding)
     if was_recently_dispatched(
         project=finding.project,
         finding_type=finding.rule,
@@ -1272,6 +1277,7 @@ def _maybe_dispatch_to_architect(
         now=now,
         project_path=project_path,
         throttle_seconds=ESCALATION_THROTTLE_SECONDS,
+        dedup_hash=dedup_hash,
     ):
         return "throttled"
     brief = format_unstick_brief(finding)
@@ -1284,6 +1290,7 @@ def _maybe_dispatch_to_architect(
         subject=finding.subject,
         brief=brief,
         project_path=project_path,
+        dedup_hash=dedup_hash,
     )
     target = _architect_window_target(storage_closet_name, finding.project)
     if target is None:
@@ -1837,6 +1844,10 @@ def _maybe_dispatch_to_operator(
     """
     if finding.rule not in _OPERATOR_DISPATCHABLE_RULES:
         return "skipped"
+    # #2015 — throttle on the subject-independent finding-body hash so
+    # the same root-cause across sibling subjects collapses to one
+    # operator inbox dispatch per window.
+    dedup_hash = dispatch_dedup_hash(finding)
     if was_recently_operator_dispatched(
         project=finding.project,
         finding_type=finding.rule,
@@ -1844,6 +1855,7 @@ def _maybe_dispatch_to_operator(
         now=now,
         project_path=project_path,
         throttle_seconds=OPERATOR_DISPATCH_THROTTLE_SECONDS,
+        dedup_hash=dedup_hash,
     ):
         return "throttled"
 
@@ -1948,6 +1960,7 @@ def _maybe_dispatch_to_operator(
         inbox_task_id=inbox_task_id,
         dedup_key=dedup_key,
         project_path=project_path,
+        dedup_hash=dedup_hash,
     )
     return "dispatched"
 

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -3487,3 +3487,134 @@ def test_cadence_operator_dispatch_throttles_burst_by_root_cause(
     assert outcomes[0] == "dispatched"
     assert outcomes[1:] == ["throttled", "throttled", "throttled"], outcomes
     assert len(created) == 1
+
+
+# ---------------------------------------------------------------------------
+# PR #2020 review — dispatch_dedup_hash no-evidence fallback regression
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_dedup_hash_no_evidence_falls_back_to_subject() -> None:
+    """No ``evidence`` and no metadata dedup key → ``subject`` must distinguish.
+
+    The PR #2020 blocker (Codex review): production detectors that
+    don't populate ``evidence`` (``stuck_draft`` is the canonical
+    example — it only sets ``metadata``) collapsed to the same hash
+    just because they shared rule+project. Two unrelated draft tasks
+    ``demo/1`` and ``demo/2`` therefore over-deduped through the
+    throttle. The fallback path must include ``subject`` so distinct
+    findings get distinct hashes.
+    """
+    from pollypm.audit.watchdog import dispatch_dedup_hash
+
+    f1 = Finding(rule=RULE_STUCK_DRAFT, project="demo", subject="demo/1")
+    f2 = Finding(rule=RULE_STUCK_DRAFT, project="demo", subject="demo/2")
+
+    h1 = dispatch_dedup_hash(f1)
+    h2 = dispatch_dedup_hash(f2)
+    assert h1 != h2, (
+        "no-evidence findings must not collapse across subjects "
+        f"(got {h1} == {h2})"
+    )
+
+
+def test_dispatch_dedup_hash_same_subject_no_evidence_stable() -> None:
+    """Same rule+project+subject, no evidence → same hash (stable fallback)."""
+    from pollypm.audit.watchdog import dispatch_dedup_hash
+
+    f1 = Finding(rule=RULE_STUCK_DRAFT, project="demo", subject="demo/7")
+    f2 = Finding(rule=RULE_STUCK_DRAFT, project="demo", subject="demo/7",
+                 message="cosmetic copy varies")
+    assert dispatch_dedup_hash(f1) == dispatch_dedup_hash(f2)
+
+
+def test_dispatch_dedup_hash_evidence_collapses_across_subjects() -> None:
+    """With evidence populated, sibling subjects must still collapse.
+
+    Pins the #2015 contract: when a detector DOES populate ``evidence``,
+    the throttle should dedupe across different subjects (samblog/32-35
+    burst). The fallback only kicks in when evidence is empty.
+    """
+    from pollypm.audit.watchdog import dispatch_dedup_hash
+
+    common = {"queued_subjects": ["demo/21", "demo/26"]}
+    f1 = Finding(rule=RULE_STUCK_DRAFT, project="demo", subject="demo/1",
+                 evidence=common)
+    f2 = Finding(rule=RULE_STUCK_DRAFT, project="demo", subject="demo/2",
+                 evidence=common)
+    assert dispatch_dedup_hash(f1) == dispatch_dedup_hash(f2)
+
+
+def test_dispatch_dedup_hash_metadata_root_cause_key_collapses() -> None:
+    """When evidence is empty but metadata has ``root_cause_hash`` /
+    ``dedup_key``, collapse across subjects using that key instead.
+
+    Lets a detector opt into root-cause dedup without restructuring
+    its payload as ``evidence`` — used by callers that already
+    computed a stable hash upstream (tier-4 promotion tracker).
+    """
+    from pollypm.audit.watchdog import dispatch_dedup_hash
+
+    f1 = Finding(
+        rule=RULE_STUCK_DRAFT, project="demo", subject="demo/1",
+        metadata={"root_cause_hash": "abc123", "detected_via": "state"},
+    )
+    f2 = Finding(
+        rule=RULE_STUCK_DRAFT, project="demo", subject="demo/2",
+        metadata={"root_cause_hash": "abc123", "detected_via": "event"},
+    )
+    f3 = Finding(
+        rule=RULE_STUCK_DRAFT, project="demo", subject="demo/3",
+        metadata={"root_cause_hash": "different"},
+    )
+    assert dispatch_dedup_hash(f1) == dispatch_dedup_hash(f2)
+    assert dispatch_dedup_hash(f1) != dispatch_dedup_hash(f3)
+
+
+def test_dispatch_dedup_hash_real_stuck_draft_detector_distinguishes_subjects(
+    now: datetime,
+) -> None:
+    """Drive the actual ``_detect_stuck_drafts`` path and assert findings
+    for different tasks get different hashes.
+
+    Pre-fix Codex repro:
+
+        Finding(rule=RULE_STUCK_DRAFT, project="demo", subject="demo/1")
+        Finding(rule=RULE_STUCK_DRAFT, project="demo", subject="demo/2")
+        → both hash to d14d2be490dfea41 (collision).
+
+    The real detector only populates ``metadata`` (no ``evidence``),
+    so the fallback path is exercised. This is the "use the actual
+    detector, not hand-built findings" regression that Codex
+    specifically requested.
+    """
+    from pollypm.audit.watchdog import dispatch_dedup_hash
+
+    events = [
+        _make_event(
+            event=EVENT_TASK_CREATED, subject="demo/1",
+            metadata={"title": "first"},
+            ts=now - timedelta(minutes=20),
+        ),
+        _make_event(
+            event=EVENT_TASK_CREATED, subject="demo/2",
+            metadata={"title": "second"},
+            ts=now - timedelta(minutes=20),
+        ),
+    ]
+    findings = [
+        f for f in scan_events(events, now=now) if f.rule == RULE_STUCK_DRAFT
+    ]
+    assert len(findings) == 2, findings
+    # Every real-detector finding sets metadata but NOT evidence.
+    for f in findings:
+        assert f.evidence == {}, (
+            "regression — _detect_stuck_drafts should not populate "
+            "evidence; the fallback test depends on this shape"
+        )
+        assert f.metadata, "_detect_stuck_drafts should populate metadata"
+
+    hashes = {dispatch_dedup_hash(f) for f in findings}
+    assert len(hashes) == len(findings), (
+        f"real-detector findings collapsed: {hashes}"
+    )

--- a/tests/test_audit_watchdog.py
+++ b/tests/test_audit_watchdog.py
@@ -3231,3 +3231,259 @@ path = "demo"
     assert captured["config"] is not None
     # The self-heal succeeded -> reviewer-spawn counter incremented.
     assert counters["worker_lane_spawned"] == 1
+
+
+# ---------------------------------------------------------------------------
+# #2015 — dispatch_dedup_hash + root-cause-keyed throttle
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_dedup_hash_collapses_across_sibling_subjects() -> None:
+    """Same finding-body across different subjects → same dedup hash.
+
+    The samblog/32-35 case: the watchdog emits one ``stuck_draft``
+    finding per draft task, so subjects differ (samblog/32, /33, /34,
+    /35) but ``rule`` / ``project`` / ``evidence`` are identical. The
+    subject-independent hash must be equal across the four findings.
+    """
+    from pollypm.audit.watchdog import dispatch_dedup_hash
+
+    common_evidence = {
+        "queued_subjects": ["samblog/21", "samblog/26", "samblog/29",
+                            "samblog/31"],
+        "queued_last_updated": "2026-05-19T13:30:00+00:00",
+    }
+    finding_template = dict(
+        rule=RULE_STUCK_DRAFT,
+        project="samblog",
+        evidence=common_evidence,
+    )
+    hashes = {
+        dispatch_dedup_hash(Finding(subject=f"samblog/{n}", **finding_template))
+        for n in (32, 33, 34, 35)
+    }
+    assert len(hashes) == 1
+
+
+def test_dispatch_dedup_hash_distinguishes_different_evidence() -> None:
+    """Different finding-bodies (different evidence) → different hashes."""
+    from pollypm.audit.watchdog import dispatch_dedup_hash
+
+    a = Finding(
+        rule=RULE_STUCK_DRAFT, project="samblog", subject="samblog/32",
+        evidence={"queued_subjects": ["samblog/21"]},
+    )
+    b = Finding(
+        rule=RULE_STUCK_DRAFT, project="samblog", subject="samblog/32",
+        evidence={"queued_subjects": ["samblog/99"]},
+    )
+    assert dispatch_dedup_hash(a) != dispatch_dedup_hash(b)
+
+
+def test_dispatch_dedup_hash_distinguishes_different_rules() -> None:
+    from pollypm.audit.watchdog import dispatch_dedup_hash
+
+    a = Finding(
+        rule=RULE_STUCK_DRAFT, project="samblog", subject="samblog/32",
+        evidence={"x": 1},
+    )
+    b = Finding(
+        rule=RULE_TASK_PROGRESS_STALE, project="samblog",
+        subject="samblog/32", evidence={"x": 1},
+    )
+    assert dispatch_dedup_hash(a) != dispatch_dedup_hash(b)
+
+
+def test_was_recently_dispatched_dedupes_by_root_cause_hash(
+    now: datetime,
+) -> None:
+    """#2015 regression — samblog/32-35 burst collapses to one dispatch.
+
+    Pre-fix: ``was_recently_dispatched`` matched on
+    ``(project, finding_type, subject)``. Four draft tasks with the
+    same root cause all had different subjects, so the throttle never
+    fired across them and the operator got four inbox entries asking
+    the same question.
+
+    Post-fix: passing the same ``dedup_hash`` across sibling subjects
+    matches the seeded event, so the second/third/fourth would-be
+    dispatch returns ``True`` (throttled) even though the subjects
+    differ from the first.
+    """
+    from pollypm.audit.watchdog import (
+        dispatch_dedup_hash,
+        emit_escalation_dispatched,
+        was_recently_dispatched,
+    )
+
+    common_evidence = {
+        "queued_subjects": ["samblog/21", "samblog/26", "samblog/29",
+                            "samblog/31"],
+    }
+    findings = [
+        Finding(
+            rule=RULE_STUCK_DRAFT,
+            project="samblog",
+            subject=f"samblog/{n}",
+            evidence=common_evidence,
+        )
+        for n in (32, 33, 34, 35)
+    ]
+    # All four share the same finding-body hash.
+    shared_hash = dispatch_dedup_hash(findings[0])
+    assert all(dispatch_dedup_hash(f) == shared_hash for f in findings)
+
+    # Seed only the first dispatch (samblog/32).
+    emit_escalation_dispatched(
+        project="samblog",
+        finding_type=RULE_STUCK_DRAFT,
+        subject="samblog/32",
+        brief="...",
+        dedup_hash=shared_hash,
+    )
+
+    # The other three siblings must see themselves as throttled even
+    # though their subjects differ from the seeded one. Pre-fix this
+    # assertion failed for /33, /34, /35 — each presented a unique
+    # subject so the legacy subject-keyed throttle let them through.
+    for f in findings:
+        assert was_recently_dispatched(
+            project=f.project,
+            finding_type=f.rule,
+            subject=f.subject,
+            now=now + timedelta(minutes=5),
+            dedup_hash=shared_hash,
+        ), f"throttle leaked for {f.subject}"
+
+
+def test_was_recently_dispatched_legacy_rows_fall_back_to_subject(
+    now: datetime,
+) -> None:
+    """Pre-#2015 rows have no ``dedup_hash`` in metadata. The throttle
+    must still honour them via the subject-match fallback so old
+    throttle windows don't evaporate at the moment of the rollout.
+    """
+    from pollypm.audit.log import (
+        EVENT_WATCHDOG_ESCALATION_DISPATCHED,
+        central_log_path,
+    )
+    from pollypm.audit.watchdog import was_recently_dispatched
+
+    central = central_log_path("legacydemo")
+    central.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": 1,
+        "ts": (now - timedelta(minutes=5)).isoformat(),
+        "project": "legacydemo",
+        "event": EVENT_WATCHDOG_ESCALATION_DISPATCHED,
+        "subject": "legacydemo/7",
+        "actor": "audit_watchdog",
+        "status": "warn",
+        # No "dedup_hash" key — simulates a pre-fix row.
+        "metadata": {
+            "finding_type": RULE_STUCK_DRAFT,
+            "subject": "legacydemo/7",
+            "brief": "...",
+        },
+    }
+    central.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    # Caller passes a dedup_hash; row has none → fall back to subject match.
+    assert was_recently_dispatched(
+        project="legacydemo",
+        finding_type=RULE_STUCK_DRAFT,
+        subject="legacydemo/7",
+        now=now,
+        dedup_hash="deadbeefdeadbeef",
+    )
+
+
+def test_cadence_dispatch_throttles_samblog_burst_by_root_cause(
+    now: datetime, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end #2015 regression: four sibling drafts → one dispatch.
+
+    Drives the real cadence ``_maybe_dispatch_to_architect`` four
+    times with Finding objects matching the samblog/32-35 burst:
+    same rule, project, evidence; subjects differ. Pre-fix all four
+    pass the throttle. Post-fix only the first emits; the next three
+    return ``"throttled"``.
+    """
+    from pollypm.plugins_builtin.core_recurring import audit_watchdog as aw
+
+    sent: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        aw, "_send_brief_to_architect",
+        lambda target, brief: sent.append((target, brief)) or True,
+    )
+
+    common_evidence = {
+        "queued_subjects": ["samblog/21", "samblog/26", "samblog/29",
+                            "samblog/31"],
+        "queued_last_updated": "2026-05-19T13:30:00+00:00",
+    }
+    outcomes: list[str] = []
+    for n in (32, 33, 34, 35):
+        finding = Finding(
+            rule=RULE_STUCK_DRAFT,
+            tier="2",
+            project="samblog",
+            subject=f"samblog/{n}",
+            message=f"Draft task samblog/{n} has sat unpromoted ...",
+            recommendation="Promote or cancel.",
+            evidence=common_evidence,
+        )
+        outcomes.append(
+            aw._maybe_dispatch_to_architect(
+                finding,
+                project_path=None,
+                storage_closet_name="pollypm-storage-closet",
+                now=now,
+            )
+        )
+
+    assert outcomes[0] == "dispatched"
+    # The remaining three siblings must be throttled — pre-fix every
+    # one would have been "dispatched" because the subject differed.
+    assert outcomes[1:] == ["throttled", "throttled", "throttled"], outcomes
+    # Only one brief was actually sent.
+    assert len(sent) == 1
+
+
+def test_cadence_operator_dispatch_throttles_burst_by_root_cause(
+    now: datetime, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same #2015 collapse for the tier-3 (operator inbox) leg."""
+    from pollypm.audit.watchdog import RULE_QUEUE_WITHOUT_MOTION
+    from pollypm.plugins_builtin.core_recurring import audit_watchdog as aw
+
+    created: list[dict] = []
+
+    def _stub_create(**kwargs):
+        created.append(kwargs)
+        return f"task-{len(created)}"
+
+    monkeypatch.setattr(aw, "_create_operator_inbox_task", _stub_create)
+
+    common_evidence = {
+        "queued_subjects": ["proj/1", "proj/2"],
+        "queued_last_updated": "2026-05-19T13:30:00+00:00",
+    }
+    outcomes: list[str] = []
+    for tag in ("a", "b", "c", "d"):
+        finding = Finding(
+            rule=RULE_QUEUE_WITHOUT_MOTION,
+            tier="3",
+            project="proj",
+            subject=f"proj-{tag}",
+            evidence=common_evidence,
+        )
+        outcomes.append(
+            aw._maybe_dispatch_to_operator(
+                finding, project_path=None, now=now,
+            )
+        )
+
+    assert outcomes[0] == "dispatched"
+    assert outcomes[1:] == ["throttled", "throttled", "throttled"], outcomes
+    assert len(created) == 1


### PR DESCRIPTION
## Summary

- Watchdog dispatch throttle was keyed by `(project, finding_type, subject)`. Same root-cause spawning sibling drafts (samblog/32, /33, /34, /35) bypassed the throttle because each task carries a different subject, so the operator saw four inbox cards asking the same question.
- Added `dispatch_dedup_hash(finding)` in `src/pollypm/audit/watchdog.py` — mirrors `audit/tier4.py:root_cause_hash` but excludes `subject` (rule + project + canonical evidence JSON only).
- Threaded `dedup_hash` through `emit_escalation_dispatched` / `emit_operator_dispatched` (stored in event metadata) and `was_recently_dispatched` / `was_recently_operator_dispatched` (matches on hash, falls back to subject match for pre-#2015 rows so old throttle windows survive the rollout).
- Cadence call sites (`_maybe_dispatch_to_architect`, `_maybe_dispatch_to_operator`) compute and thread the hash.

## Why not fold into `root_cause_hash`?

`audit/tier4.py:root_cause_hash` is a stored DB key in `tier4_promotion_state`. Mutating its inputs would invalidate every persisted row mid-RC. The new helper coexists; tier-4 promotion accounting keeps the subject-bearing hash.

## Surfaced by

samblog architect, acting on tonight's TIER HANDOFF cascade. It emitted the same finding-body four times and the cards landed in the operator inbox with identical `queued_subjects` evidence. The architect manually cancelled /33 and /34 as duplicates of /35, then filed #2015.

## Test plan

- [x] `tests/test_audit_watchdog.py` — six new regression cases (hash symmetry across sibling subjects, hash sensitivity to rule / evidence drift, throttle collapses the samblog/32-35 burst, legacy-row subject fallback, two end-to-end cadence drives for architect + operator legs).
- [x] Direct-import smoke (14/14 + 5/5 backward-compat assertions) — used because the full `tests/test_audit_watchdog.py` suite-level run hangs on this developer machine due to the home-write-guard fixture snapshotting `~/.pollypm/` between tests against a live cockpit. Each new test passes individually under the real conftest.
- [ ] Post-merge: watch the samblog architect cascade and confirm a single `watchdog.escalation_dispatched` row per finding-body even when multiple sibling drafts trigger.

Closes #2015.