### PR TITLE
feat(state-cache): PR 3 route remaining 5 call sites + remove TTL (refs #1664)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,9 +86,13 @@ Added, Changed, and Removed.
   `cockpit_rail._project_tasks_for_rollup` is folded into the
   refresher (no longer called from `build_items` when cache is
   authoritative); and `cockpit_rail`'s two `latest_heartbeat()`
-  per-project sites read from `entry.latest_heartbeat_by_session`.
-  Each call site keeps a flag-off fall-through, so behaviour is
-  unchanged until PR 4 flips the default. Flag still defaults OFF.
+  per-project sites read directly from the pg facade
+  (`pollypm.storage.pg_heartbeats.latest_heartbeat`) — the cache had
+  no `heartbeat.*` invalidation, so any prefetch could only serve a
+  stale snapshot. Bulk heartbeat prefetch is deferred to #2050 (once
+  the refresher subscribes to heartbeat audit events). Each call
+  site keeps a flag-off fall-through, so behaviour is unchanged
+  until PR 4 flips the default. Flag still defaults OFF.
 
 ### Removed
 - Rail-side 2s TTL on `CockpitRouter._project_categorizations`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,34 @@ Added, Changed, and Removed.
   `ProjectStateCache.invalidate(None)` only iterates known entries.
   PR #2016 review blocker.
 
