### PR TITLE
fix(sweeps): include draft in _emit_inbox_task dedupe scan (closes #2021)

### DIFF
--- a/src/pollypm/plugins_builtin/core_recurring/sweeps.py
+++ b/src/pollypm/plugins_builtin/core_recurring/sweeps.py
@@ -1254,7 +1254,11 @@ def _emit_inbox_task(
 ) -> bool:
     """Create a user-routed inbox task on the chat flow."""
     try:
-        existing = work.list_tasks(project=project, work_status="queued")
+        # #2021: include ``draft`` so we don't re-emit on every sweep — inbox
+        # tasks land via ``flow_template="chat"`` which starts in draft, not
+        # queued. Without this we churn ~30 dupes per orphan over 10h.
+        existing = work.list_tasks(project=project, work_status="draft")
+        existing += work.list_tasks(project=project, work_status="queued")
         existing += work.list_tasks(project=project, work_status="in_progress")
         for task in existing:
             labels = getattr(task, "labels", None) or ()

--- a/tests/test_worktree_state_audit.py
+++ b/tests/test_worktree_state_audit.py
@@ -527,3 +527,98 @@ class TestHandler:
         key = ("worker-demo-9", "worktree_state:demo/9:dirty_stale")
         assert fake_store.alerts[key]["status"] == "cleared"
         assert result["alerts_cleared"] >= 1
+
+    def test_merge_conflict_dedupe_skips_existing_draft_inbox_task(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Regression for #2021: inbox tasks land in ``draft`` state under
+        the ``chat`` flow template. The dedupe scan must include ``draft``
+        or every sweep re-emits a duplicate (we saw ~30 dupes per orphan
+        over 10h on coffeeboardnm before the fix).
+
+        We seed a prior-sweep task carrying the dedupe label in
+        ``draft`` state, re-run the merge-conflict sweep, and assert no
+        new inbox task is created.
+        """
+        repo = _make_repo(tmp_path / "repo")
+        wt = _add_worktree(repo, "conflict-dupe")
+        (wt / "file.txt").write_text("left\n")
+        _run("git", "-C", str(wt), "add", "file.txt")
+        _run("git", "-C", str(wt), "commit", "-m", "L")
+        (repo / "file.txt").write_text("right\n")
+        _run("git", "-C", str(repo), "add", "file.txt")
+        _run("git", "-C", str(repo), "commit", "-m", "R")
+        merge = _run("git", "-C", str(wt), "merge", "main", check=False)
+        assert merge.returncode != 0
+
+        sessions = [
+            _FakeSession(
+                task_project="demo", task_number=42,
+                agent_name="worker-demo-42", worktree_path=str(wt),
+            ),
+        ]
+
+        # Capture the calls so we can verify the handler actually queried
+        # ``draft`` (otherwise this test would still pass by accident if
+        # the dedupe scan were removed entirely).
+        @dataclass
+        class _StubTask:
+            labels: tuple
+            work_status: str
+
+        dedupe_label = "worktree_audit:demo/42:merge_conflict"
+        prior_draft = _StubTask(
+            labels=("audit:worktree_state", dedupe_label),
+            work_status="draft",
+        )
+        statuses_queried: list[str] = []
+
+        from pollypm.plugins_builtin.core_recurring import plugin as plugin_module
+        from pollypm.plugins_builtin.core_recurring import sweeps as sweeps_module
+
+        fake_store = _FakeStore()
+        fake_work = _FakeWork(sessions)
+
+        def _list_tasks(**kwargs: Any):
+            status = kwargs.get("work_status")
+            statuses_queried.append(status)
+            if status == "draft":
+                return [prior_draft]
+            return []
+
+        fake_work.list_tasks = _list_tasks  # type: ignore[method-assign]
+
+        @dataclass
+        class _FakeProject:
+            root_dir: Path
+
+        @dataclass
+        class _FakeConfig:
+            project: _FakeProject
+
+        cfg = _FakeConfig(project=_FakeProject(root_dir=repo))
+        monkeypatch.setattr(
+            sweeps_module, "_load_config_and_store",
+            _fake_load_cm(cfg, fake_store),
+        )
+        monkeypatch.setattr(
+            sweeps_module, "_open_msg_store", lambda _config: fake_store,
+        )
+        monkeypatch.setattr(
+            sweeps_module, "_close_msg_store", lambda _store: None,
+        )
+        import pollypm.work as work_mod
+
+        monkeypatch.setattr(
+            work_mod, "create_work_service",
+            lambda *a, **kw: fake_work,
+        )
+
+        result = plugin_module.worktree_state_audit_handler({})
+        # Alert still raised (alerts are deduped by msg_store, not this scan).
+        assert result["classified"].get("merge_conflict") == 1
+        # But NO new inbox task — the draft was found.
+        assert result["inbox_emitted"] == 0
+        assert fake_work.created == []
+        # And the handler did query draft (this is what #2021 was missing).
+        assert "draft" in statuses_queried


### PR DESCRIPTION
## Summary

- `_emit_inbox_task` dedupe scan only checked `queued` + `in_progress`, but inbox tasks use `flow_template="chat"` which starts in `draft`. Every 10-min sweep missed the existing draft row and created a duplicate — ~30 dupes per orphan over 10h. On coffeeboardnm we saw 151 unique stuck_draft tasks vs ~5-10 healthy, and 5481 stuck_draft watchdog warnings in 24h.
- Fix: add `work_status="draft"` to the dedupe scan at `src/pollypm/plugins_builtin/core_recurring/sweeps.py:1257`. Both `_worktree_audit_handle_orphan_branch` and `_worktree_audit_handle_merge_conflict` inherit the fix (both go through `_emit_inbox_task`).
- Regression test seeds a prior-sweep draft task with the dedupe label, runs the merge-conflict sweep, and asserts `inbox_emitted == 0` and no new `work.create`. Verified the test fails against unpatched code (`assert 1 == 0`) and passes with the fix.

## Test plan

- [x] `HOME=/tmp/pytest-agent-2021-fix uv run --with pytest pytest --noconftest tests/test_worktree_state_audit.py -v` — all 13 tests pass (12 existing + 1 new).
- [x] Confirmed the new test fails when the `draft` line is removed from the dedupe scan (assertion `inbox_emitted == 0` becomes `1 == 0`).
- [ ] Soak test on a project with orphan/merge-conflict worktrees: confirm a single inbox task per dedupe label across multiple sweep cycles.

Closes #2021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)