### PR TITLE
feat(audit): per-project audit.jsonl rotation + retention (refs #2023)

### DIFF
--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -778,27 +778,99 @@ def _iter_log_lines(path: Path) -> Iterable[dict[str, Any]]:
     mid-write) can leave a truncated final line. Skip those rather
     than crashing the reader — the heartbeat must keep working
     even when the log has a junk tail.
+
+    Routes ``.gz`` archives through :func:`gzip.open` in text mode so
+    callers walking a rotation chain (live ``.jsonl`` + ``.gz``
+    siblings) get the same line-iteration shape regardless of file
+    format. See :func:`_walk_log_chain` for the chain producer.
     """
     if not path.exists():
         return
     try:
-        with open(path, "r", encoding="utf-8") as fh:
-            for line in fh:
-                stripped = line.strip()
-                if not stripped:
-                    continue
-                try:
-                    obj = json.loads(stripped)
-                except json.JSONDecodeError:
-                    # Truncated / corrupt line — skip silently. We
-                    # do not log here because a single bad tail line
-                    # would otherwise spam the error log on every
-                    # heartbeat tick.
-                    continue
-                if isinstance(obj, dict):
-                    yield obj
+        if path.suffix == ".gz":
+            fh = gzip.open(path, "rt", encoding="utf-8")
+        else:
+            fh = open(path, "r", encoding="utf-8")
     except OSError as exc:
         logger.warning("audit.read: open failed for %s: %s", path, exc)
+        return
+    try:
+        for line in fh:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                obj = json.loads(stripped)
+            except json.JSONDecodeError:
+                # Truncated / corrupt line — skip silently. We
+                # do not log here because a single bad tail line
+                # would otherwise spam the error log on every
+                # heartbeat tick.
+                continue
+            if isinstance(obj, dict):
+                yield obj
+    except OSError as exc:
+        logger.warning("audit.read: read failed for %s: %s", path, exc)
+    finally:
+        try:
+            fh.close()
+        except Exception:  # noqa: BLE001 — close-time errors are noise
+            pass
+
+
+def _archive_sort_key(path: Path) -> tuple[float, str]:
+    """Sort key for ``audit.jsonl.<ts>[.bump].gz`` archives.
+
+    We want newest-first iteration. Use mtime as primary because the
+    rotation timestamp is embedded in the filename but tests + edge
+    cases can leave clock-skew; fall back to filename for stable
+    ordering within the same mtime second.
+
+    Mirrors the helper in ``pollypm.cli_features.audit`` (PR #2036).
+    Duplicated rather than imported because that module pulls in
+    typer and would create an import cycle from this stdlib-only
+    audit primitive.
+    """
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        mtime = 0.0
+    return (mtime, path.name)
+
+
+def _walk_log_chain(live: Path) -> Iterable[Path]:
+    """Yield ``live`` first, then ``live.<ts>[.bump].gz`` archives newest-first.
+
+    Yields only paths that exist. Used by :func:`read_events` so
+    rotation never hides events from consumers (#2032 codex blocker):
+    once ``_maybe_rotate`` moves ``audit.jsonl`` into ``audit.jsonl.<ts>.gz``
+    the rotated chunk must remain visible to the watchdog dedupe
+    window, SSE, morning briefing, and doctor checks — otherwise a
+    rotation would silently allow duplicate escalation dispatches.
+
+    Mirrors the helper in ``pollypm.cli_features.audit`` (PR #2036).
+    """
+    if live.exists():
+        yield live
+    parent = live.parent
+    if not parent.exists():
+        return
+    prefix = live.name + "."
+    archives: list[Path] = []
+    try:
+        for sibling in parent.iterdir():
+            if not sibling.is_file():
+                continue
+            if not sibling.name.startswith(prefix):
+                continue
+            if not sibling.name.endswith(".gz"):
+                continue
+            archives.append(sibling)
+    except OSError:
+        return
+    archives.sort(key=_archive_sort_key, reverse=True)
+    for archive in archives:
+        yield archive
 
 
 def read_events(
@@ -814,10 +886,20 @@ def read_events(
     Source preference:
 
     1. If ``project_path`` is provided AND the per-project log
-       exists, read from there. This is the source of truth and
-       carries events from before any central-tail rotation.
+       exists, read from there + walk its rotated ``.gz`` siblings.
+       This is the source of truth and carries events from before
+       any central-tail rotation.
     2. Otherwise read from the central tail at
-       ``~/.pollypm/audit/<project>.jsonl``.
+       ``~/.pollypm/audit/<project>.jsonl`` + its rotated ``.gz``
+       siblings.
+
+    Rotation visibility (#2032 codex blocker): each source above is a
+    *chain* — live ``.jsonl`` first, then ``.gz`` archives newest-
+    first. Once a rotation moves recent events into a ``.gz``, those
+    rows must still satisfy ``read_events(..., since=..., event=...)``
+    queries. The watchdog dedupe window depends on this: if the prior
+    ``watchdog.escalation_dispatched`` row disappears after rotation
+    the next tick would dispatch a duplicate.
 
     Filters apply in order:
 
@@ -832,15 +914,22 @@ def read_events(
     chatty project lands in the low thousands per day — so loading
     fully into memory is fine.
     """
-    paths_to_try: list[Path] = []
     per_project = project_log_path(project_path)
     if per_project is not None and per_project.exists():
-        paths_to_try.append(per_project)
+        live = per_project
     else:
-        paths_to_try.append(central_log_path(project))
+        live = central_log_path(project)
 
-    events: list[AuditEvent] = []
-    for path in paths_to_try:
+    # ``_walk_log_chain`` yields live first then archives newest-first.
+    # Each file is a chronological run of records (older-first within
+    # the file), so the cross-file order is:
+    #   live (oldest→newest in live), then archive_N (newest archive),
+    #   then archive_N-1, ... archive_1 (oldest archive).
+    # We collect per-file then reverse the inter-file order so the
+    # final list is globally chronological (oldest→newest).
+    per_file: list[list[AuditEvent]] = []
+    for path in _walk_log_chain(live):
+        bucket: list[AuditEvent] = []
         for obj in _iter_log_lines(path):
             if event is not None and obj.get("event") != event:
                 continue
@@ -854,10 +943,21 @@ def read_events(
             # mutation hooks).
             if obj.get("project") and obj.get("project") != project:
                 continue
-            events.append(AuditEvent.from_dict(obj))
-        # Once we've found a real source, don't fall through.
-        if events:
-            break
+            bucket.append(AuditEvent.from_dict(obj))
+        per_file.append(bucket)
+
+    # Inter-file order from walker: [live, newest_gz, ..., oldest_gz].
+    # Chronological (oldest→newest) is the reverse: [oldest_gz, ...,
+    # newest_gz, live]. Within each file, records are already in
+    # write-order (oldest→newest).
+    events: list[AuditEvent] = []
+    for bucket in reversed(per_file):
+        events.extend(bucket)
+
+    # Re-sort by ts to defend against clock-skew between rotations
+    # (the walker uses mtime which is approximate, but ts is the
+    # actual write time). ISO-8601 UTC sorts lexicographically.
+    events.sort(key=lambda e: e.ts)
 
     if limit is not None and limit >= 0:
         return events[-limit:]

--- a/src/pollypm/audit/log.py
+++ b/src/pollypm/audit/log.py
@@ -9,15 +9,38 @@ session-services, tmux, supervisor — without creating import cycles.
 
 from __future__ import annotations
 
+import gzip
 import json
 import logging
 import os
+import shutil
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
 logger = logging.getLogger(__name__)
+
+# Rotation defaults — mirrored by :class:`pollypm.models.AuditSettings`.
+# These constants are the fallback when config loading fails so a
+# broken config never turns rotation off by stealth. Operators who
+# want a different policy set ``[audit] rotate_size_mb`` /
+# ``retention_count`` in pollypm.toml; see ``_resolve_rotation_policy``.
+_DEFAULT_ROTATE_SIZE_MB = 50
+_DEFAULT_RETENTION_COUNT = 4
+# Env-var escape hatch for tests + ops debugging. When set to ``"1"``
+# / ``"true"`` rotation is short-circuited even if the config says to
+# rotate. The config ``disable_rotation`` knob is the supported user
+# surface; this env var exists so tests in CI don't have to mutate
+# ``~/.pollypm/pollypm.toml`` to assert non-rotating behaviour.
+_DISABLE_ENV = "POLLYPM_AUDIT_DISABLE_ROTATION"
+# Tests override these via monkeypatch to drive rotation without
+# building 50 MB log files. The resolver below honours
+# ``_test_rotate_size_bytes`` / ``_test_retention_count`` before
+# falling through to config / defaults.
+_test_rotate_size_bytes: int | None = None
+_test_retention_count: int | None = None
 
 # Override for tests + central tail relocation. When set, the central
 # tail goes under ``$POLLYPM_AUDIT_HOME/<project>.jsonl``. The
@@ -388,8 +411,231 @@ def _assert_no_doubled_pollypm(path: Path) -> None:
         )
 
 
+def _resolve_rotation_policy() -> tuple[int, int, bool]:
+    """Return ``(max_bytes, retention_count, disabled)`` for rotation.
+
+    Resolution order:
+
+    1. Test overrides (``_test_rotate_size_bytes`` /
+       ``_test_retention_count``) win so unit tests can drive rotation
+       on tiny files without rewriting ``pollypm.toml``.
+    2. Env var ``POLLYPM_AUDIT_DISABLE_ROTATION`` (``"1"`` / ``"true"``)
+       forces ``disabled=True``. This is the ops-debugging escape hatch
+       that doesn't require editing config.
+    3. Live config ``[audit]`` section — lazy-imported so this module
+       stays import-cycle-safe.
+    4. Module defaults (50 MB / 4 retentions).
+
+    Config-loading failures fall back to defaults rather than crashing
+    the audit write — rotation is hygiene, never load-bearing.
+    """
+    # Test overrides take precedence so a unit test can pin a 1 KB
+    # threshold without disturbing the user's real config.
+    if _test_rotate_size_bytes is not None or _test_retention_count is not None:
+        max_bytes = (
+            int(_test_rotate_size_bytes)
+            if _test_rotate_size_bytes is not None
+            else _DEFAULT_ROTATE_SIZE_MB * 1024 * 1024
+        )
+        retention = (
+            int(_test_retention_count)
+            if _test_retention_count is not None
+            else _DEFAULT_RETENTION_COUNT
+        )
+        env_disabled = os.environ.get(_DISABLE_ENV, "").strip().lower() in ("1", "true", "yes")
+        return max(1, max_bytes), max(0, retention), env_disabled
+
+    env_disabled = os.environ.get(_DISABLE_ENV, "").strip().lower() in ("1", "true", "yes")
+    cfg_size_mb: int | None = None
+    cfg_retention: int | None = None
+    cfg_disabled: bool = False
+    try:
+        from pollypm.config import DEFAULT_CONFIG_PATH, load_config
+
+        config = load_config(Path(DEFAULT_CONFIG_PATH))
+    except Exception:  # noqa: BLE001 — never break audit on config errors
+        config = None
+    if config is not None:
+        try:
+            cfg_size_mb = int(config.audit.rotate_size_mb)
+            cfg_retention = int(config.audit.retention_count)
+            cfg_disabled = bool(config.audit.disable_rotation)
+        except Exception:  # noqa: BLE001
+            cfg_size_mb = None
+            cfg_retention = None
+            cfg_disabled = False
+    size_mb = cfg_size_mb if cfg_size_mb and cfg_size_mb > 0 else _DEFAULT_ROTATE_SIZE_MB
+    retention = (
+        cfg_retention
+        if cfg_retention is not None and cfg_retention >= 0
+        else _DEFAULT_RETENTION_COUNT
+    )
+    return max(1, size_mb * 1024 * 1024), retention, (env_disabled or cfg_disabled)
+
+
+def _prune_old_audit_archives(path: Path, retention_count: int) -> None:
+    """Delete archived ``<path>.<ts>[.bump].gz`` siblings beyond cap.
+
+    Sorts surviving archives by mtime descending so the newest are
+    kept even if a timestamp collision tripped the parser. Errors
+    are silently logged at DEBUG — pruning is hygiene, not critical.
+    """
+    if retention_count < 0:
+        return
+    parent = path.parent
+    prefix = path.name + "."
+    candidates: list[tuple[float, Path]] = []
+    try:
+        for sibling in parent.iterdir():
+            if not sibling.is_file():
+                continue
+            if not sibling.name.startswith(prefix):
+                continue
+            if not sibling.name.endswith(".gz"):
+                continue
+            try:
+                mtime = sibling.stat().st_mtime
+            except OSError:
+                continue
+            candidates.append((mtime, sibling))
+    except OSError:
+        return
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    for _mtime, stale in candidates[retention_count:]:
+        try:
+            stale.unlink()
+        except OSError:
+            logger.debug(
+                "audit.log: prune failed for %s", stale, exc_info=True,
+            )
+
+
+def _maybe_rotate(path: Path) -> None:
+    """Rotate ``path`` if it exceeds the configured size threshold.
+
+    Atomicity strategy:
+
+    1. ``os.rename(audit.jsonl, audit.jsonl.<ts>.rotating)`` — POSIX
+       rename is atomic, so concurrent readers either see the live
+       file at its old name (pre-rename) or no file there (post-
+       rename; ``_append_line`` will recreate on the next call).
+       They never see a half-state.
+    2. Gzip the renamed file into ``audit.jsonl.<ts>.gz.partial``
+       (writing to a sibling tempfile keeps the final ``.gz`` name
+       invisible until the compression finishes).
+    3. Atomic rename ``.gz.partial`` -> ``.gz`` so readers that walk
+       the directory for archived rotations only see complete files.
+    4. Unlink the uncompressed ``.rotating`` rename.
+    5. Prune old ``.gz`` siblings beyond the retention count.
+
+    Best-effort: any OSError is logged at WARNING and rotation skips;
+    the caller still proceeds to ``_append_line`` so the audit write
+    never fails because of housekeeping. If step 1 succeeded but a
+    later step failed we leave the ``.rotating`` rename in place
+    rather than losing the data — a follow-up rotation will find and
+    process it (filename collisions are handled by a bump suffix).
+    """
+    max_bytes, retention, disabled = _resolve_rotation_policy()
+    if disabled:
+        return
+    try:
+        st = os.stat(path)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        logger.debug(
+            "audit.log: stat failed for %s during rotation check: %s",
+            path, exc,
+        )
+        return
+    if st.st_size <= max_bytes:
+        return
+
+    # Pick a name that is free for BOTH the in-flight ``.rotating``
+    # rename target AND the final ``.gz`` archive. A second rotation
+    # in the same wall-clock second would otherwise collide on the
+    # ``.gz`` name and ``os.rename(gz_partial, gz_final)`` would
+    # silently overwrite the previous archive (POSIX rename
+    # semantics) — losing the older chunk of events. The bump
+    # suffix keeps the names unique within the second.
+    ts = int(time.time())
+    bump = 0
+    while True:
+        if bump == 0:
+            stem = f".{ts}"
+        else:
+            stem = f".{ts}.{bump}"
+        rotating = path.with_suffix(path.suffix + stem + ".rotating")
+        gz_final = path.with_suffix(path.suffix + stem + ".gz")
+        if not rotating.exists() and not gz_final.exists():
+            break
+        bump += 1
+        if bump > 10_000:
+            # Defensive cap: if we somehow can't find a free name in
+            # 10K bumps within the same second, abort the rotation
+            # rather than spin forever. The append below still fires.
+            logger.warning(
+                "audit.log: rotation name-collision loop exhausted for %s",
+                path,
+            )
+            return
+
+    # Step 1: atomic rename moves the live file out of the way.
+    try:
+        os.rename(path, rotating)
+    except OSError as exc:
+        logger.warning(
+            "audit.log: rotation rename failed for %s: %s", path, exc,
+        )
+        return
+
+    # Steps 2-4: gzip + atomic rename. If anything fails we still
+    # return cleanly so the caller's append fires against a fresh
+    # empty file (the rename above already created that condition).
+    gz_partial = Path(str(gz_final) + ".partial")
+    try:
+        with open(rotating, "rb") as src, gzip.open(gz_partial, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+        os.rename(gz_partial, gz_final)
+        try:
+            rotating.unlink()
+        except OSError:
+            logger.debug(
+                "audit.log: post-gzip unlink failed for %s",
+                rotating, exc_info=True,
+            )
+    except OSError as exc:
+        logger.warning(
+            "audit.log: gzip failed for %s: %s", rotating, exc,
+        )
+        # Clean up the partial gz so a future rotation isn't tripped
+        # by half-written archives. Leave the ``.rotating`` rename in
+        # place — it still holds the data and a future rotation will
+        # find + retry it.
+        try:
+            if gz_partial.exists():
+                gz_partial.unlink()
+        except OSError:
+            pass
+
+    # Step 5: prune old archives. Best-effort, isolated from rotation.
+    try:
+        _prune_old_audit_archives(path, retention)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "audit.log: prune sweep failed for %s",
+            path, exc_info=True,
+        )
+
+
 def _append_line(path: Path, line: str) -> None:
     """Append a single line to ``path``, creating parents as needed.
+
+    Fires rotation (``_maybe_rotate``) *before* the append so the
+    append always lands in a file that is under the size threshold.
+    Rotation failures are swallowed inside ``_maybe_rotate`` — the
+    append fires unconditionally so a housekeeping bug can never
+    cause audit data loss.
 
     Uses POSIX append-mode (``"a"``) so concurrent writers from
     multiple processes interleave at the line level — provided the
@@ -400,6 +646,17 @@ def _append_line(path: Path, line: str) -> None:
     """
     _assert_no_doubled_pollypm(path)
     path.parent.mkdir(parents=True, exist_ok=True)
+    # Rotate first so the impending append starts a fresh file when
+    # we cross the threshold. Wrap in a broad try because nothing
+    # about rotation should ever prevent an audit write — that is
+    # the central guarantee of this module.
+    try:
+        _maybe_rotate(path)
+    except Exception:  # noqa: BLE001 — never block audit on housekeeping
+        logger.debug(
+            "audit.log: _maybe_rotate raised unexpectedly for %s",
+            path, exc_info=True,
+        )
     # Newline added here so the encoded record stays a single
     # JSON object on its own line.
     with open(path, "a", encoding="utf-8") as fh:

--- a/src/pollypm/config.py
+++ b/src/pollypm/config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from pollypm.models import (
     AccountConfig,
+    AuditSettings,
     EmbeddingScoreWeights,
     EmbeddingSettings,
     EventsRetentionSettings,
@@ -505,6 +506,53 @@ def _parse_logging_settings(raw: dict[str, object]) -> LoggingSettings:
     return LoggingSettings(rotate_size_mb=size_mb, rotate_keep=keep)
 
 
+def _parse_audit_settings(raw: dict[str, object]) -> AuditSettings:
+    """Parse the ``[audit]`` TOML section for audit-log rotation tuning.
+
+    Recognised keys:
+
+    * ``rotate_size_mb`` (int, default 50) — live ``audit.jsonl`` is
+      rotated when it exceeds this many megabytes. Values below 1 are
+      coerced to the default so a fat-fingered config can never
+      disable rotation by stealth (use ``disable_rotation`` for that).
+    * ``retention_count`` (int, default 4) — number of gzipped
+      rotations to retain per audit file. ``0`` is allowed (rotate +
+      immediately delete all archives), negative values fall back.
+    * ``disable_rotation`` (bool, default false) — operator escape
+      hatch; when true the rotation check short-circuits.
+
+    Fat-fingered values (non-int, negative) fall back to defaults so a
+    malformed config never silently breaks rotation. Missing section
+    yields defaults. See :class:`pollypm.models.AuditSettings`.
+    """
+    audit_raw = raw.get("audit", {})
+    if not isinstance(audit_raw, dict):
+        return AuditSettings()
+    defaults = AuditSettings()
+    size_raw = audit_raw.get("rotate_size_mb", defaults.rotate_size_mb)
+    try:
+        size_mb = int(size_raw)
+    except (TypeError, ValueError):
+        size_mb = defaults.rotate_size_mb
+    if isinstance(size_raw, bool) or size_mb < 1:
+        # ``bool`` is a subclass of ``int`` so reject it explicitly.
+        size_mb = defaults.rotate_size_mb
+    keep_raw = audit_raw.get("retention_count", defaults.retention_count)
+    try:
+        keep = int(keep_raw)
+    except (TypeError, ValueError):
+        keep = defaults.retention_count
+    if isinstance(keep_raw, bool) or keep < 0:
+        keep = defaults.retention_count
+    disable_raw = audit_raw.get("disable_rotation", defaults.disable_rotation)
+    disable = bool(disable_raw) if isinstance(disable_raw, bool) else defaults.disable_rotation
+    return AuditSettings(
+        rotate_size_mb=size_mb,
+        retention_count=keep,
+        disable_rotation=disable,
+    )
+
+
 def _parse_events_retention_settings(
     raw: dict[str, object],
 ) -> EventsRetentionSettings:
@@ -903,6 +951,7 @@ def load_config(path: Path = DEFAULT_CONFIG_PATH) -> PollyPMConfig:
     rail = _parse_rail_settings(raw)
     planner = _parse_planner_settings(raw)
     logging_settings = _parse_logging_settings(raw)
+    audit_settings = _parse_audit_settings(raw)
     events = _parse_events_retention_settings(raw)
     storage = _parse_storage_settings(raw, project=project)
     projects = _parse_known_projects(raw, base=base)
@@ -920,6 +969,7 @@ def load_config(path: Path = DEFAULT_CONFIG_PATH) -> PollyPMConfig:
         rail=rail,
         planner=planner,
         logging=logging_settings,
+        audit=audit_settings,
         events=events,
         storage=storage,
     )
@@ -1079,6 +1129,23 @@ def _render_global_config(config: PollyPMConfig) -> str:
     if logging_overrides:
         lines.append("[logging]")
         lines.extend(logging_overrides)
+        lines.append("")
+
+    # Emit [audit] only when the user has deviated from defaults so
+    # existing configs don't churn on rewrite (matches the [logging]
+    # convention above).
+    audit_defaults = AuditSettings()
+    audit_overrides: list[str] = []
+    if config.audit.rotate_size_mb != audit_defaults.rotate_size_mb:
+        audit_overrides.append(f"rotate_size_mb = {config.audit.rotate_size_mb}")
+    if config.audit.retention_count != audit_defaults.retention_count:
+        audit_overrides.append(f"retention_count = {config.audit.retention_count}")
+    if config.audit.disable_rotation != audit_defaults.disable_rotation:
+        flag = "true" if config.audit.disable_rotation else "false"
+        audit_overrides.append(f"disable_rotation = {flag}")
+    if audit_overrides:
+        lines.append("[audit]")
+        lines.extend(audit_overrides)
         lines.append("")
 
     for account_name, account in config.accounts.items():

--- a/src/pollypm/models.py
+++ b/src/pollypm/models.py
@@ -253,6 +253,51 @@ class PlannerSettings:
 
 
 @dataclass(slots=True)
+class AuditSettings:
+    """Per-project ``audit.jsonl`` rotation + retention configuration
+    from the ``[audit]`` TOML section.
+
+    The forensic audit log (``<project>/.pollypm/audit.jsonl`` plus the
+    central-tail mirror at ``~/.pollypm/audit/<project>.jsonl``) is
+    append-only and grows unbounded by default. A noisy project can
+    accumulate thousands of ``stuck_draft`` events per day; without
+    rotation, this fills disks and slows down readers that scan the
+    full file. The audit writer (see :mod:`pollypm.audit.log`) consults
+    these knobs *before each append*; if the live file is over the size
+    threshold it is gzipped to a timestamped sibling and the next
+    append starts at offset 0 in a fresh empty file.
+
+    ``rotate_size_mb`` — threshold in megabytes above which the live
+    ``audit.jsonl`` is rotated. Files at or below this size are left
+    alone. Default 50 MB — large enough that real incident debugging
+    still has plenty of scrollback in the live file, small enough that
+    a runaway ``stuck_draft`` loop (5550 events / day on coffeeboardnm)
+    can't fill a disk before rotation kicks in.
+
+    ``retention_count`` — number of gzipped rotations to keep per
+    audit file. Older ``audit.jsonl.<ts>.gz`` siblings beyond this
+    count are deleted oldest-first. Default 4: at 50 MB live + 4 x
+    ~10 MB gzipped rotations, the ceiling per project is ~90 MB,
+    well-bounded for a workstation tool while keeping enough history
+    to reconstruct a multi-day incident timeline.
+
+    ``disable_rotation`` — operator escape hatch. When ``True`` the
+    rotation check short-circuits and the live file grows forever.
+    Useful when an incident investigation needs a continuous file
+    that won't be archived mid-debug. Default ``False``.
+
+    Rotation is best-effort and isolated from the append: if rotation
+    fails (disk full, perms) we log + skip rotation and the append
+    still happens. The audit log is load-bearing for the watchdog;
+    housekeeping must never break audit writes.
+    """
+
+    rotate_size_mb: int = 50
+    retention_count: int = 4
+    disable_rotation: bool = False
+
+
+@dataclass(slots=True)
 class EventsRetentionSettings:
     """Tiered retention windows for the ``events`` table.
 
@@ -378,6 +423,7 @@ class PollyPMConfig:
     rail: RailSettings = field(default_factory=RailSettings)
     planner: PlannerSettings = field(default_factory=PlannerSettings)
     logging: LoggingSettings = field(default_factory=LoggingSettings)
+    audit: AuditSettings = field(default_factory=AuditSettings)
     events: EventsRetentionSettings = field(
         default_factory=EventsRetentionSettings,
     )

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -306,6 +306,270 @@ def test_emit_with_empty_project_only_writes_per_project(tmp_path: Path) -> None
 
 
 # ---------------------------------------------------------------------------
+# Rotation + retention (#2023)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _tiny_rotation(monkeypatch: pytest.MonkeyPatch):
+    """Pin a tiny rotation threshold so tests fire rotation without
+    building 50 MB of audit data. Yields a helper that lets a test
+    tune the retention count too.
+    """
+    import pollypm.audit.log as log_mod
+
+    monkeypatch.setattr(log_mod, "_test_rotate_size_bytes", 512)
+    monkeypatch.setattr(log_mod, "_test_retention_count", 4)
+    # Ensure no env-var override leaks across tests.
+    monkeypatch.delenv(log_mod._DISABLE_ENV, raising=False)
+    return log_mod
+
+
+def _gz_archives(audit_path: Path) -> list[Path]:
+    prefix = audit_path.name + "."
+    return sorted(
+        sibling
+        for sibling in audit_path.parent.iterdir()
+        if sibling.name.startswith(prefix) and sibling.name.endswith(".gz")
+    )
+
+
+def test_rotation_fires_when_size_exceeds_threshold(
+    tmp_path: Path, _tiny_rotation
+) -> None:
+    """Write past the threshold; the live file should be empty (or
+    contain only the post-rotation line) and a single .gz archive
+    should exist with the pre-rotation events."""
+    project_root = tmp_path / "rotproj"
+    (project_root / ".pollypm").mkdir(parents=True)
+    audit_path = project_root / ".pollypm" / "audit.jsonl"
+
+    # Write enough events to push us past the 512-byte threshold but
+    # leave the file small enough that we can inspect every line.
+    for i in range(20):
+        emit(
+            event="task.created",
+            project="rotproj",
+            subject=f"rotproj/{i}",
+            metadata={"i": i, "padding": "x" * 64},
+            project_path=project_root,
+        )
+
+    archives = _gz_archives(audit_path)
+    assert len(archives) >= 1, (
+        f"expected at least one .gz rotation, found {archives}"
+    )
+    # The live file must still exist and (because the last append
+    # fired after the most recent rotation) hold at most the events
+    # written since the last rotation — strictly smaller than the
+    # original 20-event payload.
+    assert audit_path.exists()
+    live_lines = [
+        l for l in audit_path.read_text(encoding="utf-8").splitlines() if l.strip()
+    ]
+    assert len(live_lines) < 20
+
+
+def test_rotation_archives_contain_pre_rotation_events(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The gzipped archive must hold a readable JSONL chunk of the
+    events written before the rotation fired.
+
+    Uses a generous retention so events written before rotation are
+    not also lost to over-aggressive pruning — the unit under test
+    is gz contents, not retention prune logic (covered separately).
+    """
+    import pollypm.audit.log as log_mod
+
+    # Big retention so multi-rotation runs don't lose history to
+    # prune; that path is exercised in
+    # ``test_rotation_retention_prunes_old_archives``.
+    monkeypatch.setattr(log_mod, "_test_rotate_size_bytes", 2048)
+    monkeypatch.setattr(log_mod, "_test_retention_count", 50)
+    monkeypatch.delenv(log_mod._DISABLE_ENV, raising=False)
+
+    project_root = tmp_path / "gzproj"
+    (project_root / ".pollypm").mkdir(parents=True)
+    audit_path = project_root / ".pollypm" / "audit.jsonl"
+
+    for i in range(40):
+        emit(
+            event="task.created",
+            project="gzproj",
+            subject=f"gzproj/{i}",
+            metadata={"i": i, "padding": "y" * 64},
+            project_path=project_root,
+        )
+
+    archives = _gz_archives(audit_path)
+    assert archives, "expected at least one .gz archive"
+    import gzip as _gz
+
+    archived_subjects: list[str] = []
+    for gz_path in archives:
+        with _gz.open(gz_path, "rt", encoding="utf-8") as fh:
+            for line in fh:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                record = json.loads(stripped)
+                archived_subjects.append(record["subject"])
+                assert record["event"] == "task.created"
+                assert record["project"] == "gzproj"
+
+    # Plus whatever is in the live file currently.
+    live_subjects = [
+        json.loads(l)["subject"]
+        for l in audit_path.read_text(encoding="utf-8").splitlines()
+        if l.strip()
+    ]
+    # With retention=50 no archive can have been pruned, so every
+    # subject we emitted must appear somewhere (archives + live).
+    all_subjects = set(archived_subjects) | set(live_subjects)
+    expected = {f"gzproj/{i}" for i in range(40)}
+    assert expected.issubset(all_subjects), (
+        f"missing subjects after rotation: {expected - all_subjects}"
+    )
+
+
+def test_rotation_retention_prunes_old_archives(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When N rotations have already happened, the next rotation must
+    delete the oldest archive so we hold steady at N total."""
+    import pollypm.audit.log as log_mod
+
+    monkeypatch.setattr(log_mod, "_test_rotate_size_bytes", 256)
+    monkeypatch.setattr(log_mod, "_test_retention_count", 2)
+    monkeypatch.delenv(log_mod._DISABLE_ENV, raising=False)
+
+    project_root = tmp_path / "retproj"
+    (project_root / ".pollypm").mkdir(parents=True)
+    audit_path = project_root / ".pollypm" / "audit.jsonl"
+
+    # Hammer enough events to trigger multiple rotations. Sleep
+    # between batches so each archive picks up a distinct mtime and
+    # the prune sort can order them deterministically.
+    import time as _time
+
+    for batch in range(5):
+        for i in range(10):
+            emit(
+                event="task.created",
+                project="retproj",
+                subject=f"retproj/b{batch}-{i}",
+                metadata={"padding": "z" * 64},
+                project_path=project_root,
+            )
+        _time.sleep(0.02)
+
+    archives = _gz_archives(audit_path)
+    assert len(archives) <= 2, (
+        f"retention=2 should cap archives at 2, got {len(archives)}: {archives}"
+    )
+    # The live file must still be writable (and contain the latest
+    # append — proving the audit pipeline never broke).
+    emit(
+        event="task.created",
+        project="retproj",
+        subject="retproj/final",
+        project_path=project_root,
+    )
+    final_lines = [
+        l for l in audit_path.read_text(encoding="utf-8").splitlines() if l.strip()
+    ]
+    assert any(
+        json.loads(l)["subject"] == "retproj/final" for l in final_lines
+    ), "post-rotation append must still land in the live file"
+
+
+def test_rotation_failure_does_not_break_append(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If rotation raises (read-only dir, disk full, etc.), the
+    append must still happen — the audit log is load-bearing for
+    the watchdog and housekeeping must never lose writes."""
+    import pollypm.audit.log as log_mod
+
+    monkeypatch.setattr(log_mod, "_test_rotate_size_bytes", 256)
+    monkeypatch.setattr(log_mod, "_test_retention_count", 4)
+    monkeypatch.delenv(log_mod._DISABLE_ENV, raising=False)
+
+    project_root = tmp_path / "failproj"
+    (project_root / ".pollypm").mkdir(parents=True)
+    audit_path = project_root / ".pollypm" / "audit.jsonl"
+
+    # Prime the audit log past the threshold so the next emit would
+    # normally trigger a rotation.
+    for i in range(20):
+        emit(
+            event="task.created",
+            project="failproj",
+            subject=f"failproj/{i}",
+            metadata={"padding": "p" * 64},
+            project_path=project_root,
+        )
+
+    # Force every subsequent rename in the rotation path to fail.
+    def _boom_rename(*_args, **_kwargs):
+        raise OSError("simulated rotation failure")
+
+    monkeypatch.setattr(log_mod.os, "rename", _boom_rename)
+
+    # The append MUST still succeed.
+    emit(
+        event="task.created",
+        project="failproj",
+        subject="failproj/after-failure",
+        project_path=project_root,
+    )
+
+    lines = [
+        l for l in audit_path.read_text(encoding="utf-8").splitlines() if l.strip()
+    ]
+    subjects = [json.loads(l)["subject"] for l in lines]
+    assert "failproj/after-failure" in subjects, (
+        "audit append must succeed even when rotation fails"
+    )
+
+
+def test_rotation_disabled_via_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The env-var escape hatch short-circuits rotation entirely so
+    incident debuggers can pin a continuous file mid-investigation."""
+    import pollypm.audit.log as log_mod
+
+    monkeypatch.setattr(log_mod, "_test_rotate_size_bytes", 256)
+    monkeypatch.setattr(log_mod, "_test_retention_count", 4)
+    monkeypatch.setenv(log_mod._DISABLE_ENV, "1")
+
+    project_root = tmp_path / "noproj"
+    (project_root / ".pollypm").mkdir(parents=True)
+    audit_path = project_root / ".pollypm" / "audit.jsonl"
+
+    for i in range(20):
+        emit(
+            event="task.created",
+            project="noproj",
+            subject=f"noproj/{i}",
+            metadata={"padding": "q" * 64},
+            project_path=project_root,
+        )
+
+    archives = _gz_archives(audit_path)
+    assert archives == [], (
+        f"rotation disabled should produce zero archives, got {archives}"
+    )
+    # All 20 lines should be in the live file because nothing rotated.
+    lines = [
+        l for l in audit_path.read_text(encoding="utf-8").splitlines() if l.strip()
+    ]
+    assert len(lines) == 20
+
+
+# ---------------------------------------------------------------------------
 # Sqlite-integration tests REMOVED for Slice K (#1737).
 #
 # The eight test_workservice_* tests that lived here exercised the

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -569,6 +569,164 @@ def test_rotation_disabled_via_env(
     assert len(lines) == 20
 
 
+def test_read_events_walks_gz_archives_after_rotation(
+    tmp_path: Path,
+) -> None:
+    """Regression for the #2032 codex blocker: ``read_events()`` must
+    walk rotated ``.gz`` archives so events that landed in the
+    rotated chunk remain visible to consumers like the watchdog
+    dedupe window.
+
+    Without rotation-aware reads, a rotation between escalation
+    dispatches would hide the prior ``watchdog.escalation_dispatched``
+    row and allow a duplicate dispatch.
+
+    Test shape:
+
+    1. Seed a ``audit.jsonl.<ts>.gz`` archive with a
+       ``watchdog.escalation_dispatched`` event.
+    2. Leave the live ``audit.jsonl`` either empty or with
+       unrelated events only.
+    3. Call ``read_events(event="watchdog.escalation_dispatched",
+       since=<old_iso>)``.
+    4. Assert the archived event is returned.
+    """
+    import gzip as _gz
+
+    project_root = tmp_path / "gzread"
+    (project_root / ".pollypm").mkdir(parents=True)
+    audit_path = project_root / ".pollypm" / "audit.jsonl"
+
+    # Seed an archived rotation: a single .gz file holding the
+    # historical watchdog.escalation_dispatched event.
+    archived_event = {
+        "schema": SCHEMA_VERSION,
+        "ts": "2026-05-19T12:00:00+00:00",
+        "project": "gzread",
+        "event": "watchdog.escalation_dispatched",
+        "subject": "gzread/finding-A",
+        "actor": "watchdog",
+        "status": "ok",
+        "metadata": {
+            "finding_type": "stuck_draft",
+            "root_cause_hash": "abc123",
+        },
+    }
+    gz_archive = audit_path.with_suffix(audit_path.suffix + ".1234567890.gz")
+    with _gz.open(gz_archive, "wt", encoding="utf-8") as fh:
+        fh.write(json.dumps(archived_event) + "\n")
+
+    # Live file: empty (touch only). The post-rotation append in
+    # production lands the next event here; for this regression the
+    # rotated chunk is what matters.
+    audit_path.touch()
+
+    # Query as the watchdog would: filter on the dedupe event +
+    # an old since-cutoff that should clearly include the archived
+    # event.
+    events = read_events(
+        "gzread",
+        project_path=project_root,
+        event="watchdog.escalation_dispatched",
+        since="2026-05-01T00:00:00+00:00",
+    )
+
+    subjects = [e.subject for e in events]
+    assert "gzread/finding-A" in subjects, (
+        "read_events must walk .gz archives — the rotated "
+        "watchdog.escalation_dispatched row went missing, which "
+        "would allow duplicate dispatches in production"
+    )
+    archived_match = next(
+        (e for e in events if e.subject == "gzread/finding-A"), None
+    )
+    assert archived_match is not None
+    assert archived_match.metadata.get("root_cause_hash") == "abc123"
+
+
+def test_read_events_chains_live_and_gz_in_chronological_order(
+    tmp_path: Path,
+) -> None:
+    """When events exist across BOTH a .gz archive and the live file,
+    ``read_events()`` must return them in chronological order so
+    downstream consumers (heartbeat, briefings, doctor) see a
+    coherent timeline."""
+    import gzip as _gz
+
+    project_root = tmp_path / "chain"
+    (project_root / ".pollypm").mkdir(parents=True)
+    audit_path = project_root / ".pollypm" / "audit.jsonl"
+
+    # Older event in an archive.
+    old_event = {
+        "schema": SCHEMA_VERSION,
+        "ts": "2026-05-01T00:00:00+00:00",
+        "project": "chain",
+        "event": "task.created",
+        "subject": "chain/old",
+        "actor": "test",
+        "status": "ok",
+        "metadata": {},
+    }
+    gz_archive = audit_path.with_suffix(audit_path.suffix + ".1700000000.gz")
+    with _gz.open(gz_archive, "wt", encoding="utf-8") as fh:
+        fh.write(json.dumps(old_event) + "\n")
+
+    # Newer event in the live file (after rotation).
+    new_event = {
+        "schema": SCHEMA_VERSION,
+        "ts": "2026-05-20T00:00:00+00:00",
+        "project": "chain",
+        "event": "task.created",
+        "subject": "chain/new",
+        "actor": "test",
+        "status": "ok",
+        "metadata": {},
+    }
+    audit_path.write_text(json.dumps(new_event) + "\n", encoding="utf-8")
+
+    events = read_events("chain", project_path=project_root)
+    subjects = [e.subject for e in events]
+    assert subjects == ["chain/old", "chain/new"], (
+        f"events should be chronological across .gz + live, got {subjects}"
+    )
+
+
+def test_read_events_walks_gz_archives_for_central_tail(
+    tmp_path: Path,
+) -> None:
+    """The rotation walker must apply to the central-tail fallback
+    too (no project_path), so the workspace-level audit grep / SSE
+    consumers also see rotated history."""
+    import gzip as _gz
+
+    central = central_log_path("centralgz")
+    central.parent.mkdir(parents=True, exist_ok=True)
+
+    archived_event = {
+        "schema": SCHEMA_VERSION,
+        "ts": "2026-05-10T00:00:00+00:00",
+        "project": "centralgz",
+        "event": "watchdog.escalation_dispatched",
+        "subject": "centralgz/finding-Z",
+        "actor": "watchdog",
+        "status": "ok",
+        "metadata": {"root_cause_hash": "deadbeef"},
+    }
+    gz_archive = central.with_suffix(central.suffix + ".1700000001.gz")
+    with _gz.open(gz_archive, "wt", encoding="utf-8") as fh:
+        fh.write(json.dumps(archived_event) + "\n")
+    # Live central tail: empty.
+    central.touch()
+
+    events = read_events(
+        "centralgz",
+        event="watchdog.escalation_dispatched",
+        since="2026-05-01T00:00:00+00:00",
+    )
+    assert [e.subject for e in events] == ["centralgz/finding-Z"]
+
+
 # ---------------------------------------------------------------------------
 # Sqlite-integration tests REMOVED for Slice K (#1737).
 #


### PR DESCRIPTION
## Summary

- Per-project `audit.jsonl` files (and the central-tail mirror) now rotate when they exceed a configured size — coffeeboardnm was logging 5550 `stuck_draft` events / 24h; samblog was past 10 MB. Without rotation those grow forever.
- New `[audit]` config section: `rotate_size_mb` (50), `retention_count` (4), `disable_rotation` (false). All knobs route through `_resolve_rotation_policy` with module-default fallbacks, so a fat-fingered config never silently kills rotation.
- Atomic rotation via `os.rename` -> gzip into `.gz.partial` -> rename to `.gz`, then unlink the in-flight `.rotating` file. Bump-suffix loop checks BOTH names so two rotations in the same second cannot overwrite an archive.
- Rotation never blocks the append. Every IO failure inside `_maybe_rotate` is caught + logged; the outer `_append_line` wraps the call in a broad try so a housekeeping bug can never cause audit data loss.

## Rotation flow

1. `os.stat` live file; skip if under threshold.
2. `os.rename(audit.jsonl, audit.jsonl.<ts>[.bump].rotating)` — atomic, no half-state.
3. `gzip` into `<final>.gz.partial`.
4. `os.rename` partial -> `.gz`.
5. unlink the `.rotating` file.
6. prune `.gz` archives beyond `retention_count` (oldest by mtime).

## Defaults + rationale

- **50 MB threshold** — large enough for real incident scrollback in the live file; small enough that 5550 events/day cannot fill a disk before rotation kicks in. ~150 bytes/event * 5550/day -> ~830 KB/day, so a normal project rotates a few times a year while a runaway loop self-bounds in hours.
- **4 retention** — 50 MB live + 4 * ~10 MB gz = ~90 MB ceiling per project, well-bounded for a workstation tool while keeping enough history to reconstruct a multi-day incident.
- **disable_rotation escape hatch** — for incident debugging that needs a continuous file. Env var `POLLYPM_AUDIT_DISABLE_ROTATION=1` exists for tests / CI without mutating `~/.pollypm/pollypm.toml`.

## Test plan

- [x] `tests/test_audit_log.py` — 19/19 pass (5 new rotation tests; full suite green without conftest):
  - rotation fires past threshold, live file truncated
  - gz archive contains readable JSONL chunk of pre-rotation events
  - retention=N caps surviving archives at N over many rotations
  - rotation failure (forced `os.rename` boom) doesn't break append
  - `POLLYPM_AUDIT_DISABLE_ROTATION=1` short-circuits rotation
- [x] `tests/test_audit_watchdog.py` + `tests/test_contract_audit.py` + `tests/test_audit_log_docs.py` — 134/134 pass
- [x] `tests/test_no_raw_pollypm_path_joins.py` — 9/9 pass (doubled-path guard still firing)
- [x] `tests/test_config.py` — 23 pass / 1 fail (pre-existing storage-default failure, unrelated)
- [ ] Manual: drop into samblog with this build; confirm `audit.jsonl` rotates the next time it crosses 50 MB and `.gz` is readable via `zcat`.

Refs #2023.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)