### PR TITLE
feat(doctor): cluster output when 3+ alerts share alert_type (refs #1988)

### DIFF
--- a/src/pollypm/cli_features/maintenance.py
+++ b/src/pollypm/cli_features/maintenance.py
@@ -264,6 +264,17 @@ def doctor(
         "--fix-dry-run",
         help="Show what --fix WOULD do, without mutating anything.",
     ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Show the full Why/Fix block for every failing check (no clustering).",
+    ),
+    alert_type: str | None = typer.Option(
+        None,
+        "--alert-type",
+        help="Drill into a single check by name — restricts output to that check and renders full detail.",
+    ),
 ) -> None:
     from pollypm.doctor import (
         apply_fixes,
@@ -322,7 +333,7 @@ def doctor(
         if banner:
             typer.echo(banner)
             typer.echo("")
-        typer.echo(render_human(report))
+        typer.echo(render_human(report, verbose=verbose, alert_type=alert_type))
         typer.echo("")
         typer.echo(release_channel_line())
         typer.echo(setup_tag_line())
@@ -1332,6 +1343,11 @@ def register_maintenance_commands(app: typer.Typer) -> None:
                 ("pm doctor", "show the full health checklist"),
                 ("pm doctor --fix", "apply safe automatic repairs"),
                 ("pm doctor --json", "emit the report as machine-readable JSON"),
+                ("pm doctor --verbose", "show full Why/Fix detail (skip clustering)"),
+                (
+                    "pm doctor --alert-type project-guide-drift",
+                    "drill into one cluster by check name",
+                ),
             ],
         )
     )(doctor)

--- a/src/pollypm/doctor/rendering.py
+++ b/src/pollypm/doctor/rendering.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import pollypm.doctor as doctor
 
 
-_TICK = "\u2713"
-_CROSS = "\u2717"
+_TICK = "✓"
+_CROSS = "✗"
 _WARN = "!"
 _SKIP = "-"
 
@@ -30,14 +31,188 @@ _CATEGORY_LABELS: dict[str, str] = {
 }
 
 
+# --------------------------------------------------------------------- #
+# Clustering
+# --------------------------------------------------------------------- #
+#
+# A long pm doctor run can pile up dozens of structurally-identical
+# warnings (e.g. project-guide-drift across 12 projects, each with
+# multiple roles). The bottom Failures: block then dwarfs the
+# checklist itself — a screen of repeated Why/Fix blob per row that
+# the operator can't act on individually.
+#
+# We cluster INSIDE a single failing check whose data payload lists
+# ≥ CLUSTER_THRESHOLD sub-alerts (e.g. result.data["stale"] = [...]),
+# replacing that one row's verbose Why/Fix block with a compact
+# "N alerts across M projects" headline + N=3 sample subjects +
+# pointer to --fix / --verbose.
+#
+# Why per-check rather than across-checks:
+# - each Check is uniquely named, so cross-check clustering would
+#   collapse unrelated alert types together;
+# - the granular alerts live inside one CheckResult's data payload
+#   (the "list" field, e.g. stale/items/orphans/dead/missing/behind),
+#   which is the natural clustering unit;
+# - the --fix machinery already operates per-check, so the clustered
+#   "Run pm doctor --fix to bulk-resolve" pointer maps 1:1 to the
+#   existing fix_fn surface.
+
+CLUSTER_THRESHOLD = 3
+CLUSTER_SAMPLE_SIZE = 3
+
+# Known list-shaped fields inside CheckResult.data that carry per-item
+# alerts. Ordered by specificity — the first one with len ≥ threshold
+# wins. Keep this list in sync with the data shapes emitted by the
+# checks in src/pollypm/doctor.py (grep "data={" there).
+_ALERT_LIST_KEYS: tuple[str, ...] = (
+    "stale",
+    "drifted",
+    "items",
+    "entries",
+    "orphans",
+    "missing",
+    "behind",
+    "dead",
+    "samples",
+    "failures",
+)
+
+# Known subject-shaped fields inside a single alert dict, in order
+# of preference. Pairs like (project, role) get joined with a colon
+# to match the spec's "booktalk:architect" sample format.
+_SUBJECT_KEY_PAIRS: tuple[tuple[str, str], ...] = (
+    ("project", "role"),
+    ("project_name", "role"),
+)
+_SUBJECT_KEYS: tuple[str, ...] = (
+    "subject",
+    "name",
+    "project",
+    "project_name",
+    "path",
+    "role",
+    "host",
+    "task",
+    "session",
+    "id",
+)
+
+
 def _category_label(category: str) -> str:
     return _CATEGORY_LABELS.get(category, category.replace("_", " ").title())
 
 
