### PR TITLE
fix(watchdog): role_session_missing carve-out for worker role (closes #2023)

### DIFF
--- a/src/pollypm/audit/watchdog.py
+++ b/src/pollypm/audit/watchdog.py
@@ -1426,12 +1426,28 @@ def _detect_role_session_missing(
     ``max_parallel_workers``) and no finding is emitted. The cadence
     handler computes the flag from live worker-session counts +
     project cap before invoking ``scan_events``.
+
+    #2023 — the #1737 carve-out was subsumed: ALL queued worker-role
+    findings are now suppressed (not just the at-cap subset) because
+    the matching self-heal is a structural no-op (per-task workers
+    spawn on ``pm task claim`` via the auto-claim sweep, not via a
+    long-running ``worker-<project>`` lane). Pre-fix this detector
+    fired ~456x/24h on pollypm with 0 corresponding spawns — pure
+    escalation noise. The ``worker_cap_back_pressure`` parameter is
+    retained on the signature so the cadence handler doesn't churn,
+    but is no longer consulted; see the comment near the carve-out
+    below for the full reasoning.
     """
     findings: list[Finding] = []
     if not open_tasks or storage_window_names is None:
         return findings
     window_set = {str(name).strip() for name in storage_window_names if name}
-    back_pressure = worker_cap_back_pressure or {}
+    # #2023 — ``worker_cap_back_pressure`` is no longer consulted; the
+    # at-cap suppression from #1737 was subsumed by the broader
+    # worker+queued carve-out further down. Discard the kwarg so the
+    # local doesn't trigger an unused-variable lint while we keep the
+    # public signature stable for the cadence handler caller.
+    del worker_cap_back_pressure
 
     for task in open_tasks:
         status = getattr(task, "work_status", None)
@@ -1485,18 +1501,27 @@ def _detect_role_session_missing(
                 role_used = "worker"
         if role_used is None:
             continue
-        # #1737 — queued worker-role tasks for a project at the
-        # ``max_parallel_workers`` ceiling are not a missing-session
-        # condition; they are normal back-pressure. The auto-claim
-        # sweep + per-task spawn-on-claim already gate fresh workers
-        # against the cap, so suppress the tier-1 finding here to
-        # avoid a noisy false-positive loop. ``in_progress`` workers
-        # already have a session, so no special-case needed there.
-        if (
-            role_used == "worker"
-            and status_value == "queued"
-            and back_pressure.get(task_project)
-        ):
+        # #2023 — queued worker-role tasks have NO addressable self-heal
+        # by construction. ``worker-<project>`` is a deprecated
+        # long-running lane (see
+        # ``_self_heal_role_session_missing``: the worker branch is a
+        # structural no-op to avoid leaking the retired per-project
+        # worker). Per-task workers are spun up by the auto-claim
+        # sweep on ``pm task claim`` — that path, not the
+        # role-session-missing detector, is the recovery for a queued
+        # worker task with no live window. Firing the finding every
+        # tick (~5.5min) just burns escalation budget on an
+        # unactionable item: 456 findings / 24h on pollypm pre-fix,
+        # 0 spawns.
+        #
+        # The #1737 carve-out only suppressed the at-cap case; #2023
+        # extends suppression to ALL queued+worker findings because
+        # the self-heal cannot structurally help in either state.
+        # ``in_progress`` workers are NOT suppressed — those
+        # genuinely require a live session (the worker claimed the
+        # task, opened a window, then the window died) and the
+        # architect escalation IS actionable there.
+        if role_used == "worker" and status_value == "queued":
             continue
         # #1737 — reviewers are per-task ephemeral
         # (``reviewer-<project>-<N>``) so the watchdog must check the

--- a/tests/test_heartbeat_cascade_foundation.py
+++ b/tests/test_heartbeat_cascade_foundation.py
@@ -639,26 +639,119 @@ def test_queue_without_motion_disabled_when_probe_flag_off(
 
 def test_role_session_missing_fires_for_queued_task(now: datetime) -> None:
     """The pre-#1546 filter only fired for in_progress / review; the
-    coffeeboardnm cancel-loop happened because queued advisor tasks
-    fell off the radar. Widened to include ``queued``."""
+    coffeeboardnm cancel-loop happened because queued non-worker tasks
+    (e.g. advisor) fell off the radar. Widened to include ``queued``.
+
+    #2023 — queued *worker*-role tasks are explicitly carved out (the
+    self-heal is a structural no-op for worker; auto-claim sweep is
+    the recovery path). This test therefore exercises the #1546
+    queued widening using an *architect* role, which still has a real
+    long-running ``architect-<project>`` lane the healer can spawn.
+    """
     task = _StubTask(
         project="demo",
         task_number=42,
         work_status_str="queued",
         executions=[],
-        roles={"worker": "claude:advisor"},
+        roles={"architect": "claude:architect"},
     )
     findings = scan_events(
         [],
         now=now,
         open_tasks=[task],
-        storage_window_names=["architect-demo"],
+        storage_window_names=["worker-demo"],
         project="demo",
     )
     matched = [f for f in findings if f.rule == RULE_ROLE_SESSION_MISSING]
     assert len(matched) == 1
     assert matched[0].subject == "demo/42"
     assert matched[0].tier == TIER_1
+
+
+def test_role_session_missing_silent_for_queued_worker_role(
+    now: datetime,
+) -> None:
+    """#2023 — queued worker-role tasks must NOT fire
+    ``role_session_missing`` even when no ``worker-<project>`` window
+    exists.
+
+    Bug: detector fired every cycle (~5.5min) while the matching
+    self-heal was a structural no-op (per-task workers spawn on
+    ``pm task claim``, not via the deprecated ``worker-<project>``
+    long-running lane). On pollypm that produced 456 findings / 24h
+    with 0 spawns — pure escalation noise. The carve-out skips
+    queued+worker entirely so the auto-claim sweep is the sole
+    recovery path for that state.
+    """
+    task = _StubTask(
+        project="pollypm",
+        task_number=36,
+        work_status_str="queued",
+        executions=[],
+        roles={"worker": "claude:worker"},
+    )
+    findings = scan_events(
+        [],
+        now=now,
+        open_tasks=[task],
+        # No ``worker-pollypm`` window — exactly the bug condition.
+        storage_window_names=["architect-pollypm"],
+        project="pollypm",
+    )
+    assert not any(f.rule == RULE_ROLE_SESSION_MISSING for f in findings)
+
+
+def test_role_session_missing_silent_for_queued_worker_assignee_fallback(
+    now: datetime,
+) -> None:
+    """#2023 — same carve-out applies when the role is resolved via
+    the ``assignee`` fallback (defaults to ``worker``). That is the
+    common production shape on tasks without an explicit ``roles``
+    dict, and was a contributor to the 456-per-24h finding count."""
+    task = _StubTask(
+        project="pollypm",
+        task_number=109,
+        work_status_str="queued",
+        executions=[],
+        roles=None,
+        assignee="alice",
+    )
+    findings = scan_events(
+        [],
+        now=now,
+        open_tasks=[task],
+        storage_window_names=[],
+        project="pollypm",
+    )
+    assert not any(f.rule == RULE_ROLE_SESSION_MISSING for f in findings)
+
+
+def test_role_session_missing_still_fires_for_in_progress_worker(
+    now: datetime,
+) -> None:
+    """#2023 — the carve-out is queued-only. ``in_progress`` worker
+    tasks legitimately require a live ``worker-<project>`` window
+    (the worker claimed the task, opened a window, then the window
+    died). That escalation IS actionable for the architect; do not
+    suppress it."""
+    task = _StubTask(
+        project="pollypm",
+        task_number=37,
+        work_status_str="in_progress",
+        executions=[],
+        roles={"worker": "claude:worker"},
+    )
+    findings = scan_events(
+        [],
+        now=now,
+        open_tasks=[task],
+        storage_window_names=["architect-pollypm"],
+        project="pollypm",
+    )
+    matched = [f for f in findings if f.rule == RULE_ROLE_SESSION_MISSING]
+    assert len(matched) == 1
+    assert matched[0].metadata["role"] == "worker"
+    assert matched[0].metadata["status"] == "in_progress"
 
 
 def test_role_session_missing_fires_for_queued_advisor_task(

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1876,7 +1876,15 @@ class TestParallelWorkerCap:
 
 
 class TestRoleSessionMissingCapAware:
-    """#1737 — cap-back-pressure suppresses queued worker_role findings."""
+    """#1737 — cap-back-pressure suppresses queued worker_role findings.
+
+    #2023 — the carve-out was extended: queued worker-role tasks are
+    now suppressed regardless of back-pressure state (the matching
+    self-heal is a structural no-op for worker; per-task workers are
+    provisioned by the auto-claim sweep on ``pm task claim``). The
+    not-at-cap test was inverted to reflect the new behaviour;
+    ``in_progress`` workers still fire and are unaffected.
+    """
 
     def test_queued_worker_at_cap_emits_no_finding(self) -> None:
         from pollypm.audit.watchdog import (
@@ -1909,7 +1917,15 @@ class TestRoleSessionMissingCapAware:
         )
         assert not any(f.rule == RULE_ROLE_SESSION_MISSING for f in findings)
 
-    def test_queued_worker_not_at_cap_still_fires(self) -> None:
+    def test_queued_worker_not_at_cap_no_longer_fires(self) -> None:
+        """#2023 — pre-fix this test asserted a queued worker task
+        with back_pressure=False fires the finding. That was the
+        every-cycle noise source (456/24h on pollypm with 0 spawns):
+        the matching self-heal is a structural no-op for worker, so
+        the finding had nowhere to go. The carve-out now suppresses
+        queued+worker regardless of cap state; the auto-claim sweep
+        is the recovery path.
+        """
         from pollypm.audit.watchdog import (
             RULE_ROLE_SESSION_MISSING,
             scan_events,
@@ -1923,7 +1939,8 @@ class TestRoleSessionMissingCapAware:
                 self.roles = roles
                 self.assignee = None
 
-        # Same shape but back_pressure False → legacy detector behaviour.
+        # Same shape but back_pressure False — pre-#2023 this fired;
+        # post-#2023 it is suppressed alongside the at-cap case.
         tasks = [_T("samblog", 9, "queued", {"worker": "worker"})]
         findings = scan_events(
             [],
@@ -1933,8 +1950,7 @@ class TestRoleSessionMissingCapAware:
             project="samblog",
             worker_cap_back_pressure={"samblog": False},
         )
-        matched = [f for f in findings if f.rule == RULE_ROLE_SESSION_MISSING]
-        assert len(matched) == 1
+        assert not any(f.rule == RULE_ROLE_SESSION_MISSING for f in findings)
 
     def test_in_progress_worker_finding_unaffected_by_back_pressure(self) -> None:
         """Back-pressure only suppresses queued; in_progress still fires


### PR DESCRIPTION
## Summary

Queued worker-role tasks were firing `role_session_missing` every cycle (~5.5min) while the matching self-heal was a structural no-op. On pollypm: **456 findings / 24h, 0 spawn events** — pure escalation noise the watchdog was dispatching to architect / operator as if it were actionable.

**Root cause** — detector ↔ self-heal contract mismatch:
- Detector (`src/pollypm/audit/watchdog.py:_detect_role_session_missing`) fires for any queued task whose `<role>-<project>` window is missing.
- Self-heal (`src/pollypm/plugins_builtin/core_recurring/audit_watchdog.py:_self_heal_role_session_missing`) early-returns for `role == "worker"` because per-task workers are provisioned by the auto-claim sweep on `pm task claim`, not via a long-running `worker-<project>` lane (the latter was deprecated).
- #1737 added back-pressure suppression only when the project was at `max_parallel_workers`. Below-cap queued worker tasks still fired the finding every tick.

## Fix decision — Option A (carve-out)

Three options were considered:

- **Option A — carve-out queued+worker in the detector.** Smallest change. Aligns the detector with the self-heal's already-documented architectural intent ("workers are auto-claim-managed").
- Option B — add the missing self-heal step. Larger change; would re-derive auto-claim sweep semantics in the watchdog path. Risk of duplicating logic.
- Option C — first-observation grace period. Defensive bandage; doesn't address the structural mismatch and would still emit findings eventually.

**Chose A**: the self-heal handler already documented (in a code comment, pre-existing) that per-task workers are spawned by the auto-claim sweep, not by spawning a `worker-<project>` lane. The detector was firing about a state it had no recovery path for. The fix is a 1-line predicate change + comments; the rest of the diff is documentation of why.

## What still fires

- `in_progress` worker tasks with missing `worker-<project>` window — still fire. A worker claimed the task, opened a window, then the window died: that IS an actionable architect escalation.
- Queued tasks for any other role (architect, advisor, reviewer) — still fire; their self-heal can spawn the long-running role lane.

## Regression tests

- `tests/test_heartbeat_cascade_foundation.py::test_role_session_missing_silent_for_queued_worker_role` — bug repro (queued worker, no window) asserts no finding.
- `tests/test_heartbeat_cascade_foundation.py::test_role_session_missing_silent_for_queued_worker_assignee_fallback` — assignee-fallback path (the common production shape on tasks without explicit `roles`) also suppressed.
- `tests/test_heartbeat_cascade_foundation.py::test_role_session_missing_still_fires_for_in_progress_worker` — pins the queued-only scope.
- Existing `test_role_session_missing_fires_for_queued_task` updated to use `architect` role (it was previously using worker — that path is the bug); preserves the #1546 queued-widening coverage.
- `tests/test_session_manager.py::TestRoleSessionMissingCapAware::test_queued_worker_not_at_cap_no_longer_fires` (renamed from `_still_fires`) — inverts the pre-fix expectation.
- Existing advisor/reviewer/in_progress coverage untouched.

All 10 affected tests verified passing via direct invocation against the patched detector (system load made full pytest crawl, inline runner used as canonical verification).

## Test plan

- [x] Bug repro test passes (queued+worker → no finding)
- [x] In-progress worker still fires (architect escalation preserved)
- [x] Queued advisor / architect / reviewer still fire
- [x] At-cap suppression behaviour preserved
- [x] Assignee-fallback path (no explicit `roles`) covered

Issue: closes #2023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)