### PR TITLE
[smoke-test] docs: note pm doctor cluster output format in post-merge checklist

### DIFF
--- a/docs/post-merge-checklist.md
+++ b/docs/post-merge-checklist.md
@@ -151,6 +151,13 @@ check. Tonight's wave specifically resolves:
 | `project-guide-drift`       | Bulk-fixable via `pm doctor --fix`. The action now refreshes drifted guides in one shot instead of per-project. | #2028 |
 | `agent-worktree-count`      | The prune handler now actually reaps stale agent worktrees. Pre-#1975 the check fired but the fix was a no-op. | #1975 |
 
+> **Note on output format:** Post-#2038, `pm doctor` clusters human
+> output when a check has 3+ sub-alerts (one summary row with sample
+> subjects and a `(+N more)` tail instead of N near-identical Why/Fix
+> blocks). That's intentional, not truncation — pass `--verbose` for
+> the full per-row detail, or `--alert-type <name>` to drill into one
+> check. `--json` output is unchanged (always full per-row payload).
+
 ### If `doubled-pollypm-path` fires
 
 ```bash


### PR DESCRIPTION
_This is a smoke-test PR for the Codex needs-review label automation. Sam asked for it — see chat. Safe to merge or close as a no-op._

## Summary

- Single 7-line addition to `docs/post-merge-checklist.md` §5 (the post-merge doctor check section).
- Adds a brief callout explaining the new `pm doctor` clustered human output that shipped in #2038, so morning-after readers don't mistake the collapsed `(+N more)` tail for truncation.
- Points at the `--verbose` and `--alert-type <name>` escape hatches; notes that `--json` output is unchanged.

## Why now

PR #2038 changed the visible shape of `pm doctor` output for any check with 3+ sub-alerts. The post-merge checklist tells operators to run `pm doctor` after every wave, so a one-paragraph note about the new format belongs in that doc.

## Test plan

- [x] Diff is docs-only (1 file, +7 -0)
- [x] No code logic changes
- [x] Flags referenced (`--verbose`, `--alert-type`, `--json`) match the actual implementation in PR #2038's `src/pollypm/cli_features/maintenance.py` Typer options

🤖 Generated with [Claude Code](https://claude.com/claude-code)