-def render_human(report: doctor.DoctorReport) -> str:
+def _alert_list(result: doctor.CheckResult) -> list[Any]:
+    """Return the most-specific list-shaped alert payload inside ``result.data``.
+
+    An empty list is returned when no recognised list field is present
+    OR the payload doesn't reach the clustering threshold — callers
+    use len(...) >= CLUSTER_THRESHOLD to gate the clustered render.
+    """
+    data = result.data or {}
+    if not isinstance(data, dict):
+        return []
+    for key in _ALERT_LIST_KEYS:
+        value = data.get(key)
+        if isinstance(value, list) and value:
+            return list(value)
+    return []
+
+
+def _subject_for(item: Any) -> str:
+    """Extract a short subject label for a single sub-alert.
+
+    Dict items prefer the (project, role) pair (yielding "booktalk:architect"),
+    then fall back to a single key from ``_SUBJECT_KEYS``. Scalars are
+    stringified as-is. Anything unrecognised becomes "<item>".
+    """
+    if isinstance(item, dict):
+        for left_key, right_key in _SUBJECT_KEY_PAIRS:
+            left = item.get(left_key)
+            right = item.get(right_key)
+            if left and right:
+                return f"{left}:{right}"
+        for key in _SUBJECT_KEYS:
+            value = item.get(key)
+            if value:
+                return str(value)
+        # Last-ditch: the first non-empty value, just so we don't print
+        # "<item>" when SOME label exists.
+        for value in item.values():
+            if value:
+                return str(value)
+        return "<item>"
+    if item is None:
+        return "<item>"
+    return str(item)
+
+
+def _cluster_summary_lines(
+    check: doctor.Check,
+    result: doctor.CheckResult,
+    alerts: list[Any],
+) -> list[str]:
+    """Render the clustered detail block for a single failing check."""
+    count = len(alerts)
+    subjects = [_subject_for(item) for item in alerts[:CLUSTER_SAMPLE_SIZE]]
+    remaining = count - len(subjects)
+    sample = ", ".join(subjects)
+    if remaining > 0:
+        sample = f"{sample} ... (+{remaining} more)"
+    lines: list[str] = []
+    # Headline mirrors the existing row's status text but reframed as
+    # a cluster count — operators scanning the Failures: block see
+    # "N alerts" before any other detail.
+    data = result.data or {}
+    project_count = data.get("projects") if isinstance(data, dict) else None
+    if isinstance(project_count, int) and project_count > 0:
+        project_word = "project" if project_count == 1 else "projects"
+        headline = f"{check.name}: {count} alerts across {project_count} {project_word}"
+    else:
+        alert_word = "alert" if count == 1 else "alerts"
+        headline = f"{check.name}: {count} {alert_word}"
+    glyph = _WARN if result.severity == "warning" else _CROSS
+    lines.append(f"{glyph} {headline}")
+    lines.append(f"  Sample subjects: {sample}")
+    fix_hint = (
+        "Run `pm doctor --fix` to bulk-resolve, or `pm doctor --verbose` for full list."
+        if doctor._auto_fix_supported(result.auto_fix) or result.fixable
+        else "Run `pm doctor --verbose` for full list."
+    )
+    lines.append(f"  {fix_hint}")
+    return lines
+
+
+def render_human(
+    report: doctor.DoctorReport,
+    *,
+    verbose: bool = False,
+    alert_type: str | None = None,
+) -> str:
+    """Render the human-readable doctor checklist.
+
+    ``verbose`` — when True, never cluster; show the full Why/Fix block
+        for every failing check (legacy behaviour, pre-#1988 cluster
+        work).
+    ``alert_type`` — when set, restrict the report to checks whose
+        ``check.name`` matches; renders verbose (per-row) detail for
+        the filtered subset so the operator can drill into one
+        cluster.
+    """
+    results = report.results
+    if alert_type is not None:
+        results = [(c, r) for c, r in results if c.name == alert_type]
+        # When the operator drilled into a specific alert_type, show
+        # the verbose detail by default — they asked to inspect THIS
+        # cluster, so the truncated cluster summary would defeat the
+        # ask. --verbose toggles between cluster-and-detail and
+        # detail-only at the top level; --alert-type forces detail
+        # for the filtered slice.
+        verbose = True
+
     lines: list[str] = []
     last_category: str | None = None
