### PR TITLE
feat(chat-api): P3 POST /api/v1/chat/{session}/send with safety gates

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -434,7 +434,12 @@ paths:
         the requested surface. `safety=loose` keeps the mid-tool
         gate but allows mid-stream sends, emitting an
         `X-PollyPM-Warning: agent-may-be-streaming` response header.
-        `safety=force` bypasses everything.
+        `safety=force` bypasses the mid-tool / mid-stream /
+        missing-transcript safety gates only. Pane and window
+        existence + liveness errors (`409 pane_invalid`,
+        `409 pane_dead`, `503 window_missing`,
+        `503 tmux_unavailable`) are NOT bypassed and will still
+        fail-closed.
 
         AskUserQuestion replies: when `answer_to` references an
         `ask_user` envelope, `selections[]` must match one of the

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -491,8 +491,12 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "503":
           description: |
-            `window_missing` — the surface is registered but its
-            tmux window is not running.
+            Typed `window_missing` (the surface is registered but its
+            tmux window is not running, including the race where the
+            window disappears between validation and `send-keys`),
+            `tmux_unavailable` (tmux binary missing or the tmux
+            server timed out), or `send_failed` (generic send
+            failure — subprocess error, paste-buffer load failure).
           content:
             application/json:
               schema:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1305,12 +1305,28 @@ components:
       type: string
       enum: [strict, loose, force]
       description: |
-        Safety gate level. `strict` (default) enforces mid-tool +
-        mid-stream checks and fails closed when the resolver can't
-        fingerprint a transcript to the requested surface. `loose`
-        keeps mid-tool but allows mid-stream sends with the
-        `X-PollyPM-Warning: agent-may-be-streaming` response header.
-        `force` bypasses both gates.
+        Safety gate level.
+
+        * `strict` (default): All safety gates active. Fails closed
+          (409) when signals are unavailable as well as when they
+          report unsafe:
+          - `unsafe_mid_tool` — open tool_use in the latest assistant
+            turn.
+          - `unsafe_mid_stream` — heartbeat <2s old.
+          - `unsafe_unavailable_transcript` — transcript file exists
+            but can't be read (permissions, IO error). Mid-tool gate
+            can't be evaluated; strict fails closed.
+          - `unsafe_unavailable_heartbeat` — pg pool / heartbeat
+            backing-store outage. Mid-stream gate can't be evaluated;
+            strict fails closed.
+        * `loose`: Mid-tool gate active. Mid-stream check is
+          best-effort. Continues on unavailable signals and surfaces
+          one of the following `X-PollyPM-Warning` response headers:
+          `agent-may-be-streaming`, `heartbeat-unavailable`, or
+          `transcript-unavailable`.
+        * `force`: All safety gates bypassed. Pane and window
+          validation (`pane_invalid`, `pane_dead`, `window_missing`,
+          `tmux_unavailable`) is NOT bypassed.
 
     ChatSendRequest:
       type: object

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -405,6 +405,99 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /chat/{session_name}/send:
+    parameters:
+      - $ref: "#/components/parameters/ChatSessionName"
+    post:
+      tags: [Chat]
+      operationId: sendChatMessage
+      summary: Send a message to a chat surface
+      description: |
+        Push text into the running CLI agent backing
+        `session_name` via `tmux send-keys`. Resolves the surface
+        through `enumerate_chat_surfaces` — operator / architect /
+        advisor sessions come from `config.sessions`; per-task
+        workers are validated against active
+        `WorkService.list_worker_sessions` rows.
+
+        Safety gates (spec §4.1 / §4.3):
+
+        - **Mid-tool**: rejects when the resolved transcript's tail
+          shows an unmatched `tool_use_id` from the current
+          assistant response. Tool-only assistant turns (no preface
+          text) are caught via the `user_turn` boundary anchor.
+        - **Mid-stream**: rejects when the pg heartbeat for
+          `session_name` is < 2 s old.
+
+        `safety=strict` (default) enforces both gates and fails
+        closed when the resolver cannot fingerprint a transcript to
+        the requested surface. `safety=loose` keeps the mid-tool
+        gate but allows mid-stream sends, emitting an
+        `X-PollyPM-Warning: agent-may-be-streaming` response header.
+        `safety=force` bypasses everything.
+
+        AskUserQuestion replies: when `answer_to` references an
+        `ask_user` envelope, `selections[]` must match one of the
+        question's option labels exactly; `notes` are appended
+        after the selections joined by newlines.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChatSendRequest"
+      responses:
+        "200":
+          description: |
+            Message sent. The response header `X-PollyPM-Warning:
+            agent-may-be-streaming` may be present when
+            `safety=loose` allowed a mid-stream send.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChatSendResponse"
+          headers:
+            X-PollyPM-Warning:
+              description: |
+                Set to `agent-may-be-streaming` when `safety=loose`
+                bypassed a mid-stream gate. Absent on strict sends.
+              schema: { type: string }
+        "400":
+          description: |
+            Typed `invalid_request`, `answer_to_missing`,
+            `selections_no_question`, or `selections_invalid`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: |
+            `session_unknown` — `session_name` is not in
+            `config.sessions` and (for `task-{project}-{N}`) has no
+            active worker-session record.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: |
+            Typed `unsafe_mid_tool`, `unsafe_mid_stream`,
+            `pane_dead`, or `pane_invalid`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: |
+            `window_missing` — the surface is registered but its
+            tmux window is not running.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /projects/{key}/tasks:
     parameters:
       - $ref: "#/components/parameters/ProjectKey"
@@ -1197,6 +1290,88 @@ components:
             Pass back as `since_id` to fetch the next page. Applied
             in the same order as the previous response so `asc` and
             `desc` pagination both walk without duplicates.
+
+    # ---- Chat POST endpoint (P3 — send) -----------------------------
+    ChatSendSafety:
+      type: string
+      enum: [strict, loose, force]
+      description: |
+        Safety gate level. `strict` (default) enforces mid-tool +
+        mid-stream checks and fails closed when the resolver can't
+        fingerprint a transcript to the requested surface. `loose`
+        keeps mid-tool but allows mid-stream sends with the
+        `X-PollyPM-Warning: agent-may-be-streaming` response header.
+        `force` bypasses both gates.
+
+    ChatSendRequest:
+      type: object
+      properties:
+        text:
+          type: string
+          description: |
+            Free-text body to send. Required when `selections` is
+            empty and no `answer_to` is set.
+        press_enter:
+          type: boolean
+          default: true
+          description: Submit the buffer by pressing Enter after the text lands.
+        answer_to:
+          type: string
+          description: |
+            ID of an `ask_user` envelope in the session's transcript
+            that this send answers. When set, `selections` must
+            reference one of the question's option labels (§4.5).
+        selections:
+          type: array
+          items: { type: string }
+          description: |
+            Selected option labels for an AskUserQuestion reply.
+            Each entry must exactly match one of the question's
+            option labels.
+        notes:
+          type: string
+          description: |
+            Optional free-text addition appended after `selections`
+            when answering an `ask_user`. Ignored for plain text
+            sends.
+        safety:
+          $ref: "#/components/schemas/ChatSendSafety"
+        pane:
+          type: integer
+          minimum: 0
+          description: |
+            0-based pane index inside the target window. Defaults
+            to the active pane. Validated against `tmux list-panes`
+            — out-of-range indexes return `409 pane_invalid`; dead
+            panes return `409 pane_dead`.
+
+    ChatSendResponse:
+      type: object
+      required: [ok, message_id, session_name, window_target, characters_sent, method]
+      properties:
+        ok: { type: boolean }
+        message_id:
+          type: string
+          description: Synthetic id for the send request (echoed for tracing).
+        session_name: { type: string }
+        window_target:
+          type: string
+          description: |
+            `tmux` target the send was routed to
+            (`<storage-closet>:<window>[.<pane>]`).
+        characters_sent: { type: integer, minimum: 0 }
+        method:
+          type: string
+          enum: [send_keys, paste_buffer]
+          description: |
+            `paste_buffer` is used automatically for bodies > 100
+            characters; `send_keys` otherwise.
+        press_enter_at:
+          type: string
+          nullable: true
+          description: |
+            ISO-8601 UTC timestamp of the Enter press, or null when
+            `press_enter=false`.
 
     # ---- Tasks ------------------------------------------------------
     TaskStatus:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -454,9 +454,16 @@ paths:
       responses:
         "200":
           description: |
-            Message sent. The response header `X-PollyPM-Warning:
-            agent-may-be-streaming` may be present when
-            `safety=loose` allowed a mid-stream send.
+            Message sent. One of the following `X-PollyPM-Warning`
+            values may be present when `safety=loose` allowed the send
+            past a gate whose signal was either confirmed-streaming or
+            unavailable:
+
+            - `agent-may-be-streaming` — heartbeat < 2 s old.
+            - `heartbeat-unavailable` — pg / heartbeat lookup failed
+              (loose-mode best-effort; strict-mode 409s instead).
+            - `transcript-unavailable` — events.jsonl tail read failed
+              (loose-mode best-effort; strict-mode 409s instead).
           content:
             application/json:
               schema:
@@ -464,9 +471,27 @@ paths:
           headers:
             X-PollyPM-Warning:
               description: |
-                Set to `agent-may-be-streaming` when `safety=loose`
-                bypassed a mid-stream gate. Absent on strict sends.
-              schema: { type: string }
+                Set when `safety=loose` allowed a send past a gate that
+                would otherwise block (strict mode) or that could not be
+                evaluated (best-effort fallback). One of:
+
+                - `agent-may-be-streaming` — heartbeat indicated
+                  mid-stream (< 2 s old); loose bypassed it.
+                - `heartbeat-unavailable` — pg / heartbeat reader
+                  raised; loose continued without the signal. Strict
+                  mode would have returned `409 unsafe_unavailable_heartbeat`.
+                - `transcript-unavailable` — events.jsonl tail couldn't
+                  be read (permissions, IO error, decode failure); loose
+                  continued without the mid-tool signal. Strict mode
+                  would have returned `409 unsafe_unavailable_transcript`.
+
+                Absent on strict sends (those fail closed instead).
+              schema:
+                type: string
+                enum:
+                  - agent-may-be-streaming
+                  - heartbeat-unavailable
+                  - transcript-unavailable
         "400":
           description: |
             Typed `invalid_request`, `answer_to_missing`,
@@ -481,27 +506,60 @@ paths:
           description: |
             `session_unknown` — `session_name` is not in
             `config.sessions` and (for `task-{project}-{N}`) has no
-            active worker-session record.
+            active worker-session record. Distinguished from
+            `503 service_unavailable`, which is returned when the
+            worker-service lookup itself fails for a worker-pattern
+            name.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
         "409":
           description: |
-            Typed `unsafe_mid_tool`, `unsafe_mid_stream`,
-            `pane_dead`, or `pane_invalid`.
+            Typed safety-gate or pane failures:
+
+            - `unsafe_mid_tool` — agent's latest assistant response has
+              an unmatched `tool_use_id`, or the transcript resolver
+              couldn't fingerprint an exact archive while other
+              archives exist for the project.
+            - `unsafe_mid_stream` — heartbeat < 2 s old (strict).
+            - `unsafe_unavailable_transcript` — strict mode and the
+              events.jsonl tail read failed (permissions, IO error,
+              decode failure). Loose mode continues with
+              `X-PollyPM-Warning: transcript-unavailable`; force mode
+              ignores.
+            - `unsafe_unavailable_heartbeat` — strict mode and the
+              pg heartbeat lookup raised (import / `latest_heartbeat`
+              failure / malformed timestamp). Loose mode continues
+              with `X-PollyPM-Warning: heartbeat-unavailable`; force
+              mode ignores. A missing heartbeat row (no record yet)
+              is NOT unavailable — that's the genuine "not streaming"
+              signal and the send proceeds.
+            - `pane_dead` — target pane is `pane_dead=1` in tmux.
+            - `pane_invalid` — requested `pane` index is < 0, not
+              present on the window, or the `list-panes` probe failed.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
         "503":
           description: |
-            Typed `window_missing` (the surface is registered but its
-            tmux window is not running, including the race where the
-            window disappears between validation and `send-keys`),
-            `tmux_unavailable` (tmux binary missing or the tmux
-            server timed out), or `send_failed` (generic send
-            failure — subprocess error, paste-buffer load failure).
+            Typed backing-store / process failures:
+
+            - `window_missing` — the session is registered but its
+              tmux window is not running (including the race where the
+              window disappears between validation and `send-keys`).
+            - `tmux_unavailable` — tmux binary missing or the tmux
+              server timed out / is unreachable.
+            - `send_failed` — generic `send-keys` failure (subprocess
+              error, paste-buffer load failure).
+            - `service_unavailable` — worker-session lookup failed for
+              a `task-{project}-{N}` send (work-service open or
+              `list_worker_sessions` raised). Distinct from
+              `404 session_unknown`, which means the worker definitely
+              isn't registered. Retry once the work-service backing
+              store is reachable (Codex #2043 review v5 blocker 3 +
+              v6 blocker 1).
           content:
             application/json:
               schema:

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -281,6 +281,26 @@ Every 4xx and 5xx response body is:
 Validation errors carry an extra `details` field shaped like
 `[{"field": "reason", "message": "must be non-empty"}]`.
 
+### Chat-send specific codes
+
+`POST /api/v1/chat/{session_name}/send` adds the following typed
+codes on top of the standard set above:
+
+| HTTP | Code | When |
+|------|------|------|
+| 400 | `answer_to_missing` | `answer_to` does not match any transcript message id in the tail |
+| 400 | `selections_no_question` | `answer_to` references a message that isn't an `ask_user` envelope |
+| 400 | `selections_invalid` | One or more `selections` entries don't match an option label on the referenced ask_user |
+| 404 | `session_unknown` | `session_name` isn't in `config.sessions` and (for `task-{project}-{N}`) has no active worker-session row |
+| 409 | `unsafe_mid_tool` | Agent's latest assistant response has an unmatched `tool_use_id`, or the resolver couldn't fingerprint a transcript to this surface while other transcripts exist in the project |
+| 409 | `unsafe_mid_stream` | pg heartbeat for `session_name` is < 2 s old |
+| 409 | `pane_dead` | Target pane is `pane_dead=1` in tmux |
+| 409 | `pane_invalid` | Requested `pane` index is < 0, not present on the window, or the `list-panes` probe failed |
+| 503 | `window_missing` | The session is registered but its tmux window is not running |
+
+`safety=force` bypasses every 409 above. `safety=loose` keeps the
+mid-tool gate but allows mid-stream sends with a response header.
+
 ---
 
 ## 7. Resource model
@@ -386,6 +406,7 @@ Fields: `schema`, `ts`, `project`, `event`, `subject`, `actor`,
 | GET    | `/api/v1/projects/{key}` | Project drilldown — state, recent activity, top tasks, pending plan review |
 | POST   | `/api/v1/projects/{key}/plan` | Kick off `pm project plan` (initial or replan) |
 | POST   | `/api/v1/projects/{key}/chat` | Send a chat message to the project's PM persona |
+| POST   | `/api/v1/chat/{session_name}/send` | Send a message to a chat surface (operator/architect/advisor/worker) via tmux |
 | GET    | `/api/v1/projects/{key}/tasks` | Task list (`?status=&limit=&cursor=`) |
 | GET    | `/api/v1/projects/{key}/plan` | Structured plan body (`?version=N` matches the active version only — see §7) |
 | GET    | `/api/v1/tasks/{project}/{n}` | Task detail — status, node, executions, transitions |
