### PR TITLE
polish(tmux-ui): wire render_footer_status into live cockpit footer (refs #1988)

### DIFF
--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -27,6 +27,7 @@ import os
 import resource
 import webbrowser
 from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
 import subprocess
 import time
@@ -368,6 +369,26 @@ def _wrap_with_hanging_indent(
     if current:
         lines.append(f"{indent}{open_tag}{current}{close_tag}")
     return lines
+
+
+@dataclass(slots=True, frozen=True)
+class FooterStateSnapshot:
+    """Precomputed inputs for the unified footer status bar.
+
+    Resolved off-thread by :meth:`PollyCockpitApp._resolve_footer_state`
+    alongside the rail's ``build_items`` worker, then cached on the
+    app instance so :meth:`PollyCockpitApp._update_hint` can render
+    the footer as a pure formatter without any synchronous supervisor
+    load / inbox fanout / heartbeat probe on the UI thread (#2027).
+
+    Fields mirror the four inputs of
+    :func:`pollypm.cockpit_footer_status.render_footer_status`.
+    """
+
+    project_count: int
+    agent_count: int
+    inbox_count: int
+    alert: str | None
 
 
 class PollyCockpitApp(App[None]):
@@ -785,6 +806,14 @@ class PollyCockpitApp(App[None]):
             window_manager=_CockpitRouteWindowApplier(self),
         )
         self._route_status_hint: str | None = None
+        # #2027 perf — precomputed snapshot of the four footer inputs
+        # (project/agent/inbox counts + heartbeat alert). Populated
+        # OFF the UI thread inside :meth:`_refresh_rows_worker` so
+        # :meth:`_update_hint` never runs the supervisor/inbox/heartbeat
+        # resolution path on the cockpit's hot repaint surface. ``None``
+        # on first paint — the legacy hint renders until the first
+        # ``build_items`` worker returns (typically <1s).
+        self._footer_state: FooterStateSnapshot | None = None
         self._transient_notice_active = False
         # #1546-followup — rail_daemon self-recovery state. Tracks the
         # most recent revival attempt (so the throttle in
@@ -1780,6 +1809,15 @@ class PollyCockpitApp(App[None]):
                 items = _build()
             except Exception:  # noqa: BLE001
                 return
+            # #2027 — resolve footer inputs inline too so the
+            # ``_update_hint`` invocation at the end of
+            # ``_apply_built_items`` has a fresh snapshot to format.
+            try:
+                snapshot = self._resolve_footer_state()
+            except Exception:  # noqa: BLE001
+                snapshot = None
+            if snapshot is not None:
+                self._footer_state = snapshot
             self._apply_built_items(items)
 
     def _refresh_rows_worker(self, build_fn, apply_fn) -> None:
@@ -1791,6 +1829,20 @@ class PollyCockpitApp(App[None]):
             except Exception:  # noqa: BLE001
                 self._refresh_in_flight = False
             return
+        # #2027 — resolve footer inputs in the SAME off-thread pass
+        # that just ran ``build_items``. The shared inbox TTL cache
+        # collapses this with the rail badge's ``_inbox_count``
+        # lookup the worker already paid for, so the marginal cost
+        # is one heartbeat probe + a couple of dict.len calls.
+        try:
+            snapshot = self._resolve_footer_state()
+        except Exception:  # noqa: BLE001
+            snapshot = None
+        if snapshot is not None:
+            try:
+                self.call_from_thread(setattr, self, "_footer_state", snapshot)
+            except Exception:  # noqa: BLE001
+                self._footer_state = snapshot
         try:
             self.call_from_thread(apply_fn, items)
         except Exception:  # noqa: BLE001
@@ -2397,17 +2449,37 @@ class PollyCockpitApp(App[None]):
         # it's a transient per-route override (e.g. "Press n to launch")
         # that the unified status bar isn't meant to displace.
         #
+        # #2027 / PR perf review: this method is invoked from the rail
+        # rebuild path (``_apply_built_items`` -> ``_update_hint``) and
+        # therefore runs on the UI thread on every repaint. The footer
+        # inputs (project_count, agent_count, inbox_count, alert) are
+        # NOT resolved here \u2014 they are precomputed off-thread inside
+        # the ``build_items`` worker and cached on ``self._footer_state``
+        # by ``_apply_built_items``. ``_update_hint`` consumes that
+        # snapshot as a pure formatter; if the snapshot is not yet
+        # populated (first paint, before the rail worker has returned)
+        # we render the legacy hint so the footer never shows blank.
+        #
         # Backstop: ``render_footer_status`` is a pure formatter, but
-        # any failure to *resolve its inputs* (supervisor load, inbox
-        # fanout, pg fallback) would otherwise blank the footer. Wrap
-        # the new path in a try/except and fall through to the legacy
-        # inline builder so the footer NEVER crashes the cockpit.
+        # any failure to format its inputs would otherwise blank the
+        # footer. Wrap the new path in a try/except and fall through
+        # to the legacy inline builder so the footer NEVER crashes the
+        # cockpit.
         route_status_hint = getattr(self, "_route_status_hint", None)
         if route_status_hint:
             self.hint.update(route_status_hint)
             return
+        snapshot = getattr(self, "_footer_state", None)
+        if snapshot is None:
+            # First paint, before the off-thread rail worker has
+            # populated ``_footer_state``. Render the legacy hint
+            # rather than synchronously resolve footer inputs on the
+            # UI thread \u2014 the next ``_apply_built_items`` will
+            # repaint with the unified bar within ~1 tick.
+            self.hint.update(self._compose_legacy_footer_hint())
+            return
         try:
-            hint_text = self._compose_unified_footer_status()
+            hint_text = self._format_unified_footer_status(snapshot)
         except Exception:  # noqa: BLE001
             # Fall back to the pre-#1988 inline builder. Logged at WARN
             # so the cockpit operator sees the degradation in pm logs
@@ -2419,44 +2491,18 @@ class PollyCockpitApp(App[None]):
             hint_text = self._compose_legacy_footer_hint()
         self.hint.update(hint_text)
 
-    def _compose_unified_footer_status(self) -> str:
-        """Build the footer text via :func:`render_footer_status`.
+    def _format_unified_footer_status(self, snapshot: "FooterStateSnapshot") -> str:
+        """Pure formatter \u2014 turns a precomputed footer snapshot into text.
 
-        Resolves the four inputs (project_count, agent_count,
-        inbox_count, alert) from the live supervisor + inbox helpers,
-        then hands them to the leaf formatter shipped in #2014. The
-        ``width`` budget reads from the ``hint`` widget's current
-        rendered size and falls back to 80 cols if Textual hasn't
-        sized the widget yet (typical on first paint).
+        Reads its width budget off the live ``hint`` widget (falling
+        back to 80 cols when Textual hasn't sized it yet) and hands
+        the precomputed counts to :func:`render_footer_status`. NO
+        supervisor load, NO inbox fanout, NO heartbeat probe \u2014 those
+        are all resolved off-thread by :meth:`_resolve_footer_state`
+        and cached in ``self._footer_state``. Keeping this path pure
+        is load-bearing for #2027 perf: ``_update_hint`` is invoked
+        from ``_apply_built_items`` on every rail repaint.
         """
-        supervisor = self.router._load_supervisor()
-        config = supervisor.config
-
-        # project_count: every configured project (tracked + paused).
-        # The footer is a workspace-wide signal \u2014 filtering to tracked
-        # would hide projects the operator just paused, contradicting
-        # the "Tracked-Filter Asymmetry" memo for the rail badge.
-        projects = getattr(config, "projects", {}) or {}
-        project_count = len(projects)
-
-        # agent_count: every configured session row, since "agents" in
-        # the audit copy maps to the session table the supervisor
-        # launches. Live-only counts would jitter as workers restart.
-        sessions = getattr(config, "sessions", {}) or {}
-        agent_count = len(sessions)
-
-        # inbox_count: re-use the shared ``pm_inbox_awaits_user_list``
-        # so the footer can never disagree with the rail badge / ``pm
-        # inbox --awaits-user`` (#1571).
-        from pollypm.cockpit_inbox import pm_inbox_awaits_user_list
-        inbox_items = pm_inbox_awaits_user_list(config) or []
-        inbox_count = len(inbox_items)
-
-        # alert: the only footer-class alert today is the
-        # heartbeat-offline warning. Reuse the existing detection +
-        # formatter so the new path and the legacy path stay aligned.
-        alert = self._resolve_heartbeat_footer_alert(supervisor)
-
         try:
             width = int(getattr(self.hint, "size", None).width)  # type: ignore[union-attr]
         except (AttributeError, TypeError, ValueError):
@@ -2465,11 +2511,72 @@ class PollyCockpitApp(App[None]):
             width = 80
 
         return render_footer_status(
+            project_count=snapshot.project_count,
+            agent_count=snapshot.agent_count,
+            inbox_count=snapshot.inbox_count,
+            alert=snapshot.alert,
+            width=width,
+        )
+
+    def _resolve_footer_state(self) -> "FooterStateSnapshot | None":
+        """Resolve footer inputs OFF the UI thread.
+
+        Called from the ``build_items`` worker (``_refresh_rows_worker``)
+        alongside the rail rebuild so all four expensive lookups
+        (``_load_supervisor`` + inbox fanout + heartbeat probe + the
+        config-dict counts) happen in the same off-thread pass that
+        the rail badge already pays for. The result is stored on
+        ``self._footer_state`` and consumed by :meth:`_update_hint`
+        as a pure formatter.
+
+        Returns ``None`` on any failure so the caller can leave the
+        previous snapshot in place (stale-but-valid beats blank).
+        """
+        try:
+            supervisor = self.router._load_supervisor()
+            config = supervisor.config
+
+            # project_count: every configured project (tracked + paused).
+            # The footer is a workspace-wide signal \u2014 filtering to
+            # tracked would hide projects the operator just paused,
+            # contradicting the "Tracked-Filter Asymmetry" memo for the
+            # rail badge.
+            projects = getattr(config, "projects", {}) or {}
+            project_count = len(projects)
+
+            # agent_count: every configured session row, since "agents"
+            # in the audit copy maps to the session table the supervisor
+            # launches. Live-only counts would jitter as workers restart.
+            sessions = getattr(config, "sessions", {}) or {}
+            agent_count = len(sessions)
+
+            # inbox_count: re-use the shared ``pm_inbox_awaits_user_list``
+            # so the footer can never disagree with the rail badge /
+            # ``pm inbox --awaits-user`` (#1571). The 1s TTL cache in
+            # ``cockpit_inbox`` collapses this with the rail badge's
+            # own ``_inbox_count`` lookup that the same worker just
+            # ran, so this is a cache hit on the hot path.
+            from pollypm.cockpit_inbox import pm_inbox_awaits_user_list
+            inbox_items = pm_inbox_awaits_user_list(config) or []
+            inbox_count = len(inbox_items)
+
+            # alert: the only footer-class alert today is the
+            # heartbeat-offline warning. Reuse the existing detection
+            # + formatter so the new path and the legacy path stay
+            # aligned.
+            alert = self._resolve_heartbeat_footer_alert(supervisor)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "footer state resolution failed; retaining previous snapshot",
+                exc_info=True,
+            )
+            return None
+
+        return FooterStateSnapshot(
             project_count=project_count,
             agent_count=agent_count,
             inbox_count=inbox_count,
             alert=alert,
-            width=width,
         )
 
     def _resolve_heartbeat_footer_alert(self, supervisor) -> str | None:

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -58,6 +58,7 @@ from textual.widgets import (
 )
 
 from pollypm.approval_notifications import notify_task_approved
+from pollypm.cockpit_footer_status import render_footer_status
 from pollypm.cockpit_formatting import format_relative_age as _format_relative_age
 from pollypm.cockpit_markup import _escape, _escape_body
 from pollypm.model_registry import load_registry
@@ -2386,26 +2387,135 @@ class PollyCockpitApp(App[None]):
         return "⚠ Heartbeat offline · open Settings"
 
     def _update_hint(self) -> None:
-        # Keep this hint short enough to fit a 30-col rail without
-        # wrapping. Anything beyond j/k/\u21b5/?/q is discoverable via the
-        # ``?`` overlay (#790). Width budget is roughly 28 chars after
-        # the leading pad applied by Textual.
+        # Unified footer status bar (#1988 / #2014). Replaces the
+        # ad-hoc ``j/k \u21b5open \u00b7 ? help \u00b7 q quit`` / heartbeat-offline
+        # string-build with a single call into
+        # :func:`pollypm.cockpit_footer_status.render_footer_status` so
+        # the cockpit footer, rail badge, and ticker share one format.
+        #
+        # The route-status hint (``_route_status_hint``) still wins \u2014
+        # it's a transient per-route override (e.g. "Press n to launch")
+        # that the unified status bar isn't meant to displace.
+        #
+        # Backstop: ``render_footer_status`` is a pure formatter, but
+        # any failure to *resolve its inputs* (supervisor load, inbox
+        # fanout, pg fallback) would otherwise blank the footer. Wrap
+        # the new path in a try/except and fall through to the legacy
+        # inline builder so the footer NEVER crashes the cockpit.
         route_status_hint = getattr(self, "_route_status_hint", None)
         if route_status_hint:
             self.hint.update(route_status_hint)
             return
+        try:
+            hint_text = self._compose_unified_footer_status()
+        except Exception:  # noqa: BLE001
+            # Fall back to the pre-#1988 inline builder. Logged at WARN
+            # so the cockpit operator sees the degradation in pm logs
+            # without it surfacing as an alert dialog.
+            logger.warning(
+                "render_footer_status failed; falling back to legacy hint",
+                exc_info=True,
+            )
+            hint_text = self._compose_legacy_footer_hint()
+        self.hint.update(hint_text)
+
+    def _compose_unified_footer_status(self) -> str:
+        """Build the footer text via :func:`render_footer_status`.
+
+        Resolves the four inputs (project_count, agent_count,
+        inbox_count, alert) from the live supervisor + inbox helpers,
+        then hands them to the leaf formatter shipped in #2014. The
+        ``width`` budget reads from the ``hint`` widget's current
+        rendered size and falls back to 80 cols if Textual hasn't
+        sized the widget yet (typical on first paint).
+        """
+        supervisor = self.router._load_supervisor()
+        config = supervisor.config
+
+        # project_count: every configured project (tracked + paused).
+        # The footer is a workspace-wide signal \u2014 filtering to tracked
+        # would hide projects the operator just paused, contradicting
+        # the "Tracked-Filter Asymmetry" memo for the rail badge.
+        projects = getattr(config, "projects", {}) or {}
+        project_count = len(projects)
+
+        # agent_count: every configured session row, since "agents" in
+        # the audit copy maps to the session table the supervisor
+        # launches. Live-only counts would jitter as workers restart.
+        sessions = getattr(config, "sessions", {}) or {}
+        agent_count = len(sessions)
+
+        # inbox_count: re-use the shared ``pm_inbox_awaits_user_list``
+        # so the footer can never disagree with the rail badge / ``pm
+        # inbox --awaits-user`` (#1571).
+        from pollypm.cockpit_inbox import pm_inbox_awaits_user_list
+        inbox_items = pm_inbox_awaits_user_list(config) or []
+        inbox_count = len(inbox_items)
+
+        # alert: the only footer-class alert today is the
+        # heartbeat-offline warning. Reuse the existing detection +
+        # formatter so the new path and the legacy path stay aligned.
+        alert = self._resolve_heartbeat_footer_alert(supervisor)
+
+        try:
+            width = int(getattr(self.hint, "size", None).width)  # type: ignore[union-attr]
+        except (AttributeError, TypeError, ValueError):
+            width = 80
+        if width <= 0:
+            width = 80
+
+        return render_footer_status(
+            project_count=project_count,
+            agent_count=agent_count,
+            inbox_count=inbox_count,
+            alert=alert,
+            width=width,
+        )
+
+    def _resolve_heartbeat_footer_alert(self, supervisor) -> str | None:
+        """Return the heartbeat-offline alert string, or None if fresh.
+
+        Mirrors the legacy ``_update_hint`` heartbeat-staleness probe
+        (pg-aware read, naive-UTC normalization, ``_HEARTBEAT_STALE_SECONDS``
+        threshold, ``_format_heartbeat_offline_hint`` for the string).
+        Any failure returns ``None`` so the footer just hides the
+        alert chunk rather than poisoning the whole bar.
+        """
+        try:
+            from pollypm.storage._backend_dispatch import is_pg_backend
+            if is_pg_backend(supervisor.config):
+                from pollypm.storage.pg_heartbeats import (
+                    last_heartbeat_at as _pg_last_heartbeat_at,
+                )
+                last_hb = _pg_last_heartbeat_at(config=supervisor.config)
+            else:
+                last_hb = supervisor.store.last_heartbeat_at()
+            if not last_hb:
+                return None
+            from datetime import UTC, datetime
+            parsed = datetime.fromisoformat(last_hb.replace(" ", "T"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=UTC)
+            elapsed = (datetime.now(UTC) - parsed).total_seconds()
+            if elapsed > self._HEARTBEAT_STALE_SECONDS:
+                return self._format_heartbeat_offline_hint(elapsed)
+        except Exception:  # noqa: BLE001
+            return None
+        return None
+
+    def _compose_legacy_footer_hint(self) -> str:
+        """Pre-#1988 inline footer builder, retained as the backstop.
+
+        Called from ``_update_hint`` only when the unified path raises;
+        keeps the cockpit footer alive through any future regression in
+        ``render_footer_status`` or its input-resolution helpers.
+        """
         if self._right_pane_has_live_session():
             hint_text = "Tab detail \u00b7 j/k \u00b7 ? help"
         else:
             hint_text = "j/k \u21b5open \u00b7 ? help \u00b7 q quit"
         try:
             supervisor = self.router._load_supervisor()
-            # Backend-aware read: on the pg backend the unified ``messages``
-            # table lives in Postgres, but ``supervisor.store`` is still the
-            # SQLite ``StateStore`` (kept for legacy domain reads). Reading
-            # the sqlite copy yields a stale row from before the pg cutover
-            # and the rail then renders a false-positive "Heartbeat offline
-            # (Nm)" warning. Route through the pg facade when configured.
             from pollypm.storage._backend_dispatch import is_pg_backend
             if is_pg_backend(supervisor.config):
                 from pollypm.storage.pg_heartbeats import (
@@ -2416,11 +2526,6 @@ class PollyCockpitApp(App[None]):
                 last_hb = supervisor.store.last_heartbeat_at()
             if last_hb:
                 from datetime import UTC, datetime
-                # Unified ``messages`` table stores SQLite's default
-                # ``CURRENT_TIMESTAMP`` which is naive-UTC
-                # (``YYYY-MM-DD HH:MM:SS``, no ``+00:00``). Force UTC
-                # so ``datetime.now(UTC) - parsed`` doesn't raise
-                # ``can't subtract offset-naive and offset-aware``.
                 parsed = datetime.fromisoformat(last_hb.replace(" ", "T"))
                 if parsed.tzinfo is None:
                     parsed = parsed.replace(tzinfo=UTC)
@@ -2429,7 +2534,7 @@ class PollyCockpitApp(App[None]):
                     hint_text = self._format_heartbeat_offline_hint(elapsed)
         except Exception:  # noqa: BLE001
             pass
-        self.hint.update(hint_text)
+        return hint_text
 
     def _sync_selected_from_nav(self) -> None:
         """Update selected_key from the current ListView cursor position."""

--- a/tests/test_cockpit_footer_status_wiring.py
+++ b/tests/test_cockpit_footer_status_wiring.py
@@ -1,17 +1,22 @@
-"""Integration tests for the cockpit footer wiring (refs #1988).
+"""Integration tests for the cockpit footer wiring (refs #1988, #2027).
 
 PR #2014 shipped :func:`pollypm.cockpit_footer_status.render_footer_status`
 as a pure formatter with leaf-level coverage. The wiring PR
 (:func:`PollyCockpitApp._update_hint` -> ``render_footer_status``) lives
 in ``src/pollypm/cockpit_ui.py``; these tests lock in:
 
-1. The wired call site actually feeds the helper with supervisor /
-   inbox counts and writes the result to ``self.hint``.
+1. The wired call site reads from the precomputed
+   :class:`FooterStateSnapshot` and writes the rendered string to
+   ``self.hint`` without doing supervisor / inbox / heartbeat resolution
+   on the UI thread (#2027 perf invariant).
 2. Narrow-width renders still satisfy the helper's "no overflow"
    invariant — the wire-up must not paint a string wider than the
    ``hint`` widget's measured width.
+3. Snapshot resolution happens off-thread in
+   :meth:`PollyCockpitApp._resolve_footer_state` and feeds the same
+   inputs as the legacy in-line builder.
 
-Both tests bypass ``__init__`` (``PollyCockpitApp.__new__``) so they
+All tests bypass ``__init__`` (``PollyCockpitApp.__new__``) so they
 can stub the router / hint widget without spinning up Textual.
 """
 
@@ -19,7 +24,7 @@ from __future__ import annotations
 
 import re
 
-from pollypm.cockpit_ui import PollyCockpitApp
+from pollypm.cockpit_ui import FooterStateSnapshot, PollyCockpitApp
 
 
 _MARKUP_RE = re.compile(r"\[/?[^\]]+\]")
@@ -73,11 +78,13 @@ def _build_app(
     inbox_count: int = 0,
     hint_width: int = 120,
     monkeypatch=None,
+    seed_footer_state: bool = True,
 ) -> tuple[PollyCockpitApp, _StubHint]:
     app = PollyCockpitApp.__new__(PollyCockpitApp)
     supervisor = _StubSupervisor(projects or {}, sessions or {})
     app.router = _StubRouter(supervisor)  # type: ignore[assignment]
     app._route_status_hint = None  # type: ignore[attr-defined]
+    app._footer_state = None  # type: ignore[attr-defined]
     app._right_pane_has_live_session = lambda: False  # type: ignore[method-assign]
     hint = _StubHint(width=hint_width)
     app.hint = hint  # type: ignore[assignment]
@@ -89,12 +96,21 @@ def _build_app(
             "pollypm.cockpit_inbox.pm_inbox_awaits_user_list",
             lambda _config: list(fake_items),
         )
+
+    # Precompute the footer snapshot so ``_update_hint`` (which is now
+    # a pure formatter — see #2027) has something to render. In
+    # production this is populated off-thread by
+    # ``_refresh_rows_worker`` before ``_apply_built_items`` ->
+    # ``_update_hint`` runs.
+    if seed_footer_state:
+        app._footer_state = app._resolve_footer_state()  # type: ignore[attr-defined]
+
     return app, hint
 
 
 def test_update_hint_renders_unified_status_with_supervisor_counts(monkeypatch) -> None:
-    """``_update_hint`` reads supervisor projects/sessions + inbox fanout
-    and writes the unified status string into ``self.hint``.
+    """``_update_hint`` reads the precomputed footer snapshot and writes
+    the unified status string into ``self.hint``.
     """
     projects = {f"p{i}": object() for i in range(5)}
     sessions = {f"s{i}": object() for i in range(7)}
@@ -168,6 +184,30 @@ def test_update_hint_falls_back_to_legacy_on_helper_failure(monkeypatch) -> None
     )
 
 
+def test_update_hint_renders_legacy_when_snapshot_not_yet_populated(
+    monkeypatch,
+) -> None:
+    """First paint, before the off-thread rail worker has populated
+    ``_footer_state``, must render the legacy hint instead of running
+    the supervisor/inbox/heartbeat resolution on the UI thread (#2027).
+    """
+    app, hint = _build_app(
+        projects={"only": object()},
+        sessions={"one": object()},
+        inbox_count=0,
+        hint_width=120,
+        monkeypatch=monkeypatch,
+        seed_footer_state=False,
+    )
+    assert app._footer_state is None  # precondition
+
+    app._update_hint()
+
+    assert hint.last_text == "j/k ↵open · ? help · q quit", (
+        f"first-paint fallback did not produce the legacy hint: {hint.last_text!r}"
+    )
+
+
 def test_update_hint_route_status_hint_still_wins() -> None:
     """The transient per-route override (e.g. ``Press n to launch``)
     must continue to short-circuit the unified status bar so route
@@ -181,3 +221,94 @@ def test_update_hint_route_status_hint_still_wins() -> None:
     app._update_hint()
 
     assert hint.last_text == "Launching worker for demo..."
+
+
+def test_update_hint_does_not_call_pm_inbox_awaits_user_list_on_hot_path(
+    monkeypatch,
+) -> None:
+    """#2027 regression — ``_update_hint`` runs on the rail repaint
+    path (``_apply_built_items`` -> ``_update_hint``) and MUST NOT
+    synchronously call :func:`pm_inbox_awaits_user_list` on the UI
+    thread. The expensive inbox fanout happens off-thread inside
+    :meth:`_resolve_footer_state`; ``_update_hint`` is a pure
+    formatter over the precomputed :class:`FooterStateSnapshot`.
+
+    A click burst (e.g. j/k spam) can re-enter ``_update_hint``
+    dozens of times per second; allowing the fanout on the hot path
+    blocks every keystroke for the duration of the supervisor load
+    + inbox sweep + heartbeat probe, which is the same surface
+    PR #2027 was already trying to keep cold.
+    """
+    inbox_call_count = 0
+
+    def _tracked_inbox(_config):
+        nonlocal inbox_call_count
+        inbox_call_count += 1
+        return []
+
+    # Patch the symbol at its source so any ``from pollypm.cockpit_inbox
+    # import pm_inbox_awaits_user_list`` re-import inside ``_update_hint``
+    # also routes through the tracker.
+    monkeypatch.setattr(
+        "pollypm.cockpit_inbox.pm_inbox_awaits_user_list",
+        _tracked_inbox,
+    )
+
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+    app._route_status_hint = None  # type: ignore[attr-defined]
+    app._right_pane_has_live_session = lambda: False  # type: ignore[method-assign]
+    # Seed a precomputed snapshot — this is the contract: by the time
+    # ``_update_hint`` is on the UI thread, ``_footer_state`` is already
+    # populated (off-thread, by ``_refresh_rows_worker``).
+    app._footer_state = FooterStateSnapshot(  # type: ignore[attr-defined]
+        project_count=4,
+        agent_count=2,
+        inbox_count=5,
+        alert=None,
+    )
+    hint = _StubHint(width=120)
+    app.hint = hint  # type: ignore[assignment]
+
+    # Simulate a click burst — many ``_update_hint`` re-entries per
+    # the rail repaint path. The fanout MUST stay at 0 calls.
+    for _ in range(25):
+        app._update_hint()
+
+    assert inbox_call_count == 0, (
+        f"_update_hint ran pm_inbox_awaits_user_list on the hot path "
+        f"({inbox_call_count} call(s)); footer inputs must be precomputed "
+        f"off-thread per #2027."
+    )
+    # Sanity check: the footer was actually rendered, not skipped.
+    assert hint.last_text is not None
+    plain = _plain(hint.last_text)
+    assert "5 inbox" in plain or "5" in plain, plain
+
+
+def test_resolve_footer_state_returns_snapshot_with_expected_counts(
+    monkeypatch,
+) -> None:
+    """The off-thread resolver produces a :class:`FooterStateSnapshot`
+    whose fields match what ``_update_hint`` would have computed
+    inline pre-#2027. Locks in that the move-to-snapshot didn't
+    change the semantic of the four footer inputs.
+    """
+    projects = {f"p{i}": object() for i in range(6)}
+    sessions = {f"s{i}": object() for i in range(4)}
+    app, _hint = _build_app(
+        projects=projects,
+        sessions=sessions,
+        inbox_count=11,
+        hint_width=120,
+        monkeypatch=monkeypatch,
+        seed_footer_state=False,
+    )
+
+    snapshot = app._resolve_footer_state()
+
+    assert isinstance(snapshot, FooterStateSnapshot)
+    assert snapshot.project_count == 6
+    assert snapshot.agent_count == 4
+    assert snapshot.inbox_count == 11
+    # Stub store reports no heartbeat → no alert chunk.
+    assert snapshot.alert is None

--- a/tests/test_cockpit_footer_status_wiring.py
+++ b/tests/test_cockpit_footer_status_wiring.py
@@ -1,0 +1,183 @@
+"""Integration tests for the cockpit footer wiring (refs #1988).
+
+PR #2014 shipped :func:`pollypm.cockpit_footer_status.render_footer_status`
+as a pure formatter with leaf-level coverage. The wiring PR
+(:func:`PollyCockpitApp._update_hint` -> ``render_footer_status``) lives
+in ``src/pollypm/cockpit_ui.py``; these tests lock in:
+
+1. The wired call site actually feeds the helper with supervisor /
+   inbox counts and writes the result to ``self.hint``.
+2. Narrow-width renders still satisfy the helper's "no overflow"
+   invariant — the wire-up must not paint a string wider than the
+   ``hint`` widget's measured width.
+
+Both tests bypass ``__init__`` (``PollyCockpitApp.__new__``) so they
+can stub the router / hint widget without spinning up Textual.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pollypm.cockpit_ui import PollyCockpitApp
+
+
+_MARKUP_RE = re.compile(r"\[/?[^\]]+\]")
+
+
+def _plain(markup: str) -> str:
+    """Strip Rich markup tags so length assertions reflect rendered width."""
+    return _MARKUP_RE.sub("", markup)
+
+
+class _StubHint:
+    """Minimal stand-in for the cockpit's ``Static`` hint widget."""
+
+    def __init__(self, width: int = 120) -> None:
+        self.size = type("Size", (), {"width": width})()
+        self.last_text: str | None = None
+
+    def update(self, text: str) -> None:
+        self.last_text = text
+
+
+class _StubConfig:
+    def __init__(self, projects: dict, sessions: dict) -> None:
+        self.projects = projects
+        self.sessions = sessions
+
+
+class _StubStore:
+    def last_heartbeat_at(self) -> str | None:
+        return None  # fresh heartbeat → no alert chunk
+
+
+class _StubSupervisor:
+    def __init__(self, projects: dict, sessions: dict) -> None:
+        self.config = _StubConfig(projects, sessions)
+        self.store = _StubStore()
+
+
+class _StubRouter:
+    def __init__(self, supervisor: _StubSupervisor) -> None:
+        self._supervisor = supervisor
+
+    def _load_supervisor(self, fresh: bool = False):  # noqa: ARG002
+        return self._supervisor
+
+
+def _build_app(
+    *,
+    projects: dict | None = None,
+    sessions: dict | None = None,
+    inbox_count: int = 0,
+    hint_width: int = 120,
+    monkeypatch=None,
+) -> tuple[PollyCockpitApp, _StubHint]:
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+    supervisor = _StubSupervisor(projects or {}, sessions or {})
+    app.router = _StubRouter(supervisor)  # type: ignore[assignment]
+    app._route_status_hint = None  # type: ignore[attr-defined]
+    app._right_pane_has_live_session = lambda: False  # type: ignore[method-assign]
+    hint = _StubHint(width=hint_width)
+    app.hint = hint  # type: ignore[assignment]
+
+    # Stub the cached inbox fanout so the test doesn't need a real DB.
+    fake_items = [object()] * inbox_count
+    if monkeypatch is not None:
+        monkeypatch.setattr(
+            "pollypm.cockpit_inbox.pm_inbox_awaits_user_list",
+            lambda _config: list(fake_items),
+        )
+    return app, hint
+
+
+def test_update_hint_renders_unified_status_with_supervisor_counts(monkeypatch) -> None:
+    """``_update_hint`` reads supervisor projects/sessions + inbox fanout
+    and writes the unified status string into ``self.hint``.
+    """
+    projects = {f"p{i}": object() for i in range(5)}
+    sessions = {f"s{i}": object() for i in range(7)}
+    app, hint = _build_app(
+        projects=projects,
+        sessions=sessions,
+        inbox_count=3,
+        hint_width=120,
+        monkeypatch=monkeypatch,
+    )
+
+    app._update_hint()
+
+    assert hint.last_text is not None, "footer was never updated"
+    plain = _plain(hint.last_text)
+    # Counts must surface as labeled chunks at this comfortable width.
+    assert "5 projects" in plain, plain
+    assert "7 agents" in plain, plain
+    assert "3 inbox" in plain, plain
+
+
+def test_update_hint_narrow_width_respects_helper_invariant(monkeypatch) -> None:
+    """The helper guarantees the rendered text fits inside ``width`` —
+    the wire-up must honor that invariant by passing the live hint
+    widget's width through. Use a narrow 30-col rail-style budget so
+    the helper has to drop labels / truncate.
+    """
+    projects = {f"p{i}": object() for i in range(99)}
+    sessions = {f"s{i}": object() for i in range(99)}
+    app, hint = _build_app(
+        projects=projects,
+        sessions=sessions,
+        inbox_count=42,
+        hint_width=30,
+        monkeypatch=monkeypatch,
+    )
+
+    app._update_hint()
+
+    assert hint.last_text is not None
+    rendered_width = len(_plain(hint.last_text))
+    assert rendered_width <= 30, (
+        f"footer overflowed 30-col rail: {rendered_width} chars "
+        f"-> {hint.last_text!r}"
+    )
+
+
+def test_update_hint_falls_back_to_legacy_on_helper_failure(monkeypatch) -> None:
+    """If the unified path raises (helper bug, transient store error,
+    anything), the footer must NEVER crash — fall through to the
+    pre-#1988 inline string so the cockpit footer keeps rendering.
+    """
+    app, hint = _build_app(
+        projects={"only": object()},
+        sessions={"one": object()},
+        inbox_count=0,
+        hint_width=120,
+        monkeypatch=monkeypatch,
+    )
+
+    def _boom(**_kwargs: object) -> str:
+        raise RuntimeError("simulated helper regression")
+
+    monkeypatch.setattr("pollypm.cockpit_ui.render_footer_status", _boom)
+
+    app._update_hint()
+
+    # Legacy default hint for the no-live-session branch.
+    assert hint.last_text == "j/k ↵open · ? help · q quit", (
+        f"backstop did not produce the legacy hint: {hint.last_text!r}"
+    )
+
+
+def test_update_hint_route_status_hint_still_wins() -> None:
+    """The transient per-route override (e.g. ``Press n to launch``)
+    must continue to short-circuit the unified status bar so route
+    feedback isn't overwritten by the workspace-wide counts.
+    """
+    app = PollyCockpitApp.__new__(PollyCockpitApp)
+    app._route_status_hint = "Launching worker for demo..."  # type: ignore[attr-defined]
+    hint = _StubHint(width=120)
+    app.hint = hint  # type: ignore[assignment]
+
+    app._update_hint()
+
+    assert hint.last_text == "Launching worker for demo..."


### PR DESCRIPTION
## Summary

- #2014 shipped `render_footer_status()` (11 tests + 100 parametrized cases) but deferred the wiring.
- This PR wires `PollyCockpitApp._update_hint` to call the helper with live counts (project/agent/inbox + heartbeat-staleness alert).
- Wrapped in try/except with a backstop fall-through to the legacy inline string build — footer never crashes the cockpit.

## Test plan

- [x] Helper invocation pulls live counts from supervisor + inbox
- [x] Exception in helper → log + fall back to legacy path
- [x] Width-budget invariant from #2014 still holds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)