-    for check, result in report.results:
+    for check, result in results:
         if check.category != last_category:
             if last_category is not None:
                 lines.append("")
@@ -55,11 +230,19 @@ def render_human(report: doctor.DoctorReport) -> str:
         badge = " [f] Fix" if not result.passed and doctor._auto_fix_supported(result.auto_fix) else ""
         lines.append(f"{glyph} {check.name}: {status}{badge}")
 
-    passed = report.passed_count
-    total = len(report.results)
-    errors = len(report.errors)
-    warnings = len(report.warnings)
-    skipped = report.skipped_count
+    passed = sum(1 for _, r in results if r.passed)
+    total = len(results)
+    errors_list = [
+        (c, r) for c, r in results
+        if not r.passed and not r.skipped and r.severity == "error"
+    ]
+    warnings_list = [
+        (c, r) for c, r in results
+        if not r.passed and not r.skipped and r.severity == "warning"
+    ]
+    errors = len(errors_list)
+    warnings = len(warnings_list)
+    skipped = sum(1 for _, r in results if r.skipped)
     warning_word = "warning" if warnings == 1 else "warnings"
     error_word = "error" if errors == 1 else "errors"
     check_word = "check" if total == 1 else "checks"
@@ -75,13 +258,18 @@ def render_human(report: doctor.DoctorReport) -> str:
     )
 
     failures = [
-        (c, r) for c, r in report.results
+        (c, r) for c, r in results
         if not r.passed and not r.skipped
     ]
     if failures:
         lines.append("")
         lines.append("Failures:")
         for check, result in failures:
+            alerts = _alert_list(result)
+            if not verbose and len(alerts) >= CLUSTER_THRESHOLD:
+                lines.append("")
+                lines.extend(_cluster_summary_lines(check, result, alerts))
+                continue
             glyph = _WARN if result.severity == "warning" else _CROSS
             lines.append("")
             lines.append(f"{glyph} {check.name}: {result.status}")

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -919,6 +919,170 @@ def test_render_json_is_parseable() -> None:
     assert payload["checks"][0]["data"] == {"foo": 1}
 
 