+### Changed
+- State-cache routing (Move A PR 3, refs #1664) extends the
+  `POLLYPM_STATE_CACHE=1` fast path to the remaining 5 hot-path call
+  sites from `docs/design/move-a-state-cache.md` §5. With the flag
+  on and the per-project cache populated:
+  `cockpit_inbox._count_inbox_tasks_for_label` sums
+  `entry.awaits_user_count` instead of running the workspace sweep;
+  `dashboard.operator_view.load_operator_view_from_config` builds
+  the view from the snapshot instead of opening the shared work
+  service; `cockpit_rail._project_state_rollups` reads pre-computed
+  `rail_state` / `rail_badge` / `approvals_pending` fields;
+  `cockpit_rail._project_tasks_for_rollup` is folded into the
+  refresher (no longer called from `build_items` when cache is
+  authoritative); and `cockpit_rail`'s two `latest_heartbeat()`
+  per-project sites read from `entry.latest_heartbeat_by_session`.
+  Each call site keeps a flag-off fall-through, so behaviour is
+  unchanged until PR 4 flips the default. Flag still defaults OFF.
+
+### Removed
+- Rail-side 2s TTL on `CockpitRouter._project_categorizations`
+  (`_PROJECT_CATEGORIZATIONS_TTL_SECONDS = 2.0`). Per
+  `docs/design/move-a-state-cache.md` §9.5, the state cache's
+  `global_version()` short-circuit plus the per-call TTL inside
+  `project_state_map_from_config` already collapse navigation-burst
+  refreshes — two cache layers were worse than one. The TTL
+  pathology (freshly completed task stuck as WORKING for up to 2s)
+  is gone with this change.
+
 ## [1.0.0] - 2026-04-20
 
 ### Added

--- a/docs/design/move-a-state-cache.md
+++ b/docs/design/move-a-state-cache.md
@@ -1,5 +1,13 @@
 # Move A — In-Process Project-State Cache with Epoch-Driven Invalidation
 
+## Implementation drift (2026-05-22)
+
+The shipped Move A behavior diverges from the original design in three places. This section is the source of truth; the original sections below are kept for historical context but should be read as superseded where they conflict.
+
+- `latest_heartbeat_by_session` is reserved on `ProjectStateCacheEntry` but NOT populated. Rail heartbeat sites read `pollypm.storage.pg_heartbeats.latest_heartbeat` directly via `CockpitRouter._latest_heartbeat_cached`. Bulk prefetch + cache invalidation deferred to [#2050](https://github.com/samhotchkiss/pollypm/issues/2050).
+- `_maybe_cache_route_rollups` declines (returns `None`) when any tracked project has a live actionable alert — cache cannot recompute the alert-to-rollup contract. Tracked in [#2049](https://github.com/samhotchkiss/pollypm/issues/2049).
+- `_maybe_cache_route_awaits_user` / `_maybe_cache_count_awaits_user` decline when the workspace-root inbox has any open message (via `has_workspace_root_open_messages` probe). Workspace-root inbox isn't yet represented in cache entries. Tracked in [#2051](https://github.com/samhotchkiss/pollypm/issues/2051).
+
 Design document for issue [#1664](https://github.com/samhotchkiss/pollypm/issues/1664).
 Status: **proposed** (design only; implementation deferred to post-RC).
 Authors: Sam, with research from the 2026-05-18 rail-perf review on [#1634](https://github.com/samhotchkiss/pollypm/issues/1634).

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -258,6 +258,13 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
         return None
 
     known_projects = set(getattr(config, "projects", {}).keys())
+    # Partial-cache guard (PR #2026 review): any tracked project missing
+    # from the snapshot would be silently dropped from ``cached_items``,
+    # causing the rail badge + count helper that falls through here to
+    # under-report. Fall through to the direct sweep so the missing
+    # project's items are included.
+    if not known_projects.issubset(snapshot.keys()):
+        return None
     cached_items: list[object] = []
     for project_key, entry in snapshot.items():
         if project_key not in known_projects:
@@ -424,9 +431,10 @@ def _count_inbox_tasks_for_label(config) -> int:
     ``entry.awaits_user_count`` across the snapshot directly. The
     snapshot read is O(N projects) and skips the workspace-wide pg
     sweep entirely. Falls through to ``len(pm_inbox_awaits_user_list)``
-    on cold / partial cache so the three-surfaces-one-predicate
-    invariant still holds (the public helper itself routes through
-    the same cache when populated).
+    on cold OR partial cache (any tracked project missing from the
+    snapshot) so the three-surfaces-one-predicate invariant still
+    holds (the public helper itself routes through the same cache
+    when populated).
     """
     cached = _maybe_cache_count_awaits_user(config)
     if cached is not None:
@@ -441,6 +449,14 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
     cold cache, or any unexpected failure → ``None`` so the caller
     falls back to the direct path. Skips the workspace-wide sweep
     when the cache is authoritative for every tracked project.
+
+    Partial-cache fall-through (PR #2026 review): if any tracked
+    project in ``config.projects`` is missing from the cache snapshot
+    we MUST return ``None`` so the caller runs the direct sweep.
+    Summing only the projects that happen to be cached would
+    under-count any tracked project that hasn't been refreshed yet —
+    the rail badge would silently drop work that's still waiting on
+    the user.
     """
 
     try:
@@ -457,6 +473,11 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
     if not snapshot:
         return None
     known_projects = set(getattr(config, "projects", {}).keys())
+    # Partial-cache guard: a tracked project not yet refreshed into the
+    # cache would be silently omitted from the sum. Fall through to the
+    # direct path so the badge stays correct during the boot-time gap.
+    if not known_projects.issubset(snapshot.keys()):
+        return None
     total = 0
     for project_key, entry in snapshot.items():
         if project_key not in known_projects:

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -418,8 +418,51 @@ def _count_inbox_tasks_for_label(config) -> int:
     The function name is kept for backward compatibility with existing
     callers; the return value is now an item count, not just a task
     count.
+
+    Move A PR 3 (#1664): when ``POLLYPM_STATE_CACHE=1`` AND the cache
+    has every tracked project populated, this sums
+    ``entry.awaits_user_count`` across the snapshot directly. The
+    snapshot read is O(N projects) and skips the workspace-wide pg
+    sweep entirely. Falls through to ``len(pm_inbox_awaits_user_list)``
+    on cold / partial cache so the three-surfaces-one-predicate
+    invariant still holds (the public helper itself routes through
+    the same cache when populated).
     """
+    cached = _maybe_cache_count_awaits_user(config)
+    if cached is not None:
+        return cached
     return len(pm_inbox_awaits_user_list(config))
+
+
+def _maybe_cache_count_awaits_user(config) -> int | None:
+    """Return the cache-routed count, or ``None`` to fall through.
+
+    Same gating as :func:`_maybe_cache_route_awaits_user`: flag off,
+    cold cache, or any unexpected failure → ``None`` so the caller
+    falls back to the direct path. Skips the workspace-wide sweep
+    when the cache is authoritative for every tracked project.
+    """
+
+    try:
+        from pollypm.state_cache import get_cache, is_enabled
+    except Exception:  # noqa: BLE001
+        return None
+    if not is_enabled():
+        return None
+    try:
+        cache = get_cache()
+        snapshot = cache.snapshot()
+    except Exception:  # noqa: BLE001
+        return None
+    if not snapshot:
+        return None
+    known_projects = set(getattr(config, "projects", {}).keys())
+    total = 0
+    for project_key, entry in snapshot.items():
+        if project_key not in known_projects:
+            continue
+        total += int(getattr(entry, "awaits_user_count", 0) or 0)
+    return total
 
 
 def pm_inbox_filtered_list(

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -237,6 +237,14 @@ def _workspace_root_inbox_has_open(config) -> bool:
     Filed as a follow-up issue (PR #2026 review blocker 3): teach the
     cache to carry a workspace-root entry so this gate can go away.
 
+    PR #2026 v3 (Codex re-review): delegates to the dedicated SQL
+    existence query :func:`pollypm.cockpit_pg_aggregates.has_workspace_root_open_messages`
+    so the answer no longer depends on whether the newest N rows happen
+    to include a workspace-root row. The old ``open_messages(limit=50)``
+    + Python-side scan path silently dropped workspace work whenever 50+
+    newer project-scoped rows pushed the workspace-root row out of the
+    window.
+
     Best-effort: a pg outage / import failure returns ``False`` so the
     fast-path still wins on the common "no workspace-root noise" case.
     A false negative here would mis-attribute the divergence to the
@@ -244,21 +252,15 @@ def _workspace_root_inbox_has_open(config) -> bool:
     """
 
     try:
-        from pollypm.cockpit_pg_aggregates import open_messages
+        from pollypm.cockpit_pg_aggregates import (
+            has_workspace_root_open_messages,
+        )
     except Exception:  # noqa: BLE001
         return False
-    known_projects = set(getattr(config, "projects", {}).keys())
     try:
-        rows = open_messages(config, known_projects=known_projects, limit=50)
+        return bool(has_workspace_root_open_messages(config))
     except Exception:  # noqa: BLE001
         return False
-    if not rows:
-        return False
-    for row in rows:
-        scope = (row.get("scope") or "").strip()
-        if scope == "" or scope == "inbox":
-            return True
-    return False
 
 
 def _maybe_cache_route_awaits_user(config) -> list[object] | None:

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -248,10 +248,10 @@ def _workspace_root_inbox_has_open(config) -> bool:
     newer project-scoped rows pushed the workspace-root row out of the
     window.
 
-    Best-effort: a pg outage / import failure returns ``False`` so the
-    fast-path still wins on the common "no workspace-root noise" case.
-    A false negative here would mis-attribute the divergence to the
-    sampler, which is the same risk the old code had.
+    Returns True on any failure (import or probe). Conservative — forces
+    cache fall-through. A false positive here is safe (the direct sweep
+    just runs); a false negative would silently drop workspace-root work,
+    violating the cache-authoritative invariant.
     """
 
     try:
@@ -259,7 +259,11 @@ def _workspace_root_inbox_has_open(config) -> bool:
             has_workspace_root_open_messages,
         )
     except Exception:  # noqa: BLE001
-        return False
+        logger.warning(
+            "workspace-root inbox probe import failed; assuming inbox is non-empty to force conservative cache decline",
+            exc_info=True,
+        )
+        return True
     try:
         return bool(has_workspace_root_open_messages(config))
     except Exception:

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -24,10 +24,13 @@ callers + the test suite.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
+
+logger = logging.getLogger(__name__)
 
 from pollypm.cockpit_inbox_sources import (
     _inbox_db_sources,
@@ -259,8 +262,12 @@ def _workspace_root_inbox_has_open(config) -> bool:
         return False
     try:
         return bool(has_workspace_root_open_messages(config))
-    except Exception:  # noqa: BLE001
-        return False
+    except Exception:
+        logger.warning(
+            "workspace-root inbox probe failed; assuming inbox is non-empty to force cache fall-through",
+            exc_info=True,
+        )
+        return True  # conservative: force cache decline
 
 
 def _maybe_cache_route_awaits_user(config) -> list[object] | None:

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -223,6 +223,44 @@ def pm_inbox_awaits_user_list(config) -> list[object]:
     return result
 
 
+def _workspace_root_inbox_has_open(config) -> bool:
+    """True iff there is at least one open workspace-root inbox row.
+
+    "Workspace-root" = messages with ``scope IN ('', 'inbox')`` —
+    these are NOT keyed to any tracked project, so the refresher's
+    per-project filter in
+    ``state_cache/refresh_impl.py::_awaits_user_items_for`` drops them
+    on the floor. The cache's per-project entries can never represent
+    them, so any cache-routed read MUST fall through whenever the
+    workspace-root inbox is non-empty.
+
+    Filed as a follow-up issue (PR #2026 review blocker 3): teach the
+    cache to carry a workspace-root entry so this gate can go away.
+
+    Best-effort: a pg outage / import failure returns ``False`` so the
+    fast-path still wins on the common "no workspace-root noise" case.
+    A false negative here would mis-attribute the divergence to the
+    sampler, which is the same risk the old code had.
+    """
+
+    try:
+        from pollypm.cockpit_pg_aggregates import open_messages
+    except Exception:  # noqa: BLE001
+        return False
+    known_projects = set(getattr(config, "projects", {}).keys())
+    try:
+        rows = open_messages(config, known_projects=known_projects, limit=50)
+    except Exception:  # noqa: BLE001
+        return False
+    if not rows:
+        return False
+    for row in rows:
+        scope = (row.get("scope") or "").strip()
+        if scope == "" or scope == "inbox":
+            return True
+    return False
+
+
 def _maybe_cache_route_awaits_user(config) -> list[object] | None:
     """Return the cache-routed result, or ``None`` to fall through.
 
@@ -232,6 +270,12 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
     * The cache has no entries yet (cold start — the refresher hasn't
       populated anything; falling through avoids serving an empty list
       while the cache warms up).
+    * Any tracked project is missing from the snapshot (partial cache).
+    * Any workspace-root awaits-user message exists live (PR #2026
+      review blocker 3) — the refresher does not project workspace-root
+      messages into any per-project entry, so the cache cannot
+      represent them and a partial answer would silently drop them
+      from the rail badge / inbox count.
     * Any unexpected exception (defensive — broken cache must never
       crash the rail badge).
 
@@ -264,6 +308,12 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
     # under-report. Fall through to the direct sweep so the missing
     # project's items are included.
     if not known_projects.issubset(snapshot.keys()):
+        return None
+    # Workspace-root guard (PR #2026 review blocker 3): the refresher
+    # only projects per-project messages, so any open workspace-root
+    # inbox row would be missing from the cache. Defer to the direct
+    # path whenever one exists.
+    if _workspace_root_inbox_has_open(config):
         return None
     cached_items: list[object] = []
     for project_key, entry in snapshot.items():
@@ -457,6 +507,12 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
     under-count any tracked project that hasn't been refreshed yet —
     the rail badge would silently drop work that's still waiting on
     the user.
+
+    Workspace-root fall-through (PR #2026 review blocker 3): the
+    refresher does not project workspace-root inbox messages
+    (``scope IN ('', 'inbox')``) into any per-project entry, so the
+    cached sum would silently under-count them. Defer to the direct
+    sweep whenever the workspace-root inbox is non-empty.
     """
 
     try:
@@ -477,6 +533,10 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
     # cache would be silently omitted from the sum. Fall through to the
     # direct path so the badge stays correct during the boot-time gap.
     if not known_projects.issubset(snapshot.keys()):
+        return None
+    # Workspace-root guard (PR #2026 review blocker 3): see
+    # ``_maybe_cache_route_awaits_user`` for rationale.
+    if _workspace_root_inbox_has_open(config):
         return None
     total = 0
     for project_key, entry in snapshot.items():

--- a/src/pollypm/cockpit_inbox.py
+++ b/src/pollypm/cockpit_inbox.py
@@ -283,6 +283,10 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
     * The cache has no entries yet (cold start — the refresher hasn't
       populated anything; falling through avoids serving an empty list
       while the cache warms up).
+    * Any snapshot entry was stamped with a different config identity
+      than the live ``config`` (PR #2026 v7 — the singleton cache can
+      serve cross-config data when project keys overlap; the
+      config-identity stamp catches this).
     * Any tracked project is missing from the snapshot (partial cache).
     * Any workspace-root awaits-user message exists live (PR #2026
       review blocker 3) — the refresher does not project workspace-root
@@ -312,6 +316,27 @@ def _maybe_cache_route_awaits_user(config) -> list[object] | None:
         # Cold cache — let the direct path populate the legacy TTL
         # cache; the refresher will fill the state cache on the next
         # audit-log event.
+        return None
+
+    # Config-identity guard (PR #2026 v7 — Codex r7 blocker): the
+    # cache is a process-wide singleton. If any snapshot entry was
+    # computed against a different ``config`` (different config_path /
+    # workspace_root) than the one the caller passed in, serving it
+    # would leak cross-config data — most acutely when the two configs
+    # share project keys. Decline and let the direct path run.
+    #
+    # Entries with an empty ``config_identity`` (legacy / unstamped —
+    # only test fixtures today) skip the check: the real refresher
+    # always stamps a non-empty identity, so a stamped-vs-unstamped
+    # mismatch can only happen in synthetic test setups.
+    try:
+        from pollypm.state_cache.entry import config_identity
+        live_identity = config_identity(config)
+        for entry in snapshot.values():
+            entry_identity = getattr(entry, "config_identity", "") or ""
+            if entry_identity and entry_identity != live_identity:
+                return None
+    except Exception:  # noqa: BLE001
         return None
 
     known_projects = set(getattr(config, "projects", {}).keys())
@@ -540,6 +565,21 @@ def _maybe_cache_count_awaits_user(config) -> int | None:
     except Exception:  # noqa: BLE001
         return None
     if not snapshot:
+        return None
+    # Config-identity guard (PR #2026 v7 — Codex r7 blocker): same
+    # rationale as ``_maybe_cache_route_awaits_user``. Without this,
+    # the count sums entries that were computed against a different
+    # ``config``, double-counting work between two configs that
+    # share project keys. Unstamped entries (``""``) skip the check —
+    # only test fixtures construct those.
+    try:
+        from pollypm.state_cache.entry import config_identity
+        live_identity = config_identity(config)
+        for entry in snapshot.values():
+            entry_identity = getattr(entry, "config_identity", "") or ""
+            if entry_identity and entry_identity != live_identity:
+                return None
+    except Exception:  # noqa: BLE001
         return None
     known_projects = set(getattr(config, "projects", {}).keys())
     # Partial-cache guard: a tracked project not yet refreshed into the

--- a/src/pollypm/cockpit_pg_aggregates.py
+++ b/src/pollypm/cockpit_pg_aggregates.py
@@ -398,6 +398,12 @@ def has_workspace_root_open_messages(
     returning False, defeating the conservative-on-error guard. Cache
     authoritativeness requires that any signal we cannot prove returns
     the safe answer that forces fall-through.
+
+    NOTE: This function's failure contract intentionally diverges from other
+    helpers in this module. On pg pool/query failure, it returns True (conservative).
+    Callers MUST treat True as "exists OR unknown" — not as "row definitely exists."
+    This preserves the cache-authoritative invariant for the Move A awaits-user cache:
+    the cache declines when any source it cannot represent might have data.
     """
 
     try:

--- a/src/pollypm/cockpit_pg_aggregates.py
+++ b/src/pollypm/cockpit_pg_aggregates.py
@@ -364,6 +364,76 @@ def open_messages(
     return rows
 
 
+def has_workspace_root_open_messages(
+    config: "PollyPMConfig | None",
+) -> bool:
+    """Return True iff any open workspace-root inbox row exists.
+
+    "Workspace-root" = messages with ``scope IN ('', 'inbox')``. The
+    state-cache refresher's per-project filter
+    (``state_cache/refresh_impl.py::_awaits_user_items_for``) drops
+    these on the floor because they aren't keyed to any tracked
+    project, so any cache-routed read MUST fall through whenever this
+    returns True.
+
+    PR #2026 v3 (Codex re-review blocker 1): the previous
+    implementation re-used :func:`open_messages` with ``limit=50`` and
+    scanned the newest 50 rows in Python for ``scope == "" / "inbox"``.
+    On a busy workspace with 50+ newer project-scoped rows + 1 older
+    workspace-root row, the probe returned False and the cache
+    silently dropped the workspace work. This helper pushes the
+    existence check into SQL (``LIMIT 1`` on a workspace-root
+    predicate) so the answer is independent of how many newer
+    project-scoped rows exist.
+
+    Best-effort: pool import / query failure returns ``False`` so the
+    fast-path still wins on the common "no workspace-root noise" case.
+    """
+
+    try:
+        from pollypm.storage.pg_pool import get_ro_pool, get_rw_pool
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "pg aggregates: pg_pool import failed (workspace-root probe)",
+            exc_info=True,
+        )
+        return False
+
+    try:
+        pool = get_ro_pool(config)
+    except Exception:  # noqa: BLE001
+        try:
+            pool = get_rw_pool(config)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "pg aggregates: pg pool open failed (workspace-root probe)",
+                exc_info=True,
+            )
+            return False
+
+    sql = (
+        "SELECT 1 "
+        "  FROM messages "
+        " WHERE recipient = %s "
+        "   AND state = %s "
+        "   AND type IN ('notify', 'inbox_task', 'alert') "
+        "   AND (scope = '' OR scope IS NULL OR scope = 'inbox') "
+        " LIMIT 1"
+    )
+    params: list[object] = ["user", "open"]
+    try:
+        with pool.connection() as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            row = cur.fetchone()
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "pg aggregates: workspace-root probe query failed",
+            exc_info=True,
+        )
+        return False
+    return row is not None
+
+
 # --------------------------------------------------------------------------- #
 # Public API surface
 # --------------------------------------------------------------------------- #
@@ -372,6 +442,7 @@ def open_messages(
 __all__ = [
     "all_tasks_for_project",
     "all_tasks_grouped",
+    "has_workspace_root_open_messages",
     "inbox_tasks_for_project",
     "inbox_tasks_grouped",
     "open_messages",

--- a/src/pollypm/cockpit_pg_aggregates.py
+++ b/src/pollypm/cockpit_pg_aggregates.py
@@ -367,7 +367,11 @@ def open_messages(
 def has_workspace_root_open_messages(
     config: "PollyPMConfig | None",
 ) -> bool:
-    """Return True iff any open workspace-root inbox row exists.
+    """Returns True if any workspace-root open message exists.
+
+    **CONSERVATIVE:** returns True on ANY pg failure (pool/query) — see
+    Move A cache-authoritative invariant. Pure SQL existence query
+    (``LIMIT 1``) — independent of how many newer rows exist.
 
     "Workspace-root" = messages with ``scope IN ('', 'inbox')``. The
     state-cache refresher's per-project filter
@@ -386,18 +390,24 @@ def has_workspace_root_open_messages(
     predicate) so the answer is independent of how many newer
     project-scoped rows exist.
 
-    Best-effort: pool import / query failure returns ``False`` so the
-    fast-path still wins on the common "no workspace-root noise" case.
+    PR #2026 v5 (Codex round-5 blocker): pool/query failures now return
+    ``True`` (with warning log) instead of ``False``. The caller
+    ``_workspace_root_inbox_has_open`` expects this helper to either
+    return a real answer or raise; v4 wrapped the outer call in
+    try/except but the helper itself was swallowing pg errors and
+    returning False, defeating the conservative-on-error guard. Cache
+    authoritativeness requires that any signal we cannot prove returns
+    the safe answer that forces fall-through.
     """
 
     try:
         from pollypm.storage.pg_pool import get_ro_pool, get_rw_pool
     except Exception:  # noqa: BLE001
         logger.warning(
-            "pg aggregates: pg_pool import failed (workspace-root probe)",
+            "workspace-root inbox probe encountered pool error (pg_pool import failed); assuming inbox is non-empty to force conservative cache decline",
             exc_info=True,
         )
-        return False
+        return True
 
     try:
         pool = get_ro_pool(config)
@@ -406,10 +416,10 @@ def has_workspace_root_open_messages(
             pool = get_rw_pool(config)
         except Exception:  # noqa: BLE001
             logger.warning(
-                "pg aggregates: pg pool open failed (workspace-root probe)",
+                "workspace-root inbox probe encountered pool error; assuming inbox is non-empty to force conservative cache decline",
                 exc_info=True,
             )
-            return False
+            return True
 
     sql = (
         "SELECT 1 "
@@ -427,10 +437,10 @@ def has_workspace_root_open_messages(
             row = cur.fetchone()
     except Exception:  # noqa: BLE001
         logger.warning(
-            "pg aggregates: workspace-root probe query failed",
+            "workspace-root inbox probe encountered query error; assuming inbox is non-empty to force conservative cache decline",
             exc_info=True,
         )
-        return False
+        return True
     return row is not None
 
 

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -814,14 +814,14 @@ class CockpitRouter:
     _COCKPIT_WINDOW = "PollyPM"
     _LEFT_PANE_WIDTH = 30  # default; actual value persisted in cockpit state.
     _STATE_WRITE_DEBOUNCE_SECONDS = 0.25
-    # #1642 — TTL for the project-state categorization sweep. Pre-#1642
-    # every rail refresh re-opened every project DB + every inbox source
-    # to recompute glyphs; with 0.8s ticks + state-mtime debouncing, a
-    # navigation burst could stack ~5-10 sweeps inside ``rail_refresh``.
-    # Picked at ~1 tick so a freshly-completed task still surfaces on
-    # the next refresh; callers that need stronger freshness clear via
-    # ``_clear_rail_caches`` (which the supervisor reload already does).
-    _PROJECT_CATEGORIZATIONS_TTL_SECONDS = 2.0
+    # Move A PR 3 (#1664, design §9.5): the rail-side categorization
+    # TTL (``_PROJECT_CATEGORIZATIONS_TTL_SECONDS = 2.0``) was removed.
+    # Reason: the in-process state cache's ``global_version()``
+    # short-circuit + the per-call TTL inside
+    # ``project_state_map_from_config`` already collapse navigation-burst
+    # refreshes to a single compute. Two cache layers were worse than
+    # one — a freshly-completed task hung around as WORKING for up to
+    # 2s with no invalidation path.
     _SUPERVISOR_FREE_STATIC_KEYS = frozenset(
         {"dashboard", "inbox", "workers", "metrics", "activity", "settings", "operator"},
     )
@@ -849,20 +849,9 @@ class CockpitRouter:
         # value: (db_mtime, git_mtime, is_active, has_working_task)
         # Skips re-opening SQLite on every 0.8s cockpit tick when nothing changed.
         self._project_activity_cache: dict[str, tuple[float, float, bool, bool]] = {}
-        # #1642 — short-TTL cache for the operator-state categorization that
-        # the rail glyph draws. ``project_state_map_from_config`` opens every
-        # project DB + walks every inbox source; running that on every
-        # rail-refresh tick (or every burst of state-bumps) stacks a
-        # multi-second sweep into the ``rail_refresh`` worker and contends
-        # with route workers / pane loaders. The cache key is
-        # ``(config_identity, dirty_marker)`` so a config reload (which
-        # ``_load_config`` already routes through ``_clear_rail_caches``)
-        # always misses; within a config lifetime entries expire after
-        # ``_PROJECT_CATEGORIZATIONS_TTL_SECONDS`` so freshly-completed work
-        # still surfaces within ~1 tick.
-        self._project_categorizations_cache_key: int | None = None
-        self._project_categorizations_cache: dict[str, str] | None = None
-        self._project_categorizations_cached_at: float = 0.0
+        # Move A PR 3 (#1664, design §9.5): the rail-side TTL cache for
+        # ``_project_categorizations`` was removed. See the class-level
+        # comment + the helper's docstring for rationale.
         # #1961 perf — per-window-target ``list_panes`` cache so static
         # rail click bursts don't each shell out to the same tmux
         # subprocess. value: (cached_at_monotonic, panes_or_None).
@@ -900,11 +889,8 @@ class CockpitRouter:
         self._collapsed_sections_cache = None
         self._grouped_rail_cache_key = None
         self._grouped_rail_cache = None
-        # #1642 — also drop the project-state categorization cache so a
-        # supervisor / config reload doesn't keep painting stale glyphs.
-        self._project_categorizations_cache_key = None
-        self._project_categorizations_cache = None
-        self._project_categorizations_cached_at = 0.0
+        # Move A PR 3 (#1664, design §9.5): the project-categorization
+        # TTL cache was removed; no rail-side state to clear here.
 
     def _config_identity(self, config: object) -> int:
         return id(config)
@@ -1513,10 +1499,9 @@ class CockpitRouter:
                 item.work_state = self._work_state_for_item_state(
                     item.state, launch.session.role,
                 )
-                try:
-                    heartbeat = supervisor.store.latest_heartbeat(session_name)
-                except Exception:  # noqa: BLE001
-                    heartbeat = None
+                heartbeat = self._latest_heartbeat_cached(
+                    supervisor, session_name,
+                )
                 item.heartbeat_at = getattr(heartbeat, "created_at", None)
         # #989 — Surface the top actionable alert's severity + message
         # on the item so the renderer can pick the right palette
@@ -1542,6 +1527,61 @@ class CockpitRouter:
             return None
         project_key = item.key.split(":", 1)[1]
         return project_session_map.get(project_key)
+
+    def _latest_heartbeat_cached(
+        self,
+        supervisor: object,
+        session_name: str,
+    ) -> object | None:
+        """Return the latest heartbeat for ``session_name``.
+
+        Move A PR 3 (#1664, design §5 row 9): with the cache flag on
+        AND the per-project entry populated, the heartbeat is read
+        from ``entry.latest_heartbeat_by_session[session_name]`` —
+        no per-project pg query. Falls through to
+        ``supervisor.store.latest_heartbeat`` on cold cache, missing
+        session, or any unexpected failure (e.g. the cache lagging
+        a brand-new session).
+        """
+
+        cached = self._maybe_cache_heartbeat(session_name)
+        if cached is not None:
+            return cached
+        store = getattr(supervisor, "store", None)
+        if store is None:
+            return None
+        try:
+            return store.latest_heartbeat(session_name)
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _maybe_cache_heartbeat(self, session_name: str) -> object | None:
+        """Cache fast-path for :meth:`_latest_heartbeat_cached`.
+
+        Returns ``None`` whenever a cache miss should defer to the
+        direct path — flag off, cold cache, unknown session, any
+        unexpected failure.
+        """
+
+        try:
+            from pollypm.state_cache import get_cache, is_enabled
+        except Exception:  # noqa: BLE001
+            return None
+        if not is_enabled():
+            return None
+        try:
+            cache = get_cache()
+            snapshot = cache.snapshot()
+        except Exception:  # noqa: BLE001
+            return None
+        if not snapshot:
+            return None
+        for entry in snapshot.values():
+            mapping = getattr(entry, "latest_heartbeat_by_session", None) or {}
+            heartbeat = mapping.get(session_name)
+            if heartbeat is not None:
+                return heartbeat
+        return None
 
     # ── #989 — alert metadata attachment ────────────────────────────────
     #
@@ -1914,34 +1954,16 @@ class CockpitRouter:
         to the tracked / paused IDLE classification rather than
         raising, mirroring the rest of the rail render path.
 
-        #1642 — Cached with a short TTL keyed on the config identity
-        (which already rolls forward on every config-file mtime change
-        via ``_load_config`` → ``_clear_rail_caches``). The underlying
-        ``project_state_map_from_config`` opens every project DB and
-        every inbox source on each call; running it on every 0.8s
-        rail-refresh tick stacked a multi-second sweep into the
-        ``rail_refresh`` worker and contended with route workers + pane
-        loaders. The TTL collapses navigation-burst refreshes into a
-        single sweep while keeping glyph staleness bounded.
-
-        Slice H decision (#1737): the TTL cache STAYS under both
-        backends. Under sqlite it remains the only thing keeping the
-        per-project fanout off the hot tick. Under pg the underlying
-        sweep collapses to one or two pool checkouts — strictly
-        cheaper, but redundant work across navigation-burst refreshes
-        is still wasted work, and the cache costs ~nothing to keep.
-        Slice K may revisit this when the sqlite path is gone.
+        Move A PR 3 (#1664, design §9.5): the prior 2s TTL cache
+        (``_PROJECT_CATEGORIZATIONS_TTL_SECONDS``) is **removed**. The
+        in-process state cache's ``global_version()`` short-circuit
+        plus the per-call TTL inside
+        :func:`project_state_map_from_config` (``_PREFETCH_PROJECT_STATE_TTL_SECONDS``)
+        already collapse navigation-burst refreshes into a single
+        compute. Two cache layers were worse than one — a freshly
+        completed task hung around as WORKING for up to 2s with no
+        invalidation path.
         """
-        cache_key = self._config_identity(config)
-        now = time.monotonic()
-        cached = self._project_categorizations_cache
-        if (
-            cached is not None
-            and self._project_categorizations_cache_key == cache_key
-            and now - self._project_categorizations_cached_at
-            < self._PROJECT_CATEGORIZATIONS_TTL_SECONDS
-        ):
-            return dict(cached)
         try:
             from pollypm.dashboard.operator_view import (
                 project_state_map_from_config,
@@ -1949,24 +1971,28 @@ class CockpitRouter:
 
             states = project_state_map_from_config(config)
         except Exception:  # noqa: BLE001
-            # Best-effort: cache the empty result too so a hard failure
-            # doesn't re-trigger the (expensive, failing) sweep on every
-            # tick until the TTL elapses.
-            self._project_categorizations_cache_key = cache_key
-            self._project_categorizations_cache = {}
-            self._project_categorizations_cached_at = now
             return {}
-        result = {key: state.value for key, state in states.items()}
-        self._project_categorizations_cache_key = cache_key
-        self._project_categorizations_cache = result
-        self._project_categorizations_cached_at = now
-        return dict(result)
+        return {key: state.value for key, state in states.items()}
 
     def _project_state_rollups(
         self,
         config: object,
         alerts: list[object],
     ) -> dict[str, ProjectStateRollup]:
+        """Return ``{project_key: ProjectStateRollup}`` for every project.
+
+        Move A PR 3 (#1664, design §5 row 7): when ``POLLYPM_STATE_CACHE=1``
+        AND the cache has every tracked project populated, this reads
+        the pre-computed ``rail_state`` / ``rail_badge`` / ``rail_sort_rank``
+        / ``rail_reason`` / ``approvals_pending`` fields directly from
+        ``cache.snapshot()`` — no per-project ``_project_tasks_for_rollup``
+        call, no bulk pg query. Falls through to the direct path on
+        cold / partial cache.
+        """
+        cached_rollups = self._maybe_cache_route_rollups(config, alerts)
+        if cached_rollups is not None:
+            return cached_rollups
+
         projects = getattr(config, "projects", {}) or {}
         rollups: dict[str, ProjectStateRollup] = {}
 
@@ -1995,6 +2021,74 @@ class CockpitRouter:
                 ),
             )
             rollups[str(project_key)] = rollup
+        return rollups
+
+    def _maybe_cache_route_rollups(
+        self,
+        config: object,
+        alerts: list[object],
+    ) -> dict[str, ProjectStateRollup] | None:
+        """Cache fast-path for :meth:`_project_state_rollups`.
+
+        Returns ``None`` when the env flag is off, the cache is cold,
+        or the cache is missing any tracked project. The fall-through
+        path then runs the direct per-project rollup compute.
+
+        When the cache is authoritative, the alert-derived
+        ``actionable_task_alert_ids`` is folded into a fresh
+        :class:`ProjectStateRollup` per project — the cache's
+        ``rail_*`` fields don't depend on alerts (the refresher
+        doesn't have them), so we re-derive ``actionable_key`` from
+        the live alert list while keeping the cached rail_state /
+        badge / rank / reason / approvals_pending.
+        """
+
+        try:
+            from pollypm.state_cache import get_cache, is_enabled
+        except Exception:  # noqa: BLE001
+            return None
+        if not is_enabled():
+            return None
+        try:
+            cache = get_cache()
+            snapshot = cache.snapshot()
+        except Exception:  # noqa: BLE001
+            return None
+        if not snapshot:
+            return None
+
+        projects = getattr(config, "projects", {}) or {}
+        known_keys = [str(key) for key in projects.keys()]
+        snapshot_keys = set(snapshot.keys())
+        if not all(key in snapshot_keys for key in known_keys):
+            return None
+
+        rollups: dict[str, ProjectStateRollup] = {}
+        for project_key in known_keys:
+            entry = snapshot[project_key]
+            rail_state = getattr(entry, "rail_state", None)
+            if rail_state is None:
+                # Refresher hasn't filled in rail fields yet — defer.
+                return None
+            # Re-derive actionable_key from live alerts (the cache
+            # entry doesn't carry alert state).
+            actionable_ids = actionable_alert_task_ids(
+                alerts, project_key=project_key,
+            )
+            actionable_key = (
+                next(iter(sorted(actionable_ids)), None)
+                if actionable_ids else None
+            )
+            rollups[project_key] = ProjectStateRollup(
+                state=rail_state,
+                badge=getattr(entry, "rail_badge", None),
+                sort_rank=int(getattr(entry, "rail_sort_rank", 0) or 0),
+                actionable_key=actionable_key,
+                reason=str(getattr(entry, "rail_reason", "") or ""),
+                approvals_pending=int(
+                    getattr(entry, "approvals_pending", 0) or 0
+                ),
+            )
         return rollups
 
     def _project_tasks_for_rollup(
@@ -2193,10 +2287,9 @@ class CockpitRouter:
             except Exception:  # noqa: BLE001
                 supervisor = None
             if supervisor is not None:
-                try:
-                    heartbeat = supervisor.store.latest_heartbeat(session_name)
-                except Exception:  # noqa: BLE001
-                    heartbeat = None
+                heartbeat = self._latest_heartbeat_cached(
+                    supervisor, session_name,
+                )
             working = self._is_pane_working(
                 window,
                 launch.session.provider,

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -2053,6 +2053,23 @@ class CockpitRouter:
         if not snapshot:
             return None
 
+        # Config-identity guard (PR #2026 v7 — Codex r7 blocker):
+        # decline if any snapshot entry was computed against a
+        # different config than the live one (different config_path /
+        # workspace_root). Without this, the rail rollup map serves
+        # cached state from a different workspace whenever project
+        # keys overlap. Unstamped entries (``""``) skip the check —
+        # only test fixtures construct those.
+        try:
+            from pollypm.state_cache.entry import config_identity
+            live_identity = config_identity(config)
+            for entry in snapshot.values():
+                entry_identity = getattr(entry, "config_identity", "") or ""
+                if entry_identity and entry_identity != live_identity:
+                    return None
+        except Exception:  # noqa: BLE001
+            return None
+
         projects = getattr(config, "projects", {}) or {}
         known_keys = [str(key) for key in projects.keys()]
         snapshot_keys = set(snapshot.keys())

--- a/src/pollypm/cockpit_rail.py
+++ b/src/pollypm/cockpit_rail.py
@@ -1535,18 +1535,34 @@ class CockpitRouter:
     ) -> object | None:
         """Return the latest heartbeat for ``session_name``.
 
-        Move A PR 3 (#1664, design §5 row 9): with the cache flag on
-        AND the per-project entry populated, the heartbeat is read
-        from ``entry.latest_heartbeat_by_session[session_name]`` —
-        no per-project pg query. Falls through to
-        ``supervisor.store.latest_heartbeat`` on cold cache, missing
-        session, or any unexpected failure (e.g. the cache lagging
-        a brand-new session).
+        PR #2026 review blocker 2 (fall-through workaround): the cache
+        fast-path is DISABLED until the refresher learns to invalidate
+        on heartbeat writes. ``state_cache/refresher.py`` only listens
+        for ``task.*`` / ``marker.*`` audit events, so a fresh
+        heartbeat row never invalidates ``latest_heartbeat_by_session``
+        — the cache would serve a stale snapshot indefinitely and
+        drive the UI's "offline" / "stale" treatments off it.
+
+        Until ``heartbeat.*`` invalidation lands (filed as a follow-up
+        issue), every call hits the direct pg facade. Method name kept
+        for call-site stability (no API change).
         """
 
-        cached = self._maybe_cache_heartbeat(session_name)
-        if cached is not None:
-            return cached
+        try:
+            from pollypm.storage import pg_heartbeats
+        except Exception:  # noqa: BLE001
+            pg_heartbeats = None  # type: ignore[assignment]
+        config = getattr(supervisor, "config", None)
+        if pg_heartbeats is not None:
+            try:
+                return pg_heartbeats.latest_heartbeat(
+                    session_name, config=config,
+                )
+            except Exception:  # noqa: BLE001
+                # pg pool unreachable / transient — fall through to
+                # the store facade so the rail still has SOMETHING to
+                # render. Both paths read the same heartbeats table.
+                pass
         store = getattr(supervisor, "store", None)
         if store is None:
             return None
@@ -1554,34 +1570,6 @@ class CockpitRouter:
             return store.latest_heartbeat(session_name)
         except Exception:  # noqa: BLE001
             return None
-
-    def _maybe_cache_heartbeat(self, session_name: str) -> object | None:
-        """Cache fast-path for :meth:`_latest_heartbeat_cached`.
-
-        Returns ``None`` whenever a cache miss should defer to the
-        direct path — flag off, cold cache, unknown session, any
-        unexpected failure.
-        """
-
-        try:
-            from pollypm.state_cache import get_cache, is_enabled
-        except Exception:  # noqa: BLE001
-            return None
-        if not is_enabled():
-            return None
-        try:
-            cache = get_cache()
-            snapshot = cache.snapshot()
-        except Exception:  # noqa: BLE001
-            return None
-        if not snapshot:
-            return None
-        for entry in snapshot.values():
-            mapping = getattr(entry, "latest_heartbeat_by_session", None) or {}
-            heartbeat = mapping.get(session_name)
-            if heartbeat is not None:
-                return heartbeat
-        return None
 
     # ── #989 — alert metadata attachment ────────────────────────────────
     #
@@ -2031,16 +2019,24 @@ class CockpitRouter:
         """Cache fast-path for :meth:`_project_state_rollups`.
 
         Returns ``None`` when the env flag is off, the cache is cold,
-        or the cache is missing any tracked project. The fall-through
-        path then runs the direct per-project rollup compute.
+        the cache is missing any tracked project, OR any tracked
+        project has a live actionable task alert. The fall-through
+        path then runs the direct per-project rollup compute, which
+        re-derives RED / badge / reason from the alerts.
 
-        When the cache is authoritative, the alert-derived
-        ``actionable_task_alert_ids`` is folded into a fresh
-        :class:`ProjectStateRollup` per project — the cache's
-        ``rail_*`` fields don't depend on alerts (the refresher
-        doesn't have them), so we re-derive ``actionable_key`` from
-        the live alert list while keeping the cached rail_state /
-        badge / rank / reason / approvals_pending.
+        Alert fall-through rationale (PR #2026 review blocker 1):
+        ``rollup_project_state`` folds ``actionable_task_alert_ids``
+        into the final ``rail_state`` / ``rail_badge`` / ``rail_reason``
+        / ``actionable_key`` — a live ``stuck_on_task:<project>/<n>``
+        or ``no_session_for_assignment:<project>/<n>`` alert can flip
+        a WORKING project to RED and reshape ``actionable_key`` into
+        the issues-route id. The cache entry's ``rail_*`` fields were
+        computed by the refresher WITHOUT alert state, so we cannot
+        synthesize a rollup that matches the direct path when an
+        actionable alert exists. Decline the cache for that whole
+        rendering so the direct path produces the authoritative answer.
+        Follow-up issue: cache ``actionable_alert_task_ids`` into the
+        refresher so the fast-path stays available with alerts.
         """
 
         try:
@@ -2063,6 +2059,15 @@ class CockpitRouter:
         if not all(key in snapshot_keys for key in known_keys):
             return None
 
+        # PR #2026 review blocker 1: ANY tracked project with a live
+        # actionable task alert forces fall-through. We don't try to
+        # serve the unaffected projects from cache because callers
+        # consume the whole map at once and a partial answer would
+        # mix cached + direct semantics in a single render.
+        for project_key in known_keys:
+            if actionable_alert_task_ids(alerts, project_key=project_key):
+                return None
+
         rollups: dict[str, ProjectStateRollup] = {}
         for project_key in known_keys:
             entry = snapshot[project_key]
@@ -2070,20 +2075,15 @@ class CockpitRouter:
             if rail_state is None:
                 # Refresher hasn't filled in rail fields yet — defer.
                 return None
-            # Re-derive actionable_key from live alerts (the cache
-            # entry doesn't carry alert state).
-            actionable_ids = actionable_alert_task_ids(
-                alerts, project_key=project_key,
-            )
-            actionable_key = (
-                next(iter(sorted(actionable_ids)), None)
-                if actionable_ids else None
-            )
             rollups[project_key] = ProjectStateRollup(
                 state=rail_state,
                 badge=getattr(entry, "rail_badge", None),
                 sort_rank=int(getattr(entry, "rail_sort_rank", 0) or 0),
-                actionable_key=actionable_key,
+                # No actionable alerts in scope (gated above), so the
+                # actionable_key derived from alerts is always None
+                # here — matches the direct path's behavior when
+                # ``actionable_task_alert_ids`` is empty.
+                actionable_key=None,
                 reason=str(getattr(entry, "rail_reason", "") or ""),
                 approvals_pending=int(
                     getattr(entry, "approvals_pending", 0) or 0

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -922,7 +922,15 @@ def load_config(path: Path = DEFAULT_CONFIG_PATH) -> PollyPMConfig:
         logging=logging_settings,
         events=events,
         storage=storage,
+        config_path=config_path,
     )
+    # PR #2026 v9 (Codex r9 blocker): stamp the on-disk identity so
+    # ``state_cache.entry.config_identity`` resolves to the actual
+    # TOML path (not the workspace_root fallback). Two configs loaded
+    # from different files but sharing a workspace_root MUST resolve
+    # to distinct identities, or the cache singleton can serve
+    # cross-config data.
+    config.config_path = config_path
     # PR #2018 review fix (id 4502598240): mint auth tokens for any
     # session that lacks one, then persist back to disk. Without this,
     # legacy sessions stay at auth_token="" and watchdog/recovery

--- a/src/pollypm/dashboard/operator_view.py
+++ b/src/pollypm/dashboard/operator_view.py
@@ -633,6 +633,23 @@ def _maybe_cache_route_operator_view(config) -> "OperatorDashboardView | None": 
     if not snapshot:
         return None
 
+    # Config-identity guard (PR #2026 v7 — Codex r7 blocker): decline
+    # if any snapshot entry was computed against a different config
+    # than the live one (different config_path / workspace_root).
+    # Without this, the dashboard view can mix cached state from one
+    # workspace into another whenever project keys overlap. Unstamped
+    # entries (``""``) skip the check — only test fixtures construct
+    # those.
+    try:
+        from pollypm.state_cache.entry import config_identity
+        live_identity = config_identity(config)
+        for entry in snapshot.values():
+            entry_identity = getattr(entry, "config_identity", "") or ""
+            if entry_identity and entry_identity != live_identity:
+                return None
+    except Exception:  # noqa: BLE001
+        return None
+
     scans = _collect_project_scans(config)
     if not scans:
         return OperatorDashboardView(

--- a/src/pollypm/dashboard/operator_view.py
+++ b/src/pollypm/dashboard/operator_view.py
@@ -449,7 +449,18 @@ def load_operator_view_from_config(config) -> OperatorDashboardView:  # noqa: AN
        against an adapter view of the prefetched dicts. Serial loop —
        no DB I/O remains in the per-project step, so parallel threads
        buy nothing.
+
+    Move A PR 3 (#1664): when ``POLLYPM_STATE_CACHE=1`` AND the cache
+    has every tracked project populated, this iterates
+    ``cache.snapshot()`` and builds rows from the pre-computed
+    ``state`` / ``glyph`` / ``detail`` fields, skipping the bulk
+    work-service open + prefetch entirely. Falls through to the
+    direct path on cold / partial cache.
     """
+    cached_view = _maybe_cache_route_operator_view(config)
+    if cached_view is not None:
+        return cached_view
+
     scans = _collect_project_scans(config)
     waiting_by_project = _waiting_items_by_project(config)
 
@@ -595,6 +606,80 @@ def _maybe_cache_route_state_map(config) -> dict[str, ProjectState] | None:
                 _log_divergence("project_state_map_from_config", reason)
 
     return cached_map
+
+
+def _maybe_cache_route_operator_view(config) -> "OperatorDashboardView | None":  # noqa: ANN001
+    """Return the cache-routed dashboard view, or ``None`` to fall through.
+
+    Move A PR 3 (#1664): with the env flag on AND the cache populated
+    for every tracked project, the dashboard view is built from
+    pre-computed ``state`` / ``glyph`` / ``detail`` fields on each
+    cache entry — no bulk work-service open, no per-project query
+    fanout. The fall-through path covers cold start and any project
+    the refresher hasn't filled yet.
+    """
+
+    try:
+        from pollypm.state_cache import get_cache, is_enabled
+    except Exception:  # noqa: BLE001
+        return None
+    if not is_enabled():
+        return None
+    try:
+        cache = get_cache()
+        snapshot = cache.snapshot()
+    except Exception:  # noqa: BLE001
+        return None
+    if not snapshot:
+        return None
+
+    scans = _collect_project_scans(config)
+    if not scans:
+        return OperatorDashboardView(
+            waiting=(), working=(), idle=(), paused=(),
+        )
+    # Authoritative only when every tracked project has a cache entry.
+    snapshot_keys = set(snapshot.keys())
+    if not all(scan.project_key in snapshot_keys for scan in scans):
+        return None
+
+    waiting: list[OperatorDashboardRow] = []
+    working: list[OperatorDashboardRow] = []
+    idle: list[OperatorDashboardRow] = []
+    paused: list[OperatorDashboardRow] = []
+    for scan in scans:
+        entry = snapshot[scan.project_key]
+        state = getattr(entry, "state", None)
+        if state is None:
+            # Refresher hasn't filled in state yet — defer.
+            return None
+        glyph = getattr(entry, "glyph", "") or glyph_for_project_state(state)
+        detail = getattr(entry, "detail", "") or "Quiet"
+        row = OperatorDashboardRow(
+            project_key=scan.project_key,
+            state=state,
+            glyph=glyph,
+            detail=detail,
+        )
+        if state is ProjectState.WAITING:
+            waiting.append(row)
+        elif state is ProjectState.WORKING:
+            working.append(row)
+        elif state is ProjectState.PAUSED:
+            paused.append(row)
+        else:
+            idle.append(row)
+
+    waiting.sort(key=lambda r: r.project_key.lower())
+    working.sort(key=lambda r: r.project_key.lower())
+    idle.sort(key=lambda r: r.project_key.lower())
+    paused.sort(key=lambda r: r.project_key.lower())
+    return OperatorDashboardView(
+        waiting=tuple(waiting),
+        working=tuple(working),
+        idle=tuple(idle),
+        paused=tuple(paused),
+    )
 
 
 def _direct_project_state_map_from_config(

--- a/src/pollypm/dashboard/operator_view.py
+++ b/src/pollypm/dashboard/operator_view.py
@@ -575,6 +575,29 @@ def _maybe_cache_route_state_map(config) -> dict[str, ProjectState] | None:
     if not snapshot:
         return None
 
+    # Config-identity guard (PR #2026 v8 — Codex r8 blocker): the
+    # cache is a process-wide singleton. If any snapshot entry was
+    # computed against a different ``config`` (different config_path /
+    # workspace_root) than the one the caller passed in, serving it
+    # would leak cross-config data — most acutely when the two configs
+    # share project keys. Decline and let the direct path run.
+    #
+    # Mirrors the v7 guards on the other 4 routed sites
+    # (cockpit_inbox._maybe_cache_{route,count}_awaits_user,
+    # operator_view._maybe_cache_route_operator_view, and
+    # cockpit_rail._maybe_cache_route_rollups). Entries with an empty
+    # ``config_identity`` (legacy / unstamped — test fixtures only)
+    # skip the check so the existing parity tests still serve.
+    try:
+        from pollypm.state_cache.entry import config_identity
+        live_identity = config_identity(config)
+        for entry in snapshot.values():
+            entry_identity = getattr(entry, "config_identity", "") or ""
+            if entry_identity and entry_identity != live_identity:
+                return None
+    except Exception:  # noqa: BLE001
+        return None
+
     projects = getattr(config, "projects", {}) or {}
     known_keys = set(projects.keys())
     if not known_keys:

--- a/src/pollypm/models.py
+++ b/src/pollypm/models.py
@@ -382,6 +382,15 @@ class PollyPMConfig:
         default_factory=EventsRetentionSettings,
     )
     storage: StorageSettings = field(default_factory=StorageSettings)
+    # PR #2026 v9 (Codex r9 blocker): stamped by :func:`load_config`
+    # immediately after constructing this dataclass. Consumed by
+    # :func:`pollypm.state_cache.entry.config_identity` as the
+    # cross-config-leak identity (the file on disk IS the identity).
+    # Falls back to ``project.workspace_root`` when ``None`` (test
+    # fixtures + the hand-rolled config_identity test stay
+    # backward-compatible). Kept LAST + defaulted so existing
+    # positional callers don't break.
+    config_path: Path | None = None
 
 
 @dataclass(slots=True)

--- a/src/pollypm/state_cache/entry.py
+++ b/src/pollypm/state_cache/entry.py
@@ -73,6 +73,7 @@ class ProjectStateCacheEntry:
 
     # ── heartbeats / live workers ──────────────────────────────────
     live_worker_sessions: tuple[Any, ...] = ()
+    # Populated when #2050 lands a heartbeat invalidation contract.
     latest_heartbeat_by_session: dict[str, Any] = field(default_factory=dict)
 
     # ── task statuses (recompute rail glyphs without re-opening) ───

--- a/src/pollypm/state_cache/entry.py
+++ b/src/pollypm/state_cache/entry.py
@@ -23,7 +23,55 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-__all__ = ["ProjectStateCacheEntry", "empty_entry"]
+__all__ = ["ProjectStateCacheEntry", "config_identity", "empty_entry"]
+
+
+def config_identity(config: Any) -> str:
+    """Return a canonical string identity for ``config``.
+
+    PR #2026 v7 (Codex r7 blocker): the cache singleton can serve
+    cross-config data when two ``PollyPMConfig`` objects share project
+    keys but were loaded from different on-disk roots. Every cache
+    lookup must compare this identity against the snapshot's stamped
+    identity and decline on mismatch.
+
+    Identity preference order:
+
+    1. ``config.config_path`` (resolved) — when a future refactor adds
+       this attribute, prefer it (the file on disk IS the identity).
+       :func:`pollypm.supervisor.SupervisorWorker._reviewer_auto_provision`
+       already probes for it via ``getattr`` for the same reason.
+    2. ``config.project.workspace_root`` (resolved) — every loaded
+       ``PollyPMConfig`` has one; it's the workspace root the config
+       was parsed against. Two configs with overlapping project keys
+       but different workspace roots are exactly the
+       cross-config-leak case this guard exists to catch.
+    3. Empty string — fall through. The guard treats two empties as
+       equal so test fixtures that don't set either field still work;
+       production configs always have a workspace_root.
+    """
+
+    try:
+        cfg_path = getattr(config, "config_path", None)
+        if cfg_path is not None:
+            try:
+                return str(Path(cfg_path).resolve())
+            except Exception:  # noqa: BLE001
+                return str(cfg_path)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        project = getattr(config, "project", None)
+        if project is not None:
+            wsr = getattr(project, "workspace_root", None)
+            if wsr:
+                try:
+                    return str(Path(wsr).resolve())
+                except Exception:  # noqa: BLE001
+                    return str(wsr)
+    except Exception:  # noqa: BLE001
+        pass
+    return ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,6 +133,17 @@ class ProjectStateCacheEntry:
     version: int = 0
     computed_at: float = 0.0
     source_db_path: Path | None = None
+
+    # ── config identity (PR #2026 v7) ─────────────────────────────
+    # Stamped by the refresher at compute time (see
+    # ``refresh_impl.compute_entry_for_project``). Every cache-routed
+    # call site MUST compare this against the live config's identity
+    # (via :func:`config_identity`) before consuming the entry — when
+    # they disagree the entry was computed against a different config
+    # and serving it would leak cross-config data. Defaults to ``""``
+    # so legacy fixtures that construct entries by hand still satisfy
+    # the guard against a config with no identity (e.g. unit tests).
+    config_identity: str = ""
 
 
 def empty_entry(

--- a/src/pollypm/state_cache/refresh_impl.py
+++ b/src/pollypm/state_cache/refresh_impl.py
@@ -38,7 +38,11 @@ import time
 from pathlib import Path
 from typing import Any, Callable
 
-from pollypm.state_cache.entry import ProjectStateCacheEntry, empty_entry
+from pollypm.state_cache.entry import (
+    ProjectStateCacheEntry,
+    config_identity,
+    empty_entry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +149,12 @@ def compute_entry_for_project(
         awaits_user_count=len(awaits_user_items),
         awaits_user_items=tuple(awaits_user_items),
         computed_at=time.monotonic(),
+        # PR #2026 v7 (Codex r7 blocker): stamp the config identity so
+        # every cache lookup can verify the snapshot was computed
+        # against the same config the caller holds. Without this the
+        # singleton cache can serve cross-config data whenever two
+        # configs share project keys.
+        config_identity=config_identity(config),
     )
     return entry
 

--- a/src/pollypm/state_cache/refresh_impl.py
+++ b/src/pollypm/state_cache/refresh_impl.py
@@ -66,7 +66,39 @@ def build_refresh_fn(
     invokes per project. It loads the config fresh on every call so
     a config reload during a long-running cockpit picks up the new
     paths automatically.
+
+    PR #2026 review: the closure also memoises a single ``store``
+    (StateStore) across refresh calls and reuses it for the
+    heartbeat-prefetch path. Without this, every per-project refresh
+    would build a fresh ``Supervisor(load_config(DEFAULT_CONFIG_PATH))``
+    inside :func:`_heartbeats_for_sessions` — heavy supervisor/store
+    setup on the cache's hot path, AND wrong-config when the cockpit
+    was launched against a non-default config. The cached store is
+    keyed by ``id(config)``: a config reload (new instance) drops the
+    old store and lazily opens a new one against the active config.
     """
+
+    # Cached (id(config), store) tuple. ``id(config)`` flips when the
+    # provider returns a freshly-loaded config object, so a reload
+    # transparently invalidates this slot without an explicit hook.
+    cached_store: dict[str, Any] = {"config_id": None, "store": None}
+
+    def _store_for(config: Any) -> Any | None:
+        """Return a StateStore for ``config``, reused across refreshes."""
+
+        try:
+            current_id = id(config)
+        except Exception:  # noqa: BLE001
+            return None
+        if (
+            cached_store["store"] is not None
+            and cached_store["config_id"] == current_id
+        ):
+            return cached_store["store"]
+        store = _open_store(config)
+        cached_store["config_id"] = current_id
+        cached_store["store"] = store
+        return store
 
     def _refresh(project_key: str) -> ProjectStateCacheEntry | None:
         try:
@@ -79,13 +111,51 @@ def build_refresh_fn(
                 exc_info=True,
             )
             return empty_entry(project_key)
-        return compute_entry_for_project(project_key, config)
+        store = _store_for(config)
+        return compute_entry_for_project(project_key, config, store=store)
 
     return _refresh
 
 
+def _open_store(config: Any) -> Any | None:
+    """Open a :class:`StateStore` against ``config`` for heartbeat reads.
+
+    PR #2026 review: replaces the per-project
+    ``Supervisor(load_config(DEFAULT_CONFIG_PATH))`` init inside
+    :func:`_heartbeats_for_sessions`. We don't need the full
+    Supervisor — only ``store.latest_heartbeat(session_name)`` —
+    so we open the StateStore directly against the injected config's
+    ``state_db`` path. Read-only because the refresher never writes.
+    Failures degrade silently to ``None``; the heartbeat prefetch
+    then returns ``{}`` and the rail's direct fall-through covers
+    the gap.
+    """
+
+    try:
+        from pollypm.storage.state import StateStore
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "state_cache: StateStore import failed; "
+            "heartbeat prefetch disabled",
+            exc_info=True,
+        )
+        return None
+    try:
+        state_db = getattr(getattr(config, "project", None), "state_db", None)
+        if not state_db:
+            return None
+        return StateStore(state_db, readonly=True)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "state_cache: StateStore open failed; "
+            "heartbeat prefetch disabled",
+            exc_info=True,
+        )
+        return None
+
+
 def compute_entry_for_project(
-    project_key: str, config: Any,
+    project_key: str, config: Any, *, store: Any | None = None,
 ) -> ProjectStateCacheEntry:
     """Recompute the entry for ``project_key`` against ``config``.
 
@@ -118,7 +188,15 @@ def compute_entry_for_project(
     # so cockpit_rail can short-circuit its per-project ``latest_heartbeat()``
     # calls. Best-effort: failures degrade silently to an empty mapping
     # (the rail's fall-through path re-fetches direct).
-    latest_heartbeat_by_session = _heartbeats_for_sessions(live_workers)
+    # PR #2026 review: ``store`` is threaded from ``build_refresh_fn`` so
+    # we reuse a single StateStore across the refresh pass instead of
+    # building ``Supervisor(load_config(DEFAULT_CONFIG_PATH))`` per
+    # project. When called without a store (tests, ad-hoc callers) we
+    # skip the heartbeat prefetch entirely — the rail's direct fall-through
+    # covers the gap.
+    latest_heartbeat_by_session = _heartbeats_for_sessions(
+        live_workers, store=store,
+    )
 
     entry = ProjectStateCacheEntry(
         project_key=project_key,
@@ -344,6 +422,8 @@ def _categorize_and_rollup(
 
 def _heartbeats_for_sessions(
     live_workers: list[Any],
+    *,
+    store: Any | None = None,
 ) -> dict[str, Any]:
     """Return ``{session_name: HeartbeatRecord}`` for ``live_workers``.
 
@@ -355,37 +435,24 @@ def _heartbeats_for_sessions(
 
     The mapping is keyed by ``session.name`` (matching the rail's
     ``_session_name_for_item`` resolution path) — NOT by task identity.
+
+    PR #2026 review: ``store`` is passed in from
+    :func:`build_refresh_fn`, which memoises it across the entire
+    refresh pass and rebuilds only when the active config changes
+    (keyed by ``id(config)``). Previously this function built a
+    ``Supervisor(load_config(DEFAULT_CONFIG_PATH))`` per project,
+    which (a) reintroduced heavy supervisor/store setup on the very
+    hot path the cache exists to flatten, and (b) ignored the
+    injected config — a cockpit launched against a non-default config
+    would read heartbeats from the wrong workspace. With ``store=None``
+    we skip the prefetch and let the rail's direct fall-through
+    handle it (correct behaviour, just no perf win for that pass).
     """
 
-    if not live_workers:
-        return {}
-    try:
-        from pollypm.supervisor import Supervisor
-        from pollypm.config import DEFAULT_CONFIG_PATH, load_config
-    except Exception:  # noqa: BLE001
-        logger.debug(
-            "state_cache: supervisor import failed; "
-            "skipping heartbeat prefetch",
-            exc_info=True,
-        )
-        return {}
-
-    try:
-        # Re-load the config; the cache refresher is the only consumer
-        # here, so the extra load is bounded to one per refresh-pass.
-        config = load_config(DEFAULT_CONFIG_PATH)
-        supervisor = Supervisor(config)
-    except Exception:  # noqa: BLE001
-        logger.debug(
-            "state_cache: Supervisor init failed during heartbeat prefetch",
-            exc_info=True,
-        )
+    if not live_workers or store is None:
         return {}
 
     out: dict[str, Any] = {}
-    store = getattr(supervisor, "store", None)
-    if store is None:
-        return {}
     for session in live_workers:
         # Look up the session_name from the worker record. The session
         # naming convention is ``worker_<project>/<task_number>``; the

--- a/src/pollypm/state_cache/refresh_impl.py
+++ b/src/pollypm/state_cache/refresh_impl.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import replace
 from pathlib import Path
 from typing import Any, Callable
 
@@ -67,38 +66,15 @@ def build_refresh_fn(
     a config reload during a long-running cockpit picks up the new
     paths automatically.
 
-    PR #2026 review: the closure also memoises a single ``store``
-    (StateStore) across refresh calls and reuses it for the
-    heartbeat-prefetch path. Without this, every per-project refresh
-    would build a fresh ``Supervisor(load_config(DEFAULT_CONFIG_PATH))``
-    inside :func:`_heartbeats_for_sessions` — heavy supervisor/store
-    setup on the cache's hot path, AND wrong-config when the cockpit
-    was launched against a non-default config. The cached store is
-    keyed by ``id(config)``: a config reload (new instance) drops the
-    old store and lazily opens a new one against the active config.
+    PR #2026 re-review: heartbeat prefetch now routes through the
+    pg facade (``pollypm.storage.pg_heartbeats.latest_heartbeat``)
+    instead of opening a legacy sqlite state store. The previous
+    memoised-store shim conflicted with the no-sqlite runtime
+    direction (#1737 / #2039) and returned the wrong rows when the
+    active backend was Postgres. The pg facade owns its own pool, so
+    there's nothing to memoise in this closure anymore — the refresh
+    function is a thin config-provider wrapper.
     """
-
-    # Cached (id(config), store) tuple. ``id(config)`` flips when the
-    # provider returns a freshly-loaded config object, so a reload
-    # transparently invalidates this slot without an explicit hook.
-    cached_store: dict[str, Any] = {"config_id": None, "store": None}
-
-    def _store_for(config: Any) -> Any | None:
-        """Return a StateStore for ``config``, reused across refreshes."""
-
-        try:
-            current_id = id(config)
-        except Exception:  # noqa: BLE001
-            return None
-        if (
-            cached_store["store"] is not None
-            and cached_store["config_id"] == current_id
-        ):
-            return cached_store["store"]
-        store = _open_store(config)
-        cached_store["config_id"] = current_id
-        cached_store["store"] = store
-        return store
 
     def _refresh(project_key: str) -> ProjectStateCacheEntry | None:
         try:
@@ -111,51 +87,13 @@ def build_refresh_fn(
                 exc_info=True,
             )
             return empty_entry(project_key)
-        store = _store_for(config)
-        return compute_entry_for_project(project_key, config, store=store)
+        return compute_entry_for_project(project_key, config)
 
     return _refresh
 
 
-def _open_store(config: Any) -> Any | None:
-    """Open a :class:`StateStore` against ``config`` for heartbeat reads.
-
-    PR #2026 review: replaces the per-project
-    ``Supervisor(load_config(DEFAULT_CONFIG_PATH))`` init inside
-    :func:`_heartbeats_for_sessions`. We don't need the full
-    Supervisor — only ``store.latest_heartbeat(session_name)`` —
-    so we open the StateStore directly against the injected config's
-    ``state_db`` path. Read-only because the refresher never writes.
-    Failures degrade silently to ``None``; the heartbeat prefetch
-    then returns ``{}`` and the rail's direct fall-through covers
-    the gap.
-    """
-
-    try:
-        from pollypm.storage.state import StateStore
-    except Exception:  # noqa: BLE001
-        logger.debug(
-            "state_cache: StateStore import failed; "
-            "heartbeat prefetch disabled",
-            exc_info=True,
-        )
-        return None
-    try:
-        state_db = getattr(getattr(config, "project", None), "state_db", None)
-        if not state_db:
-            return None
-        return StateStore(state_db, readonly=True)
-    except Exception:  # noqa: BLE001
-        logger.debug(
-            "state_cache: StateStore open failed; "
-            "heartbeat prefetch disabled",
-            exc_info=True,
-        )
-        return None
-
-
 def compute_entry_for_project(
-    project_key: str, config: Any, *, store: Any | None = None,
+    project_key: str, config: Any,
 ) -> ProjectStateCacheEntry:
     """Recompute the entry for ``project_key`` against ``config``.
 
@@ -188,14 +126,10 @@ def compute_entry_for_project(
     # so cockpit_rail can short-circuit its per-project ``latest_heartbeat()``
     # calls. Best-effort: failures degrade silently to an empty mapping
     # (the rail's fall-through path re-fetches direct).
-    # PR #2026 review: ``store`` is threaded from ``build_refresh_fn`` so
-    # we reuse a single StateStore across the refresh pass instead of
-    # building ``Supervisor(load_config(DEFAULT_CONFIG_PATH))`` per
-    # project. When called without a store (tests, ad-hoc callers) we
-    # skip the heartbeat prefetch entirely — the rail's direct fall-through
-    # covers the gap.
+    # PR #2026 re-review: routes through the pg heartbeats facade —
+    # no more legacy sqlite state-store dependency in state_cache.
     latest_heartbeat_by_session = _heartbeats_for_sessions(
-        live_workers, store=store,
+        live_workers, config=config,
     )
 
     entry = ProjectStateCacheEntry(
@@ -423,7 +357,7 @@ def _categorize_and_rollup(
 def _heartbeats_for_sessions(
     live_workers: list[Any],
     *,
-    store: Any | None = None,
+    config: Any | None = None,
 ) -> dict[str, Any]:
     """Return ``{session_name: HeartbeatRecord}`` for ``live_workers``.
 
@@ -436,20 +370,40 @@ def _heartbeats_for_sessions(
     The mapping is keyed by ``session.name`` (matching the rail's
     ``_session_name_for_item`` resolution path) — NOT by task identity.
 
-    PR #2026 review: ``store`` is passed in from
-    :func:`build_refresh_fn`, which memoises it across the entire
-    refresh pass and rebuilds only when the active config changes
-    (keyed by ``id(config)``). Previously this function built a
-    ``Supervisor(load_config(DEFAULT_CONFIG_PATH))`` per project,
-    which (a) reintroduced heavy supervisor/store setup on the very
-    hot path the cache exists to flatten, and (b) ignored the
-    injected config — a cockpit launched against a non-default config
-    would read heartbeats from the wrong workspace. With ``store=None``
-    we skip the prefetch and let the rail's direct fall-through
-    handle it (correct behaviour, just no perf win for that pass).
+    PR #2026 re-review: routes strictly through
+    :func:`pollypm.storage.pg_heartbeats.latest_heartbeat`. The
+    previous implementation opened a legacy sqlite state store
+    against the per-project sqlite db, which (a) reintroduced a
+    sqlite dependency the no-sqlite runtime track (#1737, #2039)
+    had just removed, and (b) returned stale rows when the active
+    backend was Postgres (the unified ``heartbeats`` table lives in
+    pg post-cutover).
+
+    Any pg failure — import error, connection failure, per-session
+    query error — is swallowed and surfaces as a missing key in the
+    returned mapping. Downstream consumers already treat a missing
+    heartbeat as ``None`` (the rail's direct fall-through then
+    re-queries). On total facade unavailability we return ``{}``,
+    matching the previous early-return shape.
+
+    Note: ``pg_heartbeats`` exposes only a per-session reader. This
+    function issues N individual ``latest_heartbeat(name)`` calls.
+    A bulk ``latest_heartbeats(names)`` facade would let us collapse
+    these into one SELECT and is worth adding once another caller
+    needs it — flagged in the commit message but out of scope here.
     """
 
-    if not live_workers or store is None:
+    if not live_workers:
+        return {}
+
+    try:
+        from pollypm.storage.pg_heartbeats import latest_heartbeat
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "state_cache: pg_heartbeats import failed; "
+            "heartbeat prefetch disabled",
+            exc_info=True,
+        )
         return {}
 
     out: dict[str, Any] = {}
@@ -463,7 +417,7 @@ def _heartbeats_for_sessions(
         if not session_name:
             continue
         try:
-            heartbeat = store.latest_heartbeat(session_name)
+            heartbeat = latest_heartbeat(session_name, config=config)
         except Exception:  # noqa: BLE001
             heartbeat = None
         if heartbeat is not None:

--- a/src/pollypm/state_cache/refresh_impl.py
+++ b/src/pollypm/state_cache/refresh_impl.py
@@ -107,17 +107,19 @@ def compute_entry_for_project(
     tracked = bool(getattr(project, "tracked", True)) if project else False
 
     awaits_user_items = _awaits_user_items_for(project_key, config)
-    state, glyph, detail, rail_rollup = _categorize_and_rollup(
+    state, glyph, detail, rail_rollup, live_workers = _categorize_and_rollup(
         project_key=project_key,
         config=config,
         tracked=tracked,
         awaits_user_items=list(awaits_user_items),
     )
 
-    # PR 2 only needs to populate the fields the routed call sites
-    # read — leave the rest at the entry defaults so the cache stays
-    # cheap to construct. PR 3 will widen this when the remaining
-    # call sites land.
+    # PR 3: populate live worker sessions + latest_heartbeat_by_session
+    # so cockpit_rail can short-circuit its per-project ``latest_heartbeat()``
+    # calls. Best-effort: failures degrade silently to an empty mapping
+    # (the rail's fall-through path re-fetches direct).
+    latest_heartbeat_by_session = _heartbeats_for_sessions(live_workers)
+
     entry = ProjectStateCacheEntry(
         project_key=project_key,
         project_path=project_path,
@@ -132,6 +134,8 @@ def compute_entry_for_project(
         approvals_pending=rail_rollup[4] if rail_rollup else 0,
         awaits_user_count=len(awaits_user_items),
         awaits_user_items=tuple(awaits_user_items),
+        live_worker_sessions=tuple(live_workers),
+        latest_heartbeat_by_session=latest_heartbeat_by_session,
         computed_at=time.monotonic(),
     )
     return entry
@@ -207,14 +211,20 @@ def _categorize_and_rollup(
     config: Any,
     tracked: bool,
     awaits_user_items: list[Any],
-) -> tuple[Any, str, str, tuple[Any, Any, int, str, int] | None]:
+) -> tuple[
+    Any, str, str,
+    tuple[Any, Any, int, str, int] | None,
+    list[Any],
+]:
     """Run ``categorize_project`` + ``rollup_project_state`` for one project.
 
-    Returns ``(state, glyph, detail, rollup_tuple_or_None)``. The
-    rollup tuple is ``(rail_state, rail_badge, sort_rank, reason,
+    Returns ``(state, glyph, detail, rollup_tuple_or_None, live_workers)``.
+    The rollup tuple is ``(rail_state, rail_badge, sort_rank, reason,
     approvals_pending)`` — kept positional so the caller can ``zip``
     it into the entry fields without a second import of the rollup
-    types here.
+    types here. ``live_workers`` is the list of active worker session
+    records for the project, used by PR 3 to populate
+    ``latest_heartbeat_by_session``.
 
     Failures degrade silently — a broken work-service drops the
     project to IDLE (or PAUSED when not tracked) with no rollup.
@@ -242,7 +252,7 @@ def _categorize_and_rollup(
             project_key,
             exc_info=True,
         )
-        return None, "", "", None
+        return None, "", "", None, []
 
     shared_svc = _open_shared_work_service(config)
     try:
@@ -258,7 +268,7 @@ def _categorize_and_rollup(
                 detail = "Paused"
             else:
                 detail = "Quiet"
-            return state, glyph, detail, None
+            return state, glyph, detail, None, []
 
         tasks_by_alias, workers_by_alias = _prefetch_project_state(
             config, shared_svc,
@@ -316,10 +326,102 @@ def _categorize_and_rollup(
             )
             rollup_tuple = None
 
-        return state, glyph, detail, rollup_tuple
+        # PR 3: gather live workers so the per-project heartbeat
+        # lookup can short-circuit in cockpit_rail. ``slice_svc``
+        # already filters by this project's aliases.
+        try:
+            live_workers = list(slice_svc.list_worker_sessions(
+                project=project_key, active_only=True,
+            ))
+        except Exception:  # noqa: BLE001
+            live_workers = []
+
+        return state, glyph, detail, rollup_tuple, live_workers
     finally:
         if shared_svc is not None:
             _safe_close(shared_svc)
+
+
+def _heartbeats_for_sessions(
+    live_workers: list[Any],
+) -> dict[str, Any]:
+    """Return ``{session_name: HeartbeatRecord}`` for ``live_workers``.
+
+    PR 3 (§5 row 9): the rail's ``latest_heartbeat()`` is called once
+    per project per refresh. Folding it into the cache refresh means
+    the rail can short-circuit on the cache snapshot instead of
+    issuing N pg queries. Best-effort — a failed lookup degrades to
+    a missing key (the rail's fall-through then re-queries direct).
+
+    The mapping is keyed by ``session.name`` (matching the rail's
+    ``_session_name_for_item`` resolution path) — NOT by task identity.
+    """
+
+    if not live_workers:
+        return {}
+    try:
+        from pollypm.supervisor import Supervisor
+        from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "state_cache: supervisor import failed; "
+            "skipping heartbeat prefetch",
+            exc_info=True,
+        )
+        return {}
+
+    try:
+        # Re-load the config; the cache refresher is the only consumer
+        # here, so the extra load is bounded to one per refresh-pass.
+        config = load_config(DEFAULT_CONFIG_PATH)
+        supervisor = Supervisor(config)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "state_cache: Supervisor init failed during heartbeat prefetch",
+            exc_info=True,
+        )
+        return {}
+
+    out: dict[str, Any] = {}
+    store = getattr(supervisor, "store", None)
+    if store is None:
+        return {}
+    for session in live_workers:
+        # Look up the session_name from the worker record. The session
+        # naming convention is ``worker_<project>/<task_number>``; the
+        # supervisor.store.latest_heartbeat call sites in cockpit_rail
+        # take the resolved session name from launches, which match
+        # the worker session bindings.
+        session_name = _session_name_for_worker(session)
+        if not session_name:
+            continue
+        try:
+            heartbeat = store.latest_heartbeat(session_name)
+        except Exception:  # noqa: BLE001
+            heartbeat = None
+        if heartbeat is not None:
+            out[session_name] = heartbeat
+    return out
+
+
+def _session_name_for_worker(session: Any) -> str:
+    """Resolve the session_name string for a worker-session record.
+
+    Workers may surface their session name as ``session_name`` (the
+    canonical tmux session) or be derivable from
+    ``(task_project, task_number)`` via the standard
+    ``worker_<project>/<number>`` convention. Returns ``""`` when no
+    name can be inferred.
+    """
+
+    direct = getattr(session, "session_name", None)
+    if direct:
+        return str(direct)
+    project = str(getattr(session, "task_project", "") or "")
+    number = getattr(session, "task_number", None)
+    if project and number is not None:
+        return f"worker_{project}/{number}"
+    return ""
 
 
 # ── refresher integration ─────────────────────────────────────────

--- a/src/pollypm/state_cache/refresh_impl.py
+++ b/src/pollypm/state_cache/refresh_impl.py
@@ -66,14 +66,13 @@ def build_refresh_fn(
     a config reload during a long-running cockpit picks up the new
     paths automatically.
 
-    PR #2026 re-review: heartbeat prefetch now routes through the
-    pg facade (``pollypm.storage.pg_heartbeats.latest_heartbeat``)
-    instead of opening a legacy sqlite state store. The previous
-    memoised-store shim conflicted with the no-sqlite runtime
-    direction (#1737 / #2039) and returned the wrong rows when the
-    active backend was Postgres. The pg facade owns its own pool, so
-    there's nothing to memoise in this closure anymore — the refresh
-    function is a thin config-provider wrapper.
+    PR #2026 v3 (Codex re-review): heartbeat prefetch removed entirely.
+    The two rail consumers (``cockpit_rail._latest_heartbeat_cached``)
+    were converted to direct pg-facade reads because the refresher had
+    no ``heartbeat.*`` audit-event subscription and so could only ever
+    serve a stale snapshot. Until that invalidation lands (filed as
+    #2050 follow-up) there's nothing for the refresher to prefetch —
+    the closure is a thin config-provider wrapper.
     """
 
     def _refresh(project_key: str) -> ProjectStateCacheEntry | None:
@@ -115,23 +114,22 @@ def compute_entry_for_project(
     tracked = bool(getattr(project, "tracked", True)) if project else False
 
     awaits_user_items = _awaits_user_items_for(project_key, config)
-    state, glyph, detail, rail_rollup, live_workers = _categorize_and_rollup(
+    state, glyph, detail, rail_rollup = _categorize_and_rollup(
         project_key=project_key,
         config=config,
         tracked=tracked,
         awaits_user_items=list(awaits_user_items),
     )
 
-    # PR 3: populate live worker sessions + latest_heartbeat_by_session
-    # so cockpit_rail can short-circuit its per-project ``latest_heartbeat()``
-    # calls. Best-effort: failures degrade silently to an empty mapping
-    # (the rail's fall-through path re-fetches direct).
-    # PR #2026 re-review: routes through the pg heartbeats facade —
-    # no more legacy sqlite state-store dependency in state_cache.
-    latest_heartbeat_by_session = _heartbeats_for_sessions(
-        live_workers, config=config,
-    )
-
+    # PR #2026 v3 (Codex re-review blocker 2): the heartbeat prefetch
+    # path was dead code. ``cockpit_rail._latest_heartbeat_cached``
+    # bypasses ``entry.latest_heartbeat_by_session`` and reads
+    # ``pollypm.storage.pg_heartbeats`` directly because the refresher
+    # has no ``heartbeat.*`` audit-event subscription and can only
+    # serve stale snapshots. Populating the field meant N pg reads
+    # per project per refresh with zero consumers. The entry field is
+    # retained (defaults to ``{}``) so callers don't crash on
+    # attribute access; the bulk-prefetch wiring lands with #2050.
     entry = ProjectStateCacheEntry(
         project_key=project_key,
         project_path=project_path,
@@ -146,8 +144,6 @@ def compute_entry_for_project(
         approvals_pending=rail_rollup[4] if rail_rollup else 0,
         awaits_user_count=len(awaits_user_items),
         awaits_user_items=tuple(awaits_user_items),
-        live_worker_sessions=tuple(live_workers),
-        latest_heartbeat_by_session=latest_heartbeat_by_session,
         computed_at=time.monotonic(),
     )
     return entry
@@ -226,17 +222,20 @@ def _categorize_and_rollup(
 ) -> tuple[
     Any, str, str,
     tuple[Any, Any, int, str, int] | None,
-    list[Any],
 ]:
     """Run ``categorize_project`` + ``rollup_project_state`` for one project.
 
-    Returns ``(state, glyph, detail, rollup_tuple_or_None, live_workers)``.
-    The rollup tuple is ``(rail_state, rail_badge, sort_rank, reason,
+    Returns ``(state, glyph, detail, rollup_tuple_or_None)``. The
+    rollup tuple is ``(rail_state, rail_badge, sort_rank, reason,
     approvals_pending)`` — kept positional so the caller can ``zip``
     it into the entry fields without a second import of the rollup
-    types here. ``live_workers`` is the list of active worker session
-    records for the project, used by PR 3 to populate
-    ``latest_heartbeat_by_session``.
+    types here.
+
+    PR #2026 v3 (Codex re-review blocker 2): no longer returns
+    ``live_workers``. The heartbeat prefetch that consumed that list
+    was dead code (cockpit_rail bypasses the cache for heartbeats);
+    keeping the slice-svc roster query alive cost N pg reads per
+    refresh with zero readers.
 
     Failures degrade silently — a broken work-service drops the
     project to IDLE (or PAUSED when not tracked) with no rollup.
@@ -264,7 +263,7 @@ def _categorize_and_rollup(
             project_key,
             exc_info=True,
         )
-        return None, "", "", None, []
+        return None, "", "", None
 
     shared_svc = _open_shared_work_service(config)
     try:
@@ -280,7 +279,7 @@ def _categorize_and_rollup(
                 detail = "Paused"
             else:
                 detail = "Quiet"
-            return state, glyph, detail, None, []
+            return state, glyph, detail, None
 
         tasks_by_alias, workers_by_alias = _prefetch_project_state(
             config, shared_svc,
@@ -338,111 +337,10 @@ def _categorize_and_rollup(
             )
             rollup_tuple = None
 
-        # PR 3: gather live workers so the per-project heartbeat
-        # lookup can short-circuit in cockpit_rail. ``slice_svc``
-        # already filters by this project's aliases.
-        try:
-            live_workers = list(slice_svc.list_worker_sessions(
-                project=project_key, active_only=True,
-            ))
-        except Exception:  # noqa: BLE001
-            live_workers = []
-
-        return state, glyph, detail, rollup_tuple, live_workers
+        return state, glyph, detail, rollup_tuple
     finally:
         if shared_svc is not None:
             _safe_close(shared_svc)
-
-
-def _heartbeats_for_sessions(
-    live_workers: list[Any],
-    *,
-    config: Any | None = None,
-) -> dict[str, Any]:
-    """Return ``{session_name: HeartbeatRecord}`` for ``live_workers``.
-
-    PR 3 (§5 row 9): the rail's ``latest_heartbeat()`` is called once
-    per project per refresh. Folding it into the cache refresh means
-    the rail can short-circuit on the cache snapshot instead of
-    issuing N pg queries. Best-effort — a failed lookup degrades to
-    a missing key (the rail's fall-through then re-queries direct).
-
-    The mapping is keyed by ``session.name`` (matching the rail's
-    ``_session_name_for_item`` resolution path) — NOT by task identity.
-
-    PR #2026 re-review: routes strictly through
-    :func:`pollypm.storage.pg_heartbeats.latest_heartbeat`. The
-    previous implementation opened a legacy sqlite state store
-    against the per-project sqlite db, which (a) reintroduced a
-    sqlite dependency the no-sqlite runtime track (#1737, #2039)
-    had just removed, and (b) returned stale rows when the active
-    backend was Postgres (the unified ``heartbeats`` table lives in
-    pg post-cutover).
-
-    Any pg failure — import error, connection failure, per-session
-    query error — is swallowed and surfaces as a missing key in the
-    returned mapping. Downstream consumers already treat a missing
-    heartbeat as ``None`` (the rail's direct fall-through then
-    re-queries). On total facade unavailability we return ``{}``,
-    matching the previous early-return shape.
-
-    Note: ``pg_heartbeats`` exposes only a per-session reader. This
-    function issues N individual ``latest_heartbeat(name)`` calls.
-    A bulk ``latest_heartbeats(names)`` facade would let us collapse
-    these into one SELECT and is worth adding once another caller
-    needs it — flagged in the commit message but out of scope here.
-    """
-
-    if not live_workers:
-        return {}
-
-    try:
-        from pollypm.storage.pg_heartbeats import latest_heartbeat
-    except Exception:  # noqa: BLE001
-        logger.debug(
-            "state_cache: pg_heartbeats import failed; "
-            "heartbeat prefetch disabled",
-            exc_info=True,
-        )
-        return {}
-
-    out: dict[str, Any] = {}
-    for session in live_workers:
-        # Look up the session_name from the worker record. The session
-        # naming convention is ``worker_<project>/<task_number>``; the
-        # supervisor.store.latest_heartbeat call sites in cockpit_rail
-        # take the resolved session name from launches, which match
-        # the worker session bindings.
-        session_name = _session_name_for_worker(session)
-        if not session_name:
-            continue
-        try:
-            heartbeat = latest_heartbeat(session_name, config=config)
-        except Exception:  # noqa: BLE001
-            heartbeat = None
-        if heartbeat is not None:
-            out[session_name] = heartbeat
-    return out
-
-
-def _session_name_for_worker(session: Any) -> str:
-    """Resolve the session_name string for a worker-session record.
-
-    Workers may surface their session name as ``session_name`` (the
-    canonical tmux session) or be derivable from
-    ``(task_project, task_number)`` via the standard
-    ``worker_<project>/<number>`` convention. Returns ``""`` when no
-    name can be inferred.
-    """
-
-    direct = getattr(session, "session_name", None)
-    if direct:
-        return str(direct)
-    project = str(getattr(session, "task_project", "") or "")
-    number = getattr(session, "task_number", None)
-    if project and number is not None:
-        return f"worker_{project}/{number}"
-    return ""
 
 
 # ── refresher integration ─────────────────────────────────────────

--- a/tests/test_cockpit_rail_categorization_cache.py
+++ b/tests/test_cockpit_rail_categorization_cache.py
@@ -1,4 +1,4 @@
-"""Tests for the rail's project-state categorization TTL cache (#1642).
+"""Tests for the rail's project-state categorization (#1642 → Move A PR 3).
 
 Pre-#1642, ``CockpitRouter._project_categorizations`` called through to
 ``project_state_map_from_config`` on every rail-refresh tick. That
@@ -6,14 +6,24 @@ function opens every project DB + walks every inbox source, so a
 navigation burst could stack a multi-second sweep inside the
 ``rail_refresh`` worker and contend with route workers + pane loaders.
 
-The fix wraps the call in a short-TTL cache keyed on the config
-identity. These tests pin two invariants:
+The original #1642 fix wrapped the call in a short-TTL cache keyed on
+the config identity. Move A PR 3 (docs/design/move-a-state-cache.md
+§9.5) **removes** that TTL: the in-process state cache's
+``global_version()`` short-circuit + the per-call TTL inside
+:func:`project_state_map_from_config` (``_PREFETCH_PROJECT_STATE_TTL_SECONDS``)
+already collapse navigation-burst refreshes into a single compute. Two
+cache layers were worse than one — a freshly completed task hung
+around as WORKING for up to 2s with no invalidation path.
 
-* Within the TTL, repeated calls collapse to a single underlying sweep
-  (no DB re-scans on every tick).
-* The cache is invalidated when ``_clear_rail_caches`` runs — which is
-  the same chokepoint ``_load_config`` already routes config-mtime
-  reloads through.
+These tests pin the post-removal invariants:
+
+* The rail's :meth:`_project_categorizations` is now a thin wrapper
+  around :func:`project_state_map_from_config`; every call delegates
+  to the underlying helper, no router-side memoisation.
+* Updates to the underlying state are visible on the next call (no
+  waiting on a TTL to elapse).
+* The router-side TTL attributes are gone — verified by introspection
+  so a future "let's add caching back" PR breaks a test loud and clear.
 """
 
 from __future__ import annotations
@@ -36,12 +46,17 @@ def _router(tmp_path: Path) -> CockpitRouter:
     return CockpitRouter(config_path)
 
 
-def test_project_categorizations_caches_within_ttl(monkeypatch, tmp_path: Path) -> None:
-    """Repeated calls within the TTL must not re-scan project DBs.
+def test_project_categorizations_does_not_cache_within_ttl(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Move A PR 3 (§9.5): the rail-side TTL is GONE.
 
-    Counts the number of times ``project_state_map_from_config`` is
-    invoked; on a 0.8s-tick cockpit, 10 calls landing inside the cache
-    window must collapse to exactly one underlying sweep.
+    Every call delegates to ``project_state_map_from_config`` so the
+    rail picks up state changes immediately. ``project_state_map_from_config``
+    itself has a 1s ``_PREFETCH_PROJECT_STATE_TTL_SECONDS`` cache plus
+    (when the env flag is on) the state-cache fast path; both yield the
+    same "skip wasted work when nothing changed" win without trapping
+    stale data behind a rail-side timer.
     """
     router = _router(tmp_path)
     config = object()
@@ -61,27 +76,26 @@ def test_project_categorizations_caches_within_ttl(monkeypatch, tmp_path: Path) 
     for _ in range(9):
         router._project_categorizations(config)
 
-    assert len(calls) == 1, (
-        "rail re-scanned project DBs within TTL — expected cached result"
-    )
+    # No router-side caching — every call delegates fresh.
+    assert len(calls) == 10
     assert first == {"alpha": "working", "beta": "idle"}
 
 
-def test_project_categorizations_invalidates_on_cache_clear(
+def test_project_categorizations_updates_visible_immediately(
     monkeypatch, tmp_path: Path,
 ) -> None:
-    """``_clear_rail_caches`` (called by ``_load_config`` on mtime change)
-    must drop the categorization cache so a reloaded config doesn't keep
-    painting stale glyphs."""
+    """A change to the underlying state is visible on the next call.
+
+    Regression test for the TTL pathology: freshly-completed work
+    hanging around as WORKING for up to 2s. Now the rail picks up
+    state transitions on the next tick.
+    """
     router = _router(tmp_path)
     config = object()
 
     state = {"map": {"alpha": ProjectState.WORKING}}
-    calls = 0
 
     def _fake_map(cfg):  # noqa: ANN001, ANN202
-        nonlocal calls
-        calls += 1
         return state["map"]
 
     monkeypatch.setattr(
@@ -89,51 +103,28 @@ def test_project_categorizations_invalidates_on_cache_clear(
         _fake_map,
     )
 
-    router._project_categorizations(config)
-    assert calls == 1
-    router._clear_rail_caches()
-    state["map"] = {"alpha": ProjectState.WAITING}
-    result = router._project_categorizations(config)
-    assert calls == 2
-    assert result == {"alpha": "waiting"}
+    first = router._project_categorizations(config)
+    assert first == {"alpha": "working"}
+
+    # Simulate the task completing — the rail's next call MUST see the
+    # new state, with no waiting on a TTL to elapse.
+    state["map"] = {"alpha": ProjectState.IDLE}
+    second = router._project_categorizations(config)
+    assert second == {"alpha": "idle"}
 
 
-def test_project_categorizations_returns_independent_dict(
+def test_project_categorizations_handles_failure_without_raising(
     monkeypatch, tmp_path: Path,
 ) -> None:
-    """Callers must not be able to mutate the cached map.
+    """A raising sweep is contained — caller gets ``{}`` instead of a crash.
 
-    The rail glues the result onto ``CockpitItem`` rendering; if a
-    caller pops keys (e.g. while walking project rows) the cached map
-    must stay intact for the next tick.
+    The router stays best-effort: a broken underlying helper degrades
+    to an empty map rather than propagating into the rail render path.
     """
     router = _router(tmp_path)
     config = object()
 
-    monkeypatch.setattr(
-        "pollypm.dashboard.operator_view.project_state_map_from_config",
-        lambda _cfg: {"alpha": ProjectState.WORKING},
-    )
-
-    first = router._project_categorizations(config)
-    first["alpha"] = "MUTATED"
-    second = router._project_categorizations(config)
-    assert second["alpha"] == "working"
-
-
-def test_project_categorizations_caches_empty_on_failure(
-    monkeypatch, tmp_path: Path,
-) -> None:
-    """A raising sweep must still be cached as ``{}`` so the rail
-    doesn't re-trigger the (expensive, failing) scan every tick."""
-    router = _router(tmp_path)
-    config = object()
-
-    calls = 0
-
     def _boom(_cfg):  # noqa: ANN001, ANN202
-        nonlocal calls
-        calls += 1
         raise RuntimeError("DB unavailable")
 
     monkeypatch.setattr(
@@ -144,4 +135,17 @@ def test_project_categorizations_caches_empty_on_failure(
     result_a = router._project_categorizations(config)
     result_b = router._project_categorizations(config)
     assert result_a == {} == result_b
-    assert calls == 1
+
+
+def test_router_no_longer_holds_categorization_cache_state(
+    tmp_path: Path,
+) -> None:
+    """The router-side TTL attributes are GONE (Move A PR 3, §9.5).
+
+    A future "let's add caching back" PR will break this test.
+    """
+    router = _router(tmp_path)
+    assert not hasattr(router, "_project_categorizations_cache")
+    assert not hasattr(router, "_project_categorizations_cache_key")
+    assert not hasattr(router, "_project_categorizations_cached_at")
+    assert not hasattr(CockpitRouter, "_PROJECT_CATEGORIZATIONS_TTL_SECONDS")

--- a/tests/test_state_cache_config_identity.py
+++ b/tests/test_state_cache_config_identity.py
@@ -1,0 +1,297 @@
+"""Move A PR 3 — config-identity guard (PR #2026 v7 / Codex r7 blocker).
+
+The cache singleton can serve cross-config data when two
+``PollyPMConfig`` objects share project keys but were loaded from
+different on-disk roots (different ``config_path`` /
+``workspace_root``). PR #2026 v7 stamps a ``config_identity`` on
+every cache entry at refresh time and re-checks it at every cache
+lookup. When the live config's identity disagrees with a stamped
+entry, the lookup MUST decline (return ``None``) and fall through to
+the direct DB path.
+
+This file pins the cross-config invariant for all four routed call
+sites:
+
+* ``_maybe_cache_route_awaits_user`` (cockpit_inbox)
+* ``_maybe_cache_count_awaits_user`` (cockpit_inbox)
+* ``_maybe_cache_route_operator_view`` (dashboard/operator_view)
+* ``CockpitRailRenderer._maybe_cache_route_rollups`` (cockpit_rail)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import pollypm.cockpit_inbox as cockpit_inbox
+import pollypm.dashboard.operator_view as operator_view
+from pollypm.dashboard.categorization import ProjectState
+from pollypm.state_cache import (
+    ProjectStateCache,
+    ProjectStateCacheEntry,
+    reset_for_test,
+)
+from pollypm.state_cache.entry import config_identity
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state_cache_singletons():
+    reset_for_test()
+    yield
+    reset_for_test()
+
+
+@pytest.fixture(autouse=True)
+def _reset_legacy_ttl_caches():
+    cockpit_inbox._AWAITS_USER_CACHE.clear()
+    operator_view._PREFETCH_PROJECT_STATE_CACHE.clear()
+    yield
+    cockpit_inbox._AWAITS_USER_CACHE.clear()
+    operator_view._PREFETCH_PROJECT_STATE_CACHE.clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_call_site_divergence_counters():
+    cockpit_inbox._AWAITS_USER_DIVERGENCE_COUNTER.reset()
+    operator_view._STATE_MAP_DIVERGENCE_COUNTER.reset()
+    yield
+
+
+def _make_config(project_keys: list[str], workspace_root: Path) -> SimpleNamespace:
+    """Build a minimal config with a distinct ``workspace_root``.
+
+    The config identity helper resolves
+    ``config.project.workspace_root`` when ``config.config_path`` is
+    absent (the production ``PollyPMConfig`` shape today). Two
+    configs with different roots but overlapping project keys are
+    exactly the cross-config-leak case the guard exists to catch.
+    """
+
+    projects = {
+        key: SimpleNamespace(
+            key=key,
+            path=workspace_root / key,
+            tracked=True,
+            name=key.title(),
+        )
+        for key in project_keys
+    }
+    return SimpleNamespace(
+        projects=projects,
+        project=SimpleNamespace(workspace_root=str(workspace_root)),
+        storage=SimpleNamespace(backend="postgres"),
+    )
+
+
+def _stamped_entry(
+    project_key: str,
+    *,
+    config: Any,
+    items: list[Any] | None = None,
+    state: ProjectState = ProjectState.WAITING,
+) -> ProjectStateCacheEntry:
+    """Build an entry stamped with ``config``'s identity (mirrors refresh)."""
+
+    items = items or []
+    return ProjectStateCacheEntry(
+        project_key=project_key,
+        project_path=Path(f"/tmp/{project_key}"),
+        tracked=True,
+        state=state,
+        glyph="?",
+        detail="x",
+        rail_state=state,
+        rail_badge=None,
+        rail_sort_rank=0,
+        rail_reason="",
+        approvals_pending=0,
+        awaits_user_count=len(items),
+        awaits_user_items=tuple(items),
+        config_identity=config_identity(config),
+    )
+
+
+def _seed_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    entries: dict[str, ProjectStateCacheEntry],
+) -> ProjectStateCache:
+    cache = ProjectStateCache(refresh_fn=lambda k: None)
+    for key, entry in entries.items():
+        cache._install_for_test(key, entry)
+    monkeypatch.setattr("pollypm.state_cache.is_enabled", lambda: True)
+    monkeypatch.setattr("pollypm.state_cache.get_cache", lambda: cache)
+    return cache
+
+
+# ── primary regression: route_awaits_user declines on identity mismatch ──
+
+
+class TestConfigIdentityGuard:
+    """All 4 cache-routed call sites decline on cross-config lookup."""
+
+    def _config_pair(
+        self, tmp_path: Path,
+    ) -> tuple[SimpleNamespace, SimpleNamespace]:
+        """Build two configs with overlapping keys but distinct roots."""
+
+        root_a = tmp_path / "workspace-a"
+        root_b = tmp_path / "workspace-b"
+        root_a.mkdir()
+        root_b.mkdir()
+        config_a = _make_config(["alpha", "beta"], root_a)
+        config_b = _make_config(["alpha", "beta"], root_b)
+        # Sanity: project keys overlap, identities don't.
+        assert set(config_a.projects.keys()) == set(config_b.projects.keys())
+        assert config_identity(config_a) != config_identity(config_b)
+        return config_a, config_b
+
+    def test_route_awaits_user_declines_on_identity_mismatch(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Cache built for config_A must NOT serve config_B."""
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config_a, config_b = self._config_pair(tmp_path)
+
+        # Seed cache with entries stamped against config_A.
+        entries = {
+            key: _stamped_entry(key, config=config_a, items=[])
+            for key in config_a.projects.keys()
+        }
+        _seed_cache(monkeypatch, entries)
+
+        # Looking up with config_B (overlapping keys, different
+        # identity) MUST decline so the caller falls through.
+        result = cockpit_inbox._maybe_cache_route_awaits_user(config_b)
+        assert result is None
+
+        # And looking up with config_A (matching identity) MUST hit.
+        result_a = cockpit_inbox._maybe_cache_route_awaits_user(config_a)
+        assert result_a is not None
+        assert result_a == []  # no items seeded, but the path served
+
+    def test_count_awaits_user_declines_on_identity_mismatch(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config_a, config_b = self._config_pair(tmp_path)
+        entries = {
+            key: _stamped_entry(key, config=config_a, items=[])
+            for key in config_a.projects.keys()
+        }
+        _seed_cache(monkeypatch, entries)
+
+        assert cockpit_inbox._maybe_cache_count_awaits_user(config_b) is None
+        # Matching identity → 0 items total.
+        assert cockpit_inbox._maybe_cache_count_awaits_user(config_a) == 0
+
+    def test_operator_view_declines_on_identity_mismatch(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config_a, config_b = self._config_pair(tmp_path)
+        entries = {
+            key: _stamped_entry(key, config=config_a)
+            for key in config_a.projects.keys()
+        }
+        _seed_cache(monkeypatch, entries)
+
+        # The operator-view fast-path also calls ``_collect_project_scans``
+        # which itself runs DB work; stub it out to a non-empty list so
+        # we're testing the identity gate alone.
+        monkeypatch.setattr(
+            operator_view,
+            "_collect_project_scans",
+            lambda cfg: [
+                SimpleNamespace(project_key=k)
+                for k in cfg.projects.keys()
+            ],
+        )
+
+        assert operator_view._maybe_cache_route_operator_view(config_b) is None
+
+    def test_rail_rollups_declines_on_identity_mismatch(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        from pollypm.cockpit_rail import CockpitRouter
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config_a, config_b = self._config_pair(tmp_path)
+        entries = {
+            key: _stamped_entry(key, config=config_a)
+            for key in config_a.projects.keys()
+        }
+        _seed_cache(monkeypatch, entries)
+
+        # The router's helper takes (config, alerts). Empty alerts
+        # list keeps the actionable-alert gate happy. Bypass __init__
+        # — only the unbound method matters for this gate test.
+        router = CockpitRouter.__new__(CockpitRouter)
+        result = router._maybe_cache_route_rollups(config_b, [])
+        assert result is None
+
+    def test_unstamped_entries_skip_identity_check(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Legacy / test-fixture entries with ``config_identity=""``
+        bypass the guard. Only the real refresher stamps; pinning
+        backward compatibility for hand-rolled entries in existing
+        parity tests.
+        """
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config_a, _ = self._config_pair(tmp_path)
+
+        # Hand-roll an unstamped entry (config_identity defaults to "").
+        unstamped = ProjectStateCacheEntry(
+            project_key="alpha",
+            project_path=Path("/tmp/alpha"),
+            tracked=True,
+            state=ProjectState.IDLE,
+            awaits_user_count=0,
+            awaits_user_items=(),
+        )
+        assert unstamped.config_identity == ""
+        _seed_cache(monkeypatch, {"alpha": unstamped})
+
+        # Even with a mismatched-looking config, unstamped entries are
+        # served (this is the test-compat escape hatch).
+        config_solo = _make_config(["alpha"], tmp_path / "workspace-a")
+        result = cockpit_inbox._maybe_cache_route_awaits_user(config_solo)
+        # Either the served path returns the empty list, or the route
+        # declines for an OTHER reason (workspace-root probe, etc.).
+        # The point is: the identity guard didn't fire on the
+        # unstamped entry.
+        # Force the workspace-root probe to "no open" to isolate the
+        # identity gate from other guards.
+        monkeypatch.setattr(
+            cockpit_inbox, "_workspace_root_inbox_has_open", lambda cfg: False,
+        )
+        result = cockpit_inbox._maybe_cache_route_awaits_user(config_solo)
+        assert result == []
+
+
+# ── refresh stamping ──────────────────────────────────────────────
+
+
+def test_refresher_stamps_config_identity(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """``compute_entry_for_project`` must stamp the config's identity."""
+
+    from pollypm.state_cache.refresh_impl import compute_entry_for_project
+
+    config = _make_config(["alpha"], tmp_path / "workspace-a")
+
+    # Stub out the awaits-user fetch + categorization import so the
+    # refresher returns a real entry without hitting any DB.
+    monkeypatch.setattr(
+        cockpit_inbox, "_pm_inbox_awaits_user_list_uncached", lambda cfg: [],
+    )
+
+    entry = compute_entry_for_project("alpha", config)
+    assert entry.config_identity == config_identity(config)
+    assert entry.config_identity != ""

--- a/tests/test_state_cache_config_identity.py
+++ b/tests/test_state_cache_config_identity.py
@@ -64,14 +64,19 @@ def _reset_call_site_divergence_counters():
     yield
 
 
-def _make_config(project_keys: list[str], workspace_root: Path) -> SimpleNamespace:
+def _make_config(
+    project_keys: list[str],
+    workspace_root: Path,
+    *,
+    config_path: Path | None = None,
+) -> SimpleNamespace:
     """Build a minimal config with a distinct ``workspace_root``.
 
-    The config identity helper resolves
-    ``config.project.workspace_root`` when ``config.config_path`` is
-    absent (the production ``PollyPMConfig`` shape today). Two
-    configs with different roots but overlapping project keys are
-    exactly the cross-config-leak case the guard exists to catch.
+    The config identity helper prefers ``config.config_path`` (the
+    file on disk IS the identity, per PR #2026 v9) and falls back to
+    ``config.project.workspace_root``. Two configs with the SAME
+    workspace_root but DIFFERENT config_path values are also a
+    cross-config-leak case the guard exists to catch.
     """
 
     projects = {
@@ -87,6 +92,7 @@ def _make_config(project_keys: list[str], workspace_root: Path) -> SimpleNamespa
         projects=projects,
         project=SimpleNamespace(workspace_root=str(workspace_root)),
         storage=SimpleNamespace(backend="postgres"),
+        config_path=config_path,
     )
 
 
@@ -265,6 +271,125 @@ class TestConfigIdentityGuard:
 
         # Cross-config lookup (config_B against config_A's snapshot)
         # MUST decline. Sanity-check the matching-identity path serves.
+        assert operator_view._maybe_cache_route_state_map(config_b) is None
+        served = operator_view._maybe_cache_route_state_map(config_a)
+        assert served is not None
+        assert set(served.keys()) == set(config_a.projects.keys())
+
+    def _same_root_different_path_pair(
+        self, tmp_path: Path,
+    ) -> tuple[SimpleNamespace, SimpleNamespace]:
+        """Two configs with the SAME workspace_root but DIFFERENT config_path.
+
+        PR #2026 v9 (Codex r9 blocker): even when two ``PollyPMConfig``
+        objects share a workspace_root (a real scenario when the same
+        repo is loaded via different TOML files — e.g. ``pollypm.toml``
+        vs ``pollypm.dev.toml``), the cache singleton MUST NOT serve
+        cross-config data. The ``config_path`` field (now stamped by
+        :func:`load_config`) is the on-disk identity that disambiguates
+        these cases.
+        """
+
+        shared_root = tmp_path / "workspace-shared"
+        shared_root.mkdir()
+        path_a = tmp_path / "pollypm.toml"
+        path_b = tmp_path / "pollypm.dev.toml"
+        path_a.touch()
+        path_b.touch()
+        config_a = _make_config(
+            ["alpha", "beta"], shared_root, config_path=path_a,
+        )
+        config_b = _make_config(
+            ["alpha", "beta"], shared_root, config_path=path_b,
+        )
+        # Sanity: workspace_root identical, identities differ via path.
+        assert config_a.project.workspace_root == config_b.project.workspace_root
+        assert config_identity(config_a) != config_identity(config_b)
+        return config_a, config_b
+
+    def test_route_awaits_user_declines_same_root_different_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """PR #2026 v9: same workspace_root + different config_path declines."""
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config_a, config_b = self._same_root_different_path_pair(tmp_path)
+        entries = {
+            key: _stamped_entry(key, config=config_a, items=[])
+            for key in config_a.projects.keys()
+        }
+        _seed_cache(monkeypatch, entries)
+
+        assert cockpit_inbox._maybe_cache_route_awaits_user(config_b) is None
+        result_a = cockpit_inbox._maybe_cache_route_awaits_user(config_a)
+        assert result_a is not None
+        assert result_a == []
+
+    def test_count_awaits_user_declines_same_root_different_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config_a, config_b = self._same_root_different_path_pair(tmp_path)
+        entries = {
+            key: _stamped_entry(key, config=config_a, items=[])
+            for key in config_a.projects.keys()
+        }
+        _seed_cache(monkeypatch, entries)
+
+        assert cockpit_inbox._maybe_cache_count_awaits_user(config_b) is None
+        assert cockpit_inbox._maybe_cache_count_awaits_user(config_a) == 0
+
+    def test_operator_view_declines_same_root_different_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config_a, config_b = self._same_root_different_path_pair(tmp_path)
+        entries = {
+            key: _stamped_entry(key, config=config_a)
+            for key in config_a.projects.keys()
+        }
+        _seed_cache(monkeypatch, entries)
+        monkeypatch.setattr(
+            operator_view,
+            "_collect_project_scans",
+            lambda cfg: [
+                SimpleNamespace(project_key=k)
+                for k in cfg.projects.keys()
+            ],
+        )
+
+        assert operator_view._maybe_cache_route_operator_view(config_b) is None
+
+    def test_rail_rollups_declines_same_root_different_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        from pollypm.cockpit_rail import CockpitRouter
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config_a, config_b = self._same_root_different_path_pair(tmp_path)
+        entries = {
+            key: _stamped_entry(key, config=config_a)
+            for key in config_a.projects.keys()
+        }
+        _seed_cache(monkeypatch, entries)
+
+        router = CockpitRouter.__new__(CockpitRouter)
+        result = router._maybe_cache_route_rollups(config_b, [])
+        assert result is None
+
+    def test_state_map_route_declines_same_root_different_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """5th routed site declines on same-root different-path lookup."""
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config_a, config_b = self._same_root_different_path_pair(tmp_path)
+        entries = {
+            key: _stamped_entry(key, config=config_a, state=ProjectState.WAITING)
+            for key in config_a.projects.keys()
+        }
+        _seed_cache(monkeypatch, entries)
+
         assert operator_view._maybe_cache_route_state_map(config_b) is None
         served = operator_view._maybe_cache_route_state_map(config_a)
         assert served is not None

--- a/tests/test_state_cache_config_identity.py
+++ b/tests/test_state_cache_config_identity.py
@@ -1,4 +1,4 @@
-"""Move A PR 3 — config-identity guard (PR #2026 v7 / Codex r7 blocker).
+"""Move A PR 3 — config-identity guard (PR #2026 v7+v8 / Codex r7+r8 blocker).
 
 The cache singleton can serve cross-config data when two
 ``PollyPMConfig`` objects share project keys but were loaded from
@@ -9,13 +9,17 @@ lookup. When the live config's identity disagrees with a stamped
 entry, the lookup MUST decline (return ``None``) and fall through to
 the direct DB path.
 
-This file pins the cross-config invariant for all four routed call
+This file pins the cross-config invariant for all five routed call
 sites:
 
 * ``_maybe_cache_route_awaits_user`` (cockpit_inbox)
 * ``_maybe_cache_count_awaits_user`` (cockpit_inbox)
 * ``_maybe_cache_route_operator_view`` (dashboard/operator_view)
 * ``CockpitRailRenderer._maybe_cache_route_rollups`` (cockpit_rail)
+* ``_maybe_cache_route_state_map`` /
+  ``project_state_map_from_config`` (dashboard/operator_view) —
+  added in PR #2026 v8 (Codex r8 follow-up: the 5th routed site
+  was missed in v7).
 """
 
 from __future__ import annotations
@@ -232,6 +236,39 @@ class TestConfigIdentityGuard:
         router = CockpitRouter.__new__(CockpitRouter)
         result = router._maybe_cache_route_rollups(config_b, [])
         assert result is None
+
+    def test_state_map_route_declines_cross_config(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """``_maybe_cache_route_state_map`` declines on cross-config lookup.
+
+        PR #2026 v8 (Codex r8 blocker): the v7 fix added the identity
+        guard to 4 routed sites but missed
+        ``_maybe_cache_route_state_map`` (the engine behind
+        ``project_state_map_from_config``). With cache stamped for
+        config_A and a lookup from config_B (overlapping keys, distinct
+        workspace_root), the route MUST return ``None`` so the direct
+        path runs.
+        """
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config_a, config_b = self._config_pair(tmp_path)
+
+        # Seed the cache with stamped entries against config_A. The
+        # state-map fast path needs every tracked project's ``state``
+        # populated, so stamp WAITING (any non-None state will do).
+        entries = {
+            key: _stamped_entry(key, config=config_a, state=ProjectState.WAITING)
+            for key in config_a.projects.keys()
+        }
+        _seed_cache(monkeypatch, entries)
+
+        # Cross-config lookup (config_B against config_A's snapshot)
+        # MUST decline. Sanity-check the matching-identity path serves.
+        assert operator_view._maybe_cache_route_state_map(config_b) is None
+        served = operator_view._maybe_cache_route_state_map(config_a)
+        assert served is not None
+        assert set(served.keys()) == set(config_a.projects.keys())
 
     def test_unstamped_entries_skip_identity_check(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,

--- a/tests/test_state_cache_no_sqlite_imports.py
+++ b/tests/test_state_cache_no_sqlite_imports.py
@@ -1,0 +1,109 @@
+"""Regression test: ``state_cache.refresh_impl`` must not depend on ``StateStore``.
+
+PR #2026 re-review (Codex blocker). An earlier fix replaced the per-project
+``Supervisor(load_config(DEFAULT_CONFIG_PATH))`` call with a memoised
+``StateStore`` open keyed by ``id(config)``. That re-introduced the legacy
+sqlite ``pollypm.storage.state`` dependency on the state-cache hot path —
+the exact runtime branch #1737 / #2039 had just removed — and returned
+stale rows under the pg-backed heartbeat path because the unified
+``heartbeats`` table lives in Postgres post-cutover.
+
+The fix routes ``_heartbeats_for_sessions`` through the pg facade
+(``pollypm.storage.pg_heartbeats.latest_heartbeat``). This test exists
+solely to make sure no future change quietly reintroduces the legacy
+StateStore on the refresher: any source-level import or reference trips
+it.
+
+Two complementary assertions:
+
+1. **Source-text grep** — the refresher source must contain neither
+   ``StateStore`` nor ``pollypm.storage.state``. Cheap, deterministic,
+   catches a lazy local import inside a helper just as well as a top-of-
+   file one.
+2. **AST scan** — walks every ``Import`` / ``ImportFrom`` node so a
+   future hidden import (e.g. inside ``if TYPE_CHECKING:``) also trips.
+
+If either assertion fires, the no-sqlite invariant on
+``state_cache.refresh_impl`` has regressed — route the heartbeat
+prefetch through the pg facade (or a backend-neutral / bulk reader
+that resolves to pg for the active config) instead.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REFRESH_IMPL = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "pollypm"
+    / "state_cache"
+    / "refresh_impl.py"
+)
+
+
+def _source() -> str:
+    return REFRESH_IMPL.read_text(encoding="utf-8")
+
+
+def test_refresh_impl_source_does_not_mention_statestore() -> None:
+    """Plain-text guard: the file must contain no ``StateStore`` identifier."""
+
+    source = _source()
+    assert REFRESH_IMPL.exists(), f"missing refresher source: {REFRESH_IMPL}"
+    assert "StateStore" not in source, (
+        "state_cache.refresh_impl mentions StateStore — heartbeat prefetch "
+        "must route through the pg facade (pollypm.storage.pg_heartbeats) "
+        "instead of reopening the legacy sqlite StateStore. See PR #2026 "
+        "re-review."
+    )
+
+
+def test_refresh_impl_source_does_not_import_pollypm_storage_state() -> None:
+    """Plain-text guard: the file must not reference ``pollypm.storage.state``."""
+
+    source = _source()
+    assert "pollypm.storage.state" not in source, (
+        "state_cache.refresh_impl references pollypm.storage.state — the "
+        "legacy sqlite StateStore module. Route heartbeat prefetch through "
+        "pollypm.storage.pg_heartbeats instead. See PR #2026 re-review."
+    )
+
+
+def test_refresh_impl_ast_has_no_statestore_imports() -> None:
+    """AST guard: walk every Import / ImportFrom node — catches hidden imports.
+
+    A source-text grep already covers most cases, but a lazy import
+    inside a helper (``from pollypm.storage.state import StateStore``)
+    or a deferred ``if TYPE_CHECKING:`` block could in principle slip
+    through future edits if the literal string were obfuscated. The AST
+    scan asserts the structural property directly.
+    """
+
+    tree = ast.parse(_source(), filename=str(REFRESH_IMPL))
+    offending: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == "pollypm.storage.state" or module.startswith(
+                "pollypm.storage.state."
+            ):
+                offending.append(f"from {module} import ...")
+            for alias in node.names:
+                if alias.name == "StateStore":
+                    offending.append(
+                        f"from {module} import {alias.name}"
+                    )
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "pollypm.storage.state" or alias.name.startswith(
+                    "pollypm.storage.state."
+                ):
+                    offending.append(f"import {alias.name}")
+    assert not offending, (
+        "state_cache.refresh_impl has forbidden imports: "
+        + ", ".join(offending)
+        + " — route heartbeat prefetch through pollypm.storage.pg_heartbeats. "
+        "See PR #2026 re-review."
+    )

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -1110,7 +1110,6 @@ class TestPr2026ReviewBlocker1ActionableAlertFallthrough:
         """
 
         from pollypm.cockpit_project_state import ProjectRailState
-        from pollypm.cockpit_rail import CockpitRouter
 
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         router = self._router(tmp_path)
@@ -1371,3 +1370,183 @@ class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
         result = cockpit_inbox.pm_inbox_awaits_user_list(config)
         assert direct_called["n"] == 0
         assert len(result) == 1
+
+
+class TestPr2026V3WorkspaceRootProbeUnbounded:
+    """PR #2026 v3 (Codex blocker 1): the workspace-root probe must NOT
+    depend on row recency. The old implementation called
+    ``open_messages(limit=50)`` and Python-scanned for ``scope IN ('',
+    'inbox')``; with 50+ newer project-scoped rows + 1 older
+    workspace-root row, the probe returned False and the cache silently
+    dropped the workspace work.
+
+    The fix adds a dedicated SQL existence query
+    (``cockpit_pg_aggregates.has_workspace_root_open_messages``) with
+    a workspace-root predicate + ``LIMIT 1`` — independent of how many
+    newer non-workspace rows exist.
+
+    This test calls the REAL ``_workspace_root_inbox_has_open`` (no
+    monkeypatch on that function) against a fake pg_pool that simulates
+    the bug scenario.
+    """
+
+    def test_workspace_root_row_under_50_newer_rows_is_still_seen(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Seed pg with 50 newer project-scoped rows + 1 older
+        workspace-root row; the SQL existence query MUST return True.
+        """
+
+        config = _make_config(["alpha"], tmp_path)
+
+        # Track which SQL was executed so the assertion proves the
+        # workspace-root existence query (not the legacy newest-50
+        # scan) is what gave the True answer.
+        executed: list[tuple[str, tuple[Any, ...]]] = []
+
+        class _FakeCursor:
+            def __init__(self) -> None:
+                self._result: list[tuple[Any, ...]] = []
+
+            def __enter__(self) -> "_FakeCursor":
+                return self
+
+            def __exit__(self, *_a: Any) -> None:
+                pass
+
+            def execute(self, sql: str, params: Any) -> None:
+                executed.append((sql, tuple(params)))
+                # Workspace-root probe: predicate includes the
+                # ``scope = '' OR scope IS NULL OR scope = 'inbox'``
+                # branch + a ``LIMIT 1``. Return one row.
+                if "scope = 'inbox'" in sql and "LIMIT 1" in sql:
+                    self._result = [(1,)]
+                    return
+                # Anything else (e.g. the legacy newest-N scan) —
+                # return 50 project-scoped rows so the OLD code
+                # would have missed the workspace-root row entirely.
+                self._result = [
+                    (i, "alpha", "notify", "info", "user", "sender",
+                     "open", "subj", "body", {}, [], "kind",
+                     None, None, None)
+                    for i in range(50)
+                ]
+
+            def fetchone(self) -> Any:
+                return self._result[0] if self._result else None
+
+            def fetchall(self) -> list[tuple[Any, ...]]:
+                return list(self._result)
+
+            @property
+            def description(self) -> list[Any]:
+                return [SimpleNamespace(name=n) for n in (
+                    "id", "scope", "type", "tier", "recipient",
+                    "sender", "state", "subject", "body",
+                    "payload_json", "labels", "kind",
+                    "created_at", "updated_at", "closed_at",
+                )]
+
+        class _FakeConn:
+            def __enter__(self) -> "_FakeConn":
+                return self
+
+            def __exit__(self, *_a: Any) -> None:
+                pass
+
+            def cursor(self) -> _FakeCursor:
+                return _FakeCursor()
+
+        class _FakePool:
+            def connection(self) -> _FakeConn:
+                return _FakeConn()
+
+        def _fake_get_ro_pool(_cfg: Any) -> _FakePool:
+            return _FakePool()
+
+        monkeypatch.setattr(
+            "pollypm.storage.pg_pool.get_ro_pool", _fake_get_ro_pool,
+        )
+
+        # Call the REAL function (no monkeypatch on _workspace_root_inbox_has_open).
+        assert cockpit_inbox._workspace_root_inbox_has_open(config) is True
+
+        # Prove the SQL the function executed was the bounded-1
+        # existence query, not the legacy newest-N scan.
+        assert executed, "fake pg pool was never queried"
+        executed_sqls = [sql for sql, _params in executed]
+        assert any(
+            "scope = 'inbox'" in sql and "LIMIT 1" in sql
+            for sql in executed_sqls
+        ), (
+            f"workspace-root probe should issue a LIMIT-1 existence "
+            f"query; saw {executed_sqls!r}"
+        )
+
+    def test_real_probe_drives_cache_fall_through(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """The probe's True answer MUST flip
+        ``_maybe_cache_route_awaits_user`` to fall through to direct.
+        """
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha"], tmp_path)
+
+        class _FakeCursor:
+            def __init__(self) -> None:
+                self._result: list[tuple[Any, ...]] = []
+
+            def __enter__(self) -> "_FakeCursor":
+                return self
+
+            def __exit__(self, *_a: Any) -> None:
+                pass
+
+            def execute(self, sql: str, params: Any) -> None:
+                if "LIMIT 1" in sql:
+                    self._result = [(1,)]
+                else:
+                    self._result = []
+
+            def fetchone(self) -> Any:
+                return self._result[0] if self._result else None
+
+            def fetchall(self) -> list[tuple[Any, ...]]:
+                return list(self._result)
+
+            @property
+            def description(self) -> list[Any]:
+                return [SimpleNamespace(name="x")]
+
+        class _FakeConn:
+            def __enter__(self) -> "_FakeConn":
+                return self
+
+            def __exit__(self, *_a: Any) -> None:
+                pass
+
+            def cursor(self) -> _FakeCursor:
+                return _FakeCursor()
+
+        class _FakePool:
+            def connection(self) -> _FakeConn:
+                return _FakeConn()
+
+        monkeypatch.setattr(
+            "pollypm.storage.pg_pool.get_ro_pool", lambda _cfg: _FakePool(),
+        )
+
+        # Seed a populated cache for alpha. No monkeypatch on
+        # _workspace_root_inbox_has_open — it executes the REAL pg
+        # path against the fake pool above and returns True.
+        entries = {
+            "alpha": _entry(
+                "alpha", state=ProjectState.IDLE, items=[],
+            ),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        # The fast-path MUST decline so the direct sweep can carry
+        # the workspace-root row.
+        assert cockpit_inbox._maybe_cache_route_awaits_user(config) is None

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -121,15 +121,34 @@ def _inbox_item(
 
 
 def _entry(
-    project_key: str, *, state: ProjectState, items: list[Any],
+    project_key: str,
+    *,
+    state: ProjectState,
+    items: list[Any],
+    rail_state: Any = None,
+    rail_badge: str | None = None,
+    rail_sort_rank: int = 0,
+    rail_reason: str = "",
+    approvals_pending: int = 0,
+    glyph: str = "",
+    detail: str = "",
+    latest_heartbeat_by_session: dict[str, Any] | None = None,
 ) -> ProjectStateCacheEntry:
     return ProjectStateCacheEntry(
         project_key=project_key,
         project_path=Path(f"/tmp/{project_key}"),
         tracked=True,
         state=state,
+        glyph=glyph,
+        detail=detail,
+        rail_state=rail_state,
+        rail_badge=rail_badge,
+        rail_sort_rank=rail_sort_rank,
+        rail_reason=rail_reason,
+        approvals_pending=approvals_pending,
         awaits_user_count=len(items),
         awaits_user_items=tuple(items),
+        latest_heartbeat_by_session=dict(latest_heartbeat_by_session or {}),
     )
 
 
@@ -560,3 +579,453 @@ class TestInboxDefaultLensInvariant:
         cockpit_inbox._AWAITS_USER_CACHE.clear()
         counted = cockpit_inbox._count_inbox_tasks_for_label(config)
         assert len(listed) == counted == len(items)
+
+
+# ── Move A PR 3 parity — _count_inbox_tasks_for_label cache route ──
+
+
+class TestCountInboxTasksForLabelParity:
+    """PR 3 (§5 row 2): ``_count_inbox_tasks_for_label`` reads ``awaits_user_count``.
+
+    Three projects, the cache fast-path sums ``entry.awaits_user_count``
+    while the direct path runs the workspace-wide sweep + ``len()``.
+    Both MUST agree.
+    """
+
+    def test_cached_count_skips_workspace_sweep(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Flag on + populated cache: no workspace sweep, sum from snapshot."""
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha", "beta", "gamma"], tmp_path)
+        items_alpha = [_inbox_item(project="alpha", source="task", ident="alpha/1")]
+        items_beta = [
+            _inbox_item(project="beta", source="task", ident="beta/2"),
+            _inbox_item(project="beta", source="message", ident="m-b1"),
+        ]
+        items_gamma: list[Any] = []
+        entries = {
+            "alpha": _entry("alpha", state=ProjectState.WAITING, items=items_alpha),
+            "beta": _entry("beta", state=ProjectState.WAITING, items=items_beta),
+            "gamma": _entry("gamma", state=ProjectState.IDLE, items=items_gamma),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        direct_called = {"n": 0}
+
+        def _no_call(_cfg: Any) -> list[Any]:
+            direct_called["n"] += 1
+            return items_alpha + items_beta + items_gamma
+
+        monkeypatch.setattr(
+            cockpit_inbox, "_pm_inbox_awaits_user_list_uncached", _no_call,
+        )
+
+        counted = cockpit_inbox._count_inbox_tasks_for_label(config)
+        # Three items total; the direct sweep wasn't touched.
+        assert counted == 3
+        assert direct_called["n"] == 0
+
+    def test_flag_off_uses_direct_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Flag off — falls back to ``len(pm_inbox_awaits_user_list)``."""
+
+        monkeypatch.delenv("POLLYPM_STATE_CACHE", raising=False)
+        config = _make_config(["alpha", "beta"], tmp_path)
+        items = [
+            _inbox_item(project="alpha", source="task", ident="alpha/1"),
+            _inbox_item(project="beta", source="task", ident="beta/2"),
+        ]
+        monkeypatch.setattr(
+            cockpit_inbox,
+            "_pm_inbox_awaits_user_list_uncached",
+            lambda cfg: list(items),
+        )
+        counted = cockpit_inbox._count_inbox_tasks_for_label(config)
+        assert counted == 2
+
+    def test_partial_cache_falls_through_to_direct(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Cache missing a tracked project → fall through.
+
+        Otherwise we'd under-count any project that hasn't been
+        refreshed yet. (The fast-path in
+        :func:`pm_inbox_awaits_user_list` already does this; the
+        count helper inherits the same gate via the public wrapper.)
+        """
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha", "beta"], tmp_path)
+        # Only alpha in the cache — beta is unknown.
+        entries = {
+            "alpha": _entry(
+                "alpha",
+                state=ProjectState.WAITING,
+                items=[_inbox_item(project="alpha", source="task", ident="alpha/1")],
+            ),
+        }
+        _seed_cache(monkeypatch, entries)
+        # The cache-routed count helper returns 1 (alpha only) — fine,
+        # because the next call into pm_inbox_awaits_user_list would
+        # fall through to the direct sweep. The contract is the same
+        # as PR 2: a partial cache still serves the cached values for
+        # the projects it knows about. We verify only that the count
+        # equals what the cache holds for known projects.
+        cockpit_inbox._AWAITS_USER_CACHE.clear()
+        counted = cockpit_inbox._count_inbox_tasks_for_label(config)
+        # alpha contributes 1; beta is missing → not summed via cache.
+        assert counted == 1
+
+
+# ── Move A PR 3 parity — load_operator_view_from_config cache route ─
+
+
+class TestLoadOperatorViewParity:
+    """PR 3 (§5 row 4): ``load_operator_view_from_config`` reads snapshot."""
+
+    def test_cached_view_skips_shared_work_service_open(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Cache fast-path: no ``_open_shared_work_service`` call."""
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha", "beta", "gamma"], tmp_path)
+        entries = {
+            "alpha": _entry(
+                "alpha", state=ProjectState.WAITING, items=[],
+                glyph="!", detail="Waiting on you",
+            ),
+            "beta": _entry(
+                "beta", state=ProjectState.WORKING, items=[],
+                glyph="*", detail="claude active on /beta/1",
+            ),
+            "gamma": _entry(
+                "gamma", state=ProjectState.IDLE, items=[],
+                glyph=".", detail="Quiet",
+            ),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        open_calls = {"n": 0}
+
+        def _no_open(_cfg: Any) -> Any:
+            open_calls["n"] += 1
+            return None
+
+        monkeypatch.setattr(
+            operator_view, "_open_shared_work_service", _no_open,
+        )
+
+        view = operator_view.load_operator_view_from_config(config)
+        assert open_calls["n"] == 0
+        # Rows landed in the right sections per state.
+        assert [r.project_key for r in view.waiting] == ["alpha"]
+        assert [r.project_key for r in view.working] == ["beta"]
+        assert [r.project_key for r in view.idle] == ["gamma"]
+        # Detail strings come from the cache entry — confirms we
+        # didn't silently re-derive them.
+        waiting_row = view.waiting[0]
+        assert waiting_row.detail == "Waiting on you"
+        assert waiting_row.glyph == "!"
+
+    def test_flag_off_runs_direct_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Flag off — the cache fast-path returns ``None``."""
+
+        monkeypatch.delenv("POLLYPM_STATE_CACHE", raising=False)
+        config = _make_config(["alpha"], tmp_path)
+        # Direct path will open svc=None → IDLE branch; tracked
+        # projects with no awaits-user items land in idle.
+        monkeypatch.setattr(
+            operator_view, "_open_shared_work_service", lambda cfg: None,
+        )
+        monkeypatch.setattr(
+            cockpit_inbox,
+            "_pm_inbox_awaits_user_list_uncached",
+            lambda cfg: [],
+        )
+        view = operator_view.load_operator_view_from_config(config)
+        # alpha is tracked + has no awaits-user → IDLE (not PAUSED).
+        assert {r.project_key for r in view.idle} == {"alpha"}
+
+    def test_partial_cache_falls_through(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Missing a tracked project in cache → defer to direct."""
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha", "beta"], tmp_path)
+        entries = {
+            "alpha": _entry("alpha", state=ProjectState.IDLE, items=[]),
+        }
+        _seed_cache(monkeypatch, entries)
+        # Direct path stub so the fall-through completes without a real
+        # work service.
+        monkeypatch.setattr(
+            operator_view, "_open_shared_work_service", lambda cfg: None,
+        )
+        monkeypatch.setattr(
+            cockpit_inbox,
+            "_pm_inbox_awaits_user_list_uncached",
+            lambda cfg: [],
+        )
+        view = operator_view.load_operator_view_from_config(config)
+        # Both projects show up — the fall-through covered the gap.
+        seen = {
+            *(r.project_key for r in view.waiting),
+            *(r.project_key for r in view.working),
+            *(r.project_key for r in view.idle),
+            *(r.project_key for r in view.paused),
+        }
+        assert seen == {"alpha", "beta"}
+
+
+# ── Move A PR 3 parity — _project_state_rollups cache route ─────────
+
+
+class TestProjectStateRollupsParity:
+    """PR 3 (§5 row 7): rail ``_project_state_rollups`` reads snapshot."""
+
+    def _router(self, tmp_path: Path):
+        from pollypm.cockpit_rail import CockpitRouter
+
+        config_path = tmp_path / "pollypm.toml"
+        config_path.write_text(
+            "[project]\n"
+            'name = "PollyPM"\n'
+            f'root_dir = "{tmp_path}"\n'
+            'tmux_session = "pollypm"\n'
+            f'base_dir = "{tmp_path / ".pollypm"}"\n'
+        )
+        return CockpitRouter(config_path)
+
+    def test_cached_rollups_skip_pg_fanout(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Cache fast-path: no ``all_tasks_grouped`` call, no per-project rollup."""
+
+        from pollypm.cockpit_project_state import ProjectRailState
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        router = self._router(tmp_path)
+        config = _make_config(["alpha", "beta"], tmp_path)
+        entries = {
+            "alpha": _entry(
+                "alpha", state=ProjectState.WAITING, items=[],
+                rail_state=ProjectRailState.RED,
+                rail_badge="(2⚠)",
+                rail_sort_rank=10,
+                rail_reason="2 approvals pending",
+                approvals_pending=2,
+            ),
+            "beta": _entry(
+                "beta", state=ProjectState.IDLE, items=[],
+                rail_state=ProjectRailState.NONE,
+            ),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        fanout_called = {"n": 0}
+
+        def _no_fanout(_cfg: Any) -> Any:
+            fanout_called["n"] += 1
+            return {}
+
+        monkeypatch.setattr(
+            "pollypm.cockpit_pg_aggregates.all_tasks_grouped", _no_fanout,
+        )
+
+        rollups = router._project_state_rollups(config, alerts=[])
+        assert fanout_called["n"] == 0
+        assert set(rollups.keys()) == {"alpha", "beta"}
+        assert rollups["alpha"].approvals_pending == 2
+        assert rollups["alpha"].badge == "(2⚠)"
+        assert rollups["alpha"].state is ProjectRailState.RED
+        assert rollups["beta"].state is ProjectRailState.NONE
+
+    def test_partial_cache_falls_through(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """A project missing from cache → defer to direct rollup path."""
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        router = self._router(tmp_path)
+        config = _make_config(["alpha", "beta"], tmp_path)
+        entries = {
+            "alpha": _entry("alpha", state=ProjectState.IDLE, items=[]),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        called = {"n": 0}
+
+        def _fanout(_cfg: Any) -> dict:
+            called["n"] += 1
+            return {}
+
+        monkeypatch.setattr(
+            "pollypm.cockpit_pg_aggregates.all_tasks_grouped", _fanout,
+        )
+
+        rollups = router._project_state_rollups(config, alerts=[])
+        # Fallthrough → direct path ran (called pg_all_grouped once).
+        assert called["n"] == 1
+        # Both keys present even though only one was cached.
+        assert set(rollups.keys()) == {"alpha", "beta"}
+
+
+# ── Move A PR 3 parity — latest_heartbeat cache route ───────────────
+
+
+class TestLatestHeartbeatParity:
+    """PR 3 (§5 row 9): cockpit_rail ``latest_heartbeat()`` reads snapshot."""
+
+    def _router(self, tmp_path: Path):
+        from pollypm.cockpit_rail import CockpitRouter
+
+        config_path = tmp_path / "pollypm.toml"
+        config_path.write_text(
+            "[project]\n"
+            'name = "PollyPM"\n'
+            f'root_dir = "{tmp_path}"\n'
+            'tmux_session = "pollypm"\n'
+            f'base_dir = "{tmp_path / ".pollypm"}"\n'
+        )
+        return CockpitRouter(config_path)
+
+    def test_cache_hit_skips_supervisor_store(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Cache holds a heartbeat → supervisor.store.latest_heartbeat is skipped."""
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        router = self._router(tmp_path)
+
+        hb = SimpleNamespace(
+            session_name="worker_alpha/1",
+            created_at="2026-05-20T01:00:00Z",
+        )
+        entries = {
+            "alpha": _entry(
+                "alpha",
+                state=ProjectState.WORKING,
+                items=[],
+                latest_heartbeat_by_session={"worker_alpha/1": hb},
+            ),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        store_calls = {"n": 0}
+
+        class _Store:
+            def latest_heartbeat(self, name):  # noqa: ANN001, ANN201
+                store_calls["n"] += 1
+                return None
+
+        supervisor = SimpleNamespace(store=_Store())
+        result = router._latest_heartbeat_cached(supervisor, "worker_alpha/1")
+        assert store_calls["n"] == 0
+        assert result is hb
+
+    def test_cache_miss_falls_back_to_supervisor_store(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Unknown session → call supervisor.store.latest_heartbeat."""
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        router = self._router(tmp_path)
+        _seed_cache(monkeypatch, {})  # empty cache
+
+        store_calls: list[str] = []
+        fallback = SimpleNamespace(created_at="2026-05-20T02:00:00Z")
+
+        class _Store:
+            def latest_heartbeat(self, name):  # noqa: ANN001, ANN201
+                store_calls.append(name)
+                return fallback
+
+        supervisor = SimpleNamespace(store=_Store())
+        result = router._latest_heartbeat_cached(supervisor, "worker_beta/3")
+        assert store_calls == ["worker_beta/3"]
+        assert result is fallback
+
+    def test_flag_off_always_uses_store(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Flag off — every call routes to ``supervisor.store``."""
+
+        monkeypatch.delenv("POLLYPM_STATE_CACHE", raising=False)
+        router = self._router(tmp_path)
+
+        called: list[str] = []
+        hb = SimpleNamespace(created_at="2026-05-20T03:00:00Z")
+
+        class _Store:
+            def latest_heartbeat(self, name):  # noqa: ANN001, ANN201
+                called.append(name)
+                return hb
+
+        supervisor = SimpleNamespace(store=_Store())
+        result = router._latest_heartbeat_cached(supervisor, "worker_alpha/1")
+        assert called == ["worker_alpha/1"]
+        assert result is hb
+
+
+# ── Move A PR 3 — TTL removal regression test ───────────────────────
+
+
+class TestProjectCategorizationsNoTtl:
+    """Design §9.5: state-cache routing replaces the 2s TTL.
+
+    The `_project_categorizations` helper used to memoise its result
+    behind ``_PROJECT_CATEGORIZATIONS_TTL_SECONDS = 2.0``. Now every
+    call delegates straight to ``project_state_map_from_config`` so
+    state changes are visible on the next call without waiting on a
+    TTL to expire.
+    """
+
+    def _router(self, tmp_path: Path):
+        from pollypm.cockpit_rail import CockpitRouter
+
+        config_path = tmp_path / "pollypm.toml"
+        config_path.write_text(
+            "[project]\n"
+            'name = "PollyPM"\n'
+            f'root_dir = "{tmp_path}"\n'
+            'tmux_session = "pollypm"\n'
+            f'base_dir = "{tmp_path / ".pollypm"}"\n'
+        )
+        return CockpitRouter(config_path)
+
+    def test_modifications_are_visible_on_next_call_no_ttl_wait(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """No TTL: a freshly-completed task is no longer stuck as WORKING."""
+
+        router = self._router(tmp_path)
+        config = object()
+        state = {"map": {"alpha": ProjectState.WORKING}}
+
+        def _fake_map(cfg):  # noqa: ANN001, ANN202
+            return state["map"]
+
+        monkeypatch.setattr(
+            "pollypm.dashboard.operator_view.project_state_map_from_config",
+            _fake_map,
+        )
+
+        assert router._project_categorizations(config) == {"alpha": "working"}
+        # Without waiting for 2s, mutate the underlying state and the
+        # next call MUST see it.
+        state["map"] = {"alpha": ProjectState.IDLE}
+        assert router._project_categorizations(config) == {"alpha": "idle"}
+
+    def test_router_class_no_longer_has_ttl_constant(self) -> None:
+        from pollypm.cockpit_rail import CockpitRouter
+
+        assert not hasattr(
+            CockpitRouter, "_PROJECT_CATEGORIZATIONS_TTL_SECONDS",
+        )

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -902,7 +902,11 @@ class TestProjectStateRollupsParity:
 
 
 class TestLatestHeartbeatParity:
-    """PR 3 (§5 row 9): cockpit_rail ``latest_heartbeat()`` reads snapshot."""
+    """PR #2026 review blocker 2: ``_latest_heartbeat_cached`` is now a
+    direct-facade pass-through until cache invalidation on heartbeat
+    writes lands (filed as follow-up). The "cached" name is preserved
+    for call-site stability; the body bypasses the cache snapshot.
+    """
 
     def _router(self, tmp_path: Path):
         from pollypm.cockpit_rail import CockpitRouter
@@ -917,79 +921,101 @@ class TestLatestHeartbeatParity:
         )
         return CockpitRouter(config_path)
 
-    def test_cache_hit_skips_supervisor_store(
+    def test_always_reads_direct_facade_even_with_populated_cache(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """Cache holds a heartbeat → supervisor.store.latest_heartbeat is skipped."""
+        """Even with a populated cache, the direct pg facade is the
+        source of truth — guards against the stale-snapshot pathology
+        the cache had with no heartbeat-write invalidation.
+        """
 
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         router = self._router(tmp_path)
 
-        hb = SimpleNamespace(
+        stale_hb = SimpleNamespace(
             session_name="worker_alpha/1",
             created_at="2026-05-20T01:00:00Z",
+            tag="STALE_CACHE",
         )
         entries = {
             "alpha": _entry(
                 "alpha",
                 state=ProjectState.WORKING,
                 items=[],
-                latest_heartbeat_by_session={"worker_alpha/1": hb},
+                latest_heartbeat_by_session={"worker_alpha/1": stale_hb},
             ),
         }
         _seed_cache(monkeypatch, entries)
 
-        store_calls = {"n": 0}
+        fresh_hb = SimpleNamespace(
+            session_name="worker_alpha/1",
+            created_at="2026-05-21T01:00:00Z",
+            tag="FRESH_DIRECT",
+        )
+        pg_calls: list[str] = []
 
-        class _Store:
-            def latest_heartbeat(self, name):  # noqa: ANN001, ANN201
-                store_calls["n"] += 1
-                return None
+        def _direct(name, *, config=None):  # noqa: ANN001, ANN201
+            pg_calls.append(name)
+            return fresh_hb
 
-        supervisor = SimpleNamespace(store=_Store())
+        monkeypatch.setattr(
+            "pollypm.storage.pg_heartbeats.latest_heartbeat", _direct,
+        )
+
+        supervisor = SimpleNamespace(store=None, config=None)
         result = router._latest_heartbeat_cached(supervisor, "worker_alpha/1")
-        assert store_calls["n"] == 0
-        assert result is hb
+        # Direct facade hit; cached stale snapshot ignored.
+        assert pg_calls == ["worker_alpha/1"]
+        assert result is fresh_hb
+        assert getattr(result, "tag", None) == "FRESH_DIRECT"
 
-    def test_cache_miss_falls_back_to_supervisor_store(
+    def test_pg_failure_falls_back_to_supervisor_store(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """Unknown session → call supervisor.store.latest_heartbeat."""
+        """If pg_heartbeats raises, fall back to supervisor.store."""
 
-        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
         router = self._router(tmp_path)
-        _seed_cache(monkeypatch, {})  # empty cache
+        fallback = SimpleNamespace(created_at="2026-05-20T02:00:00Z")
+
+        def _boom(name, *, config=None):  # noqa: ANN001, ANN201
+            raise RuntimeError("pg pool unreachable")
+
+        monkeypatch.setattr(
+            "pollypm.storage.pg_heartbeats.latest_heartbeat", _boom,
+        )
 
         store_calls: list[str] = []
-        fallback = SimpleNamespace(created_at="2026-05-20T02:00:00Z")
 
         class _Store:
             def latest_heartbeat(self, name):  # noqa: ANN001, ANN201
                 store_calls.append(name)
                 return fallback
 
-        supervisor = SimpleNamespace(store=_Store())
+        supervisor = SimpleNamespace(store=_Store(), config=None)
         result = router._latest_heartbeat_cached(supervisor, "worker_beta/3")
         assert store_calls == ["worker_beta/3"]
         assert result is fallback
 
-    def test_flag_off_always_uses_store(
+    def test_flag_off_still_uses_direct_facade(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """Flag off — every call routes to ``supervisor.store``."""
+        """Flag state is irrelevant — the cache is fully bypassed."""
 
         monkeypatch.delenv("POLLYPM_STATE_CACHE", raising=False)
         router = self._router(tmp_path)
 
-        called: list[str] = []
         hb = SimpleNamespace(created_at="2026-05-20T03:00:00Z")
+        called: list[str] = []
 
-        class _Store:
-            def latest_heartbeat(self, name):  # noqa: ANN001, ANN201
-                called.append(name)
-                return hb
+        def _direct(name, *, config=None):  # noqa: ANN001, ANN201
+            called.append(name)
+            return hb
 
-        supervisor = SimpleNamespace(store=_Store())
+        monkeypatch.setattr(
+            "pollypm.storage.pg_heartbeats.latest_heartbeat", _direct,
+        )
+
+        supervisor = SimpleNamespace(store=None, config=None)
         result = router._latest_heartbeat_cached(supervisor, "worker_alpha/1")
         assert called == ["worker_alpha/1"]
         assert result is hb
@@ -1050,3 +1076,298 @@ class TestProjectCategorizationsNoTtl:
         assert not hasattr(
             CockpitRouter, "_PROJECT_CATEGORIZATIONS_TTL_SECONDS",
         )
+
+
+# ── PR #2026 review blockers — fall-through regression tests ────────
+
+
+class TestPr2026ReviewBlocker1ActionableAlertFallthrough:
+    """Blocker 1: cache fast-path MUST defer when a live actionable
+    task alert exists, because the direct ``rollup_project_state``
+    folds alerts into ``rail_state`` / ``badge`` / ``reason`` /
+    ``actionable_key`` and the cache entry's ``rail_*`` fields were
+    computed without alert state.
+    """
+
+    def _router(self, tmp_path: Path):
+        from pollypm.cockpit_rail import CockpitRouter
+
+        config_path = tmp_path / "pollypm.toml"
+        config_path.write_text(
+            "[project]\n"
+            'name = "PollyPM"\n'
+            f'root_dir = "{tmp_path}"\n'
+            'tmux_session = "pollypm"\n'
+            f'base_dir = "{tmp_path / ".pollypm"}"\n'
+        )
+        return CockpitRouter(config_path)
+
+    def test_actionable_alert_forces_cache_fallthrough(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Cached base state WORKING, live actionable alert exists →
+        the cache MUST decline so the direct path can paint RED.
+        """
+
+        from pollypm.cockpit_project_state import ProjectRailState
+        from pollypm.cockpit_rail import CockpitRouter
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        router = self._router(tmp_path)
+        config = _make_config(["alpha"], tmp_path)
+
+        # Cache entry says WORKING / NONE — no idea about the alert.
+        entries = {
+            "alpha": _entry(
+                "alpha", state=ProjectState.WORKING, items=[],
+                rail_state=ProjectRailState.WORKING,
+                rail_badge=None,
+                rail_sort_rank=0,
+                rail_reason="worker active",
+                approvals_pending=0,
+            ),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        # Live actionable alert for alpha/1 — should turn alpha RED.
+        alert = SimpleNamespace(
+            alert_type="stuck_on_task:alpha/1",
+            severity="high",
+            message="stuck",
+        )
+
+        # Cache fast-path declines (the gate fires).
+        assert (
+            router._maybe_cache_route_rollups(config, alerts=[alert]) is None
+        )
+
+    def test_no_alert_still_uses_cache_fast_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Empty / non-actionable alerts → cache fast-path stays available."""
+
+        from pollypm.cockpit_project_state import ProjectRailState
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        router = self._router(tmp_path)
+        config = _make_config(["alpha"], tmp_path)
+        entries = {
+            "alpha": _entry(
+                "alpha", state=ProjectState.WORKING, items=[],
+                rail_state=ProjectRailState.WORKING,
+                rail_badge=None,
+                rail_reason="worker active",
+            ),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        rollups = router._maybe_cache_route_rollups(config, alerts=[])
+        assert rollups is not None
+        assert rollups["alpha"].state is ProjectRailState.WORKING
+        # No alerts → actionable_key is None (matches direct path).
+        assert rollups["alpha"].actionable_key is None
+
+
+class TestPr2026ReviewBlocker2HeartbeatNoStale:
+    """Blocker 2: heartbeat reads MUST reflect the latest pg write
+    immediately. The cache had no invalidation on heartbeat ticks and
+    would serve a stale snapshot indefinitely — until the follow-up
+    issue lands, every call hits the direct facade.
+    """
+
+    def _router(self, tmp_path: Path):
+        from pollypm.cockpit_rail import CockpitRouter
+
+        config_path = tmp_path / "pollypm.toml"
+        config_path.write_text(
+            "[project]\n"
+            'name = "PollyPM"\n'
+            f'root_dir = "{tmp_path}"\n'
+            'tmux_session = "pollypm"\n'
+            f'base_dir = "{tmp_path / ".pollypm"}"\n'
+        )
+        return CockpitRouter(config_path)
+
+    def test_newer_store_heartbeat_reflected_immediately(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """A second pg write is visible on the next call — no stale cache."""
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        router = self._router(tmp_path)
+
+        # Seed the cache with an OLD heartbeat to prove we're not
+        # reading from it.
+        stale = SimpleNamespace(created_at="2026-05-20T01:00:00Z", n="stale")
+        entries = {
+            "alpha": _entry(
+                "alpha", state=ProjectState.WORKING, items=[],
+                latest_heartbeat_by_session={"worker_alpha/1": stale},
+            ),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        # First direct read.
+        first = SimpleNamespace(created_at="2026-05-20T02:00:00Z", n="first")
+        second = SimpleNamespace(created_at="2026-05-20T03:00:00Z", n="second")
+        state = {"next": first}
+
+        def _direct(name, *, config=None):  # noqa: ANN001, ANN201
+            return state["next"]
+
+        monkeypatch.setattr(
+            "pollypm.storage.pg_heartbeats.latest_heartbeat", _direct,
+        )
+
+        supervisor = SimpleNamespace(store=None, config=None)
+        assert router._latest_heartbeat_cached(
+            supervisor, "worker_alpha/1",
+        ) is first
+        # Simulate a fresh pg row landing. Without cache invalidation,
+        # the stale snapshot would have won; the direct-facade contract
+        # means the next call sees the newer row.
+        state["next"] = second
+        assert router._latest_heartbeat_cached(
+            supervisor, "worker_alpha/1",
+        ) is second
+
+
+class TestPr2026ReviewBlocker3WorkspaceRootFallthrough:
+    """Blocker 3: workspace-root inbox messages (``scope IN ('', 'inbox')``)
+    are not represented in any per-project cache entry, so the cache
+    routes for awaits-user list + count MUST fall through to the
+    direct path whenever the workspace-root inbox is non-empty.
+    """
+
+    def test_workspace_root_message_forces_list_fallthrough(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """A live workspace-root row → list cache declines, direct path runs.
+
+        Pinned to the cached vs direct equality: both MUST return the
+        same set of items (workspace-root included), proving the
+        fall-through is what carried the workspace row.
+        """
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha"], tmp_path)
+
+        # Per-project items the cache CAN represent.
+        per_project = [
+            _inbox_item(project="alpha", source="task", ident="alpha/1"),
+        ]
+        # The workspace-root item with project="inbox" — the cache
+        # CANNOT represent this (refresher filters by project_key only).
+        workspace_root = _inbox_item(
+            project="inbox", source="message", ident="ws-root-1",
+        )
+        # And the workspace-root probe MUST see it (simulate pg row).
+        monkeypatch.setattr(
+            cockpit_inbox,
+            "_workspace_root_inbox_has_open",
+            lambda cfg: True,
+        )
+        entries = {
+            "alpha": _entry(
+                "alpha", state=ProjectState.WAITING, items=per_project,
+            ),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        # Direct sweep returns BOTH (per-project + workspace-root).
+        direct_items = list(per_project) + [workspace_root]
+        direct_called = {"n": 0}
+
+        def _direct(_cfg: Any) -> list[Any]:
+            direct_called["n"] += 1
+            return list(direct_items)
+
+        monkeypatch.setattr(
+            cockpit_inbox, "_pm_inbox_awaits_user_list_uncached", _direct,
+        )
+        cockpit_inbox._AWAITS_USER_CACHE.clear()
+        result = cockpit_inbox.pm_inbox_awaits_user_list(config)
+        assert direct_called["n"] == 1
+        # Workspace-root item is in the result (would have been
+        # silently dropped if we had stayed on the fast-path).
+        ids = {getattr(item, "message_id", None) or getattr(item, "task_id", None) for item in result}
+        assert "ws-root-1" in ids
+        assert "alpha/1" in ids
+
+    def test_workspace_root_message_forces_count_fallthrough(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Same gate fires on the count helper — sums match direct len()."""
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha"], tmp_path)
+        per_project = [
+            _inbox_item(project="alpha", source="task", ident="alpha/1"),
+        ]
+        workspace_root = _inbox_item(
+            project="inbox", source="message", ident="ws-root-2",
+        )
+        monkeypatch.setattr(
+            cockpit_inbox,
+            "_workspace_root_inbox_has_open",
+            lambda cfg: True,
+        )
+        entries = {
+            "alpha": _entry(
+                "alpha", state=ProjectState.WAITING, items=per_project,
+            ),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        direct_items = list(per_project) + [workspace_root]
+        monkeypatch.setattr(
+            cockpit_inbox,
+            "_pm_inbox_awaits_user_list_uncached",
+            lambda cfg: list(direct_items),
+        )
+        cockpit_inbox._AWAITS_USER_CACHE.clear()
+        counted = cockpit_inbox._count_inbox_tasks_for_label(config)
+        # Cache would have returned 1 (only alpha); fall-through gives 2.
+        assert counted == 2
+
+    def test_workspace_root_empty_keeps_cache_fast_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Empty workspace-root → cache fast-path stays available."""
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha"], tmp_path)
+        per_project = [
+            _inbox_item(project="alpha", source="task", ident="alpha/1"),
+        ]
+        monkeypatch.setattr(
+            cockpit_inbox,
+            "_workspace_root_inbox_has_open",
+            lambda cfg: False,
+        )
+        entries = {
+            "alpha": _entry(
+                "alpha", state=ProjectState.WAITING, items=per_project,
+            ),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        # Pin the sampler off so the divergence-comparator path
+        # doesn't masquerade as a fall-through. Earlier tests in this
+        # module may have swapped in a rate-1 counter that would
+        # sample every call; restore a fresh default-rate counter.
+        cockpit_inbox._AWAITS_USER_DIVERGENCE_COUNTER = DivergenceCounter()
+        # Direct sweep MUST NOT be called.
+        direct_called = {"n": 0}
+
+        def _direct(_cfg: Any) -> list[Any]:
+            direct_called["n"] += 1
+            return list(per_project)
+
+        monkeypatch.setattr(
+            cockpit_inbox, "_pm_inbox_awaits_user_list_uncached", _direct,
+        )
+        cockpit_inbox._AWAITS_USER_CACHE.clear()
+        result = cockpit_inbox.pm_inbox_awaits_user_list(config)
+        assert direct_called["n"] == 0
+        assert len(result) == 1

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -1550,3 +1550,172 @@ class TestPr2026V3WorkspaceRootProbeUnbounded:
         # The fast-path MUST decline so the direct sweep can carry
         # the workspace-root row.
         assert cockpit_inbox._maybe_cache_route_awaits_user(config) is None
+
+    # ── PR #2026 v6 regression tests (Codex round-6 blocker) ──────────
+    #
+    # The v5 helper returns True on pool/query failure to keep the cache
+    # authoritative-or-deferred. These tests pin that contract end-to-end:
+    # (1) the helper itself returns True on each failure mode, and
+    # (2) the failure flows through _maybe_cache_{route,count}_awaits_user
+    # as a fall-through (cache declines).
+
+    def test_pool_open_failure_returns_true_conservative(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """``has_workspace_root_open_messages`` must return True when the
+        pg pool cannot be opened — conservative-on-failure contract.
+        """
+
+        from pollypm import cockpit_pg_aggregates
+
+        config = _make_config(["alpha"], tmp_path)
+
+        def _boom_ro(_cfg: Any) -> Any:
+            raise RuntimeError("ro pool unavailable")
+
+        def _boom_rw(_cfg: Any) -> Any:
+            raise RuntimeError("rw pool unavailable")
+
+        monkeypatch.setattr(
+            "pollypm.storage.pg_pool.get_ro_pool", _boom_ro,
+        )
+        monkeypatch.setattr(
+            "pollypm.storage.pg_pool.get_rw_pool", _boom_rw,
+        )
+
+        assert (
+            cockpit_pg_aggregates.has_workspace_root_open_messages(config)
+            is True
+        )
+
+    def test_query_failure_returns_true_conservative(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Pool open succeeds but ``cur.execute()`` raises — the helper
+        must still return True (conservative).
+        """
+
+        from pollypm import cockpit_pg_aggregates
+
+        config = _make_config(["alpha"], tmp_path)
+
+        class _FakeCursor:
+            def __enter__(self) -> "_FakeCursor":
+                return self
+
+            def __exit__(self, *_a: Any) -> None:
+                pass
+
+            def execute(self, _sql: str, _params: Any) -> None:
+                raise RuntimeError("query exploded")
+
+            def fetchone(self) -> Any:
+                return None
+
+        class _FakeConn:
+            def __enter__(self) -> "_FakeConn":
+                return self
+
+            def __exit__(self, *_a: Any) -> None:
+                pass
+
+            def cursor(self) -> _FakeCursor:
+                return _FakeCursor()
+
+        class _FakePool:
+            def connection(self) -> _FakeConn:
+                return _FakeConn()
+
+        monkeypatch.setattr(
+            "pollypm.storage.pg_pool.get_ro_pool", lambda _cfg: _FakePool(),
+        )
+
+        assert (
+            cockpit_pg_aggregates.has_workspace_root_open_messages(config)
+            is True
+        )
+
+    def test_pool_failure_drives_cache_fall_through(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Pool failure → wrapper returns True → ``_maybe_cache_route_awaits_user``
+        declines so the direct sweep carries any uncached awaits-user work.
+        """
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha"], tmp_path)
+
+        def _boom_ro(_cfg: Any) -> Any:
+            raise RuntimeError("ro pool unavailable")
+
+        def _boom_rw(_cfg: Any) -> Any:
+            raise RuntimeError("rw pool unavailable")
+
+        monkeypatch.setattr(
+            "pollypm.storage.pg_pool.get_ro_pool", _boom_ro,
+        )
+        monkeypatch.setattr(
+            "pollypm.storage.pg_pool.get_rw_pool", _boom_rw,
+        )
+
+        # Cache seeded with an uncached-style entry — the only way the
+        # fast-path can decline is via the workspace-root guard, which
+        # depends on the failing probe.
+        entries = {
+            "alpha": _entry(
+                "alpha", state=ProjectState.IDLE, items=[],
+            ),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        assert cockpit_inbox._maybe_cache_route_awaits_user(config) is None
+
+    def test_query_failure_drives_count_fall_through(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """Query failure → wrapper returns True → ``_maybe_cache_count_awaits_user``
+        declines so the rail badge falls back to the direct sweep.
+        """
+
+        monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
+        config = _make_config(["alpha"], tmp_path)
+
+        class _FakeCursor:
+            def __enter__(self) -> "_FakeCursor":
+                return self
+
+            def __exit__(self, *_a: Any) -> None:
+                pass
+
+            def execute(self, _sql: str, _params: Any) -> None:
+                raise RuntimeError("query exploded")
+
+            def fetchone(self) -> Any:
+                return None
+
+        class _FakeConn:
+            def __enter__(self) -> "_FakeConn":
+                return self
+
+            def __exit__(self, *_a: Any) -> None:
+                pass
+
+            def cursor(self) -> _FakeCursor:
+                return _FakeCursor()
+
+        class _FakePool:
+            def connection(self) -> _FakeConn:
+                return _FakeConn()
+
+        monkeypatch.setattr(
+            "pollypm.storage.pg_pool.get_ro_pool", lambda _cfg: _FakePool(),
+        )
+
+        entries = {
+            "alpha": _entry(
+                "alpha", state=ProjectState.IDLE, items=[],
+            ),
+        }
+        _seed_cache(monkeypatch, entries)
+
+        assert cockpit_inbox._maybe_cache_count_awaits_user(config) is None

--- a/tests/test_state_cache_parity.py
+++ b/tests/test_state_cache_parity.py
@@ -649,12 +649,16 @@ class TestCountInboxTasksForLabelParity:
     def test_partial_cache_falls_through_to_direct(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """Cache missing a tracked project → fall through.
+        """Cache missing a tracked project → fall through to direct sweep.
 
-        Otherwise we'd under-count any project that hasn't been
-        refreshed yet. (The fast-path in
-        :func:`pm_inbox_awaits_user_list` already does this; the
-        count helper inherits the same gate via the public wrapper.)
+        PR #2026 review: summing only the cached projects would
+        silently under-count any tracked project that hasn't been
+        refreshed yet (e.g. during the boot-time gap before the
+        initial-full-refresh completes). The gate is
+        ``known_projects.issubset(snapshot.keys())`` —
+        when ``False`` we MUST fall through so the direct sweep
+        covers the missing project, and the rail badge keeps showing
+        every awaits-user item.
         """
 
         monkeypatch.setenv("POLLYPM_STATE_CACHE", "1")
@@ -668,16 +672,33 @@ class TestCountInboxTasksForLabelParity:
             ),
         }
         _seed_cache(monkeypatch, entries)
-        # The cache-routed count helper returns 1 (alpha only) — fine,
-        # because the next call into pm_inbox_awaits_user_list would
-        # fall through to the direct sweep. The contract is the same
-        # as PR 2: a partial cache still serves the cached values for
-        # the projects it knows about. We verify only that the count
-        # equals what the cache holds for known projects.
+
+        # Direct path returns BOTH projects' items (1 in alpha, 1 in
+        # beta). If the fast-path under-counts (the pre-fix bug) the
+        # helper would return 1 — alpha only — because beta isn't in
+        # the snapshot. With the issubset() gate the helper MUST fall
+        # through to the direct sweep and return 2.
+        direct_items = [
+            _inbox_item(project="alpha", source="task", ident="alpha/1"),
+            _inbox_item(project="beta", source="task", ident="beta/2"),
+        ]
+        direct_called = {"n": 0}
+
+        def _direct(_cfg: Any) -> list[Any]:
+            direct_called["n"] += 1
+            return list(direct_items)
+
+        monkeypatch.setattr(
+            cockpit_inbox, "_pm_inbox_awaits_user_list_uncached", _direct,
+        )
         cockpit_inbox._AWAITS_USER_CACHE.clear()
         counted = cockpit_inbox._count_inbox_tasks_for_label(config)
-        # alpha contributes 1; beta is missing → not summed via cache.
-        assert counted == 1
+        # Both projects counted because the fall-through ran the
+        # direct sweep — beta was NOT silently dropped.
+        assert counted == 2
+        # And the direct sweep was actually invoked (proof of
+        # fall-through, not the fast-path quietly returning 1).
+        assert direct_called["n"] >= 1
 
 
 # ── Move A PR 3 parity — load_operator_view_from_config cache route ─

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ wheels = [
 
 [[package]]
 name = "pollypm"
-version = "1.0.0rc2"
+version = "1.0.0rc3.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Move A PR 3 — routes the remaining 5 hot-path call sites from
`docs/design/move-a-state-cache.md` §5 through the in-process state
cache. **Flag (`POLLYPM_STATE_CACHE`) still defaults OFF.** PR 4
flips the default after this lands.

This is PR 3 of 4 in the Move A sequence (#1664). PR 1 (#2000) shipped
the cache infra + env flag. PR 2 (#2016) routed the two hottest
call sites + added the divergence sampler. PR 4 will flip the default.

## Routed call sites (each preserves a flag-off fall-through)

Per §5 of the design doc:

1. **`cockpit_inbox._count_inbox_tasks_for_label`** — sums
   `entry.awaits_user_count` across `cache.snapshot()` instead of
   running the full workspace sweep + `len()`. The
   three-surfaces-one-predicate invariant (rail badge, dashboard
   waiting section, inbox default lens) still holds because the
   count helper falls back to `pm_inbox_awaits_user_list`, which
   itself routes through the same cache.
2. **`dashboard.operator_view.load_operator_view_from_config`** —
   iterates `cache.snapshot()` and builds `OperatorDashboardRow`
   from pre-computed `state` / `glyph` / `detail` fields, skipping
   the bulk work-service open + per-project prefetch entirely.
3. **`cockpit_rail._project_state_rollups`** — reads pre-computed
   `rail_state` / `rail_badge` / `rail_sort_rank` / `rail_reason`
   / `approvals_pending` from each snapshot entry, skipping the
   `all_tasks_grouped()` fan-out. Live alerts are folded into a
   fresh `ProjectStateRollup` so `actionable_key` reflects
   current alerts (the cache doesn't carry alert state).
4. **`cockpit_rail._project_tasks_for_rollup`** — becomes an
   internal helper of the cache refresher (`refresh_impl.py`
   already populates the rail fields it produced). Still callable
   from the direct-path fall-through.
5. **`cockpit_rail.latest_heartbeat()` per-project** (lines
   1474-1490, 2200-2220) — replaced with `_latest_heartbeat_cached`
   that reads from `entry.latest_heartbeat_by_session[session_name]`
   with a fall-through to `supervisor.store.latest_heartbeat` on
   cache miss.

## TTL removal (design §9.5)

`CockpitRouter._PROJECT_CATEGORIZATIONS_TTL_SECONDS = 2.0` is
**GONE**, along with the three instance fields it backed
(`_project_categorizations_cache` / `_cache_key` / `_cached_at`).
The state cache's `global_version()` short-circuit + the per-call
TTL inside `project_state_map_from_config` already collapse
navigation-burst refreshes. Two cache layers were worse than one:
the freshly-completed-task-stuck-as-WORKING pathology (up to 2s of
stale data) is gone.

## Refresher extension (`refresh_impl.py`)

`compute_entry_for_project` now also:
- Gathers live worker sessions via `slice_svc.list_worker_sessions`.
- Fetches their latest heartbeats via `Supervisor.store`, populating
  `entry.latest_heartbeat_by_session` so the rail's per-tick
  heartbeat lookups become snapshot reads.

## Tests

- `tests/test_state_cache_parity.py` — 15 new tests across 4 new
  classes covering the 4 new call sites + the TTL-removal
  regression. Each routed site asserts:
  - Cached fast-path skips the heavy direct call.
  - Flag-off path uses the direct call.
  - Partial cache (missing tracked project) falls through.
- `tests/test_cockpit_rail_categorization_cache.py` rewritten
  against the post-TTL contract:
  - Modifications to underlying state visible on the next call (no
    waiting on a TTL to expire).
  - TTL constant + instance fields introspected as absent — a
    future "let's add caching back" PR will break a test loudly.

Verified with a no-pytest smoke harness driving all 5 routed call
sites + the TTL removal; pytest collected 39 tests cleanly across
the parity suite.

## Test plan

- [ ] `pytest tests/test_state_cache_parity.py tests/test_state_cache_env_flag.py tests/test_cockpit_rail_categorization_cache.py`
- [ ] Cockpit smoke test with `POLLYPM_STATE_CACHE=1` to confirm rail glyph + dashboard rows render identically to flag-off.
- [ ] Confirm divergence sampler stays silent in 24h of telemetry before flipping the default in PR 4.

Closes part of #1664 (this is PR 3 of 4; PR 4 flips the default and closes the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)