### PR TITLE
polish(tmux-ui): SURFACE_* State constants for dashboard tints (refs #1988)

### DIFF
--- a/src/pollypm/cockpit_theme.py
+++ b/src/pollypm/cockpit_theme.py
@@ -131,6 +131,36 @@ class State:
     ATTENTION_BRIGHT = "#ffb454"
     NEUTRAL = "#97a6b2"
 
+    # Dashboard surface tints — used by the per-project dashboard's
+    # action-bar (attention/critical fills) and the celebratory plan-
+    # review CTA. Each "surface" is a triple of (text, background,
+    # border) tuned to read as a single tinted card without yelling
+    # over the rail/inbox palette. Promoted from raw hex literals in
+    # the dashboard CSS (#1988 follow-up) so a tint tweak in one place
+    # propagates everywhere a surface uses it.
+    #
+    # WARN (amber) — "Action Needed" action-bar + drafts/empty-state
+    # affordance. Sits one notch warmer than ``WAITING`` (foreground
+    # text vs. card fill) so the surface reads as a banner, not a row.
+    SURFACE_WARN = "#f7d67a"
+    SURFACE_WARN_BG = "#3a2c08"
+    SURFACE_WARN_BORDER = "#7a5a14"
+
+    # DANGER (red/pink) — critical action-bar variant (stuck/blocked
+    # alerts). Mirrors ``BLOCKED`` for rail glyphs but tinted softer
+    # so a full-width card doesn't bleed when stacked above body text.
+    SURFACE_DANGER = "#ffd7d9"
+    SURFACE_DANGER_BG = "#3a1719"
+    SURFACE_DANGER_BORDER = "#8d3137"
+
+    # SUCCESS (green) — celebratory plan-review CTA (#1531). Sits
+    # under the "Plan's ready" banner so the pair reads as a single
+    # affordance; the green hue distinguishes "ship-it" from the amber
+    # "decide" tone of the WARN surface.
+    SURFACE_SUCCESS = "#b6f0c0"
+    SURFACE_SUCCESS_BG = "#1a2e1c"
+    SURFACE_SUCCESS_BORDER = "#2c5b32"
+
 
 class Glyph:
     """Semantic glyph vocabulary.

--- a/src/pollypm/cockpit_ui.py
+++ b/src/pollypm/cockpit_ui.py
@@ -13311,13 +13311,22 @@ def _dashboard_css_with_palette(raw_css: str) -> str:
     dashboard CSS block so a palette tweak in ``cockpit_theme`` propagates
     here without a manual edit.
 
-    The dashboard CSS predates ``cockpit_theme`` and contains ~25 raw hex
-    literals. Five of them are the canonical semantic colors used across
-    the cockpit (rail, inbox, activity, footer status); the rest are
-    dashboard-specific surface tints (action-bar attention/critical fill,
-    section backgrounds, scrollbar slate) with no current ``State.*``
-    equivalent. We route only the canonical five through ``State.*`` —
-    the remaining hexes stay literal until a future audit promotes them.
+    The dashboard CSS predates ``cockpit_theme`` and contained ~25 raw hex
+    literals before promotion landed in two waves:
+
+    1. The five cockpit-wide canonical colors (info blue, muted gray,
+       neutral gray, body bright, heading) shared with rail / inbox /
+       activity / footer — landed in PR #2022.
+    2. The three dashboard surface tints (WARN amber, DANGER red, SUCCESS
+       green), each a triple of (text, background, border) used by the
+       action-bar and the celebratory plan-review CTA — landed here as
+       follow-up to PR #2022 once ``cockpit_theme.State`` grew the matching
+       ``SURFACE_*`` semantic constants.
+
+    What stays literal: pure dashboard chrome that has no analog elsewhere
+    in the cockpit (screen background, section borders, scrollbar slate,
+    plan-scroll backdrop). Promoting those would require inventing
+    single-use constants with no other consumer.
 
     Using ``str.replace`` (rather than an f-string CSS) keeps the source
     CSS readable: Textual CSS uses ``{ ... }`` rule blocks everywhere,
@@ -13326,11 +13335,22 @@ def _dashboard_css_with_palette(raw_css: str) -> str:
     ``State.*`` literal), so this is a source-level rename, not a redesign.
     """
     palette = (
+        # Canonical cockpit-wide colors (PR #2022).
         ("#5b8aff", _State.INFO),
         ("#6b7a88", _State.MUTED),
         ("#97a6b2", _State.NEUTRAL),
         ("#d6dee5", _State.BODY_BRIGHT),
         ("#eef2f4", _State.HEADING),
+        # Dashboard surface tints — WARN / DANGER / SUCCESS triples.
+        ("#f7d67a", _State.SURFACE_WARN),
+        ("#3a2c08", _State.SURFACE_WARN_BG),
+        ("#7a5a14", _State.SURFACE_WARN_BORDER),
+        ("#ffd7d9", _State.SURFACE_DANGER),
+        ("#3a1719", _State.SURFACE_DANGER_BG),
+        ("#8d3137", _State.SURFACE_DANGER_BORDER),
+        ("#b6f0c0", _State.SURFACE_SUCCESS),
+        ("#1a2e1c", _State.SURFACE_SUCCESS_BG),
+        ("#2c5b32", _State.SURFACE_SUCCESS_BORDER),
     )
     result = raw_css
     for old, new in palette:
@@ -13352,10 +13372,11 @@ class PollyProjectDashboardApp(App[None]):
 
     # Dashboard CSS — routed through ``cockpit_theme.State`` so the five
     # canonical semantic colors (info blue, muted gray, neutral gray, body
-    # bright, heading) stay in lockstep with the rail/inbox/activity/footer
-    # palette. See ``_dashboard_css_with_palette`` above for the substitution
-    # contract and rationale for staying with ``str.replace`` instead of an
-    # f-string.
+    # bright, heading) AND the three dashboard surface tints (WARN amber,
+    # DANGER red, SUCCESS green — each a text/background/border triple)
+    # stay in lockstep with the rest of the cockpit. See
+    # ``_dashboard_css_with_palette`` above for the substitution contract
+    # and rationale for staying with ``str.replace`` instead of an f-string.
     CSS = _dashboard_css_with_palette("""
     Screen {
         background: #0f1317;

--- a/tests/test_project_dashboard_css_palette.py
+++ b/tests/test_project_dashboard_css_palette.py
@@ -4,15 +4,15 @@ The per-project dashboard CSS in ``cockpit_ui.PollyProjectDashboardApp``
 historically duplicated raw hex literals (``#5b8aff``, ``#6b7a88``, etc.)
 that also lived in the rail / inbox / activity / footer palette. PR
 #1989 introduced ``cockpit_theme.State`` as the single source of truth;
-this test pins that the dashboard's CSS string is produced by routing
-those five canonical colors through ``State.*`` (so a future palette
-tweak in ``cockpit_theme`` propagates to the dashboard without a
-manual edit and without silent drift).
+PR #2022 promoted the five cockpit-wide canonical colors through
+``State.*``; this follow-up promotes the three dashboard surface tints
+(WARN amber, DANGER red, SUCCESS green — each a text/background/border
+triple) so a tint tweak propagates to the dashboard without a manual
+edit and without silent drift.
 
-We deliberately do NOT assert on dashboard-specific surface tints
-(action-bar attention/critical fills, section backgrounds, scrollbar
-slate) — those have no current ``State.*`` equivalent and stay literal
-until a future audit promotes them.
+What stays literal: pure dashboard chrome that has no analog elsewhere
+in the cockpit (screen background, section borders, scrollbar slate,
+plan-scroll backdrop).
 """
 
 from __future__ import annotations
@@ -36,6 +36,31 @@ _CANONICAL_PAIRS = [
 ]
 
 
+# The three dashboard surface tints, each a (text, background, border)
+# triple. Pinned so a future ``State.SURFACE_*`` rename can't silently
+# drop a substitution out of ``_dashboard_css_with_palette``.
+_SURFACE_TRIPLES = [
+    (
+        "WARN",
+        State.SURFACE_WARN,
+        State.SURFACE_WARN_BG,
+        State.SURFACE_WARN_BORDER,
+    ),
+    (
+        "DANGER",
+        State.SURFACE_DANGER,
+        State.SURFACE_DANGER_BG,
+        State.SURFACE_DANGER_BORDER,
+    ),
+    (
+        "SUCCESS",
+        State.SURFACE_SUCCESS,
+        State.SURFACE_SUCCESS_BG,
+        State.SURFACE_SUCCESS_BORDER,
+    ),
+]
+
+
 def test_dashboard_css_contains_canonical_state_hexes() -> None:
     """Every canonical ``State.*`` color used by the dashboard must
     appear in the rendered CSS at least once. If a future palette tweak
@@ -49,6 +74,26 @@ def test_dashboard_css_contains_canonical_state_hexes() -> None:
             f"State.{name} ({hex_value}) missing from dashboard CSS — "
             f"the palette substitution helper is broken or out of date."
         )
+
+
+def test_dashboard_css_contains_surface_tint_state_hexes() -> None:
+    """Every ``State.SURFACE_*`` color used by the dashboard must appear
+    in the rendered CSS at least once. Same contract as the canonical-
+    hex test above but pinned for the three surface tint triples
+    promoted as the PR #2022 follow-up.
+    """
+    css = PollyProjectDashboardApp.CSS
+    for family, text, bg, border in _SURFACE_TRIPLES:
+        for role, hex_value in (
+            ("text", text),
+            ("background", bg),
+            ("border", border),
+        ):
+            assert hex_value in css, (
+                f"State.SURFACE_{family} {role} ({hex_value}) missing "
+                f"from dashboard CSS — the palette substitution helper "
+                f"is broken or out of date."
+            )
 
 
 def test_dashboard_css_helper_substitutes_each_canonical_color() -> None:
@@ -72,17 +117,60 @@ def test_dashboard_css_helper_substitutes_each_canonical_color() -> None:
         assert hex_value in rendered
 
 
+def test_dashboard_css_helper_substitutes_each_surface_tint() -> None:
+    """Directly exercise the substitution helper on the three surface
+    tint triples (WARN / DANGER / SUCCESS). Mirrors the canonical-color
+    helper test so a missing entry in the palette tuple fails loudly.
+    """
+    stub_css = (
+        # WARN triple
+        "color: #f7d67a;\n"
+        "background: #3a2c08;\n"
+        "border: round #7a5a14;\n"
+        # DANGER triple
+        "color: #ffd7d9;\n"
+        "background: #3a1719;\n"
+        "border: round #8d3137;\n"
+        # SUCCESS triple
+        "color: #b6f0c0;\n"
+        "background: #1a2e1c;\n"
+        "border: round #2c5b32;\n"
+    )
+    rendered = _dashboard_css_with_palette(stub_css)
+    for _, text, bg, border in _SURFACE_TRIPLES:
+        assert text in rendered
+        assert bg in rendered
+        assert border in rendered
+
+
 def test_dashboard_css_is_byte_identical_to_pre_migration_palette() -> None:
     """The migration is intentionally source-level, not visual. Today
-    each canonical ``State.*`` value matches the original raw hex
-    byte-for-byte, so the rendered CSS still contains the original five
-    literals (``#5b8aff``, ``#6b7a88``, ``#97a6b2``, ``#d6dee5``,
-    ``#eef2f4``). If somebody changes a ``State.*`` value, this test
-    will fail loudly so the visual shift is a deliberate decision, not
-    an accident.
+    each ``State.*`` value matches the original raw hex byte-for-byte,
+    so the rendered CSS still contains the original literals (canonical
+    five plus the nine surface-tint hexes). If somebody changes a
+    ``State.*`` value, this test will fail loudly so the visual shift
+    is a deliberate decision, not an accident.
     """
     css = PollyProjectDashboardApp.CSS
-    for raw in ("#5b8aff", "#6b7a88", "#97a6b2", "#d6dee5", "#eef2f4"):
+    raw_hexes = (
+        # Canonical five (PR #2022).
+        "#5b8aff",
+        "#6b7a88",
+        "#97a6b2",
+        "#d6dee5",
+        "#eef2f4",
+        # Surface tints (this PR) — WARN / DANGER / SUCCESS triples.
+        "#f7d67a",
+        "#3a2c08",
+        "#7a5a14",
+        "#ffd7d9",
+        "#3a1719",
+        "#8d3137",
+        "#b6f0c0",
+        "#1a2e1c",
+        "#2c5b32",
+    )
+    for raw in raw_hexes:
         assert raw in css, (
             f"{raw} no longer in dashboard CSS — a State.* value moved. "
             f"If this was intentional, update this test."


### PR DESCRIPTION
## Summary

Follow-up to PR #2022, which promoted the five cockpit-wide canonical hexes through `cockpit_theme.State` but explicitly deferred dashboard-specific surface tints because they needed new semantic constants. This PR adds those constants and migrates the remaining surface-tint hexes through `_dashboard_css_with_palette` — CSS output is byte-identical.

- **Adds 9 `State.SURFACE_*` constants** (WARN / DANGER / SUCCESS, each a text/background/border triple)
- **Extends `_dashboard_css_with_palette` substitution map** with the 9 matching raw hexes
- **Extends regression tests** to pin the new surface tint promotion

## Color mapping

| Family  | Text     | Background | Border   | Used by |
|---------|----------|------------|----------|---------|
| WARN    | `#f7d67a` | `#3a2c08`  | `#7a5a14` | `#proj-action-bar.-attention`, `#proj-empty-state` |
| DANGER  | `#ffd7d9` | `#3a1719`  | `#8d3137` | `#proj-action-bar.-critical` |
| SUCCESS | `#b6f0c0` | `#1a2e1c`  | `#2c5b32` | `#proj-review-cta` (#1531 plan-review CTA) |

What stays literal: pure dashboard chrome with no analog elsewhere in the cockpit (screen background, section borders, scrollbar slate, plan-scroll backdrop) — promoting those would require inventing single-use constants with no other consumer.

## Byte-identity

Verified the rendered `PollyProjectDashboardApp.CSS` is byte-for-byte identical to PR #2022's output: same length (5093 bytes), same bytes. This is a source-level rename, not a redesign — a future tint tweak in `cockpit_theme` will now propagate without a manual edit.

## Test plan

- [x] `tests/test_project_dashboard_css_palette.py` — added `test_dashboard_css_contains_surface_tint_state_hexes` and `test_dashboard_css_helper_substitutes_each_surface_tint`; extended byte-identity test with the 9 new raw hexes. All 5 tests pass via direct `python -c` execution.
- [x] Byte-identity vs PR #2022 head verified programmatically.
- [x] `ruff check` on `cockpit_theme.py` and `tests/test_project_dashboard_css_palette.py` — clean. Lint on `cockpit_ui.py` unchanged at 51 pre-existing errors (none introduced).
- [ ] CI to verify under standard pytest harness.

## Validation method note

Sibling sessions had saturated CPU (load avg 10+, multiple pytest invocations in flight) during this run, so per the mission spec I validated via direct `.venv/bin/python -c "..."` execution of every test function in the file plus `ruff check`. No `--no-verify` was used; commit hooks ran normally.

## Stacking

This PR is based on `polish/tmux-ui-dashboard-css-palette` (PR #2022). Merge order: #2022 first, then this. If #2022 retargets, this will need a rebase.

Refs #1988.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>