+# --------------------------------------------------------------------- #
+# Cluster-output rendering (refs #1988)
+# --------------------------------------------------------------------- #
+#
+# A long doctor run can pile up dozens of structurally-identical
+# warnings — e.g. project-guide-drift across 12 projects with several
+# roles each. The Failures: block then dwarfs the checklist itself.
+# These tests lock the clustering contract:
+# - cluster ≥ CLUSTER_THRESHOLD → compact summary
+# - cluster < CLUSTER_THRESHOLD → unchanged verbose Why/Fix
+# - --verbose suppresses clustering even past threshold
+# - --alert-type filters and drills into one cluster (verbose)
+# - --json output is never clustered (programmatic consumers depend
+#   on the full per-row payload)
+
+
+def _make_drift_check(stale_count: int, project_count: int) -> tuple[doctor.Check, list[dict]]:
+    """Build a project-guide-drift-shaped failing check with N sub-alerts."""
+    stale = [
+        {
+            "project": f"proj{i // 2}",
+            "role": "architect" if i % 2 == 0 else "worker",
+            "path": f"/tmp/proj{i // 2}/{i}.md",
+        }
+        for i in range(stale_count)
+    ]
+
+    def _run() -> doctor.CheckResult:
+        return doctor._fail(
+            f"{stale_count} stale across {project_count} projects",
+            why="upstream prompt drifted",
+            fix="Refresh each stale guide\nRecheck: pm doctor",
+            severity="warning",
+            data={"count": stale_count, "projects": project_count, "stale": stale},
+        )
+
+    return doctor.Check("project-guide-drift", _run, "guides", severity="warning"), stale
+
+
+def test_render_human_clusters_when_alerts_at_or_above_threshold() -> None:
+    """≥3 sub-alerts collapse into the compact cluster summary."""
+    check, _ = _make_drift_check(stale_count=4, project_count=2)
+    report = doctor.run_checks([check])
+    text = doctor.render_human(report)
+    # Cluster headline: count + project count + alert_type (= check.name)
+    assert "project-guide-drift: 4 alerts across 2 projects" in text
+    # Exactly CLUSTER_SAMPLE_SIZE=3 subjects in the sample
+    assert "Sample subjects: proj0:architect, proj0:worker, proj1:architect" in text
+    # "+N more" overflow tag is the literal remainder, not "..."-only
+    assert "(+1 more)" in text
+    # Pointer hints
+    assert "pm doctor --verbose" in text
+    # Verbose Why/Fix detail SUPPRESSED in clustered mode (the whole point)
+    assert "Why: upstream prompt drifted" not in text
+    assert "Refresh each stale guide" not in text
+
+
+def test_render_human_does_not_cluster_below_threshold() -> None:
+    """<3 sub-alerts fall through to the existing per-row Why/Fix format."""
+    check, _ = _make_drift_check(stale_count=2, project_count=1)
+    report = doctor.run_checks([check])
+    text = doctor.render_human(report)
+    # No cluster summary
+    assert "Sample subjects:" not in text
+    assert "alerts across" not in text
+    # Verbose detail rendered as before
+    assert "Why: upstream prompt drifted" in text
+    assert "Refresh each stale guide" in text
+
+
+def test_render_human_verbose_suppresses_clustering() -> None:
+    """--verbose bypasses clustering even at large sub-alert counts."""
+    check, _ = _make_drift_check(stale_count=10, project_count=10)
+    report = doctor.run_checks([check])
+    text = doctor.render_human(report, verbose=True)
+    assert "Sample subjects:" not in text
+    assert "alerts across" not in text
+    assert "Why: upstream prompt drifted" in text
+    assert "Refresh each stale guide" in text
+
+
+def test_render_human_alert_type_filters_and_drills_in() -> None:
+    """--alert-type restricts to the named check AND renders full detail."""
+    drift_check, _ = _make_drift_check(stale_count=5, project_count=5)
+
+    def _other() -> doctor.CheckResult:
+        return doctor._fail("system broken", why="other-why", fix="other-fix")
+
+    report = doctor.run_checks([
+        drift_check,
+        doctor.Check("other-check", _other, "system"),
+    ])
+    text = doctor.render_human(report, alert_type="project-guide-drift")
+    # Filtered: other-check is gone
+    assert "other-check" not in text
+    assert "other-why" not in text
+    # Drilled-in: verbose detail for the targeted cluster
+    assert "project-guide-drift" in text
+    assert "Why: upstream prompt drifted" in text
+    # Not the cluster summary — the operator asked to see the detail
+    assert "Sample subjects:" not in text
+
+
+def test_render_human_cluster_summary_uses_n3_samples_plus_overflow() -> None:
+    """Sample line has exactly 3 subjects and '(+N more)' for the remainder."""
+    check, _ = _make_drift_check(stale_count=24, project_count=12)
+    report = doctor.run_checks([check])
+    text = doctor.render_human(report)
+    assert "project-guide-drift: 24 alerts across 12 projects" in text
+    # Three subjects, then the +21 overflow.
+    assert (
+        "Sample subjects: proj0:architect, proj0:worker, proj1:architect ... (+21 more)"
+        in text
+    )
+
+
+def test_render_human_cluster_exactly_at_threshold_has_no_overflow() -> None:
+    """Edge case: count == sample size → no '+0 more' noise."""
+    check, _ = _make_drift_check(stale_count=3, project_count=3)
+    report = doctor.run_checks([check])
+    text = doctor.render_human(report)
+    assert "project-guide-drift: 3 alerts across 3 projects" in text
+    assert "Sample subjects: proj0:architect, proj0:worker, proj1:architect" in text
+    assert "+0 more" not in text
+    assert "(+" not in text  # no overflow tag at all
+
+
+def test_render_json_never_clusters() -> None:
+    """--json output preserves the full per-row payload regardless of cluster size."""
+    check, stale = _make_drift_check(stale_count=24, project_count=12)
+    report = doctor.run_checks([check])
+    payload = json.loads(doctor.render_json(report))
+    assert len(payload["checks"]) == 1
+    rendered = payload["checks"][0]
+    # The full why/fix blob and the full sub-alert list MUST be present —
+    # programmatic consumers (cockpit, alert daemons) rely on this.
+    assert rendered["why"] == "upstream prompt drifted"
+    assert "Refresh each stale guide" in rendered["fix"]
+    assert rendered["data"]["count"] == 24
+    assert len(rendered["data"]["stale"]) == 24
+    # The "alerts across" cluster headline is a render_human concern —
+    # JSON must not leak it into the status field.
+    assert "alerts across" not in rendered["status"]
+
+
+def test_render_human_cluster_extracts_subject_from_scalar_items() -> None:
+    """Scalar sub-alert lists (e.g. data['missing'] = ['/a', '/b', '/c']) cluster too."""
+    def _missing() -> doctor.CheckResult:
+        return doctor._fail(
+            "3 missing parents",
+            why="why",
+            fix="fix",
+            severity="warning",
+            data={"missing": ["/p/state-a.db", "/p/state-b.db", "/p/state-c.db", "/p/state-d.db"]},
+        )
+
+    report = doctor.run_checks([doctor.Check("state-parents", _missing, "filesystem", severity="warning")])
+    text = doctor.render_human(report)
+    assert "state-parents: 4 alerts" in text
+    # Scalars stringify directly
+    assert "Sample subjects: /p/state-a.db, /p/state-b.db, /p/state-c.db" in text
+    assert "(+1 more)" in text
+
+
 def test_apply_fixes_invokes_fix_fn(tmp_path: Path) -> None:
     called = {"ok": False}
 