@@ -399,9 +420,56 @@ Fields: `schema`, `ts`, `project`, `event`, `subject`, `actor`,
 | GET    | `/api/v1/events` | SSE stream of audit-log events (`?since=&project=&event=`) |
 | GET    | `/api/v1/chat/sessions` | Discover every chat surface (operator/architect/advisor/worker) |
 | GET    | `/api/v1/chat/{session_name}/messages` | Paginated message history for one chat surface (`?since=&since_id=&limit=&direction=&source=`) — `include_subagents` deferred (#2052) |
+| POST   | `/api/v1/chat/{session_name}/send` | Push a message into a chat surface via tmux (P3) |
 
-That's 19 endpoints in v1. The OpenAPI document is the authoritative
-list; if anything here drifts, the YAML wins.
+The OpenAPI document is the authoritative list; if anything here
+drifts, the YAML wins.
+
+### Chat-send (`POST /api/v1/chat/{session_name}/send`)
+
+Pushes text into the CLI agent backing `session_name` via tmux
+`send-keys`. Resolves surfaces through the shared P1 chat registry
+(`enumerate_chat_surfaces`): operator / architect / advisor sessions
+come from `config.sessions`; per-task workers
+(`task-{project}-{N}`) are validated against the work-service's
+active `list_worker_sessions()` rows — an authenticated caller
+cannot address a stale or unrelated tmux window by guessing names.
+
+Request body fields:
+
+| Field         | Type                                          | Required? | Notes |
+|---------------|-----------------------------------------------|-----------|-------|
+| `text`        | string                                        | when `selections` is empty | Free-text body. |
+| `press_enter` | bool (default true)                           | no        | Submit by pressing Enter after the text lands. |
+| `answer_to`   | string                                        | no        | Message id of an `ask_user` envelope this send answers. |
+| `selections`  | string[]                                      | no        | AskUserQuestion option labels (must match exactly). |
+| `notes`       | string                                        | no        | Appended after selections when answering an ask_user. |
+| `safety`      | enum `strict` (default) / `loose` / `force`   | no        | See safety gates below. |
+| `pane`        | integer ≥ 0                                   | no        | 0-based pane index; defaults to the active pane. |
+
+Response shape: `{ ok, message_id, session_name, window_target,
+characters_sent, method, press_enter_at? }`. `method` is
+`paste_buffer` for bodies > 100 chars and `send_keys` otherwise.
+
+#### Safety gates (`safety` enum)
+
+- `strict` (default) — both gates enforced; fails closed with
+  `409 unsafe_mid_tool` when the resolver cannot fingerprint a
+  transcript to the requested surface and other transcripts exist
+  in the project.
+- `loose` — keeps the mid-tool gate; allows mid-stream sends but
+  sets `X-PollyPM-Warning: agent-may-be-streaming` on the response.
+- `force` — bypasses both gates and the missing-fingerprint
+  fail-closed.
+
+#### Response header
+
+`X-PollyPM-Warning: agent-may-be-streaming` — set on a 200 response
+when `safety=loose` allowed a send while the pg heartbeat indicated
+the agent was streaming (< 2 s old). Absent on strict sends.
+
+Error codes for this endpoint are documented in §6 under the
+"Chat-send specific codes" table.
 
 ---
 

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -291,14 +291,17 @@ codes on top of the standard set above:
 | 400 | `answer_to_missing` | `answer_to` does not match any transcript message id in the tail |
 | 400 | `selections_no_question` | `answer_to` references a message that isn't an `ask_user` envelope |
 | 400 | `selections_invalid` | One or more `selections` entries don't match an option label on the referenced ask_user |
-| 404 | `session_unknown` | `session_name` isn't in `config.sessions` and (for `task-{project}-{N}`) has no active worker-session row |
+| 404 | `session_unknown` | `session_name` isn't in `config.sessions` and (for `task-{project}-{N}`) has no active worker-session row. Distinct from `503 service_unavailable` (lookup itself failed). |
 | 409 | `unsafe_mid_tool` | Agent's latest assistant response has an unmatched `tool_use_id`, or the resolver couldn't fingerprint a transcript to this surface while other transcripts exist in the project |
 | 409 | `unsafe_mid_stream` | pg heartbeat for `session_name` is < 2 s old |
+| 409 | `unsafe_unavailable_transcript` | `safety=strict` and the events.jsonl tail read failed (permissions / IO / decode). Loose mode continues with `X-PollyPM-Warning: transcript-unavailable`; force mode ignores. (Codex #2043 review v5 blocker 1.) |
+| 409 | `unsafe_unavailable_heartbeat` | `safety=strict` and the pg heartbeat lookup raised (import / `latest_heartbeat` failure / malformed timestamp). A missing record (no row) is NOT unavailable — that's "not streaming". Loose mode continues with `X-PollyPM-Warning: heartbeat-unavailable`; force mode ignores. (Codex #2043 review v5 blocker 2.) |
 | 409 | `pane_dead` | Target pane is `pane_dead=1` in tmux |
 | 409 | `pane_invalid` | Requested `pane` index is < 0, not present on the window, or the `list-panes` probe failed |
 | 503 | `window_missing` | The session is registered but its tmux window is not running (or it disappears between validation and `send-keys`) |
 | 503 | `tmux_unavailable` | tmux binary missing or the tmux server timed out / is unreachable |
 | 503 | `send_failed` | Generic `send-keys` failure (subprocess error, paste-buffer load failure) |
+| 503 | `service_unavailable` | Worker-session lookup failed for a `task-{project}-{N}` send (work-service open or `list_worker_sessions` raised). Distinct from `404 session_unknown` — retry once the work-service backing store is reachable. (Codex #2043 review v5 blocker 3 + v6 blocker 1.) |
 
 `safety=force` bypasses the mid-tool / mid-stream / missing-transcript
 safety gates only. Pane and window existence + liveness errors
@@ -465,20 +468,55 @@ characters_sent, method, press_enter_at? }`. `method` is
 
 #### Safety gates (`safety` enum)
 
-- `strict` (default) — both gates enforced; fails closed with
-  `409 unsafe_mid_tool` when the resolver cannot fingerprint a
-  transcript to the requested surface and other transcripts exist
-  in the project.
-- `loose` — keeps the mid-tool gate; allows mid-stream sends but
-  sets `X-PollyPM-Warning: agent-may-be-streaming` on the response.
-- `force` — bypasses both gates and the missing-fingerprint
-  fail-closed.
+Each gate has three possible signal states the level interprets
+differently: `clean` (signal evaluated, no problem), `blocked`
+(signal evaluated, the agent is mid-tool or mid-stream), and
+`unavailable` (the signal itself couldn't be read — pg outage,
+unreadable transcript). Pre-v5 `unavailable` was silently mapped to
+`clean`, which let strict sends through during outages; v5/v6
+distinguishes the two.
 
-#### Response header
+- `strict` (default) — both gates enforced; fails closed on EVERY
+  non-`clean` outcome.
+  - mid-tool `blocked` → `409 unsafe_mid_tool`.
+  - mid-tool `unavailable` → `409 unsafe_unavailable_transcript`.
+  - mid-stream `blocked` → `409 unsafe_mid_stream`.
+  - mid-stream `unavailable` → `409 unsafe_unavailable_heartbeat`.
+  - Resolver couldn't fingerprint a transcript to this surface
+    while other transcripts exist in the project →
+    `409 unsafe_mid_tool` (treated as ambiguity / wrong-surface).
+- `loose` — keeps the mid-tool `blocked` gate; allows mid-stream
+  `blocked` and BOTH `unavailable` paths with a warning header.
+  - mid-stream `blocked` → 200 + `X-PollyPM-Warning:
+    agent-may-be-streaming`.
+  - mid-tool `unavailable` → 200 + `X-PollyPM-Warning:
+    transcript-unavailable` (the gate could not actually be
+    evaluated — operator sees the best-effort signal).
+  - mid-stream `unavailable` → 200 + `X-PollyPM-Warning:
+    heartbeat-unavailable`.
+  - mid-tool `blocked` still returns `409 unsafe_mid_tool` — loose
+    is "best-effort on availability", not "skip the mid-tool gate".
+- `force` — bypasses both gates, both `unavailable` paths, AND the
+  missing-fingerprint fail-closed. Pane and window validation still
+  run (`409 pane_dead`, `409 pane_invalid`, `503 window_missing`,
+  `503 tmux_unavailable` are NOT bypassed).
 
-`X-PollyPM-Warning: agent-may-be-streaming` — set on a 200 response
-when `safety=loose` allowed a send while the pg heartbeat indicated
-the agent was streaming (< 2 s old). Absent on strict sends.
+#### Response headers
+
+`X-PollyPM-Warning` is set on a 200 response when `safety=loose`
+allowed the send past a gate that would otherwise block or that
+couldn't be evaluated. The value is one of:
+
+- `agent-may-be-streaming` — heartbeat < 2 s old (loose bypassed
+  the mid-stream `blocked` signal).
+- `heartbeat-unavailable` — pg / heartbeat reader raised; loose
+  continued without the mid-stream signal. Strict mode would have
+  returned `409 unsafe_unavailable_heartbeat`.
+- `transcript-unavailable` — events.jsonl tail couldn't be read;
+  loose continued without the mid-tool signal. Strict mode would
+  have returned `409 unsafe_unavailable_transcript`.
+
+Absent on strict sends — strict fails closed instead of warning.
 
 Error codes for this endpoint are documented in §6 under the
 "Chat-send specific codes" table.

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -296,10 +296,17 @@ codes on top of the standard set above:
 | 409 | `unsafe_mid_stream` | pg heartbeat for `session_name` is < 2 s old |
 | 409 | `pane_dead` | Target pane is `pane_dead=1` in tmux |
 | 409 | `pane_invalid` | Requested `pane` index is < 0, not present on the window, or the `list-panes` probe failed |
-| 503 | `window_missing` | The session is registered but its tmux window is not running |
+| 503 | `window_missing` | The session is registered but its tmux window is not running (or it disappears between validation and `send-keys`) |
+| 503 | `tmux_unavailable` | tmux binary missing or the tmux server timed out / is unreachable |
+| 503 | `send_failed` | Generic `send-keys` failure (subprocess error, paste-buffer load failure) |
 
 `safety=force` bypasses every 409 above. `safety=loose` keeps the
 mid-tool gate but allows mid-stream sends with a response header.
+
+Explicit `pane` (including `pane=0`) always validates via
+`list_panes()` and routes to the indexed target (`session:window.N`);
+only an omitted `pane` falls back to the window-level (active-pane)
+target.
 
 ---
 

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -300,8 +300,13 @@ codes on top of the standard set above:
 | 503 | `tmux_unavailable` | tmux binary missing or the tmux server timed out / is unreachable |
 | 503 | `send_failed` | Generic `send-keys` failure (subprocess error, paste-buffer load failure) |
 
-`safety=force` bypasses every 409 above. `safety=loose` keeps the
-mid-tool gate but allows mid-stream sends with a response header.
+`safety=force` bypasses the mid-tool / mid-stream / missing-transcript
+safety gates only. Pane and window existence + liveness errors
+(`409 pane_invalid`, `409 pane_dead`, `503 window_missing`,
+`503 tmux_unavailable`) are NOT bypassed and will still fail-closed
+— sending into a dead pane or a vanished window is never safe.
+`safety=loose` keeps the mid-tool gate but allows mid-stream sends
+with a response header.
 
 Explicit `pane` (including `pane=0`) always validates via
 `list_panes()` and routes to the indexed target (`session:window.N`);

--- a/docs/web-api-spec.md
+++ b/docs/web-api-spec.md
@@ -435,7 +435,6 @@ Fields: `schema`, `ts`, `project`, `event`, `subject`, `actor`,
 | GET    | `/api/v1/events` | SSE stream of audit-log events (`?since=&project=&event=`) |
 | GET    | `/api/v1/chat/sessions` | Discover every chat surface (operator/architect/advisor/worker) |
 | GET    | `/api/v1/chat/{session_name}/messages` | Paginated message history for one chat surface (`?since=&since_id=&limit=&direction=&source=`) — `include_subagents` deferred (#2052) |
-| POST   | `/api/v1/chat/{session_name}/send` | Push a message into a chat surface via tmux (P3) |
 
 The OpenAPI document is the authoritative list; if anything here
 drifts, the YAML wins.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,16 @@ dev = [
   "ruff>=0.15.12",
   "testcontainers[postgres]>=4.8.0",
 ]
+# #2043 review: a fresh ``uv run --with pytest`` collection of the
+# Web API tests crashed because ``fastapi.testclient`` imports
+# ``httpx`` and httpx wasn't a guaranteed test-time dep. The
+# ``test`` extra mirrors the ``dev`` set down to the bits a CI
+# matrix actually needs so reviewers can use
+# ``uv run --extra test pytest`` and stay green.
+test = [
+  "httpx>=0.27.0",
+  "pytest>=8.4.0",
+]
 
 [project.scripts]
 pm = "pollypm.cli:app"

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -32,6 +32,7 @@ from pollypm.web_api.errors import (
     handle_validation_error,
 )
 from pollypm.web_api.routes import chat_messages as chat_messages_routes
+from pollypm.web_api.routes import chat_send as chat_send_routes
 from pollypm.web_api.routes import events as events_routes
 from pollypm.web_api.routes import health as health_routes
 from pollypm.web_api.routes import inbox as inbox_routes
@@ -115,10 +116,20 @@ def create_app(
     app.include_router(events_routes.router, prefix=API_V1_PREFIX, dependencies=sse_auth_deps)
     # P2 of the chat-endpoints spec — GET /api/v1/chat/sessions and
     # GET /api/v1/chat/{session_name}/messages. Sits under the same
-    # ``/chat`` prefix the P3 send endpoint will share so all
+    # ``/chat`` prefix the P3 send endpoint shares so all
     # chat-surface verbs are co-located in the routing table.
     app.include_router(
         chat_messages_routes.router,
+        prefix=f"{API_V1_PREFIX}/chat",
+        dependencies=auth_deps,
+    )
+    # P3 of the chat-endpoints spec — POST /api/v1/chat/{session}/send.
+    # P1 (surface registry + transcript readers) and P2 (GET messages)
+    # ship in separate PRs; the send endpoint is independently mergeable
+    # because it depends only on the supervisor's storage-closet naming
+    # convention + ``TmuxClient.send_keys`` + ``pg_heartbeats``.
+    app.include_router(
+        chat_send_routes.router,
         prefix=f"{API_V1_PREFIX}/chat",
         dependencies=auth_deps,
     )

--- a/src/pollypm/web_api/app.py
+++ b/src/pollypm/web_api/app.py
@@ -87,7 +87,12 @@ def create_app(
         allow_credentials=True,
         allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
         allow_headers=["Authorization", "Content-Type", "Last-Event-ID"],
-        expose_headers=["Last-Event-ID"],
+        # ``X-PollyPM-Warning`` is set by ``POST /chat/{session}/send``
+        # with ``safety=loose`` when the heartbeat suggests the agent
+        # may still be streaming (see ``chat_send.py``). Without
+        # exposing it here, browsers strip the header before the
+        # frontend can read it, defeating the documented contract.
+        expose_headers=["Last-Event-ID", "X-PollyPM-Warning"],
     )
 
     # Wire the config provider so every endpoint shares the same

--- a/src/pollypm/web_api/routes/chat_send.py
+++ b/src/pollypm/web_api/routes/chat_send.py
@@ -9,9 +9,11 @@ The router is a thin adapter over the P1 shared facade in
 - :func:`pollypm.web_api.chat.enumerate_chat_surfaces` resolves
   ``session_name`` → :class:`ChatSurface` (window, transcript, cwd).
   Workers are validated against the work-service's active
-  :class:`WorkerSessionRecord` rows; an authenticated caller cannot
-  address a stale or unrelated tmux window by guessing
-  ``task-{project}-{id}`` names (Codex review block 2 in #2043).
+  :class:`WorkerSessionRecord` rows via the public service facade
+  :func:`pollypm.web_api.service.list_active_worker_sessions`;
+  an authenticated caller cannot address a stale or unrelated tmux
+  window by guessing ``task-{project}-{id}`` names (Codex review
+  block 2 in #2043, public-facade refactor for #2043 review v3).
 - :func:`pollypm.web_api.chat.resolve_transcript_path` produces the
   exact ``events.jsonl`` for the session, with ``cwd``-based scoping
   so multi-session projects don't bleed transcripts (Codex review
@@ -36,16 +38,30 @@ Safety gates per spec §4.1 / §4.3:
 mid-tool check but allows mid-stream sends with a warning header.
 ``safety=force`` bypasses everything.
 
-Pane validation: ``pane >= 0`` plus a ``list_panes`` probe verifies the
-requested pane exists AND is alive before any ``send_keys``. Negative
-or nonexistent panes now raise ``409 pane_invalid`` / ``409 pane_dead``
-instead of leaking subprocess errors (Codex review block 5 in #2043).
+Pane validation: explicit ``pane`` (including ``pane=0``) always goes
+through ``list_panes(target)`` to verify the requested index exists
+AND is alive before any ``send_keys``. Only ``pane is None`` falls
+back to the window-level (default active-pane) target — explicit
+``pane=0`` no longer silently aliases to the active pane (Codex
+review v3 block 1 in #2043). Negative or nonexistent panes raise
+``409 pane_invalid``; dead panes raise ``409 pane_dead``.
+
+Send failures: ``tmux.send_keys`` can raise ``DeadPaneError`` (mapped
+to ``409 pane_dead``), ``FileNotFoundError`` when the tmux binary is
+missing (``503 tmux_unavailable``), ``subprocess.CalledProcessError``
+when the window/pane disappears between validation and send
+(``503 window_missing``), ``subprocess.TimeoutExpired`` when the tmux
+server is wedged (``503 tmux_unavailable``), and arbitrary
+``OSError`` from paste-buffer load failures (``503 send_failed``).
+Every send-time failure now returns a typed envelope instead of a
+generic 500 (Codex review v3 block 2 in #2043).
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import subprocess
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
@@ -61,6 +77,7 @@ from pollypm.web_api.chat import (
 )
 from pollypm.web_api.errors import APIError
 from pollypm.web_api.routes._deps import ConfigDep
+from pollypm.web_api.service import list_active_worker_sessions
 
 logger = logging.getLogger(__name__)
 
@@ -181,6 +198,42 @@ def _pane_invalid(pane: int, target: str) -> APIError:
     )
 
 
+def _send_failed(target: str, detail: str) -> APIError:
+    """Generic send failure (subprocess error, paste-buffer load fail).
+
+    Spec §6 ``send_failed``. Wraps the underlying subprocess /
+    paste-buffer exception so the operator gets actionable text
+    instead of a generic 500 envelope (Codex #2043 review v3 block 2).
+    """
+    return APIError(
+        status_code=503,
+        code="send_failed",
+        message=f"tmux send_keys failed for {target!r}: {detail}",
+        hint=(
+            "Retry the request; if it keeps failing inspect the tmux "
+            "session directly or check the cockpit for an unhealthy pane."
+        ),
+    )
+
+
+def _tmux_unavailable(detail: str) -> APIError:
+    """tmux process is unreachable (binary missing, server wedged/timed out).
+
+    Spec §6 ``tmux_unavailable``. Distinguishes "the tmux server
+    itself is down" from "the specific window vanished" so the
+    operator knows whether retrying will help.
+    """
+    return APIError(
+        status_code=503,
+        code="tmux_unavailable",
+        message=f"tmux unavailable: {detail}",
+        hint=(
+            "The tmux binary is missing or the tmux server timed out. "
+            "Try `pm up` to restart the storage-closet session."
+        ),
+    )
+
+
 def _unsafe_mid_tool() -> APIError:
     return APIError(
         status_code=409,
@@ -234,90 +287,29 @@ def _selections_invalid(invalid: list[str], valid: list[str]) -> APIError:
 
 
 # ---------------------------------------------------------------------------
-# Worker-service handle (mirrors P2's pattern in chat_messages.py)
+# Worker-session discovery (thin wrapper over the public service facade)
 # ---------------------------------------------------------------------------
 
 
-class _WorkServiceHandle:
-    """Defers the ``_open_work_service_readonly`` ctx until first use.
-
-    The route function only needs the service for the duration of one
-    :func:`enumerate_chat_surfaces` call; this wrapper keeps the
-    ``with`` block readable.
-    """
-
-    def __init__(self, factory: Any, **kwargs: Any) -> None:
-        self._factory = factory
-        self._kwargs = kwargs
-        self._cm: Any = None
-
-    def __enter__(self) -> Any:
-        self._cm = self._factory(**self._kwargs)
-        return self._cm.__enter__()
-
-    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
-        if self._cm is not None:
-            try:
-                self._cm.__exit__(exc_type, exc, tb)
-            finally:
-                self._cm = None
-
-
-def _open_work_service_for_discovery(config: Any) -> _WorkServiceHandle | None:
-    """Best-effort handle for enumerating per-task workers.
-
-    Returns ``None`` when the work-service can't be opened (no DB
-    yet, pg pool down, etc.). The caller then enumerates configured
-    surfaces only — the send route never 500s because the worker
-    table is unreachable; it just won't recognise worker sessions.
-    """
-    try:
-        from pollypm.web_api.service import _open_work_service_readonly
-    except Exception:  # noqa: BLE001
-        return None
-    project = getattr(config, "project", None)
-    if project is None:
-        return None
-    project_key = getattr(project, "name", "")
-    project_path = getattr(project, "root_dir", None)
-    if not project_key or project_path is None:
-        return None
-    return _WorkServiceHandle(
-        _open_work_service_readonly,
-        config=config,
-        project_key=project_key,
-        project_path=project_path,
-    )
-
-
-# Test seam: a thin wrapper around the work-service open so tests can
-# monkeypatch :func:`_list_worker_sessions` without spinning up pg.
+# Test seam: routes monkeypatch this to inject fake worker records
+# without spinning up pg. The default implementation delegates to the
+# public :func:`pollypm.web_api.service.list_active_worker_sessions`
+# facade so chat_send doesn't reach into private service internals
+# (Codex #2043 review v3 block 3).
 def _list_worker_sessions(config: Any) -> list[Any]:
     """Return active :class:`WorkerSessionRecord` rows or ``[]``.
 
-    Wraps :func:`_open_work_service_readonly` so the per-task worker
-    validation gate stays mock-friendly. Failures fall back to an
-    empty list — strict mode then 404s the request (the safer
-    posture for an authenticated send call).
+    Delegates to the public service-layer facade. Tests monkeypatch
+    this module-level name (``chat_send_routes._list_worker_sessions``)
+    to feed fake records into :func:`_resolve_surface` without opening
+    a real work-service. Failures fall back to ``[]`` — strict mode
+    then 404s the request (the safer posture for a send call).
     """
-    handle = _open_work_service_for_discovery(config)
-    if handle is None:
-        return []
     try:
-        with handle as svc:
-            list_fn = getattr(svc, "list_worker_sessions", None)
-            if not callable(list_fn):
-                return []
-            try:
-                return list(list_fn(active_only=True)) or []
-            except Exception:  # noqa: BLE001
-                logger.debug(
-                    "chat_send: list_worker_sessions failed", exc_info=True,
-                )
-                return []
+        return list(list_active_worker_sessions(config)) or []
     except Exception:  # noqa: BLE001
         logger.debug(
-            "chat_send: _open_work_service_for_discovery failed", exc_info=True,
+            "chat_send: list_active_worker_sessions failed", exc_info=True,
         )
         return []
 
@@ -763,10 +755,22 @@ def _resolve_pane_target(
 ) -> tuple[str, bool]:
     """Return ``(target, present)`` for a window + optional pane index.
 
-    ``present`` is True when the window exists. When the window
-    exists but a requested pane index is out of range, this raises
-    ``409 pane_invalid``; a dead pane raises ``409 pane_dead``
-    (Codex #2043 review block 5).
+    ``present`` is True when the window exists.
+
+    - ``pane_index is None`` — default active-pane target
+      (``session:window``). Uses ``window.pane_dead`` from
+      ``list_windows`` as the liveness signal.
+    - ``pane_index >= 0`` (including 0) — explicit pane target. ALWAYS
+      probes ``list_panes(window_target)`` to verify the index exists
+      AND is alive, then routes to ``session:window.N``. Explicit
+      ``pane=0`` does NOT alias to the window-level target — tmux's
+      active pane is not necessarily index 0, and silently aliasing
+      bypasses the pane existence/liveness checks the explicit form
+      is supposed to add (Codex #2043 review v3 block 1).
+    - ``pane_index < 0`` — rejected with ``409 pane_invalid``.
+
+    Raises ``409 pane_invalid`` for out-of-range / missing panes,
+    ``409 pane_dead`` for dead panes (Codex #2043 review block 5).
     """
     try:
         windows = tmux.list_windows(storage_session)
@@ -779,20 +783,23 @@ def _resolve_pane_target(
     if not matching:
         return f"{storage_session}:{window_name}", False
     window = matching[0]
-    # Default-pane path: window.pane_dead from list_windows is the
-    # active-pane health bit, which is the right signal when the
-    # caller didn't pick a specific pane.
-    if pane_index is None or pane_index == 0:
+    # Default-pane path: caller didn't pick a specific pane, so we
+    # use tmux's active-pane target. window.pane_dead from
+    # list_windows is the active-pane health bit, which is the right
+    # signal here.
+    if pane_index is None:
         if window.pane_dead:
             raise _pane_dead(f"{storage_session}:{window_name}")
         return f"{storage_session}:{window_name}", True
-    # Specific pane requested. Pane indexes must be >= 0 and the pane
-    # has to exist on the window AND be alive. Without this gate a
-    # negative or out-of-range index slips through to ``send_keys``
-    # and surfaces as a 500.
-    if pane_index < 0:
-        raise _pane_invalid(pane_index, f"{storage_session}:{window_name}")
+    # Specific pane requested (including 0). Pane indexes must be
+    # >= 0 and the pane has to exist on the window AND be alive.
+    # Without this gate a negative or out-of-range index slips
+    # through to ``send_keys`` and surfaces as a 500 — and explicit
+    # ``pane=0`` would silently go to tmux's active pane, which is
+    # not guaranteed to be pane 0.
     window_target = f"{storage_session}:{window_name}"
+    if pane_index < 0:
+        raise _pane_invalid(pane_index, window_target)
     try:
         panes = tmux.list_panes(window_target)
     except Exception:  # noqa: BLE001
@@ -919,7 +926,41 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
     try:
         tmux.send_keys(target, text_to_send, press_enter=body.press_enter)
     except DeadPaneError as exc:
+        # Pane died between validation and send. Already mapped to a
+        # typed 409 before this refactor — keep that shape.
         raise _pane_dead(str(exc)) from exc
+    except FileNotFoundError as exc:
+        # Tmux binary missing entirely. The server can't reach tmux —
+        # this is a deployment problem, not a per-request bug.
+        raise _tmux_unavailable(f"tmux binary not found: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        # Tmux server itself wedged (see ``TmuxClient.run`` for the
+        # canonical 15s timeout). The send may or may not have landed;
+        # 503 lets the operator retry with knowledge of the cause.
+        raise _tmux_unavailable(
+            f"tmux command timed out after {exc.timeout}s",
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        # Most commonly: the window disappeared between
+        # ``list_windows`` validation and the actual ``send-keys``
+        # invocation (e.g. supervisor torn it down mid-request).
+        # ``send-keys`` returns exit code 1 with "can't find session"
+        # / "can't find window" on stderr. The window_missing envelope
+        # is documented for exactly this race (Codex #2043 review v3
+        # block 2).
+        stderr = (exc.stderr or "").strip().lower()
+        if "can't find" in stderr or "no such" in stderr or "session not found" in stderr:
+            raise _window_missing(target) from exc
+        # Other subprocess failures (permissions, malformed args we
+        # didn't sanitize, etc.) — generic send_failed envelope.
+        raise _send_failed(
+            target, exc.stderr.strip() if exc.stderr else f"exit {exc.returncode}",
+        ) from exc
+    except OSError as exc:
+        # Paste-buffer load failure (tempfile creation, load-buffer
+        # disk IO error). Map to send_failed so the operator can
+        # retry rather than seeing a 500.
+        raise _send_failed(target, str(exc)) from exc
     if body.press_enter:
         press_enter_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
 

--- a/src/pollypm/web_api/routes/chat_send.py
+++ b/src/pollypm/web_api/routes/chat_send.py
@@ -72,7 +72,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 import subprocess
 import uuid
 from datetime import UTC, datetime
@@ -89,7 +88,11 @@ from pollypm.web_api.chat import (
 )
 from pollypm.web_api.errors import APIError
 from pollypm.web_api.routes._deps import ConfigDep
-from pollypm.web_api.service import list_active_worker_sessions
+from pollypm.web_api.service import (
+    list_active_worker_sessions,
+    list_active_worker_sessions_strict,
+)
+from pollypm.work.task_state import parse_task_window_name
 
 logger = logging.getLogger(__name__)
 
@@ -165,13 +168,16 @@ class _WorkerFacadeUnavailable(Exception):
 # pattern check below lets ``_resolve_surface`` skip the worker facade
 # for sessions that syntactically cannot be workers, avoiding a pg hit
 # on every operator/architect/advisor send (Codex #2043 review v5
-# blocker 3).
-_WORKER_SESSION_PATTERN = re.compile(r"^task-[A-Za-z0-9_.-]+-\d+$")
+# blocker 3). Codex #2043 review v7 blocker 3: delegate to the
+# canonical parser in :mod:`pollypm.work.task_state` so we don't
+# duplicate the ``task-<project>-<n>`` regex (worker / project keys
+# may legitimately include ``_``, ``.``, ``-`` — the parser is the
+# source of truth).
 
 
 def _looks_like_worker_session(session_name: str) -> bool:
     """True when ``session_name`` syntactically matches ``task-<proj>-<n>``."""
-    return bool(_WORKER_SESSION_PATTERN.match(session_name))
+    return parse_task_window_name(session_name) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -492,26 +498,26 @@ def _list_worker_sessions(config: Any) -> list[Any]:
 
 
 def _list_worker_sessions_strict(config: Any) -> list[Any]:
-    """Strict worker-lookup: bypass the public facade.
+    """Strict worker-lookup via the public service facade.
 
-    Codex #2043 review v6 blocker 1: the public facade
+    Codex #2043 review v6 blocker 1 / v7 blocker 2: the *non-strict*
+    public facade
     :func:`pollypm.web_api.service.list_active_worker_sessions`
     swallows ``_open_work_service_readonly`` open failures and
     ``list_worker_sessions`` read failures and returns ``[]``. That
     conflates "no active workers" with "could not query workers", so
     a real pg / work-service outage on a ``task-<project>-<n>`` send
     fell out as ``404 session_unknown`` instead of
-    ``503 service_unavailable``. The v5 wrapper *would* have re-raised
-    if the facade itself raised, but the facade never raised in
-    production — it always returned ``[]``.
+    ``503 service_unavailable``.
 
-    This helper opens the work-service directly, so any failure on
-    the open OR the ``list_worker_sessions`` call propagates as a
-    typed :class:`_WorkerFacadeUnavailable` that :func:`_resolve_surface`
-    maps to ``503 service_unavailable``. A missing project (config
-    has no ``project``) returns ``[]`` (genuinely no workers, not an
-    outage). An empty list from a successful ``list_worker_sessions``
-    call also returns ``[]``.
+    v7 fix: route through the *strict* public facade
+    :func:`pollypm.web_api.service.list_active_worker_sessions_strict`
+    which propagates open/list failures. This wrapper then translates
+    any raised exception into the typed
+    :class:`_WorkerFacadeUnavailable` that :func:`_resolve_surface`
+    maps to ``503 service_unavailable``. Pre-v7 we reached into the
+    private ``_open_work_service_readonly`` context manager directly,
+    a service-boundary violation flagged by Codex round-7 review.
 
     Tests monkeypatch this module-level name to feed fake records or
     simulate the outage path without touching pg. The mandatory
@@ -519,25 +525,8 @@ def _list_worker_sessions_strict(config: Any) -> list[Any]:
     :func:`pollypm.web_api.service._open_work_service_readonly` to
     raise, exercising the real public-facade-bypass path end-to-end.
     """
-    project = getattr(config, "project", None)
-    if project is None:
-        return []
-    project_key = getattr(project, "name", "")
-    project_path = getattr(project, "root_dir", None)
-    if not project_key or project_path is None:
-        return []
     try:
-        from pollypm.web_api.service import _open_work_service_readonly
-
-        with _open_work_service_readonly(
-            config=config,
-            project_key=project_key,
-            project_path=project_path,
-        ) as work_service:
-            list_fn = getattr(work_service, "list_worker_sessions", None)
-            if not callable(list_fn):
-                return []
-            return list(list_fn(active_only=True))
+        return list(list_active_worker_sessions_strict(config))
     except _WorkerFacadeUnavailable:
         raise
     except Exception as exc:  # noqa: BLE001
@@ -1122,15 +1111,25 @@ def _tmux_session_for_send(config: Any, project_key: str | None) -> str:
     All chat surfaces (operator, architect, advisor, per-task workers)
     live inside the project's storage-closet session — matches the
     invariant the supervisor enforces
-    (``Supervisor.storage_closet_session_name``). We don't import the
-    supervisor here to keep the HTTP layer light; the suffix
-    convention is stable enough to inline.
+    (``Supervisor.storage_closet_session_name``).
+
+    Codex #2043 review v7 blocker 4: source the ``-storage-closet``
+    suffix from :data:`Supervisor._STORAGE_CLOSET_SESSION_SUFFIX` so
+    we don't inline the literal alongside the supervisor's own
+    builder. Mirrors :func:`pollypm.cli_features.tier4
+    ._resolve_storage_closet_session` and the runtime-services
+    ``storage_closet_name`` builder — keep one source of truth.
     """
+    from pollypm.supervisor import Supervisor
+
     project = getattr(config, "project", None)
     tmux_session = getattr(project, "tmux_session", None) if project else None
     if not isinstance(tmux_session, str) or not tmux_session:
         tmux_session = project_key or "pollypm"
-    return f"{tmux_session}-storage-closet"
+    suffix = getattr(
+        Supervisor, "_STORAGE_CLOSET_SESSION_SUFFIX", "-storage-closet",
+    )
+    return f"{tmux_session}{suffix}"
 
 
 def _resolve_pane_target(

--- a/src/pollypm/web_api/routes/chat_send.py
+++ b/src/pollypm/web_api/routes/chat_send.py
@@ -34,9 +34,16 @@ Safety gates per spec §4.1 / §4.3:
   :func:`pollypm.storage.pg_heartbeats.latest_heartbeat` and reject
   when it landed within the last 2s.
 
-``safety=strict`` (default) enforces both. ``safety=loose`` keeps the
-mid-tool check but allows mid-stream sends with a warning header.
-``safety=force`` bypasses the mid-tool / mid-stream /
+``safety=strict`` (default) enforces both AND fails closed when the
+signals themselves can't be evaluated — an unreadable transcript
+yields ``409 unsafe_unavailable_transcript`` and a pg/heartbeat outage
+yields ``409 unsafe_unavailable_heartbeat`` (Codex #2043 review v5
+blockers 1+2; pre-v5 both modes silently collapsed to "safe to
+send"). ``safety=loose`` keeps the mid-tool check but allows
+mid-stream sends with a warning header; on unavailable signals it
+continues with ``X-PollyPM-Warning: transcript-unavailable`` /
+``heartbeat-unavailable`` so the operator sees the gate was
+best-effort. ``safety=force`` bypasses the mid-tool / mid-stream /
 missing-transcript safety gates only. Pane and window existence +
 liveness errors (``409 pane_invalid``, ``409 pane_dead``,
 ``503 window_missing``, ``503 tmux_unavailable``) are NOT bypassed
@@ -65,6 +72,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import subprocess
 import uuid
 from datetime import UTC, datetime
@@ -86,6 +94,62 @@ from pollypm.web_api.service import list_active_worker_sessions
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Chat"])
+
+
+# ---------------------------------------------------------------------------
+# Strict-mode "signal unavailable" exceptions (Codex #2043 review v5)
+# ---------------------------------------------------------------------------
+#
+# Pre-v5 the tail reader returned ``[]`` on every read/decode failure and
+# the heartbeat helper returned ``None`` on every pg/import failure. Both
+# routes interpreted the "empty" signal as "no problem detected" — so an
+# unreadable transcript or a pg outage silently let a strict send
+# through. That defeated the whole point of strict mode.
+#
+# The fix is tri-state: distinguish "signal evaluated and clean" from
+# "signal could not be evaluated". The exceptions below mark the
+# unavailable case explicitly so the route can fail closed in strict
+# mode, emit a warning header in loose mode, and ignore in force mode.
+
+
+class TranscriptUnavailable(Exception):
+    """Raised when the transcript tail can't be evaluated.
+
+    Covers ``stat`` / ``open`` / ``read`` / ``decode`` failures on the
+    resolved ``events.jsonl``. The strict-mode mid-tool gate maps this
+    to ``409 unsafe_unavailable_transcript``; loose mode continues with
+    a warning header; force mode ignores entirely.
+    """
+
+
+class HeartbeatUnavailable(Exception):
+    """Raised when the heartbeat signal can't be evaluated.
+
+    Covers ``pollypm.storage.pg_heartbeats`` import failure,
+    ``latest_heartbeat`` raising (pg pool down, network outage,
+    auth failure), or a malformed ``created_at`` string. The
+    strict-mode mid-stream gate maps this to
+    ``409 unsafe_unavailable_heartbeat``; loose mode continues with a
+    warning header; force mode ignores entirely.
+
+    NOTE: a *missing* heartbeat row (no record exists for the session
+    yet) is NOT unavailable — that's a real "not streaming" signal and
+    the helper returns ``None`` for it. Only actual evaluation failures
+    raise.
+    """
+
+
+# Per-spec §2.3 — worker sessions follow ``task-<project>-<n>``. The
+# pattern check below lets ``_resolve_surface`` skip the worker facade
+# for sessions that syntactically cannot be workers, avoiding a pg hit
+# on every operator/architect/advisor send (Codex #2043 review v5
+# blocker 3).
+_WORKER_SESSION_PATTERN = re.compile(r"^task-[A-Za-z0-9_.-]+-\d+$")
+
+
+def _looks_like_worker_session(session_name: str) -> bool:
+    """True when ``session_name`` syntactically matches ``task-<proj>-<n>``."""
+    return bool(_WORKER_SESSION_PATTERN.match(session_name))
 
 
 # ---------------------------------------------------------------------------
@@ -131,9 +195,17 @@ class ChatSendRequest(BaseModel):
     safety: Literal["strict", "loose", "force"] = Field(
         default="strict",
         description=(
-            "Safety gate level: strict (default) enforces mid-tool and "
-            "mid-stream checks; loose keeps mid-tool but skips mid-stream "
-            "(emits warning header); force bypasses both."
+            "Safety gate level.\n\n"
+            "- strict (default): All safety gates active. Fails closed "
+            "(409) when signals are unavailable — unreadable transcript "
+            "yields unsafe_unavailable_transcript; pg/heartbeat outage "
+            "yields unsafe_unavailable_heartbeat.\n"
+            "- loose: Mid-tool gate active. Mid-stream check best-effort "
+            "with X-PollyPM-Warning header on unavailable signals "
+            "(agent-may-be-streaming, heartbeat-unavailable, "
+            "transcript-unavailable).\n"
+            "- force: All safety gates bypassed. Pane and window "
+            "validation still active."
         ),
     )
     pane: int | None = Field(
@@ -260,6 +332,74 @@ def _unsafe_mid_stream() -> APIError:
     )
 
 
+def _unsafe_unavailable_transcript(detail: str) -> APIError:
+    """Strict-mode fail-closed when the transcript can't be read.
+
+    Codex #2043 review v5 blocker 1: pre-v5 ``_read_events_tail``
+    returned ``[]`` on stat/open/read/decode failures, which the
+    mid-tool gate treated as "no open tools". An unreadable transcript
+    (chmod 000, IO error, rotated mid-request) therefore let a strict
+    send through. The fix raises :class:`TranscriptUnavailable` from
+    the reader and maps it here in strict mode.
+    """
+    return APIError(
+        status_code=409,
+        code="unsafe_unavailable_transcript",
+        message=(
+            "Refusing to send under safety=strict because the transcript "
+            f"can't be evaluated for mid-tool safety: {detail}. "
+            "Use safety=loose to continue with a best-effort warning, or "
+            "safety=force to bypass entirely."
+        ),
+    )
+
+
+def _unsafe_unavailable_heartbeat(detail: str) -> APIError:
+    """Strict-mode fail-closed when the heartbeat signal is unavailable.
+
+    Codex #2043 review v5 blocker 2: pre-v5 ``_heartbeat_age_seconds``
+    swallowed pg outages and returned ``None``, which the mid-stream
+    gate treated as "not streaming". A pg outage therefore let a
+    strict send through even though the endpoint couldn't tell whether
+    the agent was mid-stream. The fix raises
+    :class:`HeartbeatUnavailable` from the helper and maps it here.
+    """
+    return APIError(
+        status_code=409,
+        code="unsafe_unavailable_heartbeat",
+        message=(
+            "Refusing to send under safety=strict because the heartbeat "
+            f"signal can't be evaluated for mid-stream safety: {detail}. "
+            "Use safety=loose to continue with a best-effort warning, or "
+            "safety=force to bypass entirely."
+        ),
+    )
+
+
+def _service_unavailable_worker_lookup(detail: str) -> APIError:
+    """503 when the worker-session lookup fails for an actual worker name.
+
+    Codex #2043 review v5 blocker 3: the work-service facade returned
+    ``[]`` on both "no active workers" AND open/list failure. For a
+    request whose ``session_name`` syntactically matches the worker
+    pattern, that conflation hid pg outages as ``404 session_unknown``.
+    We now route real lookup failures to ``503 service_unavailable``
+    so operators can distinguish "no such worker" from "can't ask".
+    """
+    return APIError(
+        status_code=503,
+        code="service_unavailable",
+        message=(
+            "Worker-session lookup failed; cannot resolve session: "
+            f"{detail}"
+        ),
+        hint=(
+            "Retry the request once the work-service backing store is "
+            "reachable. Check pg pool health."
+        ),
+    )
+
+
 def _answer_to_missing(answer_to: str) -> APIError:
     return APIError(
         status_code=400,
@@ -300,22 +440,26 @@ def _selections_invalid(invalid: list[str], valid: list[str]) -> APIError:
 # public :func:`pollypm.web_api.service.list_active_worker_sessions`
 # facade so chat_send doesn't reach into private service internals
 # (Codex #2043 review v3 block 3).
+#
+# Codex #2043 review v5 blocker 3: this wrapper re-raises any
+# exception from the underlying facade so :func:`_resolve_surface`
+# can map "worker-syntactic session_name + lookup failed" to a typed
+# ``503 service_unavailable`` (instead of the previous ``[]``
+# fallback that masqueraded as ``404 session_unknown``). The facade
+# itself already catches and returns ``[]`` on failure — tests that
+# need to simulate a worker-service outage monkeypatch THIS wrapper
+# (or its caller) to raise.
 def _list_worker_sessions(config: Any) -> list[Any]:
     """Return active :class:`WorkerSessionRecord` rows or ``[]``.
 
     Delegates to the public service-layer facade. Tests monkeypatch
     this module-level name (``chat_send_routes._list_worker_sessions``)
-    to feed fake records into :func:`_resolve_surface` without opening
-    a real work-service. Failures fall back to ``[]`` — strict mode
-    then 404s the request (the safer posture for a send call).
+    to feed fake records into :func:`_resolve_surface`. Raises any
+    exception from the underlying facade so the resolver can map
+    worker-pattern lookup failure to a typed 503 — see the
+    ``_resolve_surface`` body for that mapping.
     """
-    try:
-        return list(list_active_worker_sessions(config)) or []
-    except Exception:  # noqa: BLE001
-        logger.debug(
-            "chat_send: list_active_worker_sessions failed", exc_info=True,
-        )
-        return []
+    return list(list_active_worker_sessions(config)) or []
 
 
 # ---------------------------------------------------------------------------
@@ -332,13 +476,36 @@ def _resolve_surface(config: Any, session_name: str) -> ChatSurface:
     valid ``task-{project}-{id}`` name is rejected with
     ``404 session_unknown`` when no matching active worker is
     registered (Codex #2043 review block 2).
+
+    Worker-facade gating (Codex #2043 review v5 blocker 3):
+
+    * The worker facade is **only** queried when ``session_name``
+      syntactically matches ``task-<project>-<n>``. Operator /
+      architect / advisor sends never pay pg cost — pre-v5 every send
+      opened the work-service facade for the worker enumeration.
+    * If the lookup itself fails (pool down, table missing) for a
+      worker-syntactic name, we raise ``503 service_unavailable``
+      instead of letting the empty list collapse into a misleading
+      ``404 session_unknown``. The operator needs to know the answer
+      was "couldn't ask" rather than "definitely not registered".
     """
-    # Build a fake-handle-aware enumeration: P1's facade takes a
-    # ``work_service`` whose only contract is ``list_worker_sessions``.
-    # We pass a small adapter so tests that monkeypatch
-    # ``_list_worker_sessions`` Just Work without touching the
-    # work-service factory.
-    worker_records = _list_worker_sessions(config)
+    is_worker_pattern = _looks_like_worker_session(session_name)
+    worker_records: list[Any]
+    if is_worker_pattern:
+        try:
+            worker_records = _list_worker_sessions(config)
+        except Exception as exc:  # noqa: BLE001
+            # Worker-pattern name + lookup raised → tell the operator
+            # the lookup failed instead of returning 404 (which would
+            # imply the worker definitely isn't registered).
+            logger.debug(
+                "chat_send: worker session lookup failed for %r",
+                session_name,
+                exc_info=True,
+            )
+            raise _service_unavailable_worker_lookup(str(exc) or type(exc).__name__) from exc
+    else:
+        worker_records = []
 
     class _Adapter:
         @staticmethod
@@ -383,27 +550,58 @@ def _read_events_tail(
     long-running sessions don't force the whole transcript into memory
     each request. Skips the (likely truncated) first line when the
     file is larger than ``max_bytes``.
+
+    Tri-state failure semantics (Codex #2043 review v5 blocker 1):
+
+    * Returns ``[]`` when the file does not exist OR exists with zero
+      bytes — that's an unambiguous "no transcript content yet"
+      signal that the mid-tool gate treats as safe.
+    * Raises :class:`TranscriptUnavailable` when the file *exists*
+      but can't be evaluated (``stat`` succeeded but ``open``/``read``
+      raised ``OSError``, decode raised, etc.). Pre-v5 these all
+      collapsed into the empty list, so chmod 000 on an events.jsonl
+      with an open ``tool_call`` made the strict-mode mid-tool gate
+      fail open.
+
+    Per-line JSON parse failures still skip silently — a single
+    malformed mid-stream line shouldn't void the whole tail.
     """
     try:
         size = events_path.stat().st_size
-    except OSError:
+    except FileNotFoundError:
+        # No transcript yet — distinct from "can't read"; safe.
         return []
+    except OSError as exc:
+        raise TranscriptUnavailable(
+            f"stat({events_path}) failed: {exc}",
+        ) from exc
     if size == 0:
         return []
     start = max(0, size - max_bytes)
     try:
         fd = os.open(events_path, os.O_RDONLY)
-    except OSError:
-        return []
+    except OSError as exc:
+        # File exists (we just stat'd it) but we can't open it —
+        # permissions error, race with rotation, FS error. Unavailable.
+        raise TranscriptUnavailable(
+            f"open({events_path}) failed: {exc}",
+        ) from exc
     try:
-        os.lseek(fd, start, os.SEEK_SET)
-        raw = os.read(fd, size - start)
+        try:
+            os.lseek(fd, start, os.SEEK_SET)
+            raw = os.read(fd, size - start)
+        except OSError as exc:
+            raise TranscriptUnavailable(
+                f"read({events_path}) failed: {exc}",
+            ) from exc
     finally:
         os.close(fd)
     try:
         text = raw.decode("utf-8", errors="replace")
-    except Exception:  # noqa: BLE001
-        return []
+    except Exception as exc:  # noqa: BLE001
+        raise TranscriptUnavailable(
+            f"decode({events_path}) failed: {exc}",
+        ) from exc
     lines = text.splitlines()
     if start > 0 and lines:
         # First line is almost certainly truncated mid-record.
@@ -418,6 +616,8 @@ def _read_events_tail(
 
             obj = json.loads(line)
         except Exception:  # noqa: BLE001
+            # Per-line parse failures: skip — one bad line shouldn't
+            # void the whole tail.
             continue
         if isinstance(obj, dict):
             events.append(obj)
@@ -563,6 +763,11 @@ def _is_mid_tool(
     from the gate — used to allow the ``answer_to`` ask_user reply
     path through (the AskUserQuestion stays "open" until the user
     types a response, see :func:`_last_assistant_open_tool_ids`).
+
+    Propagates :class:`TranscriptUnavailable` from
+    :func:`_read_events_tail` so the caller can map it per safety
+    level (Codex #2043 review v5 blocker 1). Returning ``False`` here
+    on read failure (the pre-v5 behavior) defeats strict mode.
     """
     if events_path is None:
         return False
@@ -586,21 +791,40 @@ def _heartbeat_age_seconds(config: Any, session_name: str) -> float | None:
     """Return seconds since ``session_name``'s latest heartbeat, or ``None``.
 
     Reads via :func:`pollypm.storage.pg_heartbeats.latest_heartbeat`
-    (pg-only). Any failure is treated as "no signal" — the caller
-    fails-open so a flaky pool doesn't block legitimate sends.
+    (pg-only).
+
+    Tri-state semantics (Codex #2043 review v5 blocker 2):
+
+    * ``float`` — heartbeat record exists and is parseable; value is
+      seconds since it landed.
+    * ``None`` — no heartbeat record exists yet for the session
+      (genuine "not streaming" — safe).
+    * Raises :class:`HeartbeatUnavailable` — the lookup itself
+      failed (pg outage, import failure, malformed timestamp). The
+      route maps to ``409 unsafe_unavailable_heartbeat`` in strict
+      mode rather than silently failing open.
+
+    Pre-v5 every failure mode collapsed to ``None``, which the
+    mid-stream gate interpreted as "not streaming" — a pg outage
+    therefore allowed a strict send through.
     """
     try:
         from pollypm.storage.pg_heartbeats import latest_heartbeat
-    except Exception:  # noqa: BLE001
-        return None
+    except Exception as exc:  # noqa: BLE001
+        raise HeartbeatUnavailable(
+            f"pollypm.storage.pg_heartbeats import failed: {exc}",
+        ) from exc
     try:
         record = latest_heartbeat(session_name, config=config)
-    except Exception:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
         logger.debug(
             "chat_send: pg_heartbeats.latest_heartbeat failed", exc_info=True,
         )
-        return None
+        raise HeartbeatUnavailable(
+            f"latest_heartbeat({session_name!r}) raised: {exc}",
+        ) from exc
     if record is None:
+        # Genuine "no row" — safe; not unavailable.
         return None
     stamp = record.created_at
     try:
@@ -608,8 +832,13 @@ def _heartbeat_age_seconds(config: Any, session_name: str) -> float | None:
             stamp.replace("Z", "+00:00") if stamp.endswith("Z") else stamp
         )
         ts = datetime.fromisoformat(normalised)
-    except (TypeError, ValueError):
-        return None
+    except (TypeError, ValueError, AttributeError) as exc:
+        # Record exists but the timestamp is malformed — we *do* have
+        # a signal, we just can't interpret it. Treat as unavailable
+        # rather than "no record" so strict mode fails closed.
+        raise HeartbeatUnavailable(
+            f"malformed heartbeat timestamp {stamp!r}: {exc}",
+        ) from exc
     if ts.tzinfo is None:
         ts = ts.replace(tzinfo=UTC)
     return max(0.0, (datetime.now(UTC) - ts).total_seconds())
@@ -644,7 +873,14 @@ def _find_ask_user_envelope(
     """
     if events_path is None:
         return None
-    events = _read_events_tail(events_path)
+    try:
+        events = _read_events_tail(events_path)
+    except TranscriptUnavailable:
+        # Surface the same fail-closed signal the mid-tool gate would
+        # raise; the route decides how to handle per safety level.
+        # Re-raise so the route's strict/loose/force fan-out applies
+        # uniformly instead of silently returning "not found" here.
+        raise
     # P1's envelope id is ``msg_<tool_use_id>``; the raw events.jsonl
     # only carries the bare id. Try both forms so the route accepts
     # the envelope id the GET endpoints hand out AND the raw id.
@@ -965,11 +1201,33 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
     # AskUserQuestion has no matching tool_result until the user
     # types a response — without this carveout the strict gate 409s
     # every legitimate ``answer_to`` send.
+    #
+    # Transcript-unavailable handling (Codex #2043 review v5
+    # blocker 1) is uniform across this lookup and the mid-tool gate:
+    # strict mode fails closed via ``unsafe_unavailable_transcript``,
+    # loose mode continues with a warning header, force mode ignores
+    # the failure entirely. We track the helper's outcome rather than
+    # short-circuiting on the first call so the warning header lands
+    # even when the answer_to lookup is what raised.
     events_path, resolution = _resolve_session_events(surface, project_root)
     ask_envelope: dict[str, Any] | None = None
     ask_exempt_ids: set[str] = set()
+    transcript_unavailable_detail: str | None = None
     if body.answer_to is not None:
-        ask_envelope = _find_ask_user_envelope(events_path, body.answer_to)
+        try:
+            ask_envelope = _find_ask_user_envelope(events_path, body.answer_to)
+        except TranscriptUnavailable as exc:
+            transcript_unavailable_detail = str(exc)
+            # Strict and loose can't validate the answer_to lookup
+            # without the transcript. Force still proceeds (no
+            # ask_envelope means selections-only sends will fail
+            # later — that's fine; force is "I know what I'm doing").
+            if body.safety == "strict":
+                raise _unsafe_unavailable_transcript(str(exc)) from exc
+            # loose: continue; the answer_to branch below will surface
+            # ``answer_to_missing`` if the envelope can't be found, and
+            # we emit the warning header at the end of the safety
+            # block.
         if ask_envelope is not None:
             # The exempted id is the raw ``payload.id`` because the
             # mid-tool gate matches on that field; the envelope id
@@ -989,14 +1247,40 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
             # almost certainly addressing the wrong session_name.
             # Fail closed; safety=force bypasses.
             raise _unsafe_mid_tool()
-        if _is_mid_tool(events_path, exempt_tool_ids=ask_exempt_ids):
-            raise _unsafe_mid_tool()
-        age = _heartbeat_age_seconds(config, session_name)
-        streaming = age is not None and age < _MID_STREAM_WINDOW_SECONDS
+        try:
+            if _is_mid_tool(events_path, exempt_tool_ids=ask_exempt_ids):
+                raise _unsafe_mid_tool()
+        except TranscriptUnavailable as exc:
+            transcript_unavailable_detail = (
+                transcript_unavailable_detail or str(exc)
+            )
+            if body.safety == "strict":
+                raise _unsafe_unavailable_transcript(str(exc)) from exc
+            # loose: continue — warning header is set below.
+        try:
+            age = _heartbeat_age_seconds(config, session_name)
+        except HeartbeatUnavailable as exc:
+            # Strict: fail closed; loose: continue with warning header.
+            if body.safety == "strict":
+                raise _unsafe_unavailable_heartbeat(str(exc)) from exc
+            # loose
+            response.headers["X-PollyPM-Warning"] = "heartbeat-unavailable"
+            streaming = False
+        else:
+            streaming = age is not None and age < _MID_STREAM_WINDOW_SECONDS
         if body.safety == "strict" and streaming:
             raise _unsafe_mid_stream()
         if body.safety == "loose" and streaming:
             response.headers["X-PollyPM-Warning"] = "agent-may-be-streaming"
+        if (
+            body.safety == "loose"
+            and transcript_unavailable_detail is not None
+            and "X-PollyPM-Warning" not in response.headers
+        ):
+            # Loose mode + unreadable transcript: continue but surface
+            # the best-effort warning so the operator knows the
+            # mid-tool gate couldn't actually be evaluated.
+            response.headers["X-PollyPM-Warning"] = "transcript-unavailable"
 
     # 4. AskUserQuestion answer handling (§4.5).
     text_to_send: str | None
@@ -1092,6 +1376,8 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
 __all__ = [
     "ChatSendRequest",
     "ChatSendResponse",
+    "HeartbeatUnavailable",
+    "TranscriptUnavailable",
     "router",
     "send_chat_message",
 ]

--- a/src/pollypm/web_api/routes/chat_send.py
+++ b/src/pollypm/web_api/routes/chat_send.py
@@ -36,7 +36,11 @@ Safety gates per spec §4.1 / §4.3:
 
 ``safety=strict`` (default) enforces both. ``safety=loose`` keeps the
 mid-tool check but allows mid-stream sends with a warning header.
-``safety=force`` bypasses everything.
+``safety=force`` bypasses the mid-tool / mid-stream /
+missing-transcript safety gates only. Pane and window existence +
+liveness errors (``409 pane_invalid``, ``409 pane_dead``,
+``503 window_missing``, ``503 tmux_unavailable``) are NOT bypassed
+and will still fail-closed.
 
 Pane validation: explicit ``pane`` (including ``pane=0``) always goes
 through ``list_panes(target)`` to verify the requested index exists
@@ -488,7 +492,11 @@ def _resolve_session_events(
     return None, "absent_clean"
 
 
-def _last_assistant_open_tool_ids(events: list[dict[str, Any]]) -> set[str]:
+def _last_assistant_open_tool_ids(
+    events: list[dict[str, Any]],
+    *,
+    exempt_tool_ids: set[str] | None = None,
+) -> set[str]:
     """Return ``tool_use_id``s in the *current* assistant turn lacking a result.
 
     The intuition is "is the agent right now waiting on a tool result
@@ -504,6 +512,14 @@ def _last_assistant_open_tool_ids(events: list[dict[str, Any]]) -> set[str]:
     ``tool_call`` events without a preceding ``assistant_turn`` —
     anchoring on ``user_turn`` instead means the mid-tool gate still
     fires for that case (Codex #2043 review block 4).
+
+    ``exempt_tool_ids`` carves out tool_use ids that the *caller* is
+    answering. A real AskUserQuestion stays "open" (no tool_result
+    until the user types) so without this carveout the strict gate
+    409s every ``answer_to`` send. The carveout is intentionally
+    narrow — only the specific id the caller addresses is exempted;
+    any *other* open tool still blocks the send (Codex #2043 review
+    v4 block 1).
     """
     # Find the most-recent boundary (user_turn or assistant_turn).
     # Everything after that belongs to the current in-flight response.
@@ -530,19 +546,32 @@ def _last_assistant_open_tool_ids(events: list[dict[str, Any]]) -> set[str]:
             tid = payload.get("tool_use_id")
             if isinstance(tid, str) and tid:
                 seen_results.add(tid)
-    return open_ids - seen_results
+    unmatched = open_ids - seen_results
+    if exempt_tool_ids:
+        unmatched -= exempt_tool_ids
+    return unmatched
 
 
 def _is_mid_tool(
     events_path: Path | None,
+    *,
+    exempt_tool_ids: set[str] | None = None,
 ) -> bool:
-    """True when ``events_path``'s tail shows an unmatched tool_use."""
+    """True when ``events_path``'s tail shows an unmatched tool_use.
+
+    ``exempt_tool_ids`` lets the caller exclude specific tool_use ids
+    from the gate — used to allow the ``answer_to`` ask_user reply
+    path through (the AskUserQuestion stays "open" until the user
+    types a response, see :func:`_last_assistant_open_tool_ids`).
+    """
     if events_path is None:
         return False
     events = _read_events_tail(events_path)
     if not events:
         return False
-    return bool(_last_assistant_open_tool_ids(events))
+    return bool(
+        _last_assistant_open_tool_ids(events, exempt_tool_ids=exempt_tool_ids),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -600,12 +629,33 @@ def _find_ask_user_envelope(
     Returns the parsed event dict or ``None`` if the id isn't in the
     tail. The lookup is restricted to the events tail — the spec
     only supports answering the most-recent open question.
+
+    Message id contract: P1's :func:`pollypm.web_api.chat.transcripts.
+    _envelope_id` returns ``msg_<tool_use_id>`` for tool_call envelopes
+    (see ``transcripts.py:398-415`` and ``_envelope_ask_user`` at
+    ``transcripts.py:690-720``). A client reading GET ``/messages``
+    therefore sees the envelope id as ``msg_toolu_ask`` and POSTs
+    ``answer_to=msg_toolu_ask``. The raw events.jsonl payload carries
+    only ``toolu_ask`` in ``payload.id`` though, so we normalise the
+    incoming ``answer_to`` by stripping the ``msg_`` prefix before the
+    lookup — and also try the literal value so callers that pass the
+    raw id (CLI tooling, integration tests) still resolve.
+    (Codex #2043 review v4 block 2.)
     """
     if events_path is None:
         return None
     events = _read_events_tail(events_path)
+    # P1's envelope id is ``msg_<tool_use_id>``; the raw events.jsonl
+    # only carries the bare id. Try both forms so the route accepts
+    # the envelope id the GET endpoints hand out AND the raw id.
+    candidates = {answer_to}
+    if answer_to.startswith("msg_"):
+        candidates.add(answer_to[len("msg_"):])
     for event in events:
-        if _event_message_id(event) == answer_to:
+        event_id = _event_message_id(event)
+        if event_id is None:
+            continue
+        if event_id in candidates:
             return event
     return None
 
@@ -771,14 +821,40 @@ def _resolve_pane_target(
 
     Raises ``409 pane_invalid`` for out-of-range / missing panes,
     ``409 pane_dead`` for dead panes (Codex #2043 review block 5).
+    Distinguishes "tmux itself is down" (``503 tmux_unavailable``)
+    from "the window/pane doesn't exist" (``503 window_missing`` /
+    ``409 pane_invalid``) so the operator gets actionable typed
+    errors instead of generic 500s (Codex #2043 review v4 block 3).
     """
     try:
         windows = tmux.list_windows(storage_session)
-    except Exception:  # noqa: BLE001
+    except FileNotFoundError as exc:
+        # tmux binary not on PATH — deployment failure, not a
+        # per-request bug.
+        raise _tmux_unavailable(f"tmux binary not found: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        # tmux server wedged (see ``TmuxClient.run`` 15s default).
+        raise _tmux_unavailable(
+            f"tmux command timed out after {exc.timeout}s",
+        ) from exc
+    except subprocess.CalledProcessError:
+        # ``list-windows`` exits non-zero when the target session
+        # doesn't exist (e.g. storage-closet was torn down). That's
+        # the documented ``window_missing`` envelope — surface it
+        # as "absent" rather than tmux-down so the operator restarts
+        # the right thing.
         logger.debug(
-            "chat_send: list_windows(%r) failed", storage_session, exc_info=True,
+            "chat_send: list_windows(%r) CalledProcessError",
+            storage_session,
+            exc_info=True,
         )
         return f"{storage_session}:{window_name}", False
+    except OSError as exc:
+        # Other subprocess plumbing errors (permission denied on
+        # ``tmux`` binary, etc.) — treat as tmux_unavailable so the
+        # operator looks at the deployment, not at this specific
+        # window.
+        raise _tmux_unavailable(str(exc)) from exc
     matching = [w for w in windows if w.name == window_name]
     if not matching:
         return f"{storage_session}:{window_name}", False
@@ -802,13 +878,33 @@ def _resolve_pane_target(
         raise _pane_invalid(pane_index, window_target)
     try:
         panes = tmux.list_panes(window_target)
-    except Exception:  # noqa: BLE001
+    except FileNotFoundError as exc:
+        raise _tmux_unavailable(f"tmux binary not found: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise _tmux_unavailable(
+            f"tmux command timed out after {exc.timeout}s",
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        # ``list-panes`` exits non-zero when the *target* (window) no
+        # longer exists. That's an "actionable for the operator"
+        # state — surface as pane_invalid so they pick a different
+        # pane / surface, rather than blaming tmux.
+        logger.debug(
+            "chat_send: list_panes(%r) CalledProcessError",
+            window_target,
+            exc_info=True,
+        )
+        raise _pane_invalid(pane_index, window_target) from exc
+    except OSError as exc:
+        raise _tmux_unavailable(str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001
+        # Fake clients / unforeseen errors — preserve the original
+        # pane_invalid mapping to avoid a 500 leak. The narrow
+        # subprocess branches above cover the production cases.
         logger.debug(
             "chat_send: list_panes(%r) failed", window_target, exc_info=True,
         )
-        # Without pane visibility we can't validate; refuse rather
-        # than leak the raw subprocess error.
-        raise _pane_invalid(pane_index, window_target) from None
+        raise _pane_invalid(pane_index, window_target) from exc
     match = next((p for p in panes if p.pane_index == pane_index), None)
     if match is None:
         raise _pane_invalid(pane_index, window_target)
@@ -863,9 +959,28 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
 
     project_root = _resolve_project_root(config, project_key)
 
-    # 2. Safety gates (§4.1, §4.3) — use the exact session transcript
-    # (Codex review block 3).
+    # 2. AskUserQuestion answer lookup runs BEFORE the safety gates so
+    # we can exempt the specific ask_user tool_use_id from the
+    # mid-tool check (Codex #2043 review v4 block 1). A real
+    # AskUserQuestion has no matching tool_result until the user
+    # types a response — without this carveout the strict gate 409s
+    # every legitimate ``answer_to`` send.
     events_path, resolution = _resolve_session_events(surface, project_root)
+    ask_envelope: dict[str, Any] | None = None
+    ask_exempt_ids: set[str] = set()
+    if body.answer_to is not None:
+        ask_envelope = _find_ask_user_envelope(events_path, body.answer_to)
+        if ask_envelope is not None:
+            # The exempted id is the raw ``payload.id`` because the
+            # mid-tool gate matches on that field; the envelope id
+            # comparison was already normalised inside
+            # ``_find_ask_user_envelope``.
+            raw_id = _event_message_id(ask_envelope)
+            if isinstance(raw_id, str) and raw_id:
+                ask_exempt_ids.add(raw_id)
+
+    # 3. Safety gates (§4.1, §4.3) — use the exact session transcript
+    # (Codex review block 3).
     if body.safety != "force":
         if resolution == "absent_but_others_exist":
             # Strict and loose both require an exact transcript
@@ -874,7 +989,7 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
             # almost certainly addressing the wrong session_name.
             # Fail closed; safety=force bypasses.
             raise _unsafe_mid_tool()
-        if _is_mid_tool(events_path):
+        if _is_mid_tool(events_path, exempt_tool_ids=ask_exempt_ids):
             raise _unsafe_mid_tool()
         age = _heartbeat_age_seconds(config, session_name)
         streaming = age is not None and age < _MID_STREAM_WINDOW_SECONDS
@@ -883,13 +998,12 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
         if body.safety == "loose" and streaming:
             response.headers["X-PollyPM-Warning"] = "agent-may-be-streaming"
 
-    # 3. AskUserQuestion answer handling (§4.5).
+    # 4. AskUserQuestion answer handling (§4.5).
     text_to_send: str | None
     if body.answer_to is not None:
-        envelope = _find_ask_user_envelope(events_path, body.answer_to)
-        if envelope is None:
+        if ask_envelope is None:
             raise _answer_to_missing(body.answer_to)
-        options = _ask_user_options(envelope)
+        options = _ask_user_options(ask_envelope)
         if options is None:
             raise _selections_no_question(body.answer_to)
         invalid = [s for s in body.selections if s not in options]
@@ -918,7 +1032,7 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
 
     assert text_to_send is not None  # noqa: S101 — narrowed above
 
-    # 4. Send via tmux.
+    # 5. Send via tmux.
     method: Literal["send_keys", "paste_buffer"] = (
         "paste_buffer" if len(text_to_send) > 100 else "send_keys"
     )

--- a/src/pollypm/web_api/routes/chat_send.py
+++ b/src/pollypm/web_api/routes/chat_send.py
@@ -1,47 +1,49 @@
-"""POST chat-send endpoint (Phase 1 — P3 of the chat-endpoints spec).
+"""POST chat-send endpoint — P3 of the chat-endpoints spec.
 
-Implements:
+Implements ``POST /api/v1/chat/{session_name}/send`` — push a message
+into the running CLI agent backing ``session_name`` via tmux.
 
-- ``POST /api/v1/chat/{session_name}/send`` — push a message into
-  the running CLI agent backing ``session_name`` via tmux.
+The router is a thin adapter over the P1 shared facade in
+:mod:`pollypm.web_api.chat`:
 
-Per ``~/Desktop/pollypm-chat-endpoints-spec.md`` §2.3 / §4. The router
-owns:
+- :func:`pollypm.web_api.chat.enumerate_chat_surfaces` resolves
+  ``session_name`` → :class:`ChatSurface` (window, transcript, cwd).
+  Workers are validated against the work-service's active
+  :class:`WorkerSessionRecord` rows; an authenticated caller cannot
+  address a stale or unrelated tmux window by guessing
+  ``task-{project}-{id}`` names (Codex review block 2 in #2043).
+- :func:`pollypm.web_api.chat.resolve_transcript_path` produces the
+  exact ``events.jsonl`` for the session, with ``cwd``-based scoping
+  so multi-session projects don't bleed transcripts (Codex review
+  block 3 in #2043). Strict safety fails closed when the resolver
+  can only fall back to "freshest" — ``safety=force`` bypasses.
+- :class:`pollypm.web_api.chat.MessageEnvelope` / the AskUserQuestion
+  detection helpers route from the same transcript parser the read
+  endpoints (P2) use.
 
-1. Session lookup — ``config.sessions[session_name]`` first, then a
-   work-service fall-back for per-task workers whose ``session_name``
-   has the canonical shape ``task-{project}-{task_id}`` (see
-   :func:`pollypm.work.session_manager.task_window_name`).
-2. tmux target resolution — ``<storage-closet>:<window_name>`` for
-   configured sessions; ``<project>-storage-closet:<task-window>``
-   for workers. Presence is verified via
-   :meth:`pollypm.tmux.client.TmuxClient.list_windows` and the
-   ``pane_dead`` flag.
-3. Safety gates (§4.1, §4.3) —
+Safety gates per spec §4.1 / §4.3:
 
-   * Mid-tool: tail-read the session's ``events.jsonl`` and reject if
-     the most-recent assistant turn has an unmatched ``tool_use_id``.
-   * Mid-stream: read the latest heartbeat from
-     :func:`pollypm.storage.pg_heartbeats.latest_heartbeat` and reject
-     if it landed within the last 2 seconds.
+- **Mid-tool** — tail-read the resolved ``events.jsonl`` and reject
+  when the latest assistant response has unmatched ``tool_use`` ids.
+  Tool-only assistant turns (no text → no ``assistant_turn``) are
+  caught by anchoring on the most-recent ``user_turn`` boundary
+  (Codex review block 4 in #2043).
+- **Mid-stream** — read the latest heartbeat from
+  :func:`pollypm.storage.pg_heartbeats.latest_heartbeat` and reject
+  when it landed within the last 2s.
 
-   ``safety=strict`` (default) enforces both. ``safety=loose`` keeps
-   the mid-tool check but allows mid-stream sends with a warning
-   header. ``safety=force`` bypasses everything.
-4. AskUserQuestion answer translation (§4.5) — when ``answer_to`` is
-   set, the router resolves the referenced ``ask_user`` envelope from
-   the transcript, validates each ``selections`` entry against the
-   question's options, and types the option labels joined by newlines
-   (followed by optional ``notes``) into the pane.
+``safety=strict`` (default) enforces both. ``safety=loose`` keeps the
+mid-tool check but allows mid-stream sends with a warning header.
+``safety=force`` bypasses everything.
 
-The router intentionally does NOT touch storage writes for the send
-itself — the user-visible side effect is the tmux ``send-keys`` call.
-The transcript will pick the message up on the next ingest tick.
+Pane validation: ``pane >= 0`` plus a ``list_panes`` probe verifies the
+requested pane exists AND is alive before any ``send_keys``. Negative
+or nonexistent panes now raise ``409 pane_invalid`` / ``409 pane_dead``
+instead of leaking subprocess errors (Codex review block 5 in #2043).
 """
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import uuid
@@ -52,8 +54,11 @@ from typing import Any, Literal
 from fastapi import APIRouter, Response
 from pydantic import BaseModel, Field
 
-from pollypm.projects import project_transcripts_dir
 from pollypm.tmux.client import DeadPaneError, TmuxClient
+from pollypm.web_api.chat import (
+    ChatSurface,
+    enumerate_chat_surfaces,
+)
 from pollypm.web_api.errors import APIError
 from pollypm.web_api.routes._deps import ConfigDep
 
@@ -142,8 +147,8 @@ def _session_unknown(session_name: str) -> APIError:
         code="session_unknown",
         message=f"No chat surface registered for session: {session_name!r}",
         hint=(
-            "Use GET /api/v1/chat/sessions to discover registered surfaces, "
-            "or check config.sessions / work-service for per-task workers."
+            "Use GET /api/v1/chat/sessions to discover registered surfaces. "
+            "Per-task workers must appear in WorkService.list_worker_sessions."
         ),
     )
 
@@ -162,6 +167,17 @@ def _pane_dead(target: str) -> APIError:
         status_code=409,
         code="pane_dead",
         message=f"tmux pane is dead: {target}",
+    )
+
+
+def _pane_invalid(pane: int, target: str) -> APIError:
+    return APIError(
+        status_code=409,
+        code="pane_invalid",
+        message=(
+            f"Pane index {pane} is not valid for window {target!r}. "
+            "Pane must be >= 0 and refer to an existing pane."
+        ),
     )
 
 
@@ -218,89 +234,134 @@ def _selections_invalid(invalid: list[str], valid: list[str]) -> APIError:
 
 
 # ---------------------------------------------------------------------------
+# Worker-service handle (mirrors P2's pattern in chat_messages.py)
+# ---------------------------------------------------------------------------
+
+
+class _WorkServiceHandle:
+    """Defers the ``_open_work_service_readonly`` ctx until first use.
+
+    The route function only needs the service for the duration of one
+    :func:`enumerate_chat_surfaces` call; this wrapper keeps the
+    ``with`` block readable.
+    """
+
+    def __init__(self, factory: Any, **kwargs: Any) -> None:
+        self._factory = factory
+        self._kwargs = kwargs
+        self._cm: Any = None
+
+    def __enter__(self) -> Any:
+        self._cm = self._factory(**self._kwargs)
+        return self._cm.__enter__()
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        if self._cm is not None:
+            try:
+                self._cm.__exit__(exc_type, exc, tb)
+            finally:
+                self._cm = None
+
+
+def _open_work_service_for_discovery(config: Any) -> _WorkServiceHandle | None:
+    """Best-effort handle for enumerating per-task workers.
+
+    Returns ``None`` when the work-service can't be opened (no DB
+    yet, pg pool down, etc.). The caller then enumerates configured
+    surfaces only — the send route never 500s because the worker
+    table is unreachable; it just won't recognise worker sessions.
+    """
+    try:
+        from pollypm.web_api.service import _open_work_service_readonly
+    except Exception:  # noqa: BLE001
+        return None
+    project = getattr(config, "project", None)
+    if project is None:
+        return None
+    project_key = getattr(project, "name", "")
+    project_path = getattr(project, "root_dir", None)
+    if not project_key or project_path is None:
+        return None
+    return _WorkServiceHandle(
+        _open_work_service_readonly,
+        config=config,
+        project_key=project_key,
+        project_path=project_path,
+    )
+
+
+# Test seam: a thin wrapper around the work-service open so tests can
+# monkeypatch :func:`_list_worker_sessions` without spinning up pg.
+def _list_worker_sessions(config: Any) -> list[Any]:
+    """Return active :class:`WorkerSessionRecord` rows or ``[]``.
+
+    Wraps :func:`_open_work_service_readonly` so the per-task worker
+    validation gate stays mock-friendly. Failures fall back to an
+    empty list — strict mode then 404s the request (the safer
+    posture for an authenticated send call).
+    """
+    handle = _open_work_service_for_discovery(config)
+    if handle is None:
+        return []
+    try:
+        with handle as svc:
+            list_fn = getattr(svc, "list_worker_sessions", None)
+            if not callable(list_fn):
+                return []
+            try:
+                return list(list_fn(active_only=True)) or []
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "chat_send: list_worker_sessions failed", exc_info=True,
+                )
+                return []
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "chat_send: _open_work_service_for_discovery failed", exc_info=True,
+        )
+        return []
+
+
+# ---------------------------------------------------------------------------
 # Session resolution
 # ---------------------------------------------------------------------------
 
 
-def _parse_task_session_name(session_name: str) -> tuple[str, int] | None:
-    """Split ``task-{project}-{task_id}`` into ``(project, task_id)``.
+def _resolve_surface(config: Any, session_name: str) -> ChatSurface:
+    """Resolve ``session_name`` → :class:`ChatSurface` via the P1 facade.
 
-    Mirrors :func:`pollypm.work.session_manager.task_window_name` —
-    workers don't appear in ``config.sessions`` so the resolver has to
-    re-derive the project/task split from the wire name. ``None`` for
-    anything that doesn't fit the canonical shape.
+    Configured operator/architect/advisor sessions come from
+    ``config.sessions``. Per-task workers are looked up in the
+    work-service via :func:`_list_worker_sessions` — a syntactically
+    valid ``task-{project}-{id}`` name is rejected with
+    ``404 session_unknown`` when no matching active worker is
+    registered (Codex #2043 review block 2).
     """
-    if not session_name.startswith("task-"):
-        return None
-    body = session_name[len("task-"):]
-    sep = body.rfind("-")
-    if sep <= 0 or sep == len(body) - 1:
-        return None
-    project = body[:sep]
-    try:
-        task_id = int(body[sep + 1 :])
-    except ValueError:
-        return None
-    if not project:
-        return None
-    return project, task_id
+    # Build a fake-handle-aware enumeration: P1's facade takes a
+    # ``work_service`` whose only contract is ``list_worker_sessions``.
+    # We pass a small adapter so tests that monkeypatch
+    # ``_list_worker_sessions`` Just Work without touching the
+    # work-service factory.
+    worker_records = _list_worker_sessions(config)
 
+    class _Adapter:
+        @staticmethod
+        def list_worker_sessions(*, active_only: bool = True) -> list[Any]:
+            if not active_only:
+                return worker_records
+            return [
+                r for r in worker_records if getattr(r, "ended_at", None) is None
+            ]
 
-def _storage_closet_session_name(tmux_session: str) -> str:
-    """Mirror ``Supervisor.storage_closet_session_name`` without importing it.
-
-    The supervisor owns this string at runtime; the chat-send router only
-    needs the same suffix convention (``-storage-closet``) so configured
-    chat surfaces resolve to the right tmux session without dragging the
-    full supervisor wiring into the HTTP layer.
-    """
-    return f"{tmux_session}-storage-closet"
-
-
-def _resolve_session(
-    config: Any,
-    session_name: str,
-) -> tuple[str, str, str | None]:
-    """Resolve ``session_name`` → ``(window_name, project_key, role)``.
-
-    Falls back to the canonical ``task-{project}-{task_id}`` shape for
-    per-task workers that aren't tracked in ``config.sessions``. Raises
-    ``404 session_unknown`` if neither resolution succeeds.
-    """
-    session = config.sessions.get(session_name) if hasattr(config, "sessions") else None
-    if session is not None:
-        window_name = session.window_name or session.name
-        return window_name, session.project, getattr(session, "role", None)
-    parsed = _parse_task_session_name(session_name)
-    if parsed is not None:
-        project, _task_id = parsed
-        # Per-task worker windows reuse the session_name verbatim as
-        # window_name (that's what ``task_window_name`` returns).
-        return session_name, project, "worker"
+    surfaces = enumerate_chat_surfaces(
+        config,
+        work_service=_Adapter,
+        tmux_client=None,
+    )
+    for surface in surfaces:
+        if surface.session_name == session_name:
+            return surface
     raise _session_unknown(session_name)
-
-
-def _resolve_project_root(config: Any, project_key: str) -> Path:
-    """Return the on-disk project root for ``project_key``.
-
-    Per-task workers may name a project that isn't tracked under
-    ``config.projects``; in that case we fall back to the operator's
-    ``config.project.root_dir`` (matches the mid-tool detector's only
-    other purpose — scanning JSONL — which is fine to skip when the
-    project root is unknown).
-    """
-    projects = getattr(config, "projects", {}) or {}
-    known = projects.get(project_key)
-    if known is not None:
-        return Path(known.path)
-    project = getattr(config, "project", None)
-    root_dir = getattr(project, "root_dir", None)
-    if root_dir is None:
-        # Last-resort: cwd. The mid-tool scan will simply find no
-        # events.jsonl and skip the check (fail-open) — the operator
-        # already opted to force or loose if they hit this path.
-        return Path.cwd()
-    return Path(root_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -312,12 +373,14 @@ def _resolve_project_root(config: Any, project_key: str) -> Path:
 # tool_result that should match its tool_use blocks. JSONL events from
 # Claude are typically a few hundred bytes each; 64 KiB gives ~300+
 # events even for verbose Bash output. We never need more than the
-# tail for the mid-tool check (we only care about the last assistant
+# tail for the mid-tool check (we only care about the latest assistant
 # turn's open tool_use ids).
 _EVENTS_TAIL_BYTES = 64 * 1024
 
 
-def _read_events_tail(events_path: Path, max_bytes: int = _EVENTS_TAIL_BYTES) -> list[dict[str, Any]]:
+def _read_events_tail(
+    events_path: Path, max_bytes: int = _EVENTS_TAIL_BYTES,
+) -> list[dict[str, Any]]:
     """Return the tail JSON events from ``events_path`` as parsed dicts.
 
     Reads at most ``max_bytes`` from the end via ``os.lseek`` so very
@@ -355,81 +418,116 @@ def _read_events_tail(events_path: Path, max_bytes: int = _EVENTS_TAIL_BYTES) ->
         if not line:
             continue
         try:
+            import json  # local import keeps the import block tight
+
             obj = json.loads(line)
-        except json.JSONDecodeError:
+        except Exception:  # noqa: BLE001
             continue
         if isinstance(obj, dict):
             events.append(obj)
     return events
 
 
-def _find_session_events_path(project_root: Path, session_name: str) -> Path | None:
-    """Locate the events.jsonl most likely to belong to ``session_name``.
+# Outcome of resolving the transcript path for a session.
+# ``exact``  — P1's fingerprint resolver matched a transcript subdir to
+#             the surface's ``cwd`` / ``account`` / ``provider`` (high
+#             confidence — never cross-attaches to another surface).
+# ``absent`` — no transcript archive matches the surface yet. May mean
+#             "brand new session" (archive about to be written) or
+#             "operator addressing the wrong session_name" — strict
+#             mode treats the ambiguity as unsafe and fails closed
+#             *only when other archives exist* in the project root.
+_ResolutionQuality = Literal["exact", "absent_but_others_exist", "absent_clean"]
 
-    PollyPM's transcript mirror writes one ``events.jsonl`` per Claude
-    session UUID under ``<project>/.pollypm/transcripts/<uuid>/``. We
-    don't currently store a ``session_name → session_uuid`` mapping
-    (P1 of the chat spec is the natural home for that registry), so
-    this function picks the freshest ``events.jsonl`` in the project
-    that has been written to recently. For the mid-tool safety check
-    that's sufficient — there is realistically one active session per
-    project at a time, and a stale mismatch only fails-open (allowing
-    a send when we should have blocked it, which is exactly what
-    ``safety=force`` is for).
 
-    TODO(P1): replace with the registry-backed lookup once P1 lands.
+def _project_has_other_transcripts(project_root: Path) -> bool:
+    """True when the project's transcripts dir holds at least one archive.
+
+    Distinguishes "brand new project, no transcripts at all" (safe to
+    send — no signal yet) from "other sessions are streaming but ours
+    isn't matched" (unsafe — operator is probably addressing the
+    wrong surface).
     """
-    transcripts_root = project_transcripts_dir(project_root)
-    if not transcripts_root.exists():
-        return None
-    candidate: Path | None = None
-    candidate_mtime = -1.0
     try:
-        entries = list(transcripts_root.iterdir())
+        from pollypm.projects import project_transcripts_dir
+
+        root = project_transcripts_dir(project_root)
+    except Exception:  # noqa: BLE001
+        return False
+    if not root.exists():
+        return False
+    try:
+        for child in root.iterdir():
+            if not child.is_dir():
+                continue
+            if child.name in {"tasks", ".ingestion-state.lock"}:
+                continue
+            if (child / "events.jsonl").exists():
+                return True
     except OSError:
-        return None
-    for entry in entries:
-        if not entry.is_dir() or entry.name.startswith("."):
-            continue
-        events = entry / "events.jsonl"
-        if not events.is_file():
-            continue
-        try:
-            mtime = events.stat().st_mtime
-        except OSError:
-            continue
-        if mtime > candidate_mtime:
-            candidate_mtime = mtime
-            candidate = events
-    return candidate
+        return False
+    return False
+
+
+def _resolve_session_events(
+    surface: ChatSurface,
+    project_root: Path,
+) -> tuple[Path | None, _ResolutionQuality]:
+    """Locate the exact events.jsonl for ``surface``.
+
+    Trusts :attr:`ChatSurface.transcript_path` populated by P1's
+    :func:`enumerate_chat_surfaces` — that's the same fingerprint
+    mapping the read endpoints (P2) use, so the send path can never
+    disagree with the GET path on "which transcript is this
+    session's". P1's resolver returns ``None`` when no archive
+    matches the surface's ``(cwd, account, provider)`` fingerprint;
+    it never opportunistically picks the freshest.
+
+    Returns ``(path, quality)``. ``absent_but_others_exist`` is the
+    fail-closed signal in strict mode (Codex #2043 review block 3):
+    archives exist in the project but none fingerprints to this
+    surface, which usually means the operator addressed the wrong
+    session_name.
+    """
+    if surface.transcript_path is not None:
+        return surface.transcript_path, "exact"
+    if _project_has_other_transcripts(project_root):
+        return None, "absent_but_others_exist"
+    return None, "absent_clean"
 
 
 def _last_assistant_open_tool_ids(events: list[dict[str, Any]]) -> set[str]:
-    """Return ``tool_use_id``s in the *latest* assistant turn lacking a result.
+    """Return ``tool_use_id``s in the *current* assistant turn lacking a result.
 
-    Walks the events tail in reverse to find the most recent
-    ``assistant_turn``; collects every ``tool_call`` (with the same
-    or later timestamp) and subtracts every ``tool_result`` matched by
-    ``tool_use_id``. The remaining set is the mid-flight tool calls.
-    The result is empty for: no assistant turn at all, no open tools,
-    or fully-matched tool_use/tool_result pairs.
+    The intuition is "is the agent right now waiting on a tool result
+    we haven't seen yet?" An assistant response is the span from the
+    most-recent ``user_turn`` (or ``assistant_turn`` boundary) to the
+    end of the tail. ``tool_call`` events in that span without a
+    matching ``tool_result`` are the open ones.
+
+    The ``user_turn`` boundary matters because
+    :class:`pollypm.transcript_ingest.TranscriptIngestor` only emits
+    ``assistant_turn`` when the assistant message carries text. A
+    tool-only assistant response (no preface text) produces
+    ``tool_call`` events without a preceding ``assistant_turn`` —
+    anchoring on ``user_turn`` instead means the mid-tool gate still
+    fires for that case (Codex #2043 review block 4).
     """
-    # Find the latest assistant_turn index — anything before that is
-    # an earlier completed turn and irrelevant to the "mid-tool right
-    # now" decision.
-    last_assistant = -1
+    # Find the most-recent boundary (user_turn or assistant_turn).
+    # Everything after that belongs to the current in-flight response.
+    boundary = -1
     for idx in range(len(events) - 1, -1, -1):
-        if events[idx].get("event_type") == "assistant_turn":
-            last_assistant = idx
+        event_type = events[idx].get("event_type")
+        if event_type in ("user_turn", "assistant_turn"):
+            boundary = idx
             break
-    if last_assistant < 0:
-        # No assistant turn in tail — could be very long pre-assistant
-        # window, but for safety check we treat "no recent assistant"
-        # as "not mid-tool".
-        return set()
+    # When no boundary exists in the tail we still scan: that's the
+    # very-long-tool-output case where the assistant_turn fell out of
+    # the 64 KiB window. Treat the whole tail as the current response.
+    span = events[boundary + 1:] if boundary >= 0 else events
     open_ids: set[str] = set()
     seen_results: set[str] = set()
-    for event in events[last_assistant:]:
+    for event in span:
         etype = event.get("event_type")
         payload = event.get("payload") or {}
         if etype == "tool_call":
@@ -443,9 +541,10 @@ def _last_assistant_open_tool_ids(events: list[dict[str, Any]]) -> set[str]:
     return open_ids - seen_results
 
 
-def _is_mid_tool(project_root: Path, session_name: str) -> bool:
-    """True when the session's tail shows an unmatched assistant tool_use."""
-    events_path = _find_session_events_path(project_root, session_name)
+def _is_mid_tool(
+    events_path: Path | None,
+) -> bool:
+    """True when ``events_path``'s tail shows an unmatched tool_use."""
     if events_path is None:
         return False
     events = _read_events_tail(events_path)
@@ -465,9 +564,9 @@ _MID_STREAM_WINDOW_SECONDS = 2.0
 def _heartbeat_age_seconds(config: Any, session_name: str) -> float | None:
     """Return seconds since ``session_name``'s latest heartbeat, or ``None``.
 
-    Reads via :func:`pollypm.storage.pg_heartbeats.latest_heartbeat` per
-    #2039 (pg-only). Any failure is treated as "no signal" — the caller
-    fails-open so a flaky pg pool doesn't block legitimate sends.
+    Reads via :func:`pollypm.storage.pg_heartbeats.latest_heartbeat`
+    (pg-only). Any failure is treated as "no signal" — the caller
+    fails-open so a flaky pool doesn't block legitimate sends.
     """
     try:
         from pollypm.storage.pg_heartbeats import latest_heartbeat
@@ -476,14 +575,17 @@ def _heartbeat_age_seconds(config: Any, session_name: str) -> float | None:
     try:
         record = latest_heartbeat(session_name, config=config)
     except Exception:  # noqa: BLE001
-        logger.debug("chat_send: pg_heartbeats.latest_heartbeat failed", exc_info=True)
+        logger.debug(
+            "chat_send: pg_heartbeats.latest_heartbeat failed", exc_info=True,
+        )
         return None
     if record is None:
         return None
     stamp = record.created_at
     try:
-        # ISO-8601 with or without ``Z`` suffix.
-        normalised = stamp.replace("Z", "+00:00") if stamp.endswith("Z") else stamp
+        normalised = (
+            stamp.replace("Z", "+00:00") if stamp.endswith("Z") else stamp
+        )
         ts = datetime.fromisoformat(normalised)
     except (TypeError, ValueError):
         return None
@@ -498,19 +600,15 @@ def _heartbeat_age_seconds(config: Any, session_name: str) -> float | None:
 
 
 def _find_ask_user_envelope(
-    project_root: Path,
-    session_name: str,
+    events_path: Path | None,
     answer_to: str,
 ) -> dict[str, Any] | None:
-    """Locate the ask_user message in ``events.jsonl`` matching ``answer_to``.
+    """Locate the ask_user message matching ``answer_to``.
 
-    Returns the parsed event dict or ``None`` if the id isn't present.
-    The lookup is restricted to the events tail — the spec only
-    supports answering the most-recent open question (matches how
-    Claude Code presents AskUserQuestion: stale questions disappear
-    after the next turn).
+    Returns the parsed event dict or ``None`` if the id isn't in the
+    tail. The lookup is restricted to the events tail — the spec
+    only supports answering the most-recent open question.
     """
-    events_path = _find_session_events_path(project_root, session_name)
     if events_path is None:
         return None
     events = _read_events_tail(events_path)
@@ -521,19 +619,20 @@ def _find_ask_user_envelope(
 
 
 def _event_message_id(event: dict[str, Any]) -> str | None:
-    """Extract the message id from an events.jsonl event.
+    """Extract the message id from a raw events.jsonl event.
 
     Different event types carry the id in different places; the chat
     transcript layer (P1) normalises these into a single ``id`` field
-    on each envelope. Until P1 lands we look in the canonical places:
-    payload.id (tool_use), top-level uuid, and source_offset as a last
-    resort (still stable per file).
+    on each envelope. The raw events.jsonl that P3 reads has the id
+    in payload.id (tool_use), top-level uuid, or source_offset as a
+    stable fallback.
     """
     payload = event.get("payload") or {}
-    for key in ("id", "uuid", "message_id"):
-        value = payload.get(key) if isinstance(payload, dict) else None
-        if isinstance(value, str) and value:
-            return value
+    if isinstance(payload, dict):
+        for key in ("id", "uuid", "message_id"):
+            value = payload.get(key)
+            if isinstance(value, str) and value:
+                return value
     for key in ("uuid", "message_id", "id"):
         value = event.get(key)
         if isinstance(value, str) and value:
@@ -544,19 +643,16 @@ def _event_message_id(event: dict[str, Any]) -> str | None:
 def _ask_user_options(event: dict[str, Any]) -> list[str] | None:
     """Pull the list of option labels from an ask_user event.
 
-    Returns ``None`` when the event isn't an ask_user. The shape comes
-    from §3.5 — ``metadata.questions[].options[].label``. We accept
-    the legacy shape (``payload.questions[]`` from the AskUserQuestion
-    tool_use payload) as well so the P3 router works against the
-    raw events.jsonl that P1 hasn't normalised yet.
+    Returns ``None`` when the event isn't an ask_user. The shape
+    comes from §3.5 — ``metadata.questions[].options[].label``.
+    Accepts the raw events.jsonl shape too (tool_call payload for
+    AskUserQuestion) so the router works pre-normalisation.
     """
-    # Spec envelope (post-P1 normalisation).
     metadata = event.get("metadata")
     if isinstance(metadata, dict):
         questions = metadata.get("questions")
         if isinstance(questions, list):
             return _flatten_question_options(questions)
-    # Raw events.jsonl (pre-P1): tool_call payload for AskUserQuestion.
     payload = event.get("payload") or {}
     if isinstance(payload, dict):
         if payload.get("name") == "AskUserQuestion":
@@ -565,7 +661,6 @@ def _ask_user_options(event: dict[str, Any]) -> list[str] | None:
                 questions = tool_input.get("questions")
                 if isinstance(questions, list):
                     return _flatten_question_options(questions)
-        # type==ask_user direct (matches §3.5 raw form).
         if payload.get("type") == "ask_user":
             questions = payload.get("questions")
             if isinstance(questions, list):
@@ -595,18 +690,15 @@ def _build_answer_text(selections: list[str], notes: str | None) -> str:
     """Format the typed string for an AskUserQuestion reply.
 
     Spec §4.5 default: option labels joined by newlines, optional
-    ``notes`` appended after another newline. Trailing newline is
-    handled by ``press_enter`` — we never append our own ``\\n`` at the
-    end here so ``press_enter=False`` produces a buffer the caller can
+    ``notes`` appended after another newline. The trailing newline is
+    handled by ``press_enter`` — we never append our own ``\\n`` at
+    the end so ``press_enter=False`` produces a buffer the caller can
     inspect.
 
     TODO(P4): Sam's open-question #1 — confirm Claude Code's
-    AskUserQuestion stdin format. The chat-endpoint spec calls out
-    this as a user-testing gate. The current implementation matches
-    the spec's default assumption ("typing the option label verbatim
-    works"). No live Claude session is reachable from this isolated
-    worktree to run the experiment in-flight; deferred to P4
-    user-testing.
+    AskUserQuestion stdin format. Current implementation matches the
+    spec default ("typing the option label verbatim works"). No live
+    Claude session reachable from this isolated worktree.
     """
     body = "\n".join(selections)
     if notes:
@@ -618,26 +710,49 @@ def _build_answer_text(selections: list[str], notes: str | None) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Project root helper
+# ---------------------------------------------------------------------------
+
+
+def _resolve_project_root(config: Any, project_key: str | None) -> Path:
+    """Return the on-disk root for ``project_key`` or the workspace root.
+
+    Operators (``project=None``) and surfaces whose project isn't
+    tracked fall back to ``config.project.root_dir`` — the resolver
+    then walks the workspace transcripts dir.
+    """
+    if project_key:
+        projects = getattr(config, "projects", {}) or {}
+        known = projects.get(project_key)
+        if known is not None:
+            return Path(known.path)
+    project = getattr(config, "project", None)
+    root_dir = getattr(project, "root_dir", None)
+    if root_dir is None:
+        return Path.cwd()
+    return Path(root_dir)
+
+
+# ---------------------------------------------------------------------------
 # tmux helpers
 # ---------------------------------------------------------------------------
 
 
-def _tmux_session_for_send(config: Any, project_key: str) -> str:
+def _tmux_session_for_send(config: Any, project_key: str | None) -> str:
     """Return the storage-closet tmux session name to address.
 
     All chat surfaces (operator, architect, advisor, per-task workers)
-    live inside the project's storage-closet session — that's the
-    invariant the supervisor enforces (``Supervisor.storage_closet_session_name``).
-    We don't import the supervisor here to keep the HTTP layer light;
-    the suffix convention is stable enough to inline.
+    live inside the project's storage-closet session — matches the
+    invariant the supervisor enforces
+    (``Supervisor.storage_closet_session_name``). We don't import the
+    supervisor here to keep the HTTP layer light; the suffix
+    convention is stable enough to inline.
     """
     project = getattr(config, "project", None)
     tmux_session = getattr(project, "tmux_session", None) if project else None
     if not isinstance(tmux_session, str) or not tmux_session:
-        # Fall back to the project key when the project block is sparse
-        # (e.g. tests that pass a minimal config).
         tmux_session = project_key or "pollypm"
-    return _storage_closet_session_name(tmux_session)
+    return f"{tmux_session}-storage-closet"
 
 
 def _resolve_pane_target(
@@ -648,27 +763,51 @@ def _resolve_pane_target(
 ) -> tuple[str, bool]:
     """Return ``(target, present)`` for a window + optional pane index.
 
-    ``present`` is True when the window exists; the caller maps
-    ``False`` to ``503 window_missing``. When the window exists but a
-    requested pane index is out of range we still raise — that's a
-    client bug, not a missing window.
+    ``present`` is True when the window exists. When the window
+    exists but a requested pane index is out of range, this raises
+    ``409 pane_invalid``; a dead pane raises ``409 pane_dead``
+    (Codex #2043 review block 5).
     """
     try:
         windows = tmux.list_windows(storage_session)
     except Exception:  # noqa: BLE001
-        logger.debug("chat_send: list_windows(%r) failed", storage_session, exc_info=True)
+        logger.debug(
+            "chat_send: list_windows(%r) failed", storage_session, exc_info=True,
+        )
         return f"{storage_session}:{window_name}", False
     matching = [w for w in windows if w.name == window_name]
     if not matching:
         return f"{storage_session}:{window_name}", False
     window = matching[0]
-    if window.pane_dead:
-        raise _pane_dead(f"{storage_session}:{window_name}")
+    # Default-pane path: window.pane_dead from list_windows is the
+    # active-pane health bit, which is the right signal when the
+    # caller didn't pick a specific pane.
     if pane_index is None or pane_index == 0:
-        # Default: address the window — send_keys hits the active pane.
+        if window.pane_dead:
+            raise _pane_dead(f"{storage_session}:{window_name}")
         return f"{storage_session}:{window_name}", True
-    # Specific pane requested: target ``session:window.<N>``.
-    return f"{storage_session}:{window_name}.{int(pane_index)}", True
+    # Specific pane requested. Pane indexes must be >= 0 and the pane
+    # has to exist on the window AND be alive. Without this gate a
+    # negative or out-of-range index slips through to ``send_keys``
+    # and surfaces as a 500.
+    if pane_index < 0:
+        raise _pane_invalid(pane_index, f"{storage_session}:{window_name}")
+    window_target = f"{storage_session}:{window_name}"
+    try:
+        panes = tmux.list_panes(window_target)
+    except Exception:  # noqa: BLE001
+        logger.debug(
+            "chat_send: list_panes(%r) failed", window_target, exc_info=True,
+        )
+        # Without pane visibility we can't validate; refuse rather
+        # than leak the raw subprocess error.
+        raise _pane_invalid(pane_index, window_target) from None
+    match = next((p for p in panes if p.pane_index == pane_index), None)
+    if match is None:
+        raise _pane_invalid(pane_index, window_target)
+    if match.pane_dead:
+        raise _pane_dead(f"{window_target}.{pane_index}")
+    return f"{window_target}.{pane_index}", True
 
 
 # ---------------------------------------------------------------------------
@@ -689,19 +828,46 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
     response: Response,
 ) -> ChatSendResponse:
     """POST /api/v1/chat/{session_name}/send — push text into a tmux pane."""
-    # 1. Resolve session + tmux target.
-    window_name, project_key, _role = _resolve_session(config, session_name)
+    # 1. Resolve session via the P1 facade (validates workers against
+    # the work-service — see Codex review block 2).
+    surface = _resolve_surface(config, session_name)
+    # ``surface.project`` is intentionally ``None`` for operators in P1
+    # (the operator is workspace-wide). The send path still needs a
+    # concrete project_key for storage-closet naming and transcripts
+    # discovery — pull it from the session config the same way P1's
+    # ``_project_key_for_session`` helper does.
+    project_key = surface.project
+    if not project_key:
+        session = (config.sessions or {}).get(session_name)
+        project_key = (
+            getattr(session, "project", None)
+            or getattr(getattr(config, "project", None), "name", None)
+        )
+
     storage_session = _tmux_session_for_send(config, project_key)
+    window_name = surface.window.window_name
+
     tmux = TmuxClient()
-    target, present = _resolve_pane_target(tmux, storage_session, window_name, body.pane)
+    target, present = _resolve_pane_target(
+        tmux, storage_session, window_name, body.pane,
+    )
     if not present:
         raise _window_missing(target)
 
     project_root = _resolve_project_root(config, project_key)
 
-    # 2. Safety gates (§4.1, §4.3).
+    # 2. Safety gates (§4.1, §4.3) — use the exact session transcript
+    # (Codex review block 3).
+    events_path, resolution = _resolve_session_events(surface, project_root)
     if body.safety != "force":
-        if _is_mid_tool(project_root, session_name):
+        if resolution == "absent_but_others_exist":
+            # Strict and loose both require an exact transcript
+            # mapping. Other transcripts exist for the project but
+            # none fingerprints to this surface — the operator is
+            # almost certainly addressing the wrong session_name.
+            # Fail closed; safety=force bypasses.
+            raise _unsafe_mid_tool()
+        if _is_mid_tool(events_path):
             raise _unsafe_mid_tool()
         age = _heartbeat_age_seconds(config, session_name)
         streaming = age is not None and age < _MID_STREAM_WINDOW_SECONDS
@@ -713,7 +879,7 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
     # 3. AskUserQuestion answer handling (§4.5).
     text_to_send: str | None
     if body.answer_to is not None:
-        envelope = _find_ask_user_envelope(project_root, session_name, body.answer_to)
+        envelope = _find_ask_user_envelope(events_path, body.answer_to)
         if envelope is None:
             raise _answer_to_missing(body.answer_to)
         options = _ask_user_options(envelope)
@@ -725,7 +891,6 @@ def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally
         if body.selections:
             text_to_send = _build_answer_text(body.selections, body.notes)
         elif body.text:
-            # Freeform reply against an ask_user (§4.5 last paragraph).
             text_to_send = body.text
         elif body.notes:
             text_to_send = body.notes

--- a/src/pollypm/web_api/routes/chat_send.py
+++ b/src/pollypm/web_api/routes/chat_send.py
@@ -139,6 +139,28 @@ class HeartbeatUnavailable(Exception):
     """
 
 
+class _WorkerFacadeUnavailable(Exception):
+    """Raised when the work-service open/list itself failed.
+
+    Codex #2043 review v6 blocker 1: the *public* facade
+    :func:`pollypm.web_api.service.list_active_worker_sessions` catches
+    ``_open_work_service_readonly`` open failures and
+    ``list_worker_sessions`` read failures, returning ``[]`` in both
+    cases. That collapsed "no active workers" and "could not query
+    workers" into the same signal — so a real pg outage on a
+    ``task-<project>-<n>`` send fell out as ``404 session_unknown``
+    instead of ``503 service_unavailable``.
+
+    The strict worker-lookup path
+    (:func:`_list_worker_sessions_strict`) bypasses the public facade
+    and re-raises the underlying exception wrapped in this typed class
+    so :func:`_resolve_surface` can map it to a typed 503. The public
+    facade is unchanged — non-strict callers (e.g. read endpoints that
+    legitimately want "best-effort list, empty on failure") still get
+    the swallow-and-return-`[]` behavior.
+    """
+
+
 # Per-spec §2.3 — worker sessions follow ``task-<project>-<n>``. The
 # pattern check below lets ``_resolve_surface`` skip the worker facade
 # for sessions that syntactically cannot be workers, avoiding a pg hit
@@ -235,13 +257,21 @@ class ChatSendResponse(BaseModel):
 
 
 def _session_unknown(session_name: str) -> APIError:
+    # Codex #2043 review v6 blocker 3: do not advertise
+    # ``GET /api/v1/chat/sessions`` here — that endpoint ships in
+    # #2045 and is still blocked. This PR (send-only) stays
+    # independently mergeable by pointing the operator at surfaces
+    # they can enumerate today (CLI / config).
     return APIError(
         status_code=404,
         code="session_unknown",
         message=f"No chat surface registered for session: {session_name!r}",
         hint=(
-            "Use GET /api/v1/chat/sessions to discover registered surfaces. "
-            "Per-task workers must appear in WorkService.list_worker_sessions."
+            "List available sessions via the `pm sessions` CLI or "
+            "`pollypm.toml` (`[sessions.*]` for operator/architect/"
+            "advisor, `task-{project}-{N}` for active workers). "
+            "Per-task workers must appear in "
+            "`WorkService.list_worker_sessions(active_only=True)`."
         ),
     )
 
@@ -452,14 +482,66 @@ def _selections_invalid(invalid: list[str], valid: list[str]) -> APIError:
 def _list_worker_sessions(config: Any) -> list[Any]:
     """Return active :class:`WorkerSessionRecord` rows or ``[]``.
 
-    Delegates to the public service-layer facade. Tests monkeypatch
-    this module-level name (``chat_send_routes._list_worker_sessions``)
-    to feed fake records into :func:`_resolve_surface`. Raises any
-    exception from the underlying facade so the resolver can map
-    worker-pattern lookup failure to a typed 503 — see the
-    ``_resolve_surface`` body for that mapping.
+    Delegates to the public service-layer facade. Kept for any
+    non-strict caller / test scaffolding that wants the empty-on-
+    outage behavior. The strict send path uses
+    :func:`_list_worker_sessions_strict` instead — see Codex #2043
+    review v6 blocker 1 for why the strict path bypasses this facade.
     """
     return list(list_active_worker_sessions(config)) or []
+
+
+def _list_worker_sessions_strict(config: Any) -> list[Any]:
+    """Strict worker-lookup: bypass the public facade.
+
+    Codex #2043 review v6 blocker 1: the public facade
+    :func:`pollypm.web_api.service.list_active_worker_sessions`
+    swallows ``_open_work_service_readonly`` open failures and
+    ``list_worker_sessions`` read failures and returns ``[]``. That
+    conflates "no active workers" with "could not query workers", so
+    a real pg / work-service outage on a ``task-<project>-<n>`` send
+    fell out as ``404 session_unknown`` instead of
+    ``503 service_unavailable``. The v5 wrapper *would* have re-raised
+    if the facade itself raised, but the facade never raised in
+    production — it always returned ``[]``.
+
+    This helper opens the work-service directly, so any failure on
+    the open OR the ``list_worker_sessions`` call propagates as a
+    typed :class:`_WorkerFacadeUnavailable` that :func:`_resolve_surface`
+    maps to ``503 service_unavailable``. A missing project (config
+    has no ``project``) returns ``[]`` (genuinely no workers, not an
+    outage). An empty list from a successful ``list_worker_sessions``
+    call also returns ``[]``.
+
+    Tests monkeypatch this module-level name to feed fake records or
+    simulate the outage path without touching pg. The mandatory
+    regression test for v6 monkeypatches
+    :func:`pollypm.web_api.service._open_work_service_readonly` to
+    raise, exercising the real public-facade-bypass path end-to-end.
+    """
+    project = getattr(config, "project", None)
+    if project is None:
+        return []
+    project_key = getattr(project, "name", "")
+    project_path = getattr(project, "root_dir", None)
+    if not project_key or project_path is None:
+        return []
+    try:
+        from pollypm.web_api.service import _open_work_service_readonly
+
+        with _open_work_service_readonly(
+            config=config,
+            project_key=project_key,
+            project_path=project_path,
+        ) as work_service:
+            list_fn = getattr(work_service, "list_worker_sessions", None)
+            if not callable(list_fn):
+                return []
+            return list(list_fn(active_only=True))
+    except _WorkerFacadeUnavailable:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise _WorkerFacadeUnavailable(str(exc) or type(exc).__name__) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -492,18 +574,36 @@ def _resolve_surface(config: Any, session_name: str) -> ChatSurface:
     is_worker_pattern = _looks_like_worker_session(session_name)
     worker_records: list[Any]
     if is_worker_pattern:
+        # Strict path: bypass the public facade so open/list outages
+        # propagate as :class:`_WorkerFacadeUnavailable` and map to a
+        # typed 503 (Codex #2043 review v6 blocker 1). The public
+        # facade swallows those failures into ``[]``, which would
+        # collapse into ``404 session_unknown`` here.
         try:
-            worker_records = _list_worker_sessions(config)
-        except Exception as exc:  # noqa: BLE001
-            # Worker-pattern name + lookup raised → tell the operator
-            # the lookup failed instead of returning 404 (which would
-            # imply the worker definitely isn't registered).
+            worker_records = _list_worker_sessions_strict(config)
+        except _WorkerFacadeUnavailable as exc:
             logger.debug(
                 "chat_send: worker session lookup failed for %r",
                 session_name,
                 exc_info=True,
             )
-            raise _service_unavailable_worker_lookup(str(exc) or type(exc).__name__) from exc
+            raise _service_unavailable_worker_lookup(
+                str(exc) or type(exc).__name__,
+            ) from exc
+        except Exception as exc:  # noqa: BLE001
+            # Any other unexpected exception (test seam raising
+            # ``RuntimeError`` directly, an unhandled programming
+            # error in the helper) also routes to 503 rather than
+            # leaking a 500 — the operator's actionable signal is
+            # still "lookup failed, can't tell".
+            logger.debug(
+                "chat_send: worker session lookup raised for %r",
+                session_name,
+                exc_info=True,
+            )
+            raise _service_unavailable_worker_lookup(
+                str(exc) or type(exc).__name__,
+            ) from exc
     else:
         worker_records = []
 

--- a/src/pollypm/web_api/routes/chat_send.py
+++ b/src/pollypm/web_api/routes/chat_send.py
@@ -1,0 +1,777 @@
+"""POST chat-send endpoint (Phase 1 — P3 of the chat-endpoints spec).
+
+Implements:
+
+- ``POST /api/v1/chat/{session_name}/send`` — push a message into
+  the running CLI agent backing ``session_name`` via tmux.
+
+Per ``~/Desktop/pollypm-chat-endpoints-spec.md`` §2.3 / §4. The router
+owns:
+
+1. Session lookup — ``config.sessions[session_name]`` first, then a
+   work-service fall-back for per-task workers whose ``session_name``
+   has the canonical shape ``task-{project}-{task_id}`` (see
+   :func:`pollypm.work.session_manager.task_window_name`).
+2. tmux target resolution — ``<storage-closet>:<window_name>`` for
+   configured sessions; ``<project>-storage-closet:<task-window>``
+   for workers. Presence is verified via
+   :meth:`pollypm.tmux.client.TmuxClient.list_windows` and the
+   ``pane_dead`` flag.
+3. Safety gates (§4.1, §4.3) —
+
+   * Mid-tool: tail-read the session's ``events.jsonl`` and reject if
+     the most-recent assistant turn has an unmatched ``tool_use_id``.
+   * Mid-stream: read the latest heartbeat from
+     :func:`pollypm.storage.pg_heartbeats.latest_heartbeat` and reject
+     if it landed within the last 2 seconds.
+
+   ``safety=strict`` (default) enforces both. ``safety=loose`` keeps
+   the mid-tool check but allows mid-stream sends with a warning
+   header. ``safety=force`` bypasses everything.
+4. AskUserQuestion answer translation (§4.5) — when ``answer_to`` is
+   set, the router resolves the referenced ``ask_user`` envelope from
+   the transcript, validates each ``selections`` entry against the
+   question's options, and types the option labels joined by newlines
+   (followed by optional ``notes``) into the pane.
+
+The router intentionally does NOT touch storage writes for the send
+itself — the user-visible side effect is the tmux ``send-keys`` call.
+The transcript will pick the message up on the next ingest tick.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from fastapi import APIRouter, Response
+from pydantic import BaseModel, Field
+
+from pollypm.projects import project_transcripts_dir
+from pollypm.tmux.client import DeadPaneError, TmuxClient
+from pollypm.web_api.errors import APIError
+from pollypm.web_api.routes._deps import ConfigDep
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Chat"])
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class ChatSendRequest(BaseModel):
+    """Body of ``POST /api/v1/chat/{session_name}/send`` per spec §2.3."""
+
+    text: str | None = Field(
+        default=None,
+        description=(
+            "Free-text body to send. Required when ``selections`` is empty."
+        ),
+    )
+    press_enter: bool = Field(
+        default=True,
+        description="Submit the buffer by pressing Enter after the text lands.",
+    )
+    answer_to: str | None = Field(
+        default=None,
+        description=(
+            "ID of an ``ask_user`` message in the session's transcript that "
+            "this send answers. When set, ``selections`` must reference one "
+            "of the question's options (§4.5)."
+        ),
+    )
+    selections: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Selected option labels for an AskUserQuestion reply. Each entry "
+            "must exactly match one of the question's option labels."
+        ),
+    )
+    notes: str | None = Field(
+        default=None,
+        description=(
+            "Optional free-text addition appended after ``selections`` when "
+            "answering an ask_user. Ignored for plain text sends."
+        ),
+    )
+    safety: Literal["strict", "loose", "force"] = Field(
+        default="strict",
+        description=(
+            "Safety gate level: strict (default) enforces mid-tool and "
+            "mid-stream checks; loose keeps mid-tool but skips mid-stream "
+            "(emits warning header); force bypasses both."
+        ),
+    )
+    pane: int | None = Field(
+        default=None,
+        description=(
+            "0-based pane index inside the target window. Defaults to the "
+            "primary pane (matches existing send_keys behaviour)."
+        ),
+    )
+
+
+class ChatSendResponse(BaseModel):
+    """Response body for ``POST /api/v1/chat/{session_name}/send``."""
+
+    ok: bool
+    message_id: str
+    session_name: str
+    window_target: str
+    characters_sent: int
+    method: Literal["send_keys", "paste_buffer"]
+    press_enter_at: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Typed error helpers (spec §2.3 error codes)
+# ---------------------------------------------------------------------------
+
+
+def _session_unknown(session_name: str) -> APIError:
+    return APIError(
+        status_code=404,
+        code="session_unknown",
+        message=f"No chat surface registered for session: {session_name!r}",
+        hint=(
+            "Use GET /api/v1/chat/sessions to discover registered surfaces, "
+            "or check config.sessions / work-service for per-task workers."
+        ),
+    )
+
+
+def _window_missing(target: str) -> APIError:
+    return APIError(
+        status_code=503,
+        code="window_missing",
+        message=f"Window not present in tmux: {target}",
+        hint="The session is configured but its tmux window is not running.",
+    )
+
+
+def _pane_dead(target: str) -> APIError:
+    return APIError(
+        status_code=409,
+        code="pane_dead",
+        message=f"tmux pane is dead: {target}",
+    )
+
+
+def _unsafe_mid_tool() -> APIError:
+    return APIError(
+        status_code=409,
+        code="unsafe_mid_tool",
+        message=(
+            "Refusing to send while the agent has an open tool_use without a "
+            "matching tool_result. Override with safety=force."
+        ),
+    )
+
+
+def _unsafe_mid_stream() -> APIError:
+    return APIError(
+        status_code=409,
+        code="unsafe_mid_stream",
+        message=(
+            "Refusing to send while the agent appears to be streaming "
+            "(heartbeat <2s old). Override with safety=loose or safety=force."
+        ),
+    )
+
+
+def _answer_to_missing(answer_to: str) -> APIError:
+    return APIError(
+        status_code=400,
+        code="answer_to_missing",
+        message=f"No transcript message found for answer_to={answer_to!r}",
+    )
+
+
+def _selections_no_question(answer_to: str) -> APIError:
+    return APIError(
+        status_code=400,
+        code="selections_no_question",
+        message=(
+            f"answer_to={answer_to!r} does not reference an ask_user message; "
+            "selections are only valid against AskUserQuestion envelopes."
+        ),
+    )
+
+
+def _selections_invalid(invalid: list[str], valid: list[str]) -> APIError:
+    return APIError(
+        status_code=400,
+        code="selections_invalid",
+        message=(
+            f"Selections not in question options: {invalid!r}. "
+            f"Valid options: {valid!r}"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Session resolution
+# ---------------------------------------------------------------------------
+
+
+def _parse_task_session_name(session_name: str) -> tuple[str, int] | None:
+    """Split ``task-{project}-{task_id}`` into ``(project, task_id)``.
+
+    Mirrors :func:`pollypm.work.session_manager.task_window_name` —
+    workers don't appear in ``config.sessions`` so the resolver has to
+    re-derive the project/task split from the wire name. ``None`` for
+    anything that doesn't fit the canonical shape.
+    """
+    if not session_name.startswith("task-"):
+        return None
+    body = session_name[len("task-"):]
+    sep = body.rfind("-")
+    if sep <= 0 or sep == len(body) - 1:
+        return None
+    project = body[:sep]
+    try:
+        task_id = int(body[sep + 1 :])
+    except ValueError:
+        return None
+    if not project:
+        return None
+    return project, task_id
+
+
+def _storage_closet_session_name(tmux_session: str) -> str:
+    """Mirror ``Supervisor.storage_closet_session_name`` without importing it.
+
+    The supervisor owns this string at runtime; the chat-send router only
+    needs the same suffix convention (``-storage-closet``) so configured
+    chat surfaces resolve to the right tmux session without dragging the
+    full supervisor wiring into the HTTP layer.
+    """
+    return f"{tmux_session}-storage-closet"
+
+
+def _resolve_session(
+    config: Any,
+    session_name: str,
+) -> tuple[str, str, str | None]:
+    """Resolve ``session_name`` → ``(window_name, project_key, role)``.
+
+    Falls back to the canonical ``task-{project}-{task_id}`` shape for
+    per-task workers that aren't tracked in ``config.sessions``. Raises
+    ``404 session_unknown`` if neither resolution succeeds.
+    """
+    session = config.sessions.get(session_name) if hasattr(config, "sessions") else None
+    if session is not None:
+        window_name = session.window_name or session.name
+        return window_name, session.project, getattr(session, "role", None)
+    parsed = _parse_task_session_name(session_name)
+    if parsed is not None:
+        project, _task_id = parsed
+        # Per-task worker windows reuse the session_name verbatim as
+        # window_name (that's what ``task_window_name`` returns).
+        return session_name, project, "worker"
+    raise _session_unknown(session_name)
+
+
+def _resolve_project_root(config: Any, project_key: str) -> Path:
+    """Return the on-disk project root for ``project_key``.
+
+    Per-task workers may name a project that isn't tracked under
+    ``config.projects``; in that case we fall back to the operator's
+    ``config.project.root_dir`` (matches the mid-tool detector's only
+    other purpose — scanning JSONL — which is fine to skip when the
+    project root is unknown).
+    """
+    projects = getattr(config, "projects", {}) or {}
+    known = projects.get(project_key)
+    if known is not None:
+        return Path(known.path)
+    project = getattr(config, "project", None)
+    root_dir = getattr(project, "root_dir", None)
+    if root_dir is None:
+        # Last-resort: cwd. The mid-tool scan will simply find no
+        # events.jsonl and skip the check (fail-open) — the operator
+        # already opted to force or loose if they hit this path.
+        return Path.cwd()
+    return Path(root_dir)
+
+
+# ---------------------------------------------------------------------------
+# events.jsonl tail reader (mid-tool detection)
+# ---------------------------------------------------------------------------
+
+
+# Heuristic: enough bytes to capture the latest assistant turn plus any
+# tool_result that should match its tool_use blocks. JSONL events from
+# Claude are typically a few hundred bytes each; 64 KiB gives ~300+
+# events even for verbose Bash output. We never need more than the
+# tail for the mid-tool check (we only care about the last assistant
+# turn's open tool_use ids).
+_EVENTS_TAIL_BYTES = 64 * 1024
+
+
+def _read_events_tail(events_path: Path, max_bytes: int = _EVENTS_TAIL_BYTES) -> list[dict[str, Any]]:
+    """Return the tail JSON events from ``events_path`` as parsed dicts.
+
+    Reads at most ``max_bytes`` from the end via ``os.lseek`` so very
+    long-running sessions don't force the whole transcript into memory
+    each request. Skips the (likely truncated) first line when the
+    file is larger than ``max_bytes``.
+    """
+    try:
+        size = events_path.stat().st_size
+    except OSError:
+        return []
+    if size == 0:
+        return []
+    start = max(0, size - max_bytes)
+    try:
+        fd = os.open(events_path, os.O_RDONLY)
+    except OSError:
+        return []
+    try:
+        os.lseek(fd, start, os.SEEK_SET)
+        raw = os.read(fd, size - start)
+    finally:
+        os.close(fd)
+    try:
+        text = raw.decode("utf-8", errors="replace")
+    except Exception:  # noqa: BLE001
+        return []
+    lines = text.splitlines()
+    if start > 0 and lines:
+        # First line is almost certainly truncated mid-record.
+        lines = lines[1:]
+    events: list[dict[str, Any]] = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            events.append(obj)
+    return events
+
+
+def _find_session_events_path(project_root: Path, session_name: str) -> Path | None:
+    """Locate the events.jsonl most likely to belong to ``session_name``.
+
+    PollyPM's transcript mirror writes one ``events.jsonl`` per Claude
+    session UUID under ``<project>/.pollypm/transcripts/<uuid>/``. We
+    don't currently store a ``session_name → session_uuid`` mapping
+    (P1 of the chat spec is the natural home for that registry), so
+    this function picks the freshest ``events.jsonl`` in the project
+    that has been written to recently. For the mid-tool safety check
+    that's sufficient — there is realistically one active session per
+    project at a time, and a stale mismatch only fails-open (allowing
+    a send when we should have blocked it, which is exactly what
+    ``safety=force`` is for).
+
+    TODO(P1): replace with the registry-backed lookup once P1 lands.
+    """
+    transcripts_root = project_transcripts_dir(project_root)
+    if not transcripts_root.exists():
+        return None
+    candidate: Path | None = None
+    candidate_mtime = -1.0
+    try:
+        entries = list(transcripts_root.iterdir())
+    except OSError:
+        return None
+    for entry in entries:
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        events = entry / "events.jsonl"
+        if not events.is_file():
+            continue
+        try:
+            mtime = events.stat().st_mtime
+        except OSError:
+            continue
+        if mtime > candidate_mtime:
+            candidate_mtime = mtime
+            candidate = events
+    return candidate
+
+
+def _last_assistant_open_tool_ids(events: list[dict[str, Any]]) -> set[str]:
+    """Return ``tool_use_id``s in the *latest* assistant turn lacking a result.
+
+    Walks the events tail in reverse to find the most recent
+    ``assistant_turn``; collects every ``tool_call`` (with the same
+    or later timestamp) and subtracts every ``tool_result`` matched by
+    ``tool_use_id``. The remaining set is the mid-flight tool calls.
+    The result is empty for: no assistant turn at all, no open tools,
+    or fully-matched tool_use/tool_result pairs.
+    """
+    # Find the latest assistant_turn index — anything before that is
+    # an earlier completed turn and irrelevant to the "mid-tool right
+    # now" decision.
+    last_assistant = -1
+    for idx in range(len(events) - 1, -1, -1):
+        if events[idx].get("event_type") == "assistant_turn":
+            last_assistant = idx
+            break
+    if last_assistant < 0:
+        # No assistant turn in tail — could be very long pre-assistant
+        # window, but for safety check we treat "no recent assistant"
+        # as "not mid-tool".
+        return set()
+    open_ids: set[str] = set()
+    seen_results: set[str] = set()
+    for event in events[last_assistant:]:
+        etype = event.get("event_type")
+        payload = event.get("payload") or {}
+        if etype == "tool_call":
+            tid = payload.get("id")
+            if isinstance(tid, str) and tid:
+                open_ids.add(tid)
+        elif etype == "tool_result":
+            tid = payload.get("tool_use_id")
+            if isinstance(tid, str) and tid:
+                seen_results.add(tid)
+    return open_ids - seen_results
+
+
+def _is_mid_tool(project_root: Path, session_name: str) -> bool:
+    """True when the session's tail shows an unmatched assistant tool_use."""
+    events_path = _find_session_events_path(project_root, session_name)
+    if events_path is None:
+        return False
+    events = _read_events_tail(events_path)
+    if not events:
+        return False
+    return bool(_last_assistant_open_tool_ids(events))
+
+
+# ---------------------------------------------------------------------------
+# Mid-stream detection (heartbeat freshness)
+# ---------------------------------------------------------------------------
+
+
+_MID_STREAM_WINDOW_SECONDS = 2.0
+
+
+def _heartbeat_age_seconds(config: Any, session_name: str) -> float | None:
+    """Return seconds since ``session_name``'s latest heartbeat, or ``None``.
+
+    Reads via :func:`pollypm.storage.pg_heartbeats.latest_heartbeat` per
+    #2039 (pg-only). Any failure is treated as "no signal" — the caller
+    fails-open so a flaky pg pool doesn't block legitimate sends.
+    """
+    try:
+        from pollypm.storage.pg_heartbeats import latest_heartbeat
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        record = latest_heartbeat(session_name, config=config)
+    except Exception:  # noqa: BLE001
+        logger.debug("chat_send: pg_heartbeats.latest_heartbeat failed", exc_info=True)
+        return None
+    if record is None:
+        return None
+    stamp = record.created_at
+    try:
+        # ISO-8601 with or without ``Z`` suffix.
+        normalised = stamp.replace("Z", "+00:00") if stamp.endswith("Z") else stamp
+        ts = datetime.fromisoformat(normalised)
+    except (TypeError, ValueError):
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return max(0.0, (datetime.now(UTC) - ts).total_seconds())
+
+
+# ---------------------------------------------------------------------------
+# AskUserQuestion answer translation (§4.5)
+# ---------------------------------------------------------------------------
+
+
+def _find_ask_user_envelope(
+    project_root: Path,
+    session_name: str,
+    answer_to: str,
+) -> dict[str, Any] | None:
+    """Locate the ask_user message in ``events.jsonl`` matching ``answer_to``.
+
+    Returns the parsed event dict or ``None`` if the id isn't present.
+    The lookup is restricted to the events tail — the spec only
+    supports answering the most-recent open question (matches how
+    Claude Code presents AskUserQuestion: stale questions disappear
+    after the next turn).
+    """
+    events_path = _find_session_events_path(project_root, session_name)
+    if events_path is None:
+        return None
+    events = _read_events_tail(events_path)
+    for event in events:
+        if _event_message_id(event) == answer_to:
+            return event
+    return None
+
+
+def _event_message_id(event: dict[str, Any]) -> str | None:
+    """Extract the message id from an events.jsonl event.
+
+    Different event types carry the id in different places; the chat
+    transcript layer (P1) normalises these into a single ``id`` field
+    on each envelope. Until P1 lands we look in the canonical places:
+    payload.id (tool_use), top-level uuid, and source_offset as a last
+    resort (still stable per file).
+    """
+    payload = event.get("payload") or {}
+    for key in ("id", "uuid", "message_id"):
+        value = payload.get(key) if isinstance(payload, dict) else None
+        if isinstance(value, str) and value:
+            return value
+    for key in ("uuid", "message_id", "id"):
+        value = event.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _ask_user_options(event: dict[str, Any]) -> list[str] | None:
+    """Pull the list of option labels from an ask_user event.
+
+    Returns ``None`` when the event isn't an ask_user. The shape comes
+    from §3.5 — ``metadata.questions[].options[].label``. We accept
+    the legacy shape (``payload.questions[]`` from the AskUserQuestion
+    tool_use payload) as well so the P3 router works against the
+    raw events.jsonl that P1 hasn't normalised yet.
+    """
+    # Spec envelope (post-P1 normalisation).
+    metadata = event.get("metadata")
+    if isinstance(metadata, dict):
+        questions = metadata.get("questions")
+        if isinstance(questions, list):
+            return _flatten_question_options(questions)
+    # Raw events.jsonl (pre-P1): tool_call payload for AskUserQuestion.
+    payload = event.get("payload") or {}
+    if isinstance(payload, dict):
+        if payload.get("name") == "AskUserQuestion":
+            tool_input = payload.get("input") or {}
+            if isinstance(tool_input, dict):
+                questions = tool_input.get("questions")
+                if isinstance(questions, list):
+                    return _flatten_question_options(questions)
+        # type==ask_user direct (matches §3.5 raw form).
+        if payload.get("type") == "ask_user":
+            questions = payload.get("questions")
+            if isinstance(questions, list):
+                return _flatten_question_options(questions)
+    return None
+
+
+def _flatten_question_options(questions: list[Any]) -> list[str]:
+    out: list[str] = []
+    for question in questions:
+        if not isinstance(question, dict):
+            continue
+        options = question.get("options")
+        if not isinstance(options, list):
+            continue
+        for option in options:
+            if isinstance(option, dict):
+                label = option.get("label")
+                if isinstance(label, str) and label:
+                    out.append(label)
+            elif isinstance(option, str) and option:
+                out.append(option)
+    return out
+
+
+def _build_answer_text(selections: list[str], notes: str | None) -> str:
+    """Format the typed string for an AskUserQuestion reply.
+
+    Spec §4.5 default: option labels joined by newlines, optional
+    ``notes`` appended after another newline. Trailing newline is
+    handled by ``press_enter`` — we never append our own ``\\n`` at the
+    end here so ``press_enter=False`` produces a buffer the caller can
+    inspect.
+
+    TODO(P4): Sam's open-question #1 — confirm Claude Code's
+    AskUserQuestion stdin format. The chat-endpoint spec calls out
+    this as a user-testing gate. The current implementation matches
+    the spec's default assumption ("typing the option label verbatim
+    works"). No live Claude session is reachable from this isolated
+    worktree to run the experiment in-flight; deferred to P4
+    user-testing.
+    """
+    body = "\n".join(selections)
+    if notes:
+        if body:
+            body = f"{body}\n{notes}"
+        else:
+            body = notes
+    return body
+
+
+# ---------------------------------------------------------------------------
+# tmux helpers
+# ---------------------------------------------------------------------------
+
+
+def _tmux_session_for_send(config: Any, project_key: str) -> str:
+    """Return the storage-closet tmux session name to address.
+
+    All chat surfaces (operator, architect, advisor, per-task workers)
+    live inside the project's storage-closet session — that's the
+    invariant the supervisor enforces (``Supervisor.storage_closet_session_name``).
+    We don't import the supervisor here to keep the HTTP layer light;
+    the suffix convention is stable enough to inline.
+    """
+    project = getattr(config, "project", None)
+    tmux_session = getattr(project, "tmux_session", None) if project else None
+    if not isinstance(tmux_session, str) or not tmux_session:
+        # Fall back to the project key when the project block is sparse
+        # (e.g. tests that pass a minimal config).
+        tmux_session = project_key or "pollypm"
+    return _storage_closet_session_name(tmux_session)
+
+
+def _resolve_pane_target(
+    tmux: TmuxClient,
+    storage_session: str,
+    window_name: str,
+    pane_index: int | None,
+) -> tuple[str, bool]:
+    """Return ``(target, present)`` for a window + optional pane index.
+
+    ``present`` is True when the window exists; the caller maps
+    ``False`` to ``503 window_missing``. When the window exists but a
+    requested pane index is out of range we still raise — that's a
+    client bug, not a missing window.
+    """
+    try:
+        windows = tmux.list_windows(storage_session)
+    except Exception:  # noqa: BLE001
+        logger.debug("chat_send: list_windows(%r) failed", storage_session, exc_info=True)
+        return f"{storage_session}:{window_name}", False
+    matching = [w for w in windows if w.name == window_name]
+    if not matching:
+        return f"{storage_session}:{window_name}", False
+    window = matching[0]
+    if window.pane_dead:
+        raise _pane_dead(f"{storage_session}:{window_name}")
+    if pane_index is None or pane_index == 0:
+        # Default: address the window — send_keys hits the active pane.
+        return f"{storage_session}:{window_name}", True
+    # Specific pane requested: target ``session:window.<N>``.
+    return f"{storage_session}:{window_name}.{int(pane_index)}", True
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{session_name}/send",
+    response_model=ChatSendResponse,
+    summary="Send a message to a chat surface",
+    operation_id="sendChatMessage",
+)
+def send_chat_message(  # noqa: PLR0912, PLR0915 — gate logic is intentionally inline
+    session_name: str,
+    body: ChatSendRequest,
+    config: ConfigDep,
+    response: Response,
+) -> ChatSendResponse:
+    """POST /api/v1/chat/{session_name}/send — push text into a tmux pane."""
+    # 1. Resolve session + tmux target.
+    window_name, project_key, _role = _resolve_session(config, session_name)
+    storage_session = _tmux_session_for_send(config, project_key)
+    tmux = TmuxClient()
+    target, present = _resolve_pane_target(tmux, storage_session, window_name, body.pane)
+    if not present:
+        raise _window_missing(target)
+
+    project_root = _resolve_project_root(config, project_key)
+
+    # 2. Safety gates (§4.1, §4.3).
+    if body.safety != "force":
+        if _is_mid_tool(project_root, session_name):
+            raise _unsafe_mid_tool()
+        age = _heartbeat_age_seconds(config, session_name)
+        streaming = age is not None and age < _MID_STREAM_WINDOW_SECONDS
+        if body.safety == "strict" and streaming:
+            raise _unsafe_mid_stream()
+        if body.safety == "loose" and streaming:
+            response.headers["X-PollyPM-Warning"] = "agent-may-be-streaming"
+
+    # 3. AskUserQuestion answer handling (§4.5).
+    text_to_send: str | None
+    if body.answer_to is not None:
+        envelope = _find_ask_user_envelope(project_root, session_name, body.answer_to)
+        if envelope is None:
+            raise _answer_to_missing(body.answer_to)
+        options = _ask_user_options(envelope)
+        if options is None:
+            raise _selections_no_question(body.answer_to)
+        invalid = [s for s in body.selections if s not in options]
+        if body.selections and invalid:
+            raise _selections_invalid(invalid, options)
+        if body.selections:
+            text_to_send = _build_answer_text(body.selections, body.notes)
+        elif body.text:
+            # Freeform reply against an ask_user (§4.5 last paragraph).
+            text_to_send = body.text
+        elif body.notes:
+            text_to_send = body.notes
+        else:
+            raise APIError(
+                status_code=400,
+                code="invalid_request",
+                message="answer_to requires selections, text, or notes.",
+            )
+    else:
+        if not body.text:
+            raise APIError(
+                status_code=400,
+                code="invalid_request",
+                message="text is required when answer_to is not set.",
+            )
+        text_to_send = body.text
+
+    assert text_to_send is not None  # noqa: S101 — narrowed above
+
+    # 4. Send via tmux.
+    method: Literal["send_keys", "paste_buffer"] = (
+        "paste_buffer" if len(text_to_send) > 100 else "send_keys"
+    )
+    press_enter_at: str | None = None
+    try:
+        tmux.send_keys(target, text_to_send, press_enter=body.press_enter)
+    except DeadPaneError as exc:
+        raise _pane_dead(str(exc)) from exc
+    if body.press_enter:
+        press_enter_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+    return ChatSendResponse(
+        ok=True,
+        message_id=f"msg_{uuid.uuid4().hex}",
+        session_name=session_name,
+        window_target=target,
+        characters_sent=len(text_to_send),
+        method=method,
+        press_enter_at=press_enter_at,
+    )
+
+
+__all__ = [
+    "ChatSendRequest",
+    "ChatSendResponse",
+    "router",
+    "send_chat_message",
+]

--- a/tests/test_chat_send_endpoint.py
+++ b/tests/test_chat_send_endpoint.py
@@ -77,8 +77,11 @@ class FakeTmuxClient:
     send_side_effect: Exception | None = None
     send_calls: list[tuple[str, str, bool]] = []
     list_panes_side_effect: Exception | None = None
+    list_windows_side_effect: Exception | None = None
 
     def list_windows(self, session: str) -> list[FakeWindow]:
+        if self.list_windows_side_effect is not None:
+            raise self.list_windows_side_effect
         return list(self.windows_by_session.get(session, []))
 
     def list_panes(self, target: str) -> list[FakePane]:
@@ -101,6 +104,7 @@ def _reset_fake_tmux():
     FakeTmuxClient.send_side_effect = None
     FakeTmuxClient.send_calls = []
     FakeTmuxClient.list_panes_side_effect = None
+    FakeTmuxClient.list_windows_side_effect = None
     yield
 
 
@@ -1430,6 +1434,258 @@ def test_unknown_task_session_404s(
     )
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "session_unknown"
+
+
+# ---------------------------------------------------------------------------
+# Codex #2043 review v4 — AskUserQuestion gate carveout
+# ---------------------------------------------------------------------------
+
+
+def test_answer_to_unmatched_ask_user_does_not_409_mid_tool(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+    workspace_root: Path,
+) -> None:
+    """Codex #2043 review v4 block 1 — real AskUserQuestion is unmatched.
+
+    Pre-fix the mid-tool gate counted every unmatched ``tool_call``,
+    including AskUserQuestion. A real ask_user has NO ``tool_result``
+    until the user answers it, so strict/loose ``answer_to`` requests
+    would 409 ``unsafe_mid_tool`` before they could submit the
+    selection. The fix exempts the specific tool_use_id being answered
+    from the mid-tool count.
+    """
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    # Note: NO matching tool_result for the AskUserQuestion — this is
+    # the real-world shape (the user hasn't answered yet).
+    _write_events_jsonl(project_root, "session-real-ask", [
+        {"event_type": "user_turn", "payload": {"text": "pick"}},
+        _ask_user_event(message_id="toolu_ask", options=["alpha", "bravo"]),
+    ], cwd=workspace_root)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"answer_to": "toolu_ask", "selections": ["alpha"]},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+    assert patched_tmux.send_calls == [
+        ("pollypm-test-storage-closet:pm-operator", "alpha", True),
+    ]
+
+
+def test_answer_to_does_not_exempt_unrelated_open_tool(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+    workspace_root: Path,
+) -> None:
+    """The carveout is narrow — only the answered ask_user id is exempt.
+
+    If the assistant has an open AskUserQuestion AND a separate open
+    Bash call (e.g. running in parallel), answering the ask_user must
+    still 409 because there's still an unmatched tool. Otherwise a
+    user could ack the question while the assistant is mid-Bash and
+    corrupt the conversation.
+    """
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-mixed-open", [
+        {"event_type": "user_turn", "payload": {"text": "pick"}},
+        _ask_user_event(message_id="toolu_ask", options=["alpha"]),
+        # A separate Bash call is also mid-flight; the gate must
+        # still trip even though the caller is answering the ask_user.
+        {
+            "event_type": "tool_call",
+            "payload": {
+                "type": "tool_use",
+                "id": "toolu_bash_open",
+                "name": "Bash",
+                "input": {"command": "sleep 5"},
+            },
+        },
+    ], cwd=workspace_root)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"answer_to": "toolu_ask", "selections": ["alpha"]},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409, response.json()
+    assert response.json()["error"]["code"] == "unsafe_mid_tool"
+
+
+def test_answer_to_msg_envelope_id_resolves(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+    workspace_root: Path,
+) -> None:
+    """Codex #2043 review v4 block 2 — accept the P1 envelope id form.
+
+    P1's ``parse_events_jsonl`` (transcripts.py:398-415) returns the
+    envelope id as ``msg_<tool_use_id>``. A client that read
+    ``GET /chat/{session}/messages`` will POST
+    ``answer_to=msg_toolu_ask``; pre-fix the route searched the raw
+    ``toolu_ask`` value and returned 400 ``answer_to_missing``. The
+    fix normalises by stripping the ``msg_`` prefix before lookup.
+    """
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-envelope-id", [
+        {"event_type": "user_turn", "payload": {"text": "pick"}},
+        _ask_user_event(message_id="toolu_ask", options=["alpha"]),
+    ], cwd=workspace_root)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        # The frontend hands ``msg_toolu_ask`` (the P1 envelope id),
+        # NOT the raw ``toolu_ask``.
+        json={"answer_to": "msg_toolu_ask", "selections": ["alpha"]},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+
+
+# ---------------------------------------------------------------------------
+# Codex #2043 review v4 — narrow tmux validation errors
+# ---------------------------------------------------------------------------
+
+
+def test_list_windows_filenotfound_maps_to_503_tmux_unavailable(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex #2043 review v4 block 3 — tmux binary missing on probe.
+
+    Pre-fix every ``list_windows`` exception collapsed to
+    ``window_missing``. A missing tmux binary is a deployment issue —
+    telling the operator the window doesn't exist would send them
+    chasing the wrong thing.
+    """
+    _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.list_windows_side_effect = FileNotFoundError(
+        "[Errno 2] No such file or directory: 'tmux'",
+    )
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hi"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 503, response.json()
+    assert response.json()["error"]["code"] == "tmux_unavailable"
+
+
+def test_list_windows_timeout_maps_to_503_tmux_unavailable(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wedged tmux server on the validation probe → ``tmux_unavailable``."""
+    import subprocess as _subprocess
+
+    _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.list_windows_side_effect = _subprocess.TimeoutExpired(
+        cmd=["tmux", "list-windows"], timeout=15,
+    )
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hi"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 503, response.json()
+    assert response.json()["error"]["code"] == "tmux_unavailable"
+
+
+def test_list_panes_filenotfound_maps_to_503_tmux_unavailable(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex #2043 review v4 block 3 — tmux missing during pane probe.
+
+    Pre-fix every ``list_panes`` exception collapsed to
+    ``pane_invalid``. ``FileNotFoundError`` is "tmux is gone" — the
+    operator should restart tmux, not pick a different pane.
+    """
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.list_panes_side_effect = FileNotFoundError(
+        "[Errno 2] No such file or directory: 'tmux'",
+    )
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hi", "pane": 1},
+        headers=auth_headers,
+    )
+    assert response.status_code == 503, response.json()
+    assert response.json()["error"]["code"] == "tmux_unavailable"
+
+
+def test_list_panes_timeout_maps_to_503_tmux_unavailable(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wedged tmux during pane probe → ``tmux_unavailable`` (not pane_invalid)."""
+    import subprocess as _subprocess
+
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.list_panes_side_effect = _subprocess.TimeoutExpired(
+        cmd=["tmux", "list-panes"], timeout=15,
+    )
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hi", "pane": 1},
+        headers=auth_headers,
+    )
+    assert response.status_code == 503, response.json()
+    assert response.json()["error"]["code"] == "tmux_unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Codex #2043 review v4 — CORS exposes X-PollyPM-Warning
+# ---------------------------------------------------------------------------
+
+
+def test_cors_exposes_x_pollypm_warning_header(
+    api_config: PollyPMConfig,
+    token_path: Path,
+    token: str,  # noqa: ARG001
+) -> None:
+    """Codex #2043 review v4 block 4 — ``X-PollyPM-Warning`` must be CORS-exposed.
+
+    The send endpoint returns ``X-PollyPM-Warning: agent-may-be-
+    streaming`` for ``safety=loose`` sends, but the frontend can't
+    read it from JS unless ``Access-Control-Expose-Headers`` lists
+    it. The pre-fix CORS config only exposed ``Last-Event-ID``.
+    """
+    from pollypm.web_api import create_app
+
+    app = create_app(config=api_config, token_path=token_path)
+    client = TestClient(app)
+    # A CORS preflight against any endpoint surfaces the
+    # Access-Control-Expose-Headers value the middleware will emit
+    # on the actual request.
+    response = client.get(
+        "/api/v1/health",
+        headers={"Origin": "http://localhost:5173"},
+    )
+    expose = response.headers.get("access-control-expose-headers", "")
+    assert "X-PollyPM-Warning" in expose, (
+        f"X-PollyPM-Warning must be CORS-exposed; got {expose!r}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_chat_send_endpoint.py
+++ b/tests/test_chat_send_endpoint.py
@@ -54,21 +54,39 @@ class FakeWindow:
     pane_id: str = "%0"
 
 
+@dataclass
+class FakePane:
+    """Subset of :class:`pollypm.tmux.client.TmuxPane` the router reads."""
+
+    pane_index: int
+    pane_dead: bool = False
+
+
 class FakeTmuxClient:
     """In-memory stand-in for :class:`pollypm.tmux.client.TmuxClient`.
 
     Captures send_keys calls so tests can assert on the target / text /
-    press_enter triple. Configurable per-instance windows + send_keys
-    side effects make the negative paths (window missing, pane dead)
-    trivial to assert without monkeypatching subprocess.
+    press_enter triple. Configurable per-instance windows / panes +
+    send_keys side effects make the negative paths (window missing,
+    pane dead, pane invalid) trivial to assert without monkeypatching
+    subprocess.
     """
 
     windows_by_session: dict[str, list[FakeWindow]] = {}
+    panes_by_target: dict[str, list[FakePane]] = {}
     send_side_effect: Exception | None = None
     send_calls: list[tuple[str, str, bool]] = []
+    list_panes_side_effect: Exception | None = None
 
     def list_windows(self, session: str) -> list[FakeWindow]:
         return list(self.windows_by_session.get(session, []))
+
+    def list_panes(self, target: str) -> list[FakePane]:
+        if self.list_panes_side_effect is not None:
+            raise self.list_panes_side_effect
+        # Tests register panes by either window target ("session:window")
+        # or session, depending on the call shape; check both.
+        return list(self.panes_by_target.get(target, []))
 
     def send_keys(self, target: str, text: str, press_enter: bool = True) -> None:
         if self.send_side_effect is not None:
@@ -79,9 +97,24 @@ class FakeTmuxClient:
 @pytest.fixture(autouse=True)
 def _reset_fake_tmux():
     FakeTmuxClient.windows_by_session = {}
+    FakeTmuxClient.panes_by_target = {}
     FakeTmuxClient.send_side_effect = None
     FakeTmuxClient.send_calls = []
+    FakeTmuxClient.list_panes_side_effect = None
     yield
+
+
+@pytest.fixture(autouse=True)
+def _default_no_workers(monkeypatch: pytest.MonkeyPatch):
+    """Default: no per-task workers registered.
+
+    Tests that need worker validation override this via
+    :func:`_patch_worker_sessions`. Keeps the router off the real
+    work-service factory (pg) during unit tests.
+    """
+    monkeypatch.setattr(
+        chat_send_routes, "_list_worker_sessions", lambda config: [],
+    )
 
 
 @pytest.fixture
@@ -210,14 +243,69 @@ def _write_events_jsonl(
     project_root: Path,
     session_id: str,
     events: list[dict[str, Any]],
+    *,
+    cwd: Path | str | None = None,
+    provider: str = "claude",
+    account_name: str = "codex_primary",
 ) -> Path:
+    """Write a synthetic events.jsonl with the ``_event_base`` envelope.
+
+    The chat-send safety gates use P1's :func:`resolve_transcript_path`
+    which fingerprints transcripts by ``(cwd, account, provider)``
+    from the FIRST line of each ``events.jsonl``. We stamp those
+    fields on every event so the resolver returns an "exact" match
+    (and the strict-mode fail-closed gate stays quiet on legitimate
+    sends).
+    """
     transcripts = project_root / ".pollypm" / "transcripts" / session_id
     transcripts.mkdir(parents=True, exist_ok=True)
     path = transcripts / "events.jsonl"
     with path.open("w", encoding="utf-8") as fh:
         for event in events:
-            fh.write(json.dumps(event) + "\n")
+            payload = dict(event)
+            payload.setdefault("session_id", session_id)
+            payload.setdefault("provider", provider)
+            payload.setdefault("account_name", account_name)
+            if cwd is not None and "cwd" not in payload:
+                payload["cwd"] = str(cwd)
+            fh.write(json.dumps(payload) + "\n")
     return path
+
+
+@dataclass
+class FakeWorkerSessionRecord:
+    """Minimal :class:`WorkerSessionRecord` subset the registry reads."""
+
+    task_project: str
+    task_number: int
+    agent_name: str = "worker"
+    pane_id: str | None = None
+    worktree_path: str | None = None
+    branch_name: str | None = None
+    started_at: str = "2026-05-21T00:00:00Z"
+    ended_at: str | None = None
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    archive_path: str | None = None
+    provider: str | None = "claude"
+    provider_home: str | None = None
+
+
+def _patch_worker_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+    records: list[FakeWorkerSessionRecord],
+) -> None:
+    """Make :func:`chat_send._list_worker_sessions` return ``records``.
+
+    Avoids spinning up pg / the work-service in the router-level tests
+    — the gate we actually care about is whether the resolver accepts
+    a session_name only when the active worker-session row exists.
+    """
+    monkeypatch.setattr(
+        chat_send_routes,
+        "_list_worker_sessions",
+        lambda config: list(records),
+    )
 
 
 def _set_storage_closet_windows(
@@ -322,6 +410,10 @@ def test_happy_path_per_task_worker(
 ) -> None:
     _set_storage_closet_windows(patched_tmux, ["task-myproj-42"])
     _patch_heartbeat_age(monkeypatch, None)
+    _patch_worker_sessions(
+        monkeypatch,
+        [FakeWorkerSessionRecord(task_project="myproj", task_number=42)],
+    )
     response = client.post(
         "/api/v1/chat/task-myproj-42/send",
         json={"text": "ping worker"},
@@ -332,6 +424,64 @@ def test_happy_path_per_task_worker(
     assert body["window_target"] == (
         "pollypm-test-storage-closet:task-myproj-42"
     )
+
+
+def test_unregistered_worker_session_returns_404(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex #2043 review block 2 — `task-{project}-{id}` is not enough.
+
+    Even when a tmux window with the canonical name exists, the
+    router must refuse the send unless the work-service has an active
+    worker-session row for that exact ``(project, task_number)``. A
+    stale window or a guessed name otherwise lets an authenticated
+    caller poke an unrelated session.
+    """
+    _set_storage_closet_windows(patched_tmux, ["task-myproj-42"])
+    _patch_heartbeat_age(monkeypatch, None)
+    # Default fixture leaves _list_worker_sessions returning [].
+    response = client.post(
+        "/api/v1/chat/task-myproj-42/send",
+        json={"text": "ping worker"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+    body = response.json()
+    assert body["error"]["code"] == "session_unknown"
+
+
+def test_ended_worker_session_returns_404(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only *active* worker sessions accept sends.
+
+    A row with ``ended_at`` set is the post-teardown state — sending
+    into the storage-closet window at that point is racing with
+    cleanup. Strict 404 so the operator notices.
+    """
+    _set_storage_closet_windows(patched_tmux, ["task-myproj-42"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _patch_worker_sessions(
+        monkeypatch,
+        [FakeWorkerSessionRecord(
+            task_project="myproj",
+            task_number=42,
+            ended_at="2026-05-21T00:00:00Z",
+        )],
+    )
+    response = client.post(
+        "/api/v1/chat/task-myproj-42/send",
+        json={"text": "ping worker"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "session_unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -450,10 +600,14 @@ def test_unsafe_mid_tool_returns_409(
     patched_tmux: type[FakeTmuxClient],
     monkeypatch: pytest.MonkeyPatch,
     project_root: Path,
+    workspace_root: Path,
 ) -> None:
     _set_storage_closet_windows(patched_tmux, ["pm-operator"])
     _patch_heartbeat_age(monkeypatch, None)
-    _write_events_jsonl(project_root, "session-open", _assistant_with_open_tool())
+    _write_events_jsonl(
+        project_root, "session-open", _assistant_with_open_tool(),
+        cwd=workspace_root,
+    )
     response = client.post(
         "/api/v1/chat/operator/send",
         json={"text": "hello"},
@@ -470,10 +624,14 @@ def test_closed_tool_allows_send(
     patched_tmux: type[FakeTmuxClient],
     monkeypatch: pytest.MonkeyPatch,
     project_root: Path,
+    workspace_root: Path,
 ) -> None:
     _set_storage_closet_windows(patched_tmux, ["pm-operator"])
     _patch_heartbeat_age(monkeypatch, None)
-    _write_events_jsonl(project_root, "session-closed", _assistant_with_closed_tool())
+    _write_events_jsonl(
+        project_root, "session-closed", _assistant_with_closed_tool(),
+        cwd=workspace_root,
+    )
     response = client.post(
         "/api/v1/chat/operator/send",
         json={"text": "hello"},
@@ -488,10 +646,14 @@ def test_safety_force_bypasses_mid_tool(
     patched_tmux: type[FakeTmuxClient],
     monkeypatch: pytest.MonkeyPatch,
     project_root: Path,
+    workspace_root: Path,
 ) -> None:
     _set_storage_closet_windows(patched_tmux, ["pm-operator"])
     _patch_heartbeat_age(monkeypatch, 0.5)  # also fresh heartbeat
-    _write_events_jsonl(project_root, "session-open", _assistant_with_open_tool())
+    _write_events_jsonl(
+        project_root, "session-open", _assistant_with_open_tool(),
+        cwd=workspace_root,
+    )
     response = client.post(
         "/api/v1/chat/operator/send",
         json={"text": "hello", "safety": "force"},
@@ -506,10 +668,14 @@ def test_safety_loose_still_enforces_mid_tool(
     patched_tmux: type[FakeTmuxClient],
     monkeypatch: pytest.MonkeyPatch,
     project_root: Path,
+    workspace_root: Path,
 ) -> None:
     _set_storage_closet_windows(patched_tmux, ["pm-operator"])
     _patch_heartbeat_age(monkeypatch, None)
-    _write_events_jsonl(project_root, "session-open", _assistant_with_open_tool())
+    _write_events_jsonl(
+        project_root, "session-open", _assistant_with_open_tool(),
+        cwd=workspace_root,
+    )
     response = client.post(
         "/api/v1/chat/operator/send",
         json={"text": "hello", "safety": "loose"},
@@ -650,6 +816,7 @@ def test_answer_to_selections_happy_path(
     patched_tmux: type[FakeTmuxClient],
     monkeypatch: pytest.MonkeyPatch,
     project_root: Path,
+    workspace_root: Path,
 ) -> None:
     _set_storage_closet_windows(patched_tmux, ["pm-operator"])
     _patch_heartbeat_age(monkeypatch, None)
@@ -662,7 +829,7 @@ def test_answer_to_selections_happy_path(
             "event_type": "tool_result",
             "payload": {"type": "tool_result", "tool_use_id": "msg_q1"},
         },
-    ])
+    ], cwd=workspace_root)
     response = client.post(
         "/api/v1/chat/operator/send",
         json={"answer_to": "msg_q1", "selections": ["alpha"]},
@@ -680,6 +847,7 @@ def test_answer_to_with_notes_appends_freeform(
     patched_tmux: type[FakeTmuxClient],
     monkeypatch: pytest.MonkeyPatch,
     project_root: Path,
+    workspace_root: Path,
 ) -> None:
     _set_storage_closet_windows(patched_tmux, ["pm-operator"])
     _patch_heartbeat_age(monkeypatch, None)
@@ -687,7 +855,7 @@ def test_answer_to_with_notes_appends_freeform(
         {"event_type": "assistant_turn", "payload": {"text": "Pick"}},
         _ask_user_event(message_id="msg_q2"),
         {"event_type": "tool_result", "payload": {"type": "tool_result", "tool_use_id": "msg_q2"}},
-    ])
+    ], cwd=workspace_root)
     response = client.post(
         "/api/v1/chat/operator/send",
         json={
@@ -709,6 +877,7 @@ def test_answer_to_multiselect_newline_joined(
     patched_tmux: type[FakeTmuxClient],
     monkeypatch: pytest.MonkeyPatch,
     project_root: Path,
+    workspace_root: Path,
 ) -> None:
     _set_storage_closet_windows(patched_tmux, ["pm-operator"])
     _patch_heartbeat_age(monkeypatch, None)
@@ -716,7 +885,7 @@ def test_answer_to_multiselect_newline_joined(
         {"event_type": "assistant_turn", "payload": {"text": "Pick many"}},
         _ask_user_event(message_id="msg_q3", multi=True),
         {"event_type": "tool_result", "payload": {"type": "tool_result", "tool_use_id": "msg_q3"}},
-    ])
+    ], cwd=workspace_root)
     response = client.post(
         "/api/v1/chat/operator/send",
         json={"answer_to": "msg_q3", "selections": ["alpha", "bravo"]},
@@ -732,11 +901,17 @@ def test_answer_to_missing_returns_400(
     auth_headers: dict[str, str],
     patched_tmux: type[FakeTmuxClient],
     monkeypatch: pytest.MonkeyPatch,
-    project_root: Path,  # noqa: ARG001
+    project_root: Path,
+    workspace_root: Path,
 ) -> None:
     _set_storage_closet_windows(patched_tmux, ["pm-operator"])
     _patch_heartbeat_age(monkeypatch, None)
-    # No events.jsonl written at all.
+    # Write a transcript so the strict-mode mapping is exact; the
+    # specific answer_to id is missing from the tail, which is the
+    # 400 path we want to hit (not the "no transcript at all" path).
+    _write_events_jsonl(project_root, "session-q", [
+        {"event_type": "assistant_turn", "payload": {"text": "hi"}},
+    ], cwd=workspace_root)
     response = client.post(
         "/api/v1/chat/operator/send",
         json={"answer_to": "msg_ghost", "selections": ["alpha"]},
@@ -753,13 +928,14 @@ def test_answer_to_not_ask_user_returns_400(
     patched_tmux: type[FakeTmuxClient],
     monkeypatch: pytest.MonkeyPatch,
     project_root: Path,
+    workspace_root: Path,
 ) -> None:
     _set_storage_closet_windows(patched_tmux, ["pm-operator"])
     _patch_heartbeat_age(monkeypatch, None)
     _write_events_jsonl(project_root, "session-q", [
         {"event_type": "assistant_turn", "payload": {"text": "hi"}, "uuid": "msg_text"},
         # No AskUserQuestion — answer_to references a plain text message.
-    ])
+    ], cwd=workspace_root)
     response = client.post(
         "/api/v1/chat/operator/send",
         json={"answer_to": "msg_text", "selections": ["alpha"]},
@@ -776,6 +952,7 @@ def test_selections_invalid_returns_400(
     patched_tmux: type[FakeTmuxClient],
     monkeypatch: pytest.MonkeyPatch,
     project_root: Path,
+    workspace_root: Path,
 ) -> None:
     _set_storage_closet_windows(patched_tmux, ["pm-operator"])
     _patch_heartbeat_age(monkeypatch, None)
@@ -783,7 +960,7 @@ def test_selections_invalid_returns_400(
         {"event_type": "assistant_turn", "payload": {"text": "pick"}},
         _ask_user_event(message_id="msg_q1", options=["alpha", "bravo"]),
         {"event_type": "tool_result", "payload": {"type": "tool_result", "tool_use_id": "msg_q1"}},
-    ])
+    ], cwd=workspace_root)
     response = client.post(
         "/api/v1/chat/operator/send",
         json={"answer_to": "msg_q1", "selections": ["delta"]},
@@ -800,6 +977,7 @@ def test_answer_to_freeform_text_allowed(
     patched_tmux: type[FakeTmuxClient],
     monkeypatch: pytest.MonkeyPatch,
     project_root: Path,
+    workspace_root: Path,
 ) -> None:
     _set_storage_closet_windows(patched_tmux, ["pm-operator"])
     _patch_heartbeat_age(monkeypatch, None)
@@ -807,7 +985,7 @@ def test_answer_to_freeform_text_allowed(
         {"event_type": "assistant_turn", "payload": {"text": "pick"}},
         _ask_user_event(message_id="msg_q1", options=["alpha", "bravo"]),
         {"event_type": "tool_result", "payload": {"type": "tool_result", "tool_use_id": "msg_q1"}},
-    ])
+    ], cwd=workspace_root)
     response = client.post(
         "/api/v1/chat/operator/send",
         json={"answer_to": "msg_q1", "text": "neither, give me dayjs"},
@@ -852,12 +1030,21 @@ def test_pane_index_targets_split_pane(
 ) -> None:
     _set_storage_closet_windows(patched_tmux, ["pm-operator"])
     _patch_heartbeat_age(monkeypatch, None)
+    # Codex #2043 review block 5 — pane targets now go through
+    # list_panes for existence + liveness validation. Seed two live
+    # panes so the requested ``pane=1`` resolves.
+    patched_tmux.panes_by_target = {
+        "pollypm-test-storage-closet:pm-operator": [
+            FakePane(pane_index=0),
+            FakePane(pane_index=1),
+        ],
+    }
     response = client.post(
         "/api/v1/chat/operator/send",
         json={"text": "split pane", "pane": 1},
         headers=auth_headers,
     )
-    assert response.status_code == 200
+    assert response.status_code == 200, response.json()
     body = response.json()
     assert body["window_target"] == (
         "pollypm-test-storage-closet:pm-operator.1"
@@ -882,6 +1069,94 @@ def test_pane_zero_targets_default_pane(
     # pane=0 stays on the default window-level target (matches the
     # existing send_keys behaviour).
     assert body["window_target"] == "pollypm-test-storage-closet:pm-operator"
+
+
+def test_negative_pane_returns_409_invalid(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex #2043 review block 5 — pane >= 0 must hold."""
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hi", "pane": -1},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error"]["code"] == "pane_invalid"
+
+
+def test_nonexistent_pane_returns_409_invalid(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An in-range pane index that isn't actually on the window 409s."""
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.panes_by_target = {
+        "pollypm-test-storage-closet:pm-operator": [FakePane(pane_index=0)],
+    }
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hi", "pane": 7},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "pane_invalid"
+
+
+def test_dead_split_pane_returns_409_pane_dead(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A live window with a dead split pane 409s on that pane."""
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.panes_by_target = {
+        "pollypm-test-storage-closet:pm-operator": [
+            FakePane(pane_index=0),
+            FakePane(pane_index=1, pane_dead=True),
+        ],
+    }
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hi", "pane": 1},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "pane_dead"
+
+
+def test_list_panes_failure_returns_409_invalid(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A list_panes failure short-circuits to a typed 409.
+
+    Without this gate the subprocess error would surface as a 500;
+    the operator can't tell whether it's safe to retry. Returning
+    pane_invalid pushes the operator to pick a known-good pane.
+    """
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.list_panes_side_effect = RuntimeError("no such target")
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hi", "pane": 2},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "pane_invalid"
 
 
 def test_no_text_no_answer_to_returns_400(
@@ -929,8 +1204,9 @@ def test_unknown_task_session_404s(
     patched_tmux: type[FakeTmuxClient],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # ``task-<garbage>`` doesn't parse to (project, int) so the
-    # resolver raises 404 even though the prefix is suggestive.
+    # A name that doesn't appear in config.sessions AND has no
+    # matching active worker-session record returns 404 — this is
+    # the post-Codex-#2043 enforcement: registry-only resolution.
     _set_storage_closet_windows(patched_tmux, ["task-myproj-42"])
     _patch_heartbeat_age(monkeypatch, None)
     response = client.post(
@@ -958,7 +1234,8 @@ def test_open_tool_ids_helper_returns_unmatched(tmp_path: Path) -> None:
     assert open_ids == {"toolu_b"}
 
 
-def test_open_tool_ids_helper_empty_when_no_assistant() -> None:
+def test_open_tool_ids_helper_empty_when_only_user_turn() -> None:
+    """A user_turn alone is not "mid-tool" — empty open-id set."""
     events = [{"event_type": "user_turn", "payload": {"text": "hi"}}]
     assert chat_send_routes._last_assistant_open_tool_ids(events) == set()
 
@@ -974,14 +1251,71 @@ def test_open_tool_ids_helper_resets_per_assistant_turn() -> None:
     assert chat_send_routes._last_assistant_open_tool_ids(events) == set()
 
 
-def test_parse_task_session_name_canonical() -> None:
-    assert chat_send_routes._parse_task_session_name("task-myproj-42") == ("myproj", 42)
+def test_open_tool_ids_helper_tool_only_assistant_no_assistant_turn() -> None:
+    """Codex #2043 review block 4 — mandatory regression.
+
+    The :class:`TranscriptIngestor` only emits ``assistant_turn`` when
+    the assistant message carries text. A tool-only assistant response
+    (Claude returning a single ``tool_use`` block with no preface text)
+    produces a ``tool_call`` event in the JSONL stream WITHOUT a
+    preceding ``assistant_turn`` anchor.
+
+    The pre-fix ``_last_assistant_open_tool_ids`` walked back for the
+    most-recent ``assistant_turn`` and returned an empty set when it
+    didn't find one, making the mid-tool gate fail open and let the
+    operator type into a window whose Claude is still waiting on a
+    Bash tool to come back.
+
+    The fix anchors on the ``user_turn`` boundary instead so the
+    tool-only assistant span is still caught.
+    """
+    events = [
+        {"event_type": "user_turn", "payload": {"text": "go ahead"}},
+        # Claude responded with ONLY a tool_use — no text → no
+        # assistant_turn ever emitted.
+        {"event_type": "tool_call", "payload": {"id": "toolu_silent"}},
+    ]
+    open_ids = chat_send_routes._last_assistant_open_tool_ids(events)
+    assert open_ids == {"toolu_silent"}, (
+        "tool-only assistant turn must still trip the mid-tool gate"
+    )
 
 
-def test_parse_task_session_name_rejects_garbage() -> None:
-    assert chat_send_routes._parse_task_session_name("operator") is None
-    assert chat_send_routes._parse_task_session_name("task-only") is None
-    assert chat_send_routes._parse_task_session_name("task-foo-bar") is None
+def test_open_tool_ids_helper_tool_only_assistant_end_to_end_409(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+    workspace_root: Path,
+) -> None:
+    """End-to-end mandate for Codex #2043 review block 4.
+
+    Synthesize an events.jsonl whose ONLY assistant artifact is a raw
+    ``tool_call`` — no preceding ``assistant_turn``. Assert the
+    chat-send strict-mode gate returns 409 ``unsafe_mid_tool``.
+    """
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-tool-only", [
+        {"event_type": "user_turn", "payload": {"text": "do thing"}},
+        {
+            "event_type": "tool_call",
+            "payload": {
+                "type": "tool_use",
+                "id": "toolu_silent",
+                "name": "Bash",
+                "input": {"command": "true"},
+            },
+        },
+    ], cwd=workspace_root)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "ping"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409, response.json()
+    assert response.json()["error"]["code"] == "unsafe_mid_tool"
 
 
 def test_build_answer_text_selections_only() -> None:

--- a/tests/test_chat_send_endpoint.py
+++ b/tests/test_chat_send_endpoint.py
@@ -564,6 +564,135 @@ def test_dead_pane_error_from_send_keys_maps_to_409(
     assert body["error"]["code"] == "pane_dead"
 
 
+def test_send_keys_subprocess_window_missing_maps_to_503_window_missing(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex #2043 review v3 block 2 — window disappears post-validation.
+
+    ``list_windows`` saw the window during validation, but tmux tore
+    it down before the ``send-keys`` shell-out completed. The
+    subprocess returns exit code 1 with ``can't find window`` on
+    stderr. Pre-fix this surfaced as a generic 500; we now map it
+    to a typed 503 ``window_missing`` so the operator knows the
+    surface vanished mid-flight (vs. tmux being entirely down).
+    """
+    import subprocess as _subprocess
+
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.send_side_effect = _subprocess.CalledProcessError(
+        returncode=1,
+        cmd=["tmux", "send-keys"],
+        stderr="can't find window: pm-operator",
+    )
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 503, response.json()
+    assert response.json()["error"]["code"] == "window_missing"
+
+
+def test_send_keys_generic_subprocess_failure_maps_to_503_send_failed(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A subprocess error that isn't a missing window → ``send_failed``.
+
+    E.g. permissions/escape issues that tmux rejects. The operator
+    gets the underlying stderr in ``message`` and a documented 503
+    code instead of a generic 500.
+    """
+    import subprocess as _subprocess
+
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.send_side_effect = _subprocess.CalledProcessError(
+        returncode=2,
+        cmd=["tmux", "send-keys"],
+        stderr="usage: send-keys ...",
+    )
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "send_failed"
+
+
+def test_send_keys_tmux_missing_binary_maps_to_503_tmux_unavailable(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``FileNotFoundError`` from subprocess.run → ``tmux_unavailable``."""
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.send_side_effect = FileNotFoundError(
+        "[Errno 2] No such file or directory: 'tmux'",
+    )
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "tmux_unavailable"
+
+
+def test_send_keys_tmux_timeout_maps_to_503_tmux_unavailable(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``subprocess.TimeoutExpired`` (wedged tmux) → ``tmux_unavailable``."""
+    import subprocess as _subprocess
+
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.send_side_effect = _subprocess.TimeoutExpired(
+        cmd=["tmux", "send-keys"], timeout=15,
+    )
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "tmux_unavailable"
+
+
+def test_send_keys_paste_buffer_oserror_maps_to_503_send_failed(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OSError on long-text paste-buffer path → ``send_failed`` (not 500)."""
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.send_side_effect = OSError("disk full while writing paste buffer")
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        # >100 chars to trigger the paste_buffer path in production
+        # (though the fake just raises regardless — the gate we care
+        # about is the route's exception handler).
+        json={"text": "x" * 250},
+        headers=auth_headers,
+    )
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "send_failed"
+
+
 # ---------------------------------------------------------------------------
 # Safety: mid-tool
 # ---------------------------------------------------------------------------
@@ -1051,23 +1180,108 @@ def test_pane_index_targets_split_pane(
     )
 
 
-def test_pane_zero_targets_default_pane(
+def test_explicit_pane_zero_validates_via_list_panes(
     client: TestClient,
     auth_headers: dict[str, str],
     patched_tmux: type[FakeTmuxClient],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Codex #2043 review v3 block 1 — explicit pane=0 != active pane.
+
+    tmux's active pane is NOT necessarily index 0 (the user can split
+    and focus the new pane). The pre-fix router treated
+    ``pane is None`` and ``pane == 0`` the same and shipped the send
+    to the window-level target (active pane). That bypasses
+    ``list_panes`` validation AND can land in the wrong pane.
+
+    The fix: any explicit integer (including 0) routes through
+    ``list_panes`` and addresses ``session:window.0`` explicitly.
+    Here we seed pane 0 alive and pane 1 alive — the request must
+    land on ``...:pm-operator.0``, NOT the window-level target.
+    """
     _set_storage_closet_windows(patched_tmux, ["pm-operator"])
     _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.panes_by_target = {
+        "pollypm-test-storage-closet:pm-operator": [
+            FakePane(pane_index=0),
+            FakePane(pane_index=1),  # active in tmux but we asked for 0
+        ],
+    }
     response = client.post(
         "/api/v1/chat/operator/send",
         json={"text": "hello", "pane": 0},
         headers=auth_headers,
     )
-    assert response.status_code == 200
+    assert response.status_code == 200, response.json()
     body = response.json()
-    # pane=0 stays on the default window-level target (matches the
-    # existing send_keys behaviour).
+    # Explicit pane=0 now resolves to the indexed target. The
+    # pre-fix code returned the window-level target and would have
+    # landed on tmux's active pane (potentially pane 1).
+    assert body["window_target"] == (
+        "pollypm-test-storage-closet:pm-operator.0"
+    )
+    target, _text, _enter = patched_tmux.send_calls[0]
+    assert target == "pollypm-test-storage-closet:pm-operator.0", (
+        "explicit pane=0 must not fall through to the window-level "
+        "(active-pane) target"
+    )
+
+
+def test_explicit_pane_zero_409s_when_pane_zero_dead(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Companion to the above: dead pane 0 must 409 instead of silent fallthrough.
+
+    Pre-fix, ``pane=0`` aliased to the window-level target whose
+    ``pane_dead`` bit reflected the ACTIVE pane. If the active pane
+    happened to be alive (pane 1) the request would succeed and the
+    text would land in pane 1 — the operator never finds out pane 0
+    was dead.
+    """
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.panes_by_target = {
+        "pollypm-test-storage-closet:pm-operator": [
+            FakePane(pane_index=0, pane_dead=True),
+            FakePane(pane_index=1),  # alive but the caller asked for 0
+        ],
+    }
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello", "pane": 0},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409, response.json()
+    assert response.json()["error"]["code"] == "pane_dead"
+    # And critically: nothing was sent.
+    assert patched_tmux.send_calls == []
+
+
+def test_default_pane_none_uses_window_level_target(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``pane`` omitted (None) still uses the window-level target.
+
+    This is the only case that goes to tmux's active pane without
+    a ``list_panes`` probe — explicit indexes always validate.
+    """
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    # Note: no panes_by_target — list_panes would fail. Default-pane
+    # path must not call it.
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+    body = response.json()
     assert body["window_target"] == "pollypm-test-storage-closet:pm-operator"
 
 

--- a/tests/test_chat_send_endpoint.py
+++ b/tests/test_chat_send_endpoint.py
@@ -1,0 +1,1018 @@
+"""P3 chat-endpoints spec — POST /api/v1/chat/{session}/send tests.
+
+Run via:
+
+    pytest --noconftest tests/test_chat_send_endpoint.py -v
+
+The ``--noconftest`` flag skips the repo's heavy conftest (which spins
+up pg pools etc.); every fixture this test needs is defined inline.
+
+Coverage targets §2.3 (endpoint contract) and §4.1 / §4.3 / §4.5
+(safety gates + AskUserQuestion answer translation) of
+``~/Desktop/pollypm-chat-endpoints-spec.md``. The TmuxClient is fully
+mocked — these are router-level integration tests, not real tmux.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from pollypm.config import (
+    AccountConfig,
+    MemorySettings,
+    PollyPMConfig,
+    PollyPMSettings,
+    ProjectSettings,
+)
+from pollypm.models import (
+    KnownProject,
+    ProjectKind,
+    ProviderKind,
+    RuntimeKind,
+    SessionConfig,
+)
+from pollypm.tmux.client import DeadPaneError
+from pollypm.web_api import create_app, ensure_token
+from pollypm.web_api.routes import chat_send as chat_send_routes
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeWindow:
+    name: str
+    pane_dead: bool = False
+    pane_id: str = "%0"
+
+
+class FakeTmuxClient:
+    """In-memory stand-in for :class:`pollypm.tmux.client.TmuxClient`.
+
+    Captures send_keys calls so tests can assert on the target / text /
+    press_enter triple. Configurable per-instance windows + send_keys
+    side effects make the negative paths (window missing, pane dead)
+    trivial to assert without monkeypatching subprocess.
+    """
+
+    windows_by_session: dict[str, list[FakeWindow]] = {}
+    send_side_effect: Exception | None = None
+    send_calls: list[tuple[str, str, bool]] = []
+
+    def list_windows(self, session: str) -> list[FakeWindow]:
+        return list(self.windows_by_session.get(session, []))
+
+    def send_keys(self, target: str, text: str, press_enter: bool = True) -> None:
+        if self.send_side_effect is not None:
+            raise self.send_side_effect
+        self.send_calls.append((target, text, press_enter))
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_tmux():
+    FakeTmuxClient.windows_by_session = {}
+    FakeTmuxClient.send_side_effect = None
+    FakeTmuxClient.send_calls = []
+    yield
+
+
+@pytest.fixture
+def patched_tmux(monkeypatch: pytest.MonkeyPatch) -> type[FakeTmuxClient]:
+    """Swap :class:`TmuxClient` in the router module for the fake."""
+    monkeypatch.setattr(chat_send_routes, "TmuxClient", FakeTmuxClient)
+    return FakeTmuxClient
+
+
+# ---------------------------------------------------------------------------
+# Config / app fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def project_root(tmp_path: Path) -> Path:
+    root = tmp_path / "myproj"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    (root / ".pollypm" / "transcripts").mkdir()
+    return root
+
+
+@pytest.fixture
+def workspace_root(tmp_path: Path) -> Path:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / ".pollypm").mkdir()
+    return root
+
+
+@pytest.fixture
+def api_config(project_root: Path, workspace_root: Path) -> PollyPMConfig:
+    base_dir = workspace_root / ".pollypm"
+    state_db = base_dir / "state.db"
+    return PollyPMConfig(
+        project=ProjectSettings(
+            name="PollyPM",
+            root_dir=workspace_root,
+            tmux_session="pollypm-test",
+            workspace_root=workspace_root,
+            base_dir=base_dir,
+            logs_dir=base_dir / "logs",
+            snapshots_dir=base_dir / "snapshots",
+            state_db=state_db,
+        ),
+        pollypm=PollyPMSettings(
+            controller_account="codex_primary",
+            open_permissions_by_default=False,
+            failover_enabled=False,
+            failover_accounts=[],
+            heartbeat_backend="local",
+            scheduler_backend="inline",
+            lease_timeout_minutes=30,
+        ),
+        accounts={
+            "codex_primary": AccountConfig(
+                name="codex_primary",
+                provider=ProviderKind.CODEX,
+                email="codex@example.com",
+                runtime=RuntimeKind.LOCAL,
+                home=base_dir / "homes" / "codex_primary",
+            ),
+        },
+        sessions={
+            "operator": SessionConfig(
+                name="operator",
+                role="operator",
+                provider=ProviderKind.CLAUDE,
+                account="codex_primary",
+                cwd=workspace_root,
+                project="myproj",
+                window_name="pm-operator",
+            ),
+            "architect_myproj": SessionConfig(
+                name="architect_myproj",
+                role="architect",
+                provider=ProviderKind.CLAUDE,
+                account="codex_primary",
+                cwd=workspace_root,
+                project="myproj",
+                window_name="pm-architect-myproj",
+            ),
+        },
+        projects={
+            "myproj": KnownProject(
+                key="myproj",
+                path=project_root,
+                name="My Project",
+                tracked=True,
+                kind=ProjectKind.GIT,
+            ),
+        },
+        memory=MemorySettings(backend="file"),
+    )
+
+
+@pytest.fixture
+def token_path(tmp_path: Path) -> Path:
+    return tmp_path / "api-token"
+
+
+@pytest.fixture
+def token(token_path: Path) -> str:
+    value, _ = ensure_token(token_path)
+    return value
+
+
+@pytest.fixture
+def auth_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def client(api_config: PollyPMConfig, token_path: Path, token: str) -> TestClient:  # noqa: ARG001
+    app = create_app(config=api_config, token_path=token_path)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to seed transcript / heartbeat fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_events_jsonl(
+    project_root: Path,
+    session_id: str,
+    events: list[dict[str, Any]],
+) -> Path:
+    transcripts = project_root / ".pollypm" / "transcripts" / session_id
+    transcripts.mkdir(parents=True, exist_ok=True)
+    path = transcripts / "events.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for event in events:
+            fh.write(json.dumps(event) + "\n")
+    return path
+
+
+def _set_storage_closet_windows(
+    patched_tmux: type[FakeTmuxClient],
+    window_names: list[str],
+    *,
+    storage: str = "pollypm-test-storage-closet",
+    dead_windows: tuple[str, ...] = (),
+) -> None:
+    patched_tmux.windows_by_session = {
+        storage: [
+            FakeWindow(name=name, pane_dead=(name in dead_windows))
+            for name in window_names
+        ]
+    }
+
+
+def _patch_heartbeat_age(monkeypatch: pytest.MonkeyPatch, seconds: float | None) -> None:
+    def _fake(config, session_name):  # noqa: ARG001
+        return seconds
+
+    monkeypatch.setattr(chat_send_routes, "_heartbeat_age_seconds", _fake)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_text_send(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello operator"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+    body = response.json()
+    assert body["ok"] is True
+    assert body["session_name"] == "operator"
+    assert body["window_target"] == "pollypm-test-storage-closet:pm-operator"
+    assert body["characters_sent"] == len("hello operator")
+    assert body["method"] == "send_keys"
+    assert body["message_id"].startswith("msg_")
+    assert body["press_enter_at"] is not None
+    assert patched_tmux.send_calls == [
+        ("pollypm-test-storage-closet:pm-operator", "hello operator", True),
+    ]
+
+
+def test_happy_path_long_text_uses_paste_buffer(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    long_text = "x" * 250
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": long_text},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["method"] == "paste_buffer"
+    assert body["characters_sent"] == 250
+
+
+def test_happy_path_architect_session(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-architect-myproj"])
+    _patch_heartbeat_age(monkeypatch, None)
+    response = client.post(
+        "/api/v1/chat/architect_myproj/send",
+        json={"text": "hi archie"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["window_target"] == (
+        "pollypm-test-storage-closet:pm-architect-myproj"
+    )
+
+
+def test_happy_path_per_task_worker(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["task-myproj-42"])
+    _patch_heartbeat_age(monkeypatch, None)
+    response = client.post(
+        "/api/v1/chat/task-myproj-42/send",
+        json={"text": "ping worker"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+    body = response.json()
+    assert body["window_target"] == (
+        "pollypm-test-storage-closet:task-myproj-42"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_session_returns_404(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],  # noqa: ARG001
+) -> None:
+    response = client.post(
+        "/api/v1/chat/nope/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+    body = response.json()
+    assert body["error"]["code"] == "session_unknown"
+
+
+def test_missing_window_returns_503(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # storage-closet has *other* windows but not the operator one.
+    _set_storage_closet_windows(patched_tmux, ["pm-architect-myproj"])
+    _patch_heartbeat_age(monkeypatch, None)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 503
+    body = response.json()
+    assert body["error"]["code"] == "window_missing"
+
+
+def test_pane_dead_returns_409(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(
+        patched_tmux,
+        ["pm-operator"],
+        dead_windows=("pm-operator",),
+    )
+    _patch_heartbeat_age(monkeypatch, None)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error"]["code"] == "pane_dead"
+
+
+def test_dead_pane_error_from_send_keys_maps_to_409(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    patched_tmux.send_side_effect = DeadPaneError("pane %5 is dead")
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error"]["code"] == "pane_dead"
+
+
+# ---------------------------------------------------------------------------
+# Safety: mid-tool
+# ---------------------------------------------------------------------------
+
+
+def _assistant_with_open_tool(tool_use_id: str = "toolu_open") -> list[dict[str, Any]]:
+    return [
+        {"event_type": "user_turn", "payload": {"text": "do thing"}},
+        {"event_type": "assistant_turn", "payload": {"text": "running"}},
+        {
+            "event_type": "tool_call",
+            "payload": {
+                "type": "tool_use",
+                "id": tool_use_id,
+                "name": "Bash",
+                "input": {"command": "true"},
+            },
+        },
+    ]
+
+
+def _assistant_with_closed_tool(tool_use_id: str = "toolu_closed") -> list[dict[str, Any]]:
+    return _assistant_with_open_tool(tool_use_id) + [
+        {
+            "event_type": "tool_result",
+            "payload": {"type": "tool_result", "tool_use_id": tool_use_id, "content": "ok"},
+        },
+    ]
+
+
+def test_unsafe_mid_tool_returns_409(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-open", _assistant_with_open_tool())
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error"]["code"] == "unsafe_mid_tool"
+
+
+def test_closed_tool_allows_send(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-closed", _assistant_with_closed_tool())
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+
+
+def test_safety_force_bypasses_mid_tool(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, 0.5)  # also fresh heartbeat
+    _write_events_jsonl(project_root, "session-open", _assistant_with_open_tool())
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello", "safety": "force"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+
+
+def test_safety_loose_still_enforces_mid_tool(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-open", _assistant_with_open_tool())
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello", "safety": "loose"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "unsafe_mid_tool"
+
+
+# ---------------------------------------------------------------------------
+# Safety: mid-stream
+# ---------------------------------------------------------------------------
+
+
+def test_unsafe_mid_stream_returns_409(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, 0.4)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error"]["code"] == "unsafe_mid_stream"
+
+
+def test_safety_loose_bypasses_mid_stream_with_warning_header(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, 0.4)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello", "safety": "loose"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.headers.get("X-PollyPM-Warning") == "agent-may-be-streaming"
+
+
+def test_safety_loose_no_warning_when_heartbeat_stale(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, 30.0)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello", "safety": "loose"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert "X-PollyPM-Warning" not in response.headers
+
+
+def test_safety_force_bypasses_mid_stream(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, 0.1)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello", "safety": "force"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert "X-PollyPM-Warning" not in response.headers
+
+
+def test_stale_heartbeat_allows_strict_send(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, 5.0)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# AskUserQuestion (§4.5)
+# ---------------------------------------------------------------------------
+
+
+def _ask_user_event(
+    *,
+    message_id: str = "msg_q1",
+    options: list[str] | None = None,
+    multi: bool = False,
+) -> dict[str, Any]:
+    return {
+        "event_type": "tool_call",
+        "uuid": message_id,
+        "payload": {
+            "type": "tool_use",
+            "id": message_id,
+            "name": "AskUserQuestion",
+            "input": {
+                "questions": [
+                    {
+                        "question": "Pick one",
+                        "header": "Q1",
+                        "multiSelect": multi,
+                        "options": [
+                            {"label": label, "description": ""}
+                            for label in (options or ["alpha", "bravo", "charlie"])
+                        ],
+                    }
+                ]
+            },
+        },
+    }
+
+
+def test_answer_to_selections_happy_path(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-q", [
+        {"event_type": "assistant_turn", "payload": {"text": "Question incoming"}},
+        _ask_user_event(message_id="msg_q1", options=["alpha", "bravo"]),
+        # Match the open tool_use so the mid-tool gate doesn't fire on
+        # the AskUserQuestion event itself.
+        {
+            "event_type": "tool_result",
+            "payload": {"type": "tool_result", "tool_use_id": "msg_q1"},
+        },
+    ])
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"answer_to": "msg_q1", "selections": ["alpha"]},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+    assert patched_tmux.send_calls == [
+        ("pollypm-test-storage-closet:pm-operator", "alpha", True),
+    ]
+
+
+def test_answer_to_with_notes_appends_freeform(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-q", [
+        {"event_type": "assistant_turn", "payload": {"text": "Pick"}},
+        _ask_user_event(message_id="msg_q2"),
+        {"event_type": "tool_result", "payload": {"type": "tool_result", "tool_use_id": "msg_q2"}},
+    ])
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={
+            "answer_to": "msg_q2",
+            "selections": ["alpha"],
+            "notes": "actually prefer luxon",
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    target, text, _enter = patched_tmux.send_calls[0]
+    assert text == "alpha\nactually prefer luxon"
+    assert target == "pollypm-test-storage-closet:pm-operator"
+
+
+def test_answer_to_multiselect_newline_joined(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-q", [
+        {"event_type": "assistant_turn", "payload": {"text": "Pick many"}},
+        _ask_user_event(message_id="msg_q3", multi=True),
+        {"event_type": "tool_result", "payload": {"type": "tool_result", "tool_use_id": "msg_q3"}},
+    ])
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"answer_to": "msg_q3", "selections": ["alpha", "bravo"]},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    _target, text, _enter = patched_tmux.send_calls[0]
+    assert text == "alpha\nbravo"
+
+
+def test_answer_to_missing_returns_400(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,  # noqa: ARG001
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    # No events.jsonl written at all.
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"answer_to": "msg_ghost", "selections": ["alpha"]},
+        headers=auth_headers,
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["code"] == "answer_to_missing"
+
+
+def test_answer_to_not_ask_user_returns_400(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-q", [
+        {"event_type": "assistant_turn", "payload": {"text": "hi"}, "uuid": "msg_text"},
+        # No AskUserQuestion — answer_to references a plain text message.
+    ])
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"answer_to": "msg_text", "selections": ["alpha"]},
+        headers=auth_headers,
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["code"] == "selections_no_question"
+
+
+def test_selections_invalid_returns_400(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-q", [
+        {"event_type": "assistant_turn", "payload": {"text": "pick"}},
+        _ask_user_event(message_id="msg_q1", options=["alpha", "bravo"]),
+        {"event_type": "tool_result", "payload": {"type": "tool_result", "tool_use_id": "msg_q1"}},
+    ])
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"answer_to": "msg_q1", "selections": ["delta"]},
+        headers=auth_headers,
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["code"] == "selections_invalid"
+
+
+def test_answer_to_freeform_text_allowed(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(project_root, "session-q", [
+        {"event_type": "assistant_turn", "payload": {"text": "pick"}},
+        _ask_user_event(message_id="msg_q1", options=["alpha", "bravo"]),
+        {"event_type": "tool_result", "payload": {"type": "tool_result", "tool_use_id": "msg_q1"}},
+    ])
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"answer_to": "msg_q1", "text": "neither, give me dayjs"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    _target, text, _enter = patched_tmux.send_calls[0]
+    assert text == "neither, give me dayjs"
+
+
+# ---------------------------------------------------------------------------
+# Misc: press_enter, pane, payload validation
+# ---------------------------------------------------------------------------
+
+
+def test_press_enter_false_skips_enter(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "draft only", "press_enter": False},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["press_enter_at"] is None
+    assert patched_tmux.send_calls == [
+        ("pollypm-test-storage-closet:pm-operator", "draft only", False),
+    ]
+
+
+def test_pane_index_targets_split_pane(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "split pane", "pane": 1},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["window_target"] == (
+        "pollypm-test-storage-closet:pm-operator.1"
+    )
+
+
+def test_pane_zero_targets_default_pane(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello", "pane": 0},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    # pane=0 stays on the default window-level target (matches the
+    # existing send_keys behaviour).
+    assert body["window_target"] == "pollypm-test-storage-closet:pm-operator"
+
+
+def test_no_text_no_answer_to_returns_400(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={},
+        headers=auth_headers,
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["code"] == "invalid_request"
+
+
+def test_auth_required(
+    client: TestClient,
+    patched_tmux: type[FakeTmuxClient],  # noqa: ARG001
+) -> None:
+    response = client.post("/api/v1/chat/operator/send", json={"text": "hi"})
+    # The bearer-auth dependency rejects before the route runs.
+    assert response.status_code == 401
+
+
+def test_invalid_token_returns_401(
+    client: TestClient,
+    patched_tmux: type[FakeTmuxClient],  # noqa: ARG001
+) -> None:
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hi"},
+        headers={"Authorization": "Bearer wrong"},
+    )
+    assert response.status_code == 401
+
+
+def test_unknown_task_session_404s(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # ``task-<garbage>`` doesn't parse to (project, int) so the
+    # resolver raises 404 even though the prefix is suggestive.
+    _set_storage_closet_windows(patched_tmux, ["task-myproj-42"])
+    _patch_heartbeat_age(monkeypatch, None)
+    response = client.post(
+        "/api/v1/chat/task-only/send",
+        json={"text": "hi"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "session_unknown"
+
+
+# ---------------------------------------------------------------------------
+# Unit-level tail/parser checks (executed via direct module access)
+# ---------------------------------------------------------------------------
+
+
+def test_open_tool_ids_helper_returns_unmatched(tmp_path: Path) -> None:
+    events = [
+        {"event_type": "assistant_turn", "payload": {"text": "x"}},
+        {"event_type": "tool_call", "payload": {"id": "toolu_a"}},
+        {"event_type": "tool_call", "payload": {"id": "toolu_b"}},
+        {"event_type": "tool_result", "payload": {"tool_use_id": "toolu_a"}},
+    ]
+    open_ids = chat_send_routes._last_assistant_open_tool_ids(events)
+    assert open_ids == {"toolu_b"}
+
+
+def test_open_tool_ids_helper_empty_when_no_assistant() -> None:
+    events = [{"event_type": "user_turn", "payload": {"text": "hi"}}]
+    assert chat_send_routes._last_assistant_open_tool_ids(events) == set()
+
+
+def test_open_tool_ids_helper_resets_per_assistant_turn() -> None:
+    # Earlier turn had unmatched tools, but a fresh assistant_turn
+    # supersedes them — only the LATEST turn's open ids matter.
+    events = [
+        {"event_type": "assistant_turn", "payload": {"text": "first"}},
+        {"event_type": "tool_call", "payload": {"id": "stale_open"}},
+        {"event_type": "assistant_turn", "payload": {"text": "second"}},
+    ]
+    assert chat_send_routes._last_assistant_open_tool_ids(events) == set()
+
+
+def test_parse_task_session_name_canonical() -> None:
+    assert chat_send_routes._parse_task_session_name("task-myproj-42") == ("myproj", 42)
+
+
+def test_parse_task_session_name_rejects_garbage() -> None:
+    assert chat_send_routes._parse_task_session_name("operator") is None
+    assert chat_send_routes._parse_task_session_name("task-only") is None
+    assert chat_send_routes._parse_task_session_name("task-foo-bar") is None
+
+
+def test_build_answer_text_selections_only() -> None:
+    assert chat_send_routes._build_answer_text(["a", "b"], None) == "a\nb"
+
+
+def test_build_answer_text_with_notes() -> None:
+    assert chat_send_routes._build_answer_text(["a"], "extra") == "a\nextra"
+
+
+def test_build_answer_text_notes_only() -> None:
+    assert chat_send_routes._build_answer_text([], "just notes") == "just notes"
+
+
+def test_read_events_tail_handles_truncated_first_line(tmp_path: Path) -> None:
+    # Write events larger than max_bytes so the tail reader trims line 1.
+    events_path = tmp_path / "events.jsonl"
+    with events_path.open("w", encoding="utf-8") as fh:
+        for idx in range(50):
+            fh.write(json.dumps({"event_type": "user_turn", "i": idx, "pad": "x" * 200}) + "\n")
+    parsed = chat_send_routes._read_events_tail(events_path, max_bytes=512)
+    # We dropped the first (likely truncated) line; remaining are valid JSON.
+    assert all(isinstance(e, dict) and "event_type" in e for e in parsed)
+    assert len(parsed) >= 1
+
+
+def test_read_events_tail_empty_file(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    events_path.write_text("")
+    assert chat_send_routes._read_events_tail(events_path) == []
+
+
+def test_read_events_tail_missing_file(tmp_path: Path) -> None:
+    assert chat_send_routes._read_events_tail(tmp_path / "nope.jsonl") == []

--- a/tests/test_chat_send_endpoint.py
+++ b/tests/test_chat_send_endpoint.py
@@ -121,7 +121,19 @@ def _default_no_workers(monkeypatch: pytest.MonkeyPatch):
     patched: the route reads the strict seam now (Codex #2043 review
     v6 blocker 1) but tests that pre-date v6 still reach for the
     legacy name and we want them to keep working.
+
+    Codex #2043 review v7 blocker 1: stash the original strict helper
+    on the module as ``_list_worker_sessions_strict_original`` so tests
+    that need to exercise the real public-facade-bypass path (#2043 v6
+    regression) can restore it without relying on ``__wrapped__``
+    (the lambda below has no ``__wrapped__``).
     """
+    monkeypatch.setattr(
+        chat_send_routes,
+        "_list_worker_sessions_strict_original",
+        chat_send_routes._list_worker_sessions_strict,
+        raising=False,
+    )
     monkeypatch.setattr(
         chat_send_routes, "_list_worker_sessions", lambda config: [],
     )
@@ -2300,13 +2312,14 @@ def test_real_open_work_service_failure_returns_503(
 
     # Override the autouse fixture's strict-seam stub so the strict
     # helper actually executes (and reaches the real
-    # ``_open_work_service_readonly``).
+    # ``_open_work_service_readonly``). The autouse fixture stashed
+    # the unpatched original on the module as
+    # ``_list_worker_sessions_strict_original`` for exactly this case
+    # (Codex #2043 review v7 blocker 1).
     monkeypatch.setattr(
         chat_send_routes,
         "_list_worker_sessions_strict",
-        chat_send_routes._list_worker_sessions_strict.__wrapped__
-        if hasattr(chat_send_routes._list_worker_sessions_strict, "__wrapped__")
-        else chat_send_routes._list_worker_sessions_strict,
+        chat_send_routes._list_worker_sessions_strict_original,
     )
 
     import pollypm.web_api.service as service_mod
@@ -2355,6 +2368,13 @@ def test_list_worker_sessions_strict_returns_empty_when_no_workers(
 
     monkeypatch.setattr(service_mod, "_open_work_service_readonly", _stub)
 
+    # Restore the original strict helper (autouse fixture replaces it).
+    monkeypatch.setattr(
+        chat_send_routes,
+        "_list_worker_sessions_strict",
+        chat_send_routes._list_worker_sessions_strict_original,
+    )
+
     assert chat_send_routes._list_worker_sessions_strict(api_config) == []
 
 
@@ -2373,6 +2393,15 @@ def test_list_worker_sessions_strict_raises_typed_on_facade_open_failure(
     import pollypm.web_api.service as service_mod
 
     monkeypatch.setattr(service_mod, "_open_work_service_readonly", _boom)
+
+    # Codex #2043 review v7 blocker 1: the autouse fixture replaces
+    # the module-level strict helper with a no-op lambda. Restore the
+    # original (stashed by that fixture) before exercising the unit.
+    monkeypatch.setattr(
+        chat_send_routes,
+        "_list_worker_sessions_strict",
+        chat_send_routes._list_worker_sessions_strict_original,
+    )
 
     with pytest.raises(chat_send_routes._WorkerFacadeUnavailable):
         chat_send_routes._list_worker_sessions_strict(api_config)

--- a/tests/test_chat_send_endpoint.py
+++ b/tests/test_chat_send_endpoint.py
@@ -115,9 +115,18 @@ def _default_no_workers(monkeypatch: pytest.MonkeyPatch):
     Tests that need worker validation override this via
     :func:`_patch_worker_sessions`. Keeps the router off the real
     work-service factory (pg) during unit tests.
+
+    Both the legacy facade-wrapped seam (``_list_worker_sessions``)
+    and the v6 strict seam (``_list_worker_sessions_strict``) are
+    patched: the route reads the strict seam now (Codex #2043 review
+    v6 blocker 1) but tests that pre-date v6 still reach for the
+    legacy name and we want them to keep working.
     """
     monkeypatch.setattr(
         chat_send_routes, "_list_worker_sessions", lambda config: [],
+    )
+    monkeypatch.setattr(
+        chat_send_routes, "_list_worker_sessions_strict", lambda config: [],
     )
 
 
@@ -299,15 +308,26 @@ def _patch_worker_sessions(
     monkeypatch: pytest.MonkeyPatch,
     records: list[FakeWorkerSessionRecord],
 ) -> None:
-    """Make :func:`chat_send._list_worker_sessions` return ``records``.
+    """Make the chat-send worker seams return ``records``.
 
     Avoids spinning up pg / the work-service in the router-level tests
     — the gate we actually care about is whether the resolver accepts
     a session_name only when the active worker-session row exists.
+
+    Patches both the legacy facade-wrapped seam and the v6 strict
+    seam so tests work regardless of which one the production code
+    paths through (Codex #2043 review v6 blocker 1 swung the live
+    route from ``_list_worker_sessions`` to
+    ``_list_worker_sessions_strict``).
     """
     monkeypatch.setattr(
         chat_send_routes,
         "_list_worker_sessions",
+        lambda config: list(records),
+    )
+    monkeypatch.setattr(
+        chat_send_routes,
+        "_list_worker_sessions_strict",
         lambda config: list(records),
     )
 
@@ -2090,6 +2110,9 @@ def test_operator_send_does_not_open_worker_facade(
         return []
 
     monkeypatch.setattr(chat_send_routes, "_list_worker_sessions", _track)
+    monkeypatch.setattr(
+        chat_send_routes, "_list_worker_sessions_strict", _track,
+    )
 
     response = client.post(
         "/api/v1/chat/operator/send",
@@ -2119,6 +2142,9 @@ def test_architect_send_does_not_open_worker_facade(
         return []
 
     monkeypatch.setattr(chat_send_routes, "_list_worker_sessions", _track)
+    monkeypatch.setattr(
+        chat_send_routes, "_list_worker_sessions_strict", _track,
+    )
 
     response = client.post(
         "/api/v1/chat/architect_myproj/send",
@@ -2145,7 +2171,13 @@ def test_worker_session_send_calls_worker_facade(
         call_count["n"] += 1
         return [FakeWorkerSessionRecord(task_project="myproj", task_number=42)]
 
+    # Route reads the strict seam now (Codex v6 blocker 1). Patching
+    # the legacy seam too keeps the assertion stable if a future
+    # refactor swaps which one runs first.
     monkeypatch.setattr(chat_send_routes, "_list_worker_sessions", _track)
+    monkeypatch.setattr(
+        chat_send_routes, "_list_worker_sessions_strict", _track,
+    )
 
     response = client.post(
         "/api/v1/chat/task-myproj-42/send",
@@ -2175,7 +2207,12 @@ def test_worker_facade_failure_returns_503_service_unavailable(
     def _raise(config):  # noqa: ARG001
         raise RuntimeError("pg pool exhausted")
 
+    # v6: route reads the strict seam — patch it so the synthetic
+    # outage is what _resolve_surface actually sees.
     monkeypatch.setattr(chat_send_routes, "_list_worker_sessions", _raise)
+    monkeypatch.setattr(
+        chat_send_routes, "_list_worker_sessions_strict", _raise,
+    )
 
     response = client.post(
         "/api/v1/chat/task-myproj-42/send",
@@ -2202,6 +2239,9 @@ def test_non_worker_session_with_worker_facade_failure_still_404(
         raise RuntimeError("would fail if asked")
 
     monkeypatch.setattr(chat_send_routes, "_list_worker_sessions", _raise)
+    monkeypatch.setattr(
+        chat_send_routes, "_list_worker_sessions_strict", _raise,
+    )
 
     response = client.post(
         "/api/v1/chat/arbitrary-name/send",
@@ -2222,3 +2262,117 @@ def test_looks_like_worker_session_pattern() -> None:
     assert not chat_send_routes._looks_like_worker_session("task-myproj")
     assert not chat_send_routes._looks_like_worker_session("task-myproj-abc")
     assert not chat_send_routes._looks_like_worker_session("task--42")
+
+
+# ---------------------------------------------------------------------------
+# Codex #2043 review v6 blocker 1 — strict path bypasses public facade
+# ---------------------------------------------------------------------------
+
+
+def test_real_open_work_service_failure_returns_503(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex #2043 review v6 blocker 1 — real facade-outage path.
+
+    Pre-v6 the v5 regression test monkeypatched
+    ``_list_worker_sessions`` directly, but the live facade
+    :func:`pollypm.web_api.service.list_active_worker_sessions`
+    catches ``_open_work_service_readonly`` failures and returns
+    ``[]`` — so a real pg outage still collapsed into a misleading
+    ``404 session_unknown`` in production.
+
+    The v6 fix in chat_send.py routes the strict worker lookup
+    through :func:`_list_worker_sessions_strict`, which opens
+    :func:`pollypm.web_api.service._open_work_service_readonly`
+    directly and propagates failures as
+    :class:`_WorkerFacadeUnavailable` → ``503 service_unavailable``.
+
+    This test exercises the real public-facade-bypass path: we
+    monkeypatch the contextmanager so it raises on enter, then verify
+    a worker-pattern POST returns 503 (NOT 404) and the autouse
+    ``_default_no_workers`` patch doesn't short-circuit the new path.
+    """
+    _set_storage_closet_windows(patched_tmux, ["task-myproj-7"])
+    _patch_heartbeat_age(monkeypatch, None)
+
+    # Override the autouse fixture's strict-seam stub so the strict
+    # helper actually executes (and reaches the real
+    # ``_open_work_service_readonly``).
+    monkeypatch.setattr(
+        chat_send_routes,
+        "_list_worker_sessions_strict",
+        chat_send_routes._list_worker_sessions_strict.__wrapped__
+        if hasattr(chat_send_routes._list_worker_sessions_strict, "__wrapped__")
+        else chat_send_routes._list_worker_sessions_strict,
+    )
+
+    import pollypm.web_api.service as service_mod
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _boom(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("pg pool down")
+        yield  # pragma: no cover — generator protocol shim
+
+    monkeypatch.setattr(service_mod, "_open_work_service_readonly", _boom)
+
+    response = client.post(
+        "/api/v1/chat/task-myproj-7/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 503, response.json()
+    assert response.json()["error"]["code"] == "service_unavailable"
+    assert "pg pool down" in response.json()["error"]["message"]
+
+
+def test_list_worker_sessions_strict_returns_empty_when_no_workers(
+    api_config: PollyPMConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct unit: strict helper returns ``[]`` for a real empty list.
+
+    A successful ``_open_work_service_readonly`` whose
+    ``list_worker_sessions`` returns ``[]`` is the genuine "no active
+    workers" case — must NOT raise. Only open/list failures raise.
+    """
+    from contextlib import contextmanager
+
+    class _StubSvc:
+        @staticmethod
+        def list_worker_sessions(*, active_only: bool = True) -> list[Any]:
+            return []
+
+    @contextmanager
+    def _stub(*args, **kwargs):  # noqa: ARG001
+        yield _StubSvc()
+
+    import pollypm.web_api.service as service_mod
+
+    monkeypatch.setattr(service_mod, "_open_work_service_readonly", _stub)
+
+    assert chat_send_routes._list_worker_sessions_strict(api_config) == []
+
+
+def test_list_worker_sessions_strict_raises_typed_on_facade_open_failure(
+    api_config: PollyPMConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct unit: open failure → :class:`_WorkerFacadeUnavailable`."""
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _boom(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("connect refused")
+        yield  # pragma: no cover
+
+    import pollypm.web_api.service as service_mod
+
+    monkeypatch.setattr(service_mod, "_open_work_service_readonly", _boom)
+
+    with pytest.raises(chat_send_routes._WorkerFacadeUnavailable):
+        chat_send_routes._list_worker_sessions_strict(api_config)

--- a/tests/test_chat_send_endpoint.py
+++ b/tests/test_chat_send_endpoint.py
@@ -1820,3 +1820,405 @@ def test_read_events_tail_empty_file(tmp_path: Path) -> None:
 
 def test_read_events_tail_missing_file(tmp_path: Path) -> None:
     assert chat_send_routes._read_events_tail(tmp_path / "nope.jsonl") == []
+
+
+# ---------------------------------------------------------------------------
+# Codex #2043 review v5 — strict mode fails closed on unavailable signals
+# ---------------------------------------------------------------------------
+
+
+def _force_transcript_unavailable(monkeypatch: pytest.MonkeyPatch, detail: str = "chmod 000") -> None:
+    """Make ``_read_events_tail`` raise :class:`TranscriptUnavailable`.
+
+    Simulates an unreadable ``events.jsonl`` (chmod 000, IO error,
+    truncated mid-rotation). Pre-v5 the route collapsed every read
+    failure into "no events" → "no open tool" → strict send proceeded.
+    """
+    def _raise(events_path, max_bytes=None):  # noqa: ARG001
+        raise chat_send_routes.TranscriptUnavailable(detail)
+
+    monkeypatch.setattr(chat_send_routes, "_read_events_tail", _raise)
+
+
+def _force_heartbeat_unavailable(monkeypatch: pytest.MonkeyPatch, detail: str = "db down") -> None:
+    """Make ``_heartbeat_age_seconds`` raise :class:`HeartbeatUnavailable`.
+
+    Simulates a pg pool / network outage on the heartbeat read. Pre-v5
+    this collapsed to ``None`` → "not streaming" → strict send through.
+    """
+    def _raise(config, session_name):  # noqa: ARG001
+        raise chat_send_routes.HeartbeatUnavailable(detail)
+
+    monkeypatch.setattr(chat_send_routes, "_heartbeat_age_seconds", _raise)
+
+
+def test_strict_fails_closed_on_unreadable_transcript(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+    workspace_root: Path,
+) -> None:
+    """Codex #2043 review v5 blocker 1 — strict 409 on read failure.
+
+    A real-world chmod 000 on ``events.jsonl`` with an open
+    ``tool_call`` previously let a strict send through because the
+    tail reader returned ``[]`` for every read failure. The fix raises
+    :class:`TranscriptUnavailable`, which the strict gate maps to
+    409 ``unsafe_unavailable_transcript``.
+    """
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    # Seed a transcript so the resolver picks it up (exact match), then
+    # force the tail reader to fail — that's the chmod 000 scenario.
+    _write_events_jsonl(
+        project_root, "session-unreadable", _assistant_with_open_tool(),
+        cwd=workspace_root,
+    )
+    _force_transcript_unavailable(monkeypatch)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409, response.json()
+    assert response.json()["error"]["code"] == "unsafe_unavailable_transcript"
+    # Critically: nothing was sent.
+    assert patched_tmux.send_calls == []
+
+
+def test_loose_continues_with_warning_on_unreadable_transcript(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+    workspace_root: Path,
+) -> None:
+    """Loose mode continues past an unreadable transcript with a warning.
+
+    Per Codex #2043 review v5 blocker 1: loose can't enforce the
+    mid-tool gate without a readable transcript, but the operator
+    explicitly opted into best-effort. Emit the
+    ``transcript-unavailable`` warning header so it's visible.
+    """
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(
+        project_root, "session-unreadable-loose", _assistant_with_open_tool(),
+        cwd=workspace_root,
+    )
+    _force_transcript_unavailable(monkeypatch)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello", "safety": "loose"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+    assert response.headers.get("X-PollyPM-Warning") == "transcript-unavailable"
+
+
+def test_force_bypasses_unreadable_transcript(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+    workspace_root: Path,
+) -> None:
+    """Force ignores transcript-unavailable entirely — no header, no 409."""
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+    _write_events_jsonl(
+        project_root, "session-unreadable-force", _assistant_with_open_tool(),
+        cwd=workspace_root,
+    )
+    _force_transcript_unavailable(monkeypatch)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello", "safety": "force"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+    assert "X-PollyPM-Warning" not in response.headers
+
+
+def test_strict_fails_closed_on_heartbeat_unavailable(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex #2043 review v5 blocker 2 — strict 409 on pg outage.
+
+    The pre-v5 helper swallowed ``latest_heartbeat`` exceptions and
+    returned ``None``, which the mid-stream gate treated as "not
+    streaming". A pg outage therefore allowed the strict send. The fix
+    raises :class:`HeartbeatUnavailable`, mapping to
+    ``unsafe_unavailable_heartbeat``.
+    """
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _force_heartbeat_unavailable(monkeypatch)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 409, response.json()
+    assert response.json()["error"]["code"] == "unsafe_unavailable_heartbeat"
+    assert patched_tmux.send_calls == []
+
+
+def test_loose_continues_with_warning_on_heartbeat_unavailable(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Loose continues past pg outage with ``heartbeat-unavailable`` header."""
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _force_heartbeat_unavailable(monkeypatch)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello", "safety": "loose"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+    assert response.headers.get("X-PollyPM-Warning") == "heartbeat-unavailable"
+
+
+def test_force_bypasses_heartbeat_unavailable(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Force ignores the heartbeat outage entirely."""
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _force_heartbeat_unavailable(monkeypatch)
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello", "safety": "force"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+    assert "X-PollyPM-Warning" not in response.headers
+
+
+def test_heartbeat_unavailable_raises_on_latest_heartbeat_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct unit test: pg failure → :class:`HeartbeatUnavailable`.
+
+    Reproduces Codex's exact diagnostic: ``latest_heartbeat`` raising
+    ``RuntimeError("db down")`` previously caused
+    ``_heartbeat_age_seconds`` to return ``None``. Now it raises.
+    """
+    import pollypm.storage.pg_heartbeats as pg_heartbeats
+
+    def _raise(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(pg_heartbeats, "latest_heartbeat", _raise)
+    with pytest.raises(chat_send_routes.HeartbeatUnavailable):
+        chat_send_routes._heartbeat_age_seconds(None, "operator")
+
+
+def test_heartbeat_none_when_no_record(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No row → ``None`` (genuine "not streaming"), not HeartbeatUnavailable."""
+    import pollypm.storage.pg_heartbeats as pg_heartbeats
+
+    monkeypatch.setattr(
+        pg_heartbeats,
+        "latest_heartbeat",
+        lambda *a, **kw: None,  # noqa: ARG005
+    )
+    assert chat_send_routes._heartbeat_age_seconds(None, "operator") is None
+
+
+def test_read_events_tail_raises_on_open_failure(tmp_path: Path) -> None:
+    """Codex #2043 review v5 blocker 1 — chmod 000 raises TranscriptUnavailable.
+
+    Reproduces Codex's exact diagnostic: an ``events.jsonl`` chmod'd
+    unreadable previously made ``_read_events_tail`` return ``[]``.
+    Now it raises.
+    """
+    import os as _os
+
+    events_path = tmp_path / "events.jsonl"
+    events_path.write_text(
+        json.dumps({"event_type": "tool_call", "payload": {"id": "x"}}) + "\n",
+    )
+    try:
+        _os.chmod(events_path, 0o000)
+        # Skip if running as root (chmod 000 doesn't block root reads).
+        if _os.access(events_path, _os.R_OK):
+            pytest.skip("running as root; chmod 000 does not block reads")
+        with pytest.raises(chat_send_routes.TranscriptUnavailable):
+            chat_send_routes._read_events_tail(events_path)
+    finally:
+        _os.chmod(events_path, 0o600)
+
+
+# ---------------------------------------------------------------------------
+# Codex #2043 review v5 blocker 3 — worker facade is lazy
+# ---------------------------------------------------------------------------
+
+
+def test_operator_send_does_not_open_worker_facade(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operator/architect/advisor sends must not pay worker-facade cost.
+
+    Pre-v5 ``_resolve_surface`` called ``_list_worker_sessions``
+    unconditionally — every send opened the work-service even when
+    the requested ``session_name`` syntactically could not be a
+    worker. Operator surfaces are workspace-wide and never need the
+    worker enumeration.
+    """
+    _set_storage_closet_windows(patched_tmux, ["pm-operator"])
+    _patch_heartbeat_age(monkeypatch, None)
+
+    call_count = {"n": 0}
+
+    def _track(config):  # noqa: ARG001
+        call_count["n"] += 1
+        return []
+
+    monkeypatch.setattr(chat_send_routes, "_list_worker_sessions", _track)
+
+    response = client.post(
+        "/api/v1/chat/operator/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+    assert call_count["n"] == 0, (
+        "operator send must not open the worker-service facade"
+    )
+
+
+def test_architect_send_does_not_open_worker_facade(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same as the operator test for the architect surface."""
+    _set_storage_closet_windows(patched_tmux, ["pm-architect-myproj"])
+    _patch_heartbeat_age(monkeypatch, None)
+
+    call_count = {"n": 0}
+
+    def _track(config):  # noqa: ARG001
+        call_count["n"] += 1
+        return []
+
+    monkeypatch.setattr(chat_send_routes, "_list_worker_sessions", _track)
+
+    response = client.post(
+        "/api/v1/chat/architect_myproj/send",
+        json={"text": "hi"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+    assert call_count["n"] == 0
+
+
+def test_worker_session_send_calls_worker_facade(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Worker-pattern session_name DOES open the facade exactly once."""
+    _set_storage_closet_windows(patched_tmux, ["task-myproj-42"])
+    _patch_heartbeat_age(monkeypatch, None)
+
+    call_count = {"n": 0}
+
+    def _track(config):  # noqa: ARG001
+        call_count["n"] += 1
+        return [FakeWorkerSessionRecord(task_project="myproj", task_number=42)]
+
+    monkeypatch.setattr(chat_send_routes, "_list_worker_sessions", _track)
+
+    response = client.post(
+        "/api/v1/chat/task-myproj-42/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.json()
+    assert call_count["n"] == 1
+
+
+def test_worker_facade_failure_returns_503_service_unavailable(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex #2043 review v5 blocker 3 — worker lookup failure ≠ 404.
+
+    Pre-v5 the facade's ``[]`` fallback on outage masqueraded as
+    ``404 session_unknown``, hiding pg outages from the operator. For
+    a worker-pattern session_name we now distinguish "lookup failed"
+    (``503 service_unavailable``) from "no such worker" (404).
+    """
+    _set_storage_closet_windows(patched_tmux, ["task-myproj-42"])
+    _patch_heartbeat_age(monkeypatch, None)
+
+    def _raise(config):  # noqa: ARG001
+        raise RuntimeError("pg pool exhausted")
+
+    monkeypatch.setattr(chat_send_routes, "_list_worker_sessions", _raise)
+
+    response = client.post(
+        "/api/v1/chat/task-myproj-42/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 503, response.json()
+    assert response.json()["error"]["code"] == "service_unavailable"
+
+
+def test_non_worker_session_with_worker_facade_failure_still_404(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    patched_tmux: type[FakeTmuxClient],  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-worker name that doesn't match config sessions stays 404.
+
+    ``arbitrary-name`` is not worker-pattern, so the facade is never
+    queried — even if it would fail. The route returns the same
+    ``session_unknown`` it always has.
+    """
+    def _raise(config):  # noqa: ARG001
+        raise RuntimeError("would fail if asked")
+
+    monkeypatch.setattr(chat_send_routes, "_list_worker_sessions", _raise)
+
+    response = client.post(
+        "/api/v1/chat/arbitrary-name/send",
+        json={"text": "hello"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 404, response.json()
+    assert response.json()["error"]["code"] == "session_unknown"
+
+
+def test_looks_like_worker_session_pattern() -> None:
+    """Worker pattern: ``task-<project>-<n>`` only."""
+    assert chat_send_routes._looks_like_worker_session("task-myproj-42")
+    assert chat_send_routes._looks_like_worker_session("task-pollypm-1")
+    assert chat_send_routes._looks_like_worker_session("task-foo_bar-99")
+    assert not chat_send_routes._looks_like_worker_session("operator")
+    assert not chat_send_routes._looks_like_worker_session("architect_myproj")
+    assert not chat_send_routes._looks_like_worker_session("task-myproj")
+    assert not chat_send_routes._looks_like_worker_session("task-myproj-abc")
+    assert not chat_send_routes._looks_like_worker_session("task--42")

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 import yaml
 from openapi_spec_validator import validate as validate_openapi
 
@@ -125,8 +124,6 @@ def test_chat_message_type_enum_matches_runtime() -> None:
 
 def test_implementation_openapi_validates_as_31() -> None:
     """The auto-generated doc must itself be a valid OpenAPI 3.x doc."""
-    from fastapi.testclient import TestClient
-
     # Re-read straight off the FastAPI app so we don't depend on the
     # `client` fixture's auth wiring.
     from pollypm.config import (
@@ -136,7 +133,7 @@ def test_implementation_openapi_validates_as_31() -> None:
         PollyPMSettings,
         ProjectSettings,
     )
-    from pollypm.models import KnownProject, ProjectKind, ProviderKind, RuntimeKind
+    from pollypm.models import ProviderKind, RuntimeKind
     from pollypm.web_api import create_app
 
     base = Path(__file__).resolve().parent

--- a/tests/web_api/test_openapi_conformance.py
+++ b/tests/web_api/test_openapi_conformance.py
@@ -42,6 +42,8 @@ PHASE_1_PATHS: set[tuple[str, str]] = {
     # Phase 2 — chat GET endpoints (PR #2045).
     ("GET", "/chat/sessions"),
     ("GET", "/chat/{session_name}/messages"),
+    # Chat-endpoints P3 (#2043) — POST send path.
+    ("POST", "/chat/{session_name}/send"),
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ wheels = [
 
 [[package]]
 name = "pollypm"
-version = "1.0.0rc2"
+version = "1.0.0rc3.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -518,17 +518,23 @@ dev = [
     { name = "ruff" },
     { name = "testcontainers" },
 ]
+test = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
+    { name = "httpx", marker = "extra == 'test'", specifier = ">=0.27.0" },
     { name = "openapi-spec-validator", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "packaging", specifier = ">=23.0" },
     { name = "pgvector", specifier = ">=0.3.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "psycopg-pool", specifier = ">=3.2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.4.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.12" },
     { name = "sqlalchemy", specifier = ">=2.0" },
@@ -537,7 +543,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.16.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "test"]
 
 [[package]]
 name = "psycopg"


### PR DESCRIPTION
## Summary
- P3 of `~/Desktop/pollypm-chat-endpoints-spec.md` — new `POST /api/v1/chat/{session_name}/send` endpoint that pushes a message into the running CLI agent via tmux.
- Safety gates per spec §4.1 / §4.3: tail-scan of events.jsonl rejects mid-tool sends (unmatched `tool_use_id`); pg-only heartbeat freshness check rejects mid-stream sends. `safety=loose` keeps mid-tool but allows mid-stream with an `X-PollyPM-Warning: agent-may-be-streaming` header; `safety=force` bypasses both.
- AskUserQuestion answering per §4.5: validates `answer_to` references an ask_user envelope, checks `selections` against the question's options, types option labels newline-joined (plus optional `notes`). Falls back to freeform `text` when provided.
- Per-task worker support: when `session_name` matches the canonical `task-{project}-{task_id}` shape, the resolver derives the project + window without needing a `config.sessions` entry (matches `session_manager.task_window_name`).
- Wired into the existing FastAPI app under `/api/v1/chat` with the existing bearer-token dependency.

## Endpoint
- File: `src/pollypm/web_api/routes/chat_send.py` — router function `send_chat_message` at L648 (`@router.post("/{session_name}/send", ...)`).
- App wiring: `src/pollypm/web_api/app.py:117-126` (`app.include_router(chat_send_routes.router, prefix=f"{API_V1_PREFIX}/chat", ...)`).

## Notes / TODOs
- `_find_session_events_path` currently picks the freshest `events.jsonl` in the project's transcript dir. P1 (chat surface registry) is the natural home for a real `session_name → session_id` lookup — the freshest-fallback is correct for single-active-session-per-project setups (the common case) and fails-open for stale mismatches (which is exactly what `safety=force` is for).
- Open question #1 in the spec ("what does Claude Code accept for AskUserQuestion stdin?") could not be answered in-flight from this isolated worktree (no live Claude session reachable). Implementation matches the spec default (typing option labels verbatim). Confirmation deferred to P4 user-testing per a `TODO(P4)` in `_build_answer_text`.

## Test plan
- [x] `pytest --noconftest tests/test_chat_send_endpoint.py -v` → 42 passing
- [x] `ruff check` clean on touched files
- [ ] (deferred to P4) Live `pm chat send operator "test"` against a real Claude pane
- [ ] (deferred to P4) Mid-stream user test: send into Polly while she's streaming, expect 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)