### PR DESCRIPTION
## Summary

- When a `pm doctor` check fails with **>=3 sub-alerts** in its `data` payload (e.g. `project-guide-drift` listing 24 stale guides across 12 projects), collapse the `Failures:` block detail into a compact cluster summary instead of the full Why/Fix blob. Spec output:
  ```
  ! project-guide-drift: 24 alerts across 12 projects
    Sample subjects: proj0:architect, proj0:worker, proj1:architect ... (+21 more)
    Run `pm doctor --fix` to bulk-resolve, or `pm doctor --verbose` for full list.
  ```
- New `--verbose`/`-v` flag: bypass clustering, show the full per-row Why/Fix block (legacy behaviour).
- New `--alert-type <name>` flag: drill into a single check by name; renders verbose detail for the filtered slice.
- `--json` output is **deliberately unchanged** — programmatic consumers (cockpit / alert daemons) expect the full per-row payload at any cluster size.

## Threshold rationale

`CLUSTER_THRESHOLD = 3` matches the spec ("cluster >=3 entries"). Sub-3 falls through to the existing Why/Fix format — at that size, the operator can usefully read each row, so clustering would only obscure detail. `CLUSTER_SAMPLE_SIZE = 3` matches the spec's "N=3 sample subjects" example.

## Files

- `src/pollypm/doctor/rendering.py` — clustering helpers + new `render_human(verbose=, alert_type=)` kwargs.
- `src/pollypm/cli_features/maintenance.py` — `--verbose`/`-v` and `--alert-type` Typer options.
- `tests/test_doctor.py` — 8 new test cases (locked against the spec).

## Test plan

- [x] `cluster >=3` -> clustered summary; verbose Why/Fix suppressed
- [x] `cluster <3` -> falls through to per-row Why/Fix
- [x] `--verbose` suppresses clustering at any size
- [x] `--alert-type X` filters report to that check + renders detail
- [x] Summary has correct count + N=3 sample subjects + `(+N more)`
- [x] Exactly 3 sub-alerts cluster cleanly with no `(+0 more)` noise
- [x] `--json` output never clusters (full per-row payload preserved)
- [x] Scalar-list subjects (e.g. `data["missing"] = ["/a", "/b", ...]`) cluster correctly
- [x] Legacy `render_human` contract (summary line, pluralisation, failure detail) unchanged for the <3 case
- [x] `ruff check` clean

Conftest collection saturated under load; tests validated by direct-Python harness invoking each test body against the production module (11/11 pass — 8 new + 3 legacy regression).

[Claude Code](https://claude.com/claude-code) refs #1988